### PR TITLE
bundler: re-exporting a missing CJS-to-ESM named import no longer emits an invalid ref

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -3528,10 +3528,21 @@ impl<'a> LinkerContext<'a> {
                         // disjoint allocation, so no aliasing with this `&mut`.
                         let symbol = unsafe { self.graph.symbol_mut(tracker.import_ref) };
                         symbol.import_item_status = ImportItemStatus::Missing;
-                        result.kind = MatchImportKind::NormalAndNamespace;
-                        result.namespace_ref = tracker.import_ref;
-                        result.alias = named_import.alias.expect("infallible: alias present");
-                        result.name_loc = named_import.alias_loc;
+                        let alias = named_import.alias.expect("infallible: alias present");
+                        if result.kind == MatchImportKind::Normal {
+                            result.kind = MatchImportKind::NormalAndNamespace;
+                            result.namespace_ref = tracker.import_ref;
+                            result.alias = alias;
+                            result.name_loc = named_import.alias_loc;
+                        } else {
+                            result = MatchImport {
+                                kind: MatchImportKind::Namespace,
+                                namespace_ref: tracker.import_ref,
+                                alias,
+                                name_loc: named_import.alias_loc,
+                                ..Default::default()
+                            };
+                        }
                     }
                 }
 

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -83,6 +83,73 @@ describe("bundler", () => {
       stdout: "undefined",
     },
   });
