### PR TITLE
bundler: emit .mjs for ESM output when --target node

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -373,8 +373,10 @@ When using `target: "bun"` and `format: "cjs"` together, the `// @bun @bun-cjs` 
 </Card>
 
 <Card title="node" icon="node">
-  For bundles that run in Node.js. Prioritizes the `"node"` export condition when resolving imports. Bun does not
-  polyfill the `Bun` global or the built-in `bun:*` modules.
+  For bundles that run in Node.js. Prioritizes the `"node"` export condition when resolving imports. When `format` is
+  `"esm"` (the default), JavaScript output files use the `.mjs` extension so Node.js loads them as ES modules; override
+  this with `naming`/`--entry-naming` if you need `.js`. Bun does not polyfill the `Bun` global or the built-in `bun:*`
+  modules.
 </Card>
 
 ### format

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -374,9 +374,8 @@ When using `target: "bun"` and `format: "cjs"` together, the `// @bun @bun-cjs` 
 
 <Card title="node" icon="node">
   For bundles that run in Node.js. Prioritizes the `"node"` export condition when resolving imports. When `format` is
-  `"esm"` (the default), JavaScript output files use the `.mjs` extension so Node.js loads them as ES modules; override
-  this with `naming`/`--entry-naming` if you need `.js`. Bun does not polyfill the `Bun` global or the built-in `bun:*`
-  modules.
+  `"esm"` (the default), JavaScript output files use the `.mjs` extension so Node.js loads them as ES modules; use
+  [`naming`](#naming) if you need `.js` instead. Bun does not polyfill the `Bun` global or the built-in `bun:*` modules.
 </Card>
 
 ### format

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1579,9 +1579,15 @@ impl Content {
         }
     }
 
