### PR TITLE
bundler: hoist `var` for sloppy-mode implicit global assignment in ESM output

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4388,6 +4388,37 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.options.bundle && self.options.output_format.is_esm()
     }
 
+    /// Whether a sloppy-mode assignment to an unbound identifier should be
+    /// given a hoisted `var` declaration because the bundled output will run
+    /// in strict mode. Excludes parser-tracked CJS refs and known host
+    /// globals so the hoist does not shadow them.
+    pub fn should_hoist_implicit_global(&self, ref_: Ref, name: &[u8]) -> bool {
+        use crate::parser::options;
+        self.symbols[ref_.inner_index() as usize].kind == js_ast::symbol::Kind::Unbound
+            && !self.is_control_flow_dead
+            && !self.is_strict_mode()
+            && self.options.module_type != options::ModuleType::Esm
+            && self.options.bundle
+            && matches!(
+                self.options.output_format,
+                options::Format::Esm | options::Format::InternalBakeDev
+            )
+            && !self.require_ref.eql(ref_)
+            && !self.dirname_ref.eql(ref_)
+            && !self.filename_ref.eql(ref_)
+            && self.define.for_identifier(name).is_none()
+            && !matches!(
+                name,
+                b"Buffer"
+                    | b"process"
+                    | b"global"
+                    | b"Bun"
+                    | b"setImmediate"
+                    | b"clearImmediate"
+                    | b"structuredClone"
+            )
+    }
+
     /// Declare an ambient symbol resolvable BY NAME via [`Self::find_symbol`]
     /// during visit (writes `module_scope.members[name]`). Use for parser-minted
     /// symbols that user code references as a bare identifier: CJS wrapper vars

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -255,14 +255,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     == js_ast::symbol::Kind::Unbound
                 && !result.is_inside_with_scope
                 && !p.is_strict_mode()
+                && p.options.module_type != crate::parser::options::ModuleType::Esm
                 && p.is_strict_mode_output_format()