+  itBundled("cjs2esm/BadNamedImportReExportedFromEntryCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import {bad} from './bar.cjs';
+        export {bad};
+        console.log(bad);
+      `,
+      "/bar.cjs": /* js */ `
+        exports.foo = 'bar';
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("__INVALID__REF__");
+    },
+    runtimeFiles: {
+      "/test.mjs": /* js */ `
+        import * as mod from './out.js';
+        if (mod.bad !== undefined) throw new Error("expected undefined, got " + mod.bad);
+      `,
+    },
+    run: [{ stdout: "undefined" }, { file: "/test.mjs" }],
+  });
+  itBundled("cjs2esm/BadNamedExportFromEntryCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        export {bad} from './bar.cjs';
+      `,
+      "/bar.cjs": /* js */ `
+        exports.foo = 'bar';
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("__INVALID__REF__");
+    },
+    runtimeFiles: {
+      "/test.mjs": /* js */ `
+        import * as mod from './out.js';
+        if (mod.bad !== undefined) throw new Error("expected undefined, got " + mod.bad);
+      `,
+    },
+    run: { file: "/test.mjs" },
+  });
+  itBundled("cjs2esm/BadNamedImportNamedReExportedToEntryFromCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import {bad} from './foo';
+        export {bad};
+        console.log(bad);
+      `,
+      "/foo.js": /* js */ `
+        export {bad} from './bar.cjs';
+      `,
+      "/bar.cjs": /* js */ `
+        exports.foo = 'bar';
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("__INVALID__REF__");
+    },
+    runtimeFiles: {
+      "/test.mjs": /* js */ `
+        import * as mod from './out.js';
+        if (mod.bad !== undefined) throw new Error("expected undefined, got " + mod.bad);
+      `,
+    },
+    run: [{ stdout: "undefined" }, { file: "/test.mjs" }],
+  });
   itBundled("cjs2esm/ExportsFunction", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -154,6 +154,7 @@ describe("bundler", () => {
     files: {
       "/entry.js": /* js */ `
         const mod = await import('./sub.js');
+        if (!('bad' in mod)) throw new Error("expected 'bad' to be exported from wrapped module");
         console.log(mod.bad);
       `,
       "/sub.js": /* js */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -99,8 +99,8 @@ describe("bundler", () => {
     },
     runtimeFiles: {
       "/test.mjs": /* js */ `
-        import * as mod from './out.js';
-        if (mod.bad !== undefined) throw new Error("expected undefined, got " + mod.bad);
+        import { bad } from './out.js';
+        if (bad !== undefined) throw new Error("expected undefined, got " + bad);
       `,
     },
     run: [{ stdout: "undefined" }, { file: "/test.mjs" }],
@@ -119,8 +119,8 @@ describe("bundler", () => {
     },
     runtimeFiles: {
       "/test.mjs": /* js */ `
-        import * as mod from './out.js';
-        if (mod.bad !== undefined) throw new Error("expected undefined, got " + mod.bad);
+        import { bad } from './out.js';
+        if (bad !== undefined) throw new Error("expected undefined, got " + bad);
       `,
     },
     run: { file: "/test.mjs" },
@@ -144,11 +144,30 @@ describe("bundler", () => {
     },
     runtimeFiles: {
       "/test.mjs": /* js */ `
-        import * as mod from './out.js';
-        if (mod.bad !== undefined) throw new Error("expected undefined, got " + mod.bad);
+        import { bad } from './out.js';
+        if (bad !== undefined) throw new Error("expected undefined, got " + bad);
       `,
     },
     run: [{ stdout: "undefined" }, { file: "/test.mjs" }],
+  });
+  itBundled("cjs2esm/BadNamedImportReExportedFromWrappedModuleCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        const mod = await import('./sub.js');
+        console.log(mod.bad);
+      `,
+      "/sub.js": /* js */ `
+        import {bad} from './bar.cjs';
+        export {bad};
+      `,
+      "/bar.cjs": /* js */ `
+        exports.foo = 'bar';
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("__INVALID__REF__");
+    },
+    run: { stdout: "undefined" },
   });
   itBundled("cjs2esm/ExportsFunction", {
     files: {


### PR DESCRIPTION
## What

When a CommonJS module is eligible for the CJS-to-ESM unwrap optimization (only top-level `exports.foo = ...` assignments) and an ESM entry point imports a name that doesn't exist and re-exports it, the bundle output contained `export { __INVALID__REF__ as name }`, which is a `ReferenceError` at runtime.

```js
// bar.cjs
exports.foo = 'bar';

// entry.mjs
import { bad } from './bar.cjs';
export { bad };
console.log(bad);
```

Before:
```js
console.log(undefined);
export {
  __INVALID__REF__ as bad
};
```

After:
```js
console.log(undefined);
var export_bad = undefined;
export {
  export_bad as bad
};
```

The same problem applied to `export { bad } from './bar.cjs'` written directly at the entry point.

## Why

`match_import_with_export` handles an unwrapped-CJS miss via `DynamicFallbackInteropDefault`: it marks the import symbol `Missing` so expression uses print as `undefined`. But it unconditionally set `result.kind = NormalAndNamespace` without populating `result.ref`/`source_index`. When the miss occurs on the *first* loop iteration (importer is the entry point, no intermediate re-export file), those fields are still `Default`, so `imports_to_bind` records a bind to `Ref::NONE`. The ESM export-clause generator then follows that bind to a symbol with no `namespace_alias` and emits it verbatim, and `Ref::NONE` resolves to the first symbol in `runtime.js`, which is `__INVALID__REF__`.

The adjacent `DynamicFallback` branch already handled this correctly by only upgrading to `NormalAndNamespace` when a prior `Found` step had populated `result.ref`, and falling back to `Namespace` otherwise. `DynamicFallbackInteropDefault` now does the same: with `Namespace`, `imports_to_bind` is left unset and the export-clause generator sees the original import symbol (which has both `namespace_alias` and `Missing` status) and lowers it through the `var export_<name> = <ImportIdentifier>` path, which the printer renders as `undefined`.

This matches what esbuild produces for the same input (modulo Bun not wrapping the CJS module).

Surfaced in a comment on #11032, though that issue itself is about a different bug.

## Tests

Three new `itBundled` cases in `test/bundler/bundler_cjs2esm.test.ts` covering:
- `import {bad} from './bar.cjs'; export {bad}` at entry
- `export {bad} from './bar.cjs'` at entry
- import through an intermediate ESM re-export, then re-exported again at entry (regression guard for the `result.kind == Normal` path this change keeps)

Each asserts the bundle contains no `__INVALID__REF__` and that importing the bundle yields `undefined` for the missing name.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (8c7082a2a)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [828.54ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [849.36ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [466.25ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [625.03ms]
93 |       "/bar.cjs": /* js */ `
94 |         exports.foo = 'bar';
95 |       `,
96 |     },
97 |     onAfterBundle(api) {
98 |       expect(api.readFile("/out.js")).not.toContain("__INVALID__REF__");
                                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "__INVALID__REF__"
Received: "// entry.js\nconsole.log(undefined);\nexport {\n  __INVALID__REF__ as bad\n};\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_cjs2esm.test.ts:98:43)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) bundler > cjs2esm/BadNamedImportReExportedFromEntryCommonJS [570.61m
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [191.67ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [29.71ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [37.58ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [42.25ms]
93 |       "/bar.cjs": /* js */ `
94 |         exports.foo = 'bar';
95 |       `,
96 |     },
97 |     onAfterBundle(api) {
98 |       expect(api.readFile("/out.js")).not.toContain("__INVALID__REF__");
                                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "__INVALID__REF__"
Received: "// entry.js\nconsole.log(undefined);\nexport {\n  __INVALID__REF__ as bad\n};\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_cjs2esm.test.ts:98:43)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) bundler > cjs2esm/BadNamedImportReExportedFromEntryCommonJS [5.87ms]
113 |       "/bar.cjs": /* js */ `
114 |         exports.foo = 'bar';
115 |       `,
116 |     },
117 |     onAfterBundle(api) {
118 |       expect(api.readFile("/ou
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (8c7082a2a)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [1219.48ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [957.84ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [408.98ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [367.41ms]
(pass) bundler > cjs2esm/BadNamedImportReExportedFromEntryCommonJS [685.10ms]
(pass) bundler > cjs2esm/BadNamedExportFromEntryCommonJS [441.75ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedToEntryFromCommonJS [1174.73ms]
(pass) bundler > cjs2esm/BadNamedImportReExportedFromWrappedModuleCommonJS [647.61ms]
(pass) bundler > cjs2esm/ExportsFunction [1001.40ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [442.39ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [402.16ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [857.04ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [768.78ms]
(pass) bundler > 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8c7082a2a5
  features     baseline

22 deps, 108 codegen, 1171 objects in 6046ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch tinycc
[tinycc] up to date
[2/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1234] gen .bind.ts → GeneratedBindings.cpp
[5/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1234] fetch zlib
[zlib] up to date
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[9/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[10/1234] subst deps/libjpeg-turbo/jconfig.h
[11/1234] subst de
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs         | 19 ++++++--
 test/bundler/bundler_cjs2esm.test.ts | 87 ++++++++++++++++++++++++++++++++++++
 2 files changed, 102 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/bundler/LinkerContext.rs              4      2      0
test/bundler/bundler_cjs2esm.test.ts      4      7      0
```

</details>

<!-- robobun:evidence:end -->