### PR TITLE
node:inspector: route CDP responses to the right client when multiple are attached

### DIFF
--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -92,12 +92,8 @@ const CONSOLE_LEVEL_MAP: Record<string, string> = {
 };
 
 // JSC's FrontendRouter::sendResponse broadcasts every command response to every
-// connected frontend channel (the FIXME in InspectorFrontendRouter.cpp), so a
-// backend id issued by one adapter also reaches every other adapter's
-// handleBackendMessage. A per-adapter counter would let two clients' first
-// commands share id 1 and each claim the other's response. Allocating ids from
-// one shared counter keeps each backend id unique across adapters; the adapter
-// whose #pending lacks the id simply drops the broadcast.
+// connected frontend, so backend ids must be unique across adapters; each
+// adapter's handleBackendMessage drops ids its #pending does not know.
 let nextBackendId = 1;
 
 class InspectorCDPAdapter {

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -91,10 +91,18 @@ const CONSOLE_LEVEL_MAP: Record<string, string> = {
   debug: "debug",
 };
 
+// JSC's FrontendRouter::sendResponse broadcasts every command response to every
+// connected frontend channel (the FIXME in InspectorFrontendRouter.cpp), so a
+// backend id issued by one adapter also reaches every other adapter's
+// handleBackendMessage. A per-adapter counter would let two clients' first
+// commands share id 1 and each claim the other's response. Allocating ids from
+// one shared counter keeps each backend id unique across adapters; the adapter
+// whose #pending lacks the id simply drops the broadcast.
+let nextBackendId = 1;
+
 class InspectorCDPAdapter {
   #writeToBackend: (message: string) => void;
   #writeToClient: (message: string) => void;
-  #nextBackendId = 1;
   #nextExceptionId = 1;
   #pending = new Map<
     number,
@@ -176,7 +184,7 @@ class InspectorCDPAdapter {
     clientMethod = method,
     onResult?: (result: AnyObject, error?: AnyObject) => void,
   ): void {
-    const id = this.#nextBackendId++;
+    const id = nextBackendId++;
     this.#pending.$set(id, { clientId, method: clientMethod, onResult });
     this.#writeToBackend(JSON.stringify(params === undefined ? { id, method } : { id, method, params }));
   }

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -311,7 +311,7 @@ test("inspector.close() followed by inspector.open() starts a new server", async
   expect(summary.secondUrl).not.toBe(summary.firstUrl);
   expect(summary.protocolVersion).toBe("1.1");
   expect(summary.finalUrl).toBeNull();
-});
+}, 30_000);
 
 // A failed inspector.open() (port already in use) must print Node's diagnostic
 // line and RETURN so a later open() can retry on the same debugger thread.
@@ -369,7 +369,7 @@ test("inspector.open() can be retried after a failed start", async () => {
   expect(summary.url).toStartWith("ws://127.0.0.1:");
   expect(summary.protocolVersion).toBe("1.1");
   expect(summary.finalUrl).toBeNull();
-});
+}, 30_000);
 
 // wait=true refs the event loop before the debugger thread attempts to bind;
 // on bind failure the ref must be released so the process can exit.
@@ -398,7 +398,7 @@ test("inspector.open() with wait=true does not hang the process after a bind fai
   expect(stderr).toContain(`Starting inspector on 127.0.0.1:${port} failed: address already in use`);
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
-});
+}, 30_000);
 
 // waitForDebugger() must block until a client sends Runtime.runIfWaitingForDebugger,
 // even when open() was called without `wait`. The client marks a global before
@@ -472,7 +472,7 @@ test("inspector.waitForDebugger() blocks until a client resumes the process", as
 
   expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ resumedByClient: true });
   expect(exitCode).toBe(0);
-});
+}, 30_000);
 
 // A second waitForDebugger() must block again for a fresh
 // Runtime.runIfWaitingForDebugger — Node blocks on every call, and it must be
@@ -562,7 +562,7 @@ test("inspector.waitForDebugger() blocks again on the second call after a fronte
 
   expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ first: 1, second: 2 });
   expect(exitCode).toBe(0);
-});
+}, 30_000);
 
 test("Runtime.consoleAPICalled is emitted while the Runtime domain is enabled", () => {
   const session = new inspector.Session();
@@ -886,7 +886,7 @@ export { after };
   expect(JSON.parse(stdoutText.trim().split("\n").at(-1)!)).toEqual({ after: 1, bump: 1, warm: 10 });
   expect(await proc.exited).toBe(0);
   await stderrDrained;
-});
+}, 30_000);
 
 // End-to-end pause/resume over the DevTools-protocol server started by
 // inspector.open(): the entry module is a top-level-await module that calls
