### PR TITLE
bundler: no spurious `with { type: ... }` on external hoisted from `module.exports = require(...)`

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1764,19 +1764,24 @@ pub mod bv2_impl {
                             while let Some(redirect_id) =
                                 get_redirect_id(self.redirects[other_source.get() as usize])
                             {
-                                let (other_src_idx, other_path) = {
+                                let (other_src_idx, other_path, other_loader) = {
                                     let other_import_records = self.all_import_records
                                         [other_source.get() as usize]
                                         .as_slice();
                                     let other_import_record =
                                         &other_import_records[redirect_id as usize];
-                                    (other_import_record.source_index, other_import_record.path)
+                                    (
+                                        other_import_record.source_index,
+                                        other_import_record.path,
+                                        other_import_record.loader,
+                                    )
                                 };
                                 let import_record = &mut self.all_import_records
                                     [import_record_list_id.get() as usize]
                                     .as_mut_slice()[ir_idx];
                                 import_record.source_index = other_src_idx;
                                 import_record.path = other_path;
+                                import_record.loader = other_loader;
                                 other_source = other_src_idx;
                                 if redirect_count == Self::MAX_REDIRECTS {
                                     import_record.path.is_disabled = true;

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -141,6 +141,73 @@ describe("bundler", () => {
       stdout: "bar",
     },
   });
+  // When `module.exports = require(external)` is collapsed into the importing
+  // file's import record, the record's path is rewritten but the loader was
+  // left as the intermediate file's loader, emitting a spurious
+  // `with { type: "..." }` attribute on the hoisted external import.
+  itBundled("cjs2esm/ModuleExportsEqualsRequireExternal", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import pkg from 'lib';
+        console.log(pkg.hello);
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        module.exports = require('the-external');
+      `,
+    },
+    external: ["the-external"],
+    target: "bun",
+    runtimeFiles: {
+      "/node_modules/the-external/index.js": /* js */ `
+        module.exports = { hello: "world" };
+      `,
+      "/node_modules/the-external/package.json": /* json */ `
+        { "name": "the-external", "main": "index.js" }
+      `,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain(`from "the-external"`);
+      expect(out).not.toContain("with {");
+      expect(out).not.toContain("with{");
+    },
+    run: {
+      stdout: "world",
+    },
+  });
+  itBundled("cjs2esm/ModuleExportsEqualsRequireExternalChained", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import pkg from './a.ts';
+        console.log(pkg.hello);
+      `,
+      "/a.ts": /* ts */ `
+        module.exports = require('./b.cjs');
+      `,
+      "/b.cjs": /* js */ `
+        module.exports = require('the-external');
+      `,
+    },
+    external: ["the-external"],
+    target: "bun",
+    runtimeFiles: {
+      "/node_modules/the-external/index.js": /* js */ `
+        module.exports = { hello: "chained" };
+      `,
+      "/node_modules/the-external/package.json": /* json */ `
+        { "name": "the-external", "main": "index.js" }
+      `,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain(`from "the-external"`);
+      expect(out).not.toContain("with {");
+      expect(out).not.toContain("with{");
+    },
+    run: {
+      stdout: "chained",
+    },
+  });
   itBundled("cjs2esm/ModuleExportsBasedOnNodeEnvProduction", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
## What

When a CJS module whose body is exactly `module.exports = require("x")` is imported and `x` is external, bundling for `--target bun` emits a stray import attribute on the hoisted import:

```sh
$ cat node_modules/mypkg/index.js
module.exports = require("some-external-thing");
$ cat index.ts
import pkg from "mypkg"; console.log(pkg);
$ bun build index.ts --target bun --external some-external-thing
// @bun
// index.ts
import pkg from "some-external-thing" with { type: "jsx" };
console.log(pkg);
```

The attribute has nothing to do with `"some-external-thing"`; it is the default loader of the *intermediate* file (`.js` maps to `Loader::Jsx` by default, `.ts` would give `with { type: "ts" }`, etc.).

## Why

`ReachableFileVisitor::visit` follows `redirect_import_record_index` redirects (the `module.exports = require(...)` pass-through optimization) by rewriting the importer's import record to point at the inner target. It copied `source_index` and `path` from the inner record but left `loader` set to whatever resolution had put there for the intermediate file. For an external target the inner record's `loader` is `None`, so the outer record should end up with `None` too; instead it kept the intermediate's loader and the printer (`src/js_printer/lib.rs`) turned that into a `with { type: "..." }` clause for the bun target.

## Fix

Copy `loader` along with `source_index` and `path` when following a redirect.

## Verified

```
bun bd test test/bundler/bundler_cjs2esm.test.ts
```

New tests `cjs2esm/ModuleExportsEqualsRequireExternal` and `cjs2esm/ModuleExportsEqualsRequireExternalChained` fail on main with the spurious `with { type: "jsx" }` / `with { type: "ts" }` and pass with this change. Existing `cjs2esm/*` and `edgecase/NestedRedirectToABuiltin` (same redirect path, builtin target) keep passing.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (1f79b220c)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [1838.34ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [920.74ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [852.30ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [1600.49ms]
(pass) bundler > cjs2esm/ExportsFunction [936.93ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [1566.07ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [830.78ms]
166 |       `,
167 |     },
168 |     onAfterBundle(api) {
169 |       const out = api.readFile("/out.js");
170 |       expect(out).toContain(`from "the-external"`);
171 |       expect(out).not.toContain("with {");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "with {"
Received: "// @bun\n// entry.ts\nimport pkg from \"the-external\" with { type: \"jsx\" };\nconsole.log(pkg.hello);\n"

      at onAfterBundle (/workspace/b
... (truncated)

release without fix: 8 FAILED
bun test v1.3.14 (0d9b296a)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [46.94ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [35.43ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [48.50ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [22.98ms]
(pass) bundler > cjs2esm/ExportsFunction [30.78ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [221.23ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [149.52ms]
166 |       `,
167 |     },
168 |     onAfterBundle(api) {
169 |       const out = api.readFile("/out.js");
170 |       expect(out).toContain(`from "the-external"`);
171 |       expect(out).not.toContain("with {");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "with {"
Received: "// @bun\n// entry.ts\nimport pkg from \"the-external\" with { type: \"jsx\" };\nconsole.log(pkg.hello);\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_cjs2esm.test.ts:171:23)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) bundler > cjs2esm/ModuleExportsEqualsRequireExtern
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (1f79b220c)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [1175.06ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [596.70ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [619.25ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [741.77ms]
(pass) bundler > cjs2esm/ExportsFunction [1229.40ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [935.68ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [530.19ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireExternal [845.43ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireExternalChained [548.71ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [1212.49ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [836.23ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [608.62ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [468.34ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrappi
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1f79b220cd
  features     baseline

22 deps, 108 codegen, 1171 objects in 1135ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] mkdir codegen
[2/1238] mkdir stamps
[3/1238] mkdir pch
[4/1238] mkdir obj
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] gen ErrorCode+*.h
[7/1238] fetch zlib
[zlib] up to date
[8/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1238] subst deps/libjpeg-turbo/jconfig.h
[10/1238] gen bindgenv2
[11/1238] fetch tinycc
[tinycc] up to date
[12/1238] fetch picohttpparser
[picohttpparser] up to date
[13/1238] fetch nodejs (prebuilt)
[nodejs] up to date
[14/1238] subst deps/zlib/zlib.h
[15/1238] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[16/1238] subst deps/libjpeg-turbo/jconfigint.h
[17/1238] subst deps/zlib/zconf.h

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs             |  9 +++--
 test/bundler/bundler_cjs2esm.test.ts | 67 ++++++++++++++++++++++++++++++++++++
 2 files changed, 74 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/bundler/bundle_v2.rs                  8      2      0
test/bundler/bundler_cjs2esm.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->