### PR TITLE
cli: forward .env to `bun run <script>` / bunx subprocesses

### DIFF
--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -64,7 +64,7 @@ process.env.FOO = "hello";
 
 ## `.env` files and `package.json` scripts
 
-When you run a `package.json` script with `bun run <script>` or `bunx`, Bun loads `.env` and exports its values to the script's subprocess. Values whose winning source is `.env.local`, `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or whose `$VAR` expansion referenced a key not supplied by process env or `.env`, are **not** exported, because a script may set its own `NODE_ENV` and needs to re-derive those itself. Use `bun --env-file=.env.local run <script>` to forward additional files explicitly.
+When you run a `package.json` script with `bun run <script>`, or a package binary with `bunx`, Bun loads `.env` and exports its values to the subprocess. Values whose winning source is `.env.local`, `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or whose `$VAR` expansion referenced a key not supplied by process env or `.env`, are **not** exported, because a script may set its own `NODE_ENV` and needs to re-derive those itself. Use `bun --env-file=.env.local run <script>` to forward additional files explicitly.
 
 ```json package.json icon="file-json"
 "scripts": {

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -64,7 +64,7 @@ process.env.FOO = "hello";
 
 ## `.env` files and `package.json` scripts
 
-When you run a `package.json` script with `bun run <script>`, or a package binary with `bunx`, Bun loads `.env` and exports its values to the subprocess. Values whose winning source is `.env.local`, `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or whose `$VAR` expansion referenced a key not supplied by process env or `.env`, are **not** exported, because a script may set its own `NODE_ENV` and needs to re-derive those itself. Use `bun --env-file=.env.local run <script>` to forward additional files explicitly.
+When you run a `package.json` script with `bun run <script>`, or a package binary with `bunx`, Bun loads `.env` and exports its values to the subprocess. A key is **not** exported if it also appears in `.env.local`, `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or if its `$VAR` expansion referenced a key not supplied by process env or `.env`, because a script may set its own `NODE_ENV` and needs to re-derive that key itself. Use `bun --env-file=.env.local run <script>` to forward additional files explicitly.
 
 ```json package.json icon="file-json"
 "scripts": {

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -64,7 +64,7 @@ process.env.FOO = "hello";
 
 ## `.env` files and `package.json` scripts
 
-When you run a `package.json` script with `bun run <script>` (or `bun --filter`, or `bunx`), Bun loads `.env` and `.env.local` and exports their values to the script's subprocess. Values whose winning source is `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or whose `$VAR` expansion resolved against one of those files, are **not** exported, because a script may set its own `NODE_ENV` and needs to re-derive those itself:
+When you run a `package.json` script with `bun run <script>` (or `bun --filter`, or `bunx`), Bun loads `.env` and `.env.local` (`.env.local` is skipped when `NODE_ENV`/`BUN_ENV` is `test`) and exports their values to the script's subprocess. Values whose winning source is `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or whose `$VAR` expansion referenced a key not supplied by process env or `.env`/`.env.local`, are **not** exported, because a script may set its own `NODE_ENV` and needs to re-derive those itself:
 
 ```json package.json icon="file-json"
 "scripts": {

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -64,7 +64,7 @@ process.env.FOO = "hello";
 
 ## `.env` files and `package.json` scripts
 
-When you run a `package.json` script with `bun run <script>`, Bun loads `.env` and `.env.local` and exports their values to the script's subprocess. It does **not** export values that exist only in `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), because a script may set its own `NODE_ENV` and needs to re-derive those itself:
+When you run a `package.json` script with `bun run <script>` (or `bun --filter`, or `bunx`), Bun loads `.env` and `.env.local` and exports their values to the script's subprocess. Values whose winning source is `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or whose `$VAR` expansion resolved against one of those files, are **not** exported, because a script may set its own `NODE_ENV` and needs to re-derive those itself:
 
 ```json package.json icon="file-json"
 "scripts": {

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -64,11 +64,11 @@ process.env.FOO = "hello";
 
 ## `.env` files and `package.json` scripts
 
-When you run a `package.json` script with `bun run <script>` (or `bun --filter`, or `bunx`), Bun loads `.env` and `.env.local` (`.env.local` is skipped when `NODE_ENV`/`BUN_ENV` is `test`) and exports their values to the script's subprocess. Values whose winning source is `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or whose `$VAR` expansion referenced a key not supplied by process env or `.env`/`.env.local`, are **not** exported, because a script may set its own `NODE_ENV` and needs to re-derive those itself:
+When you run a `package.json` script with `bun run <script>` or `bunx`, Bun loads `.env` and exports its values to the script's subprocess. Values whose winning source is `.env.local`, `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), or whose `$VAR` expansion referenced a key not supplied by process env or `.env`, are **not** exported, because a script may set its own `NODE_ENV` and needs to re-derive those itself. Use `bun --env-file=.env.local run <script>` to forward additional files explicitly.
 
 ```json package.json icon="file-json"
 "scripts": {
-  "dev": "vite",                               // sees .env and .env.local
+  "dev": "vite",                               // sees .env
   "start": "NODE_ENV=production bun server.ts" // bun re-reads .env.production here
 }
 ```

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -62,6 +62,17 @@ process.env.FOO = "hello";
 
 ---
 
+## `.env` files and `package.json` scripts
+
+When you run a `package.json` script with `bun run <script>`, Bun loads `.env` and `.env.local` and exports their values to the script's subprocess. It does **not** export values that exist only in `.env.development`, `.env.production`, or `.env.test` (or their `.local` variants), because a script may set its own `NODE_ENV` and needs to re-derive those itself:
+
+```json package.json icon="file-json"
+"scripts": {
+  "dev": "vite",                               // sees .env and .env.local
+  "start": "NODE_ENV=production bun server.ts" // bun re-reads .env.production here
+}
+```
+
 ## Manually specifying `.env` files
 
 The `--env-file` flag overrides which `.env` files Bun loads. It works both when running a file with `bun` and when running `package.json` scripts.

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -777,12 +777,19 @@ impl Loader {
         self.env_development_local = None;
         self.env_production_local = None;
         self.env_test_local = None;
+        self.custom_files_loaded.clear_retaining_capacity();
     }
 
     /// `Map::create_null_delimited_env_map` plus [`Self::script_forward`].
     pub fn create_null_delimited_env_map(&mut self) -> Result<NullDelimitedEnvMap, AllocError> {
         self.map
             .create_null_delimited_env_map_with_extra(&self.script_forward)
+    }
+
+    /// `Map::write_windows_env_block` plus [`Self::script_forward`].
+    pub fn write_windows_env_block(&mut self) -> Vec<u16> {
+        self.map
+            .write_windows_env_block_with_extra(&self.script_forward)
     }
 
     pub fn print_loaded(&self, start: i128) {
@@ -1235,7 +1242,12 @@ impl<'a> Parser<'a> {
                             }
                             Some(&*entry.value)
                         }
