### PR TITLE
jsc: make named capture group regex compilation linear instead of quadratic

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-342-7da9e7d9";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/regexp-named-groups.test.ts
+++ b/test/js/web/regexp-named-groups.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Compiling a regex with N sibling named capture groups used to be O(N^2):
+// YarrParser copied the full active-names set on every open paren. 30000
+// named groups took well over a minute in release (and tens of minutes under
+// debug+asan) while 30000 unnamed groups took tens of ms. After the fix
+// parsing is O(N) and this completes in a few hundred ms.
+test("compiling many sibling named capture groups is not quadratic", async () => {
+  const code = `
+    let src = "";
+    for (let i = 0; i < 30000; i++) src += "(?<g" + i + ">a)";
+    new RegExp(src);
+    process.stdout.write("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await Promise.race([
+    proc.exited,
+    Bun.sleep(30_000).then(() => {
+      proc.kill();
+      return "timeout" as const;
+    }),
+  ]);
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok");
+  expect(exitCode).toBe(0);
+}, 60_000);
+
+test("duplicate named capture group detection is unchanged", () => {
+  expect(() => new RegExp("(?<a>x)(?<a>y)")).toThrow(SyntaxError);
+  expect(() => new RegExp("(?<a>(?<a>x))")).toThrow(SyntaxError);
+  expect(() => new RegExp("((?<a>x)|(?<b>y))(?<a>z)")).toThrow(SyntaxError);
+  expect(() => new RegExp("((?<a>x)|(?<b>y))(?<b>z)")).toThrow(SyntaxError);
+
+  expect(() => new RegExp("(?<a>x)|(?<a>y)")).not.toThrow();
+  expect(() => new RegExp("(?<a>x)|(?<a>y)|(?<a>z)")).not.toThrow();
+  expect(() => new RegExp("((?<a>x)|(?<b>y))(?<c>z)")).not.toThrow();
+  expect(() => new RegExp("((?<a>x)|(?<a>y))|(?<a>z)")).not.toThrow();
+
+  expect("y".match(/(?<a>x)|(?<a>y)/)?.groups?.a).toBe("y");
+  expect("xz".match(/((?<a>x)|(?<b>y))(?<c>z)/)?.groups).toEqual({ a: "x", b: undefined, c: "z" });
+});


### PR DESCRIPTION
## Problem

`new RegExp()` compile time is quadratic in the number of named capture groups. A ~180 KB pattern of 16000 sibling named groups takes ~80 seconds to construct (single uninterruptible tick), while 32000 unnamed groups compile in ~130 ms. Node/V8 handles the same source in tens of ms or rejects it at its capture cap, so a pattern Node handles instantly wedges Bun's thread for over a minute. This is a compile-time DoS for anything that constructs a RegExp from user-controlled source.

```js
for (const k of [1000, 2000, 4000, 8000, 16000]) {
  const src = Array.from({ length: k }, (_, i) => `(?<g${i}>a)`).join("");
  const t0 = performance.now(); new RegExp(src);
  console.log(k, "named groups:", (performance.now() - t0).toFixed(0) + "ms");
}
// before: 1000=76ms 2000=343ms 4000=1526ms 8000=6271ms 16000=~25s+ (4x per doubling)
```

## Cause

`NamedCaptureGroups::pushParenthesis()` in YarrParser.h copied the entire `m_activeCaptureGroupNames.last()` hash set on every open paren. For N sibling named groups the top-level active set has k entries by the time group k opens, so parsing does 0+1+...+(N-1) hash-set copies plus the matching `addAll` work on pop. Unnamed groups keep the set empty so they stayed linear.

## Fix

The parser change lives in oven-sh/WebKit#342: keep a single currently-active set for the duplicate check and, per nesting level, track only the names newly activated there. `pushParenthesis()` is two empty-set appends, `popParenthesis()` only touches names introduced inside that group, and the flat case parses in O(N).

This PR bumps `WEBKIT_VERSION` to that change and adds:
- a regression test that compiles 30000 sibling named groups with a 30 s ceiling (previously well over a minute in release, tens of minutes in debug),
- coverage for the ES2025 duplicate-named-group semantics the rewritten tracker preserves.

## Verification

```
# fail-before
$ USE_SYSTEM_BUN=1 bun test test/js/web/regexp-named-groups.test.ts
(fail) compiling many sibling named capture groups is not quadratic [30027ms]
(pass) duplicate named capture group detection is unchanged
```

Depends on oven-sh/WebKit#342. `WEBKIT_VERSION` currently points at that PR's preview build and should be updated to the merged commit's `autobuild-` tag before this lands.
