### PR TITLE
spawn: clear PR_SET_THP_DISABLE in the child on Linux

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -94,6 +94,13 @@ typedef int mode_t;
 
 #if OS(LINUX)
 #include <features.h>
+#include <sys/prctl.h>
+#ifndef PR_SET_THP_DISABLE
+#define PR_SET_THP_DISABLE 41
+#endif
+#ifndef PR_GET_THP_DISABLE
+#define PR_GET_THP_DISABLE 42
+#endif
 #ifdef __GNU_LIBRARY__
 #include <gnu/libc-version.h>
 #endif
@@ -1823,6 +1830,15 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionExecve, (JSGlobalObject * lexicalGlobal
     sigset_t emptyMask;
     sigemptyset(&emptyMask);
     pthread_sigmask(SIG_SETMASK, &emptyMask, nullptr);
+
+#if OS(LINUX)
+    // mimalloc sets PR_SET_THP_DISABLE at startup; the flag survives execve.
+    // Clear it so the replacement image gets the system default. A failed
+    // execve aborts below, so there is no state to restore.
+    if (prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0) == 1) {
+        (void)prctl(PR_SET_THP_DISABLE, 0, 0, 0, 0);
+    }
+#endif
 
     ::execve(execPathUtf8.data(), argv.begin(), envp.begin());
     savedErrno = errno;

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -174,7 +174,9 @@ extern "C" ssize_t posix_spawn_bun(
     // startup. That flag lives on mm->flags (MMF_DISABLE_THP), is inherited by
     // fork and preserved across execve, so every subprocess would inherit it.
     // The vfork child shares our mm, so save now, clear in the child just
-    // before exec, and restore in the parent once vfork returns.
+    // before exec, and restore in the parent once vfork returns. Only act on
+    // the exact state mimalloc sets (1 = fully disabled); any other value
+    // (0, 3 = PR_THP_DISABLE_EXCEPT_ADVISED, -1 = unsupported) is left alone.
     int saved_thp_disable = prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0);
     pid_t child = vfork();
 #else
