### PR TITLE
run --filter: load root .env so workspace scripts inherit it

### DIFF
--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -667,7 +667,7 @@ impl BunxCommand {
         let mut original_path: Vec<u8> = Vec::new();
 
         let root_dir_info =
-            Run::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, true)?;
+            Run::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, true, true)?;
         // SAFETY: `configure_env_for_run` returned `Ok`, so the slot is fully
         // initialized via `MaybeUninit::write`.
         let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -734,7 +734,17 @@ pub(crate) fn run_scripts_with_filter(
     // `RunCommand::configure_env_for_run(...) -> Result<Transpiler, _>`; until then
     // pass `&mut MaybeUninit<Transpiler>` (zeroed() is invalid: Transpiler is not #[repr(C)] POD).
     let mut this_transpiler = core::mem::MaybeUninit::<bun_bundler::Transpiler<'static>>::uninit();
-    let _ = RunCommand::configure_env_for_run(&mut *ctx, &mut this_transpiler, None, true, false)?;
+    // `skip_default_env = false`: scripts are spawned with cwd set to each
+    // workspace package, so the child bun cannot find the root .env files.
+    // Load them here so they are inherited through the spawned env.
+    let _ = RunCommand::configure_env_for_run(
+        &mut *ctx,
+        &mut this_transpiler,
+        None,
+        true,
+        false,
+        false,
+    )?;
     // SAFETY: configure_env_for_run fully initializes the out-param on Ok.
     let mut this_transpiler = unsafe { this_transpiler.assume_init() };
 

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -795,7 +795,19 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     // Out-param init pattern.
     let mut this_transpiler_slot =
         ::core::mem::MaybeUninit::<bun_bundler::Transpiler<'static>>::uninit();
-    let _ = RunCommand::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, false)?;
+    // When `--filter`/`--workspaces` is active, scripts are spawned with cwd set
+    // to each workspace package and the child bun cannot find the root .env
+    // files; load them here so they are inherited. Without a filter the child
+    // runs in the same cwd and loads .env itself (preserves #9635 behavior).
+    let skip_default_env = ctx.filters.is_empty() && !ctx.workspaces;
+    let _ = RunCommand::configure_env_for_run(
+        ctx,
+        &mut this_transpiler_slot,
+        None,
+        true,
+        false,
+        skip_default_env,
+    )?;
     // SAFETY: `configure_env_for_run` fully writes the slot on the success path.
     let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };
     let cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2018,6 +2018,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         Some(pm_env(ctx.manager)),
         ctx.manager.options.log_level != LogLevel::Silent,
         false,
+        true,
     ) {
         if matches!(err, crate::Error::Alloc(_)) {
             return Err(PackError::OutOfMemory);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -532,8 +532,17 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         env: Option<*mut DotEnv::Loader>,
         log_errors: bool,
         store_root_fd: bool,
+        skip_default_env: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
-        Self::configure_env_for_run_impl(ctx, this_transpiler, env, log_errors, store_root_fd, true)
+        Self::configure_env_for_run_impl(
+            ctx,
+            this_transpiler,
+            env,
+            log_errors,
+            store_root_fd,
+            true,
+            skip_default_env,
+        )
     }
 
     /// Like [`Self::configure_env_for_run`] but does **not** construct the
@@ -546,6 +555,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         env: Option<*mut DotEnv::Loader>,
         log_errors: bool,
         store_root_fd: bool,
+        skip_default_env: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
         Self::configure_env_for_run_impl(
             ctx,
@@ -554,6 +564,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             log_errors,
             store_root_fd,
             false,
+            skip_default_env,
         )
     }
 
@@ -579,6 +590,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         log_errors: bool,
         store_root_fd: bool,
         with_linker: bool,
+        skip_default_env: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
         let args = ctx.args.clone();
         let env_is_none = env.is_none();
@@ -660,9 +672,11 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 }
             }
 
-            // Always skip default .env files for package.json script runner
-            // (the script's own bun instance loads .env)
-            let _ = this_transpiler.run_env_loader(true);
+            // Default .env files are normally skipped for the package.json script
+            // runner (the script's own bun instance loads .env; see #9635).
+            // Callers that spawn scripts in a different cwd (`--filter`, workspace
+            // runs) pass `skip_default_env = false` so root .env is inherited.
+            let _ = this_transpiler.run_env_loader(skip_default_env);
         }
 
         // Re-derive after `run_env_loader` — that call creates its own
@@ -2412,6 +2426,7 @@ impl RunCommand {
             None,
             log_errors,
             false,
+            true,
         )?;
         // SAFETY: `configure_env_for_run_without_linker` returned `Ok`, so the
         // slot is fully initialized via `MaybeUninit::write`.

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -471,6 +471,90 @@ describe("bun", () => {
     expect(exitCode).toBe(23);
   });
 
