### PR TITLE
bun test: match positional filters containing glob syntax as globs

### DIFF
--- a/docs/test/discovery.mdx
+++ b/docs/test/discovery.mdx
@@ -32,7 +32,7 @@ To filter which test files run, pass additional positional arguments to `bun tes
 bun test <filter> <filter> ...
 ```
 
-Any test file with a path that contains one of the filters runs. Filters are substring matches, not glob patterns.
+Any test file with a path that contains one of the filters runs. Filters are substring matches by default.
 
 For example, to run all tests in a `utils` directory:
 
@@ -41,6 +41,12 @@ bun test utils
 ```
 
 This matches files like `src/utils/string.test.ts` and `lib/utils/array_test.js`.
+
+A filter that contains `*` is matched as a glob pattern against the project-relative path instead of as a substring. Quote the pattern so your shell does not expand it first:
+
+```bash terminal icon="terminal"
+bun test 'test/**/*.test.ts'
+```
 
 ### Specifying Exact File Paths
 

--- a/docs/test/index.mdx
+++ b/docs/test/index.mdx
@@ -42,7 +42,7 @@ The runner recursively searches the working directory for files that match the f
 - `*.spec.{js|jsx|ts|tsx|mjs|cjs|mts|cts}`
 - `*_spec.{js|jsx|ts|tsx|mjs|cjs|mts|cts}`
 
-To filter the set of _test files_ to run, pass additional positional arguments to `bun test`. Any test file with a path that matches one of the filters runs. Filters are commonly file or directory names; glob patterns are not yet supported.
+To filter the set of _test files_ to run, pass additional positional arguments to `bun test`. Any test file with a path that matches one of the filters runs. A filter that contains `*` is matched as a glob pattern (for example `bun test 'test/**/*.test.ts'`); other filters are substring matches against the path.
 
 ```bash terminal icon="terminal"
 bun test <filter> <filter> ...

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -300,7 +300,11 @@ impl<'a> Scanner<'a> {
         }
 
         for filter_name in self.filter_names {
-            if strings::index_of(name, filter_name).is_some() {
+            if bun_glob::detect_glob_syntax(filter_name) {
+                if bun_glob::r#match(filter_name, name).matches() {
+                    return true;
+                }
+            } else if strings::index_of(name, filter_name).is_some() {
                 return true;
             }
         }

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -300,7 +300,7 @@ impl<'a> Scanner<'a> {
         }
 
         for filter_name in self.filter_names {
-            if bun_glob::detect_glob_syntax(filter_name) {
+            if is_glob_filter(filter_name) {
                 if bun_glob::r#match(filter_name, name).matches() {
                     return true;
                 }
@@ -449,3 +449,10 @@ impl<'a> Scanner<'a> {
 }
 
 pub(crate) const TEST_NAME_SUFFIXES: [&[u8]; 4] = [b".test", b"_test", b".spec", b"_spec"];
+
+/// A positional filter is treated as a glob only when it contains `*`.
+/// `?`, `[`, `{`, and leading `!` are legal path characters on POSIX (e.g.
+/// Next.js `[slug]` directories) and must keep their substring semantics.
+pub(crate) fn is_glob_filter(filter: &[u8]) -> bool {
+    strings::index_of_char(filter, b'*').is_some()
+}

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -450,9 +450,7 @@ impl<'a> Scanner<'a> {
 
 pub(crate) const TEST_NAME_SUFFIXES: [&[u8]; 4] = [b".test", b"_test", b".spec", b"_spec"];
 
-/// A positional filter is treated as a glob only when it contains `*`.
-/// `?`, `[`, `{`, and leading `!` are legal path characters on POSIX (e.g.
-/// Next.js `[slug]` directories) and must keep their substring semantics.
+/// Only `*` (never valid in a path) flips a filter to glob matching; `?[{!` stay substring.
 pub(crate) fn is_glob_filter(filter: &[u8]) -> bool {
     strings::index_of_char(filter, b'*').is_some()
 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2464,9 +2464,7 @@ impl TestCommand {
                     // in the pattern as the native separator, and rewriting to
                     // `\` would turn `\*` into an escaped literal.
                     if !bun_glob::detect_glob_syntax(in_) {
-                        bun_path::resolve_path::posix_to_platform_in_place::<u8>(
-                            &mut to_normalize,
-                        );
+                        bun_path::resolve_path::posix_to_platform_in_place::<u8>(&mut to_normalize);
                     }
                     normalized.push(to_normalize.into_boxed_slice());
                 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2461,7 +2461,7 @@ impl TestCommand {
                 for in_ in filter_names {
                     let mut to_normalize = in_.to_vec();
                     // Glob patterns stay posix-form; `\` is a glob escape, not a separator.
-                    if !bun_glob::detect_glob_syntax(in_) {
+                    if !scanner::is_glob_filter(in_) {
                         bun_path::resolve_path::posix_to_platform_in_place::<u8>(&mut to_normalize);
                     }
                     normalized.push(to_normalize.into_boxed_slice());
@@ -2830,7 +2830,7 @@ impl TestCommand {
                     pretty_error!(" {}", bstr::BStr::new(filter));
 
                     if has_file_like.is_none()
-                        && !bun_glob::detect_glob_syntax(filter)
+                        && !scanner::is_glob_filter(filter)
                         && (strings::ends_with(filter, b".ts")
                             || strings::ends_with(filter, b".tsx")
                             || strings::ends_with(filter, b".js")

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2460,7 +2460,14 @@ impl TestCommand {
                 let mut normalized = Vec::with_capacity(filter_names.len());
                 for in_ in filter_names {
                     let mut to_normalize = in_.to_vec();
-                    bun_path::resolve_path::posix_to_platform_in_place::<u8>(&mut to_normalize);
+                    // Glob patterns stay posix-form: `bun_glob::match` treats `/`
+                    // in the pattern as the native separator, and rewriting to
+                    // `\` would turn `\*` into an escaped literal.
+                    if !bun_glob::detect_glob_syntax(in_) {
+                        bun_path::resolve_path::posix_to_platform_in_place::<u8>(
+                            &mut to_normalize,
+                        );
+                    }
                     normalized.push(to_normalize.into_boxed_slice());
                 }
                 normalized
@@ -2827,6 +2834,7 @@ impl TestCommand {
                     pretty_error!(" {}", bstr::BStr::new(filter));
 
                     if has_file_like.is_none()
+                        && !bun_glob::detect_glob_syntax(filter)
                         && (strings::ends_with(filter, b".ts")
                             || strings::ends_with(filter, b".tsx")
                             || strings::ends_with(filter, b".js")

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2460,9 +2460,7 @@ impl TestCommand {
                 let mut normalized = Vec::with_capacity(filter_names.len());
                 for in_ in filter_names {
                     let mut to_normalize = in_.to_vec();
-                    // Glob patterns stay posix-form: `bun_glob::match` treats `/`
-                    // in the pattern as the native separator, and rewriting to
-                    // `\` would turn `\*` into an escaped literal.
+                    // Glob patterns stay posix-form; `\` is a glob escape, not a separator.
                     if !bun_glob::detect_glob_syntax(in_) {
                         bun_path::resolve_path::posix_to_platform_in_place::<u8>(&mut to_normalize);
                     }

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1635,4 +1635,91 @@ describe.concurrent("test file discovery (scanner)", () => {
     expect(stderr).toContain(" 1 pass");
     expect(exitCode).toBe(0);
   });
+
+  // https://github.com/oven-sh/bun/issues/10353
+  describe("glob filters", () => {
+    const make = (name: string) =>
+      `import { test } from "bun:test"; test("${name}", () => { console.log("RAN ${name}"); });`;
+    const fixture = () =>
+      tempDir("scanner-glob-filter", {
+        "test/module.test.ts": make("module"),
+        "test/script.test.ts": make("script"),
+        "test/dir/file.test.ts": make("dirfile"),
+        "test/config/config.test.ts": make("config"),
+        "other/elsewhere.test.ts": make("elsewhere"),
+      });
+
+    async function run(dir: string, args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", ...args],
+        env: bunEnv,
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test("'test/**/*.test.ts' matches top-level and nested files", async () => {
+      using dir = fixture();
+      const { stdout, stderr, exitCode } = await run(String(dir), ["test/**/*.test.ts"]);
+
+      expect(stdout).toContain("RAN module");
+      expect(stdout).toContain("RAN script");
+      expect(stdout).toContain("RAN dirfile");
+      expect(stdout).toContain("RAN config");
+      expect(stdout).not.toContain("RAN elsewhere");
+      expect(stderr).toContain(" 4 pass");
+      expect(exitCode).toBe(0);
+    });
+
+    test("'test/*.test.ts' matches only the top level of test/", async () => {
+      using dir = fixture();
+      const { stdout, stderr, exitCode } = await run(String(dir), ["test/*.test.ts"]);
+
+      expect(stdout).toContain("RAN module");
+      expect(stdout).toContain("RAN script");
+      expect(stdout).not.toContain("RAN dirfile");
+      expect(stdout).not.toContain("RAN config");
+      expect(stdout).not.toContain("RAN elsewhere");
+      expect(stderr).toContain(" 2 pass");
+      expect(exitCode).toBe(0);
+    });
+
+    test("glob and substring filters can be mixed", async () => {
+      using dir = fixture();
+      const { stdout, stderr, exitCode } = await run(String(dir), ["test/*.test.ts", "elsewhere"]);
+
+      expect(stdout).toContain("RAN module");
+      expect(stdout).toContain("RAN script");
+      expect(stdout).toContain("RAN elsewhere");
+      expect(stdout).not.toContain("RAN dirfile");
+      expect(stdout).not.toContain("RAN config");
+      expect(stderr).toContain(" 3 pass");
+      expect(exitCode).toBe(0);
+    });
+
+    test("brace expansion works in glob filters", async () => {
+      using dir = fixture();
+      const { stdout, stderr, exitCode } = await run(String(dir), ["test/{module,script}.test.ts"]);
+
+      expect(stdout).toContain("RAN module");
+      expect(stdout).toContain("RAN script");
+      expect(stdout).not.toContain("RAN dirfile");
+      expect(stdout).not.toContain("RAN config");
+      expect(stderr).toContain(" 2 pass");
+      expect(exitCode).toBe(0);
+    });
+
+    test("filters without glob syntax still substring-match", async () => {
+      using dir = fixture();
+      const { stdout, stderr, exitCode } = await run(String(dir), ["config"]);
+
+      expect(stdout).toContain("RAN config");
+      expect(stdout).not.toContain("RAN module");
+      expect(stderr).toContain(" 1 pass");
+      expect(exitCode).toBe(0);
+    });
+  });
 });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1647,6 +1647,7 @@ describe.concurrent("test file discovery (scanner)", () => {
         "test/dir/file.test.ts": make("dirfile"),
         "test/config/config.test.ts": make("config"),
         "other/elsewhere.test.ts": make("elsewhere"),
+        "app/[slug]/page.test.ts": make("slug"),
       });
 
     async function run(dir: string, args: string[]) {
@@ -1670,6 +1671,7 @@ describe.concurrent("test file discovery (scanner)", () => {
       expect(stdout).toContain("RAN dirfile");
       expect(stdout).toContain("RAN config");
       expect(stdout).not.toContain("RAN elsewhere");
+      expect(stdout).not.toContain("RAN slug");
       expect(stderr).toContain(" 4 pass");
       expect(exitCode).toBe(0);
     });
@@ -1700,16 +1702,53 @@ describe.concurrent("test file discovery (scanner)", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("brace expansion works in glob filters", async () => {
+    test("brace expansion works when the filter also contains '*'", async () => {
       using dir = fixture();
-      const { stdout, stderr, exitCode } = await run(String(dir), ["test/{module,script}.test.ts"]);
+      const { stdout, stderr, exitCode } = await run(String(dir), ["test/{dir,config}/*.test.ts"]);
 
-      expect(stdout).toContain("RAN module");
-      expect(stdout).toContain("RAN script");
-      expect(stdout).not.toContain("RAN dirfile");
-      expect(stdout).not.toContain("RAN config");
+      expect(stdout).toContain("RAN dirfile");
+      expect(stdout).toContain("RAN config");
+      expect(stdout).not.toContain("RAN module");
+      expect(stdout).not.toContain("RAN script");
       expect(stderr).toContain(" 2 pass");
       expect(exitCode).toBe(0);
+    });
+
+    test("'[slug]' (no '*') is still a substring filter, not a character class", async () => {
+      using dir = fixture();
+      const { stdout, stderr, exitCode } = await run(String(dir), ["[slug]"]);
+
+      expect(stdout).toContain("RAN slug");
+      expect(stdout).not.toContain("RAN module");
+      expect(stderr).toContain(" 1 pass");
+      expect(exitCode).toBe(0);
+    });
+
+    test("leading '!' (no '*') is not a negated glob", async () => {
+      using dir = fixture();
+      const { stderr, exitCode } = await run(String(dir), ["!nope"]);
+
+      expect(stderr).toContain("did not match any test files");
+      expect(exitCode).toBe(1);
+    });
+
+    test("a non-matching glob does not suggest prefixing with './'", async () => {
+      using dir = fixture();
+      const { stderr, exitCode } = await run(String(dir), ["nope/**/*.test.ts"]);
+
+      expect(stderr).toContain("did not match any test files");
+      expect(stderr).not.toContain("filter as a path");
+      expect(stderr).not.toContain("bun test ./");
+      expect(exitCode).toBe(1);
+    });
+
+    test("a non-matching plain filter still suggests prefixing with './'", async () => {
+      using dir = fixture();
+      const { stderr, exitCode } = await run(String(dir), ["missing.test.ts"]);
+
+      expect(stderr).toContain("did not match any test files");
+      expect(stderr).toContain(`bun test ./missing.test.ts`);
+      expect(exitCode).toBe(1);
     });
 
     test("filters without glob syntax still substring-match", async () => {


### PR DESCRIPTION
Fixes #10353.

## Problem

`bun test` treats positional arguments that do not start with `./`, `../`, or an absolute path as substring filters: a file is included when its project-relative path contains the argument as a literal substring. A glob pattern like `test/**/*.test.ts` therefore matches nothing, because no path literally contains `**`.

```sh
D=$(mktemp -d); cd "$D"
mkdir -p test/dir test/config
for f in test/module test/script test/dir/file test/config/config; do
  printf 'import { test } from "bun:test"; test("x", () => {});\n' > "$f.test.ts"
done
bun test 'test/**/*.test.ts'
# The following filters did not match any test files:
#  test/**/*.test.ts
```

This is also what users hit in a package.json `"scripts"` entry on POSIX: `bun run` invokes `bash -c`, which does not enable `globstar` by default, so an unquoted `test/**/*.test.ts` collapses to `test/*/*.test.ts` before `bun test` even sees it. Quoting the pattern (the usual convention for mocha/vitest) then runs into the substring-only filter above.

## Fix

In `Scanner::does_path_match_filter`, when a filter contains `*`, match it against the project-relative path with `bun_glob::match` instead of `strings::index_of`. Filters without `*` keep their substring behaviour, so `bun test serve` still finds every test whose path contains `serve`, and `bun test '[slug]'` still substring-matches Next.js-style route directories.

Only `*` triggers glob mode. `?`, `[`, `{`, and leading `!` are legal path characters on POSIX; routing them through the glob matcher would have broken `bun test '[slug]'` (becomes a single-char class that matches nothing) and turned `bun test '!foo'` into a negated glob that matches every file. `*` is the only metacharacter that cannot appear in a real path and is the one that motivates #10353. Other glob metacharacters (`?`, `[...]`, `{,}`) are still honoured inside a filter that also contains `*`.

On Windows, positional filters were previously rewritten to backslash separators for substring matching. That rewrite is now skipped for `*`-containing filters so that `/` in the pattern continues to match the native separator via the glob matcher (the matcher treats `\` in a pattern as an escape).

The "To treat the \"...\" filter as a path, run \"bun test ./...\"" hint is no longer printed for glob-shaped filters, since prefixing a glob with `./` does not help.

`docs/test/index.mdx` and `docs/test/discovery.mdx`, which stated glob patterns were not supported, are updated.

## Why

Other test runners (mocha, vitest) accept glob patterns as positional arguments and expand them themselves; users coming from those tools expect `bun test 'test/**/*.test.ts'` to work. The change is additive: `*` is not a legal path character, so filters that previously matched anything via substring continue to do so, and filters that previously matched nothing because they contained `*` now match what the glob describes.

## Verification

New tests in `test/cli/test/bun-test.test.ts` (`test file discovery (scanner) > glob filters`) cover `test/**/*.test.ts`, `test/*.test.ts`, `{a,b}/*.test.ts`, mixed glob + substring filters, the `[slug]` and `!foo` substring-preservation cases, and the suppressed `./` hint. The five glob tests fail on main and pass on this branch; the four substring/hint tests pass on both. `bun-test.test.ts`, `path-ignore-patterns.test.ts`, and `concurrent-test-glob.test.ts` pass in full.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->