### PR TITLE
install: install devDependencies before running `prepare` for git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,7 @@ dependencies = [
  "bun_resolver",
  "bun_semver",
  "bun_sha_hmac",
+ "bun_shell_parser",
  "bun_simdutf_sys",
  "bun_spawn",
  "bun_sys",

--- a/src/install/Cargo.toml
+++ b/src/install/Cargo.toml
@@ -62,6 +62,7 @@ bun_ptr.workspace = true
 bun_resolver.workspace = true
 bun_semver.workspace = true
 bun_sha_hmac.workspace = true
+bun_shell_parser.workspace = true
 bun_simdutf_sys.workspace = true
 bun_spawn.workspace = true
 bun_sys.workspace = true

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -228,8 +228,7 @@ impl Scripts {
                             if first_script_index == -1
                                 || first_script_index > i8::try_from(PREPREPARE).expect("int cast")
                             {
-                                first_script_index =
-                                    i8::try_from(PREPREPARE).expect("int cast");
+                                first_script_index = i8::try_from(PREPREPARE).expect("int cast");
                             }
                             install_cmd
                         }

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -31,7 +31,7 @@ fn git_dep_dev_install_command() -> Option<Box<[u8]>> {
         bun_exe.as_bytes(),
         &mut cmd,
     ));
