### PR TITLE
error: include the top-level-await caller in async stack traces

### DIFF
--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -303,7 +303,20 @@ impl fmt::Display for NameFormatter {
                 write!(f, "new {}", name)?;
             }
             _ => {
-                if !name.is_empty() {
+                if self.is_async {
+                    if self.enable_color {
+                        f.write_str(concat!(
+                            Output::pretty_fmt!("<r><d>", true),
+                            "async",
+                            Output::pretty_fmt!("<r>", true),
+                        ))?;
+                    } else {
+                        f.write_str("async")?;
+                    }
+                    if !name.is_empty() {
+                        write!(f, " {}", name)?;
+                    }
+                } else if !name.is_empty() {
                     write!(f, "{}", name)?;
                 }
             }

--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -40,6 +40,16 @@ static inline bool dynamicCastValue(JSValue v, T** out)
     return *out != nullptr;
 }
 
+// With AsyncLocalStorage active, JSPromise::resolveWithInternalMicrotaskForAsyncAwait
+// wraps the await context in InternalFieldTuple(context, asyncContext). Unwrap
+// to field 0 so both the generator and module-record probes see the real cell.
+static inline JSValue unwrapAsyncContextTuple(JSValue v)
+{
+    if (auto* tuple = cellAs<InternalFieldTuple>(v))
+        return tuple->getInternalField(0);
+    return v;
+}
+
 static BytecodeIndex yieldStateToBytecodeIndex(CodeBlock* codeBlock, int32_t state)
 {
     size_t numberOfJumpTables = codeBlock->numberOfUnlinkedSwitchJumpTables();
@@ -92,15 +102,6 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
 
     JSC::AssertNoGC assertNoGC;
 
-    auto unwrapGeneratorFromContext = [&](JSC::JSValue context) -> JSC::JSAsyncFunctionGenerator* {
-        JSC::InternalFieldTuple* tuple = nullptr;
-        if (dynamicCastValue(context, &tuple))
-            context = tuple->getInternalField(0);
-        JSC::JSAsyncFunctionGenerator* generator = nullptr;
-        dynamicCastValue(context, &generator);
-        return generator;
-    };
-
     // Walk reaction->context → generator. If context is not a generator (e.g.
     // thenable-chain from `return promise` without await inside an async
     // function), follow reaction->promise() to the next promise in the chain.
@@ -120,8 +121,8 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
                 return nullptr;
             switch (p->inlineReactionKind()) {
             case JSC::JSPromise::InlineReactionKind::InternalMicrotask: {
-                JSValue context = p->inlineReactionContext();
-                if (auto* generator = unwrapGeneratorFromContext(context))
+                JSValue context = unwrapAsyncContextTuple(p->inlineReactionContext());
+                if (auto* generator = cellAs<JSC::JSAsyncFunctionGenerator>(context))
                     return generator;
                 terminalModule = cellAs<JSModuleRecord>(context);
                 // No generator in the context. For the resolve-with-promise fast
@@ -147,8 +148,8 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
             auto* reaction = dynamicDowncast<JSC::JSPromiseReaction>(p->payloadCell());
             if (!reaction)
                 return nullptr;
-            JSValue context = JSC::JSPromiseReaction::tryGetContext(reaction);
-            if (auto* generator = unwrapGeneratorFromContext(context))
+            JSValue context = unwrapAsyncContextTuple(JSC::JSPromiseReaction::tryGetContext(reaction));
+            if (auto* generator = cellAs<JSC::JSAsyncFunctionGenerator>(context))
                 return generator;
             terminalModule = cellAs<JSModuleRecord>(context);
             // No generator in context — follow the thenable chain to the
@@ -258,7 +259,7 @@ void Bun::appendTopLevelAwaitStackFrame(VM& vm, JSCell* owner, Vector<StackFrame
 
     auto reactionContext = [](JSValue v) -> JSValue {
         auto* promise = cellAs<JSPromise>(v);
-        return promise ? promise->asyncStackTraceContext() : JSValue();
+        return promise ? unwrapAsyncContextTuple(promise->asyncStackTraceContext()) : JSValue();
     };
 
     JSModuleRecord* moduleRecord = nullptr;
@@ -270,7 +271,7 @@ void Bun::appendTopLevelAwaitStackFrame(VM& vm, JSCell* owner, Vector<StackFrame
             continue;
         }
         if (auto* promise = cellAs<JSPromise>(context)) {
-            JSValue inner = promise->asyncStackTraceContext();
+            JSValue inner = unwrapAsyncContextTuple(promise->asyncStackTraceContext());
             if (auto* next = cellAs<JSAsyncFunctionGenerator>(inner)) {
                 generator = next;
                 continue;

--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -23,6 +23,23 @@
 
 using namespace JSC;
 
+// dynamicDowncast(JSValue)'s isCell() check is true for the empty value on
+// JSVALUE64, so it would read through a null cell. asyncStackTraceContext()
+// and reaction getters return the empty value in several paths, so every
+// JSValue downcast in this file goes through this helper.
+template<typename T>
+static inline T* cellAs(JSValue v)
+{
+    return (v && v.isCell()) ? dynamicDowncast<T>(v.asCell()) : nullptr;
+}
+
+template<typename T>
+static inline bool dynamicCastValue(JSValue v, T** out)
+{
+    *out = cellAs<T>(v);
+    return *out != nullptr;
+}
+
 static BytecodeIndex yieldStateToBytecodeIndex(CodeBlock* codeBlock, int32_t state)
 {
     size_t numberOfJumpTables = codeBlock->numberOfUnlinkedSwitchJumpTables();
@@ -33,6 +50,30 @@ static BytecodeIndex yieldStateToBytecodeIndex(CodeBlock* codeBlock, int32_t sta
             return BytecodeIndex(offset);
     }
     return BytecodeIndex(0);
+}
+
+// SAFETY: a positive Field::State (a yield index) means the module body is
+// suspended at an await, the only state in which JSModuleRecord::evaluate has
+// not cleared m_moduleProgramExecutable, so getOrMakeExecutable() returns the
+// stored executable without allocating. Callers run under AssertNoGC.
+static bool appendSuspendedModuleFrame(VM& vm, JSCell* owner, JSModuleRecord* moduleRecord, Vector<StackFrame>& results)
+{
+    JSValue stateValue = moduleRecord->internalField(AbstractModuleRecord::Field::State).get();
+    if (!stateValue.isInt32())
+        return false;
+    int32_t state = stateValue.asInt32();
+    if (state <= 0)
+        return false;
+
+    ModuleProgramExecutable* executable = moduleRecord->getOrMakeExecutable(moduleRecord->globalObject());
+    if (!executable)
+        return false;
+    CodeBlock* codeBlock = executable->codeBlock();
+    if (!codeBlock)
+        return false;
+
+    results.append(StackFrame(vm, owner, moduleRecord, codeBlock, yieldStateToBytecodeIndex(codeBlock, state), /* isAsyncFrame */ true));
+    return true;
 }
 
 // Walk a promise's reaction chain to find the async generators awaiting it,
@@ -50,13 +91,6 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
         return;
 
     JSC::AssertNoGC assertNoGC;
-
-    auto dynamicCastValue = []<typename T>(JSC::JSValue v, T** out) -> bool {
-        if (!v || !v.isCell())
-            return false;
-        *out = dynamicDowncast<T>(v.asCell());
-        return *out != nullptr;
-    };
 
     auto unwrapGeneratorFromContext = [&](JSC::JSValue context) -> JSC::JSAsyncFunctionGenerator* {
         JSC::InternalFieldTuple* tuple = nullptr;
@@ -79,14 +113,17 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
     //    payloadCell() and the handler in m_slot.
     //  - As a heap-allocated JSPromiseReaction list once a second handler is
     //    attached, headed at payloadCell().
+    JSModuleRecord* terminalModule = nullptr;
     auto getAwaitingGenerator = [&](JSC::JSPromise* p) -> JSC::JSAsyncFunctionGenerator* {
         for (unsigned hops = 0; p && hops < 32; hops++) {
             if (p->status() != JSC::JSPromise::Status::Pending)
                 return nullptr;
             switch (p->inlineReactionKind()) {
             case JSC::JSPromise::InlineReactionKind::InternalMicrotask: {
-                if (auto* generator = unwrapGeneratorFromContext(p->inlineReactionContext()))
+                JSValue context = p->inlineReactionContext();
+                if (auto* generator = unwrapGeneratorFromContext(context))
                     return generator;
+                terminalModule = cellAs<JSModuleRecord>(context);
                 // No generator in the context. For the resolve-with-promise fast
                 // path (`return promise` without await inside an async function),
                 // the reaction's cell payload is the outer promise being resolved —
@@ -110,8 +147,10 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
             auto* reaction = dynamicDowncast<JSC::JSPromiseReaction>(p->payloadCell());
             if (!reaction)
                 return nullptr;
-            if (auto* generator = unwrapGeneratorFromContext(JSC::JSPromiseReaction::tryGetContext(reaction)))
+            JSValue context = JSC::JSPromiseReaction::tryGetContext(reaction);
+            if (auto* generator = unwrapGeneratorFromContext(context))
                 return generator;
+            terminalModule = cellAs<JSModuleRecord>(context);
             // No generator in context — follow the thenable chain to the
             // promise this reaction resolves/rejects.
             if (!dynamicCastValue(reaction->promise(), &p))
@@ -150,6 +189,9 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
             break;
         gen = getAwaitingGenerator(returnPromise);
     }
+
+    if (terminalModule && results.size() < maxStackSize)
+        appendSuspendedModuleFrame(vm, owner, terminalModule, results);
 }
 
 extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue errorValue, JSC::JSPromise* promise)
@@ -214,56 +256,31 @@ void Bun::appendTopLevelAwaitStackFrame(VM& vm, JSCell* owner, Vector<StackFrame
     if (!origin)
         return;
 
-    auto reactionContext = [](JSValue context) -> JSValue {
-        auto* promise = dynamicDowncast<JSPromise>(context);
+    auto reactionContext = [](JSValue v) -> JSValue {
+        auto* promise = cellAs<JSPromise>(v);
         return promise ? promise->asyncStackTraceContext() : JSValue();
     };
 
-    JSValue terminal;
+    JSModuleRecord* moduleRecord = nullptr;
     JSAsyncFunctionGenerator* generator = origin;
     for (unsigned hops = 0; generator && hops < 256; hops++) {
         JSValue context = reactionContext(generator->internalField(JSAsyncFunctionGenerator::Field::Context).get());
-        if (!context)
-            return;
-        if (auto* next = dynamicDowncast<JSAsyncFunctionGenerator>(context)) {
+        if (auto* next = cellAs<JSAsyncFunctionGenerator>(context)) {
             generator = next;
             continue;
         }
-        if (auto* promise = dynamicDowncast<JSPromise>(context)) {
-            JSValue inner = reactionContext(promise);
-            if (auto* next = dynamicDowncast<JSAsyncFunctionGenerator>(inner)) {
+        if (auto* promise = cellAs<JSPromise>(context)) {
+            JSValue inner = promise->asyncStackTraceContext();
+            if (auto* next = cellAs<JSAsyncFunctionGenerator>(inner)) {
                 generator = next;
                 continue;
             }
-            terminal = inner;
+            moduleRecord = cellAs<JSModuleRecord>(inner);
         } else
-            terminal = context;
+            moduleRecord = cellAs<JSModuleRecord>(context);
         break;
     }
 
-    auto* moduleRecord = dynamicDowncast<JSModuleRecord>(terminal);
-    if (!moduleRecord)
-        return;
-
-    // SAFETY: a positive Field::State (a yield index) means the module body is
-    // suspended at an await, the only state in which JSModuleRecord::evaluate
-    // has not cleared m_moduleProgramExecutable, so getOrMakeExecutable()
-    // returns the stored executable without allocating. Required because
-    // getStackTrace runs under AssertNoGC.
-    JSValue stateValue = moduleRecord->internalField(AbstractModuleRecord::Field::State).get();
-    if (!stateValue.isInt32())
-        return;
-    int32_t state = stateValue.asInt32();
-    if (state <= 0)
-        return;
-
-    ModuleProgramExecutable* executable = moduleRecord->getOrMakeExecutable(moduleRecord->globalObject());
-    if (!executable)
-        return;
-    CodeBlock* codeBlock = executable->codeBlock();
-    if (!codeBlock)
-        return;
-
-    BytecodeIndex bytecodeIndex = yieldStateToBytecodeIndex(codeBlock, state);
-    results.append(StackFrame(vm, owner, moduleRecord, codeBlock, bytecodeIndex, /* isAsyncFrame */ true));
+    if (moduleRecord)
+        appendSuspendedModuleFrame(vm, owner, moduleRecord, results);
 }

--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -23,10 +23,7 @@
 
 using namespace JSC;
 
-// dynamicDowncast(JSValue)'s isCell() check is true for the empty value on
-// JSVALUE64, so it would read through a null cell. asyncStackTraceContext()
-// and reaction getters return the empty value in several paths, so every
-// JSValue downcast in this file goes through this helper.
+// dynamicDowncast(JSValue) reads through a null cell for the empty value (isCell() is true for 0 on JSVALUE64); asyncStackTraceContext() can return empty, so all JSValue downcasts here go through this.
 template<typename T>
 static inline T* cellAs(JSValue v)
 {
@@ -40,9 +37,7 @@ static inline bool dynamicCastValue(JSValue v, T** out)
     return *out != nullptr;
 }
 
-// With AsyncLocalStorage active, JSPromise::resolveWithInternalMicrotaskForAsyncAwait
-// wraps the await context in InternalFieldTuple(context, asyncContext). Unwrap
-// to field 0 so both the generator and module-record probes see the real cell.
+// Under AsyncLocalStorage the await context is wrapped in InternalFieldTuple(context, asyncContext); field 0 is the real cell.
 static inline JSValue unwrapAsyncContextTuple(JSValue v)
 {
     if (auto* tuple = cellAs<InternalFieldTuple>(v))
@@ -224,15 +219,7 @@ extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObje
     instance->setStackFrames(vm, WTF::move(frames));
 }
 
-// Installed as VM::onAppendStackTrace. Interpreter::getAsyncStackTrace walks
-// the await chain in terms of JSAsyncFunctionGenerator only, so when the
-// outermost awaiter is a module's top-level await the reaction context is a
-// JSModuleRecord and the walk stops one frame short of the
-// `at async file.mjs:N:M` frame Node shows. getStackTrace calls this hook
-// after the sync walk and before inserting its async frames, so a frame
-// appended here lands at the bottom of the result. We locate the same origin
-// generator getStackTrace will use, follow the same chain, and if it ends at
-// a suspended module record append one frame for that await.
+// VM::onAppendStackTrace hook. Interpreter::getAsyncStackTrace only follows JSAsyncFunctionGenerator links, so a top-level-await module (JSModuleRecord reaction context) is dropped; we locate the same origin generator and append one frame for that module's await. getStackTrace calls this after its sync walk and before inserting async frames, so the frame lands at the bottom.
 void Bun::appendTopLevelAwaitStackFrame(VM& vm, JSCell* owner, Vector<StackFrame>& results, size_t maxToAppend)
 {
     if (!maxToAppend || !Options::useAsyncStackTrace())
@@ -240,11 +227,7 @@ void Bun::appendTopLevelAwaitStackFrame(VM& vm, JSCell* owner, Vector<StackFrame
 
     AssertNoGC assertNoGC;
 
-    // getStackTrace only inspects entry frames that contributed visible
-    // (non-private) frames; the innermost entry frame with a generator context
-    // is the microtask resume behind the current sync stack and is what it
-    // picks. Deeper entry frames belong to the embedder's scheduler and would
-    // walk into internal modules.
+    // getStackTrace only inspects entry frames that contributed visible frames; the innermost one with a generator context is the microtask resume behind the current sync stack. Deeper entry frames belong to the embedder's scheduler and would walk into internal modules.
     JSAsyncFunctionGenerator* origin = nullptr;
     for (EntryFrame* entryFrame = vm.topEntryFrame; entryFrame;) {
         VMEntryRecord* record = vmEntryRecord(entryFrame);

--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -12,12 +12,28 @@
 #include <JavaScriptCore/InternalFieldTuple.h>
 #include <JavaScriptCore/JSAsyncFunctionGenerator.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSModuleRecord.h>
 #include <JavaScriptCore/JSPromiseReaction.h>
+#include <JavaScriptCore/ModuleProgramCodeBlock.h>
+#include <JavaScriptCore/ModuleProgramExecutable.h>
 #include <JavaScriptCore/Options.h>
 #include <JavaScriptCore/StackFrame.h>
 #include <JavaScriptCore/UnlinkedCodeBlock.h>
+#include <JavaScriptCore/VMEntryRecord.h>
 
 using namespace JSC;
+
+static BytecodeIndex yieldStateToBytecodeIndex(CodeBlock* codeBlock, int32_t state)
+{
+    size_t numberOfJumpTables = codeBlock->numberOfUnlinkedSwitchJumpTables();
+    if (state > 0 && numberOfJumpTables > 0) {
+        const UnlinkedSimpleJumpTable& jumpTable = codeBlock->unlinkedSwitchJumpTable(numberOfJumpTables - 1);
+        int32_t offset = jumpTable.offsetForValue(state);
+        if (offset)
+            return BytecodeIndex(offset);
+    }
+    return BytecodeIndex(0);
+}
 
 // Walk a promise's reaction chain to find the async generators awaiting it,
 // and collect them as async StackFrames. Used when an error is created from
@@ -105,20 +121,8 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
     };
 
     auto computeBytecodeIndex = [&](JSC::CodeBlock* codeBlock, JSC::JSAsyncFunctionGenerator* generator) -> JSC::BytecodeIndex {
-        JSC::BytecodeIndex bytecodeIndex(0);
         JSC::JSValue stateValue = generator->internalField(JSC::JSAsyncFunctionGenerator::Field::State).get();
-        if (stateValue.isInt32()) {
-            int32_t state = stateValue.asInt32();
-            size_t numberOfJumpTables = codeBlock->numberOfUnlinkedSwitchJumpTables();
-            if (state > 0 && numberOfJumpTables > 0) {
-                size_t lastTableIndex = numberOfJumpTables - 1;
-                const JSC::UnlinkedSimpleJumpTable& jumpTable = codeBlock->unlinkedSwitchJumpTable(lastTableIndex);
-                int32_t offset = jumpTable.offsetForValue(state);
-                if (offset)
-                    bytecodeIndex = JSC::BytecodeIndex(offset);
-            }
-        }
-        return bytecodeIndex;
+        return stateValue.isInt32() ? yieldStateToBytecodeIndex(codeBlock, stateValue.asInt32()) : JSC::BytecodeIndex(0);
     };
 
     auto appendFrame = [&](JSC::JSAsyncFunctionGenerator* generator) {
@@ -175,4 +179,91 @@ extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObje
         return;
 
     instance->setStackFrames(vm, WTF::move(frames));
+}
+
+// Installed as VM::onAppendStackTrace. Interpreter::getAsyncStackTrace walks
+// the await chain in terms of JSAsyncFunctionGenerator only, so when the
+// outermost awaiter is a module's top-level await the reaction context is a
+// JSModuleRecord and the walk stops one frame short of the
+// `at async file.mjs:N:M` frame Node shows. getStackTrace calls this hook
+// after the sync walk and before inserting its async frames, so a frame
+// appended here lands at the bottom of the result. We locate the same origin
+// generator getStackTrace will use, follow the same chain, and if it ends at
+// a suspended module record append one frame for that await.
+void Bun::appendTopLevelAwaitStackFrame(VM& vm, JSCell* owner, Vector<StackFrame>& results, size_t maxToAppend)
+{
+    if (!maxToAppend || !Options::useAsyncStackTrace())
+        return;
+
+    AssertNoGC assertNoGC;
+
+    // getStackTrace only inspects entry frames that contributed visible
+    // (non-private) frames; the innermost entry frame with a generator context
+    // is the microtask resume behind the current sync stack and is what it
+    // picks. Deeper entry frames belong to the embedder's scheduler and would
+    // walk into internal modules.
+    JSAsyncFunctionGenerator* origin = nullptr;
+    for (EntryFrame* entryFrame = vm.topEntryFrame; entryFrame;) {
+        VMEntryRecord* record = vmEntryRecord(entryFrame);
+        if (auto* generator = dynamicDowncast<JSAsyncFunctionGenerator>(record->m_context)) {
+            origin = generator;
+            break;
+        }
+        entryFrame = record->prevTopEntryFrame();
+    }
+    if (!origin)
+        return;
+
+    auto reactionContext = [](JSValue context) -> JSValue {
+        auto* promise = dynamicDowncast<JSPromise>(context);
+        return promise ? promise->asyncStackTraceContext() : JSValue();
+    };
+
+    JSValue terminal;
+    JSAsyncFunctionGenerator* generator = origin;
+    for (unsigned hops = 0; generator && hops < 256; hops++) {
+        JSValue context = reactionContext(generator->internalField(JSAsyncFunctionGenerator::Field::Context).get());
+        if (!context)
+            return;
+        if (auto* next = dynamicDowncast<JSAsyncFunctionGenerator>(context)) {
+            generator = next;
+            continue;
+        }
+        if (auto* promise = dynamicDowncast<JSPromise>(context)) {
+            JSValue inner = reactionContext(promise);
+            if (auto* next = dynamicDowncast<JSAsyncFunctionGenerator>(inner)) {
+                generator = next;
+                continue;
+            }
+            terminal = inner;
+        } else
+            terminal = context;
+        break;
+    }
+
+    auto* moduleRecord = dynamicDowncast<JSModuleRecord>(terminal);
+    if (!moduleRecord)
+        return;
+
+    // SAFETY: a positive Field::State (a yield index) means the module body is
+    // suspended at an await, the only state in which JSModuleRecord::evaluate
+    // has not cleared m_moduleProgramExecutable, so getOrMakeExecutable()
+    // returns the stored executable without allocating. Required because
+    // getStackTrace runs under AssertNoGC.
+    JSValue stateValue = moduleRecord->internalField(AbstractModuleRecord::Field::State).get();
+    if (!stateValue.isInt32())
+        return;
+    int32_t state = stateValue.asInt32();
+    if (state <= 0)
+        return;
+
+    ModuleProgramExecutable* executable = moduleRecord->getOrMakeExecutable(moduleRecord->globalObject());
+    if (!executable)
+        return;
+    CodeBlock* codeBlock = executable->codeBlock();
+    if (!codeBlock)
+        return;
+
+    BytecodeIndex bytecodeIndex = yieldStateToBytecodeIndex(codeBlock, state);
+    results.append(StackFrame(vm, owner, moduleRecord, codeBlock, bytecodeIndex, /* isAsyncFrame */ true));
 }

--- a/src/jsc/bindings/AsyncStackTrace.h
+++ b/src/jsc/bindings/AsyncStackTrace.h
@@ -11,6 +11,10 @@
 // ErrorInstance with no stack of its own; no-op otherwise. Never throws.
 extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject*, JSC::EncodedJSValue errorValue, JSC::JSPromise*);
 
+namespace JSC {
+class StackFrame;
+}
+
 namespace Bun {
 
 // C++ convenience wrapper over Bun__attachAsyncStackFromPromise.
@@ -18,5 +22,8 @@ inline void attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObject, JSC::
 {
     Bun__attachAsyncStackFromPromise(globalObject, JSC::JSValue::encode(error), promise);
 }
+
+// VM::onAppendStackTrace hook: appends the top-level-await module frame that JSC's async stack walk drops. See AsyncStackTrace.cpp.
+void appendTopLevelAwaitStackFrame(JSC::VM&, JSC::JSCell* owner, WTF::Vector<JSC::StackFrame>&, size_t maxToAppend);
 
 } // namespace Bun

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -366,6 +366,8 @@ WTF::String formatStackTrace(
             }
             sb.append(functionName);
             sb.append(" ("_s);
+        } else if (frame.isAsyncFrame()) {
+            sb.append("async "_s);
         }
 
         if (!sourceURLForFrame.isEmpty()) {

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -86,6 +86,7 @@ static void populateStackFrameMetadata(JSC::VM& vm, JSC::JSGlobalObject* globalO
 
     auto sourceURL = Zig::sourceURL(vm, stackFrame);
     frame.source_url = Bun::toStringRef(sourceURL);
+    frame.is_async = stackFrame.isAsyncFrame();
     auto m_codeBlock = stackFrame.codeBlock();
     if (m_codeBlock) {
         switch (m_codeBlock->codeType()) {
@@ -123,8 +124,6 @@ static void populateStackFrameMetadata(JSC::VM& vm, JSC::JSGlobalObject* globalO
     }
     if (!functionName.isEmpty())
         frame.function_name = Bun::toStringRef(functionName);
-
-    frame.is_async = stackFrame.isAsyncFrame();
 }
 
 static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunString* source_lines,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -61,6 +61,7 @@
 #include "JavaScriptCore/VM.h"
 #include "AddEventListenerOptions.h"
 #include "AsyncContextFrame.h"
+#include "AsyncStackTrace.h"
 #include "BunClientData.h"
 #include "BunIDLConvert.h"
 #include "BunObject.h"
@@ -557,6 +558,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     vm.setOnComputeErrorInfo(computeErrorInfoWrapperToString);
     vm.setOnComputeErrorInfoJSValue(computeErrorInfoWrapperToJSValue);
     vm.setComputeLineColumnWithSourcemap(computeLineColumnWithSourcemap);
+    vm.setOnAppendStackTrace(Bun::appendTopLevelAwaitStackFrame);
     vm.setOnEachMicrotaskTick([](JSC::VM& vm) -> void {
         // if you process.nextTick on a microtask we need this
         auto* globalObject = defaultGlobalObject();

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -112,12 +112,13 @@ test("throwing inside an error suppresses the error and continues printing prope
 
   const { stderr, exitCode } = result;
 
-  expect(stderr.toString().trim()).toStartWith(`ENOENT: no such file or directory, open 'this-file-path-is-bad'
+  expect(stderr.toString()).toContain(`ENOENT: no such file or directory, open 'this-file-path-is-bad'
     path: "this-file-path-is-bad",
  syscall: "open",
    errno: ${process.binding("uv").UV_ENOENT},
     code: "ENOENT"
 `);
+  expect(stderr.toString()).toContain("err-fd-fixture.js:2");
   expect(exitCode).toBe(1);
 });
 

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1167,6 +1167,16 @@ await some();
 }
 await inner();
 `,
+    // The async chain can terminate at a combinator result promise with no
+    // awaiter. asyncStackTraceContext() returns the empty JSValue there, which
+    // isCell() misclassifies on JSVALUE64, so it must be checked explicitly.
+    "race.mjs": `async function inner() {
+  await 0;
+  console.log(new Error("boom").stack);
+}
+Promise.race([inner()]);
+await Promise.resolve();
+`,
     // A module's await frame reaches across an import boundary.
     "entry.mjs": `import { run } from "./lib.mjs";
 await run();
@@ -1225,8 +1235,16 @@ export async function run() { await inner(); }
   {
     const { stderr, exitCode } = await run("anon.mjs");
     expect(stderr).toMatch(/anon\.mjs:4:\d+/);
-    expect(stderr).toMatch(/anon\.mjs:8:\d+/);
+    expect(stderr).toMatch(/async \(.*anon\.mjs:8:\d+\)/);
     expect(exitCode).toBe(1);
+  }
+
+  {
+    const { stdout, exitCode } = await run("race.mjs");
+    const lines = stdout.trim().split("\n");
+    expect(lines[1]).toMatch(/^ {4}at inner \(.*race\.mjs:3:\d+\)$/);
+    expect(lines).toHaveLength(2);
+    expect(exitCode).toBe(0);
   }
 
   {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1177,6 +1177,25 @@ await inner();
 Promise.race([inner()]);
 await Promise.resolve();
 `,
+    // With AsyncLocalStorage active the reaction context is wrapped in an
+    // InternalFieldTuple; the walk has to unwrap field 0 to see the module.
+    "als.mjs": `import { AsyncLocalStorage } from "node:async_hooks";
+new AsyncLocalStorage().enterWith({});
+async function inner() {
+  await 0;
+  console.log(new Error("boom").stack);
+}
+await inner();
+`,
+    // Errors created in native code with no JS frames (e.g. fs.promises) take
+    // a separate reaction-chain walk (Bun__attachAsyncStackFromPromise).
+    "native.mjs": `import { readFile } from "node:fs/promises";
+try {
+  await readFile("/nonexistent-tla-probe/x");
+} catch (e) {
+  console.log(e.stack);
+}
+`,
     // A module's await frame reaches across an import boundary.
     "entry.mjs": `import { run } from "./lib.mjs";
 await run();
@@ -1244,6 +1263,21 @@ export async function run() { await inner(); }
     const lines = stdout.trim().split("\n");
     expect(lines[1]).toMatch(/^ {4}at inner \(.*race\.mjs:3:\d+\)$/);
     expect(lines).toHaveLength(2);
+    expect(exitCode).toBe(0);
+  }
+
+  {
+    const { stdout, exitCode } = await run("als.mjs");
+    const lines = stdout.trim().split("\n");
+    expect(lines[1]).toMatch(/^ {4}at inner \(.*als\.mjs:5:\d+\)$/);
+    expect(lines[lines.length - 1]).toMatch(/^ {4}at async .*als\.mjs:7:\d+$/);
+    expect(exitCode).toBe(0);
+  }
+
+  {
+    const { stdout, exitCode } = await run("native.mjs");
+    const lines = stdout.trim().split("\n");
+    expect(lines[lines.length - 1]).toMatch(/^ {4}at async .*native\.mjs:3:\d+$/);
     expect(exitCode).toBe(0);
   }
 

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1,7 +1,7 @@
 import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
 import { afterEach, expect, mock, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
   Error.prepareStackTrace = origPrepareStackTrace;
@@ -1120,4 +1120,122 @@ test("lazy error-info materialization does not store an empty stack value when t
     signalCode: null,
   });
   expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/10483
+// Errors created inside an async function that is awaited at a module's top
+// level should include that top-level await as an async frame, matching Node.
+test("async stack trace includes the top-level-await caller frame", async () => {
+  using dir = tempDir("tla-async-stack", {
+    // One level: the async function is awaited directly at the module top level.
+    "direct.mjs": `async function inner() {
+  await 0;
+  console.log(new Error("boom").stack);
+}
+await inner();
+`,
+    // Three nested async functions under the module's top-level await.
+    "chain.mjs": `async function inner() {
+  await 0;
+  console.log(new Error("boom").stack);
+}
+async function mid() { await inner(); }
+async function outer() { await mid(); }
+await outer();
+`,
+    // The issue's original reproduction: an anonymous async arrow awaited at
+    // top level, thrown so Bun's own error printer renders the stack.
+    "anon.mjs": `export function throwSome(b) {
+  return async () => {
+    await b();
+    throw new Error("asd");
+  };
+}
+export const some = throwSome(async () => {});
+await some();
+`,
+    // The module frame is exposed as a CallSite with isAsync() true and no
+    // function name, matching Node.
+    "callsites.mjs": `async function inner() {
+  await 0;
+  Error.prepareStackTrace = (e, sites) => JSON.stringify(sites.map(s => ({
+    fn: s.getFunctionName() || null,
+    async: s.isAsync(),
+    line: s.getLineNumber(),
+  })));
+  console.log(new Error("x").stack);
+}
+await inner();
+`,
+    // A module's await frame reaches across an import boundary.
+    "entry.mjs": `import { run } from "./lib.mjs";
+await run();
+`,
+    "lib.mjs": `async function inner() {
+  await 0;
+  console.log(new Error("boom").stack);
+}
+export async function run() { await inner(); }
+`,
+  });
+
+  const run = async name => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), name],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  };
+
+  {
+    const { stdout, exitCode } = await run("direct.mjs");
+    const lines = stdout.trim().split("\n");
+    expect(lines[0]).toBe("Error: boom");
+    expect(lines[1]).toMatch(/^ {4}at inner \(.*direct\.mjs:3:\d+\)$/);
+    expect(lines[2]).toMatch(/^ {4}at async .*direct\.mjs:5:\d+$/);
+    expect(lines).toHaveLength(3);
+    expect(exitCode).toBe(0);
+  }
+
+  {
+    const { stdout, exitCode } = await run("chain.mjs");
+    const lines = stdout.trim().split("\n");
+    expect(lines[1]).toMatch(/^ {4}at inner \(.*chain\.mjs:3:\d+\)$/);
+    expect(lines[2]).toMatch(/^ {4}at async mid \(.*chain\.mjs:5:\d+\)$/);
+    expect(lines[3]).toMatch(/^ {4}at async outer \(.*chain\.mjs:6:\d+\)$/);
+    expect(lines[4]).toMatch(/^ {4}at async .*chain\.mjs:7:\d+$/);
+    expect(lines).toHaveLength(5);
+    expect(exitCode).toBe(0);
+  }
+
+  {
+    const { stdout, exitCode } = await run("entry.mjs");
+    const lines = stdout.trim().split("\n");
+    expect(lines[1]).toMatch(/^ {4}at inner \(.*lib\.mjs:3:\d+\)$/);
+    expect(lines[2]).toMatch(/^ {4}at async run \(.*lib\.mjs:5:\d+\)$/);
+    expect(lines[3]).toMatch(/^ {4}at async .*entry\.mjs:2:\d+$/);
+    expect(lines).toHaveLength(4);
+    expect(exitCode).toBe(0);
+  }
+
+  {
+    const { stderr, exitCode } = await run("anon.mjs");
+    expect(stderr).toMatch(/anon\.mjs:4:\d+/);
+    expect(stderr).toMatch(/anon\.mjs:8:\d+/);
+    expect(exitCode).toBe(1);
+  }
+
+  {
+    const { stdout, exitCode } = await run("callsites.mjs");
+    const sites = JSON.parse(stdout.trim());
+    expect(sites).toEqual([
+      { fn: "inner", async: false, line: 8 },
+      { fn: null, async: true, line: 10 },
+    ]);
+    expect(exitCode).toBe(0);
+  }
 });

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1217,77 +1217,57 @@ export async function run() { await inner(); }
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
+    return { stdout: stdout.trim().split("\n"), stderr, exitCode };
   };
 
-  {
-    const { stdout, exitCode } = await run("direct.mjs");
-    const lines = stdout.trim().split("\n");
-    expect(lines[0]).toBe("Error: boom");
-    expect(lines[1]).toMatch(/^ {4}at inner \(.*direct\.mjs:3:\d+\)$/);
-    expect(lines[2]).toMatch(/^ {4}at async .*direct\.mjs:5:\d+$/);
-    expect(lines).toHaveLength(3);
-    expect(exitCode).toBe(0);
-  }
+  const [direct, chain, entry, anon, race, als, native, callsites] = await Promise.all([
+    run("direct.mjs"),
+    run("chain.mjs"),
+    run("entry.mjs"),
+    run("anon.mjs"),
+    run("race.mjs"),
+    run("als.mjs"),
+    run("native.mjs"),
+    run("callsites.mjs"),
+  ]);
 
-  {
-    const { stdout, exitCode } = await run("chain.mjs");
-    const lines = stdout.trim().split("\n");
-    expect(lines[1]).toMatch(/^ {4}at inner \(.*chain\.mjs:3:\d+\)$/);
-    expect(lines[2]).toMatch(/^ {4}at async mid \(.*chain\.mjs:5:\d+\)$/);
-    expect(lines[3]).toMatch(/^ {4}at async outer \(.*chain\.mjs:6:\d+\)$/);
-    expect(lines[4]).toMatch(/^ {4}at async .*chain\.mjs:7:\d+$/);
-    expect(lines).toHaveLength(5);
-    expect(exitCode).toBe(0);
-  }
+  expect(direct.stdout[0]).toBe("Error: boom");
+  expect(direct.stdout[1]).toMatch(/^ {4}at inner \(.*direct\.mjs:3:\d+\)$/);
+  expect(direct.stdout[2]).toMatch(/^ {4}at async .*direct\.mjs:5:\d+$/);
+  expect(direct.stdout).toHaveLength(3);
+  expect(direct.exitCode).toBe(0);
 
-  {
-    const { stdout, exitCode } = await run("entry.mjs");
-    const lines = stdout.trim().split("\n");
-    expect(lines[1]).toMatch(/^ {4}at inner \(.*lib\.mjs:3:\d+\)$/);
-    expect(lines[2]).toMatch(/^ {4}at async run \(.*lib\.mjs:5:\d+\)$/);
-    expect(lines[3]).toMatch(/^ {4}at async .*entry\.mjs:2:\d+$/);
-    expect(lines).toHaveLength(4);
-    expect(exitCode).toBe(0);
-  }
+  expect(chain.stdout[1]).toMatch(/^ {4}at inner \(.*chain\.mjs:3:\d+\)$/);
+  expect(chain.stdout[2]).toMatch(/^ {4}at async mid \(.*chain\.mjs:5:\d+\)$/);
+  expect(chain.stdout[3]).toMatch(/^ {4}at async outer \(.*chain\.mjs:6:\d+\)$/);
+  expect(chain.stdout[4]).toMatch(/^ {4}at async .*chain\.mjs:7:\d+$/);
+  expect(chain.stdout).toHaveLength(5);
+  expect(chain.exitCode).toBe(0);
 
-  {
-    const { stderr, exitCode } = await run("anon.mjs");
-    expect(stderr).toMatch(/anon\.mjs:4:\d+/);
-    expect(stderr).toMatch(/async \(.*anon\.mjs:8:\d+\)/);
-    expect(exitCode).toBe(1);
-  }
+  expect(entry.stdout[1]).toMatch(/^ {4}at inner \(.*lib\.mjs:3:\d+\)$/);
+  expect(entry.stdout[2]).toMatch(/^ {4}at async run \(.*lib\.mjs:5:\d+\)$/);
+  expect(entry.stdout[3]).toMatch(/^ {4}at async .*entry\.mjs:2:\d+$/);
+  expect(entry.stdout).toHaveLength(4);
+  expect(entry.exitCode).toBe(0);
 
-  {
-    const { stdout, exitCode } = await run("race.mjs");
-    const lines = stdout.trim().split("\n");
-    expect(lines[1]).toMatch(/^ {4}at inner \(.*race\.mjs:3:\d+\)$/);
-    expect(lines).toHaveLength(2);
-    expect(exitCode).toBe(0);
-  }
+  expect(anon.stderr).toMatch(/anon\.mjs:4:\d+/);
+  expect(anon.stderr).toMatch(/async \(.*anon\.mjs:8:\d+\)/);
+  expect(anon.exitCode).toBe(1);
 
-  {
-    const { stdout, exitCode } = await run("als.mjs");
-    const lines = stdout.trim().split("\n");
-    expect(lines[1]).toMatch(/^ {4}at inner \(.*als\.mjs:5:\d+\)$/);
-    expect(lines[lines.length - 1]).toMatch(/^ {4}at async .*als\.mjs:7:\d+$/);
-    expect(exitCode).toBe(0);
-  }
+  expect(race.stdout[1]).toMatch(/^ {4}at inner \(.*race\.mjs:3:\d+\)$/);
+  expect(race.stdout).toHaveLength(2);
+  expect(race.exitCode).toBe(0);
 
-  {
-    const { stdout, exitCode } = await run("native.mjs");
-    const lines = stdout.trim().split("\n");
-    expect(lines[lines.length - 1]).toMatch(/^ {4}at async .*native\.mjs:3:\d+$/);
-    expect(exitCode).toBe(0);
-  }
+  expect(als.stdout[1]).toMatch(/^ {4}at inner \(.*als\.mjs:5:\d+\)$/);
+  expect(als.stdout.at(-1)).toMatch(/^ {4}at async .*als\.mjs:7:\d+$/);
+  expect(als.exitCode).toBe(0);
 
-  {
-    const { stdout, exitCode } = await run("callsites.mjs");
-    const sites = JSON.parse(stdout.trim());
-    expect(sites).toEqual([
-      { fn: "inner", async: false, line: 8 },
-      { fn: null, async: true, line: 10 },
-    ]);
-    expect(exitCode).toBe(0);
-  }
+  expect(native.stdout.at(-1)).toMatch(/^ {4}at async .*native\.mjs:3:\d+$/);
+  expect(native.exitCode).toBe(0);
+
+  expect(JSON.parse(callsites.stdout[0])).toEqual([
+    { fn: "inner", async: false, line: 8 },
+    { fn: null, async: true, line: 10 },
+  ]);
+  expect(callsites.exitCode).toBe(0);
 });

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1,6 +1,6 @@
 import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
-import { afterEach, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
@@ -1125,17 +1125,19 @@ test("lazy error-info materialization does not store an empty stack value when t
 // https://github.com/oven-sh/bun/issues/10483
 // Errors created inside an async function that is awaited at a module's top
 // level should include that top-level await as an async frame, matching Node.
-test("async stack trace includes the top-level-await caller frame", async () => {
-  using dir = tempDir("tla-async-stack", {
-    // One level: the async function is awaited directly at the module top level.
-    "direct.mjs": `async function inner() {
+describe("async stack trace includes the top-level-await caller frame", () => {
+  let dir;
+  beforeAll(() => {
+    dir = tempDir("tla-async-stack", {
+      // One level: the async function is awaited directly at the module top level.
+      "direct.mjs": `async function inner() {
   await 0;
   console.log(new Error("boom").stack);
 }
 await inner();
 `,
-    // Three nested async functions under the module's top-level await.
-    "chain.mjs": `async function inner() {
+      // Three nested async functions under the module's top-level await.
+      "chain.mjs": `async function inner() {
   await 0;
   console.log(new Error("boom").stack);
 }
@@ -1143,9 +1145,9 @@ async function mid() { await inner(); }
 async function outer() { await mid(); }
 await outer();
 `,
-    // The issue's original reproduction: an anonymous async arrow awaited at
-    // top level, thrown so Bun's own error printer renders the stack.
-    "anon.mjs": `export function throwSome(b) {
+      // The issue's original reproduction: an anonymous async arrow awaited at
+      // top level, thrown so Bun's own error printer renders the stack.
+      "anon.mjs": `export function throwSome(b) {
   return async () => {
     await b();
     throw new Error("asd");
@@ -1154,9 +1156,9 @@ await outer();
 export const some = throwSome(async () => {});
 await some();
 `,
-    // The module frame is exposed as a CallSite with isAsync() true and no
-    // function name, matching Node.
-    "callsites.mjs": `async function inner() {
+      // The module frame is exposed as a CallSite with isAsync() true and no
+      // function name, matching Node.
+      "callsites.mjs": `async function inner() {
   await 0;
   Error.prepareStackTrace = (e, sites) => JSON.stringify(sites.map(s => ({
     fn: s.getFunctionName() || null,
@@ -1167,19 +1169,20 @@ await some();
 }
 await inner();
 `,
-    // The async chain can terminate at a combinator result promise with no
-    // awaiter. asyncStackTraceContext() returns the empty JSValue there, which
-    // isCell() misclassifies on JSVALUE64, so it must be checked explicitly.
-    "race.mjs": `async function inner() {
+      // The async chain can terminate at a combinator result promise with no
+      // awaiter. asyncStackTraceContext() returns the empty JSValue there,
+      // which isCell() misclassifies on JSVALUE64, so it must be checked
+      // explicitly.
+      "race.mjs": `async function inner() {
   await 0;
   console.log(new Error("boom").stack);
 }
 Promise.race([inner()]);
 await Promise.resolve();
 `,
-    // With AsyncLocalStorage active the reaction context is wrapped in an
-    // InternalFieldTuple; the walk has to unwrap field 0 to see the module.
-    "als.mjs": `import { AsyncLocalStorage } from "node:async_hooks";
+      // With AsyncLocalStorage active the reaction context is wrapped in an
+      // InternalFieldTuple; the walk has to unwrap field 0 to see the module.
+      "als.mjs": `import { AsyncLocalStorage } from "node:async_hooks";
 new AsyncLocalStorage().enterWith({});
 async function inner() {
   await 0;
@@ -1187,26 +1190,28 @@ async function inner() {
 }
 await inner();
 `,
-    // Errors created in native code with no JS frames (e.g. fs.promises) take
-    // a separate reaction-chain walk (Bun__attachAsyncStackFromPromise).
-    "native.mjs": `import { readFile } from "node:fs/promises";
+      // Errors created in native code with no JS frames (e.g. fs.promises) take
+      // a separate reaction-chain walk (Bun__attachAsyncStackFromPromise).
+      "native.mjs": `import { readFile } from "node:fs/promises";
 try {
   await readFile("/nonexistent-tla-probe/x");
 } catch (e) {
   console.log(e.stack);
 }
 `,
-    // A module's await frame reaches across an import boundary.
-    "entry.mjs": `import { run } from "./lib.mjs";
+      // A module's await frame reaches across an import boundary.
+      "entry.mjs": `import { run } from "./lib.mjs";
 await run();
 `,
-    "lib.mjs": `async function inner() {
+      "lib.mjs": `async function inner() {
   await 0;
   console.log(new Error("boom").stack);
 }
 export async function run() { await inner(); }
 `,
+    });
   });
+  afterAll(() => dir[Symbol.dispose]());
 
   const run = async name => {
     await using proc = Bun.spawn({
@@ -1220,54 +1225,67 @@ export async function run() { await inner(); }
     return { stdout: stdout.trim().split("\n"), stderr, exitCode };
   };
 
-  const [direct, chain, entry, anon, race, als, native, callsites] = await Promise.all([
-    run("direct.mjs"),
-    run("chain.mjs"),
-    run("entry.mjs"),
-    run("anon.mjs"),
-    run("race.mjs"),
-    run("als.mjs"),
-    run("native.mjs"),
-    run("callsites.mjs"),
-  ]);
+  test("direct await", async () => {
+    const { stdout, exitCode } = await run("direct.mjs");
+    expect(stdout[0]).toBe("Error: boom");
+    expect(stdout[1]).toMatch(/^ {4}at inner \(.*direct\.mjs:3:\d+\)$/);
+    expect(stdout[2]).toMatch(/^ {4}at async .*direct\.mjs:5:\d+$/);
+    expect(stdout).toHaveLength(3);
+    expect(exitCode).toBe(0);
+  });
 
-  expect(direct.stdout[0]).toBe("Error: boom");
-  expect(direct.stdout[1]).toMatch(/^ {4}at inner \(.*direct\.mjs:3:\d+\)$/);
-  expect(direct.stdout[2]).toMatch(/^ {4}at async .*direct\.mjs:5:\d+$/);
-  expect(direct.stdout).toHaveLength(3);
-  expect(direct.exitCode).toBe(0);
+  test("nested async chain", async () => {
+    const { stdout, exitCode } = await run("chain.mjs");
+    expect(stdout[1]).toMatch(/^ {4}at inner \(.*chain\.mjs:3:\d+\)$/);
+    expect(stdout[2]).toMatch(/^ {4}at async mid \(.*chain\.mjs:5:\d+\)$/);
+    expect(stdout[3]).toMatch(/^ {4}at async outer \(.*chain\.mjs:6:\d+\)$/);
+    expect(stdout[4]).toMatch(/^ {4}at async .*chain\.mjs:7:\d+$/);
+    expect(stdout).toHaveLength(5);
+    expect(exitCode).toBe(0);
+  });
 
-  expect(chain.stdout[1]).toMatch(/^ {4}at inner \(.*chain\.mjs:3:\d+\)$/);
-  expect(chain.stdout[2]).toMatch(/^ {4}at async mid \(.*chain\.mjs:5:\d+\)$/);
-  expect(chain.stdout[3]).toMatch(/^ {4}at async outer \(.*chain\.mjs:6:\d+\)$/);
-  expect(chain.stdout[4]).toMatch(/^ {4}at async .*chain\.mjs:7:\d+$/);
-  expect(chain.stdout).toHaveLength(5);
-  expect(chain.exitCode).toBe(0);
+  test("across an import boundary", async () => {
+    const { stdout, exitCode } = await run("entry.mjs");
+    expect(stdout[1]).toMatch(/^ {4}at inner \(.*lib\.mjs:3:\d+\)$/);
+    expect(stdout[2]).toMatch(/^ {4}at async run \(.*lib\.mjs:5:\d+\)$/);
+    expect(stdout[3]).toMatch(/^ {4}at async .*entry\.mjs:2:\d+$/);
+    expect(stdout).toHaveLength(4);
+    expect(exitCode).toBe(0);
+  });
 
-  expect(entry.stdout[1]).toMatch(/^ {4}at inner \(.*lib\.mjs:3:\d+\)$/);
-  expect(entry.stdout[2]).toMatch(/^ {4}at async run \(.*lib\.mjs:5:\d+\)$/);
-  expect(entry.stdout[3]).toMatch(/^ {4}at async .*entry\.mjs:2:\d+$/);
-  expect(entry.stdout).toHaveLength(4);
-  expect(entry.exitCode).toBe(0);
+  test("anonymous async arrow (issue #10483 repro) via Bun's error printer", async () => {
+    const { stderr, exitCode } = await run("anon.mjs");
+    expect(stderr).toMatch(/anon\.mjs:4:\d+/);
+    expect(stderr).toMatch(/async \(.*anon\.mjs:8:\d+\)/);
+    expect(exitCode).toBe(1);
+  });
 
-  expect(anon.stderr).toMatch(/anon\.mjs:4:\d+/);
-  expect(anon.stderr).toMatch(/async \(.*anon\.mjs:8:\d+\)/);
-  expect(anon.exitCode).toBe(1);
+  test("Promise.race terminal context (empty JSValue)", async () => {
+    const { stdout, exitCode } = await run("race.mjs");
+    expect(stdout[1]).toMatch(/^ {4}at inner \(.*race\.mjs:3:\d+\)$/);
+    expect(stdout).toHaveLength(2);
+    expect(exitCode).toBe(0);
+  });
 
-  expect(race.stdout[1]).toMatch(/^ {4}at inner \(.*race\.mjs:3:\d+\)$/);
-  expect(race.stdout).toHaveLength(2);
-  expect(race.exitCode).toBe(0);
+  test("under AsyncLocalStorage (InternalFieldTuple context)", async () => {
+    const { stdout, exitCode } = await run("als.mjs");
+    expect(stdout[1]).toMatch(/^ {4}at inner \(.*als\.mjs:5:\d+\)$/);
+    expect(stdout.at(-1)).toMatch(/^ {4}at async .*als\.mjs:7:\d+$/);
+    expect(exitCode).toBe(0);
+  });
 
-  expect(als.stdout[1]).toMatch(/^ {4}at inner \(.*als\.mjs:5:\d+\)$/);
-  expect(als.stdout.at(-1)).toMatch(/^ {4}at async .*als\.mjs:7:\d+$/);
-  expect(als.exitCode).toBe(0);
+  test("native-created error (fs.promises) via reaction-chain walk", async () => {
+    const { stdout, exitCode } = await run("native.mjs");
+    expect(stdout.at(-1)).toMatch(/^ {4}at async .*native\.mjs:3:\d+$/);
+    expect(exitCode).toBe(0);
+  });
 
-  expect(native.stdout.at(-1)).toMatch(/^ {4}at async .*native\.mjs:3:\d+$/);
-  expect(native.exitCode).toBe(0);
-
-  expect(JSON.parse(callsites.stdout[0])).toEqual([
-    { fn: "inner", async: false, line: 8 },
-    { fn: null, async: true, line: 10 },
-  ]);
-  expect(callsites.exitCode).toBe(0);
+  test("CallSite shape matches Node (getFunctionName null, isAsync true)", async () => {
+    const { stdout, exitCode } = await run("callsites.mjs");
+    expect(JSON.parse(stdout[0])).toEqual([
+      { fn: "inner", async: false, line: 8 },
+      { fn: null, async: true, line: 10 },
+    ]);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1125,7 +1125,7 @@ test("lazy error-info materialization does not store an empty stack value when t
 // https://github.com/oven-sh/bun/issues/10483
 // Errors created inside an async function that is awaited at a module's top
 // level should include that top-level await as an async frame, matching Node.
-describe("async stack trace includes the top-level-await caller frame", () => {
+describe.concurrent("async stack trace includes the top-level-await caller frame", () => {
   let dir;
   beforeAll(() => {
     dir = tempDir("tla-async-stack", {


### PR DESCRIPTION
Fixes #10483.

## What

When an async function throws after being awaited at a module's top level, the stack trace is missing the `at async file.mjs:N:M` line that points at the top-level `await`. Node includes it.

```js
// check.mjs
export function throwSome(b) {
    return async () => {
        await b()
        throw new Error('asd')
    }
}
export const some = throwSome(async () => {})
await some()
```

Before:
```
error: asd
      at <anonymous> (/tmp/check.mjs:4:19)
```

After (and Node):
```
error: asd
      at <anonymous> (/tmp/check.mjs:4:19)
      at /tmp/check.mjs:8:7
```

The frame also appears in `error.stack` as `at async /tmp/check.mjs:8:7` and in `Error.prepareStackTrace` call sites with `isAsync() === true`, matching Node.

## Why

`Interpreter::getAsyncStackTrace` walks the await chain by hopping `JSAsyncFunctionGenerator -> Field::Context (return JSPromise) -> asyncStackTraceContext() -> next JSAsyncFunctionGenerator`. A module body with top-level await stores the `JSModuleRecord` (not a generator) as the awaited promise's reaction context, so the chain walk's `dynamicDowncast<JSAsyncFunctionGenerator>` fails and it stops without emitting a frame for the module.

## How

Installs a `VM::onAppendStackTrace` hook that reproduces the chain walk from the same origin generator `getStackTrace` will use and, if it terminates at a suspended `JSModuleRecord`, appends one async `StackFrame` for that module's await point. `getStackTrace` calls the hook after its synchronous walk and before it inserts its own async frames at `asyncStackTraceInsertPos`, so the module frame lands at the bottom of the result in the right order.

The bytecode index for the frame comes from the module record's `Field::State` (the yield index) via the module code block's resume jump table, the same way `getAsyncStackTrace` computes positions for suspended async functions.

Also teaches the `.stack` formatter to print `at async <url>:line:col` when an async frame has no function name, matching Node's format for module frames.

## Tests

New subprocess-based test in `capture-stack-trace.test.js` covers: a single async function under TLA, a three-deep chain under TLA, a cross-module import where the awaiting module differs from the throwing one, the issue's anonymous-arrow repro via Bun's own error printer, and the `CallSite` shape (`getFunctionName() === null`, `isAsync() === true`). Fails before, passes after; the call-site output is byte-identical to Node 26.

## Known limitation

When a `Promise.all`/`allSettled`/`any` sits between the error site and the module's top-level `await`, the module frame is still omitted (behaviour is unchanged from before this PR). `Promise.race` works because its reaction context is a plain `JSPromise`. Following through `all`/`any` needs `JSPromiseCombinatorsGlobalContext`, whose header is not installed in the prebuilt JavaScriptCore we link against; the right fix is to teach `Interpreter::getAsyncStackTrace` itself about module records in a follow-up JSC change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/stack.test.ts "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (fbef40ec7)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [15.86ms]
(pass) name property is used for function calls in Bun.inspect [14.75ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [466.16ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-debug+fbef40ec7 (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [514.01ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.0-debug+fbef40ec7 (Linux x64)
116 |     path: "this-file-path-is-bad",
117 |  syscall: "open",
118 |    errno: ${process.binding("uv").UV_ENOENT},
119 |     code: "E
... (truncated)

release without fix: 13 failed, 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [0.16ms]
(pass) name property is used for function calls in Bun.inspect [0.43ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [33.43ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-canary.1+1498d7b77 (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [26.93ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.0-canary.1+1498d7b77 (Linux x64)
116 |     path: "this-file-path-is-bad",
117 |  syscall: "open",
118 |    errno: ${process.binding("uv").UV_ENOENT},
119 |     code: "ENOENT"
120 | `);
121 |   expect(stderr.toString()).toContain("err-fd-fixture.js:2");
                                  ^
error: expect(received).toContain(expected)

Expected to contain: "err-fd-fixt
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/stack.test.ts "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (fbef40ec7)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [20.40ms]
(pass) name property is used for function calls in Bun.inspect [16.49ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [675.72ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-debug+fbef40ec7 (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [534.08ms]
1 | try {
2 |   await require("fs").promises.readFile("this-file-path-is-bad");
                                   ^
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"

      at async (/workspace/bun/test/js/bun/test/err-fd-fix
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1692ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/1069] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/1069] cc obj/vendor/libdeflate/lib/x86/cpu_features.c.o
[3/1069] gen cpp.rs (cppbind)
[4/1069] cc obj/vendor/libdeflate/lib/arm/cpu_features.c.o
[5/1069] cc obj/vendor/libdeflate/lib/zlib_compress.c.o
[6/1069] cc obj/vendor/libdeflate/lib/zlib_decompress.c.o
[7/1069] cc obj/vendor/libdeflate/lib/gzip_decompress.c.o
[8/1069] cc obj/vendor/libdeflate/lib/deflate_decompress.c.o
[9/1069] cc obj/vendor/libdeflate/lib/adler32.c.o
[10/1069] cc obj/vendor/libdeflate/lib/gzip_compress.c.o
[11/1069] cc obj/vendor/libarchive/libarchive/archive_check_magic.c.o
[12/1069] cc obj/vendor/libarchive/libarchive/archive_cmdline.c.o
[13/1069] cc obj/vendor/libarchive/libarchive/archive_cryptor.c.o
[14/1069] cc obj/vendor/libarchive/libarchive/archive_digest.c.o
[15/1069] cc obj/vendor/libdeflate/lib/deflate_compress.c.o
[16/1069] cc obj/vendor/libarchive/libarchive/archive_entry_l
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ZigStackFrame.rs                    |  15 ++-
 src/jsc/bindings/AsyncStackTrace.cpp        | 154 ++++++++++++++++++++-----
 src/jsc/bindings/AsyncStackTrace.h          |   7 ++
 src/jsc/bindings/FormatStackTraceForJS.cpp  |   2 +
 src/jsc/bindings/ZigException.cpp           |   3 +-
 src/jsc/bindings/ZigGlobalObject.cpp        |   2 +
 test/js/bun/test/stack.test.ts              |   3 +-
 test/js/node/v8/capture-stack-trace.test.js | 172 +++++++++++++++++++++++++++-
 8 files changed, 321 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/ZigStackFrame.rs                         3      2      0
src/jsc/bindings/AsyncStackTrace.cpp            10     31      0
src/jsc/bindings/AsyncStackTrace.h               2      3      0
src/jsc/bindings/FormatStackTraceForJS.cpp       2      3      0
src/jsc/bindings/ZigException.cpp                3      3      0
src/jsc/bindings/ZigGlobalObject.cpp             2      4      0
test/js/bun/test/stack.test.ts                   2      1      0
test/js/node/v8/capture-stack-trace.test.js      4     12      0
```

</details>

<!-- robobun:evidence:end -->