### PR TITLE
spyOn: check exception after reading a tainted slot's value

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1523,6 +1523,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             } else {
                 value = slot.getValue(globalObject, propertyKey);
             }
+            RETURN_IF_EXCEPTION(scope, {});
 
             if (dynamicDowncast<JSMockFunction>(value)) {
                 return JSValue::encode(value);

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -8,6 +8,7 @@
 // - Write test for import {foo} from "./foo"; export {foo}
 
 import { expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -38,6 +39,63 @@ test("spyOn", () => {
   expect(spyFixture.iSpy).not.toHaveBeenCalled();
   spyFixture.iSpy(123);
   expect(spyFixture.iSpy).toHaveBeenCalled();
+});
+
+// JSMock__jsSpyOn reads the spy target's value via JSObject::get (JSModuleNamespaceObject
+// and Proxy are isTaintedByOpaqueObject) but did not check the scope before copyNameAndLength
+// declares a TopExceptionScope, whose constructor asserts the prior check. The very first
+// spyOn in a process happened to lazily initialize mockFunctionStructure (which clears the
+// need-check bit) between the get and the scope, so only a second spyOn on a namespace export
+// tripped the validator.
+test("spyOn on a module namespace survives BUN_JSC_validateExceptionChecks", async () => {
+  using dir = tempDir("spyon-namespace-exception-check", {
+    "fixture.ts": `export const iSpy = (x: any) => x;\n`,
+    "spy.test.ts": `
+      import { expect, jest, mock, spyOn, test } from "bun:test";
+      import * as ns from "./fixture";
+      jest.fn();
+      test("spy twice on a module namespace export", () => {
+        const original = ns.iSpy;
+        const first = spyOn(ns, "iSpy");
+        ns.iSpy(1);
+        expect(first).toHaveBeenCalledTimes(1);
+        mock.restore();
+        expect(ns.iSpy).toBe(original);
+        const second = spyOn(ns, "iSpy");
+        ns.iSpy(2);
+        expect(second).toHaveBeenCalledTimes(1);
+        mock.restore();
+      });
+      test("spy twice on a Proxy target", () => {
+        const target = { m: (x: any) => x };
+        const proxy = new Proxy(target, {});
+        expect(spyOn(proxy, "m")).toBeFunction();
+        mock.restore();
+        expect(spyOn(proxy, "m")).toBeFunction();
+        mock.restore();
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "spy.test.ts"],
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Surface the validator's scope report in the diff when the child aborts instead of
+  // asserting only on exitCode.
+  const uncheckedScopes = stderr
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+  expect({ stderr, uncheckedScopes, signalCode: proc.signalCode, exitCode }).toMatchObject({
+    stderr: expect.stringContaining("2 pass"),
+    uncheckedScopes: [],
+    signalCode: null,
+    exitCode: 0,
+  });
 });
 
 test("mocking a module that points to a file which does not resolve successfully still works", async () => {


### PR DESCRIPTION
Under `BUN_JSC_validateExceptionChecks=1`, spying on a module-namespace export (or a Proxy) more than once aborts the process:

```ts
import { jest, mock, spyOn } from "bun:test";
import * as ns from "./fixture"; // export const iSpy = (x) => x;
jest.fn();
spyOn(ns, "iSpy");
```
```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: get @ JSObjectInlines.h:133
    But the exception was unchecked as of this scope: copyNameAndLength @ JSMockFunction.cpp:298
ASSERTION FAILED: exception check validation failed
```

## Cause

When the spy target's slot `isTaintedByOpaqueObject()` (true for `JSModuleNamespaceObject` and `Proxy`), `JSMock__jsSpyOn` falls back to `object->get(globalObject, propertyKey)` to read the current value. That `get` declares a `ThrowScope` and simulates a throw on destruction, but `scope` was not checked before `mock->copyNameAndLength` declares a `TopExceptionScope` a few lines later. `TopExceptionScope`'s constructor calls `verifyExceptionCheckNeedIsSatisfied`, which asserts.

The very first `spyOn` in a process usually survives by accident: between the unchecked `get` and `copyNameAndLength`, `mockFunctionStructure.getInitializedOnMainThread` runs its lazy initializer on first use, and that initializer happens to check the VM's exception (clearing `m_needExceptionCheck`). Once the structure is cached, nothing masks the missing check, so the next `spyOn` on a namespace export (or the first one after any `jest.fn()` / `mock()` call) aborts. The existing `mock.restore` + `spyOn` pair in `mock-module.test.ts` already hits this when the file is run under `BUN_JSC_validateExceptionChecks=1`.

This also means a Proxy target whose `get` trap actually throws was being ignored: execution continued with `value = jsUndefined()` and only tripped the pending exception later.

## Fix

Add `RETURN_IF_EXCEPTION(scope, {});` immediately after the `get` / `getValue` branch, before `value` is inspected. A real throw from a Proxy `get` trap now propagates out of `spyOn`, and the validator is satisfied for the module-namespace path.

## Verification

New test spawns `bun test` with `BUN_JSC_validateExceptionChecks=1` over a fixture that spies on a namespace export and a Proxy twice each. It asserts `exitCode: 0`, `signalCode: null`, and surfaces the validator's "This scope can throw / unchecked as of" pair in the diff when it aborts.

```
# fail-before (src/ stashed)
(fail) spyOn on a module namespace survives BUN_JSC_validateExceptionChecks
  exitCode: 134, signalCode: SIGABRT
  uncheckedScopes: [
    "This scope can throw a JS exception: get @ JSObjectInlines.h:133",
    "But the exception was unchecked as of this scope: copyNameAndLength @ JSMockFunction.cpp:298",
  ]

# pass-after
10 pass / 1 todo  test/js/bun/test/mock/mock-module.test.ts
77 pass           test/js/bun/test/mock-fn.test.js
147 pass / 3 todo test/js/bun/test/spyMatchers.test.ts
```

On release builds `EXCEPTION_SCOPE_VERIFICATION` is compiled out, so the env var is a no-op and the child simply runs its two tests to completion.