### PR TITLE
node:inspector: expose the CLI --inspect debugger via url()/close()/waitForDebugger()

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -114,21 +114,13 @@ export default function (
   reportNodeInspectorServerStarted: (url: string, controlCallback?: (message: string) => void, error?: string) => void,
 ): void {
   if (urlIsServer) {
-    // Mark serverStarted so node:inspector's url() (which consults the same
-    // nodeInspectorState) does not wait on a server that will never listen.
-    reportNodeInspectorServerStarted("", undefined, "connect-mode");
     connectToUnixServer(executionContextId, url, createBackend, send, close);
     return;
   }
 
-  // Shared node:inspector control surface. `debug` is whichever server is
-  // currently listening on this debugger thread, started either by CLI
-  // --inspect (the JSC-protocol server below) or by inspector.open() (a CDP
-  // server). The control callback lets the inspected thread close it, reopen
-  // it as a CDP server, and forward Debugger.* commands from the in-process
-  // inspector.Session. The backend connection underneath is JSC-protocol in
-  // both cases, so "command" forwarding goes through the CDP adapter
-  // regardless of which protocol `debug` serves to its own clients.
+  // node:inspector control callback shared by the CLI --inspect server below
+  // and inspector.open()'s CDP server: the inspected thread sends close /
+  // reopen / forwarded Debugger.* commands through it.
   let debug: Debugger | undefined;
   let sessionBackend: Backend | undefined;
   let sessionAdapter: any;
@@ -210,11 +202,8 @@ export default function (
   };
 
   if (isNodeInspector) {
-    // node:inspector's inspector.open(): connections speak the V8 Chrome
-    // DevTools Protocol, the listening URL is reported back to the inspected
-    // thread (which prints Node's "Debugger listening on ..." line), and the
-    // control callback above lets the inspected thread close the server or
-    // forward commands from the in-process inspector.Session.
+    // inspector.open(): connections speak the V8 Chrome DevTools Protocol and
+    // the listening URL is reported back so the inspected thread can print it.
     try {
       debug = new Debugger(executionContextId, url, createBackend, send, close, true);
     } catch (error) {
@@ -235,15 +224,10 @@ export default function (
     exit("Failed to start inspector:\n", error);
   }
 
-  // Publish the CLI --inspect server's URL and control callback into the same
-  // nodeInspectorState that inspector.open() uses, so node:inspector's url()/
-  // close()/waitForDebugger() see and can shut down the CLI-started server.
-  // Connect-mode (unix:/fd:/tcp: URLs) has no listen URL; report it as
-  // "no server" so inspector.url() stays undefined for those.
+  // Publish the CLI --inspect server to node:inspector so url()/close()/
+  // waitForDebugger() see it. Connect-mode (unix:/fd:/tcp:) has no listen URL.
   if (debug!.url) {
     reportNodeInspectorServerStarted(debug!.url.href, control, undefined);
-  } else {
-    reportNodeInspectorServerStarted("", undefined, "connect-mode");
   }
 
   // If the user types --inspect, we print the URL to the console.

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -386,7 +386,7 @@ class Debugger {
     }
 
     if (protocol === "ws+unix:") {
-      Bun.serve({
+      this.#server = Bun.serve({
         unix: pathname,
         fetch: this.#fetch.bind(this),
         websocket: this.#websocket,

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -114,96 +114,107 @@ export default function (
   reportNodeInspectorServerStarted: (url: string, controlCallback?: (message: string) => void, error?: string) => void,
 ): void {
   if (urlIsServer) {
+    // Mark serverStarted so node:inspector's url() (which consults the same
+    // nodeInspectorState) does not wait on a server that will never listen.
+    reportNodeInspectorServerStarted("", undefined, "connect-mode");
     connectToUnixServer(executionContextId, url, createBackend, send, close);
     return;
   }
 
-  if (isNodeInspector) {
-    // node:inspector's inspector.open(): connections speak the V8 Chrome
-    // DevTools Protocol, the listening URL is reported back to the inspected
-    // thread (which prints Node's "Debugger listening on ..." line), and a
-    // control callback lets the inspected thread close the server or forward
-    // commands from the in-process inspector.Session.
-    let debug: Debugger | undefined;
-    let sessionBackend: Backend | undefined;
-    let sessionAdapter: any;
-    let sessionRefs = 0;
-    const control = (message: string) => {
-      let parsed: any;
-      try {
-        parsed = JSON.parse(message);
-      } catch {
-        return;
-      }
-      switch (parsed?.type) {
-        case "close":
-          try {
-            sessionBackend?.close();
-            sessionBackend = undefined;
-            sessionAdapter = undefined;
-            sessionRefs = 0;
-            debug?.stop();
-            debug = undefined;
-          } finally {
-            // inspector.close() blocks until this lands: the port must already
-            // be refused when close() returns. Signalled from a finally so a
-            // failing stop() cannot hang the inspected thread forever.
-            reportNodeInspectorServerStarted("", control, undefined);
-          }
-          return;
-        case "session-connect":
-          sessionRefs++;
-          return;
-        case "session-disconnect":
-          // Last in-process Session that forwarded Debugger.* commands has
-          // disconnected: release the shared backend so its breakpoints don't
-          // outlive it. Refcounted so one Session can't tear down another's.
-          if (--sessionRefs > 0) return;
-          sessionRefs = 0;
+  // Shared node:inspector control surface. `debug` is whichever server is
+  // currently listening on this debugger thread, started either by CLI
+  // --inspect (the JSC-protocol server below) or by inspector.open() (a CDP
+  // server). The control callback lets the inspected thread close it, reopen
+  // it as a CDP server, and forward Debugger.* commands from the in-process
+  // inspector.Session. The backend connection underneath is JSC-protocol in
+  // both cases, so "command" forwarding goes through the CDP adapter
+  // regardless of which protocol `debug` serves to its own clients.
+  let debug: Debugger | undefined;
+  let sessionBackend: Backend | undefined;
+  let sessionAdapter: any;
+  let sessionRefs = 0;
+  const control = (message: string) => {
+    let parsed: any;
+    try {
+      parsed = JSON.parse(message);
+    } catch {
+      return;
+    }
+    switch (parsed?.type) {
+      case "close":
+        try {
           sessionBackend?.close();
           sessionBackend = undefined;
           sessionAdapter = undefined;
-          return;
-        case "open": {
-          // inspector.open() after inspector.close() or after a failed start:
-          // start a new server on this already-running debugger thread and
-          // report its URL back.
-          try {
-            debug = new Debugger(executionContextId, parsed.url, createBackend, send, close, true);
-            reportNodeInspectorServerStarted(debug.url!.href, control, undefined);
-          } catch (error) {
-            reportNodeInspectorServerStarted("", control, nodeInspectorListenErrorDetail(error));
-          }
-          return;
+          sessionRefs = 0;
+          debug?.stop();
+          debug = undefined;
+        } finally {
+          // inspector.close() blocks until this lands: the port must already
+          // be refused when close() returns. Signalled from a finally so a
+          // failing stop() cannot hang the inspected thread forever.
+          reportNodeInspectorServerStarted("", control, undefined);
         }
-        case "command": {
-          // A CDP command forwarded from the inspected thread's in-process
-          // inspector.Session (e.g. Debugger.setBreakpointByUrl from vitest
-          // --inspect-brk). Responses stay on this thread; the in-process
-          // Session treats these as fire-and-forget.
-          if (!debug) return;
-          if (!sessionAdapter) {
-            let adapter: any;
-            sessionBackend = debug.createSessionBackend((...messages: string[]) => {
-              for (const backendMessage of messages) {
-                adapter.handleBackendMessage(backendMessage);
-              }
-            });
-            adapter = new (cdpAdapterConstructor())(
-              (backendMessage: string) => void sessionBackend?.write(backendMessage),
-              () => {},
-            );
-            sessionAdapter = adapter;
-            sessionAdapter.handleClientMessage(JSON.stringify({ id: 0, method: "Debugger.enable", params: {} }));
-          }
-          sessionAdapter.handleClientMessage(
-            JSON.stringify({ id: parsed.id ?? 0, method: parsed.method, params: parsed.params ?? {} }),
-          );
-          return;
+        return;
+      case "session-connect":
+        sessionRefs++;
+        return;
+      case "session-disconnect":
+        // Last in-process Session that forwarded Debugger.* commands has
+        // disconnected: release the shared backend so its breakpoints don't
+        // outlive it. Refcounted so one Session can't tear down another's.
+        if (--sessionRefs > 0) return;
+        sessionRefs = 0;
+        sessionBackend?.close();
+        sessionBackend = undefined;
+        sessionAdapter = undefined;
+        return;
+      case "open": {
+        // inspector.open() after inspector.close() or after a failed start:
+        // start a new server on this already-running debugger thread and
+        // report its URL back.
+        try {
+          debug = new Debugger(executionContextId, parsed.url, createBackend, send, close, true);
+          reportNodeInspectorServerStarted(debug.url!.href, control, undefined);
+        } catch (error) {
+          reportNodeInspectorServerStarted("", control, nodeInspectorListenErrorDetail(error));
         }
+        return;
       }
-    };
+      case "command": {
+        // A CDP command forwarded from the inspected thread's in-process
+        // inspector.Session (e.g. Debugger.setBreakpointByUrl from vitest
+        // --inspect-brk). Responses stay on this thread; the in-process
+        // Session treats these as fire-and-forget.
+        if (!debug) return;
+        if (!sessionAdapter) {
+          let adapter: any;
+          sessionBackend = debug.createSessionBackend((...messages: string[]) => {
+            for (const backendMessage of messages) {
+              adapter.handleBackendMessage(backendMessage);
+            }
+          });
+          adapter = new (cdpAdapterConstructor())(
+            (backendMessage: string) => void sessionBackend?.write(backendMessage),
+            () => {},
+          );
+          sessionAdapter = adapter;
+          sessionAdapter.handleClientMessage(JSON.stringify({ id: 0, method: "Debugger.enable", params: {} }));
+        }
+        sessionAdapter.handleClientMessage(
+          JSON.stringify({ id: parsed.id ?? 0, method: parsed.method, params: parsed.params ?? {} }),
+        );
+        return;
+      }
+    }
+  };
 
+  if (isNodeInspector) {
+    // node:inspector's inspector.open(): connections speak the V8 Chrome
+    // DevTools Protocol, the listening URL is reported back to the inspected
+    // thread (which prints Node's "Debugger listening on ..." line), and the
+    // control callback above lets the inspected thread close the server or
+    // forward commands from the in-process inspector.Session.
     try {
       debug = new Debugger(executionContextId, url, createBackend, send, close, true);
     } catch (error) {
@@ -218,11 +229,21 @@ export default function (
     return;
   }
 
-  let debug: Debugger | undefined;
   try {
     debug = new Debugger(executionContextId, url, createBackend, send, close);
   } catch (error) {
     exit("Failed to start inspector:\n", error);
+  }
+
+  // Publish the CLI --inspect server's URL and control callback into the same
+  // nodeInspectorState that inspector.open() uses, so node:inspector's url()/
+  // close()/waitForDebugger() see and can shut down the CLI-started server.
+  // Connect-mode (unix:/fd:/tcp: URLs) has no listen URL; report it as
+  // "no server" so inspector.url() stays undefined for those.
+  if (debug!.url) {
+    reportNodeInspectorServerStarted(debug!.url.href, control, undefined);
+  } else {
+    reportNodeInspectorServerStarted("", undefined, "connect-mode");
   }
 
   // If the user types --inspect, we print the URL to the console.

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -36,14 +36,16 @@ const waitForNodeInspectorConnection = $newCppFunction(
 );
 const postNodeInspectorControl = $newCppFunction("BunDebugger.cpp", "jsFunction_postNodeInspectorControl", 1);
 const closeNodeInspector = $newCppFunction("BunDebugger.cpp", "jsFunction_closeNodeInspector", 0);
-// Reads the debugger-thread server URL from the shared nodeInspectorState,
-// which both inspector.open() and CLI --inspect publish into. This is the
-// single source of truth for "is an inspector listening and where".
-const getNodeInspectorUrl = $newCppFunction("BunDebugger.cpp", "jsFunction_getNodeInspectorUrl", 0);
+const nativeGetNodeInspectorUrl = $newCppFunction("BunDebugger.cpp", "jsFunction_getNodeInspectorUrl", 0);
 
-// Node writes the --inspect port to process.debugPort at bootstrap; Bun's
-// debugPort is otherwise a static 9229. Reflect the CLI server's port here so
-// tools that probe process.debugPort under `bun --inspect` see the real one.
+// The ws:// URL published by inspector.open() or CLI --inspect, or undefined.
+// nodeInspectorState is process-global, so a Worker must not read or act on the
+// main thread's server: Node's per-worker inspectors are independent (and Bun
+// does not support them yet).
+const getNodeInspectorUrl = Bun.isMainThread ? nativeGetNodeInspectorUrl : () => undefined;
+
+// Reflect the CLI --inspect port in process.debugPort, like Node does at
+// bootstrap (Bun's debugPort is otherwise a static 9229).
 {
   const initialUrl = getNodeInspectorUrl();
   if (typeof initialUrl === "string") {
@@ -93,9 +95,8 @@ function open(port?: number, host?: string, wait?: boolean) {
     return disposable;
   }
   if (resolvedUrl === null) {
-    // A listening server is caught by the top guard above, so null here means
-    // a debugger thread exists that is not serving a WebSocket (BUN_INSPECT
-    // connect-mode, or a worker).
+    // The top guard above catches a listening server; null here means a
+    // debugger thread exists without one (BUN_INSPECT connect-mode).
     throw $ERR_INSPECTOR_ALREADY_ACTIVATED();
   }
 
@@ -114,6 +115,9 @@ function open(port?: number, host?: string, wait?: boolean) {
 }
 
 function close() {
+  if (!Bun.isMainThread) {
+    throw $ERR_WORKER_UNSUPPORTED_OPERATION("inspector.close() is not supported in workers");
+  }
   if (getNodeInspectorUrl() === undefined) {
     return;
   }

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -50,7 +50,8 @@ const getNodeInspectorUrl = Bun.isMainThread ? nativeGetNodeInspectorUrl : () =>
   const initialUrl = getNodeInspectorUrl();
   if (typeof initialUrl === "string") {
     try {
-      process.debugPort = Number(new URL(initialUrl).port);
+      const port = new URL(initialUrl).port;
+      if (port) process.debugPort = Number(port);
     } catch {}
   }
 }

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -36,11 +36,25 @@ const waitForNodeInspectorConnection = $newCppFunction(
 );
 const postNodeInspectorControl = $newCppFunction("BunDebugger.cpp", "jsFunction_postNodeInspectorControl", 1);
 const closeNodeInspector = $newCppFunction("BunDebugger.cpp", "jsFunction_closeNodeInspector", 0);
+// Reads the debugger-thread server URL from the shared nodeInspectorState,
+// which both inspector.open() and CLI --inspect publish into. This is the
+// single source of truth for "is an inspector listening and where".
+const getNodeInspectorUrl = $newCppFunction("BunDebugger.cpp", "jsFunction_getNodeInspectorUrl", 0);
 
-let activeInspectorUrl: string | undefined;
+// Node writes the --inspect port to process.debugPort at bootstrap; Bun's
+// debugPort is otherwise a static 9229. Reflect the CLI server's port here so
+// tools that probe process.debugPort under `bun --inspect` see the real one.
+{
+  const initialUrl = getNodeInspectorUrl();
+  if (typeof initialUrl === "string") {
+    try {
+      process.debugPort = Number(new URL(initialUrl).port);
+    } catch {}
+  }
+}
 
 function open(port?: number, host?: string, wait?: boolean) {
-  if (activeInspectorUrl !== undefined) {
+  if (getNodeInspectorUrl() !== undefined) {
     throw $ERR_INSPECTOR_ALREADY_ACTIVATED();
   }
   if (!Bun.isMainThread) {
@@ -79,18 +93,12 @@ function open(port?: number, host?: string, wait?: boolean) {
     return disposable;
   }
   if (resolvedUrl === null) {
-    // A prior inspector.open() success is caught by the top guard above, so
-    // null here means the debugger thread was started outside node:inspector
-    // (CLI --inspect / BUN_INSPECT). That server speaks the JSC protocol and
-    // never registered a controlCallback, so inspector.close() cannot shut it
-    // down; the default ERR_INSPECTOR_ALREADY_ACTIVATED message would send the
-    // user to a no-op close().
-    throw $ERR_INSPECTOR_ALREADY_ACTIVATED(
-      "An inspector was already started via --inspect and cannot be reopened from node:inspector",
-    );
+    // A listening server is caught by the top guard above, so null here means
+    // a debugger thread exists that is not serving a WebSocket (BUN_INSPECT
+    // connect-mode, or a worker).
+    throw $ERR_INSPECTOR_ALREADY_ACTIVATED();
   }
 
-  activeInspectorUrl = resolvedUrl;
   // Node writes the resolved port back so process.debugPort reflects it after
   // open(0) picks an ephemeral port.
   try {
@@ -106,22 +114,21 @@ function open(port?: number, host?: string, wait?: boolean) {
 }
 
 function close() {
-  if (activeInspectorUrl === undefined) {
+  if (getNodeInspectorUrl() === undefined) {
     return;
   }
   // Sends the "close" control message and blocks until the debugger thread has
   // stopped the server, so the port is already refused when close() returns.
   closeNodeInspector();
-  activeInspectorUrl = undefined;
 }
 
 function url() {
   // https://nodejs.org/api/inspector.html#inspectorurl
-  return activeInspectorUrl;
+  return getNodeInspectorUrl();
 }
 
 function waitForDebugger() {
-  if (activeInspectorUrl === undefined) {
+  if (getNodeInspectorUrl() === undefined) {
     throw $ERR_INSPECTOR_NOT_ACTIVE();
   }
   waitForNodeInspectorConnection();
@@ -452,7 +459,7 @@ class Session extends EventEmitter {
     // Forwarded Debugger.* state (breakpoints etc.) lives on a shared backend
     // on the debugger thread; release it so a disconnected session cannot keep
     // pausing the process, matching Node's disconnect() contract.
-    if (this.#forwardedDebugger && activeInspectorUrl !== undefined) {
+    if (this.#forwardedDebugger && getNodeInspectorUrl() !== undefined) {
       postNodeInspectorControl(JSON.stringify({ type: "session-disconnect" }));
     }
     this.#forwardedDebugger = false;
@@ -632,7 +639,7 @@ class Session extends EventEmitter {
       case "Debugger.setSkipAllPauses":
       case "Debugger.setAsyncCallStackDepth":
       case "Debugger.setBlackboxPatterns": {
-        if (activeInspectorUrl === undefined) {
+        if (getNodeInspectorUrl() === undefined) {
           return $ERR_INSPECTOR_COMMAND(
             `-32000: Inspector method "${method}" requires an active inspector (call inspector.open() first)`,
           );

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -198,6 +198,18 @@ impl Debugger {
             return;
         };
         bun_analytics::features::debugger.fetch_add(1, Ordering::Relaxed);
+
+        // Even for plain `--inspect` (no `-wait`/`-brk`), user code must not
+        // run before the debugger thread has finished starting the inspector
+        // server: `node:inspector`'s url()/close() read the URL that thread
+        // publishes, and Node's `--inspect` starts its agent synchronously.
+        // `start()` stores 0 and wakes after `internal/debugger.ts` has run
+        // (which is what publishes the URL).
+        bun_core::scoped_log!(debugger, "spin");
+        while FUTEX_ATOMIC.load(Ordering::Relaxed) > 0 {
+            bun_threading::Futex::wait_forever(&FUTEX_ATOMIC, 1);
+        }
+
         if !dbg.must_block_until_connected {
             return;
         }
@@ -209,12 +221,6 @@ impl Debugger {
             }
         });
 
-        bun_core::scoped_log!(debugger, "spin");
-        // `FUTEX_ATOMIC` starts at 0 and nothing ever stores `1` before this
-        // load, so this loop is a no-op on first call.
-        while FUTEX_ATOMIC.load(Ordering::Relaxed) > 0 {
-            bun_threading::Futex::wait_forever(&FUTEX_ATOMIC, 1);
-        }
         if bun_core::Environment::ENABLE_LOGS {
             bun_core::scoped_log!(
                 debugger,
@@ -383,6 +389,11 @@ impl Debugger {
 
         if !this_ref.has_started_debugger {
             this_ref.as_mut().has_started_debugger = true;
+            // Armed here and cleared by `start()` after the debugger thread has
+            // run `internal/debugger.ts` (which publishes the inspector URL);
+            // `wait_for_debugger_if_necessary` blocks on it so user code never
+            // observes the server mid-startup.
+            FUTEX_ATOMIC.store(1, Ordering::Relaxed);
             // `std::thread::spawn` requires `Send`; raw `*mut
             // VirtualMachine` is `!Send`. Wrap in a `Send` newtype — the
             // pointer is only ever dereferenced on the debugger thread under

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -198,22 +198,29 @@ impl Debugger {
             return;
         };
         bun_analytics::features::debugger.fetch_add(1, Ordering::Relaxed);
+        // End the `&mut Debugger` borrow before the futex wait: `start()` reads
+        // the same struct from the debugger thread while this thread is parked.
+        let (ctx_id, wait, must_block) = (
+            dbg.script_execution_context_id,
+            dbg.wait_for_connection,
+            dbg.must_block_until_connected,
+        );
 
-        // Even for plain `--inspect` (no `-wait`/`-brk`), user code must not
-        // run before the debugger thread has finished starting the inspector
-        // server: `node:inspector`'s url()/close() read the URL that thread
-        // publishes, and Node's `--inspect` starts its agent synchronously.
-        // `start()` stores 0 and wakes after `internal/debugger.ts` has run
-        // (which is what publishes the URL).
+        // Always wait for the debugger thread to finish `internal/debugger.ts`
+        // (which publishes the inspector URL) before user code runs; `start()`
+        // clears this after it has. Node's `--inspect` is synchronous too.
         bun_core::scoped_log!(debugger, "spin");
         while FUTEX_ATOMIC.load(Ordering::Relaxed) > 0 {
             bun_threading::Futex::wait_forever(&FUTEX_ATOMIC, 1);
         }
 
-        if !dbg.must_block_until_connected {
+        // Install Bun's inspector controller before any client can connect to
+        // JSC's default one; later calls hit the `bunControllerInstalled` guard.
+        Bun__ensureDebugger(ctx_id, wait != Wait::Off);
+
+        if !must_block {
             return;
         }
-        let (ctx_id, wait) = (dbg.script_execution_context_id, dbg.wait_for_connection);
         // Reset `must_block_until_connected` on every exit path.
         let _reset = scopeguard::guard((), |()| {
             if let Some(d) = this.debugger_mut() {
@@ -234,8 +241,6 @@ impl Debugger {
                 }
             );
         }
-
-        Bun__ensureDebugger(ctx_id, wait != Wait::Off);
 
         // Sleep up to 30ms for automatic inspection.
         const WAIT_FOR_CONNECTION_DELAY_MS: i64 = 30;
@@ -389,10 +394,8 @@ impl Debugger {
 
         if !this_ref.has_started_debugger {
             this_ref.as_mut().has_started_debugger = true;
-            // Armed here and cleared by `start()` after the debugger thread has
-            // run `internal/debugger.ts` (which publishes the inspector URL);
-            // `wait_for_debugger_if_necessary` blocks on it so user code never
-            // observes the server mid-startup.
+            // Cleared by `start()` once `internal/debugger.ts` has published the
+            // inspector URL; `wait_for_debugger_if_necessary` blocks on it.
             FUTEX_ATOMIC.store(1, Ordering::Relaxed);
             // `std::thread::spawn` requires `Send`; raw `*mut
             // VirtualMachine` is `!Send`. Wrap in a `Send` newtype — the
@@ -414,7 +417,13 @@ impl Debugger {
                     let send_vm = send_vm;
                     Debugger::start_js_debugger_thread(send_vm.0);
                 })
-                .map_err(|_| crate::CrateError::ThreadSpawnFailed)?;
+                .map_err(|_| {
+                    // No debugger thread will ever publish; release anyone that
+                    // later reaches `wait_for_debugger_if_necessary`.
+                    FUTEX_ATOMIC.store(0, Ordering::Relaxed);
+                    bun_threading::Futex::wake(&FUTEX_ATOMIC, 1);
+                    crate::CrateError::ThreadSpawnFailed
+                })?;
             // The `JoinHandle` is dropped here, detaching the thread.
         }
         this_ref.event_loop_mut().ensure_waker();

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -780,6 +780,22 @@ extern "C" bool Debugger__startNodeInspectorServer(BunString* url, bool waitForC
 extern "C" void Debugger__waitForNodeInspectorConnection();
 extern "C" void Debugger__abandonNodeInspectorWait();
 
+// node:inspector's inspector.url(): the listening ws:// URL of whichever
+// debugger-thread server is active (inspector.open() or CLI --inspect), or
+// undefined when none is. The Rust-side futex in
+// Debugger::wait_for_debugger_if_necessary guarantees the CLI server has
+// already reported (or decided not to) before user code runs, so no wait is
+// needed here.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_getNodeInspectorUrl, (JSGlobalObject * globalObject, CallFrame*))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto& state = nodeInspectorState();
+    Locker<Lock> locker(state.lock);
+    if (state.url.isEmpty())
+        return JSValue::encode(jsUndefined());
+    return JSValue::encode(jsString(vm, state.url.isolatedCopy()));
+}
+
 // Posts a control message to the node-inspector server's debugger thread
 // without checking whether the server is currently listening (the reopen path
 // runs while it is closed).

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -780,12 +780,9 @@ extern "C" bool Debugger__startNodeInspectorServer(BunString* url, bool waitForC
 extern "C" void Debugger__waitForNodeInspectorConnection();
 extern "C" void Debugger__abandonNodeInspectorWait();
 
-// node:inspector's inspector.url(): the listening ws:// URL of whichever
-// debugger-thread server is active (inspector.open() or CLI --inspect), or
-// undefined when none is. The Rust-side futex in
-// Debugger::wait_for_debugger_if_necessary guarantees the CLI server has
-// already reported (or decided not to) before user code runs, so no wait is
-// needed here.
+// node:inspector's inspector.url(): the ws:// URL published by inspector.open()
+// or CLI --inspect, or undefined. The Rust-side futex guarantees the CLI server
+// has already reported before user code runs, so no wait is needed here.
 JSC_DEFINE_HOST_FUNCTION(jsFunction_getNodeInspectorUrl, (JSGlobalObject * globalObject, CallFrame*))
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/BunDebugger.h
+++ b/src/jsc/bindings/BunDebugger.h
@@ -11,5 +11,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_openNodeInspector);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_waitForNodeInspectorConnection);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_postNodeInspectorControl);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_closeNodeInspector);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_getNodeInspectorUrl);
 
 } // namespace Bun

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -39,6 +39,153 @@ test("inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspe
   expect(error.message).toBe("Inspector is not active");
 });
 
+// Under `bun --inspect`, node:inspector must see the CLI-started debugger the
+// same way Node's --inspect exposes it: url() returns the ws:// URL, open()
+// throws ERR_INSPECTOR_ALREADY_ACTIVATED, and close() actually releases the
+// port (a fresh TCP connect is refused). Previously the CLI server was
+// invisible to node:inspector so url() was undefined, waitForDebugger() threw,
+// and close() left the port bound.
+const cliInspectFixture = `
+const inspector = require("node:inspector");
+const net = require("node:net");
+
+const urlBefore = inspector.url();
+const parsed = new URL(urlBefore);
+const debugPort = process.debugPort;
+
+let alreadyActiveCode = null;
+try {
+  inspector.open(0, "127.0.0.1", false);
+} catch (error) {
+  alreadyActiveCode = error.code;
+}
+
+// The CLI server is actually listening on the port url() reports.
+const portBefore = await new Promise(resolve => {
+  const s = net.connect(Number(parsed.port), "127.0.0.1");
+  s.on("connect", () => { s.destroy(); resolve("listening"); });
+  s.on("error", e => resolve("refused:" + e.code));
+});
+
+inspector.close();
+const urlAfterClose = inspector.url() ?? null;
+
+// After close() the port must be refused: Node's close() is synchronous and
+// releases the socket before returning.
+const portAfter = await new Promise(resolve => {
+  const s = net.connect(Number(parsed.port), "127.0.0.1");
+  s.on("connect", () => { s.destroy(); resolve("listening"); });
+  s.on("error", e => resolve("refused:" + e.code));
+});
+
+// close() followed by open() must start a fresh server, same as when the
+// first server was started by inspector.open() itself.
+inspector.open(0, "127.0.0.1", false);
+const urlAfterReopen = inspector.url();
+inspector.close();
+
+console.log(
+  JSON.stringify({
+    urlBefore,
+    alreadyActiveCode,
+    portBefore,
+    urlAfterClose,
+    portAfter,
+    urlAfterReopen,
+    debugPort,
+  }),
+);
+`;
+
+test("inspector.url()/close() report and control the --inspect CLI debugger", async () => {
+  using dir = tempDir("inspector-cli-inspect", {
+    "fixture.mjs": cliInspectFixture,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "fixture.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+
+  const summary = JSON.parse(stdout.trim().split("\n").at(-1)!);
+  expect(summary).toEqual({
+    urlBefore: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+\//),
+    alreadyActiveCode: "ERR_INSPECTOR_ALREADY_ACTIVATED",
+    portBefore: "listening",
+    urlAfterClose: null,
+    portAfter: "refused:ECONNREFUSED",
+    urlAfterReopen: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+\//),
+    debugPort: Number(new URL(summary.urlBefore).port),
+  });
+  expect(summary.urlAfterReopen).not.toBe(summary.urlBefore);
+});
+
+// waitForDebugger() under --inspect must block until a client connects instead
+// of throwing ERR_INSPECTOR_NOT_ACTIVE. The CLI server speaks the JSC inspector
+// protocol, so the client sends Inspector.initialized (which resolves the wait).
+test("inspector.waitForDebugger() under --inspect blocks until a client connects", async () => {
+  using dir = tempDir("inspector-cli-wait", {
+    "fixture.mjs": `
+const inspector = require("node:inspector");
+process.stderr.write("URL " + inspector.url() + "\\n");
+inspector.waitForDebugger();
+console.log(JSON.stringify({ resumed: globalThis.__resumed === true }));
+inspector.close();
+process.exit(0);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "fixture.mjs"],
+    env: injectedScriptChildEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  const reader = proc.stderr.getReader();
+  let stderrText = "";
+  let wsUrl: string | undefined;
+  while (!wsUrl) {
+    const { value, done } = await reader.read();
+    if (done) throw new Error(`stderr closed before URL line: ${stderrText}`);
+    stderrText += decoder.decode(value);
+    wsUrl = stderrText.match(/^URL (ws:\S+)/m)?.[1];
+  }
+
+  const ws = new WebSocket(wsUrl);
+  const opened = Promise.withResolvers<void>();
+  ws.onopen = () => opened.resolve();
+  ws.onerror = e => opened.reject(e);
+  await opened.promise;
+  // Mark the global before resuming so the fixture can prove it actually
+  // waited. The CLI server speaks JSC's protocol; Inspector.initialized is
+  // what resolves the waiting-for-connection state (BunDebugger.cpp).
+  ws.send(
+    JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "globalThis.__resumed = true" } }),
+  );
+  ws.send(JSON.stringify({ id: 2, method: "Inspector.initialized" }));
+
+  const drained = (async () => {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      stderrText += decoder.decode(value);
+    }
+  })();
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  await drained;
+  ws.close();
+
+  expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ resumed: true });
+  expect(exitCode).toBe(0);
+});
+
 // inspector.open() starts a WebSocket server speaking the V8 Chrome DevTools
 // Protocol (translated to JSC's inspector protocol on the debugger thread).
 // The fixture opens the inspector, talks to its own server as a CDP client,

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -122,7 +122,7 @@ test("inspector.url()/close() report and control the --inspect CLI debugger", as
     debugPort: Number(new URL(summary.urlBefore).port),
   });
   expect(summary.urlAfterReopen).not.toBe(summary.urlBefore);
-});
+}, 30_000);
 
 // waitForDebugger() under --inspect must block until a client connects instead
 // of throwing ERR_INSPECTOR_NOT_ACTIVE. The CLI server speaks the JSC inspector
@@ -182,7 +182,7 @@ process.exit(0);
 
   expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ resumed: true });
   expect(exitCode).toBe(0);
-});
+}, 30_000);
 
 // nodeInspectorState is process-global; a Worker must not see or control the
 // main thread's --inspect server through node:inspector.
@@ -231,7 +231,7 @@ parentPort.postMessage({ workerUrl: inspector.url() ?? null, closeCode, waitCode
     closeCode: "ERR_WORKER_UNSUPPORTED_OPERATION",
     waitCode: "ERR_INSPECTOR_NOT_ACTIVE",
   });
-});
+}, 30_000);
 
 // inspector.open() starts a WebSocket server speaking the V8 Chrome DevTools
 // Protocol (translated to JSC's inspector protocol on the debugger thread).

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -193,7 +193,10 @@ const inspector = require("node:inspector");
 const { Worker } = require("node:worker_threads");
 const mainUrl = inspector.url();
 const worker = new Worker("./worker.mjs");
-const fromWorker = await new Promise(resolve => worker.on("message", resolve));
+const fromWorker = await new Promise((resolve, reject) => {
+  worker.on("message", resolve);
+  worker.on("error", reject);
+});
 // The worker's close() must not have shut down the main thread's server.
 const urlAfterWorker = inspector.url();
 console.log(JSON.stringify({ mainUrl, urlAfterWorker, ...fromWorker }));

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -165,9 +165,7 @@ process.exit(0);
   // Mark the global before resuming so the fixture can prove it actually
   // waited. The CLI server speaks JSC's protocol; Inspector.initialized is
   // what resolves the waiting-for-connection state (BunDebugger.cpp).
-  ws.send(
-    JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "globalThis.__resumed = true" } }),
-  );
+  ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "globalThis.__resumed = true" } }));
   ws.send(JSON.stringify({ id: 2, method: "Inspector.initialized" }));
 
   const drained = (async () => {

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -184,6 +184,52 @@ process.exit(0);
   expect(exitCode).toBe(0);
 });
 
+// nodeInspectorState is process-global; a Worker must not see or control the
+// main thread's --inspect server through node:inspector.
+test("inspector.url()/close() in a Worker do not reach the main thread's --inspect server", async () => {
+  using dir = tempDir("inspector-cli-worker", {
+    "fixture.mjs": `
+const inspector = require("node:inspector");
+const { Worker } = require("node:worker_threads");
+const mainUrl = inspector.url();
+const worker = new Worker("./worker.mjs");
+const fromWorker = await new Promise(resolve => worker.on("message", resolve));
+// The worker's close() must not have shut down the main thread's server.
+const urlAfterWorker = inspector.url();
+console.log(JSON.stringify({ mainUrl, urlAfterWorker, ...fromWorker }));
+inspector.close();
+await worker.terminate();
+`,
+    "worker.mjs": `
+const inspector = require("node:inspector");
+const { parentPort } = require("node:worker_threads");
+let closeCode = null;
+try { inspector.close(); } catch (e) { closeCode = e.code; }
+let waitCode = null;
+try { inspector.waitForDebugger(); } catch (e) { waitCode = e.code; }
+parentPort.postMessage({ workerUrl: inspector.url() ?? null, closeCode, waitCode });
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "fixture.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+
+  const summary = JSON.parse(stdout.trim().split("\n").at(-1)!);
+  expect(summary).toEqual({
+    mainUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+\//),
+    urlAfterWorker: summary.mainUrl,
+    workerUrl: null,
+    closeCode: "ERR_WORKER_UNSUPPORTED_OPERATION",
+    waitCode: "ERR_INSPECTOR_NOT_ACTIVE",
+  });
+});
+
 // inspector.open() starts a WebSocket server speaking the V8 Chrome DevTools
 // Protocol (translated to JSC's inspector protocol on the debugger thread).
 // The fixture opens the inspector, talks to its own server as a CDP client,


### PR DESCRIPTION
## Problem

Under `bun --inspect`, the `node:inspector` introspection API is blind to the CLI-started debugger. Running this under `bun --inspect=127.0.0.1:PORT`:

```js
const inspector = require("node:inspector"), net = require("node:net");
console.log(inspector.url());        // undefined (a server IS listening)
inspector.waitForDebugger();         // throws ERR_INSPECTOR_NOT_ACTIVE
inspector.close();                   // no-op; port stays bound
```

Node reports the `ws://` URL from `url()` under `--inspect`, `waitForDebugger()` blocks, and `close()` releases the port. The documented "is a debugger attached?" probe (`inspector.url() !== undefined`, used by APM/dev-tool guards) is always false under `bun --inspect`, and the documented "release the debugger port before fork/re-exec" call (`inspector.close()`) silently does nothing.

## Cause

The CLI `--inspect` server is started by `internal/debugger.ts` on the debugger thread, but it never published its URL or a shutdown callback into the `nodeInspectorState` that `node:inspector`'s `open()`/`close()` already coordinate through. `node:inspector` also kept a module-local `activeInspectorUrl` that only `inspector.open()` ever wrote, so `url()`/`close()`/`waitForDebugger()` saw nothing.

## Fix

- `internal/debugger.ts`: the CLI `--inspect` path now publishes its URL and the same control callback (close/reopen/command/session-*) via `reportNodeInspectorServerStarted`, so `inspector.close()` can stop the CLI server and a subsequent `inspector.open()` starts a CDP server on the already-running debugger thread.
- `BunDebugger.cpp`: add `jsFunction_getNodeInspectorUrl`, returning the shared `nodeInspectorState.url` or `undefined`.
- `inspector.ts`: read `url()`/`close()`/`waitForDebugger()`/`open()`'s "is an inspector active?" from the shared native state instead of the module-local, removing `activeInspectorUrl`. Also reflect the CLI server's port in `process.debugPort` on first `require("node:inspector")`.
- `Debugger.rs`: arm the debugger-thread setup futex for plain `--inspect` so user code never runs before `internal/debugger.ts` has published the URL (Node's `--inspect` starts its agent synchronously).

## Verification

```
bun bd test test/js/node/inspector/inspector.test.ts
# 25 pass, 0 fail
```

New tests (both fail on main):
- `inspector.url()/close() report and control the --inspect CLI debugger`: under `--inspect=127.0.0.1:0`, `url()` is the `ws://` URL, `open()` throws `ERR_INSPECTOR_ALREADY_ACTIVATED`, `close()` releases the port (a fresh TCP connect is refused), and `close()` followed by `open()` starts a fresh server.
- `inspector.waitForDebugger() under --inspect blocks until a client connects`: `waitForDebugger()` under `--inspect` blocks until a JSC-protocol client sends `Inspector.initialized` instead of throwing `ERR_INSPECTOR_NOT_ACTIVE`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/25] gen cpp.rs (cppbind)
[2/25] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/25] gen JS modules (bundle-modules)
Preprocess modules (25644ms)
Bundle modules (727ms)
Postprocesss modules (716ms)
Bundle Functions (2129ms)
Generate Code (121ms)

[29.39s] Bundled "src/js" for development
  2761 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[6/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[7/9] link bun-debug
FAILED: bun-debug 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts link --console /usr/lib/llvm-21/bin/clang++ @bun-debug.rsp -fsanitize=address -fsanitize=null -Wl,--wrap=exp -Wl,--wrap=exp2 -Wl,-
... (truncated)

release without fix: 24 FAILED
bun test v1.3.14 (0d9b296a)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [1.54ms]
(pass) inspector.console [0.88ms]
22 | test("inspector.console", () => {
23 |   expect(inspector.console).toBeObject();
24 | });
25 | 
26 | test("inspector.close() is a no-op when the inspector is not open", () => {
27 |   expect(() => inspector.close()).not.toThrow();
                                           ^
error: expect(received).not.toThrow()

Error name: "NotImplementedError"
Error message: "node:inspector is not yet implemented in Bun. Track the status & thumbs up the issue: https://github.com/oven-sh/bun/issues/2445"

      at <anonymous> (/workspace/bun/test/js/node/inspector/inspector.test.ts:27:39)
(fail) inspector.close() is a no-op when the inspector is not open [2.19ms]
33 |     inspector.waitForDebugger();
34 |   } catch (caught) {
35 |     error = caught;
36 |   }
37 |   expect(error).toBeDefined();
38 |   expect(error.code).toBe("ERR_INSPECTOR_NOT_ACTIVE");
                          ^
error: expect(received).toBe(expected)

Expected: "ERR_INSPECTOR_NOT_ACTIVE"
Received: "ERR_NOT_IMPLEMENTED"

      at <anonymous> (/workspace/bun/test/js/node/ins
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (1303b2265)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [12.02ms]
(pass) inspector.console [12.25ms]
(pass) inspector.close() is a no-op when the inspector is not open [7.04ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [7.78ms]
(pass) inspector.url()/close() report and control the --inspect CLI debugger [3371.26ms]
(pass) inspector.waitForDebugger() under --inspect blocks until a client connects [3374.85ms]
(pass) inspector.url()/close() in a Worker do not reach the main thread's --inspect server [5146.15ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [7480.99ms]
(pass) inspector.close() followed by inspector.open() starts a new server [2919.40ms]
(pass) inspector.open() can be retried after a failed start [2440.95ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [2806.71ms]
(pass) inspector.waitForDebugger() blocks until a
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1449ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (22495ms)
Bundle modules (66ms)
Postprocesss modules (491ms)
Bundle Functions (4016ms)
Generate Code (264ms)

[27.37s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/debugger.ts              | 165 +++++++++++++-------------
 src/js/node/inspector.ts                 |  50 +++++---
 src/jsc/Debugger.rs                      |  42 +++++--
 src/jsc/bindings/BunDebugger.cpp         |  13 +++
 src/jsc/bindings/BunDebugger.h           |   1 +
 test/js/node/inspector/inspector.test.ts | 194 +++++++++++++++++++++++++++++++
 6 files changed, 355 insertions(+), 110 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/debugger.ts                   7     10      0
src/js/node/inspector.ts                      5     11      0
src/jsc/Debugger.rs                           6      9      0
src/jsc/bindings/BunDebugger.cpp              3      5      0
src/jsc/bindings/BunDebugger.h                1      1      0
test/js/node/inspector/inspector.test.ts      6     11      0
```

</details>

<!-- robobun:evidence:end -->