### PR TITLE
bundler: skip __toESM for unwrapped require() that lands on a CJS wrapper

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -943,6 +943,8 @@ pub fn scan_imports_and_exports(
                                 // - The "default" and "__esModule" exports must not be accessed
                                 //
                                 if kind != ImportKind::Require
+                                    && !rec_flags
+                                        .contains(ImportRecordFlags::WAS_ORIGINALLY_REQUIRE)
                                     && (kind != ImportKind::Stmt
                                         || rec_flags
                                             .contains(ImportRecordFlags::CONTAINS_IMPORT_STAR)
@@ -1001,6 +1003,7 @@ pub fn scan_imports_and_exports(
                         // This is an ES6 import of a CommonJS module, so it needs the
                         // "__toESM" wrapper as long as it's not a bare "require()"
                         if kind != ImportKind::Require
+                            && !rec_flags.contains(ImportRecordFlags::WAS_ORIGINALLY_REQUIRE)
                             && other_export_kind == ExportsKind::Cjs
                             && output_format != Format::InternalBakeDev
                         {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1149,6 +1149,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
                             handles_import_errors,
                         );
+                    self.import_records.items_mut()[import_record_index as usize]
+                        .flags
+                        .insert(bun_ast::ImportRecordFlags::WAS_ORIGINALLY_REQUIRE);
 
                     // Note that this symbol may be completely removed later.
                     let path_name = fs::PathName::init(pathname);

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -278,7 +278,8 @@ describe("bundler", () => {
     },
     onAfterBundle: api => {
       const code = api.readFile("out.js");
-      expect(code).toContain("__toESM(");
+      expect(code).not.toContain("__toESM(");
+      expect(code).toContain("require_react()");
     },
     run: {
       stdout: "react\nreact\nreact\nreact\nundefined\nreact\nreact\nreact\nreact\nreact\nreact\n1 react\nreact\nreact",
@@ -500,5 +501,125 @@ describe("bundler", () => {
     },
     cjs2esm: true,
     run: { stdout: "[1,2]" },
+  });
+  // https://github.com/oven-sh/bun/issues/12463
+  //
+  // react/index.js is the two-branch `module.exports = require('./cjs/react.*.js')`
+  // redirect. `unwrap_commonjs_packages` turns each `require()` into a star import,
+  // but only the single-branch shape can be rewritten to `export *`; with two
+  // branches the file stays a CJS wrapper holding a star import of another CJS
+  // wrapper. Star-importing a CJS module normally needs `__toESM`, but this import
+  // was a `require()`, so the result must be the raw `module.exports` (no synthetic
+  // `default`), matching esbuild.
+  const reactProdDevRedirect = {
+    "/node_modules/react/index.js": /* js */ `
+      if (process.env.NODE_ENV === "production") {
+        module.exports = require("./cjs/react.prod.js");
+      } else {
+        module.exports = require("./cjs/react.dev.js");
+      }
+    `,
+    "/node_modules/react/cjs/react.prod.js": /* js */ `
+      (function () {
+        exports.useState = function () { return "prod"; };
+        exports.version = "18.0.0";
+      })();
+    `,
+    "/node_modules/react/cjs/react.dev.js": /* js */ `
+      (function () {
+        exports.useState = function () { return "dev"; };
+        exports.version = "18.0.0-dev";
+      })();
+    `,
+    "/node_modules/react/package.json": /* json */ `
+      { "name": "react", "version": "18.0.0", "main": "index.js" }
+    `,
+  };
+  itBundled("cjs2esm/UnwrappedRequireOfWrappedCjsNoToESM#12463", {
+    files: {
+      "/entry.js": /* js */ `
+        import react from "react";
+        console.log(JSON.stringify({
+          useState: react.useState(),
+          version: react.version,
+          hasDefault: "default" in react,
+          propKind: Object.getOwnPropertyDescriptor(react, "useState").get ? "getter" : "value",
+        }));
+      `,
+      ...reactProdDevRedirect,
+    },
+    onAfterBundle: api => {
+      expect(api.readFile("out.js")).not.toMatch(/__toESM\(require_react_dev/);
+    },
+    run: {
+      stdout: '{"useState":"dev","version":"18.0.0-dev","hasDefault":false,"propKind":"value"}',
+    },
+  });
+  itBundled("cjs2esm/UnwrappedRequireOfWrappedCjsEntryPoint#12463", {
+    files: {
+      "/entry.js": /* js */ `
+        const compiled = await import("./out/react.js");
+        console.log(JSON.stringify({
+          useState: compiled.default.useState(),
+          hasDefault: "default" in compiled.default,
+        }));
+      `,
+      ...reactProdDevRedirect,
+    },
+    entryPointsRaw: ["./node_modules/react/index.js"],
+    outdir: "/out",
+    entryNaming: "react.[ext]",
+    runtimeFiles: {
+      "/entry.js": /* js */ `
+        const compiled = await import("./out/react.js");
+        console.log(JSON.stringify({
+          useState: compiled.default.useState(),
+          hasDefault: "default" in compiled.default,
+        }));
+      `,
+    },
+    onAfterBundle: api => {
+      expect(api.readFile("out/react.js")).not.toContain("__toESM(");
+    },
+    run: {
+      file: "/entry.js",
+      stdout: '{"useState":"dev","hasDefault":false}',
+    },
+  });
+  itBundled("cjs2esm/UnwrappedRequireInCjsFunctionBody", {
+    files: {
+      "/entry.js": /* js */ `
+        const loader = require("react/loader");
+        const r = loader.load();
+        console.log(JSON.stringify({
+          useState: r.useState(),
+          hasDefault: "default" in r,
+        }));
+      `,
+      "/node_modules/react/loader.js": /* js */ `
+        exports.load = function () {
+          return require("./cjs/react.dev.js");
+        };
+      `,
+      ...reactProdDevRedirect,
+    },
+    run: {
+      stdout: '{"useState":"dev","hasDefault":false}',
+    },
+  });
+  itBundled("cjs2esm/UnwrappedRequireOfConvertedCjsStillWorks", {
+    files: {
+      "/entry.js": /* js */ `
+        const react = require("react");
+        console.log(react.react);
+      `,
+      ...fakeReactNodeModules,
+    },
+    onAfterBundle: api => {
+      expect(api.readFile("out.js")).not.toContain("__toESM(");
+    },
+    run: {
+      stdout: "react",
+    },
   });
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -556,16 +556,7 @@ describe("bundler", () => {
     },
   });
   itBundled("cjs2esm/UnwrappedRequireOfWrappedCjsEntryPoint#12463", {
-    files: {
-      "/entry.js": /* js */ `
-        const compiled = await import("./out/react.js");
-        console.log(JSON.stringify({
-          useState: compiled.default.useState(),
-          hasDefault: "default" in compiled.default,
-        }));
-      `,
-      ...reactProdDevRedirect,
-    },
+    files: reactProdDevRedirect,
     entryPointsRaw: ["./node_modules/react/index.js"],
     outdir: "/out",
     entryNaming: "react.[ext]",
@@ -607,19 +598,30 @@ describe("bundler", () => {
       stdout: '{"useState":"dev","hasDefault":false}',
     },
   });
-  itBundled("cjs2esm/UnwrappedRequireOfConvertedCjsStillWorks", {
+  // Marking the record WAS_ORIGINALLY_REQUIRE also stops TypeScript's
+  // unused-import trimming from dropping an unwrapped require() whose binding
+  // is unused (scan_imports.rs:282). esbuild keeps it.
+  itBundled("cjs2esm/UnwrappedRequireUnusedBindingKeptForSideEffects", {
     files: {
-      "/entry.js": /* js */ `
-        const react = require("react");
-        console.log(react.react);
+      "/entry.ts": /* ts */ `
+        const _unused = require("react");
+        console.log("__reactLoaded:" + globalThis.__reactLoaded);
       `,
-      ...fakeReactNodeModules,
+      "/node_modules/react/index.js": /* js */ `
+        (function () {
+          globalThis.__reactLoaded = true;
+          exports.version = "18.0.0";
+        })();
+      `,
+      "/node_modules/react/package.json": /* json */ `
+        { "name": "react", "version": "18.0.0", "main": "index.js" }
+      `,
     },
     onAfterBundle: api => {
-      expect(api.readFile("out.js")).not.toContain("__toESM(");
+      expect(api.readFile("out.js")).toContain("require_react()");
     },
     run: {
-      stdout: "react",
+      stdout: "__reactLoaded:true",
     },
   });
 });

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -60,14 +60,14 @@ describe("bundler", () => {
           ["react.development.js:524:'getContextName'", "1:5623:nt"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:ar++"],
           ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
-          ["entry.tsx:6:'\"Content-Type\"'", '100:18808:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:19062:void"],
-          ["entry.tsx:23:'await'", "100:19161:await"],
+          ["entry.tsx:6:'\"Content-Type\"'", '100:18796:"Content-Type"'],
+          ["entry.tsx:11:'<html>'", "100:19050:void"],
+          ["entry.tsx:23:'await'", "100:19149:await"],
         ],
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221969,
+      "out/entry.js": 221945,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",


### PR DESCRIPTION
Fixes the Bun-specific half of #12463.

## Repro

```sh
mkdir x && cd x && bun add react
bun build ./node_modules/react/index.js --outfile compiled.js
bun -e 'import r from "./compiled.js"; console.log("default" in r, typeof r.default)'
```

|              | `"default" in r` | `typeof r.default` |
| ------------ | ------------------- | -------------------- |
| esbuild      | `false`           | `undefined`        |
| bun (before) | `true`            | `object`           |
| bun (after)  | `false`           | `undefined`        |

`bun build` of `react/index.js` emitted:

```js
var require_react = __commonJS(function(exports, module) {
  var react_development = __toESM(require_react_development());  // <— extra wrap
  if (false) {} else { module.exports = react_development; }
});
export default require_react();
```

so `import r from "./compiled.js"` gave `r === { default: reactExports, useState: [Getter], ... }` instead of the raw `module.exports`. esbuild emits `var react_development = require_react_development();` with no `__toESM`.

## Cause

The `unwrap_commonjs_packages` list (react, react-dom, scheduler, react-is, react-refresh, react-client, react-server) makes the parser rewrite every `require("x")` that resolves into those packages as an `ImportKind::Stmt` star import, so that when the target converts to ESM it tree-shakes. `react/index.js` is the two-branch `module.exports = require('./cjs/react.*.js')` redirect; neither it nor the inner files can convert, so both stay `__commonJS`-wrapped. `scanImportsAndExports` then set `WRAP_WITH_TO_ESM` on the synthesized star-import record because `kind != ImportKind::Require`, and the printer emitted `__toESM(require_react_development())`.

## Fix

`ImportRecordFlags::WAS_ORIGINALLY_REQUIRE` already exists (and is already checked in the printer's disabled-path and `scan_imports` unused-import logic) but nothing ever set it. Set it on the record created by the `should_unwrap_require` path, and check it alongside `kind != ImportKind::Require` at both `WRAP_WITH_TO_ESM` decision points in `scanImportsAndExports`. A record that was a `require()` call keeps `require()` semantics: the raw `module.exports`, no synthetic `default`.

The bundled output for `require("react")` now matches esbuild (`var react = require_react();`).

### Secondary fix

Setting the flag also wakes the previously-dead `WAS_ORIGINALLY_REQUIRE` guard in `scan_imports.rs:282`. Before, a `.ts` entry containing

```ts
const _unused = require("react");
```

was dropped by TypeScript's unused-import trimming (the synthesized star import had a zero use count), so react's side effects never ran. Now the record is kept, matching esbuild. Covered by `cjs2esm/UnwrappedRequireUnusedBindingKeptForSideEffects`.

## What this does not change

#12463 also notes that `import { useState } from "./compiled.js"` is `undefined` because a CJS entrypoint in ESM output format bundles to `export default require_x()` with no named exports. That is identical to esbuild (tracked upstream as evanw/esbuild#442) and is a design limitation of bundling a dynamic `module.exports` value. This PR does not change it.

#12726 (extra `__commonJS` wrapper on `react/index.js` itself) and #17755 (non-react package) are not addressed here; verified both still reproduce with this patch.

## Tests

- `cjs2esm/UnwrappedRequireOfWrappedCjsNoToESM#12463`, `cjs2esm/UnwrappedRequireOfWrappedCjsEntryPoint#12463`, `cjs2esm/UnwrappedRequireInCjsFunctionBody`, `cjs2esm/UnwrappedRequireUnusedBindingKeptForSideEffects` in `bundler_cjs2esm.test.ts`. All four fail on main.
- `cjs2esm/UnwrappedModuleRequireAssigned`: assertion flipped to `not.toContain("__toESM(")` (the output now matches esbuild).
- `npm/ReactSSR`: sourcemap columns and `expectExactFilesize` rebased (output is 24 bytes smaller; the rendered HTML is byte-identical).

Also ran `bundler_cjs`, `bundler_jsx`, `bundler_npm`, `bundler_edgecase`, `bundler_regressions`, `bundler_browser`, `bundler_bun`, `bundler_splitting`, `esbuild/importstar`, `esbuild/default`, `esbuild/splitting`, `bake/dev/react-spa` with no new failures.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_npm.test.ts

<!-- robobun:evidence:end -->