### PR TITLE
error: prefix stack frames with the receiver's built-in class name

### DIFF
--- a/docs/runtime/debugger.mdx
+++ b/docs/runtime/debugger.mdx
@@ -262,7 +262,7 @@ The `CallSite` object has the following methods:
 | Method                     | Returns                                               |
 | -------------------------- | ----------------------------------------------------- |
 | `getThis`                  | `this` value of the function call                     |
-| `getTypeName`              | typeof `this`                                         |
+| `getTypeName`              | class name of the receiver, or `null`                 |
 | `getFunction`              | function object                                       |
 | `getFunctionName`          | function name as a string                             |
 | `getMethodName`            | method name as a string                               |

--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -158,9 +158,13 @@ void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WT
             sb.append("new "_s);
         }
 
-        if (!typeName.isEmpty() && !functionName.startsWith(typeName)) {
-            sb.append(typeName);
-            sb.append('.');
+        if (!typeName.isEmpty()) {
+            bool alreadyQualified = functionName.startsWith(typeName)
+                && (functionName.length() == typeName.length() || functionName[typeName.length()] == '.');
+            if (!alreadyQualified) {
+                sb.append(typeName);
+                sb.append('.');
+            }
         }
 
         sb.append(functionName);

--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -59,6 +59,10 @@ void CallSite::finishCreation(VM& vm, JSC::JSGlobalObject* globalObject, JSCStac
     m_functionName.set(vm, this, stackFrame.functionName());
     m_sourceURL.set(vm, this, stackFrame.sourceURL());
     m_sourceID = stackFrame.sourceID();
+    if (!stackFrame.receiverTypeName().isEmpty())
+        m_receiverTypeName.set(vm, this, JSC::jsString(vm, stackFrame.receiverTypeName()));
+    else
+        m_receiverTypeName.set(vm, this, JSC::jsNull());
 
     const auto* sourcePositions = stackFrame.getSourcePositions();
     if (sourcePositions) {
@@ -91,6 +95,7 @@ void CallSite::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisCallSite->m_function);
     visitor.append(thisCallSite->m_functionName);
     visitor.append(thisCallSite->m_sourceURL);
+    visitor.append(thisCallSite->m_receiverTypeName);
 }
 JSC_DEFINE_HOST_FUNCTION(nativeFrameForTesting, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
@@ -125,23 +130,37 @@ void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WT
     std::optional<OrdinalNumber> column = columnNumber().zeroBasedInt() >= 0 ? std::optional(columnNumber()) : std::nullopt;
     std::optional<OrdinalNumber> line = lineNumber().zeroBasedInt() >= 0 ? std::optional(lineNumber()) : std::nullopt;
 
+    String typeName;
+    if (!isConstructor()) {
+        if (auto* object = thisValue.getObject()) {
+            auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            typeName = object->calculatedClassName(object);
+            if (topExceptionScope.exception()) {
+                (void)topExceptionScope.tryClearException();
+            }
+        }
+        if (typeName.isEmpty()) {
+            JSValue stored = m_receiverTypeName.get();
+            if (auto* str = dynamicDowncast<JSString>(stored)) {
+                auto view = str->tryGetValueWithoutGC();
+                if (!view->isEmpty())
+                    typeName = view;
+            }
+        }
+    }
+
+    if (functionName.isEmpty() && !typeName.isEmpty())
+        functionName = "<anonymous>"_s;
+
     if (functionName.length() > 0) {
 
         if (isConstructor()) {
             sb.append("new "_s);
         }
 
-        if (auto* object = thisValue.getObject()) {
-            auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            auto className = object->calculatedClassName(object);
-            if (topExceptionScope.exception()) {
-                (void)topExceptionScope.tryClearException();
-            }
-
-            if (className.length() > 0) {
-                sb.append(className);
-                sb.append('.');
-            }
+        if (!typeName.isEmpty() && !functionName.startsWith(typeName)) {
+            sb.append(typeName);
+            sb.append('.');
         }
 
         sb.append(functionName);

--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -158,13 +158,9 @@ void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WT
             sb.append("new "_s);
         }
 
-        if (!typeName.isEmpty()) {
-            bool alreadyQualified = functionName.startsWith(typeName)
-                && (functionName.length() == typeName.length() || functionName[typeName.length()] == '.');
-            if (!alreadyQualified) {
-                sb.append(typeName);
-                sb.append('.');
-            }
+        if (!typeName.isEmpty() && !functionNameHasTypeNamePrefix(functionName, typeName)) {
+            sb.append(typeName);
+            sb.append('.');
         }
 
         sb.append(functionName);

--- a/src/jsc/bindings/CallSite.h
+++ b/src/jsc/bindings/CallSite.h
@@ -36,6 +36,7 @@ private:
     JSC::WriteBarrier<JSC::Unknown> m_function;
     JSC::WriteBarrier<JSC::Unknown> m_functionName;
     JSC::WriteBarrier<JSC::Unknown> m_sourceURL;
+    JSC::WriteBarrier<JSC::Unknown> m_receiverTypeName;
     OrdinalNumber m_lineNumber;
     OrdinalNumber m_columnNumber;
     intptr_t m_sourceID;
@@ -73,6 +74,7 @@ public:
     }
 
     JSC::JSValue thisValue() const { return m_thisValue.get(); }
+    JSC::JSValue receiverTypeName() const { return m_receiverTypeName.get(); }
     JSC::JSValue function() const { return m_function.get(); }
     JSC::JSValue functionName() const { return m_functionName.get(); }
     JSC::JSValue sourceURL() const { return m_sourceURL.get(); }

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -102,11 +102,26 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetThis, (JSGlobalObject * globalObjec
     return JSC::JSValue::encode(callSite->thisValue());
 }
 
-// TODO: doesn't get class name
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetTypeName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
-    return JSC::JSValue::encode(JSC::jsTypeStringForValue(globalObject, callSite->thisValue()));
+
+    JSC::JSValue thisValue = callSite->thisValue();
+    if (thisValue && thisValue.isCell()) {
+        if (JSC::JSObject* thisObject = thisValue.getObject()) {
+            if (!thisObject->isGlobalObject()) {
+                String className = JSObject::calculatedClassName(thisObject);
+                if (!className.isEmpty())
+                    return JSC::JSValue::encode(JSC::jsString(vm, className));
+            }
+        }
+    }
+
+    JSValue stored = callSite->receiverTypeName();
+    if (stored && stored.isString())
+        return JSC::JSValue::encode(stored);
+
+    return JSC::JSValue::encode(JSC::jsNull());
 }
 
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFunction, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -25,6 +25,7 @@
 #include <JavaScriptCore/FunctionCodeBlock.h>
 
 #include "ErrorStackFrame.h"
+#include "ErrorStackTraceMetadata.h"
 
 using namespace JSC;
 using namespace WebCore;
@@ -138,15 +139,26 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
     // JSC's getStackTrace uses StackVisitor::isImplementationVisibilityPrivate
     // which differs from Bun's helper — post-filter to keep behavior consistent
     // with new Error() stack formatting.
+    // syncIndices records each kept frame's position among the raw sync frames so remapStackTraceMetadata can follow the trimming below.
+    WTF::Vector<unsigned> syncIndices;
     stackTrace.reserveInitialCapacity(rawFrames.size());
+    syncIndices.reserveInitialCapacity(rawFrames.size());
+    unsigned rawSyncIndex = 0;
     for (auto& frame : rawFrames) {
-        if (!isImplementationVisibilityPrivate(frame))
+        bool isAsync = frame.isAsyncFrame();
+        if (!isImplementationVisibilityPrivate(frame)) {
+            syncIndices.append(isAsync ? Bun::noSyncFrameIndex : rawSyncIndex);
             stackTrace.append(WTF::move(frame));
+        }
+        if (!isAsync)
+            rawSyncIndex++;
     }
 
     if (!caller.isObject()) {
         if (stackTrace.size() > stackTraceLimit)
             stackTrace.shrink(stackTraceLimit);
+        syncIndices.shrink(stackTrace.size());
+        Bun::remapStackTraceMetadata(owner, syncIndices.span());
         return;
     }
 
@@ -175,11 +187,15 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
         }
     }
 
