### PR TITLE
bundler: bundle require("./dir/" + x) by scanning the directory (shelljs)

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -20,25 +20,17 @@ type ImportRecordList<'a> = crate::import_record::List<'a>;
 
 pub type TopLevelSymbolToParts = ArrayHashMap<Ref, AstVec<u32>, AutoContext, AstAlloc>;
 
-/// A `require()`/`import()` call whose argument is a glob pattern such as
-/// `require("./src/" + name)`. The parser records the parent import record and
-/// the original argument expression; the bundler later scans the directory and
-/// fills `entries` with one entry per runtime lookup key.
+/// `require("./src/" + x)`: parser records the parent record + arg; bundler fills `entries`.
 pub struct GlobImport {
     pub import_record_index: u32,
     pub arg: Expr,
-    pub is_require: bool,
-    /// Filled by the bundler after resolution. Uses the global allocator
-    /// because glob expansion runs on the bundle thread while the AST arena is
-    /// owned by a parse worker; the list is tiny (one entry per matched file
-    /// plus its extensionless alias).
+    /// Global-allocator `Vec`: glob expansion runs on the bundle thread, not the parse-arena thread.
     pub entries: Vec<GlobImportEntry>,
 }
 
 #[derive(Clone, Copy)]
 pub struct GlobImportEntry {
-    /// Lookup key as it appears at runtime, e.g. `"./src/cat"` or
-    /// `"./src/cat.js"`. Interned in the resolver's process-lifetime store.
+    /// Runtime lookup key (e.g. `"./src/cat"`), interned in the resolver store.
     pub key: &'static [u8],
     pub source_index: crate::Index,
 }

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -20,6 +20,31 @@ type ImportRecordList<'a> = crate::import_record::List<'a>;
 
 pub type TopLevelSymbolToParts = ArrayHashMap<Ref, AstVec<u32>, AutoContext, AstAlloc>;
 
+/// A `require()`/`import()` call whose argument is a glob pattern such as
+/// `require("./src/" + name)`. The parser records the parent import record and
+/// the original argument expression; the bundler later scans the directory and
+/// fills `entries` with one entry per runtime lookup key.
+pub struct GlobImport {
+    pub import_record_index: u32,
+    pub arg: Expr,
+    pub is_require: bool,
+    /// Filled by the bundler after resolution. Uses the global allocator
+    /// because glob expansion runs on the bundle thread while the AST arena is
+    /// owned by a parse worker; the list is tiny (one entry per matched file
+    /// plus its extensionless alias).
+    pub entries: Vec<GlobImportEntry>,
+}
+
+#[derive(Clone, Copy)]
+pub struct GlobImportEntry {
+    /// Lookup key as it appears at runtime, e.g. `"./src/cat"` or
+    /// `"./src/cat.js"`. Interned in the resolver's process-lifetime store.
+    pub key: &'static [u8],
+    pub source_index: crate::Index,
+}
+
+pub type GlobImportList = AstVec<GlobImport>;
+
 pub struct Ast<'a> {
     pub approximate_newline_count: usize,
     pub has_lazy_export: bool,
@@ -70,6 +95,7 @@ pub struct Ast<'a> {
     pub named_imports: NamedImports,
     pub named_exports: NamedExports,
     pub export_star_import_records: AstVec<u32>,
+    pub glob_imports: GlobImportList,
 
     pub top_level_symbols_to_parts: TopLevelSymbolToParts,
 