-                        None => None,
+                        None => {
+                            if key_start < end {
+                                *touched_conditional = true;
+                            }
+                            None
+                        }
                     };
                     let default_value: &[u8] = if value[end..].starts_with(b":-") {
                         end += b":-".len();
@@ -1465,6 +1477,15 @@ impl Map {
     /// Unicode block has no documented size limit, so this sizes the buffer to
     /// the actual contents instead of failing when the environment is large.
     pub fn write_windows_env_block(&mut self) -> Vec<u16> {
+        self.write_windows_env_block_with_extra(&[])
+    }
+
+    /// [`Self::write_windows_env_block`] plus an `extra` tail appended after
+    /// the map's own entries; keys already in `self` are skipped.
+    pub fn write_windows_env_block_with_extra(
+        &mut self,
+        extra: &[(Box<[u8]>, Box<[u8]>)],
+    ) -> Vec<u16> {
         // UTF-16 output is at most one code unit per UTF-8 input byte (ASCII
         // is 1:1; multi-byte sequences shrink; surrogate pairs are 2 units
         // from 4 bytes), so the UTF-8 byte length is a safe upper bound.
@@ -1475,22 +1496,29 @@ impl Map {
                 capacity += pair.key_ptr.len() + 1 + pair.value_ptr.value.len() + 1;
             }
         }
+        for (k, v) in extra {
+            capacity += k.len() + 1 + v.len() + 1;
+        }
 
         let mut result = vec![0u16; capacity];
         let mut i: usize = 0;
+        let mut push = |result: &mut [u16], key: &[u8], value: &[u8]| {
+            i += strings::convert_utf8_to_utf16_in_buffer(&mut result[i..], key).len();
+            result[i] = b'=' as u16;
+            i += 1;
+            i += strings::convert_utf8_to_utf16_in_buffer(&mut result[i..], value).len();
+            result[i] = 0;
+            i += 1;
+        };
         {
             let mut it = self.map.iterator();
             while let Some(pair) = it.next() {
-                i += strings::convert_utf8_to_utf16_in_buffer(&mut result[i..], pair.key_ptr).len();
-                result[i] = b'=' as u16;
-                i += 1;
-                i += strings::convert_utf8_to_utf16_in_buffer(
-                    &mut result[i..],
-                    &pair.value_ptr.value,
-                )
-                .len();
-                result[i] = 0;
-                i += 1;
+                push(&mut result, pair.key_ptr, &pair.value_ptr.value);
+            }
+        }
+        for (k, v) in extra {
+            if !self.map.contains(k) {
+                push(&mut result, k, v);
             }
         }
         // Terminator: four trailing NUL u16s (already zero-initialized above).

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -119,10 +119,8 @@ pub struct Loader {
     /// only populated with files specified explicitly (e.g. --env-file arg)
     pub custom_files_loaded: StringArrayHashMap<bun_ast::Source>,
 
-    /// `.env` / `.env.local` entries the `bun run <script>` dispatcher moved
-    /// out of `map` via [`Self::take_script_dotenv`]; merged back into the
-    /// subprocess env by [`Self::create_null_delimited_env_map`] / the
-    /// bun-shell's export copy. Empty outside that path.
+    /// `.env`/`.env.local` entries [`Self::take_script_dotenv`] lifted out of
+    /// `map` for the `bun run <script>` subprocess env; empty elsewhere.
     pub script_forward: Vec<(Box<[u8]>, Box<[u8]>)>,
 
     pub quiet: bool,
@@ -750,18 +748,9 @@ impl Loader {
         Ok(())
     }
 
-    /// After `load_default_files`, move the `.env` / `.env.local`-sourced
-    /// entries (every non-conditional entry past `process_env_count`) into
-    /// `script_forward` and truncate the map back to the process-env prefix.
-    /// Clears every default-file slot.
-    ///
-    /// `bun run <script>` calls this so the script's subprocess environment
-    /// carries `.env` / `.env.local` values (no NODE_ENV dependency, #9877)
-    /// while leaving `.env.{NODE_ENV}[.local]` keys for the script's own
-    /// `bun` instance to re-derive under whatever NODE_ENV it sets (#9635).
-    /// The map is restored to exactly the process-env state so the
-    /// `bun run <file>` slow path, which boots a VM on this same singleton,
-    /// observes what it would on a fresh loader.
+    /// Move non-conditional dotenv entries (indices `process_env_count..`)
+    /// into `script_forward`, truncate `map` to the process-env prefix, and
+    /// clear every default-file slot. See #9877 / #9635.
     pub fn take_script_dotenv(&mut self, process_env_count: usize) {
         self.script_forward.clear();
         {
@@ -790,9 +779,7 @@ impl Loader {
         self.env_test_local = None;
     }
 
-    /// `Map::create_null_delimited_env_map` plus the `.env` / `.env.local`
-    /// entries captured by [`Self::take_script_dotenv`]. Used by the
-    /// `bun run <script>` / `bunx` / `--filter` spawn sites.
+    /// `Map::create_null_delimited_env_map` plus [`Self::script_forward`].
     pub fn create_null_delimited_env_map(&mut self) -> Result<NullDelimitedEnvMap, AllocError> {
         self.map
             .create_null_delimited_env_map_with_extra(&self.script_forward)
@@ -1383,11 +1370,8 @@ pub struct HashTableValue {
     // `Box<[u8]>` is owned-by-default, trading some copies for uniform
     // ownership.
     pub value: Box<[u8]>,
-    /// Set for keys whose value came from a NODE_ENV-dependent default file
-    /// (`.env.development`, `.env.production`, `.env.test`, or their `.local`
-    /// variants). The `bun run <script>` dispatcher drops these before
-    /// spawning so a script that sets its own NODE_ENV can re-derive them;
-    /// keys that exist in `.env` / `.env.local` stay. See #9635 / #9877.
+    /// Set for values from a NODE_ENV-specific default file
+    /// (`.env.{development,production,test}[.local]`) or expanded from one.
     pub conditional: bool,
 }
 
@@ -1417,10 +1401,8 @@ impl Map {
         self.create_null_delimited_env_map_with_extra(&[])
     }
 
-    /// [`Self::create_null_delimited_env_map`] plus an `extra` tail of
-    /// `K`/`V` pairs appended after the map's own entries. Entries in `extra`
-    /// whose key already appears in `self` are skipped so process env keeps
-    /// winning.
+    /// [`Self::create_null_delimited_env_map`] plus an `extra` tail appended
+    /// after the map's own entries; keys already in `self` are skipped.
     pub fn create_null_delimited_env_map_with_extra(
         &mut self,
         extra: &[(Box<[u8]>, Box<[u8]>)],

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -732,13 +732,11 @@ impl Loader {
         self.try_load_default::<_, false>(dir, dir_handle, b".env", value_buffer)
     }
 
-    /// Load every NODE_ENV-specific default file (`.env.{development,
-    /// production,test}[.local]` + `.env.local`) as conditional. Files whose
-    /// slot is already set are skipped, so calling this after
-    /// [`Self::load_default_files`] visits only the other-suffix files. Used by
-    /// the `bun run <script>` path to mark `.env` keys that are shadowed by a
-    /// NODE_ENV file the parent's suffix did not load.
-    pub fn mark_keys_in_other_node_env_files<D: DirEntryProbe + ?Sized>(
+    /// Load every NODE_ENV-dependent default file as conditional, then `.env`
+    /// as non-conditional. `.env` expanding `$VAR` against a key that any
+    /// NODE_ENV-dependent file defines is thereby tainted before
+    /// [`Self::take_script_dotenv`] runs. See #9877 / #9635.
+    pub fn load_default_files_for_script_runner<D: DirEntryProbe + ?Sized>(
         &mut self,
         dir: &D,
     ) -> crate::Result<()> {
@@ -755,7 +753,7 @@ impl Loader {
         ] {
             self.try_load_default::<_, true>(dir, dir_handle, name, &mut value_buffer)?;
         }
-        Ok(())
+        self.try_load_default::<_, false>(dir, dir_handle, b".env", &mut value_buffer)
     }
 
     /// Probe `dir` for a known `.env*` filename and, if present, load it into
@@ -769,7 +767,7 @@ impl Loader {
         name: &'static [u8],
         value_buffer: &mut Vec<u8>,
     ) -> crate::Result<()> {
-        if dir.has_comptime_query(name) {
+        if dir.has_comptime_query(name) && self.default_file_slot(name).is_none() {
             self.load_env_file::<false, CONDITIONAL>(dir_handle, name, value_buffer)?;
             analytics::Features::dotenv_inc();
         }
@@ -782,10 +780,17 @@ impl Loader {
     pub fn take_script_dotenv(&mut self, process_env_count: usize) {
         self.script_forward.clear();
         {
+            #[cfg(windows)]
+            let is_suffix_key = |k: &[u8]| {
+                strings::eql_case_insensitive_ascii_check_length(k, b"NODE_ENV")
+                    || strings::eql_case_insensitive_ascii_check_length(k, b"BUN_ENV")
+            };
+            #[cfg(not(windows))]
+            let is_suffix_key = |k: &[u8]| k == b"NODE_ENV" || k == b"BUN_ENV";
             let keys = self.map.map.keys();
             let values = self.map.map.values();
             for i in process_env_count..keys.len() {
-                if !values[i].conditional {
+                if !values[i].conditional && !is_suffix_key(&keys[i]) {
                     self.script_forward
                         .push((keys[i].clone(), values[i].value.clone()));
                 }
@@ -1416,8 +1421,8 @@ pub struct HashTableValue {
     // `Box<[u8]>` is owned-by-default, trading some copies for uniform
     // ownership.
     pub value: Box<[u8]>,
-    /// Set for values from a NODE_ENV-specific default file
-    /// (`.env.{development,production,test}[.local]`) or expanded from one.
+    /// Set for values whose presence depends on NODE_ENV; gates what
+    /// [`Loader::take_script_dotenv`] forwards.
     pub conditional: bool,
 }
 

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -620,7 +620,7 @@ impl Loader {
         // `Source.contents: &'static [u8]` lifetime constraint (callers like
         // `node:util.parseEnv` pass JS-owned non-'static buffers).
         let mut value_buffer: Vec<u8> = Vec::new();
-        Parser::parse_bytes::<OVERWRITE, false, EXPAND, false>(
+        Parser::parse_bytes::<OVERWRITE, false, EXPAND, false, false>(
             str,
             &mut self.map,
             &mut value_buffer,
@@ -708,8 +708,10 @@ impl Loader {
             }
         }
 
+        // `.env.local` is gated on `suffix != Test`, so its presence in the
+        // child's load set depends on NODE_ENV — treat it as conditional.
         if suffix != DotEnvFileSuffix::Test {
-            self.try_load_default::<_, false>(dir, dir_handle, b".env.local", value_buffer)?;
+            self.try_load_default::<_, true>(dir, dir_handle, b".env.local", value_buffer)?;
         }
 
         match suffix {
@@ -927,7 +929,7 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true, CONDITIONAL>(
+                Parser::parse_bytes::<OVERRIDE, false, true, CONDITIONAL, true>(
                     &buf,
                     &mut self.map,
                     value_buffer,
@@ -978,7 +980,7 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true, false>(
+                Parser::parse_bytes::<OVERRIDE, false, true, false, false>(
                     &buf,
                     &mut self.map,
                     value_buffer,
@@ -1202,6 +1204,7 @@ impl<'a> Parser<'a> {
         &mut self,
         map: &Map,
         value: &[u8],
+        taint_unresolved: bool,
         touched_conditional: &mut bool,
     ) -> Result<Option<&[u8]>, AllocError> {
         if value.len() < 2 {
@@ -1243,7 +1246,7 @@ impl<'a> Parser<'a> {
                             Some(&*entry.value)
                         }
                         None => {
-                            if key_start < end {
+                            if taint_unresolved && key_start < end {
                                 *touched_conditional = true;
                             }
                             None
@@ -1295,6 +1298,7 @@ impl<'a> Parser<'a> {
         const IS_PROCESS: bool,
         const EXPAND: bool,
         const CONDITIONAL: bool,
+        const DEFAULT_FILE: bool,
     >(
         &mut self,
         map: &mut Map,
@@ -1335,7 +1339,7 @@ impl<'a> Parser<'a> {
                 let current: Box<[u8]> = Box::from(&*map.map.values()[idx].value);
                 let mut touched_conditional = false;
                 if let Some(expanded) =
-                    self.expand_value(map, &current, &mut touched_conditional)?
+                    self.expand_value(map, &current, DEFAULT_FILE, &mut touched_conditional)?
                 {
                     let slot = &mut map.map.values_mut()[idx];
                     slot.value = Box::from(expanded);
@@ -1359,6 +1363,7 @@ impl<'a> Parser<'a> {
         const IS_PROCESS: bool,
         const EXPAND: bool,
         const CONDITIONAL: bool,
+        const DEFAULT_FILE: bool,
     >(
         src: &[u8],
         map: &mut Map,
@@ -1373,7 +1378,7 @@ impl<'a> Parser<'a> {
             src: strings::without_utf8_bom(src),
             value_buffer,
         };
-        parser._parse::<OVERRIDE, IS_PROCESS, EXPAND, CONDITIONAL>(map)
+        parser._parse::<OVERRIDE, IS_PROCESS, EXPAND, CONDITIONAL, DEFAULT_FILE>(map)
     }
 }
 

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -732,6 +732,32 @@ impl Loader {
         self.try_load_default::<_, false>(dir, dir_handle, b".env", value_buffer)
     }
 
+    /// Load every NODE_ENV-specific default file (`.env.{development,
+    /// production,test}[.local]` + `.env.local`) as conditional. Files whose
+    /// slot is already set are skipped, so calling this after
+    /// [`Self::load_default_files`] visits only the other-suffix files. Used by
+    /// the `bun run <script>` path to mark `.env` keys that are shadowed by a
+    /// NODE_ENV file the parent's suffix did not load.
+    pub fn mark_keys_in_other_node_env_files<D: DirEntryProbe + ?Sized>(
+        &mut self,
+        dir: &D,
+    ) -> crate::Result<()> {
+        let dir_handle = bun_sys::Fd::cwd();
+        let mut value_buffer: Vec<u8> = Vec::new();
+        for name in [
+            b".env.development.local".as_slice(),
+            b".env.production.local".as_slice(),
+            b".env.test.local".as_slice(),
+            b".env.local".as_slice(),
+            b".env.development".as_slice(),
+            b".env.production".as_slice(),
+            b".env.test".as_slice(),
+        ] {
+            self.try_load_default::<_, true>(dir, dir_handle, name, &mut value_buffer)?;
+        }
+        Ok(())
+    }
+
     /// Probe `dir` for a known `.env*` filename and, if present, load it into
     /// its dedicated slot and bump the analytics counter. Shared body for the
     /// eight call sites in `load_default_files`.
@@ -1318,6 +1344,9 @@ impl<'a> Parser<'a> {
                     // Allow keys defined later in the same file to override keys defined earlier
                     // https://github.com/oven-sh/bun/issues/1262
                     if !OVERRIDE {
+                        if CONDITIONAL {
+                            entry.value_ptr.conditional = true;
+                        }
                         continue;
                     }
                 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -88,10 +88,6 @@ impl DotEnvBehavior {
     }
 }
 
-/// Mirrors the value fields of `bun_s3_signing::S3Credentials` (T5). Defined locally so
-/// this T2 crate names no `bun_s3_signing` types — see PORTING.md §Dispatch (cold-path,
-/// upward dep). The high-tier caller constructs the real refcounted `S3Credentials` from
-/// this POD at the call site.
 #[inline]
 fn is_suffix_key(k: &[u8]) -> bool {
     #[cfg(windows)]
@@ -101,6 +97,10 @@ fn is_suffix_key(k: &[u8]) -> bool {
     return k == b"NODE_ENV" || k == b"BUN_ENV";
 }
 
+/// Mirrors the value fields of `bun_s3_signing::S3Credentials` (T5). Defined locally so
+/// this T2 crate names no `bun_s3_signing` types — see PORTING.md §Dispatch (cold-path,
+/// upward dep). The high-tier caller constructs the real refcounted `S3Credentials` from
+/// this POD at the call site.
 #[derive(Clone, Default)]
 pub struct S3Credentials {
     pub access_key_id: Box<[u8]>,
@@ -1355,9 +1355,6 @@ impl<'a> Parser<'a> {
                     // Allow keys defined later in the same file to override keys defined earlier
                     // https://github.com/oven-sh/bun/issues/1262
                     if !OVERRIDE {
-                        if CONDITIONAL {
-                            entry.value_ptr.conditional = true;
-                        }
                         continue;
                     }
                 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -119,6 +119,12 @@ pub struct Loader {
     /// only populated with files specified explicitly (e.g. --env-file arg)
     pub custom_files_loaded: StringArrayHashMap<bun_ast::Source>,
 
+    /// `.env` / `.env.local` entries the `bun run <script>` dispatcher moved
+    /// out of `map` via [`Self::take_script_dotenv`]; merged back into the
+    /// subprocess env by [`Self::create_null_delimited_env_map`] / the
+    /// bun-shell's export copy. Empty outside that path.
+    pub script_forward: Vec<(Box<[u8]>, Box<[u8]>)>,
+
     pub quiet: bool,
 
     pub did_load_process: bool,
@@ -573,6 +579,7 @@ impl Loader {
             env_test_local: None,
             env: None,
             custom_files_loaded: StringArrayHashMap::default(),
+            script_forward: Vec::new(),
             quiet: false,
             did_load_process: false,
             reject_unauthorized: Cell::new(None),
@@ -743,26 +750,52 @@ impl Loader {
         Ok(())
     }
 
-    /// Drop every entry whose value came from a NODE_ENV-specific default file
-    /// (`.env.{development,production,test}[.local]`). `bun run <script>`
-    /// calls this after `load_default_files` so the script's subprocess
-    /// environment carries `.env` / `.env.local` values (no NODE_ENV
-    /// dependency) while leaving NODE_ENV-specific keys for the script's own
-    /// `bun` instance to re-derive under whatever NODE_ENV it sets.
-    /// See https://github.com/oven-sh/bun/issues/9635#issuecomment-2021350123
-    /// and https://github.com/oven-sh/bun/issues/9877.
+    /// After `load_default_files`, move the `.env` / `.env.local`-sourced
+    /// entries (every non-conditional entry past `process_env_count`) into
+    /// `script_forward` and truncate the map back to the process-env prefix.
+    /// Clears every default-file slot.
     ///
-    /// The corresponding file slots are cleared so a later
-    /// `load_default_files` on the same `Loader` (the `bun run <file>` slow
-    /// path boots a VM that shares the process singleton) re-reads them.
-    pub fn remove_conditional(&mut self) {
-        self.map.map.retain(|_, v| !v.conditional);
+    /// `bun run <script>` calls this so the script's subprocess environment
+    /// carries `.env` / `.env.local` values (no NODE_ENV dependency, #9877)
+    /// while leaving `.env.{NODE_ENV}[.local]` keys for the script's own
+    /// `bun` instance to re-derive under whatever NODE_ENV it sets (#9635).
+    /// The map is restored to exactly the process-env state so the
+    /// `bun run <file>` slow path, which boots a VM on this same singleton,
+    /// observes what it would on a fresh loader.
+    pub fn take_script_dotenv(&mut self, process_env_count: usize) {
+        self.script_forward.clear();
+        {
+            let keys = self.map.map.keys();
+            let values = self.map.map.values();
+            for i in process_env_count..keys.len() {
+                if !values[i].conditional {
+                    self.script_forward
+                        .push((keys[i].clone(), values[i].value.clone()));
+                }
+            }
+        }
+        let mut i = 0usize;
+        self.map.map.retain(|_, _| {
+            let keep = i < process_env_count;
+            i += 1;
+            keep
+        });
+        self.env = None;
+        self.env_local = None;
         self.env_development = None;
         self.env_production = None;
         self.env_test = None;
         self.env_development_local = None;
         self.env_production_local = None;
         self.env_test_local = None;
+    }
+
+    /// `Map::create_null_delimited_env_map` plus the `.env` / `.env.local`
+    /// entries captured by [`Self::take_script_dotenv`]. Used by the
+    /// `bun run <script>` / `bunx` / `--filter` spawn sites.
+    pub fn create_null_delimited_env_map(&mut self) -> Result<NullDelimitedEnvMap, AllocError> {
+        self.map
+            .create_null_delimited_env_map_with_extra(&self.script_forward)
     }
 
     pub fn print_loaded(&self, start: i128) {
@@ -1171,7 +1204,12 @@ impl<'a> Parser<'a> {
         Ok(strings::trim(&self.src[start..end], WHITESPACE_CHARS))
     }
 
-    fn expand_value(&mut self, map: &Map, value: &[u8]) -> Result<Option<&[u8]>, AllocError> {
+    fn expand_value(
+        &mut self,
+        map: &Map,
+        value: &[u8],
+        touched_conditional: &mut bool,
+    ) -> Result<Option<&[u8]>, AllocError> {
         if value.len() < 2 {
             return Ok(None);
         }
@@ -1203,7 +1241,15 @@ impl<'a> Parser<'a> {
                             _ => break,
                         }
                     }
-                    let lookup_value = map.get(&value[key_start..end]);
+                    let lookup_value = match map.map.get(&value[key_start..end]) {
+                        Some(entry) => {
+                            if entry.conditional {
+                                *touched_conditional = true;
+                            }
+                            Some(&*entry.value)
+                        }
+                        None => None,
+                    };
                     let default_value: &[u8] = if value[end..].starts_with(b":-") {
                         end += b":-".len();
                         let value_start = end;
@@ -1288,8 +1334,15 @@ impl<'a> Parser<'a> {
             let mut idx = count;
             while idx < total {
                 let current: Box<[u8]> = Box::from(&*map.map.values()[idx].value);
-                if let Some(expanded) = self.expand_value(map, &current)? {
-                    map.map.values_mut()[idx].value = Box::from(expanded);
+                let mut touched_conditional = false;
+                if let Some(expanded) =
+                    self.expand_value(map, &current, &mut touched_conditional)?
+                {
+                    let slot = &mut map.map.values_mut()[idx];
+                    slot.value = Box::from(expanded);
+                    if touched_conditional {
+                        slot.conditional = true;
+                    }
                 }
                 idx += 1;
             }
@@ -1361,23 +1414,41 @@ impl Map {
     /// Builds a NULL-terminated `K=V\0` envp array. Returns an owning struct so
     /// dropping it frees the joined buffers (PORTING.md §Forbidden: no Box::leak).
     pub fn create_null_delimited_env_map(&mut self) -> Result<NullDelimitedEnvMap, AllocError> {
-        let envp_count = self.map.count();
+        self.create_null_delimited_env_map_with_extra(&[])
+    }
+
+    /// [`Self::create_null_delimited_env_map`] plus an `extra` tail of
+    /// `K`/`V` pairs appended after the map's own entries. Entries in `extra`
+    /// whose key already appears in `self` are skipped so process env keeps
+    /// winning.
+    pub fn create_null_delimited_env_map_with_extra(
+        &mut self,
+        extra: &[(Box<[u8]>, Box<[u8]>)],
+    ) -> Result<NullDelimitedEnvMap, AllocError> {
+        let envp_count = self.map.count() + extra.len();
         let mut storage: Vec<Box<[u8]>> = Vec::with_capacity(envp_count);
         let mut envp_buf: Vec<*const c_char> = Vec::with_capacity(envp_count + 1);
+        let mut push = |key: &[u8], value: &[u8]| {
+            let klen = key.len();
+            let vlen = value.len();
+            let mut env_buf = vec![0u8; klen + vlen + 2].into_boxed_slice();
+            env_buf[..klen].copy_from_slice(key);
+            env_buf[klen] = b'=';
+            env_buf[klen + 1..klen + 1 + vlen].copy_from_slice(value);
+            // env_buf[klen + 1 + vlen] = 0; (already zero-initialized)
+            envp_buf.push(env_buf.as_ptr().cast::<c_char>());
+            storage.push(env_buf);
+        };
         {
             let mut it = self.map.iterator();
             while let Some(pair) = it.next() {
-                let klen = pair.key_ptr.len();
-                let vlen = pair.value_ptr.value.len();
-                let mut env_buf = vec![0u8; klen + vlen + 2].into_boxed_slice();
-                env_buf[..klen].copy_from_slice(pair.key_ptr);
-                env_buf[klen] = b'=';
-                env_buf[klen + 1..klen + 1 + vlen].copy_from_slice(&pair.value_ptr.value);
-                // env_buf[klen + 1 + vlen] = 0; (already zero-initialized)
-                envp_buf.push(env_buf.as_ptr().cast::<c_char>());
-                storage.push(env_buf);
+                push(pair.key_ptr, &pair.value_ptr.value);
             }
-            debug_assert!(envp_buf.len() == envp_count);
+        }
+        for (k, v) in extra {
+            if !self.map.contains(k) {
+                push(k, v);
+            }
         }
         envp_buf.push(core::ptr::null()); // sentinel
         Ok(NullDelimitedEnvMap {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -449,6 +449,7 @@ impl Loader {
                 *cxx_gop.key_ptr = Box::<[u8]>::from(&**cxx_gop.key_ptr);
                 *cxx_gop.value_ptr = HashTableValue {
                     value: ccache_path.clone(),
+                    conditional: false,
                 };
             }
             let c_gop = self
@@ -456,7 +457,10 @@ impl Loader {
                 .get_or_put_without_value(b"CMAKE_C_COMPILER_LAUNCHER")?;
             if !c_gop.found_existing {
                 *c_gop.key_ptr = Box::<[u8]>::from(&**c_gop.key_ptr);
-                *c_gop.value_ptr = HashTableValue { value: ccache_path };
+                *c_gop.value_ptr = HashTableValue {
+                    value: ccache_path,
+                    conditional: false,
+                };
             }
         }
         Ok(())
@@ -611,7 +615,11 @@ impl Loader {
         // `Source.contents: &'static [u8]` lifetime constraint (callers like
         // `node:util.parseEnv` pass JS-owned non-'static buffers).
         let mut value_buffer: Vec<u8> = Vec::new();
-        Parser::parse_bytes::<OVERWRITE, false, EXPAND>(str, &mut self.map, &mut value_buffer)
+        Parser::parse_bytes::<OVERWRITE, false, EXPAND, false>(
+            str,
+            &mut self.map,
+            &mut value_buffer,
+        )
     }
 
     pub fn load<D: DirEntryProbe + ?Sized>(
@@ -629,17 +637,8 @@ impl Loader {
 
         if !env_files.is_empty() {
             self.load_explicit_files(env_files, &mut value_buffer)?;
-        } else {
-            // Do not automatically load .env files in `bun run <script>`
-            // Instead, it is the responsibility of the script's instance of `bun` to load .env,
-            // so that if the script runner is NODE_ENV=development, but the script is
-            // "NODE_ENV=production bun ...", there should be no development env loaded.
-            //
-            // See https://github.com/oven-sh/bun/issues/9635#issuecomment-2021350123
-            // for more details on how this edge case works.
-            if !skip_default_env {
-                self.load_default_files(suffix, dir, &mut value_buffer)?;
-            }
+        } else if !skip_default_env {
+            self.load_default_files(suffix, dir, &mut value_buffer)?;
         }
 
         if !self.quiet {
@@ -687,41 +686,50 @@ impl Loader {
         // directory entry is taken generically — `bun_resolver::fs::DirEntry`
         // impls `DirEntryProbe`.
         match suffix {
-            DotEnvFileSuffix::Development => {
-                self.try_load_default(dir, dir_handle, b".env.development.local", value_buffer)?
-            }
-            DotEnvFileSuffix::Production => {
-                self.try_load_default(dir, dir_handle, b".env.production.local", value_buffer)?
-            }
+            DotEnvFileSuffix::Development => self.try_load_default::<_, true>(
+                dir,
+                dir_handle,
+                b".env.development.local",
+                value_buffer,
+            )?,
+            DotEnvFileSuffix::Production => self.try_load_default::<_, true>(
+                dir,
+                dir_handle,
+                b".env.production.local",
+                value_buffer,
+            )?,
             DotEnvFileSuffix::Test => {
-                self.try_load_default(dir, dir_handle, b".env.test.local", value_buffer)?
+                self.try_load_default::<_, true>(dir, dir_handle, b".env.test.local", value_buffer)?
             }
         }
 
         if suffix != DotEnvFileSuffix::Test {
-            self.try_load_default(dir, dir_handle, b".env.local", value_buffer)?;
+            self.try_load_default::<_, false>(dir, dir_handle, b".env.local", value_buffer)?;
         }
 
         match suffix {
-            DotEnvFileSuffix::Development => {
-                self.try_load_default(dir, dir_handle, b".env.development", value_buffer)?
-            }
+            DotEnvFileSuffix::Development => self.try_load_default::<_, true>(
+                dir,
+                dir_handle,
+                b".env.development",
+                value_buffer,
+            )?,
             DotEnvFileSuffix::Production => {
-                self.try_load_default(dir, dir_handle, b".env.production", value_buffer)?
+                self.try_load_default::<_, true>(dir, dir_handle, b".env.production", value_buffer)?
             }
             DotEnvFileSuffix::Test => {
-                self.try_load_default(dir, dir_handle, b".env.test", value_buffer)?
+                self.try_load_default::<_, true>(dir, dir_handle, b".env.test", value_buffer)?
             }
         }
 
-        self.try_load_default(dir, dir_handle, b".env", value_buffer)
+        self.try_load_default::<_, false>(dir, dir_handle, b".env", value_buffer)
     }
 
     /// Probe `dir` for a known `.env*` filename and, if present, load it into
     /// its dedicated slot and bump the analytics counter. Shared body for the
     /// eight call sites in `load_default_files`.
     #[inline]
-    fn try_load_default<D: DirEntryProbe + ?Sized>(
+    fn try_load_default<D: DirEntryProbe + ?Sized, const CONDITIONAL: bool>(
         &mut self,
         dir: &D,
         dir_handle: bun_sys::Fd,
@@ -729,10 +737,32 @@ impl Loader {
         value_buffer: &mut Vec<u8>,
     ) -> crate::Result<()> {
         if dir.has_comptime_query(name) {
-            self.load_env_file::<false>(dir_handle, name, value_buffer)?;
+            self.load_env_file::<false, CONDITIONAL>(dir_handle, name, value_buffer)?;
             analytics::Features::dotenv_inc();
         }
         Ok(())
+    }
+
+    /// Drop every entry whose value came from a NODE_ENV-specific default file
+    /// (`.env.{development,production,test}[.local]`). `bun run <script>`
+    /// calls this after `load_default_files` so the script's subprocess
+    /// environment carries `.env` / `.env.local` values (no NODE_ENV
+    /// dependency) while leaving NODE_ENV-specific keys for the script's own
+    /// `bun` instance to re-derive under whatever NODE_ENV it sets.
+    /// See https://github.com/oven-sh/bun/issues/9635#issuecomment-2021350123
+    /// and https://github.com/oven-sh/bun/issues/9877.
+    ///
+    /// The corresponding file slots are cleared so a later
+    /// `load_default_files` on the same `Loader` (the `bun run <file>` slow
+    /// path boots a VM that shares the process singleton) re-reads them.
+    pub fn remove_conditional(&mut self) {
+        self.map.map.retain(|_, v| !v.conditional);
+        self.env_development = None;
+        self.env_production = None;
+        self.env_test = None;
+        self.env_development_local = None;
+        self.env_production_local = None;
+        self.env_test_local = None;
     }
 
     pub fn print_loaded(&self, start: i128) {
@@ -816,7 +846,7 @@ impl Loader {
         }
     }
 
-    pub fn load_env_file<const OVERRIDE: bool>(
+    pub fn load_env_file<const OVERRIDE: bool, const CONDITIONAL: bool>(
         &mut self,
         dir: bun_sys::Fd,
         base: &'static [u8],
@@ -870,7 +900,11 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
+                Parser::parse_bytes::<OVERRIDE, false, true, CONDITIONAL>(
+                    &buf,
+                    &mut self.map,
+                    value_buffer,
+                )?;
             }
         }
 
@@ -917,7 +951,11 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
+                Parser::parse_bytes::<OVERRIDE, false, true, false>(
+                    &buf,
+                    &mut self.map,
+                    value_buffer,
+                )?;
             }
         }
 
@@ -1207,7 +1245,12 @@ impl<'a> Parser<'a> {
         Ok(Some(self.value_buffer.as_slice()))
     }
 
-    fn _parse<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
+    fn _parse<
+        const OVERRIDE: bool,
+        const IS_PROCESS: bool,
+        const EXPAND: bool,
+        const CONDITIONAL: bool,
+    >(
         &mut self,
         map: &mut Map,
     ) -> Result<(), AllocError> {
@@ -1231,7 +1274,10 @@ impl<'a> Parser<'a> {
                 }
                 // else: previous value freed by Drop on assignment below
             }
-            *entry.value_ptr = HashTableValue { value: value_owned };
+            *entry.value_ptr = HashTableValue {
+                value: value_owned,
+                conditional: CONDITIONAL,
+            };
         }
         if !IS_PROCESS && EXPAND {
             // borrowck — index-based iteration: clone the value bytes, run
@@ -1243,9 +1289,7 @@ impl<'a> Parser<'a> {
             while idx < total {
                 let current: Box<[u8]> = Box::from(&*map.map.values()[idx].value);
                 if let Some(expanded) = self.expand_value(map, &current)? {
-                    map.map.values_mut()[idx] = HashTableValue {
-                        value: Box::from(expanded),
-                    };
+                    map.map.values_mut()[idx].value = Box::from(expanded);
                 }
                 idx += 1;
             }
@@ -1258,7 +1302,12 @@ impl<'a> Parser<'a> {
     /// Same as [`parse`] but takes the source bytes directly. Exists so
     /// `load_env_file*` can parse a transient `Vec<u8>` without constructing a
     /// `bun_ast::Source` (whose `contents` field is currently `&'static [u8]`).
-    pub(crate) fn parse_bytes<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
+    pub(crate) fn parse_bytes<
+        const OVERRIDE: bool,
+        const IS_PROCESS: bool,
+        const EXPAND: bool,
+        const CONDITIONAL: bool,
+    >(
         src: &[u8],
         map: &mut Map,
         value_buffer: &mut Vec<u8>,
@@ -1272,7 +1321,7 @@ impl<'a> Parser<'a> {
             src: strings::without_utf8_bom(src),
             value_buffer,
         };
-        parser._parse::<OVERRIDE, IS_PROCESS, EXPAND>(map)
+        parser._parse::<OVERRIDE, IS_PROCESS, EXPAND, CONDITIONAL>(map)
     }
 }
 
@@ -1281,6 +1330,12 @@ pub struct HashTableValue {
     // `Box<[u8]>` is owned-by-default, trading some copies for uniform
     // ownership.
     pub value: Box<[u8]>,
+    /// Set for keys whose value came from a NODE_ENV-dependent default file
+    /// (`.env.development`, `.env.production`, `.env.test`, or their `.local`
+    /// variants). The `bun run <script>` dispatcher drops these before
+    /// spawning so a script that sets its own NODE_ENV can re-derive them;
+    /// keys that exist in `.env` / `.env.local` stay. See #9635 / #9877.
+    pub conditional: bool,
 }
 
 // On Windows, environment variables are case-insensitive. So we use a case-insensitive hash map.
@@ -1411,6 +1466,7 @@ impl Map {
             key,
             HashTableValue {
                 value: Box::from(value),
+                conditional: false,
             },
         )
     }
@@ -1428,6 +1484,7 @@ impl Map {
             key,
             HashTableValue {
                 value: Box::from(value),
+                conditional: false,
             },
         );
     }
@@ -1437,6 +1494,7 @@ impl Map {
         let gop = self.map.get_or_put(key)?;
         *gop.value_ptr = HashTableValue {
             value: Box::from(value),
+            conditional: false,
         };
         if !gop.found_existing {
             *gop.key_ptr = Box::from(key);
@@ -1471,6 +1529,7 @@ impl Map {
             key,
             HashTableValue {
                 value: Box::from(value),
+                conditional: false,
             },
         )?;
         Ok(())

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -119,8 +119,8 @@ pub struct Loader {
     /// only populated with files specified explicitly (e.g. --env-file arg)
     pub custom_files_loaded: StringArrayHashMap<bun_ast::Source>,
 
-    /// `.env`/`.env.local` entries [`Self::take_script_dotenv`] lifted out of
-    /// `map` for the `bun run <script>` subprocess env; empty elsewhere.
+    /// Non-conditional dotenv entries [`Self::take_script_dotenv`] lifted out
+    /// of `map` for the `bun run <script>` subprocess env; empty elsewhere.
     pub script_forward: Vec<(Box<[u8]>, Box<[u8]>)>,
 
     pub quiet: bool,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -92,6 +92,15 @@ impl DotEnvBehavior {
 /// this T2 crate names no `bun_s3_signing` types — see PORTING.md §Dispatch (cold-path,
 /// upward dep). The high-tier caller constructs the real refcounted `S3Credentials` from
 /// this POD at the call site.
+#[inline]
+fn is_suffix_key(k: &[u8]) -> bool {
+    #[cfg(windows)]
+    return strings::eql_case_insensitive_ascii_check_length(k, b"NODE_ENV")
+        || strings::eql_case_insensitive_ascii_check_length(k, b"BUN_ENV");
+    #[cfg(not(windows))]
+    return k == b"NODE_ENV" || k == b"BUN_ENV";
+}
+
 #[derive(Clone, Default)]
 pub struct S3Credentials {
     pub access_key_id: Box<[u8]>,
@@ -777,20 +786,13 @@ impl Loader {
     /// Move non-conditional dotenv entries (indices `process_env_count..`)
     /// into `script_forward`, truncate `map` to the process-env prefix, and
     /// clear every default-file slot. See #9877 / #9635.
-    pub fn take_script_dotenv(&mut self, process_env_count: usize) {
+    pub fn take_script_dotenv(&mut self, process_env_count: usize, filter_suffix_keys: bool) {
         self.script_forward.clear();
         {
-            #[cfg(windows)]
-            let is_suffix_key = |k: &[u8]| {
-                strings::eql_case_insensitive_ascii_check_length(k, b"NODE_ENV")
-                    || strings::eql_case_insensitive_ascii_check_length(k, b"BUN_ENV")
-            };
-            #[cfg(not(windows))]
-            let is_suffix_key = |k: &[u8]| k == b"NODE_ENV" || k == b"BUN_ENV";
             let keys = self.map.map.keys();
             let values = self.map.map.values();
             for i in process_env_count..keys.len() {
-                if !values[i].conditional && !is_suffix_key(&keys[i]) {
+                if !values[i].conditional && !(filter_suffix_keys && is_suffix_key(&keys[i])) {
                     self.script_forward
                         .push((keys[i].clone(), values[i].value.clone()));
                 }
@@ -1269,7 +1271,11 @@ impl<'a> Parser<'a> {
                             _ => break,
                         }
                     }
-                    let lookup_value = match map.map.get(&value[key_start..end]) {
+                    let referenced_key = &value[key_start..end];
+                    if taint_unresolved && is_suffix_key(referenced_key) {
+                        *touched_conditional = true;
+                    }
+                    let lookup_value = match map.map.get(referenced_key) {
                         Some(entry) => {
                             if entry.conditional {
                                 *touched_conditional = true;

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1050,6 +1050,7 @@ fn configure_env_for_scripts_run(
             value: Box::<[u8]>::from(strings::without_trailing_slash(
                 FileSystem::instance().top_level_dir(),
             )),
+            conditional: false,
         };
     }
 

--- a/src/install_jsc/ini_jsc.rs
+++ b/src/install_jsc/ini_jsc.rs
@@ -71,6 +71,7 @@ impl IniTestingAPIs {
                     &keyslice,
                     dotenv::map::Entry {
                         value: slice.into_boxed_slice(),
+                        conditional: false,
                     },
                 )?;
             }

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1273,7 +1273,7 @@ impl BunxCommand {
             .put(b"BUN_INTERNAL_BUNX_INSTALL", b"true")
             .expect("oom");
 
-        let envp = env_loader.map.create_null_delimited_env_map()?;
+        let envp = env_loader.create_null_delimited_env_map()?;
 
         let spawn_result = match proc_sync::spawn(&proc_sync::Options {
             argv: argv_to_use.iter().map(|s| Box::<[u8]>::from(*s)).collect(),

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -667,7 +667,7 @@ impl BunxCommand {
         let mut original_path: Vec<u8> = Vec::new();
 
         let root_dir_info =
-            Run::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, true)?;
+            Run::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, true, true)?;
         // SAFETY: `configure_env_for_run` returned `Ok`, so the slot is fully
         // initialized via `MaybeUninit::write`.
         let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -109,7 +109,10 @@ impl<'a> ProcessHandle<'a> {
                 let _ = unsafe { (*env_ptr).map.put(b"PATH", &original_path) };
             }
             // SAFETY: see above; reborrow through raw ptr to avoid overlapping &mut with guard.
-            let envp = unsafe { (*env_ptr).create_null_delimited_env_map()? };
+            // `script_forward` is NOT merged: it was loaded from the
+            // invocation cwd's `.env`, but each script runs in a different
+            // package cwd whose own `.env` a nested bun must be able to read.
+            let envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
             // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
             // with argv[0] non-null; valid for this call.
             break 'brk unsafe {

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -109,7 +109,7 @@ impl<'a> ProcessHandle<'a> {
                 let _ = unsafe { (*env_ptr).map.put(b"PATH", &original_path) };
             }
             // SAFETY: see above; reborrow through raw ptr to avoid overlapping &mut with guard.
-            let envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
+            let envp = unsafe { (*env_ptr).create_null_delimited_env_map()? };
             // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
             // with argv[0] non-null; valid for this call.
             break 'brk unsafe {

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -109,9 +109,6 @@ impl<'a> ProcessHandle<'a> {
                 let _ = unsafe { (*env_ptr).map.put(b"PATH", &original_path) };
             }
             // SAFETY: see above; reborrow through raw ptr to avoid overlapping &mut with guard.
-            // `script_forward` is NOT merged: it was loaded from the
-            // invocation cwd's `.env`, but each script runs in a different
-            // package cwd whose own `.env` a nested bun must be able to read.
             let envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
             // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
             // with argv[0] non-null; valid for this call.
@@ -737,7 +734,14 @@ pub(crate) fn run_scripts_with_filter(
     // `RunCommand::configure_env_for_run(...) -> Result<Transpiler, _>`; until then
     // pass `&mut MaybeUninit<Transpiler>` (zeroed() is invalid: Transpiler is not #[repr(C)] POD).
     let mut this_transpiler = core::mem::MaybeUninit::<bun_bundler::Transpiler<'static>>::uninit();
-    let _ = RunCommand::configure_env_for_run(&mut *ctx, &mut this_transpiler, None, true, false)?;
+    let _ = RunCommand::configure_env_for_run(
+        &mut *ctx,
+        &mut this_transpiler,
+        None,
+        true,
+        false,
+        false,
+    )?;
     // SAFETY: configure_env_for_run fully initializes the out-param on Ok.
     let mut this_transpiler = unsafe { this_transpiler.assume_init() };
 

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -150,7 +150,6 @@ impl<'a> ProcessHandle<'a> {
                 let _ = unsafe { (*env_ptr).map.put(b"PATH", &original_path) };
             });
             // SAFETY: same loader; the `_restore` guard's closure has not fired yet.
-            // `script_forward` is NOT merged: see the matching filter_run.rs note.
             envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
             // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
             // with argv[0] non-null; valid for this call.
@@ -796,7 +795,14 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     // Out-param init pattern.
     let mut this_transpiler_slot =
         ::core::mem::MaybeUninit::<bun_bundler::Transpiler<'static>>::uninit();
-    let _ = RunCommand::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, false)?;
+    let _ = RunCommand::configure_env_for_run(
+        ctx,
+        &mut this_transpiler_slot,
+        None,
+        true,
+        false,
+        false,
+    )?;
     // SAFETY: `configure_env_for_run` fully writes the slot on the success path.
     let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };
     let cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -150,7 +150,8 @@ impl<'a> ProcessHandle<'a> {
                 let _ = unsafe { (*env_ptr).map.put(b"PATH", &original_path) };
             });
             // SAFETY: same loader; the `_restore` guard's closure has not fired yet.
-            envp = unsafe { (*env_ptr).create_null_delimited_env_map()? };
+            // `script_forward` is NOT merged: see the matching filter_run.rs note.
+            envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
             // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
             // with argv[0] non-null; valid for this call.
             unsafe {

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -150,7 +150,7 @@ impl<'a> ProcessHandle<'a> {
                 let _ = unsafe { (*env_ptr).map.put(b"PATH", &original_path) };
             });
             // SAFETY: same loader; the `_restore` guard's closure has not fired yet.
-            envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
+            envp = unsafe { (*env_ptr).create_null_delimited_env_map()? };
             // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
             // with argv[0] non-null; valid for this call.
             unsafe {

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2018,6 +2018,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         Some(pm_env(ctx.manager)),
         ctx.manager.options.log_level != LogLevel::Silent,
         false,
+        false,
     ) {
         if matches!(err, crate::Error::Alloc(_)) {
             return Err(PackError::OutOfMemory);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -680,19 +680,19 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 // boots a VM on this singleton) matches the fast path.
                 let process_env_count = env_loader.map.map.count();
                 let disable_default = this_transpiler.options.env.disable_default_env_files;
-                let _ = this_transpiler.run_env_loader(disable_default);
-                // A `.env` key shadowed by a file under a NODE_ENV the parent
-                // does not run under must not be forwarded either, so visit
-                // the other-suffix files to mark those keys conditional.
+                // Explicit --env-file (if any); skip auto-discovery here.
+                let _ = this_transpiler.run_env_loader(true);
                 if !disable_default && this_transpiler.options.env.files.is_empty() {
                     if let Some(entries) =
                         root_dir_info.get_entries(this_transpiler.resolver.generation)
                     {
                         // SAFETY: BSSMap-owned; single-threaded dispatch.
                         let dir: &bun_resolver::fs::DirEntry = unsafe { &*entries };
+                        // Every NODE_ENV-dependent file is loaded before .env
+                        // so .env's expansion sees their keys as conditional.
                         let _ = this_transpiler
                             .env_mut()
-                            .mark_keys_in_other_node_env_files(dir);
+                            .load_default_files_for_script_runner(dir);
                     }
                 }
                 this_transpiler

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -660,17 +660,12 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 }
             }
 
-            // Load the default .env files so package.json scripts that spawn a
-            // non-bun tool (vite, node, cypress, psql, ...) see them (#9877),
-            // then move the `.env` / `.env.local` entries into `script_forward`
-            // and restore the map to the process-env prefix. Entries that came
-            // from a NODE_ENV-specific file (`.env.{development,production,
-            // test}[.local]`), or whose expansion resolved against one, are
-            // dropped so a script that sets its own NODE_ENV
-            // ("NODE_ENV=production bun ...") re-derives them under the right
-            // suffix (#9635). The map returning to process-env state keeps the
-            // slow `bun run <file>` path (which boots a VM on this singleton)
-            // observationally identical to the fast path.
+            // Load the default .env files and lift the `.env`/`.env.local`
+            // entries into `script_forward` for the subprocess (#9877);
+            // `.env.{NODE_ENV}[.local]` entries are dropped so a script
+            // re-derives them under its own NODE_ENV (#9635). The map returns
+            // to the process-env prefix so the `bun run <file>` slow path
+            // (which boots a VM on this singleton) matches the fast path.
             let process_env_count = env_loader.map.map.count();
             let disable_default = this_transpiler.options.env.disable_default_env_files;
             let _ = this_transpiler.run_env_loader(disable_default);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -660,9 +660,19 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 }
             }
 
-            // Always skip default .env files for package.json script runner
-            // (the script's own bun instance loads .env)
-            let _ = this_transpiler.run_env_loader(true);
+            // Load the default .env files so package.json scripts that spawn a
+            // non-bun tool (vite, node, cypress, psql, ...) see them (#9877),
+            // then drop the entries that came from a NODE_ENV-specific file
+            // (`.env.{development,production,test}[.local]`) so a script that
+            // sets its own NODE_ENV (e.g. "NODE_ENV=production bun ...") can
+            // re-derive the right file instead of inheriting this process's
+            // choice (#9635). Keys that also appear in `.env` / `.env.local`
+            // but were first supplied by a NODE_ENV-specific file are dropped
+            // here and re-derived by the child; keys that appear only in
+            // `.env` / `.env.local` are forwarded.
+            let disable_default = this_transpiler.options.env.disable_default_env_files;
+            let _ = this_transpiler.run_env_loader(disable_default);
+            this_transpiler.env_mut().remove_conditional();
         }
 
         // Re-derive after `run_env_loader` — that call creates its own

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -681,6 +681,20 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 let process_env_count = env_loader.map.map.count();
                 let disable_default = this_transpiler.options.env.disable_default_env_files;
                 let _ = this_transpiler.run_env_loader(disable_default);
+                // A `.env` key shadowed by a file under a NODE_ENV the parent
+                // does not run under must not be forwarded either, so visit
+                // the other-suffix files to mark those keys conditional.
+                if !disable_default && this_transpiler.options.env.files.is_empty() {
+                    if let Some(entries) =
+                        root_dir_info.get_entries(this_transpiler.resolver.generation)
+                    {
+                        // SAFETY: BSSMap-owned; single-threaded dispatch.
+                        let dir: &bun_resolver::fs::DirEntry = unsafe { &*entries };
+                        let _ = this_transpiler
+                            .env_mut()
+                            .mark_keys_in_other_node_env_files(dir);
+                    }
+                }
                 this_transpiler
                     .env_mut()
                     .take_script_dotenv(process_env_count);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -532,8 +532,17 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         env: Option<*mut DotEnv::Loader>,
         log_errors: bool,
         store_root_fd: bool,
+        forward_dotenv: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
-        Self::configure_env_for_run_impl(ctx, this_transpiler, env, log_errors, store_root_fd, true)
+        Self::configure_env_for_run_impl(
+            ctx,
+            this_transpiler,
+            env,
+            log_errors,
+            store_root_fd,
+            true,
+            forward_dotenv,
+        )
     }
 
     /// Like [`Self::configure_env_for_run`] but does **not** construct the
@@ -554,6 +563,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             log_errors,
             store_root_fd,
             false,
+            true,
         )
     }
 
@@ -579,6 +589,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         log_errors: bool,
         store_root_fd: bool,
         with_linker: bool,
+        forward_dotenv: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
         let args = ctx.args.clone();
         let env_is_none = env.is_none();
@@ -660,18 +671,26 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 }
             }
 
-            // Load the default .env files and lift the `.env`/`.env.local`
-            // entries into `script_forward` for the subprocess (#9877);
-            // `.env.{NODE_ENV}[.local]` entries are dropped so a script
-            // re-derives them under its own NODE_ENV (#9635). The map returns
-            // to the process-env prefix so the `bun run <file>` slow path
-            // (which boots a VM on this singleton) matches the fast path.
-            let process_env_count = env_loader.map.map.count();
-            let disable_default = this_transpiler.options.env.disable_default_env_files;
-            let _ = this_transpiler.run_env_loader(disable_default);
-            this_transpiler
-                .env_mut()
-                .take_script_dotenv(process_env_count);
+            if forward_dotenv {
+                // Load the default .env files and lift the non-conditional
+                // entries into `script_forward` for the subprocess (#9877);
+                // NODE_ENV-dependent entries are dropped so a script re-derives
+                // them under its own NODE_ENV (#9635). The map returns to the
+                // process-env prefix so the `bun run <file>` slow path (which
+                // boots a VM on this singleton) matches the fast path.
+                let process_env_count = env_loader.map.map.count();
+                let disable_default = this_transpiler.options.env.disable_default_env_files;
+                let _ = this_transpiler.run_env_loader(disable_default);
+                this_transpiler
+                    .env_mut()
+                    .take_script_dotenv(process_env_count);
+            } else {
+                // `--filter` / multi-run spawn each script in a different
+                // package cwd; forwarding the invocation-cwd `.env` would
+                // shadow per-package `.env` in a nested bun. Skip the default
+                // files (pre-#9877 behavior for these callers).
+                let _ = this_transpiler.run_env_loader(true);
+            }
         }
 
         // Re-derive after `run_env_loader` — that call creates its own

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -4077,7 +4077,7 @@ impl BunXFastPath {
         // contract is that *this* `passthrough` wins.
         ctx.passthrough = passthrough.to_vec();
 
-        let env_block = env.map.write_windows_env_block();
+        let env_block = env.write_windows_env_block();
 
         let run_ctx = bun_install::windows_shim::bun_shim_impl::FromBunRunContext {
             handle,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -682,7 +682,15 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 let disable_default = this_transpiler.options.env.disable_default_env_files;
                 // Explicit --env-file (if any); skip auto-discovery here.
                 let _ = this_transpiler.run_env_loader(true);
-                if !disable_default && this_transpiler.options.env.files.is_empty() {
+                // Auto-discover only when the script's spawn cwd is the
+                // invocation cwd; otherwise the forwarded values were read from
+                // the wrong directory and would shadow the child's own `.env`.
+                let default_files_loaded = if !disable_default
+                    && this_transpiler.options.env.files.is_empty()
+                    && root_dir_info.enclosing_package_json.is_none_or(|pj| {
+                        strings::without_trailing_slash(pj.source.path.name().dir)
+                            == strings::without_trailing_slash(top_level_dir)
+                    }) {
                     if let Some(entries) =
                         root_dir_info.get_entries(this_transpiler.resolver.generation)
                     {
@@ -693,11 +701,16 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                         let _ = this_transpiler
                             .env_mut()
                             .load_default_files_for_script_runner(dir);
+                        true
+                    } else {
+                        false
                     }
-                }
+                } else {
+                    false
+                };
                 this_transpiler
                     .env_mut()
-                    .take_script_dotenv(process_env_count);
+                    .take_script_dotenv(process_env_count, default_files_loaded);
             } else {
                 // `--filter` / multi-run spawn each script in a different
                 // package cwd; forwarding the invocation-cwd `.env` would

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -376,7 +376,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
         // TODO: remember to free this when we add --filter or --concurrent
         // in the meantime we don't need to free it.
-        let envp = env.map.create_null_delimited_env_map()?;
+        let envp = env.create_null_delimited_env_map()?;
 
         let spawn_result = match sync::spawn(&sync::Options {
             argv,
@@ -662,17 +662,21 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
             // Load the default .env files so package.json scripts that spawn a
             // non-bun tool (vite, node, cypress, psql, ...) see them (#9877),
-            // then drop the entries that came from a NODE_ENV-specific file
-            // (`.env.{development,production,test}[.local]`) so a script that
-            // sets its own NODE_ENV (e.g. "NODE_ENV=production bun ...") can
-            // re-derive the right file instead of inheriting this process's
-            // choice (#9635). Keys that also appear in `.env` / `.env.local`
-            // but were first supplied by a NODE_ENV-specific file are dropped
-            // here and re-derived by the child; keys that appear only in
-            // `.env` / `.env.local` are forwarded.
+            // then move the `.env` / `.env.local` entries into `script_forward`
+            // and restore the map to the process-env prefix. Entries that came
+            // from a NODE_ENV-specific file (`.env.{development,production,
+            // test}[.local]`), or whose expansion resolved against one, are
+            // dropped so a script that sets its own NODE_ENV
+            // ("NODE_ENV=production bun ...") re-derives them under the right
+            // suffix (#9635). The map returning to process-env state keeps the
+            // slow `bun run <file>` path (which boots a VM on this singleton)
+            // observationally identical to the fast path.
+            let process_env_count = env_loader.map.map.count();
             let disable_default = this_transpiler.options.env.disable_default_env_files;
             let _ = this_transpiler.run_env_loader(disable_default);
-            this_transpiler.env_mut().remove_conditional();
+            this_transpiler
+                .env_mut()
+                .take_script_dotenv(process_env_count);
         }
 
         // Re-derive after `run_env_loader` — that call creates its own
@@ -2153,7 +2157,7 @@ impl RunCommand {
 
         // TODO: remember to free this when we add --filter or --concurrent
         // in the meantime we don't need to free it.
-        let envp = env.map.create_null_delimited_env_map()?;
+        let envp = env.create_null_delimited_env_map()?;
 
         let spawn_result = match sync::spawn(&sync::Options {
             argv,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2327,6 +2327,7 @@ impl TestCommand {
             *node_env_entry.key_ptr = Box::<[u8]>::from(&**node_env_entry.key_ptr);
             *node_env_entry.value_ptr = DotEnv::HashTableValue {
                 value: Box::<[u8]>::from(b"test" as &[u8]),
+                conditional: false,
             };
         }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -482,11 +482,21 @@ impl Interpreter {
             // `DotEnv::Loader`, which is set by `init_global()` and outlives
             // the interpreter (thread-lifetime singleton).
             let env_loader = unsafe { &mut *event_loop.env() };
-            let mut export_env = EnvMap::init_with_capacity(env_loader.map.map.count());
+            let mut export_env = EnvMap::init_with_capacity(
+                env_loader.map.map.count() + env_loader.script_forward.len(),
+            );
             let mut iter = env_loader.iterator();
             while let Some(entry) = iter.next() {
                 let key = crate::shell::EnvStr::init_slice(&entry.key_ptr[..]);
                 let value = crate::shell::EnvStr::init_slice(&entry.value_ptr.value[..]);
+                export_env.insert(key, value);
+            }
+            for (k, v) in &env_loader.script_forward {
+                if env_loader.map.map.contains(k) {
+                    continue;
+                }
+                let key = crate::shell::EnvStr::init_slice(k);
+                let value = crate::shell::EnvStr::init_slice(v);
                 export_env.insert(key, value);
             }
             export_env

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -897,18 +897,23 @@ for (const shell of ["system", "bun"]) {
       );
     });
 
-    test.skipIf(isWindowsCMD)("e2e: .env expansion re-derives under the script's NODE_ENV", () => {
-      const tmp = tempDirWithFiles("script-runner-dotenv", {
-        "package.json": `{"scripts":{"start":"NODE_ENV=production '${bunExe().replaceAll("\\", "\\\\")}' run index.ts"}}`,
-        "index.ts": "console.log('DATABASE_URL=' + process.env.DATABASE_URL);",
-        ".env": "DATABASE_URL=postgres://$DB_HOST/app",
-        ".env.development": "DB_HOST=localhost",
-        ".env.production": "DB_HOST=prod.internal",
-      });
-      expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe(
-        "DATABASE_URL=postgres://prod.internal/app",
+    for (const withDevFile of [true, false]) {
+      test.skipIf(isWindowsCMD)(
+        `e2e: .env expansion re-derives under the script's NODE_ENV${withDevFile ? "" : " (key absent under this NODE_ENV)"}`,
+        () => {
+          const tmp = tempDirWithFiles("script-runner-dotenv", {
+            "package.json": `{"scripts":{"start":"NODE_ENV=production '${bunExe().replaceAll("\\", "\\\\")}' run index.ts"}}`,
+            "index.ts": "console.log('DATABASE_URL=' + process.env.DATABASE_URL);",
+            ".env": "DATABASE_URL=postgres://$DB_HOST/app",
+            ...(withDevFile ? { ".env.development": "DB_HOST=localhost" } : {}),
+            ".env.production": "DB_HOST=prod.internal",
+          });
+          expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe(
+            "DATABASE_URL=postgres://prod.internal/app",
+          );
+        },
       );
-    });
+    }
 
     test("--no-env-file disables .env loading for scripts", () => {
       const tmp = tempDirWithFiles("script-runner-dotenv", {
@@ -986,21 +991,38 @@ for (const shell of ["system", "bun"]) {
 // `bun run ./<file>` fast path.
 test("bun run <bare-file> and bun run ./<file> agree when .env sets NODE_ENV", () => {
   const tmp = tempDirWithFiles("script-runner-nodeenv", {
+    "package.json": "{}",
     "index.ts": "console.log('API=' + process.env.API + ', NODE_ENV=' + process.env.NODE_ENV);",
     ".env": "NODE_ENV=production",
     ".env.development": "API=dev",
     ".env.production": "API=prod",
   });
-  const run = (target: string) =>
-    Bun.spawnSync([bunExe(), "run", target], {
+  const run = (target: string) => {
+    const r = Bun.spawnSync([bunExe(), "run", target], {
       cwd: tmp,
       env: { ...bunEnv, NODE_ENV: undefined },
-    })
-      .stdout.toString("utf8")
-      .trim();
+    });
+    return { stdout: r.stdout.toString("utf8").trim(), exitCode: r.exitCode };
+  };
   const fast = run("./index.ts");
-  const slow = run("index");
-  expect({ fast, slow }).toEqual({ fast: slow, slow });
+  expect(fast).toEqual({ stdout: "API=dev, NODE_ENV=production", exitCode: 0 });
+  expect(run("index")).toEqual(fast);
+});
+
+test("bun --env-file run <bare-file> sees the --env-file values (slow path)", () => {
+  const tmp = tempDirWithFiles("script-runner-envfile-slow", {
+    "package.json": "{}",
+    "index.ts": "console.log('X=' + process.env.BUNTEST_ENVFILE_X);",
+    "custom.env": "BUNTEST_ENVFILE_X=from-custom",
+  });
+  const r = Bun.spawnSync([bunExe(), "--env-file=custom.env", "run", "index"], {
+    cwd: tmp,
+    env: { ...bunEnv, NODE_ENV: undefined },
+  });
+  expect({ stdout: r.stdout.toString("utf8").trim(), exitCode: r.exitCode }).toEqual({
+    stdout: "X=from-custom",
+    exitCode: 0,
+  });
 });
 
 const todoOnPosix = process.platform !== "win32" ? test.todo : test;

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -953,6 +953,21 @@ for (const shell of ["system", "bun"]) {
       expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe("API_URL=https://api.example.com");
     });
 
+    test.skipIf(isWindowsCMD)(
+      "e2e: .env expansion of a same-file key shadowed only by .env.{other_NODE_ENV} is not pinned",
+      () => {
+        const tmp = tempDirWithFiles("script-runner-dotenv", {
+          "package.json": `{"scripts":{"start":"NODE_ENV=production '${bunExe().replaceAll("\\", "\\\\")}' run index.ts"}}`,
+          "index.ts": "console.log('API_URL=' + process.env.API_URL);",
+          ".env": "HOST=localhost\nAPI_URL=http://$HOST/api",
+          ".env.production": "HOST=api.example.com",
+        });
+        expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe(
+          "API_URL=http://api.example.com/api",
+        );
+      },
+    );
+
     test("--no-env-file disables .env loading for scripts", () => {
       const tmp = tempDirWithFiles("script-runner-dotenv", {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
@@ -1026,10 +1041,11 @@ for (const shell of ["system", "bun"]) {
 // `bun run <bare>` that resolves to a file shares the dot_env singleton with
 // the dispatch transpiler; forwarding `.env` values to scripts must not leave
 // that singleton in a state where the VM's suffix decision diverges from the
-// `bun run ./<file>` fast path.
+// `bun run ./<file>` fast path. A package.json script that re-invokes bun
+// must agree with both too.
 test("bun run <bare-file> and bun run ./<file> agree when .env sets NODE_ENV", () => {
   const tmp = tempDirWithFiles("script-runner-nodeenv", {
-    "package.json": "{}",
+    "package.json": `{"scripts":{"start":"'${bunExe().replaceAll("\\", "\\\\")}' index.ts"}}`,
     "index.ts": "console.log('API=' + process.env.API + ', NODE_ENV=' + process.env.NODE_ENV);",
     ".env": "NODE_ENV=production",
     ".env.development": "API=dev",
@@ -1045,6 +1061,7 @@ test("bun run <bare-file> and bun run ./<file> agree when .env sets NODE_ENV", (
   const fast = run("./index.ts");
   expect(fast).toEqual({ stdout: "API=dev, NODE_ENV=production", exitCode: 0 });
   expect(run("index")).toEqual(fast);
+  expect(run("start")).toEqual(fast);
 });
 
 test("bun --env-file run <bare-file> sees the --env-file values (slow path)", () => {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -886,12 +886,14 @@ for (const shell of ["system", "bun"]) {
       // An `.env` entry that references a key supplied by a NODE_ENV-dependent
       // file is itself NODE_ENV-dependent and must not be forwarded, or a
       // script like "NODE_ENV=production bun ..." would inherit the
-      // development expansion. An entry that expands only process-env /
-      // same-file keys stays forwarded.
+      // development expansion. An entry that expands a process-env key stays
+      // forwarded even when a NODE_ENV-dependent file also defines that key
+      // (process env wins under every NODE_ENV).
       const tmp = tempDirWithFiles("script-runner-dotenv", {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
         ".env": "BUNTEST_DOTENV_A=$BUNTEST_DOTENV_C\nBUNTEST_DOTENV_B=b-$BUNTEST_DOTENV_PROC",
         ".env.development": "BUNTEST_DOTENV_C=from-dev",
+        ".env.production": "BUNTEST_DOTENV_PROC=from-prod",
       });
       const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_A%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", "", ""];
       expect(bunRunAsScript(tmp, "show-env", { BUNTEST_DOTENV_PROC: "proc" }, ["--shell=" + shell]).stdout).toBe(

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -943,6 +943,18 @@ for (const shell of ["system", "bun"]) {
       expect(stderr + stdout).toContain("1 pass");
     });
 
+    test.skipIf(isWindowsCMD)("e2e: .env value shadowed only by .env.{other_NODE_ENV} is not pinned", () => {
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": `{"scripts":{"start":"NODE_ENV=production '${bunExe().replaceAll("\\", "\\\\")}' run index.ts"}}`,
+        "index.ts": "console.log('API_URL=' + process.env.API_URL);",
+        ".env": "API_URL=http://localhost:3000",
+        ".env.production": "API_URL=https://api.example.com",
+      });
+      expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe(
+        "API_URL=https://api.example.com",
+      );
+    });
+
     test("--no-env-file disables .env loading for scripts", () => {
       const tmp = tempDirWithFiles("script-runner-dotenv", {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -847,26 +847,28 @@ for (const shell of ["system", "bun"]) {
 
     // https://github.com/oven-sh/bun/issues/9877: running a package.json script
     // whose body spawns a non-bun tool (vite, node, cypress, psql, ...) should
-    // see values from `.env` and `.env.local`. Values that exist only in a
-    // NODE_ENV-specific file are withheld so a script that assigns its own
-    // NODE_ENV can re-derive them (the e2e tests below cover that).
+    // see values from `.env`. Values from NODE_ENV-dependent files are withheld
+    // so a script that assigns its own NODE_ENV can re-derive them (the e2e
+    // tests below cover that).
     const show_dotenv_script = isWindowsCMD
       ? "echo A=%BUNTEST_DOTENV_A%, B=%BUNTEST_DOTENV_B%, C=%BUNTEST_DOTENV_C%, D=%BUNTEST_DOTENV_D%"
       : "echo A=$BUNTEST_DOTENV_A, B=$BUNTEST_DOTENV_B, C=$BUNTEST_DOTENV_C, D=$BUNTEST_DOTENV_D";
 
-    test("passes .env and .env.local values into scripts", () => {
+    test("passes .env values into scripts", () => {
       const tmp = tempDirWithFiles("script-runner-dotenv", {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
         ".env": "BUNTEST_DOTENV_A=from-env\nBUNTEST_DOTENV_B=from-env",
-        ".env.local": "BUNTEST_DOTENV_B=from-local",
       });
       const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", ""];
       expect(bunRunAsScript(tmp, "show-env", {}, ["--shell=" + shell]).stdout).toBe(
-        `A=from-env, B=from-local, C=${unset[0]}, D=${unset[1]}`,
+        `A=from-env, B=from-env, C=${unset[0]}, D=${unset[1]}`,
       );
     });
 
-    test("withholds .env.{NODE_ENV} values from scripts", () => {
+    test("withholds NODE_ENV-dependent file values from scripts", () => {
+      // .env.local is skipped under NODE_ENV=test, so forwarding it would
+      // shadow a .env.test value in a 'bun test' child; treat it the same as
+      // the .env.{NODE_ENV}[.local] files.
       const tmp = tempDirWithFiles("script-runner-dotenv", {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
         ".env": "BUNTEST_DOTENV_A=from-env",
@@ -874,27 +876,45 @@ for (const shell of ["system", "bun"]) {
         ".env.development": "BUNTEST_DOTENV_C=from-dev",
         ".env.development.local": "BUNTEST_DOTENV_D=from-dev-local",
       });
-      const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", ""];
+      const unset = isWindowsCMD
+        ? ["%BUNTEST_DOTENV_B%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"]
+        : ["", "", ""];
       expect(bunRunAsScript(tmp, "show-env", {}, ["--shell=" + shell]).stdout).toBe(
-        `A=from-env, B=from-local, C=${unset[0]}, D=${unset[1]}`,
+        `A=from-env, B=${unset[0]}, C=${unset[1]}, D=${unset[2]}`,
       );
     });
 
-    test("withholds .env values that expand a .env.{NODE_ENV} key", () => {
-      // An `.env` entry that references a key supplied by a NODE_ENV-specific
+    test("withholds .env values that expand a NODE_ENV-dependent key", () => {
+      // An `.env` entry that references a key supplied by a NODE_ENV-dependent
       // file is itself NODE_ENV-dependent and must not be forwarded, or a
       // script like "NODE_ENV=production bun ..." would inherit the
-      // development expansion.
+      // development expansion. An entry that expands only process-env /
+      // same-file keys stays forwarded.
       const tmp = tempDirWithFiles("script-runner-dotenv", {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
-        ".env": "BUNTEST_DOTENV_A=$BUNTEST_DOTENV_C\nBUNTEST_DOTENV_B=$BUNTEST_DOTENV_E",
+        ".env": "BUNTEST_DOTENV_A=$BUNTEST_DOTENV_C\nBUNTEST_DOTENV_B=b-$BUNTEST_DOTENV_PROC",
         ".env.development": "BUNTEST_DOTENV_C=from-dev",
-        ".env.local": "BUNTEST_DOTENV_E=from-local",
       });
       const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_A%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", "", ""];
-      expect(bunRunAsScript(tmp, "show-env", {}, ["--shell=" + shell]).stdout).toBe(
-        `A=${unset[0]}, B=from-local, C=${unset[1]}, D=${unset[2]}`,
-      );
+      expect(
+        bunRunAsScript(tmp, "show-env", { BUNTEST_DOTENV_PROC: "proc" }, ["--shell=" + shell]).stdout,
+      ).toBe(`A=${unset[0]}, B=b-proc, C=${unset[1]}, D=${unset[2]}`);
+    });
+
+    test("forwards --env-file values that expand an unresolved key", () => {
+      // --env-file loads no default files, so an unresolved $VAR cannot be
+      // NODE_ENV-dependent here; the (possibly defaulted) expansion must be
+      // forwarded.
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
+        "custom.env": "BUNTEST_DOTENV_A=${BUNTEST_DOTENV_UNSET:-fallback}",
+      });
+      const unset = isWindowsCMD
+        ? ["%BUNTEST_DOTENV_B%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"]
+        : ["", "", ""];
+      expect(
+        bunRunAsScript(tmp, "show-env", {}, ["--env-file=custom.env", "--shell=" + shell]).stdout,
+      ).toBe(`A=fallback, B=${unset[0]}, C=${unset[1]}, D=${unset[2]}`);
     });
 
     for (const withDevFile of [true, false]) {
@@ -914,6 +934,18 @@ for (const shell of ["system", "bun"]) {
         },
       );
     }
+
+    test.skipIf(isWindowsCMD)("e2e: .env.local does not shadow .env.test in a 'bun test' child", () => {
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": `{"scripts":{"test":"'${bunExe().replaceAll("\\", "\\\\")}' test db.test.ts"}}`,
+        "db.test.ts":
+          "import {test,expect} from 'bun:test'; test('db', () => expect(process.env.DATABASE_URL).toBe('test-db'));",
+        ".env.local": "DATABASE_URL=dev-db",
+        ".env.test": "DATABASE_URL=test-db",
+      });
+      const { stdout, stderr } = bunRunAsScript(tmp, "test", {}, ["--shell=" + shell]);
+      expect(stderr + stdout).toContain("1 pass");
+    });
 
     test("--no-env-file disables .env loading for scripts", () => {
       const tmp = tempDirWithFiles("script-runner-dotenv", {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -876,9 +876,7 @@ for (const shell of ["system", "bun"]) {
         ".env.development": "BUNTEST_DOTENV_C=from-dev",
         ".env.development.local": "BUNTEST_DOTENV_D=from-dev-local",
       });
-      const unset = isWindowsCMD
-        ? ["%BUNTEST_DOTENV_B%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"]
-        : ["", "", ""];
+      const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_B%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", "", ""];
       expect(bunRunAsScript(tmp, "show-env", {}, ["--shell=" + shell]).stdout).toBe(
         `A=from-env, B=${unset[0]}, C=${unset[1]}, D=${unset[2]}`,
       );
@@ -896,9 +894,9 @@ for (const shell of ["system", "bun"]) {
         ".env.development": "BUNTEST_DOTENV_C=from-dev",
       });
       const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_A%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", "", ""];
-      expect(
-        bunRunAsScript(tmp, "show-env", { BUNTEST_DOTENV_PROC: "proc" }, ["--shell=" + shell]).stdout,
-      ).toBe(`A=${unset[0]}, B=b-proc, C=${unset[1]}, D=${unset[2]}`);
+      expect(bunRunAsScript(tmp, "show-env", { BUNTEST_DOTENV_PROC: "proc" }, ["--shell=" + shell]).stdout).toBe(
+        `A=${unset[0]}, B=b-proc, C=${unset[1]}, D=${unset[2]}`,
+      );
     });
 
     test("forwards --env-file values that expand an unresolved key", () => {
@@ -909,12 +907,10 @@ for (const shell of ["system", "bun"]) {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
         "custom.env": "BUNTEST_DOTENV_A=${BUNTEST_DOTENV_UNSET:-fallback}",
       });
-      const unset = isWindowsCMD
-        ? ["%BUNTEST_DOTENV_B%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"]
-        : ["", "", ""];
-      expect(
-        bunRunAsScript(tmp, "show-env", {}, ["--env-file=custom.env", "--shell=" + shell]).stdout,
-      ).toBe(`A=fallback, B=${unset[0]}, C=${unset[1]}, D=${unset[2]}`);
+      const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_B%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", "", ""];
+      expect(bunRunAsScript(tmp, "show-env", {}, ["--env-file=custom.env", "--shell=" + shell]).stdout).toBe(
+        `A=fallback, B=${unset[0]}, C=${unset[1]}, D=${unset[2]}`,
+      );
     });
 
     for (const withDevFile of [true, false]) {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -830,7 +830,7 @@ for (const shell of ["system", "bun"]) {
     : "echo ENV_FILE_NAME=$ENV_FILE_NAME, NODE_ENV=$NODE_ENV";
 
   describe(`script runner with ${shell} shell`, () => {
-    test("does not pass variables from .env files into scripts", () => {
+    test(".env file values do not override process env", () => {
       const tmp = tempDirWithFiles("script-runner-env", {
         "package.json": '{"scripts":{"show-env":"' + show_env_script + '"}}',
 
@@ -842,6 +842,55 @@ for (const shell of ["system", "bun"]) {
 
       expect(bunRunAsScript(tmp, "show-env", { ...env }, ["--shell=" + shell]).stdout).toBe(
         "ENV_FILE_NAME=N/A, NODE_ENV=" + (isWindowsCMD ? "%NODE_ENV%" : ""),
+      );
+    });
+
+    // https://github.com/oven-sh/bun/issues/9877: running a package.json script
+    // whose body spawns a non-bun tool (vite, node, cypress, psql, ...) should
+    // see values from `.env` and `.env.local`. Values that exist only in a
+    // NODE_ENV-specific file are withheld so a script that assigns its own
+    // NODE_ENV can re-derive them (the e2e tests below cover that).
+    const show_dotenv_script = isWindowsCMD
+      ? "echo A=%BUNTEST_DOTENV_A%, B=%BUNTEST_DOTENV_B%, C=%BUNTEST_DOTENV_C%, D=%BUNTEST_DOTENV_D%"
+      : "echo A=$BUNTEST_DOTENV_A, B=$BUNTEST_DOTENV_B, C=$BUNTEST_DOTENV_C, D=$BUNTEST_DOTENV_D";
+
+    test("passes .env and .env.local values into scripts", () => {
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
+        ".env": "BUNTEST_DOTENV_A=from-env\nBUNTEST_DOTENV_B=from-env",
+        ".env.local": "BUNTEST_DOTENV_B=from-local",
+      });
+      const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", ""];
+      expect(bunRunAsScript(tmp, "show-env", {}, ["--shell=" + shell]).stdout).toBe(
+        `A=from-env, B=from-local, C=${unset[0]}, D=${unset[1]}`,
+      );
+    });
+
+    test("withholds .env.{NODE_ENV} values from scripts", () => {
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
+        ".env": "BUNTEST_DOTENV_A=from-env",
+        ".env.local": "BUNTEST_DOTENV_B=from-local",
+        ".env.development": "BUNTEST_DOTENV_C=from-dev",
+        ".env.development.local": "BUNTEST_DOTENV_D=from-dev-local",
+      });
+      const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", ""];
+      expect(bunRunAsScript(tmp, "show-env", {}, ["--shell=" + shell]).stdout).toBe(
+        `A=from-env, B=from-local, C=${unset[0]}, D=${unset[1]}`,
+      );
+    });
+
+    test("--no-env-file disables .env loading for scripts", () => {
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
+        ".env": "BUNTEST_DOTENV_A=from-env",
+        ".env.local": "BUNTEST_DOTENV_B=from-local",
+      });
+      const unset = isWindowsCMD
+        ? ["%BUNTEST_DOTENV_A%", "%BUNTEST_DOTENV_B%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"]
+        : ["", "", "", ""];
+      expect(bunRunAsScript(tmp, "show-env", {}, ["--no-env-file", "--shell=" + shell]).stdout).toBe(
+        `A=${unset[0]}, B=${unset[1]}, C=${unset[2]}, D=${unset[3]}`,
       );
     });
 

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -902,14 +902,15 @@ for (const shell of ["system", "bun"]) {
     test("forwards --env-file values that expand an unresolved key", () => {
       // --env-file loads no default files, so an unresolved $VAR cannot be
       // NODE_ENV-dependent here; the (possibly defaulted) expansion must be
-      // forwarded.
+      // forwarded, as must NODE_ENV itself (B).
       const tmp = tempDirWithFiles("script-runner-dotenv", {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
-        "custom.env": "BUNTEST_DOTENV_A=${BUNTEST_DOTENV_UNSET:-fallback}",
+        "custom.env":
+          "BUNTEST_DOTENV_A=${BUNTEST_DOTENV_UNSET:-fallback}\nNODE_ENV=from-envfile\nBUNTEST_DOTENV_B=$NODE_ENV",
       });
-      const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_B%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", "", ""];
+      const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", ""];
       expect(bunRunAsScript(tmp, "show-env", {}, ["--env-file=custom.env", "--shell=" + shell]).stdout).toBe(
-        `A=fallback, B=${unset[0]}, C=${unset[1]}, D=${unset[2]}`,
+        `A=fallback, B=from-envfile, C=${unset[0]}, D=${unset[1]}`,
       );
     });
 
@@ -967,6 +968,33 @@ for (const shell of ["system", "bun"]) {
         );
       },
     );
+
+    test.skipIf(isWindowsCMD)("e2e: .env value expanding $NODE_ENV is not pinned", () => {
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": `{"scripts":{"start":"NODE_ENV=production '${bunExe().replaceAll("\\", "\\\\")}' run index.ts"}}`,
+        "index.ts": "console.log('CONFIG=' + process.env.CONFIG);",
+        ".env": "CONFIG=config.$NODE_ENV.json",
+      });
+      expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe("CONFIG=config.production.json");
+    });
+
+    test.skipIf(isWindowsCMD)("e2e: subdirectory .env does not shadow package-root .env in a nested bun", () => {
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": `{"scripts":{"start":"'${bunExe().replaceAll("\\", "\\\\")}' index.ts"}}`,
+        "index.ts": "console.log('X=' + process.env.X);",
+        ".env": "X=root",
+        "src/.env": "X=cwd",
+        "src/placeholder": "",
+      });
+      const r = Bun.spawnSync([bunExe(), "--shell=" + shell, "run", "start"], {
+        cwd: path.join(tmp, "src"),
+        env: { ...bunEnv, NODE_ENV: undefined },
+      });
+      expect({ stdout: r.stdout.toString("utf8").trim(), exitCode: r.exitCode }).toEqual({
+        stdout: "X=root",
+        exitCode: 0,
+      });
+    });
 
     test("--no-env-file disables .env loading for scripts", () => {
       const tmp = tempDirWithFiles("script-runner-dotenv", {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -880,6 +880,36 @@ for (const shell of ["system", "bun"]) {
       );
     });
 
+    test("withholds .env values that expand a .env.{NODE_ENV} key", () => {
+      // An `.env` entry that references a key supplied by a NODE_ENV-specific
+      // file is itself NODE_ENV-dependent and must not be forwarded, or a
+      // script like "NODE_ENV=production bun ..." would inherit the
+      // development expansion.
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
+        ".env": "BUNTEST_DOTENV_A=$BUNTEST_DOTENV_C\nBUNTEST_DOTENV_B=$BUNTEST_DOTENV_E",
+        ".env.development": "BUNTEST_DOTENV_C=from-dev",
+        ".env.local": "BUNTEST_DOTENV_E=from-local",
+      });
+      const unset = isWindowsCMD ? ["%BUNTEST_DOTENV_A%", "%BUNTEST_DOTENV_C%", "%BUNTEST_DOTENV_D%"] : ["", "", ""];
+      expect(bunRunAsScript(tmp, "show-env", {}, ["--shell=" + shell]).stdout).toBe(
+        `A=${unset[0]}, B=from-local, C=${unset[1]}, D=${unset[2]}`,
+      );
+    });
+
+    test.skipIf(isWindowsCMD)("e2e: .env expansion re-derives under the script's NODE_ENV", () => {
+      const tmp = tempDirWithFiles("script-runner-dotenv", {
+        "package.json": `{"scripts":{"start":"NODE_ENV=production '${bunExe().replaceAll("\\", "\\\\")}' run index.ts"}}`,
+        "index.ts": "console.log('DATABASE_URL=' + process.env.DATABASE_URL);",
+        ".env": "DATABASE_URL=postgres://$DB_HOST/app",
+        ".env.development": "DB_HOST=localhost",
+        ".env.production": "DB_HOST=prod.internal",
+      });
+      expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe(
+        "DATABASE_URL=postgres://prod.internal/app",
+      );
+    });
+
     test("--no-env-file disables .env loading for scripts", () => {
       const tmp = tempDirWithFiles("script-runner-dotenv", {
         "package.json": '{"scripts":{"show-env":"' + show_dotenv_script + '"}}',
@@ -949,6 +979,29 @@ for (const shell of ["system", "bun"]) {
     }
   });
 }
+
+// `bun run <bare>` that resolves to a file shares the dot_env singleton with
+// the dispatch transpiler; forwarding `.env` values to scripts must not leave
+// that singleton in a state where the VM's suffix decision diverges from the
+// `bun run ./<file>` fast path.
+test("bun run <bare-file> and bun run ./<file> agree when .env sets NODE_ENV", () => {
+  const tmp = tempDirWithFiles("script-runner-nodeenv", {
+    "index.ts": "console.log('API=' + process.env.API + ', NODE_ENV=' + process.env.NODE_ENV);",
+    ".env": "NODE_ENV=production",
+    ".env.development": "API=dev",
+    ".env.production": "API=prod",
+  });
+  const run = (target: string) =>
+    Bun.spawnSync([bunExe(), "run", target], {
+      cwd: tmp,
+      env: { ...bunEnv, NODE_ENV: undefined },
+    })
+      .stdout.toString("utf8")
+      .trim();
+  const fast = run("./index.ts");
+  const slow = run("index");
+  expect({ fast, slow }).toEqual({ fast: slow, slow });
+});
 
 const todoOnPosix = process.platform !== "win32" ? test.todo : test;
 todoOnPosix("setting process.env coerces the value to a string", () => {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -950,9 +950,7 @@ for (const shell of ["system", "bun"]) {
         ".env": "API_URL=http://localhost:3000",
         ".env.production": "API_URL=https://api.example.com",
       });
-      expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe(
-        "API_URL=https://api.example.com",
-      );
+      expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe("API_URL=https://api.example.com");
     });
 
     test("--no-env-file disables .env loading for scripts", () => {


### PR DESCRIPTION
## What

`bun run <package.json-script>` and `bunx` now load `.env` and export its values to the subprocess, so tools that are not bun (vite, node, cypress, psql, ...) see them. A key is withheld if it also appears in `.env.local` or any `.env.{development,production,test}[.local]` file, or if its `$VAR` expansion referenced a key that does, or if it is `NODE_ENV`/`BUN_ENV`, so that a script can set its own `NODE_ENV` and re-derive it. `bun --filter` / workspace multi-run are unchanged.

## Repro

```sh
d=$(mktemp -d); cd "$d"
printf 'VITE_BACKEND=https://api.example.com\n' > .env
cat > package.json <<'JSON'
{"scripts":{"check":"sh -c 'echo VITE_BACKEND=$VITE_BACKEND'"}}
JSON
bun run check
# before: VITE_BACKEND=
# after:  VITE_BACKEND=https://api.example.com
```

## Cause

#9689 fixed #9635 by having `configure_env_for_run` skip every default `.env` file so a script that assigns its own `NODE_ENV` can re-derive the NODE_ENV-specific set. That also withheld `.env`, so any script that does not go through another bun invocation lost it.

## Fix

- Add a per-entry `conditional` bit: `true` for `.env.local` and `.env.{development,production,test}[.local]`, and for any entry whose `$VAR` expansion resolved against a conditional key or (for auto-discovered files) against an unresolved key. Parsing a conditional file also marks an already-present key conditional.
- `configure_env_for_run` (when `forward_dotenv` is true: `bun run` / `bunx`) loads every NODE_ENV-dependent default file as conditional first, then `.env`, so `.env` expansion sees shadowed keys as conditional before it runs. `take_script_dotenv()` moves the non-conditional file-sourced entries (skipping `NODE_ENV` / `BUN_ENV`) into `script_forward`, truncates the map back to the process-env prefix, and clears the file slots plus `custom_files_loaded`. The spawn sites (system shell, bun-shell, `.bin` binaries, Windows `.bunx` fast path) build the subprocess env from map + `script_forward`.
- `bun --filter` / workspace multi-run / pack pass `forward_dotenv=false` (skip default files, no truncation); their spawn cwd differs from the `.env`-load cwd, so forwarding would shadow per-package `.env` in a nested bun. Their behaviour is unchanged from before this PR.
- `--no-env-file` is honored. `--env-file` values are forwarded and unresolved `$VAR` expansion there is not tainted (no NODE_ENV-specific default file is loaded alongside it).

Restoring the map to process-env state keeps the slow `bun run <file>` path (VM on the same singleton) observationally identical to the `bun run ./<file>` fast path even when `.env` sets `NODE_ENV`.

## Why this is correct

A key reaches the subprocess only if `.env` is its sole source across every default `.env*` file (directly and via `$VAR` expansion) and it is not one of the two keys that pick the suffix. Under any `NODE_ENV` a nested bun loads the same `.env` plus its `.env.{NODE_ENV}` set, none of which define the key, so the child would have read the same value from `.env` anyway and forwarding it at process-env precedence cannot change what it observes. Every key a NODE_ENV-dependent file also defines, or that expands from one, is withheld so the child re-derives it. The existing #9689 regression tests (`script runner with {system,bun} shell > e2e NODE_ENV=...`) continue to pass unchanged.

## Verification

```
bun bd test test/cli/run/env.test.ts test/cli/run/no-envfile.test.ts \
            test/cli/run/filter-workspace.test.ts test/cli/run/multi-run.test.ts \
            test/cli/run/run_command.test.ts
# 298 pass, 2 skip, 2 todo, 0 fail
```

Fixes #9877
Fixes #23962

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->