-    if (removeCount > 0)
+    if (removeCount > 0) {
         stackTrace.removeAt(0, removeCount);
+        syncIndices.removeAt(0, removeCount);
+    }
 
     if (stackTrace.size() > stackTraceLimit)
         stackTrace.shrink(stackTraceLimit);
+    syncIndices.shrink(stackTrace.size());
+    Bun::remapStackTraceMetadata(owner, syncIndices.span());
 }
 
 JSCStackTrace JSCStackTrace::getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue)

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -59,6 +59,7 @@ private:
     WTF::String m_sourceURL;
     WTF::String m_functionName;
     WTF::String m_typeName;
+    WTF::String m_receiverTypeName;
 
     // m_wasmFunctionIndexOrName has meaning only when m_isWasmFrame is set
     JSC::Wasm::IndexOrName m_wasmFunctionIndexOrName;
@@ -88,6 +89,9 @@ public:
     JSC::JSString* sourceURL();
     JSC::JSString* functionName();
     JSC::JSString* typeName();
+
+    const WTF::String& receiverTypeName() const { return m_receiverTypeName; }
+    void setReceiverTypeName(const WTF::String& name) { m_receiverTypeName = name; }
 
     bool isFunctionOrEval() const { return m_isFunctionOrEval; }
     bool isAsync() const { return m_isAsync; }

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -215,6 +215,13 @@ private:
 bool isImplementationVisibilityPrivate(JSC::StackVisitor& visitor);
 bool isImplementationVisibilityPrivate(const JSC::StackFrame& frame);
 
+// True when functionName is exactly typeName or already starts with "typeName.".
+inline bool functionNameHasTypeNamePrefix(const WTF::String& functionName, const WTF::String& typeName)
+{
+    return functionName.startsWith(typeName)
+        && (functionName.length() == typeName.length() || functionName[typeName.length()] == '.');
+}
+
 String sourceURL(const JSC::SourceOrigin& origin);
 String sourceURL(JSC::SourceProvider* sourceProvider);
 String sourceURL(const JSC::SourceCode& sourceCode);

