### PR TITLE
process: skip uncaught-exception dispatch on a terminating worker

### DIFF
--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -126,6 +126,10 @@ impl VM {
         crate::cpp::JSC__VM__clearHasTerminationRequest(self)
     }
 
+    pub fn has_termination_request(&self) -> bool {
+        crate::cpp::JSC__VM__hasTerminationRequest(self)
+    }
+
     #[track_caller]
     pub fn throw_error(&self, global_object: &JSGlobalObject, value: JSValue) -> JsError {
         crate::validation_scope!(scope, global_object);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3287,7 +3287,7 @@ impl VirtualMachine {
     ) {
         use bun_options_types::schema::api::UnhandledRejections as Mode;
 
-        if self.is_shutting_down() {
+        if self.script_execution_status() != crate::ScriptExecutionStatus::Running {
             bun_core::debug_warn!("unhandledRejection during shutdown.");
             return;
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1074,7 +1074,7 @@ impl VirtualMachine {
     }
 
     pub fn handled_promise(&self, global_object: &JSGlobalObject, promise: JSValue) -> bool {
-        if self.is_shutting_down() {
+        if self.script_execution_status() != crate::ScriptExecutionStatus::Running {
             return true;
         }
         Bun__emitHandledPromiseEvent(global_object, promise)
@@ -1348,7 +1348,7 @@ impl VirtualMachine {
         err: JSValue,
         is_rejection: bool,
     ) -> bool {
-        if self.is_shutting_down() {
+        if self.script_execution_status() != crate::ScriptExecutionStatus::Running {
             return true;
         }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1212,9 +1212,25 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+
+    // A worker whose terminate() has been requested must not run its
+    // uncaught-exception machinery: the exception reaching here is either the
+    // TerminationException itself or was produced while it was pending, and the
+    // process->get / emit / call sequence below walks the JS heap and may call
+    // user code. With terminate() racing (possibly while the parent/process is
+    // already tearing down), that property walk has tripped
+    // ASSERT(object->structure() == this) in Structure::storedPrototype. Treat
+    // as handled so the Rust caller does not go on to dispatch more JS either.
+    // scriptExecutionStatus is Stopped exactly when has_requested_terminate()
+    // is set on the worker (or the VM is shutting down, which the Rust caller
+    // already short-circuits), so a main-thread node:vm watchdog does not trip
+    // this.
+    if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
+        return true;
+
     auto* process = globalObject->processObject();
     auto& wrapped = process->wrapped();
-    auto& vm = JSC::getVM(globalObject);
 
     // node parity (exitWithUndefinedFatalException): the internal fatal-exception
     // handler is monkey-patchable as process._fatalException. If user code

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1214,10 +1214,7 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
 
-    // Stopped == a worker with has_requested_terminate() set; skip the
-    // process->get / emit / call walk (asserts under a terminate() race) and
-    // return handled so the Rust caller dispatches no more JS either. The
-    // main-thread node:vm watchdog does not set this.
+    // Stopped == a worker with has_requested_terminate(); the process->get / emit / call walk below asserts under a terminate() race.
     if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
         return true;
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1362,6 +1362,10 @@ extern "C" int Bun__handleUnhandledRejection(JSC::JSGlobalObject* lexicalGlobalO
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    // See Bun__handleUncaughtException above: do not lazily create process or
+    // emit on a worker whose terminate() has been requested.
+    if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
+        return false;
     auto* process = globalObject->processObject();
 
     auto eventType = Identifier::fromString(JSC::getVM(globalObject), "unhandledRejection"_s);
@@ -1385,6 +1389,9 @@ extern "C" bool Bun__emitHandledPromiseEvent(JSC::JSGlobalObject* lexicalGlobalO
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    // See Bun__handleUncaughtException above.
+    if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
+        return false;
     auto* process = globalObject->processObject();
 
     auto eventType = Identifier::fromString(JSC::getVM(globalObject), "rejectionHandled"_s);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1214,18 +1214,10 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
 
-    // A worker whose terminate() has been requested must not run its
-    // uncaught-exception machinery: the exception reaching here is either the
-    // TerminationException itself or was produced while it was pending, and the
-    // process->get / emit / call sequence below walks the JS heap and may call
-    // user code. With terminate() racing (possibly while the parent/process is
-    // already tearing down), that property walk has tripped
-    // ASSERT(object->structure() == this) in Structure::storedPrototype. Treat
-    // as handled so the Rust caller does not go on to dispatch more JS either.
-    // scriptExecutionStatus is Stopped exactly when has_requested_terminate()
-    // is set on the worker (or the VM is shutting down, which the Rust caller
-    // already short-circuits), so a main-thread node:vm watchdog does not trip
-    // this.
+    // Stopped == a worker with has_requested_terminate() set; skip the
+    // process->get / emit / call walk (asserts under a terminate() race) and
+    // return handled so the Rust caller dispatches no more JS either. The
+    // main-thread node:vm watchdog does not set this.
     if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
         return true;
 
@@ -1362,8 +1354,6 @@ extern "C" int Bun__handleUnhandledRejection(JSC::JSGlobalObject* lexicalGlobalO
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
-    // See Bun__handleUncaughtException above: do not lazily create process or
-    // emit on a worker whose terminate() has been requested.
     if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
         return false;
     auto* process = globalObject->processObject();
@@ -1389,7 +1379,6 @@ extern "C" bool Bun__emitHandledPromiseEvent(JSC::JSGlobalObject* lexicalGlobalO
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
-    // See Bun__handleUncaughtException above.
     if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
         return false;
     auto* process = globalObject->processObject();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1465,6 +1465,9 @@ impl WebWorker {
         if vm_log.msgs.is_empty() {
             return;
         }
+        if self.has_requested_terminate() {
+            return;
+        }
         let global = vm.global();
         let result: jsc::JsResult<(JSValue, BunString)> = (|| {
             let err = vm_log.to_js(global, "Error in worker")?;
@@ -1474,7 +1477,22 @@ impl WebWorker {
         let (err, str) = match result {
             Ok(pair) => pair,
             Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
-            Err(JsError::Thrown | JsError::Terminated) => panic!("unhandled exception"),
+            Err(JsError::Terminated) => return,
+            Err(e @ JsError::Thrown) => {
+                if self.has_requested_terminate() {
+                    return;
+                }
+                if let Some(exc) = global
+                    .take_exception(e)
+                    .as_exception(global.vm().as_mut_ptr())
+                {
+                    let _ = jsc::js_global_object::report_uncaught_exception(
+                        global,
+                        jsc::Exception::opaque_ref(exc),
+                    );
+                }
+                return;
+            }
         };
         let mut str = bun_core::OwnedString::new(str);
         let dispatch = jsc::host_fn::from_js_host_call_generic(global, || {
@@ -1482,6 +1500,9 @@ impl WebWorker {
             WebWorker__dispatchError(global, self.cpp_worker, &mut str, err)
         });
         if let Err(e) = dispatch {
+            if self.has_requested_terminate() {
+                return;
+            }
             // `take_exception` on a `JsError` always returns an Exception
             // cell; None is unreachable. Do not silently drop the error.
             let exc = global

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1470,7 +1470,7 @@ impl WebWorker {
         }
         let global = vm.global();
         let report_thrown = |e: JsError| {
-            if self.has_requested_terminate() {
+            if self.has_requested_terminate() && global.vm().has_termination_request() {
                 return;
             }
             // take_exception on a JsError always yields an Exception cell; None is unreachable.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1135,8 +1135,7 @@ impl WebWorker {
             }
         }
 
-        // terminate() may have landed during load_entry_point_for_web_worker;
-        // don't reach dispatchOnline/fireEarlyMessages/tick() in that case.
+        // terminate() may have landed during load_entry_point_for_web_worker; skip dispatchOnline/tick().
         if self.has_requested_terminate() {
             self.flush_logs(vm);
             return self.shutdown();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1464,9 +1464,7 @@ impl WebWorker {
         if vm_log.msgs.is_empty() {
             return;
         }
-        // Keyed on the JSC request so the same-thread self-signals that only set the atomic
-        // (start_vm()'s configure_defines failure: "vm.log carries the error for flushLogs")
-        // still dispatch.
+        // Keyed on the JSC request so same-thread self-signals that only set the atomic (configure_defines) still dispatch.
         if self.has_requested_terminate() && vm.jsc_vm().has_termination_request() {
             return;
         }
@@ -1475,8 +1473,7 @@ impl WebWorker {
             if self.has_requested_terminate() {
                 return;
             }
-            // `take_exception` on a `JsError` always returns an Exception
-            // cell; None is unreachable. Do not silently drop the error.
+            // take_exception on a JsError always yields an Exception cell; None is unreachable.
             let exc = global
                 .take_exception(e)
                 .as_exception(global.vm().as_mut_ptr())

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1135,10 +1135,8 @@ impl WebWorker {
             }
         }
 
-        // terminate() may have landed during load_entry_point_for_web_worker
-        // (between its own has_requested_terminate() check and here). Mirror
-        // the checkpoints at :1083 and the event-loop body so a terminated
-        // worker does not reach dispatchOnline/fireEarlyMessages/tick().
+        // terminate() may have landed during load_entry_point_for_web_worker;
+        // don't reach dispatchOnline/fireEarlyMessages/tick() in that case.
         if self.has_requested_terminate() {
             self.flush_logs(vm);
             return self.shutdown();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1135,6 +1135,15 @@ impl WebWorker {
             }
         }
 
+        // terminate() may have landed during load_entry_point_for_web_worker
+        // (between its own has_requested_terminate() check and here). Mirror
+        // the checkpoints at :1083 and the event-loop body so a terminated
+        // worker does not reach dispatchOnline/fireEarlyMessages/tick().
+        if self.has_requested_terminate() {
+            self.flush_logs(vm);
+            return self.shutdown();
+        }
+
         self.flush_logs(vm);
         log!("[{}] event loop start", self.execution_context_id);
         // dispatchOnline fires the parent-side 'open' event and flips the C++

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1135,8 +1135,8 @@ impl WebWorker {
             }
         }
 
-        // terminate() may have landed during load_entry_point_for_web_worker; skip dispatchOnline/tick().
-        if self.has_requested_terminate() {
+        // terminate() may have landed during entrySettled / the status block above; skip dispatchOnline/tick().
+        if self.has_requested_terminate() && !self.exit_called.load(Ordering::Relaxed) {
             self.flush_logs(vm);
             return self.shutdown();
         }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1137,7 +1137,6 @@ impl WebWorker {
 
         // terminate() may have landed during entrySettled / the status block above; skip dispatchOnline/tick().
         if self.has_requested_terminate() && !self.exit_called.load(Ordering::Relaxed) {
-            self.flush_logs(vm);
             return self.shutdown();
         }
 
@@ -1465,41 +1464,14 @@ impl WebWorker {
         if vm_log.msgs.is_empty() {
             return;
         }
-        if self.has_requested_terminate() {
+        // Keyed on the JSC request so the same-thread self-signals that only set the atomic
+        // (start_vm()'s configure_defines failure: "vm.log carries the error for flushLogs")
+        // still dispatch.
+        if self.has_requested_terminate() && vm.jsc_vm().has_termination_request() {
             return;
         }
         let global = vm.global();
-        let result: jsc::JsResult<(JSValue, BunString)> = (|| {
-            let err = vm_log.to_js(global, "Error in worker")?;
-            let str = err.to_bun_string(global)?;
-            Ok((err, str))
-        })();
-        let (err, str) = match result {
-            Ok(pair) => pair,
-            Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
-            Err(JsError::Terminated) => return,
-            Err(e @ JsError::Thrown) => {
-                if self.has_requested_terminate() {
-                    return;
-                }
-                if let Some(exc) = global
-                    .take_exception(e)
-                    .as_exception(global.vm().as_mut_ptr())
-                {
-                    let _ = jsc::js_global_object::report_uncaught_exception(
-                        global,
-                        jsc::Exception::opaque_ref(exc),
-                    );
-                }
-                return;
-            }
-        };
-        let mut str = bun_core::OwnedString::new(str);
-        let dispatch = jsc::host_fn::from_js_host_call_generic(global, || {
-            // `cpp_worker` is the opaque C++-owned handle; `str` reffed for the call.
-            WebWorker__dispatchError(global, self.cpp_worker, &mut str, err)
-        });
-        if let Err(e) = dispatch {
+        let report_thrown = |e: JsError| {
             if self.has_requested_terminate() {
                 return;
             }
@@ -1509,13 +1481,29 @@ impl WebWorker {
                 .take_exception(e)
                 .as_exception(global.vm().as_mut_ptr())
                 .expect("takeException returned non-Exception");
-            // `Exception` is an `opaque_ffi!` ZST handle; `opaque_ref` is the
-            // centralised non-null-ZST deref proof (`exc` is non-null per the
-            // `expect` above).
             let _ = jsc::js_global_object::report_uncaught_exception(
                 global,
                 jsc::Exception::opaque_ref(exc),
             );
+        };
+        let result: jsc::JsResult<(JSValue, BunString)> = (|| {
+            let err = vm_log.to_js(global, "Error in worker")?;
+            let str = err.to_bun_string(global)?;
+            Ok((err, str))
+        })();
+        let (err, str) = match result {
+            Ok(pair) => pair,
+            Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
+            Err(JsError::Terminated) => return,
+            Err(e @ JsError::Thrown) => return report_thrown(e),
+        };
+        let mut str = bun_core::OwnedString::new(str);
+        let dispatch = jsc::host_fn::from_js_host_call_generic(global, || {
+            // `cpp_worker` is the opaque C++-owned handle; `str` reffed for the call.
+            WebWorker__dispatchError(global, self.cpp_worker, &mut str, err)
+        });
+        if let Err(e) = dispatch {
+            report_thrown(e);
         }
     }
 }

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -121,45 +121,34 @@ test(
   timeout,
 );
 
-// Regression: a nested worker whose grandchild's module fails to load reports
-// its uncaught MODULE_NOT_FOUND via flush_logs → report_uncaught_exception →
-// Bun__handleUncaughtException. When worker.terminate() and process.exit()
-// land mid-dispatch, that handler would still lazily create `process` and do
-// `process->get("_fatalException")` on a VM already asked to terminate, which
-// tripped ASSERT(object->structure() == this) in Structure::storedPrototype.
-// Debug-assert-only; the race is non-deterministic (~2/14 on
-// release-asan-cov), so loop it.
+// Regression: a worker whose module fails to load reports its uncaught
+// MODULE_NOT_FOUND via flush_logs → report_uncaught_exception →
+// Bun__handleUncaughtException. When worker.terminate() + process.exit() land
+// mid-dispatch, flush_logs panicked on JsError::Terminated, and the handler
+// would still lazily create `process` and do `process->get("_fatalException")`
+// on a VM already asked to terminate, which tripped
+// ASSERT(object->structure() == this) in Structure::storedPrototype. The race
+// is non-deterministic (~2/14 on release-asan-cov), so loop it.
 test.skipIf(!isASAN)(
-  "terminating a worker while its grandchildren are reporting load errors does not assert",
+  "terminate() + process.exit() while workers are reporting load errors does not crash",
   async () => {
-    // Each subprocess run spawns a middle worker that creates grandchildren
-    // whose module load fails, then main terminates the middle worker and
-    // exits. The race window is between the grandchild's error dispatch and
-    // terminate_all_and_wait arming TerminationException. The grandchild path
-    // is an absolute nonexistent file so MODULE_NOT_FOUND is independent of
-    // import.meta.url's value inside the data-URL middle worker.
+    // Each subprocess run spawns workers whose module load fails, then main
+    // terminates them and exits. The race window is between a worker's error
+    // dispatch and terminate_all_and_wait arming TerminationException. Two
+    // levels only (no middle worker) to avoid also tripping the unrelated
+    // nested-worker parent-VM UAF that #31951 addresses.
     const code = `
       const { Worker } = require("node:worker_threads");
       const bad = require("node:path").join(process.cwd(), "does-not-exist-xyzzy.mjs");
-      const middleSrc = \`
-        const { Worker, parentPort } = require("node:worker_threads");
-        for (let j = 0; j < 4; j++) {
-          const w = new Worker(\${JSON.stringify(bad)});
-          w.on("error", () => {});
-        }
-        parentPort.postMessage("spawned");
-        setInterval(() => {}, 1000);
-      \`;
-      const middle = new Worker(new URL(
-        "data:text/javascript;base64," + Buffer.from(middleSrc).toString("base64"),
-      ));
-      middle.on("error", e => { console.error("middle error:", e.message); process.exit(1); });
-      middle.on("message", () => {
-        middle.terminate();
-        console.log("ok");
-        process.exit(0);
-      });
-      setTimeout(() => { console.error("timeout"); process.exit(1); }, 5000);
+      const workers = [];
+      for (let j = 0; j < 4; j++) {
+        const w = new Worker(bad);
+        w.on("error", () => {});
+        workers.push(w);
+      }
+      for (const w of workers) w.terminate();
+      console.log("ok");
+      process.exit(0);
     `;
 
     for (let i = 0; i < 20; i++) {

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -121,6 +121,62 @@ test(
   timeout,
 );
 
+// Regression: a nested worker whose grandchild's module fails to load reports
+// its uncaught MODULE_NOT_FOUND via flush_logs → report_uncaught_exception →
+// Bun__handleUncaughtException. When worker.terminate() and process.exit()
+// land mid-dispatch, that handler would still lazily create `process` and do
+// `process->get("_fatalException")` on a VM already asked to terminate, which
+// tripped ASSERT(object->structure() == this) in Structure::storedPrototype.
+// Debug-assert-only; the race is non-deterministic (~2/14 on
+// release-asan-cov), so loop it.
+test.skipIf(!isASAN)(
+  "terminating a worker while its grandchildren are reporting load errors does not assert",
+  async () => {
+    // Each subprocess run spawns a middle worker that creates grandchildren
+    // whose module load fails, then main terminates the middle worker and
+    // exits. The race window is between the grandchild's error dispatch and
+    // terminate_all_and_wait arming TerminationException.
+    const code = `
+      const { Worker } = require("node:worker_threads");
+      const middleSrc = \`
+        const { Worker, parentPort } = require("node:worker_threads");
+        for (let j = 0; j < 4; j++) {
+          const w = new Worker(new URL("./does-not-exist-xyzzy.mjs", import.meta.url));
+          w.on("error", () => {});
+        }
+        parentPort.postMessage("spawned");
+        setInterval(() => {}, 1000);
+      \`;
+      const middle = new Worker(new URL(
+        "data:text/javascript;base64," + Buffer.from(middleSrc).toString("base64"),
+      ));
+      middle.on("error", () => {});
+      middle.on("message", () => {
+        middle.terminate();
+        process.exit(0);
+      });
+      setTimeout(() => process.exit(0), 2000);
+    `;
+
+    for (let i = 0; i < 20; i++) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", code],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, stdout, exitCode, signalCode: proc.signalCode }).toEqual({
+        stderr: "",
+        stdout: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    }
+  },
+  timeout * 2,
+);
+
 // Regression: the per-VM c-ares channel was destroyed in deinit_runtime_state
 // (RuntimeState drop) AFTER JSC teardown and RareData.file_polls drop.
 // ares_destroy() synchronously fires EDESTRUCTION query callbacks and socket-

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -135,13 +135,16 @@ test.skipIf(!isASAN)(
     // Each subprocess run spawns a middle worker that creates grandchildren
     // whose module load fails, then main terminates the middle worker and
     // exits. The race window is between the grandchild's error dispatch and
-    // terminate_all_and_wait arming TerminationException.
+    // terminate_all_and_wait arming TerminationException. The grandchild path
+    // is an absolute nonexistent file so MODULE_NOT_FOUND is independent of
+    // import.meta.url's value inside the data-URL middle worker.
     const code = `
       const { Worker } = require("node:worker_threads");
+      const bad = require("node:path").join(process.cwd(), "does-not-exist-xyzzy.mjs");
       const middleSrc = \`
         const { Worker, parentPort } = require("node:worker_threads");
         for (let j = 0; j < 4; j++) {
-          const w = new Worker(new URL("./does-not-exist-xyzzy.mjs", import.meta.url));
+          const w = new Worker(\${JSON.stringify(bad)});
           w.on("error", () => {});
         }
         parentPort.postMessage("spawned");
@@ -150,12 +153,13 @@ test.skipIf(!isASAN)(
       const middle = new Worker(new URL(
         "data:text/javascript;base64," + Buffer.from(middleSrc).toString("base64"),
       ));
-      middle.on("error", () => {});
+      middle.on("error", e => { console.error("middle error:", e.message); process.exit(1); });
       middle.on("message", () => {
         middle.terminate();
+        console.log("ok");
         process.exit(0);
       });
-      setTimeout(() => process.exit(0), 2000);
+      setTimeout(() => { console.error("timeout"); process.exit(1); }, 5000);
     `;
 
     for (let i = 0; i < 20; i++) {
@@ -168,7 +172,7 @@ test.skipIf(!isASAN)(
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stderr, stdout, exitCode, signalCode: proc.signalCode }).toEqual({
         stderr: "",
-        stdout: "",
+        stdout: "ok\n",
         exitCode: 0,
         signalCode: null,
       });


### PR DESCRIPTION
## Repro

A worker whose module fails to load (MODULE_NOT_FOUND) reports its error via `flush_logs` while `worker.terminate()` and `process.exit()` on main land mid-dispatch. On the worker's thread, with `has_requested_terminate()` set:

- `flush_logs`'s `vm_log.to_js` / `to_bun_string` / `WebWorker__dispatchError` throws the TerminationException → `Err(Thrown | Terminated)` → `panic!("unhandled exception")` aborts the process
- if the JS-conversion step survives but `WebWorker__dispatchError` throws, `report_uncaught_exception` → `Bun__handleUncaughtException` lazily creates `process` and does `process->get("_fatalException")`, which trips `ASSERTION FAILED: isCompilationThread() || Thread::mayBeGCThread() || object->structure() == this` in `JSC::Structure::storedPrototype`

Both are debug-assert / debug-build only; the race is non-deterministic (~2/14 for the assert on release-asan-cov; the panic reproduced on the debian-13 x64-asan CI lane in build 81199). Looped driver:

```sh
for i in $(seq 1 40); do bun-asan worker-dataurl-importmeta-url-mangled.mjs >/dev/null 2>err || { head -2 err; break; }; done
```

## Cause

`flush_logs` panicked on `JsError::Thrown | Terminated` instead of recognising termination, and `Bun__handleUncaughtException` (and its siblings `Bun__handleUnhandledRejection`, `Bun__emitHandledPromiseEvent`, `Bun__promises__emitUnhandledRejectionWarning`) had no termination guard. Once a worker's termination has been requested, running the uncaught-exception / unhandled-rejection machinery is wrong: the exception is either the TerminationException itself or was produced while it was pending, and the `process->get` / `emit` / `call` sequence walks the JS heap and may call user code on a VM that is being wound down concurrently with the parent's (or process-wide) teardown. The `_fatalException` check that landed in ab84aa22d2 is the first property walk in `Bun__handleUncaughtException`, which is why the assert is a new signature.

## Fix

- `flush_logs`: return early when `has_requested_terminate() && has_termination_request()` (keyed on the JSC-side trap so the same-thread `configure_defines()` self-signal, which sets only the atomic, still dispatches its error); on `JsError::Terminated` return; on a genuine `JsError::Thrown` report it via `report_uncaught_exception` instead of crashing; after `WebWorker__dispatchError` throws, re-check `has_requested_terminate()` before reporting.
- Guard `Bun__handleUncaughtException`, `Bun__handleUnhandledRejection`, and `Bun__emitHandledPromiseEvent` on `scriptExecutionStatus()`, the same check used by `MessagePort` and the same class of guard as `dispatchExitInternal` in the same file. `scriptExecutionStatus` is `Stopped` exactly when a worker's `has_requested_terminate()` is set (or the VM is shutting down), so the main-thread `node:vm` watchdog is not caught by it.
- `VirtualMachine::uncaught_exception` / `unhandled_rejection` / `handled_promise` now gate on `script_execution_status() != Running` (a strict superset of their previous `is_shutting_down()` check), which covers the `isBunTest` fast-path in `uncaught_exception` and all six `--unhandled-rejections` mode arms including the `emitUnhandledRejectionWarning` path that has its own `reason.get(stack)` prototype walk.
- `WebWorker::spin()` gets a `has_requested_terminate() && !exit_called` checkpoint after the entry-promise status block, so an external terminate that lands during `entrySettled` / the status block goes straight to `shutdown()` rather than reaching `dispatchOnline`/`fireEarlyMessages`/`tick()`. The `!exit_called` carve-out preserves pre-PR `'online'` ordering for a worker whose own `uncaughtException` handler calls `process.exit(N)`.

## Verification

The added stress test in `test/js/web/workers/worker-terminate-lifetime.test.ts` loops the failing-worker + terminate + `process.exit()` shape 20 times under ASAN. Two levels only (main spawns the failing workers directly), so it does not also trip the nested-worker parent-VM UAF that #31951 addresses; an earlier three-level fixture caught that UAF on the debian-13 x64-asan lane in build 81404. The two-level fixture reproduced the `flush_logs` `panic: unhandled exception` SIGABRT on the debian-13 x64-asan lane at c298be50 (before the `flush_logs` change) and passes with the full diff applied. The `storedPrototype` assert itself did not fire on this machine's debug+ASAN build in 230 iterations; it was reported at ~2/14 on release-asan-cov.

Also verified unchanged:

- `test/js/node/test/parallel/test-worker-nested-uncaught.js`, `test-worker-nested-on-process-exit.js`, `test-worker-beforeexit-throw-exit.js`, `test-worker-abort-on-uncaught-exception.js`, `test-worker-exit-code.js` (exercises the `_fatalException` → exit 6 path), `test-worker-exit-from-uncaught-exception.js`
- `test/js/node/test/parallel/test-promise-unhandled-{default,error,flag}.js`, `test-promise-handled-rejection-no-warning.js`
- `test/js/node/process/process.test.js -t uncaught` (including "throwing inside a worker runs that worker's uncaughtException handler", since `beforeExit` only fires when `has_requested_terminate()` is false)
- `test/js/node/worker_threads/worker_threads.test.ts` (91 pass)
- `test/js/web/workers/worker.test.ts` (25 pass)

## Related

#31951 addresses the same `flush_logs` panic plus the nested-worker parent-VM UAF; this PR takes the minimal `flush_logs` termination handling and additionally guards the downstream handlers and Rust dispatchers so every caller is covered. The parent-VM UAF is left for #31951.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->