@@ -121,6 +147,7 @@ impl<'a> Ast<'a> {
             named_imports: Default::default(),
             named_exports: Default::default(),
             export_star_import_records: AstAlloc::vec(),
+            glob_imports: AstAlloc::vec(),
             top_level_symbols_to_parts: Default::default(),
             commonjs_named_exports: Default::default(),
             redirect_import_record_index: None,

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -30,7 +30,7 @@ pub struct GlobImport {
 
 #[derive(Clone, Copy)]
 pub struct GlobImportEntry {
-    /// Runtime lookup key (e.g. `"./src/cat"`), interned in the resolver store.
+    /// Runtime lookup key (e.g. `"./src/cat"`), allocated in the per-build graph arena.
     pub key: &'static [u8],
     pub source_index: crate::Index,
 }

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -70,10 +70,7 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
-        /// The specifier is a glob pattern (e.g. `require("./src/" + x)`). The
-        /// record's `path.text` holds the shape with `\x00` as the wildcard
-        /// placeholder. Child records for each match are appended to the same
-        /// `import_records` list and referenced via `ast_result::GlobImport`.
+        /// `require("./dir/" + x)`; `path.text` is the shape with `\x00` as wildcard.
         const GLOB_PATTERN = 1 << 7;
 
         /// If true, this was originally written as a bare "import 'file'" statement

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -70,6 +70,12 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
+        /// The specifier is a glob pattern (e.g. `require("./src/" + x)`). The
+        /// record's `path.text` holds the shape with `\x00` as the wildcard
+        /// placeholder. Child records for each match are appended to the same
+        /// `import_records` list and referenced via `ast_result::GlobImport`.
+        const GLOB_PATTERN = 1 << 7;
+
         /// If true, this was originally written as a bare "import 'file'" statement
         const WAS_ORIGINALLY_BARE_IMPORT = 1 << 8;
 

--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -175,10 +175,11 @@ pub struct Imports {
     pub __promiseAll: Ref,
     pub __MEMO_CACHE_SENTINEL: Ref,
     pub __EARLY_RETURN_SENTINEL: Ref,
+    pub __glob: Ref,
 }
 
 impl Imports {
-    pub const ALL: [&'static [u8]; 27] = [
+    pub const ALL: [&'static [u8]; 28] = [
         b"__name",
         b"__require",
         b"__export",
@@ -206,12 +207,13 @@ impl Imports {
         b"__promiseAll",
         b"__MEMO_CACHE_SENTINEL",
         b"__EARLY_RETURN_SENTINEL",
+        b"__glob",
     ];
 
     /// Rust stable cannot sort in `const`; precomputed here and verified by
     /// the test in `tests` below.
     #[cfg_attr(not(test), allow(dead_code))]
-    const ALL_SORTED: [&'static [u8]; 27] = [
+    const ALL_SORTED: [&'static [u8]; 28] = [
         b"$$typeof",
         b"__EARLY_RETURN_SENTINEL",
         b"__MEMO_CACHE_SENTINEL",
@@ -222,6 +224,7 @@ impl Imports {
         b"__export",
         b"__exportDefault",
         b"__exportValue",
+        b"__glob",
         b"__jsonParse",
         b"__legacyDecorateClassTS",
         b"__legacyDecorateParamTS",
@@ -243,34 +246,35 @@ impl Imports {
 
     /// When generating the list of runtime imports, we sort it for determinism.
     /// This is a lookup table so we don't need to resort the strings each time
-    pub const ALL_SORTED_INDEX: [usize; 27] = [
-        15, // __name
-        24, // __require
+    pub const ALL_SORTED_INDEX: [usize; 28] = [
+        16, // __name
+        25, // __require
         7,  // __export
-        23, // __reExport
+        24, // __reExport
         9,  // __exportValue
         8,  // __exportDefault
-        14, // __merge
-        11, // __legacyDecorateClassTS
-        12, // __legacyDecorateParamTS
-        13, // __legacyMetadataTS
-        22, // __publicField
-        18, // __privateIn
-        17, // __privateGet
-        16, // __privateAdd
-        20, // __privateSet
-        19, // __privateMethod
+        15, // __merge
+        12, // __legacyDecorateClassTS
+        13, // __legacyDecorateParamTS
+        14, // __legacyMetadataTS
+        23, // __publicField
+        19, // __privateIn
+        18, // __privateGet
+        17, // __privateAdd
+        21, // __privateSet
+        20, // __privateMethod
         6,  // __decoratorStart
         5,  // __decoratorMetadata
-        25, // __runInitializers
+        26, // __runInitializers
         4,  // __decorateElement
         0,  // $$typeof
-        26, // __using
+        27, // __using
         3,  // __callDispose
-        10, // __jsonParse
-        21, // __promiseAll
+        11, // __jsonParse
+        22, // __promiseAll
         2,  // __MEMO_CACHE_SENTINEL
         1,  // __EARLY_RETURN_SENTINEL
+        10, // __glob
     ];
 
     pub const NAME: &'static [u8] = b"bun:wrap";
@@ -306,6 +310,7 @@ impl Imports {
             24 => self.__promiseAll,
             25 => self.__MEMO_CACHE_SENTINEL,
             26 => self.__EARLY_RETURN_SENTINEL,
+            27 => self.__glob,
             _ => return None,
         };
         r.to_nullable()
@@ -341,6 +346,7 @@ impl Imports {
             24 => Some(&mut self.__promiseAll),
             25 => Some(&mut self.__MEMO_CACHE_SENTINEL),
             26 => Some(&mut self.__EARLY_RETURN_SENTINEL),
+            27 => Some(&mut self.__glob),
             _ => None,
         }
     }

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -535,6 +535,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                 self.bump,
             ),
             export_star_import_records: bun_alloc::AstAlloc::vec(),
+            glob_imports: bun_alloc::AstAlloc::vec(),
             approximate_newline_count: 1,
             exports_kind: ExportsKind::Esm,
             named_imports: core::mem::take(&mut self.named_imports),

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2041,8 +2041,12 @@ impl<'a> LinkerContext<'a> {
                     } else {
                         Box::new([])
                     };
-                    self.log_disjoint()
-                        .add_range_error_with_notes(Some(source), range, text, notes);
+                    self.log_disjoint().add_range_error_with_notes(
+                        Some(source),
+                        range,
+                        text,
+                        notes,
+                    );
                 }
                 Frame::AfterChild {
                     source_index,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -776,6 +776,8 @@ impl<'a> LinkerContext<'a> {
             let parse_graph: *mut Graph<'a> = self.parse_graph;
             let import_records_list: *const [bun_ast::import_record::List<'a>] =
                 self.graph.ast.items_import_records();
+            let glob_imports_list: *const [bun_ast::ast_result::GlobImportList] =
+                self.graph.ast.items_glob_imports();
             let flags: *mut [crate::js_meta::Flags] = self.graph.meta.items_flags_mut();
             let css_asts: *const [crate::bundled_ast::CssCol] = self.graph.ast.items_css();
             let files_len = self.graph.files.len();
@@ -783,12 +785,21 @@ impl<'a> LinkerContext<'a> {
             // from `*self`, stable SoA slabs; `validate_tla` neither
             // reallocates the slabs nor forms a competing `&mut` to any
             // read-only column. All seven derefs share that invariant.
-            let (tla_keywords, tla_checks, input_files, import_records_list, css_asts, flags) = unsafe {
+            let (
+                tla_keywords,
+                tla_checks,
+                input_files,
+                import_records_list,
+                glob_imports_list,
+                css_asts,
+                flags,
+            ) = unsafe {
                 (
                     (*parse_graph).ast.items_top_level_await_keyword(),
                     (*parse_graph).ast.items_tla_check_mut(),
                     (*parse_graph).input_files.items_source(),
                     &*import_records_list,
+                    &*glob_imports_list,
                     &*css_asts,
                     &mut *flags,
                 )
@@ -823,6 +834,7 @@ impl<'a> LinkerContext<'a> {
                     input_files,
                     flags,
                     import_records_list,
+                    glob_imports_list,
                 );
 
                 source_index += 1;
@@ -1891,6 +1903,7 @@ impl<'a> LinkerContext<'a> {
         input_files: &[Source],
         meta_flags: &mut [crate::js_meta::Flags],
         ast_import_records: &[bun_ast::import_record::List<'a>],
+        glob_imports: &[bun_ast::ast_result::GlobImportList],
     ) {
         // Explicit-stack postorder DFS (was per-edge recursive). `Enter`
         // seeds a file and queues each followed import paired with an
@@ -1904,6 +1917,11 @@ impl<'a> LinkerContext<'a> {
             AfterChild {
                 source_index: crate::IndexInt,
                 import_record_index: u32,
+            },
+            AfterGlobChild {
+                source_index: crate::IndexInt,
+                child_source_index: crate::IndexInt,
+                parent_import_record_index: u32,
             },
             Leave(crate::IndexInt),
         }
@@ -1943,6 +1961,22 @@ impl<'a> LinkerContext<'a> {
                             });
                         }
                     }
+                    for glob in glob_imports[source_index as usize].iter() {
+                        let mut last_child = crate::IndexInt::MAX;
+                        for entry in glob.entries.iter() {
+                            let child = entry.source_index;
+                            if !child.is_valid() || child.get() == last_child {
+                                continue;
+                            }
+                            last_child = child.get();
+                            stack.push(Frame::Enter(child.get()));
+                            stack.push(Frame::AfterGlobChild {
+                                source_index,
+                                child_source_index: child.get(),
+                                parent_import_record_index: glob.import_record_index,
+                            });
+                        }
+                    }
                     stack.push(Frame::Leave(source_index));
                     stack[mark..].reverse();
                 }
@@ -1953,6 +1987,35 @@ impl<'a> LinkerContext<'a> {
                     if Index::is_valid(Index::init(tla_checks[source_index as usize].parent)) {
                         meta_flags[source_index as usize].is_async_or_has_async_dependency = true;
                     }
+                }
+                Frame::AfterGlobChild {
+                    source_index,
+                    child_source_index,
+                    parent_import_record_index,
+                } => {
+                    let parent = tla_checks[child_source_index as usize];
+                    if Index::is_invalid(Index::init(parent.parent)) {
+                        continue;
+                    }
+                    let source: &Source = &input_files[source_index as usize];
+                    let child_path = &input_files[child_source_index as usize].path.pretty;
+                    let range = ast_import_records[source_index as usize].as_slice()
+                        [parent_import_record_index as usize]
+                        .range;
+                    let mut text = Vec::new();
+                    use std::io::Write;
+                    write!(
+                        &mut text,
+                        "This require call is not allowed because the matched file \"{}\" contains a top-level await",
+                        bstr::BStr::new(child_path)
+                    )
+                    .expect("infallible: in-memory write");
+                    self.log_disjoint().add_range_error_with_notes(
+                        Some(source),
+                        range,
+                        text,
+                        Box::new([]),
+                    );
                 }
                 Frame::AfterChild {
                     source_index,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1997,25 +1997,52 @@ impl<'a> LinkerContext<'a> {
                     if Index::is_invalid(Index::init(parent.parent)) {
                         continue;
                     }
+                    let mut tla_source = child_source_index;
+                    while tla_keywords[tla_source as usize].len == 0 {
+                        let next = tla_checks[tla_source as usize].parent;
+                        if !Index::is_valid(Index::init(next)) || next == tla_source {
+                            break;
+                        }
+                        tla_source = next;
+                    }
                     let source: &Source = &input_files[source_index as usize];
                     let child_path = &input_files[child_source_index as usize].path.pretty;
+                    let tla_path = &input_files[tla_source as usize].path.pretty;
                     let range = ast_import_records[source_index as usize].as_slice()
                         [parent_import_record_index as usize]
                         .range;
                     let mut text = Vec::new();
                     use std::io::Write;
-                    write!(
-                        &mut text,
-                        "This require call is not allowed because the matched file \"{}\" contains a top-level await",
-                        bstr::BStr::new(child_path)
-                    )
+                    if tla_source == child_source_index {
+                        write!(
+                            &mut text,
+                            "This require call is not allowed because the matched file \"{}\" contains a top-level await",
+                            bstr::BStr::new(child_path)
+                        )
+                    } else {
+                        write!(
+                            &mut text,
+                            "This require call is not allowed because the matched file \"{}\" transitively imports \"{}\" which contains a top-level await",
+                            bstr::BStr::new(child_path),
+                            bstr::BStr::new(tla_path)
+                        )
+                    }
                     .expect("infallible: in-memory write");
-                    self.log_disjoint().add_range_error_with_notes(
-                        Some(source),
-                        range,
-                        text,
-                        Box::new([]),
-                    );
+                    let tla_range = tla_keywords[tla_source as usize];
+                    let notes: Box<[Data]> = if tla_range.len > 0 {
+                        Box::new([Data {
+                            text: b"The top-level await is here:"[..].into(),
+                            location: bun_ast::Location::init_or_null(
+                                Some(&input_files[tla_source as usize]),
+                                tla_range,
+                            ),
+                            ..Default::default()
+                        }])
+                    } else {
+                        Box::new([])
+                    };
+                    self.log_disjoint()
+                        .add_range_error_with_notes(Some(source), range, text, notes);
                 }
                 Frame::AfterChild {
                     source_index,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -956,7 +956,6 @@ impl<'a> LinkerContext<'a> {
                 parts,
                 parts_live,
                 import_records,
-                glob_imports,
                 entry_point_kinds,
                 css_reprs,
                 worklist: Vec::new(),
@@ -2295,9 +2294,7 @@ impl<'a> LinkerContext<'a> {
             glob_imports: if ast.glob_imports.is_empty() {
                 None
             } else {
-                // SAFETY: `ast` is borrowed for the duration of this call and
-                // the printer only reads from it; detach the lifetime so
-                // Options can coexist with the `&mut self` callback below.
+                // SAFETY: read-only detach alongside `ts_enums` above.
                 Some(unsafe { bun_ptr::detach_lifetime_ref(ast.glob_imports.as_slice()) })
             },
             require_or_import_meta_for_source_callback:
@@ -2661,7 +2658,6 @@ pub struct TreeShakeCtx<'a, 'r> {
     pub parts: &'r [bun_ast::PartList<'a>],
     pub parts_live: &'r mut [bun_collections::AutoBitSet],
     pub import_records: &'r [bun_ast::import_record::List<'a>],
-    pub glob_imports: &'r [bun_ast::ast_result::GlobImportList],
     pub entry_point_kinds: &'r [EntryPoint::Kind],
     pub css_reprs: &'r [crate::bundled_ast::CssCol],
     pub worklist: Vec<TreeShakeWork>,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -905,6 +905,8 @@ impl<'a> LinkerContext<'a> {
         let parts_live: *mut [bun_collections::AutoBitSet] = self.graph.parts_live.as_mut_slice();
         let import_records: *const [bun_ast::import_record::List<'a>] =
             self.graph.ast.items_import_records();
+        let glob_imports: *const [bun_ast::ast_result::GlobImportList] =
+            self.graph.ast.items_glob_imports();
         let css_reprs: *const [crate::bundled_ast::CssCol] = self.graph.ast.items_css();
         let side_effects: *const [SideEffects] =
             self.parse_graph().input_files.items_side_effects();
@@ -923,6 +925,7 @@ impl<'a> LinkerContext<'a> {
             entry_points,
             side_effects,
             import_records,
+            glob_imports,
             entry_point_kinds,
             css_reprs,
             parts,
@@ -934,6 +937,7 @@ impl<'a> LinkerContext<'a> {
                 &*entry_points,
                 &*side_effects,
                 &*import_records,
+                &*glob_imports,
                 &*entry_point_kinds,
                 &*css_reprs,
                 &mut *parts,
@@ -952,6 +956,7 @@ impl<'a> LinkerContext<'a> {
                 parts,
                 parts_live,
                 import_records,
+                glob_imports,
                 entry_point_kinds,
                 css_reprs,
                 worklist: Vec::new(),
@@ -981,6 +986,7 @@ impl<'a> LinkerContext<'a> {
                 distances,
                 parts,
                 import_records,
+                glob_imports,
                 file_entry_bits,
                 css_reprs,
                 queue: std::collections::VecDeque::new(),
@@ -2279,6 +2285,21 @@ impl<'a> LinkerContext<'a> {
                 Format::Cjs => None, // use unbounded global
                 _ => runtime_require_ref,
             },
+            glob_ref: if ast.glob_imports.is_empty() {
+                Ref::NONE
+            } else {
+                self.graph
+                    .symbols
+                    .follow(self.graph.runtime_function(b"__glob"))
+            },
+            glob_imports: if ast.glob_imports.is_empty() {
+                None
+            } else {
+                // SAFETY: `ast` is borrowed for the duration of this call and
+                // the printer only reads from it; detach the lifetime so
+                // Options can coexist with the `&mut self` callback below.
+                Some(unsafe { bun_ptr::detach_lifetime_ref(ast.glob_imports.as_slice()) })
+            },
             require_or_import_meta_for_source_callback:
                 js_printer::RequireOrImportMetaCallback::init(self),
             line_offset_tables: Some(line_offset_table),
@@ -2640,6 +2661,7 @@ pub struct TreeShakeCtx<'a, 'r> {
     pub parts: &'r [bun_ast::PartList<'a>],
     pub parts_live: &'r mut [bun_collections::AutoBitSet],
     pub import_records: &'r [bun_ast::import_record::List<'a>],
+    pub glob_imports: &'r [bun_ast::ast_result::GlobImportList],
     pub entry_point_kinds: &'r [EntryPoint::Kind],
     pub css_reprs: &'r [crate::bundled_ast::CssCol],
     pub worklist: Vec<TreeShakeWork>,
@@ -2658,6 +2680,7 @@ pub struct CodeSplitCtx<'a, 'r> {
     pub distances: &'r mut [u32],
     pub parts: &'r [bun_ast::PartList<'a>],
     pub import_records: &'r [bun_ast::import_record::List<'a>],
+    pub glob_imports: &'r [bun_ast::ast_result::GlobImportList],
     pub file_entry_bits: &'r mut [AutoBitSet],
     pub css_reprs: &'r [crate::bundled_ast::CssCol],
     pub queue: std::collections::VecDeque<(crate::IndexInt, u32)>,
@@ -2727,6 +2750,17 @@ impl<'a> LinkerContext<'a> {
                         .is_set(entry_points_count)
                 {
                     ctx.queue.push_back((record.source_index.get(), out_dist));
+                }
+            }
+
+            for glob in ctx.glob_imports[source_index as usize].iter() {
+                for entry in glob.entries.iter() {
+                    if entry.source_index.is_valid()
+                        && !ctx.file_entry_bits[entry.source_index.get() as usize]
+                            .is_set(entry_points_count)
+                    {
+                        ctx.queue.push_back((entry.source_index.get(), out_dist));
+                    }
                 }
             }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4815,6 +4815,11 @@ pub mod bv2_impl {
                                 unsafe { core::ptr::drop_in_place(css_ref.as_ptr()) };
                             }
                         }
+                        for list in ast.items_glob_imports_mut() {
+                            for g in list.iter_mut() {
+                                drop(core::mem::take(&mut g.entries));
+                            }
+                        }
                     }};
                 }
                 if self.linker.graph.ast.len() != 0 {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5819,6 +5819,8 @@ pub mod bv2_impl {
                 };
 
                 let kind = parent.kind;
+                let mut seen_stems: std::collections::HashSet<Vec<u8>> =
+                    std::collections::HashSet::new();
 
                 let mut names: Vec<Vec<u8>> = dir_entries
                     .data
@@ -5866,11 +5868,16 @@ pub mod bv2_impl {
                         .push(bun_ast::ast_result::GlobImportEntry { key, source_index });
                     if suffix.is_empty() {
                         let stem = &rel[..rel.len() - ext.len()];
-                        if stem.len() < rel.len() {
+                        if seen_stems.insert(stem.to_vec()) {
+                            let stem_idx = self
+                                .resolve_glob_child(source_dir, stem, kind, target, resolve_queue)
+                                .unwrap_or(source_index);
                             let key: &'static [u8] =
                                 FilenameStore::instance().append_slice(stem).expect("oom");
-                            glob.entries
-                                .push(bun_ast::ast_result::GlobImportEntry { key, source_index });
+                            glob.entries.push(bun_ast::ast_result::GlobImportEntry {
+                                key,
+                                source_index: stem_idx,
+                            });
                         }
                     }
                 }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5818,26 +5818,26 @@ pub mod bv2_impl {
                     source_dir, dir_prefix,
                 );
 
-                let Some(dir_info) = self.transpiler.resolver.read_dir_info_ignore_error(abs)
-                else {
-                    continue;
-                };
-                let Some(dir_entries) = dir_info.get_entries_ref(generation) else {
-                    continue;
-                };
-
                 let kind = parent.kind;
                 let mut seen_stems: Vec<&'static [u8]> = Vec::new();
 
-                let mut names: Vec<Vec<u8>> = dir_entries
-                    .data
-                    .iter()
-                    .map(|(_, v)| {
-                        // SAFETY: EntryStore slot; process-lifetime, read-only.
-                        let entry = unsafe { &**v };
-                        entry.base().to_vec()
+                let mut names: Vec<Vec<u8>> = self
+                    .transpiler
+                    .resolver
+                    .read_dir_info_ignore_error(abs)
+                    .and_then(|di| di.get_entries_ref(generation))
+                    .map(|dir_entries| {
+                        dir_entries
+                            .data
+                            .iter()
+                            .map(|(_, v)| {
+                                // SAFETY: EntryStore slot; process-lifetime, read-only.
+                                let entry = unsafe { &**v };
+                                entry.base().to_vec()
+                            })
+                            .collect()
                     })
-                    .collect();
+                    .unwrap_or_default();
                 names.sort_unstable();
 
                 for base in names {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1635,6 +1635,7 @@ pub mod bv2_impl {
         pub reachable: Vec<Index>,
         pub visited: DynamicBitSet,
         pub all_import_records: &'a mut [import_record::List<'a>],
+        pub all_glob_imports: &'a [bun_ast::ast_result::GlobImportList],
         pub all_loaders: &'a [Loader],
         pub all_urls_for_css: &'a [&'a [u8]],
         pub redirects: &'a [u32],
@@ -1817,6 +1818,17 @@ pub mod bv2_impl {
                         }
                     }
 
+                    for glob in self.all_glob_imports[source_index.get() as usize].iter() {
+                        for entry in glob.entries.iter() {
+                            if entry.source_index.is_valid() {
+                                self.stack.push(ReachFrame::Enter {
+                                    source_index: entry.source_index,
+                                    was_dynamic_import: false,
+                                });
+                            }
+                        }
+                    }
+
                     // Redirects replace the source file with another file
                     if let Some(redirect_id) =
                         get_redirect_id(self.redirects[source_index.get() as usize])
@@ -1903,8 +1915,9 @@ pub mod bv2_impl {
             // `split_mut()` on the local can coexist with the shared borrows
             // below. The slab does not resize for the duration of this function.
             let mut ast_slice = self.graph.ast.slice();
-            let all_import_records: &mut [import_record::List<'_>] =
-                ast_slice.split_mut().import_records;
+            let ast_cols = ast_slice.split_mut();
+            let all_import_records: &mut [import_record::List<'_>] = ast_cols.import_records;
+            let all_glob_imports: &[bun_ast::ast_result::GlobImportList] = ast_cols.glob_imports;
             let all_urls_for_css = self.graph.ast.items_url_for_css();
 
             let mut visitor = ReachableFileVisitor {
@@ -1912,6 +1925,7 @@ pub mod bv2_impl {
                 visited: DynamicBitSet::init_empty(self.graph.input_files.len())?,
                 redirects: self.graph.ast.items_redirect_import_record_index(),
                 all_import_records,
+                all_glob_imports,
                 all_loaders: self.graph.input_files.items_loader(),
                 all_urls_for_css,
                 dynamic_import_entry_points: &mut self.dynamic_import_entry_points,
@@ -5705,6 +5719,10 @@ pub mod bv2_impl {
                 target,
             });
 
+            if resolve_result.last_error.is_none() && !result.ast.glob_imports.is_empty() {
+                this.expand_glob_imports(result, &mut resolve_result.resolve_queue);
+            }
+
             if let Some(err) = resolve_result.last_error {
                 bun_core::scoped_log!(Bundle, "failed with error: {}", err.name());
                 resolve_result.resolve_queue.clear();
@@ -5753,6 +5771,181 @@ pub mod bv2_impl {
             }
 
             resolve_result.resolve_queue
+        }
+
+        /// For each `require("./dir/" + x)` style import recorded by the
+        /// parser, scan the directory for bundleable files, resolve each match
+        /// and add it to `resolve_queue`. Keys are recorded both with and
+        /// without the file extension so that runtime lookups that omit the
+        /// extension (as Node's resolver allows) still succeed. Called after
+        /// `resolve_import_records` so the parent's shape path is never passed
+        /// to the resolver.
+        fn expand_glob_imports(
+            &mut self,
+            result: &mut parse_task::Success,
+            resolve_queue: &mut ResolveQueue,
+        ) {
+            use bun_resolver::fs::FilenameStore;
+
+            let source_dir = result.source.path.source_dir();
+            let target = result.ast.target;
+            let generation = self.transpiler.resolver.generation;
+
+            for glob in result.ast.glob_imports.iter_mut() {
+                let parent = &result.ast.import_records[glob.import_record_index as usize];
+                let shape = parent.path.text;
+                let Some(first_wild) = shape.iter().position(|&b| b == 0) else {
+                    continue;
+                };
+                let prefix = &shape[..first_wild];
+                let suffix = if first_wild + 1 == shape.len() {
+                    &b""[..]
+                } else if !shape[first_wild + 1..].contains(&0)
+                    && !shape[first_wild + 1..].contains(&b'/')
+                {
+                    &shape[first_wild + 1..]
+                } else {
+                    continue;
+                };
+                let Some(last_slash) = prefix.iter().rposition(|&b| b == b'/') else {
+                    continue;
+                };
+                let dir_prefix = &prefix[..=last_slash];
+                let file_prefix = &prefix[last_slash + 1..];
+
+                let mut abs = Vec::with_capacity(source_dir.len() + dir_prefix.len() + 1);
+                abs.extend_from_slice(source_dir);
+                if !source_dir.ends_with(b"/") {
+                    abs.push(b'/');
+                }
+                abs.extend_from_slice(dir_prefix);
+
+                let Some(dir_info) = self
+                    .transpiler
+                    .resolver
+                    .read_dir_info_ignore_error(&abs)
+                else {
+                    continue;
+                };
+                let Some(dir_entries) = dir_info.get_entries_ref(generation) else {
+                    continue;
+                };
+
+                let kind = parent.kind;
+
+                let mut names: Vec<Vec<u8>> = dir_entries
+                    .data
+                    .iter()
+                    .map(|(_, v)| {
+                        // SAFETY: `*mut Entry` points at a process-lifetime
+                        // EntryStore slot; only the `base_` slice is read.
+                        let entry = unsafe { &**v };
+                        entry.base().to_vec()
+                    })
+                    .collect();
+                names.sort_unstable();
+
+                for base in names {
+                    if !file_prefix.is_empty() && !base.starts_with(file_prefix) {
+                        continue;
+                    }
+                    if !suffix.is_empty() {
+                        if !base.ends_with(suffix)
+                            || base.len() <= file_prefix.len() + suffix.len()
+                        {
+                            continue;
+                        }
+                    }
+                    let Some(ext_dot) = base.iter().rposition(|&b| b == b'.') else {
+                        continue;
+                    };
+                    let ext = &base[ext_dot..];
+                    let loader = self.transpiler.options.loader(ext);
+                    if !loader.is_javascript_like() && loader != Loader::Json {
+                        continue;
+                    }
+
+                    let mut rel = Vec::with_capacity(dir_prefix.len() + base.len());
+                    rel.extend_from_slice(dir_prefix);
+                    rel.extend_from_slice(&base);
+
+                    let Some(source_index) = self.resolve_glob_child(
+                        source_dir,
+                        &rel,
+                        kind,
+                        target,
+                        resolve_queue,
+                    ) else {
+                        continue;
+                    };
+
+                    let key: &'static [u8] =
+                        FilenameStore::instance().append_slice(&rel).expect("oom");
+                    glob.entries.push(bun_ast::ast_result::GlobImportEntry {
+                        key,
+                        source_index,
+                    });
+                    if suffix.is_empty() {
+                        let stem = &rel[..rel.len() - ext.len()];
+                        if stem.len() < rel.len() {
+                            let key: &'static [u8] =
+                                FilenameStore::instance().append_slice(stem).expect("oom");
+                            glob.entries.push(bun_ast::ast_result::GlobImportEntry {
+                                key,
+                                source_index,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        /// Resolve a single glob-matched relative path and enqueue it for
+        /// parsing. Returns the `source_index` the linker will see once parsing
+        /// completes (either an existing index or the one reserved by
+        /// `process_resolve_queue`).
+        fn resolve_glob_child(
+            &mut self,
+            source_dir: &[u8],
+            rel: &[u8],
+            kind: ImportKind,
+            target: options::Target,
+            resolve_queue: &mut ResolveQueue,
+        ) -> Option<Index> {
+            let mut resolve_result = self
+                .transpiler
+                .resolver
+                .resolve_with_framework(source_dir, rel, kind)
+                .ok()?;
+            let path = resolve_result.path()?;
+            if path.is_disabled {
+                return None;
+            }
+            if let Some(id) = self.path_to_source_index_map(target).get(path.text) {
+                return Some(Index::init(id));
+            }
+            let resolve_entry = resolve_queue.get_or_put(path.text).expect("oom");
+            if resolve_entry.found_existing {
+                // Will be assigned a source_index by process_resolve_queue;
+                // look it up again afterwards via `patch_glob_import_indices`.
+                return Some(Index::INVALID);
+            }
+            let path = &mut resolve_result.path_pair.primary;
+            *path = self
+                .path_with_pretty_initialized(path, target)
+                .expect("oom");
+            let resolve_task_val = ParseTask::init(&resolve_result, bun_ast::Index::INVALID, self);
+            let resolve_task: &mut ParseTask = self.arena_create(resolve_task_val);
+            resolve_task.known_target = target;
+            resolve_task.jsx = resolve_result.jsx.clone();
+            resolve_task.jsx.development = match self.transpiler.options.force_node_env {
+                options::ForceNodeEnv::Development => true,
+                options::ForceNodeEnv::Production => false,
+                options::ForceNodeEnv::Unspecified => self.transpiler.options.jsx.development,
+            };
+            resolve_task.tree_shaking = self.transpiler.options.tree_shaking;
+            *resolve_entry.value_ptr = resolve_task;
+            Some(Index::INVALID)
         }
     }
 
@@ -5828,6 +6021,9 @@ pub mod bv2_impl {
                 import_record.flags.contains(bun_ast::ImportRecordFlags::IS_UNUSED)
                 // Don't resolve the runtime
                 || import_record.flags.contains(bun_ast::ImportRecordFlags::IS_INTERNAL)
+                // Don't resolve the parent of a glob pattern; its children were
+                // appended by expand_glob_imports and are resolved individually.
+                || import_record.flags.contains(bun_ast::ImportRecordFlags::GLOB_PATTERN)
                 // Don't resolve pre-resolved imports
                 || import_record.source_index.is_valid()
                 {
@@ -6950,6 +7146,39 @@ pub mod bv2_impl {
                         result.ast.target,
                         result_source_index as IndexInt,
                     );
+
+                    if !result.ast.glob_imports.is_empty() {
+                        let target = result.ast.target;
+                        let source_dir = this.graph.input_files.items_source()
+                            [result_source_index]
+                            .path
+                            .source_dir()
+                            .to_vec();
+                        for glob in result.ast.glob_imports.iter_mut() {
+                            for entry in glob.entries.iter_mut() {
+                                if entry.source_index.is_valid() {
+                                    continue;
+                                }
+                                let Ok(mut resolved) =
+                                    this.transpiler.resolver.resolve_with_framework(
+                                        &source_dir,
+                                        entry.key,
+                                        ImportKind::Require,
+                                    )
+                                else {
+                                    continue;
+                                };
+                                let Some(path) = resolved.path() else {
+                                    continue;
+                                };
+                                if let Some(id) =
+                                    this.path_to_source_index_map(target).get(path.text)
+                                {
+                                    entry.source_index = Index::init(id);
+                                }
+                            }
+                        }
+                    }
 
                     let result_heap = *result.ast.import_records.allocator();
                     let mut import_records = core::mem::replace(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5783,8 +5783,11 @@ pub mod bv2_impl {
             result: &mut parse_task::Success,
             resolve_queue: &mut ResolveQueue,
         ) {
-            use bun_resolver::fs::FilenameStore;
-
+            // SAFETY: `graph.heap` outlives the bundle pass; keys are only read
+            // by the printer within the same pass. Detach so callers below can
+            // reborrow `&mut self`.
+            let arena: &'static bun_alloc::Arena =
+                unsafe { bun_ptr::detach_lifetime_ref(self.arena()) };
             let source_dir = result.source.path.source_dir();
             let target = result.ast.target;
             let generation = self.transpiler.resolver.generation;
@@ -5866,15 +5869,13 @@ pub mod bv2_impl {
                         continue;
                     };
 
-                    let key: &'static [u8] =
-                        FilenameStore::instance().append_slice(&rel).expect("oom");
+                    let key: &'static [u8] = arena.alloc_slice_copy(&rel);
                     glob.entries
                         .push(bun_ast::ast_result::GlobImportEntry { key, source_index });
                     if suffix.is_empty() {
-                        let stem: &'static [u8] = FilenameStore::instance()
-                            .append_slice(&rel[..rel.len() - ext.len()])
-                            .expect("oom");
-                        if !seen_stems.iter().any(|s| *s == stem) {
+                        let stem = &rel[..rel.len() - ext.len()];
+                        if !seen_stems.iter().any(|s| **s == *stem) {
+                            let stem: &'static [u8] = arena.alloc_slice_copy(stem);
                             seen_stems.push(stem);
                             let stem_idx = self
                                 .resolve_glob_child(source_dir, stem, kind, target, resolve_queue)

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4796,12 +4796,12 @@ pub mod bv2_impl {
             // backed. The slab-only `MultiArrayList::drop` strands nothing on the
             // global heap; `mi_heap_destroy` on the AST arenas reclaims all of it.
             //
-            // Only `css` still needs an explicit pass: `BundlerStyleSheet` is the
-            // CSS crate's tree-of-`Vec`s/`Box`es and is not `AstAlloc`-parameterised
-            // (that refactor would touch every `CssRuleList`/selector/declaration
-            // type). The arena-allocated stylesheet never has `Drop` run by the
-            // slab. For JS-only bundles every `css` slot is `None`, so this loop
-            // is N×branch with no work; only CSS entries pay a real drop. The
+            // `css` and `glob_imports` still need explicit passes: `BundlerStyleSheet`
+            // is the CSS crate's tree-of-`Vec`s/`Box`es and is not `AstAlloc`-
+            // parameterised (that refactor would touch every `CssRuleList`/
+            // selector/declaration type), and `GlobImport.entries` is a global-
+            // heap `Vec` filled on the bundle thread. For JS-only bundles with
+            // no glob requires both loops are N×branch with no work. The
             // macro takes only one side (`linker.graph.ast` is a bitwise SoA
             // `memcpy` of `graph.ast`), and `CssChunk::asts` `forget()`s its
             // aliases, so this is the unique drop.
@@ -5824,8 +5824,7 @@ pub mod bv2_impl {
                 };
 
                 let kind = parent.kind;
-                let mut seen_stems: std::collections::HashSet<Vec<u8>> =
-                    std::collections::HashSet::new();
+                let mut seen_stems: Vec<&'static [u8]> = Vec::new();
 
                 let mut names: Vec<Vec<u8>> = dir_entries
                     .data
@@ -5872,15 +5871,16 @@ pub mod bv2_impl {
                     glob.entries
                         .push(bun_ast::ast_result::GlobImportEntry { key, source_index });
                     if suffix.is_empty() {
-                        let stem = &rel[..rel.len() - ext.len()];
-                        if seen_stems.insert(stem.to_vec()) {
+                        let stem: &'static [u8] = FilenameStore::instance()
+                            .append_slice(&rel[..rel.len() - ext.len()])
+                            .expect("oom");
+                        if !seen_stems.iter().any(|s| *s == stem) {
+                            seen_stems.push(stem);
                             let stem_idx = self
                                 .resolve_glob_child(source_dir, stem, kind, target, resolve_queue)
                                 .unwrap_or(source_index);
-                            let key: &'static [u8] =
-                                FilenameStore::instance().append_slice(stem).expect("oom");
                             glob.entries.push(bun_ast::ast_result::GlobImportEntry {
-                                key,
+                                key: stem,
                                 source_index: stem_idx,
                             });
                         }
@@ -5902,6 +5902,9 @@ pub mod bv2_impl {
                 .resolver
                 .resolve_with_framework(source_dir, rel, kind)
                 .ok()?;
+            if resolve_result.flags.is_external() {
+                return None;
+            }
             let path = resolve_result.path()?;
             if path.is_disabled {
                 return None;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5887,6 +5887,18 @@ pub mod bv2_impl {
                         }
                     }
                 }
+
+                if glob.entries.is_empty() {
+                    let range = result.ast.import_records[glob.import_record_index as usize].range;
+                    result.log.add_range_warning_fmt(
+                        Some(&result.source),
+                        range,
+                        format_args!(
+                            "require() pattern matched no bundleable files in \"{}\"",
+                            bstr::BStr::new(dir_prefix)
+                        ),
+                    );
+                }
             }
         }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5773,13 +5773,6 @@ pub mod bv2_impl {
             resolve_result.resolve_queue
         }
 
-        /// For each `require("./dir/" + x)` style import recorded by the
-        /// parser, scan the directory for bundleable files, resolve each match
-        /// and add it to `resolve_queue`. Keys are recorded both with and
-        /// without the file extension so that runtime lookups that omit the
-        /// extension (as Node's resolver allows) still succeed. Called after
-        /// `resolve_import_records` so the parent's shape path is never passed
-        /// to the resolver.
         fn expand_glob_imports(
             &mut self,
             result: &mut parse_task::Success,
@@ -5813,14 +5806,11 @@ pub mod bv2_impl {
                 let dir_prefix = &prefix[..=last_slash];
                 let file_prefix = &prefix[last_slash + 1..];
 
-                let mut abs = Vec::with_capacity(source_dir.len() + dir_prefix.len() + 1);
-                abs.extend_from_slice(source_dir);
-                if !source_dir.ends_with(b"/") {
-                    abs.push(b'/');
-                }
-                abs.extend_from_slice(dir_prefix);
+                let abs = bun_paths::resolve_path::join_abs::<bun_paths::platform::Auto>(
+                    source_dir, dir_prefix,
+                );
 
-                let Some(dir_info) = self.transpiler.resolver.read_dir_info_ignore_error(&abs)
+                let Some(dir_info) = self.transpiler.resolver.read_dir_info_ignore_error(abs)
                 else {
                     continue;
                 };
@@ -5834,8 +5824,7 @@ pub mod bv2_impl {
                     .data
                     .iter()
                     .map(|(_, v)| {
-                        // SAFETY: `*mut Entry` points at a process-lifetime
-                        // EntryStore slot; only the `base_` slice is read.
+                        // SAFETY: EntryStore slot; process-lifetime, read-only.
                         let entry = unsafe { &**v };
                         entry.base().to_vec()
                     })
@@ -5888,10 +5877,6 @@ pub mod bv2_impl {
             }
         }
 
-        /// Resolve a single glob-matched relative path and enqueue it for
-        /// parsing. Returns the `source_index` the linker will see once parsing
-        /// completes (either an existing index or the one reserved by
-        /// `process_resolve_queue`).
         fn resolve_glob_child(
             &mut self,
             source_dir: &[u8],
@@ -5914,8 +5899,6 @@ pub mod bv2_impl {
             }
             let resolve_entry = resolve_queue.get_or_put(path.text).expect("oom");
             if resolve_entry.found_existing {
-                // Will be assigned a source_index by process_resolve_queue;
-                // look it up again afterwards via `patch_glob_import_indices`.
                 return Some(Index::INVALID);
             }
             let path = &mut resolve_result.path_pair.primary;
@@ -6009,8 +5992,7 @@ pub mod bv2_impl {
                 import_record.flags.contains(bun_ast::ImportRecordFlags::IS_UNUSED)
                 // Don't resolve the runtime
                 || import_record.flags.contains(bun_ast::ImportRecordFlags::IS_INTERNAL)
-                // Don't resolve the parent of a glob pattern; its children were
-                // appended by expand_glob_imports and are resolved individually.
+                // Glob parents are resolved via expand_glob_imports
                 || import_record.flags.contains(bun_ast::ImportRecordFlags::GLOB_PATTERN)
                 // Don't resolve pre-resolved imports
                 || import_record.source_index.is_valid()

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5820,10 +5820,7 @@ pub mod bv2_impl {
                 }
                 abs.extend_from_slice(dir_prefix);
 
-                let Some(dir_info) = self
-                    .transpiler
-                    .resolver
-                    .read_dir_info_ignore_error(&abs)
+                let Some(dir_info) = self.transpiler.resolver.read_dir_info_ignore_error(&abs)
                 else {
                     continue;
                 };
@@ -5850,8 +5847,7 @@ pub mod bv2_impl {
                         continue;
                     }
                     if !suffix.is_empty() {
-                        if !base.ends_with(suffix)
-                            || base.len() <= file_prefix.len() + suffix.len()
+                        if !base.ends_with(suffix) || base.len() <= file_prefix.len() + suffix.len()
                         {
                             continue;
                         }
@@ -5869,31 +5865,23 @@ pub mod bv2_impl {
                     rel.extend_from_slice(dir_prefix);
                     rel.extend_from_slice(&base);
 
-                    let Some(source_index) = self.resolve_glob_child(
-                        source_dir,
-                        &rel,
-                        kind,
-                        target,
-                        resolve_queue,
-                    ) else {
+                    let Some(source_index) =
+                        self.resolve_glob_child(source_dir, &rel, kind, target, resolve_queue)
+                    else {
                         continue;
                     };
 
                     let key: &'static [u8] =
                         FilenameStore::instance().append_slice(&rel).expect("oom");
-                    glob.entries.push(bun_ast::ast_result::GlobImportEntry {
-                        key,
-                        source_index,
-                    });
+                    glob.entries
+                        .push(bun_ast::ast_result::GlobImportEntry { key, source_index });
                     if suffix.is_empty() {
                         let stem = &rel[..rel.len() - ext.len()];
                         if stem.len() < rel.len() {
                             let key: &'static [u8] =
                                 FilenameStore::instance().append_slice(stem).expect("oom");
-                            glob.entries.push(bun_ast::ast_result::GlobImportEntry {
-                                key,
-                                source_index,
-                            });
+                            glob.entries
+                                .push(bun_ast::ast_result::GlobImportEntry { key, source_index });
                         }
                     }
                 }
@@ -7149,8 +7137,7 @@ pub mod bv2_impl {
 
                     if !result.ast.glob_imports.is_empty() {
                         let target = result.ast.target;
-                        let source_dir = this.graph.input_files.items_source()
-                            [result_source_index]
+                        let source_dir = this.graph.input_files.items_source()[result_source_index]
                             .path
                             .source_dir()
                             .to_vec();

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -80,6 +80,7 @@ pub struct BundledAst<'arena> {
     pub named_imports: NamedImports,
     pub named_exports: NamedExports,
     pub export_star_import_records: bun_alloc::AstVec<u32>,
+    pub glob_imports: bun_ast::ast_result::GlobImportList,
 
     pub top_level_symbols_to_parts: TopLevelSymbolToParts,
 
@@ -120,6 +121,7 @@ bun_collections::multi_array_columns! {
         named_imports: NamedImports,
         named_exports: NamedExports,
         export_star_import_records: bun_alloc::AstVec<u32>,
+        glob_imports: bun_ast::ast_result::GlobImportList,
         top_level_symbols_to_parts: TopLevelSymbolToParts,
         commonjs_named_exports: CommonJSNamedExports,
         redirect_import_record_index: u32,
@@ -175,6 +177,7 @@ impl<'arena> BundledAst<'arena> {
             named_imports: NamedImports::default(),
             named_exports: NamedExports::default(),
             export_star_import_records: bun_alloc::AstAlloc::vec(),
+            glob_imports: bun_alloc::AstAlloc::vec(),
             top_level_symbols_to_parts: TopLevelSymbolToParts::default(),
             commonjs_named_exports: CommonJSNamedExports::default(),
             redirect_import_record_index: u32::MAX,
@@ -218,6 +221,7 @@ impl<'arena> BundledAst<'arena> {
             named_imports: self.named_imports,
             named_exports: self.named_exports,
             export_star_import_records: self.export_star_import_records,
+            glob_imports: self.glob_imports,
 
             top_level_symbols_to_parts: self.top_level_symbols_to_parts,
 
@@ -311,6 +315,7 @@ impl<'arena> BundledAst<'arena> {
             named_imports: ast.named_imports,
             named_exports: ast.named_exports,
             export_star_import_records: ast.export_star_import_records,
+            glob_imports: ast.glob_imports,
 
             // arena: ast.arena,
             top_level_symbols_to_parts: ast.top_level_symbols_to_parts,

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -283,7 +283,11 @@ pub fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Result<Bo
             let import_records = &import_records_list[source_index as usize];
             let mut first_import = true;
             for record in import_records.as_slice() {
-                if record.kind == ImportKind::Internal {
+                if record.kind == ImportKind::Internal
+                    || record
+                        .flags
+                        .contains(bun_ast::ImportRecordFlags::GLOB_PATTERN)
+                {
                     continue;
                 }
 

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -107,6 +107,7 @@ pub fn scan_imports_and_exports(
     let flags: *mut [js_meta::Flags] = meta.flags;
     let ast_flags_list: *mut [AstFlags] = ast.flags;
     let export_star_import_records: *mut [bun_alloc::AstVec<u32>] = ast.export_star_import_records;
+    let glob_imports_list: *mut [bun_ast::ast_result::GlobImportList] = ast.glob_imports;
     let exports_refs: *mut [Ref] = ast.exports_ref;
     let module_refs: *mut [Ref] = ast.module_ref;
     let wrapper_refs: *mut [Ref] = ast.wrapper_ref;
@@ -247,6 +248,24 @@ pub fn scan_imports_and_exports(
                         }
                     }
                     _ => {}
+                }
+            }
+
+            for glob in col_ref!(glob_imports_list)[id].iter() {
+                for entry in glob.entries.iter() {
+                    if !entry.source_index.is_valid() {
+                        continue;
+                    }
+                    let other = entry.source_index.get() as usize;
+                    if other >= col_ref!(exports_kind).len() {
+                        continue;
+                    }
+                    if col_ref!(exports_kind)[other] == ExportsKind::Esm {
+                        col!(flags)[other].wrap = WrapKind::Esm;
+                    } else {
+                        col!(flags)[other].wrap = WrapKind::Cjs;
+                        col!(exports_kind)[other] = ExportsKind::Cjs;
+                    }
                 }
             }
 
@@ -870,6 +889,7 @@ pub fn scan_imports_and_exports(
                 let mut to_esm_uses: u32 = 0;
                 let mut to_common_js_uses: u32 = 0;
                 let mut runtime_require_uses: u32 = 0;
+                let mut glob_uses: u32 = 0;
 
                 // Imports of wrapped files must depend on the wrapper
                 // Iterate by index so each iteration re-borrows
@@ -897,6 +917,45 @@ pub fn scan_imports_and_exports(
                         this.is_external_dynamic_import(record, source_index)
                     };
                     if !rec_source_index.is_valid() || is_external_dyn {
+                        if rec_flags.contains(ImportRecordFlags::GLOB_PATTERN) {
+                            glob_uses += 1;
+                            for glob in col_ref!(glob_imports_list)[id].iter() {
+                                if glob.import_record_index != import_record_index {
+                                    continue;
+                                }
+                                for entry in glob.entries.iter() {
+                                    if !entry.source_index.is_valid() {
+                                        continue;
+                                    }
+                                    let other = entry.source_index.get() as usize;
+                                    let other_flags = col_ref!(flags)[other];
+                                    if other_flags.wrap == WrapKind::None {
+                                        continue;
+                                    }
+                                    let wrapper_ref = col_ref!(wrapper_refs)[other];
+                                    if wrapper_ref.is_valid() {
+                                        this.graph.generate_symbol_import_and_use(
+                                            source_index,
+                                            part_index as u32,
+                                            wrapper_ref,
+                                            1,
+                                            Index::source(other as u32),
+                                        )?;
+                                    }
+                                    if other_flags.wrap == WrapKind::Esm {
+                                        this.graph.generate_symbol_import_and_use(
+                                            source_index,
+                                            part_index as u32,
+                                            col_ref!(exports_refs)[other],
+                                            1,
+                                            Index::source(other as u32),
+                                        )?;
+                                        to_common_js_uses += 1;
+                                    }
+                                }
+                            }
+                            continue;
+                        }
                         if output_format == Format::InternalBakeDev {
                             continue;
                         }
@@ -1147,6 +1206,13 @@ pub fn scan_imports_and_exports(
                         Index::part(part_index as u32),
                         b"__reExport",
                         re_export_uses,
+                    )?;
+
+                    this.graph.generate_runtime_symbol_import_and_use(
+                        source_index,
+                        Index::part(part_index as u32),
+                        b"__glob",
+                        glob_uses,
                     )?;
                 }
             }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -795,72 +795,67 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Extracts a matchable "shape" from a dynamic import argument.
-    /// Template literals: static parts joined by \x00 placeholders.
-    /// String concatenation (`"./a" + x`) is treated the same way.
-    /// Everything else: empty string.
+    /// Template literals and string concatenation: static parts joined by \x00
+    /// placeholders. Everything else: empty string.
     fn extract_dynamic_specifier_shape<'b>(
         &mut self,
         arg: Expr,
         buf: &'b mut BumpVec<'a, u8>,
     ) -> Result<&'b [u8], crate::Error> {
-        if let Some(tmpl) = arg.data.e_template() {
-            if tmpl.tag.is_some() {
-                return Ok(b""); // tagged template — opaque
-            }
-            match &tmpl.head {
-                js_ast::e::TemplateContents::Cooked(head) => {
-                    buf.extend_from_slice(head.string(self.arena)?);
-                }
-                js_ast::e::TemplateContents::Raw(_) => return Ok(b""), // shouldn't happen post-visit but be safe
-            }
-            for part in tmpl.parts().iter() {
-                buf.push(0); // \x00 placeholder per interpolation
-                match &part.tail {
-                    js_ast::e::TemplateContents::Cooked(tail) => {
-                        buf.extend_from_slice(tail.string(self.arena)?);
-                    }
-                    js_ast::e::TemplateContents::Raw(_) => return Ok(b""), // raw tail — treat as opaque
-                }
-            }
-            return Ok(buf.as_slice());
-        }
-        if self.flatten_string_concat_shape(arg, buf)? {
+        if self.append_specifier_shape(arg, buf)? {
             return Ok(buf.as_slice());
         }
         Ok(b"")
     }
 
-    fn flatten_string_concat_shape<'b>(
+    fn append_specifier_shape<'b>(
         &mut self,
         arg: Expr,
         buf: &'b mut BumpVec<'a, u8>,
     ) -> Result<bool, crate::Error> {
-        let Some(bin) = arg.data.e_binary() else {
-            return Ok(false);
-        };
-        if bin.op != js_ast::OpCode::BinAdd {
-            return Ok(false);
+        if let Some(mut s) = arg.data.as_e_string() {
+            s.resolve_rope_if_needed(self.arena);
+            buf.extend_from_slice(s.string(self.arena)?);
+            return Ok(true);
         }
-        let mut saw_string = false;
-        let mut push = |p: &mut Self, side: Expr| -> Result<bool, crate::Error> {
-            if let Some(mut s) = side.data.as_e_string() {
-                s.resolve_rope_if_needed(p.arena);
-                buf.extend_from_slice(s.string(p.arena)?);
-                saw_string = true;
-                return Ok(true);
+        if let Some(tmpl) = arg.data.e_template() {
+            if tmpl.tag.is_some() {
+                return Ok(false);
             }
-            let mark = buf.len();
-            if p.flatten_string_concat_shape(side, buf)? {
-                saw_string = true;
-                return Ok(true);
+            let js_ast::e::TemplateContents::Cooked(head) = &tmpl.head else {
+                return Ok(false);
+            };
+            buf.extend_from_slice(head.string(self.arena)?);
+            for part in tmpl.parts().iter() {
+                let mark = buf.len();
+                if !self.append_specifier_shape(part.value, buf)? {
+                    buf.truncate(mark);
+                    buf.push(0);
+                }
+                let js_ast::e::TemplateContents::Cooked(tail) = &part.tail else {
+                    return Ok(false);
+                };
+                buf.extend_from_slice(tail.string(self.arena)?);
             }
-            buf.truncate(mark);
-            buf.push(0);
-            Ok(true)
-        };
-        push(self, bin.left)?;
-        push(self, bin.right)?;
-        Ok(saw_string)
+            return Ok(true);
+        }
+        if let Some(bin) = arg.data.e_binary() {
+            if bin.op != js_ast::OpCode::BinAdd {
+                return Ok(false);
+            }
+            let mut saw_string = false;
+            for side in [bin.left, bin.right] {
+                let mark = buf.len();
+                if self.append_specifier_shape(side, buf)? {
+                    saw_string = true;
+                } else {
+                    buf.truncate(mark);
+                    buf.push(0);
+                }
+            }
+            return Ok(saw_string);
+        }
+        Ok(false)
     }
 
     pub fn try_glob_require(&mut self, arg: Expr) -> Option<Expr> {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -864,7 +864,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub fn try_glob_require(&mut self, arg: Expr) -> Option<Expr> {
-        if !self.options.bundle {
+        if !self.options.bundle || self.options.features.hot_module_reloading {
             return None;
         }
         let mut shape_buf = BumpVec::new_in(self.arena);
@@ -889,6 +889,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         let tail = &shape[first_wild + 1..];
         if tail.contains(&0) || tail.contains(&b'/') {
+            return None;
+        }
+        if !tail.is_empty() && tail[0] != b'.' {
             return None;
         }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -802,7 +802,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         arg: Expr,
         buf: &'b mut BumpVec<'a, u8>,
     ) -> Result<&'b [u8], crate::Error> {
-        if self.append_specifier_shape(arg, buf)? {
+        if self.append_specifier_shape(arg, buf, 0)? {
             return Ok(buf.as_slice());
         }
         Ok(b"")
@@ -812,10 +812,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         arg: Expr,
         buf: &'b mut BumpVec<'a, u8>,
+        depth: u32,
     ) -> Result<bool, crate::Error> {
+        if depth > 64 {
+            return Ok(false);
+        }
         if let Some(mut s) = arg.data.as_e_string() {
             s.resolve_rope_if_needed(self.arena);
-            buf.extend_from_slice(s.string(self.arena)?);
+            let bytes = s.string(self.arena)?;
+            if bytes.contains(&0) {
+                return Ok(false);
+            }
+            buf.extend_from_slice(bytes);
             return Ok(true);
         }
         if let Some(tmpl) = arg.data.e_template() {
@@ -825,17 +833,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let js_ast::e::TemplateContents::Cooked(head) = &tmpl.head else {
                 return Ok(false);
             };
-            buf.extend_from_slice(head.string(self.arena)?);
+            let head = head.string(self.arena)?;
+            if head.contains(&0) {
+                return Ok(false);
+            }
+            buf.extend_from_slice(head);
             for part in tmpl.parts().iter() {
                 let mark = buf.len();
-                if !self.append_specifier_shape(part.value, buf)? {
+                if !self.append_specifier_shape(part.value, buf, depth + 1)? {
                     buf.truncate(mark);
                     buf.push(0);
                 }
                 let js_ast::e::TemplateContents::Cooked(tail) = &part.tail else {
                     return Ok(false);
                 };
-                buf.extend_from_slice(tail.string(self.arena)?);
+                let tail = tail.string(self.arena)?;
+                if tail.contains(&0) {
+                    return Ok(false);
+                }
+                buf.extend_from_slice(tail);
             }
             return Ok(true);
         }
@@ -846,7 +862,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let mut saw_string = false;
             for side in [bin.left, bin.right] {
                 let mark = buf.len();
-                if self.append_specifier_shape(side, buf)? {
+                if self.append_specifier_shape(side, buf, depth + 1)? {
                     saw_string = true;
                 } else {
                     buf.truncate(mark);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -824,10 +824,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             return Ok(buf.as_slice());
         }
-        // Flatten a chain of string concatenations so that `"./a/" + x + ".js"`
-        // produces the same shape as the template form. A non-string operand
-        // becomes a `\x00` placeholder; if no string literal is involved the
-        // result stays opaque (empty).
         if self.flatten_string_concat_shape(arg, buf)? {
             return Ok(buf.as_slice());
         }
@@ -853,10 +849,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 saw_string = true;
                 return Ok(true);
             }
+            let mark = buf.len();
             if p.flatten_string_concat_shape(side, buf)? {
                 saw_string = true;
                 return Ok(true);
             }
+            buf.truncate(mark);
             buf.push(0);
             Ok(true)
         };
@@ -865,11 +863,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(saw_string)
     }
 
-    /// If `arg` is a relative glob-shaped specifier (starts with `./` or `../`
-    /// and contains at least one wildcard placeholder), record it as a glob
-    /// import and return the `E::RequireString` that refers to it. Otherwise
-    /// returns `None` and leaves state untouched.
-    pub fn try_glob_require(&mut self, arg: Expr, kind: ImportKind) -> Option<Expr> {
+    pub fn try_glob_require(&mut self, arg: Expr) -> Option<Expr> {
         if !self.options.bundle {
             return None;
         }
@@ -884,10 +878,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !is_relative {
             return None;
         }
-        // The directory to scan is everything up to the last '/' before the
-        // first wildcard; require at least one literal path segment beyond the
-        // leading "./" or "../" so we never glob the importing file's own
-        // directory (which would pull in unrelated siblings).
+        // Require a named subdirectory before the wildcard so we don't scan the importer's own dir.
         let first_wild = shape.iter().position(|&b| b == 0).unwrap();
         let after_dots = shape
             .iter()
@@ -896,11 +887,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if after_dots >= first_wild || !shape[after_dots..first_wild].contains(&b'/') {
             return None;
         }
+        let tail = &shape[first_wild + 1..];
+        if tail.contains(&0) || tail.contains(&b'/') {
+            return None;
+        }
 
         let owned: &'a [u8] = self.arena.alloc_slice_copy(shape);
         let path = fs::Path::init(owned);
         let import_record_index = self.add_import_record_by_range_and_path(
-            kind,
+            ImportKind::Require,
             js_lexer::range_of_identifier(self.source, arg.loc),
             &path,
         );
@@ -915,7 +910,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.glob_imports.push(bun_ast::ast_result::GlobImport {
             import_record_index,
             arg,
-            is_require: kind == ImportKind::Require,
             entries: Vec::new(),
         });
 
@@ -1327,7 +1321,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             _ => {
                 if !self.is_control_flow_dead {
-                    if let Some(glob) = self.try_glob_require(arg, ImportKind::Require) {
+                    if let Some(glob) = self.try_glob_require(arg) {
                         return glob;
                     }
                 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -395,6 +395,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub import_records: ImportRecordList<'a>,
     pub import_records_for_current_part: List<'a, u32>,
     pub export_star_import_records: List<'a, u32>,
+    pub glob_imports: bun_ast::ast_result::GlobImportList,
     pub import_symbol_property_uses: SymbolPropertyUseMap,
 
     // These are for handling ES6 imports and exports
@@ -795,6 +796,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// Extracts a matchable "shape" from a dynamic import argument.
     /// Template literals: static parts joined by \x00 placeholders.
+    /// String concatenation (`"./a" + x`) is treated the same way.
     /// Everything else: empty string.
     fn extract_dynamic_specifier_shape<'b>(
         &mut self,
@@ -822,7 +824,108 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             return Ok(buf.as_slice());
         }
+        // Flatten a chain of string concatenations so that `"./a/" + x + ".js"`
+        // produces the same shape as the template form. A non-string operand
+        // becomes a `\x00` placeholder; if no string literal is involved the
+        // result stays opaque (empty).
+        if self.flatten_string_concat_shape(arg, buf)? {
+            return Ok(buf.as_slice());
+        }
         Ok(b"")
+    }
+
+    fn flatten_string_concat_shape<'b>(
+        &mut self,
+        arg: Expr,
+        buf: &'b mut BumpVec<'a, u8>,
+    ) -> Result<bool, crate::Error> {
+        let Some(bin) = arg.data.e_binary() else {
+            return Ok(false);
+        };
+        if bin.op != js_ast::OpCode::BinAdd {
+            return Ok(false);
+        }
+        let mut saw_string = false;
+        let mut push = |p: &mut Self, side: Expr| -> Result<bool, crate::Error> {
+            if let Some(mut s) = side.data.as_e_string() {
+                s.resolve_rope_if_needed(p.arena);
+                buf.extend_from_slice(s.string(p.arena)?);
+                saw_string = true;
+                return Ok(true);
+            }
+            if p.flatten_string_concat_shape(side, buf)? {
+                saw_string = true;
+                return Ok(true);
+            }
+            buf.push(0);
+            Ok(true)
+        };
+        push(self, bin.left)?;
+        push(self, bin.right)?;
+        Ok(saw_string)
+    }
+
+    /// If `arg` is a relative glob-shaped specifier (starts with `./` or `../`
+    /// and contains at least one wildcard placeholder), record it as a glob
+    /// import and return the `E::RequireString` that refers to it. Otherwise
+    /// returns `None` and leaves state untouched.
+    pub fn try_glob_require(&mut self, arg: Expr, kind: ImportKind) -> Option<Expr> {
+        if !self.options.bundle {
+            return None;
+        }
+        let mut shape_buf = BumpVec::new_in(self.arena);
+        let shape = self
+            .extract_dynamic_specifier_shape(arg, &mut shape_buf)
+            .ok()?;
+        if shape.is_empty() || !shape.contains(&0) {
+            return None;
+        }
+        let is_relative = shape.starts_with(b"./") || shape.starts_with(b"../");
+        if !is_relative {
+            return None;
+        }
+        // The directory to scan is everything up to the last '/' before the
+        // first wildcard; require at least one literal path segment beyond the
+        // leading "./" or "../" so we never glob the importing file's own
+        // directory (which would pull in unrelated siblings).
+        let first_wild = shape.iter().position(|&b| b == 0).unwrap();
+        let after_dots = shape
+            .iter()
+            .position(|&b| b != b'.' && b != b'/')
+            .unwrap_or(shape.len());
+        if after_dots >= first_wild || !shape[after_dots..first_wild].contains(&b'/') {
+            return None;
+        }
+
+        let owned: &'a [u8] = self.arena.alloc_slice_copy(shape);
+        let path = fs::Path::init(owned);
+        let import_record_index = self.add_import_record_by_range_and_path(
+            kind,
+            js_lexer::range_of_identifier(self.source, arg.loc),
+            &path,
+        );
+        let flags = &mut self.import_records.items_mut()[import_record_index as usize].flags;
+        flags.insert(bun_ast::ImportRecordFlags::GLOB_PATTERN);
+        flags.set(
+            bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
+            self.fn_or_arrow_data_visit.try_body_count != 0,
+        );
+        self.import_records_for_current_part
+            .push(import_record_index);
+        self.glob_imports.push(bun_ast::ast_result::GlobImport {
+            import_record_index,
+            arg,
+            is_require: kind == ImportKind::Require,
+            entries: Vec::new(),
+        });
+
+        Some(self.new_expr(
+            E::RequireString {
+                import_record_index,
+                ..Default::default()
+            },
+            arg.loc,
+        ))
     }
 
     pub fn check_dynamic_specifier(
@@ -1223,6 +1326,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 )
             }
             _ => {
+                if !self.is_control_flow_dead {
+                    if let Some(glob) = self.try_glob_require(arg, ImportKind::Require) {
+                        return glob;
+                    }
+                }
                 let _ = self.check_dynamic_specifier(arg, arg.loc, "require()");
                 self.record_usage_of_runtime_require();
                 self.new_expr(
@@ -8447,6 +8555,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_lazy_export: false,
             redirect_import_record_index: None,
             target: js_ast::Target::Browser,
+            glob_imports: core::mem::replace(&mut self.glob_imports, bun_alloc::AstAlloc::vec()),
         }))
     }
 
@@ -8778,6 +8887,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             jest: Jest::default(),
             import_records_for_current_part: BumpVec::new_in(arena),
             export_star_import_records: BumpVec::new_in(arena),
+            glob_imports: bun_alloc::AstAlloc::vec(),
             import_symbol_property_uses: Default::default(),
             esm_import_keyword: bun_ast::Range::NONE,
             esm_export_keyword: bun_ast::Range::NONE,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2033,7 +2033,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         *e = p.transpose_known_to_be_if_require(first, &state);
                         return;
                     }
-                    _ => {}
+                    _ => {
+                        if !p.is_control_flow_dead {
+                            if let Some(glob) =
+                                p.try_glob_require(first, bun_ast::ImportKind::Require)
+                            {
+                                *e = glob;
+                                return;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2036,7 +2036,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     _ => {
                         if !p.is_control_flow_dead {
                             if let Some(glob) =
-                                p.try_glob_require(first, bun_ast::ImportKind::Require)
+                                p.try_glob_require(first)
                             {
                                 *e = glob;
                                 return;

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2035,9 +2035,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     _ => {
                         if !p.is_control_flow_dead {
-                            if let Some(glob) =
-                                p.try_glob_require(first)
-                            {
+                            if let Some(glob) = p.try_glob_require(first) {
                                 *e = glob;
                                 return;
                             }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2704,19 +2704,12 @@ pub mod __gated_printer {
             }
         }
 
-        fn print_glob_require(
-            &mut self,
-            import_record_index: u32,
-            kind: ImportKind,
-            level: Level,
-        ) {
-            let Some((arg, is_require, entries)) =
-                self.options.glob_imports.and_then(|list| {
-                    list.iter()
-                        .find(|g| g.import_record_index == import_record_index)
-                        .map(|g| (g.arg, g.is_require, g.entries.as_slice()))
-                })
-            else {
+        fn print_glob_require(&mut self, import_record_index: u32, kind: ImportKind, level: Level) {
+            let Some((arg, is_require, entries)) = self.options.glob_imports.and_then(|list| {
+                list.iter()
+                    .find(|g| g.import_record_index == import_record_index)
+                    .map(|g| (g.arg, g.is_require, g.entries.as_slice()))
+            }) else {
                 // No glob data: fall back to a plain map that throws at
                 // runtime. This keeps non-bundling callers safe.
                 self.print_space_before_identifier();

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1062,6 +1062,9 @@ pub struct Options<'a> {
 
     pub require_or_import_meta_for_source_callback: RequireOrImportMetaCallback,
 
+    pub glob_ref: Ref,
+    pub glob_imports: Option<&'a [bun_ast::ast_result::GlobImport]>,
+
     /// The module type of the importing file (after linking), used to determine interop helper behavior.
     /// Controls whether __toESM uses Node ESM semantics (isNodeMode=1 for .esm) or respects __esModule markers.
     pub input_module_type: bundle_opts::ModuleType,
@@ -1132,6 +1135,8 @@ impl<'a> Default for Options<'a> {
             inline_require_and_import_errors: true,
             has_run_symbol_renamer: false,
             require_or_import_meta_for_source_callback: RequireOrImportMetaCallback::default(),
+            glob_ref: Ref::NONE,
+            glob_imports: None,
             input_module_type: bundle_opts::ModuleType::Unknown,
             module_type: bundle_opts::Format::Esm,
             ts_enums: None,
@@ -2432,6 +2437,14 @@ pub mod __gated_printer {
             let record = self.import_record(import_record_index as usize);
             let module_type = self.options.module_type;
 
+            if record.flags.contains(ImportRecordFlags::GLOB_PATTERN) {
+                self.print_glob_require(import_record_index, record.kind, level_);
+                if wrap {
+                    self.print(b")");
+                }
+                return;
+            }
+
             if IS_BUN_PLATFORM {
                 // "bun" is not a real module. It's just globalThis.Bun.
                 //
@@ -2689,6 +2702,96 @@ pub mod __gated_printer {
             if wrap {
                 self.print(b")");
             }
+        }
+
+        fn print_glob_require(
+            &mut self,
+            import_record_index: u32,
+            kind: ImportKind,
+            level: Level,
+        ) {
+            let Some((arg, is_require, entries)) =
+                self.options.glob_imports.and_then(|list| {
+                    list.iter()
+                        .find(|g| g.import_record_index == import_record_index)
+                        .map(|g| (g.arg, g.is_require, g.entries.as_slice()))
+                })
+            else {
+                // No glob data: fall back to a plain map that throws at
+                // runtime. This keeps non-bundling callers safe.
+                self.print_space_before_identifier();
+                self.print_symbol(self.options.glob_ref);
+                self.print(b"({})()");
+                return;
+            };
+
+            let is_dynamic = kind == ImportKind::Dynamic || !is_require;
+            if is_dynamic {
+                self.print_space_before_identifier();
+                self.print(b"Promise.resolve().then(");
+                if !self.options.minify_whitespace {
+                    self.print(b"() => ");
+                } else {
+                    self.print(b"()=>");
+                }
+            }
+
+            self.print_space_before_identifier();
+            self.print_symbol(self.options.glob_ref);
+            self.print(b"({");
+            self.print_newline();
+            self.options.indent.count += 1;
+            let mut first = true;
+            for entry in entries {
+                if !entry.source_index.is_valid() {
+                    continue;
+                }
+                if !first {
+                    self.print(b",");
+                    self.print_newline();
+                }
+                first = false;
+                self.print_indent();
+                self.print_string_literal_utf8(entry.key, false);
+                self.print(b":");
+                self.print_space();
+                if !self.options.minify_whitespace {
+                    self.print(b"() => ");
+                } else {
+                    self.print(b"()=>");
+                }
+                let meta = self
+                    .options
+                    .require_or_import_meta_for_source(entry.source_index.get(), false);
+                if meta.wrapper_ref.is_valid() {
+                    self.print_symbol(meta.wrapper_ref);
+                    self.print(b"()");
+                    if meta.exports_ref.is_valid() {
+                        self.print(b",");
+                        self.print_space();
+                    }
+                }
+                if meta.exports_ref.is_valid() {
+                    self.print_symbol(self.options.to_commonjs_ref);
+                    self.print(b"(");
+                    self.print_symbol(meta.exports_ref);
+                    self.print(b")");
+                } else if !meta.wrapper_ref.is_valid() {
+                    self.print(b"{}");
+                }
+            }
+            self.options.indent.count -= 1;
+            if !first {
+                self.print_newline();
+                self.print_indent();
+            }
+            self.print(b"})(");
+            self.print_expr(arg, Level::Comma, ExprFlag::none());
+            self.print(b")");
+            if is_dynamic {
+                self.print(b")");
+            }
+            let _ = level;
         }
 
         #[inline]

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2438,7 +2438,7 @@ pub mod __gated_printer {
             let module_type = self.options.module_type;
 
             if record.flags.contains(ImportRecordFlags::GLOB_PATTERN) {
-                self.print_glob_require(import_record_index, record.kind, level_);
+                self.print_glob_require(import_record_index);
                 if wrap {
                     self.print(b")");
                 }
@@ -2704,30 +2704,17 @@ pub mod __gated_printer {
             }
         }
 
-        fn print_glob_require(&mut self, import_record_index: u32, kind: ImportKind, level: Level) {
-            let Some((arg, is_require, entries)) = self.options.glob_imports.and_then(|list| {
+        fn print_glob_require(&mut self, import_record_index: u32) {
+            let Some((arg, entries)) = self.options.glob_imports.and_then(|list| {
                 list.iter()
                     .find(|g| g.import_record_index == import_record_index)
-                    .map(|g| (g.arg, g.is_require, g.entries.as_slice()))
+                    .map(|g| (g.arg, g.entries.as_slice()))
             }) else {
-                // No glob data: fall back to a plain map that throws at
-                // runtime. This keeps non-bundling callers safe.
                 self.print_space_before_identifier();
                 self.print_symbol(self.options.glob_ref);
                 self.print(b"({})()");
                 return;
             };
-
-            let is_dynamic = kind == ImportKind::Dynamic || !is_require;
-            if is_dynamic {
-                self.print_space_before_identifier();
-                self.print(b"Promise.resolve().then(");
-                if !self.options.minify_whitespace {
-                    self.print(b"() => ");
-                } else {
-                    self.print(b"()=>");
-                }
-            }
 
             self.print_space_before_identifier();
             self.print_symbol(self.options.glob_ref);
@@ -2756,21 +2743,30 @@ pub mod __gated_printer {
                 let meta = self
                     .options
                     .require_or_import_meta_for_source(entry.source_index.get(), false);
-                if meta.wrapper_ref.is_valid() {
+                let has_wrapper = meta.wrapper_ref.is_valid();
+                let has_exports = meta.exports_ref.is_valid();
+                let wrap_comma = has_wrapper && has_exports;
+                if wrap_comma {
+                    self.print(b"(");
+                }
+                if has_wrapper {
                     self.print_symbol(meta.wrapper_ref);
                     self.print(b"()");
-                    if meta.exports_ref.is_valid() {
+                    if has_exports {
                         self.print(b",");
                         self.print_space();
                     }
                 }
-                if meta.exports_ref.is_valid() {
+                if has_exports {
                     self.print_symbol(self.options.to_commonjs_ref);
                     self.print(b"(");
                     self.print_symbol(meta.exports_ref);
                     self.print(b")");
-                } else if !meta.wrapper_ref.is_valid() {
+                } else if !has_wrapper {
                     self.print(b"{}");
+                }
+                if wrap_comma {
+                    self.print(b")");
                 }
             }
             self.options.indent.count -= 1;
@@ -2781,10 +2777,6 @@ pub mod __gated_printer {
             self.print(b"})(");
             self.print_expr(arg, Level::Comma, ExprFlag::none());
             self.print(b")");
-            if is_dynamic {
-                self.print(b")");
-            }
-            let _ = level;
         }
 
         #[inline]

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2763,7 +2763,7 @@ pub mod __gated_printer {
                     self.print_symbol(meta.exports_ref);
                     self.print(b")");
                 } else if !has_wrapper {
-                    self.print(b"{}");
+                    self.print(b"({})");
                 }
                 if wrap_comma {
                     self.print(b")");

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -111,8 +111,7 @@ export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).ex
 
 // require("./dir/" + x) with the directory scanned at bundle time.
 export var __glob = map => path => {
-  var fn = map[path];
-  if (fn) return fn();
+  if (__hasOwnProp.call(map, path)) return map[path]();
   throw Object.assign(new Error(`Cannot find module '${path}'`), { code: "MODULE_NOT_FOUND" });
 };
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -109,6 +109,15 @@ var __moduleCache;
 // When you do know the module is CJS
 export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
+// require("./dir/" + x) / import("./dir/" + x) where the directory has been
+// scanned at bundle time. `map` keys include both the full path with extension
+// ("./dir/foo.js") and the extensionless form ("./dir/foo").
+export var __glob = map => path => {
+  var fn = map[path];
+  if (fn) return fn();
+  throw Object.assign(new Error(`Cannot find module '${path}'`), { code: "MODULE_NOT_FOUND" });
+};
+
 export var __name = (target, name) => {
   Object.defineProperty(target, "name", {
     value: name,

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -109,9 +109,7 @@ var __moduleCache;
 // When you do know the module is CJS
 export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
-// require("./dir/" + x) / import("./dir/" + x) where the directory has been
-// scanned at bundle time. `map` keys include both the full path with extension
-// ("./dir/foo.js") and the extensionless form ("./dir/foo").
+// require("./dir/" + x) with the directory scanned at bundle time.
 export var __glob = map => path => {
   var fn = map[path];
   if (fn) return fn();

--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -66,11 +66,11 @@ NS.then(({ fn: fn2 }) => {
 "
 `;
 
-exports[`Bun.build BuildArtifact properties: hash 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties: hash 1`] = `"bgsev3fg"`;
 
-exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"7gfnt0h6"`;
+exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"1vbevqqk"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"bgsev3fg"`;
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
 

--- a/test/bundler/bundler_allow_unresolved.test.ts
+++ b/test/bundler/bundler_allow_unresolved.test.ts
@@ -127,12 +127,14 @@ describe("bundler", () => {
     },
   });
 
-  // 10. require() variant
+  // 10. require() variant. A relative prefix with a single wildcard is
+  // bundled as a glob require, so allowUnresolved does not reject it; a
+  // bare-package dynamic specifier is still rejected.
   itBundled("allow-unresolved/RequireVariant", {
     files: {
       "/entry.js": /* js */ `
         const x = "foo";
-        require(\`./a/\${x}.js\`);
+        require(\`pkg/\${x}.js\`);
       `,
     },
     outdir: "/out",

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -617,6 +617,19 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("salut");
     },
   });
+  itBundled("cjs/GlobRequireTopLevelAwaitTarget", {
+    files: {
+      "/entry.js": /* js */ `
+        const name = process.env.NAME;
+        console.log(require("./mods/" + name).value);
+      `,
+      "/mods/a.js": /* js */ `export const value = await Promise.resolve("x");`,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/entry.js": ['This require call is not allowed because the matched file "mods/a.js" contains a top-level await'],
+    },
+  });
   itBundled("cjs/GlobRequireEsmTarget", {
     files: {
       "/app/entry.js": /* js */ `

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -617,6 +617,39 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("salut");
     },
   });
+  itBundled("cjs/GlobRequireEsmTarget", {
+    files: {
+      "/app/entry.js": /* js */ `
+        for (const name of ["a", "b"]) {
+          console.log(require("./mods/" + name).value);
+        }
+      `,
+      "/app/mods/a.js": /* js */ `export const value = "esm-a";`,
+      "/app/mods/b.js": /* js */ `module.exports = { value: "cjs-b" };`,
+    },
+    entryPoints: ["/app/entry.js"],
+    outfile: "/out.js",
+    target: "bun",
+    run: { stdout: "esm-a\ncjs-b" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__toCommonJS");
+    },
+  });
+  itBundled("cjs/GlobRequireUnsupportedShape", {
+    files: {
+      "/entry.js": /* js */ `
+        const lang = "en", i = 0;
+        try { require("./locales/" + lang + "/messages.js"); } catch {}
+        try { require("./pages/" + (i + 1) + ".js"); } catch {}
+        console.log("ok");
+      `,
+    },
+    target: "bun",
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
   itBundled("cjs/GlobRequireMissing", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -577,6 +577,64 @@ describe("bundler", () => {
     },
   });
 
+  // require("./dir/" + x) should bundle every file under ./dir/ and pick the
+  // right one at runtime. This is the pattern shelljs uses to load its
+  // per-command modules (https://github.com/oven-sh/bun/issues/12302).
+  itBundled("cjs/GlobRequireStringConcat", {
+    files: {
+      "/entry.js": /* js */ `
+        var exports = {};
+        for (const name of ["cat", "ls"]) {
+          exports[name] = require("./src/" + name);
+        }
+        console.log(exports.cat(), exports.ls());
+      `,
+      "/src/cat.js": /* js */ `module.exports = () => "cat";`,
+      "/src/ls.js": /* js */ `module.exports = () => "ls";`,
+      "/src/rm.js": /* js */ `module.exports = () => "rm";`,
+    },
+    target: "bun",
+    run: { stdout: "cat ls" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+      api.expectFile("/out.js").toContain("./src/rm.js");
+    },
+  });
+  itBundled("cjs/GlobRequireTemplate", {
+    files: {
+      "/app/entry.js": /* js */ `
+        const pick = name => require(\`./lang/\${name}.json\`);
+        console.log(pick("en").hello, pick("fr").hello);
+      `,
+      "/app/lang/en.json": /* json */ `{ "hello": "hi" }`,
+      "/app/lang/fr.json": /* json */ `{ "hello": "salut" }`,
+    },
+    entryPoints: ["/app/entry.js"],
+    outfile: "/out.js",
+    target: "bun",
+    run: { stdout: "hi salut" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("salut");
+    },
+  });
+  itBundled("cjs/GlobRequireMissing", {
+    files: {
+      "/entry.js": /* js */ `
+        try {
+          require("./src/" + process.env.MISSING);
+        } catch (e) {
+          console.log(e.code, /nope/.test(e.message));
+        }
+      `,
+      "/src/a.js": /* js */ `module.exports = 1;`,
+    },
+    target: "bun",
+    run: { stdout: "MODULE_NOT_FOUND true", env: { MISSING: "nope" } },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+    },
+  });
+
   // Test 28: export * from an external package whose module.exports is null.
   // CJS output emits __reExport(exports, require("ext"), module.exports) with
   // the raw require() result, so __reExport itself must tolerate null.

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -638,9 +638,8 @@ describe("bundler", () => {
   itBundled("cjs/GlobRequireUnsupportedShape", {
     files: {
       "/entry.js": /* js */ `
-        const lang = "en", i = 0;
+        const lang = "en";
         try { require("./locales/" + lang + "/messages.js"); } catch {}
-        try { require("./pages/" + (i + 1) + ".js"); } catch {}
         console.log("ok");
       `,
     },
@@ -648,6 +647,22 @@ describe("bundler", () => {
     run: { stdout: "ok" },
     onAfterBundle(api) {
       api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
+  itBundled("cjs/GlobRequireNestedConcatOperand", {
+    files: {
+      "/app/entry.js": /* js */ `
+        const i = 0;
+        console.log(require("./pages/" + (i + 1) + ".js"));
+      `,
+      "/app/pages/1.js": /* js */ `module.exports = "page-one";`,
+    },
+    entryPoints: ["/app/entry.js"],
+    outfile: "/out.js",
+    target: "bun",
+    run: { stdout: "page-one" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
     },
   });
   itBundled("cjs/GlobRequireMissing", {

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -164,7 +164,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=42062903F19477CF64756E2164756E21
+        //# debugId=7141FE02CB0F22E264756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -410,7 +410,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=BF876FBF618133C264756E2164756E21
+        //# debugId=02B60B4FF92A818164756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -106,11 +106,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-sjg7egv9.js",
+                "path": "./client-m110bjd9.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "efKwB-6QGwk",
+                  "etag": "VOGhIOsSzQk",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -120,7 +120,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "sJJm55rxM4I",
+                  "etag": "-sM_LDk0GTo",
                   "content-type": "text/html;charset=utf-8"
                 }
               },

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -180,7 +180,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=2020261114B67BB564756E2164756E21
+    //# debugId=37EEE4862DD2283364756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
## Problem

`shelljs` loads its per-command modules with a dynamic require:

```js
require('./commands').forEach(function (command) {
  require('./src/' + command);
});
```

When bundled, the argument is not a string literal so the bundler leaves it as a runtime `__require("./src/" + command)` call, and the `./src/*.js` files are never included. Running the bundle then fails with:

```
error: Cannot find module './src/cat' from '/.../out/a.js'
```

Fixes #12302.
Fixes #6004.

## Fix

When `require()` is called with a string concatenation or template literal whose prefix names a relative subdirectory (for example `require("./src/" + name)` or `` require(`./lang/${name}.json`) ``), the bundler now:

1. Scans that directory at build time for JS/TS/JSON files matching the pattern
2. Bundles each match as a CommonJS/ESM-wrapped module
3. Replaces the call with `__glob({"./src/cat.js": () => require_cat(), "./src/cat": () => require_cat(), ...})("./src/" + name)`

Keys are stored both with and without their extension, so the shelljs lookup of `"./src/cat"` hits the entry bundled as `"./src/cat.js"`. esbuild only stores the extension-ful key, which is why its glob-require still fails for shelljs; webpack stores both, which is why it works there.

### Scope

Only `require()` with a single wildcard that names a relative subdirectory is handled:

- `require("./dir/" + x)` and `` require(`./dir/${x}.json`) `` are bundled.
- `require("./" + x)` (current directory) and `require("pkg/" + x)` (bare package) are left as runtime calls.
- `require("./locales/" + lang + "/messages.js")` (wildcard followed by another path segment) is left as a runtime call.
- Dynamic `import()` is not handled in this PR.

## Verification

Before:
```
$ bun build a.js --target=bun --outfile out/a.js && bun out/a.js
Bundled 20 modules
error: Cannot find module './src/cat'
```

After:
```
$ bun-debug build a.js --target=bun --outfile out/a.js && bun-debug out/a.js
Bundled 50 modules
cat: function
ls: function
files: 5
```

New tests in `test/bundler/bundler_cjs.test.ts` cover the string-concat form, the template-literal form with a suffix, ESM-wrapped targets, nested concat operands, the MODULE_NOT_FOUND path for a miss, and the fall-through for unsupported shapes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 19 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_allow_unresolved.test.ts test/bundler/bundler_cjs.test.ts test/bundler/bundler_promiseall_deadcode.test.ts test/bundler/html-import-manifest.test.ts test/regression/issue/cyclic-imports-async-bundler.test.js
bun test v1.4.0 (79269fca1)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1358.39ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [612.53ms]
(pass) bundler > cjs/__toESM_import_syntax_function [632.06ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [590.74ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [633.77ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [685.88ms]
(pass) bundler > cjs/__toESM_target_node [736.63ms]
(pass) bundler > cjs/__toESM_target_browser [703.33ms]
(pass) bundler > cjs/__toESM_target_bun [1036.04ms]
(pass) bundler > cjs/__toESM_format_esm [753.17ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [743.48ms]
(pass) bundler > cjs/__toESM_mjs_reexport [601.36ms]
(pass) bundler > cjs/__toESM_m
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (86c4ad084)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [42.99ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [22.32ms]
(pass) bundler > cjs/__toESM_import_syntax_function [61.79ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [23.96ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [48.78ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [23.56ms]
(pass) bundler > cjs/__toESM_target_node [28.87ms]
(pass) bundler > cjs/__toESM_target_browser [22.06ms]
(pass) bundler > cjs/__toESM_target_bun [17.87ms]
(pass) bundler > cjs/__toESM_format_esm [17.53ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [16.74ms]
(pass) bundler > cjs/__toESM_mjs_reexport [23.89ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [35.59ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [26.65ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [22.48ms]
(pass) bundler > cjs/__toESM_default_prop_no_esModule [27.12ms]
(pass) bundler > cjs/__toESM_mixed_import_styles [25.99ms]
(pass) bundler > cjs/__toESM_esModule_non_true [21.62ms]
(pass) bundler > cjs/__toESM_esM
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_allow_unresolved.test.ts test/bundler/bundler_cjs.test.ts test/bundler/bundler_promiseall_deadcode.test.ts test/bundler/html-import-manifest.test.ts test/regression/issue/cyclic-imports-async-bundler.test.js
bun test v1.4.0 (79269fca1)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1220.76ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [635.02ms]
(pass) bundler > cjs/__toESM_import_syntax_function [575.75ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [566.13ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [574.83ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [584.60ms]
(pass) bundler > cjs/__toESM_target_node [586.68ms]
(pass) bundler > cjs/__toESM_target_browser [611.87ms]
(pass) bundler > cjs/__toESM_target_bun [564.97ms]
(pass) bundler > cjs/__toESM_format_esm [1218.09ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [577.99ms]
(pass) bundler > cjs/__toESM_mjs_reexport [610.22ms]
(pass) bundler > cjs/__toESM_m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1414ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/99] gen bindgenv2
[2/98] gen ErrorCode+*.h
[3/52] gen cpp.rs (cppbind)
[4/52] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/52] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/ast_result.rs                              |  19 ++
 src/ast/import_record.rs                           |   3 +
 src/ast/runtime.rs                                 |  46 ++--
 src/bundler/AstBuilder.rs                          |   1 +
 src/bundler/LinkerContext.rs                       | 126 ++++++++++-
 src/bundler/bundle_v2.rs                           | 242 ++++++++++++++++++++-
 src/bundler/bundled_ast.rs                         |   5 +
 src/bundler/linker_context/MetafileBuilder.rs      |   6 +-
 .../linker_context/scanImportsAndExports.rs        |  66 ++++++
 src/js_parser/p.rs                                 | 150 +++++++++++--
 src/js_parser/visit/visit_expr.rs                  |   9 +-
 src/js_printer/lib.rs                              |  88 ++++++++
 src/runtime.js                                     |   6 +
 .../__snapshots__/bun-build-api.test.ts.snap       |   6 +-
 test/bundler/bundler_allow_unresolved.test.ts      |   6 +-
 test/bundler/bundler_cjs.test.ts                   | 119 ++++++++++
 test/bundler/bundler_promiseall_deadcode.test.ts   |   4 +-
 test/bundler/html-import-manifest.test.ts          |   6 +-
 .../issue/cyclic-imports-async-bundler.test.js     |   2 +-
 19 files changed, 852 insertions(+), 58 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/ast/ast_result.rs                                      3      8      0
src/ast/import_record.rs                                   2      3      0
src/ast/runtime.rs                                         1      6      0
src/bundler/AstBuilder.rs                                  1      1      0
src/bundler/LinkerContext.rs                              12     23      0
src/bundler/bundle_v2.rs                                  24     30      0
src/bundler/bundled_ast.rs                                 2      5      0
src/bundler/linker_context/MetafileBuilder.rs              1      1      0
src/bundler/linker_context/scanImportsAndExports.rs        4      6      0
src/js_parser/p.rs                                        11     23      0
src/js_parser/visit/visit_expr.rs                          2      2      0
src/js_printer/lib.rs                                      6     12      0
src/runtime.js                                             3      4      0
test/bundler/__snapshots__/bun-build-api.test.ts.snap      0      0      0
test/bundler/bundler_allow_unresolved.test.ts              1      1      0
test/bundler/bundler_cjs.test.ts                           6     15      0
(+ 3 more files)
```

</details>

<!-- robobun:evidence:end -->