### PR TITLE
node:inspector: isolate Runtime.evaluate responses across concurrent CDP clients

### DIFF
--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -91,10 +91,20 @@ const CONSOLE_LEVEL_MAP: Record<string, string> = {
   debug: "debug",
 };
 
+// Backend command ids are allocated from one counter shared by every adapter.
+// All adapters talk to the same JSGlobalObjectInspectorController, and WebKit's
+// FrontendRouter::sendResponse() broadcasts each response to every connected
+// FrontendChannel. With a per-adapter counter two adapters would both have a
+// pending entry for the same id, so a broadcast response would satisfy both and
+// one client would receive the other's Runtime.evaluate result. A single id
+// space means a broadcast response only ever matches its originating adapter's
+// #pending map. All adapters run in the debugger thread's realm, so module
+// state is shared.
+let nextBackendId = 1;
+
 class InspectorCDPAdapter {
   #writeToBackend: (message: string) => void;
   #writeToClient: (message: string) => void;
-  #nextBackendId = 1;
   #nextExceptionId = 1;
   #pending = new Map<
     number,
@@ -176,7 +186,7 @@ class InspectorCDPAdapter {
     clientMethod = method,
     onResult?: (result: AnyObject, error?: AnyObject) => void,
   ): void {
-    const id = this.#nextBackendId++;
+    const id = nextBackendId++;
     this.#pending.$set(id, { clientId, method: clientMethod, onResult });
     this.#writeToBackend(JSON.stringify(params === undefined ? { id, method } : { id, method, params }));
   }

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1011,6 +1011,84 @@ export { after };
   expect(await proc.exited).toBe(0);
 });
 
+// WebKit's FrontendRouter::sendResponse broadcasts every command response to
+// every connected FrontendChannel. When each adapter allocated backend command
+// ids from its own counter (so every connection's first command was backend
+// id 1), a response broadcast while two connections both had that id pending
+// satisfied both: one client received the other's Runtime.evaluate result.
+test("concurrent inspector.open() clients each receive their own Runtime.evaluate result", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `require("node:inspector").open(0, "127.0.0.1", false);
+       setInterval(() => {}, 60_000);`,
+    ],
+    env: injectedScriptChildEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  const reader = proc.stderr.getReader();
+  let stderrText = "";
+  let wsUrl: string | undefined;
+  while (!wsUrl) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    stderrText += decoder.decode(value);
+    wsUrl ??= stderrText.match(/Debugger listening on (ws:\S+)/)?.[1];
+  }
+  reader.releaseLock();
+  expect(wsUrl).toBeDefined();
+
+  const CLIENTS = 3;
+  const ROUNDS = 8;
+  const misrouted: Array<{ round: number; client: number; expected: string; got: unknown }> = [];
+
+  for (let round = 0; round < ROUNDS; round++) {
+    const clients = await Promise.all(
+      Array.from({ length: CLIENTS }, () => {
+        const ws = new WebSocket(wsUrl!);
+        const result = Promise.withResolvers<unknown>();
+        ws.onmessage = event => {
+          const parsed = JSON.parse(String(event.data));
+          if (parsed.id === 1) result.resolve(parsed.result?.result?.value);
+        };
+        ws.onerror = error => result.reject(error);
+        return new Promise<{ ws: WebSocket; result: Promise<unknown> }>((resolve, reject) => {
+          ws.onopen = () => resolve({ ws, result: result.promise });
+          ws.onerror = error => reject(error);
+        });
+      }),
+    );
+
+    // Each adapter allocates its first backend command id here. Send every
+    // client's request before awaiting any reply so the same id is in flight
+    // on every connection at once; the busy-loop keeps the first evaluate on
+    // the inspected thread long enough for the rest to queue behind it.
+    for (let k = 0; k < CLIENTS; k++) {
+      clients[k].ws.send(
+        JSON.stringify({
+          id: 1,
+          method: "Runtime.evaluate",
+          params: { expression: `(() => { for (let i = 0; i < 5e5; i++); return 'secret-${round}-${k}'; })()` },
+        }),
+      );
+    }
+
+    const received = await Promise.all(clients.map(client => client.result));
+    for (let k = 0; k < CLIENTS; k++) {
+      const expected = `secret-${round}-${k}`;
+      if (received[k] !== expected) misrouted.push({ round, client: k, expected, got: received[k] });
+      clients[k].ws.close();
+    }
+  }
+
+  proc.kill();
+  expect(misrouted).toEqual([]);
+}, 30_000);
+
 test("disconnect does not clobber a console method reassigned by user code", () => {
   const session = new inspector.Session();
   session.connect();


### PR DESCRIPTION
Fixes the CDP multi-client response crosstalk from #3320.

## Repro

Two clients connect to the same `inspector.open()` server and each sends `Runtime.evaluate` with a distinct string literal. Client B receives client A's result under its own request id:

```
client 0: sent Runtime.evaluate 'secret-0' -> received 'secret-0'
client 1: sent Runtime.evaluate 'secret-1' -> received 'secret-0'
client 2: sent Runtime.evaluate 'secret-2' -> received 'secret-0'
```

Node v26 with the same driver: 0 foreign deliveries.

## Cause

WebKit's `FrontendRouter::sendResponse()` broadcasts every command response to every connected `FrontendChannel` (the upstream `// FIXME: send responses to the appropriate frontend.` in `InspectorFrontendRouter.cpp`). Bun connects every WebSocket client as its own `BunInspectorConnection` onto the one per-process `JSGlobalObjectInspectorController`, and each connection's `InspectorCDPAdapter` allocated backend command ids from a private `#nextBackendId` starting at 1 and matched responses by id in its own `#pending` map.

N clients issuing their first command concurrently all sent backend id 1. The first response, broadcast to all N adapters, satisfied every adapter's `#pending[1]`, so every client was answered with the first client's payload; the remaining N-1 responses matched nothing and were dropped.

## Fix

Allocate backend command ids from a single module-level counter shared by every adapter. A broadcast response id can then only match the originating adapter's `#pending` map. All adapters run in the debugger thread's realm, so module state is shared.

The proper fix is the WebKit FIXME (route responses only to the requesting `FrontendChannel`); this change makes the adapter correct regardless.

The wider state-isolation questions (shared Debugger/Runtime/Console enable state, shared `objectId` namespace) are tracked separately as #3350.

## Verification

New test in `test/js/node/inspector/inspector.test.ts` connects 3 clients over 8 rounds and asserts each receives its own `Runtime.evaluate` result.

```
# without fix (src/ stashed)
(fail) concurrent inspector.open() clients each receive their own Runtime.evaluate result
  expected: []
  received: [{client:1, expected:'secret-0-1', got:'secret-0-0'}, ...]
# 5/5 runs fail

# with fix
(pass) concurrent inspector.open() clients each receive their own Runtime.evaluate result [5169ms]
# 5/5 runs pass; full inspector.test.ts: 24 pass / 0 fail
```