### PR TITLE
node:quic h3: concatenate duplicate cookie field lines with '; ' in onheaders

### DIFF
--- a/src/js/internal/quic/http2util.ts
+++ b/src/js/internal/quic/http2util.ts
@@ -194,4 +194,5 @@ export default {
   assertValidPseudoHeader,
   assertValidPseudoHeaderTrailer,
   buildNgHeaderString,
+  kSingleValueFields,
 };

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -244,6 +244,7 @@ const {
   buildNgHeaderString,
   assertValidPseudoHeader,
   assertValidPseudoHeaderTrailer,
+  kSingleValueFields,
 } = require("internal/quic/http2util");
 
 const kEmptyObject = { __proto__: null };
@@ -1302,7 +1303,13 @@ function validateBody(body) {
 
 /**
  * Parses an alternating [name, value, name, value, ...] array from C++
- * into a plain header object. Multi-value headers become arrays.
+ * into a plain header object, applying the same duplicate-field rules as
+ * node's http2 `toHeaderObject` (lib/internal/http2/util.js) so the app
+ * sees a generic HTTP header block:
+ *  - `cookie`: concatenated with "; " (RFC 9114 §4.2.1 / RFC 7540 §8.1.2.5)
+ *  - `set-cookie`: always an array, even for a single value
+ *  - known single-value fields: first value wins, later duplicates discarded
+ *  - everything else: concatenated with ", "
  * @param {string[]} pairs
  * @returns {object}
  */
@@ -1311,14 +1318,23 @@ function parseHeaderPairs(pairs) {
   assert(pairs.length % 2 === 0);
   const block = { __proto__: null };
   for (let n = 0; n + 1 < pairs.length; n += 2) {
-    if (block[pairs[n]] !== undefined) {
-      if (ArrayIsArray(block[pairs[n]])) {
-        ArrayPrototypePush(block[pairs[n]], pairs[n + 1]);
-      } else {
-        block[pairs[n]] = [block[pairs[n]], pairs[n + 1]];
+    const name = pairs[n];
+    const value = pairs[n + 1];
+    const existing = block[name];
+    if (existing === undefined) {
+      block[name] = name === "set-cookie" ? [value] : value;
+    } else if (!kSingleValueFields.has(name)) {
+      switch (name) {
+        case "cookie":
+          block[name] = `${existing}; ${value}`;
+          break;
+        case "set-cookie":
+          ArrayPrototypePush(existing, value);
+          break;
+        default:
+          block[name] = `${existing}, ${value}`;
+          break;
       }
-    } else {
-      block[pairs[n]] = pairs[n + 1];
     }
   }
   return block;

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -1302,14 +1302,9 @@ function validateBody(body) {
 }
 
 /**
- * Parses an alternating [name, value, name, value, ...] array from C++
- * into a plain header object, applying the same duplicate-field rules as
- * node's http2 `toHeaderObject` (lib/internal/http2/util.js) so the app
- * sees a generic HTTP header block:
- *  - `cookie`: concatenated with "; " (RFC 9114 §4.2.1 / RFC 7540 §8.1.2.5)
- *  - `set-cookie`: always an array, even for a single value
- *  - known single-value fields: first value wins, later duplicates discarded
- *  - everything else: concatenated with ", "
+ * Parses an alternating [name, value, name, value, ...] array from C++ into a
+ * plain header object. Duplicate-field folding matches node's http2
+ * `toHeaderObject` (lib/internal/http2/util.js).
  * @param {string[]} pairs
  * @returns {object}
  */
@@ -1326,6 +1321,7 @@ function parseHeaderPairs(pairs) {
     } else if (!kSingleValueFields.has(name)) {
       switch (name) {
         case "cookie":
+          // RFC 9114 §4.2.1: MUST concatenate with "; " before non-h3 context.
           block[name] = `${existing}; ${value}`;
           break;
         case "set-cookie":

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -207,7 +207,13 @@ describe("HTTP/3 duplicate field lines", () => {
             // generic multi-value: joins with ", "
             "x-multi": ["one", "two", "three"],
           });
+          this.writer.writeSync(new TextEncoder().encode("body"));
           this.writer.endSync();
+        },
+        onwanttrailers(this: any) {
+          // sendTrailers doesn't enforce strict single-value, so this reaches
+          // the wire as two field lines and exercises the discard branch.
+          this.sendTrailers({ "content-type": ["text/html", "text/plain"] });
         },
       },
     );
@@ -220,7 +226,8 @@ describe("HTTP/3 duplicate field lines", () => {
     await client.opened;
 
     const clientSaw = Promise.withResolvers<Record<string, unknown>>();
-    await client.createBidirectionalStream({
+    const clientTrailers = Promise.withResolvers<Record<string, unknown>>();
+    const stream = await client.createBidirectionalStream({
       headers: {
         ":method": "GET",
         ":path": "/",
@@ -235,7 +242,12 @@ describe("HTTP/3 duplicate field lines", () => {
       onheaders(headers: Record<string, unknown>) {
         clientSaw.resolve(headers);
       },
+      ontrailers(trailers: Record<string, unknown>) {
+        clientTrailers.resolve(trailers);
+      },
     });
+    for await (const _ of stream) {
+    }
 
     const serverHeaders = await serverSaw.promise;
     expect({
@@ -255,6 +267,10 @@ describe("HTTP/3 duplicate field lines", () => {
       "set-cookie": ["a=1", "b=2"],
       "x-multi": "one, two, three",
     });
+
+    // known single-value field duplicated: first value wins, second discarded
+    const trailers = await clientTrailers.promise;
+    expect(trailers["content-type"]).toBe("text/html");
 
     client.close();
   });

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -179,3 +179,120 @@ describe("HTTP/3 header encoding", () => {
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
 });
+
+// RFC 9114 §4.2.1: an HTTP/3 intermediary presenting headers to a non-HTTP/3
+// consumer MUST concatenate multiple `cookie` field lines with "; ". Node's
+// http2/quic header object applies the same http2 `toHeaderObject` rules:
+// `cookie` joins with "; ", `set-cookie` is always an array, known
+// single-value fields discard duplicates, and everything else joins with ", ".
+describe("HTTP/3 duplicate field lines", () => {
+  test("are folded per RFC 9114 / http2 toHeaderObject rules", async () => {
+    const serverSaw = Promise.withResolvers<Record<string, unknown>>();
+    await using server = await listen(
+      async serverSession => {
+        serverSession.onstream = (stream: any) => {
+          stream.closed.catch(() => {});
+        };
+        await serverSession.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 1 },
+        onheaders(this: any, headers: Record<string, unknown>) {
+          serverSaw.resolve(headers);
+          this.sendHeaders({
+            ":status": "200",
+            // set-cookie: multiple field lines, must reach the client as an array
+            "set-cookie": ["a=1", "b=2"],
+            // generic multi-value: joins with ", "
+            "x-multi": ["one", "two", "three"],
+          });
+          this.writer.endSync();
+        },
+      },
+    );
+
+    const client = await connect(server.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 1 },
+    });
+    await client.opened;
+
+    const clientSaw = Promise.withResolvers<Record<string, unknown>>();
+    await client.createBidirectionalStream({
+      headers: {
+        ":method": "GET",
+        ":path": "/",
+        ":scheme": "https",
+        ":authority": "localhost",
+        // RFC 9114 §4.2.1: h3 clients MAY (browsers/curl do) send each cookie
+        // crumb as its own field line. The app must see a single joined string.
+        "cookie": ["a=1", "b=2", "c=3"],
+        // generic multi-value header
+        "accept": ["text/html", "application/json"],
+      },
+      onheaders(headers: Record<string, unknown>) {
+        clientSaw.resolve(headers);
+      },
+    });
+
+    const serverHeaders = await serverSaw.promise;
+    expect({
+      cookie: serverHeaders.cookie,
+      accept: serverHeaders.accept,
+    }).toEqual({
+      cookie: "a=1; b=2; c=3",
+      accept: "text/html, application/json",
+    });
+    expect(typeof serverHeaders.cookie).toBe("string");
+
+    const clientHeaders = await clientSaw.promise;
+    expect({
+      "set-cookie": clientHeaders["set-cookie"],
+      "x-multi": clientHeaders["x-multi"],
+    }).toEqual({
+      "set-cookie": ["a=1", "b=2"],
+      "x-multi": "one, two, three",
+    });
+
+    client.close();
+  });
+
+  test("single set-cookie is still delivered as an array", async () => {
+    await using server = await listen(
+      async serverSession => {
+        serverSession.onstream = (stream: any) => {
+          stream.closed.catch(() => {});
+        };
+        await serverSession.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 1 },
+        onheaders(this: any) {
+          this.sendHeaders({ ":status": "200", "set-cookie": "only=one" });
+          this.writer.endSync();
+        },
+      },
+    );
+
+    const client = await connect(server.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 1 },
+    });
+    await client.opened;
+
+    const got = Promise.withResolvers<unknown>();
+    await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost" },
+      onheaders(headers: Record<string, unknown>) {
+        got.resolve(headers["set-cookie"]);
+      },
+    });
+
+    expect(await got.promise).toEqual(["only=one"]);
+    client.close();
+  });
+});


### PR DESCRIPTION
## Problem

HTTP/3 clients routinely send each cookie crumb as its own `cookie` field line (RFC 9114 §4.2.1 explicitly permits this for compression efficiency; browsers and `curl --http3` do it). When bun's `node:quic` server received such a request, `parseHeaderPairs` turned the duplicates into an array:

```js
// curl-h3 -H 'Cookie: a=1' -H 'Cookie: b=2'
onheaders(h) {
  h.cookie           // ["a=1", "b=2"]  (expected: "a=1; b=2")
  h.cookie.split(";") // TypeError: h.cookie.split is not a function
}
```

RFC 9114 §4.2.1 says that when presenting the header section to a non-HTTP/3 consumer, multiple `cookie` field lines MUST be concatenated with `"; "`. Node's own http2/quic `toHeaderObject` converter does this.

The same naive array-ing also applied to every other duplicated field, so a peer sending two `content-length` lines produced `["3","5"]` instead of a string.

## Fix

`parseHeaderPairs` in `src/js/internal/quic/quic.ts` now applies the same duplicate-field rules as node's http2 `toHeaderObject` (lib/internal/http2/util.js):

- `cookie`: joined with `"; "`
- `set-cookie`: always an array, even for a single value
- known single-value fields (`:status`, `content-length`, `content-type`, ...): first value wins, later duplicates discarded
- everything else: joined with `", "`

`kSingleValueFields` is exported from `internal/quic/http2util` so both the outbound validator and the inbound parser share the same list.

## Verification

Added two tests to `test/js/node/quic/quic-stream.test.ts` covering `cookie` / `accept` folding on the request side and `set-cookie` / generic folding on the response side, plus the single-value `set-cookie` array case. Before the fix the request-side `cookie` arrives as `["a=1","b=2","c=3"]`; after, it is `"a=1; b=2; c=3"`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (5a02d2203)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [849.56ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [221.67ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1323.11ms]
251 | 
252 |     const serverHeaders = await serverSaw.promise;
253 |     expect({
254 |       cookie: serverHeaders.cookie,
255 |       accept: serverHeaders.accept,
256 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
-   "accept": "text/html, application/json",
-   "cookie": "a=1; b=2; c=3",
+   "accept": [
+     "text/html",
+     "application/json",
+   ],
+   "cookie": [
+     "a=1",
+     "b=2",
+     "c=3",
+   ],
  }

- Expected  
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/quic/quic-stream.test.ts:

# Unhandled error between tests
-------------------------------
8 | import { connect, listen } from "node:quic";
                                    ^
error: Could not resolve: "node:quic". Maybe you need to "bun install"?
    at /workspace/bun/test/js/node/quic/quic-stream.test.ts:8:33
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [487.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (5a02d2203)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [857.82ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [162.98ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1240.15ms]
(pass) HTTP/3 duplicate field lines > are folded per RFC 9114 / http2 toHeaderObject rules [303.96ms]
(pass) HTTP/3 duplicate field lines > single set-cookie is still delivered as an array [127.69ms]

 5 pass
 0 fail
 12 expect() calls
Ran 5 tests across 1 file. [9.70s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2218ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (20559ms)
Bundle modules (2924ms)
Postprocesss modules (1354ms)
Bundle Functions (1815ms)
Generate Code (147ms)

[26.89s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/quic/http2util.ts     |   1 +
 src/js/internal/quic/quic.ts          |  30 +++++---
 test/js/node/quic/quic-stream.test.ts | 133 ++++++++++++++++++++++++++++++++++
 3 files changed, 155 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/internal/quic/http2util.ts          1      1      0
src/js/internal/quic/quic.ts               5      4      0
test/js/node/quic/quic-stream.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->