### PR TITLE
shell(cp): parse every short flag in a -Rv/-vR cluster

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1986,26 +1986,33 @@ mod _async_tasks {
 
             #[cfg(target_os = "macos")]
             {
-                // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
-                // mirror the O_NOFOLLOW directory open below instead of dereferencing.
-                if let Some(err) = Maybe::<ret::Cp>::errno_sys_p(
-                    bun_sys::c::clonefile_rc(src, dest, CLONE_NOFOLLOW),
-                    sys::Tag::clonefile,
-                    src.as_bytes(),
-                ) {
-                    match err.get_errno() {
-                        E::EACCES | E::ENAMETOOLONG | E::EROFS | E::EPERM | E::EINVAL => {
-                            // `errno_sys_p`
-                            // already boxed `src.as_bytes()` into `err.path`, so just forward.
-                            this_ref.finish_concurrently(err);
-                            return false;
+                // clonefile() copies the whole tree in one syscall, so there is no
+                // per-file `on_copy` callback. Skip it when the shell wants verbose
+                // output so the directory walk below reports each copy.
+                let skip_clonefile =
+                    IS_SHELL && this_ref.shelltask.is_some_and(|s| s.opts.verbose);
+                if !skip_clonefile {
+                    // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
+                    // mirror the O_NOFOLLOW directory open below instead of dereferencing.
+                    if let Some(err) = Maybe::<ret::Cp>::errno_sys_p(
+                        bun_sys::c::clonefile_rc(src, dest, CLONE_NOFOLLOW),
+                        sys::Tag::clonefile,
+                        src.as_bytes(),
+                    ) {
+                        match err.get_errno() {
+                            E::EACCES | E::ENAMETOOLONG | E::EROFS | E::EPERM | E::EINVAL => {
+                                // `errno_sys_p`
+                                // already boxed `src.as_bytes()` into `err.path`, so just forward.
+                                this_ref.finish_concurrently(err);
+                                return false;
+                            }
+                            // Other errors may be due to clonefile() not being supported
+                            // We'll fall back to other implementations
+                            _ => {}
                         }
-                        // Other errors may be due to clonefile() not being supported
-                        // We'll fall back to other implementations
-                        _ => {}
+                    } else {
+                        return true;
                     }
-                } else {
-                    return true;
                 }
             }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1987,8 +1987,12 @@ mod _async_tasks {
             #[cfg(target_os = "macos")]
             {
                 // clonefile() has no per-file callback, so shell `cp -v` needs the walk below.
-                let skip_clonefile =
-                    IS_SHELL && this_ref.shelltask.expect("IS_SHELL ⇒ shelltask").opts.verbose;
+                let skip_clonefile = IS_SHELL
+                    && this_ref
+                        .shelltask
+                        .expect("IS_SHELL ⇒ shelltask")
+                        .opts
+                        .verbose;
                 if !skip_clonefile {
                     // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
                     // mirror the O_NOFOLLOW directory open below instead of dereferencing.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1986,10 +1986,9 @@ mod _async_tasks {
 
             #[cfg(target_os = "macos")]
             {
-                // clonefile() copies the whole tree in one syscall, so there is no
-                // per-file `on_copy` callback. Skip it when the shell wants verbose
-                // output so the directory walk below reports each copy.
-                let skip_clonefile = IS_SHELL && this_ref.shelltask.is_some_and(|s| s.opts.verbose);
+                // clonefile() has no per-file callback, so shell `cp -v` needs the walk below.
+                let skip_clonefile =
+                    IS_SHELL && this_ref.shelltask.expect("IS_SHELL ⇒ shelltask").opts.verbose;
                 if !skip_clonefile {
                     // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
                     // mirror the O_NOFOLLOW directory open below instead of dereferencing.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1989,8 +1989,7 @@ mod _async_tasks {
                 // clonefile() copies the whole tree in one syscall, so there is no
                 // per-file `on_copy` callback. Skip it when the shell wants verbose
                 // output so the directory walk below reports each copy.
-                let skip_clonefile =
-                    IS_SHELL && this_ref.shelltask.is_some_and(|s| s.opts.verbose);
+                let skip_clonefile = IS_SHELL && this_ref.shelltask.is_some_and(|s| s.opts.verbose);
                 if !skip_clonefile {
                     // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
                     // mirror the O_NOFOLLOW directory open below instead of dereferencing.

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -791,13 +791,13 @@ impl FlagParser for Opts {
             b'p' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-P"))),
             b'R' => {
                 self.recursive = true;
-                Some(ParseFlagResult::ContinueParsing)
+                None
             }
             b'v' => {
                 self.verbose = true;
-                Some(ParseFlagResult::ContinueParsing)
+                None
             }
-            b'n' => Some(ParseFlagResult::ContinueParsing),
+            b'n' => None,
             _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..])),
         }
     }

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -783,12 +783,13 @@ impl FlagParser for Opts {
 
     fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult> {
         match ch {
-            b'f' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-f"))),
+            // `-f` is always on (see `CpFlags { force: true, .. }` below).
+            b'f' => None,
             b'H' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-H"))),
             b'i' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-i"))),
             b'L' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-L"))),
             b'P' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-P"))),
-            b'p' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-P"))),
+            b'p' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-p"))),
             b'R' => {
                 self.recursive = true;
                 None

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -783,7 +783,7 @@ impl FlagParser for Opts {
 
     fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult> {
         match ch {
-            // `-f` is always on (see `CpFlags { force: true, .. }` below).
+            // `-f` is always on (see `CpFlags { force: true, .. }` above).
             b'f' => None,
             b'H' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-H"))),
             b'i' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-i"))),

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -226,21 +226,23 @@ describe("bunshell cp combined short flags (builtin)", () => {
     });
   }
 
-  test.concurrent("cp -Rvn parses every flag in the cluster", async () => {
-    using dir = tempDir("cp-cluster-flags-n", {
-      "src/a.txt": "hi",
+  for (const flag of ["-nRv", "-fRv"]) {
+    test.concurrent(`cp ${flag} parses every flag in the cluster`, async () => {
+      using dir = tempDir("cp-cluster-flags-leading", {
+        "src/a.txt": "hi",
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `await Bun.$\`cp ${flag} src dest\``],
+        env,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("a.txt");
+      expect(await Bun.file(join(String(dir), "dest", "a.txt")).text()).toBe("hi");
+      expect(exitCode).toBe(0);
     });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", `await Bun.$\`cp -Rvn src dest\``],
-      env,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toContain("a.txt");
-    expect(await Bun.file(join(String(dir), "dest", "a.txt")).text()).toBe("hi");
-    expect(exitCode).toBe(0);
-  });
+  }
 });

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,8 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, tempDir, tempDirWithFiles } from "harness";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -59,6 +60,19 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
     .exitCode(1)
     .testMini()
     .runAsTest("dir -> ? fails without -R");
+
+  describe("combined short flags", () => {
+    for (const flag of ["-Rv", "-vR"]) {
+      TestBuilder.command`mkdir src; echo hi > src/a.txt; cp ${{ raw: flag }} src dest`
+        .ensureTempDir()
+        .exitCode(0)
+        .stderr("")
+        .stdout(out => expect(out).toContain("a.txt"))
+        .fileEquals("dest/a.txt", "hi\n")
+        .testMini()
+        .runAsTest(`cp ${flag} dir -> dir copies and prints each file`);
+    }
+  });
 
   describe("EBUSY windows", () => {
     TestBuilder.command /* sh */ `
@@ -179,3 +193,54 @@ function expectSortedOutput(expected: string) {
       sortedShellOutput(expected).join("\n").replaceAll("$TEMP_DIR", tempdir),
     );
 }
+
+// The cp builtin is disabled on POSIX by default; force-enable it so the flag
+// parser is covered on every platform.
+describe("bunshell cp combined short flags (builtin)", () => {
+  const env = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  for (const flag of ["-Rv", "-vR"]) {
+    test.concurrent(`cp ${flag} dir -> dir copies and prints each file`, async () => {
+      using dir = tempDir("cp-cluster-flags", {
+        "src/a.txt": "hello a",
+        "src/b.txt": "hello b",
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `await Bun.$\`cp ${flag} src dest\``],
+        env,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      // -v should print a line per copied entry; subtasks run concurrently so
+      // order is not guaranteed.
+      const lines = sortedShellOutput(stdout);
+      expect(lines.filter(l => l.includes("a.txt"))).toHaveLength(1);
+      expect(lines.filter(l => l.includes("b.txt"))).toHaveLength(1);
+      // -R should actually copy the tree.
+      expect(await Bun.file(join(String(dir), "dest", "a.txt")).text()).toBe("hello a");
+      expect(await Bun.file(join(String(dir), "dest", "b.txt")).text()).toBe("hello b");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test.concurrent("cp -Rvn parses every flag in the cluster", async () => {
+    using dir = tempDir("cp-cluster-flags-n", {
+      "src/a.txt": "hi",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `await Bun.$\`cp -Rvn src dest\``],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("a.txt");
+    expect(await Bun.file(join(String(dir), "dest", "a.txt")).text()).toBe("hi");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The shell `cp` builtin only applied the **first** flag of a combined short-flag cluster and silently discarded the rest:

```
$ cp -Rv srcdir dest     # copies the tree but prints nothing (v dropped)
$ cp -vR srcdir dest     # cp: srcdir is a directory (not copied) (R dropped)
$ cp -v -R srcdir dest   # works
```

On POSIX this is hidden because the builtin is disabled by default (falls through to /bin/cp); on Windows and with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` it's the only implementation.

### Cause

`FlagParser::parse_short` is documented as "return `None` to keep iterating" the `-abc` cluster, and `parse_one_flag` returns immediately on any `Some(_)`. `cp`'s impl returned `Some(ContinueParsing)` for `-R`/`-v`/`-n`, so `parse_one_flag` advanced to the next argv entry after the first recognised letter instead of the next letter in the cluster.

### Fix

- Return `None` for accepted short flags (`R`/`v`/`n`), matching the `mkdir` builtin.
- Accept `-f` as a no-op: the builtin already hardcodes `force: true`, so `cp -Rf` (very common) keeps working instead of newly erroring on the now-reachable `f`.
- Fix the pre-existing `-p` unsupported-flag message (was reporting `-P`).
- On macOS the recursive path shortcuts through `clonefile()`, which copies the whole tree in one syscall with no per-file `on_copy` callback. When the shell asked for verbose output, skip that fast path so the directory walk reports each copy. node `fs.cp` (`IS_SHELL=false`) is unaffected.

### Intentional behavior change

`cp -Rp` / `-Ri` / `-RH` / `-RL` / `-RP` previously set `-R` and silently dropped the second letter (so e.g. `-Rp` copied without preserving attributes). They now error with "unsupported option" the same way standalone `-p`/`-i`/`-H`/`-L`/`-P` already did. That's the honest answer: those flags aren't implemented.

### Verification

New tests spawn with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` so the builtin's flag parser runs on every platform, plus `TestBuilder` cases inside the existing Windows-only block:

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/cp.test.ts   # 4 fail
$ bun bd test test/js/bun/shell/commands/cp.test.ts                  # 4 pass
```

Related to #35616 (which adds `-r`/`--verbose` aliases; same `parse_short` site).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->