### PR TITLE
bundler: keep CJS wrapper when a cjs-to-esm converted file is import()-ed

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -104,6 +104,8 @@ pub fn scan_imports_and_exports(
     let entry_point_kinds: *mut [EntryPoint::Kind] = files.entry_point_kind;
     let named_imports: *mut [NamedImports] = ast.named_imports;
     let named_exports: *mut [NamedExports] = ast.named_exports;
+    let commonjs_named_exports: *mut [bundled_ast::CommonJSNamedExports] =
+        ast.commonjs_named_exports;
     let flags: *mut [js_meta::Flags] = meta.flags;
     let ast_flags_list: *mut [AstFlags] = ast.flags;
     let export_star_import_records: *mut [bun_alloc::AstVec<u32>] = ast.export_star_import_records;
@@ -236,8 +238,19 @@ pub fn scan_imports_and_exports(
                     ImportKind::Dynamic => {
                         if !this.graph.code_splitting {
                             // If we're not splitting, then import() is just a require() that
-                            // returns a promise, so the imported file must be a CommonJS module
-                            if col_ref!(exports_kind)[other_file] == ExportsKind::Esm {
+                            // returns a promise, so the imported file must be a CommonJS module.
+                            //
+                            // FORCE_CJS_TO_ESM alone is path-based, so check for CJS syntax too.
+                            let was_converted_from_cjs = other_flags
+                                .contains(AstFlags::FORCE_CJS_TO_ESM)
+                                && col_ref!(commonjs_named_exports)[other_file].count() > 0;
+                            if was_converted_from_cjs
+                                && !col_ref!(entry_point_kinds)[other_file].is_entry_point()
+                            {
+                                // Keep the CJS wrapper so __toESM supplies `.default`.
+                                col!(exports_kind)[other_file] = ExportsKind::Cjs;
+                                col!(flags)[other_file].wrap = WrapKind::Cjs;
+                            } else if col_ref!(exports_kind)[other_file] == ExportsKind::Esm {
                                 col!(flags)[other_file].wrap = WrapKind::Esm;
                             } else {
                                 // TODO: introduce a NamedRequire for require("./foo").Bar AST nodes to support tree-shaking those.

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -501,4 +501,178 @@ describe("bundler", () => {
     cjs2esm: true,
     run: { stdout: "[1,2]" },
   });
+  // https://github.com/oven-sh/bun/issues/14061
+  // Dynamic import of a CommonJS package that was converted to ESM must still
+  // expose `default` (the original module.exports). react-dom is in the
+  // unwrap-to-ESM allowlist, which is what triggers the conversion.
+  const fakeReactDomServer = {
+    "/node_modules/react-dom/package.json": /* json */ `
+      { "name": "react-dom", "exports": { "./server": "./server.js" } }
+    `,
+    "/node_modules/react-dom/server.js": /* js */ `
+      'use strict';
+      exports.version = "18.3.1";
+      exports.renderToString = function () { return "html"; };
+    `,
+  };
+  itBundled("cjs2esm/DynamicImportDefault#14061", {
+    files: {
+      "/entry.mjs": /* js */ `
+        const ns = await import("react-dom/server");
+        console.log(JSON.stringify(ns.default));
+        console.log(Object.hasOwn(ns.default, "renderToString"));
+        console.log("default" in ns.default);
+      `,
+      ...fakeReactDomServer,
+    },
+    run: { stdout: '{"version":"18.3.1"}\ntrue\nfalse' },
+  });
+  itBundled("cjs2esm/DynamicImportYieldDefault#14061", {
+    files: {
+      "/entry.mjs": /* js */ `
+        // mimics transpiled async/await (e.g. esbuild's __async helper)
+        function* g() {
+          const { default: mod } = yield import("react-dom/server");
+          console.log(JSON.stringify(mod));
+          console.log(mod.renderToString());
+        }
+        const it = g();
+        await Promise.resolve(it.next().value).then(v => it.next(v));
+      `,
+      ...fakeReactDomServer,
+    },
+    run: { stdout: '{"version":"18.3.1"}\nhtml' },
+  });
+  itBundled("cjs2esm/DynamicImportWithStaticNamed#14061", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import { version } from "react-dom/server";
+        const ns = await import("react-dom/server");
+        console.log(version, ns.version, JSON.stringify(ns.default));
+      `,
+      ...fakeReactDomServer,
+    },
+    run: { stdout: '18.3.1 18.3.1 {"version":"18.3.1"}' },
+  });
+  itBundled("cjs2esm/DynamicImportRealEsmUnaffected", {
+    files: {
+      "/entry.mjs": /* js */ `
+        const ns = await import("react-dom/server");
+        console.log(ns.foo, ns.default);
+      `,
+      "/node_modules/react-dom/package.json": /* json */ `
+        { "name": "react-dom", "exports": { "./server": "./server.mjs" } }
+      `,
+      "/node_modules/react-dom/server.mjs": /* js */ `
+        export const foo = 42;
+        export default "real-default";
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("out.js")).not.toContain("__commonJS");
+    },
+    run: { stdout: "42 real-default" },
+  });
+  itBundled("cjs2esm/DynamicImportRealEsmNoDefaultUnaffected", {
+    // FORCE_CJS_TO_ESM is path-based; a genuine ESM file under react-dom with
+    // no `export default` must not be forced into a CJS wrapper.
+    files: {
+      "/entry.mjs": /* js */ `
+        const ns = await import("react-dom/server");
+        console.log(ns.foo, ns.default);
+      `,
+      "/node_modules/react-dom/package.json": /* json */ `
+        { "name": "react-dom", "exports": { "./server": "./server.mjs" } }
+      `,
+      "/node_modules/react-dom/server.mjs": /* js */ `
+        export const foo = 42;
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("out.js")).not.toContain("__commonJS");
+    },
+    run: { stdout: "42 undefined" },
+  });
+  itBundled("cjs2esm/DynamicImportModuleExportsRequire#14061", {
+    // `module.exports = require('./impl')` is the shape of react/index.js.
+    // The parser redirects the import record to ./impl.js, whose
+    // commonjs_named_exports then drives the CJS-wrapper decision.
+    files: {
+      "/entry.mjs": /* js */ `
+        const ns = await import("react");
+        console.log(JSON.stringify(ns.default));
+        console.log(ns.version);
+      `,
+      "/node_modules/react/package.json": /* json */ `
+        { "name": "react", "main": "./index.js" }
+      `,
+      "/node_modules/react/index.js": /* js */ `
+        'use strict';
+        module.exports = require('./impl.js');
+      `,
+      "/node_modules/react/impl.js": /* js */ `
+        exports.version = "18";
+        exports.createElement = function () {};
+      `,
+    },
+    run: { stdout: '{"version":"18"}\n18' },
+  });
+  itBundled("cjs2esm/DynamicImportCjsExportsDefault#14061", {
+    // Even when the CJS file has its own `exports.default = X`, Node gives
+    // `ns.default === module.exports`, so the bundled output should too.
+    files: {
+      "/entry.mjs": /* js */ `
+        const ns = await import("react-dom/server");
+        console.log(JSON.stringify(ns.default));
+      `,
+      "/node_modules/react-dom/package.json": /* json */ `
+        { "name": "react-dom", "exports": { "./server": "./server.js" } }
+      `,
+      "/node_modules/react-dom/server.js": /* js */ `
+        'use strict';
+        exports.default = "X";
+        exports.version = "1.0";
+      `,
+    },
+    run: { stdout: '{"default":"X","version":"1.0"}' },
+  });
+  itBundled("cjs2esm/DynamicImportTargetIsEntryPointUnaffected", {
+    // When the converted CJS file is itself an entry point, keep its named
+    // ESM exports instead of collapsing to `export default require_x()`.
+    files: {
+      "/entry.js": /* js */ `
+        import("react-dom/server");
+      `,
+      ...fakeReactDomServer,
+    },
+    entryPoints: ["/entry.js", "/node_modules/react-dom/server.js"],
+    outputPaths: ["/out/entry.js", "/out/node_modules/react-dom/server.js"],
+    onAfterBundle(api) {
+      const server = api.readFile("out/node_modules/react-dom/server.js");
+      expect(server).toContain("as version");
+      expect(server).toContain("as renderToString");
+    },
+  });
+  itBundled("cjs2esm/DynamicImportRealEsmExportStarUnaffected", {
+    // A hand-written ESM `export * from` under react-dom must stay ESM-wrapped.
+    files: {
+      "/entry.mjs": /* js */ `
+        const ns = await import("react-dom/server");
+        console.log(ns.foo, ns.default);
+      `,
+      "/node_modules/react-dom/package.json": /* json */ `
+        { "name": "react-dom", "exports": { "./server": "./server.mjs" } }
+      `,
+      "/node_modules/react-dom/server.mjs": /* js */ `
+        export * from "./inner.mjs";
+      `,
+      "/node_modules/react-dom/inner.mjs": /* js */ `
+        export const foo = 42;
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("out.js")).not.toContain("__commonJS");
+    },
+    run: { stdout: "42 undefined" },
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #14061.

`@react-email/render` (and anything else that dynamically imports `react-dom/server`) crashes when bundled with `bun build` / `bun build --compile`:

```
const { default: reactDOMServer } = yield Promise.resolve().then(() => (init_server_node(), exports_server_node));
if (Object.hasOwn(reactDOMServer, "renderToReadableStream")) {
                  ^
TypeError: undefined is not an object
```

### Why

Bun converts a small allowlist of CommonJS packages (`react`, `react-dom`, `scheduler`, ...) to ESM for better tree shaking. The generated namespace has one getter per `exports.x = ...` assignment but no `default`. When that converted module is the target of a same-chunk dynamic `import()` (no code-splitting), the linker wraps it with `__esm` and rewrites the call to

```js
Promise.resolve().then(() => (init_x(), exports_x))
```

so `ns.default` is `undefined`, unlike every other path:

* runtime `import()` of CJS returns `{ ...named, default: module.exports }`
* esbuild keeps the file CJS and emits `__toESM(require_x(), 1)`
* static `import d from 'react-dom/server'` already reverts the conversion (the `CONTAINS_DEFAULT_ALIAS` branch in the same function)
* code-splitting already synthesises `export default { get ... }` via `needs_synthetic_default_export`

### Fix

In step 1 of `scanImportsAndExports`, when a dynamic `import()` (without code-splitting) targets a file that was actually converted from CJS, keep the `__commonJS` wrapper so the rewrite becomes `__toESM(require_x(), 1)` and `.default` is the original `module.exports`.

"Actually converted from CJS" is `FORCE_CJS_TO_ESM && commonjs_named_exports.count() > 0`: the flag on its own is path-based and is also true for genuine ESM shipped under `react/*`, so the second term is what distinguishes a parser-converted `exports.x = ...` file from a real `.mjs`. The branch is skipped when the target is itself an entry point so a multi-entry build keeps its named ESM exports.

This is the same revert the static `CONTAINS_DEFAULT_ALIAS` branch already performs; it trades the direct-binding optimisation for that one module against a correct `.default` on the dynamic namespace. Code-splitting and genuine ESM targets are unchanged.

### How did you verify your code works?

New `itBundled` cases in `test/bundler/bundler_cjs2esm.test.ts`:

* `await import()` and `yield import()` (the transpiled-async shape from the issue) of an `exports.x = ...` file
* mixed static-named + dynamic import of the same file
* `exports.default = X` (Node returns `module.exports`, not `X`)
* `module.exports = require('./impl')` entry shape (covered via the parser's redirect to `./impl.js`)
* guard tests: real ESM under `react-dom/*` with and without `export default`, a hand-written `export * from`, and the multi-entry-point case all stay ESM-wrapped

The `#14061` tests fail on `main` and pass with this change; the guard tests pass on both. `bundler_cjs2esm`, `bundler_cjs`, `bundler_edgecase`, `bundler_splitting`, `bundler_npm`, and `test/bundler/esbuild/default.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (935287e3a)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [976.81ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [610.52ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [693.10ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [493.54ms]
(pass) bundler > cjs2esm/ExportsFunction [660.73ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [615.62ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [588.75ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [1177.99ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [1223.71ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [849.33ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [1118.00ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [675.10ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [2174.79ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [607.19ms]
(pass) b
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [82.80ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [60.61ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [44.12ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [33.38ms]
(pass) bundler > cjs2esm/ExportsFunction [32.89ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [183.83ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [41.60ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [38.20ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [38.79ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [71.98ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [108.72ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [272.65ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [40.12ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [106.63ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingAssignDeOpt [94.25ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingAssignExportsDeOpt [53.42ms]
397 |   // converted to `var $x = ...; exp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (935287e3a)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [1208.04ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [723.84ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [785.71ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [783.96ms]
(pass) bundler > cjs2esm/ExportsFunction [557.90ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [548.28ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [703.68ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [991.38ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [894.63ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [682.14ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [1238.70ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [681.18ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [1541.47ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [590.79ms]
(pass) bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     935287e3a6
  features     baseline

22 deps, 108 codegen, 1171 objects in 3620ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[2/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/1234] fetch zlib
[zlib] up to date
[4/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1234] fetch tinycc
[tinycc] up to date
[6/1234] fetch picohttpparser
[picohttpparser] up to date
[7/1234] gen bindgenv2
[8/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[9/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[10/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/Pro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/scanImportsAndExports.rs        |  17 +-
 test/bundler/bundler_cjs2esm.test.ts               | 174 +++++++++++++++++++++
 2 files changed, 189 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/linker_context/scanImportsAndExports.rs     10     11      0
test/bundler/bundler_cjs2esm.test.ts                     2      8      0
```

</details>

<!-- robobun:evidence:end -->