### PR TITLE
console, error printer: render instanceof-Error objects as errors, not object dumps

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2330,6 +2330,19 @@ pub mod formatter {
                 }
             }
 
+            // Function-based Error subclasses (`X.prototype =
+            // Object.create(Error.prototype)`) are plain FinalObject cells, not
+            // ErrorInstance. Node renders any `instanceof Error` value as an
+            // error, so check the prototype chain for Error.prototype here.
+            if matches!(js_type, jsc::JSType::Object | jsc::JSType::FinalObject)
+                && value.is_error_like()
+            {
+                return Ok(TagResult {
+                    tag: TagPayload::Error,
+                    cell: js_type,
+                });
+            }
+
             use jsc::JSType as T;
             let tag = match js_type {
                 T::ErrorInstance => TagPayload::Error,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2330,10 +2330,6 @@ pub mod formatter {
                 }
             }
 
-            // Function-based Error subclasses (`X.prototype =
-            // Object.create(Error.prototype)`) are plain FinalObject cells, not
-            // ErrorInstance. Node renders any `instanceof Error` value as an
-            // error, so check the prototype chain for Error.prototype here.
             if matches!(js_type, jsc::JSType::Object | jsc::JSType::FinalObject)
                 && value.is_error_like()
             {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -361,8 +361,7 @@ impl JSValue {
     pub fn is_error(self) -> bool {
         self.is_cell() && self.js_type() == JSType::ErrorInstance
     }
-    /// `ErrorInstance`, or an object whose `[[Prototype]]` chain (read via
-    /// `getPrototypeDirect`, no traps) reaches `Error.prototype`.
+    /// `ErrorInstance`, or `Error.prototype` is on its `getPrototypeDirect` chain.
     #[inline]
     pub fn is_error_like(self) -> bool {
         if !self.is_cell() {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -361,11 +361,8 @@ impl JSValue {
     pub fn is_error(self) -> bool {
         self.is_cell() && self.js_type() == JSType::ErrorInstance
     }
-    /// True iff this is a native `ErrorInstance`, or an object whose
-    /// `[[Prototype]]` chain (read directly, without invoking Proxy traps or
-    /// `Symbol.hasInstance`) contains `Error.prototype` or an `ErrorInstance`.
-    /// Matches Node's `isNativeError(e) || e instanceof Error` test used to
-    /// decide whether to render a value as an error.
+    /// `ErrorInstance`, or an object whose `[[Prototype]]` chain (read via
+    /// `getPrototypeDirect`, no traps) reaches `Error.prototype`.
     #[inline]
     pub fn is_error_like(self) -> bool {
         if !self.is_cell() {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -361,6 +361,18 @@ impl JSValue {
     pub fn is_error(self) -> bool {
         self.is_cell() && self.js_type() == JSType::ErrorInstance
     }
+    /// True iff this is a native `ErrorInstance`, or an object whose
+    /// `[[Prototype]]` chain (read directly, without invoking Proxy traps or
+    /// `Symbol.hasInstance`) contains `Error.prototype` or an `ErrorInstance`.
+    /// Matches Node's `isNativeError(e) || e instanceof Error` test used to
+    /// decide whether to render a value as an error.
+    #[inline]
+    pub fn is_error_like(self) -> bool {
+        if !self.is_cell() {
+            return false;
+        }
+        JSC__JSValue__isErrorLike(self)
+    }
     /// `JSValue.isJSXElement(globalObject)`. Checks via the
     /// global's `Symbol.for("react.element")` / `Symbol.for("react.transitional.element")`
     /// for `$$typeof`; may invoke a user getter and throw.
@@ -2086,6 +2098,7 @@ unsafe extern "C" {
         promise: &JSPromise,
     );
     safe fn JSC__JSValue__isAnyError(this: JSValue) -> bool;
+    safe fn JSC__JSValue__isErrorLike(this: JSValue) -> bool;
     // safe: `JSValue` is a by-value scalar; `&mut *const u8` / `&mut usize` are
     // ABI-identical to non-null `*mut` out-params the C++ side fills on success.
     safe fn JSC__JSValue__getClassInfoName(

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6088,10 +6088,14 @@ impl VirtualMachine {
                     let stack = bun_core::OwnedString::new(stack.to_bun_string(global_ref)?);
                     let bytes = stack.to_utf8();
                     let slice = bytes.slice();
-                    let tail = match bun_core::strings::index_of_char_usize(slice, b'\n') {
-                        Some(i) => bun_core::trim_right(&slice[i + 1..], b"\n"),
-                        None => b"",
+                    let tail = if bun_core::strings::has_prefix_comptime(slice, b"    at ") {
+                        slice
+                    } else if let Some(i) = bun_core::strings::index_of(slice, b"\n    at ") {
+                        &slice[i + 1..]
+                    } else {
+                        b""
                     };
+                    let tail = bun_core::trim_right(tail, b"\n");
                     if !tail.is_empty() {
                         writer.write_all(tail)?;
                         writer.write_all(b"\n")?;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6083,8 +6083,8 @@ impl VirtualMachine {
         let mut printed_stack_string = false;
         if exception.stack.frames().is_empty() && is_error_instance && !error_instance.is_error() {
             // `toZigException` leaves `frames` empty for a non-ErrorInstance.
-            if let Ok(Some(stack)) = error_instance.get_own_truthy(global_ref, "stack") {
-                if stack.is_string() {
+            match error_instance.get_own_truthy(global_ref, "stack") {
+                Ok(Some(stack)) if stack.is_string() => {
                     let stack = bun_core::OwnedString::new(stack.to_bun_string(global_ref)?);
                     let bytes = stack.to_utf8();
                     let slice = bytes.slice();
@@ -6098,8 +6098,12 @@ impl VirtualMachine {
                     }
                     printed_stack_string = true;
                 }
-            } else if allow_side_effects && global_ref.has_exception() {
-                global_ref.clear_exception();
+                Ok(_) => {}
+                Err(_) => {
+                    if global_ref.has_exception() {
+                        global_ref.clear_exception();
+                    }
+                }
             }
         }
         if !printed_stack_string {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6088,7 +6088,7 @@ impl VirtualMachine {
                     let stack = bun_core::OwnedString::new(stack.to_bun_string(global_ref)?);
                     let bytes = stack.to_utf8();
                     let slice = bytes.slice();
-                    let tail = match slice.iter().position(|&b| b == b'\n') {
+                    let tail = match bun_core::strings::index_of_char_usize(slice, b'\n') {
                         Some(i) => bun_core::trim_right(&slice[i + 1..], b"\n"),
                         None => b"",
                     };

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6082,9 +6082,7 @@ impl VirtualMachine {
 
         let mut printed_stack_string = false;
         if exception.stack.frames().is_empty() && is_error_instance && !error_instance.is_error() {
-            // `toZigException` only populates frames for a native
-            // `ErrorInstance` or a `JSC::Exception` wrapper; an error-like
-            // plain object's only trace is its own `.stack` string.
+            // `toZigException` leaves `frames` empty for a non-ErrorInstance.
             if let Ok(Some(stack)) = error_instance.get_own_truthy(global_ref, "stack") {
                 if stack.is_string() {
                     let stack = bun_core::OwnedString::new(stack.to_bun_string(global_ref)?);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6080,7 +6080,33 @@ impl VirtualMachine {
             }
         }
 
-        Self::print_stack_trace(writer, &exception.stack, allow_ansi_color)?;
+        let mut printed_stack_string = false;
+        if exception.stack.frames().is_empty() && is_error_instance && !error_instance.is_error() {
+            // `toZigException` only populates frames for a native
+            // `ErrorInstance` or a `JSC::Exception` wrapper; an error-like
+            // plain object's only trace is its own `.stack` string.
+            if let Ok(Some(stack)) = error_instance.get_own_truthy(global_ref, "stack") {
+                if stack.is_string() {
+                    let stack = bun_core::OwnedString::new(stack.to_bun_string(global_ref)?);
+                    let bytes = stack.to_utf8();
+                    let slice = bytes.slice();
+                    let tail = match slice.iter().position(|&b| b == b'\n') {
+                        Some(i) => bun_core::trim_right(&slice[i + 1..], b"\n"),
+                        None => b"",
+                    };
+                    if !tail.is_empty() {
+                        writer.write_all(tail)?;
+                        writer.write_all(b"\n")?;
+                    }
+                    printed_stack_string = true;
+                }
+            } else if allow_side_effects && global_ref.has_exception() {
+                global_ref.clear_exception();
+            }
+        }
+        if !printed_stack_string {
+            Self::print_stack_trace(writer, &exception.stack, allow_ansi_color)?;
+        }
 
         if !exception.browser_url.is_empty() {
             pretty_write!(

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5596,7 +5596,6 @@ impl VirtualMachine {
         allow_ansi_color: bool,
         allow_side_effects: bool,
     ) -> crate::CrateResult<()> {
-        use crate::JSType;
         use crate::console_object::formatter::TagOptions;
         use crate::console_object::{self, Tag, TagPayload};
 
@@ -5738,9 +5737,7 @@ impl VirtualMachine {
         let name = exception.name;
         let message = exception.message;
 
-        let is_error_instance = error_instance != JSValue::ZERO
-            && error_instance.is_cell()
-            && error_instance.js_type() == JSType::ErrorInstance;
+        let is_error_instance = error_instance != JSValue::ZERO && error_instance.is_error_like();
         // NOTE: cannot use `self.global()` — `global_ref` outlives a
         // `&mut self` recursion (`print_error_instance_js`) and is passed to
         // `Formatter<'2>::format`, which requires an unbounded (VM-lifetime)
@@ -5963,7 +5960,7 @@ impl VirtualMachine {
                 }
 
                 let kind = value.js_type();
-                if kind == JSType::ErrorInstance && !prev_had_errors {
+                if value.is_error_like() && !prev_had_errors {
                     if field.eql_comptime(b"cause") {
                         saw_cause = true;
                     }
@@ -6060,7 +6057,7 @@ impl VirtualMachine {
             if !saw_cause {
                 let key = bun_core::String::static_(b"cause");
                 if let Some(cause) = error_instance.get_own(global_ref, &key)? {
-                    if cause.is_cell() && cause.js_type() == JSType::ErrorInstance {
+                    if cause.is_error_like() {
                         cause.protect();
                         errors_to_append.push(cause);
                     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3687,11 +3687,6 @@ bool JSC__JSValue__isAnyError(JSC::EncodedJSValue JSValue0)
     return type == JSC::ErrorInstanceType;
 }
 
-// True if the value is a native ErrorInstance, or its [[Prototype]] chain
-// (read via getPrototypeDirect, so Proxy traps and Symbol.hasInstance are not
-// consulted) contains Error.prototype or an ErrorInstance. This is the
-// "isNativeError(e) || e instanceof Error" shape Node uses to decide whether to
-// render a value as an error.
 [[ZIG_EXPORT(nothrow)]] bool JSC__JSValue__isErrorLike(JSC::EncodedJSValue JSValue0)
 {
     JSC::JSValue value = JSC::JSValue::decode(JSValue0);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -39,6 +39,7 @@
 #include "JavaScriptCore/CodeBlock.h"
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/ErrorInstance.h"
+#include "JavaScriptCore/ErrorPrototype.h"
 #include "JavaScriptCore/ExceptionHelpers.h"
 #include "JavaScriptCore/ExceptionScope.h"
 #include "JavaScriptCore/FunctionConstructor.h"
@@ -3684,6 +3685,37 @@ bool JSC__JSValue__isAnyError(JSC::EncodedJSValue JSValue0)
     }
 
     return type == JSC::ErrorInstanceType;
+}
+
+// True if the value is a native ErrorInstance, or its [[Prototype]] chain
+// (read via getPrototypeDirect, so Proxy traps and Symbol.hasInstance are not
+// consulted) contains Error.prototype or an ErrorInstance. This is the
+// "isNativeError(e) || e instanceof Error" shape Node uses to decide whether to
+// render a value as an error.
+[[ZIG_EXPORT(nothrow)]] bool JSC__JSValue__isErrorLike(JSC::EncodedJSValue JSValue0)
+{
+    JSC::JSValue value = JSC::JSValue::decode(JSValue0);
+
+    JSC::JSCell* cell = value.asCell();
+    if (cell->type() == JSC::ErrorInstanceType)
+        return true;
+
+    JSC::JSObject* object = value.getObject();
+    if (!object)
+        return false;
+
+    JSValue proto = object->getPrototypeDirect();
+    unsigned depth = 0;
+    while (proto.isCell()) {
+        JSC::JSCell* protoCell = proto.asCell();
+        if (protoCell->type() == JSC::ErrorInstanceType || protoCell->inherits<JSC::ErrorPrototype>())
+            return true;
+        JSC::JSObject* protoObject = proto.getObject();
+        if (!protoObject || ++depth == 64)
+            return false;
+        proto = protoObject->getPrototypeDirect();
+    }
+    return false;
 }
 
 // This implementation closely mimics the one in JSC::JSPromise::reject

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -242,6 +242,7 @@ CPP_DECL double JSC__JSValue__getUnixTimestamp(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__hasOwnProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString arg2);
 CPP_DECL bool JSC__JSValue__isAggregateError(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL bool JSC__JSValue__isAnyError(JSC::EncodedJSValue JSValue0);
+CPP_DECL bool JSC__JSValue__isErrorLike(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isAnyInt(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isBigInt(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isBigInt32(JSC::EncodedJSValue JSValue0);

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -562,6 +562,10 @@ impl Tag {
             }
         }
 
+        if matches!(js_type, JSType::Object | JSType::FinalObject) && value.is_error_like() {
+            return Ok(TagResult { tag: Tag::Error, cell: js_type });
+        }
+
         let tag = match js_type {
             JSType::ErrorInstance => Tag::Error,
             JSType::NumberObject => Tag::Double,

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -271,6 +271,43 @@ describe("Error-like object (instanceof Error, not a native ErrorInstance)", () 
     expect(called).toBe(false);
   });
 
+  test("a header-less .stack (frames-only prepareStackTrace) keeps its first frame", () => {
+    const err = Object.create(Error.prototype);
+    err.name = "JsonWebTokenError";
+    err.message = "boom";
+    err.stack = "    at inner (x.js:1:1)\n    at outer (x.js:2:2)";
+    const out = Bun.inspect(err, { colors: false });
+    expect(out).toContain("JsonWebTokenError: boom");
+    expect(out).toContain("at inner (x.js:1:1)");
+    expect(out).toContain("at outer (x.js:2:2)");
+  });
+
+  test("a multi-line message in the .stack header is stripped without duplication", () => {
+    const err = Object.create(Error.prototype);
+    err.name = "JsonWebTokenError";
+    err.message = "line1\nline2";
+    err.stack = new Error(err.message).stack;
+    const out = Bun.inspect(err, { colors: false });
+    expect(out.split("line2").length - 1).toBe(1);
+    expect(out).toMatch(/^\s+at /m);
+  });
+
+  test("a throwing own .stack getter is absorbed", () => {
+    const err = Object.create(Error.prototype);
+    err.name = "JsonWebTokenError";
+    err.message = "boom";
+    Object.defineProperty(err, "stack", {
+      get() {
+        throw new Error("nope");
+      },
+    });
+    expect(() => Bun.inspect(err, { colors: false })).not.toThrow();
+  });
+
+  test("the test-runner formatter renders it as [Name: message], not an object dump", () => {
+    expect(makeErrorLike()).toMatchInlineSnapshot(`[JsonWebTokenError: boom]`);
+  });
+
   const fixture = `
     function JsonWebTokenError(msg) {
       this.name = "JsonWebTokenError";

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -194,6 +194,8 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
 // ErrorInstance cells. Node renders any `instanceof Error` value as an error,
 // not as a generic object dump; Bun used to fall through to the generic object
 // formatter for these.
+// (Import placed here so the inline snapshots above keep their line numbers.)
+import { bunEnv, bunExe } from "harness";
 describe("Error-like object (instanceof Error, not a native ErrorInstance)", () => {
   function makeErrorLike(extra) {
     function JsonWebTokenError(msg) {
@@ -278,7 +280,6 @@ describe("Error-like object (instanceof Error, not a native ErrorInstance)", () 
   `;
 
   test.concurrent("console.error renders it as an error", async () => {
-    const { bunEnv, bunExe } = require("harness");
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture + `console.error(new JsonWebTokenError("boom"));`],
       env: { ...bunEnv, NO_COLOR: "1" },
@@ -293,7 +294,6 @@ describe("Error-like object (instanceof Error, not a native ErrorInstance)", () 
   });
 
   test.concurrent("the uncaught-error printer renders it as an error", async () => {
-    const { bunEnv, bunExe } = require("harness");
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture + `throw new JsonWebTokenError("boom");`],
       env: { ...bunEnv, NO_COLOR: "1" },

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -73,11 +73,11 @@ note: "duplicateConstDecl" was originally declared here
 
 const normalizeError = str => {
   // remove debug-only stack trace frames
-  // like "at require (:1:21)"
-  if (str.includes(" (:")) {
+  // like "at require (:1:21)" or "at require (51:24)"
+  if (/ \(:?\d+:\d+\)$/m.test(str)) {
     const splits = str.split("\n");
     for (let i = 0; i < splits.length; i++) {
-      if (splits[i].includes(" (:")) {
+      if (/ \(:?\d+:\d+\)$/.test(splits[i])) {
         splits.splice(i, 1);
         i--;
       }
@@ -187,4 +187,123 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
   expect(() => {
     throw err;
   }).toThrow();
+});
+
+// A function-based Error subclass (prototype = Object.create(Error.prototype))
+// is `instanceof Error` but its instances are plain objects, not JSC
+// ErrorInstance cells. Node renders any `instanceof Error` value as an error,
+// not as a generic object dump; Bun used to fall through to the generic object
+// formatter for these.
+describe("Error-like object (instanceof Error, not a native ErrorInstance)", () => {
+  function makeErrorLike(extra) {
+    function JsonWebTokenError(msg) {
+      this.name = "JsonWebTokenError";
+      this.message = msg;
+      Error.captureStackTrace(this, JsonWebTokenError);
+      if (extra) this.extra = extra;
+    }
+    JsonWebTokenError.prototype = Object.create(Error.prototype);
+    JsonWebTokenError.prototype.constructor = JsonWebTokenError;
+    return new JsonWebTokenError("boom");
+  }
+
+  // The generic object formatter would list `name:`/`message:`/`stack:` as own
+  // properties, plus `toString` picked up from Error.prototype by the
+  // prototype-walking enumerator.
+  const objectDump = /toString: \[Function|^\s*name: "JsonWebTokenError"|^\s*stack: /m;
+
+  test("Bun.inspect renders it as an error, not an object dump", () => {
+    const err = makeErrorLike();
+    expect(err instanceof Error).toBe(true);
+    const out = Bun.inspect(err, { colors: false });
+    expect(out).toContain("JsonWebTokenError: boom");
+    expect(out).not.toMatch(objectDump);
+    expect(out).not.toContain("{");
+  });
+
+  test("Bun.inspect still lists extra own properties after the header", () => {
+    const err = makeErrorLike("payload");
+    const out = Bun.inspect(err, { colors: false });
+    expect(out).toContain("JsonWebTokenError: boom");
+    expect(out).toContain('extra: "payload"');
+    expect(out).not.toMatch(objectDump);
+    expect(out).not.toMatch(/^\s*message: /m);
+  });
+
+  test("Error-like cause is rendered as an error, not an object dump", () => {
+    const err = new Error("outer", { cause: makeErrorLike() });
+    // Slice off the outer error's source preview so assertions below don't
+    // match this file's own source code.
+    const out = Bun.inspect(err, { colors: false });
+    const inner = out.slice(out.indexOf("error: outer"));
+    expect(inner).toContain("JsonWebTokenError: boom");
+    expect(inner).not.toMatch(objectDump);
+  });
+
+  test("a plain object with name/message/stack but no Error prototype is still an object dump", () => {
+    const obj = { name: "E", message: "boom", stack: "E: boom\n    at fake" };
+    expect(obj instanceof Error).toBe(false);
+    const out = Bun.inspect(obj, { colors: false });
+    expect(out).toContain("{");
+    expect(out).toContain('name: "E"');
+  });
+
+  test("the prototype-chain check does not consult Symbol.hasInstance", () => {
+    let called = false;
+    Object.defineProperty(Error, Symbol.hasInstance, {
+      configurable: true,
+      value() {
+        called = true;
+        return false;
+      },
+    });
+    try {
+      const out = Bun.inspect(makeErrorLike(), { colors: false });
+      expect(out).toContain("JsonWebTokenError: boom");
+      expect(out).not.toMatch(objectDump);
+    } finally {
+      delete Error[Symbol.hasInstance];
+    }
+    expect(called).toBe(false);
+  });
+
+  const fixture = `
+    function JsonWebTokenError(msg) {
+      this.name = "JsonWebTokenError";
+      this.message = msg;
+      Error.captureStackTrace(this, JsonWebTokenError);
+    }
+    JsonWebTokenError.prototype = Object.create(Error.prototype);
+    JsonWebTokenError.prototype.constructor = JsonWebTokenError;
+  `;
+
+  test.concurrent("console.error renders it as an error", async () => {
+    const { bunEnv, bunExe } = require("harness");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture + `console.error(new JsonWebTokenError("boom"));`],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("JsonWebTokenError: boom");
+    expect(stderr).not.toMatch(objectDump);
+    expect(stderr).not.toContain("{");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("the uncaught-error printer renders it as an error", async () => {
+    const { bunEnv, bunExe } = require("harness");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture + `throw new JsonWebTokenError("boom");`],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("JsonWebTokenError: boom");
+    expect(stderr.split("JsonWebTokenError: boom").length - 1).toBe(1);
+    expect(stderr).not.toMatch(objectDump);
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -214,11 +214,12 @@ describe("Error-like object (instanceof Error, not a native ErrorInstance)", () 
   // prototype-walking enumerator.
   const objectDump = /toString: \[Function|^\s*name: "JsonWebTokenError"|^\s*stack: /m;
 
-  test("Bun.inspect renders it as an error, not an object dump", () => {
+  test("Bun.inspect renders it as an error with its .stack, not an object dump", () => {
     const err = makeErrorLike();
     expect(err instanceof Error).toBe(true);
     const out = Bun.inspect(err, { colors: false });
     expect(out).toContain("JsonWebTokenError: boom");
+    expect(out).toMatch(/^\s+at .*makeErrorLike/m);
     expect(out).not.toMatch(objectDump);
     expect(out).not.toContain("{");
   });
@@ -239,6 +240,7 @@ describe("Error-like object (instanceof Error, not a native ErrorInstance)", () 
     const out = Bun.inspect(err, { colors: false });
     const inner = out.slice(out.indexOf("error: outer"));
     expect(inner).toContain("JsonWebTokenError: boom");
+    expect(inner).toMatch(/^\s+at .*makeErrorLike/m);
     expect(inner).not.toMatch(objectDump);
   });
 
@@ -279,31 +281,35 @@ describe("Error-like object (instanceof Error, not a native ErrorInstance)", () 
     JsonWebTokenError.prototype.constructor = JsonWebTokenError;
   `;
 
-  test.concurrent("console.error renders it as an error", async () => {
+  test.concurrent("console.error renders it as an error with its .stack", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture + `console.error(new JsonWebTokenError("boom"));`],
       env: { ...bunEnv, NO_COLOR: "1" },
       stderr: "pipe",
       stdout: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("JsonWebTokenError: boom");
+    expect(stderr).toMatch(/^\s+at .*\[eval\]/m);
     expect(stderr).not.toMatch(objectDump);
     expect(stderr).not.toContain("{");
+    expect(stdout).toBe("");
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("the uncaught-error printer renders it as an error", async () => {
+  test.concurrent("the uncaught-error printer renders it as an error with a stack", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture + `throw new JsonWebTokenError("boom");`],
       env: { ...bunEnv, NO_COLOR: "1" },
       stderr: "pipe",
       stdout: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("JsonWebTokenError: boom");
     expect(stderr.split("JsonWebTokenError: boom").length - 1).toBe(1);
+    expect(stderr).toMatch(/^\s+at .*\[eval\]/m);
     expect(stderr).not.toMatch(objectDump);
+    expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
## What

A function-based Error subclass such as jsonwebtoken's `JsonWebTokenError`:

```js
function JsonWebTokenError(msg) {
  this.name = 'JsonWebTokenError';
  this.message = msg;
  Error.captureStackTrace(this, JsonWebTokenError);
}
JsonWebTokenError.prototype = Object.create(Error.prototype);

throw new JsonWebTokenError('boom');
```

is `instanceof Error`, but because the object is constructed without calling `super()` its JSC cell type is `FinalObject`, not `ErrorInstance`. `Bun.inspect`, `console.error`, and the uncaught-error printer only recognised `ErrorInstance` cells, so this value fell through to the generic object formatter:

```
JsonWebTokenError: boom
JsonWebTokenError {
  name: "JsonWebTokenError",
  message: "boom",
  stack: "Error\n    at ...",
  toString: [Function: toString],
}
```

(the `toString` entry is `Error.prototype.toString`, picked up by the prototype-walking property enumerator used for generic object dumps). Node prints the error header and stack:

```
JsonWebTokenError: boom
    at Object.<anonymous> (/tmp/x.js:8:7)
    ...
```

`util.inspect` already handled this correctly; `Bun.inspect`/`console.*` and the uncaught handler did not.

## Cause

`Tag::get_advanced` in `src/jsc/ConsoleObject.rs` and `print_error_instance_body` in `src/jsc/VirtualMachine.rs` both gate error formatting on `js_type() == JSType::ErrorInstance`. A function-based subclass has `js_type() == FinalObject`, so the generic-object branch runs. The sibling `Tag::get` in the test-runner diff formatter (`src/runtime/test_runner/pretty_format.rs`) has the same gap.

## Fix

Add `JSValue::is_error_like()`, which is true for a native `ErrorInstance` or an object whose `[[Prototype]]` chain contains `Error.prototype` (or an `ErrorInstance`). The chain is walked with `getPrototypeDirect()`, so Proxy `getPrototypeOf` traps and `Symbol.hasInstance` are not consulted; this is what Node's `util.inspect` does via primordials. Use it:

- in `Tag::get_advanced` / `Tag::get` for `Object`/`FinalObject` cells, routing them to the error formatter
- in `print_error_instance_body` at the three is-error decision points (top-level, nested-property, and non-enumerable `cause`)

Since `toZigException` only populates native stack frames for an `ErrorInstance` or a `JSC::Exception` wrapper, `print_error_instance_body` also gains a fallback: when the value is error-like but not an `ErrorInstance` and there are no native frames, print its own `.stack` string (minus the header line, which `print_error_name_and_message` already wrote). Without this the `Bun.inspect`/`console.error` path would print only the header.

A plain object with `name`/`message`/`stack` own properties but no `Error` in its prototype chain is unchanged (still an object dump), matching Node.

## Why this is correct

Node's `isError` helper (`lib/internal/util.js`) is `isNativeError(e) || e instanceof Error`, evaluated through primordials so a user-installed `Error[Symbol.hasInstance]` is not observed. Verified against Node v26.3.0: a user `Symbol.hasInstance` is not called, and a plain object without `Error.prototype` in its chain stays an object dump.

## Tests

Seven new tests in `test/js/bun/util/inspect-error.test.js` cover `Bun.inspect` (header + stack, extra own properties, error-like `cause`, `Symbol.hasInstance` not consulted, the negative plain-object case) plus spawned-process checks for `console.error` and an uncaught throw, each asserting an `at ...` frame line appears. Six fail on the current canary, all seven pass with this change.

Also updated that file's `normalizeError` helper to match debug-only internal frames rendered as `at require (51:24)` (no leading colon); the helper was written for the older `(:1:21)` format and has been stale against debug builds since #12791. Release builds never emit these frames, so CI was unaffected; the update keeps the two pre-existing minified-source tests green under `bun bd test`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.0 (491fb8d32)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [6.45ms]
(pass) Error [3.70ms]
(pass) BuildMessage [120.91ms]
(pass) Error inside minified file (no color)  [99.54ms]
(pass) Error inside minified file (color)  [63.31ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [458.93ms]
(pass) observable properties > sourceURL is observable [5.98ms]
(pass) observable properties > line is observable [2.30ms]
(pass) observable properties > column is observable [1.93ms]
(pass) error.stack throwing an error doesn't lead to a crash [4.91ms]
216 | 
217 |   test("Bun.inspect renders it as an error with its .stack, not an object dump", () => {
218 |     const err = makeErrorLike();
219 |     expect(err instanceof Error).toBe(true);
220 |     const out = Bun.inspect(err, { colors: false });
221 |     expect(out).toContain("JsonWebTokenError: boom");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "Jso
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [0.32ms]
(pass) Error [0.10ms]
(pass) BuildMessage [1.14ms]
(pass) Error inside minified file (no color)  [2.13ms]
(pass) Error inside minified file (color)  [0.42ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [5.79ms]
(pass) observable properties > sourceURL is observable [0.22ms]
(pass) observable properties > line is observable [0.06ms]
(pass) observable properties > column is observable [0.05ms]
(pass) error.stack throwing an error doesn't lead to a crash [0.09ms]
216 | 
217 |   test("Bun.inspect renders it as an error with its .stack, not an object dump", () => {
218 |     const err = makeErrorLike();
219 |     expect(err instanceof Error).toBe(true);
220 |     const out = Bun.inspect(err, { colors: false });
221 |     expect(out).toContain("JsonWebTokenError: boom");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "JsonWebTokenError: boom"
Received: "JsonWebTokenError {\n  name: \"JsonWebTokenError\",\n  message: \"boom\",\n  originalLine: 157,\n  originalColumn: 33,\n  stack: \"Error
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.0 (491fb8d32)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [6.81ms]
(pass) Error [3.94ms]
(pass) BuildMessage [15.20ms]
(pass) Error inside minified file (no color)  [91.51ms]
(pass) Error inside minified file (color)  [56.50ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [332.96ms]
(pass) observable properties > sourceURL is observable [6.12ms]
(pass) observable properties > line is observable [2.37ms]
(pass) observable properties > column is observable [2.06ms]
(pass) error.stack throwing an error doesn't lead to a crash [4.40ms]
(pass) Error-like object (instanceof Error, not a native ErrorInstance) > Bun.inspect renders it as an error with its .stack, not an object dump [10.47ms]
(pass) Error-like object (instanceof Error, not a native ErrorInstance) > Bun.inspect still lists extra own properties after the header [5.90ms]
(pass) Error-like object (instanceof Error, not a native ErrorInstance) > Error-like cause is rendered as 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     491fb8d324
  features     baseline

22 deps, 108 codegen, 1171 objects in 3337ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] gen ErrorCode+*.h
[3/1234] fetch zlib
[zlib] up to date
[4/1234] fetch picohttpparser
[picohttpparser] up to date
[5/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1234] gen .bind.ts → GeneratedBindings.cpp
[7/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[9/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingFs.lut.h 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                 |   9 ++
 src/jsc/JSValue.rs                       |   9 ++
 src/jsc/VirtualMachine.rs                |  43 ++++++--
 src/jsc/bindings/bindings.cpp            |  27 +++++
 src/jsc/bindings/headers.h               |   1 +
 src/runtime/test_runner/pretty_format.rs |   4 +
 test/js/bun/util/inspect-error.test.js   | 168 ++++++++++++++++++++++++++++++-
 7 files changed, 251 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/ConsoleObject.rs                      6      4      0
src/jsc/JSValue.rs                            7      5      0
src/jsc/VirtualMachine.rs                    16     12      0
src/jsc/bindings/bindings.cpp                 3      4      0
src/jsc/bindings/headers.h                    1      1      0
src/runtime/test_runner/pretty_format.rs      2      1      0
test/js/bun/util/inspect-error.test.js        6     17      0
```

</details>

<!-- robobun:evidence:end -->