### PR TITLE
node:inspector: answer Host-less HTTP requests instead of 500 + stderr stack dump

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -486,7 +486,14 @@ class Debugger {
 
   #fetch(request: Request, server: WebSocketServer): Response | undefined {
     const { method, url, headers } = request;
-    const { pathname } = new URL(url);
+    // request.url is the raw request-target (e.g. "/json/version") when the
+    // request has no Host header (HTTP/1.0); give URL a base so it parses.
+    let pathname: string;
+    try {
+      ({ pathname } = new URL(url, "http://localhost/"));
+    } catch {
+      return new Response(null, { status: 400 });
+    }
 
     if (method !== "GET") {
       return new Response(null, {

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -313,6 +313,69 @@ test("inspector.close() followed by inspector.open() starts a new server", async
   expect(summary.finalUrl).toBeNull();
 });
 
+// An HTTP/1.0 request (or any request without a Host header) to the inspector's
+// HTTP endpoints must be answered like Node does, not 500 with an
+// ERR_INVALID_URL stack dumped to the debuggee's stderr.
+const hostlessRequestFixture = `
+import inspector from "node:inspector";
+import net from "node:net";
+
+inspector.open(0, "127.0.0.1", false);
+const port = Number(new URL(inspector.url()).port);
+
+function raw(requestText) {
+  return new Promise(resolve => {
+    let data = "";
+    const socket = net.connect(port, "127.0.0.1", () => socket.write(requestText));
+    socket.on("data", chunk => (data += chunk));
+    socket.on("close", () => resolve(data));
+    socket.on("error", () => resolve(data));
+  });
+}
+
+const withHost = await raw(\`GET /json/version HTTP/1.1\\r\\nHost: 127.0.0.1:\${port}\\r\\nConnection: close\\r\\n\\r\\n\`);
+const withoutHost = await raw(\`GET /json/version HTTP/1.0\\r\\n\\r\\n\`);
+const emptyHost = await raw(\`GET /json/version HTTP/1.1\\r\\nHost: \\r\\nConnection: close\\r\\n\\r\\n\`);
+
+const statusLine = response => response.split("\\r\\n")[0];
+console.log(
+  JSON.stringify({
+    withHost: statusLine(withHost),
+    withoutHost: statusLine(withoutHost),
+    emptyHost: statusLine(emptyHost),
+    withoutHostBody: JSON.parse(withoutHost.slice(withoutHost.indexOf("\\r\\n\\r\\n") + 4)),
+  }),
+);
+inspector.close();
+`;
+
+test("inspector.open() HTTP endpoints answer requests without a Host header", async () => {
+  using dir = tempDir("inspector-hostless", {
+    "fixture.mjs": hostlessRequestFixture,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+
+  const summary = JSON.parse(stdout.trim().split("\n").at(-1)!);
+  expect(summary).toEqual({
+    withHost: "HTTP/1.1 200 OK",
+    withoutHost: "HTTP/1.1 200 OK",
+    emptyHost: "HTTP/1.1 200 OK",
+    withoutHostBody: { "Browser": expect.stringContaining("Bun/"), "Protocol-Version": "1.1" },
+  });
+  // The inspected process's own stderr must not receive an internal:debugger
+  // stack dump for an ordinary Host-less request.
+  expect(stderr).not.toContain("ERR_INVALID_URL");
+  expect(stderr).not.toContain("internal:debugger");
+});
+
 // A failed inspector.open() (port already in use) must print Node's diagnostic
 // line and RETURN so a later open() can retry on the same debugger thread.
 const failedOpenRetryFixture = `


### PR DESCRIPTION
## What

An HTTP/1.0 request without a `Host` header (or with an empty one) to the `inspector.open()` HTTP endpoints returned **500** with Bun's 66 KB dev-error-overlay page, and dumped an `internal:debugger` source snippet + stack trace to the inspected process's own stderr on every such request. Node answers these 200.

## Repro

```js
import inspector from "node:inspector";
import net from "node:net";
inspector.open(0, "127.0.0.1", false);
const port = Number(new URL(inspector.url()).port);
const s = net.connect(port, "127.0.0.1", () => s.write("GET /json/version HTTP/1.0\r\n\r\n"));
s.on("data", d => process.stdout.write(d)); // HTTP/1.1 500 Internal Server Error, ~66 KB body
```

stderr of the inspected process:
```
TypeError: "/json/version" cannot be parsed as a URL.
 code: "ERR_INVALID_URL"
      at #fetch (internal:debugger:400:26)
```

## Cause

When the request has no `Host` header, `request.url` in the `Bun.serve` handler is the raw request-target (`/json/version`), not an absolute URL. `new URL(url)` at the top of `#fetch` threw `ERR_INVALID_URL`, which `Bun.serve` turned into a 500 with the dev-error page and printed the error to stderr.

## Fix

Give `new URL()` a base so relative request-targets parse (the base is ignored when `url` is already absolute). If parsing still fails, return 400 instead of letting it escape. `isHostAllowed` already treats a missing Host as allowed, matching Node.

## Verification

`bun bd test test/js/node/inspector/inspector.test.ts` passes (24 tests). New test `inspector.open() HTTP endpoints answer requests without a Host header` fails on main with the `ERR_INVALID_URL` stderr dump shown above and passes with this fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (2678017c6)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [15.72ms]
(pass) inspector.console [12.48ms]
(pass) inspector.close() is a no-op when the inspector is not open [5.76ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [7.51ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [6168.80ms]
(pass) inspector.close() followed by inspector.open() starts a new server [2771.91ms]
359 |     env: bunEnv,
360 |     cwd: String(dir),
361 |     stderr: "pipe",
362 |   });
363 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
364 |   expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
                                                                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderrIfFailed": "",
+   "exit
... (truncated)

release without fix: 22 FAILED
bun test v1.3.14 (0d9b296a)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [4.19ms]
(pass) inspector.console [0.09ms]
22 | test("inspector.console", () => {
23 |   expect(inspector.console).toBeObject();
24 | });
25 | 
26 | test("inspector.close() is a no-op when the inspector is not open", () => {
27 |   expect(() => inspector.close()).not.toThrow();
                                           ^
error: expect(received).not.toThrow()

Error name: "NotImplementedError"
Error message: "node:inspector is not yet implemented in Bun. Track the status & thumbs up the issue: https://github.com/oven-sh/bun/issues/2445"

      at <anonymous> (/workspace/bun/test/js/node/inspector/inspector.test.ts:27:39)
(fail) inspector.close() is a no-op when the inspector is not open [1.33ms]
33 |     inspector.waitForDebugger();
34 |   } catch (caught) {
35 |     error = caught;
36 |   }
37 |   expect(error).toBeDefined();
38 |   expect(error.code).toBe("ERR_INSPECTOR_NOT_ACTIVE");
                          ^
error: expect(received).toBe(expected)

Expected: "ERR_INSPECTOR_NOT_ACTIVE"
Received: "ERR_NOT_IMPLEMENTED"

      at <anonymous> (/workspace/bun/test/js/node/ins
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (2678017c6)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [15.36ms]
(pass) inspector.console [2.55ms]
(pass) inspector.close() is a no-op when the inspector is not open [5.81ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [18.45ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [5797.44ms]
(pass) inspector.close() followed by inspector.open() starts a new server [2257.95ms]
(pass) inspector.open() HTTP endpoints answer requests without a Host header [3413.93ms]
(pass) inspector.open() can be retried after a failed start [2544.72ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [2742.19ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [3356.92ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [3597.09ms]
hello 42
after disable
(pass) Runtime.consoleAPIC
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2678017c64
  features     baseline

22 deps, 108 codegen, 1171 objects in 10898ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] mkdir codegen
[2/1238] mkdir stamps
[3/1238] mkdir pch
[4/1238] fetch zlib
[zlib] up to date
[5/1238] gen ErrorCode+*.h
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1238] fetch picohttpparser
[picohttpparser] up to date
[9/1238] gen bindgenv2
[10/1238] fetch libdeflate
[libdeflate] up to date
[11/1238] subst deps/zlib/zconf.h
[12/1238] subst deps/libjpeg-turbo/jconfig.h
[13/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[14/1238] fetch zstd
[zstd] up to date
[15/1238] subst deps/zlib/zlib.h
[16/1238] subst deps/libjpeg-turbo/jconfigint.h
[17/1238] mkdir obj
[18/1238] fetch libarchive
[libarchive] up to date
[19/1238] subst deps/libjpeg-turbo/jversion.h
[20/1238] fetch nodejs (prebuilt)
[nodejs] u
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/debugger.ts              |  9 ++++-
 test/js/node/inspector/inspector.test.ts | 63 ++++++++++++++++++++++++++++++++
 2 files changed, 71 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/debugger.ts                   2      1      0
test/js/node/inspector/inspector.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->