### PR TITLE
js_parser: lower undecorated auto-accessors to a native #-private storage field

### DIFF
--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -317,7 +317,7 @@ pub enum Kind {
 
 impl Kind {
     #[inline]
-    pub(crate) fn is_private(self) -> bool {
+    pub fn is_private(self) -> bool {
         (self as u8) >= (Kind::PrivateField as u8)
             && (self as u8) <= (Kind::PrivateStaticGetSetPair as u8)
     }

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -317,7 +317,7 @@ pub enum Kind {
 
 impl Kind {
     #[inline]
-    pub fn is_private(self) -> bool {
+    pub(crate) fn is_private(self) -> bool {
         (self as u8) >= (Kind::PrivateField as u8)
             && (self as u8) <= (Kind::PrivateStaticGetSetPair as u8)
     }

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -356,9 +356,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name
     }
 
-    /// A synthetic `#__N = void <expr>` class-body property. Placed at a
-    /// lowered private's source position so its brand-add runs on the
-    /// class-body initializer timeline alongside native fields.
+    /// Synthetic `#__N = void <expr>` class-body field at a lowered private's position.
     fn inline_brand_field(
         &mut self,
         used: &mut HashMap<&'a [u8], ()>,
@@ -1472,9 +1470,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // Generated `#`-privates must not textually shadow any private name
-        // already parsed (this class's declarations and any enclosing class's),
-        // because `NoOpRenamer` prints symbol names verbatim.
+        // Every `#`-name already parsed (this class or an enclosing one).
         let mut class_private_names: HashMap<&'a [u8], ()> = HashMap::default();
         for sym in p.symbols.iter() {
             if sym.kind.is_private() {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -386,36 +386,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Emit __privateAdd for a given storage ref.
-    fn emit_private_add(
-        &mut self,
-        is_static: bool,
-        storage_ref: Ref,
-        value: Option<Expr>,
-        loc: bun_ast::Loc,
-        constructor_inject: &mut BumpVec<'_, Stmt>,
-        static_blocks: &mut BumpVec<'_, Property>,
-    ) {
-        let target = self.new_expr(E::This {}, loc);
-        let storage = self.use_ref(storage_ref, loc);
-        let call = if let Some(v) = value {
-            self.call_rt(loc, b"__privateAdd", &[target, storage, v])
-        } else {
-            self.call_rt(loc, b"__privateAdd", &[target, storage])
-        };
-        if is_static {
-            static_blocks.push(self.make_static_block(call, loc));
-        } else {
-            constructor_inject.push(self.s(
-                S::SExpr {
-                    value: call,
-                    ..Default::default()
-                },
-                loc,
-            ));
-        }
-    }
-
     /// Get the method kind code (1=method, 2=getter, 3=setter).
     fn method_kind(prop: &Property) -> u8 {
         match prop.kind {
@@ -2019,14 +1989,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 };
                 if !emitted_private_adds.contains_key(&priv_inner2) {
                     emitted_private_adds.insert(priv_inner2, ());
-                    p.emit_private_add(
-                        prop.flags.contains(Flags::Property::IsStatic),
-                        private_storage_ref.unwrap(),
-                        None,
-                        loc,
-                        &mut constructor_inject_stmts,
-                        &mut static_private_add_blocks,
-                    );
+                    let t = p.new_expr(E::This {}, loc);
+                    let s = p.use_ref(private_storage_ref.unwrap(), loc);
+                    let call = p.call_rt(loc, b"__privateAdd", &[t, s]);
+                    if prop.flags.contains(Flags::Property::IsStatic) {
+                        static_private_add_blocks.push(p.make_static_block(call, loc));
+                    } else {
+                        new_properties.push(p.inline_brand_field(
+                            &mut class_private_names,
+                            &mut brand_field_counter,
+                            call,
+                            loc,
+                        ));
+                    }
                 }
                 if prop.flags.contains(Flags::Property::IsStatic) {
                     static_non_field_elements.push(element);

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1393,8 +1393,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
 
-        // Pre-scan: determine if all private members need lowering
+        // Pre-scan: determine if all private members need lowering, and collect
+        // the class's private-name set so generated accessor-storage privates
+        // can pick an unused name.
         let mut lower_all_private = false;
+        let mut class_private_names: HashMap<&'a [u8], ()> = HashMap::default();
         {
             let mut has_any_private = false;
             let mut has_any_decorated = false;
@@ -1412,16 +1415,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         )
                     {
                         lower_all_private = true;
-                        break;
                     }
                 }
-                if cprop.key.is_some()
-                    && matches!(
-                        cprop.key.unwrap().data,
-                        js_ast::ExprData::EPrivateIdentifier(_)
-                    )
+                if let Some(k) = cprop.key
+                    && let js_ast::ExprData::EPrivateIdentifier(pi) = &k.data
                 {
                     has_any_private = true;
+                    let name: &'a [u8] =
+                        p.symbols[pi.ref_.inner_index() as usize].original_name.slice();
+                    class_private_names.insert(name, ());
                 }
             }
             if !lower_all_private && has_any_private && has_any_decorated {
@@ -1539,29 +1541,80 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         continue;
                     }
                 }
-                // Undecorated auto-accessor → WeakMap + getter/setter
+                // Undecorated auto-accessor → native `#`-storage field + get/set.
+                // The storage initializer stays at the accessor's class-body
+                // position so it runs in source order with neighbouring fields,
+                // and the per-class private name needs no module-scope binding.
                 if prop.kind == PropertyKind::AutoAccessor {
-                    let accessor_name: &'a [u8] = 'brk: {
+                    let storage_base: &'a [u8] = 'brk: {
                         if let Some(k) = prop.key {
-                            if let js_ast::ExprData::EString(s) = &k.data
-                                && s.is_utf8()
-                            {
-                                break 'brk p.bump_name2(b"_", &s.data);
+                            match &k.data {
+                                js_ast::ExprData::EString(s)
+                                    if s.is_utf8()
+                                        && js_lexer::is_identifier(&s.data) =>
+                                {
+                                    break 'brk p.bump_name2(b"#_", &s.data);
+                                }
+                                js_ast::ExprData::EPrivateIdentifier(pi) => {
+                                    let orig: &'a [u8] = p.symbols
+                                        [pi.ref_.inner_index() as usize]
+                                        .original_name
+                                        .slice();
+                                    break 'brk p.bump_name2(b"#_", &orig[1..]);
+                                }
+                                _ => {}
                             }
                         }
-                        let name =
-                            p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
+                        let name = p.bump_name(
+                            b"#_accessor_storage",
+                            Some(accessor_storage_counter),
+                        );
                         accessor_storage_counter += 1;
                         name
                     };
-                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
-                    let wme = p.new_weak_map_expr(loc);
-                    prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
+                    let mut storage_name: &'a [u8] = storage_base;
+                    let mut tries: usize = 2;
+                    while class_private_names.contains_key(storage_name) {
+                        storage_name = p.bump_name(storage_base, Some(tries));
+                        tries += 1;
+                    }
+                    class_private_names.insert(storage_name, ());
 
-                    // Getter: get foo() { return __privateGet(this, _foo); }
+                    let is_static = prop.flags.contains(Flags::Property::IsStatic);
+                    let storage_kind = if is_static {
+                        js_ast::symbol::Kind::PrivateStaticField
+                    } else {
+                        js_ast::symbol::Kind::PrivateField
+                    };
+                    let storage_ref = p.new_sym(storage_kind, storage_name);
+                    let storage_key =
+                        p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+
+                    let storage_flags = if is_static {
+                        Flags::Property::IsStatic.into()
+                    } else {
+                        js_ast::flags::PROPERTY_NONE
+                    };
+                    new_properties.push(Property {
+                        key: Some(storage_key),
+                        initializer: prop.initializer,
+                        kind: PropertyKind::Normal,
+                        flags: storage_flags,
+                        ..Default::default()
+                    });
+
+                    // get foo() { return this.#_foo; }
                     let this_e = p.new_expr(E::This {}, loc);
-                    let wm_e = p.use_ref(wm_ref, loc);
-                    let get_ret = p.call_rt(loc, b"__privateGet", &[this_e, wm_e]);
+                    let idx_e =
+                        p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+                    let get_ret = p.new_expr(
+                        E::Index {
+                            target: this_e,
+                            index: idx_e,
+                            optional_chain: None,
+                        },
+                        loc,
+                    );
                     let get_body = bump.alloc_slice_copy(&[p.s(
                         S::Return {
                             value: Some(get_ret),
@@ -1576,19 +1629,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ..Default::default()
                     };
 
-                    // Setter: set foo(v) { __privateSet(this, _foo, v); }
+                    // set foo(v) { this.#_foo = v; }
                     let setter_param_ref = p.new_sym(js_ast::symbol::Kind::Other, b"v");
                     let this_e2 = p.new_expr(E::This {}, loc);
-                    let wm_e2 = p.use_ref(wm_ref, loc);
-                    let v_e = p.use_ref(setter_param_ref, loc);
-                    let set_call = p.call_rt(loc, b"__privateSet", &[this_e2, wm_e2, v_e]);
-                    let set_body = bump.alloc_slice_copy(&[p.s(
-                        S::SExpr {
-                            value: set_call,
-                            ..Default::default()
+                    let idx_e2 =
+                        p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+                    let lhs = p.new_expr(
+                        E::Index {
+                            target: this_e2,
+                            index: idx_e2,
+                            optional_chain: None,
                         },
                         loc,
-                    )]);
+                    );
+                    let v_e = p.use_ref(setter_param_ref, loc);
+                    let set_body = bump.alloc_slice_copy(&[Stmt::assign(lhs, v_e)]);
                     let setter_binding = p.b(
                         B::Identifier {
                             r#ref: setter_param_ref,
@@ -1624,30 +1679,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         flags: getter_flags,
                         ..Default::default()
                     });
-
-                    let init_val = prop
-                        .initializer
-                        .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
-                    if !prop.flags.contains(Flags::Property::IsStatic) {
-                        let this_e3 = p.new_expr(E::This {}, loc);
-                        let wm_e3 = p.use_ref(wm_ref, loc);
-                        let call = p.call_rt(loc, b"__privateAdd", &[this_e3, wm_e3, init_val]);
-                        constructor_inject_stmts.push(p.s(
-                            S::SExpr {
-                                value: call,
-                                ..Default::default()
-                            },
-                            loc,
-                        ));
-                    } else {
-                        let cn_e = p.use_ref(class_name_ref, class_name_loc);
-                        let wm_e3 = p.use_ref(wm_ref, loc);
-                        suffix_exprs.push(p.call_rt(
-                            loc,
-                            b"__privateAdd",
-                            &[cn_e, wm_e3, init_val],
-                        ));
-                    }
                     continue;
                 }
                 // Static blocks → extract to suffix

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1521,15 +1521,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // __privateAdd (once per name)
                         if !emitted_private_adds.contains_key(&npriv_inner) {
                             emitted_private_adds.insert(npriv_inner, ());
+                            let t = p.new_expr(E::This {}, loc);
+                            let s = p.use_ref(ws_ref, loc);
+                            let call = p.call_rt(loc, b"__privateAdd", &[t, s]);
                             if prop.flags.contains(Flags::Property::IsStatic) {
-                                let t = p.new_expr(E::This {}, loc);
-                                let s = p.use_ref(ws_ref, loc);
-                                let call = p.call_rt(loc, b"__privateAdd", &[t, s]);
                                 static_private_add_blocks.push(p.make_static_block(call, loc));
                             } else {
-                                let t = p.new_expr(E::This {}, loc);
-                                let s = p.use_ref(ws_ref, loc);
-                                let call = p.call_rt(loc, b"__privateAdd", &[t, s]);
                                 new_properties.push(p.inline_brand_field(
                                     &mut class_private_names,
                                     &mut brand_field_counter,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -414,6 +414,151 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Expand an undecorated `accessor k = v` into the three class elements it
+    /// stands for: a `#k_accessor_storage = v` field plus a `get k`/`set k`
+    /// pair over it. They are then lowered (or kept native) like any other
+    /// field, getter and setter of the class.
+    fn expand_auto_accessor(
+        &mut self,
+        prop: &Property,
+        used: &mut HashMap<&'a [u8], ()>,
+        storage_counter: &mut usize,
+        loc: bun_ast::Loc,
+        out: &mut BumpVec<'a, Property>,
+    ) {
+        let bump = self.arena;
+        let is_static = prop.flags.contains(Flags::Property::IsStatic);
+
+        let storage_base: &'a [u8] = 'brk: {
+            if let Some(k) = prop.key {
+                match &k.data {
+                    js_ast::ExprData::EString(s)
+                        if s.is_utf8() && js_lexer::is_identifier(&s.data) =>
+                    {
+                        let mut v = BumpVec::<u8>::new_in(bump);
+                        v.push(b'#');
+                        v.extend_from_slice(&s.data);
+                        v.extend_from_slice(b"_accessor_storage");
+                        break 'brk v.into_bump_slice();
+                    }
+                    js_ast::ExprData::EPrivateIdentifier(pi) => {
+                        let orig: &'a [u8] = self.symbols[pi.ref_.inner_index() as usize]
+                            .original_name
+                            .slice();
+                        break 'brk self.bump_name2(orig, b"_accessor_storage");
+                    }
+                    _ => {}
+                }
+            }
+            let name = self.bump_name(b"#_accessor_storage", Some(*storage_counter));
+            *storage_counter += 1;
+            name
+        };
+        let storage_name = self.fresh_private_name(used, storage_base);
+        let storage_kind = if is_static {
+            js_ast::symbol::Kind::PrivateStaticField
+        } else {
+            js_ast::symbol::Kind::PrivateField
+        };
+        let storage_ref = self.new_sym(storage_kind, storage_name);
+        let storage_key = self.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+        out.push(Property {
+            key: Some(storage_key),
+            initializer: prop.initializer,
+            kind: PropertyKind::Normal,
+            flags: if is_static {
+                Flags::Property::IsStatic.into()
+            } else {
+                js_ast::flags::PROPERTY_NONE
+            },
+            ..Default::default()
+        });
+
+        // get k() { return this.#storage; }
+        let this_e = self.new_expr(E::This {}, loc);
+        let idx_e = self.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+        let get_ret = self.new_expr(
+            E::Index {
+                target: this_e,
+                index: idx_e,
+                optional_chain: None,
+            },
+            loc,
+        );
+        let get_body = bump.alloc_slice_copy(&[self.s(
+            S::Return {
+                value: Some(get_ret),
+            },
+            loc,
+        )]);
+        let get_fn = G::Fn {
+            body: G::FnBody {
+                stmts: bun_ast::StoreSlice::new_mut(get_body),
+                loc,
+            },
+            ..Default::default()
+        };
+
+        // set k(v) { this.#storage = v; }
+        let setter_param_ref = self.new_sym(js_ast::symbol::Kind::Other, b"v");
+        let this_e2 = self.new_expr(E::This {}, loc);
+        let idx_e2 = self.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+        let lhs = self.new_expr(
+            E::Index {
+                target: this_e2,
+                index: idx_e2,
+                optional_chain: None,
+            },
+            loc,
+        );
+        let v_e = self.use_ref(setter_param_ref, loc);
+        let set_body = bump.alloc_slice_copy(&[Stmt::assign(lhs, v_e)]);
+        let setter_binding = self.b(
+            B::Identifier {
+                r#ref: setter_param_ref,
+            },
+            loc,
+        );
+        let setter_fn_args = bump.alloc(G::Arg {
+            binding: setter_binding,
+            ..Default::default()
+        });
+        let set_fn = G::Fn {
+            args: bun_ast::StoreSlice::new_mut(core::slice::from_mut(setter_fn_args)),
+            body: G::FnBody {
+                stmts: bun_ast::StoreSlice::new_mut(set_body),
+                loc,
+            },
+            ..Default::default()
+        };
+
+        // `get [_k = expr]()` / `set [_k](v)`: the key runs once.
+        let (getter_key, setter_key) = match prop.key {
+            Some(key) if prop.flags.contains(Flags::Property::IsComputed) => {
+                let key_ref = self.generate_temp_ref(Some(b"_computedKey"));
+                let captured = self.assign_to(key_ref, key, key.loc);
+                (Some(captured), Some(self.use_ref(key_ref, key.loc)))
+            }
+            key => (key, key),
+        };
+        let mut method_flags = prop.flags;
+        method_flags.insert(Flags::Property::IsMethod);
+        out.push(Property {
+            key: getter_key,
+            value: Some(self.new_expr(E::Function { func: get_fn }, loc)),
+            kind: PropertyKind::Get,
+            flags: method_flags,
+            ..Default::default()
+        });
+        out.push(Property {
+            key: setter_key,
+            value: Some(self.new_expr(E::Function { func: set_fn }, loc)),
+            kind: PropertyKind::Set,
+            flags: method_flags,
+            ..Default::default()
+        });
+    }
+
     /// Get the method kind code (1=method, 2=getter, 3=setter).
     fn method_kind(prop: &Property) -> u8 {
         match prop.kind {
@@ -1237,6 +1382,96 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // Pre-scan: determine if all private members need lowering.
+        let mut lower_all_private = false;
+        {
+            let mut has_any_private = false;
+            let mut has_any_decorated = false;
+            let cprops: &[Property] = class.properties.slice();
+            for cprop in cprops.iter() {
+                if cprop.kind == PropertyKind::ClassStaticBlock {
+                    continue;
+                }
+                if cprop.ts_decorators.len_u32() > 0 {
+                    has_any_decorated = true;
+                    if cprop.key.is_some()
+                        && matches!(
+                            cprop.key.unwrap().data,
+                            js_ast::ExprData::EPrivateIdentifier(_)
+                        )
+                    {
+                        lower_all_private = true;
+                    }
+                }
+                if cprop.key.is_some()
+                    && matches!(
+                        cprop.key.unwrap().data,
+                        js_ast::ExprData::EPrivateIdentifier(_)
+                    )
+                {
+                    has_any_private = true;
+                }
+            }
+            if !lower_all_private && has_any_private && has_any_decorated {
+                lower_all_private = true;
+            }
+        }
+
+        // `#`-names in scope here, which a generated private must not shadow.
+        let mut class_private_names: HashMap<&'a [u8], ()> = HashMap::default();
+        for cprop in class.properties.slice() {
+            if let Some(k) = cprop.key
+                && let js_ast::ExprData::EPrivateIdentifier(pi) = &k.data
+            {
+                let name: &'a [u8] = p.symbols[pi.ref_.inner_index() as usize]
+                    .original_name
+                    .slice();
+                class_private_names.insert(name, ());
+            }
+        }
+        let mut scope = p.current_scope;
+        loop {
+            if scope.kind == js_ast::scope::Kind::ClassBody {
+                for member in scope.members.values() {
+                    let name: &'a [u8] = p.symbols[member.ref_.inner_index() as usize]
+                        .original_name
+                        .slice();
+                    if name.first() == Some(&b'#') {
+                        class_private_names.insert(name, ());
+                    }
+                }
+            }
+            let Some(parent) = scope.parent else { break };
+            scope = parent;
+        }
+
+        // Undecorated accessors become ordinary field + getter + setter
+        // elements before anything below indexes `class.properties`.
+        let mut accessor_storage_counter: usize = 0;
+        if class
+            .properties
+            .slice()
+            .iter()
+            .any(|cp| cp.kind == PropertyKind::AutoAccessor && cp.ts_decorators.len_u32() == 0)
+        {
+            let old: &[Property] = class.properties.slice();
+            let mut expanded = BumpVec::<Property>::with_capacity_in(old.len() + 2, bump);
+            for cprop in old.iter() {
+                if cprop.kind == PropertyKind::AutoAccessor && cprop.ts_decorators.len_u32() == 0 {
+                    p.expand_auto_accessor(
+                        cprop,
+                        &mut class_private_names,
+                        &mut accessor_storage_counter,
+                        loc,
+                        &mut expanded,
+                    );
+                } else {
+                    expanded.push(prop_full_copy(cprop));
+                }
+            }
+            class.properties = bun_ast::StoreSlice::new_mut(expanded.into_bump_slice_mut());
+        }
+
         // ── Phase 2: Pre-evaluate decorators/keys ────────
         let mut dec_counter: usize = 0;
         let mut class_dec_ref: Option<Ref> = None;
@@ -1429,73 +1664,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BumpVec::<js_ast::StoreRef<G::ClassStaticBlock>>::new_in(bump);
         let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
         let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
-        let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
         let mut instance_method_brands = BumpVec::<Property>::new_in(bump);
-
-        // Pre-scan: determine if all private members need lowering.
-        let mut lower_all_private = false;
-        {
-            let mut has_any_private = false;
-            let mut has_any_decorated = false;
-            let cprops: &[Property] = class.properties.slice();
-            for cprop in cprops.iter() {
-                if cprop.kind == PropertyKind::ClassStaticBlock {
-                    continue;
-                }
-                if cprop.ts_decorators.len_u32() > 0 {
-                    has_any_decorated = true;
-                    if cprop.key.is_some()
-                        && matches!(
-                            cprop.key.unwrap().data,
-                            js_ast::ExprData::EPrivateIdentifier(_)
-                        )
-                    {
-                        lower_all_private = true;
-                    }
-                }
-                if cprop.key.is_some()
-                    && matches!(
-                        cprop.key.unwrap().data,
-                        js_ast::ExprData::EPrivateIdentifier(_)
-                    )
-                {
-                    has_any_private = true;
-                }
-            }
-            if !lower_all_private && has_any_private && has_any_decorated {
-                lower_all_private = true;
-            }
-        }
-
-        // `#`-names in scope here, which a generated private must not shadow.
-        let mut class_private_names: HashMap<&'a [u8], ()> = HashMap::default();
-        for cprop in class.properties.slice() {
-            if let Some(k) = cprop.key
-                && let js_ast::ExprData::EPrivateIdentifier(pi) = &k.data
-            {
-                let name: &'a [u8] = p.symbols[pi.ref_.inner_index() as usize]
-                    .original_name
-                    .slice();
-                class_private_names.insert(name, ());
-            }
-        }
-        let mut scope = p.current_scope;
-        loop {
-            if scope.kind == js_ast::scope::Kind::ClassBody {
-                for member in scope.members.values() {
-                    let name: &'a [u8] = p.symbols[member.ref_.inner_index() as usize]
-                        .original_name
-                        .slice();
-                    if name.first() == Some(&b'#') {
-                        class_private_names.insert(name, ());
-                    }
-                }
-            }
-            let Some(parent) = scope.parent else { break };
-            scope = parent;
-        }
         let mut brand_field_counter: usize = 0;
 
         let props_slice2: &mut [Property] = class.properties.slice_mut();
@@ -1506,7 +1677,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     && let Some(nk_expr) = prop.key
                     && matches!(nk_expr.data, js_ast::ExprData::EPrivateIdentifier(_))
                     && prop.kind != PropertyKind::ClassStaticBlock
-                    && prop.kind != PropertyKind::AutoAccessor
                 {
                     let npriv_ref = match &nk_expr.data {
                         js_ast::ExprData::EPrivateIdentifier(pi) => pi.ref_,
@@ -1607,144 +1777,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         );
                         continue;
                     }
-                }
-                // Undecorated auto-accessor → native `#`-storage field + get/set.
-                if prop.kind == PropertyKind::AutoAccessor {
-                    let storage_base: &'a [u8] = 'brk: {
-                        if let Some(k) = prop.key {
-                            match &k.data {
-                                js_ast::ExprData::EString(s)
-                                    if s.is_utf8() && js_lexer::is_identifier(&s.data) =>
-                                {
-                                    let mut v = BumpVec::<u8>::new_in(bump);
-                                    v.push(b'#');
-                                    v.extend_from_slice(&s.data);
-                                    v.extend_from_slice(b"_accessor_storage");
-                                    break 'brk v.into_bump_slice();
-                                }
-                                js_ast::ExprData::EPrivateIdentifier(pi) => {
-                                    let orig: &'a [u8] = p.symbols[pi.ref_.inner_index() as usize]
-                                        .original_name
-                                        .slice();
-                                    break 'brk p.bump_name2(orig, b"_accessor_storage");
-                                }
-                                _ => {}
-                            }
-                        }
-                        let name =
-                            p.bump_name(b"#_accessor_storage", Some(accessor_storage_counter));
-                        accessor_storage_counter += 1;
-                        name
-                    };
-                    let storage_name = p.fresh_private_name(&mut class_private_names, storage_base);
-
-                    let is_static = prop.flags.contains(Flags::Property::IsStatic);
-                    let storage_kind = if is_static {
-                        js_ast::symbol::Kind::PrivateStaticField
-                    } else {
-                        js_ast::symbol::Kind::PrivateField
-                    };
-                    let storage_ref = p.new_sym(storage_kind, storage_name);
-                    let storage_key = p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
-
-                    let storage_flags = if is_static {
-                        Flags::Property::IsStatic.into()
-                    } else {
-                        js_ast::flags::PROPERTY_NONE
-                    };
-                    new_properties.push(Property {
-                        key: Some(storage_key),
-                        initializer: prop.initializer,
-                        kind: PropertyKind::Normal,
-                        flags: storage_flags,
-                        ..Default::default()
-                    });
-
-                    // get foo() { return this.#_foo; }
-                    let this_e = p.new_expr(E::This {}, loc);
-                    let idx_e = p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
-                    let get_ret = p.new_expr(
-                        E::Index {
-                            target: this_e,
-                            index: idx_e,
-                            optional_chain: None,
-                        },
-                        loc,
-                    );
-                    let get_body = bump.alloc_slice_copy(&[p.s(
-                        S::Return {
-                            value: Some(get_ret),
-                        },
-                        loc,
-                    )]);
-                    let get_fn = G::Fn {
-                        body: G::FnBody {
-                            stmts: bun_ast::StoreSlice::new_mut(get_body),
-                            loc,
-                        },
-                        ..Default::default()
-                    };
-
-                    // set foo(v) { this.#_foo = v; }
-                    let setter_param_ref = p.new_sym(js_ast::symbol::Kind::Other, b"v");
-                    let this_e2 = p.new_expr(E::This {}, loc);
-                    let idx_e2 = p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
-                    let lhs = p.new_expr(
-                        E::Index {
-                            target: this_e2,
-                            index: idx_e2,
-                            optional_chain: None,
-                        },
-                        loc,
-                    );
-                    let v_e = p.use_ref(setter_param_ref, loc);
-                    let set_body = bump.alloc_slice_copy(&[Stmt::assign(lhs, v_e)]);
-                    let setter_binding = p.b(
-                        B::Identifier {
-                            r#ref: setter_param_ref,
-                        },
-                        loc,
-                    );
-                    let setter_fn_args = bump.alloc(G::Arg {
-                        binding: setter_binding,
-                        ..Default::default()
-                    });
-                    let set_fn = G::Fn {
-                        args: bun_ast::StoreSlice::new_mut(core::slice::from_mut(setter_fn_args)),
-                        body: G::FnBody {
-                            stmts: bun_ast::StoreSlice::new_mut(set_body),
-                            loc,
-                        },
-                        ..Default::default()
-                    };
-
-                    // `get [_k = expr]()` / `set [_k](v)`: the key runs once.
-                    let (getter_key, setter_key) = match prop.key {
-                        Some(key) if prop.flags.contains(Flags::Property::IsComputed) => {
-                            let key_ref = p.generate_temp_ref(Some(b"_computedKey"));
-                            let captured = p.assign_to(key_ref, key, key.loc);
-                            (Some(captured), Some(p.use_ref(key_ref, key.loc)))
-                        }
-                        key => (key, key),
-                    };
-
-                    let mut getter_flags = prop.flags;
-                    getter_flags.insert(Flags::Property::IsMethod);
-                    new_properties.push(Property {
-                        key: getter_key,
-                        value: Some(p.new_expr(E::Function { func: get_fn }, loc)),
-                        kind: PropertyKind::Get,
-                        flags: getter_flags,
-                        ..Default::default()
-                    });
-                    new_properties.push(Property {
-                        key: setter_key,
-                        value: Some(p.new_expr(E::Function { func: set_fn }, loc)),
-                        kind: PropertyKind::Set,
-                        flags: getter_flags,
-                        ..Default::default()
-                    });
-                    continue;
                 }
                 // Static blocks → extract to suffix
                 if prop.kind == PropertyKind::ClassStaticBlock {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1865,6 +1865,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let accessor_name: &'a [u8] = 'brk: {
                     if let js_ast::ExprData::EString(s) = &key_expr.data
                         && s.is_utf8()
+                        && js_lexer::is_identifier(&s.data)
                     {
                         break 'brk p.bump_name2(b"_", &s.data);
                     }

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -2020,9 +2020,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // ── Phase 5: Rewrite private accesses ────────────
         if !private_lowered_map.is_empty() {
-            for nprop in new_properties.iter_mut() {
+            for nprop in new_properties
+                .iter_mut()
+                .chain(static_private_add_blocks.iter_mut())
+            {
                 if let Some(v) = &mut nprop.value {
                     p.rewrite_private_accesses_in_expr(v, &private_lowered_map);
+                }
+                if let Some(ini) = &mut nprop.initializer {
+                    p.rewrite_private_accesses_in_expr(ini, &private_lowered_map);
                 }
                 if let Some(sb) = nprop.class_static_block_mut() {
                     p.rewrite_private_accesses_in_stmts(sb.stmts.slice_mut(), &private_lowered_map);

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -356,9 +356,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name
     }
 
-    /// `__privateAdd(this, storage[, init])` for a lowered private. Instance
-    /// method brands (`init == None`) go to `method_brands`, which the caller
-    /// puts before every field per InitializeInstanceElements.
+    /// Method brands (`init == None`) go to `method_brands`, which run before every field.
     fn emit_private_add(
         &mut self,
         is_static: bool,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -356,12 +356,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name
     }
 
-    /// Emit the `__privateAdd(this, storage[, init])` that installs a lowered
-    /// private. Static ones run from a static block. Instance method brands
-    /// (`init` is `None`) are collected in `method_brands`, which the caller
-    /// places ahead of every field, as InitializeInstanceElements does;
-    /// instance field brands carry their initializer and stay at their source
-    /// position in `fields`.
+    /// `__privateAdd(this, storage[, init])` for a lowered private. Instance
+    /// method brands (`init == None`) go to `method_brands`, which the caller
+    /// puts before every field per InitializeInstanceElements.
     fn emit_private_add(
         &mut self,
         is_static: bool,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1421,8 +1421,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     && let js_ast::ExprData::EPrivateIdentifier(pi) = &k.data
                 {
                     has_any_private = true;
-                    let name: &'a [u8] =
-                        p.symbols[pi.ref_.inner_index() as usize].original_name.slice();
+                    let name: &'a [u8] = p.symbols[pi.ref_.inner_index() as usize]
+                        .original_name
+                        .slice();
                     class_private_names.insert(name, ());
                 }
             }
@@ -1550,14 +1551,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if let Some(k) = prop.key {
                             match &k.data {
                                 js_ast::ExprData::EString(s)
-                                    if s.is_utf8()
-                                        && js_lexer::is_identifier(&s.data) =>
+                                    if s.is_utf8() && js_lexer::is_identifier(&s.data) =>
                                 {
                                     break 'brk p.bump_name2(b"#_", &s.data);
                                 }
                                 js_ast::ExprData::EPrivateIdentifier(pi) => {
-                                    let orig: &'a [u8] = p.symbols
-                                        [pi.ref_.inner_index() as usize]
+                                    let orig: &'a [u8] = p.symbols[pi.ref_.inner_index() as usize]
                                         .original_name
                                         .slice();
                                     break 'brk p.bump_name2(b"#_", &orig[1..]);
@@ -1565,10 +1564,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 _ => {}
                             }
                         }
-                        let name = p.bump_name(
-                            b"#_accessor_storage",
-                            Some(accessor_storage_counter),
-                        );
+                        let name =
+                            p.bump_name(b"#_accessor_storage", Some(accessor_storage_counter));
                         accessor_storage_counter += 1;
                         name
                     };
@@ -1587,8 +1584,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         js_ast::symbol::Kind::PrivateField
                     };
                     let storage_ref = p.new_sym(storage_kind, storage_name);
-                    let storage_key =
-                        p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+                    let storage_key = p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
 
                     let storage_flags = if is_static {
                         Flags::Property::IsStatic.into()
@@ -1605,8 +1601,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     // get foo() { return this.#_foo; }
                     let this_e = p.new_expr(E::This {}, loc);
-                    let idx_e =
-                        p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+                    let idx_e = p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
                     let get_ret = p.new_expr(
                         E::Index {
                             target: this_e,
@@ -1632,8 +1627,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // set foo(v) { this.#_foo = v; }
                     let setter_param_ref = p.new_sym(js_ast::symbol::Kind::Other, b"v");
                     let this_e2 = p.new_expr(E::This {}, loc);
-                    let idx_e2 =
-                        p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
+                    let idx_e2 = p.new_expr(E::PrivateIdentifier { ref_: storage_ref }, loc);
                     let lhs = p.new_expr(
                         E::Index {
                             target: this_e2,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -356,7 +356,40 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name
     }
 
-    /// Synthetic `#__N = void <expr>` class-body field at a lowered private's position.
+    /// Emit the `__privateAdd(this, storage[, init])` that installs a lowered
+    /// private. Static ones run from a static block. Instance method brands
+    /// (`init` is `None`) are collected in `method_brands`, which the caller
+    /// places ahead of every field, as InitializeInstanceElements does;
+    /// instance field brands carry their initializer and stay at their source
+    /// position in `fields`.
+    fn emit_private_add(
+        &mut self,
+        is_static: bool,
+        storage_ref: Ref,
+        init: Option<Expr>,
+        loc: bun_ast::Loc,
+        used: &mut HashMap<&'a [u8], ()>,
+        counter: &mut usize,
+        static_blocks: &mut BumpVec<'a, Property>,
+        method_brands: &mut BumpVec<'a, Property>,
+        fields: &mut BumpVec<'a, Property>,
+    ) {
+        let target = self.new_expr(E::This {}, loc);
+        let storage = self.use_ref(storage_ref, loc);
+        let is_field = init.is_some();
+        let call = match init {
+            Some(v) => self.call_rt(loc, b"__privateAdd", &[target, storage, v]),
+            None => self.call_rt(loc, b"__privateAdd", &[target, storage]),
+        };
+        if is_static {
+            static_blocks.push(self.make_static_block(call, loc));
+        } else {
+            let field = self.inline_brand_field(used, counter, call, loc);
+            if is_field { fields } else { method_brands }.push(field);
+        }
+    }
+
+    /// Synthetic `#__N = void <expr>` class-body field.
     fn inline_brand_field(
         &mut self,
         used: &mut HashMap<&'a [u8], ()>,
@@ -1404,6 +1437,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
+        let mut instance_method_brands = BumpVec::<Property>::new_in(bump);
 
         // Pre-scan: determine if all private members need lowering.
         let mut lower_all_private = false;
@@ -1541,19 +1575,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // __privateAdd (once per name)
                         if !emitted_private_adds.contains_key(&npriv_inner) {
                             emitted_private_adds.insert(npriv_inner, ());
-                            let t = p.new_expr(E::This {}, loc);
-                            let s = p.use_ref(ws_ref, loc);
-                            let call = p.call_rt(loc, b"__privateAdd", &[t, s]);
-                            if prop.flags.contains(Flags::Property::IsStatic) {
-                                static_private_add_blocks.push(p.make_static_block(call, loc));
-                            } else {
-                                new_properties.push(p.inline_brand_field(
-                                    &mut class_private_names,
-                                    &mut brand_field_counter,
-                                    call,
-                                    loc,
-                                ));
-                            }
+                            p.emit_private_add(
+                                prop.flags.contains(Flags::Property::IsStatic),
+                                ws_ref,
+                                None,
+                                loc,
+                                &mut class_private_names,
+                                &mut brand_field_counter,
+                                &mut static_private_add_blocks,
+                                &mut instance_method_brands,
+                                &mut new_properties,
+                            );
                         }
                         continue;
                     } else {
@@ -1567,19 +1599,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let init_val = prop
                             .initializer
                             .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
-                        let this_e = p.new_expr(E::This {}, loc);
-                        let wm_e = p.use_ref(wm_ref, loc);
-                        let call = p.call_rt(loc, b"__privateAdd", &[this_e, wm_e, init_val]);
-                        if prop.flags.contains(Flags::Property::IsStatic) {
-                            static_private_add_blocks.push(p.make_static_block(call, loc));
-                        } else {
-                            new_properties.push(p.inline_brand_field(
-                                &mut class_private_names,
-                                &mut brand_field_counter,
-                                call,
-                                loc,
-                            ));
-                        }
+                        p.emit_private_add(
+                            prop.flags.contains(Flags::Property::IsStatic),
+                            wm_ref,
+                            Some(init_val),
+                            loc,
+                            &mut class_private_names,
+                            &mut brand_field_counter,
+                            &mut static_private_add_blocks,
+                            &mut instance_method_brands,
+                            &mut new_properties,
+                        );
                         continue;
                     }
                 }
@@ -2017,19 +2047,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 };
                 if !emitted_private_adds.contains_key(&priv_inner2) {
                     emitted_private_adds.insert(priv_inner2, ());
-                    let t = p.new_expr(E::This {}, loc);
-                    let s = p.use_ref(private_storage_ref.unwrap(), loc);
-                    let call = p.call_rt(loc, b"__privateAdd", &[t, s]);
-                    if prop.flags.contains(Flags::Property::IsStatic) {
-                        static_private_add_blocks.push(p.make_static_block(call, loc));
-                    } else {
-                        new_properties.push(p.inline_brand_field(
-                            &mut class_private_names,
-                            &mut brand_field_counter,
-                            call,
-                            loc,
-                        ));
-                    }
+                    p.emit_private_add(
+                        prop.flags.contains(Flags::Property::IsStatic),
+                        private_storage_ref.unwrap(),
+                        None,
+                        loc,
+                        &mut class_private_names,
+                        &mut brand_field_counter,
+                        &mut static_private_add_blocks,
+                        &mut instance_method_brands,
+                        &mut new_properties,
+                    );
                 }
                 if prop.flags.contains(Flags::Property::IsStatic) {
                     static_non_field_elements.push(element);
@@ -2047,6 +2075,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     instance_non_field_elements.push(element);
                 }
             }
+        }
+
+        if !instance_method_brands.is_empty() {
+            instance_method_brands.extend(new_properties.drain(..));
+            new_properties = instance_method_brands;
         }
 
         // ── Phase 5: Rewrite private accesses ────────────

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -356,7 +356,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name
     }
 
-    /// Method brands (`init == None`) go to `method_brands`, which run before every field.
+    /// Method brands (`init == None`) go to `hoisted`, which runs before every field.
     fn emit_private_add(
         &mut self,
         is_static: bool,
@@ -365,8 +365,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         used: &mut HashMap<&'a [u8], ()>,
         counter: &mut usize,
-        static_blocks: &mut BumpVec<'a, Property>,
-        method_brands: &mut BumpVec<'a, Property>,
+        hoisted: &mut BumpVec<'a, Property>,
         fields: &mut BumpVec<'a, Property>,
     ) {
         let target = self.new_expr(E::This {}, loc);
@@ -376,12 +375,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             Some(v) => self.call_rt(loc, b"__privateAdd", &[target, storage, v]),
             None => self.call_rt(loc, b"__privateAdd", &[target, storage]),
         };
-        if is_static {
-            static_blocks.push(self.make_static_block(call, loc));
+        let element = if is_static {
+            self.make_static_block(call, loc)
         } else {
-            let field = self.inline_brand_field(used, counter, call, loc);
-            if is_field { fields } else { method_brands }.push(field);
-        }
+            self.inline_brand_field(used, counter, call, loc)
+        };
+        if is_field { fields } else { hoisted }.push(element);
     }
 
     /// Synthetic `#__N = void <expr>` class-body field.
@@ -1661,8 +1660,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
         let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
-        let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
-        let mut instance_method_brands = BumpVec::<Property>::new_in(bump);
+        let mut hoisted_brands = BumpVec::<Property>::new_in(bump);
         let mut brand_field_counter: usize = 0;
 
         let props_slice2: &mut [Property] = class.properties.slice_mut();
@@ -1743,8 +1741,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 loc,
                                 &mut class_private_names,
                                 &mut brand_field_counter,
-                                &mut static_private_add_blocks,
-                                &mut instance_method_brands,
+                                &mut hoisted_brands,
                                 &mut new_properties,
                             );
                         }
@@ -1767,8 +1764,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             loc,
                             &mut class_private_names,
                             &mut brand_field_counter,
-                            &mut static_private_add_blocks,
-                            &mut instance_method_brands,
+                            &mut hoisted_brands,
                             &mut new_properties,
                         );
                         continue;
@@ -2077,8 +2073,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         loc,
                         &mut class_private_names,
                         &mut brand_field_counter,
-                        &mut static_private_add_blocks,
-                        &mut instance_method_brands,
+                        &mut hoisted_brands,
                         &mut new_properties,
                     );
                 }
@@ -2100,17 +2095,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        if !instance_method_brands.is_empty() {
-            instance_method_brands.extend(new_properties.drain(..));
-            new_properties = instance_method_brands;
+        if !hoisted_brands.is_empty() {
+            hoisted_brands.extend(new_properties.drain(..));
+            new_properties = hoisted_brands;
         }
 
         // ── Phase 5: Rewrite private accesses ────────────
         if !private_lowered_map.is_empty() {
-            for nprop in new_properties
-                .iter_mut()
-                .chain(static_private_add_blocks.iter_mut())
-            {
+            for nprop in new_properties.iter_mut() {
                 if let Some(v) = &mut nprop.value {
                     p.rewrite_private_accesses_in_expr(v, &private_lowered_map);
                 }
@@ -2544,21 +2536,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     },
                 );
             }
-        }
-
-        // Static private __privateAdd blocks at beginning
-        if !static_private_add_blocks.is_empty() {
-            let mut merged = BumpVec::<Property>::with_capacity_in(
-                static_private_add_blocks.len() + new_properties.len(),
-                bump,
-            );
-            for sp in static_private_add_blocks.drain(..) {
-                merged.push(sp);
-            }
-            for np in new_properties.drain(..) {
-                merged.push(np);
-            }
-            new_properties = merged;
         }
 
         class.properties = bun_ast::StoreSlice::new_mut(new_properties.into_bump_slice_mut());

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -414,10 +414,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Expand an undecorated `accessor k = v` into the three class elements it
-    /// stands for: a `#k_accessor_storage = v` field plus a `get k`/`set k`
-    /// pair over it. They are then lowered (or kept native) like any other
-    /// field, getter and setter of the class.
+    /// `accessor k = v` → a `#k_accessor_storage = v` field plus a `get k`/`set k` pair over it.
     fn expand_auto_accessor(
         &mut self,
         prop: &Property,
@@ -1445,8 +1442,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             scope = parent;
         }
 
-        // Undecorated accessors become ordinary field + getter + setter
-        // elements before anything below indexes `class.properties`.
+        // Must precede Phase 2, which indexes `class.properties` by position.
         let mut accessor_storage_counter: usize = 0;
         if class
             .properties

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1440,12 +1440,33 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // Every `#`-name already parsed (this class or an enclosing one).
+        // `#`-names a generated private must not shadow: this class's own and
+        // those of every lexically enclosing class.
         let mut class_private_names: HashMap<&'a [u8], ()> = HashMap::default();
-        for sym in p.symbols.iter() {
-            if sym.kind.is_private() {
-                class_private_names.insert(sym.original_name.slice(), ());
+        for cprop in class.properties.slice() {
+            if let Some(k) = cprop.key
+                && let js_ast::ExprData::EPrivateIdentifier(pi) = &k.data
+            {
+                let name: &'a [u8] = p.symbols[pi.ref_.inner_index() as usize]
+                    .original_name
+                    .slice();
+                class_private_names.insert(name, ());
             }
+        }
+        let mut scope = p.current_scope;
+        loop {
+            if scope.kind == js_ast::scope::Kind::ClassBody {
+                for member in scope.members.values() {
+                    let name: &'a [u8] = p.symbols[member.ref_.inner_index() as usize]
+                        .original_name
+                        .slice();
+                    if name.first() == Some(&b'#') {
+                        class_private_names.insert(name, ());
+                    }
+                }
+            }
+            let Some(parent) = scope.parent else { break };
+            scope = parent;
         }
         let mut brand_field_counter: usize = 0;
 
@@ -1673,17 +1694,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ..Default::default()
                     };
 
+                    // A computed key is evaluated once, by the getter's key
+                    // position: `get [_k = expr]() {}` / `set [_k](v) {}`.
+                    let (getter_key, setter_key) = match prop.key {
+                        Some(key) if prop.flags.contains(Flags::Property::IsComputed) => {
+                            let key_ref = p.generate_temp_ref(Some(b"_computedKey"));
+                            let captured = p.assign_to(key_ref, key, key.loc);
+                            (Some(captured), Some(p.use_ref(key_ref, key.loc)))
+                        }
+                        key => (key, key),
+                    };
+
                     let mut getter_flags = prop.flags;
                     getter_flags.insert(Flags::Property::IsMethod);
                     new_properties.push(Property {
-                        key: prop.key,
+                        key: getter_key,
                         value: Some(p.new_expr(E::Function { func: get_fn }, loc)),
                         kind: PropertyKind::Get,
                         flags: getter_flags,
                         ..Default::default()
                     });
                     new_properties.push(Property {
-                        key: prop.key,
+                        key: setter_key,
                         value: Some(p.new_expr(E::Function { func: set_fn }, loc)),
                         kind: PropertyKind::Set,
                         flags: getter_flags,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -344,6 +344,50 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         (((5 + 2 * idx) << 1) | 1) as f64
     }
 
+    /// Pick an unused `#`-private name (suffixing on collision) and record it.
+    fn fresh_private_name(&self, used: &mut HashMap<&'a [u8], ()>, base: &'a [u8]) -> &'a [u8] {
+        let mut name = base;
+        let mut tries: usize = 2;
+        while used.contains_key(name) {
+            name = self.bump_name(base, Some(tries));
+            tries += 1;
+        }
+        used.insert(name, ());
+        name
+    }
+
+    /// A synthetic `#__N = void <expr>` class-body property. Placed at a
+    /// lowered private's source position so its brand-add runs on the
+    /// class-body initializer timeline alongside native fields.
+    fn inline_brand_field(
+        &mut self,
+        used: &mut HashMap<&'a [u8], ()>,
+        counter: &mut usize,
+        expr: Expr,
+        loc: bun_ast::Loc,
+    ) -> Property {
+        let base = self.bump_name(b"#__lowered_", Some(*counter));
+        *counter += 1;
+        let name = self.fresh_private_name(used, base);
+        let ref_ = self.new_sym(js_ast::symbol::Kind::PrivateField, name);
+        let key = self.new_expr(E::PrivateIdentifier { ref_ }, loc);
+        let init = self.new_expr(
+            E::Unary {
+                op: js_ast::OpCode::UnVoid,
+                value: expr,
+                flags: js_ast::e::UnaryFlags::empty(),
+            },
+            loc,
+        );
+        Property {
+            key: Some(key),
+            initializer: Some(init),
+            kind: PropertyKind::Normal,
+            flags: js_ast::flags::PROPERTY_NONE,
+            ..Default::default()
+        }
+    }
+
     /// Emit __privateAdd for a given storage ref.
     fn emit_private_add(
         &mut self,
@@ -1393,11 +1437,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
 
-        // Pre-scan: determine if all private members need lowering, and collect
-        // the class's private-name set so generated accessor-storage privates
-        // can pick an unused name.
+        // Pre-scan: determine if all private members need lowering.
         let mut lower_all_private = false;
-        let mut class_private_names: HashMap<&'a [u8], ()> = HashMap::default();
         {
             let mut has_any_private = false;
             let mut has_any_decorated = false;
@@ -1417,20 +1458,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         lower_all_private = true;
                     }
                 }
-                if let Some(k) = cprop.key
-                    && let js_ast::ExprData::EPrivateIdentifier(pi) = &k.data
+                if cprop.key.is_some()
+                    && matches!(
+                        cprop.key.unwrap().data,
+                        js_ast::ExprData::EPrivateIdentifier(_)
+                    )
                 {
                     has_any_private = true;
-                    let name: &'a [u8] = p.symbols[pi.ref_.inner_index() as usize]
-                        .original_name
-                        .slice();
-                    class_private_names.insert(name, ());
                 }
             }
             if !lower_all_private && has_any_private && has_any_decorated {
                 lower_all_private = true;
             }
         }
+
+        // Generated `#`-privates must not textually shadow any private name
+        // already parsed (this class's declarations and any enclosing class's),
+        // because `NoOpRenamer` prints symbol names verbatim.
+        let mut class_private_names: HashMap<&'a [u8], ()> = HashMap::default();
+        for sym in p.symbols.iter() {
+            if sym.kind.is_private() {
+                class_private_names.insert(sym.original_name.slice(), ());
+            }
+        }
+        let mut brand_field_counter: usize = 0;
 
         let props_slice2: &mut [Property] = class.properties.slice_mut();
         for (prop_idx, prop) in props_slice2.iter_mut().enumerate() {
@@ -1504,14 +1555,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // __privateAdd (once per name)
                         if !emitted_private_adds.contains_key(&npriv_inner) {
                             emitted_private_adds.insert(npriv_inner, ());
-                            p.emit_private_add(
-                                prop.flags.contains(Flags::Property::IsStatic),
-                                ws_ref,
-                                None,
-                                loc,
-                                &mut constructor_inject_stmts,
-                                &mut static_private_add_blocks,
-                            );
+                            if prop.flags.contains(Flags::Property::IsStatic) {
+                                let t = p.new_expr(E::This {}, loc);
+                                let s = p.use_ref(ws_ref, loc);
+                                let call = p.call_rt(loc, b"__privateAdd", &[t, s]);
+                                static_private_add_blocks.push(p.make_static_block(call, loc));
+                            } else {
+                                let t = p.new_expr(E::This {}, loc);
+                                let s = p.use_ref(ws_ref, loc);
+                                let call = p.call_rt(loc, b"__privateAdd", &[t, s]);
+                                new_properties.push(p.inline_brand_field(
+                                    &mut class_private_names,
+                                    &mut brand_field_counter,
+                                    call,
+                                    loc,
+                                ));
+                            }
                         }
                         continue;
                     } else {
@@ -1528,24 +1587,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let this_e = p.new_expr(E::This {}, loc);
                         let wm_e = p.use_ref(wm_ref, loc);
                         let call = p.call_rt(loc, b"__privateAdd", &[this_e, wm_e, init_val]);
-                        if !prop.flags.contains(Flags::Property::IsStatic) {
-                            constructor_inject_stmts.push(p.s(
-                                S::SExpr {
-                                    value: call,
-                                    ..Default::default()
-                                },
+                        if prop.flags.contains(Flags::Property::IsStatic) {
+                            static_private_add_blocks.push(p.make_static_block(call, loc));
+                        } else {
+                            new_properties.push(p.inline_brand_field(
+                                &mut class_private_names,
+                                &mut brand_field_counter,
+                                call,
                                 loc,
                             ));
-                        } else {
-                            static_private_add_blocks.push(p.make_static_block(call, loc));
                         }
                         continue;
                     }
                 }
                 // Undecorated auto-accessor → native `#`-storage field + get/set.
-                // The storage initializer stays at the accessor's class-body
-                // position so it runs in source order with neighbouring fields,
-                // and the per-class private name needs no module-scope binding.
                 if prop.kind == PropertyKind::AutoAccessor {
                     let storage_base: &'a [u8] = 'brk: {
                         if let Some(k) = prop.key {
@@ -1553,13 +1608,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 js_ast::ExprData::EString(s)
                                     if s.is_utf8() && js_lexer::is_identifier(&s.data) =>
                                 {
-                                    break 'brk p.bump_name2(b"#_", &s.data);
+                                    let mut v = BumpVec::<u8>::new_in(bump);
+                                    v.push(b'#');
+                                    v.extend_from_slice(&s.data);
+                                    v.extend_from_slice(b"_accessor_storage");
+                                    break 'brk v.into_bump_slice();
                                 }
                                 js_ast::ExprData::EPrivateIdentifier(pi) => {
                                     let orig: &'a [u8] = p.symbols[pi.ref_.inner_index() as usize]
                                         .original_name
                                         .slice();
-                                    break 'brk p.bump_name2(b"#_", &orig[1..]);
+                                    break 'brk p.bump_name2(orig, b"_accessor_storage");
                                 }
                                 _ => {}
                             }
@@ -1569,13 +1628,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         accessor_storage_counter += 1;
                         name
                     };
-                    let mut storage_name: &'a [u8] = storage_base;
-                    let mut tries: usize = 2;
-                    while class_private_names.contains_key(storage_name) {
-                        storage_name = p.bump_name(storage_base, Some(tries));
-                        tries += 1;
-                    }
-                    class_private_names.insert(storage_name, ());
+                    let storage_name = p.fresh_private_name(&mut class_private_names, storage_base);
 
                     let is_static = prop.flags.contains(Flags::Property::IsStatic);
                     let storage_kind = if is_static {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1440,8 +1440,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // `#`-names a generated private must not shadow: this class's own and
-        // those of every lexically enclosing class.
+        // `#`-names in scope here, which a generated private must not shadow.
         let mut class_private_names: HashMap<&'a [u8], ()> = HashMap::default();
         for cprop in class.properties.slice() {
             if let Some(k) = cprop.key
@@ -1694,8 +1693,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ..Default::default()
                     };
 
-                    // A computed key is evaluated once, by the getter's key
-                    // position: `get [_k = expr]() {}` / `set [_k](v) {}`.
+                    // `get [_k = expr]()` / `set [_k](v)`: the key runs once.
                     let (getter_key, setter_key) = match prop.key {
                         Some(key) if prop.flags.contains(Flags::Property::IsComputed) => {
                             let key_ref = p.generate_temp_ref(Some(b"_computedKey"));

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1364,6 +1364,21 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("decorated instance #-private method's brand is installed before a following undecorated #-private field reads it", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v) { return v; }
+        class C {
+          @dec #m() { return 1; }
+          #a = this.readM();
+          readM() { return this.#m(); }
+        }
+        console.log(new C().readM());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("WeakMap-lowered #-private does not strip NamedEvaluation or new.target from sibling fields", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec(v) { return v; }

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1450,6 +1450,28 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("lowered #-method and #-getter brands are installed before any field, while #-field brands keep source order", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v) { return v; }
+        const log = [];
+        class C {
+          @dec y;
+          a = (log.push("a"), this.#m() + this.#g);
+          #f = (log.push("f"), 10);
+          b = (log.push("b"), this.#f);
+          #m() { return 1; }
+          get #g() { return 100; }
+          @dec #dm() { return 1000; }
+          c = this.#dm();
+        }
+        const o = new C();
+        console.log(log.join(","), o.a, o.b, o.c);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a,f,b 101 10 1000\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("undecorated field, accessor and #-field initializers may read a WeakMap-lowered #-private directly", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec(v) { return v; }

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1379,6 +1379,41 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("undecorated field, accessor and #-field initializers may read a WeakMap-lowered #-private directly", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v) { return v; }
+        class C {
+          @dec m() {}
+          #a = 1;
+          b = this.#a;
+          accessor c = this.#a + 10;
+          #d = this.#a + 100;
+          readD() { return this.#d; }
+        }
+        const o = new C();
+        console.log(o.b, o.c, o.readD());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 11 101\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("undecorated static #-field initializer may read a WeakMap-lowered static #-private directly", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v) { return v; }
+        class C {
+          @dec m() {}
+          static #a = 1;
+          static #b = C.#a + 1;
+          static readB() { return C.#b; }
+        }
+        console.log(C.readB());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("2\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("WeakMap-lowered #-private does not strip NamedEvaluation or new.target from sibling fields", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec(v) { return v; }

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1345,6 +1345,59 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("static accessor with a private-name key round-trips", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class C {
+          static accessor #z = 5;
+          static get z() { return C.#z; }
+          static set z(v) { C.#z = v; }
+        }
+        console.log(C.z);
+        C.z = 50;
+        console.log(C.z);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("5\n50\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("accessor with a non-identifier string key round-trips", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class C {
+          accessor "a-b" = 1;
+          static accessor "c d" = 2;
+        }
+        const c = new C();
+        c["a-b"] = 10;
+        C["c d"] = 20;
+        console.log(c["a-b"], C["c d"]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("10 20\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("computed accessor key is evaluated once, in source order, and shared by get and set", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const order = [];
+        const k = (name) => (order.push(name), name);
+        class C {
+          [k("m")]() {}
+          accessor [k("a")] = 1;
+          static accessor [k("s")] = 2;
+        }
+        console.log(order.join(","));
+        const c = new C();
+        c.a = 10;
+        C.s = 20;
+        const d = Object.getOwnPropertyDescriptor(C.prototype, "a");
+        console.log(c.a, C.s, typeof d.get, typeof d.set);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("m,a,s\n10 20 function function\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("instance fields run in source order when sibling #-privates are WeakMap-lowered", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec(v) { return v; }

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1210,4 +1210,126 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  describe("undecorated auto-accessor lowering", () => {
+    test("initializer runs in source order with sibling fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        const mk = (name, v) => (log.push(name), v);
+        class C {
+          a = mk("a", 1);
+          accessor b = mk("b", 2);
+          c = mk("c", this.b);
+        }
+        const c = new C();
+        console.log(log.join(","));
+        console.log(c.a, c.b, c.c);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a,b,c\n1 2 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("static accessor initializer runs in source order with sibling static fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        const mk = (name, v) => (log.push(name), v);
+        class C {
+          static a = mk("a", 1);
+          static accessor b = mk("b", 2);
+          static c = mk("c", C.b);
+        }
+        console.log(log.join(","));
+        console.log(C.a, C.b, C.c);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a,b,c\n1 2 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("subclass may declare an accessor with the same name as its base", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class Base { accessor v = 1; }
+        class Sub extends Base { accessor v = 2; }
+        const s = new Sub();
+        console.log(s.v);
+        s.v = 99;
+        console.log(s.v);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("2\n99\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("two classes in a file may each declare a same-named accessor", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class A { accessor x = 1; }
+        class B { accessor x = 2; }
+        const a = new A(), b = new B();
+        a.x = 10;
+        console.log(a.x, b.x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("10 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("instance and static accessors may share a name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class C {
+          accessor x = 1;
+          static accessor x = 2;
+        }
+        const c = new C();
+        c.x = 10;
+        C.x = 20;
+        console.log(c.x, C.x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("10 20\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("generated storage name avoids existing private names", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class C {
+          #_y = "user";
+          accessor y = "acc";
+          read() { return this.#_y; }
+        }
+        const c = new C();
+        console.log(c.y, c.read());
+        c.y = "changed";
+        console.log(c.y, c.read());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("acc user\nchanged user\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("accessor with a private-name key round-trips", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class C {
+          accessor #z = 5;
+          get z() { return this.#z; }
+          set z(v) { this.#z = v; }
+        }
+        const c = new C();
+        console.log(c.z);
+        c.z = 50;
+        console.log(c.z);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("5\n50\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("storage is a class-body private field, not a module-scope WeakMap", () => {
+      const transpiler = new Bun.Transpiler({ loader: "js", target: "bun" });
+      const out = transpiler.transformSync(`class C { accessor x = 1; }`);
+      expect(out).toContain("#_x");
+      expect(out).not.toContain("WeakMap");
+      expect(out).not.toContain("__privateAdd");
+    });
+  });
 });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1361,6 +1361,27 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("private-name accessor is lowered with its siblings when the class WeakMap-lowers its privates", async () => {
+      // #helper's body is hoisted out of the class, so its this.#z must be
+      // rewritten along with every other lowered private.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v) { return v; }
+        class C {
+          @dec m() {}
+          accessor #z = 5;
+          #helper() { return this.#z; }
+          bump() { this.#z = this.#z + 1; return this.#helper(); }
+          static accessor #s = 10;
+          static #sh() { return C.#s; }
+          static readS() { C.#s = C.#s * 2; return C.#sh(); }
+        }
+        console.log(new C().bump(), C.readS());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("6 20\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("accessor with a non-identifier string key round-trips", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         class C {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1493,6 +1493,28 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("the same holds for static members: lowered static accessor storage and #-fields keep source order", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v) { return v; }
+        const log = [];
+        const mk = (n, v) => (log.push(n), v);
+        class C {
+          @dec m() {}
+          #p;
+          static a = mk("a", 1);
+          static accessor b = mk("b", C.a);
+          static #c = mk("c", C.b + 1);
+          static d = mk("d", C.#c);
+          static #sm() { return 1; }
+          static e = mk("e", C.#sm());
+        }
+        console.log(log.join(","), C.b, C.d, C.e);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a,b,c,d,e 1 2 1\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("undecorated field, accessor and #-field initializers may read a WeakMap-lowered #-private directly", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec(v) { return v; }

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1293,9 +1293,9 @@ describe("ES Decorators", () => {
     test("generated storage name avoids existing private names", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         class C {
-          #_y = "user";
+          #y_accessor_storage = "user";
           accessor y = "acc";
-          read() { return this.#_y; }
+          read() { return this.#y_accessor_storage; }
         }
         const c = new C();
         console.log(c.y, c.read());
@@ -1304,6 +1304,27 @@ describe("ES Decorators", () => {
       `);
       expect(stderr).toBe("");
       expect(stdout).toBe("acc user\nchanged user\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("generated storage name does not shadow a private referenced from an enclosing class", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class Outer {
+          #x_accessor_storage = 42;
+          make() {
+            const outer = this;
+            return class Inner {
+              accessor x = 1;
+              readOuter() { return outer.#x_accessor_storage; }
+            };
+          }
+        }
+        const Inner = new Outer().make();
+        const i = new Inner();
+        console.log(i.readOuter(), i.x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("42 1\n");
       expect(exitCode).toBe(0);
     });
 
@@ -1324,10 +1345,46 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("instance fields run in source order when sibling #-privates are WeakMap-lowered", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v) { return v; }
+        const log = [];
+        class C {
+          @dec m() {}
+          #a = (log.push("a"), 1);
+          accessor b = (log.push("b"), this.readA());
+          c = (log.push("c"), this.b);
+          readA() { return this.#a; }
+        }
+        const o = new C();
+        console.log(log.join(","), o.b, o.c, o.readA());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a,b,c 1 1 1\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("WeakMap-lowered #-private does not strip NamedEvaluation or new.target from sibling fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v) { return v; }
+        class C {
+          @dec m() {}
+          #p;
+          onClick = () => {};
+          nt = new.target;
+        }
+        const c = new C();
+        console.log(c.onClick.name, c.nt === undefined);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("onClick true\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("storage is a class-body private field, not a module-scope WeakMap", () => {
       const transpiler = new Bun.Transpiler({ loader: "js", target: "bun" });
       const out = transpiler.transformSync(`class C { accessor x = 1; }`);
-      expect(out).toContain("#_x");
+      expect(out).toContain("#x_accessor_storage");
       expect(out).not.toContain("WeakMap");
       expect(out).not.toContain("__privateAdd");
     });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1377,6 +1377,24 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("decorated accessor with a non-identifier string key round-trips", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const seen = [];
+        function dec(target, ctx) { seen.push(ctx.name); }
+        class C {
+          @dec accessor "a-b" = 1;
+          @dec static accessor "c d" = 2;
+        }
+        const c = new C();
+        c["a-b"] = 10;
+        C["c d"] = 20;
+        console.log(seen.sort().join(","), c["a-b"], C["c d"]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a-b,c d 10 20\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("computed accessor key is evaluated once, in source order, and shared by get and set", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         const order = [];


### PR DESCRIPTION
Refs #29837

> **Scope note.** This PR and #31926 were opened as alternative fixes for the undecorated-accessor bugs in #29837. #31926 is now the fix for classes that have no decorators at all (it lowers those in place and never enters the machinery changed here), so this PR's remaining job is the decorated path: classes that have at least one decorator and also contain undecorated `accessor` members or lowered `#`-privates. The diff below still applies unchanged to that case; once #31926 lands, the tests here that use undecorated classes become redundant and should be rewritten against decorated classes when this is rebased. The decorated-class repro this PR keeps fixing:
>
> ```js
> function dec(v) { return v; }
> class A { @dec m() {} accessor name = "A"; }
> class B extends A { @dec m() {} accessor name = "B"; logName() { console.log(this.name, super.name); } }
> new B().logName(); // main: TypeError: Cannot add the same private member more than once; this branch: B A
> ```
>
> and the ordering case `class C { @dec m() {} #a = 1; accessor b = this.readA(); c = this.b; ... }`, which throws `Cannot read from private field` on main because both initializers are moved into the constructor, behind the class-body field `c`. #31930 is the other related PR: it makes the module-level temporaries the decorated path still uses (`_init`, `_dec`, and the `WeakMap`s of decorated members) unique per file, which is independent of the class-body placement done here.
>
> Brought up to date with `main` while consolidating. The generated-name collision scan walks the class's own keys and the enclosing class-body scopes, so it no longer needs the `symbol::Kind::is_private` visibility change that an earlier revision (and #31926) carried. On top of current `main` the es-decorators, es-decorators-esbuild, decorators, decorator-metadata and bundler_decorator_metadata suites pass with this branch.

## What

When the standard-decorator lowering handles an undecorated `accessor x = v`, emit a class-body private field for the backing storage instead of a module-scope `WeakMap`:

```js
// input
class C { a = 1; accessor b = 2; c = this.b; }

// before
var _b = new WeakMap;
class C {
  constructor() { __privateAdd(this, _b, 2); }
  a = 1;
  get b() { return __privateGet(this, _b); }
  set b(v) { __privateSet(this, _b, v); }
  c = this.b;
}

// after
class C {
  a = 1;
  #b_accessor_storage = 2;
  get b() { return this.#b_accessor_storage; }
  set b(v) { this.#b_accessor_storage = v; }
  c = this.b;
}
```

When a class has a decorated member and a `#`-private so that the existing lowering turns every `#`-private into `WeakMap`/`WeakSet` storage, each undecorated instance `#`-private's `__privateAdd` call is emitted as the initializer of a synthetic class-body private field at that member's source position instead of being spliced into the constructor body:

```js
// input
function dec(v) { return v; }
class C { @dec m() {}; #a = 1; accessor b = this.readA(); c = this.b; readA() { return this.#a; } }

// after
var _a = new WeakMap;
class C {
  m() {}
  #__lowered_0 = void __privateAdd(this, _a, 1);
  #b_accessor_storage = this.readA();
  get b() { return this.#b_accessor_storage; }
  set b(v) { this.#b_accessor_storage = v; }
  c = this.b;
  readA() { return __privateGet(this, _a); }
}
```

## Why

The previous lowering injected `__privateAdd(this, _<key>, init)` into the constructor body after `super()`, while plain sibling fields stayed as class-body fields. Class-body fields evaluate before any constructor-body statement, so the accessor's initializer ran after every plain field regardless of source order; in the first example `c = this.b` ran before the storage was populated and threw `Cannot read from private field`. Because the storage binding name was derived from the key alone and declared at module scope, a subclass with the same accessor name as its base reused the same `WeakMap` and constructing it threw:

```
TypeError: Cannot add the same private member more than once
```

Mechanically, an undecorated `accessor` is expanded up front into the field and getter/setter pair it denotes, and those flow through the same arms as user-written members. That is what produces the native shape above, and it also means a `#`-keyed accessor in a class that lowers its privates is lowered and registered like any other private, so a sibling `#`-method body hoisted out of the class can still reference it (previously a `SyntaxError`).

Lowered instance `#`-method, getter and setter brands are placed ahead of the class body's fields (InitializeInstanceElements installs every method brand before any field initializer runs), so a field may call a `#`-method declared below it; field brands (lowered `#`-fields and accessor storage) carry their initializer and stay at their source position. This applies to static members the same way: static method brands are hoisted, static field brands become a static block at the member's position, whereas previously every static brand was prepended to the class body and a lowered static field could run before the static fields above it.

Keeping every undecorated instance initializer on the class-body timeline fixes both without touching untouched fields: the engine still applies NamedEvaluation, `new.target`-in-field-initializer and computed-key semantics to public fields, and the super()-scan never runs for classes that have only undecorated instance members. This also fixes the pre-existing failures for undecorated initializers that read a preceding lowered `#`-private: indirectly through a method (second example, previously a runtime `Cannot read from private field`), and directly as `b = this.#a` / `accessor c = this.#a` / `#d = this.#a` / `static #b = C.#a` (previously a `SyntaxError: Cannot reference undeclared private names`, because the private-access rewrite pass skipped field initializers and the static brand blocks; it now visits both).

Generated `#`-privates (accessor storage and the synthetic `#__lowered_N` fields) are named against the class's own private keys plus the members of every enclosing class-body scope, so they cannot textually shadow a private declared in the same class or any enclosing class. Storage is named `#<key>_accessor_storage`, matching tsc; non-identifier and computed keys fall back to a counter (the old lowering emitted an invalid `var _a-b` binding for `accessor "a-b"`; the decorated-accessor arm had the same hole and gets the same guard). A computed accessor key is captured once at the getter's key position (`get [_k = expr]()` / `set [_k](v)`), so it is evaluated a single time, in class-body order, and shared by both members; previously it was evaluated once per synthesized member.

Decorated accessors and decorated fields are untouched; they still route through the runtime helpers because the decorator protocol requires out-of-class access to the storage.

## Verification

`bun run` on a `.js` file before this change:

```
$ bun repro-order.js
a,c,b
$ bun repro-subclass.js
TypeError: Cannot add the same private member more than once
```

After:

```
$ bun repro-order.js
a,b,c
$ bun repro-subclass.js
Sub.v=2
```

New tests in `test/bundler/transpiler/es-decorators.test.ts` cover instance and static initializer order, the subclass and sibling-class same-name cases, storage-name collisions with same-class and enclosing-class privates, the `#a; accessor b; c` source-order case under `lower_all_private`, method brands installed before a preceding field that calls them, a `#`-keyed accessor referenced from a hoisted `#`-method body, direct reads of a lowered private from field/accessor/static initializers, the `.name`/`new.target` guard, private-name (instance and static), non-identifier string and computed accessor keys, and the emitted shape. The existing `es-decorators` tests, 147 esbuild-suite decorator tests and 24 legacy decorator tests all pass.

Related: #31930 gives the remaining module-scope lowering temporaries (`_init`, `_base`, `_dec`, and the storage bindings still used for decorated members) file-unique names; #35537 switches decorated plain fields from `[[Set]]` to `[[Define]]`. Neither overlaps with this change.


<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.0 (7db08ef49)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [381.49ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [321.79ms]
(pass) ES Decorators > class decorators > class decorator can replace class [339.25ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [354.71ms]
(pass) ES Decorators > method decorators > instance method decorator [350.45ms]
(pass) ES Decorators > method decorators > static method decorator [382.08ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [377.67ms]
(pass) ES Decorators > getter decorators > getter decorator [342.18ms]
(pass) ES Decorators > setter decorators > setter decorator [390.34ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [380.27ms]
(pass) ES Decorators > field decorators > multiple field decorators [340.03ms]

... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (240a8daf0)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [15.05ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [11.63ms]
(pass) ES Decorators > class decorators > class decorator can replace class [10.63ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [12.64ms]
(pass) ES Decorators > method decorators > instance method decorator [10.15ms]
(pass) ES Decorators > method decorators > static method decorator [13.16ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [9.23ms]
(pass) ES Decorators > getter decorators > getter decorator [11.84ms]
(pass) ES Decorators > setter decorators > setter decorator [11.69ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [10.64ms]
(pass) ES Decorators > field decorators > multiple field decorators [9.43ms]
(pass) ES Decorators > field decorators > static field decorator [9.10ms]
(pass) ES Decorators > non-ASCII string-literal keys > Bun.Transpiler output preserves the key [2.63ms]
(pass
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.0 (7db08ef49)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [583.38ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [344.27ms]
(pass) ES Decorators > class decorators > class decorator can replace class [442.71ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [359.58ms]
(pass) ES Decorators > method decorators > instance method decorator [356.55ms]
(pass) ES Decorators > method decorators > static method decorator [402.71ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [359.70ms]
(pass) ES Decorators > getter decorators > getter decorator [361.57ms]
(pass) ES Decorators > setter decorators > setter decorator [381.13ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [440.30ms]
(pass) ES Decorators > field decorators > multiple field decorators [423.21ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 895ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/34] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/34] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/34] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/34] gen cpp.rs (cppbind)
[5/34] gen JS modules (bundle-modules)
Preprocess modules (9080ms)
Bundle modules (54ms)
Postprocesss modules (217ms)
Bundle Functions (729ms)
Generate Code (39ms)

[10.15s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[5/24] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_jsc_macros v0.0.0 (/workspace/bun/sr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lower/lower_decorators.rs       | 514 ++++++++++++++++----------
 test/bundler/transpiler/es-decorators.test.ts | 365 ++++++++++++++++++
 2 files changed, 680 insertions(+), 199 deletions(-)
```

</details>

**gate history** · 10 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/lower/lower_decorators.rs           45     48      0
test/bundler/transpiler/es-decorators.test.ts     11     15      0
```

</details>

<!-- robobun:evidence:end -->



