### PR TITLE
node:inspector: count calls in modules loaded before Profiler.startPreciseCoverage

### DIFF
--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -417,9 +417,21 @@ class Session extends EventEmitter {
   #preciseCoverageCallCount = false;
   #preciseCoverageDetailed = false;
   #forwardedDebugger = false;
-  // Baseline for delta semantics: takePreciseCoverage must reset counters, but
-  // JSC has no counter-reset API, so subtract the previous take instead.
+  // Baseline for delta semantics: start/takePreciseCoverage must reset counters,
+  // but JSC has no counter-reset API, so subtract a recorded snapshot instead.
   #coverageBaseline: Map<string, number> = new Map();
+
+  #snapshotCoverageBaseline() {
+    const baseline = this.#coverageBaseline;
+    baseline.$clear();
+    const scripts = collectCoverageScripts();
+    if (scripts instanceof Error) return;
+    for (const script of scripts) {
+      for (const block of script.blocks) {
+        baseline.$set(`${script.scriptId}:${block[0]}:${block[1]}`, block[2]);
+      }
+    }
+  }
 
   connect() {
     if (this.#connected) {
@@ -483,8 +495,8 @@ class Session extends EventEmitter {
     const payload = deferred ? result[kDeferToImmediate] : result;
 
     if (callback) {
-      // Callback API - async. Deferred results (start/stop precise coverage)
-      // wait one event-loop turn so deleteAllCode's whenIdle work has run.
+      // Callback API - async. Deferred results wait one event-loop turn so
+      // deleteAllCode's whenIdle work has run before the callback.
       const deliver = () => {
         if (payload instanceof Error) {
           callback(payload, undefined);
@@ -563,7 +575,10 @@ class Session extends EventEmitter {
         if (!this.#profilerEnabled) return $ERR_INSPECTOR_COMMAND("-32000: Profiler is not enabled");
         this.#preciseCoverageCallCount = !!(params as any)?.callCount;
         this.#preciseCoverageDetailed = !!(params as any)?.detailed;
-        this.#coverageBaseline.$clear();
+        // CDP: "resets execution counters". The VM profiler stays on across
+        // stop/start, so snapshot current raw counts as the baseline instead
+        // (the native side returns [] when the profiler is not yet enabled).
+        this.#snapshotCoverageBaseline();
         // CDP: monotonic seconds since an arbitrary origin (V8 uses TimeTicks).
         const response = { timestamp: performance.now() / 1000 };
         if (this.#preciseCoverageEnabled) return response;
@@ -589,8 +604,7 @@ class Session extends EventEmitter {
         if (scripts instanceof Error) return scripts;
         // CDP contract: takePreciseCoverage resets execution counters, so a
         // second take reports the delta. JSC has no counter reset, so subtract
-        // the previous take's raw block counts (function-level call counts are
-        // derived from the entry block, so they follow automatically).
+        // the previous baseline and record the new raw counts as the next one.
         const baseline = this.#coverageBaseline;
         for (const script of scripts) {
           for (const block of script.blocks) {

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -27,7 +27,6 @@ const stopCPUProfiler = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_s
 const setCPUSamplingInterval = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_setCPUSamplingInterval", 1);
 const isCPUProfilerRunning = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_isCPUProfilerRunning", 0);
 const startPreciseCoverage = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_startPreciseCoverage", 0);
-const stopPreciseCoverage = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_stopPreciseCoverage", 0);
 const collectPreciseCoverage = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_collectPreciseCoverage", 0);
 
 // Native bindings for inspector.open(): they start Bun's debugger thread with a
@@ -439,10 +438,7 @@ class Session extends EventEmitter {
   disconnect() {
     if (!this.#connected) return;
     if (isCPUProfilerRunning()) stopCPUProfiler();
-    if (this.#preciseCoverageEnabled) {
-      stopPreciseCoverage();
-      this.#preciseCoverageEnabled = false;
-    }
+    this.#preciseCoverageEnabled = false;
     this.#profilerEnabled = false;
     this.#connected = false;
     this.#coverageBaseline.$clear();
@@ -535,12 +531,8 @@ class Session extends EventEmitter {
         if (isCPUProfilerRunning()) {
           stopCPUProfiler();
         }
-        // V8's Profiler agent stops precise coverage on disable; without this
-        // the control-flow profiler keeps instrumenting newly-compiled code.
-        if (this.#preciseCoverageEnabled) {
-          stopPreciseCoverage();
-          this.#preciseCoverageEnabled = false;
-        }
+        // V8's Profiler agent stops precise coverage on disable.
+        this.#preciseCoverageEnabled = false;
         this.#profilerEnabled = false;
         return {};
 
@@ -582,11 +574,12 @@ class Session extends EventEmitter {
 
       case "Profiler.stopPreciseCoverage": {
         if (!this.#profilerEnabled) return $ERR_INSPECTOR_COMMAND("-32000: Profiler is not enabled");
+        // The VM-level profiler stays enabled for the process lifetime; see
+        // the comment on jsFunction_startPreciseCoverage for why disabling is
+        // unsafe once any async body has compiled under it.
         this.#coverageBaseline.$clear();
-        if (!this.#preciseCoverageEnabled) return {};
-        stopPreciseCoverage();
         this.#preciseCoverageEnabled = false;
-        return { [kDeferToImmediate]: {} };
+        return {};
       }
 
       case "Profiler.takePreciseCoverage": {

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -10,6 +10,7 @@ const EventEmitter = require("node:events");
 const { pathToFileURL } = require("node:url");
 const { isAbsolute } = require("node:path");
 const DateNow = Date.now;
+const setImmediate = globalThis.setImmediate;
 
 // #handleMethod return marker for inspector-protocol errors: the callback
 // receives the plain `{ code, message }` object (Node delivers protocol

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -16,6 +16,11 @@ const DateNow = Date.now;
 // errors as plain objects, not Error instances).
 const kProtocolError = Symbol("kProtocolError");
 
+// #handleMethod marker: deliver via setImmediate, not queueMicrotask. The
+// native side scheduled VM::whenIdle work (deleteAllCode) and microtasks drain
+// inside the same VMEntryScope, so a microtask callback would run too early.
+const kDeferToImmediate = Symbol("kDeferToImmediate");
+
 // Native profiler functions exposed via $newCppFunction
 const startCPUProfiler = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_startCPUProfiler", 0);
 const stopCPUProfiler = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_stopCPUProfiler", 0);
@@ -272,19 +277,16 @@ function removeConsoleHooks() {
   hookedConsoleMethods.length = 0;
 }
 
-// Reshapes the raw control-flow-profiler data from jsFunction_collectPreciseCoverage
-// ([{ url, scriptId, sourceLength, blocks: [[start, end, count]], functions: [[start, end, executed]] }])
-// into the V8 ScriptCoverage list returned by Profiler.takePreciseCoverage:
-// each function gets an entry whose first range spans the whole function with its
-// call count, followed by the basic-block ranges inside it; blocks outside any
-// function go on a synthetic whole-script entry.
+// Reshapes jsFunction_collectPreciseCoverage output ([{ url, scriptId,
+// sourceLength, blocks: [[start,end,count]], functions: [[start,end,name]] }])
+// into the V8 ScriptCoverage list returned by Profiler.takePreciseCoverage.
 function buildScriptCoverageList(
   rawScripts: Array<{
     url: string;
     scriptId: number;
     sourceLength: number;
     blocks: Array<[number, number, number]>;
-    functions: Array<[number, number, boolean]>;
+    functions: Array<[number, number, string]>;
   }>,
   callCount: boolean,
   detailed: boolean,
@@ -363,31 +365,28 @@ function buildScriptCoverageList(
     });
 
     for (let i = 0; i < functions.length; i++) {
-      const [startOffset, endOffset, executed] = functions[i];
-      if (!executed) {
+      const [startOffset, endOffset, name] = functions[i];
+      const ownBlocks = blocksPerFunction[i];
+      if (ownBlocks.length === 0) {
         entries.push({
-          functionName: "",
+          functionName: name,
           ranges: [{ startOffset, endOffset, count: 0 }],
           isBlockCoverage: false,
         });
         continue;
       }
 
-      const ownBlocks = blocksPerFunction[i];
       // Approximate the call count from the entry block (the one with the
       // smallest start offset). Diverges from V8 for generators/async
       // functions, which JSC compiles as two nested CodeBlocks whose body
       // entry counts state-0 resumes rather than user-visible calls.
-      let count = 1;
-      if (ownBlocks.length > 0) {
-        let entryBlock = ownBlocks[0];
-        for (const block of ownBlocks) {
-          if (block[0] < entryBlock[0]) entryBlock = block;
-        }
-        count = entryBlock[2];
+      let entryBlock = ownBlocks[0];
+      for (const block of ownBlocks) {
+        if (block[0] < entryBlock[0]) entryBlock = block;
       }
+      const count = entryBlock[2];
       entries.push({
-        functionName: "",
+        functionName: name,
         ranges: [
           { startOffset, endOffset, count: callCount ? count : count > 0 ? 1 : 0 },
           ...(detailed ? ownBlocks.map(toRange) : []),
@@ -484,30 +483,35 @@ class Session extends EventEmitter {
     }
 
     const result = this.#handleMethod(method, params as object | undefined);
+    const deferred = result !== null && typeof result === "object" && kDeferToImmediate in result;
+    const payload = deferred ? result[kDeferToImmediate] : result;
 
     if (callback) {
-      // Callback API - async
-      queueMicrotask(() => {
-        if (result instanceof Error) {
-          callback(result, undefined);
-        } else if (result !== null && typeof result === "object" && kProtocolError in result) {
-          callback(result[kProtocolError], undefined);
+      // Callback API - async. Deferred results (start/stop precise coverage)
+      // wait one event-loop turn so deleteAllCode's whenIdle work has run.
+      const deliver = () => {
+        if (payload instanceof Error) {
+          callback(payload, undefined);
+        } else if (payload !== null && typeof payload === "object" && kProtocolError in payload) {
+          callback(payload[kProtocolError], undefined);
         } else {
-          callback(null, result);
+          callback(null, payload);
         }
-      });
+      };
+      if (deferred) setImmediate(deliver);
+      else queueMicrotask(deliver);
     } else {
       // Sync throw for errors when no callback
-      if (result instanceof Error) {
-        throw result;
+      if (payload instanceof Error) {
+        throw payload;
       }
-      if (result !== null && typeof result === "object" && kProtocolError in result) {
-        const protocolError = result[kProtocolError];
+      if (payload !== null && typeof payload === "object" && kProtocolError in payload) {
+        const protocolError = payload[kProtocolError];
         const error = new Error(protocolError.message);
         error.code = protocolError.code;
         throw error;
       }
-      return result;
+      return payload;
     }
   }
 
@@ -565,25 +569,24 @@ class Session extends EventEmitter {
 
       case "Profiler.startPreciseCoverage": {
         if (!this.#profilerEnabled) return $ERR_INSPECTOR_COMMAND("-32000: Profiler is not enabled");
-        if (!this.#preciseCoverageEnabled) {
-          startPreciseCoverage();
-          this.#preciseCoverageEnabled = true;
-        }
         this.#preciseCoverageCallCount = !!(params as any)?.callCount;
         this.#preciseCoverageDetailed = !!(params as any)?.detailed;
         this.#coverageBaseline.$clear();
         // CDP: monotonic seconds since an arbitrary origin (V8 uses TimeTicks).
-        return { timestamp: performance.now() / 1000 };
+        const response = { timestamp: performance.now() / 1000 };
+        if (this.#preciseCoverageEnabled) return response;
+        startPreciseCoverage();
+        this.#preciseCoverageEnabled = true;
+        return { [kDeferToImmediate]: response };
       }
 
       case "Profiler.stopPreciseCoverage": {
         if (!this.#profilerEnabled) return $ERR_INSPECTOR_COMMAND("-32000: Profiler is not enabled");
-        if (this.#preciseCoverageEnabled) {
-          stopPreciseCoverage();
-          this.#preciseCoverageEnabled = false;
-        }
         this.#coverageBaseline.$clear();
-        return {};
+        if (!this.#preciseCoverageEnabled) return {};
+        stopPreciseCoverage();
+        this.#preciseCoverageEnabled = false;
+        return { [kDeferToImmediate]: {} };
       }
 
       case "Profiler.takePreciseCoverage": {

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -29,6 +29,35 @@ namespace Bun {
 using namespace JSC;
 using namespace WebCore;
 
+// Debugger.setBreakpointsActive triggers Debugger::setBreakpointsActivated
+// → recompileAllJSFunctions → vm.deleteAllCode, which iterates each
+// ScriptExecutable subspace's clearableCodeSet and calls clearCode. For
+// ModuleProgramExecutable, clearCode drops m_unlinkedCodeBlock and
+// m_moduleEnvironmentSymbolTable; the next executeModuleProgram (a
+// top-level-await resume, or a linked-but-not-yet-evaluated module)
+// regenerates the unlinked code block under the now-different
+// CodeGenerationMode, whose module-environment / generator-frame layout no
+// longer matches the live JSModuleEnvironment, and the next op_put_to_scope
+// writes past it. This is the invariant documented in
+// UnlinkedModuleProgramCodeBlock.h. Module bodies execute once, so dropping
+// their unlinked code block cannot recover debug hooks for the body anyway
+// (inner functions are recompiled independently via
+// deleteAllUnlinkedCodeBlocks); pre-removing every module executable from
+// the clearableCodeSet makes deleteAllCodeBlocks skip them and keeps the
+// original bytecode in place. Registered via whenIdle so it runs ahead of
+// any deferred deleteAllCode callback regardless of whether the dispatch
+// happens with a VMEntryScope on the stack.
+void protectModuleExecutablesFromClearCode(JSC::VM& vm)
+{
+    if (auto* spaceAndSet = vm.heap.m_moduleProgramExecutableSpace.get()) {
+        JSC::HeapIterationScope iterationScope(vm.heap);
+        auto& set = spaceAndSet->clearableCodeSet;
+        set.forEachLiveCell([&](JSC::HeapCell* cell, JSC::HeapCell::Kind) {
+            set.remove(cell);
+        });
+    }
+}
+
 class BunInspectorConnection;
 
 static WebCore::ScriptExecutionContext* debuggerScriptExecutionContext = nullptr;
@@ -328,35 +357,6 @@ public:
         auto& wait = pausedWait();
         Locker<Lock> locker(wait.lock);
         wait.condition.notifyAll();
-    }
-
-    // Debugger.setBreakpointsActive triggers Debugger::setBreakpointsActivated
-    // → recompileAllJSFunctions → vm.deleteAllCode, which iterates each
-    // ScriptExecutable subspace's clearableCodeSet and calls clearCode. For
-    // ModuleProgramExecutable, clearCode drops m_unlinkedCodeBlock and
-    // m_moduleEnvironmentSymbolTable; the next executeModuleProgram (a
-    // top-level-await resume, or a linked-but-not-yet-evaluated module)
-    // regenerates the unlinked code block under the now-different
-    // CodeGenerationMode::Debugger, whose module-environment / generator-frame
-    // layout no longer matches the live JSModuleEnvironment, and the next
-    // op_put_to_scope writes past it. This is the invariant documented in
-    // UnlinkedModuleProgramCodeBlock.h. Module bodies execute once, so dropping
-    // their unlinked code block cannot recover debug hooks for the body anyway
-    // (inner functions are recompiled independently via
-    // deleteAllUnlinkedCodeBlocks); pre-removing every module executable from
-    // the clearableCodeSet makes deleteAllCodeBlocks skip them and keeps the
-    // original bytecode in place. Registered via whenIdle so it runs ahead of
-    // any deferred deleteAllCode callback regardless of whether the dispatch
-    // happens with a VMEntryScope on the stack (the run-while-paused case).
-    static void protectModuleExecutablesFromClearCode(JSC::VM& vm)
-    {
-        if (auto* spaceAndSet = vm.heap.m_moduleProgramExecutableSpace.get()) {
-            JSC::HeapIterationScope iterationScope(vm.heap);
-            auto& set = spaceAndSet->clearableCodeSet;
-            set.forEachLiveCell([&](JSC::HeapCell* cell, JSC::HeapCell::Kind) {
-                set.remove(cell);
-            });
-        }
     }
 
     void receiveMessagesOnInspectorThread(ScriptExecutionContext& context, Zig::GlobalObject* globalObject, bool connectIfNeeded)

--- a/src/jsc/bindings/BunDebugger.h
+++ b/src/jsc/bindings/BunDebugger.h
@@ -5,6 +5,11 @@
 
 namespace Bun {
 
+// Pre-removes every ModuleProgramExecutable from clearableCodeSet so a
+// following vm.deleteAllCode() skips their clearCode() and keeps each module's
+// m_moduleEnvironmentSymbolTable/live JSModuleEnvironment consistent.
+void protectModuleExecutablesFromClearCode(JSC::VM&);
+
 // node:inspector's inspector.open() / close() / waitForDebugger(), backed by
 // the debugger-thread WebSocket server in src/js/internal/debugger.ts.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_openNodeInspector);

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -8,6 +8,7 @@
 #include <JavaScriptCore/ControlFlowProfiler.h>
 #include <JavaScriptCore/FunctionHasExecutedCache.h>
 #include <JavaScriptCore/HeapIterationScope.h>
+#include <JavaScriptCore/IsoCellSetInlines.h>
 #include <JavaScriptCore/MarkedSpaceInlines.h>
 #include <JavaScriptCore/ScriptExecutable.h>
 #include <JavaScriptCore/FunctionExecutable.h>
@@ -59,23 +60,34 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject*, Call
 }
 
 // Precise code coverage via JSC's control-flow profiler. Only newly generated
-// bytecode carries op_profile_control_flow, so also deleteAllCode() (deferred
-// via VM::whenIdle) so already-loaded functions recompile instrumented.
+// bytecode carries op_profile_control_flow, so also deleteAllCode() so
+// already-loaded functions recompile instrumented on their next call.
+//
+// Both run inside whenIdle (like InspectorRuntimeAgent) so no instrumented JS
+// executes between them, and ModuleProgramExecutables are excluded via the
+// same clearableCodeSet guard BunDebugger applies before its deleteAllCode.
+//
+// There is no matching stop: once an async body has compiled under the
+// profiler its m_codeGenerationModeForGeneratorBody is pinned, so disabling
+// would make that body's next recompile dereference a null controlFlowProfiler
+// in CodeBlock::insertBasicBlockBoundariesForControlFlowProfiler.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_startPreciseCoverage);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_startPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
 {
     auto& vm = globalObject->vm();
-    if (vm.enableControlFlowProfiler())
-        vm.deleteAllCode(PreventCollectionAndDeleteAllCode);
-    return JSValue::encode(jsUndefined());
-}
-
-JSC_DECLARE_HOST_FUNCTION(jsFunction_stopPreciseCoverage);
-JSC_DEFINE_HOST_FUNCTION(jsFunction_stopPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
-{
-    auto& vm = globalObject->vm();
-    if (vm.disableControlFlowProfiler())
-        vm.deleteAllCode(PreventCollectionAndDeleteAllCode);
+    vm.whenIdle([&vm] {
+        if (vm.controlFlowProfiler())
+            return;
+        if (auto* spaceAndSet = vm.heap.m_moduleProgramExecutableSpace.get()) {
+            HeapIterationScope iterationScope(vm.heap);
+            auto& set = spaceAndSet->clearableCodeSet;
+            set.forEachLiveCell([&](HeapCell* cell, HeapCell::Kind) {
+                set.remove(cell);
+            });
+        }
+        if (vm.enableControlFlowProfiler())
+            vm.deleteAllCode(PreventCollectionAndDeleteAllCode);
+    });
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -115,8 +115,9 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
                     return;
                 SourceID sourceID = provider->asID();
                 auto& info = scriptsByID.ensure(sourceID, [&] {
-                    return ScriptInfo { provider, {}, {} };
-                }).iterator->value;
+                                            return ScriptInfo { provider, {}, {} };
+                                        })
+                                 .iterator->value;
                 if (executable->type() != FunctionExecutableType)
                     return;
                 auto* functionExecutable = static_cast<FunctionExecutable*>(executable);

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 #include "helpers.h"
 #include "BunCPUProfiler.h"
+#include "BunDebugger.h"
 #include "NodeValidator.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/VM.h>
@@ -8,7 +9,6 @@
 #include <JavaScriptCore/ControlFlowProfiler.h>
 #include <JavaScriptCore/FunctionHasExecutedCache.h>
 #include <JavaScriptCore/HeapIterationScope.h>
-#include <JavaScriptCore/IsoCellSetInlines.h>
 #include <JavaScriptCore/MarkedSpaceInlines.h>
 #include <JavaScriptCore/ScriptExecutable.h>
 #include <JavaScriptCore/FunctionExecutable.h>
@@ -64,8 +64,9 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject*, Call
 // already-loaded functions recompile instrumented on their next call.
 //
 // Both run inside whenIdle (like InspectorRuntimeAgent) so no instrumented JS
-// executes between them, and ModuleProgramExecutables are excluded via the
-// same clearableCodeSet guard BunDebugger applies before its deleteAllCode.
+// executes between them, and ModuleProgramExecutables are excluded via
+// Bun::protectModuleExecutablesFromClearCode so their live
+// JSModuleEnvironment stays consistent.
 //
 // There is no matching stop: once an async body has compiled under the
 // profiler its m_codeGenerationModeForGeneratorBody is pinned, so disabling
@@ -78,13 +79,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_startPreciseCoverage, (JSGlobalObject * glob
     vm.whenIdle([&vm] {
         if (vm.controlFlowProfiler())
             return;
-        if (auto* spaceAndSet = vm.heap.m_moduleProgramExecutableSpace.get()) {
-            HeapIterationScope iterationScope(vm.heap);
-            auto& set = spaceAndSet->clearableCodeSet;
-            set.forEachLiveCell([&](HeapCell* cell, HeapCell::Kind) {
-                set.remove(cell);
-            });
-        }
+        Bun::protectModuleExecutablesFromClearCode(vm);
         if (vm.enableControlFlowProfiler())
             vm.deleteAllCode(PreventCollectionAndDeleteAllCode);
     });

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -10,6 +10,7 @@
 #include <JavaScriptCore/HeapIterationScope.h>
 #include <JavaScriptCore/MarkedSpaceInlines.h>
 #include <JavaScriptCore/ScriptExecutable.h>
+#include <JavaScriptCore/FunctionExecutable.h>
 #include <JavaScriptCore/SourceProvider.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/JSONValues.h>
@@ -57,27 +58,30 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject*, Call
     return JSValue::encode(jsBoolean(Bun::isCPUProfilerRunning()));
 }
 
-// Precise code coverage via JSC's control-flow profiler. Unlike V8 (which
-// deopts and instruments already-compiled code), only functions compiled from
-// this point on are instrumented; recompiling would corrupt live TLA modules.
+// Precise code coverage via JSC's control-flow profiler. Only newly generated
+// bytecode carries op_profile_control_flow, so also deleteAllCode() (deferred
+// via VM::whenIdle) so already-loaded functions recompile instrumented.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_startPreciseCoverage);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_startPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
 {
-    globalObject->vm().enableControlFlowProfiler();
+    auto& vm = globalObject->vm();
+    if (vm.enableControlFlowProfiler())
+        vm.deleteAllCode(PreventCollectionAndDeleteAllCode);
     return JSValue::encode(jsUndefined());
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsFunction_stopPreciseCoverage);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_stopPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
 {
-    globalObject->vm().disableControlFlowProfiler();
+    auto& vm = globalObject->vm();
+    if (vm.disableControlFlowProfiler())
+        vm.deleteAllCode(PreventCollectionAndDeleteAllCode);
     return JSValue::encode(jsUndefined());
 }
 
 // Returns a JSON string describing every script the control flow profiler has
 // data for: [{ url, scriptId, sourceLength, blocks: [[start, end, count]],
-// functions: [[start, end, executed]] }]. The JS layer in node/inspector.ts
-// reshapes this into the V8 ScriptCoverage format.
+// functions: [[start, end, name]] }]. node/inspector.ts reshapes it to V8 form.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_collectPreciseCoverage);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
 {
@@ -86,13 +90,21 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
     if (!profiler)
         return JSValue::encode(jsNull());
 
-    // Enumerate SourceIDs by walking only the four ScriptExecutable subspaces
-    // (not the whole heap). Providers whose executables were all GC'd are not
-    // reported, and offsets index the transpiled source for Bun-loaded modules;
-    // Bun appends an inline //# sourceMappingURL, so consumers that read the
-    // script source (v8-to-istanbul) can remap.
-    Vector<Ref<JSC::SourceProvider>> providers;
-    HashSet<SourceID> seenSourceIDs;
+    struct FunctionRange {
+        unsigned start;
+        unsigned end;
+        String name;
+    };
+    struct ScriptInfo {
+        RefPtr<JSC::SourceProvider> provider;
+        Vector<FunctionRange> functions;
+        UncheckedKeyHashSet<uint64_t> seenRanges;
+    };
+
+    // Walk only the four ScriptExecutable subspaces to enumerate SourceIDs.
+    // FunctionExecutable ranges are collected here because FunctionHasExecutedCache
+    // misses children of bodies that ran before the profiler was enabled.
+    UncheckedKeyHashMap<SourceID, ScriptInfo> scriptsByID;
     {
         HeapIterationScope iterationScope(vm.heap);
         vm.heap.forEachScriptExecutableSpace([&](auto& spaceAndSet) {
@@ -101,28 +113,49 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
                 auto* provider = executable->source().provider();
                 if (!provider)
                     return;
-                if (!seenSourceIDs.add(provider->asID()).isNewEntry)
+                SourceID sourceID = provider->asID();
+                auto& info = scriptsByID.ensure(sourceID, [&] {
+                    return ScriptInfo { provider, {}, {} };
+                }).iterator->value;
+                if (executable->type() != FunctionExecutableType)
                     return;
-                providers.append(*provider);
+                auto* functionExecutable = static_cast<FunctionExecutable*>(executable);
+                unsigned start = functionExecutable->typeProfilingStartOffset();
+                unsigned end = functionExecutable->typeProfilingEndOffset();
+                if (start > end || end > provider->source().length())
+                    return;
+                if (!info.seenRanges.add((static_cast<uint64_t>(start) << 32) | end).isNewEntry)
+                    return;
+                info.functions.append({ start, end, functionExecutable->ecmaName().string() });
             });
         });
     }
 
     auto scripts = JSON::Array::create();
-    for (auto& provider : providers) {
-        SourceID sourceID = provider->asID();
+    for (auto& entry : scriptsByID) {
+        SourceID sourceID = entry.key;
+        auto& info = entry.value;
         auto blocks = profiler->getBasicBlocksForSourceIDWithoutFunctionRange(sourceID, vm);
-        auto functionRanges = vm.functionHasExecutedCache()->getFunctionRanges(sourceID);
-        if (blocks.isEmpty() && functionRanges.isEmpty())
+        auto cacheRanges = vm.functionHasExecutedCache()->getFunctionRanges(sourceID);
+        if (blocks.isEmpty() && info.functions.isEmpty() && cacheRanges.isEmpty())
             continue;
+
+        // Merge in ranges the profiler recorded whose FunctionExecutable was GCed.
+        for (auto& range : cacheRanges) {
+            unsigned start = std::get<1>(range);
+            unsigned end = std::get<2>(range);
+            if (!info.seenRanges.add((static_cast<uint64_t>(start) << 32) | end).isNewEntry)
+                continue;
+            info.functions.append({ start, end, String() });
+        }
 
         auto script = JSON::Object::create();
         // A `//# sourceURL` directive overrides the script's resource name,
         // like it does in V8's coverage output.
-        const String& sourceURLDirective = provider->sourceURLDirective();
-        script->setString("url"_s, sourceURLDirective.isEmpty() ? provider->sourceURL() : sourceURLDirective);
+        const String& sourceURLDirective = info.provider->sourceURLDirective();
+        script->setString("url"_s, sourceURLDirective.isEmpty() ? info.provider->sourceURL() : sourceURLDirective);
         script->setDouble("scriptId"_s, static_cast<double>(sourceID));
-        script->setDouble("sourceLength"_s, static_cast<double>(provider->source().length()));
+        script->setDouble("sourceLength"_s, static_cast<double>(info.provider->source().length()));
 
         auto blockArray = JSON::Array::create();
         for (const auto& block : blocks) {
@@ -135,11 +168,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
         script->setValue("blocks"_s, WTF::move(blockArray));
 
         auto functionArray = JSON::Array::create();
-        for (const auto& functionRange : functionRanges) {
+        for (const auto& fn : info.functions) {
             auto range = JSON::Array::create();
-            range->pushDouble(static_cast<double>(std::get<1>(functionRange)));
-            range->pushDouble(static_cast<double>(std::get<2>(functionRange)));
-            range->pushBoolean(std::get<0>(functionRange));
+            range->pushDouble(static_cast<double>(fn.start));
+            range->pushDouble(static_cast<double>(fn.end));
+            range->pushString(fn.name.isNull() ? emptyString() : fn.name);
             functionArray->pushValue(WTF::move(range));
         }
         script->setValue("functions"_s, WTF::move(functionArray));

--- a/src/jsc/bindings/JSInspectorProfiler.h
+++ b/src/jsc/bindings/JSInspectorProfiler.h
@@ -8,5 +8,4 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_stopCPUProfiler);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_setCPUSamplingInterval);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_startPreciseCoverage);
-JSC_DECLARE_HOST_FUNCTION(jsFunction_stopPreciseCoverage);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_collectPreciseCoverage);

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -518,6 +518,37 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       expect(JSON.parse(stdout.trim())).toEqual({ first: 3, second: 1 });
     });
 
+    // CDP contract: startPreciseCoverage also resets execution counters, so a
+    // stop/start restart opens a fresh window (matching V8 and pre-#31823 Bun).
+    test.concurrent("restart (stop then start) resets counters", async () => {
+      using dir = tempDir("inspector-coverage-restart", {
+        "fixture.mjs": `
+import { Session } from "node:inspector/promises";
+import vm from "node:vm";
+const session = new Session();
+session.connect();
+await session.post("Profiler.enable");
+await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+const url = "file:///restart-fixture/virtual.js";
+const f = vm.runInThisContext("function f(){return 1}; f", { filename: url });
+f(); f(); f();
+await session.post("Profiler.stopPreciseCoverage");
+f(); f(); // calls while coverage is stopped: must not be counted
+await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+f(); f(); f(); f();
+const take = await session.post("Profiler.takePreciseCoverage");
+session.disconnect();
+const entry = take.result.find(s => s.url === url);
+const fn = entry?.functions?.find(x => x.functionName === "f");
+console.log(JSON.stringify({ count: fn?.ranges?.[0]?.count }));
+`,
+      });
+      await using proc = Bun.spawn({ cmd: [bunExe(), "fixture.mjs"], env: bunEnv, cwd: String(dir), stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+      expect(JSON.parse(stdout.trim())).toEqual({ count: 4 });
+    });
+
     test.concurrent("collects block coverage with call counts for vm scripts", async () => {
       using dir = tempDir("inspector-coverage-vm", {
         "fixture.mjs": coverageVmFixture,

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -652,10 +652,45 @@ console.log(JSON.stringify({ count: fn?.ranges?.[0]?.count }));
       expect(functionCounts).toContain(0);
     });
 
-    // A --preload that starts coverage before the entry module is linked (the
-    // c8 --import shape). ModuleProgramExecutables are excluded from
-    // deleteAllCode so the entry's JSModuleEnvironment stays consistent.
+    // entry.mjs is linked (JSModuleEnvironment created) but not yet evaluated
+    // when setup.mjs's TLA-awaited startPreciseCoverage fires deleteAllCode.
+    // Proves the scenario doesn't crash; the clearableCodeSet guard is shared
+    // with BunDebugger for the Debugger-mode case where layout does diverge.
     test.concurrent("does not corrupt a linked-but-unevaluated module after start", async () => {
+      using dir = tempDir("inspector-coverage-sibling", {
+        "setup.mjs": `import { Session } from "node:inspector/promises";
+const s = new Session();
+s.connect();
+await s.post("Profiler.enable");
+await s.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+globalThis.__coverageSession = s;
+`,
+        "entry.mjs": `import "./setup.mjs";
+import { run } from "./target.mjs";
+for (let i = 0; i < 4; i++) run();
+const { result } = await globalThis.__coverageSession.post("Profiler.takePreciseCoverage");
+const me = result.find(sc => /target\\.mjs$/.test(sc.url));
+const runFn = me?.functions?.find(f => f.functionName === "run");
+process.stdout.write(JSON.stringify({ count: runFn?.ranges?.[0]?.count }));
+`,
+        "target.mjs": `let hits = 0;
+export function run() { hits++; return hits; }
+`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+      expect(JSON.parse(stdout)).toEqual({ count: 4 });
+    });
+
+    // The c8 --import / --preload pattern: coverage starts before the entry
+    // graph is even linked, so everything compiles instrumented on first load.
+    test.concurrent("counts calls when coverage is started via --preload", async () => {
       using dir = tempDir("inspector-coverage-preload", {
         "setup.mjs": `import { Session } from "node:inspector/promises";
 const s = new Session();

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -446,15 +446,29 @@ describe("node:inspector", () => {
       session.disconnect();
     });
 
-    test("Profiler.disable stops precise coverage, like V8", () => {
-      const session = new inspector.Session();
-      session.connect();
-      session.post("Profiler.enable");
-      session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
-      session.post("Profiler.disable");
-      session.post("Profiler.enable");
-      expect(() => session.post("Profiler.takePreciseCoverage")).toThrow("Precise coverage has not been started.");
-      session.disconnect();
+    // startPreciseCoverage deletes all compiled code VM-wide so already-loaded
+    // functions recompile instrumented; run it in a child, never in this VM.
+    test.concurrent("Profiler.disable stops precise coverage, like V8", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const s = new (require("node:inspector").Session)();
+s.connect();
+s.post("Profiler.enable");
+s.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+s.post("Profiler.disable");
+s.post("Profiler.enable");
+s.post("Profiler.takePreciseCoverage", (err) =>
+  process.stdout.write(err?.message ?? "no error"));
+`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+      expect(stdout).toContain("Precise coverage has not been started.");
     });
 
     // Unlike V8 (which has always-on invocation counters), JSC has none, so
@@ -549,7 +563,7 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       // neverCalled() reports a single function-granularity range with count 0.
       const neverCalledEntry = entryCoveringOffset(entry.functions, offsets.neverCalledBody);
       expect(neverCalledEntry).toEqual({
-        functionName: "",
+        functionName: "neverCalled",
         isBlockCoverage: false,
         ranges: [{ startOffset: expect.any(Number), endOffset: expect.any(Number), count: 0 }],
       });
@@ -606,6 +620,59 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       expect(functionCounts).toContain(2);
       expect(functionCounts).toContain(0);
     });
+
+    for (const kind of ["mjs", "cjs"] as const) {
+      test.concurrent(`counts calls in a ${kind} module loaded before start`, async () => {
+        const appSource =
+          kind === "mjs"
+            ? `export function warm() { return 1; }
+export function cold() { return 2; }
+export function dead() { return 3; }
+`
+            : `exports.warm = function warm() { return 1; };
+exports.cold = function cold() { return 2; };
+exports.dead = function dead() { return 3; };
+`;
+        const load =
+          kind === "mjs" ? `const A = await import("./app.mjs");` : `const A = require("./app.cjs");`;
+        using dir = tempDir(`inspector-coverage-preloaded-${kind}`, {
+          [`app.${kind}`]: appSource,
+          "driver.mjs": `import { Session } from "node:inspector/promises";
+${load} // loaded BEFORE coverage starts
+const s = new Session();
+s.connect();
+await s.post("Profiler.enable");
+await s.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+for (let i = 0; i < 5; i++) A.warm();
+for (let i = 0; i < 3; i++) A.cold();
+const { result } = await s.post("Profiler.takePreciseCoverage");
+await s.post("Profiler.stopPreciseCoverage");
+const app = result.find(sc => /app\\.${kind}$/.test(sc.url));
+const driver = result.find(sc => /driver\\.mjs$/.test(sc.url));
+process.stdout.write(JSON.stringify({
+  counts: Object.fromEntries(
+    (app?.functions ?? []).filter(f => f.functionName).map(f => [f.functionName, f.ranges[0].count]),
+  ),
+  driverPresent: !!driver,
+}));
+`,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "driver.mjs"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+        const out = JSON.parse(stdout);
+        // warm and cold were compiled before startPreciseCoverage but called
+        // after; their call counts must be exact. dead was never called.
+        expect(out.counts).toEqual({ warm: 5, cold: 3, dead: 0 });
+        // The entry module itself appears in the report.
+        expect(out.driverPresent).toBe(true);
+      });
+    }
   });
 
   describe("exports", () => {

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -621,6 +621,40 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       expect(functionCounts).toContain(0);
     });
 
+    // A --preload that starts coverage before the entry module is linked (the
+    // c8 --import shape). ModuleProgramExecutables are excluded from
+    // deleteAllCode so the entry's JSModuleEnvironment stays consistent.
+    test.concurrent("does not corrupt a linked-but-unevaluated module after start", async () => {
+      using dir = tempDir("inspector-coverage-preload", {
+        "setup.mjs": `import { Session } from "node:inspector/promises";
+const s = new Session();
+s.connect();
+await s.post("Profiler.enable");
+await s.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+globalThis.__coverageSession = s;
+`,
+        "entry.mjs": `import { run } from "./target.mjs";
+for (let i = 0; i < 4; i++) run();
+const { result } = await globalThis.__coverageSession.post("Profiler.takePreciseCoverage");
+const me = result.find(sc => /target\\.mjs$/.test(sc.url));
+const runFn = me?.functions?.find(f => f.functionName === "run");
+process.stdout.write(JSON.stringify({ count: runFn?.ranges?.[0]?.count }));
+`,
+        "target.mjs": `let hits = 0;
+export function run() { hits++; return hits; }
+`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--preload", "./setup.mjs", "entry.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+      expect(JSON.parse(stdout)).toEqual({ count: 4 });
+    });
+
     for (const kind of ["mjs", "cjs"] as const) {
       test.concurrent(`counts calls in a ${kind} module loaded before start`, async () => {
         const appSource =

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -633,8 +633,7 @@ export function dead() { return 3; }
 exports.cold = function cold() { return 2; };
 exports.dead = function dead() { return 3; };
 `;
-        const load =
-          kind === "mjs" ? `const A = await import("./app.mjs");` : `const A = require("./app.cjs");`;
+        const load = kind === "mjs" ? `const A = await import("./app.mjs");` : `const A = require("./app.cjs");`;
         using dir = tempDir(`inspector-coverage-preloaded-${kind}`, {
           [`app.${kind}`]: appSource,
           "driver.mjs": `import { Session } from "node:inspector/promises";


### PR DESCRIPTION
## What

`Profiler.startPreciseCoverage` on the in-process `node:inspector` Session now instruments functions that were already compiled when it was called. The standard pattern of importing the app, then starting coverage, then driving the workload now produces correct per-function call counts for the already-imported modules. Before, those modules reported no per-function entries at all (only a whole-script `count: 1`), and the entry module was absent from `takePreciseCoverage` entirely.

## Repro

```js
import { Session } from "node:inspector/promises";
const A = await import("./app.mjs");   // imported BEFORE coverage starts
const s = new Session(); s.connect();
await s.post("Profiler.enable");
await s.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
for (let i = 0; i < 5; i++) { A.warm(); A.cold(); }   // both called 5x UNDER coverage
const { result } = await s.post("Profiler.takePreciseCoverage");
const app = result.find(sc => /app\.mjs$/.test(sc.url));
console.log(app.functions.filter(f => f.functionName).map(f => [f.functionName, f.ranges[0].count]));
```

| | `app.mjs` functions |
|---|---|
| Node | `warm: 5, cold: 5` |
| Bun before | no per-function entries (only whole-script `count: 1`) |
| Bun after | `warm: 5, cold: 5` |

## Cause

JSC's control-flow profiler only instruments bytecode generated while it is enabled (`op_profile_control_flow` is emitted only when `vm.controlFlowProfiler()` is non-null at bytecode generation time). Functions compiled before `startPreciseCoverage` carry no instrumentation, so calling them under coverage records nothing. `FunctionHasExecutedCache` also never learns about those functions because it is only populated when the parent body is compiled under the profiler.

## Fix

- `jsFunction_startPreciseCoverage` enables the control-flow profiler and calls `vm.deleteAllCode(PreventCollectionAndDeleteAllCode)` **together inside `vm.whenIdle`** (mirroring `InspectorRuntimeAgent::setControlFlowProfilerEnabledState`), so no instrumented JS runs between them and every live function regenerates instrumented bytecode on its next call. `ModuleProgramExecutable`s are removed from `clearableCodeSet` first (the same guard `BunDebugger` applies before its own `deleteAllCode`) so a linked-but-not-yet-evaluated module keeps its `m_moduleEnvironmentSymbolTable`. The JS-side `post()` delivers the `startPreciseCoverage` callback via `setImmediate` so the `whenIdle` work has run before the caller's `await` resumes.
- **There is no matching stop at the VM level.** Once an async function body has compiled under the profiler its `m_codeGenerationModeForGeneratorBody` is pinned, so disabling the profiler would make that body's next recompile dereference a null `vm.controlFlowProfiler()` in `CodeBlock::insertBasicBlockBoundariesForControlFlowProfiler` (vitest's worker fork hit this on every run). `Profiler.stopPreciseCoverage` / `Profiler.disable` / `disconnect()` are now pure JS-state flips; the profiler stays enabled for the life of the VM.
- `jsFunction_collectPreciseCoverage` records `FunctionExecutable` ranges (with their ECMA names) during the existing subspace walk, so per-function attribution works for modules whose body ran before the profiler was on. Ranges from `FunctionHasExecutedCache` are still merged in for any function whose executable was GCed.
- `buildScriptCoverageList` now derives executed / call-count from a function's own block data and emits the real `functionName`.
- The in-process `Profiler.disable stops precise coverage` test moves into a subprocess, since `startPreciseCoverage` now deletes all compiled code VM-wide.

## Verification

```
bun bd test test/js/node/inspector/inspector-profiler.test.ts test/js/third_party/vitest/vitest.test.ts
  47 + 2 pass, 0 fail

git checkout origin/main -- src/ && bun bd test ... -t "loaded before start"
  counts = {}   (both new tests fail on main)
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (2265c30b1)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [12.47ms]
(pass) node:inspector > Session > Session extends EventEmitter [2.31ms]
(pass) node:inspector > Session > connect() establishes connection [5.68ms]
(pass) node:inspector > Session > connect() throws if already connected [4.16ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [4.74ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [3.07ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.33ms]
(pass) node:inspector > Session > post() throws if not connected [7.70ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [8.76ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [18.85ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [2.62ms]
(pass) node:inspecto
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (667fb589c)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [0.18ms]
(pass) node:inspector > Session > Session extends EventEmitter [0.03ms]
(pass) node:inspector > Session > connect() establishes connection [0.07ms]
(pass) node:inspector > Session > connect() throws if already connected [0.06ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [0.06ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [0.03ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [0.03ms]
(pass) node:inspector > Session > post() throws if not connected [0.13ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [0.19ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [0.39ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [0.04ms]
(pass) node:inspector > Profiler > Profiler.start without enable throws [0.05ms]
(pass) node:inspector > Profiler > Profiler.start after enable succeeds [0.19ms]
(pass) node:inspector > Profiler >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (2265c30b1)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [13.24ms]
(pass) node:inspector > Session > Session extends EventEmitter [2.47ms]
(pass) node:inspector > Session > connect() establishes connection [5.95ms]
(pass) node:inspector > Session > connect() throws if already connected [4.35ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [4.92ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [2.82ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.91ms]
(pass) node:inspector > Session > post() throws if not connected [9.17ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [13.27ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [19.91ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [2.73ms]
(pass) node:inspect
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2265c30b13
  features     baseline

22 deps, 108 codegen, 1171 objects in 661ms

ninja: Entering directory `/workspace/bun/build/release'
[1/142] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/142] gen cpp.rs (cppbind)
[3/142] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[4/142] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemR
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/inspector.ts                          | 125 ++++++++-------
 src/jsc/bindings/BunDebugger.cpp                  |  58 +++----
 src/jsc/bindings/BunDebugger.h                    |   5 +
 src/jsc/bindings/JSInspectorProfiler.cpp          | 107 +++++++++----
 src/jsc/bindings/JSInspectorProfiler.h            |   1 -
 test/js/node/inspector/inspector-profiler.test.ts | 186 ++++++++++++++++++++--
 6 files changed, 352 insertions(+), 130 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/js/node/inspector.ts                               2      0      0
src/jsc/bindings/BunDebugger.cpp                       0      0      0
src/jsc/bindings/BunDebugger.h                         0      0      0
src/jsc/bindings/JSInspectorProfiler.cpp               1      0      0
src/jsc/bindings/JSInspectorProfiler.h                 0      0      0
test/js/node/inspector/inspector-profiler.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->