### PR TITLE
test(shell): size shell-load iterations by build type and assert output

### DIFF
--- a/test/js/bun/shell/shell-immediate-exit-fixture.js
+++ b/test/js/bun/shell/shell-immediate-exit-fixture.js
@@ -4,7 +4,11 @@ const cmd = which("true");
 
 const promises = [];
 
-const upperCount = process.platform === "darwin" ? 100 : 300;
+// The caller sizes the outer loop based on build type. Under ASAN/debug the
+// parent is slower relative to the native child, so the "exited before watch()"
+// race this fixture was written for is hit with far fewer iterations than a
+// release build needs.
+const upperCount = parseInt(process.env.SHELL_LOAD_OUTER, 10) || (process.platform === "darwin" ? 100 : 300);
 
 for (let j = 0; j < upperCount; j++) {
   for (let i = 0; i < 100; i++) {

--- a/test/js/bun/shell/shell-load.test.ts
+++ b/test/js/bun/shell/shell-load.test.ts
@@ -1,15 +1,35 @@
 import { describe, expect, test } from "bun:test";
-import { isCI, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, isWindows } from "harness";
 import path from "path";
+
 describe("shell load", () => {
   // windows process spawning is a lot slower
   test.skipIf(isCI && isWindows)(
     "immediate exit",
-    () => {
-      expect([path.join(import.meta.dir, "./shell-immediate-exit-fixture.js")]).toRun();
+    async () => {
+      // Regression test for a crash when a spawned command exits before the
+      // shell registers its exit watcher. 300 batches of 100 on a release
+      // build; ASAN/debug slow the parent enough that 60 batches exercise the
+      // same race at a fraction of the wall time.
+      const outer = isASAN || isDebug ? 60 : process.platform === "darwin" ? 100 : 300;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "shell-immediate-exit-fixture.js")],
+        env: { ...bunEnv, SHELL_LOAD_OUTER: String(outer) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      // console.count("Ran") fires on every tenth outer iteration.
+      const expectedBatches = Math.floor((outer - 1) / 10) + 1;
+      const lines = stdout.split("\n").filter(Boolean);
+      expect(lines).toEqual(Array.from({ length: expectedBatches }, (_, i) => `Ran: ${i + 1}`));
+      expect(exitCode).toBe(0);
     },
     {
-      timeout: 1000 * 90,
+      timeout: isASAN || isDebug ? 1000 * 45 : 1000 * 90,
     },
   );
 });


### PR DESCRIPTION
## What does this PR do?

`test/js/bun/shell/shell-load.test.ts` is one of the slowest files on the ASAN lanes: 24s wall time on debian 13 x64-asan (build #80083). The fixture spawns `which("true")` 30,000 times (300 outer × 100 inner) to exercise the "child exits before the shell registers its exit watcher" race from #18320.

Under ASAN/debug the instrumented parent is much slower than release while the child (`/usr/bin/true`) is a native binary that exits in microseconds, so the race window is *wider* and far fewer iterations are needed to hit it reliably. macOS release already runs 100 outer for the same reason.

### Changes

* Fixture: read the outer-loop count from `SHELL_LOAD_OUTER` (falls back to the old platform default so running the fixture directly behaves the same).
* Test: pass `60` under `isASAN || isDebug`, keep `300`/`100` on release linux/macOS.
* Test: replace the bare `toRun()` (exit-code-only) with an async `Bun.spawn` that asserts `stderr === ""` and that `stdout` is exactly the `Ran: 1 … Ran: N` progress sequence before checking `exitCode`, so any failure surfaces the shell's own error text.
* Tighten the ASAN/debug timeout from 90s to 45s.

No tests skipped or deleted; release-build coverage is unchanged.

## How did you verify your code works?

The local container has `pids.max=512`, which is below the fixture's peak of ~1000 concurrent subprocesses, so I could not time the CI concurrency pattern directly. Instead I measured the same workload with 100-wide batches under the debug+ASAN binary:

| outer | spawns | debug+ASAN |
|------:|-------:|-----------:|
| 300   | 30,000 | 150.0s     |
| 60    |  6,000 |  30.5s     |

That is a 4.9× reduction. Applied to the 24s debian 13 x64-asan baseline this puts the file at roughly 5s on that lane.

I also verified the new assertions by running with `SHELL_LOAD_OUTER=5` (fits the cgroup) under `bun bd test`: 3 `expect()` calls pass and a forced `EAGAIN` run fails on the `stderr` assertion with the shell's own error text in the diff.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->