### PR TITLE
node:quic h3: reset only the malformed stream on content-length mismatch

### DIFF
--- a/patches/lsquic/h3-message-error-stream.patch
+++ b/patches/lsquic/h3-message-error-stream.patch
@@ -1,0 +1,88 @@
+RFC 9114 s4.1.2: a malformed HTTP/3 message (which includes a request
+whose DATA-frame byte count does not match its content-length header)
+MUST be treated as a stream error of type H3_MESSAGE_ERROR. lsquic's
+verify_cl_on_fin / verify_cl_on_new_data_frame instead call
+ci_abort_error on the whole connection, so one bad request tears down
+every concurrent stream on the same QUIC connection.
+
+Replace the connection abort with a per-stream RESET_STREAM carrying
+HEC_MESSAGE_ERROR and report it via on_reset(how=0) so the application
+observes it the same way as a peer-initiated reset. STREAM_RST_RECVD is
+set so the read state machine reaches a final state and subsequent
+reads return -1 ECONNRESET.
+
+--- a/src/liblsquic/lsquic_stream.c
++++ b/src/liblsquic/lsquic_stream.c
+@@ -1481,22 +1481,45 @@
+ }
+ 
+ 
++/* bun: RFC 9114 s4.1.2 requires a malformed message to be a *stream* error
++ * (H3_MESSAGE_ERROR), not a connection error.  lsquic originally called
++ * ci_abort_error on the whole connection here, which kills every unrelated
++ * in-flight request.  Reset this stream and report it via on_reset(how=0) so
++ * the application observes it the same way as a peer-initiated reset.
++ * STREAM_RST_RECVD is set so the read state machine reaches a final state and
++ * subsequent reads return -1 ECONNRESET. */
++static void
++stream_reject_malformed (struct lsquic_stream *stream)
++{
++    stream->sm_bflags &= ~SMBF_VERIFY_CL;
++    stream->error_code = HEC_MESSAGE_ERROR;
++    if (!(stream->stream_flags & STREAM_RST_SENT)
++                                    && !(stream->sm_qflags & SMQF_SEND_RST))
++        stream_reset(stream, HEC_MESSAGE_ERROR, 0);
++    stream->stream_flags |= STREAM_RST_RECVD;
++    if (stream->stream_if->on_reset
++                            && !(stream->stream_flags & STREAM_ONCLOSE_DONE)
++                            && !(stream->sm_dflags & SMDF_ONRESET0))
++    {
++        stream->sm_dflags |= SMDF_ONRESET0;
++        stream->stream_if->on_reset(stream, stream->st_ctx, 0);
++    }
++}
++
++
+ static void
+ verify_cl_on_fin (struct lsquic_stream *stream)
+ {
+-    struct lsquic_conn *lconn;
+-
+     /* The rules in RFC7230, Section 3.3.2 are a bit too intricate.  We take
+      * a simple approach and verify content-length only when there was any
+      * payload at all.
+      */
+     if (stream->sm_data_in != 0 && stream->sm_cont_len != stream->sm_data_in)
+     {
+-        lconn = stream->conn_pub->lconn;
+-        lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
+-            "number of bytes in DATA frames of stream %"PRIu64" is %llu, "
+-            "while content-length specified of %llu", stream->id,
+-            stream->sm_data_in, stream->sm_cont_len);
++        LSQ_INFO("number of bytes in DATA frames of stream %"PRIu64" is %llu, "
++            "while content-length specified %llu; resetting the stream",
++            stream->id, stream->sm_data_in, stream->sm_cont_len);
++        stream_reject_malformed(stream);
+     }
+ }
+ 
+@@ -4894,17 +4917,13 @@
+ verify_cl_on_new_data_frame (struct lsquic_stream *stream,
+                                                     struct hq_filter *filter)
+ {
+-    struct lsquic_conn *lconn;
+-
+     stream->sm_data_in += filter->hqfi_left;
+     if (stream->sm_data_in > stream->sm_cont_len)
+     {
+-        lconn = stream->conn_pub->lconn;
+         filter->hqfi_flags |= HQFI_FLAG_ERROR;
+-        stream->sm_bflags &= ~SMBF_VERIFY_CL;
+-        lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
+-            "number of bytes in DATA frames of stream %"PRIu64" exceeds "
++        LSQ_INFO("number of bytes in DATA frames of stream %"PRIu64" exceeds "
+             "content-length limit of %llu", stream->id, stream->sm_cont_len);
++        stream_reject_malformed(stream);
+     }
+ }
+ 

