### PR TITLE
RegExp: throw RangeError when YARR exhausts its match budget

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "c9ad5813fd23bd8b98b0738abc3d037ec716aa92";
+export const WEBKIT_VERSION = "70cc6c33f514dc0db37f7cd25bb5931cd7e4ad61";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/regexp/regexp-match-limit.test.ts
+++ b/test/js/web/regexp/regexp-match-limit.test.ts
@@ -1,0 +1,134 @@
+// When YARR's internal resource limits are reached during a RegExp match, the
+// engine must throw instead of silently reporting "no match". Previously the
+// interpreter's allocator exhaustion (ErrorNoMemory) and the 100M-call
+// matchLimit (ErrorHitLimit) were collapsed to offsetNoMatch, so patterns like
+// /^(?:a|b)+$/ over multi-megabyte inputs quietly returned false where Node
+// returns true.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function run(code: string, extraEnv: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: { ...bunEnv, ...extraEnv },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr, exitCode };
+}
+
+// Force the interpreter and shrink its BumpPointerPool so the per-iteration
+// ParenthesesDisjunctionContext allocations run out after a few thousand
+// characters instead of ~1.24M. Keeps the test well under a second.
+const smallPool = {
+  BUN_JSC_useRegExpJIT: "0",
+  BUN_JSC_maxRegExpStackSize: "1048576",
+};
+
+const makeInput = (n: number) => `Buffer.alloc(${n}, "a").toString()`;
+
+describe.concurrent("RegExp throws when the YARR interpreter runs out of backtracking memory", () => {
+  const input = makeInput(20_000);
+
+  test("RegExp.prototype.test", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const s = ${input};
+       try { console.log("result=" + /^(?:a|b)+$/.test(s)); }
+       catch (e) { console.log("threw=" + e.constructor.name); }`,
+      smallPool,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("threw=RangeError");
+    expect(exitCode).toBe(0);
+  });
+
+  test("RegExp.prototype.exec", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const s = ${input};
+       try { console.log("result=" + (/^(?:a|b)+$/.exec(s) === null ? "null" : "match")); }
+       catch (e) { console.log("threw=" + e.constructor.name); }`,
+      smallPool,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("threw=RangeError");
+    expect(exitCode).toBe(0);
+  });
+
+  test("String.prototype.match", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const s = ${input};
+       try { console.log("result=" + (s.match(/^(?:a|b)+$/) === null ? "null" : "match")); }
+       catch (e) { console.log("threw=" + e.constructor.name); }`,
+      smallPool,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("threw=RangeError");
+    expect(exitCode).toBe(0);
+  });
+
+  test("String.prototype.search", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const s = ${input};
+       try { console.log("result=" + s.search(/^(?:a|b)+$/)); }
+       catch (e) { console.log("threw=" + e.constructor.name); }`,
+      smallPool,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("threw=RangeError");
+    expect(exitCode).toBe(0);
+  });
+
+  test("String.prototype.replace", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const s = ${input};
+       try { console.log("result=" + (s.replace(/^(?:a|b)+$/, "x") === s ? "unchanged" : "replaced")); }
+       catch (e) { console.log("threw=" + e.constructor.name); }`,
+      smallPool,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("threw=RangeError");
+    expect(exitCode).toBe(0);
+  });
+
+  test("patterns without a quantified group are unaffected", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const s = ${input};
+       console.log(/^[ab]+$/.test(s));
+       console.log(/^a+$/.test(s));`,
+      smallPool,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("true\ntrue");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("RegExp throws at default settings for large inputs", () => {
+  // Default pool (128MB), default JIT. Quantified alternation over ~2M chars
+  // exhausts it in a few hundred ms (release). This is the shape real
+  // validators hit: /^(?:[0-9a-f]{2})+$/ on a multi-MB hex payload.
+  const input = makeInput(2_000_000);
+
+  test("test() over a quantified alternation", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const s = ${input};
+       try { console.log("result=" + /^(?:a|b)+$/.test(s)); }
+       catch (e) { console.log("threw=" + e.constructor.name); }`,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("threw=RangeError");
+    expect(exitCode).toBe(0);
+  });
+
+  test("exec() over a quantified capture group", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const s = ${input};
+       try { console.log("result=" + (/^(a)*$/.exec(s) === null ? "null" : "match")); }
+       catch (e) { console.log("threw=" + e.constructor.name); }`,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("threw=RangeError");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

RegExp silently returns "no match" when JSC/YARR exhausts its internal match budget, instead of throwing. Any regex with a quantified group (alternation or counted term inside) iterated enough times over its input reports the wrong answer:

```js
/^(?:[0-9a-f]{2})+$/.test("ab".repeat(1_500_000))  // bun: false, node: true
/^(?:a|b)+$/.test("a".repeat(3_000_000))           // bun: false, node: true
/^(a)*$/.test("a".repeat(3_000_000))               // bun: false, node: true
"a".repeat(3_000_000).search(/^(?:a|b)+$/)         // bun: -1,    node: 0
/^[ab]+$/.test("a".repeat(3_000_000))              // true both (no group)
```

The cliff is at ~1.24M iterations for `^(?:a|b)+$`, independent of `ulimit -s`. The same applies through `URLPattern`, and to the backtrack-budget case where a pattern that does match but needs more than 100M disjunction calls returns false in ~1s where Node returns true. Validators, routers and filters silently flip verdict on large but ordinary inputs.

## Cause

YARR has two internal limits:

- `matchDisjunction()` decrements a 100M `matchLimit` counter and returns `JSRegExpResult::ErrorHitLimit` at zero.
- `allocParenthesesDisjunctionContext()` allocates from a 128MB `BumpPointerPool` (one context per iteration of a quantified group) and returns `JSRegExpResult::ErrorNoMemory` on failure. `^(?:a|b)+$` hits this at ~1.24M characters.

Both error codes are swallowed: `Interpreter::interpret()` only checks `result == Match` and otherwise returns `output[0]` (still `offsetNoMatch`); the JIT's `generateJITFailReturn()` emits `ErrorNoMatch` for `m_hitMatchLimit`. `RegExp::matchInline` only special-cases `JITCodeFailure`, so the JS caller sees `-1` / `MatchResult::failed()` / `false` / `null` with no exception.

## Fix

WebKit side (oven-sh/WebKit#343, picked up here via the `WEBKIT_VERSION` bump): surface `ErrorHitLimit` / `ErrorNoMemory` out of `Interpreter::interpret()` and `YarrJIT::generateJITFailReturn()`, and have both `RegExp::matchInline` overloads throw `RangeError` when they see them. `ErrorNoMemory` throws `Maximum call stack size exceeded.` (it is a stack/allocator exhaustion, matching what Node throws at its limit); `ErrorHitLimit` throws `Maximum regular expression match count exceeded.`. On the compiler thread or with a null `globalObject` the behaviour degrades to no-match as before. `Yarr::RegularExpression::match` (no `globalObject`) treats any negative result as no-match.

## Verification

`USE_SYSTEM_BUN=1 bun test test/js/web/regexp/regexp-match-limit.test.ts`: 7 fail, 1 pass (the control). The failing tests show `result=false` / `result=null` / `result=-1` / `result=unchanged` where `threw=RangeError` is expected.

The test runs each of `test` / `exec` / `match` / `search` / `replace` twice: once with `BUN_JSC_useRegExpJIT=0 BUN_JSC_maxRegExpStackSize=1048576` so the interpreter trips at 20K characters (fast, deterministic), and once at default settings with a 2M-character input (the shape a real `/^(?:[0-9a-f]{2})+$/` hex validator hits). A control case confirms character-class-only patterns are unaffected.

Depends on oven-sh/WebKit#343; CI here will fail on the prebuilt download until that build publishes `autobuild-70cc6c33f514dc0db37f7cd25bb5931cd7e4ad61`.
