### PR TITLE
node:quic(h3): lift outbound 128-header cap in us_nq_stream_send_headers

### DIFF
--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -294,19 +294,27 @@ const char *us_nq_hset_pairs(void *hset, size_t *len) {
 }
 void us_nq_hset_free(void *hset) { nq_hsi_discard_header_set(hset); }
 
-#define US_NQ_MAX_HEADERS 128
+/* Stack allocation covers node's default maxHeaderPairs; above that we
+ * spill to the heap. maxHeaderPairs is an inbound decoder limit only
+ * (node/src/quic/application.cc), so the encoder path imposes no policy cap. */
+#define US_NQ_STACK_HEADERS 128
 int us_nq_stream_send_headers(lsquic_stream_t *s, const char *buf, size_t len,
                               int expected, int eos) {
-    struct lsxpack_header hdrs[US_NQ_MAX_HEADERS];
-    int count = 0;
+    struct lsxpack_header stack_hdrs[US_NQ_STACK_HEADERS];
+    struct lsxpack_header *hdrs = stack_hdrs;
+    int count = 0, rv = -1;
     size_t i = 0;
-    if (expected < 0 || expected > US_NQ_MAX_HEADERS) return -1;
+    if (expected < 0) return -1;
+    if (expected > US_NQ_STACK_HEADERS) {
+        hdrs = malloc((size_t) expected * sizeof(*hdrs));
+        if (!hdrs) return -1;
+    }
     while (i < len) {
         /* The caller's pair count is authoritative: latin1 encoding of the
          * NUL-joined buffer maps U+0100-style code points onto the delimiter,
          * which would otherwise splice extra headers out of one user value
          * (node/src/node_http_common-inl.h bails the same way on n >= count_). */
-        if (count >= expected) return -1;
+        if (count >= expected) goto done;
         size_t name_off = i;
         while (i < len && buf[i]) i++;
         size_t name_len = i - name_off;
@@ -319,7 +327,7 @@ int us_nq_stream_send_headers(lsquic_stream_t *s, const char *buf, size_t len,
         i++;
         unsigned char flags = (i < len) ? (unsigned char) buf[i++] : 0;
         if (name_len > LSXPACK_MAX_STRLEN || val_len > LSXPACK_MAX_STRLEN)
-            return -1;
+            goto done;
         lsxpack_header_set_offset2(&hdrs[count], buf, name_off, name_len,
                                    val_off, val_len);
         if (flags & 1) {
@@ -328,9 +336,13 @@ int us_nq_stream_send_headers(lsquic_stream_t *s, const char *buf, size_t len,
         }
         count++;
     }
-    if (count != expected) return -1;
-    lsquic_http_headers_t list = { count, hdrs };
-    return lsquic_stream_send_headers(s, &list, eos);
+    if (count == expected) {
+        lsquic_http_headers_t list = { count, hdrs };
+        rv = lsquic_stream_send_headers(s, &list, eos);
+    }
+done:
+    if (hdrs != stack_hdrs) free(hdrs);
+    return rv;
 }
 
 static const struct lsquic_stream_if nq_stream_if = {

--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -326,10 +326,12 @@ int us_nq_stream_send_headers(lsquic_stream_t *s, const char *buf, size_t len,
         if (i >= len) break;
         i++;
         unsigned char flags = (i < len) ? (unsigned char) buf[i++] : 0;
-        if (name_len > LSXPACK_MAX_STRLEN || val_len > LSXPACK_MAX_STRLEN)
+        if (name_len >= LSXPACK_MAX_STRLEN || val_len > LSXPACK_MAX_STRLEN)
             goto done;
-        lsxpack_header_set_offset2(&hdrs[count], buf, name_off, name_len,
-                                   val_off, val_len);
+        /* Per-entry base keeps val_offset (= name_len+1) under the setter's
+         * LSXPACK_MAX_STRLEN assert no matter how large the joined buffer is. */
+        lsxpack_header_set_offset2(&hdrs[count], buf + name_off, 0, name_len,
+                                   val_off - name_off, val_len);
         if (flags & 1) {
             hdrs[count].flags = LSXPACK_NEVER_INDEX;
             hdrs[count].indexed_type = 2;

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -226,13 +226,15 @@ impl QuicStream {
             let _ = s.set_http_prio(urgency, incremental);
         }
         for (bytes, count, eos) in self.pending_headers.with_mut(core::mem::take) {
-            self.wrote_to_lsquic.set(true);
-            if s.send_headers(&bytes, count, eos) == 0 && eos {
-                self.with_state(|st| {
-                    st.fin_sent = 1;
-                    st.write_ended = 1;
-                });
-                s.shutdown(1);
+            if s.send_headers(&bytes, count, eos) == 0 {
+                self.wrote_to_lsquic.set(true);
+                if eos {
+                    self.with_state(|st| {
+                        st.fin_sent = 1;
+                        st.write_ended = 1;
+                    });
+                    s.shutdown(1);
+                }
             }
         }
         if uni {

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -186,8 +186,12 @@ describe("HTTP/3 header encoding", () => {
   // idle timeout tore down the whole connection.
   test("encodes a HEADERS block with more than 128 field lines", async () => {
     const CUSTOM = 200;
+    // Long enough that the NUL-joined encode buffer runs well past 64KB,
+    // exercising the per-entry lsxpack_header base (not just the count path).
+    const VAL = Buffer.alloc(400, "a").toString();
     const app = { maxHeaderPairs: 1024, maxHeaderLength: 1 << 20 };
     const serverSaw = Promise.withResolvers<Record<string, string>>();
+    const serverSendOk = Promise.withResolvers<boolean>();
     await using server = await listen(
       async serverSession => {
         serverSession.onstream = (stream: any) => {
@@ -203,8 +207,7 @@ describe("HTTP/3 header encoding", () => {
           serverSaw.resolve(headers);
           const resp: Record<string, string> = { ":status": "200" };
           for (let i = 0; i < CUSTOM; i++) resp["x-resp-" + i] = String(i);
-          // Server direction too: more than 128 response headers.
-          expect(this.sendHeaders(resp)).toBe(true);
+          serverSendOk.resolve(this.sendHeaders(resp));
           this.writer.endSync();
         },
       },
@@ -227,7 +230,7 @@ describe("HTTP/3 header encoding", () => {
       ":scheme": "https",
       ":authority": "localhost",
     };
-    for (let i = 0; i < CUSTOM; i++) req["x-req-" + i] = String(i);
+    for (let i = 0; i < CUSTOM; i++) req["x-req-" + i] = VAL;
 
     const gotHeaders = Promise.withResolvers<Record<string, string>>();
     const stream = await client.createBidirectionalStream({
@@ -235,12 +238,15 @@ describe("HTTP/3 header encoding", () => {
         gotHeaders.resolve(headers);
       },
     });
+    stream.closed.catch(gotHeaders.reject);
     expect(stream.sendHeaders(req, { terminal: true })).toBe(true);
 
     const seen = await serverSaw.promise;
     expect(Object.keys(seen)).toHaveLength(CUSTOM + 4);
-    expect(seen["x-req-0"]).toBe("0");
-    expect(seen["x-req-" + (CUSTOM - 1)]).toBe(String(CUSTOM - 1));
+    expect(seen["x-req-0"]).toBe(VAL);
+    expect(seen["x-req-" + (CUSTOM - 1)]).toBe(VAL);
+    // Server direction too: more than 128 response headers.
+    expect(await serverSendOk.promise).toBe(true);
 
     const resp = await gotHeaders.promise;
     expect(resp[":status"]).toBe("200");

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -178,4 +178,78 @@ describe("HTTP/3 header encoding", () => {
     expect(seen.length).toBe(1);
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
+
+  // `application.maxHeaderPairs` is an inbound decoder limit; the outbound
+  // encoder path must not impose its own cap. Before the fix, the shim's
+  // stack buffer rejected any block with >128 field lines, sendHeaders()
+  // returned false, nothing went on the wire, and the request hung until the
+  // idle timeout tore down the whole connection.
+  test("encodes a HEADERS block with more than 128 field lines", async () => {
+    const CUSTOM = 200;
+    const app = { maxHeaderPairs: 1024, maxHeaderLength: 1 << 20 };
+    const serverSaw = Promise.withResolvers<Record<string, string>>();
+    await using server = await listen(
+      async serverSession => {
+        serverSession.onstream = (stream: any) => {
+          stream.closed.catch(() => {});
+        };
+        await serverSession.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        application: app,
+        transportParams: { maxIdleTimeout: 1 },
+        onheaders(this: any, headers: Record<string, string>) {
+          serverSaw.resolve(headers);
+          const resp: Record<string, string> = { ":status": "200" };
+          for (let i = 0; i < CUSTOM; i++) resp["x-resp-" + i] = String(i);
+          // Server direction too: more than 128 response headers.
+          expect(this.sendHeaders(resp)).toBe(true);
+          this.writer.endSync();
+        },
+      },
+    );
+
+    // A fresh endpoint so this test's `application` options reach the lsquic
+    // engine rather than whatever an earlier `connect()` in this file built.
+    const client = await connect(server.address, {
+      endpoint: {},
+      servername: "localhost",
+      verifyPeer: "manual",
+      application: app,
+      transportParams: { maxIdleTimeout: 1 },
+    });
+    await client.opened;
+
+    const req: Record<string, string> = {
+      ":method": "GET",
+      ":path": "/",
+      ":scheme": "https",
+      ":authority": "localhost",
+    };
+    for (let i = 0; i < CUSTOM; i++) req["x-req-" + i] = String(i);
+
+    const gotHeaders = Promise.withResolvers<Record<string, string>>();
+    const stream = await client.createBidirectionalStream({
+      onheaders(headers: Record<string, string>) {
+        gotHeaders.resolve(headers);
+      },
+    });
+    expect(stream.sendHeaders(req, { terminal: true })).toBe(true);
+
+    const seen = await serverSaw.promise;
+    expect(Object.keys(seen)).toHaveLength(CUSTOM + 4);
+    expect(seen["x-req-0"]).toBe("0");
+    expect(seen["x-req-" + (CUSTOM - 1)]).toBe(String(CUSTOM - 1));
+
+    const resp = await gotHeaders.promise;
+    expect(resp[":status"]).toBe("200");
+    expect(Object.keys(resp)).toHaveLength(CUSTOM + 1);
+    expect(resp["x-resp-" + (CUSTOM - 1)]).toBe(String(CUSTOM - 1));
+
+    for await (const _ of stream) {
+    }
+    expect(client.destroyed).toBe(false);
+    client.close();
+  });
 });


### PR DESCRIPTION
## Problem

Sending an HTTP/3 HEADERS block with more than 128 field lines via `node:quic` silently stalls the stream and eventually kills the whole connection:

```js
const h = { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost" };
for (let i = 0; i < 125; i++) h["x-h" + i] = "v";   // 125 custom + 4 pseudo = 129 lines
const st = await cli.createBidirectionalStream({ headers: h });
for await (const c of st) {}
// status never arrives; after maxIdleTimeout the connection CONNECTION_CLOSEs with code 0
```

`sendHeaders()` returns `false`, nothing goes on the wire, `stream.closed` / `session.closed` resolve cleanly, every concurrent stream on the session dies with it. Setting `application.maxHeaderPairs: 65535` has no effect on the outbound path.

## Cause

`us_nq_stream_send_headers` in `packages/bun-usockets/src/node_quic_shim.c` builds a stack `struct lsxpack_header[US_NQ_MAX_HEADERS]` with `US_NQ_MAX_HEADERS = 128` and bails with `-1` when `expected > 128`. That was never a policy limit, just the stack buffer size; `application.maxHeaderPairs` is an inbound decoder limit (applied in `nq_hsi_process_header`) and node's encoder path imposes no count cap.

With the shim returning `-1`, the Rust caller returns `false` from `sendHeaders`, `createBidirectionalStream({headers})` ignores it, and the stream sits in lsquic with `want_read(true)` but no bytes ever sent. The `for await` blocks until `maxIdleTimeout` fires a `CONNECTION_CLOSE(0)`.

## Fix

Heap-allocate the `lsxpack_header[]` array when `expected > 128`; keep the stack buffer for the common case. `lsquic_stream_send_headers` encodes into its own buffer before returning, so the array is freed immediately after.

Also: in `bind_raw`, only set `wrote_to_lsquic` once the pending-headers replay actually reaches lsquic (matches the already-bound path at `send_headers`).

## Test

`test/js/node/quic/quic-stream.test.ts` round-trips a request and a response with 204 field lines each, asserting `sendHeaders()` returns `true` and every header arrives at the peer. Fails on main with `expect(stream.sendHeaders(req, { terminal: true })).toBe(true)` receiving `false`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (2e3cb71a9)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [857.27ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [175.42ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1190.24ms]
237 |       onheaders(headers: Record<string, string>) {
238 |         gotHeaders.resolve(headers);
239 |       },
240 |     });
241 |     stream.closed.catch(gotHeaders.reject);
242 |     expect(stream.sendHeaders(req, { terminal: true })).toBe(true);
                                                              ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/js/node/quic/quic-stream.test.ts:242:57)
(fa
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/quic/quic-stream.test.ts:

# Unhandled error between tests
-------------------------------
8 | import { connect, listen } from "node:quic";
                                    ^
error: Could not resolve: "node:quic". Maybe you need to "bun install"?
    at /workspace/bun/test/js/node/quic/quic-stream.test.ts:8:33
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [182.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (2e3cb71a9)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [727.12ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [194.57ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1183.97ms]
(pass) HTTP/3 header encoding > encodes a HEADERS block with more than 128 field lines [333.96ms]

 4 pass
 0 fail
 16 expect() calls
Ran 4 tests across 1 file. [6.37s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2e3cb71a93
  features     baseline

22 deps, 108 codegen, 1171 objects in 1814ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] gen ErrorCode+*.h
[3/1234] gen .bind.ts → GeneratedBindings.cpp
[4/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] fetch zlib
[zlib] up to date
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[11/1234] subst deps/zlib/zconf.h
[12/1234] subst dep
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/node_quic_shim.c | 38 +++++++++-----
 src/runtime/node/quic/stream.rs            | 16 +++---
 test/js/node/quic/quic-stream.test.ts      | 80 ++++++++++++++++++++++++++++++
 3 files changed, 115 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-usockets/src/node_quic_shim.c      5      3      0
src/runtime/node/quic/stream.rs                 1      1      0
test/js/node/quic/quic-stream.test.ts           3      8      0
```

</details>

<!-- robobun:evidence:end -->