### PR TITLE
HTMLRewriter: dispatch SVG/MathML integration-point siblings to selector handlers

### DIFF
--- a/patches/lolhtml/integration-point-stale-hint-flag.patch
+++ b/patches/lolhtml/integration-point-stale-hint-flag.patch
@@ -1,0 +1,25 @@
+Upstream: https://github.com/cloudflare/lol-html/pull/329 (shipped in v3.0.1)
+The oven-sh/lol-html bun branch is based on upstream v2.7.2, which predates
+the fix; drop this patch when the fork rebases onto v3.0.1 or later.
+
+--- a/src/transform_stream/dispatcher.rs
++++ b/src/transform_stream/dispatcher.rs
+@@ -368,8 +368,16 @@
+         flags: TokenCaptureFlags,
+     ) -> ParserDirective {
+         self.delegate.capture_flags = flags;
+-        self.got_flags_from_hint = true;
+-        self.get_next_parser_directive()
++        let directive = self.get_next_parser_directive();
++        // NOTE: `got_flags_from_hint` tells the lexer's `handle_tag` that selector
++        // matching already ran for the tag it is about to emit. That is only true
++        // when the scanner is actually switching to the lexer for this tag. If the
++        // hint keeps us in scan mode we must clear it, otherwise a subsequent tag
++        // that enters the lexer via tree-builder `RequestLexeme` feedback (which
++        // emits no hint of its own) would inherit the stale flag and skip selector
++        // matching entirely.
++        self.got_flags_from_hint = matches!(directive, ParserDirective::Lex);
++        directive
+     }
+ 
+     /// Emit text chunk with is_last_in_node

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -39,6 +39,8 @@ export const lolhtml: Dependency = {
     commit: LOLHTML_COMMIT,
   }),
 
+  patches: ["patches/lolhtml/integration-point-stale-hint-flag.patch"],
+
   // No separate build — compiled as part of the workspace cargo build via
   // `bun_runtime`/`bun_bundler`'s path dep on `vendor/lolhtml`.
   build: () => ({ kind: "none" }),

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -226,6 +226,25 @@ export const workarounds: Workaround[] = [
       `(options.detached block), replace the local 0x80 with libc::POSIX_SPAWN_SETSID, ` +
       `drop the explanatory comments, and delete this entry.`,
   },