@@ -1009,7 +1009,7 @@ export { after };
 
   expect(JSON.parse(stdoutText.trim().split("\n").at(-1)!)).toEqual({ after: 1, beforeOpen: 1 });
   expect(await proc.exited).toBe(0);
-});
+}, 30_000);
 
 // JSC's FrontendRouter broadcasts every command response to every connected
 // frontend channel. With a per-connection backend-id counter, two clients'
@@ -1081,7 +1081,7 @@ test("two inspector.open() clients each receive their own Runtime.evaluate resul
     proc.kill("SIGKILL");
     await stderrDrained;
   }
-});
+}, 30_000);
 
 test("disconnect does not clobber a console method reassigned by user code", () => {
   const session = new inspector.Session();

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1011,6 +1011,76 @@ export { after };
   expect(await proc.exited).toBe(0);
 });
 
+// JSC's FrontendRouter broadcasts every command response to every connected
+// frontend channel. With a per-connection backend-id counter, two clients'
+// first commands both carry backend id 1 and each adapter claims whichever
+// response arrives first, so one client receives the other's result under its
+// own command id.
+test("two inspector.open() clients each receive their own Runtime.evaluate result", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const inspector = require("node:inspector");
+       inspector.open(0, "127.0.0.1", false);
+       process.stdout.write("URL " + inspector.url() + "\\n");
+       setInterval(() => {}, 1000);`,
+    ],
+    env: injectedScriptChildEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  const stdoutReader = proc.stdout.getReader();
+  let stdoutText = "";
+  let wsUrl: string | undefined;
+  while (!wsUrl) {
+    const { value, done } = await stdoutReader.read();
+    if (done) throw new Error(`child exited before printing its URL; stdout: ${stdoutText}`);
+    stdoutText += decoder.decode(value);
+    wsUrl = stdoutText.match(/URL (ws:\S+)/)?.[1];
+  }
+
+  const attach = async () => {
+    const ws = new WebSocket(wsUrl!);
+    const opened = Promise.withResolvers<void>();
+    ws.onopen = () => opened.resolve();
+    ws.onerror = e => opened.reject(e);
+    await opened.promise;
+    return ws;
+  };
+  const evaluate = (ws: WebSocket, id: number, expression: string) =>
+    new Promise<any>((resolve, reject) => {
+      ws.addEventListener("message", event => {
+        const msg = JSON.parse(String(event.data));
+        if (msg.id === id) resolve(msg.result?.result?.value);
+      });
+      ws.addEventListener("error", reject);
+      ws.addEventListener("close", () => reject(new Error("socket closed before response")));
+      ws.send(JSON.stringify({ id, method: "Runtime.evaluate", params: { expression } }));
+    });
+
+  const a = await attach();
+  const b = await attach();
+  // A short busy loop keeps the inspected thread inside A's evaluate long
+  // enough for B's command to reach the adapter on the debugger thread, so both
+  // adapters have a backend command in flight when the response broadcasts.
+  const aValue = evaluate(
+    a,
+    1,
+    `(() => { let n = 0; for (let i = 0; i < 1e6; i++) n++; return "answer-for-A"; })()`,
+  );
+  const bValue = evaluate(b, 2, `"answer-for-B"`);
+  try {
+    expect({ a: await aValue, b: await bValue }).toEqual({ a: "answer-for-A", b: "answer-for-B" });
+  } finally {
+    a.close();
+    b.close();
+    proc.kill("SIGKILL");
+  }
+});
+
 test("disconnect does not clobber a console method reassigned by user code", () => {
   const session = new inspector.Session();
   session.connect();

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1071,11 +1071,18 @@ test("concurrent inspector.open() clients never receive another client's Runtime
       else client.foreign++;
       if (--totalOutstanding === 0) allResponded.resolve();
     };
-    ws.onerror = e => failed.reject(e);
-    ws.onclose = () =>
-      totalOutstanding > 0 && failed.reject(new Error(`client ${i} closed early; stderr: ${stderrText}`));
     const opened = Promise.withResolvers<void>();
     ws.onopen = () => opened.resolve();
+    ws.onerror = e => {
+      opened.reject(e);
+      failed.reject(e);
+    };
+    ws.onclose = () => {
+      if (totalOutstanding === 0) return;
+      const err = new Error(`client ${i} closed early; stderr: ${stderrText}`);
+      opened.reject(err);
+      failed.reject(err);
+    };
     await opened.promise;
     clients.push(client);
   }

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1057,54 +1057,56 @@ test("concurrent inspector.open() clients never receive another client's Runtime
   const clients: Client[] = [];
   const allResponded = Promise.withResolvers<void>();
   const failed = Promise.withResolvers<never>();
+  failed.promise.catch(() => {});
   let totalOutstanding = CLIENTS * EVALS_PER_CLIENT;
 
-  for (let i = 0; i < CLIENTS; i++) {
-    const ws = new WebSocket(wsUrl!);
-    const client: Client = { ws, marker: `client-${i}:`, own: 0, foreign: 0, outstanding: new Set() };
-    ws.onmessage = event => {
-      const msg = JSON.parse(String(event.data));
-      if (msg.id === undefined || !client.outstanding.has(msg.id)) return;
-      client.outstanding.delete(msg.id);
-      const value = msg.result?.result?.value;
-      if (typeof value === "string" && value.startsWith(client.marker)) client.own++;
-      else client.foreign++;
-      if (--totalOutstanding === 0) allResponded.resolve();
-    };
-    const opened = Promise.withResolvers<void>();
-    ws.onopen = () => opened.resolve();
-    ws.onerror = e => {
-      opened.reject(e);
-      failed.reject(e);
-    };
-    ws.onclose = () => {
-      if (totalOutstanding === 0) return;
-      const err = new Error(`client ${i} closed early; stderr: ${stderrText}`);
-      opened.reject(err);
-      failed.reject(err);
-    };
-    await opened.promise;
-    clients.push(client);
-  }
-
-  // Interleave sends round-robin so every adapter has backend commands in
-  // flight while the others' responses broadcast; then wait for every response.
-  for (let j = 0; j < EVALS_PER_CLIENT; j++) {
-    for (const client of clients) {
-      const id = j + 1;
-      client.outstanding.add(id);
-      client.ws.send(
-        JSON.stringify({ id, method: "Runtime.evaluate", params: { expression: `"${client.marker}${j}"` } }),
-      );
-    }
-  }
-
   try {
+    for (let i = 0; i < CLIENTS; i++) {
+      const ws = new WebSocket(wsUrl!);
+      const client: Client = { ws, marker: `client-${i}:`, own: 0, foreign: 0, outstanding: new Set() };
+      clients.push(client);
+      ws.onmessage = event => {
+        const msg = JSON.parse(String(event.data));
+        if (msg.id === undefined || !client.outstanding.has(msg.id)) return;
+        client.outstanding.delete(msg.id);
+        const value = msg.result?.result?.value;
+        if (typeof value === "string" && value.startsWith(client.marker)) client.own++;
+        else client.foreign++;
+        if (--totalOutstanding === 0) allResponded.resolve();
+      };
+      const opened = Promise.withResolvers<void>();
+      ws.onopen = () => opened.resolve();
+      ws.onerror = e => {
+        opened.reject(e);
+        failed.reject(e);
+      };
+      ws.onclose = () => {
+        if (totalOutstanding === 0) return;
+        const err = new Error(`client ${i} closed early; stderr: ${stderrText}`);
+        opened.reject(err);
+        failed.reject(err);
+      };
+      await opened.promise;
+    }
+
+    // Interleave sends round-robin so every adapter has backend commands in
+    // flight while the others' responses broadcast; then wait for every response.
+    for (let j = 0; j < EVALS_PER_CLIENT; j++) {
+      for (const client of clients) {
+        const id = j + 1;
+        client.outstanding.add(id);
+        client.ws.send(
+          JSON.stringify({ id, method: "Runtime.evaluate", params: { expression: `"${client.marker}${j}"` } }),
+        );
+      }
+    }
+
     await Promise.race([allResponded.promise, failed.promise]);
     const own = clients.reduce((n, c) => n + c.own, 0);
     const foreign = clients.reduce((n, c) => n + c.foreign, 0);
     expect({ own, foreign }).toEqual({ own: CLIENTS * EVALS_PER_CLIENT, foreign: 0 });
   } finally {
+    totalOutstanding = 0;
     for (const { ws } of clients) ws.close();
     proc.kill("SIGKILL");
     await stderrDrained;

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1031,13 +1031,18 @@ test("two inspector.open() clients each receive their own Runtime.evaluate resul
     stderr: "pipe",
   });
 
+  let stderrText = "";
+  const stderrDrained = (async () => {
+    for await (const chunk of proc.stderr) stderrText += Buffer.from(chunk).toString();
+  })();
+
   const decoder = new TextDecoder();
   const stdoutReader = proc.stdout.getReader();
   let stdoutText = "";
   let wsUrl: string | undefined;
   while (!wsUrl) {
     const { value, done } = await stdoutReader.read();
-    if (done) throw new Error(`child exited before printing its URL; stdout: ${stdoutText}`);
+    if (done) throw new Error(`child exited before printing its URL; stdout: ${stdoutText}; stderr: ${stderrText}`);
     stdoutText += decoder.decode(value);
     wsUrl = stdoutText.match(/URL (ws:\S+)/)?.[1];
   }
@@ -1057,7 +1062,7 @@ test("two inspector.open() clients each receive their own Runtime.evaluate resul
         if (msg.id === id) resolve(msg.result?.result?.value);
       });
       ws.addEventListener("error", reject);
-      ws.addEventListener("close", () => reject(new Error("socket closed before response")));
+      ws.addEventListener("close", () => reject(new Error(`socket closed before response; stderr: ${stderrText}`)));
       ws.send(JSON.stringify({ id, method: "Runtime.evaluate", params: { expression } }));
     });
 
@@ -1074,6 +1079,7 @@ test("two inspector.open() clients each receive their own Runtime.evaluate resul
     a.close();
     b.close();
     proc.kill("SIGKILL");
+    await stderrDrained;
   }
 });
 

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1011,12 +1011,18 @@ export { after };
   expect(await proc.exited).toBe(0);
 }, 30_000);
 
-// JSC's FrontendRouter broadcasts every command response to every connected
-// frontend channel. With a per-connection backend-id counter, two clients'
-// first commands both carry backend id 1 and each adapter claims whichever
-// response arrives first, so one client receives the other's result under its
-// own command id.
-test("two inspector.open() clients each receive their own Runtime.evaluate result", async () => {
+// JSC's FrontendRouter::sendResponse broadcasts every command response to every
+// connected frontend channel. With a per-connection backend-id counter, each
+// adapter starts at backend id 1, so concurrently-attached adapters have the
+// same ids in #pending and claim each other's broadcast responses, delivering
+// one client's Runtime.evaluate result to another client under that client's
+// own command id. The census below fires CLIENTS*EVALS_PER_CLIENT evaluates
+// with a per-client marker string and asserts that no client ever observes
+// another client's marker.
+test("concurrent inspector.open() clients never receive another client's Runtime.evaluate result", async () => {
+  const CLIENTS = 5;
+  const EVALS_PER_CLIENT = 40;
+
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -1047,37 +1053,52 @@ test("two inspector.open() clients each receive their own Runtime.evaluate resul
     wsUrl = stdoutText.match(/URL (ws:\S+)/)?.[1];
   }
 
-  const attach = async () => {
+  type Client = { ws: WebSocket; marker: string; own: number; foreign: number; outstanding: Set<number> };
+  const clients: Client[] = [];
+  const allResponded = Promise.withResolvers<void>();
+  const failed = Promise.withResolvers<never>();
+  let totalOutstanding = CLIENTS * EVALS_PER_CLIENT;
+
+  for (let i = 0; i < CLIENTS; i++) {
     const ws = new WebSocket(wsUrl!);
+    const client: Client = { ws, marker: `client-${i}:`, own: 0, foreign: 0, outstanding: new Set() };
+    ws.onmessage = event => {
+      const msg = JSON.parse(String(event.data));
+      if (msg.id === undefined || !client.outstanding.has(msg.id)) return;
+      client.outstanding.delete(msg.id);
+      const value = msg.result?.result?.value;
+      if (typeof value === "string" && value.startsWith(client.marker)) client.own++;
+      else client.foreign++;
+      if (--totalOutstanding === 0) allResponded.resolve();
+    };
+    ws.onerror = e => failed.reject(e);
+    ws.onclose = () =>
+      totalOutstanding > 0 && failed.reject(new Error(`client ${i} closed early; stderr: ${stderrText}`));
     const opened = Promise.withResolvers<void>();
     ws.onopen = () => opened.resolve();
-    ws.onerror = e => opened.reject(e);
     await opened.promise;
-    return ws;
-  };
-  const evaluate = (ws: WebSocket, id: number, expression: string) =>
-    new Promise<any>((resolve, reject) => {
-      ws.addEventListener("message", event => {
-        const msg = JSON.parse(String(event.data));
-        if (msg.id === id) resolve(msg.result?.result?.value);
-      });
-      ws.addEventListener("error", reject);
-      ws.addEventListener("close", () => reject(new Error(`socket closed before response; stderr: ${stderrText}`)));
-      ws.send(JSON.stringify({ id, method: "Runtime.evaluate", params: { expression } }));
-    });
+    clients.push(client);
+  }
 
-  const a = await attach();
-  const b = await attach();
-  // A short busy loop keeps the inspected thread inside A's evaluate long
-  // enough for B's command to reach the adapter on the debugger thread, so both
-  // adapters have a backend command in flight when the response broadcasts.
-  const aValue = evaluate(a, 1, `(() => { let n = 0; for (let i = 0; i < 5e7; i++) n++; return "answer-for-A"; })()`);
-  const bValue = evaluate(b, 2, `"answer-for-B"`);
+  // Interleave sends round-robin so every adapter has backend commands in
+  // flight while the others' responses broadcast; then wait for every response.
+  for (let j = 0; j < EVALS_PER_CLIENT; j++) {
+    for (const client of clients) {
+      const id = j + 1;
+      client.outstanding.add(id);
+      client.ws.send(
+        JSON.stringify({ id, method: "Runtime.evaluate", params: { expression: `"${client.marker}${j}"` } }),
+      );
+    }
+  }
+
   try {
-    expect({ a: await aValue, b: await bValue }).toEqual({ a: "answer-for-A", b: "answer-for-B" });
+    await Promise.race([allResponded.promise, failed.promise]);
+    const own = clients.reduce((n, c) => n + c.own, 0);
+    const foreign = clients.reduce((n, c) => n + c.foreign, 0);
+    expect({ own, foreign }).toEqual({ own: CLIENTS * EVALS_PER_CLIENT, foreign: 0 });
   } finally {
-    a.close();
-    b.close();
+    for (const { ws } of clients) ws.close();
     proc.kill("SIGKILL");
     await stderrDrained;
   }

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1071,7 +1071,7 @@ test("two inspector.open() clients each receive their own Runtime.evaluate resul
   // A short busy loop keeps the inspected thread inside A's evaluate long
   // enough for B's command to reach the adapter on the debugger thread, so both
   // adapters have a backend command in flight when the response broadcasts.
-  const aValue = evaluate(a, 1, `(() => { let n = 0; for (let i = 0; i < 1e6; i++) n++; return "answer-for-A"; })()`);
+  const aValue = evaluate(a, 1, `(() => { let n = 0; for (let i = 0; i < 5e7; i++) n++; return "answer-for-A"; })()`);
   const bValue = evaluate(b, 2, `"answer-for-B"`);
   try {
     expect({ a: await aValue, b: await bValue }).toEqual({ a: "answer-for-A", b: "answer-for-B" });

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1066,11 +1066,7 @@ test("two inspector.open() clients each receive their own Runtime.evaluate resul
   // A short busy loop keeps the inspected thread inside A's evaluate long
   // enough for B's command to reach the adapter on the debugger thread, so both
   // adapters have a backend command in flight when the response broadcasts.
-  const aValue = evaluate(
-    a,
-    1,
-    `(() => { let n = 0; for (let i = 0; i < 1e6; i++) n++; return "answer-for-A"; })()`,
-  );
+  const aValue = evaluate(a, 1, `(() => { let n = 0; for (let i = 0; i < 1e6; i++) n++; return "answer-for-A"; })()`);
   const bValue = evaluate(b, 2, `"answer-for-B"`);
   try {
     expect({ a: await aValue, b: await bValue }).toEqual({ a: "answer-for-A", b: "answer-for-B" });


### PR DESCRIPTION
With two or more clients attached to an `inspector.open()` server, one client's command response is delivered to another client under that client's own command id, and the real response is dropped.

## Repro

```js
// two WebSocket clients attach to inspector.open(), each sends one Runtime.evaluate
a.ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "'answer-for-A'" } }));
b.ws.send(JSON.stringify({ id: 2, method: "Runtime.evaluate", params: { expression: "'answer-for-B'" } }));
// B receives {id:2, result:{result:{value:"answer-for-A"}}}
```

## Cause

JSC's `FrontendRouter::sendResponse` broadcasts every command response to every connected frontend channel (the FIXME at [InspectorFrontendRouter.cpp:95](https://github.com/oven-sh/bun/blob/df6c7eed6b/vendor/WebKit/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp#L93-L98)). Each `InspectorCDPAdapter` assigned backend command ids from its own `#nextBackendId = 1` counter, so two clients' first commands both carried backend id 1. When the response for A's id 1 was broadcast, B's adapter also had id 1 in its `#pending` map and claimed it, replying to B with A's result under B's client id.

