### PR TITLE
runtime transpiler: attach module_info to ESM sources, fixing TypeScript type-only re-exports

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -223,6 +223,10 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_MEMFD, "BUN_FEATURE_FLAG_DISABLE_MEMFD", {});
     // The RedisClient supports auto-pipelining by default. This flag disables that behavior.
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING, "BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING", {});
+    // Disable module_info generation in the runtime transpiler (falls back to
+    // JSC re-parsing the transpiled output for import/export discovery). This
+    // is the escape hatch for the #7384 fix.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_RUNTIME_MODULE_INFO, "BUN_FEATURE_FLAG_DISABLE_RUNTIME_MODULE_INFO", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK, "BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK", {});
     // Fall back to the scalar byte-at-a-time VLQ decode in
     // bun_sourcemap::mapping::parse (skips the Highway-dispatched path).

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,11 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-const EXPECTED_VERSION: u32 = 23;
+/// Version 24: The runtime transpiler attaches module_info unconditionally
+/// (was: only under `bun test --isolate`). Old entries have an empty
+/// `esm_record`, which would regress TypeScript type-only re-exports (#7384)
+/// to the JSC re-parse path on cache hit.
+const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -930,11 +930,8 @@ impl TranspilerJob {
             }
         }
 
-        // SAFETY: leaf scalar field read; see `vm` note above. Inlined
-        // `VirtualMachine::use_isolation_source_provider_cache` to avoid forming
-        // `&VirtualMachine`.
-        let use_isolation_source_provider_cache = unsafe { (*vm).test_isolation_enabled }
-            && !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE::get()
+        let generate_module_info =
+            !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_RUNTIME_MODULE_INFO::get()
                 .unwrap_or(false);
 
         if let Some(entry_ptr) = cache.entry.take() {
@@ -958,7 +955,7 @@ impl TranspilerJob {
                 dump_source_string(vm, specifier, entry.output_code.byte_slice());
             }
 
-            let module_info: *mut c_void = if use_isolation_source_provider_cache
+            let module_info: *mut c_void = if generate_module_info
                 && entry.metadata.module_type != CacheModuleType::Cjs
                 && !entry.esm_record.is_empty()
             {
@@ -1075,22 +1072,16 @@ impl TranspilerJob {
         let is_commonjs_module = parse_result.ast.has_commonjs_export_names
             || parse_result.ast.exports_kind == ExportsKind::Cjs;
         let mut module_info: Option<Box<analyze_transpiled_module::ModuleInfo>> =
-            if use_isolation_source_provider_cache
-                && !is_commonjs_module
-                && loader.is_java_script_like()
-            {
+            if generate_module_info && !is_commonjs_module && loader.is_java_script_like() {
                 Some(analyze_transpiled_module::ModuleInfo::create(
                     loader.is_type_script(),
                 ))
             } else {
                 None
             };
-        // Propagate top-level-await to the cached
-        // module record. Without this, modules cached via the isolation source
-        // provider (used under --isolate / --parallel) are reported to JSC as
-        // having no TLA, so the module's evaluation promise resolves before the
-        // top-level-await actually completes — causing the caller's
-        // `wait_for_promise` on the preload to return early.
+        // Propagate top-level-await to the module record. Without this, JSC
+        // reports no TLA for the module and the evaluation promise resolves
+        // before the top-level-await actually completes.
         if let Some(mi) = module_info.as_deref_mut() {
             mi.flags.has_tla = !parse_result.ast.top_level_await_keyword.is_empty();
         }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2805,12 +2805,10 @@ fn transpile_source_code_inner(
                             list: core::mem::take(&mut entry.sourcemap).into_vec(),
                         },
                     );
-                    // Rebuild the cached ESM record for the
-                    // isolation source-provider cache (same shape as
+                    // Rebuild the cached ESM record (same shape as
                     // `RuntimeTranspilerStore`).
-                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                    let module_info: *mut core::ffi::c_void = if unsafe { &*jsc_vm }
-                        .use_isolation_source_provider_cache()
+                    let module_info: *mut core::ffi::c_void = if !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_RUNTIME_MODULE_INFO::get()
+                        .unwrap_or(false)
                         && entry.metadata.module_type != CacheModuleType::Cjs
                         && !entry.esm_record.is_empty()
                     {
@@ -2957,12 +2955,12 @@ fn transpile_source_code_inner(
 
                 let is_commonjs_module = parse_result.ast.has_commonjs_export_names
                     || parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
-                // Collect the ESM record while printing, for the isolation
-                // source-provider cache (same shape as `RuntimeTranspilerStore`).
-                // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                // Collect the ESM record while printing (same shape as
+                // `RuntimeTranspilerStore`).
                 let mut module_info: Option<
                     Box<bun_bundler::analyze_transpiled_module::ModuleInfo>,
-                > = if unsafe { &*jsc_vm }.use_isolation_source_provider_cache()
+                > = if !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_RUNTIME_MODULE_INFO::get()
+                    .unwrap_or(false)
                     && !is_commonjs_module
                     && loader.is_java_script_like()
                 {
@@ -2972,10 +2970,8 @@ fn transpile_source_code_inner(
                 } else {
                     None
                 };
-                // Propagate top-level-await to the
-                // cached module record (see the matching note in
-                // RuntimeTranspilerStore.rs for why this matters under
-                // --isolate / --parallel).
+                // Propagate top-level-await to the module record (see the
+                // matching note in RuntimeTranspilerStore.rs).
                 if let Some(mi) = module_info.as_deref_mut() {
                     mi.flags.has_tla = !parse_result.ast.top_level_await_keyword.is_empty();
                 }

--- a/test/js/bun/typescript/type-export.test.ts
+++ b/test/js/bun/typescript/type-export.test.ts
@@ -3,10 +3,10 @@ import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
 
 const ext = isWindows ? ".exe" : "";
 
-async function run(cmd: string[], cwd: string) {
+async function run(cmd: string[], cwd: string, extraEnv: Record<string, string> = {}) {
   await using proc = Bun.spawn({
     cmd,
-    env: bunEnv,
+    env: { ...bunEnv, ...extraEnv },
     cwd,
     stdio: ["inherit", "pipe", "pipe"],
   });
@@ -117,11 +117,7 @@ for (const b_file of b_files) {
         });
 
         describe.each(["run", "compile", "build"])("%s", mode => {
-          // TODO: "run" is skipped until ESM module_info is enabled in the runtime transpiler.
-          // Currently module_info is only generated for standalone ESM bytecode (--compile).
-          // Once enabled, flip this to include "run".
-          const testFn = mode === "run" ? test.skip : test.concurrent;
-          testFn("works", async () => {
+          test.concurrent("works", async () => {
             let result: { stdout: string; stderr: string; exitCode: number };
             if (mode === "compile") {
               result = await compileAndRun(dir, dir + "/c.ts");
@@ -305,9 +301,7 @@ describe("check ownkeys from a star import", () => {
   };
 
   describe.each(["run", "compile"] as const)("%s", mode => {
-    const testFn = mode === "run" ? test.skip : test.concurrent;
-
-    testFn("works", async () => {
+    test.concurrent("works", async () => {
       const result =
         mode === "compile" ? await compileAndRun(dir, dir + "/main.ts") : await run([bunExe(), "main.ts"], dir);
 
@@ -430,14 +424,53 @@ describe("import only used in decorator (#8439)", () => {
   });
 
   describe.each(["run", "compile"] as const)("%s", mode => {
-    const testFn = mode === "run" ? test.skip : test.concurrent;
-
-    testFn("works", async () => {
+    test.concurrent("works", async () => {
       const result =
         mode === "compile" ? await compileAndRun(dir, dir + "/index.ts") : await run([bunExe(), "index.ts"], dir);
 
       expect(result.stderr.trim()).toBe("");
       expect(result.exitCode).toBe(0);
     });
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/7384
+describe("re-export type alias without `export type` (#7384)", () => {
+  // Exercises both load paths: the async transpiler store (the default for a
+  // static `import` from the entry file) and the sync path (`importSync` /
+  // `require(esm)`, forced via BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER).
+  for (const asyncTranspiler of [true, false]) {
+    test.concurrent(`${asyncTranspiler ? "async" : "sync"} transpiler path`, async () => {
+      const dir = tempDirWithFiles("issue-7384", {
+        "EventTypes.ts": `
+          export type ValueOf<T> = T[keyof T];
+          export const SomeConst = 42;
+        `,
+        "utils.ts": `export { ValueOf, SomeConst } from './EventTypes';`,
+        "index.ts": `
+          import { SomeConst } from './utils';
+          console.log(JSON.stringify({ SomeConst }));
+        `,
+      });
+      const result = await run([bunExe(), "index.ts"], dir, {
+        ...(asyncTranspiler ? {} : { BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" }),
+      });
+      expect(result.stderr.trim()).toBe("");
+      expect(JSON.parse(result.stdout.trim())).toEqual({ SomeConst: 42 });
+      expect(result.exitCode).toBe(0);
+    });
+  }
+
+  test.concurrent("BUN_FEATURE_FLAG_DISABLE_RUNTIME_MODULE_INFO restores old behavior", async () => {
+    const dir = tempDirWithFiles("issue-7384-disable", {
+      "EventTypes.ts": `export type ValueOf<T> = T[keyof T];`,
+      "utils.ts": `export { ValueOf } from './EventTypes';`,
+      "index.ts": `import './utils';`,
+    });
+    const result = await run([bunExe(), "index.ts"], dir, {
+      BUN_FEATURE_FLAG_DISABLE_RUNTIME_MODULE_INFO: "1",
+    });
+    expect(result.stderr).toContain("export 'ValueOf' not found");
+    expect(result.exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #7384
Fixes #8439

## Repro

```ts
// EventTypes.ts
export type ValueOf<T> = T[keyof T];
export const SomeConst = 42;

// utils.ts
export { ValueOf, SomeConst } from './EventTypes';

// index.ts
import { SomeConst } from './utils';
console.log(SomeConst);
```

```
$ bun index.ts
SyntaxError: export 'ValueOf' not found in './EventTypes'
```

## Cause

The printer already builds a `ModuleInfo` record while printing (imports, exports, var declarations, and which import entries were erased TypeScript types). When present on a `ResolvedSource`, `ZigSourceProvider` tags the provider `BunTranspiledModule`, and `JSModuleLoader::makeModule` routes to `Bun__analyzeTranspiledModule` instead of re-parsing the stripped JavaScript; the resulting `JSModuleRecord` carries `m_isTypeScript=true` and `ImportEntryType::SingleTypeScript` for the erased names, and `CyclicModuleRecord` / `AbstractModuleRecord` tolerate a `NotFound` resolution for those entries instead of throwing.

That record was only attached under `bun test --isolate` (via the `use_isolation_source_provider_cache()` gate in `RuntimeTranspilerStore` / `jsc_hooks`). Plain `bun run` / `bun test` still took the default path, where JSC re-parses the transpiled output: the `export { ValueOf }` is preserved verbatim, `ValueOf` does not exist in the stripped `./EventTypes`, and module linking throws.

The same mechanism is what #15758 / #16296 were building toward; the infrastructure landed for `--compile` and `--isolate` but was never enabled for the runtime.

## Fix

- Drop the `use_isolation_source_provider_cache` gate on both load paths (async `RuntimeTranspilerStore` and sync `jsc_hooks::transpile_source_code_inner`), for both the fresh-transpile branch and the on-disk-cache-hit branch. `module_info` is now attached for every JS-like ESM source.
- Add `BUN_FEATURE_FLAG_DISABLE_RUNTIME_MODULE_INFO` as an escape hatch (falls back to JSC re-parsing).
- Bump the `RuntimeTranspilerCache` version (23 -> 24): entries written before this change carry an empty `esm_record`, which would keep sending cache hits down the JSC re-parse path and reinstate the bug.

The C++ side already handles non-isolation correctly: `Bun__analyzeTranspiledModule` eagerly frees the record after building the `JSModuleRecord` when `IsolatedModuleCache::canUse` is false, and `IsolatedModuleCache` itself remains gated on `--isolate`. In `BUN_DEBUG` builds, `fallbackParse` continues to verify the Bun-derived record against JSC's own re-parse of the printed output.

## Verification

`test/js/bun/typescript/type-export.test.ts`:

- Un-skipped the 18 `"run"`-mode cases (re-export via `export from` / `import then export` / `export *` / star-merge, consumed via `require` / `import *` / `await import` / named import). All 18 fail on released bun (`USE_SYSTEM_BUN=1`: 10 fail, 8 pass) and pass with the debug build.
- Un-skipped `check ownkeys from a star import > run` and `import only used in decorator (#8439) > run`.
- Added the exact #7384 repro for both the async transpiler store path and the sync path (`BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1`), plus a test that the disable flag restores the old error.

Sanity: `test/cli/test/isolation.test.ts` (19/19), `test/bundler/transpiler/runtime-transpiler.test.ts` (15/15), `test/js/bun/resolve/import-meta.test.js` (32/32), `test/js/bun/resolve/esModule-annotation.test.js` (8/8) all pass on the debug build; no `Imports different between parseFromSourceCode and fallbackParse` diagnostics observed.

Error message for `SyntaxError: export 'ValueOf' not found in './EventTypes'` is preserved for dedup search.