+  {
+    id: "lolhtml-integration-point-stale-hint",
+    issue: "https://github.com/cloudflare/lol-html/pull/329",
+    description:
+      "lol-html skips selector matching for the second of two consecutive SVG/MathML " +
+      "integration-point siblings (stale got_flags_from_hint in the dispatcher). Fixed " +
+      "upstream in v3.0.1; the oven-sh/lol-html bun branch is based on v2.7.2, so the " +
+      "fix is carried as a vendored patch until the fork rebases.",
+    applies: () => true,
+    expectedToBeFixed: cfg => {
+      // Trips when the fork rebases onto upstream v3.0.1 or later, which
+      // carries the fix (merged as cloudflare/lol-html#329).
+      const v = lockedCrateVersion(cfg, "lol_html");
+      return v !== undefined && satisfiesRange(v, ">3.0.0");
+    },
+    cleanup:
+      `Delete patches/lolhtml/integration-point-stale-hint-flag.patch, the patches: list in ` +
+      `scripts/build/deps/lolhtml.ts, and this entry.`,
+  },
 ];
 
 /**

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2786,3 +2786,82 @@ describe("GC pressure mid-rewrite", () => {
     expect(await start()).toBe('<p one="" two="">x</p>');
   });
 });
+
+describe("SVG/MathML integration-point elements reach handlers after a sibling integration point", () => {
+  // A stale dispatcher flag made the second consecutive integration-point
+  // sibling skip selector matching: https://github.com/cloudflare/lol-html/pull/329
+
+  async function census(doc) {
+    const tags = [];
+    await new HTMLRewriter()
+      .on("*", {
+        element(el) {
+          tags.push(el.tagName);
+        },
+      })
+      .transform(new Response(doc))
+      .text();
+    return tags;
+  }
+
+  it("matches consecutive SVG html-integration-point siblings", async () => {
+    expect(await census(`<svg><desc>d</desc><title>t</title></svg>`)).toEqual(["svg", "desc", "title"]);
+    expect(await census(`<svg><desc>d</desc><title>t</title><foreignObject>f</foreignObject></svg>`)).toEqual([
+      "svg",
+      "desc",
+      "title",
+      "foreignobject",
+    ]);
+    // intervening whitespace/text must not mask the bug
+    expect(await census(`<svg><desc>d</desc> <title>t</title></svg>`)).toEqual(["svg", "desc", "title"]);
+    // intervening non-integration-point element (always worked, regression guard)
+    expect(await census(`<svg><desc>d</desc><circle/><title>t</title></svg>`)).toEqual([
+      "svg",
+      "desc",
+      "circle",
+      "title",
+    ]);
+  });
+
+  it("matches consecutive MathML text-integration-point siblings", async () => {
+    expect(await census(`<math><mi>x</mi><mo>+</mo><mn>1</mn></math>`)).toEqual(["math", "mi", "mo", "mn"]);
+    expect(await census(`<math><mi>x</mi><ms>s</ms><mtext>t</mtext></math>`)).toEqual(["math", "mi", "ms", "mtext"]);
+  });
+
+  it("sanitizer rules on foreignObject are not bypassed by a preceding <title>/<desc>", async () => {
+    const strip = doc =>
+      new HTMLRewriter()
+        .on("foreignobject", {
+          element(el) {
+            el.remove();
+          },
+        })
+        .transform(new Response(doc))
+        .text();
+
+    // Baseline: element is first child, handler fires.
+    expect(await strip(`<svg><foreignObject><script>evil()</script></foreignObject></svg>`)).toBe(`<svg></svg>`);
+    // Previously bypassed: preceded by another integration-point element.
+    expect(await strip(`<svg><title>x</title><foreignObject><script>evil()</script></foreignObject></svg>`)).toBe(
+      `<svg><title>x</title></svg>`,
+    );
+    expect(await strip(`<svg><desc>d</desc><foreignObject><script>evil()</script></foreignObject></svg>`)).toBe(
+      `<svg><desc>d</desc></svg>`,
+    );
+  });
+
+  it("matches annotation-xml html-integration-point after a sibling text-integration-point", async () => {
+    const handlers = [];
+    await new HTMLRewriter()
+      .on("annotation-xml", {
+        element(el) {
+          handlers.push(el.tagName);
+        },
+      })
+      .transform(
+        new Response(`<math><mi>x</mi><annotation-xml encoding="text/html"><span>y</span></annotation-xml></math>`),
+      )
+      .text();
+    expect(handlers).toEqual(["annotation-xml"]);
+  });
+});


### PR DESCRIPTION
## What

A sanitizer rule like `.on("foreignobject", el => el.remove())` could be silently bypassed by preceding the target element with another SVG/MathML integration-point sibling:

```js
const strip = doc =>
  new HTMLRewriter()
    .on("foreignobject", { element: el => el.remove() })
    .transform(new Response(doc))
    .text();

await strip(`<svg><foreignObject><script>evil()</script></foreignObject></svg>`);
// => "<svg></svg>"                                               handler fires, removed

await strip(`<svg><title>x</title><foreignObject><script>evil()</script></foreignObject></svg>`);
// => "<svg><title>x</title><foreignObject><script>evil()</script></foreignObject></svg>"
//                                                                 handler never fires
```

The second integration-point element in a row was invisible to every selector, including `*`:

```js
// .on("*", el => tags.push(el.tagName))
"<svg><desc>d</desc><title>t</title></svg>"        // => svg,desc          (title missing)
"<math><mi>x</mi><mo>+</mo><mn>1</mn></math>"      // => math,mi           (mo,mn missing)
"<svg><desc>d</desc><circle/><title>t</title></svg>" // => svg,desc,circle,title (ok)
```

The element was still emitted verbatim to the output and its children still matched; only handler dispatch skipped it.

## Why

lol-html's fast-path tag scanner normally emits a "tag hint" for each tag so the dispatcher can run selector matching and decide whether the full lexer is needed. The dispatcher records `got_flags_from_hint = true` so that when the lexer later emits the same tag, `handle_tag` does not re-run selector matching.

Integration-point start tags (`title`, `desc`, `foreignObject` in SVG; `mi`, `mo`, `mn`, `ms`, `mtext`, `annotation-xml` in MathML) take a different path: the tree-builder simulator returns `RequestLexeme` feedback and the scanner switches to the lexer *without emitting a hint*. If the previous tag's hint kept the parser in scan-only mode, the stale flag made `handle_tag` skip selector matching for the next such tag entirely.

## Fix

In `Dispatcher::apply_capture_flags_from_hint_and_get_next_parser_directive`, keep `got_flags_from_hint` only when the hint actually switches the parser to the lexer. We wrote the fix and it was merged upstream (cloudflare/lol-html#329, shipped in lol-html v3.0.1).

Bun's lolhtml pin is now the oven-sh/lol-html fork (`bun` branch, content-handler suspension for `HtmlRewriter::resume()`), which is based on upstream v2.7.2 and so predates the upstream fix. This PR carries the fix as a vendored patch on top of the fork pin:

- `patches/lolhtml/integration-point-stale-hint-flag.patch` applied at fetch time via the dep's `patches:` list
- a `workarounds.ts` registry entry that trips when the fork rebases past v3.0.0 (upstream v3.0.1 has the fix), so the patch cannot outlive its usefulness

### History

Earlier revisions of this branch bumped the vendored pin to upstream v3.0.0 and then v3.0.1 (dropping the patch) with the matching settings-builder API migration, as requested at the time. Main has since moved the pin to the oven-sh fork for `resume()`, which reverted lol-html to a v2.7.2 base and reintroduced the bug, so the rebase resolves back to the patch approach: the fork pin, `html_rewriter.rs`, `HTMLScanner.rs`, `Cargo.lock`, and `process.versions` expectations stay exactly as they are on main, and the fork picks up the fix when it rebases onto v3.0.1+ (or cherry-picks upstream 633435e5).

## Verification

New tests in `test/js/workerd/html-rewriter.test.js` cover the SVG and MathML sibling cases, the `foreignObject` sanitizer bypass, and `annotation-xml` after `mi`. All four fail on current main (the fork pin without the patch) and pass with it; the full rewriter suite (171 tests, including the fork's suspension coverage) passes on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->