### PR TITLE
node:http: apply the server's idleTimeout at accept so headersTimeout > ~13s is honored

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -788,6 +788,11 @@ public:
         return std::move(*this);
     }
 
+    TemplatedApp &&setIdleTimeout(uint8_t seconds) {
+        httpContext->getSocketContextData()->idleTimeout = seconds;
+        return std::move(*this);
+    }
+
 };
 
 typedef TemplatedApp<false> App;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -187,15 +187,21 @@ private:
          * HttpResponseData<SSL, true> block; the listen socket was sized for it
          * (see socketExtSize()) and this handler instantiation was installed by
          * enableNodeHttpCompat(). */
+        HttpResponseData<SSL> *httpResponseData;
         if constexpr (IsNodeHttp) {
-            new (us_socket_ext(s)) HttpResponseData<SSL, true>;
+            httpResponseData = new (us_socket_ext(s)) HttpResponseData<SSL, true>;
         } else {
-            new (us_socket_ext(s)) HttpResponseData<SSL>;
+            httpResponseData = new (us_socket_ext(s)) HttpResponseData<SSL>;
         }
-          /* Any connected socket should timeout until it has a request */
-        ((HttpResponse<SSL> *) s)->resetTimeout();
 
         HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
+
+        /* Any connected socket should timeout until it has a request. Seed the
+         * per-socket idleTimeout from the context so the configured value
+         * governs the pre-request window too, instead of the compiled-in 10s
+         * default (which would otherwise cap node:http's headersTimeout). */
+        httpResponseData->idleTimeout = httpContextData->idleTimeout;
+        ((HttpResponse<SSL> *) s)->resetTimeout();
 
         /* node:http compat: the headers/request timeout window opens at accept
          * (mirrors the parser-initialize timestamp in Node's ConnectionsList),

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -80,6 +80,12 @@ private:
     OnClientErrorCallback onClientError = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
+    /* Initial per-socket idleTimeout applied at accept (onOpen), before the
+     * first request arrives. Bun.serve seeds this from its `idleTimeout` option
+     * so a pre-request connection is governed by the same value a parsed
+     * request would re-arm. node:http passes 0, leaving the receive window
+     * entirely to its own headersTimeout/requestTimeout sweep. */
+    uint8_t idleTimeout = 10;
 
     // TODO: SNI
     void clearRoutes() {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1511,6 +1511,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
     pub fn set_idle_timeout(&mut self, seconds: core::ffi::c_uint) {
         self.config.idle_timeout = seconds.min(255) as u8;
+        if let Some(app) = self.app {
+            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+            bun_opaque::opaque_deref_mut(app).set_idle_timeout(self.config.idle_timeout);
+        }
     }
 
     pub fn set_flags(
@@ -2097,6 +2101,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
         // set_routes is only called after `self.app = Some(..)` in listen().
         let app = bun_opaque::opaque_deref_mut(self.app.unwrap());
+        // The uWS context needs the configured idleTimeout up front so onOpen
+        // can seed each accepted socket with it; otherwise the compiled-in 10s
+        // default governs the pre-request window regardless of what the
+        // per-request handler re-arms it to.
+        app.set_idle_timeout(self.config.idle_timeout);
         let self_ptr: *mut Self = self;
         let any_server = AnyServer::from(self_ptr.cast_const());
         // reshaped for borrowck — `dev_server` is `Option<Box<..>>`;

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -143,6 +143,10 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_set_max_http_header_size(Self::SSL_FLAG, self.as_raw(), max_header_size)
     }
 
+    pub fn set_idle_timeout(&mut self, seconds: u8) {
+        c::uws_app_set_idle_timeout(Self::SSL_FLAG, self.as_raw(), seconds)
+    }
+
     pub fn clear_routes(&mut self) {
         c::uws_app_clear_routes(Self::SSL_FLAG, self.as_raw())
     }
@@ -490,6 +494,7 @@ pub mod c {
             app: &mut uws_app_t,
             max_header_size: u64,
         );
+        pub(crate) safe fn uws_app_set_idle_timeout(ssl: i32, app: &mut uws_app_t, seconds: u8);
         pub(crate) fn uws_app_get(
             ssl: i32,
             app: *mut uws_app_t,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -541,6 +541,15 @@ extern "C"
       uwsApp->setMaxHTTPHeaderSize(max_header_size);
     }
   }