`handleBackendMessage` already returns early on `if (!pending)`, so an unknown backend id is silently dropped; the only way a foreign payload reaches a client is the id collision. Simulating the fix from the client side (pre-consuming disjoint backend-id ranges per connection) yields 0 foreign deliveries on an unmodified main, confirming the collision is the sole mechanism.

## Fix

Allocate backend command ids from a single module-level counter shared across adapters, so every in-flight backend id is unique process-wide. `handleBackendMessage` drops broadcast responses whose id is not in the adapter's own `#pending`, so the adapter that did not issue the command ignores them. All adapters (per-WebSocket-client and the in-process `inspector.Session` forwarder) are created in `src/js/internal/debugger.ts` on the same debugger-thread JS context, so a plain module-level `let` is the right scope and the unguarded `++` is single-threaded.

The broadcast response string is still delivered to every adapter and parsed before being dropped; that is a per-process perf cost, not a cross-client disclosure. Routing the response to only the originating channel would require plumbing a channel id through WebKit's `BackendDispatcher::dispatch`, which is an upstream change that composes with (and still needs) process-unique ids.

## Scope

This fixes response-payload crosstalk only. Debugger/Runtime agent state (enable/disable, breakpoints, `objectId` namespace) remains shared across attached clients because JSC has a single agent set per global object; a second client's `Debugger.setBreakpointsActive{false}` still affects the first. Attaching already requires knowing the inspector URL's bearer-token path, so co-attached clients are trusted peers; the disclosure of one client's evaluate results to another is the part that crosses a confidentiality line, and that is what this PR closes.