--- a/patches/lsquic/h3-message-error-stream.patch
+++ b/patches/lsquic/h3-message-error-stream.patch
@@ -15,7 +15,7 @@ Applies after node-quic-accessors.patch (which adds ss_error_code).
 
 --- a/src/liblsquic/lsquic_stream.c
 +++ b/src/liblsquic/lsquic_stream.c
-@@ -1481,22 +1481,51 @@
+@@ -1481,22 +1481,55 @@
  }
  
  
@@ -35,11 +35,15 @@ Applies after node-quic-accessors.patch (which adds ss_error_code).
 +    if (!(stream->stream_flags & STREAM_RST_SENT)
 +                                    && !(stream->sm_qflags & SMQF_SEND_RST))
 +        stream_reset(stream, HEC_MESSAGE_ERROR, 0);
-+    /* stream_reset clears every SENDING flag and re-queues SEND_RST, so the
-+     * STOP_SENDING goes on here afterwards.  RESET_STREAM only aborts our
-+     * send side; without STOP_SENDING a peer mid-body keeps uploading. */
++    /* RESET_STREAM only aborts our send side; without STOP_SENDING a peer
++     * mid-body keeps uploading into a request nothing will answer. */
 +    if (!(stream->stream_flags & (STREAM_FIN_RECVD|STREAM_SS_SENT)))
++    {
++        if (!(stream->sm_qflags & SMQF_SENDING_FLAGS))
++            TAILQ_INSERT_TAIL(&stream->conn_pub->sending_streams, stream,
++                                                        next_send_stream);
 +        stream->sm_qflags |= SMQF_SEND_STOP_SENDING;
++    }
 +    stream->stream_flags |= STREAM_RST_RECVD;
 +    if (stream->stream_if->on_reset
 +                            && !(stream->stream_flags & STREAM_ONCLOSE_DONE)
@@ -74,7 +78,7 @@ Applies after node-quic-accessors.patch (which adds ss_error_code).
      }
  }
  
-@@ -4893,17 +4922,13 @@
+@@ -4893,17 +4926,13 @@
  verify_cl_on_new_data_frame (struct lsquic_stream *stream,
                                                      struct hq_filter *filter)
  {

--- a/patches/lsquic/h3-message-error-stream.patch
+++ b/patches/lsquic/h3-message-error-stream.patch
@@ -5,15 +5,17 @@ verify_cl_on_fin / verify_cl_on_new_data_frame instead call
 ci_abort_error on the whole connection, so one bad request tears down
 every concurrent stream on the same QUIC connection.
 
-Replace the connection abort with a per-stream RESET_STREAM carrying
-HEC_MESSAGE_ERROR and report it via on_reset(how=0) so the application
-observes it the same way as a peer-initiated reset. STREAM_RST_RECVD is
-set so the read state machine reaches a final state and subsequent
-reads return -1 ECONNRESET.
+Replace the connection abort with a per-stream RESET_STREAM plus
+STOP_SENDING carrying HEC_MESSAGE_ERROR and report it via on_reset(how=0)
+so the application observes it the same way as a peer-initiated reset.
+STREAM_RST_RECVD is set so the read state machine reaches a final state
+and subsequent reads return -1 ECONNRESET.
+
+Applies after node-quic-accessors.patch (which adds ss_error_code).
 
 --- a/src/liblsquic/lsquic_stream.c
 +++ b/src/liblsquic/lsquic_stream.c
-@@ -1481,22 +1481,45 @@
+@@ -1481,22 +1481,51 @@
  }
  
  
@@ -29,9 +31,15 @@ reads return -1 ECONNRESET.
 +{
 +    stream->sm_bflags &= ~SMBF_VERIFY_CL;
 +    stream->error_code = HEC_MESSAGE_ERROR;
++    stream->ss_error_code = HEC_MESSAGE_ERROR;
 +    if (!(stream->stream_flags & STREAM_RST_SENT)
 +                                    && !(stream->sm_qflags & SMQF_SEND_RST))
 +        stream_reset(stream, HEC_MESSAGE_ERROR, 0);
++    /* stream_reset clears every SENDING flag and re-queues SEND_RST, so the
++     * STOP_SENDING goes on here afterwards.  RESET_STREAM only aborts our
++     * send side; without STOP_SENDING a peer mid-body keeps uploading. */
++    if (!(stream->stream_flags & (STREAM_FIN_RECVD|STREAM_SS_SENT)))
++        stream->sm_qflags |= SMQF_SEND_STOP_SENDING;
 +    stream->stream_flags |= STREAM_RST_RECVD;
 +    if (stream->stream_if->on_reset
 +                            && !(stream->stream_flags & STREAM_ONCLOSE_DONE)
@@ -66,7 +74,7 @@ reads return -1 ECONNRESET.
      }
  }
  