+  void uws_app_set_idle_timeout(int ssl, uws_app_t *app, uint8_t seconds) {
+    if (ssl) {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->setIdleTimeout(seconds);
+    } else {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->setIdleTimeout(seconds);
+    }
+  }
   void uws_app_set_flags(int ssl, uws_app_t *app, bool require_host_header, bool use_strict_method_validation, bool use_insecure_http_parser, bool http_allow_half_open) {
     if (ssl) {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;

--- a/test/js/node/http/node-http-server-timeouts.test.ts
+++ b/test/js/node/http/node-http-server-timeouts.test.ts
@@ -154,6 +154,50 @@ describe("node:http server timeout enforcement", () => {
     }
   });
 
+  // A headersTimeout above the uWS default pre-request idle window must be
+  // honored end to end: the connection survives past the old ~12s cap and is
+  // reaped by the checkConnections sweep at the configured value with a 408,
+  // not by a bare FIN. The old behavior closed the socket at ~12s regardless
+  // of headersTimeout, so the 13s marker below is the fail-before witness.
+  test("headersTimeout above the old ~12s cap is honored", async () => {
+    const server = http.createServer({ connectionsCheckingInterval: 200 }, (req, res) => res.end("ok"));
+    server.headersTimeout = 15000;
+    server.requestTimeout = 0;
+    let clientErrorCode: string | undefined;
+    server.on("clientError", (err: any, socket) => {
+      clientErrorCode = err.code;
+      socket.destroy();
+    });
+    const port = await listen(server);
+    try {
+      const { promise: stillOpenAt13s, resolve: markStillOpen } = Promise.withResolvers<boolean>();
+      const { promise: closed, resolve: onClosed } = Promise.withResolvers<number>();
+      const socket = net.connect(port, "127.0.0.1");
+      const t0 = Date.now();
+      socket.setNoDelay(true);
+      socket.on("error", () => {});
+      socket.resume();
+      socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: a\r\n"));
+      const marker = setTimeout(() => markStillOpen(true), 13000);
+      socket.on("close", () => {
+        clearTimeout(marker);
+        markStillOpen(false);
+        onClosed(Date.now() - t0);
+      });
+      // Must survive past the old 10s-default reap window (~12s wall clock).
+      expect(await stillOpenAt13s).toBe(true);
+      // And then be reaped by the headersTimeout sweep with the Node error.
+      const elapsed = await closed;
+      expect({ clientErrorCode, reapedAfterHeadersTimeout: elapsed >= 15000 }).toEqual({
+        clientErrorCode: "ERR_HTTP_REQUEST_TIMEOUT",
+        reapedAfterHeadersTimeout: true,
+      });
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+  }, 30000);
+
   test("headersTimeout answers 408 when there is no 'clientError' listener", async () => {
     const server = http.createServer({ connectionsCheckingInterval: 50 }, (req, res) => res.end("ok"));
     server.headersTimeout = 200;


### PR DESCRIPTION
## What

`node:http` Server: any `headersTimeout` above ~13s was silently capped. A connection that sent a partial request head (or nothing at all) was closed with a bare FIN at ~12s regardless of `headersTimeout`; values below the cap worked, and keep-alive idle between requests was not affected.

## Repro

```js
import http from "node:http";
import net from "node:net";
const server = http.createServer((req, res) => res.end("ok"));
server.headersTimeout = 40000;
server.listen(0, "127.0.0.1", () => {
  const s = net.connect(server.address().port, "127.0.0.1", () => s.write("GET /o"));
  const t0 = Date.now();
  s.on("close", () => console.log("closed after", Date.now() - t0, "ms"));
});
```

Before: `closed after 12008 ms` (bare FIN). Node v26.3.0 holds the connection to ~40s then answers 408.

## Cause

`HttpResponseData::idleTimeout` is compiled in as `10` and `onOpen` calls `resetTimeout()` with that value before any request bytes arrive. The server's configured `idleTimeout` (`0` for node:http) is only pushed per request, once a head is parsed (`on_node_http_request` / `prepare_js_request_context`). So the uWS 10s default governs the pre-request window (usockets' 4s sweep granularity puts the reap at ~12s wall clock), preempting the `checkConnections` sweep that enforces `headersTimeout`.

## Fix

Store the configured `idleTimeout` on `HttpContextData` and seed each accepted socket from it in `onOpen`, so the same value governs the pre-request window that governs an in-flight request. node:http's `idleTimeout: 0` disables the uWS window and the `checkConnections` sweep owns the deadline (408 + `'clientError'` with `ERR_HTTP_REQUEST_TIMEOUT`). A `Bun.serve` `idleTimeout` now also applies from accept; the default (10) is unchanged, so `Bun.serve` without the option still reaps a stalled pre-request connection at ~10s.

## Verification

New case in `test/js/node/http/node-http-server-timeouts.test.ts`: partial-head connection with `headersTimeout = 15000` survives past 13s and is then reaped by the sweep with `ERR_HTTP_REQUEST_TIMEOUT`. Fails on the previous build at ~12s with a bare FIN.

Note: #33061 is a larger reimplementation of headers/request timeout enforcement inside uWS itself; this change is the minimal fix on top of the existing `checkConnections` sweep on main.