## Verification

New test `concurrent inspector.open() clients never receive another client's Runtime.evaluate result` in `test/js/node/inspector/inspector.test.ts`: 5 clients × 40 evaluates with per-client marker strings fired round-robin.

- Without fix: 160/200 foreign deliveries (80%), deterministic across 3 runs.
- With fix: 0/200 foreign, 200/200 own, 3/3 runs.
- Full file 24/24 green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (ec5a12f70)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [12.71ms]
(pass) inspector.console [2.24ms]
(pass) inspector.close() is a no-op when the inspector is not open [26.41ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [45.66ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [6606.70ms]
(pass) inspector.close() followed by inspector.open() starts a new server [2464.61ms]
(pass) inspector.open() can be retried after a failed start [2031.06ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [2506.31ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [2918.72ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [2793.17ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [83.59ms]
-0 NaN Infinity -Infinity
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ec5a12f70)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [0.89ms]
(pass) inspector.console [0.06ms]
(pass) inspector.close() is a no-op when the inspector is not open [0.05ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [0.09ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [92.71ms]
(pass) inspector.close() followed by inspector.open() starts a new server [275.14ms]
(pass) inspector.open() can be retried after a failed start [42.76ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [58.08ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [74.85ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [48.60ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [1.50ms]
-0 NaN Infinity -Infinity 1n
(pass) Runtime.consoleAPICalled encodes -0/NaN/Infinity/bigint as unserializableValue like Node [0.18ms]
(pass) Session errors carry Node's ERR_INSPECTOR_* codes and post() val
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (ec5a12f70)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [9.72ms]
(pass) inspector.console [2.44ms]
(pass) inspector.close() is a no-op when the inspector is not open [5.31ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [16.37ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [7098.19ms]
(pass) inspector.close() followed by inspector.open() starts a new server [2881.57ms]
(pass) inspector.open() can be retried after a failed start [2471.80ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [2436.16ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [3146.52ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [3057.70ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [115.85ms]
-0 NaN Infinity -Infinity 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2352ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (16952ms)
Bundle modules (442ms)
Postprocesss modules (471ms)
Bundle Functions (1936ms)
Generate Code (68ms)

[19.95s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/inspector/cdp.ts         |   8 ++-
 test/js/node/inspector/inspector.test.ts | 116 +++++++++++++++++++++++++++++--
 2 files changed, 115 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 3 passed · 3 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/inspector/cdp.ts              3      4      0
test/js/node/inspector/inspector.test.ts      8     15      0
```

</details>

<!-- robobun:evidence:end -->