-    pub fn ext(&self) -> &'static [u8] {
+    pub fn ext(&self, target: options::Target, output_format: options::Format) -> &'static [u8] {
         match self {
-            Content::Javascript(_) => b"js",
+            Content::Javascript(_) => match (target, output_format) {
+                // Node treats `.js` as CommonJS unless the nearest package.json
+                // says `"type": "module"`, so an ESM bundle written as `.js`
+                // fails to load there. Emit `.mjs` so the output runs as-is.
+                (options::Target::Node, options::Format::Esm) => b"mjs",
+                _ => b"js",
+            },
             Content::Css(_) => b"css",
             Content::Html => b"html",
         }

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1582,9 +1582,7 @@ impl Content {
     pub fn ext(&self, target: options::Target, output_format: options::Format) -> &'static [u8] {
         match self {
             Content::Javascript(_) => match (target, output_format) {
-                // Node treats `.js` as CommonJS unless the nearest package.json
-                // says `"type": "module"`, so an ESM bundle written as `.js`
-                // fails to load there. Emit `.mjs` so the output runs as-is.
+                // Node loads `.js` as CJS by default; `.mjs` makes the ESM output runnable as-is.
                 (options::Target::Node, options::Format::Esm) => b"mjs",
                 _ => b"js",
             },

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -619,7 +619,11 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
             output_paths[chunk.entry_point.entry_point_id() as usize].slice(),
         );
         chunk.template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
-        chunk.template.placeholder.ext = chunk.content.ext().to_vec().into_boxed_slice();
+        chunk.template.placeholder.ext = chunk
+            .content
+            .ext(this.options.target, this.options.output_format)
+            .to_vec()
+            .into_boxed_slice();
 
         if chunk.template.needs(PlaceholderField::Target) {
             // Determine the target from the AST of the entry point source

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -618,9 +618,7 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
         let pathname = bun_fs::PathName::init(
             output_paths[chunk.entry_point.entry_point_id() as usize].slice(),
         );
-        // Use the entry-point AST's target, not `this.options.target`: an HTML
-        // import in a server-side build produces browser chunks whose
-        // extension must not follow the server target.
+        // Per-chunk target: an HTML import in a server-side build yields browser chunks that must keep `.js`.
         let chunk_target = ast_targets[chunk.entry_point.source_index() as usize];
         chunk.template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
         chunk.template.placeholder.ext = chunk

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -618,16 +618,18 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
         let pathname = bun_fs::PathName::init(
             output_paths[chunk.entry_point.entry_point_id() as usize].slice(),
         );
+        // Use the entry-point AST's target, not `this.options.target`: an HTML
+        // import in a server-side build produces browser chunks whose
+        // extension must not follow the server target.
+        let chunk_target = ast_targets[chunk.entry_point.source_index() as usize];
         chunk.template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
         chunk.template.placeholder.ext = chunk
             .content
-            .ext(this.options.target, this.options.output_format)
+            .ext(chunk_target, this.options.output_format)
             .to_vec()
             .into_boxed_slice();
 
         if chunk.template.needs(PlaceholderField::Target) {
-            // Determine the target from the AST of the entry point source
-            let chunk_target = ast_targets[chunk.entry_point.source_index() as usize];
             chunk.template.placeholder.target = match chunk_target {
                 Target::Browser => b"browser".to_vec().into_boxed_slice(),
                 Target::Bun => b"bun".to_vec().into_boxed_slice(),

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -375,7 +375,7 @@ describe("bundler", async () => {
           "/empty.txt": "",
         },
         onAfterBundle(api) {
-          const jsFile = readdirSync(api.outdir).find(x => x.endsWith(".js"))!;
+          const jsFile = readdirSync(api.outdir).find(x => /\.m?js$/.test(x))!;
           const module = require(join(api.outdir, jsFile));
           api.assertFileExists(join("out", module.default));
         },

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -379,6 +379,29 @@ describe("bundler", () => {
       api.assertFileExists("/out/b/entry.js");
     },
   });
+  // A `--target node` build that imports HTML emits the server chunk as .mjs
+  // but the browser-side chunk referenced from the HTML stays .js; the
+  // extension follows the chunk's own target, not the global one.
+  itBundled("naming/NodeTargetHtmlImportBrowserChunkStaysJs", {
+    files: {
+      "/server.ts": `import page from "./index.html"; console.log(JSON.stringify(page));`,
+      "/index.html": `<!DOCTYPE html><script type="module" src="./client.ts"></script>`,
+      "/client.ts": `console.log("client");`,
+    },
+    target: "node",
+    outdir: "/out",
+    outputPaths: ["/out/server.mjs"],
+    entryPointsRaw: ["./server.ts"],
+    onAfterBundle(api) {
+      api.assertFileExists("/out/server.mjs");
+      const html = api.readFile("/out/index.html");
+      const m = html.match(/src="\.\/([^"]+)"/);
+      if (!m) throw new Error("no script src in " + html);
+      if (!m[1].endsWith(".js")) throw new Error("browser chunk should be .js, got " + m[1]);
+      api.assertFileExists("/out/" + m[1]);
+      api.expectFile("/out/server.mjs").toContain(m[1]);
+    },
+  });
   // A non-ASCII ID_Continue basename char is preserved in the generated
   // CommonJS wrapper symbol, not replaced per-code-point (nor per-UTF-8-byte,
   // which once regressed to `require_caf__utils`).

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -302,6 +302,83 @@ describe("bundler", () => {
       },
     ],
   });
+  // https://github.com/oven-sh/bun/issues/10607
+  // `--target node` emits ESM by default; Node loads `.js` as CommonJS unless
+  // the nearest package.json says `"type": "module"`, so the default `[ext]`
+  // for a JS chunk must be `mjs` to produce output that runs as-is.
+  itBundled("naming/NodeTargetEsmEmitsMjs#10607", {
+    files: {
+      "/a/entry.ts": `console.log(1);`,
+      "/b/entry.ts": `console.log(2);`,
+    },
+    target: "node",
+    entryPointsRaw: ["./a/entry.ts", "./b/entry.ts"],
+    run: [
+      { file: "/out/a/entry.mjs", stdout: "1", runtime: "node" },
+      { file: "/out/b/entry.mjs", stdout: "2", runtime: "node" },
+    ],
+    onAfterBundle(api) {
+      api.assertFileExists("/out/a/entry.mjs");
+      api.assertFileExists("/out/b/entry.mjs");
+    },
+  });
+  itBundled("naming/NodeTargetEsmSplittingEmitsMjs#10607", {
+    files: {
+      "/shared.ts": `export const v = 42;`,
+      "/a.ts": `import { v } from "./shared"; console.log("a", v);`,
+      "/b.ts": `import { v } from "./shared"; console.log("b", v);`,
+    },
+    target: "node",
+    splitting: true,
+    entryPointsRaw: ["./a.ts", "./b.ts"],
+    run: [
+      { file: "/out/a.mjs", stdout: "a 42", runtime: "node" },
+      { file: "/out/b.mjs", stdout: "b 42", runtime: "node" },
+    ],
+    onAfterBundle(api) {
+      // The shared chunk is .mjs and the entries reference it by that name.
+      api.expectFile("/out/a.mjs").toMatch(/from "\.\/[^"]+\.mjs"/);
+      api.expectFile("/out/b.mjs").toMatch(/from "\.\/[^"]+\.mjs"/);
+    },
+  });
+  itBundled("naming/NodeTargetCjsEmitsJs", {
+    files: {
+      "/a/entry.ts": `console.log(1);`,
+      "/b/entry.ts": `console.log(2);`,
+    },
+    target: "node",
+    format: "cjs",
+    entryPointsRaw: ["./a/entry.ts", "./b/entry.ts"],
+    run: [
+      { file: "/out/a/entry.js", stdout: "1", runtime: "node" },
+      { file: "/out/b/entry.js", stdout: "2", runtime: "node" },
+    ],
+  });
+  itBundled("naming/BrowserTargetEsmEmitsJs", {
+    files: {
+      "/a/entry.ts": `console.log(1);`,
+      "/b/entry.ts": `console.log(2);`,
+    },
+    target: "browser",
+    entryPointsRaw: ["./a/entry.ts", "./b/entry.ts"],
+    run: [
+      { file: "/out/a/entry.js", stdout: "1" },
+      { file: "/out/b/entry.js", stdout: "2" },
+    ],
+  });
+  itBundled("naming/NodeTargetEntryNamingOverridesExt", {
+    files: {
+      "/a/entry.ts": `console.log(1);`,
+      "/b/entry.ts": `console.log(2);`,
+    },
+    target: "node",
+    entryNaming: "[dir]/[name].js",
+    entryPointsRaw: ["./a/entry.ts", "./b/entry.ts"],
+    onAfterBundle(api) {
+      api.assertFileExists("/out/a/entry.js");
+      api.assertFileExists("/out/b/entry.js");
+    },
+  });
   // A non-ASCII ID_Continue basename char is preserved in the generated
   // CommonJS wrapper symbol, not replaced per-code-point (nor per-UTF-8-byte,
   // which once regressed to `require_caf__utils`).

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -676,11 +676,12 @@ function expectBundled(
     outfile = useOutFile ? path.join(root, outfile ?? (compile ? "/out" : "/out.js")) : undefined;
     outdir = !useOutFile && generateOutput ? path.join(root, outdir ?? "/out") : undefined;
     metafile = metafile ? path.join(root, metafile) : undefined;
+    const derivedJsExt = target === "node" && (format ?? "esm") === "esm" ? ".mjs" : ".js";
     outputPaths = (
       outputPaths
         ? outputPaths.map(file => path.join(root, file))
-        : entryPaths.map(file => path.join(outdir || "", path.basename(file).replace(/\.[jt]sx?$/, ".js")))
-    ).map(x => x.replace(/\.ts$/, ".js"));
+        : entryPaths.map(file => path.join(outdir || "", path.basename(file).replace(/\.[jt]sx?$/, derivedJsExt)))
+    ).map(x => x.replace(/\.ts$/, derivedJsExt));
 
     if (cjs2esm && !outfile && !minifySyntax && !minifyWhitespace) {
       throw new Error("cjs2esm=true requires one output file, minifyWhitespace=false, and minifySyntax=false");

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -72,6 +72,7 @@ beforeAll(async () => {
 describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   describe.each(["esm", "cjs"])("bundle .node files to %s via", format => {
     describe.each(["node", "bun"])("target %s", target => {
+      const mainOut = target === "node" && format === "esm" ? "main.mjs" : "main.js";
       it("Bun.build", async () => {
         const dir = tempDirWithFiles("node-file-cli", {
           "package.json": JSON.stringify({
@@ -100,7 +101,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
 
         for (let exec of target === "bun" ? [bunExe()] : [bunExe(), await nodeExeMatchingAbi()]) {
           const result = spawnSync({
-            cmd: [exec, join(dir, "main.js"), "self"],
+            cmd: [exec, join(dir, mainOut), "self"],
             env: bunEnv,
             stdin: "inherit",
             stderr: "inherit",
@@ -184,7 +185,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
 
         for (let exec of target === "bun" ? [bunExe()] : [bunExe(), await nodeExeMatchingAbi()]) {
           const result = spawnSync({
-            cmd: [exec, join(dir, "main.js"), "self"],
+            cmd: [exec, join(dir, mainOut), "self"],
             env: bunEnv,
             stdin: "inherit",
             stderr: "inherit",


### PR DESCRIPTION
Fixes #10607
Fixes #7252

## What

`bun build --target node` now writes `.mjs` files (for both entry points and split chunks) when the output format is ESM, which is the default. Other targets, and `--target node --format cjs`/`--format iife`, still write `.js`. `--outfile` and `--entry-naming`/`--chunk-naming` continue to override the extension.

## Why

Node.js loads a `.js` file as CommonJS unless the nearest `package.json` declares `"type": "module"`, so the ESM bundle `bun build --target node` currently writes cannot be loaded by Node without extra setup:

```
$ bun build ./index.ts --outdir out --target node
$ node out/index.js
SyntaxError: Cannot use import statement outside a module
```

The docs documented the node target as "outputs `.mjs`" from the time `--target` shipped until the recent fact-check sweep removed the claim to match the implementation, and the per-target `out_extensions()` table populates `.mjs` entries for `Target::Node`, but none of that was wired to chunk filenames: the `[ext]` placeholder for a JavaScript chunk was hardcoded to `"js"` in `Content::ext()` regardless of target or format.

## How

`Content::ext()` now takes the linker's `target` and `output_format` and returns `"mjs"` for the `(Node, Esm)` pair. Its single caller in `compute_chunks` supplies both, so entry and chunk filenames (and the cross-chunk import specifiers that reference them) use `.mjs` together.

## Verification

New tests in `test/bundler/bundler_naming.test.ts` cover `--target node` with `--outdir` (single bundle and `--splitting`), confirm `--format cjs` / `--target browser` still emit `.js`, and that `--entry-naming '[dir]/[name].js'` still forces `.js`. The splitting case also asserts the generated `import ... from "./chunk-*.mjs"` specifier and executes the output under Node.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->