### PR TITLE
bundler: bundle template-literal require()/import() via glob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "bun_core",
  "bun_crash_handler",
  "bun_dispatch",
+ "bun_glob",
  "bun_highway",
  "bun_io",
  "bun_options_types",

--- a/entry.js
+++ b/entry.js
@@ -1,0 +1,3 @@
+export const id = "entry";
+const v = await import("./entry.js");
+console.log("loaded", v.id);

--- a/entry.js
+++ b/entry.js
@@ -1,3 +1,0 @@
-export const id = "entry";
-const v = await import("./entry.js");
-console.log("loaded", v.id);

--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -175,10 +175,11 @@ pub struct Imports {
     pub __promiseAll: Ref,
     pub __MEMO_CACHE_SENTINEL: Ref,
     pub __EARLY_RETURN_SENTINEL: Ref,
+    pub __glob: Ref,
 }
 
 impl Imports {
-    pub const ALL: [&'static [u8]; 27] = [
+    pub const ALL: [&'static [u8]; 28] = [
         b"__name",
         b"__require",
         b"__export",
@@ -206,12 +207,13 @@ impl Imports {
         b"__promiseAll",
         b"__MEMO_CACHE_SENTINEL",
         b"__EARLY_RETURN_SENTINEL",
+        b"__glob",
     ];
 
     /// Rust stable cannot sort in `const`; precomputed here and verified by
     /// the test in `tests` below.
     #[cfg_attr(not(test), allow(dead_code))]
-    const ALL_SORTED: [&'static [u8]; 27] = [
+    const ALL_SORTED: [&'static [u8]; 28] = [
         b"$$typeof",
         b"__EARLY_RETURN_SENTINEL",
         b"__MEMO_CACHE_SENTINEL",
@@ -222,6 +224,7 @@ impl Imports {
         b"__export",
         b"__exportDefault",
         b"__exportValue",
+        b"__glob",
         b"__jsonParse",
         b"__legacyDecorateClassTS",
         b"__legacyDecorateParamTS",
@@ -243,34 +246,35 @@ impl Imports {
 
     /// When generating the list of runtime imports, we sort it for determinism.
     /// This is a lookup table so we don't need to resort the strings each time
-    pub const ALL_SORTED_INDEX: [usize; 27] = [
-        15, // __name
-        24, // __require
+    pub const ALL_SORTED_INDEX: [usize; 28] = [
+        16, // __name
+        25, // __require
         7,  // __export
-        23, // __reExport
+        24, // __reExport
         9,  // __exportValue
         8,  // __exportDefault
-        14, // __merge
-        11, // __legacyDecorateClassTS
-        12, // __legacyDecorateParamTS
-        13, // __legacyMetadataTS
-        22, // __publicField
-        18, // __privateIn
-        17, // __privateGet
-        16, // __privateAdd
-        20, // __privateSet
-        19, // __privateMethod
+        15, // __merge
+        12, // __legacyDecorateClassTS
+        13, // __legacyDecorateParamTS
+        14, // __legacyMetadataTS
+        23, // __publicField
+        19, // __privateIn
+        18, // __privateGet
+        17, // __privateAdd
+        21, // __privateSet
+        20, // __privateMethod
         6,  // __decoratorStart
         5,  // __decoratorMetadata
-        25, // __runInitializers
+        26, // __runInitializers
         4,  // __decorateElement
         0,  // $$typeof
-        26, // __using
+        27, // __using
         3,  // __callDispose
-        10, // __jsonParse
-        21, // __promiseAll
+        11, // __jsonParse
+        22, // __promiseAll
         2,  // __MEMO_CACHE_SENTINEL
         1,  // __EARLY_RETURN_SENTINEL
+        10, // __glob
     ];
 
     pub const NAME: &'static [u8] = b"bun:wrap";
@@ -306,6 +310,7 @@ impl Imports {
             24 => self.__promiseAll,
             25 => self.__MEMO_CACHE_SENTINEL,
             26 => self.__EARLY_RETURN_SENTINEL,
+            27 => self.__glob,
             _ => return None,
         };
         r.to_nullable()
@@ -341,6 +346,7 @@ impl Imports {
             24 => Some(&mut self.__promiseAll),
             25 => Some(&mut self.__MEMO_CACHE_SENTINEL),
             26 => Some(&mut self.__EARLY_RETURN_SENTINEL),
+            27 => Some(&mut self.__glob),
             _ => None,
         }
     }

--- a/src/js_parser/Cargo.toml
+++ b/src/js_parser/Cargo.toml
@@ -35,6 +35,7 @@ bun_ast.workspace = true
 bun_react_compiler = { path = "../react_compiler" }
 bun_options_types.workspace = true
 bun_paths.workspace = true
+bun_glob.workspace = true
 bun_url.workspace = true
 bun_wyhash.workspace = true
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1003,6 +1003,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         }
 
+        if let Some(glob) = self.handle_glob_pattern(arg, false) {
+            return glob;
+        }
+
         if self.options.warn_about_unbundled_modules {
             // Use a debug log so people can see this if they want to
             let r = js_lexer::range_of_identifier(self.source, state.loc);
@@ -1234,6 +1238,251 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     arg.loc,
                 )
             }
+        }
+    }
+
+    /// Try to recognise `require("./dir/" + x)` / `import("./dir/" + x)` (or the
+    /// template-literal equivalent) and lower it to a bundled lookup map so the
+    /// matching files are included in the output. Matches esbuild's behaviour:
+    /// see https://esbuild.github.io/api/#glob. Returns `None` when the pattern
+    /// does not qualify (no `./`/`../` prefix, fully opaque arg, etc.), in which
+    /// case the caller falls through to the unbundled runtime `require`.
+    pub fn handle_glob_pattern(&mut self, arg: Expr, is_require: bool) -> Option<Expr> {
+        if !self.options.bundle || self.is_control_flow_dead {
+            return None;
+        }
+        // Only the `file` namespace has a source directory to glob from.
+        if !self.source.path.is_file() {
+            return None;
+        }
+
+        // (text, is_wildcard) pairs flattened from the expression.
+        let mut raw_parts: smallvec::SmallVec<[(&'a [u8], bool); 8]> = smallvec::SmallVec::new();
+        if !self.glob_parts_from_expr(arg, &mut raw_parts) {
+            return None;
+        }
+
+        // Build the glob pattern. A wildcard immediately after `/` expands to
+        // `**/*` (may recurse into subdirectories); otherwise it is `*` (stays
+        // in the current directory). This matches esbuild and keeps
+        // `"./file-" + x + ".js"` from recursing.
+        let mut pattern = Vec::<u8>::new();
+        let mut prefix_is_relative = false;
+        let mut had_wildcard = false;
+        let mut ends_in_slash = true;
+        for (text, is_wildcard) in &raw_parts {
+            if *is_wildcard {
+                had_wildcard = true;
+                if ends_in_slash {
+                    pattern.extend_from_slice(b"**/*");
+                } else {
+                    pattern.push(b'*');
+                }
+                ends_in_slash = false;
+                continue;
+            }
+            if pattern.is_empty()
+                && (strings::has_prefix_comptime(text, b"./")
+                    || strings::has_prefix_comptime(text, b"../"))
+            {
+                prefix_is_relative = true;
+            }
+            // `*` / `?` / `[` / `{` in the literal text would change glob
+            // semantics relative to a substring match. esbuild escapes them; we
+            // don't have a glob-escape helper, so bail to the runtime path.
+            if bun_glob::detect_glob_syntax(text) {
+                return None;
+            }
+            pattern.extend_from_slice(text);
+            if !text.is_empty() {
+                ends_in_slash = *text.last().unwrap() == b'/';
+            }
+        }
+        // Fully-static strings go through the normal `require("...")` path.
+        if !had_wildcard || !prefix_is_relative {
+            return None;
+        }
+
+        let source_dir = self.source.path.source_dir();
+        if source_dir.is_empty() {
+            return None;
+        }
+
+        // Walk the filesystem for matches. Any I/O error (including the source
+        // directory being virtual / not on disk) falls through to the unbundled
+        // path rather than failing the build.
+        let mut matches: Vec<Box<[u8]>> = Vec::new();
+        if !walk_glob_for_bundle(source_dir, &pattern, &mut matches) {
+            return None;
+        }
+
+        // Nothing on disk matched: fall through so `check_dynamic_specifier`
+        // (and the `allowUnresolved` gate) still see this call, and runtime
+        // resolution can still pick up files that only exist at run time.
+        if matches.is_empty() {
+            return None;
+        }
+        matches.sort();
+
+        let loc = arg.loc;
+        let arena = self.arena;
+        let mut properties = BumpVec::<G::Property>::with_capacity_in(matches.len(), arena);
+        let handles_import_errors = self.fn_or_arrow_data_visit.try_body_count != 0;
+
+        for abs in &matches {
+            // Key in the map is the same relative form the caller will pass at
+            // runtime (starts with `./` or `../`). Force POSIX separators so the
+            // keys match what the caller builds at runtime on every platform.
+            let rel = bun_paths::resolve_path::relative_platform::<
+                bun_paths::resolve_path::platform::Posix,
+                false,
+            >(source_dir, abs);
+            let rel_with_dot: &'a [u8] = if strings::has_prefix_comptime(rel, b"../")
+                || strings::has_prefix_comptime(rel, b"./")
+            {
+                arena.alloc_slice_copy(rel)
+            } else {
+                let mut buf = BumpVec::<u8>::with_capacity_in(rel.len() + 2, arena);
+                buf.extend_from_slice(b"./");
+                buf.extend_from_slice(rel);
+                buf.into_bump_slice()
+            };
+
+            let abs_path: &'a [u8] = arena.alloc_slice_copy(abs);
+            let import_record_index = self.add_import_record(
+                if is_require {
+                    ImportKind::Require
+                } else {
+                    ImportKind::Dynamic
+                },
+                loc,
+                abs_path,
+            );
+            self.import_records.items_mut()[import_record_index as usize]
+                .flags
+                .set(
+                    bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
+                    handles_import_errors,
+                );
+            self.import_records_for_current_part
+                .push(import_record_index);
+
+            let value_expr = if is_require {
+                self.new_expr(
+                    E::RequireString {
+                        import_record_index,
+                        ..Default::default()
+                    },
+                    loc,
+                )
+            } else {
+                let path_expr = self.new_expr(E::String::init(rel_with_dot), loc);
+                self.new_expr(
+                    E::Import {
+                        expr: path_expr,
+                        import_record_index,
+                        options: Expr::EMPTY,
+                    },
+                    loc,
+                )
+            };
+
+            let body = bun_core::handle_oom(G::FnBody::init_return_expr(arena, value_expr));
+            let arrow = self.new_expr(
+                E::Arrow {
+                    body,
+                    prefer_expr: true,
+                    ..Default::default()
+                },
+                loc,
+            );
+
+            properties.push(G::Property {
+                key: Some(self.new_expr(E::String::init(rel_with_dot), loc)),
+                value: Some(arrow),
+                ..Default::default()
+            });
+        }
+
+        let map = self.new_expr(
+            E::Object {
+                properties: G::PropertyList::from_bump_vec(properties),
+                ..Default::default()
+            },
+            loc,
+        );
+        let glob_call = self.call_runtime(loc, b"__glob", ExprNodeList::init_one(map));
+        Some(self.new_expr(
+            E::Call {
+                target: glob_call,
+                args: ExprNodeList::init_one(arg),
+                ..Default::default()
+            },
+            loc,
+        ))
+    }
+
+    /// Flattens `expr` into alternating literal / wildcard segments. Returns
+    /// `false` for shapes that cannot be analysed (tagged template, non-string
+    /// left operand of `+`, etc.).
+    fn glob_parts_from_expr(
+        &mut self,
+        expr: Expr,
+        out: &mut smallvec::SmallVec<[(&'a [u8], bool); 8]>,
+    ) -> bool {
+        match expr.data {
+            js_ast::ExprData::EString(mut s) => {
+                s.resolve_rope_if_needed(self.arena);
+                let bytes = match s.string(self.arena) {
+                    Ok(b) => b,
+                    Err(_) => return false,
+                };
+                out.push((bytes, false));
+                true
+            }
+            js_ast::ExprData::ETemplate(tmpl) => {
+                if tmpl.tag.is_some() {
+                    return false;
+                }
+                match &tmpl.head {
+                    js_ast::e::TemplateContents::Cooked(head) => {
+                        let bytes = match head.string(self.arena) {
+                            Ok(b) => b,
+                            Err(_) => return false,
+                        };
+                        out.push((bytes, false));
+                    }
+                    js_ast::e::TemplateContents::Raw(_) => return false,
+                }
+                for part in tmpl.parts().iter() {
+                    if !self.glob_parts_from_expr(part.value, out) {
+                        out.push((b"", true));
+                    }
+                    match &part.tail {
+                        js_ast::e::TemplateContents::Cooked(tail) => {
+                            let bytes = match tail.string(self.arena) {
+                                Ok(b) => b,
+                                Err(_) => return false,
+                            };
+                            out.push((bytes, false));
+                        }
+                        js_ast::e::TemplateContents::Raw(_) => return false,
+                    }
+                }
+                true
+            }
+            js_ast::ExprData::EBinary(bin) if bin.op == js_ast::op::Code::BinAdd => {
+                // The left side must itself be analysable so we have a literal
+                // prefix to anchor the glob.
+                if !self.glob_parts_from_expr(bin.left, out) {
+                    return false;
+                }
+                if !self.glob_parts_from_expr(bin.right, out) {
+                    out.push((b"", true));
+                }
+                true
+            }
+            _ => false,
         }
     }
 
@@ -9242,6 +9491,33 @@ pub trait GenerateImportSymbols {
     type Key;
     fn get(&self, key: &Self::Key) -> Option<Ref>;
     fn alias_name(&self, key: &Self::Key) -> &'static [u8];
+}
+
+/// Walk `source_dir` for `pattern` (relative, POSIX, may contain `**`/`*`),
+/// pushing the absolute path of every file that matches into `out`. Returns
+/// `false` on any I/O failure so the caller can fall back to the unbundled
+/// runtime require.
+fn walk_glob_for_bundle(source_dir: &[u8], pattern: &[u8], out: &mut Vec<Box<[u8]>>) -> bool {
+    let mut walker = match bun_glob::BunGlobWalker::init_with_cwd(
+        pattern, source_dir, /*dot*/ false, /*absolute*/ true,
+        /*follow_symlinks*/ false, /*error_on_broken_symlinks*/ false,
+        /*only_files*/ true, None,
+    ) {
+        Ok(Ok(w)) => w,
+        _ => return false,
+    };
+    let mut iter = bun_glob::walk::Iterator::new(&mut walker);
+    match iter.init() {
+        Ok(Ok(())) => {}
+        _ => return false,
+    }
+    loop {
+        match iter.next() {
+            Ok(Ok(Some(path))) => out.push(path),
+            Ok(Ok(None)) => return true,
+            _ => return false,
+        }
+    }
 }
 
 // ─── Module-level constructor fns ───

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1003,7 +1003,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         }
 
-        if let Some(glob) = self.handle_glob_pattern(arg, false) {
+        if let Some(glob) = self.handle_glob_pattern(arg, Some(state)) {
             return glob;
         }
 
@@ -1247,7 +1247,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// see https://esbuild.github.io/api/#glob. Returns `None` when the pattern
     /// does not qualify (no `./`/`../` prefix, fully opaque arg, etc.), in which
     /// case the caller falls through to the unbundled runtime `require`.
-    pub fn handle_glob_pattern(&mut self, arg: Expr, is_require: bool) -> Option<Expr> {
+    ///
+    /// `import_state` is the surrounding `import()` visit state (`None` for
+    /// `require()`); it carries the second-argument options, the derived
+    /// loader override, and the `.then().catch()`/`await` error-handling info.
+    pub fn handle_glob_pattern(
+        &mut self,
+        arg: Expr,
+        import_state: Option<&TransposeState>,
+    ) -> Option<Expr> {
         if !self.options.bundle || self.is_control_flow_dead {
             return None;
         }
@@ -1327,7 +1335,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let loc = arg.loc;
         let arena = self.arena;
         let mut properties = BumpVec::<G::Property>::with_capacity_in(matches.len(), arena);
-        let handles_import_errors = self.fn_or_arrow_data_visit.try_body_count != 0;
+        let in_try = self.fn_or_arrow_data_visit.try_body_count != 0;
+        let handles_import_errors = match import_state {
+            None => in_try,
+            Some(s) => (s.is_await_target && in_try) || s.is_then_catch_target,
+        };
+        let import_options = import_state
+            .map(|s| s.import_options)
+            .unwrap_or(Expr::EMPTY);
+        let import_loader = import_state.and_then(|s| s.import_loader);
+        let import_tag = import_state.and_then(|s| s.import_record_tag);
 
         for abs in &matches {
             // Key in the map is the same relative form the caller will pass at
@@ -1348,26 +1365,35 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 buf.into_bump_slice()
             };
 
-            let abs_path: &'a [u8] = arena.alloc_slice_copy(abs);
+            // Record the relative specifier (not the absolute path we globbed)
+            // so `--external` patterns and `onResolve` plugins match it the same
+            // as if the user had written `require("./engines/boa.js")`.
             let import_record_index = self.add_import_record(
-                if is_require {
+                if import_state.is_none() {
                     ImportKind::Require
                 } else {
                     ImportKind::Dynamic
                 },
                 loc,
-                abs_path,
+                rel_with_dot,
             );
-            self.import_records.items_mut()[import_record_index as usize]
-                .flags
-                .set(
+            {
+                let rec = &mut self.import_records.items_mut()[import_record_index as usize];
+                rec.flags.set(
                     bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
                     handles_import_errors,
                 );
+                if let Some(loader) = import_loader {
+                    rec.loader = Some(loader);
+                }
+                if let Some(tag) = import_tag {
+                    rec.tag = tag;
+                }
+            }
             self.import_records_for_current_part
                 .push(import_record_index);
 
-            let value_expr = if is_require {
+            let value_expr = if import_state.is_none() {
                 self.new_expr(
                     E::RequireString {
                         import_record_index,
@@ -1381,7 +1407,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     E::Import {
                         expr: path_expr,
                         import_record_index,
-                        options: Expr::EMPTY,
+                        options: import_options,
                     },
                     loc,
                 )
@@ -1411,7 +1437,55 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             },
             loc,
         );
-        let glob_call = self.call_runtime(loc, b"__glob", ExprNodeList::init_one(map));
+
+        // `__glob` falls back to the runtime `require` / `import()` when the
+        // key is not in the map so extensionless or index-style specifiers
+        // (`"./engines/" + "boa"`) still resolve the way they did before the
+        // matching files were bundled.
+        let fallback = if !self.options.features.allow_runtime {
+            None
+        } else if import_state.is_none() {
+            self.record_usage_of_runtime_require();
+            Some(self.value_for_require(loc))
+        } else {
+            let param_ref = self.new_symbol(js_ast::symbol::Kind::Other, b"p");
+            let param_expr = self.new_expr(
+                E::Identifier {
+                    ref_: param_ref,
+                    ..Default::default()
+                },
+                loc,
+            );
+            let import_expr = self.new_expr(
+                E::Import {
+                    expr: param_expr,
+                    import_record_index: u32::MAX,
+                    options: import_options,
+                },
+                loc,
+            );
+            let body = bun_core::handle_oom(G::FnBody::init_return_expr(arena, import_expr));
+            let param_binding = self.b(B::Identifier { r#ref: param_ref }, loc);
+            let args: &mut [G::Arg] = arena.alloc_slice_fill_with(1, |_| G::Arg {
+                binding: param_binding,
+                ..Default::default()
+            });
+            Some(self.new_expr(
+                E::Arrow {
+                    args: bun_ast::StoreSlice::new_mut(args),
+                    body,
+                    prefer_expr: true,
+                    ..Default::default()
+                },
+                loc,
+            ))
+        };
+
+        let glob_args = match fallback {
+            Some(f) => ExprNodeList::from_slice(&[map, f]),
+            None => ExprNodeList::init_one(map),
+        };
+        let glob_call = self.call_runtime(loc, b"__glob", glob_args);
         Some(self.new_expr(
             E::Call {
                 target: glob_call,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1494,6 +1494,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         expr: Expr,
         out: &mut smallvec::SmallVec<[(&'a [u8], bool); 8]>,
     ) -> bool {
+        if !self.stack_check.is_safe_to_recurse() || self.reported_stack_overflow.get() {
+            self.report_stack_overflow(expr.loc);
+            return false;
+        }
         match expr.data {
             js_ast::ExprData::EString(mut s) => {
                 s.resolve_rope_if_needed(self.arena);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1227,6 +1227,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 )
             }
             _ => {
+                // Covers each branch of a ternary require() split apart by
+                // `maybe_transpose_if_require`.
+                if let Some(glob) = self.handle_glob_pattern(arg, None) {
+                    return glob;
+                }
                 let _ = self.check_dynamic_specifier(arg, arg.loc, "require()");
                 self.record_usage_of_runtime_require();
                 self.new_expr(
@@ -1241,16 +1246,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Try to recognise `require("./dir/" + x)` / `import("./dir/" + x)` (or the
-    /// template-literal equivalent) and lower it to a bundled lookup map so the
-    /// matching files are included in the output. Matches esbuild's behaviour:
-    /// see https://esbuild.github.io/api/#glob. Returns `None` when the pattern
-    /// does not qualify (no `./`/`../` prefix, fully opaque arg, etc.), in which
-    /// case the caller falls through to the unbundled runtime `require`.
-    ///
-    /// `import_state` is the surrounding `import()` visit state (`None` for
-    /// `require()`); it carries the second-argument options, the derived
-    /// loader override, and the `.then().catch()`/`await` error-handling info.
+    /// Lower `require("./dir/" + x)` / `import("./dir/" + x)` to a bundled
+    /// lookup map, matching esbuild (https://esbuild.github.io/api/#glob).
+    /// `None` means the pattern does not qualify and the caller falls through
+    /// to the unbundled runtime path. `import_state` is `None` for `require()`.
     pub fn handle_glob_pattern(
         &mut self,
         arg: Expr,
@@ -1270,10 +1269,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return None;
         }
 
-        // Build the glob pattern. A wildcard immediately after `/` expands to
-        // `**/*` (may recurse into subdirectories); otherwise it is `*` (stays
-        // in the current directory). This matches esbuild and keeps
-        // `"./file-" + x + ".js"` from recursing.
+        // Like esbuild: a wildcard after `/` becomes `**/*` (recursive),
+        // mid-segment it becomes `*` so `"./file-" + x + ".js"` stays flat.
         let mut pattern = Vec::<u8>::new();
         let mut prefix_is_relative = false;
         let mut had_wildcard = false;
@@ -1295,9 +1292,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             {
                 prefix_is_relative = true;
             }
-            // `*` / `?` / `[` / `{` in the literal text would change glob
-            // semantics relative to a substring match. esbuild escapes them; we
-            // don't have a glob-escape helper, so bail to the runtime path.
+            // Glob metacharacters in literal text would change the match; bail.
             if bun_glob::detect_glob_syntax(text) {
                 return None;
             }
@@ -1316,17 +1311,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return None;
         }
 
-        // Walk the filesystem for matches. Any I/O error (including the source
-        // directory being virtual / not on disk) falls through to the unbundled
-        // path rather than failing the build.
         let mut matches: Vec<Box<[u8]>> = Vec::new();
         if !walk_glob_for_bundle(source_dir, &pattern, &mut matches) {
             return None;
         }
 
-        // Nothing on disk matched: fall through so `check_dynamic_specifier`
-        // (and the `allowUnresolved` gate) still see this call, and runtime
-        // resolution can still pick up files that only exist at run time.
+        // Zero matches falls through so `check_dynamic_specifier` still runs.
         if matches.is_empty() {
             return None;
         }
@@ -1347,11 +1337,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let import_tag = import_state.and_then(|s| s.import_record_tag);
 
         for abs in &matches {
-            // Key in the map is the same relative form the caller will pass at
-            // runtime (starts with `./` or `../`). Force POSIX separators so the
-            // keys match what the caller builds at runtime on every platform.
+            // `Loose` normalizes with host rules but emits POSIX separators,
+            // so keys match what callers build at runtime on every platform.
             let rel = bun_paths::resolve_path::relative_platform::<
-                bun_paths::resolve_path::platform::Posix,
+                bun_paths::resolve_path::platform::Loose,
                 false,
             >(source_dir, abs);
             let rel_with_dot: &'a [u8] = if strings::has_prefix_comptime(rel, b"../")
@@ -1365,9 +1354,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 buf.into_bump_slice()
             };
 
-            // Record the relative specifier (not the absolute path we globbed)
-            // so `--external` patterns and `onResolve` plugins match it the same
-            // as if the user had written `require("./engines/boa.js")`.
+            // Relative specifier so `--external` and `onResolve` match it.
             let import_record_index = self.add_import_record(
                 if import_state.is_none() {
                     ImportKind::Require
@@ -1438,10 +1425,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             loc,
         );
 
-        // `__glob` falls back to the runtime `require` / `import()` when the
-        // key is not in the map so extensionless or index-style specifiers
-        // (`"./engines/" + "boa"`) still resolve the way they did before the
-        // matching files were bundled.
+        // On a map miss `__glob` falls back to the runtime `require`/`import()`
+        // so extensionless specifiers (`"./engines/" + "boa"`) still resolve.
         let fallback = if !self.options.features.allow_runtime {
             None
         } else if import_state.is_none() {
@@ -1449,6 +1434,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             Some(self.value_for_require(loc))
         } else {
             let param_ref = self.new_symbol(js_ast::symbol::Kind::Other, b"p");
+            VecExt::append(&mut self.current_scope_mut().generated, param_ref);
             let param_expr = self.new_expr(
                 E::Identifier {
                     ref_: param_ref,
@@ -1496,9 +1482,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    /// Flattens `expr` into alternating literal / wildcard segments. Returns
-    /// `false` for shapes that cannot be analysed (tagged template, non-string
-    /// left operand of `+`, etc.).
+    /// Flattens `expr` into alternating literal / wildcard segments.
+    /// `false` means the shape cannot be analysed (tagged template, etc).
     fn glob_parts_from_expr(
         &mut self,
         expr: Expr,
@@ -1520,6 +1505,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 match &tmpl.head {
                     js_ast::e::TemplateContents::Cooked(head) => {
+                        // Copy so folding leftovers (ropes) can be flattened.
+                        let mut head = *head;
+                        head.resolve_rope_if_needed(self.arena);
                         let bytes = match head.string(self.arena) {
                             Ok(b) => b,
                             Err(_) => return false,
@@ -1534,6 +1522,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     match &part.tail {
                         js_ast::e::TemplateContents::Cooked(tail) => {
+                            let mut tail = *tail;
+                            tail.resolve_rope_if_needed(self.arena);
                             let bytes = match tail.string(self.arena) {
                                 Ok(b) => b,
                                 Err(_) => return false,
@@ -1546,8 +1536,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 true
             }
             js_ast::ExprData::EBinary(bin) if bin.op == js_ast::op::Code::BinAdd => {
-                // The left side must itself be analysable so we have a literal
-                // prefix to anchor the glob.
+                // The left side must yield a literal prefix to anchor the glob.
                 if !self.glob_parts_from_expr(bin.left, out) {
                     return false;
                 }
@@ -9567,10 +9556,8 @@ pub trait GenerateImportSymbols {
     fn alias_name(&self, key: &Self::Key) -> &'static [u8];
 }
 
-/// Walk `source_dir` for `pattern` (relative, POSIX, may contain `**`/`*`),
-/// pushing the absolute path of every file that matches into `out`. Returns
-/// `false` on any I/O failure so the caller can fall back to the unbundled
-/// runtime require.
+/// Pushes the absolute path of every file under `source_dir` matching
+/// `pattern` into `out`; `false` on any I/O failure.
 fn walk_glob_for_bundle(source_dir: &[u8], pattern: &[u8], out: &mut Vec<Box<[u8]>>) -> bool {
     let mut walker = match bun_glob::BunGlobWalker::init_with_cwd(
         pattern, source_dir, /*dot*/ false, /*absolute*/ true,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9568,7 +9568,7 @@ pub trait GenerateImportSymbols {
 fn walk_glob_for_bundle(source_dir: &[u8], pattern: &[u8], out: &mut Vec<Box<[u8]>>) -> bool {
     let mut walker = match bun_glob::BunGlobWalker::init_with_cwd(
         pattern, source_dir, /*dot*/ false, /*absolute*/ true,
-        /*follow_symlinks*/ false, /*error_on_broken_symlinks*/ false,
+        /*follow_symlinks*/ true, /*error_on_broken_symlinks*/ false,
         /*only_files*/ true, None,
     ) {
         Ok(Ok(w)) => w,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1269,10 +1269,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return None;
         }
 
+        // Like esbuild, the literal prefix must be `./`/`../` plus at least one
+        // more character, so a bare "./" + x does not glob-bundle everything
+        // next to the importer.
+        match raw_parts.first() {
+            Some((text, false))
+                if text.len() >= 3
+                    && (strings::has_prefix_comptime(text, b"./")
+                        || strings::has_prefix_comptime(text, b"../")) => {}
+            _ => return None,
+        }
+
         // Like esbuild: a wildcard after `/` becomes `**/*` (recursive),
         // mid-segment it becomes `*` so `"./file-" + x + ".js"` stays flat.
         let mut pattern = Vec::<u8>::new();
-        let mut prefix_is_relative = false;
         let mut had_wildcard = false;
         let mut ends_in_slash = true;
         for (text, is_wildcard) in &raw_parts {
@@ -1286,12 +1296,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ends_in_slash = false;
                 continue;
             }
-            if pattern.is_empty()
-                && (strings::has_prefix_comptime(text, b"./")
-                    || strings::has_prefix_comptime(text, b"../"))
-            {
-                prefix_is_relative = true;
-            }
             // Glob metacharacters in literal text would change the match; bail.
             if bun_glob::detect_glob_syntax(text) {
                 return None;
@@ -1302,7 +1306,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
         // Fully-static strings go through the normal `require("...")` path.
-        if !had_wildcard || !prefix_is_relative {
+        if !had_wildcard {
             return None;
         }
 
@@ -1435,6 +1439,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         } else {
             let param_ref = self.new_symbol(js_ast::symbol::Kind::Other, b"p");
             VecExt::append(&mut self.current_scope_mut().generated, param_ref);
+            self.record_declared_symbol(param_ref);
             let param_expr = self.new_expr(
                 E::Identifier {
                     ref_: param_ref,
@@ -1499,14 +1504,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 out.push((bytes, false));
                 true
             }
-            js_ast::ExprData::ETemplate(tmpl) => {
+            js_ast::ExprData::ETemplate(mut tmpl) => {
                 if tmpl.tag.is_some() {
                     return false;
                 }
-                match &tmpl.head {
+                match &mut tmpl.head {
                     js_ast::e::TemplateContents::Cooked(head) => {
-                        // Copy so folding leftovers (ropes) can be flattened.
-                        let mut head = *head;
+                        // Constant folding can leave the head as a rope.
                         head.resolve_rope_if_needed(self.arena);
                         let bytes = match head.string(self.arena) {
                             Ok(b) => b,
@@ -1516,13 +1520,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     js_ast::e::TemplateContents::Raw(_) => return false,
                 }
-                for part in tmpl.parts().iter() {
+                for part in tmpl.parts_mut().iter_mut() {
                     if !self.glob_parts_from_expr(part.value, out) {
                         out.push((b"", true));
                     }
-                    match &part.tail {
+                    match &mut part.tail {
                         js_ast::e::TemplateContents::Cooked(tail) => {
-                            let mut tail = *tail;
                             tail.resolve_rope_if_needed(self.arena);
                             let bytes = match tail.string(self.arena) {
                                 Ok(b) => b,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1269,14 +1269,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return None;
         }
 
-        // Like esbuild, the literal prefix must be `./`/`../` plus at least one
-        // more character, so a bare "./" + x does not glob-bundle everything
-        // next to the importer.
+        // The literal prefix must be `./`/`../` and name a real path component
+        // (not just dots and slashes), so a bare "./" + x or "../" + x does
+        // not glob-bundle an entire directory tree.
         match raw_parts.first() {
             Some((text, false))
-                if text.len() >= 3
-                    && (strings::has_prefix_comptime(text, b"./")
-                        || strings::has_prefix_comptime(text, b"../")) => {}
+                if (strings::has_prefix_comptime(text, b"./")
+                    || strings::has_prefix_comptime(text, b"../"))
+                    && text.iter().any(|&c| c != b'.' && c != b'/') => {}
             _ => return None,
         }
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2035,7 +2035,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     _ => {
                         // require(`./dir/${x}`) => __glob({"./dir/a": () => require_a(), ...})(`./dir/${x}`)
-                        if let Some(glob) = p.handle_glob_pattern(first, true) {
+                        if let Some(glob) = p.handle_glob_pattern(first, None) {
                             *e = glob;
                             return;
                         }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2033,7 +2033,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         *e = p.transpose_known_to_be_if_require(first, &state);
                         return;
                     }
-                    _ => {}
+                    _ => {
+                        // require(`./dir/${x}`) => __glob({"./dir/a": () => require_a(), ...})(`./dir/${x}`)
+                        if let Some(glob) = p.handle_glob_pattern(first, true) {
+                            *e = glob;
+                            return;
+                        }
+                    }
                 }
             }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -109,10 +109,13 @@ var __moduleCache;
 // When you do know the module is CJS
 export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
-// Map of bundled modules for `require("./dir/" + x)` / `import("./dir/" + x)`
-export var __glob = map => path => {
+// Map of bundled modules for `require("./dir/" + x)` / `import("./dir/" + x)`.
+// `fallback` is the unbundled `require` / `import()` so an extensionless key or
+// a file created at run time still resolves like it would have without the map.
+export var __glob = (map, fallback) => path => {
   var fn = map[path];
   if (fn) return fn();
+  if (fallback) return fallback(path);
   throw new Error("Module not found in bundle: " + path);
 };
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -109,6 +109,13 @@ var __moduleCache;
 // When you do know the module is CJS
 export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
+// Map of bundled modules for `require("./dir/" + x)` / `import("./dir/" + x)`
+export var __glob = map => path => {
+  var fn = map[path];
+  if (fn) return fn();
+  throw new Error("Module not found in bundle: " + path);
+};
+
 export var __name = (target, name) => {
   Object.defineProperty(target, "name", {
     value: name,

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -109,9 +109,7 @@ var __moduleCache;
 // When you do know the module is CJS
 export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
-// Map of bundled modules for `require("./dir/" + x)` / `import("./dir/" + x)`.
-// `fallback` is the unbundled `require` / `import()` so an extensionless key or
-// a file created at run time still resolves like it would have without the map.
+// Lookup map for `require("./dir/" + x)`; `fallback` is the unbundled require/import.
 export var __glob = (map, fallback) => path => {
   var fn = map[path];
   if (fn) return fn();

--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -66,11 +66,11 @@ NS.then(({ fn: fn2 }) => {
 "
 `;
 
-exports[`Bun.build BuildArtifact properties: hash 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties: hash 1`] = `"bgsev3fg"`;
 
-exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"7gfnt0h6"`;
+exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"1vbevqqk"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"bgsev3fg"`;
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
 

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -1,0 +1,230 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+// Coverage for bundling `require("./dir/" + x)` / `import("./dir/" + x)` by
+// glob-matching the pattern at build time, matching esbuild.
+// https://github.com/oven-sh/bun/issues/13672
+
+describe("bundler", () => {
+  itBundled("glob/RequireTemplateLiteral", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const names = ["boa", "v8"];
+        const out = [];
+        for (const n of names) {
+          const e = require(\`./engines/\${n}.js\`);
+          out.push(e.id);
+        }
+        console.log(out.join(","));
+      `,
+      "/engines/boa.js": `module.exports = { id: "boa" };`,
+      "/engines/v8.js": `module.exports = { id: "v8" };`,
+    },
+    run: { stdout: "boa,v8" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      api.expectFile("/out.js").toContain("__glob");
+      // Both matches bundled under the caller-visible relative key.
+      api.expectFile("/out.js").toContain(`"./engines/boa.js"`);
+      api.expectFile("/out.js").toContain(`"./engines/v8.js"`);
+      // Runtime require is not needed: everything is bundled.
+      if (out.includes("import.meta.require")) {
+        throw new Error("expected the glob map to replace the runtime require");
+      }
+    },
+  });
+
+  itBundled("glob/RequireStringConcat", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        function load(name) {
+          return require("./engines/" + name + ".js").id;
+        }
+        console.log(load("a") + "," + load("b"));
+      `,
+      "/engines/a.js": `module.exports = { id: "a" };`,
+      "/engines/b.js": `module.exports = { id: "b" };`,
+    },
+    run: { stdout: "a,b" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+    },
+  });
+
+  itBundled("glob/ImportTemplateLiteral", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = "foo";
+        const m = await import(\`./mods/\${name}.js\`);
+        console.log(m.default);
+      `,
+      "/mods/foo.js": `export default "FOO";`,
+      "/mods/bar.js": `export default "BAR";`,
+    },
+    run: { stdout: "FOO" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+      api.expectFile("/out.js").toContain(`"./mods/foo.js"`);
+      api.expectFile("/out.js").toContain(`"./mods/bar.js"`);
+    },
+  });
+
+  itBundled("glob/RequireKeyNotInMap", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = globalThis.__missing ?? "missing";
+        try {
+          require(\`./engines/\${name}.js\`);
+          console.log("unreachable");
+        } catch (e) {
+          console.log(e.message.startsWith("Module not found in bundle:") ? "caught" : e.message);
+        }
+      `,
+      "/engines/a.js": `module.exports = 1;`,
+    },
+    run: { stdout: "caught" },
+  });
+
+  // No files match the pattern: leave the call as a runtime `require` so
+  // `allowUnresolved` still applies and runtime-created files can be loaded.
+  itBundled("glob/NoMatchesFallThrough", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = globalThis.__x ?? "a";
+        try { require(\`./nope/\${name}.js\`); } catch {}
+        console.log("ok");
+      `,
+    },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("zero-match glob should fall through to runtime require");
+      }
+    },
+  });
+
+  itBundled("glob/IgnoresBarePackage", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = "fs";
+        const fs = require(\`node:\${name}\`);
+        console.log(typeof fs.readFileSync);
+      `,
+    },
+    run: { stdout: "function" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("bare package template should not be glob-bundled");
+      }
+    },
+  });
+
+  // `./file-${x}.js` has its wildcard mid-segment, so it should not recurse
+  // into subdirectories (`*`, not `**/*`).
+  itBundled("glob/WildcardNotAfterSlash", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const n = "a";
+        console.log(require(\`./file-\${n}.js\`));
+      `,
+      "/file-a.js": `module.exports = "A";`,
+      "/file-b.js": `module.exports = "B";`,
+      "/sub/file-c.js": `module.exports = "C";`,
+    },
+    run: { stdout: "A" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`"./file-a.js"`);
+      api.expectFile("/out.js").toContain(`"./file-b.js"`);
+      const out = api.readFile("/out.js");
+      if (out.includes("file-c")) {
+        throw new Error("mid-segment wildcard should not recurse into subdirectories");
+      }
+    },
+  });
+
+  // `./engines/${f}` has its wildcard right after `/`, so it recurses.
+  itBundled("glob/WildcardAfterSlashRecurses", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const p = "deep/inner";
+        console.log(require(\`./engines/\${p}.js\`));
+      `,
+      "/engines/top.js": `module.exports = "TOP";`,
+      "/engines/deep/inner.js": `module.exports = "INNER";`,
+    },
+    run: { stdout: "INNER" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`"./engines/top.js"`);
+      api.expectFile("/out.js").toContain(`"./engines/deep/inner.js"`);
+    },
+  });
+
+  itBundled("glob/ParentDirectory", {
+    target: "bun",
+    files: {
+      "/nested/entry.js": /* js */ `
+        const n = "x";
+        console.log(require(\`../other/\${n}.js\`));
+      `,
+      "/other/x.js": `module.exports = "X";`,
+    },
+    entryPoints: ["/nested/entry.js"],
+    run: { stdout: "X" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`"../other/x.js"`);
+    },
+  });
+
+  // Literal `*` in a template segment would change glob semantics; bail to
+  // the runtime require rather than mis-globbing.
+  itBundled("glob/LiteralGlobCharsFallThrough", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = "a";
+        try { require(\`./dir*/\${name}.js\`); } catch {}
+        console.log("ok");
+      `,
+    },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("literal * in template should fall through to runtime require");
+      }
+    },
+  });
+
+  // The original #13672 scenario: readdir + require(`./engines/${f}`), run
+  // as a compiled standalone executable from an unrelated cwd.
+  itBundled("compile/GlobRequireReaddir#13672", {
+    compile: true,
+    backend: "cli",
+    files: {
+      "/entry.js": /* js */ `
+        const fs = require("fs");
+        const path = require("path");
+        const engines = {};
+        for (const f of fs.readdirSync(path.join(__dirname, "engines"))) {
+          if (!f.endsWith(".js")) continue;
+          const e = require(\`./engines/\${f}\`);
+          engines[e.id] = e;
+        }
+        console.log(Object.keys(engines).sort().join(","));
+      `,
+      "/engines/boa.js": `module.exports = { id: "boa" };`,
+      "/engines/v8.js": `module.exports = { id: "v8" };`,
+    },
+    run: { stdout: "boa,v8", setCwd: false },
+  });
+});

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -23,15 +23,10 @@ describe("bundler", () => {
     },
     run: { stdout: "boa,v8" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
       api.expectFile("/out.js").toContain("__glob");
       // Both matches bundled under the caller-visible relative key.
       api.expectFile("/out.js").toContain(`"./engines/boa.js"`);
       api.expectFile("/out.js").toContain(`"./engines/v8.js"`);
-      // Runtime require is not needed: everything is bundled.
-      if (out.includes("import.meta.require")) {
-        throw new Error("expected the glob map to replace the runtime require");
-      }
     },
   });
 
@@ -72,21 +67,62 @@ describe("bundler", () => {
     },
   });
 
-  itBundled("glob/RequireKeyNotInMap", {
+  // An extensionless key (`"./engines/" + "boa"`) is not in the bundled map;
+  // fall back to the runtime `require` so it resolves the same as before the
+  // files were bundled. Running from the source directory so the fallback
+  // can actually find the file on disk.
+  itBundled("glob/ExtensionlessFallbackRequire", {
     target: "bun",
     files: {
       "/entry.js": /* js */ `
-        const name = globalThis.__missing ?? "missing";
-        try {
-          require(\`./engines/\${name}.js\`);
-          console.log("unreachable");
-        } catch (e) {
-          console.log(e.message.startsWith("Module not found in bundle:") ? "caught" : e.message);
-        }
+        const name = globalThis.__which ?? "boa";
+        const e = require("./engines/" + name);
+        console.log(e.id);
       `,
-      "/engines/a.js": `module.exports = 1;`,
+      "/engines/boa.js": `module.exports = { id: "boa" };`,
+      "/engines/v8.js": `module.exports = { id: "v8" };`,
     },
-    run: { stdout: "caught" },
+    outfile: "/out.js",
+    run: { stdout: "boa", setCwd: true },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__glob");
+      api.expectFile("/out.js").toContain(`"./engines/boa.js"`);
+    },
+  });
+
+  itBundled("glob/ExtensionlessFallbackImport", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = globalThis.__which ?? "boa";
+        const e = await import("./engines/" + name);
+        console.log(e.default.id);
+      `,
+      "/engines/boa.js": `export default { id: "boa" };`,
+    },
+    outfile: "/out.js",
+    run: { stdout: "boa", setCwd: true },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("(p) => import(p)");
+    },
+  });
+
+  // A second argument to `import()` carrying `with: { type }` must reach both
+  // the bundled matches and the runtime fallback.
+  itBundled("glob/ImportWithTypeOption", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = globalThis.__which ?? "a";
+        const m = await import(\`./data/\${name}.txt\`, { with: { type: "text" } });
+        console.log(m.default);
+      `,
+      "/data/a.txt": "hello-from-text",
+    },
+    run: { stdout: "hello-from-text" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`{ with: { type: "text" } }`);
+    },
   });
 
   // No files match the pattern: leave the call as a runtime `require` so

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -365,11 +365,7 @@ test.skipIf(isWindows)("glob/SymlinkedFileIsBundled", async () => {
     cwd: String(dir),
     stderr: "pipe",
   });
-  const [, buildStderr, buildExitCode] = await Promise.all([
-    build.stdout.text(),
-    build.stderr.text(),
-    build.exited,
-  ]);
+  const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
   expect(buildStderr).toBe("");
   expect(buildExitCode).toBe(0);
 

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -365,7 +365,11 @@ test.skipIf(isWindows)("glob/SymlinkedFileIsBundled", async () => {
     cwd: String(dir),
     stderr: "pipe",
   });
-  const [buildStderr, buildExitCode] = await Promise.all([build.stderr.text(), build.exited]);
+  const [, buildStderr, buildExitCode] = await Promise.all([
+    build.stdout.text(),
+    build.stderr.text(),
+    build.exited,
+  ]);
   expect(buildStderr).toBe("");
   expect(buildExitCode).toBe(0);
 

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -108,20 +108,80 @@ describe("bundler", () => {
   });
 
   // A second argument to `import()` carrying `with: { type }` must reach both
-  // the bundled matches and the runtime fallback.
+  // the bundled matches and the runtime fallback. `.html` defaults to a
+  // non-text loader, so the raw-text output proves the attribute was applied.
   itBundled("glob/ImportWithTypeOption", {
     target: "bun",
     files: {
       "/entry.js": /* js */ `
         const name = globalThis.__which ?? "a";
-        const m = await import(\`./data/\${name}.txt\`, { with: { type: "text" } });
+        const m = await import(\`./data/\${name}.html\`, { with: { type: "text" } });
         console.log(m.default);
       `,
-      "/data/a.txt": "hello-from-text",
+      "/data/a.html": "<b>hello-from-text</b>",
     },
-    run: { stdout: "hello-from-text" },
+    run: { stdout: "<b>hello-from-text</b>" },
     onAfterBundle(api) {
       api.expectFile("/out.js").toContain(`{ with: { type: "text" } }`);
+    },
+  });
+
+  // Both branches of a ternary argument get glob-bundled.
+  itBundled("glob/RequireTernaryArg", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const n = "a";
+        const which = globalThis.__y ? "y" : "x";
+        const m = require(which === "y" ? \`./y/\${n}.js\` : \`./x/\${n}.js\`);
+        console.log(m);
+      `,
+      "/x/a.js": `module.exports = "X";`,
+      "/y/a.js": `module.exports = "Y";`,
+    },
+    run: { stdout: "X" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`"./x/a.js"`);
+      api.expectFile("/out.js").toContain(`"./y/a.js"`);
+    },
+  });
+
+  // A constant template part is folded into the head as a rope; the rope must
+  // be flattened so the pattern is "./v2/**/*.js", not "./v*.js".
+  itBundled("glob/TemplateFoldedConstantPart", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = "a";
+        console.log(require(\`./v\${2}/\${name}.js\`));
+      `,
+      "/v2/a.js": `module.exports = "V2A";`,
+    },
+    run: { stdout: "V2A" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`"./v2/a.js"`);
+    },
+  });
+
+  // The generated fallback parameter must not shadow a user binding that is
+  // passed as the import options.
+  itBundled("glob/FallbackParamNoShadow", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const p = { with: { type: "text" } };
+        const name = globalThis.__which ?? "a";
+        const m = await import(\`./data/\${name}.txt\`, p);
+        console.log(m.default);
+      `,
+      "/data/a.txt": "hello",
+    },
+    run: { stdout: "hello" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("import(p, p)")) {
+        throw new Error("fallback parameter shadows user binding 'p'");
+      }
     },
   });
 

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -206,6 +206,27 @@ describe("bundler", () => {
     },
   });
 
+  // Same for a bare "../" prefix: it would glob-bundle the entire parent tree.
+  itBundled("glob/BareDotDotSlashFallsThrough", {
+    target: "bun",
+    files: {
+      "/nested/entry.js": /* js */ `
+        const name = globalThis.__x ?? "a";
+        try { require(\`../\${name}\`); } catch {}
+        console.log("ok");
+      `,
+      "/a.js": `module.exports = "A";`,
+    },
+    entryPoints: ["/nested/entry.js"],
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("bare ../ template should fall through to runtime require");
+      }
+    },
+  });
+
   // No files match the pattern: leave the call as a runtime `require` so
   // `allowUnresolved` still applies and runtime-created files can be loaded.
   itBundled("glob/NoMatchesFallThrough", {

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { symlinkSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 // Coverage for bundling `require("./dir/" + x)` / `import("./dir/" + x)` by

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -178,10 +178,7 @@ describe("bundler", () => {
     },
     run: { stdout: "hello" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("import(p, p)")) {
-        throw new Error("fallback parameter shadows user binding 'p'");
-      }
+      api.expectFile("/out.js").not.toContain("import(p, p)");
     },
   });
 
@@ -199,10 +196,7 @@ describe("bundler", () => {
     },
     run: { stdout: "ok" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("bare ./ template should fall through to runtime require");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
 
@@ -220,10 +214,7 @@ describe("bundler", () => {
     entryPoints: ["/nested/entry.js"],
     run: { stdout: "ok" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("bare ../ template should fall through to runtime require");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
 
@@ -240,10 +231,7 @@ describe("bundler", () => {
     },
     run: { stdout: "ok" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("zero-match glob should fall through to runtime require");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
 
@@ -258,10 +246,7 @@ describe("bundler", () => {
     },
     run: { stdout: "function" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("bare package template should not be glob-bundled");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
 
@@ -282,10 +267,7 @@ describe("bundler", () => {
     onAfterBundle(api) {
       api.expectFile("/out.js").toContain(`"./file-a.js"`);
       api.expectFile("/out.js").toContain(`"./file-b.js"`);
-      const out = api.readFile("/out.js");
-      if (out.includes("file-c")) {
-        throw new Error("mid-segment wildcard should not recurse into subdirectories");
-      }
+      api.expectFile("/out.js").not.toContain("file-c");
     },
   });
 
@@ -336,10 +318,7 @@ describe("bundler", () => {
     },
     run: { stdout: "ok" },
     onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      if (out.includes("__glob")) {
-        throw new Error("literal * in template should fall through to runtime require");
-      }
+      api.expectFile("/out.js").not.toContain("__glob");
     },
   });
 

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -1,4 +1,7 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 // Coverage for bundling `require("./dir/" + x)` / `import("./dir/" + x)` by
@@ -344,4 +347,39 @@ describe("bundler", () => {
     },
     run: { stdout: "boa,v8", setCwd: false },
   });
+});
+
+// A symlinked file under the wildcard is followed and bundled like the
+// resolver would. itBundled cannot create symlinks, so this one is manual.
+test.skipIf(isWindows)("glob/SymlinkedFileIsBundled", async () => {
+  using dir = tempDir("bundler-glob-symlink", {
+    "entry.js": `const n = "a";\nconsole.log(require(\`./engines/\${n}.js\`));`,
+    "engines/b.js": `module.exports = "B";`,
+    "real/a.js": `module.exports = "REAL-A";`,
+  });
+  symlinkSync(join(String(dir), "real", "a.js"), join(String(dir), "engines", "a.js"));
+
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--target=bun", "./entry.js", "--outfile=out.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [buildStderr, buildExitCode] = await Promise.all([build.stderr.text(), build.exited]);
+  expect(buildStderr).toBe("");
+  expect(buildExitCode).toBe(0);
+
+  const out = await Bun.file(join(String(dir), "out.js")).text();
+  expect(out).toContain(`"./engines/a.js"`);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./out.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("REAL-A\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { symlinkSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { itBundled } from "./expectBundled";
 
 // Coverage for bundling `require("./dir/" + x)` / `import("./dir/" + x)` by
@@ -322,6 +322,46 @@ describe("bundler", () => {
     run: { stdout: "ok" },
     onAfterBundle(api) {
       api.expectFile("/out.js").not.toContain("__glob");
+    },
+  });
+
+  // Glob-generated records carry the relative specifier, so onResolve
+  // plugins can redirect them like a hand-written require.
+  itBundled("glob/OnResolvePluginApplies", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const n = "a";
+        console.log(require(\`./engines/\${n}.js\`));
+      `,
+      "/engines/a.js": `module.exports = "ORIGINAL";`,
+      "/redirected.js": `module.exports = "REDIRECTED";`,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /engines\/a\.js$/ }, args => {
+        return { path: resolve(dirname(args.importer), "redirected.js") };
+      });
+    },
+    run: { stdout: "REDIRECTED" },
+  });
+
+  // `--external` patterns match the relative specifier too, leaving the
+  // matched file unbundled.
+  itBundled("glob/ExternalPatternApplies", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const n = "a";
+        console.log(require(\`./engines/\${n}.js\`));
+      `,
+      "/engines/a.js": `module.exports = "FROM-DISK";`,
+    },
+    external: ["./engines/*"],
+    outfile: "/out.js",
+    run: { stdout: "FROM-DISK", setCwd: true },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`require("./engines/a.js")`);
+      api.expectFile("/out.js").not.toContain("FROM-DISK");
     },
   });
 

--- a/test/bundler/bundler_glob.test.ts
+++ b/test/bundler/bundler_glob.test.ts
@@ -185,6 +185,27 @@ describe("bundler", () => {
     },
   });
 
+  // A bare "./" prefix has no path component to anchor the glob; bundling
+  // every sibling of the importer would be far too greedy (esbuild bails too).
+  itBundled("glob/BareDotSlashFallsThrough", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        const name = globalThis.__x ?? "a";
+        try { require(\`./\${name}\`); } catch {}
+        console.log("ok");
+      `,
+      "/a.js": `module.exports = "A";`,
+    },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      if (out.includes("__glob")) {
+        throw new Error("bare ./ template should fall through to runtime require");
+      }
+    },
+  });
+
   // No files match the pattern: leave the call as a runtime `require` so
   // `allowUnresolved` still applies and runtime-created files can be loaded.
   itBundled("glob/NoMatchesFallThrough", {

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -164,7 +164,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=42062903F19477CF64756E2164756E21
+        //# debugId=7141FE02CB0F22E264756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -410,7 +410,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=BF876FBF618133C264756E2164756E21
+        //# debugId=02B60B4FF92A818164756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -106,11 +106,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-sjg7egv9.js",
+                "path": "./client-m110bjd9.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "efKwB-6QGwk",
+                  "etag": "VOGhIOsSzQk",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -120,7 +120,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "sJJm55rxM4I",
+                  "etag": "-sM_LDk0GTo",
                   "content-type": "text/html;charset=utf-8"
                 }
               },

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -180,7 +180,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=2020261114B67BB564756E2164756E21
+    //# debugId=37EEE4862DD2283364756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
## What does this PR do?

Fixes #13672.

When `bun build` (including `--compile`) encounters a `require()` or `import()` whose argument is a template literal or string concatenation with a relative prefix, it now globs the matching files at build time and bundles them into a lookup map, matching [esbuild's behaviour](https://esbuild.github.io/api/#glob).

### Before

```js
// require(`./engines/${f}`) was left as an unbundled runtime call:
var __require = import.meta.require;
const e = __require(`./engines/${f}`);
```

In a `--compile`'d binary this resolved relative to `/$bunfs/root` and failed:

```
error: Cannot find module './engines/boa.js' from '/$bunfs/root/esvu'
```

### After

```js
var __glob = (map, fallback) => (path) => {
  var fn = map[path];
  if (fn) return fn();
  if (fallback) return fallback(path);
  throw new Error("Module not found in bundle: " + path);
};
const e = __glob({
  "./engines/boa.js": () => require_boa(),
  "./engines/v8.js": () => require_v8(),
}, __require)(`./engines/${f}`);
```

The matching files are bundled and the lookup succeeds regardless of where the binary runs. On a map miss (for example `"./engines/" + "boa"` with no extension), `__glob` falls back to the runtime `require` / `import()` so those cases resolve exactly as they did before this change.

## How does it work?

When the parser visits `require(expr)` / `import(expr)` and `expr` is not a plain string:

1. Flatten `expr` into alternating literal / wildcard segments. Supports untagged template literals and `"prefix" + x` chains (the left operand of `+` must itself be analysable so there is a literal prefix to anchor the glob).
2. Bail unless the first literal starts with `./` or `../` and names a real path component (so a bare `./` + x or `../` + x does not glob-bundle an entire directory tree) and there is at least one wildcard.
3. Build a glob pattern: a wildcard immediately after `/` becomes `**/*` (recurses into subdirectories); a mid-segment wildcard becomes `*` (current directory only). Literal glob metacharacters (`*`, `?`, `[`, `{`) in a template segment bail to the runtime path.
4. Walk the filesystem from the source file's directory. If nothing matches (or any I/O error), fall through unchanged so `allowUnresolved` still applies and runtime-created files can still be loaded.
5. For each match, create a normal `ImportKind::Require` / `ImportKind::Dynamic` import record (using the relative specifier, so `--external` patterns and `onResolve` plugins still match) and emit `__glob({ "./rel/path": () => <require>, ... }, <fallback>)(expr)`. For `import()`, the surrounding `{ with: { type } }` options and the `.then().catch()` / awaited-in-try error-handling flag are threaded through to both the bundled entries and the fallback.

`__glob` is a new runtime helper in `src/runtime.js`.

## Why is this the correct fix?

The reported bug is not a resolver quirk: the `./engines/*.js` files were never bundled because the specifier was dynamic, so there was nothing for the standalone resolver to find. Making the standalone resolver search the build-machine path would only paper over it on the machine that built the binary. Bundling the matches is what actually makes the executable self-contained, and it is the established behaviour in esbuild that users coming from that ecosystem expect. The runtime fallback on map miss keeps everything that worked before working.

## Notes

The glob walk runs in the parser using a direct `readdir`. Each matched file's import record is the relative specifier, so the bundler's resolver, `--external` matching, and `onResolve` plugins still see every file. The pattern itself is not exposed to plugins (same as esbuild), and the directory listing is not registered with the resolver's `DirEntry` cache, so a file added to a globbed directory during `--watch` does not trigger a rebuild until one of the already-tracked files changes. Moving the walk to `bundle_v2::resolve_import_records` behind `DirEntryAccessor` would close that gap; it is a larger refactor left for a follow-up.

## Tested by

`test/bundler/bundler_glob.test.ts` (new, 13 cases): template-literal `require`, string-concat `require`, template-literal `import()`, extensionless-key fallback for `require` and `import()`, `import(..., { with: { type } })`, zero-match fallthrough, bare-package ignored, `*` vs `**/*` wildcard placement, `../` prefix, literal-`*` fallthrough, and the original #13672 `readdir + require(\`./engines/\${f}\`)` scenario run as a compiled standalone executable.

9 of the 13 fail on `main` (the negative cases that assert the glob does *not* fire, and the extensionless fallback cases that exercise pre-existing runtime resolution, pass on both). `test/bundler/bundler_allow_unresolved.test.ts`, `bundler_cjs.test.ts`, and `bundler_edgecase.test.ts` still pass unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_glob.test.ts

<!-- robobun:evidence:end -->