@@ -361,7 +363,7 @@ extern "C" ssize_t posix_spawn_bun(
         // Reset THP to the system default for the new process. Done as late as
         // possible because under vfork this also flips the flag on the shared
         // parent mm until the parent restores it after vfork returns.
-        if (saved_thp_disable > 0) {
+        if (saved_thp_disable == 1) {
             (void)prctl(PR_SET_THP_DISABLE, 0, 0, 0, 0);
         }
 #endif
@@ -451,8 +453,8 @@ extern "C" ssize_t posix_spawn_bun(
     if (saved_dumpable == 0 || saved_dumpable == 1) {
         (void)prctl(PR_SET_DUMPABLE, saved_dumpable, 0, 0, 0);
     }
-    if (saved_thp_disable > 0) {
-        (void)prctl(PR_SET_THP_DISABLE, saved_thp_disable, 0, 0, 0);
+    if (saved_thp_disable == 1) {
+        (void)prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
     }
 #endif
 

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -25,6 +25,13 @@ extern char** environ;
 #define CLOSE_RANGE_CLOEXEC (1U << 2)
 #endif
 
+#ifndef PR_SET_THP_DISABLE
+#define PR_SET_THP_DISABLE 41
+#endif
+#ifndef PR_GET_THP_DISABLE
+#define PR_GET_THP_DISABLE 42
+#endif
+
 #if OS(LINUX)
 extern "C" ssize_t bun_close_range(unsigned int start, unsigned int end, unsigned int flags);
 #endif
@@ -163,6 +170,12 @@ extern "C" ssize_t posix_spawn_bun(
     // Save it so the parent can restore it once vfork returns, like Go's
     // forkAndExecInChild1 and systemd's safe_fork_full do.
     int saved_dumpable = (request->set_uid || request->set_gid) ? prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) : -1;
+    // mimalloc (built with MI_DEFAULT_ALLOW_THP=0) sets PR_SET_THP_DISABLE at
+    // startup. That flag lives on mm->flags (MMF_DISABLE_THP), is inherited by
+    // fork and preserved across execve, so every subprocess would inherit it.
+    // The vfork child shares our mm, so save now, clear in the child just
+    // before exec, and restore in the parent once vfork returns.
+    int saved_thp_disable = prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0);
     pid_t child = vfork();
 #else
     // On macOS, we must use fork() because vfork() is more strictly enforced.
@@ -344,6 +357,15 @@ extern "C" ssize_t posix_spawn_bun(
         // Close all fds > current_max_fd, preferring cloexec if available
         closeRangeOrLoop(current_max_fd + 1, INT_MAX, true);
 
+#if OS(LINUX)
+        // Reset THP to the system default for the new process. Done as late as
+        // possible because under vfork this also flips the flag on the shared
+        // parent mm until the parent restores it after vfork returns.
+        if (saved_thp_disable > 0) {
+            (void)prctl(PR_SET_THP_DISABLE, 0, 0, 0, 0);
+        }
+#endif
+
         if (execve(path, argv, envp) == -1) {
             return childFailed();
         }
@@ -428,6 +450,9 @@ extern "C" ssize_t posix_spawn_bun(
     // a saved value of 2 (suid_dumpable=2) means it was already the reset value.
     if (saved_dumpable == 0 || saved_dumpable == 1) {
         (void)prctl(PR_SET_DUMPABLE, saved_dumpable, 0, 0, 0);
+    }
+    if (saved_thp_disable > 0) {
+        (void)prctl(PR_SET_THP_DISABLE, saved_thp_disable, 0, 0, 0);
     }
 #endif
 

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -173,11 +173,14 @@ extern "C" ssize_t posix_spawn_bun(
     // mimalloc (built with MI_DEFAULT_ALLOW_THP=0) sets PR_SET_THP_DISABLE at
     // startup. That flag lives on mm->flags (MMF_DISABLE_THP), is inherited by
     // fork and preserved across execve, so every subprocess would inherit it.
-    // The vfork child shares our mm, so save now, clear in the child just
-    // before exec, and restore in the parent once vfork returns. Only act on
-    // the exact state mimalloc sets (1 = fully disabled); any other value
-    // (0, 3 = PR_THP_DISABLE_EXCEPT_ADVISED, -1 = unsupported) is left alone.
-    int saved_thp_disable = prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0);
+    // The vfork child shares our mm, so clear in the child just before exec
+    // and restore in the parent once vfork returns. mimalloc sets this before
+    // any threads exist, so capture it once; reading the live value on every
+    // spawn can observe another thread's vfork child having cleared it. Only
+    // act on the exact state mimalloc sets (1 = fully disabled); any other
+    // value (0, 3 = PR_THP_DISABLE_EXCEPT_ADVISED, -1 = unsupported) is left
+    // alone.
+    static const int initial_thp_disable = prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0);
     pid_t child = vfork();
 #else
     // On macOS, we must use fork() because vfork() is more strictly enforced.
@@ -363,7 +366,7 @@ extern "C" ssize_t posix_spawn_bun(
         // Reset THP to the system default for the new process. Done as late as
         // possible because under vfork this also flips the flag on the shared
         // parent mm until the parent restores it after vfork returns.
-        if (saved_thp_disable == 1) {
+        if (initial_thp_disable == 1) {
             (void)prctl(PR_SET_THP_DISABLE, 0, 0, 0, 0);
         }
 #endif
@@ -453,7 +456,7 @@ extern "C" ssize_t posix_spawn_bun(
     if (saved_dumpable == 0 || saved_dumpable == 1) {
         (void)prctl(PR_SET_DUMPABLE, saved_dumpable, 0, 0, 0);
     }
-    if (saved_thp_disable == 1) {
+    if (initial_thp_disable == 1) {
         (void)prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
     }
 #endif

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -15,7 +15,7 @@ import {
   tmpdirSync,
   withoutAggressiveGC,
 } from "harness";
-import { closeSync, fstatSync, openSync, readFileSync, readSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, openSync, readFileSync, readSync, rmSync, writeFileSync } from "node:fs";
 import path, { join } from "path";
 
 let tmp: string;
@@ -1270,13 +1270,18 @@ const ownThp = readOwnThp();
 // mimalloc sets PR_SET_THP_DISABLE at startup on Linux; the flag is inherited
 // across fork and preserved across execve. Spawn should clear it so children
 // get the system default instead of having transparent huge pages disabled.
-it.if(ownThp === "0")("child does not inherit PR_SET_THP_DISABLE", async () => {
-  await using proc = spawn({ cmd: ["cat", "/proc/self/status"], stdout: "pipe", stderr: "pipe" });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout.match(/^THP_enabled:\s*(\d)/m)?.[1]).toBe("1");
-  expect(exitCode).toBe(0);
+// /proc reports THP_enabled: 0 on CONFIG_TRANSPARENT_HUGEPAGE=n kernels too,
+// so also require the sysfs directory that only exists when THP is built in.
+it.if(ownThp === "0" && existsSync("/sys/kernel/mm/transparent_hugepage"))(
+  "child does not inherit PR_SET_THP_DISABLE",
+  async () => {
+    await using proc = spawn({ cmd: ["cat", "/proc/self/status"], stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.match(/^THP_enabled:\s*(\d)/m)?.[1]).toBe("1");
+    expect(exitCode).toBe(0);
 
-  // Parent's flag is restored once vfork returns.
-  expect(readOwnThp()).toBe("0");
-});
+    // Parent's flag is restored once vfork returns.
+    expect(readOwnThp()).toBe("0");
+  },
+);

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -7,6 +7,7 @@ import {
   getMaxFD,
   isBroken,
   isDebug,
+  isLinux,
   isMacOS,
   isPosix,
   isWindows,
@@ -1254,4 +1255,20 @@ describe("uid/gid", () => {
     }
     expect(thrown?.code).toBe("EPERM");
   });
+});
+
+const ownThp = isLinux ? readFileSync("/proc/self/status", "utf8").match(/^THP_enabled:\s*(\d)/m)?.[1] : undefined;
+
+// mimalloc sets PR_SET_THP_DISABLE at startup on Linux; the flag is inherited
+// across fork and preserved across execve. Spawn should clear it so children
+// get the system default instead of having transparent huge pages disabled.
+it.if(ownThp === "0")("child does not inherit PR_SET_THP_DISABLE", async () => {
+  await using proc = spawn({ cmd: ["cat", "/proc/self/status"], stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.match(/^THP_enabled:\s*(\d)/m)?.[1]).toBe("1");
+  expect(exitCode).toBe(0);
+
+  // Parent's flag is restored once vfork returns.
+  expect(readFileSync("/proc/self/status", "utf8").match(/^THP_enabled:\s*(\d)/m)?.[1]).toBe("0");
 });

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1257,7 +1257,15 @@ describe("uid/gid", () => {
   });
 });
 
-const ownThp = isLinux ? readFileSync("/proc/self/status", "utf8").match(/^THP_enabled:\s*(\d)/m)?.[1] : undefined;
+function readOwnThp() {
+  if (!isLinux) return undefined;
+  try {
+    return readFileSync("/proc/self/status", "utf8").match(/^THP_enabled:\s*(\d)/m)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+const ownThp = readOwnThp();
 
 // mimalloc sets PR_SET_THP_DISABLE at startup on Linux; the flag is inherited
 // across fork and preserved across execve. Spawn should clear it so children
@@ -1270,5 +1278,5 @@ it.if(ownThp === "0")("child does not inherit PR_SET_THP_DISABLE", async () => {
   expect(exitCode).toBe(0);
 
   // Parent's flag is restored once vfork returns.
-  expect(readFileSync("/proc/self/status", "utf8").match(/^THP_enabled:\s*(\d)/m)?.[1]).toBe("0");
+  expect(readOwnThp()).toBe("0");
 });

--- a/test/js/node/process/process-execve.test.ts
+++ b/test/js/node/process/process-execve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
 
 describe.concurrent("process.execve", () => {
   test("is a function", () => {
@@ -175,6 +176,33 @@ describe.concurrent("process.execve", () => {
     ]);
     expect(exitCode).toBe(0);
   });
+
+  let ownThp;
+  try {
+    ownThp = isLinux ? readFileSync("/proc/self/status", "utf8").match(/^THP_enabled:\s*(\d)/m)?.[1] : undefined;
+  } catch {}
+
+  test.if(ownThp === "0" && existsSync("/sys/kernel/mm/transparent_hugepage"))(
+    "clears PR_SET_THP_DISABLE for the replacement image",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.execve("/bin/grep", ["grep", "THP_enabled", "/proc/self/status"], process.env);`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(stdout.match(/^THP_enabled:\s*(\d)/m)?.[1]).toBe("1");
+      expect(exitCode).toBe(0);
+    },
+  );
 
   test.skipIf(!isWindows)("throws ERR_FEATURE_UNAVAILABLE_ON_PLATFORM on Windows", () => {
     expect(() => process.execve(process.execPath, [process.execPath], {})).toThrow(


### PR DESCRIPTION
mimalloc is built with `MI_DEFAULT_ALLOW_THP=0` on Linux (`scripts/build/deps/mimalloc.ts`), so it calls `prctl(PR_SET_THP_DISABLE, 1)` during process init. That flag lives on `mm->flags` (`MMF_DISABLE_THP`), is inherited across `fork`, and is preserved across `execve`, so every subprocess we spawn was also running with transparent huge pages disabled.

## Repro

```sh
$ bun -e 'console.log(Bun.spawnSync(["grep","THP_enabled","/proc/self/status"]).stdout.toString())'
THP_enabled:    0     # inherited from bun, should be the system default
```

## Fix

Clear the flag in the vfork child just before `execve` so children get the system default. Because the vfork child shares our `mm`, save the flag in the parent before `vfork` and restore it once `vfork` returns (same dance as the existing `PR_SET_DUMPABLE` save/restore for the setuid path).

## Verification

```
Bun.spawnSync: THP_enabled:     1
cp.spawnSync:  THP_enabled:     1
cp.execSync:   THP_enabled:     1
self:          THP_enabled:     0   (bun itself keeps THP disabled)
```

New test in `spawn.test.ts` checks the child has `THP_enabled: 1` and that bun's own flag is restored to 0 after the spawn. Gated on `ownThp === "0"` so it skips on kernels without the `/proc/self/status` field or when `MIMALLOC_ALLOW_THP=1` is set.

---

Separately, measured the RSS/throughput cost of dropping `MI_DEFAULT_ALLOW_THP=0` entirely (via `MIMALLOC_ALLOW_THP=1`, release bun 1.4.0, kernel THP=`[madvise]`, 5 runs each):

| | THP off (current) | THP on | delta |
|---|---|---|---|
| `bun -e 1` | ~32 MB | ~48 MB | +16 MB |
| express idle | ~54 MB | ~72 MB | +18 MB (11 hugepages) |
| express hello 30k/c64 | 13011 rps, 58k minflt | 12640 rps, 47k minflt | rps noise, -18% minflt |
| express busy 30k/c64 | 10532 rps, 146k minflt | 10716 rps, 143k minflt | both noise |

No throughput win from enabling THP on this box. This PR keeps THP disabled for bun itself and only resets it for children.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts test/js/node/process/process-execve.test.ts

<!-- robobun:evidence:end -->