### PR TITLE
node:quic: enforce QuicEndpoint maxConnectionsPerHost

### DIFF
--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -1328,6 +1328,30 @@ impl QuicEndpoint {
         // SAFETY: see doc comment.
         self.sessions.get().contains(&p).then(|| unsafe { &*p })
     }
+    /// Count live server sessions whose remote `(family, ip)` matches `peer`'s
+    /// (port ignored: Node keys `maxConnectionsPerHost` by source IP only;
+    /// node/src/quic/endpoint.cc SocketAddressInfoTraits).
+    fn server_sessions_from_host(&self, peer: &StoredAddr) -> usize {
+        let Some((family, _, ip)) = peer.decode() else {
+            return 0;
+        };
+        self.sessions
+            .get()
+            .iter()
+            // SAFETY: registered pointers are live on the JS thread (see
+            // `live_session`).
+            .map(|&p| unsafe { &*p })
+            .filter(|s| {
+                if !s.is_server() {
+                    return false;
+                }
+                let remote = s.remote_addr.get();
+                remote
+                    .decode()
+                    .is_some_and(|(f, _, a)| f == family && a == ip)
+            })
+            .count()
+    }
     fn write_stat(&self, idx: usize, value: u64) {
         if !self.stats.is_null() && idx < ENDPOINT_STATS_FIELDS.len() {
             // SAFETY: `stats` is a live `[u64; N]` view.
@@ -1676,12 +1700,15 @@ impl QuicEndpoint {
         }
         let peer_stored = stored_addr_from_sockaddr(peer);
         let peer_decoded = peer_stored.decode();
-        let (busy, max_conns) = self.with_state(|s| (s.busy, s.max_connections_total));
+        let (busy, max_conns, max_per_host) =
+            self.with_state(|s| (s.busy, s.max_connections_total, s.max_connections_per_host));
         // `closing`: on_new_conn refuses these at promotion, so announcing one
         // here would surface a session that can never open.
         if self.closing.get()
             || busy != 0
             || (max_conns > 0 && self.sessions.get().len() >= max_conns as usize)
+            || (max_per_host > 0
+                && self.server_sessions_from_host(&peer_stored) >= max_per_host as usize)
         {
             return;
         }
@@ -1705,6 +1732,10 @@ impl QuicEndpoint {
             return;
         }
         if let Ok((session, _handle)) = created {
+            // Record the peer now so the per-host count includes provisional
+            // sessions; `bind_conn` refreshes it from the lsquic conn later.
+            // SAFETY: `session` was just created.
+            unsafe { (*session).remote_addr.set(peer_stored) };
             self.apply_server_session_options(global, session);
             self.sessions.with_mut(|v| v.push(session));
             self.pending_new_sessions.with_mut(|v| v.push(session));
@@ -1813,8 +1844,15 @@ impl QuicEndpoint {
             }
             return null_mut();
         }
-        let (busy, max_conns) = self.with_state(|s| (s.busy, s.max_connections_total));
-        if busy != 0 || (max_conns > 0 && self.sessions.get().len() >= max_conns as usize) {
+        let (busy, max_conns, max_per_host) =
+            self.with_state(|s| (s.busy, s.max_connections_total, s.max_connections_per_host));
+        if busy != 0
+            || (max_conns > 0 && self.sessions.get().len() >= max_conns as usize)
+            || (max_per_host > 0
+                && peer
+                    .as_ref()
+                    .is_some_and(|p| self.server_sessions_from_host(p) >= max_per_host as usize))
+        {
             // SAFETY: `conn` is the live conn lsquic just created.
             unsafe {
                 lsquic::lsquic_conn_abort_error(

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -267,3 +267,55 @@ describe("endpoint.close() while a session is live", () => {
     expect({ announced, resolved }).toEqual({ announced: 1, resolved: true });
   });
 });
+
+// Node keys this on source IP (node/src/quic/endpoint.cc SocketAddressInfoTraits),
+// refusing the N+1st concurrent server session from the same host with
+// CONNECTION_REFUSED, same as `busy` and `maxConnectionsTotal` do.
+describe("QuicEndpoint({ maxConnectionsPerHost })", () => {
+  test("refuses the N+1st concurrent session from the same source IP", async () => {
+    const tp = { maxIdleTimeout: 30 };
+    const sniOpt = { "*": { keys: [key], certs: [cert] } };
+    let announced = 0;
+    await using ep = new QuicEndpoint({ maxConnectionsPerHost: 2 });
+    await using server = await listen(
+      async (s: any) => {
+        announced++;
+        await s.closed.catch(() => {});
+      },
+      { endpoint: ep, sni: sniOpt, alpn: ["quic-test"], transportParams: tp },
+    );
+
+    // Each attempt is a fresh source port, same 127.0.0.1 host.
+    const sessions: any[] = [];
+    const outcome = async () => {
+      const c: any = await connect(server.address, {
+        endpoint: new QuicEndpoint(),
+        alpn: "quic-test",
+        verifyPeer: "manual",
+        transportParams: tp,
+      });
+      c.closed.catch(() => {});
+      sessions.push(c);
+      return c.opened.then(
+        () => "open",
+        (e: any) => e?.code ?? "error",
+      );
+    };
+
+    const first = await outcome();
+    const second = await outcome();
+    const third = await outcome();
+    const fourth = await outcome();
+
+    for (const s of sessions) s.close();
+
+    expect({ first, second, third, fourth, announced, busy: server.stats.serverBusyCount }).toEqual({
+      first: "open",
+      second: "open",
+      third: "ERR_QUIC_TRANSPORT_ERROR",
+      fourth: "ERR_QUIC_TRANSPORT_ERROR",
+      announced: 2,
+      busy: 2n,
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`new QuicEndpoint({ maxConnectionsPerHost: N })` is documented as *"when the limit is reached, new connections from the same IP are refused with CONNECTION_REFUSED"*. The option was parsed into `EndpointState.max_connections_per_host` and exposed through the JS getters/setters, but the accept path never consulted it, so a single source IP could open unbounded concurrent server sessions. The sibling `maxConnectionsTotal` on the same rig is enforced.

```js
import { listen, connect, QuicEndpoint } from "node:quic";
const ep = new QuicEndpoint({ maxConnectionsPerHost: 2 });
const srv = await listen(onSession, { endpoint: ep, sni, alpn: ["echo"] });
for (let i = 0; i < 4; i++) {
  const c = await connect(srv.address, { endpoint: new QuicEndpoint(), alpn: "echo", verifyPeer: "manual" });
  await c.opened;            // all four resolve
}
srv.stats.serverSessions;    // 4n (expected 2n)
srv.stats.serverBusyCount;   // 0n (expected 2n)
```

## Cause

`endpoint.rs` reads `max_connections_total` at both accept sites (`maybe_announce_provisional` and `on_new_conn`) but never reads `max_connections_per_host`.

## Fix

`server_sessions_from_host(&StoredAddr)` counts live server sessions in `self.sessions` whose remote `(family, ip)` matches the incoming peer (port ignored, matching Node's `SocketAddressInfoTraits` keying). Both accept sites check it alongside `busy`/`max_connections_total` and refuse with `CONNECTION_REFUSED` once the limit is reached. A provisional session now records its peer address at creation so it counts toward the per-host tally before lsquic promotes it; `bind_conn` overwrites it with the lsquic sockaddr afterwards.

## Verification

New test in `test/js/node/quic/quic-endpoint.test.ts` opens four sessions from 127.0.0.1 against a `{ maxConnectionsPerHost: 2 }` endpoint and asserts the first two open, the next two reject with `ERR_QUIC_TRANSPORT_ERROR`, `announced == 2`, and `serverBusyCount == 2n`.

Without the fix:
```
{ announced: 4, busy: 0n, first: "open", second: "open", third: "open", fourth: "open" }
```
With the fix:
```
{ announced: 2, busy: 2n, first: "open", second: "open", third: "ERR_QUIC_TRANSPORT_ERROR", fourth: "ERR_QUIC_TRANSPORT_ERROR" }
```

All 15 `test/js/node/quic/` tests pass.