-@@ -4894,17 +4917,13 @@
+@@ -4893,17 +4922,13 @@
  verify_cl_on_new_data_frame (struct lsquic_stream *stream,
                                                      struct hq_filter *filter)
  {

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -128,6 +128,10 @@ export const lsquic: Dependency = {
     // never be encrypted and the peer idled out instead of learning of the
     // close. Select the PNS by handshake progress, as ngtcp2 does.
     "patches/lsquic/connection-close-pns.patch",
+    // verify_cl_on_fin / verify_cl_on_new_data_frame aborted the whole
+    // connection on a content-length mismatch; RFC 9114 s4.1.2 says a
+    // malformed message is a stream error (H3_MESSAGE_ERROR).
+    "patches/lsquic/h3-message-error-stream.patch",
   ],
 
   fetchDeps: ["zlib", "lshpack", "lsqpack", "boringssl"],

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -358,6 +358,13 @@ impl QuicStream {
             return;
         }
         self.inbound.with_mut(|inbound| {
+            // `on_reset` can fire from inside the same `lsquic_stream_read`
+            // that produced `data` (a locally-detected malformed message
+            // resets mid-read); once `mark_reset` has errored the queue the
+            // bytes belong to the reset and never reach the reader.
+            if inbound.errored {
+                return;
+            }
             if !data.is_empty() {
                 inbound.chunks.push_back(data.to_vec());
             }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -358,8 +358,6 @@ impl QuicStream {
             return;
         }
         let enqueued = self.inbound.with_mut(|inbound| {
-            // A locally-detected malformed message fires `on_reset` from
-            // inside the `lsquic_stream_read` that produced `data`.
             if inbound.errored {
                 return false;
             }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -358,10 +358,8 @@ impl QuicStream {
             return;
         }
         let enqueued = self.inbound.with_mut(|inbound| {
-            // `on_reset` can fire from inside the same `lsquic_stream_read`
-            // that produced `data` (a locally-detected malformed message
-            // resets mid-read); once `mark_reset` has errored the queue the
-            // bytes belong to the reset and never reach the reader.
+            // A locally-detected malformed message fires `on_reset` from
+            // inside the `lsquic_stream_read` that produced `data`.
             if inbound.errored {
                 return false;
             }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -357,13 +357,13 @@ impl QuicStream {
         if self.destroyed.get() {
             return;
         }
-        self.inbound.with_mut(|inbound| {
+        let enqueued = self.inbound.with_mut(|inbound| {
             // `on_reset` can fire from inside the same `lsquic_stream_read`
             // that produced `data` (a locally-detected malformed message
             // resets mid-read); once `mark_reset` has errored the queue the
             // bytes belong to the reset and never reach the reader.
             if inbound.errored {
-                return;
+                return false;
             }
             if !data.is_empty() {
                 inbound.chunks.push_back(data.to_vec());
@@ -371,8 +371,9 @@ impl QuicStream {
             if fin {
                 inbound.ended = true;
             }
+            true
         });
-        if !data.is_empty() {
+        if enqueued && !data.is_empty() {
             self.add_stat(IDX_STATS_BYTES_RECEIVED, data.len() as u64);
             self.write_stat(IDX_STATS_RECEIVED_AT, super::now_ns());
             let acc = self.read_stat(IDX_STATS_BYTES_ACCUMULATED) + data.len() as u64;

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -187,15 +187,15 @@ describe("HTTP/3 header encoding", () => {
 // `closed` as ERR_QUIC_TRANSPORT_ERROR code 1.
 describe("HTTP/3 malformed request (content-length mismatch)", () => {
   test("resets only the offending stream; sibling streams and the session survive", async () => {
-    const resets: bigint[] = [];
+    const resets: unknown[] = [];
     const serverClosed = Promise.withResolvers<any>();
-    const sawReset = Promise.withResolvers<void>();
+    const sawResets = Promise.withResolvers<void>();
     await using server = await listen(
       async serverSession => {
         serverSession.onstream = (stream: any) => {
           stream.onreset = (err: any) => {
-            resets.push(typeof err?.code === "bigint" ? err.code : -1n);
-            sawReset.resolve();
+            resets.push(err?.errorCode);
+            if (resets.length === 2) sawResets.resolve();
           };
           stream.closed.catch(() => {});
         };
@@ -267,10 +267,11 @@ describe("HTTP/3 malformed request (content-length mismatch)", () => {
     const status = await Promise.race([goodAnswered.promise, serverClosed.promise.then(e => e ?? "closed")]);
     expect(status).toBe("200");
 
-    // Server surfaces the rejection as stream.onreset with H3_MESSAGE_ERROR.
-    await sawReset.promise;
-    expect(resets.every(c => c === 0x10en)).toBe(true);
-    expect(resets.length).toBeGreaterThanOrEqual(1);
+    // Server surfaces the rejection as stream.onreset with H3_MESSAGE_ERROR,
+    // once per patched lsquic verifier (verify_cl_on_fin and
+    // verify_cl_on_new_data_frame).
+    await Promise.race([sawResets.promise, serverClosed.promise]);
+    expect(resets).toEqual([0x10en, 0x10en]);
 
     client.close();
     expect(await serverClosed.promise).toBe(null);

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -179,3 +179,100 @@ describe("HTTP/3 header encoding", () => {
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
 });
+
+// RFC 9114 s4.1.2: a malformed HTTP/3 message MUST be a *stream* error
+// (H3_MESSAGE_ERROR, 0x10e). lsquic's content-length verifier used to call
+// ci_abort_error on the whole connection instead, so one malformed request
+// tore down every concurrent stream and surfaced on the server session's
+// `closed` as ERR_QUIC_TRANSPORT_ERROR code 1.
+describe("HTTP/3 malformed request (content-length mismatch)", () => {
+  test("resets only the offending stream; sibling streams and the session survive", async () => {
+    const resets: bigint[] = [];
+    const serverClosed = Promise.withResolvers<any>();
+    const sawReset = Promise.withResolvers<void>();
+    await using server = await listen(
+      async serverSession => {
+        serverSession.onstream = (stream: any) => {
+          stream.onreset = (err: any) => {
+            resets.push(typeof err?.code === "bigint" ? err.code : -1n);
+            sawReset.resolve();
+          };
+          stream.closed.catch(() => {});
+        };
+        await serverSession.closed.then(
+          () => serverClosed.resolve(null),
+          (e: any) => serverClosed.resolve(e),
+        );
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 2 },
+        onheaders(this: any, headers: Record<string, string>) {
+          if (headers[":path"] === "/good") {
+            this.sendHeaders({ ":status": "200" });
+            this.writer.writeSync("ok");
+            this.writer.endSync();
+          }
+        },
+      },
+    );
+
+    const client = await connect(server.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 2 },
+    });
+    await client.opened;
+    client.closed.catch(() => {});
+
+    // content-length says 1000, body ends at 3 bytes.
+    const short = await client.createBidirectionalStream({
+      headers: {
+        ":method": "POST",
+        ":path": "/short",
+        ":scheme": "https",
+        ":authority": "localhost",
+        "content-length": "1000",
+      },
+      body: new TextEncoder().encode("abc"),
+    });
+    short.closed.catch(() => {});
+
+    // content-length says 3, body is 1000 bytes.
+    const over = await client.createBidirectionalStream({
+      headers: {
+        ":method": "POST",
+        ":path": "/over",
+        ":scheme": "https",
+        ":authority": "localhost",
+        "content-length": "3",
+      },
+      body: new Uint8Array(Buffer.alloc(1000, "x")),
+    });
+    over.closed.catch(() => {});
+
+    // A sibling request on the SAME connection, AFTER the malformed ones,
+    // proves the connection survived.
+    const goodAnswered = Promise.withResolvers<string>();
+    const good = await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":path": "/good", ":scheme": "https", ":authority": "localhost" },
+      onheaders(h: Record<string, string>) {
+        goodAnswered.resolve(h[":status"]);
+      },
+    });
+    good.closed.catch(() => {});
+
+    // Before: the malformed request triggers CONNECTION_CLOSE, so the server
+    // session errors and the sibling request never sees a response.
+    const status = await Promise.race([goodAnswered.promise, serverClosed.promise.then(e => e ?? "closed")]);
+    expect(status).toBe("200");
+
+    // Server surfaces the rejection as stream.onreset with H3_MESSAGE_ERROR.
+    await sawReset.promise;
+    expect(resets.every(c => c === 0x10en)).toBe(true);
+    expect(resets.length).toBeGreaterThanOrEqual(1);
+
+    client.close();
+    expect(await serverClosed.promise).toBe(null);
+  });
+});


### PR DESCRIPTION
## What

One malformed HTTP/3 request (a body whose DATA-frame byte count does not match its `content-length` header) was escalating to `CONNECTION_CLOSE`, which tears down every concurrent stream on the same QUIC connection. The server surfaced it as `ERR_QUIC_TRANSPORT_ERROR` code 1 (the generic `LSCONN_ST_ERROR` mapping in `map_conn_status`).

RFC 9114 s4.1.2: a malformed message MUST be treated as a **stream** error of type `H3_MESSAGE_ERROR` (0x10e); other streams are unaffected.

## Repro

```js
// raw client -> bun h3 server
fs = b"\x00\x00"+lit(":method","POST")+lit(":scheme","https")+lit(":authority","localhost")+lit(":path","/")+lit("content-length","1000")
q.send_stream_data(q.get_next_available_stream_id(is_unidirectional=False), frame(0x01, fs)+frame(0x00, b"abc"), end_stream=True)
// server onerror: ERR_QUIC_TRANSPORT_ERROR code 1; any sibling stream dies too
```

## Cause

lsquic's `verify_cl_on_fin` (body shorter than `content-length` at FIN) and `verify_cl_on_new_data_frame` (body exceeds `content-length`) both call `ci_abort_error(conn, 1, HEC_MESSAGE_ERROR, ...)` on the whole connection ([lsquic_stream.c:1496](https://github.com/litespeedtech/lsquic/blob/3181911301b1aa4f54c1ed690901abc674ee08fb/src/liblsquic/lsquic_stream.c#L1496)). That sets `IFC_ERROR` and the next tick emits `CONNECTION_CLOSE`.

## Fix

`patches/lsquic/h3-message-error-stream.patch` replaces the `ci_abort_error` with a per-stream reset:

- queue `RESET_STREAM(H3_MESSAGE_ERROR)` via `stream_reset`
- set `STREAM_RST_RECVD` so the read state machine reaches a final state and subsequent reads return -1 `ECONNRESET`
- fire `on_reset(how=0)`, the same callback path a peer-initiated reset takes, so the application observes `stream.onreset` with the 0x10e code

`push_inbound` now drops bytes produced by the same `lsquic_stream_read` call once `mark_reset` has errored the inbound queue, so the malformed body is never delivered after the reset.

## Test

`test/js/node/quic/quic-stream.test.ts` opens three streams on one h3 connection: two malformed (short body and long body) and one valid. The valid stream must receive its 200 response, the server session's `closed` must resolve cleanly, and the server must observe `stream.onreset` carrying `0x10e` for the malformed ones.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (f7b8dda96)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [569.27ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [141.75ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1125.63ms]
(pass) HTTP/3 malformed request (content-length mismatch) > resets only the offending stream; sibling streams and the session survive [227.50ms]

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [6.79s]
__F:0:S:0

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/quic/quic-stream.test.ts:

# Unhandled error between tests
-------------------------------
8 | import { connect, listen } from "node:quic";
                                    ^
error: Could not resolve: "node:quic". Maybe you need to "bun install"?
    at /workspace/bun/test/js/node/quic/quic-stream.test.ts:8:33
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [184.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (f7b8dda96)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [1058.25ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [233.47ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1235.19ms]
(pass) HTTP/3 malformed request (content-length mismatch) > resets only the offending stream; sibling streams and the session survive [266.46ms]

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [7.04s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f7b8dda96c
  features     baseline

22 deps, 108 codegen, 1171 objects in 4573ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch tinycc
[tinycc] up to date
[2/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[3/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/1234] gen bindgenv2
[6/1234] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[7/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[8/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/Proces
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
patches/lsquic/h3-message-error-stream.patch | 100 +++++++++++++++++++++++++++
 scripts/build/deps/lsquic.ts                 |   4 ++
 src/runtime/node/quic/stream.rs              |   8 ++-
 test/js/node/quic/quic-stream.test.ts        |  98 ++++++++++++++++++++++++++
 4 files changed, 208 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
patches/lsquic/h3-message-error-stream.patch      1      5      0
scripts/build/deps/lsquic.ts                      1      2      0
src/runtime/node/quic/stream.rs                   5      5      0
test/js/node/quic/quic-stream.test.ts             3      4      0
```

</details>

<!-- robobun:evidence:end -->