+  // https://github.com/oven-sh/bun/issues/10358
+  test("loads root .env files into workspace scripts", () => {
+    // `bun --filter` spawns each script with cwd set to the workspace package
+    // dir. A `.env` at the root must still be loaded by the `--filter` parent
+    // and inherited by those children; before the fix it was dropped and the
+    // script saw `undefined`.
+    const dir = tempDirWithFiles("filter-root-env", {
+      ".env": "ROOT_ENV_VAL=from-root-dotenv\n",
+      ".env.local": "ROOT_LOCAL_VAL=from-root-local\n",
+      packages: {
+        backend: {
+          ".env": "PKG_ENV_VAL=from-pkg-dotenv\n",
+          "index.js":
+            'console.log("ROOT_ENV_VAL=" + process.env.ROOT_ENV_VAL);\n' +
+            'console.log("ROOT_LOCAL_VAL=" + process.env.ROOT_LOCAL_VAL);\n' +
+            'console.log("PKG_ENV_VAL=" + process.env.PKG_ENV_VAL);\n',
+          "package.json": JSON.stringify({
+            name: "backend",
+            scripts: {
+              // A child bun loads packages/backend/.env from its own cwd; the
+              // root .env values arrive as inherited process env.
+              go: `${bunExe()} index.js`,
+            },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({
+        name: "ws",
+        workspaces: ["packages/*"],
+      }),
+    });
+
+    for (const args of [
+      ["run", "--filter", "*", "go"],
+      ["--filter", "*", "go"],
+    ]) {
+      const { exitCode, stdout } = spawnSync({
+        cwd: dir,
+        cmd: [bunExe(), ...args],
+        env: { ...bunEnv, NO_COLOR: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const out = stdout.toString();
+      expect(out).toContain("ROOT_ENV_VAL=from-root-dotenv");
+      expect(out).toContain("ROOT_LOCAL_VAL=from-root-local");
+      expect(out).toContain("PKG_ENV_VAL=from-pkg-dotenv");
+      expect(exitCode).toBe(0);
+    }
+  });
+
+  test("root .env reaches workspace scripts that are not bun", () => {
+    // The workspace script may be any shell command; root .env must still be in
+    // its environment even when no child bun process runs.
+    const dir = tempDirWithFiles("filter-root-env-shell", {
+      ".env": "ROOT_ENV_VAL=shell-sees-root-dotenv\n",
+      packages: {
+        tool: {
+          "package.json": JSON.stringify({
+            name: "tool",
+            scripts: {
+              // On Windows the script runner is bun's own shell, which also
+              // expands `$VAR`, so the same script body works everywhere.
+              go: 'echo "val=$ROOT_ENV_VAL"',
+            },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({
+        name: "ws",
+        workspaces: ["packages/*"],
+      }),
+    });
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "*", "go"],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toContain("val=shell-sees-root-dotenv");
+    expect(exitCode).toBe(0);
+  });
+
   function runElideLinesTest({
     elideLines,
     target_pattern,

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1803,6 +1803,20 @@ describe("workspace integration", () => {
     expect(r.exitCode).toBe(0);
   });
 
+  test("--parallel --filter='*' inherits root .env into workspace scripts", async () => {
+    using dir = tempDir("mr-ws-rootenv", {
+      ".env": "ROOT_ENV_VAL=mr-root-dotenv\n",
+      "package.json": JSON.stringify({ name: "monorepo", workspaces: ["packages/*"] }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        scripts: { go: `${bunExe()} -e "console.log('seen=' + process.env.ROOT_ENV_VAL)"` },
+      }),
+    });
+    const r = await runMulti(["run", "--parallel", "--filter", "*", "go"], String(dir));
+    expectPrefixed(r.stdout, "pkg-a:go", "seen=mr-root-dotenv");
+    expect(r.exitCode).toBe(0);
+  });
+
   test("--parallel --filter='pkg-a' runs only in matching package", async () => {
     using dir = makeWorkspace("mr-ws-single", {
       "pkg-a": { build: `echo a-only` },


### PR DESCRIPTION
## What does this PR do?

Fixes #10358.

`bun --filter` (and `bun --parallel --filter` / `--workspaces`) spawns each workspace script with `cwd` set to that package's directory. The package.json script runner intentionally skips auto-loading `.env` files in the parent process, leaving it to the child bun (the fix for #9635). But once the child's `cwd` is the workspace package, it can only see that package's own `.env`, never the root's, so values from a root-level `.env` were silently dropped:

```sh
# root/.env has TEST_VAL=...
# packages/backend/package.json: "dev": "bun src/index.ts"
$ bun --filter '*' dev
backend dev: TEST_VAL=undefined
```

This threads a `skip_default_env` flag through `RunCommand::configure_env_for_run` so the filter/workspace runners can opt into loading the invoking directory's `.env*` files into the env map that is handed to every spawned script. The values then reach the child as inherited process env, which also covers scripts that are not bun at all (`echo $ROOT_ENV_VAL`, `node ...`, etc.). A workspace package's own `.env` is still loaded by the child bun as before.

Plain `bun run <script>`, `bunx`, and `bun pm pack` keep passing `skip_default_env = true`, so their behavior (including the #9635 fix) is unchanged. `bun --parallel` without a filter also keeps skipping, since those scripts run in the same `cwd` and the child loads `.env` itself.

## How did you verify your code works?

New tests in `test/cli/run/filter-workspace.test.ts` and `test/cli/run/multi-run.test.ts`:
- root `.env` and `.env.local` reach a workspace script run via `bun --filter '*'`
- a workspace package's own `.env` is still picked up alongside the inherited root values
- a non-bun workspace script (`echo "$VAR"`) sees the root `.env` value
- `bun --parallel --filter '*'` inherits root `.env` into workspace scripts

All three fail with `Received: ...=undefined` before the fix and pass after. The existing `filter-workspace`, `multi-run`, `env`, `no-envfile`, and `bun-run` suites pass unchanged.