### PR TITLE
bundler: bundle template-literal and concatenated require()/import() specifiers via a __glob lookup map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "bun_errno",
  "bun_event_loop",
  "bun_exe_format",
+ "bun_glob",
  "bun_hash",
  "bun_http_types",
  "bun_io",

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1478,6 +1478,24 @@ interface BuildMetafile {
 }
 ```
 
+## Glob imports
+
+A `require()` or `import()` whose argument is a relative path built from a template literal or string concatenation is bundled like in [esbuild](https://esbuild.github.io/api/#glob). The static parts become a glob pattern, every file that matches is bundled, and the call becomes a lookup in a map from specifier to module:
+
+```ts title="index.ts" icon="/icons/typescript.svg"
+const lang = process.env.LANG ?? "en";
+const messages = require(`./locales/${lang}.json`); // bundles every ./locales/**/*.json
+```
+
+The rules:
+
+- The path must start with `./` or `../` and name a directory or file prefix before the first `${}` or `+`. A bare `require("./" + name)` is left alone.
+- A placeholder right after a `/` matches across directories (`**/*`). Anywhere else it matches one path segment (`*`).
+- A `const` whose initializer is such a template or concatenation is followed, so `` const file = `./bin/${arch}/addon.node`; require(file) `` is bundled too.
+- When the path ends in a placeholder, each file can also be reached without its extension: `require("./src/" + name)` finds `./src/cat.js` for `"cat"`.
+- A specifier that is not in the map falls back to the runtime `require()` or `import()`. With `allowUnresolved: []` (or `--reject-unresolved`) the map is a closed set and a miss throws `MODULE_NOT_FOUND`.
+- A pattern that matches no files, or more than 1024 files, leaves the call as a runtime call.
+
 ## Outputs
 
 The `Bun.build` function returns a `Promise<BuildOutput>`, defined as:

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1490,7 +1490,7 @@ const messages = require(`./locales/${lang}.json`); // bundles every ./locales/*
 The rules:
 
 - The path must start with `./` or `../` and name a directory or file prefix before the first `${}` or `+`. A bare `require("./" + name)` is left alone.
-- Static text that contains a glob metacharacter (`*`, `?`, `[`, `{`, `!`, or `\`) leaves the call as a runtime call.
+- Static text that contains a glob metacharacter (`*`, `?`, `[`, `{`, `!`, or `\`), or a `.`, `..`, or empty path segment past the leading `./` or `../`, leaves the call as a runtime call.
 - A placeholder right after a `/` matches across directories (`**/*`). Anywhere else it matches one path segment (`*`).
 - A `const` whose initializer is such a template or concatenation is followed, so ``const file = `./bin/${arch}/addon.node`; require(file)`` is bundled too.
 - When the path ends in a placeholder, each file can also be reached without its extension: `require("./src/" + name)` finds `./src/cat.js` for `"cat"`.

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1491,7 +1491,7 @@ The rules:
 
 - The path must start with `./` or `../` and name a directory or file prefix before the first `${}` or `+`. A bare `require("./" + name)` is left alone.
 - A placeholder right after a `/` matches across directories (`**/*`). Anywhere else it matches one path segment (`*`).
-- A `const` whose initializer is such a template or concatenation is followed, so `` const file = `./bin/${arch}/addon.node`; require(file) `` is bundled too.
+- A `const` whose initializer is such a template or concatenation is followed, so ``const file = `./bin/${arch}/addon.node`; require(file)`` is bundled too.
 - When the path ends in a placeholder, each file can also be reached without its extension: `require("./src/" + name)` finds `./src/cat.js` for `"cat"`.
 - A specifier that is not in the map falls back to the runtime `require()` or `import()`. With `allowUnresolved: []` (or `--reject-unresolved`) the map is a closed set and a miss throws `MODULE_NOT_FOUND`.
 - A pattern that matches no files, or more than 1024 files, leaves the call as a runtime call.

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1490,6 +1490,7 @@ const messages = require(`./locales/${lang}.json`); // bundles every ./locales/*
 The rules:
 
 - The path must start with `./` or `../` and name a directory or file prefix before the first `${}` or `+`. A bare `require("./" + name)` is left alone.
+- Static text that contains a glob metacharacter (`*`, `?`, `[`, `{`, `!`, or `\`) leaves the call as a runtime call.
 - A placeholder right after a `/` matches across directories (`**/*`). Anywhere else it matches one path segment (`*`).
 - A `const` whose initializer is such a template or concatenation is followed, so ``const file = `./bin/${arch}/addon.node`; require(file)`` is bundled too.
 - When the path ends in a placeholder, each file can also be reached without its extension: `require("./src/" + name)` finds `./src/cat.js` for `"cat"`.

--- a/docs/snippets/cli/build.mdx
+++ b/docs/snippets/cli/build.mdx
@@ -104,12 +104,14 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--allow-unresolved" type="string" default="*">
-  Allow unresolved dynamic import()/require() specifiers matching these glob patterns. Pass <code>''</code> to allow
-  opaque specifiers
+  Allow unresolved dynamic import()/require() specifiers matching these glob patterns. A pattern is matched against
+  the specifier's static parts (a template literal, a string concatenation, or a <code>const</code> bound to one) with
+  <code>*</code> in place of each dynamic part. Pass <code>''</code> to allow opaque specifiers
 </ParamField>
 
 <ParamField path="--reject-unresolved" type="boolean">
-  Fail the build on any dynamic import()/require() specifier that cannot be resolved at build time
+  Fail the build on any dynamic import()/require() specifier that cannot be resolved at build time. A relative
+  template or concatenation that matches files on disk is bundled as a closed glob map and passes
 </ParamField>
 
 <ParamField path="--packages" type="string" default="bundle">

--- a/docs/snippets/cli/build.mdx
+++ b/docs/snippets/cli/build.mdx
@@ -104,14 +104,14 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--allow-unresolved" type="string" default="*">
-  Allow unresolved dynamic import()/require() specifiers matching these glob patterns. A pattern is matched against
-  the specifier's static parts (a template literal, a string concatenation, or a <code>const</code> bound to one) with
+  Allow unresolved dynamic import()/require() specifiers matching these glob patterns. A pattern is matched against the
+  specifier's static parts (a template literal, a string concatenation, or a <code>const</code> bound to one) with
   <code>*</code> in place of each dynamic part. Pass <code>''</code> to allow opaque specifiers
 </ParamField>
 
 <ParamField path="--reject-unresolved" type="boolean">
-  Fail the build on any dynamic import()/require() specifier that cannot be resolved at build time. A relative
-  template or concatenation that matches files on disk is bundled as a closed glob map and passes
+  Fail the build on any dynamic import()/require() specifier that cannot be resolved at build time. A relative template
+  or concatenation that matches files on disk is bundled as a closed glob map and passes
 </ParamField>
 
 <ParamField path="--packages" type="string" default="bundle">

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3254,9 +3254,16 @@ declare module "bun" {
      * - `["*"]` (default) — allow all dynamic specifiers
      * - `[]` — fail the build on any dynamic specifier
      * - `["./locales/*.json", ...]` — allow only specifiers whose static
-     *   template parts match one of these glob patterns
+     *   parts match one of these glob patterns
      *
+     * The static parts come from a template literal, a string concatenation,
+     * or a `const` bound to one of those; each dynamic part becomes `*`.
      * Add `""` to the list to allow fully opaque specifiers like `import(fn())`.
+     *
+     * A relative template or concatenation that matches files on disk is
+     * bundled as a glob map and always passes. The map keeps a runtime
+     * fallback for specifiers it does not contain only when this option
+     * allows the shape; with `[]` a miss throws `MODULE_NOT_FOUND`.
      *
      * @default ["*"]
      */

--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -173,10 +173,11 @@ pub struct Imports {
     pub(crate) __promiseAll: Ref,
     pub(crate) __MEMO_CACHE_SENTINEL: Ref,
     pub(crate) __EARLY_RETURN_SENTINEL: Ref,
+    pub(crate) __glob: Ref,
 }
 
 impl Imports {
-    pub const ALL: [&'static [u8]; 27] = [
+    pub const ALL: [&'static [u8]; 28] = [
         b"__name",
         b"__require",
         b"__export",
@@ -204,12 +205,13 @@ impl Imports {
         b"__promiseAll",
         b"__MEMO_CACHE_SENTINEL",
         b"__EARLY_RETURN_SENTINEL",
+        b"__glob",
     ];
 
     /// Rust stable cannot sort in `const`; precomputed here and verified by
     /// the test in `tests` below.
     #[cfg_attr(not(test), allow(dead_code))]
-    const ALL_SORTED: [&'static [u8]; 27] = [
+    const ALL_SORTED: [&'static [u8]; 28] = [
         b"$$typeof",
         b"__EARLY_RETURN_SENTINEL",
         b"__MEMO_CACHE_SENTINEL",
@@ -220,6 +222,7 @@ impl Imports {
         b"__export",
         b"__exportDefault",
         b"__exportValue",
+        b"__glob",
         b"__jsonParse",
         b"__legacyDecorateClassTS",
         b"__legacyDecorateParamTS",
@@ -241,34 +244,35 @@ impl Imports {
 
     /// When generating the list of runtime imports, we sort it for determinism.
     /// This is a lookup table so we don't need to resort the strings each time
-    pub const ALL_SORTED_INDEX: [usize; 27] = [
-        15, // __name
-        24, // __require
+    pub const ALL_SORTED_INDEX: [usize; 28] = [
+        16, // __name
+        25, // __require
         7,  // __export
-        23, // __reExport
+        24, // __reExport
         9,  // __exportValue
         8,  // __exportDefault
-        14, // __merge
-        11, // __legacyDecorateClassTS
-        12, // __legacyDecorateParamTS
-        13, // __legacyMetadataTS
-        22, // __publicField
-        18, // __privateIn
-        17, // __privateGet
-        16, // __privateAdd
-        20, // __privateSet
-        19, // __privateMethod
+        15, // __merge
+        12, // __legacyDecorateClassTS
+        13, // __legacyDecorateParamTS
+        14, // __legacyMetadataTS
+        23, // __publicField
+        19, // __privateIn
+        18, // __privateGet
+        17, // __privateAdd
+        21, // __privateSet
+        20, // __privateMethod
         6,  // __decoratorStart
         5,  // __decoratorMetadata
-        25, // __runInitializers
+        26, // __runInitializers
         4,  // __decorateElement
         0,  // $$typeof
-        26, // __using
+        27, // __using
         3,  // __callDispose
-        10, // __jsonParse
-        21, // __promiseAll
+        11, // __jsonParse
+        22, // __promiseAll
         2,  // __MEMO_CACHE_SENTINEL
         1,  // __EARLY_RETURN_SENTINEL
+        10, // __glob
     ];
 
     pub const NAME: &'static [u8] = b"bun:wrap";
@@ -304,6 +308,7 @@ impl Imports {
             24 => self.__promiseAll,
             25 => self.__MEMO_CACHE_SENTINEL,
             26 => self.__EARLY_RETURN_SENTINEL,
+            27 => self.__glob,
             _ => return None,
         };
         r.to_nullable()
@@ -339,6 +344,7 @@ impl Imports {
             24 => Some(&mut self.__promiseAll),
             25 => Some(&mut self.__MEMO_CACHE_SENTINEL),
             26 => Some(&mut self.__EARLY_RETURN_SENTINEL),
+            27 => Some(&mut self.__glob),
             _ => None,
         }
     }

--- a/src/bundler/Cargo.toml
+++ b/src/bundler/Cargo.toml
@@ -39,6 +39,7 @@ bun_collections.workspace = true
 bun_css.workspace = true
 bun_dotenv.workspace = true
 bun_event_loop.workspace = true
+bun_glob.workspace = true
 bun_http_types.workspace = true
 bun_parsers.workspace = true
 bun_io.workspace = true

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2445,6 +2445,7 @@ pub mod parse_worker {
         // a worker-owned `Transpiler` that outlives the parse.
         // SAFETY: ARENA — `topts` outlives `opts` (worker-owned for the bundle pass).
         opts.allow_unresolved = unsafe { bun_collections::detach_ref(&topts.allow_unresolved) };
+        opts.glob_resolver = Some(crate::options::parser_glob_resolver);
         // `Transpiler.macro_context` is `Option<bun_ast::Macro::MacroContext>`
         // (same nominal type as `ParserOptions.macro_context`'s pointee). Reborrow
         // through the raw `*mut Transpiler` so the `&mut MacroContext` is disjoint

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2446,6 +2446,13 @@ pub mod parse_worker {
         // SAFETY: ARENA — `topts` outlives `opts` (worker-owned for the bundle pass).
         opts.allow_unresolved = unsafe { bun_collections::detach_ref(&topts.allow_unresolved) };
         opts.glob_resolver = Some(crate::options::parser_glob_resolver);
+        // SAFETY: ARENA — `topts` outlives `opts` (worker-owned for the bundle pass).
+        opts.glob_stem_extension_orders = unsafe {
+            [
+                bun_collections::detach_ref(&*topts.extension_order.default.default),
+                bun_collections::detach_ref(&*topts.extension_order.default.esm),
+            ]
+        };
         // `Transpiler.macro_context` is `Option<bun_ast::Macro::MacroContext>`
         // (same nominal type as `ParserOptions.macro_context`'s pointee). Reborrow
         // through the raw `*mut Transpiler` so the `&mut MacroContext` is disjoint

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -81,8 +81,7 @@ pub use bun_js_parser::options::AllowUnresolved;
 /// `glob_resolver` for the parser's template-literal `require()` / `import()`
 /// support: every file under `source_dir` matching `pattern`, each as the
 /// `./`- or `../`-prefixed POSIX-separated relative specifier the runtime
-/// string would have to equal. Hidden entries are skipped (`dot: false`), so
-/// a `**` walk never descends into `.git`.
+/// string would have to equal. Hidden entries are skipped (`dot: false`).
 pub fn parser_glob_resolver(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>> {
     let mut out: Vec<Box<[u8]>> = Vec::new();
     if !(pattern.starts_with(b"./") || pattern.starts_with(b"../")) {
@@ -105,9 +104,8 @@ pub fn parser_glob_resolver(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>>
     loop {
         match iter.next() {
             Ok(Ok(Some(abs))) => {
-                // `Loose` normalizes with host rules but emits `/` separators,
-                // so the key matches what the source builds at runtime on
-                // every platform.
+                // `Loose` emits `/` separators, so the key matches the
+                // string the source builds at runtime on every platform.
                 let rel = bun_paths::resolve_path::relative_platform::<
                     bun_paths::resolve_path::platform::Loose,
                     false,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -90,14 +90,9 @@ pub fn parser_glob_resolver(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>>
     }
 
     let walker = match bun_glob::BunGlobWalker::init_with_cwd(
-        pattern,
-        source_dir,
-        /* dot */ false,
-        /* absolute */ true,
-        /* follow_symlinks */ true,
-        /* error_on_broken_symlinks */ false,
-        /* only_files */ true,
-        None,
+        pattern, source_dir, /* dot */ false, /* absolute */ true,
+        /* follow_symlinks */ true, /* error_on_broken_symlinks */ false,
+        /* only_files */ true, None,
     ) {
         Ok(Ok(w)) => w,
         _ => return out,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -78,6 +78,47 @@ pub(crate) fn validate_path(
 // `&transpiler.options.allow_unresolved` straight through.
 pub use bun_js_parser::options::AllowUnresolved;
 
+/// `glob_resolver` for the parser's template-literal `require()` / `import()`
+/// support: returns each match as a `./`- or `../`-prefixed relative specifier.
+pub fn parser_glob_resolver(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>> {
+    let mut out: Vec<Box<[u8]>> = Vec::new();
+    if !(pattern.starts_with(b"./") || pattern.starts_with(b"../")) {
+        return out;
+    }
+
+    let walker = match bun_glob::BunGlobWalker::init_with_cwd(
+        pattern, source_dir, true, false, true, false, true, None,
+    ) {
+        Ok(Ok(w)) => w,
+        _ => return out,
+    };
+    let mut walker = Box::new(walker);
+    let mut iter = bun_glob::walk::Iterator::new(&mut *walker);
+    if iter.init().map(|m| m.is_err()).unwrap_or(true) {
+        return out;
+    }
+    loop {
+        match iter.next() {
+            Ok(Ok(Some(m))) => {
+                let p: &[u8] = &m;
+                let mut s: Vec<u8> = p
+                    .iter()
+                    .map(|&b| if cfg!(windows) && b == b'\\' { b'/' } else { b })
+                    .collect();
+                if !(s.starts_with(b"./") || s.starts_with(b"../")) {
+                    s.splice(0..0, b"./".iter().copied());
+                }
+                out.push(s.into_boxed_slice());
+            }
+            Ok(Ok(None)) => break,
+            // A mid-walk failure would otherwise emit a partial map whose
+            // keys can never cover the runtime specifier.
+            Ok(Err(_)) | Err(_) => return Vec::new(),
+        }
+    }
+    out
+}
+
 // Canonical defs live in `bun_resolver::options` (lower tier; resolver is the
 // runtime consumer of `.patterns`/`.abs_paths`/`.node_modules`). Re-export so
 // `BundleOptions.external` and `Resolver.opts.external` are the SAME nominal

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -79,7 +79,10 @@ pub(crate) fn validate_path(
 pub use bun_js_parser::options::AllowUnresolved;
 
 /// `glob_resolver` for the parser's template-literal `require()` / `import()`
-/// support: returns each match as a `./`- or `../`-prefixed relative specifier.
+/// support: every file under `source_dir` matching `pattern`, each as the
+/// `./`- or `../`-prefixed POSIX-separated relative specifier the runtime
+/// string would have to equal. Hidden entries are skipped (`dot: false`), so
+/// a `**` walk never descends into `.git`.
 pub fn parser_glob_resolver(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>> {
     let mut out: Vec<Box<[u8]>> = Vec::new();
     if !(pattern.starts_with(b"./") || pattern.starts_with(b"../")) {
@@ -87,7 +90,14 @@ pub fn parser_glob_resolver(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>>
     }
 
     let walker = match bun_glob::BunGlobWalker::init_with_cwd(
-        pattern, source_dir, true, false, true, false, true, None,
+        pattern,
+        source_dir,
+        /* dot */ false,
+        /* absolute */ true,
+        /* follow_symlinks */ true,
+        /* error_on_broken_symlinks */ false,
+        /* only_files */ true,
+        None,
     ) {
         Ok(Ok(w)) => w,
         _ => return out,
@@ -99,16 +109,20 @@ pub fn parser_glob_resolver(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>>
     }
     loop {
         match iter.next() {
-            Ok(Ok(Some(m))) => {
-                let p: &[u8] = &m;
-                let mut s: Vec<u8> = p
-                    .iter()
-                    .map(|&b| if cfg!(windows) && b == b'\\' { b'/' } else { b })
-                    .collect();
-                if !(s.starts_with(b"./") || s.starts_with(b"../")) {
-                    s.splice(0..0, b"./".iter().copied());
+            Ok(Ok(Some(abs))) => {
+                // `Loose` normalizes with host rules but emits `/` separators,
+                // so the key matches what the source builds at runtime on
+                // every platform.
+                let rel = bun_paths::resolve_path::relative_platform::<
+                    bun_paths::resolve_path::platform::Loose,
+                    false,
+                >(source_dir, &abs);
+                let mut key: Vec<u8> = Vec::with_capacity(rel.len() + 2);
+                if !(rel.starts_with(b"./") || rel.starts_with(b"../")) {
+                    key.extend_from_slice(b"./");
                 }
-                out.push(s.into_boxed_slice());
+                key.extend_from_slice(rel);
+                out.push(key.into_boxed_slice());
             }
             Ok(Ok(None)) => break,
             // A mid-walk failure would otherwise emit a partial map whose

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1580,6 +1580,7 @@ impl<'a> Transpiler<'a> {
                     macro_context: None,
                     warn_about_unbundled_modules: !target.is_bun(),
                     allow_unresolved: &p_opts::AllowUnresolved::DEFAULT,
+                    glob_resolver: None,
                     module_type: to_parser_module_type(this_parse.module_type),
                     output_format: p_opts::Format::Esm,
                     transform_only: self.options.transform_only,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1581,6 +1581,7 @@ impl<'a> Transpiler<'a> {
                     warn_about_unbundled_modules: !target.is_bun(),
                     allow_unresolved: &p_opts::AllowUnresolved::DEFAULT,
                     glob_resolver: None,
+                    glob_stem_extension_orders: [&[], &[]],
                     module_type: to_parser_module_type(this_parse.module_type),
                     output_format: p_opts::Format::Esm,
                     transform_only: self.options.transform_only,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1074,11 +1074,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         for m in matches.iter() {
             keys.push(self.arena.alloc_slice_copy(m));
         }
-        // `require("./src/" + name)` passes `./src/cat` for `./src/cat.js`.
-        // The alias record's path is the stem, so the bundler resolves it with
-        // its extension order exactly like a hand-written `require("./src/cat")`.
-        // Only stems the runtime string can still produce are added: they must
-        // end with the static text after the last placeholder.
+        // `require("./src/" + name)` passes the stem `./src/cat` for
+        // `./src/cat.js`, so also alias each stem the runtime string can
+        // produce (it must end with the static text after the last placeholder).
         let static_suffix = &shape[strings::last_index_of_char(shape, 0).map_or(0, |i| i + 1)..];
         for i in 0..matches.len() {
             let Some(stem) = Self::glob_resolvable_stem(keys[i]) else {
@@ -1164,11 +1162,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             loc,
         );
 
-        // On a map miss `__glob` hands the specifier to the runtime
-        // `require`/`import()`, so a file that is not in the bundle loads the
-        // same way it did before the call was rewritten. That is runtime
-        // resolution, so it exists only where `allowUnresolved` permits it;
-        // under `--reject-unresolved` the map is a closed set and a miss throws.
+        // On a map miss `__glob` falls back to the runtime `require`/`import()`.
+        // That is runtime resolution, so no fallback is emitted when
+        // `allowUnresolved` forbids the shape; a miss then throws.
         let fallback = if !self.options.allow_unresolved.allows(shape) {
             None
         } else if kind == ImportKind::Require {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -798,8 +798,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Extracts a matchable "shape" from a dynamic import argument.
-    /// Template literals: static parts joined by \x00 placeholders.
-    /// Everything else: empty string.
+    /// Template literals and string concatenation: static parts joined by
+    /// \x00 placeholders. Everything else: empty string.
     fn extract_dynamic_specifier_shape<'b>(
         &mut self,
         arg: Expr,
@@ -822,7 +822,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut cur: Option<&js_ast::e::EString> = Some(s);
         while let Some(seg) = cur {
             let bytes = seg.string(self.arena)?;
-            if bytes.iter().any(|&b| b == 0) {
+            // A literal NUL would be confused with the placeholder marker.
+            if strings::contains_char(bytes, 0) {
                 buf.truncate(start);
                 return Ok(false);
             }
@@ -897,6 +898,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     && self.symbols[ref_.inner_index() as usize].kind
                         == js_ast::symbol::Kind::Constant
                 {
+                    // Taken out while recursing so a self-referential
+                    // initializer (const a = `./x/${a}`) terminates.
                     if let Some(init) = self.glob_specifier_values.remove(&ref_) {
                         let r = self.append_dynamic_specifier_shape(init, buf, depth + 1);
                         self.glob_specifier_values.put(ref_, init).expect("oom");
@@ -913,27 +916,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(ok)
     }
 
+    /// Relative, has a placeholder, and the static text before the first
+    /// placeholder names a path component: `./${x}` would otherwise glob the
+    /// importer's whole directory tree.
     fn glob_shape_is_eligible(shape: &[u8]) -> bool {
         if !(shape.starts_with(b"./") || shape.starts_with(b"../")) {
             return false;
         }
-        if !shape.iter().any(|b| *b == 0) {
+        let Some(first_placeholder) = strings::index_of_char_usize(shape, 0) else {
+            return false;
+        };
+        if !shape[..first_placeholder]
+            .iter()
+            .any(|&b| b != b'.' && b != b'/')
+        {
             return false;
         }
-        match shape.last() {
-            Some(&0) | Some(&b'/') => return false,
-            _ => {}
+        if shape.last() == Some(&b'/') {
+            return false;
         }
-        for &b in shape {
-            if matches!(b, b'*' | b'?' | b'[' | b'{' | b'!' | b'\\') {
-                return false;
-            }
-        }
-        true
+        // Glob metacharacters in the literal text would change the match.
+        strings::index_of_any(shape, b"*?[{!\\").is_none()
     }
 
-    /// `\x00` placeholders become `**/*` between slashes, `*` otherwise
-    /// (matches esbuild; keeps `./mods/${x}.js` bounded to one directory).
+    /// Like esbuild, a placeholder right after `/` becomes `**/*` (it may
+    /// span directories); anywhere else it becomes `*` (one path segment).
     fn glob_shape_to_pattern(shape: &[u8], out: &mut Vec<u8>) {
         out.clear();
         let mut i = 0;
@@ -947,14 +954,33 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             while i < shape.len() && shape[i] == 0 {
                 i += 1;
             }
-            let left_slash = out.last() == Some(&b'/');
-            let right_slash = shape.get(i) == Some(&b'/');
-            if left_slash && right_slash {
+            if out.last() == Some(&b'/') {
                 out.extend_from_slice(b"**/*");
             } else {
                 out.push(b'*');
             }
         }
+    }
+
+    /// Extensions every resolver extension order probes, so a key without one
+    /// of them (`./src/cat` for `./src/cat.js`) resolves through the normal
+    /// `require("./src/cat")` path.
+    const GLOB_STEM_EXTENSIONS: &'static [&'static [u8]] = &[
+        b".js", b".mjs", b".cjs", b".jsx", b".ts", b".mts", b".cts", b".tsx", b".json",
+    ];
+
+    fn glob_resolvable_stem(key: &[u8]) -> Option<&[u8]> {
+        let base_start = strings::last_index_of_char(key, b'/').map_or(0, |i| i + 1);
+        let base = &key[base_start..];
+        let dot = strings::last_index_of_char(base, b'.')?;
+        if dot == 0 {
+            return None;
+        }
+        let ext = &base[dot..];
+        if !Self::GLOB_STEM_EXTENSIONS.iter().any(|e| *e == ext) {
+            return None;
+        }
+        Some(&key[..base_start + dot])
     }
 
     /// Record `const x = <template>` so `require(x)` can glob. Lookup gates on
@@ -979,18 +1005,29 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Rewrite `require(arg)` with a relative-path template/concat arg into
-    /// `__glob({ "./a.js": () => require("./a.js"), ... })(arg)`.
+    /// Rewrite `require(arg)` / `import(arg)` whose argument is a relative-path
+    /// template or concatenation into
+    /// `__glob({ "./a.js": () => require("./a.js"), ... }, fallback)(arg)`,
+    /// bundling every file the shape can name (https://esbuild.github.io/api/#glob).
+    /// `import_state` is `None` for `require()`. `None` means the call does not
+    /// qualify and the caller keeps the runtime `require`/`import()`.
     pub fn try_glob_dynamic_require(
         &mut self,
         arg: Expr,
-        kind: ImportKind,
-        handles_import_errors: bool,
+        import_state: Option<&TransposeState>,
     ) -> Option<Expr> {
-        if !self.options.bundle || self.is_control_flow_dead {
+        if !self.options.bundle
+            || !self.options.features.allow_runtime
+            || self.is_control_flow_dead
+        {
             return None;
         }
         let resolver = self.options.glob_resolver?;
+        let kind = if import_state.is_some() {
+            ImportKind::Dynamic
+        } else {
+            ImportKind::Require
+        };
 
         let mut shape_buf = BumpVec::new_in(self.arena);
         let shape = self
@@ -1008,54 +1045,87 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut pattern = Vec::with_capacity(shape.len() + 4);
         Self::glob_shape_to_pattern(shape, &mut pattern);
 
+        let loc = arg.loc;
         let mut matches = resolver(source_dir, &pattern);
+        // Zero matches falls through so `check_dynamic_specifier` still runs
+        // and files created at runtime keep loading as before.
         if matches.is_empty() {
             return None;
         }
-        const GLOB_MATCH_CAP: usize = 256;
+        const GLOB_MATCH_CAP: usize = 1024;
         if matches.len() > GLOB_MATCH_CAP {
+            self.log().add_debug_fmt(
+                Some(self.source),
+                loc,
+                format_args!(
+                    "This dynamic specifier will not be bundled because its pattern \"{}\" matches more than {} files",
+                    bstr::BStr::new(&pattern),
+                    GLOB_MATCH_CAP
+                ),
+            );
             return None;
         }
         matches.sort();
         matches.dedup();
 
-        let loc = arg.loc;
-
-        let mut properties: BumpVec<'_, G::Property> =
-            BumpVec::with_capacity_in(matches.len(), self.arena);
+        let mut keys: Vec<&'a [u8]> = Vec::with_capacity(matches.len() * 2);
         for m in matches.iter() {
-            let path_bytes: &'a [u8] = self.arena.alloc_slice_copy(m);
-            let path = fs::Path::init(path_bytes);
-            let import_record_index = self.add_import_record_by_range_and_path(
-                kind,
-                self.source.range_of_string(loc),
-                &path,
-            );
-            self.import_records.items_mut()[import_record_index as usize]
-                .flags
-                .set(
+            keys.push(self.arena.alloc_slice_copy(m));
+        }
+        // `require("./src/" + name)` passes `./src/cat` for `./src/cat.js`.
+        // The alias record's path is the stem, so the bundler resolves it with
+        // its extension order exactly like a hand-written `require("./src/cat")`.
+        // Only stems the runtime string can still produce are added: they must
+        // end with the static text after the last placeholder.
+        let static_suffix = &shape[strings::last_index_of_char(shape, 0).map_or(0, |i| i + 1)..];
+        for i in 0..matches.len() {
+            let Some(stem) = Self::glob_resolvable_stem(keys[i]) else {
+                continue;
+            };
+            if !stem.ends_with(static_suffix) || keys.iter().any(|k| *k == stem) {
+                continue;
+            }
+            keys.push(stem);
+        }
+        keys.sort();
+
+        let in_try = self.fn_or_arrow_data_visit.try_body_count != 0;
+        let handles_import_errors = match import_state {
+            None => in_try,
+            Some(s) => (s.is_await_target && in_try) || s.is_then_catch_target,
+        };
+        let import_options = import_state.map_or(Expr::EMPTY, |s| s.import_options);
+
+        let arena = self.arena;
+        let mut properties: BumpVec<'_, G::Property> =
+            BumpVec::with_capacity_in(keys.len(), arena);
+        for key in keys {
+            let import_record_index = self.add_import_record(kind, loc, key);
+            {
+                let record = &mut self.import_records.items_mut()[import_record_index as usize];
+                record.flags.set(
                     bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
                     handles_import_errors,
                 );
+                if let Some(state) = import_state {
+                    if let Some(loader) = state.import_loader {
+                        record.loader = Some(loader);
+                    }
+                    if let Some(tag) = state.import_record_tag {
+                        record.tag = tag;
+                    }
+                }
+            }
             self.import_records_for_current_part
                 .push(import_record_index);
 
             let value_expr = if kind == ImportKind::Dynamic {
-                let path_str = self.new_expr(
-                    E::String {
-                        data: path_bytes.into(),
-                        ..Default::default()
-                    },
-                    loc,
-                );
+                let path_str = self.new_expr(E::String::init(key), loc);
                 self.new_expr(
                     E::Import {
                         expr: path_str,
                         import_record_index,
-                        options: Expr {
-                            loc,
-                            data: js_ast::ExprData::EMissing(E::Missing {}),
-                        },
+                        options: import_options,
                     },
                     loc,
                 )
@@ -1069,35 +1139,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 )
             };
 
-            let ret_stmt = self.s(
-                S::Return {
-                    value: Some(value_expr),
-                },
-                loc,
-            );
-            let body_stmts = self.arena.alloc_slice_copy(&[ret_stmt]);
+            let body = bun_core::handle_oom(G::FnBody::init_return_expr(arena, value_expr));
             let thunk = self.new_expr(
                 E::Arrow {
-                    args: bun_ast::StoreSlice::EMPTY,
-                    body: G::FnBody {
-                        loc,
-                        stmts: body_stmts.into(),
-                    },
+                    body,
                     prefer_expr: true,
                     ..Default::default()
                 },
                 loc,
             );
-
-            let key = self.new_expr(
-                E::String {
-                    data: path_bytes.into(),
-                    ..Default::default()
-                },
-                loc,
-            );
             properties.push(G::Property {
-                key: Some(key),
+                key: Some(self.new_expr(E::String::init(key), loc)),
                 value: Some(thunk),
                 ..Default::default()
             });
@@ -1111,7 +1163,45 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             loc,
         );
 
-        let glob_call = self.call_runtime(loc, b"__glob", ExprNodeList::init_one(map_obj));
+        // On a map miss `__glob` hands the specifier to the runtime
+        // `require`/`import()`, so a file that is not in the bundle loads the
+        // same way it did before the call was rewritten.
+        let fallback = if kind == ImportKind::Require {
+            self.record_usage_of_runtime_require();
+            self.value_for_require(loc)
+        } else {
+            let param_ref = self.new_symbol(js_ast::symbol::Kind::Other, b"specifier");
+            VecExt::append(&mut self.current_scope_mut().generated, param_ref);
+            self.record_declared_symbol(param_ref);
+            let import_expr = self.new_expr(
+                E::Import {
+                    expr: Expr::init_identifier(param_ref, loc),
+                    import_record_index: u32::MAX,
+                    options: import_options,
+                },
+                loc,
+            );
+            let body = bun_core::handle_oom(G::FnBody::init_return_expr(arena, import_expr));
+            let args = bun_ast::StoreSlice::new_mut(arena.alloc_slice_fill_iter([G::Arg {
+                binding: self.b(B::Identifier { r#ref: param_ref }, loc),
+                ..Default::default()
+            }]));
+            self.new_expr(
+                E::Arrow {
+                    args,
+                    body,
+                    prefer_expr: true,
+                    ..Default::default()
+                },
+                loc,
+            )
+        };
+
+        let glob_call = self.call_runtime(
+            loc,
+            b"__glob",
+            ExprNodeList::from_slice(&[map_obj, fallback]),
+        );
 
         Some(self.new_expr(
             E::Call {
@@ -1309,13 +1399,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         }
 
-        if matches!(state.import_options.data, js_ast::ExprData::EMissing(..)) {
-            let handles = (state.is_await_target
-                && self.fn_or_arrow_data_visit.try_body_count != 0)
-                || state.is_then_catch_target;
-            if let Some(glob) = self.try_glob_dynamic_require(arg, ImportKind::Dynamic, handles) {
-                return glob;
-            }
+        if let Some(glob) = self.try_glob_dynamic_require(arg, Some(state)) {
+            return glob;
         }
 
         if self.options.warn_about_unbundled_modules {
@@ -1544,9 +1629,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 )
             }
             _ => {
-                let handles = self.fn_or_arrow_data_visit.try_body_count != 0;
-                if let Some(glob) = self.try_glob_dynamic_require(arg, ImportKind::Require, handles)
-                {
+                // Also reached for each branch of a ternary argument split
+                // apart by `maybe_transpose_if_require`.
+                if let Some(glob) = self.try_glob_dynamic_require(arg, None) {
                     return glob;
                 }
                 let _ = self.check_dynamic_specifier(arg, arg.loc, "require()");

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -977,7 +977,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return None;
         }
         let ext = &base[dot..];
-        if !Self::GLOB_STEM_EXTENSIONS.iter().any(|e| *e == ext) {
+        if !Self::GLOB_STEM_EXTENSIONS.contains(&ext) {
             return None;
         }
         Some(&key[..base_start + dot])
@@ -1082,7 +1082,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let Some(stem) = Self::glob_resolvable_stem(keys[i]) else {
                 continue;
             };
-            if !stem.ends_with(static_suffix) || keys.iter().any(|k| *k == stem) {
+            if !stem.ends_with(static_suffix) || keys.contains(&stem) {
                 continue;
             }
             keys.push(stem);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1016,9 +1016,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         arg: Expr,
         import_state: Option<&TransposeState>,
     ) -> Option<Expr> {
-        if !self.options.bundle
-            || !self.options.features.allow_runtime
-            || self.is_control_flow_dead
+        if !self.options.bundle || !self.options.features.allow_runtime || self.is_control_flow_dead
         {
             return None;
         }
@@ -1101,8 +1099,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let import_options = import_state.map_or(Expr::EMPTY, |s| s.import_options);
 
         let arena = self.arena;
-        let mut properties: BumpVec<'_, G::Property> =
-            BumpVec::with_capacity_in(keys.len(), arena);
+        let mut properties: BumpVec<'_, G::Property> = BumpVec::with_capacity_in(keys.len(), arena);
         for key in keys {
             let import_record_index = self.add_import_record(kind, loc, key);
             {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -935,6 +935,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if shape.last() == Some(&b'/') {
             return false;
         }
+        // Past the leading relative prefix, a `.`, `..`, or empty segment in
+        // the static text is normalized away in the map keys, so the runtime
+        // string could never equal a key and every lookup would miss.
+        let mut rest = shape;
+        if let Some(s) = rest.strip_prefix(b"./") {
+            rest = s;
+        } else {
+            while let Some(s) = rest.strip_prefix(b"../") {
+                rest = s;
+            }
+        }
+        for seg in strings::split(rest, b"/") {
+            if seg.is_empty() || strings::eql(seg, b".") || strings::eql(seg, b"..") {
+                return false;
+            }
+        }
         // Glob metacharacters in the literal text would change the match.
         strings::index_of_any(shape, b"*?[{!\\").is_none()
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1013,11 +1013,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Extensions every resolver extension order probes, so a key without one
-    /// of them (`./src/cat` for `./src/cat.js`) resolves through the normal
-    /// `require("./src/cat")` path.
+    /// Extensions the default extension orders probe (`.node` on target bun),
+    /// so a stem key (`./src/cat` for `./src/cat.js`) resolves like a
+    /// hand-written `require("./src/cat")`.
     const GLOB_STEM_EXTENSIONS: &'static [&'static [u8]] = &[
-        b".js", b".mjs", b".cjs", b".jsx", b".ts", b".mts", b".cts", b".tsx", b".json",
+        b".js", b".mjs", b".cjs", b".jsx", b".ts", b".mts", b".cts", b".tsx", b".json", b".node",
     ];
 
     fn glob_resolvable_stem(key: &[u8]) -> Option<&[u8]> {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1013,14 +1013,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Extensions the default extension orders probe (`.node` on target bun),
-    /// so a stem key (`./src/cat` for `./src/cat.js`) resolves like a
-    /// hand-written `require("./src/cat")`.
-    const GLOB_STEM_EXTENSIONS: &'static [&'static [u8]] = &[
-        b".js", b".mjs", b".cjs", b".jsx", b".ts", b".mts", b".cts", b".tsx", b".json", b".node",
-    ];
-
-    fn glob_resolvable_stem(key: &[u8]) -> Option<&[u8]> {
+    /// A stem key (`./src/cat` for `./src/cat.js`) resolves like a
+    /// hand-written `require("./src/cat")`, so the extension must be in the
+    /// effective resolver order or the probe could not find the file.
+    fn glob_resolvable_stem<'k>(key: &'k [u8], extension_order: &[Box<[u8]>]) -> Option<&'k [u8]> {
         let base_start = strings::last_index_of_char(key, b'/').map_or(0, |i| i + 1);
         let base = &key[base_start..];
         let dot = strings::last_index_of_char(base, b'.')?;
@@ -1028,7 +1024,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return None;
         }
         let ext = &base[dot..];
-        if !Self::GLOB_STEM_EXTENSIONS.contains(&ext) {
+        if !extension_order.iter().any(|e| strings::eql(e, ext)) {
             return None;
         }
         Some(&key[..base_start + dot])
@@ -1129,8 +1125,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `./src/cat.js`, so also alias each stem the runtime string can
         // produce (it must end with the static text after the last placeholder).
         let static_suffix = &shape[strings::last_index_of_char(shape, 0).map_or(0, |i| i + 1)..];
+        let stem_order =
+            self.options.glob_stem_extension_orders[(kind == ImportKind::Dynamic) as usize];
         for i in 0..matches.len() {
-            let Some(stem) = Self::glob_resolvable_stem(keys[i].0) else {
+            let Some(stem) = Self::glob_resolvable_stem(keys[i].0, stem_order) else {
                 continue;
             };
             if !stem.ends_with(static_suffix) || keys.iter().any(|&(k, _)| k == stem) {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1037,6 +1037,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return None;
         }
 
+        // Only the `file` namespace has a directory to walk.
+        if !self.source.path.is_file() {
+            return None;
+        }
         let source_dir = self.source.path.source_dir();
         if source_dir.is_empty() {
             return None;
@@ -1165,10 +1169,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // On a map miss `__glob` hands the specifier to the runtime
         // `require`/`import()`, so a file that is not in the bundle loads the
-        // same way it did before the call was rewritten.
-        let fallback = if kind == ImportKind::Require {
+        // same way it did before the call was rewritten. That is runtime
+        // resolution, so it exists only where `allowUnresolved` permits it;
+        // under `--reject-unresolved` the map is a closed set and a miss throws.
+        let fallback = if !self.options.allow_unresolved.allows(shape) {
+            None
+        } else if kind == ImportKind::Require {
             self.record_usage_of_runtime_require();
-            self.value_for_require(loc)
+            Some(self.value_for_require(loc))
         } else {
             let param_ref = self.new_symbol(js_ast::symbol::Kind::Other, b"specifier");
             VecExt::append(&mut self.current_scope_mut().generated, param_ref);
@@ -1186,7 +1194,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 binding: self.b(B::Identifier { r#ref: param_ref }, loc),
                 ..Default::default()
             }]));
-            self.new_expr(
+            Some(self.new_expr(
                 E::Arrow {
                     args,
                     body,
@@ -1194,14 +1202,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     ..Default::default()
                 },
                 loc,
-            )
+            ))
         };
 
-        let glob_call = self.call_runtime(
-            loc,
-            b"__glob",
-            ExprNodeList::from_slice(&[map_obj, fallback]),
-        );
+        let glob_args = match fallback {
+            Some(fallback) => ExprNodeList::from_slice(&[map_obj, fallback]),
+            None => ExprNodeList::init_one(map_obj),
+        };
+        let glob_call = self.call_runtime(loc, b"__glob", glob_args);
 
         Some(self.new_expr(
             E::Call {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -786,6 +786,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 }
 
+/// How a sub-expression contributes to a dynamic specifier shape.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ShapePart {
+    /// The expression's static shape was appended to the buffer (it may
+    /// contain placeholders from nested dynamic parts).
+    Appended,
+    /// Unknown at compile time: the caller adds one placeholder for it.
+    Opaque,
+    /// A literal NUL would be confused with the placeholder marker, so the
+    /// whole specifier cannot be shaped.
+    Poison,
+}
+
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub(crate) const ALLOW_MACROS: bool = !cfg!(target_family = "wasm");
 
@@ -805,7 +818,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         arg: Expr,
         buf: &'b mut BumpVec<'a, u8>,
     ) -> Result<&'b [u8], crate::Error> {
-        if self.append_dynamic_specifier_shape(arg, buf, 0)? {
+        if self.append_dynamic_specifier_shape(arg, buf, 0)? == ShapePart::Appended {
             Ok(buf.as_slice())
         } else {
             buf.clear();
@@ -833,64 +846,86 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(true)
     }
 
-    /// Appends `arg`'s static shape to `buf`; `false` means nothing was
-    /// appended (`buf` is truncated back to its entry length).
+    /// Appends `arg`'s static shape to `buf`. On `Opaque` and `Poison`
+    /// nothing is appended (`buf` is truncated back to its entry length).
     fn append_dynamic_specifier_shape(
         &mut self,
         arg: Expr,
         buf: &mut BumpVec<'a, u8>,
         depth: u32,
-    ) -> Result<bool, crate::Error> {
+    ) -> Result<ShapePart, crate::Error> {
+        use ShapePart::{Appended, Opaque, Poison};
         if depth >= 32 {
-            return Ok(false);
+            return Ok(Opaque);
         }
         let start = buf.len();
-        let ok = match &arg.data {
-            js_ast::ExprData::EString(s) => self.append_estring_rope(s, buf)?,
+        let part = match &arg.data {
+            js_ast::ExprData::EString(s) => {
+                if self.append_estring_rope(s, buf)? {
+                    Appended
+                } else {
+                    Poison
+                }
+            }
             js_ast::ExprData::ETemplate(tmpl) => 'tmpl: {
                 if tmpl.tag.is_some() {
-                    break 'tmpl false;
+                    break 'tmpl Opaque;
                 }
                 match &tmpl.head {
                     js_ast::e::TemplateContents::Cooked(head) => {
                         if !self.append_estring_rope(head, buf)? {
-                            break 'tmpl false;
+                            break 'tmpl Poison;
                         }
                     }
-                    js_ast::e::TemplateContents::Raw(_) => break 'tmpl false,
+                    js_ast::e::TemplateContents::Raw(_) => break 'tmpl Opaque,
                 }
-                let mut ok = true;
+                let mut out = Appended;
                 for part in tmpl.parts().iter() {
                     let value = part.value;
-                    if !self.append_dynamic_specifier_shape(value, buf, depth + 1)? {
-                        buf.push(0);
+                    match self.append_dynamic_specifier_shape(value, buf, depth + 1)? {
+                        Appended => {}
+                        Opaque => buf.push(0),
+                        Poison => {
+                            out = Poison;
+                            break;
+                        }
                     }
                     match &part.tail {
                         js_ast::e::TemplateContents::Cooked(tail) => {
                             if !self.append_estring_rope(tail, buf)? {
-                                ok = false;
+                                out = Poison;
                                 break;
                             }
                         }
                         js_ast::e::TemplateContents::Raw(_) => {
-                            ok = false;
+                            out = Opaque;
                             break;
                         }
                     }
                 }
-                ok
+                out
             }
-            js_ast::ExprData::EBinary(bin) if bin.op == js_ast::Op::Code::BinAdd => {
+            js_ast::ExprData::EBinary(bin) if bin.op == js_ast::Op::Code::BinAdd => 'add: {
                 let (l, r) = (bin.left, bin.right);
-                let ok_l = self.append_dynamic_specifier_shape(l, buf, depth + 1)?;
-                if !ok_l {
+                let part_l = self.append_dynamic_specifier_shape(l, buf, depth + 1)?;
+                if part_l == Poison {
+                    break 'add Poison;
+                }
+                if part_l == Opaque {
                     buf.push(0);
                 }
-                let ok_r = self.append_dynamic_specifier_shape(r, buf, depth + 1)?;
-                if !ok_r {
+                let part_r = self.append_dynamic_specifier_shape(r, buf, depth + 1)?;
+                if part_r == Poison {
+                    break 'add Poison;
+                }
+                if part_r == Opaque {
                     buf.push(0);
                 }
-                ok_l || ok_r
+                if part_l == Opaque && part_r == Opaque {
+                    Opaque
+                } else {
+                    Appended
+                }
             }
             js_ast::ExprData::EIdentifier(id) => {
                 let ref_ = id.ref_;
@@ -906,14 +941,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         return r;
                     }
                 }
-                false
+                Opaque
             }
-            _ => false,
+            _ => Opaque,
         };
-        if !ok {
+        if part != Appended {
             buf.truncate(start);
         }
-        Ok(ok)
+        Ok(part)
     }
 
     /// Relative, has a placeholder, and the static text before the first
@@ -1216,6 +1251,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let glob_args = match fallback {
             Some(fallback) => ExprNodeList::from_slice(&[map_obj, fallback]),
+            // Native `import()` rejects instead of throwing, so a miss with no
+            // fallback must reach `.catch()`. The third argument tells
+            // `__glob` to return a rejected Promise.
+            None if kind == ImportKind::Dynamic => {
+                let undef = self.new_expr(E::Undefined {}, loc);
+                let reject = self.new_expr(E::Number::new(1.0), loc);
+                ExprNodeList::from_slice(&[map_obj, undef, reject])
+            }
             None => ExprNodeList::init_one(map_obj),
         };
         let glob_call = self.call_runtime(loc, b"__glob", glob_args);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1121,22 +1121,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         matches.sort();
         matches.dedup();
 
-        let mut keys: Vec<&'a [u8]> = Vec::with_capacity(matches.len() * 2);
+        let mut keys: Vec<(&'a [u8], bool)> = Vec::with_capacity(matches.len() * 2);
         for m in matches.iter() {
-            keys.push(self.arena.alloc_slice_copy(m));
+            keys.push((self.arena.alloc_slice_copy(m), false));
         }
         // `require("./src/" + name)` passes the stem `./src/cat` for
         // `./src/cat.js`, so also alias each stem the runtime string can
         // produce (it must end with the static text after the last placeholder).
         let static_suffix = &shape[strings::last_index_of_char(shape, 0).map_or(0, |i| i + 1)..];
         for i in 0..matches.len() {
-            let Some(stem) = Self::glob_resolvable_stem(keys[i]) else {
+            let Some(stem) = Self::glob_resolvable_stem(keys[i].0) else {
                 continue;
             };
-            if !stem.ends_with(static_suffix) || keys.contains(&stem) {
+            if !stem.ends_with(static_suffix) || keys.iter().any(|&(k, _)| k == stem) {
                 continue;
             }
-            keys.push(stem);
+            keys.push((stem, true));
         }
         keys.sort();
 
@@ -1149,13 +1149,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let arena = self.arena;
         let mut properties: BumpVec<'_, G::Property> = BumpVec::with_capacity_in(keys.len(), arena);
-        for key in keys {
+        for (key, is_stem) in keys {
             let import_record_index = self.add_import_record(kind, loc, key);
             {
                 let record = &mut self.import_records.items_mut()[import_record_index as usize];
+                // A stem is a speculative alias the parser invented. When the
+                // configured extension order cannot resolve it, disable the
+                // entry instead of failing the build.
                 record.flags.set(
                     bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
-                    handles_import_errors,
+                    handles_import_errors || is_stem,
                 );
                 if let Some(state) = import_state {
                     if let Some(loader) = state.import_loader {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -563,6 +563,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     pub(crate) const_values: bun_ast::ast_result::ConstValuesMap,
 
+    /// `const x = <relative-path template>` initializers, consulted by
+    /// `append_dynamic_specifier_shape` so `require(x)` can glob.
+    pub glob_specifier_values: bun_ast::ast_result::ConstValuesMap,
+
     // These are backed by stack fallback allocators in _parse, and are uninitialized until then.
     pub(crate) binary_expression_stack: ListManaged<'a, BinaryExpressionVisitor>,
     // Reusable stack for `SideEffects::simplify_unused_binary_comma_expr`;
@@ -801,28 +805,322 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         arg: Expr,
         buf: &'b mut BumpVec<'a, u8>,
     ) -> Result<&'b [u8], crate::Error> {
-        if let Some(tmpl) = arg.data.e_template() {
-            if tmpl.tag.is_some() {
-                return Ok(b""); // tagged template — opaque
-            }
-            match &tmpl.head {
-                js_ast::e::TemplateContents::Cooked(head) => {
-                    buf.extend_from_slice(head.string(self.arena)?);
-                }
-                js_ast::e::TemplateContents::Raw(_) => return Ok(b""), // shouldn't happen post-visit but be safe
-            }
-            for part in tmpl.parts().iter() {
-                buf.push(0); // \x00 placeholder per interpolation
-                match &part.tail {
-                    js_ast::e::TemplateContents::Cooked(tail) => {
-                        buf.extend_from_slice(tail.string(self.arena)?);
-                    }
-                    js_ast::e::TemplateContents::Raw(_) => return Ok(b""), // raw tail — treat as opaque
-                }
-            }
-            return Ok(buf.as_slice());
+        if self.append_dynamic_specifier_shape(arg, buf, 0)? {
+            Ok(buf.as_slice())
+        } else {
+            buf.clear();
+            Ok(b"")
         }
-        Ok(b"")
+    }
+
+    fn append_estring_rope(
+        &self,
+        s: &js_ast::e::EString,
+        buf: &mut BumpVec<'a, u8>,
+    ) -> Result<bool, crate::Error> {
+        let start = buf.len();
+        let mut cur: Option<&js_ast::e::EString> = Some(s);
+        while let Some(seg) = cur {
+            let bytes = seg.string(self.arena)?;
+            if bytes.iter().any(|&b| b == 0) {
+                buf.truncate(start);
+                return Ok(false);
+            }
+            buf.extend_from_slice(bytes);
+            cur = seg.next.as_ref().map(|r| r.get());
+        }
+        Ok(true)
+    }
+
+    /// Appends `arg`'s static shape to `buf`; `false` means nothing was
+    /// appended (`buf` is truncated back to its entry length).
+    fn append_dynamic_specifier_shape(
+        &mut self,
+        arg: Expr,
+        buf: &mut BumpVec<'a, u8>,
+        depth: u32,
+    ) -> Result<bool, crate::Error> {
+        if depth >= 32 {
+            return Ok(false);
+        }
+        let start = buf.len();
+        let ok = match &arg.data {
+            js_ast::ExprData::EString(s) => self.append_estring_rope(s, buf)?,
+            js_ast::ExprData::ETemplate(tmpl) => 'tmpl: {
+                if tmpl.tag.is_some() {
+                    break 'tmpl false;
+                }
+                match &tmpl.head {
+                    js_ast::e::TemplateContents::Cooked(head) => {
+                        if !self.append_estring_rope(head, buf)? {
+                            break 'tmpl false;
+                        }
+                    }
+                    js_ast::e::TemplateContents::Raw(_) => break 'tmpl false,
+                }
+                let mut ok = true;
+                for part in tmpl.parts().iter() {
+                    let value = part.value;
+                    if !self.append_dynamic_specifier_shape(value, buf, depth + 1)? {
+                        buf.push(0);
+                    }
+                    match &part.tail {
+                        js_ast::e::TemplateContents::Cooked(tail) => {
+                            if !self.append_estring_rope(tail, buf)? {
+                                ok = false;
+                                break;
+                            }
+                        }
+                        js_ast::e::TemplateContents::Raw(_) => {
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                ok
+            }
+            js_ast::ExprData::EBinary(bin) if bin.op == js_ast::Op::Code::BinAdd => {
+                let (l, r) = (bin.left, bin.right);
+                let ok_l = self.append_dynamic_specifier_shape(l, buf, depth + 1)?;
+                if !ok_l {
+                    buf.push(0);
+                }
+                let ok_r = self.append_dynamic_specifier_shape(r, buf, depth + 1)?;
+                if !ok_r {
+                    buf.push(0);
+                }
+                ok_l || ok_r
+            }
+            js_ast::ExprData::EIdentifier(id) => {
+                let ref_ = id.ref_;
+                if ref_.source_index() == self.source.index.0
+                    && self.symbols[ref_.inner_index() as usize].kind
+                        == js_ast::symbol::Kind::Constant
+                {
+                    if let Some(init) = self.glob_specifier_values.remove(&ref_) {
+                        let r = self.append_dynamic_specifier_shape(init, buf, depth + 1);
+                        self.glob_specifier_values.put(ref_, init).expect("oom");
+                        return r;
+                    }
+                }
+                false
+            }
+            _ => false,
+        };
+        if !ok {
+            buf.truncate(start);
+        }
+        Ok(ok)
+    }
+
+    fn glob_shape_is_eligible(shape: &[u8]) -> bool {
+        if !(shape.starts_with(b"./") || shape.starts_with(b"../")) {
+            return false;
+        }
+        if !shape.iter().any(|b| *b == 0) {
+            return false;
+        }
+        match shape.last() {
+            Some(&0) | Some(&b'/') => return false,
+            _ => {}
+        }
+        for &b in shape {
+            if matches!(b, b'*' | b'?' | b'[' | b'{' | b'!' | b'\\') {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// `\x00` placeholders become `**/*` between slashes, `*` otherwise
+    /// (matches esbuild; keeps `./mods/${x}.js` bounded to one directory).
+    fn glob_shape_to_pattern(shape: &[u8], out: &mut Vec<u8>) {
+        out.clear();
+        let mut i = 0;
+        while i < shape.len() {
+            let b = shape[i];
+            if b != 0 {
+                out.push(b);
+                i += 1;
+                continue;
+            }
+            while i < shape.len() && shape[i] == 0 {
+                i += 1;
+            }
+            let left_slash = out.last() == Some(&b'/');
+            let right_slash = shape.get(i) == Some(&b'/');
+            if left_slash && right_slash {
+                out.extend_from_slice(b"**/*");
+            } else {
+                out.push(b'*');
+            }
+        }
+    }
+
+    /// Record `const x = <template>` so `require(x)` can glob. Lookup gates on
+    /// `Kind::Constant`, so non-const entries stored here are simply ignored.
+    pub fn maybe_track_glob_specifier(&mut self, ref_: Ref, value: Option<Expr>) {
+        if self.options.glob_resolver.is_none() {
+            return;
+        }
+        let Some(val) = value else { return };
+        match val.data {
+            js_ast::ExprData::ETemplate(ref t) if t.tag.is_none() => {}
+            js_ast::ExprData::EBinary(ref b) if b.op == js_ast::Op::Code::BinAdd => {}
+            _ => return,
+        }
+        let mut shape_buf = BumpVec::new_in(self.arena);
+        let shape = match self.extract_dynamic_specifier_shape(val, &mut shape_buf) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        if shape.starts_with(b"./") || shape.starts_with(b"../") {
+            self.glob_specifier_values.put(ref_, val).expect("oom");
+        }
+    }
+
+    /// Rewrite `require(arg)` with a relative-path template/concat arg into
+    /// `__glob({ "./a.js": () => require("./a.js"), ... })(arg)`.
+    pub fn try_glob_dynamic_require(
+        &mut self,
+        arg: Expr,
+        kind: ImportKind,
+        handles_import_errors: bool,
+    ) -> Option<Expr> {
+        if !self.options.bundle || self.is_control_flow_dead {
+            return None;
+        }
+        let resolver = self.options.glob_resolver?;
+
+        let mut shape_buf = BumpVec::new_in(self.arena);
+        let shape = self
+            .extract_dynamic_specifier_shape(arg, &mut shape_buf)
+            .ok()?;
+        if !Self::glob_shape_is_eligible(shape) {
+            return None;
+        }
+
+        let source_dir = self.source.path.source_dir();
+        if source_dir.is_empty() {
+            return None;
+        }
+
+        let mut pattern = Vec::with_capacity(shape.len() + 4);
+        Self::glob_shape_to_pattern(shape, &mut pattern);
+
+        let mut matches = resolver(source_dir, &pattern);
+        if matches.is_empty() {
+            return None;
+        }
+        const GLOB_MATCH_CAP: usize = 256;
+        if matches.len() > GLOB_MATCH_CAP {
+            return None;
+        }
+        matches.sort();
+        matches.dedup();
+
+        let loc = arg.loc;
+
+        let mut properties: BumpVec<'_, G::Property> =
+            BumpVec::with_capacity_in(matches.len(), self.arena);
+        for m in matches.iter() {
+            let path_bytes: &'a [u8] = self.arena.alloc_slice_copy(m);
+            let path = fs::Path::init(path_bytes);
+            let import_record_index = self.add_import_record_by_range_and_path(
+                kind,
+                self.source.range_of_string(loc),
+                &path,
+            );
+            self.import_records.items_mut()[import_record_index as usize]
+                .flags
+                .set(
+                    bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
+                    handles_import_errors,
+                );
+            self.import_records_for_current_part
+                .push(import_record_index);
+
+            let value_expr = if kind == ImportKind::Dynamic {
+                let path_str = self.new_expr(
+                    E::String {
+                        data: path_bytes.into(),
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                self.new_expr(
+                    E::Import {
+                        expr: path_str,
+                        import_record_index,
+                        options: Expr {
+                            loc,
+                            data: js_ast::ExprData::EMissing(E::Missing {}),
+                        },
+                    },
+                    loc,
+                )
+            } else {
+                self.new_expr(
+                    E::RequireString {
+                        import_record_index,
+                        ..Default::default()
+                    },
+                    loc,
+                )
+            };
+
+            let ret_stmt = self.s(
+                S::Return {
+                    value: Some(value_expr),
+                },
+                loc,
+            );
+            let body_stmts = self.arena.alloc_slice_copy(&[ret_stmt]);
+            let thunk = self.new_expr(
+                E::Arrow {
+                    args: bun_ast::StoreSlice::EMPTY,
+                    body: G::FnBody {
+                        loc,
+                        stmts: body_stmts.into(),
+                    },
+                    prefer_expr: true,
+                    ..Default::default()
+                },
+                loc,
+            );
+
+            let key = self.new_expr(
+                E::String {
+                    data: path_bytes.into(),
+                    ..Default::default()
+                },
+                loc,
+            );
+            properties.push(G::Property {
+                key: Some(key),
+                value: Some(thunk),
+                ..Default::default()
+            });
+        }
+
+        let map_obj = self.new_expr(
+            E::Object {
+                properties: G::PropertyList::from_bump_vec(properties),
+                ..Default::default()
+            },
+            loc,
+        );
+
+        let glob_call = self.call_runtime(loc, b"__glob", ExprNodeList::init_one(map_obj));
+
+        Some(self.new_expr(
+            E::Call {
+                target: glob_call,
+                args: ExprNodeList::init_one(arg),
+                ..Default::default()
+            },
+            loc,
+        ))
     }
 
     pub(crate) fn check_dynamic_specifier(
@@ -1009,6 +1307,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 },
                 state.loc,
             );
+        }
+
+        if matches!(state.import_options.data, js_ast::ExprData::EMissing(..)) {
+            let handles = (state.is_await_target
+                && self.fn_or_arrow_data_visit.try_body_count != 0)
+                || state.is_then_catch_target;
+            if let Some(glob) = self.try_glob_dynamic_require(arg, ImportKind::Dynamic, handles) {
+                return glob;
+            }
         }
 
         if self.options.warn_about_unbundled_modules {
@@ -1237,6 +1544,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 )
             }
             _ => {
+                let handles = self.fn_or_arrow_data_visit.try_body_count != 0;
+                if let Some(glob) = self.try_glob_dynamic_require(arg, ImportKind::Require, handles)
+                {
+                    return glob;
+                }
                 let _ = self.check_dynamic_specifier(arg, arg.loc, "require()");
                 self.record_usage_of_runtime_require();
                 self.new_expr(
@@ -8736,6 +9048,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             relocated_top_level_vars: BumpVec::new_in(arena),
             after_arrow_body_loc: bun_ast::Loc::EMPTY,
             const_values: Default::default(),
+            glob_specifier_values: Default::default(),
             binary_expression_stack: BumpVec::new_in(arena),
             binary_expression_simplify_stack: BumpVec::new_in(arena),
             ref_to_ts_namespace_member: Default::default(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -565,7 +565,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     /// `const x = <relative-path template>` initializers, consulted by
     /// `append_dynamic_specifier_shape` so `require(x)` can glob.
-    pub glob_specifier_values: bun_ast::ast_result::ConstValuesMap,
+    pub(crate) glob_specifier_values: bun_ast::ast_result::ConstValuesMap,
 
     // These are backed by stack fallback allocators in _parse, and are uninitialized until then.
     pub(crate) binary_expression_stack: ListManaged<'a, BinaryExpressionVisitor>,
@@ -985,7 +985,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// Record `const x = <template>` so `require(x)` can glob. Lookup gates on
     /// `Kind::Constant`, so non-const entries stored here are simply ignored.
-    pub fn maybe_track_glob_specifier(&mut self, ref_: Ref, value: Option<Expr>) {
+    pub(crate) fn maybe_track_glob_specifier(&mut self, ref_: Ref, value: Option<Expr>) {
         if self.options.glob_resolver.is_none() {
             return;
         }
@@ -1011,7 +1011,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// bundling every file the shape can name (https://esbuild.github.io/api/#glob).
     /// `import_state` is `None` for `require()`. `None` means the call does not
     /// qualify and the caller keeps the runtime `require`/`import()`.
-    pub fn try_glob_dynamic_require(
+    pub(crate) fn try_glob_dynamic_require(
         &mut self,
         arg: Expr,
         import_state: Option<&TransposeState>,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -87,6 +87,10 @@ pub struct Options<'a> {
 
     pub allow_unresolved: &'a options::AllowUnresolved,
 
+    /// Enables the `__glob({...})(arg)` rewrite for template-literal
+    /// `require()`/`import()`.
+    pub glob_resolver: Option<options::GlobResolver>,
+
     pub module_type: options::ModuleType,
     pub output_format: options::Format,
 
@@ -137,6 +141,7 @@ impl<'a> Default for Options<'a> {
             macro_context: None,
             warn_about_unbundled_modules: true,
             allow_unresolved: &options::AllowUnresolved::DEFAULT,
+            glob_resolver: None,
             module_type: options::ModuleType::Unknown,
             output_format: options::Format::Esm,
             transform_only: false,
@@ -222,6 +227,7 @@ impl<'a> Options<'a> {
             macro_context: None,
             warn_about_unbundled_modules: self.warn_about_unbundled_modules,
             allow_unresolved: self.allow_unresolved,
+            glob_resolver: self.glob_resolver,
             module_type: self.module_type,
             output_format: self.output_format,
             transform_only: self.transform_only,
@@ -295,6 +301,7 @@ impl<'a> Options<'a> {
             macro_context: None,
             warn_about_unbundled_modules: true,
             allow_unresolved: &options::AllowUnresolved::DEFAULT,
+            glob_resolver: None,
             module_type: options::ModuleType::Unknown,
             output_format: options::Format::Esm,
             transform_only: false,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -91,6 +91,12 @@ pub struct Options<'a> {
     /// `require()`/`import()`.
     pub glob_resolver: Option<options::GlobResolver>,
 
+    /// Effective resolver extension orders for glob stem aliases:
+    /// `[require, dynamic import]`. The bundler injects them with
+    /// `glob_resolver`. An extension outside the order for the call's kind
+    /// gets no stem alias.
+    pub glob_stem_extension_orders: [&'a [Box<[u8]>]; 2],
+
     pub module_type: options::ModuleType,
     pub output_format: options::Format,
 
@@ -142,6 +148,7 @@ impl<'a> Default for Options<'a> {
             warn_about_unbundled_modules: true,
             allow_unresolved: &options::AllowUnresolved::DEFAULT,
             glob_resolver: None,
+            glob_stem_extension_orders: [&[], &[]],
             module_type: options::ModuleType::Unknown,
             output_format: options::Format::Esm,
             transform_only: false,
@@ -228,6 +235,7 @@ impl<'a> Options<'a> {
             warn_about_unbundled_modules: self.warn_about_unbundled_modules,
             allow_unresolved: self.allow_unresolved,
             glob_resolver: self.glob_resolver,
+            glob_stem_extension_orders: self.glob_stem_extension_orders,
             module_type: self.module_type,
             output_format: self.output_format,
             transform_only: self.transform_only,
@@ -302,6 +310,7 @@ impl<'a> Options<'a> {
             warn_about_unbundled_modules: true,
             allow_unresolved: &options::AllowUnresolved::DEFAULT,
             glob_resolver: None,
+            glob_stem_extension_orders: [&[], &[]],
             module_type: options::ModuleType::Unknown,
             output_format: options::Format::Esm,
             transform_only: false,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -59,8 +59,9 @@ pub mod options {
     /// is captured.
     pub(crate) type AllowUnresolvedMatcher = fn(pattern: &[u8], shape: &[u8]) -> bool;
 
-    /// Filesystem glob for template-literal `require()`/`import()`; injected
-    /// by the bundler since the parser cannot depend on `bun_glob`.
+    /// Filesystem glob for template-literal `require()`/`import()`. The
+    /// bundler injects it; the transpiler leaves it `None`, so the parser
+    /// itself never touches the filesystem.
     pub type GlobResolver = fn(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>>;
 
     #[derive(Debug, Clone, Default)]

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -59,6 +59,10 @@ pub mod options {
     /// is captured.
     pub(crate) type AllowUnresolvedMatcher = fn(pattern: &[u8], shape: &[u8]) -> bool;
 
+    /// Filesystem glob for template-literal `require()`/`import()`; injected
+    /// by the bundler since the parser cannot depend on `bun_glob`.
+    pub type GlobResolver = fn(source_dir: &[u8], pattern: &[u8]) -> Vec<Box<[u8]>>;
+
     #[derive(Debug, Clone, Default)]
     pub enum AllowUnresolved {
         /// Default. Skip all checks — current behavior.

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -539,6 +539,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 } else {
                     self.vis_scope().is_after_const_local_prefix = true;
                 }
+                self.maybe_track_glob_specifier(id_ref, decl.value);
                 // SAFETY: original_name is arena-owned, valid for 'a.
                 let original_name: &'a [u8] = self.symbols[id_ref.inner_index() as usize]
                     .original_name

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2030,10 +2030,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         return;
                     }
                     _ => {
-                        let handles = p.fn_or_arrow_data_visit.try_body_count != 0;
-                        if let Some(glob) =
-                            p.try_glob_dynamic_require(first, bun_ast::ImportKind::Require, handles)
-                        {
+                        if let Some(glob) = p.try_glob_dynamic_require(first, None) {
                             *e = glob;
                             return;
                         }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2029,7 +2029,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         *e = p.transpose_known_to_be_if_require(first, &state);
                         return;
                     }
-                    _ => {}
+                    _ => {
+                        let handles = p.fn_or_arrow_data_visit.try_body_count != 0;
+                        if let Some(glob) =
+                            p.try_glob_dynamic_require(first, bun_ast::ImportKind::Require, handles)
+                        {
+                            *e = glob;
+                            return;
+                        }
+                    }
                 }
             }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -109,14 +109,9 @@ var __moduleCache;
 // When you do know the module is CJS
 export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
-// Lookup table for template-literal require()/import(); throws MODULE_NOT_FOUND on miss.
-export var __glob = map => path => {
-  var fn = map[path];
-  if (fn) return fn();
-  var e = new Error("Cannot find module '" + path + "' in glob import map. Available: " + Object.keys(map).join(", "));
-  e.code = "MODULE_NOT_FOUND";
-  throw e;
-};
+// require("./dir/" + x) bundled as a lookup map. `fallback` is the runtime
+// require/import for a specifier that is not in the bundle.
+export var __glob = (map, fallback) => path => (__hasOwnProp.call(map, path) ? map[path]() : fallback(path));
 
 export var __name = (target, name) => {
   Object.defineProperty(target, "name", {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -110,8 +110,15 @@ var __moduleCache;
 export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
 // require("./dir/" + x) bundled as a lookup map. `fallback` is the runtime
-// require/import for a specifier that is not in the bundle.
-export var __glob = (map, fallback) => path => (__hasOwnProp.call(map, path) ? map[path]() : fallback(path));
+// require/import for a specifier that is not in the bundle; it is absent when
+// the build forbids runtime resolution (--reject-unresolved).
+export var __glob = (map, fallback) => path => {
+  if (__hasOwnProp.call(map, path)) return map[path]();
+  if (fallback) return fallback(path);
+  var e = new Error("Cannot find module '" + path + "' in bundle. Known: " + Object.keys(map).join(", "));
+  e.code = "MODULE_NOT_FOUND";
+  throw e;
+};
 
 export var __name = (target, name) => {
   Object.defineProperty(target, "name", {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -109,6 +109,15 @@ var __moduleCache;
 // When you do know the module is CJS
 export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
+// Lookup table for template-literal require()/import(); throws MODULE_NOT_FOUND on miss.
+export var __glob = map => path => {
+  var fn = map[path];
+  if (fn) return fn();
+  var e = new Error("Cannot find module '" + path + "' in glob import map. Available: " + Object.keys(map).join(", "));
+  e.code = "MODULE_NOT_FOUND";
+  throw e;
+};
+
 export var __name = (target, name) => {
   Object.defineProperty(target, "name", {
     value: name,

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -111,12 +111,14 @@ export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).ex
 
 // require("./dir/" + x) bundled as a lookup map. `fallback` is the runtime
 // require/import for a specifier that is not in the bundle; it is absent when
-// the build forbids runtime resolution (--reject-unresolved).
-export var __glob = (map, fallback) => path => {
+// the build forbids runtime resolution (--reject-unresolved). `reject` makes
+// a miss return a rejected Promise, matching native import().
+export var __glob = (map, fallback, reject) => path => {
   if (__hasOwnProp.call(map, path)) return map[path]();
   if (fallback) return fallback(path);
   var e = new Error("Cannot find module '" + path + "' in bundle. Known: " + Object.keys(map).join(", "));
   e.code = "MODULE_NOT_FOUND";
+  if (reject) return Promise.reject(e);
   throw e;
 };
 

--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -66,11 +66,11 @@ NS.then(({ fn: fn2 }) => {
 "
 `;
 
-exports[`Bun.build BuildArtifact properties: hash 1`] = `"g9c33042"`;
+exports[`Bun.build BuildArtifact properties: hash 1`] = `"fdy9q7tr"`;
 
-exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"2ksyc1td"`;
+exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"8dm5nam1"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"g9c33042"`;
+exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"fdy9q7tr"`;
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
 

--- a/test/bundler/bundler_allow_unresolved.test.ts
+++ b/test/bundler/bundler_allow_unresolved.test.ts
@@ -226,4 +226,138 @@ describe("bundler", () => {
     backend: "cli",
     allowUnresolved: ["./locales/*.json"],
   });
+
+  // 17. String concatenation has a shape ("./a/*"), so it is not opaque.
+  itBundled("allow-unresolved/ConcatShapeRejectedByEmptyString", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        require("./a/" + x);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [""],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 18. ... and a pattern that matches the concatenation's shape allows it.
+  itBundled("allow-unresolved/ConcatShapeAllowedByPattern", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        require("./a/" + x);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./a/*"],
+  });
+
+  // 19. A const bound to a template carries the template's shape.
+  itBundled("allow-unresolved/ConstBoundTemplateRejectedByEmptyString", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        const specifier = \`./a/\${x}.js\`;
+        require(specifier);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [""],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 20. ... and matches a pattern like the template itself would.
+  itBundled("allow-unresolved/ConstBoundTemplateAllowedByPattern", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        const specifier = \`./a/\${x}.js\`;
+        require(specifier);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./a/*.js"],
+  });
+
+  // 21. require.resolve() with a concatenation is checked the same way. It is
+  // never glob-bundled, so the pattern is the only way to allow it.
+  itBundled("allow-unresolved/RequireResolveConcatRejectedByEmptyString", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        require.resolve("./a/" + x);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [""],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+  itBundled("allow-unresolved/RequireResolveConcatAllowedByPattern", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        require.resolve("./a/" + x);
+      `,
+      "/a/foo.js": `module.exports = 1;`,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./a/*"],
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").not.toContain("__glob");
+    },
+  });
+
+  // 22. Strict mode with files on disk: the matches are bundled into a closed
+  // __glob map with no runtime fallback, so nothing resolves at runtime.
+  itBundled("allow-unresolved/StrictGlobIsClosedSet", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = process.env.NAME;
+        try {
+          console.log(require(\`./a/\${name}.js\`));
+        } catch (e) {
+          console.log(e.code, e.message.includes("in bundle"));
+        }
+      `,
+      "/a/foo.js": `module.exports = "foo";`,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    run: [
+      { env: { NAME: "foo" }, stdout: "foo" },
+      { env: { NAME: "bar" }, stdout: "MODULE_NOT_FOUND true" },
+    ],
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("__glob(");
+      api.expectFile("/out/entry.js").not.toContain("__require");
+      api.expectFile("/out/entry.js").not.toContain("import.meta.require");
+    },
+  });
+
+  // 23. A pattern that allows the shape keeps the runtime fallback next to the
+  // bundled matches.
+  itBundled("allow-unresolved/PatternGlobKeepsFallback", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = process.env.NAME;
+        console.log(require(\`./a/\${name}.js\`));
+      `,
+      "/a/foo.js": `module.exports = "foo";`,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./a/*.js"],
+    run: { env: { NAME: "foo" }, stdout: "foo" },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("__glob(");
+      api.expectFile("/out/entry.js").toContain("__require");
+    },
+  });
 });

--- a/test/bundler/bundler_allow_unresolved.test.ts
+++ b/test/bundler/bundler_allow_unresolved.test.ts
@@ -341,6 +341,30 @@ describe("bundler", () => {
     },
   });
 
+  // A dynamic import() miss in the closed map rejects the Promise like native
+  // import(), so .catch() observes it instead of a synchronous throw.
+  itBundled("allow-unresolved/StrictGlobImportMissRejects", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = process.env.NAME;
+        import(\`./a/\${name}.js\`)
+          .then(m => console.log(m.default))
+          .catch(e => console.log("caught", e.code));
+      `,
+      "/a/foo.js": `export default "foo";`,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    run: [
+      { env: { NAME: "foo" }, stdout: "foo" },
+      { env: { NAME: "bar" }, stdout: "caught MODULE_NOT_FOUND" },
+    ],
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("__glob(");
+    },
+  });
+
   // 23. A pattern that allows the shape keeps the runtime fallback next to the
   // bundled matches.
   itBundled("allow-unresolved/PatternGlobKeepsFallback", {

--- a/test/bundler/bundler_glob_require.test.ts
+++ b/test/bundler/bundler_glob_require.test.ts
@@ -630,6 +630,29 @@ describe("bundler", () => {
     },
   });
 
+  // An extensionless runtime string can name a native addon: target bun's
+  // extension order probes .node. The stem key must exist in the closed map,
+  // or the require throws MODULE_NOT_FOUND instead of reaching dlopen.
+  itBundled("glob-require/NativeAddonExtensionlessStem", {
+    target: "bun",
+    allowUnresolved: [],
+    files: {
+      "/entry.js": /* js */ `
+        const plat = process.env.PLAT || "x64-linux";
+        try {
+          require("./bin/" + plat);
+        } catch (e) {
+          console.log(e.code);
+        }
+      `,
+      "/bin/x64-linux.node": Buffer.from("dummy addon bytes"),
+    },
+    run: { stdout: "ERR_DLOPEN_FAILED" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./bin/x64-linux"');
+    },
+  });
+
   // The #9951 scenario end to end: a platform-specific .node addon required
   // via a const template specifier is embedded in a --compile binary. We use
   // dummy addon bytes so the test does not need node-gyp; loading is expected

--- a/test/bundler/bundler_glob_require.test.ts
+++ b/test/bundler/bundler_glob_require.test.ts
@@ -240,6 +240,23 @@ describe("bundler", () => {
     },
   });
 
+  // A literal NUL anywhere in the specifier expression poisons the shape. It
+  // must not become a wildcard that globs the directory.
+  itBundled("glob-require/LiteralNulOperandNotGlobbed", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH || "a";
+        try { require("./mods/" + which + "\\0"); } catch { console.log("caught"); }
+      `,
+      "/mods/a.js": `module.exports = 1;`,
+    },
+    run: { stdout: "caught" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
+
   // A `..` segment in the static text is normalized away in the map keys, so
   // the runtime string could never equal a key. The call must stay a runtime
   // call.

--- a/test/bundler/bundler_glob_require.test.ts
+++ b/test/bundler/bundler_glob_require.test.ts
@@ -741,3 +741,33 @@ test.skipIf(isWindows)("glob-require/SymlinkedFileIsBundled", async () => {
   expect(stdout).toBe("REAL-A\n");
   expect(exitCode).toBe(0);
 });
+
+// A stem alias is speculative. When a custom --extension-order cannot probe
+// the matched extension, the build must not fail on the alias record.
+test("glob-require/StemAliasCustomExtensionOrder", async () => {
+  using dir = tempDir("bundler-glob-extorder", {
+    "entry.js": `const which = process.env.WHICH || "foo.mjs";\nconsole.log(require("./mods/" + which));`,
+    "mods/foo.mjs": `module.exports = "mjs";`,
+  });
+
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--target=bun", "--extension-order", ".ts,.js", "./entry.js", "--outfile=out.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+  expect(buildStderr).toBe("");
+  expect(buildExitCode).toBe(0);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./out.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("mjs\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/bundler/bundler_glob_require.test.ts
+++ b/test/bundler/bundler_glob_require.test.ts
@@ -1,0 +1,341 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+// esbuild-style glob imports: `require()` / `import()` whose argument is a
+// relative-path template literal bundles every file matching the pattern and
+// dispatches at runtime via a __glob({...}) lookup table.
+//
+// Also covers the `const specifier = <template>; require(specifier)` shape,
+// which is how many native-addon loaders (e.g. tigerbeetle-node, issue #9951)
+// pick a platform-specific .node file.
+describe("bundler", () => {
+  itBundled("glob-require/TemplateLiteralDirect", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH;
+        console.log(require(\`./mods/\${which}.js\`));
+      `,
+      "/mods/a.js": `module.exports = "value-a";`,
+      "/mods/b.js": `module.exports = "value-b";`,
+    },
+    run: [
+      { env: { WHICH: "a" }, stdout: "value-a" },
+      { env: { WHICH: "b" }, stdout: "value-b" },
+    ],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      api.expectFile("/out.js").toContain("__glob");
+      api.expectFile("/out.js").toContain('"./mods/a.js"');
+      api.expectFile("/out.js").toContain('"./mods/b.js"');
+      if (out.includes("import.meta.require")) {
+        throw new Error("expected template-literal require to be bundled, not deferred to runtime");
+      }
+    },
+  });
+
+  itBundled("glob-require/TemplateLiteralMiss", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH || "c";
+        try {
+          require(\`./mods/\${which}.js\`);
+        } catch (e) {
+          console.log(e.code, e.message);
+        }
+      `,
+      "/mods/a.js": `module.exports = 1;`,
+      "/mods/b.js": `module.exports = 2;`,
+    },
+    run: {
+      stdout:
+        "MODULE_NOT_FOUND Cannot find module './mods/c.js' in glob import map. Available: ./mods/a.js, ./mods/b.js",
+    },
+  });
+
+  itBundled("glob-require/StringConcatenation", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH;
+        console.log(require("./mods/" + which + ".js"));
+      `,
+      "/mods/a.js": `module.exports = "concat-a";`,
+      "/mods/b.js": `module.exports = "concat-b";`,
+    },
+    run: { env: { WHICH: "b" }, stdout: "concat-b" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+    },
+  });
+
+  // Adjacent string literals are folded into a rope EString before the glob
+  // check; the shape extractor must read every segment.
+  itBundled("glob-require/StringConcatenationAdjacentLiterals", {
+    target: "bun",
+    minifySyntax: true,
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH;
+        console.log(require("./mods" + "/" + which + ".js"));
+      `,
+      "/mods/a.js": `module.exports = "rope-a";`,
+      "/mods/b.js": `module.exports = "rope-b";`,
+    },
+    run: { env: { WHICH: "a" }, stdout: "rope-a" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./mods/a.js"');
+    },
+  });
+
+  // A self-referential const must not send the bundler into unbounded
+  // recursion. The self-reference contributes a placeholder, so a map is
+  // still emitted; the entry throws TDZ at runtime before the lookup.
+  itBundled("glob-require/SelfReferentialConst", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        try {
+          const a = \`./mods/\${a}.js\`;
+          require(a);
+        } catch (e) {
+          console.log("caught");
+        }
+      `,
+      "/mods/x.js": `module.exports = 1;`,
+    },
+    run: { stdout: "caught" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./mods/x.js"');
+    },
+  });
+
+  // A literal NUL in a template's static content must not be confused with
+  // the placeholder marker.
+  itBundled("glob-require/LiteralNulNotGlobbed", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH || "a";
+        try { require(\`./mods/\\0\${which}.js\`); } catch {}
+        console.log("ok");
+      `,
+      "/mods/a.js": `module.exports = 1;`,
+    },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("literal NUL must not be treated as a glob placeholder");
+      }
+    },
+  });
+
+  // import() with a second argument (import attributes) is not glob-resolved;
+  // it falls through to the runtime import so the attributes are preserved.
+  itBundled("glob-require/DynamicImportWithOptionsNotGlobbed", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH || "a";
+        const m = await import(\`./mods/\${which}.json\`, { with: { type: "json" } });
+        void m;
+        console.log("ok");
+      `,
+      "/mods/a.json": `{"a":1}`,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("import() with attributes must not be glob-resolved");
+      }
+    },
+  });
+
+  itBundled("glob-require/ConstIndirection", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH;
+        const specifier = \`./mods/\${which}.js\`;
+        console.log(require(specifier));
+      `,
+      "/mods/a.js": `module.exports = "indirect-a";`,
+      "/mods/b.js": `module.exports = "indirect-b";`,
+    },
+    run: { env: { WHICH: "a" }, stdout: "indirect-a" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+    },
+  });
+
+  // A `let` binding may be reassigned, so the bundler must not treat its
+  // initializer as the specifier shape.
+  itBundled("glob-require/LetIndirectionNotBundled", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        let specifier = \`./mods/\${process.env.WHICH}.js\`;
+        if (process.env.OVERRIDE) specifier = process.env.OVERRIDE;
+        try { require(specifier); } catch {}
+        console.log("ok");
+      `,
+      "/mods/a.js": `module.exports = 1;`,
+    },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("let-bound specifier should not be glob-resolved");
+      }
+    },
+  });
+
+  // Zero matches falls through to runtime require (same as before), so
+  // bundling still succeeds and the call can be caught at runtime.
+  itBundled("glob-require/ZeroMatchesFallsThrough", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        try {
+          require(\`./nowhere/\${process.env.X}.js\`);
+        } catch (e) {
+          console.log("caught");
+        }
+      `,
+    },
+    run: { stdout: "caught" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("zero-match glob should fall through, not emit __glob");
+      }
+    },
+  });
+
+  itBundled("glob-require/DynamicImport", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH;
+        const m = await import(\`./mods/\${which}.js\`);
+        console.log(m.default);
+      `,
+      "/mods/a.js": `export default "import-a";`,
+      "/mods/b.js": `export default "import-b";`,
+    },
+    run: { env: { WHICH: "b" }, stdout: "import-b" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+    },
+  });
+
+  itBundled("glob-require/SubdirectoryMatch", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const plat = process.env.PLAT;
+        console.log(require(\`./bin/\${plat}/client.js\`));
+      `,
+      "/bin/x64-linux/client.js": `module.exports = "linux";`,
+      "/bin/arm64-darwin/client.js": `module.exports = "darwin";`,
+      "/bin/README.md": `not js`,
+    },
+    run: [
+      { env: { PLAT: "x64-linux" }, stdout: "linux" },
+      { env: { PLAT: "arm64-darwin" }, stdout: "darwin" },
+    ],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./bin/x64-linux/client.js"');
+      api.expectFile("/out.js").toContain('"./bin/arm64-darwin/client.js"');
+      api.expectFile("/out.js").not.toContain("README");
+    },
+  });
+
+  // The tigerbeetle-node pattern: a const specifier built from several
+  // interpolations, declared after control flow that computes one of the
+  // pieces, inside an IIFE.
+  itBundled("glob-require/NativeAddonLoaderPattern", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const binding = (() => {
+          const { PLAT, ARCH } = process.env;
+          let extra = "";
+          if (PLAT === "linux") extra = "-gnu";
+          const filename = \`./bin/\${ARCH}-\${PLAT}\${extra}/client.js\`;
+          return require(filename);
+        })();
+        console.log(binding);
+      `,
+      "/bin/x64-linux-gnu/client.js": `module.exports = "linux-gnu";`,
+      "/bin/x64-darwin/client.js": `module.exports = "darwin";`,
+      "/bin/arm64-darwin/client.js": `module.exports = "arm-darwin";`,
+    },
+    run: [
+      { env: { PLAT: "linux", ARCH: "x64" }, stdout: "linux-gnu" },
+      { env: { PLAT: "darwin", ARCH: "x64" }, stdout: "darwin" },
+      { env: { PLAT: "darwin", ARCH: "arm64" }, stdout: "arm-darwin" },
+    ],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+      api.expectFile("/out.js").toContain('"./bin/x64-linux-gnu/client.js"');
+    },
+  });
+
+  // The #9951 scenario end to end: a platform-specific .node addon required
+  // via a const template specifier is embedded in a --compile binary. We use
+  // dummy addon bytes so the test does not need node-gyp; loading is expected
+  // to fail at dlopen time, which is past the point the glob resolution and
+  // asset embedding this PR adds have both succeeded.
+  itBundled("glob-require/CompileEmbedsNodeAddon", {
+    compile: true,
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+        const binding = (() => {
+          const plat = process.env.PLAT || "x64-linux";
+          const filename = \`./bin/\${plat}/client.node\`;
+          try {
+            return require(filename);
+          } catch (e) {
+            // Embedding worked when we got as far as trying to dlopen the
+            // dummy bytes; a resolver miss would be MODULE_NOT_FOUND instead.
+            if (e.code === "ERR_DLOPEN_FAILED") return "dlopen-attempted";
+            throw e;
+          }
+        })();
+        const names = Bun.embeddedFiles.map(f => f.name).sort();
+        console.log(JSON.stringify({ binding, count: names.length }));
+      `,
+      "/bin/x64-linux/client.node": Buffer.from("not a real addon"),
+      "/bin/arm64-darwin/client.node": Buffer.from("not a real addon either"),
+    },
+    run: {
+      setCwd: true,
+      env: { PLAT: "x64-linux" },
+      stdout: JSON.stringify({ binding: "dlopen-attempted", count: 2 }),
+    },
+  });
+
+  // Bare specifiers (no `./` / `../`) must not be globbed.
+  itBundled("glob-require/BareSpecifierNotGlobbed", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        try {
+          require(\`some-pkg/\${process.env.X}\`);
+        } catch {}
+        console.log("ok");
+      `,
+    },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("bare specifiers must not be glob-resolved");
+      }
+    },
+  });
+});

--- a/test/bundler/bundler_glob_require.test.ts
+++ b/test/bundler/bundler_glob_require.test.ts
@@ -1,13 +1,18 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { symlinkSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { itBundled } from "./expectBundled";
 
 // esbuild-style glob imports: `require()` / `import()` whose argument is a
-// relative-path template literal bundles every file matching the pattern and
-// dispatches at runtime via a __glob({...}) lookup table.
+// relative-path template literal or string concatenation bundles every file
+// matching the pattern and dispatches at runtime via a __glob({...}) lookup
+// table (https://esbuild.github.io/api/#glob).
 //
 // Also covers the `const specifier = <template>; require(specifier)` shape,
 // which is how many native-addon loaders (e.g. tigerbeetle-node, issue #9951)
-// pick a platform-specific .node file.
+// pick a platform-specific .node file, and the extensionless
+// `require("./src/" + name)` shape shelljs uses (issue #12302).
 describe("bundler", () => {
   itBundled("glob-require/TemplateLiteralDirect", {
     target: "bun",
@@ -24,16 +29,14 @@ describe("bundler", () => {
       { env: { WHICH: "b" }, stdout: "value-b" },
     ],
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
       api.expectFile("/out.js").toContain("__glob");
       api.expectFile("/out.js").toContain('"./mods/a.js"');
       api.expectFile("/out.js").toContain('"./mods/b.js"');
-      if (out.includes("import.meta.require")) {
-        throw new Error("expected template-literal require to be bundled, not deferred to runtime");
-      }
     },
   });
 
+  // A specifier that is not in the map goes to the runtime require, which
+  // reports it the same way it did before the call was rewritten.
   itBundled("glob-require/TemplateLiteralMiss", {
     target: "bun",
     files: {
@@ -42,15 +45,15 @@ describe("bundler", () => {
         try {
           require(\`./mods/\${which}.js\`);
         } catch (e) {
-          console.log(e.code, e.message);
+          console.log(e.code, e.message.includes("./mods/c.js"));
         }
       `,
       "/mods/a.js": `module.exports = 1;`,
       "/mods/b.js": `module.exports = 2;`,
     },
-    run: {
-      stdout:
-        "MODULE_NOT_FOUND Cannot find module './mods/c.js' in glob import map. Available: ./mods/a.js, ./mods/b.js",
+    run: { stdout: "MODULE_NOT_FOUND true" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
     },
   });
 
@@ -86,6 +89,114 @@ describe("bundler", () => {
     run: { env: { WHICH: "a" }, stdout: "rope-a" },
     onAfterBundle(api) {
       api.expectFile("/out.js").toContain('"./mods/a.js"');
+    },
+  });
+
+  // A constant template part is folded into the head as a rope; the rope must
+  // be flattened so the pattern is "./v2/**/*.js", not "./v*.js".
+  itBundled("glob-require/TemplateFoldedConstantPart", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = "a";
+        console.log(require(\`./v\${2}/\${name}.js\`));
+      `,
+      "/v2/a.js": `module.exports = "V2A";`,
+    },
+    run: { stdout: "V2A" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./v2/a.js"');
+    },
+  });
+
+  // The shelljs pattern (#12302): the directory is scanned and every file is
+  // also reachable by its extensionless name, which is what the runtime string
+  // holds. The alias resolves through the bundler like a hand-written
+  // require("./src/cat"), so both keys share one module instance.
+  itBundled("glob-require/TrailingPlaceholderExtensionlessKeys", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const commands = {};
+        for (const name of ["cat", "ls"]) {
+          commands[name] = require("./src/" + name);
+        }
+        console.log(commands.cat(), commands.ls(), require("./src/" + "cat.js") === commands.cat);
+      `,
+      "/src/cat.js": /* js */ `module.exports = () => "cat";`,
+      "/src/ls.js": /* js */ `module.exports = () => "ls";`,
+      "/src/rm.js": /* js */ `module.exports = () => "rm";`,
+    },
+    run: { stdout: "cat ls true" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+      api.expectFile("/out.js").toContain('"./src/cat"');
+      api.expectFile("/out.js").toContain('"./src/cat.js"');
+      api.expectFile("/out.js").toContain('"./src/rm.js"');
+    },
+  });
+
+  // An ESM file required through the map gets the same CommonJS interop
+  // wrapper a static require("./mods/a") gets.
+  itBundled("glob-require/TrailingPlaceholderEsmTarget", {
+    target: "bun",
+    files: {
+      "/app/entry.js": /* js */ `
+        for (const name of ["a", "b"]) {
+          console.log(require("./mods/" + name).value);
+        }
+      `,
+      "/app/mods/a.js": /* js */ `export const value = "esm-a";`,
+      "/app/mods/b.js": /* js */ `module.exports = { value: "cjs-b" };`,
+    },
+    entryPoints: ["/app/entry.js"],
+    outfile: "/out.js",
+    run: { stdout: "esm-a\ncjs-b" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__toCommonJS");
+    },
+  });
+
+  itBundled("glob-require/TemplateLiteralJson", {
+    target: "bun",
+    files: {
+      "/app/entry.js": /* js */ `
+        const pick = name => require(\`./lang/\${name}.json\`);
+        console.log(pick("en").hello, pick("fr").hello);
+      `,
+      "/app/lang/en.json": /* json */ `{ "hello": "hi" }`,
+      "/app/lang/fr.json": /* json */ `{ "hello": "salut" }`,
+    },
+    entryPoints: ["/app/entry.js"],
+    outfile: "/out.js",
+    run: { stdout: "hi salut" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("salut");
+      // The runtime string always ends in ".json", so no extensionless alias.
+      api.expectFile("/out.js").not.toContain('"./lang/en"');
+    },
+  });
+
+  // A hidden file is not scanned, so it is not in the map; the miss goes to
+  // the runtime require, which still loads it from disk.
+  itBundled("glob-require/MissFallsBackToRuntimeRequire", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = process.env.PLUGIN;
+        console.log(require("./plugins/" + name));
+      `,
+      "/plugins/a.js": `module.exports = "bundled-a";`,
+      "/plugins/.local.js": `module.exports = "from-disk";`,
+    },
+    outfile: "/out.js",
+    run: [
+      { env: { PLUGIN: "a" }, stdout: "bundled-a", setCwd: true },
+      { env: { PLUGIN: ".local.js" }, stdout: "from-disk", setCwd: true },
+    ],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./plugins/a.js"');
+      api.expectFile("/out.js").not.toContain(".local.js");
     },
   });
 
@@ -125,31 +236,46 @@ describe("bundler", () => {
     },
     run: { stdout: "ok" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("literal NUL must not be treated as a glob placeholder");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
 
-  // import() with a second argument (import attributes) is not glob-resolved;
-  // it falls through to the runtime import so the attributes are preserved.
-  itBundled("glob-require/DynamicImportWithOptionsNotGlobbed", {
+  // A second argument to `import()` carrying `with: { type }` must reach both
+  // the bundled matches and the runtime fallback. `.html` defaults to a
+  // non-text loader, so the raw-text output proves the attribute was applied.
+  itBundled("glob-require/ImportWithTypeOption", {
     target: "bun",
     files: {
       "/entry.js": /* js */ `
-        const which = process.env.WHICH || "a";
-        const m = await import(\`./mods/\${which}.json\`, { with: { type: "json" } });
-        void m;
-        console.log("ok");
+        const name = process.env.WHICH || "a";
+        const m = await import(\`./data/\${name}.html\`, { with: { type: "text" } });
+        console.log(m.default);
       `,
-      "/mods/a.json": `{"a":1}`,
+      "/data/a.html": "<b>hello-from-text</b>",
     },
+    run: { stdout: "<b>hello-from-text</b>" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("import() with attributes must not be glob-resolved");
-      }
+      api.expectFile("/out.js").toContain("__glob");
+      api.expectFile("/out.js").toContain(`{ with: { type: "text" } }`);
+    },
+  });
+
+  // The generated fallback parameter must not shadow a user binding that is
+  // passed as the import options.
+  itBundled("glob-require/FallbackParamNoShadow", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const specifier = { with: { type: "text" } };
+        const name = process.env.WHICH || "a";
+        const m = await import(\`./data/\${name}.txt\`, specifier);
+        console.log(m.default);
+      `,
+      "/data/a.txt": "hello",
+    },
+    run: { stdout: "hello" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("import(specifier, specifier)");
     },
   });
 
@@ -185,10 +311,7 @@ describe("bundler", () => {
     },
     run: { stdout: "ok" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("let-bound specifier should not be glob-resolved");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
 
@@ -207,10 +330,7 @@ describe("bundler", () => {
     },
     run: { stdout: "caught" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("zero-match glob should fall through, not emit __glob");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
 
@@ -228,6 +348,29 @@ describe("bundler", () => {
     run: { env: { WHICH: "b" }, stdout: "import-b" },
     onAfterBundle(api) {
       api.expectFile("/out.js").toContain("__glob");
+    },
+  });
+
+  // Both branches of a ternary argument get glob-bundled.
+  itBundled("glob-require/RequireTernaryArg", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const n = "a";
+        const which = process.env.WHICH;
+        const m = require(which === "y" ? \`./y/\${n}.js\` : \`./x/\${n}.js\`);
+        console.log(m);
+      `,
+      "/x/a.js": `module.exports = "X";`,
+      "/y/a.js": `module.exports = "Y";`,
+    },
+    run: [
+      { env: { WHICH: "x" }, stdout: "X" },
+      { env: { WHICH: "y" }, stdout: "Y" },
+    ],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./x/a.js"');
+      api.expectFile("/out.js").toContain('"./y/a.js"');
     },
   });
 
@@ -250,6 +393,155 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain('"./bin/x64-linux/client.js"');
       api.expectFile("/out.js").toContain('"./bin/arm64-darwin/client.js"');
       api.expectFile("/out.js").not.toContain("README");
+    },
+  });
+
+  // `./file-${x}.js` has its wildcard mid-segment, so it matches one path
+  // segment only (`*`) and does not descend into subdirectories.
+  itBundled("glob-require/WildcardNotAfterSlash", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const n = process.env.WHICH || "a";
+        console.log(require(\`./file-\${n}.js\`));
+      `,
+      "/file-a.js": `module.exports = "A";`,
+      "/file-b.js": `module.exports = "B";`,
+      "/sub/file-c.js": `module.exports = "C";`,
+    },
+    run: { stdout: "A" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./file-a.js"');
+      api.expectFile("/out.js").toContain('"./file-b.js"');
+      api.expectFile("/out.js").not.toContain("file-c");
+    },
+  });
+
+  // `./engines/${f}.js` has its wildcard right after `/`, so like esbuild it
+  // becomes `**/*` and also matches files in subdirectories.
+  itBundled("glob-require/WildcardAfterSlashRecurses", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const p = process.env.WHICH || "deep/inner";
+        console.log(require(\`./engines/\${p}.js\`));
+      `,
+      "/engines/top.js": `module.exports = "TOP";`,
+      "/engines/deep/inner.js": `module.exports = "INNER";`,
+    },
+    run: { stdout: "INNER" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"./engines/top.js"');
+      api.expectFile("/out.js").toContain('"./engines/deep/inner.js"');
+    },
+  });
+
+  itBundled("glob-require/ParentDirectory", {
+    target: "bun",
+    files: {
+      "/nested/entry.js": /* js */ `
+        const n = process.env.WHICH || "x";
+        console.log(require(\`../other/\${n}.js\`));
+      `,
+      "/other/x.js": `module.exports = "X";`,
+    },
+    entryPoints: ["/nested/entry.js"],
+    run: { stdout: "X" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('"../other/x.js"');
+    },
+  });
+
+  // A bare "./" prefix has no path component to anchor the glob; bundling
+  // every file under the importer's directory would be far too greedy.
+  itBundled("glob-require/BareDotSlashFallsThrough", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = process.env.WHICH || "a";
+        try { require(\`./\${name}\`); } catch {}
+        console.log("ok");
+      `,
+      "/a.js": `module.exports = "A";`,
+    },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
+
+  // Same for a bare "../" prefix: it would glob-bundle the entire parent tree.
+  itBundled("glob-require/BareDotDotSlashFallsThrough", {
+    target: "bun",
+    files: {
+      "/nested/entry.js": /* js */ `
+        const name = process.env.WHICH || "a";
+        try { require(\`../\${name}\`); } catch {}
+        console.log("ok");
+      `,
+      "/a.js": `module.exports = "A";`,
+    },
+    entryPoints: ["/nested/entry.js"],
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
+
+  // Literal `*` in a template segment would change glob semantics; bail to
+  // the runtime require rather than mis-globbing.
+  itBundled("glob-require/LiteralGlobCharsFallThrough", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = process.env.WHICH || "a";
+        try { require(\`./dir*/\${name}.js\`); } catch {}
+        console.log("ok");
+      `,
+    },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
+
+  // Glob-generated records carry the relative specifier, so onResolve
+  // plugins can redirect them like a hand-written require.
+  itBundled("glob-require/OnResolvePluginApplies", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const n = process.env.WHICH || "a";
+        console.log(require(\`./engines/\${n}.js\`));
+      `,
+      "/engines/a.js": `module.exports = "ORIGINAL";`,
+      "/redirected.js": `module.exports = "REDIRECTED";`,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /engines\/a\.js$/ }, args => {
+        return { path: resolve(dirname(args.importer), "redirected.js") };
+      });
+    },
+    run: { stdout: "REDIRECTED" },
+  });
+
+  // `--external` patterns match the relative specifier too, leaving the
+  // matched file unbundled.
+  itBundled("glob-require/ExternalPatternApplies", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const n = process.env.WHICH || "a";
+        console.log(require(\`./engines/\${n}.js\`));
+      `,
+      "/engines/a.js": `module.exports = "FROM-DISK";`,
+    },
+    external: ["./engines/*"],
+    outfile: "/out.js",
+    run: { stdout: "FROM-DISK", setCwd: true },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`require("./engines/a.js")`);
+      api.expectFile("/out.js").not.toContain("FROM-DISK");
     },
   });
 
@@ -319,6 +611,30 @@ describe("bundler", () => {
     },
   });
 
+  // The #13672 (esvu) and #12302 (shelljs) shapes in a compiled executable run
+  // from an unrelated cwd: the runtime string names the file with its
+  // extension in one case and without it in the other.
+  itBundled("glob-require/CompileTrailingPlaceholder", {
+    compile: true,
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const engines = {};
+        for (const f of ["boa.js", "v8.js"]) {
+          const e = require(\`./engines/\${f}\`);
+          engines[e.id] = e;
+        }
+        const commands = ["cat", "ls"].map(name => require("./src/" + name)());
+        console.log(Object.keys(engines).sort().join(","), commands.join(","));
+      `,
+      "/engines/boa.js": `module.exports = { id: "boa" };`,
+      "/engines/v8.js": `module.exports = { id: "v8" };`,
+      "/src/cat.js": `module.exports = () => "cat";`,
+      "/src/ls.js": `module.exports = () => "ls";`,
+    },
+    run: { stdout: "boa,v8 cat,ls", setCwd: false },
+  });
+
   // Bare specifiers (no `./` / `../`) must not be globbed.
   itBundled("glob-require/BareSpecifierNotGlobbed", {
     target: "bun",
@@ -332,10 +648,42 @@ describe("bundler", () => {
     },
     run: { stdout: "ok" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("bare specifiers must not be glob-resolved");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
+});
+
+// A symlinked file under the wildcard is followed and bundled like the
+// resolver would. itBundled cannot create symlinks, so this one is manual.
+test.skipIf(isWindows)("glob-require/SymlinkedFileIsBundled", async () => {
+  using dir = tempDir("bundler-glob-symlink", {
+    "entry.js": `const n = process.env.WHICH || "a";\nconsole.log(require(\`./engines/\${n}.js\`));`,
+    "engines/b.js": `module.exports = "B";`,
+    "real/a.js": `module.exports = "REAL-A";`,
+  });
+  symlinkSync(join(String(dir), "real", "a.js"), join(String(dir), "engines", "a.js"));
+
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--target=bun", "./entry.js", "--outfile=out.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+  expect(buildStderr).toBe("");
+  expect(buildExitCode).toBe(0);
+
+  const out = await Bun.file(join(String(dir), "out.js")).text();
+  expect(out).toContain('"./engines/a.js"');
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./out.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("REAL-A\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/bundler/bundler_glob_require.test.ts
+++ b/test/bundler/bundler_glob_require.test.ts
@@ -240,6 +240,43 @@ describe("bundler", () => {
     },
   });
 
+  // A `..` segment in the static text is normalized away in the map keys, so
+  // the runtime string could never equal a key. The call must stay a runtime
+  // call.
+  itBundled("glob-require/DotDotSegmentNotGlobbed", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH || "x";
+        console.log(require(\`./a/../mods/\${which}.js\`));
+      `,
+      "/a/unused.js": `module.exports = 0;`,
+      "/mods/x.js": `module.exports = 1;`,
+    },
+    run: { stdout: "1" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
+
+  // A placeholder right after a `..` segment would otherwise glob the whole
+  // source tree through the collapsed pattern ./a/../**/*.js.
+  itBundled("glob-require/DotDotSegmentBeforePlaceholderNotGlobbed", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const which = process.env.WHICH || "mods/x";
+        console.log(require(\`./a/../\${which}.js\`));
+      `,
+      "/a/unused.js": `module.exports = 0;`,
+      "/mods/x.js": `module.exports = 2;`,
+    },
+    run: { stdout: "2" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
+
   // A second argument to `import()` carrying `with: { type }` must reach both
   // the bundled matches and the runtime fallback. `.html` defaults to a
   // non-text loader, so the raw-text output proves the attribute was applied.

--- a/test/bundler/bundler_glob_require.test.ts
+++ b/test/bundler/bundler_glob_require.test.ts
@@ -765,8 +765,9 @@ test.skipIf(isWindows)("glob-require/SymlinkedFileIsBundled", async () => {
   expect(exitCode).toBe(0);
 });
 
-// A stem alias is speculative. When a custom --extension-order cannot probe
-// the matched extension, the build must not fail on the alias record.
+// When a custom --extension-order cannot probe the matched extension, no stem
+// alias is emitted: the build succeeds, the literal key still works, and the
+// extensionless runtime string reaches the runtime require fallback.
 test("glob-require/StemAliasCustomExtensionOrder", async () => {
   using dir = tempDir("bundler-glob-extorder", {
     "entry.js": `const which = process.env.WHICH || "foo.mjs";\nconsole.log(require("./mods/" + which));`,
@@ -783,14 +784,20 @@ test("glob-require/StemAliasCustomExtensionOrder", async () => {
   expect(buildStderr).toBe("");
   expect(buildExitCode).toBe(0);
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "./out.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout).toBe("mjs\n");
-  expect(exitCode).toBe(0);
+  const out = await Bun.file(join(String(dir), "out.js")).text();
+  expect(out).toContain('"./mods/foo.mjs"');
+  expect(out).not.toContain('"./mods/foo"');
+
+  for (const which of ["foo.mjs", "foo"]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./out.js"],
+      env: { ...bunEnv, WHICH: which },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("mjs\n");
+    expect(exitCode).toBe(0);
+  }
 });

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -164,7 +164,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=19FD1E5354FE6B6564756E2164756E21
+        //# debugId=7605811487A37C7064756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -410,7 +410,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=EA1AA30E1BD7B08E64756E2164756E21
+        //# debugId=D0450BECA083E99764756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -107,11 +107,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-tevdxjba.js",
+                "path": "./client-2gf83hha.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "2s77zd0SC2o",
+                  "etag": "whAPiONREUo",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -121,7 +121,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "GDn0RdEyL2w",
+                  "etag": "0QzlnAGasio",
                   "content-type": "text/html;charset=utf-8"
                 }
               },

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -180,7 +180,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=66236CFF39257E1264756E2164756E21
+    //# debugId=60002634B4F4E3E864756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
### Problem
- A `require()` or `import()` with a template literal or concatenated argument stays a runtime call, so the files it names are not bundled. A compiled executable then fails: `Cannot find module "./engines/boa.js" from "/$bunfs/root/esvu"` (#13672). Same for `client.node` (#9951) and shelljs `./src/cat` (#12302).
- `transpose_require` and `transpose_import` (`src/js_parser/p.rs`) bundle only string literals.

### Fix
- For a relative-path template literal, concat chain, or a `const` initialized with one, the parser turns the static parts into a glob, adds an import record per matched file, and rewrites the call to `__glob({ "./a.js": () => require_a(), ... }, fallback)(arg)` (new helper in `src/runtime.js`).
- A shape that ends in a placeholder (`require("./src/" + name)`) also gets extensionless keys. Their records carry the stem, so the bundler resolves `./src/cat` with its normal extension order.
- A miss calls the runtime `require` or `import()`, so nothing that loaded before stops loading. The fallback exists only where `allowUnresolved` permits the shape: with `[]` (`--reject-unresolved`) a miss throws `MODULE_NOT_FOUND`. Zero matches, a bare `./${x}` prefix, or more than 1024 matches leave the call unchanged.
- Verified: `test/bundler/bundler_glob_require.test.ts` (32 cases, 24 fail on released bun), 8 new cases in `bundler_allow_unresolved.test.ts`, and the rest of `test/bundler`. Self-reviewed: the review asked for the strict-mode contract, the `allowUnresolved` tests, and docs, all three are in. It also suggested splitting the extensionless keys and the `const` lookthrough into follow-ups; kept here because the shelljs and tigerbeetle shapes need them.

### Background
- esbuild's glob imports (https://esbuild.github.io/api/#glob) are the model: a placeholder right after `/` becomes `**/*`, elsewhere `*`. Only the bundler sets the parser's `glob_resolver` function pointer.
- An import record is the parser's note "this file imports that path". Records that resolve to one file share one module wrapper, which makes the extensionless alias cheap.
- `allowUnresolved` matches its patterns against the same shape, which now sees through `+` and `const`: `require("./a/" + x)` is `./a/*` for the check, no longer opaque. Documented in `docs/bundler/index.mdx`, the CLI flags, and `bun.d.ts`.
- Supersedes #35676 (extensionless keys) and #35699 (runtime fallback, `import()` options).

Fixes #9951
Fixes #13672
Fixes #12302
Fixes #5005

<details><summary>Notes</summary>

- `HANDLES_IMPORT_ERRORS` on a record marks a call inside try/catch (or with a `.catch()`), so a resolve failure is a warning and not an error. Each glob entry copies the flag from the call site.
- Shape extraction joins the static parts with `\x00` placeholders (the same representation `--allow-unresolved` uses). A literal NUL in the source, a tagged template, a raw template part, or a `let`/`var` binding makes the shape opaque.
- Eligibility: the shape starts with `./` or `../`, has a placeholder, does not end in `/`, has a character other than `.` and `/` before the first placeholder, and has no `* ? [ { ! \`. A bare `./${x}` would otherwise walk the whole tree below the importer.
- Hidden entries are skipped (`dot: false`) so a `**` walk never descends into `.git`. Symlinked files are followed. A walk error discards the partial result and leaves the call unchanged.
- Keys are relative to the importing file with `/` separators on every platform, so they equal what the source builds at runtime.
- The extensionless alias is added only for extensions every resolver extension order probes (`.js .mjs .cjs .jsx .ts .mts .cts .tsx .json`) and only when the stem still ends with the static text after the last placeholder, so `./mods/${x}.js` never gets a `./mods/a` key.
- `import()` entries carry the call's `with: { type }` options, loader, and record tag like a static `import("./a.html", { with: { type: "text" } })` does. The fallback is `(specifier) => import(specifier, options)` with a generated symbol, so a user binding of the same name is renamed.
- The match cap (1024) falls through to the old runtime call with a debug-level log.
- `allowUnresolved` behavior change: the shape extractor is shared with the `--allow-unresolved` check, so a concatenation or a `const`-bound template now has a shape (`./a/*`) where it used to be opaque (`""`). `--allow-unresolved ''` no longer accepts `require("./a/" + x)`, and `--allow-unresolved './a/*'` now does. Tests 17 to 21 in `bundler_allow_unresolved.test.ts` pin this. `require.resolve()` is checked the same way but is never glob-bundled.
- Under `allowUnresolved: []` a glob site with matches builds (the files are resolved at build time) and emits `__glob({...})` with no second argument, so no runtime resolution is left in the output (test 22). A pattern that allows the shape keeps the fallback (test 23).
- #6004 (selenium-webdriver) is not covered: it passes the specifier through a function parameter, which has no static shape.
- Suites run with the debug build: `bundler_glob_require` (32 pass), `bundler_cjs`, `bundler_allow_unresolved`, `esbuild/default` (196 pass, 5 skip), `bundler_compile` (82 pass; `compile/HelloWorldWithProcessVersionsBun` compares a version string with `-debug` stripped and fails for every debug build), `bun-build-api`, `bundler_promiseall_deadcode`, `html-import-manifest`, `cyclic-imports-async-bundler` (snapshot hashes updated for the new runtime helper), the source lints, and the rest of `test/bundler`.
- The esvu scenario was also run by hand as a compiled executable: `readdirSync(path.join(__dirname, "engines"))` plus `` require(`./engines/${f}`) `` prints `boa,v8` when run from another directory.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_glob_require.test.ts

<!-- robobun:evidence:end -->