### PR TITLE
bundler: never pick bare `$` as a minified identifier

### DIFF
--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -275,7 +275,7 @@ impl MinifyRenamer {
     pub fn init(
         symbols: symbol::Map,
         first_top_level_slots: &js_ast::SlotCounts,
-        reserved_names: StringHashMap<u32>,
+        mut reserved_names: StringHashMap<u32>,
     ) -> Result<Box<MinifyRenamer>, bun_alloc::AllocError> {
         let mut slots = SymbolSlotList::default();
 
@@ -285,6 +285,9 @@ impl MinifyRenamer {
             v.resize(count, SymbolSlot::default());
             slots[ns] = v;
         }
+
+        // #14586: here, not in `compute_initial_reserved_names`, so `NumberRenamer` keeps user `$` verbatim.
+        reserved_names.put(b"$", 1).expect("unreachable");
 
         Ok(Box::new(MinifyRenamer {
             symbols: ManuallyDrop::new(symbols),

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1298,6 +1298,73 @@ describe("bundler", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/14586
+  // Enough top-level bindings to exhaust every single-char name. With `$`
+  // unreferenced it sorts last in the head alphabet, so it is the 54th name
+  // the minifier would otherwise hand out.
+  const manyDecls = Array.from({ length: 60 }, (_, i) => `class C${i} { m${i}() {} }`).join("\n");
+  const manyRefs = Array.from({ length: 60 }, (_, i) => `C${i}`).join(",");
+  itBundled("minify/IdentifiersNeverBareDollar", {
+    files: {
+      "/entry.js": /* js */ `
+        ${manyDecls}
+        console.log(${manyRefs});
+      `,
+    },
+    minifyIdentifiers: true,
+    minifyWhitespace: true,
+    target: "browser",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      // No bare `$` identifier (allow `$` inside longer names like `a$`/`$a`).
+      const bareDollar = /(?<![A-Za-z0-9_$])\$(?![A-Za-z0-9_$])/;
+      expect(bareDollar.test(code)).toBe(false);
+    },
+  });
+  itBundled("minify/IdentifiersDollarStillUsableWhenReferenced", {
+    files: {
+      "/entry.js": /* js */ `
+        $(document).ready(() => {});
+        ${manyDecls}
+        console.log(${manyRefs});
+      `,
+    },
+    minifyIdentifiers: true,
+    minifyWhitespace: true,
+    target: "browser",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      // The unbound reference to `$` must be preserved verbatim; reserving
+      // the name must not break referencing an existing global `$`.
+      expect(code).toContain("$(document)");
+      // Count bare `$` occurrences: exactly the one reference above.
+      const bareDollar = /(?<![A-Za-z0-9_$])\$(?![A-Za-z0-9_$])/g;
+      expect([...code.matchAll(bareDollar)].length).toBe(1);
+    },
+  });
+  // The reservation is scoped to the minify renamer; the non-minifying
+  // `NumberRenamer` must keep user-written `$` bindings verbatim (React
+  // Compiler emits `let $ = _c(n)` inside every optimized component).
+  itBundled("minify/IdentifiersDollarPreservedWithoutMinify", {
+    files: {
+      "/entry.js": /* js */ `
+        function Component() {
+          let $ = _c(3);
+          return $[0];
+        }
+        console.log(Component);
+      `,
+    },
+    minifyIdentifiers: false,
+    target: "browser",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("let $ = _c(3)");
+      expect(code).toContain("return $[0]");
+      expect(code).not.toContain("$2");
+    },
+  });
+
   // Without minifySyntax the block body must be preserved verbatim.
   itBundled("minify/ArrowReturnNotCollapsedWithoutMinifySyntax", {
     files: {

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -57,8 +57,8 @@ describe("bundler", () => {
           "../entry.tsx",
         ],
         mappings: [
-          ["react.development.js:524:'getContextName'", "1:5623:nt"],
-          ["react.development.js:2495:'actScopeDepth'", "23:4082:ar++"],
+          ["react.development.js:524:'getContextName'", "1:5623:at"],
+          ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
           ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
           ["entry.tsx:6:'\"Content-Type\"'", '100:18808:"Content-Type"'],
           ["entry.tsx:11:'<html>'", "100:19062:void"],
@@ -67,7 +67,7 @@ describe("bundler", () => {
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221969,
+      "out/entry.js": 222000,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",


### PR DESCRIPTION
## What

`--minify-identifiers` can hand out a bare `$` as a generated name. In Bun's default ESM output the chunk top level is the real top level, so a `class $` / `var $` there shadows `window.$` when the bundle is loaded as a classic `<script>`. That breaks any page that also uses jQuery (or Prototype / Zepto / Cash, which all claim `$`).

```js
// bun build ./src/* --minify --target browser
class X extends Error { ... }
class $ extends Error { ... }   // <- stomps on jQuery's global $
```

## Why this fix

Both esbuild and terser include `$` in their minifier alphabets, but each avoids this collision structurally by default: esbuild defaults `--platform=browser` to `format=iife` (everything wrapped in `(()=>{...})()`), and terser leaves top-level names unmangled unless `--toplevel` is passed. Bun defaults browser builds to ESM and mangles top-level names, so the bare `$` actually lands at global scope.

Changing Bun's default output format would be a breaking change. Reserving one single-char name is effectively free (on the 222 KB React SSR bundle the size delta is +31 bytes, ~0.01%) and removes the most common real-world collision. `$` can still appear inside longer generated names, and user references to a global `$` are still preserved verbatim.

The reservation is scoped to `MinifyRenamer::init` so the non-minifying `NumberRenamer` keeps user-written `$` bindings untouched (React Compiler emits `let $ = _c(n)` inside every optimized component).

## Testing

- `minify/IdentifiersNeverBareDollar`: 60 top-level classes exhaust every single-char slot; asserts no standalone `$` appears in the output.
- `minify/IdentifiersDollarStillUsableWhenReferenced`: input references `$(document)`; the reference is preserved and is the only bare `$` in the output.
- `minify/IdentifiersDollarPreservedWithoutMinify`: a nested `let $` in a non-minified bundle stays `$` (covers the `NumberRenamer` path).
- `npm/ReactSSR`: updated the hardcoded sourcemap positions and exact file size for the shifted minified-name sequence.

Fixes #14586

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_npm.test.ts

<!-- robobun:evidence:end -->