-    cmd.extend_from_slice(b" install --ignore-scripts --no-summary --no-progress");
+    cmd.extend_from_slice(b" install --ignore-scripts --no-save --no-summary --no-progress");
     if !registry.is_empty() {
         cmd.extend_from_slice(b" --registry ");
         bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
@@ -216,7 +216,7 @@ impl Scripts {
                             chained.extend_from_slice(&install_cmd);
                             chained.extend_from_slice(b" && ( ");
                             chained.extend_from_slice(&user_preprepare);
-                            chained.extend_from_slice(b" )");
+                            chained.extend_from_slice(b"\n)");
                             chained.into_boxed_slice()
                         }
                         None => {

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -212,11 +212,11 @@ impl Scripts {
                     scripts[PREPREPARE] = Some(match scripts[PREPREPARE].take() {
                         Some(user_preprepare) => {
                             let mut chained =
-                                Vec::with_capacity(install_cmd.len() + 10 + user_preprepare.len());
+                                Vec::with_capacity(install_cmd.len() + 8 + user_preprepare.len());
                             chained.extend_from_slice(&install_cmd);
-                            chained.extend_from_slice(b" && { ");
+                            chained.extend_from_slice(b" && ( ");
                             chained.extend_from_slice(&user_preprepare);
-                            chained.extend_from_slice(b" ; }");
+                            chained.extend_from_slice(b" )");
                             chained.into_boxed_slice()
                         }
                         None => {

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -21,11 +21,16 @@ const SCRIPT_NAMES_LEN: usize = LockfileScripts::NAMES.len();
 
 fn git_dep_dev_install_command() -> Option<Box<[u8]>> {
     let bun_exe = bun_core::self_exe_path().ok()?;
-    let registry = crate::package_manager_real::PackageManager::get()
+    let scope_url = &crate::package_manager_real::PackageManager::get()
         .options
         .scope
-        .url
-        .href();
+        .url;
+    let url = scope_url.url();
+    let registry: Box<[u8]> = if url.username.is_empty() && url.password.is_empty() {
+        Box::from(scope_url.href())
+    } else {
+        url.href_without_auth()
+    };
     let mut cmd: Vec<u8> = Vec::with_capacity(bun_exe.len() + registry.len() + 64);
     bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
         bun_exe.as_bytes(),
@@ -35,7 +40,7 @@ fn git_dep_dev_install_command() -> Option<Box<[u8]>> {
     if !registry.is_empty() {
         cmd.extend_from_slice(b" --registry ");
         bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
-            registry, &mut cmd,
+            &registry, &mut cmd,
         ));
     }
     Some(cmd.into_boxed_slice())

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -19,18 +19,31 @@ bun_output::declare_scope!(Lockfile, hidden);
 
 const SCRIPT_NAMES_LEN: usize = LockfileScripts::NAMES.len();
 
+fn registry_href_without_userinfo(href: &[u8]) -> Box<[u8]> {
+    if let Some(scheme_end) = strings::index_of(href, b"://") {
+        let auth_start = scheme_end + 3;
+        let path_start = strings::index_of_char(&href[auth_start..], b'/')
+            .map(|i| auth_start + i as usize)
+            .unwrap_or(href.len());
+        if let Some(at) = strings::index_of_char(&href[auth_start..path_start], b'@') {
+            let host_start = auth_start + at as usize + 1;
+            let mut out = Vec::with_capacity(href.len() - (host_start - auth_start));
+            out.extend_from_slice(&href[..auth_start]);
+            out.extend_from_slice(&href[host_start..]);
+            return out.into_boxed_slice();
+        }
+    }
+    Box::from(href)
+}
+
 fn git_dep_dev_install_command() -> Option<Box<[u8]>> {
     let bun_exe = bun_core::self_exe_path().ok()?;
-    let scope_url = &crate::package_manager_real::PackageManager::get()
+    let href = crate::package_manager_real::PackageManager::get()
         .options
         .scope
-        .url;
-    let url = scope_url.url();
-    let registry: Box<[u8]> = if url.username.is_empty() && url.password.is_empty() {
-        Box::from(scope_url.href())
-    } else {
-        url.href_without_auth()
-    };
+        .url
+        .href();
+    let registry = registry_href_without_userinfo(href);
     let mut cmd: Vec<u8> = Vec::with_capacity(bun_exe.len() + registry.len() + 64);
     bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
         bun_exe.as_bytes(),

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -19,9 +19,6 @@ bun_output::declare_scope!(Lockfile, hidden);
 
 const SCRIPT_NAMES_LEN: usize = LockfileScripts::NAMES.len();
 
-/// Build the shell command that installs a git dependency's own
-/// `dependencies`/`devDependencies` into its `node_modules/` before the
-/// package's prepare scripts run. `None` only when `self_exe_path` fails.
 fn git_dep_dev_install_command() -> Option<Box<[u8]>> {
     let bun_exe = bun_core::self_exe_path().ok()?;
     let registry = crate::package_manager_real::PackageManager::get()
@@ -30,13 +27,16 @@ fn git_dep_dev_install_command() -> Option<Box<[u8]>> {
         .url
         .href();
     let mut cmd: Vec<u8> = Vec::with_capacity(bun_exe.len() + registry.len() + 64);
-    cmd.push(b'"');
-    cmd.extend_from_slice(bun_exe.as_bytes());
-    cmd.extend_from_slice(b"\" install --ignore-scripts --no-summary --no-progress");
+    bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
+        bun_exe.as_bytes(),
+        &mut cmd,
+    ));
+    cmd.extend_from_slice(b" install --ignore-scripts --no-summary --no-progress");
     if !registry.is_empty() {
-        cmd.extend_from_slice(b" --registry \"");
-        cmd.extend_from_slice(registry);
-        cmd.push(b'"');
+        cmd.extend_from_slice(b" --registry ");
+        bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
+            registry, &mut cmd,
+        ));
     }
     Some(cmd.into_boxed_slice())
 }
@@ -186,12 +186,8 @@ impl Scripts {
             ResolutionTag::Git | ResolutionTag::Github | ResolutionTag::Root => {
                 let prepare_scripts = [&self.preprepare, &self.prepare, &self.postprepare];
 
-                // npm installs a git dependency by cloning it, running a full
-                // `npm install` (dependencies + devDependencies), running
-                // `prepare`, then packing the result. Run a nested install
-                // first so `prepare` can find the package's own devDependencies
-                // without adding them to the consumer's lockfile
-                // (oven-sh/bun#10297, #6138).
+                // npm installs a git dep's devDependencies before `prepare`; do the
+                // same via a nested install so they are resolvable (#10297, #6138).
                 let install_deps = if resolution_tag != ResolutionTag::Root
                     && prepare_scripts.iter().any(|s| !s.is_empty())
                 {

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -19,6 +19,28 @@ bun_output::declare_scope!(Lockfile, hidden);
 
 const SCRIPT_NAMES_LEN: usize = LockfileScripts::NAMES.len();
 
+/// Build the shell command that installs a git dependency's own
+/// `dependencies`/`devDependencies` into its `node_modules/` before the
+/// package's prepare scripts run. `None` only when `self_exe_path` fails.
+fn git_dep_dev_install_command() -> Option<Box<[u8]>> {
+    let bun_exe = bun_core::self_exe_path().ok()?;
+    let registry = crate::package_manager_real::PackageManager::get()
+        .options
+        .scope
+        .url
+        .href();
+    let mut cmd: Vec<u8> = Vec::with_capacity(bun_exe.len() + registry.len() + 64);
+    cmd.push(b'"');
+    cmd.extend_from_slice(bun_exe.as_bytes());
+    cmd.extend_from_slice(b"\" install --ignore-scripts --no-summary --no-progress");
+    if !registry.is_empty() {
+        cmd.extend_from_slice(b" --registry \"");
+        cmd.extend_from_slice(registry);
+        cmd.push(b'"');
+    }
+    Some(cmd.into_boxed_slice())
+}
+
 #[repr(C)]
 #[derive(Default, Clone, Copy)]
 pub struct Scripts {
@@ -164,6 +186,20 @@ impl Scripts {
             ResolutionTag::Git | ResolutionTag::Github | ResolutionTag::Root => {
                 let prepare_scripts = [&self.preprepare, &self.prepare, &self.postprepare];
 
+                // npm installs a git dependency by cloning it, running a full
+                // `npm install` (dependencies + devDependencies), running
+                // `prepare`, then packing the result. Run a nested install
+                // first so `prepare` can find the package's own devDependencies
+                // without adding them to the consumer's lockfile
+                // (oven-sh/bun#10297, #6138).
+                let install_deps = if resolution_tag != ResolutionTag::Root
+                    && prepare_scripts.iter().any(|s| !s.is_empty())
+                {
+                    git_dep_dev_install_command()
+                } else {
+                    None
+                };
+
                 for script in prepare_scripts {
                     if !script.is_empty() {
                         if first_script_index == -1 {
@@ -174,6 +210,30 @@ impl Scripts {
                         counter += 1;
                     }
                     script_index += 1;
+                }
+
+                if let Some(install_cmd) = install_deps {
+                    const PREPREPARE: usize = 3;
+                    scripts[PREPREPARE] = Some(match scripts[PREPREPARE].take() {
+                        Some(user_preprepare) => {
+                            let mut chained =
+                                Vec::with_capacity(install_cmd.len() + 4 + user_preprepare.len());
+                            chained.extend_from_slice(&install_cmd);
+                            chained.extend_from_slice(b" && ");
+                            chained.extend_from_slice(&user_preprepare);
+                            chained.into_boxed_slice()
+                        }
+                        None => {
+                            counter += 1;
+                            if first_script_index == -1
+                                || first_script_index > i8::try_from(PREPREPARE).expect("int cast")
+                            {
+                                first_script_index =
+                                    i8::try_from(PREPREPARE).expect("int cast");
+                            }
+                            install_cmd
+                        }
+                    });
                 }
             }
             ResolutionTag::Workspace => {

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -186,8 +186,7 @@ impl Scripts {
             ResolutionTag::Git | ResolutionTag::Github | ResolutionTag::Root => {
                 let prepare_scripts = [&self.preprepare, &self.prepare, &self.postprepare];
 
-                // npm installs a git dep's devDependencies before `prepare`; do the
-                // same via a nested install so they are resolvable (#10297, #6138).
+                // Match npm: make a git dep's devDependencies available to `prepare` (#10297).
                 let install_deps = if resolution_tag != ResolutionTag::Root
                     && prepare_scripts.iter().any(|s| !s.is_empty())
                 {
@@ -213,10 +212,11 @@ impl Scripts {
                     scripts[PREPREPARE] = Some(match scripts[PREPREPARE].take() {
                         Some(user_preprepare) => {
                             let mut chained =
-                                Vec::with_capacity(install_cmd.len() + 4 + user_preprepare.len());
+                                Vec::with_capacity(install_cmd.len() + 10 + user_preprepare.len());
                             chained.extend_from_slice(&install_cmd);
-                            chained.extend_from_slice(b" && ");
+                            chained.extend_from_slice(b" && { ");
                             chained.extend_from_slice(&user_preprepare);
+                            chained.extend_from_slice(b" ; }");
                             chained.into_boxed_slice()
                         }
                         None => {

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -40,23 +40,21 @@ fn registry_href_without_userinfo(href: &[u8]) -> Box<[u8]> {
 
 fn git_dep_dev_install_command() -> Option<Box<[u8]>> {
     let bun_exe = bun_core::self_exe_path().ok()?;
-    let href = crate::package_manager_real::PackageManager::get()
-        .options
-        .scope
-        .url
-        .href();
-    let registry = registry_href_without_userinfo(href);
-    let mut cmd: Vec<u8> = Vec::with_capacity(bun_exe.len() + registry.len() + 64);
+    let options = &crate::package_manager_real::PackageManager::get().options;
+    let mut cmd: Vec<u8> = Vec::with_capacity(bun_exe.len() + 128);
     bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
         bun_exe.as_bytes(),
         &mut cmd,
     ));
     cmd.extend_from_slice(b" install --ignore-scripts --no-save --no-summary --no-progress");
-    if !registry.is_empty() {
-        cmd.extend_from_slice(b" --registry ");
-        bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
-            &registry, &mut cmd,
-        ));
+    if options.did_override_default_scope {
+        let registry = registry_href_without_userinfo(options.scope.url.href());
+        if !registry.is_empty() {
+            cmd.extend_from_slice(b" --registry ");
+            bun_core::handle_oom(bun_shell_parser::escape_8bit::<true, false>(
+                &registry, &mut cmd,
+            ));
+        }
     }
     Some(cmd.into_boxed_slice())
 }

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -572,7 +572,10 @@ mod tests {
         assert_eq!(&*strip(b"https://user:pass@host/"), b"https://host/");
         assert_eq!(&*strip(b"http://TOKEN@host:4873/"), b"http://host:4873/");
         assert_eq!(&*strip(b"https://user:p@ss@host/"), b"https://host/");
-        assert_eq!(&*strip(b"https://host?m=@backup"), b"https://host?m=@backup");
+        assert_eq!(
+            &*strip(b"https://host?m=@backup"),
+            b"https://host?m=@backup"
+        );
         assert_eq!(&*strip(b"https://host#@frag"), b"https://host#@frag");
         assert_eq!(&*strip(b"host:4873/"), b"host:4873/");
         assert_eq!(&*strip(b""), b"");

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -20,14 +20,14 @@ bun_output::declare_scope!(Lockfile, hidden);
 const SCRIPT_NAMES_LEN: usize = LockfileScripts::NAMES.len();
 
 fn registry_href_without_userinfo(href: &[u8]) -> Box<[u8]> {
-    if let Some(scheme_end) = strings::index_of(href, b"://") {
+    if let Some(scheme_end) = href.windows(3).position(|w| w == b"://") {
         let auth_start = scheme_end + 3;
         let auth_end = href[auth_start..]
             .iter()
             .position(|&b| b == b'/' || b == b'?' || b == b'#')
             .map(|i| auth_start + i)
             .unwrap_or(href.len());
-        if let Some(at) = strings::last_index_of_char(&href[auth_start..auth_end], b'@') {
+        if let Some(at) = href[auth_start..auth_end].iter().rposition(|&b| b == b'@') {
             let host_start = auth_start + at + 1;
             let mut out = Vec::with_capacity(href.len() - (host_start - auth_start));
             out.extend_from_slice(&href[..auth_start]);
@@ -559,5 +559,22 @@ impl List {
                     .push(script.to_vec().into_boxed_slice());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::registry_href_without_userinfo as strip;
+
+    #[test]
+    fn strips_userinfo() {
+        assert_eq!(&*strip(b"http://host:4873/"), b"http://host:4873/");
+        assert_eq!(&*strip(b"https://user:pass@host/"), b"https://host/");
+        assert_eq!(&*strip(b"http://TOKEN@host:4873/"), b"http://host:4873/");
+        assert_eq!(&*strip(b"https://user:p@ss@host/"), b"https://host/");
+        assert_eq!(&*strip(b"https://host?m=@backup"), b"https://host?m=@backup");
+        assert_eq!(&*strip(b"https://host#@frag"), b"https://host#@frag");
+        assert_eq!(&*strip(b"host:4873/"), b"host:4873/");
+        assert_eq!(&*strip(b""), b"");
     }
 }

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -27,8 +27,8 @@ fn registry_href_without_userinfo(href: &[u8]) -> Box<[u8]> {
             .position(|&b| b == b'/' || b == b'?' || b == b'#')
             .map(|i| auth_start + i)
             .unwrap_or(href.len());
-        if let Some(at) = strings::index_of_char(&href[auth_start..auth_end], b'@') {
-            let host_start = auth_start + at as usize + 1;
+        if let Some(at) = strings::last_index_of_char(&href[auth_start..auth_end], b'@') {
+            let host_start = auth_start + at + 1;
             let mut out = Vec::with_capacity(href.len() - (host_start - auth_start));
             out.extend_from_slice(&href[..auth_start]);
             out.extend_from_slice(&href[host_start..]);

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -22,10 +22,12 @@ const SCRIPT_NAMES_LEN: usize = LockfileScripts::NAMES.len();
 fn registry_href_without_userinfo(href: &[u8]) -> Box<[u8]> {
     if let Some(scheme_end) = strings::index_of(href, b"://") {
         let auth_start = scheme_end + 3;
-        let path_start = strings::index_of_char(&href[auth_start..], b'/')
-            .map(|i| auth_start + i as usize)
+        let auth_end = href[auth_start..]
+            .iter()
+            .position(|&b| b == b'/' || b == b'?' || b == b'#')
+            .map(|i| auth_start + i)
             .unwrap_or(href.len());
-        if let Some(at) = strings::index_of_char(&href[auth_start..path_start], b'@') {
+        if let Some(at) = strings::index_of_char(&href[auth_start..auth_end], b'@') {
             let host_start = auth_start + at as usize + 1;
             let mut out = Vec::with_capacity(href.len() - (host_start - auth_start));
             out.extend_from_slice(&href[..auth_start]);

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -624,7 +624,7 @@ impl RepositoryExt for Repository {
         // it is only valid until the next use of `TlBufs::final_path_buf()` on this
         // thread (another `try_https` call, or `checkout`'s `get_fd_path`).
         let final_path_buf = TlBufs::final_path_buf();
-        if url.starts_with(b"http") {
+        if url.starts_with(b"http") || url.starts_with(b"file:") {
             return Some(url);
         }
 

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1885,6 +1885,82 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(await exists(join(packageDir, "node_modules", "lifecycle-install-test", "postinstall.txt"))).toBeTrue();
     });
 
+    // https://github.com/oven-sh/bun/issues/10297
+    // https://github.com/oven-sh/bun/issues/6138
+    test("git dependency devDependencies are installed before `prepare` runs", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      // A local git repo that needs a devDependency (`what-bin`, served by the
+      // verdaccio registry) for its `prepare` script. npm clones a git
+      // dependency, runs a full install including devDependencies, runs
+      // `prepare`, then installs the packaged result.
+      const repoDir = join(packageDir, "repo");
+      await mkdir(repoDir, { recursive: true });
+      await writeFile(
+        join(repoDir, "package.json"),
+        JSON.stringify({
+          name: "git-dep-needs-dev",
+          version: "1.0.0",
+          devDependencies: { "what-bin": "1.0.0" },
+          scripts: { prepare: "what-bin" },
+        }),
+      );
+
+      const gitEnv = {
+        ...baseEnv,
+        GIT_AUTHOR_NAME: "bun",
+        GIT_AUTHOR_EMAIL: "bun@example.com",
+        GIT_COMMITTER_NAME: "bun",
+        GIT_COMMITTER_EMAIL: "bun@example.com",
+        GIT_CONFIG_NOSYSTEM: "1",
+      };
+      for (const args of [["init", "-b", "main"], ["add", "."], ["commit", "-m", "init"]]) {
+        const r = Bun.spawnSync({ cmd: ["git", ...args], cwd: repoDir, env: gitEnv, stdout: "ignore", stderr: "pipe" });
+        if (r.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+      }
+
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "consumer",
+          version: "1.0.0",
+          dependencies: {
+            "git-dep-needs-dev": `git+file://${repoDir.replaceAll("\\", "/")}#main`,
+          },
+          trustedDependencies: ["git-dep-needs-dev"],
+        }),
+      );
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: testEnv,
+      });
+
+      const err = stderrForInstall(await stderr.text());
+      const out = await stdout.text();
+      const depDir = join(packageDir, "node_modules", "git-dep-needs-dev");
+
+      expect(err).not.toContain("what-bin: command not found");
+      expect(err).not.toContain("what-bin: not found");
+      expect(err).not.toContain("error:");
+      expect(out).toContain("+ git-dep-needs-dev@git+file://");
+      expect(await exited).toBe(0);
+
+      // `prepare` ran and found the `what-bin` devDependency.
+      expect(await file(join(depDir, "what-bin.txt")).text()).toBe("what-bin@1.0.0");
+
+      // npm does not add the git dependency's devDependencies to the outer
+      // lockfile or hoist them into the outer node_modules.
+      expect(await exists(join(packageDir, "node_modules", "what-bin"))).toBeFalse();
+      expect(await file(join(packageDir, "bun.lock")).text()).not.toContain("what-bin");
+    });
+
     test("root lifecycle scripts should wait for dependency lifecycle scripts", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1913,6 +1913,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         }),
       );
 
+      const emptyGitConfig = join(packageDir, "empty.gitconfig");
+      await writeFile(emptyGitConfig, "");
       const gitEnv = {
         ...baseEnv,
         GIT_AUTHOR_NAME: "bun",
@@ -1920,6 +1922,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         GIT_COMMITTER_NAME: "bun",
         GIT_COMMITTER_EMAIL: "bun@example.com",
         GIT_CONFIG_NOSYSTEM: "1",
+        GIT_CONFIG_GLOBAL: emptyGitConfig,
       };
       for (const args of [
         ["init", "-b", "main"],

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1963,6 +1963,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       // lockfile or hoist them into the outer node_modules.
       expect(await exists(join(packageDir, "node_modules", "what-bin"))).toBeFalse();
       expect(await file(join(packageDir, "bun.lock")).text()).not.toContain("what-bin");
+      // The nested install runs with --no-save.
+      expect(await exists(join(depDir, "bun.lock"))).toBeFalse();
     });
 
     test("root lifecycle scripts should wait for dependency lifecycle scripts", async () => {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1904,7 +1904,12 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           name: "git-dep-needs-dev",
           version: "1.0.0",
           devDependencies: { "what-bin": "1.0.0" },
-          scripts: { prepare: "what-bin" },
+          scripts: {
+            // Exercise the chained-preprepare path (`<install> && ( <user>\n)`),
+            // including a trailing shell comment that must not swallow the `)`.
+            preprepare: "what-bin && echo preprepare-ran > preprepare.txt # done",
+            prepare: "what-bin",
+          },
         }),
       );
 
@@ -1946,17 +1951,19 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         env: testEnv,
       });
 
-      const err = stderrForInstall(await stderr.text());
-      const out = await stdout.text();
+      const [rawErr, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+      const err = stderrForInstall(rawErr);
       const depDir = join(packageDir, "node_modules", "git-dep-needs-dev");
 
       expect(err).not.toContain("what-bin: command not found");
       expect(err).not.toContain("what-bin: not found");
       expect(err).not.toContain("error:");
       expect(out).toContain("+ git-dep-needs-dev@git+file://");
-      expect(await exited).toBe(0);
+      expect(exitCode).toBe(0);
 
-      // `prepare` ran and found the `what-bin` devDependency.
+      // Both the user-declared `preprepare` and `prepare` ran and found the
+      // `what-bin` devDependency.
+      expect((await file(join(depDir, "preprepare.txt")).text()).trim()).toBe("preprepare-ran");
       expect(await file(join(depDir, "what-bin.txt")).text()).toBe("what-bin@1.0.0");
 
       // npm does not add the git dependency's devDependencies to the outer

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1916,7 +1916,11 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         GIT_COMMITTER_EMAIL: "bun@example.com",
         GIT_CONFIG_NOSYSTEM: "1",
       };
-      for (const args of [["init", "-b", "main"], ["add", "."], ["commit", "-m", "init"]]) {
+      for (const args of [
+        ["init", "-b", "main"],
+        ["add", "."],
+        ["commit", "-m", "init"],
+      ]) {
         const r = Bun.spawnSync({ cmd: ["git", ...args], cwd: repoDir, env: gitEnv, stdout: "ignore", stderr: "pipe" });
         if (r.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
       }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1907,7 +1907,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           scripts: {
             // Exercise the chained-preprepare path (`<install> && ( <user>\n)`),
             // including a trailing shell comment that must not swallow the `)`.
-            preprepare: "what-bin && echo preprepare-ran > preprepare.txt # done",
+            preprepare: "echo preprepare-ran > preprepare.txt # done",
             prepare: "what-bin",
           },
         }),
@@ -1961,8 +1961,9 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(out).toContain("+ git-dep-needs-dev@git+file://");
       expect(exitCode).toBe(0);
 
-      // Both the user-declared `preprepare` and `prepare` ran and found the
-      // `what-bin` devDependency.
+      // The user-declared `preprepare` ran (after the injected nested install,
+      // which is chained with `&&`), and `prepare` ran and found the `what-bin`
+      // devDependency.
       expect((await file(join(depDir, "preprepare.txt")).text()).trim()).toBe("preprepare-ran");
       expect(await file(join(depDir, "what-bin.txt")).text()).toBe("what-bin@1.0.0");
 

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1931,7 +1931,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           name: "consumer",
           version: "1.0.0",
           dependencies: {
-            "git-dep-needs-dev": `git+file://${repoDir.replaceAll("\\", "/")}#main`,
+            "git-dep-needs-dev": `git+${Bun.pathToFileURL(repoDir).href}#main`,
           },
           trustedDependencies: ["git-dep-needs-dev"],
         }),


### PR DESCRIPTION
## What does this PR do?

When a git dependency has a `prepare` script, npm handles it by cloning the package, running a full `npm install` (dependencies **and** devDependencies), running `prepare`, and then packing and installing the result. Bun was running `prepare` in `node_modules/<pkg>` without making the package's devDependencies available, so build tools declared as devDependencies (`tsup`, `typescript`, `peggy`, ...) were not resolvable when the script ran:

```
bun add v1.1.0 (5903a614)
  ⚙️  @elysiajs/eden [1/1] $ rimraf dist && tsup
Error: Cannot find module 'typescript'
...
error: prepare script from "@elysiajs/eden" exited with 1
```

### Fix

For `git`/`github` dependencies that declare a `preprepare`/`prepare`/`postprepare` script, a nested `bun install --ignore-scripts` is injected into the `preprepare` step. The nested install runs in `node_modules/<pkg>`, so the package's own `dependencies` and `devDependencies` (and their `.bin` entries) are resolvable when the prepare scripts execute.

* Nothing is added to the consumer's lockfile or hoisted into the outer `node_modules` (matching npm and pnpm).
* The step stays gated on `trustedDependencies`: if the git dependency is not trusted, none of its lifecycle scripts run and no nested install happens.
* The outer install's default registry is forwarded via `--registry` so private registries configured via `bunfig.toml` keep working for the nested install.

### Also fixed

`git+file://` dependencies are now cloned. The protocol was already recognised by the dependency parser, but the clone handler only passed `http(s)`/`ssh` URLs to `git clone`, so `git+file://` went through neither path and resolution failed with `no commit matching "..." found (but repository exists)`. This change was needed to write an offline regression test for the main fix.

Fixes #10297
Fixes #6138
Fixes #16548

## How did you verify your code works?

New test in `test/cli/install/bun-install-lifecycle-scripts.test.ts`:

* creates a local git repository whose `prepare` script invokes a binary (`what-bin`) that is only declared in `devDependencies` (served from the local verdaccio registry),
* installs it via `git+file://` with the package trusted,
* asserts the `prepare` script succeeded and produced its output file,
* asserts the devDependency is not present in the outer `node_modules` or `bun.lock`.

The existing `git dependencies also run preprepare, prepare, and postprepare scripts` test continues to pass unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->