--- a/src/jsc/bindings/ErrorStackTraceMetadata.cpp
+++ b/src/jsc/bindings/ErrorStackTraceMetadata.cpp
@@ -25,9 +25,7 @@ struct CacheSlot {
 
 using Cache = std::array<CacheSlot, kCacheSize>;
 
-// Direct-mapped per-thread cache. .stack is almost always read in the same
-// turn it was captured, so a small cache suffices; on eviction the only
-// consequence is that the older error's stack loses its receiver prefixes.
+// Per-thread cache; eviction just drops the older error's receiver prefixes.
 static CacheSlot& slotFor(JSCell* owner)
 {
     static LazyNeverDestroyed<ThreadSpecific<Cache>> cache;
@@ -45,10 +43,8 @@ static WTF::String typeNameForReceiver(JSValue thisValue)
     if (!thisObject)
         return String();
 
-    // For bare `foo()` JSC passes the resolved scope as |this| and the callee
-    // converts it via to_this when |this| is used; the raw slot holds a scope
-    // (JSLexicalEnvironment, GlobalObject, etc.), which is never a real
-    // receiver. The global proxy is likewise a stand-in for "no receiver".
+    // Bare `foo()`: JSC passes the resolved scope as raw |this| (normalized
+    // later by to_this), so a scope/global-proxy here means "no receiver".
     JSC::JSType type = thisObject->type();
     if ((JSC::FirstScopeType <= type && type <= JSC::LastScopeType) || type == JSC::GlobalProxyType)
         return String();
@@ -58,18 +54,15 @@ static WTF::String typeNameForReceiver(JSValue thisValue)
         return String();
 
     ASCIILiteral name = classInfo->className;
-    // Generic classInfo names that would need calculatedClassName() to resolve
-    // to the user-visible constructor name; skip rather than mislabel.
+    // These need calculatedClassName() for the real name; skip rather than mislabel.
     if (name == "Object"_s || name == "Function"_s || name == "Module"_s || name == "GlobalObject"_s)
         return String();
     return name;
 }
 
-// Installed as VM::onAppendStackTrace. Runs inside Interpreter::getStackTrace
-// under AssertNoGC while the physical call frames are still live. Re-walks the
-// stack via StackVisitor, matches the already-filtered `stackTrace` frames by
-// callee in order, and records each frame's receiver type name into the cache
-// slot for this ErrorInstance.
+// VM::onAppendStackTrace hook: runs under AssertNoGC inside getStackTrace
+// while call frames are live; matches stackTrace[] frames by callee and
+// records each receiver's classInfo name into this ErrorInstance's cache slot.
 void captureStackFrameReceivers(VM& vm, JSCell* owner, WTF::Vector<StackFrame>& stackTrace, size_t maxToAppend)
 {
     UNUSED_PARAM(maxToAppend);
@@ -136,9 +129,7 @@ void captureStackFrameReceivers(VM& vm, JSCell* owner, WTF::Vector<StackFrame>& 
     uintptr_t gen = generation.fetch_add(1, std::memory_order_relaxed) + 1;
     slot.owner = owner;
     slot.generation = gen;
-    // Stamp the instance with the generation so a recycled cell at the same
-    // address does not pick up stale metadata. The value is never a real
-    // pointer; Bun__errorInstance__finalize is a no-op.
+    // Generation stamp guards against a recycled cell at the same address.
     errorInstance->setBunErrorData(reinterpret_cast<void*>(gen));
 }
 

--- a/src/jsc/bindings/ErrorStackTraceMetadata.cpp
+++ b/src/jsc/bindings/ErrorStackTraceMetadata.cpp
@@ -43,8 +43,7 @@ static WTF::String typeNameForReceiver(JSValue thisValue)
     if (!thisObject)
         return String();
 
-    // Bare `foo()`: JSC passes the resolved scope as raw |this| (normalized
-    // later by to_this), so a scope/global-proxy here means "no receiver".
+    // A scope or global-proxy cell here is a bare call's raw un-normalized |this|, not a receiver.
     JSC::JSType type = thisObject->type();
     if ((JSC::FirstScopeType <= type && type <= JSC::LastScopeType) || type == JSC::GlobalProxyType)
         return String();
@@ -60,9 +59,7 @@ static WTF::String typeNameForReceiver(JSValue thisValue)
     return name;
 }
 
-// VM::onAppendStackTrace hook: runs under AssertNoGC inside getStackTrace
-// while call frames are live; matches stackTrace[] frames by callee and
-// records each receiver's classInfo name into this ErrorInstance's cache slot.
+// VM::onAppendStackTrace hook; runs inside getStackTrace while the captured frames are still live on the machine stack.
 void captureStackFrameReceivers(VM& vm, JSCell* owner, WTF::Vector<StackFrame>& stackTrace, size_t maxToAppend)
 {
     UNUSED_PARAM(maxToAppend);
@@ -83,19 +80,17 @@ void captureStackFrameReceivers(VM& vm, JSCell* owner, WTF::Vector<StackFrame>& 
     if (!topCallFrame)
         return;
 
-    slot.data.entries.reserveCapacity(stackTrace.size());
-
     size_t cursor = 0;
-    bool any = false;
     StackVisitor::visit(topCallFrame, vm, [&](StackVisitor& visitor) -> IterationStatus {
+        while (cursor < stackTrace.size() && !stackTrace[cursor].callee())
+            cursor++;
         if (cursor >= stackTrace.size())
             return IterationStatus::Done;
 
         if (visitor->callee().isNativeCallee())
             return IterationStatus::Continue;
 
-        JSCell* callee = visitor->callee().asCell();
-        if (stackTrace[cursor].callee() != callee)
+        if (stackTrace[cursor].callee() != visitor->callee().asCell())
             return IterationStatus::Continue;
 
         String typeName;
@@ -110,20 +105,14 @@ void captureStackFrameReceivers(VM& vm, JSCell* owner, WTF::Vector<StackFrame>& 
             }
         }
         if (!typeName.isEmpty())
-            any = true;
-        slot.data.entries.append({ callee, WTF::move(typeName) });
+            slot.data.entries.append({ static_cast<unsigned>(cursor), WTF::move(typeName) });
         cursor++;
-
-        while (cursor < stackTrace.size() && !stackTrace[cursor].callee())
-            cursor++;
 
         return IterationStatus::Continue;
     });
 
-    if (!any) {
-        slot.data.entries.shrink(0);
+    if (slot.data.entries.isEmpty())
         return;
-    }
 
     static std::atomic<uintptr_t> generation { 0 };
     uintptr_t gen = generation.fetch_add(1, std::memory_order_relaxed) + 1;
@@ -131,6 +120,36 @@ void captureStackFrameReceivers(VM& vm, JSCell* owner, WTF::Vector<StackFrame>& 
     slot.generation = gen;
     // Generation stamp guards against a recycled cell at the same address.
     errorInstance->setBunErrorData(reinterpret_cast<void*>(gen));
+}
+
+void remapStackTraceMetadata(JSCell* owner, std::span<const unsigned> frameSyncIndices)
+{
+    auto* errorInstance = dynamicDowncast<ErrorInstance>(owner);
+    if (!errorInstance)
+        return;
+    CacheSlot& slot = slotFor(owner);
+    if (slot.owner != owner || reinterpret_cast<uintptr_t>(errorInstance->bunErrorData()) != slot.generation)
+        return;
+
+    WTF::Vector<StackTraceMetadata::Entry> remapped;
+    size_t cursor = 0;
+    unsigned newIndex = 0;
+    for (unsigned original : frameSyncIndices) {
+        if (original == noSyncFrameIndex)
+            continue;
+        while (cursor < slot.data.entries.size() && slot.data.entries[cursor].frameIndex < original)
+            cursor++;
+        if (cursor < slot.data.entries.size() && slot.data.entries[cursor].frameIndex == original)
+            remapped.append({ newIndex, WTF::move(slot.data.entries[cursor].typeName) });
+        newIndex++;
+    }
+
+    slot.data.entries = WTF::move(remapped);
+    if (slot.data.entries.isEmpty()) {
+        slot.owner = nullptr;
+        slot.generation = 0;
+        errorInstance->setBunErrorData(nullptr);
+    }
 }
 
 const StackTraceMetadata* stackTraceMetadataFor(JSCell* owner)

--- a/src/jsc/bindings/ErrorStackTraceMetadata.cpp
+++ b/src/jsc/bindings/ErrorStackTraceMetadata.cpp
@@ -1,0 +1,158 @@
+#include "root.h"
+#include "ErrorStackTraceMetadata.h"
+
+#include <JavaScriptCore/ErrorInstance.h>
+#include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSGlobalProxy.h>
+#include <JavaScriptCore/StackFrame.h>
+#include <JavaScriptCore/StackVisitor.h>
+#include <JavaScriptCore/VM.h>
+#include <wtf/IterationStatus.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/ThreadSpecific.h>
+
+namespace Bun {
+
+using namespace JSC;
+
+static constexpr size_t kCacheSize = 128;
+
+struct CacheSlot {
+    JSCell* owner { nullptr };
+    uintptr_t generation { 0 };
+    StackTraceMetadata data;
+};
+
+using Cache = std::array<CacheSlot, kCacheSize>;
+
+// Direct-mapped per-thread cache. .stack is almost always read in the same
+// turn it was captured, so a small cache suffices; on eviction the only
+// consequence is that the older error's stack loses its receiver prefixes.
+static CacheSlot& slotFor(JSCell* owner)
+{
+    static LazyNeverDestroyed<ThreadSpecific<Cache>> cache;
+    static std::once_flag once;
+    std::call_once(once, [] { cache.construct(); });
+    return (*cache.get())[(reinterpret_cast<uintptr_t>(owner) >> 4) % kCacheSize];
+}
+
+static WTF::String typeNameForReceiver(JSValue thisValue)
+{
+    if (!thisValue || !thisValue.isCell())
+        return String();
+
+    JSObject* thisObject = thisValue.getObject();
+    if (!thisObject)
+        return String();
+
+    // For bare `foo()` JSC passes the resolved scope as |this| and the callee
+    // converts it via to_this when |this| is used; the raw slot holds a scope
+    // (JSLexicalEnvironment, GlobalObject, etc.), which is never a real
+    // receiver. The global proxy is likewise a stand-in for "no receiver".
+    JSC::JSType type = thisObject->type();
+    if ((JSC::FirstScopeType <= type && type <= JSC::LastScopeType) || type == JSC::GlobalProxyType)
+        return String();
+
+    auto* classInfo = thisObject->structure()->classInfoForCells();
+    if (!classInfo)
+        return String();
+
+    ASCIILiteral name = classInfo->className;
+    // Generic classInfo names that would need calculatedClassName() to resolve
+    // to the user-visible constructor name; skip rather than mislabel.
+    if (name == "Object"_s || name == "Function"_s || name == "Module"_s || name == "GlobalObject"_s)
+        return String();
+    return name;
+}
+
+// Installed as VM::onAppendStackTrace. Runs inside Interpreter::getStackTrace
+// under AssertNoGC while the physical call frames are still live. Re-walks the
+// stack via StackVisitor, matches the already-filtered `stackTrace` frames by
+// callee in order, and records each frame's receiver type name into the cache
+// slot for this ErrorInstance.
+void captureStackFrameReceivers(VM& vm, JSCell* owner, WTF::Vector<StackFrame>& stackTrace, size_t maxToAppend)
+{
+    UNUSED_PARAM(maxToAppend);
+
+    auto* errorInstance = dynamicDowncast<ErrorInstance>(owner);
+    if (!errorInstance)
+        return;
+
+    CacheSlot& slot = slotFor(owner);
+    slot.owner = nullptr;
+    slot.generation = 0;
+    slot.data.entries.shrink(0);
+
+    if (stackTrace.isEmpty())
+        return;
+
+    CallFrame* topCallFrame = vm.topCallFrame;
+    if (!topCallFrame)
+        return;
+
+    slot.data.entries.reserveCapacity(stackTrace.size());
+
+    size_t cursor = 0;
+    bool any = false;
+    StackVisitor::visit(topCallFrame, vm, [&](StackVisitor& visitor) -> IterationStatus {
+        if (cursor >= stackTrace.size())
+            return IterationStatus::Done;
+
+        if (visitor->callee().isNativeCallee())
+            return IterationStatus::Continue;
+
+        JSCell* callee = visitor->callee().asCell();
+        if (stackTrace[cursor].callee() != callee)
+            return IterationStatus::Continue;
+
+        String typeName;
+        if (!visitor->isInlinedDFGFrame()) {
+            if (auto* codeBlock = visitor->codeBlock()) {
+                if (codeBlock->codeType() == FunctionCode && !codeBlock->isConstructor()) {
+                    if (CallFrame* frame = visitor->callFrame())
+                        typeName = typeNameForReceiver(frame->thisValue());
+                }
+            } else if (CallFrame* frame = visitor->callFrame()) {
+                typeName = typeNameForReceiver(frame->thisValue());
+            }
+        }
+        if (!typeName.isEmpty())
+            any = true;
+        slot.data.entries.append({ callee, WTF::move(typeName) });
+        cursor++;
+
+        while (cursor < stackTrace.size() && !stackTrace[cursor].callee())
+            cursor++;
+
+        return IterationStatus::Continue;
+    });
+
+    if (!any) {
+        slot.data.entries.shrink(0);
+        return;
+    }
+
+    static std::atomic<uintptr_t> generation { 0 };
+    uintptr_t gen = generation.fetch_add(1, std::memory_order_relaxed) + 1;
+    slot.owner = owner;
+    slot.generation = gen;
+    // Stamp the instance with the generation so a recycled cell at the same
+    // address does not pick up stale metadata. The value is never a real
+    // pointer; Bun__errorInstance__finalize is a no-op.
+    errorInstance->setBunErrorData(reinterpret_cast<void*>(gen));
+}
+
+const StackTraceMetadata* stackTraceMetadataFor(JSCell* owner)
+{
+    auto* errorInstance = dynamicDowncast<ErrorInstance>(owner);
+    if (!errorInstance)
+        return nullptr;
+    CacheSlot& slot = slotFor(owner);
+    if (slot.owner != owner)
+        return nullptr;
+    if (reinterpret_cast<uintptr_t>(errorInstance->bunErrorData()) != slot.generation)
+        return nullptr;
+    return &slot.data;
+}
+
+}

--- a/src/jsc/bindings/ErrorStackTraceMetadata.h
+++ b/src/jsc/bindings/ErrorStackTraceMetadata.h
@@ -12,13 +12,10 @@ class StackFrame;
 
 namespace Bun {
 
-// Side-channel metadata captured for an ErrorInstance's stack trace at
-// construction time, while the call stack is still live. Stored in a small
-// per-thread direct-mapped cache so that memory is bounded and does not depend
-// on the ErrorInstance's GC lifecycle. ErrorInstance has no destructor hook
-// Bun can reach (finalizeUnconditionally only runs for marked cells), so a
-// per-instance heap allocation would leak for errors collected before being
-// marked.
+// Per-frame receiver class names captured at Error construction. Held in a
+// bounded per-thread cache because ErrorInstance has no destructor hook Bun
+// can reach (finalizeUnconditionally only visits marked cells), so a
+// per-instance allocation would leak for errors collected without being marked.
 struct StackTraceMetadata {
     struct Entry {
         JSC::JSCell* callee;

--- a/src/jsc/bindings/ErrorStackTraceMetadata.h
+++ b/src/jsc/bindings/ErrorStackTraceMetadata.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "root.h"
+#include <limits>
+#include <span>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -12,20 +14,35 @@ class StackFrame;
 
 namespace Bun {
 
-// Per-frame receiver class names captured at Error construction. Held in a
-// bounded per-thread cache because ErrorInstance has no destructor hook Bun
-// can reach (finalizeUnconditionally only visits marked cells), so a
-// per-instance allocation would leak for errors collected without being marked.
+// Receiver class names captured per stack frame at Error construction, kept in a bounded per-thread cache because ErrorInstance has no finalizer hook Bun can use for cleanup.
 struct StackTraceMetadata {
     struct Entry {
-        JSC::JSCell* callee;
+        unsigned frameIndex; // position among the stored trace's non-async frames
         WTF::String typeName;
     };
-    WTF::Vector<Entry> entries;
+    WTF::Vector<Entry> entries; // ascending by frameIndex
 };
+
+// Marks a frame with no position among the capture-time sync frames.
+inline constexpr unsigned noSyncFrameIndex = std::numeric_limits<unsigned>::max();
 
 void captureStackFrameReceivers(JSC::VM&, JSC::JSCell* owner, WTF::Vector<JSC::StackFrame>& stackTrace, size_t maxToAppend);
 
 const StackTraceMetadata* stackTraceMetadataFor(JSC::JSCell* owner);
+
+// Rewrites entry indices after Error.captureStackTrace filters and trims the raw frames it captured.
+void remapStackTraceMetadata(JSC::JSCell* owner, std::span<const unsigned> frameSyncIndices);
+
+// Returns the receiver type name for the syncIndex-th non-async frame, or nullptr. `cursor` must start at 0 and be reused across ascending syncIndex values.
+inline const WTF::String* receiverTypeName(const StackTraceMetadata* metadata, size_t& cursor, unsigned syncIndex)
+{
+    if (!metadata)
+        return nullptr;
+    while (cursor < metadata->entries.size() && metadata->entries[cursor].frameIndex < syncIndex)
+        cursor++;
+    if (cursor < metadata->entries.size() && metadata->entries[cursor].frameIndex == syncIndex)
+        return &metadata->entries[cursor].typeName;
+    return nullptr;
+}
 
 }

--- a/src/jsc/bindings/ErrorStackTraceMetadata.h
+++ b/src/jsc/bindings/ErrorStackTraceMetadata.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "root.h"
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+class VM;
+class JSCell;
+class StackFrame;
+}
+
+namespace Bun {
+
+// Side-channel metadata captured for an ErrorInstance's stack trace at
+// construction time, while the call stack is still live. Stored in a small
+// per-thread direct-mapped cache so that memory is bounded and does not depend
+// on the ErrorInstance's GC lifecycle. ErrorInstance has no destructor hook
+// Bun can reach (finalizeUnconditionally only runs for marked cells), so a
+// per-instance heap allocation would leak for errors collected before being
+// marked.
+struct StackTraceMetadata {
+    struct Entry {
+        JSC::JSCell* callee;
+        WTF::String typeName;
+    };
+    WTF::Vector<Entry> entries;
+};
+
+void captureStackFrameReceivers(JSC::VM&, JSC::JSCell* owner, WTF::Vector<JSC::StackFrame>& stackTrace, size_t maxToAppend);
+
+const StackTraceMetadata* stackTraceMetadataFor(JSC::JSCell* owner);
+
+}

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -22,6 +22,7 @@
 #include "BunClientData.h"
 #include "CallSite.h"
 #include "ErrorStackTrace.h"
+#include "ErrorStackTraceMetadata.h"
 #include "headers-handwritten.h"
 
 #include <wtf/Scope.h>
@@ -151,6 +152,9 @@ WTF::String formatStackTrace(
     JSC::JSObject* errorInstance)
 {
     WTF::StringBuilder sb;
+
+    const Bun::StackTraceMetadata* metadata = Bun::stackTraceMetadataFor(errorInstance);
+    size_t metadataCursor = 0;
 
     if (!name.isEmpty()) {
         sb.append(name);
@@ -309,6 +313,18 @@ WTF::String formatStackTrace(
         }
 
         WTF::String functionName = Zig::functionName(vm, globalObjectForFrame, frame, errorInstance ? Zig::FinalizerSafety::NotInFinalizer : Zig::FinalizerSafety::MustNotTriggerGC, &flags);
+        WTF::String typeName;
+        // Async frames are spliced into the trace after the metadata hook ran,
+        // so they never have a corresponding entry; skip without advancing.
+        if (metadata && !frame.isAsyncFrame()) {
+            size_t probe = metadataCursor;
+            while (probe < metadata->entries.size() && metadata->entries[probe].callee != frame.callee())
+                probe++;
+            if (probe < metadata->entries.size()) {
+                typeName = metadata->entries[probe].typeName;
+                metadataCursor = probe + 1;
+            }
+        }
         OrdinalNumber originalLine = {};
         OrdinalNumber originalColumn = {};
         OrdinalNumber displayLine = {};
@@ -343,9 +359,13 @@ WTF::String formatStackTrace(
         }
 
         if (functionName.isEmpty()) {
-            if (flags & (static_cast<unsigned int>(FunctionNameFlags::Eval) | static_cast<unsigned int>(FunctionNameFlags::Function))) {
+            if (!typeName.isEmpty() || (flags & (static_cast<unsigned int>(FunctionNameFlags::Eval) | static_cast<unsigned int>(FunctionNameFlags::Function)))) {
                 functionName = "<anonymous>"_s;
             }
+        }
+
+        if (!typeName.isEmpty() && !functionName.startsWith(typeName)) {
+            functionName = makeString(typeName, '.', functionName);
         }
 
         if (sourceURLForFrame.isEmpty()) {
@@ -433,6 +453,21 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSCStackTrace stackTrace = JSCStackTrace::fromExisting(vm, stackFrames);
+
+    if (const Bun::StackTraceMetadata* metadata = Bun::stackTraceMetadataFor(errorObject)) {
+        size_t cursor = 0;
+        for (size_t i = 0; i < stackTrace.size(); i++) {
+            if (stackTrace.at(i).isAsync())
+                continue;
+            size_t probe = cursor;
+            while (probe < metadata->entries.size() && metadata->entries[probe].callee != stackTrace.at(i).callee())
+                probe++;
+            if (probe >= metadata->entries.size())
+                continue;
+            stackTrace.at(i).setReceiverTypeName(metadata->entries[probe].typeName);
+            cursor = probe + 1;
+        }
+    }
 
     // Note: we cannot use tryCreateUninitializedRestricted here because we cannot allocate memory inside initializeIndex()
     MarkedArgumentBuffer callSites;

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -155,6 +155,7 @@ WTF::String formatStackTrace(
 
     const Bun::StackTraceMetadata* metadata = Bun::stackTraceMetadataFor(errorInstance);
     size_t metadataCursor = 0;
+    unsigned syncFrameIndex = 0;
 
     if (!name.isEmpty()) {
         sb.append(name);
@@ -314,16 +315,11 @@ WTF::String formatStackTrace(
 
         WTF::String functionName = Zig::functionName(vm, globalObjectForFrame, frame, errorInstance ? Zig::FinalizerSafety::NotInFinalizer : Zig::FinalizerSafety::MustNotTriggerGC, &flags);
         WTF::String typeName;
-        // Async frames are spliced into the trace after the metadata hook ran,
-        // so they never have a corresponding entry; skip without advancing.
-        if (metadata && !frame.isAsyncFrame() && frame.callee()) {
-            size_t probe = metadataCursor;
-            while (probe < metadata->entries.size() && metadata->entries[probe].callee != frame.callee())
-                probe++;
-            if (probe < metadata->entries.size()) {
-                typeName = metadata->entries[probe].typeName;
-                metadataCursor = probe + 1;
-            }
+        // Async frames were spliced in after capture and have no sync-frame position.
+        if (!frame.isAsyncFrame()) {
+            if (const WTF::String* name = Bun::receiverTypeName(metadata, metadataCursor, syncFrameIndex))
+                typeName = *name;
+            syncFrameIndex++;
         }
         OrdinalNumber originalLine = {};
         OrdinalNumber originalColumn = {};
@@ -364,12 +360,8 @@ WTF::String formatStackTrace(
             }
         }
 
-        if (!typeName.isEmpty()) {
-            bool alreadyQualified = functionName.startsWith(typeName)
-                && (functionName.length() == typeName.length() || functionName[typeName.length()] == '.');
-            if (!alreadyQualified)
-                functionName = makeString(typeName, '.', functionName);
-        }
+        if (!typeName.isEmpty() && !Zig::functionNameHasTypeNamePrefix(functionName, typeName))
+            functionName = makeString(typeName, '.', functionName);
 
         if (sourceURLForFrame.isEmpty()) {
             if (flags & static_cast<unsigned int>(FunctionNameFlags::Builtin)) {
@@ -459,16 +451,20 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
 
     if (const Bun::StackTraceMetadata* metadata = Bun::stackTraceMetadataFor(errorObject)) {
         size_t cursor = 0;
-        for (size_t i = 0; i < stackTrace.size(); i++) {
-            if (stackTrace.at(i).isAsync() || !stackTrace.at(i).callee())
-                continue;
-            size_t probe = cursor;
-            while (probe < metadata->entries.size() && metadata->entries[probe].callee != stackTrace.at(i).callee())
-                probe++;
-            if (probe >= metadata->entries.size())
-                continue;
-            stackTrace.at(i).setReceiverTypeName(metadata->entries[probe].typeName);
-            cursor = probe + 1;
+        unsigned syncFrameIndex = 0;
+        size_t filteredIndex = 0;
+        // Walk stackFrames with the same filter fromExisting applied so metadata indices line up.
+        for (auto& frame : stackFrames) {
+            bool kept = !Zig::isImplementationVisibilityPrivate(frame);
+            if (!frame.isAsyncFrame()) {
+                if (kept && filteredIndex < stackTrace.size()) {
+                    if (const WTF::String* name = Bun::receiverTypeName(metadata, cursor, syncFrameIndex))
+                        stackTrace.at(filteredIndex).setReceiverTypeName(*name);
+                }
+                syncFrameIndex++;
+            }
+            if (kept)
+                filteredIndex++;
         }
     }
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -316,7 +316,7 @@ WTF::String formatStackTrace(
         WTF::String typeName;
         // Async frames are spliced into the trace after the metadata hook ran,
         // so they never have a corresponding entry; skip without advancing.
-        if (metadata && !frame.isAsyncFrame()) {
+        if (metadata && !frame.isAsyncFrame() && frame.callee()) {
             size_t probe = metadataCursor;
             while (probe < metadata->entries.size() && metadata->entries[probe].callee != frame.callee())
                 probe++;
@@ -364,8 +364,11 @@ WTF::String formatStackTrace(
             }
         }
 
-        if (!typeName.isEmpty() && !functionName.startsWith(typeName)) {
-            functionName = makeString(typeName, '.', functionName);
+        if (!typeName.isEmpty()) {
+            bool alreadyQualified = functionName.startsWith(typeName)
+                && (functionName.length() == typeName.length() || functionName[typeName.length()] == '.');
+            if (!alreadyQualified)
+                functionName = makeString(typeName, '.', functionName);
         }
 
         if (sourceURLForFrame.isEmpty()) {
@@ -457,7 +460,7 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
     if (const Bun::StackTraceMetadata* metadata = Bun::stackTraceMetadataFor(errorObject)) {
         size_t cursor = 0;
         for (size_t i = 0; i < stackTrace.size(); i++) {
-            if (stackTrace.at(i).isAsync())
+            if (stackTrace.at(i).isAsync() || !stackTrace.at(i).callee())
                 continue;
             size_t probe = cursor;
             while (probe < metadata->entries.size() && metadata->entries[probe].callee != stackTrace.at(i).callee())

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -78,6 +78,7 @@
 #include "ConsoleObject.h"
 #include "DOMWrapperWorld-class.h"
 #include "ErrorStackTrace.h"
+#include "ErrorStackTraceMetadata.h"
 #include "IDLTypes.h"
 #include "ImportMetaObject.h"
 #include "JS2Native.h"
@@ -554,6 +555,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     vm.setOnComputeErrorInfo(computeErrorInfoWrapperToString);
     vm.setOnComputeErrorInfoJSValue(computeErrorInfoWrapperToJSValue);
     vm.setComputeLineColumnWithSourcemap(computeLineColumnWithSourcemap);
+    vm.setOnAppendStackTrace(Bun::captureStackFrameReceivers);
     vm.setOnEachMicrotaskTick([](JSC::VM& vm) -> void {
         // if you process.nextTick on a microtask we need this
         auto* globalObject = defaultGlobalObject();

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1212,6 +1212,29 @@ test("CallSite.getTypeName returns the receiver's built-in class name", () => {
   }
 });
 
+test("captureStackTrace caller trimming does not reuse receiver names from removed frames", () => {
+  // The inner recur() is called as Reflect.recur; captureStackTrace(e, recur)
+  // removes that frame, and the surviving outer recur frame is a bare call
+  // that must not inherit the removed frame's Reflect prefix.
+  let depth = 0;
+  function recur() {
+    if (depth++ === 0) {
+      Object.defineProperty(Reflect, "recur", { value: recur, writable: true, configurable: true });
+      try {
+        return Reflect.recur();
+      } finally {
+        delete Reflect.recur;
+      }
+    }
+    const e = new Error();
+    Error.captureStackTrace(e, recur);
+    return e.stack;
+  }
+  const frame = recur().split("\n")[1];
+  expect(frame).toMatch(/^\s+at recur /);
+  expect(frame).not.toContain("Reflect");
+});
+
 // https://github.com/oven-sh/bun/issues/34095
 test("lazy error-info materialization does not store an empty stack value when the compute hook throws", async () => {
   const src = `

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1130,6 +1130,15 @@ test("Error.stack includes the receiver's built-in class name", () => {
   arr.push(capture);
   expect(arr[0]()).toMatch(/^\s+at Array\.capture /);
 
+  // a function whose name begins with the receiver's class name still gets
+  // the prefix (the guard must check for a word boundary, not a bare prefix)
+  const map = new Map();
+  function Mapper() {
+    return new Error().stack.split("\n")[1];
+  }
+  map.Mapper = Mapper;
+  expect(map.Mapper()).toMatch(/^\s+at Map\.Mapper /);
+
   // direct call has no receiver prefix (strict mode receiver is undefined)
   expect(capture()).toMatch(/^\s+at capture /);
 

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -420,7 +420,10 @@ test("sanity check", () => {
     Error.prepareStackTrace = (e, s) => {
       // getThis returns undefined in strict mode
       expect(s[0].getThis()).toBe(undefined);
-      expect(s[0].getTypeName()).toBe("undefined");
+      // V8 returns null when the receiver isn't an object (e.g. a direct
+      // strict-mode function call). Previously Bun returned the string
+      // "undefined" here.
+      expect(s[0].getTypeName()).toBe(null);
       // getFunction returns undefined in strict mode
       expect(s[0].getFunction()).toBe(undefined);
       expect(s[0].getFunctionName()).toBe("f3");
@@ -1096,6 +1099,108 @@ test("printing an error whose message getter calls Error.captureStackTrace on it
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ lastLine: stdout.trimEnd().split("\n").pop(), exitCode }).toEqual({ lastLine: "after", exitCode: 0 });
+});
+
+// https://github.com/oven-sh/bun/issues/13766
+// https://github.com/oven-sh/bun/issues/4323
+// https://github.com/oven-sh/bun/issues/7780
+test("Error.stack includes the receiver's built-in class name", () => {
+  function capture() {
+    return new Error().stack.split("\n")[1];
+  }
+
+  // function attached to a built-in namespace object
+  Object.defineProperty(Reflect, "capture", { value: capture, writable: true, configurable: true });
+  try {
+    expect(Reflect.capture()).toMatch(/^\s+at Reflect\.capture /);
+  } finally {
+    delete Reflect.capture;
+  }
+
+  // function attached to another built-in
+  Math.capture = capture;
+  try {
+    expect(Math.capture()).toMatch(/^\s+at Math\.capture /);
+  } finally {
+    delete Math.capture;
+  }
+
+  // function called as an element of an array
+  const arr = [];
+  arr.push(capture);
+  expect(arr[0]()).toMatch(/^\s+at Array\.capture /);
+
+  // direct call has no receiver prefix (strict mode receiver is undefined)
+  expect(capture()).toMatch(/^\s+at capture /);
+
+  // constructor frames don't get a receiver prefix
+  function Ctor() {
+    this.frame = new Error().stack.split("\n")[1];
+  }
+  expect(new Ctor().frame).toMatch(/^\s+at new Ctor /);
+});
+
+// https://github.com/oven-sh/bun/issues/13766
+test("Error.stack includes Reflect.decorate for SWC-style decorator helpers", () => {
+  // MikroORM's Utils.lookupPathFromDecorator scans the error stack for
+  // /Reflect\.decorate/ to locate the file that defined a decorated class.
+  // reflect-metadata assigns a plain named function to Reflect.decorate, and
+  // swc/tsc-emitted helpers call it as Reflect.decorate(...). Without the
+  // receiver prefix that regex never matches under Bun and metadata keys
+  // diverge from Node.
+  function decorate(decorators, target, key) {
+    for (var i = decorators.length - 1; i >= 0; i--) decorators[i](target, key);
+  }
+  Object.defineProperty(Reflect, "decorate", { value: decorate, writable: true, configurable: true });
+
+  function _ts_decorate(decorators, target, key, desc) {
+    if (typeof Reflect.decorate === "function") return Reflect.decorate(decorators, target, key, desc);
+  }
+
+  let line;
+  function deco() {
+    line = new Error().stack.split("\n").find(l => /Reflect\.decorate/.test(l));
+  }
+  class Entity {}
+  try {
+    _ts_decorate([deco], Entity.prototype, "field", void 0);
+  } finally {
+    delete Reflect.decorate;
+  }
+
+  expect(line).toMatch(/^\s+at Reflect\.decorate /);
+});
+
+// https://github.com/oven-sh/bun/issues/30938
+test("CallSite.getTypeName returns the receiver's built-in class name", () => {
+  let typeName;
+  Error.prepareStackTrace = (_, s) => {
+    typeName = s[0].getTypeName();
+  };
+  try {
+    function capture() {
+      const e = new Error();
+      void e.stack;
+    }
+
+    Object.defineProperty(Reflect, "capture", { value: capture, writable: true, configurable: true });
+    try {
+      Reflect.capture();
+      expect(typeName).toBe("Reflect");
+    } finally {
+      delete Reflect.capture;
+    }
+
+    const arr = [];
+    arr.push(capture);
+    arr[0]();
+    expect(typeName).toBe("Array");
+
+    capture();
+    expect(typeName).toBe(null);
+  } finally {
+    Error.prepareStackTrace = origPrepareStackTrace;
+  }
 });
 
 // https://github.com/oven-sh/bun/issues/34095

--- a/test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap
+++ b/test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap
@@ -7,7 +7,7 @@ throw new Error("hello");
 
 Error: hello
     at hellohello.js:2:16
-    at runInNewContext (unknown)
+    at Script.runInNewContext (unknown)
     at <anonymous> (<this-url>:6:5)"
 `;
 


### PR DESCRIPTION
## Problem

V8 formats method-call stack frames as `TypeName.functionName`, where `TypeName` is the receiver's constructor name. JSC's `StackFrame` stores only the callee, so Bun prints the bare function name:

```js
function foo() { return new Error().stack; }
Reflect.foo = foo;
Reflect.foo();
// Node:  at Reflect.foo (...)
// Bun:   at foo (...)
```

This breaks MikroORM (#13766). Its `Utils.lookupPathFromDecorator` scans the error stack for `/Reflect\.decorate/` to find the file that defined a decorated class. Under Bun the regex never matches, so the function falls back to returning the class name instead of a file path. When the user's app has two classes with the same name in different files (e.g. a mixin applied twice, or an entity shadowing a library base class), their metadata keys collide and properties go missing from the merged entity.

It also underlies #4323, #7780 and #20385 (class names missing from stack traces) and #30938 (`CallSite.getTypeName()` returning the string `"undefined"`).

## Cause

`JSC::StackFrame` carries the callee, code block and bytecode index, not the call receiver. By the time Bun's formatter runs the physical `CallFrame` is gone, so there is nothing to read `this` from.

## Fix

Capture each frame's receiver class name at Error construction, while the call stack is still live, without touching `JSC::StackFrame`:

- Install a `VM::onAppendStackTrace` hook (`captureStackFrameReceivers`). Inside `Interpreter::getStackTrace`, after the stored `Vector<StackFrame>` is built, the hook re-walks the live stack with `StackVisitor`, matches each stored frame to a live frame by callee in order, and records `callFrame()->thisValue()->classInfo()->className` per frame. `className` is a static `ASCIILiteral`, so nothing is GC-allocated inside the `AssertNoGC` scope that guards `getStackTrace`.
- Store the result in a small per-thread direct-mapped cache keyed by `ErrorInstance` address. `ErrorInstance` has no destructor hook Bun can reach (`finalizeUnconditionally` runs only for cells that survived marking), so hanging a heap allocation off each instance would leak for errors that are collected before ever being marked. The cache bounds memory regardless of GC lifecycle; a slot is simply overwritten when reused, which is fine because `.stack` is almost always read in the same turn it was captured. Each instance is also stamped with a generation counter via the otherwise-unused `bunErrorData` slot so a recycled cell at the same address cannot read a stale entry.
- Thread the captured name into both formatting paths: `formatStackTrace` prepends it for the default `.stack` string, and `CallSite` exposes it through `getTypeName()` and `formatAsString`.

### What gets prefixed

Only concrete built-in class names are emitted (`Reflect`, `Math`, `JSON`, `Array`, `Map`, `Promise`, ...). The following are treated as "no receiver" and produce no prefix:

- Scope objects. For a bare `foo()` call JSC's bytecode passes the resolved scope object as the raw `this` argument and lets the callee's `to_this` op normalize it; reading `thisValue()` there yields a `JSLexicalEnvironment`, not a user-visible receiver.
- The global object / global proxy.
- `Object`, `Function` and `Module`: these are what `classInfo()->className` reports for user class instances, class constructors and Bun's CJS module wrapper respectively. Resolving them to the user-visible constructor name needs `calculatedClassName`, which walks the prototype chain and may allocate; showing the generic name would mislabel (`Function.method` for a static method) and churn a large amount of snapshot output. Full user-class prefixes can follow once `JSC::StackFrame` carries the receiver.
- DFG-inlined frames (the physical frame's `this` slot belongs to the outer call).

`CallSite.getTypeName()` now returns the captured class name, or `null` when none was captured, matching V8's null-for-unknown instead of the previous `typeof this` string. #30941 reached the same null-return behaviour by treating the missing receiver as unknown; this PR actually captures it, so `getTypeName()` returns real names.

## Verification

```
// Before
{"resolved":"Entity","isPath":false}
// After (matches Node)
{"resolved":"/tmp/mikro-repro.js","isPath":true}
```

New tests in `test/js/node/v8/capture-stack-trace.test.js`:

- `Error.stack` shows `Reflect.capture`, `Math.capture`, `Array.capture`; bare call has no prefix; constructors keep `new Ctor`.
- `Error.stack` includes `Reflect.decorate` for an SWC-style `_ts_decorate` helper.
- `CallSite.getTypeName()` returns `"Reflect"`/`"Array"`/`null`.
- The existing "sanity check" assertion `getTypeName() === "undefined"` now expects `null`.

```
bun bd test test/js/node/v8/capture-stack-trace.test.js
46 pass, 0 fail
```

Fail-before (`USE_SYSTEM_BUN=1`): all four assertions above fail.

RSS growth for 1M transient `new Error()` objects is unchanged from `main` (~17 bytes/error in a debug+ASAN build, all attributable to the existing baseline).

Fixes #13766

### Limitation

WebKit only invokes the `onAppendStackTrace` hook when the captured frame count is below `Error.stackTraceLimit` (`Interpreter.cpp` guards it with `if (maxStackSize > results.size())`). A call stack that fills the limit (10 by default) therefore has no receiver metadata and prints unprefixed frames; this does not affect the MikroORM path, whose decorator chain is shallow, but full coverage (and user-class names such as `MyClass.method`) requires `JSC::StackFrame` to carry the receiver directly.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 12 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (90e723632)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.19ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [10.18ms]
(pass) capture stack trace [7.80ms]
(pass) capture stack trace with message [8.23ms]
(pass) capture stack trace with constructor [5.66ms]
(pass) capture stack trace limit [24.04ms]
(pass) prepare stack trace [18.53ms]
(pass) capture stack trace second argument [28.73ms]
(pass) capture stack trace edge cases [17.35ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [24.41ms]
(pass) prepare stack trace call sites [21.08ms]
421 |       // getThis returns undefined in strict mode
422 |       expect(s[0].getThis()).toBe(undefined);
423 |       // V8 returns null when the receiver isn't an object (e.g. a direct
424 |       // strict-mode function call). Previously Bun returned the string
425 |       // "undefined" here.
426 |       expect(s[0].getTypeName()).toBe(null);
                                       ^
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [11.77ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.30ms]
(pass) capture stack trace [1.90ms]
(pass) capture stack trace with message [0.26ms]
(pass) capture stack trace with constructor [0.15ms]
(pass) capture stack trace limit [0.46ms]
(pass) prepare stack trace [0.28ms]
(pass) capture stack trace second argument [0.35ms]
(pass) capture stack trace edge cases [0.20ms]
312 |   };
313 | 
314 |   // plain object target
315 |   const o = { a: 1 };
316 |   Error.captureStackTrace(o);
317 |   expect(Object.keys(o)).toEqual(["a"]);
                               ^
error: expect(received).toEqual(expected)

  [
    "a",
+   "stack",
  ]

- Expected  - 0
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/v8/capture-stack-trace.test.js:317:26)
(fail) Error.captureStackTrace installs .stack as non-enumerable [2.57ms]
(pass) prepare stack trace call sites [0.38ms]
421 |       // getThis returns undefined in strict mode
422 |       expect(s[0].getThis()).toBe(undefined);
423 |       // V8 returns null when the receiver isn't an object (e.g.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (90e723632)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [16.17ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [12.47ms]
(pass) capture stack trace [11.99ms]
(pass) capture stack trace with message [13.52ms]
(pass) capture stack trace with constructor [9.29ms]
(pass) capture stack trace limit [37.71ms]
(pass) prepare stack trace [15.49ms]
(pass) capture stack trace second argument [30.67ms]
(pass) capture stack trace edge cases [18.83ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [32.19ms]
(pass) prepare stack trace call sites [15.37ms]
(pass) sanity check [21.49ms]
(pass) CallFrame isEval works as expected [13.65ms]
(pass) CallFrame isTopLevel returns false for Function constructor [13.97ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [16.10ms]
(pass) CallFrame.p.isConstructor [5.92ms]
(pass) CallFrame.p.isNative [5.86ms]
(pass) return non-strings from Error.prepareStackTrace [3.83ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     90e7236320
  features     baseline

22 deps, 108 codegen, 1171 objects in 2247ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[4/1234] fetch tinycc
[tinycc] up to date
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1234] fetch zlib
[zlib] up to date
[8/1234] gen .bind.ts → GeneratedBindings.cpp
[9/1234] gen bindgenv2
[10/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingFs.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingFs.cpp
[11/1234] subst deps/zlib/zlib.h
[12/1234] fetch nodejs (prebuilt)
[nodejs] u
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/debugger.mdx                          |   2 +-
 src/jsc/bindings/CallSite.cpp                      |  41 +++--
 src/jsc/bindings/CallSite.h                        |   2 +
 src/jsc/bindings/CallSitePrototype.cpp             |  19 ++-
 src/jsc/bindings/ErrorStackTrace.cpp               |  20 ++-
 src/jsc/bindings/ErrorStackTrace.h                 |  11 ++
 src/jsc/bindings/ErrorStackTraceMetadata.cpp       | 168 +++++++++++++++++++++
 src/jsc/bindings/ErrorStackTraceMetadata.h         |  48 ++++++
 src/jsc/bindings/FormatStackTraceForJS.cpp         |  36 ++++-
 src/jsc/bindings/ZigGlobalObject.cpp               |   2 +
 test/js/node/v8/capture-stack-trace.test.js        | 139 ++++++++++++++++-
 .../vm/__snapshots__/vm-sourceUrl.test.ts.snap     |   2 +-
 12 files changed, 471 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
docs/runtime/debugger.mdx                                    0      0      0
src/jsc/bindings/CallSite.cpp                                1      1      0
src/jsc/bindings/CallSite.h                                  0      0      0
src/jsc/bindings/CallSitePrototype.cpp                       2      0      0
src/jsc/bindings/ErrorStackTrace.cpp                         1      2      0
src/jsc/bindings/ErrorStackTrace.h                           1      2      0
src/jsc/bindings/ErrorStackTraceMetadata.cpp                 1      1      0
src/jsc/bindings/ErrorStackTraceMetadata.h                   1      2      0
src/jsc/bindings/FormatStackTraceForJS.cpp                   2      2      0
src/jsc/bindings/ZigGlobalObject.cpp                         0      0      0
test/js/node/v8/capture-stack-trace.test.js                  1      1      0
test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap      0      0      0
```

</details>

**root cause** · written by the author bot

The bug was that `Error.captureStackTrace` and `CallSite.getTypeName()` reported incorrect or missing receiver type names because the receiver was matched to stack frames by value after caller trimming, which misattributed frames when the same function appeared multiple times or frames were removed. The fix captures receiver class names as per-error metadata at stack capture time and matches receivers to frames by index, remapping those indices after caller trimming so each frame retains its correct receiver. This metadata is then threaded through the formatting path and `getTypeName()`, pr…

<!-- robobun:evidence:end -->