### PR TITLE
FormData: parse RFC 5987 `filename*` in multipart Content-Disposition

### DIFF
--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -79,6 +79,10 @@ pub struct Field<'a> {
     /// Borrows into the caller-owned input buffer (binary body slice).
     pub value: &'a [u8],
     pub filename: bun_semver::String,
+    /// Decoded `filename*` (RFC 5987 ext-value). Owned because the
+    /// percent-decoded bytes are not a subslice of the input buffer.
+    /// When present, takes precedence over `filename` (RFC 6266 §4.3).
+    pub filename_star: Option<Box<[u8]>>,
     pub content_type: bun_semver::String,
     pub is_file: bool,
     pub zero_count: u8,
@@ -89,11 +93,28 @@ impl Default for Field<'_> {
         Field {
             value: b"",
             filename: bun_semver::String::default(),
+            filename_star: None,
             content_type: bun_semver::String::default(),
             is_file: false,
             zero_count: 0,
         }
     }
+}
+
+/// Decode an RFC 5987 `ext-value` of the form `charset'[language]'pct-encoded`.
+/// Only the `utf-8` charset is accepted (matching Node.js/undici). Returns
+/// `None` on any parse/decode failure so the caller can fall back to the
+/// plain `filename` parameter instead of rejecting the whole body.
+fn decode_rfc5987_utf8(raw: &[u8]) -> Option<Box<[u8]>> {
+    let first_quote = strings::index_of_char(raw, b'\'')? as usize;
+    let charset = &raw[..first_quote];
+    if !strings::eql_case_insensitive_ascii(charset, b"utf-8", true) {
+        return None;
+    }
+    let after_charset = &raw[first_quote + 1..];
+    let second_quote = strings::index_of_char(after_charset, b'\'')? as usize;
+    let encoded = &after_charset[second_quote + 1..];
+    bun_url::PercentEncoding::decode_alloc(encoded).ok()
 }
 
 impl FormData {
@@ -190,7 +211,10 @@ pub fn to_js_from_multipart_data(
             let key = ZigString::init_utf8(name.slice(buf));
 
             if field.is_file {
-                let filename_str = field.filename.slice(buf);
+                let filename_str: &[u8] = match field.filename_star.as_deref() {
+                    Some(decoded) => decoded,
+                    None => field.filename.slice(buf),
+                };
 
                 let mut blob = Blob::create(value_str, wrap.global, false);
                 let filename = ZigString::init_utf8(filename_str);
@@ -306,6 +330,7 @@ pub fn for_each_multipart_entry<C>(
         let mut field = Field::default();
         let mut name = bun_semver::String::default();
         let mut filename: Option<bun_semver::String> = None;
+        let mut filename_star: Option<Box<[u8]>> = None;
         let mut header_chunk = header;
         let mut is_file = false;
         while !header_chunk.is_empty() && (filename.is_none() || name.len() == 0) {
@@ -334,6 +359,26 @@ pub fn for_each_multipart_entry<C>(
                 while let Some(eql_start) = strings::index_of(value, b"=") {
                     let eql_key = strings::trim(&value[..eql_start], b" \t;");
                     value = &value[eql_start + 1..];
+
+                    // RFC 5987 extended parameter (e.g. `filename*=UTF-8''%E2%82%AC.txt`).
+                    // The ext-value is a bare token, never quoted, so it is consumed up
+                    // to the next `;` before the quoted-string scanner runs.
+                    if strings::eql_case_insensitive_ascii(eql_key, b"filename*", true) {
+                        let raw = match strings::index_of_char(value, b';') {
+                            Some(semi) => {
+                                let r = &value[..semi as usize];
+                                value = &value[semi as usize + 1..];
+                                r
+                            }
+                            None => core::mem::take(&mut value),
+                        };
+                        if let Some(decoded) = decode_rfc5987_utf8(strings::trim(raw, b" \t")) {
+                            filename_star = Some(decoded);
+                            is_file = true;
+                        }
+                        continue;
+                    }
+
                     if value.starts_with(b"\"") {
                         value = &value[1..];
                     }
@@ -364,10 +409,6 @@ pub fn for_each_multipart_entry<C>(
                     } else if strings::eql_case_insensitive_ascii(eql_key, b"filename", true) {
                         filename = Some(subslicer.sub(field_value).value());
                         is_file = true;
-                    }
-
-                    if !name.is_empty() && filename.is_some() {
-                        break;
                     }
 
                     if let Some(semi_start) = strings::index_of_char(value, b';') {
@@ -406,6 +447,7 @@ pub fn for_each_multipart_entry<C>(
         }
         field.value = body;
         field.filename = filename.unwrap_or_default();
+        field.filename_star = filename_star;
         field.is_file = is_file;
 
         iterator(ctx, name, &field, input);

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -339,6 +339,65 @@ describe("FormData", () => {
     }
   });
 
+  // RFC 5987/6266: `filename*=UTF-8''…` extended parameter. RFC 7578 §4.2 says
+  // senders MUST NOT generate it, but Node.js/undici and busboy accept it.
+  describe("multipart filename* (RFC 5987 ext-value)", () => {
+    const boundary = "AaB03x";
+    const headers = { "content-type": `multipart/form-data; boundary=${boundary}` };
+    const part = (cd: string, body = "data") =>
+      `--${boundary}\r\nContent-Disposition: ${cd}\r\nContent-Type: text/plain\r\n\r\n${body}\r\n--${boundary}--\r\n`;
+
+    for (const C of [Response, Request] as const) {
+      const make = (body: string) =>
+        C === Response ? new Response(body, { headers }) : new Request("http://x/", { method: "POST", body, headers });
+
+      it(`${C.name}: filename* only is a File with the decoded name`, async () => {
+        const fd = await make(part(`form-data; name="f"; filename*=UTF-8''%E2%82%AC%20rates.txt`)).formData();
+        const v = fd.get("f") as File;
+        expect(v).toBeInstanceOf(File);
+        expect({ name: v.name, type: v.type, text: await v.text() }).toEqual({
+          name: "€ rates.txt",
+          type: "text/plain",
+          text: "data",
+        });
+      });
+
+      it(`${C.name}: filename* wins over a later plain filename`, async () => {
+        const fd = await make(
+          part(`form-data; name="f"; filename*=UTF-8''%E2%82%AC.txt; filename="plain.txt"`),
+        ).formData();
+        const v = fd.get("f") as File;
+        expect(v).toBeInstanceOf(File);
+        expect(v.name).toBe("€.txt");
+      });
+
+      it(`${C.name}: filename* wins over an earlier plain filename`, async () => {
+        const fd = await make(
+          part(`form-data; name="f"; filename="plain.txt"; filename*=UTF-8''%E2%82%AC.txt`),
+        ).formData();
+        const v = fd.get("f") as File;
+        expect(v).toBeInstanceOf(File);
+        expect(v.name).toBe("€.txt");
+      });
+
+      it(`${C.name}: charset is case-insensitive and the language tag is skipped`, async () => {
+        const fd = await make(part(`form-data; name="f"; filename*=utf-8'en'%E2%82%AC.txt`)).formData();
+        const v = fd.get("f") as File;
+        expect(v).toBeInstanceOf(File);
+        expect(v.name).toBe("€.txt");
+      });
+
+      it(`${C.name}: malformed filename* falls back to the plain filename`, async () => {
+        const fd = await make(
+          part(`form-data; name="f"; filename*=ISO-8859-1''%E9.txt; filename="fallback.txt"`),
+        ).formData();
+        const v = fd.get("f") as File;
+        expect(v).toBeInstanceOf(File);
+        expect(v.name).toBe("fallback.txt");
+      });
+    }
+  });
+
   test("FormData.from (URLSearchParams)", () => {
     expect(
       // @ts-expect-error


### PR DESCRIPTION
## What

A multipart part whose `Content-Disposition` header carries only an RFC 5987/6266 extended `filename*=UTF-8''...` parameter (no plain `filename=`) was demoted to a plain string field, because the Content-Disposition parameter scanner only matched the literal key `filename`:

```js
const CRLF = "\r\n", B = "AaB03x";
const body = `--${B}${CRLF}Content-Disposition: form-data; name="f"; filename*=UTF-8''%E2%82%AC%20rates.txt${CRLF}Content-Type: text/plain${CRLF}${CRLF}data${CRLF}--${B}--${CRLF}`;
const v = (await new Response(body, { headers: { "content-type": `multipart/form-data; boundary=${B}` } }).formData()).get("f");
console.log(typeof v, v);
// bun (before): string "data"
// node/undici, busboy: File { name: "€ rates.txt" }
```

With both `filename=` and `filename*=` present, Bun kept the plain filename while Node.js and busboy prefer `filename*` per RFC 6266 §4.3.

RFC 7578 §4.2 does say form-data senders MUST NOT generate `filename*`, so ignoring it is spec-defensible; this change is for Node.js ecosystem parity (the file-to-string demotion is the observable divergence).

## How

In `for_each_multipart_entry`, the Content-Disposition parameter loop now recognises `filename*` (case-insensitive), consumes its bare-token value up to the next `;`, and decodes the RFC 5987 `ext-value` (`charset'[language]'pct-encoded`). Only the `utf-8` charset is accepted, matching undici. The decoded bytes are stored in a new `Field.filename_star: Option<Box<[u8]>>` because the percent-decoded result is not a subslice of the input buffer that `bun_semver::String` can point into. `on_entry` prefers `filename_star` over the plain `filename` when both are present.

The inner parameter-loop early `break` (once `name` + `filename` were both seen) is removed so a `filename*` following a plain `filename` on the same header line is reached.

A malformed ext-value (non-UTF-8 charset, missing `'` delimiters, bad percent-encoding) returns `None` and the parser falls back to the plain `filename` if one was given, rather than rejecting the whole body. Node.js throws here; being lenient avoids breaking existing clients that currently have the parameter silently ignored.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/html/FormData.test.ts -t "filename\\*"
 0 pass
 10 fail

$ bun bd test test/js/web/html/FormData.test.ts
 159 pass
 0 fail
```