+                && p.define.for_identifier(name).is_none()
             {
-                // Sloppy-mode code can assign to an undeclared identifier to create a
-                // property on the global object. Bundling into an ES module forces strict
-                // mode, which would turn that into a ReferenceError at runtime. Hoist a
-                // `var` declaration so the bundled output keeps working. Compound
-                // assignments (`Update`) read the value first and already throw in sloppy
-                // mode, so they are excluded.
+                // `X = ...` with no declaration creates a global in sloppy mode but
+                // throws ReferenceError in strict-mode ESM output; hoist a `var` so the
+                // bundle runs. Known globals are skipped so `var X` does not shadow them.
                 p.symbols[result.r#ref.inner_index() as usize].kind = js_ast::symbol::Kind::Hoisted;
                 p.relocated_top_level_vars.push(js_ast::LocRef {
                     loc: expr.loc,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -258,7 +258,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && p.options.module_type != crate::parser::options::ModuleType::Esm
                 && p.is_strict_mode_output_format()
                 && p.define.for_identifier(name).is_none()
-                && !matches!(name, b"Buffer" | b"process" | b"global" | b"Bun")
+                && !matches!(
+                    name,
+                    b"Buffer"
+                        | b"process"
+                        | b"global"
+                        | b"Bun"
+                        | b"setImmediate"
+                        | b"clearImmediate"
+                        | b"structuredClone"
+                )
             {
                 // `X = ...` with no declaration creates a global in sloppy mode but
                 // throws ReferenceError in strict-mode ESM output; hoist a `var` so the

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -250,6 +250,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // Assigning to `exports` in a CommonJS module must be tracked to undo the
                 // `module.exports` -> `exports` optimization.
                 p.commonjs_module_exports_assigned_deoptimized = true;
+            } else if in_.assign_target == js_ast::AssignTarget::Replace
+                && p.symbols[result.r#ref.inner_index() as usize].kind
+                    == js_ast::symbol::Kind::Unbound
+                && !result.is_inside_with_scope
+                && !p.is_strict_mode()
+                && p.is_strict_mode_output_format()
+            {
+                // Sloppy-mode code can assign to an undeclared identifier to create a
+                // property on the global object. Bundling into an ES module forces strict
+                // mode, which would turn that into a ReferenceError at runtime. Hoist a
+                // `var` declaration so the bundled output keeps working. Compound
+                // assignments (`Update`) read the value first and already throw in sloppy
+                // mode, so they are excluded.
+                p.symbols[result.r#ref.inner_index() as usize].kind =
+                    js_ast::symbol::Kind::Hoisted;
+                p.relocated_top_level_vars.push(js_ast::LocRef {
+                    loc: expr.loc,
+                    ref_: result.r#ref,
+                });
             }
 
             p.symbols[result.r#ref.inner_index() as usize].set_has_been_assigned_to(true);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -263,8 +263,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // `var` declaration so the bundled output keeps working. Compound
                 // assignments (`Update`) read the value first and already throw in sloppy
                 // mode, so they are excluded.
-                p.symbols[result.r#ref.inner_index() as usize].kind =
-                    js_ast::symbol::Kind::Hoisted;
+                p.symbols[result.r#ref.inner_index() as usize].kind = js_ast::symbol::Kind::Hoisted;
                 p.relocated_top_level_vars.push(js_ast::LocRef {
                     loc: expr.loc,
                     ref_: result.r#ref,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -251,26 +251,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // `module.exports` -> `exports` optimization.
                 p.commonjs_module_exports_assigned_deoptimized = true;
             } else if in_.assign_target == js_ast::AssignTarget::Replace
-                && p.symbols[result.r#ref.inner_index() as usize].kind
-                    == js_ast::symbol::Kind::Unbound
+                && p.should_hoist_implicit_global(result.r#ref, name)
                 && !result.is_inside_with_scope
-                && !p.is_strict_mode()
-                && p.options.module_type != crate::parser::options::ModuleType::Esm
-                && p.is_strict_mode_output_format()
-                && !p.require_ref.eql(result.r#ref)
-                && !p.dirname_ref.eql(result.r#ref)
-                && !p.filename_ref.eql(result.r#ref)
-                && p.define.for_identifier(name).is_none()
-                && !matches!(
-                    name,
-                    b"Buffer"
-                        | b"process"
-                        | b"global"
-                        | b"Bun"
-                        | b"setImmediate"
-                        | b"clearImmediate"
-                        | b"structuredClone"
-                )
             {
                 // `X = ...` with no declaration creates a global in sloppy mode but
                 // throws ReferenceError in strict-mode ESM output; hoist a `var` so the

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -257,6 +257,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && !p.is_strict_mode()
                 && p.options.module_type != crate::parser::options::ModuleType::Esm
                 && p.is_strict_mode_output_format()
+                && !p.require_ref.eql(result.r#ref)
+                && !p.dirname_ref.eql(result.r#ref)
+                && !p.filename_ref.eql(result.r#ref)
                 && p.define.for_identifier(name).is_none()
                 && !matches!(
                     name,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -258,6 +258,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && p.options.module_type != crate::parser::options::ModuleType::Esm
                 && p.is_strict_mode_output_format()
                 && p.define.for_identifier(name).is_none()
+                && !matches!(name, b"Buffer" | b"process" | b"global" | b"Bun")
             {
                 // `X = ...` with no declaration creates a global in sloppy mode but
                 // throws ReferenceError in strict-mode ESM output; hoist a `var` so the

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -597,4 +597,128 @@ describe("bundler", () => {
       stdout: "loaded ok",
     },
   });
+
+  // ============================================================================
+  // Sloppy-mode CommonJS can assign to an undeclared identifier to create a
+  // property on the global object. ESM output is always strict mode, so such
+  // assignments would throw ReferenceError at runtime unless a `var` is hoisted
+  // for them. https://github.com/oven-sh/bun/issues/13008
+  // ============================================================================
+
+  itBundled("cjs/ImplicitGlobalAssignESM#13008", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.cjs';
+        console.log(lib().name);
+        console.log(new lib.Generator().name);
+      `,
+      "/lib.cjs": /* js */ `
+        module.exports = function () {
+          return new Generator();
+        };
+        Generator = function () {
+          this.name = "gen";
+        };
+        module.exports.Generator = Generator;
+      `,
+    },
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "gen\ngen",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.mjs").toContain("var Generator");
+    },
+  });
+
+  itBundled("cjs/ImplicitGlobalAssignNestedESM", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.cjs';
+        console.log(lib.init());
+      `,
+      "/lib.cjs": /* js */ `
+        function init() {
+          helper = function () { return 42; };
+          return helper();
+        }
+        exports.init = init;
+      `,
+    },
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "42",
+    },
+  });
+
+  itBundled("cjs/ImplicitGlobalAssignDestructureESM", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.cjs';
+        console.log(lib.a, lib.b);
+      `,
+      "/lib.cjs": /* js */ `
+        ({ x: a } = { x: 1 });
+        for (b in { k: 0 }) {}
+        module.exports = { a: a, b: b };
+      `,
+    },
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "1 k",
+    },
+  });
+
+  itBundled("cjs/ImplicitGlobalAssignStrictDirective", {
+    files: {
+      "/entry.js": /* js */ `
+        import './lib.cjs';
+      `,
+      "/lib.cjs": /* js */ `
+        "use strict";
+        try {
+          Foo = 1;
+          console.log("no throw");
+        } catch (e) {
+          console.log(e.constructor.name);
+        }
+      `,
+    },
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "ReferenceError",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.mjs").not.toContain("var Foo");
+    },
+  });
+
+  itBundled("cjs/ImplicitGlobalAssignCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require('./lib.cjs');
+        console.log(lib().name);
+      `,
+      "/lib.cjs": /* js */ `
+        module.exports = function () {
+          return new Generator();
+        };
+        Generator = function () {
+          this.name = "gen";
+        };
+      `,
+    },
+    format: "cjs",
+    outfile: "/out.cjs",
+    run: {
+      stdout: "gen",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.cjs").not.toContain("var Generator");
+    },
+  });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -749,6 +749,30 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("cjs/ImplicitGlobalAssignRequire", {
+    files: {
+      "/entry.js": /* js */ `
+        import v from './lib.cjs';
+        console.log(v);
+      `,
+      "/lib.cjs": /* js */ `
+        if (globalThis.__MOCK__) require = globalThis.__MOCK__;
+        module.exports = require('./dep.cjs');
+      `,
+      "/dep.cjs": /* js */ `
+        module.exports = "dep-value";
+      `,
+    },
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "dep-value",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.mjs").toContain("dep-value");
+    },
+  });
+
   itBundled("cjs/ImplicitGlobalAssignMJS", {
     files: {
       "/entry.mjs": /* js */ `

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -749,6 +749,50 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("cjs/ImplicitGlobalAssignBakeDev", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.cjs';
+        console.log(lib().name);
+      `,
+      "/lib.cjs": /* js */ `
+        module.exports = function () {
+          return new Generator();
+        };
+        Generator = function () {
+          this.name = "gen";
+        };
+      `,
+    },
+    format: "internal_bake_dev",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var Generator");
+    },
+  });
+
+  itBundled("cjs/ImplicitGlobalAssignDeadCode", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.cjs';
+        console.log(lib);
+      `,
+      "/lib.cjs": /* js */ `
+        if (false) {
+          DebugFoo = 1;
+        }
+        module.exports = typeof DebugFoo;
+      `,
+    },
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "undefined",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.mjs").not.toContain("var DebugFoo");
+    },
+  });
+
   itBundled("cjs/ImplicitGlobalAssignRequire", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -721,4 +721,51 @@ describe("bundler", () => {
       api.expectFile("/out.cjs").not.toContain("var Generator");
     },
   });
+
+  itBundled("cjs/ImplicitGlobalAssignKnownGlobal", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.cjs';
+        console.log(typeof lib.orig, lib.orig === Promise);
+      `,
+      "/lib.cjs": /* js */ `
+        var orig = Promise;
+        Promise = function Patched() {};
+        module.exports = { orig: orig };
+        Promise = orig;
+      `,
+    },
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "function true",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.mjs").not.toContain("var Promise");
+    },
+  });
+
+  itBundled("cjs/ImplicitGlobalAssignMJS", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import './lib.mjs';
+      `,
+      "/lib.mjs": /* js */ `
+        try {
+          Foo = 1;
+          console.log("no throw");
+        } catch (e) {
+          console.log(e.constructor.name);
+        }
+      `,
+    },
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "ReferenceError",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.mjs").not.toContain("var Foo");
+    },
+  });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -726,22 +726,26 @@ describe("bundler", () => {
     files: {
       "/entry.js": /* js */ `
         import lib from './lib.cjs';
-        console.log(typeof lib.orig, lib.orig === Promise);
+        console.log(typeof lib.orig, lib.orig === Promise, typeof lib.buf);
       `,
       "/lib.cjs": /* js */ `
         var orig = Promise;
         Promise = function Patched() {};
-        module.exports = { orig: orig };
+        var buf = Buffer;
+        Buffer = function PatchedBuffer() {};
+        module.exports = { orig: orig, buf: buf };
         Promise = orig;
+        Buffer = buf;
       `,
     },
     format: "esm",
     outfile: "/out.mjs",
     run: {
-      stdout: "function true",
+      stdout: "function true function",
     },
     onAfterBundle(api) {
       api.expectFile("/out.mjs").not.toContain("var Promise");
+      api.expectFile("/out.mjs").not.toContain("var Buffer");
     },
   });
 


### PR DESCRIPTION
## Problem

The `csv-generate` package (pulled in by `objects-to-csv`) assigns to `Generator` without declaring it:

```js
module.exports = function () {
  return new Generator(options);
};
Generator = function (options = {}) { ... };   // no var/let/const
```

In the original CommonJS module this is sloppy mode, so the assignment creates a property on the global object and everything works. When the module is bundled into an ES module the whole output runs in strict mode, and that assignment throws at runtime:

```
ReferenceError: Generator is not defined
```

Repro from the issue:

```sh
bun add objects-to-csv
echo 'import O from "objects-to-csv"; console.log(await new O([]).toString());' > a.ts
bun build a.ts > out.js && bun out.js
```

## Fix

When bundling to an output format that always runs in strict mode (`esm` and `internal_bake_dev`), if the parser sees a plain assignment (`X = ...`, destructuring target, or for-in/of target) to an identifier that has no declaration, it now marks the symbol as `Hoisted` and records it in `relocated_top_level_vars`. The existing `append_part` machinery then emits a `var X;` declaration at the top level of the module, so the assignment has a binding to write to inside the `__commonJS` wrapper.

The gate is `P::should_hoist_implicit_global`. It skips the hoist when:

- the symbol is not `Kind::Unbound`;
- the assignment is inside dead code (`is_control_flow_dead`);
- the source is already strict (`"use strict"` directive, import/export/TLA syntax) or is an ES module by extension / `"type": "module"`, so the original ReferenceError is preserved;
- the ref is `require_ref` / `dirname_ref` / `filename_ref`, whose downstream handling is gated on `Kind::Unbound`;
- the name matches a known pure global (the `defines_table` list plus `Buffer` / `process` / `global` / `Bun` / `setImmediate` / `clearImmediate` / `structuredClone`) or a user `--define`, since strict-mode assignment to an existing global property already succeeds and a hoisted `var` would shadow it.

Compound assignments (`X += 1`, `X++`) are excluded because `AssignTarget::Replace` does not match them; they read the value first and already throw in sloppy mode. CJS and IIFE output formats are unaffected because they stay in sloppy mode.

This is a semantic change in one corner: the identifier becomes local to the bundled module closure rather than a real global. That only matters if another module reads the same leaked global by name, which is not the case for any of the packages I looked at; the alternative is a guaranteed ReferenceError. esbuild, webpack and Parcel all leave this case broken in their ESM output.

## Tests

Added to `test/bundler/bundler_cjs.test.ts`:

- `cjs/ImplicitGlobalAssignESM#13008`: the original pattern from `csv-generate`
- `cjs/ImplicitGlobalAssignNestedESM`: assignment inside a nested function
- `cjs/ImplicitGlobalAssignDestructureESM`: destructuring and for-in targets
- `cjs/ImplicitGlobalAssignStrictDirective`: `"use strict"` source still throws, no `var` emitted
- `cjs/ImplicitGlobalAssignCJS`: `--format=cjs` does not emit the extra `var`
- `cjs/ImplicitGlobalAssignKnownGlobal`: `Promise` / `Buffer` are not shadowed
- `cjs/ImplicitGlobalAssignBakeDev`: `--format=internal_bake_dev` also gets the hoist
- `cjs/ImplicitGlobalAssignDeadCode`: assignment in an eliminated branch emits no `var`
- `cjs/ImplicitGlobalAssignRequire`: `require = ...` does not drop subsequent `require('./dep')` from the bundle
- `cjs/ImplicitGlobalAssignMJS`: `.mjs` source without import/export still throws ReferenceError

Also verified the original `objects-to-csv` repro bundles and runs correctly, including with `--minify`.

Fixes #13008
Fixes #14002

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.0 (bffd29dfc)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1636.65ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [832.29ms]
(pass) bundler > cjs/__toESM_import_syntax_function [702.05ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [1377.39ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [452.87ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [637.71ms]
(pass) bundler > cjs/__toESM_target_node [1188.61ms]
(pass) bundler > cjs/__toESM_target_browser [743.70ms]
(pass) bundler > cjs/__toESM_target_bun [748.48ms]
(pass) bundler > cjs/__toESM_format_esm [678.33ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [565.43ms]
(pass) bundler > cjs/__toESM_mjs_reexport [569.24ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [808.66ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [651.93ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [939.82ms]
(pass) bundler > cjs/__toESM_default_
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bffd29dfc)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [53.63ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [45.86ms]
(pass) bundler > cjs/__toESM_import_syntax_function [40.05ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [211.70ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [17.28ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [13.95ms]
(pass) bundler > cjs/__toESM_target_node [18.04ms]
(pass) bundler > cjs/__toESM_target_browser [15.26ms]
(pass) bundler > cjs/__toESM_target_bun [18.29ms]
(pass) bundler > cjs/__toESM_format_esm [174.79ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [98.57ms]
(pass) bundler > cjs/__toESM_mjs_reexport [94.95ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [51.88ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [64.70ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [164.59ms]
(pass) bundler > cjs/__toESM_default_prop_no_esModule [83.48ms]
(pass) bundler > cjs/__toESM_mixed_import_styles [27.74ms]
(pass) bundler > cjs/__toESM_esModule_non_true [176.11ms]
(pass) bundler > cjs/__toESM
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.0 (bffd29dfc)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1341.97ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [618.37ms]
(pass) bundler > cjs/__toESM_import_syntax_function [784.44ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [746.18ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [642.23ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [958.24ms]
(pass) bundler > cjs/__toESM_target_node [920.58ms]
(pass) bundler > cjs/__toESM_target_browser [2035.68ms]
(pass) bundler > cjs/__toESM_target_bun [922.88ms]
(pass) bundler > cjs/__toESM_format_esm [640.93ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [788.78ms]
(pass) bundler > cjs/__toESM_mjs_reexport [722.86ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [566.58ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [1038.30ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [506.91ms]
(pass) bundler > cjs/__toESM_default_
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1328ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/99] gen bindgenv2
[2/98] gen ErrorCode+*.h
[3/52] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/52] gen cpp.rs (cppbind)
[5/52] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                |  31 +++++
 src/js_parser/visit/visit_expr.rs |  12 ++
 test/bundler/bundler_cjs.test.ts  | 243 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 286 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/js_parser/p.rs                     9      1      0
src/js_parser/visit/visit_expr.rs      7      8      0
test/bundler/bundler_cjs.test.ts       4      7      0
```

</details>

<!-- robobun:evidence:end -->