### PR TITLE
node:inspector: report real functionName and original-file offsets in Profiler.takePreciseCoverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,6 +1866,7 @@ dependencies = [
  "bun_options_types",
  "bun_paths",
  "bun_sourcemap",
+ "bun_sys",
  "bun_wyhash",
  "const_format",
  "enum-map",

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -272,13 +272,10 @@ function removeConsoleHooks() {
   hookedConsoleMethods.length = 0;
 }
 
-// Reshapes the raw control-flow-profiler data from jsFunction_collectPreciseCoverage
-// ([{ url, scriptId, sourceLength, blocks: [[start, end, count, rStart?, rEnd?]],
-// functions: [[start, end, executed, name, rStart?, rEnd?]] }]) into the V8
-// ScriptCoverage list returned by Profiler.takePreciseCoverage.
-// Block→function assignment is done on the raw (transpiled) start/end so
-// containment holds; the emitted CoverageRange uses the remapped start/end
-// (original-file bytes) when present, so offsets address the file the url names.
+// Reshapes jsFunction_collectPreciseCoverage's output into V8 ScriptCoverage.
+// Block-to-function assignment uses raw (transpiled) offsets so containment
+// holds across the transpiler's class hoisting; the emitted CoverageRange uses
+// the remapped (original-file byte) offsets when present.
 type RawBlock = [number, number, number, number?, number?];
 type RawFunction = [number, number, boolean, string, number?, number?];
 function buildScriptCoverageList(

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -273,18 +273,21 @@ function removeConsoleHooks() {
 }
 
 // Reshapes the raw control-flow-profiler data from jsFunction_collectPreciseCoverage
-// ([{ url, scriptId, sourceLength, blocks: [[start, end, count]], functions: [[start, end, executed]] }])
-// into the V8 ScriptCoverage list returned by Profiler.takePreciseCoverage:
-// each function gets an entry whose first range spans the whole function with its
-// call count, followed by the basic-block ranges inside it; blocks outside any
-// function go on a synthetic whole-script entry.
+// ([{ url, scriptId, sourceLength, blocks: [[start, end, count, rStart?, rEnd?]],
+// functions: [[start, end, executed, name, rStart?, rEnd?]] }]) into the V8
+// ScriptCoverage list returned by Profiler.takePreciseCoverage.
+// Block→function assignment is done on the raw (transpiled) start/end so
+// containment holds; the emitted CoverageRange uses the remapped start/end
+// (original-file bytes) when present, so offsets address the file the url names.
+type RawBlock = [number, number, number, number?, number?];
+type RawFunction = [number, number, boolean, string, number?, number?];
 function buildScriptCoverageList(
   rawScripts: Array<{
     url: string;
     scriptId: number;
     sourceLength: number;
-    blocks: Array<[number, number, number]>;
-    functions: Array<[number, number, boolean]>;
+    blocks: RawBlock[];
+    functions: RawFunction[];
   }>,
   callCount: boolean,
   detailed: boolean,
@@ -309,8 +312,8 @@ function buildScriptCoverageList(
     const blocks = script.blocks.filter(([start, end]) => start >= 0 && end >= start).sort((a, b) => a[0] - b[0]);
 
     // Assign each basic block to the innermost function range containing it.
-    const blocksPerFunction: Array<Array<[number, number, number]>> = functions.map(() => []);
-    const topLevelBlocks: Array<[number, number, number]> = [];
+    const blocksPerFunction: RawBlock[][] = functions.map(() => []);
+    const topLevelBlocks: RawBlock[] = [];
     const stack: number[] = [];
     let nextFunction = 0;
     for (const block of blocks) {
@@ -346,10 +349,10 @@ function buildScriptCoverageList(
     const scriptExecuted = blocks.some(([, , count]) => count > 0) ? 1 : 0;
     const entries: object[] = [];
 
-    const toRange = ([startOffset, endOffset, count]: [number, number, number]) => ({
-      startOffset,
-      endOffset,
-      count: callCount ? count : count > 0 ? 1 : 0,
+    const toRange = (b: RawBlock) => ({
+      startOffset: b[3] ?? b[0],
+      endOffset: b[4] ?? b[1],
+      count: callCount ? b[2] : b[2] > 0 ? 1 : 0,
     });
 
     // Whole-script entry. V8 always reports one covering the entire source.
@@ -363,10 +366,12 @@ function buildScriptCoverageList(
     });
 
     for (let i = 0; i < functions.length; i++) {
-      const [startOffset, endOffset, executed] = functions[i];
+      const [rawStart, rawEnd, executed, functionName, rStart, rEnd] = functions[i];
+      const startOffset = rStart ?? rawStart;
+      const endOffset = rEnd ?? rawEnd;
       if (!executed) {
         entries.push({
-          functionName: "",
+          functionName,
           ranges: [{ startOffset, endOffset, count: 0 }],
           isBlockCoverage: false,
         });
@@ -387,7 +392,7 @@ function buildScriptCoverageList(
         count = entryBlock[2];
       }
       entries.push({
-        functionName: "",
+        functionName,
         ranges: [
           { startOffset, endOffset, count: callCount ? count : count > 0 ? 1 : 0 },
           ...(detailed ? ownBlocks.map(toRange) : []),

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -6,6 +6,7 @@
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ControlFlowProfiler.h>
+#include <JavaScriptCore/FunctionExecutable.h>
 #include <JavaScriptCore/FunctionHasExecutedCache.h>
 #include <JavaScriptCore/HeapIterationScope.h>
 #include <JavaScriptCore/MarkedSpaceInlines.h>
@@ -13,6 +14,8 @@
 #include <JavaScriptCore/SourceProvider.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/JSONValues.h>
+
+extern "C" bool InspectorCoverage__remapOffsets(BunString sourceURL, BunString transpiled, int32_t* offsets, size_t count, uint32_t* outOriginalLen);
 
 using namespace JSC;
 
@@ -76,8 +79,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_stopPreciseCoverage, (JSGlobalObject * globa
 
 // Returns a JSON string describing every script the control flow profiler has
 // data for: [{ url, scriptId, sourceLength, blocks: [[start, end, count]],
-// functions: [[start, end, executed]] }]. The JS layer in node/inspector.ts
-// reshapes this into the V8 ScriptCoverage format.
+// functions: [[start, end, executed, name]] }]. The JS layer in
+// node/inspector.ts reshapes this into the V8 ScriptCoverage format.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_collectPreciseCoverage);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
 {
@@ -88,11 +91,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
 
     // Enumerate SourceIDs by walking only the four ScriptExecutable subspaces
     // (not the whole heap). Providers whose executables were all GC'd are not
-    // reported, and offsets index the transpiled source for Bun-loaded modules;
-    // Bun appends an inline //# sourceMappingURL, so consumers that read the
-    // script source (v8-to-istanbul) can remap.
+    // reported. FunctionHasExecutedCache carries no names, so also index every
+    // live FunctionExecutable's ecmaName by its (sourceID, start offset) to
+    // fill FunctionCoverage.functionName.
     Vector<Ref<JSC::SourceProvider>> providers;
     HashSet<SourceID> seenSourceIDs;
+    // Key packs (functionStart, functionEnd) so it is never 0 (WTF's empty
+    // hash key for integers) even for a function at byte 0.
+    UncheckedKeyHashMap<SourceID, UncheckedKeyHashMap<uint64_t, String>> functionNames;
+    auto rangeKey = [](unsigned start, unsigned end) -> uint64_t {
+        return (static_cast<uint64_t>(start) << 32) | static_cast<uint64_t>(end);
+    };
     {
         HeapIterationScope iterationScope(vm.heap);
         vm.heap.forEachScriptExecutableSpace([&](auto& spaceAndSet) {
@@ -101,9 +110,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
                 auto* provider = executable->source().provider();
                 if (!provider)
                     return;
-                if (!seenSourceIDs.add(provider->asID()).isNewEntry)
-                    return;
-                providers.append(*provider);
+                SourceID sourceID = provider->asID();
+                if (seenSourceIDs.add(sourceID).isNewEntry)
+                    providers.append(*provider);
+                if (executable->type() == FunctionExecutableType) {
+                    auto* fn = static_cast<FunctionExecutable*>(executable);
+                    // functionStart()/functionEnd() equal typeProfilingStart/End,
+                    // which are what FunctionHasExecutedCache stores, so the
+                    // (start, end) pair keys the join.
+                    functionNames.add(sourceID, UncheckedKeyHashMap<uint64_t, String> {})
+                        .iterator->value.add(rangeKey(fn->functionStart(), fn->functionEnd()), fn->ecmaName().string());
+                }
             });
         });
     }
@@ -116,20 +133,56 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
         if (blocks.isEmpty() && functionRanges.isEmpty())
             continue;
 
+        // JSC's offsets index the text the VM compiled, which for Bun-loaded
+        // modules is the runtime-transpiled output (comments stripped, class
+        // declarations hoisted, TS lowered). V8-coverage consumers slice the
+        // on-disk file by offset, so remap every offset back through the saved
+        // sourcemap to original-file bytes. vm.Script / eval / builtins have no
+        // saved sourcemap; the remap call reports false for those and their
+        // offsets already index the text the caller gave.
+        Vector<int32_t> remap;
+        remap.reserveInitialCapacity(blocks.size() * 2 + functionRanges.size() * 2);
+        for (const auto& block : blocks) {
+            remap.append(block.m_startOffset);
+            remap.append(block.m_endOffset);
+        }
+        for (const auto& functionRange : functionRanges) {
+            remap.append(static_cast<int32_t>(std::get<1>(functionRange)));
+            remap.append(static_cast<int32_t>(std::get<2>(functionRange)));
+        }
+        uint32_t sourceLength = provider->source().length();
+        auto transpiledSource = provider->source().toStringWithoutCopying();
+        bool remapped = InspectorCoverage__remapOffsets(
+            Bun::toString(provider->sourceURL()),
+            Bun::toString(transpiledSource),
+            remap.begin(),
+            remap.size(),
+            &sourceLength);
+
         auto script = JSON::Object::create();
         // A `//# sourceURL` directive overrides the script's resource name,
         // like it does in V8's coverage output.
         const String& sourceURLDirective = provider->sourceURLDirective();
         script->setString("url"_s, sourceURLDirective.isEmpty() ? provider->sourceURL() : sourceURLDirective);
         script->setDouble("scriptId"_s, static_cast<double>(sourceID));
-        script->setDouble("sourceLength"_s, static_cast<double>(provider->source().length()));
+        script->setDouble("sourceLength"_s, static_cast<double>(sourceLength));
 
+        auto namesForSource = functionNames.find(sourceID);
+        size_t i = 0;
+        // Blocks and functions carry the raw (transpiled) start/end for the JS
+        // layer's containment sort and, when the source was remapped, the
+        // original-file start/end for the emitted CoverageRange.
         auto blockArray = JSON::Array::create();
         for (const auto& block : blocks) {
             auto range = JSON::Array::create();
             range->pushInteger(block.m_startOffset);
             range->pushInteger(block.m_endOffset);
             range->pushDouble(static_cast<double>(block.m_executionCount));
+            if (remapped) {
+                range->pushInteger(remap[i]);
+                range->pushInteger(remap[i + 1]);
+            }
+            i += 2;
             blockArray->pushValue(WTF::move(range));
         }
         script->setValue("blocks"_s, WTF::move(blockArray));
@@ -137,9 +190,21 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
         auto functionArray = JSON::Array::create();
         for (const auto& functionRange : functionRanges) {
             auto range = JSON::Array::create();
-            range->pushDouble(static_cast<double>(std::get<1>(functionRange)));
-            range->pushDouble(static_cast<double>(std::get<2>(functionRange)));
+            range->pushInteger(static_cast<int32_t>(std::get<1>(functionRange)));
+            range->pushInteger(static_cast<int32_t>(std::get<2>(functionRange)));
             range->pushBoolean(std::get<0>(functionRange));
+            String name = emptyString();
+            if (namesForSource != functionNames.end()) {
+                auto found = namesForSource->value.find(rangeKey(std::get<1>(functionRange), std::get<2>(functionRange)));
+                if (found != namesForSource->value.end())
+                    name = found->value;
+            }
+            range->pushString(name);
+            if (remapped) {
+                range->pushInteger(remap[i]);
+                range->pushInteger(remap[i + 1]);
+            }
+            i += 2;
             functionArray->pushValue(WTF::move(range));
         }
         script->setValue("functions"_s, WTF::move(functionArray));

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -89,15 +89,12 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
     if (!profiler)
         return JSValue::encode(jsNull());
 
-    // Enumerate SourceIDs by walking only the four ScriptExecutable subspaces
-    // (not the whole heap). Providers whose executables were all GC'd are not
-    // reported. FunctionHasExecutedCache carries no names, so also index every
-    // live FunctionExecutable's ecmaName by its (sourceID, start offset) to
-    // fill FunctionCoverage.functionName.
+    // FunctionHasExecutedCache carries no names, so also index each live
+    // FunctionExecutable's ecmaName by (functionStart, functionEnd) during the
+    // same ScriptExecutable-subspace walk that enumerates SourceIDs. The key
+    // packs both offsets so it is never 0 (WTF's empty integer hash key).
     Vector<Ref<JSC::SourceProvider>> providers;
     HashSet<SourceID> seenSourceIDs;
-    // Key packs (functionStart, functionEnd) so it is never 0 (WTF's empty
-    // hash key for integers) even for a function at byte 0.
     UncheckedKeyHashMap<SourceID, UncheckedKeyHashMap<uint64_t, String>> functionNames;
     auto rangeKey = [](unsigned start, unsigned end) -> uint64_t {
         return (static_cast<uint64_t>(start) << 32) | static_cast<uint64_t>(end);
@@ -115,9 +112,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
                     providers.append(*provider);
                 if (executable->type() == FunctionExecutableType) {
                     auto* fn = static_cast<FunctionExecutable*>(executable);
-                    // functionStart()/functionEnd() equal typeProfilingStart/End,
-                    // which are what FunctionHasExecutedCache stores, so the
-                    // (start, end) pair keys the join.
+                    // functionStart()/End() == typeProfilingStart/End(), the same offsets FunctionHasExecutedCache stores.
                     functionNames.add(sourceID, UncheckedKeyHashMap<uint64_t, String> {})
                         .iterator->value.add(rangeKey(fn->functionStart(), fn->functionEnd()), fn->ecmaName().string());
                 }
@@ -133,13 +128,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
         if (blocks.isEmpty() && functionRanges.isEmpty())
             continue;
 
-        // JSC's offsets index the text the VM compiled, which for Bun-loaded
-        // modules is the runtime-transpiled output (comments stripped, class
-        // declarations hoisted, TS lowered). V8-coverage consumers slice the
-        // on-disk file by offset, so remap every offset back through the saved
-        // sourcemap to original-file bytes. vm.Script / eval / builtins have no
-        // saved sourcemap; the remap call reports false for those and their
-        // offsets already index the text the caller gave.
+        // JSC's offsets index the runtime-transpiled text for Bun-loaded modules
+        // (comments stripped, classes hoisted, TS lowered); remap them through
+        // the saved sourcemap to original-file bytes so V8-coverage consumers
+        // that slice the on-disk file see the right text. vm.Script/eval have
+        // no saved sourcemap, so the remap call returns false for those.
         Vector<int32_t> remap;
         remap.reserveInitialCapacity(blocks.size() * 2 + functionRanges.size() * 2);
         for (const auto& block : blocks) {
@@ -169,9 +162,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
 
         auto namesForSource = functionNames.find(sourceID);
         size_t i = 0;
-        // Blocks and functions carry the raw (transpiled) start/end for the JS
-        // layer's containment sort and, when the source was remapped, the
-        // original-file start/end for the emitted CoverageRange.
+        // Emit raw offsets (for the JS layer's containment sort) and, when remapped, original-file offsets.
         auto blockArray = JSON::Array::create();
         for (const auto& block : blocks) {
             auto range = JSON::Array::create();

--- a/src/sourcemap_jsc/Cargo.toml
+++ b/src/sourcemap_jsc/Cargo.toml
@@ -31,4 +31,5 @@ bun_paths.workspace = true
 # re-gated on bun_runtime::bake::production::PerThread. Dep dropped to keep
 # this crate's transitive surface minimal during B-2.
 bun_sourcemap.workspace = true
+bun_sys.workspace = true
 bun_wyhash.workspace = true

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -984,21 +984,27 @@ pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
 
     // The original text is what external consumers (c8, v8-to-istanbul) read
     // from disk; we need its line-start table to turn the sourcemap's
-    // (line, column) answers back into byte offsets.
+    // (line, column) answers back into byte offsets. The `OwnedLineOffsetTables`
+    // wrapper runs `MultiArrayList::drop_elements` so each line's
+    // `columns_for_non_ascii` box is freed (the bare list's `Drop` is
+    // slab-only by design).
     let original = match bun_sys::File::read_from(bun_core::Fd::cwd(), path.slice()) {
         Ok(bytes) => bytes,
         Err(_) => return false,
     };
-    let Ok(original_table) = LineOffsetTable::generate(&original, 0) else {
+    let Ok(table) = LineOffsetTable::generate(&original, 0) else {
         return false;
     };
-    let original_starts = original_table.items_byte_offset_to_start_of_line();
+    let original_table = bun_sourcemap::chunk::OwnedLineOffsetTables(table);
+    let original_starts = original_table.0.items_byte_offset_to_start_of_line();
+    let original_first_na = original_table.0.items_byte_offset_to_first_non_ascii();
 
     let transpiled = transpiled.to_utf8();
-    let Ok(transpiled_table) = LineOffsetTable::generate(transpiled.slice(), 0) else {
+    let Ok(table) = LineOffsetTable::generate(transpiled.slice(), 0) else {
         return false;
     };
-    let transpiled_starts = transpiled_table.items_byte_offset_to_start_of_line();
+    let transpiled_table = bun_sourcemap::chunk::OwnedLineOffsetTables(table);
+    let transpiled_starts = transpiled_table.0.items_byte_offset_to_start_of_line();
 
     // SAFETY: caller contract.
     let offsets = unsafe { core::slice::from_raw_parts_mut(offsets, count) };
@@ -1039,8 +1045,23 @@ pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
             // output line that would otherwise start past column 0
             // (`cover_lines_without_mappings` in `sourcemap::Chunk`), so bytes
             // between a mapping and the target do not line up 1:1.
-            let mut remapped =
-                original_starts[orig_line as usize] as i32 + m.original.columns.zero_based();
+            // Sourcemap columns are UTF-16 code units; invert `add_source_mapping`'s
+            // byte->code-unit table when this original line has non-ASCII before
+            // the mapped position so the code-unit column becomes a byte column.
+            let orig_col_units = m.original.columns.zero_based();
+            let first_na = original_first_na[orig_line as usize];
+            let orig_col_bytes = if orig_col_units >= 0 && (orig_col_units as u32) >= first_na {
+                let cols: &[i32] = &original_table
+                    .0
+                    .items::<"columns_for_non_ascii", Box<[i32]>>()[orig_line as usize];
+                first_na as i32
+                    + cols
+                        .partition_point(|&c| c < orig_col_units)
+                        .min(cols.len().saturating_sub(1)) as i32
+            } else {
+                orig_col_units
+            };
+            let mut remapped = original_starts[orig_line as usize] as i32 + orig_col_bytes;
             // Closing `}` has no explicit mapping (FnBody carries no
             // close_brace_loc), so an end offset lands on the last statement's
             // start. Extend to the end of that original line so the range still
@@ -1057,7 +1078,7 @@ pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
             remapped.clamp(0, original_len)
         };
 
-    for pair in offsets.chunks_exact_mut(2) {
+    for pair in offsets.as_chunks_mut::<2>().0 {
         let start = remap_one(pair[0], false, &mut cursor);
         let end = remap_one(pair[1], true, &mut cursor);
         pair[0] = start;

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -946,3 +946,125 @@ pub struct Block {
     pub start_line: u32,
     pub end_line: u32,
 }
+
+/// Remap ControlFlowProfiler byte offsets (which index the runtime-transpiled
+/// source JSC compiled) back to byte offsets into the original file on disk,
+/// so `Profiler.takePreciseCoverage` output matches what Node/V8 produce for
+/// the same file. Scripts with no saved sourcemap (vm.Script, eval, modules
+/// the transpiler passed through untouched) return false and keep their
+/// offsets unchanged.
+///
+/// # Safety
+/// `offsets` must point to `count` writable `i32`s and `out_original_len` to a
+/// writable `u32`. Must be called on the JS thread (touches the per-VM
+/// `SavedSourceMap`).
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
+    source_url: bun_core::String,
+    transpiled: bun_core::String,
+    offsets: *mut i32,
+    count: usize,
+    out_original_len: *mut u32,
+) -> bool {
+    let path = source_url.to_utf8();
+    // Only filesystem-backed modules have a saved sourcemap AND a file to read
+    // the original text from. vm.Script / eval / builtins fall through here.
+    if !bun_paths::is_absolute(path.slice()) {
+        return false;
+    }
+
+    // SAFETY: JS-thread-only; `VirtualMachine::get()` returns the live singleton.
+    let Some(parsed) = bun_jsc::VirtualMachine::VirtualMachine::get()
+        .as_mut()
+        .source_mappings()
+        .get(path.slice())
+    else {
+        return false;
+    };
+
+    // The original text is what external consumers (c8, v8-to-istanbul) read
+    // from disk; we need its line-start table to turn the sourcemap's
+    // (line, column) answers back into byte offsets.
+    let original = match bun_sys::File::read_from(bun_core::Fd::cwd(), path.slice()) {
+        Ok(bytes) => bytes,
+        Err(_) => return false,
+    };
+    let Ok(original_table) = LineOffsetTable::generate(&original, 0) else {
+        return false;
+    };
+    let original_starts = original_table.items_byte_offset_to_start_of_line();
+
+    let transpiled = transpiled.to_utf8();
+    let Ok(transpiled_table) = LineOffsetTable::generate(transpiled.slice(), 0) else {
+        return false;
+    };
+    let transpiled_starts = transpiled_table.items_byte_offset_to_start_of_line();
+
+    // SAFETY: caller contract.
+    let offsets = unsafe { core::slice::from_raw_parts_mut(offsets, count) };
+    let original_len = i32::try_from(original.len()).unwrap_or(i32::MAX);
+    let mut cursor = parsed.internal_cursor();
+
+    let remap_one =
+        |off: i32, is_end: bool, cursor: &mut Option<internal_source_map::Cursor>| -> i32 {
+            if off < 0 {
+                return off;
+            }
+            let line = LineOffsetTable::find_line(transpiled_starts, Loc { start: off });
+            if line < 0 {
+                return if is_end { original_len } else { 0 };
+            }
+            let line_start = transpiled_starts[line as usize] as i32;
+            let col = off - line_start;
+            let found = if let Some(c) = cursor.as_mut() {
+                c.move_to(
+                    Ordinal::from_zero_based(line),
+                    Ordinal::from_zero_based(col),
+                )
+            } else {
+                parsed.find_mapping(
+                    Ordinal::from_zero_based(line),
+                    Ordinal::from_zero_based(col),
+                )
+            };
+            let Some(m) = found else {
+                return if is_end { original_len } else { 0 };
+            };
+            let orig_line = m.original.lines.zero_based();
+            if orig_line < 0 || (orig_line as usize) >= original_starts.len() {
+                return if is_end { original_len } else { 0 };
+            }
+            // The nearest-at-or-before mapping's original position. No byte-delta
+            // carry: the builder inserts a synthetic column-0 mapping on every
+            // output line that would otherwise start past column 0
+            // (`cover_lines_without_mappings` in `sourcemap::Chunk`), so bytes
+            // between a mapping and the target do not line up 1:1.
+            let mut remapped =
+                original_starts[orig_line as usize] as i32 + m.original.columns.zero_based();
+            // Closing `}` has no explicit mapping (FnBody carries no
+            // close_brace_loc), so an end offset lands on the last statement's
+            // start. Extend to the end of that original line so the range still
+            // encloses the function body for line-based coverage consumers.
+            if is_end {
+                let next_line = orig_line as usize + 1;
+                let line_end = if next_line < original_starts.len() {
+                    original_starts[next_line] as i32
+                } else {
+                    original_len
+                };
+                remapped = remapped.max(line_end);
+            }
+            remapped.clamp(0, original_len)
+        };
+
+    for pair in offsets.chunks_exact_mut(2) {
+        let start = remap_one(pair[0], false, &mut cursor);
+        let end = remap_one(pair[1], true, &mut cursor);
+        pair[0] = start;
+        pair[1] = start.max(end);
+    }
+
+    // SAFETY: caller contract.
+    unsafe { *out_original_len = original_len as u32 };
+    true
+}

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -1042,10 +1042,13 @@ pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
                 let cols: &[i32] = &original_table
                     .0
                     .items::<"columns_for_non_ascii", Box<[i32]>>()[orig_line as usize];
+                // A codepoint's continuation bytes carry the NEXT column (the
+                // extend in `generate` runs before `column +=`), so pick the
+                // last index in the equal-value run, not the first.
                 first_na as i32
                     + cols
-                        .partition_point(|&c| c < orig_col_units)
-                        .min(cols.len().saturating_sub(1)) as i32
+                        .partition_point(|&c| c <= orig_col_units)
+                        .saturating_sub(1) as i32
             } else {
                 orig_col_units
             };

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -948,16 +948,12 @@ pub struct Block {
 }
 
 /// Remap ControlFlowProfiler byte offsets (which index the runtime-transpiled
-/// source JSC compiled) back to byte offsets into the original file on disk,
-/// so `Profiler.takePreciseCoverage` output matches what Node/V8 produce for
-/// the same file. Scripts with no saved sourcemap (vm.Script, eval, modules
-/// the transpiler passed through untouched) return false and keep their
-/// offsets unchanged.
+/// source JSC compiled) to byte offsets into the original file on disk, so
+/// `Profiler.takePreciseCoverage` matches Node/V8 for the same file. Returns
+/// false (offsets unchanged) for scripts with no saved sourcemap.
 ///
-/// # Safety
-/// `offsets` must point to `count` writable `i32`s and `out_original_len` to a
-/// writable `u32`. Must be called on the JS thread (touches the per-VM
-/// `SavedSourceMap`).
+/// SAFETY: `offsets` points to `count` writable `i32`s and `out_original_len`
+/// to a writable `u32`; JS-thread-only (touches the per-VM `SavedSourceMap`).
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
     source_url: bun_core::String,
@@ -967,8 +963,7 @@ pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
     out_original_len: *mut u32,
 ) -> bool {
     let path = source_url.to_utf8();
-    // Only filesystem-backed modules have a saved sourcemap AND a file to read
-    // the original text from. vm.Script / eval / builtins fall through here.
+    // vm.Script / eval / builtins: no file on disk, no saved sourcemap.
     if !bun_paths::is_absolute(path.slice()) {
         return false;
     }
@@ -982,12 +977,8 @@ pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
         return false;
     };
 
-    // The original text is what external consumers (c8, v8-to-istanbul) read
-    // from disk; we need its line-start table to turn the sourcemap's
-    // (line, column) answers back into byte offsets. The `OwnedLineOffsetTables`
-    // wrapper runs `MultiArrayList::drop_elements` so each line's
-    // `columns_for_non_ascii` box is freed (the bare list's `Drop` is
-    // slab-only by design).
+    // `OwnedLineOffsetTables` runs `drop_elements` so each non-ASCII line's
+    // `columns_for_non_ascii` box is freed (`MultiArrayList::Drop` is slab-only).
     let original = match bun_sys::File::read_from(bun_core::Fd::cwd(), path.slice()) {
         Ok(bytes) => bytes,
         Err(_) => return false,
@@ -1040,14 +1031,11 @@ pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
             if orig_line < 0 || (orig_line as usize) >= original_starts.len() {
                 return if is_end { original_len } else { 0 };
             }
-            // The nearest-at-or-before mapping's original position. No byte-delta
-            // carry: the builder inserts a synthetic column-0 mapping on every
-            // output line that would otherwise start past column 0
-            // (`cover_lines_without_mappings` in `sourcemap::Chunk`), so bytes
-            // between a mapping and the target do not line up 1:1.
-            // Sourcemap columns are UTF-16 code units; invert `add_source_mapping`'s
-            // byte->code-unit table when this original line has non-ASCII before
-            // the mapped position so the code-unit column becomes a byte column.
+            // Use the nearest mapping's original position as-is (no byte-delta
+            // carry: `cover_lines_without_mappings` inserts synthetic column-0
+            // mappings, so bytes between a mapping and the target do not line
+            // up 1:1). Sourcemap columns are UTF-16 code units, so invert the
+            // line's `columns_for_non_ascii` table back to a byte column.
             let orig_col_units = m.original.columns.zero_based();
             let first_na = original_first_na[orig_line as usize];
             let orig_col_bytes = if orig_col_units >= 0 && (orig_col_units as u32) >= first_na {
@@ -1062,10 +1050,9 @@ pub(crate) unsafe extern "C" fn InspectorCoverage__remapOffsets(
                 orig_col_units
             };
             let mut remapped = original_starts[orig_line as usize] as i32 + orig_col_bytes;
-            // Closing `}` has no explicit mapping (FnBody carries no
-            // close_brace_loc), so an end offset lands on the last statement's
-            // start. Extend to the end of that original line so the range still
-            // encloses the function body for line-based coverage consumers.
+            // A closing `}` has no mapping of its own (FnBody has no
+            // close_brace_loc), so extend end offsets to the end of the mapped
+            // original line so the range still encloses the function body.
             if is_end {
                 let next_line = orig_line as usize + 1;
                 let line_end = if next_line < original_starts.len() {

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -679,9 +679,8 @@ console.log(JSON.stringify(entry));
       expect(byName("alpha").ranges[0].startOffset).toBe(bytes.indexOf("function alpha"));
       expect(byName("m").ranges[0].startOffset).toBe(bytes.indexOf("m() {"));
       expect(byName("caf\u00e9").ranges[0].startOffset).toBe(bytes.indexOf("function caf\u00e9"));
-      // The CJK method 語 is on a line with earlier non-ASCII (the other
-      // method body returns '語'), so its UTF-16 column sits inside an
-      // equal-value run of columns_for_non_ascii.
+      // 語 is a 3-byte BMP codepoint (é is 2, 🎉 is astral), exercising the
+      // columns_for_non_ascii inversion at first_na exactly.
       expect(slice(byName("\u8a9e"))).toStartWith("\u8a9e() { return '\u8a9e'; }");
       expect(byName("\u8a9e").ranges[0].startOffset).toBe(bytes.indexOf("\u8a9e() {"));
     });

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -619,7 +619,7 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
         "export function alpha() { return 'A'; }   // called 3x",
         "export function beta() { return 'B'; }    // called 1x",
         "const tag='\u00e9\u{1f389}'; export function caf\u00e9() { return tag; }   // non-ASCII before the function",
-        "export class Zed { m() { return 'Z'; } }   // hoisted in the transpiled text",
+        "export class Zed { m() { return 'Z'; } \u8a9e() { return '\u8a9e'; } }   // hoisted in the transpiled text",
         "",
       ].join("\n");
       using dir = tempDir("inspector-coverage-original", {
@@ -631,7 +631,7 @@ session.connect();
 await session.post("Profiler.enable");
 await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
 const M = await import("./m.mjs");
-M.alpha(); M.alpha(); M.alpha(); M.beta(); new M.Zed().m(); M.caf\u00e9();
+M.alpha(); M.alpha(); M.alpha(); M.beta(); const z = new M.Zed(); z.m(); z.\u8a9e(); M.caf\u00e9();
 const coverage = await session.post("Profiler.takePreciseCoverage");
 await session.post("Profiler.stopPreciseCoverage");
 session.disconnect();
@@ -679,6 +679,11 @@ console.log(JSON.stringify(entry));
       expect(byName("alpha").ranges[0].startOffset).toBe(bytes.indexOf("function alpha"));
       expect(byName("m").ranges[0].startOffset).toBe(bytes.indexOf("m() {"));
       expect(byName("caf\u00e9").ranges[0].startOffset).toBe(bytes.indexOf("function caf\u00e9"));
+      // The CJK method 語 is on a line with earlier non-ASCII (the other
+      // method body returns '語'), so its UTF-16 column sits inside an
+      // equal-value run of columns_for_non_ascii.
+      expect(slice(byName("\u8a9e"))).toStartWith("\u8a9e() { return '\u8a9e'; }");
+      expect(byName("\u8a9e").ranges[0].startOffset).toBe(bytes.indexOf("\u8a9e() {"));
     });
   });
 

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -618,6 +618,7 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
         "// header comment that the runtime transpiler strips",
         "export function alpha() { return 'A'; }   // called 3x",
         "export function beta() { return 'B'; }    // called 1x",
+        "const tag='\u00e9\u{1f389}'; export function caf\u00e9() { return tag; }   // non-ASCII before the function",
         "export class Zed { m() { return 'Z'; } }   // hoisted in the transpiled text",
         "",
       ].join("\n");
@@ -630,7 +631,7 @@ session.connect();
 await session.post("Profiler.enable");
 await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
 const M = await import("./m.mjs");
-M.alpha(); M.alpha(); M.alpha(); M.beta(); new M.Zed().m();
+M.alpha(); M.alpha(); M.alpha(); M.beta(); new M.Zed().m(); M.caf\u00e9();
 const coverage = await session.post("Profiler.takePreciseCoverage");
 await session.post("Profiler.stopPreciseCoverage");
 session.disconnect();
@@ -651,10 +652,11 @@ console.log(JSON.stringify(entry));
       }).toEqual({ alpha: 3, beta: 1, m: 1 });
 
       // The whole-script range must cover the on-disk file length, not the
-      // transpiled text's length (which is shorter: no comments).
+      // transpiled text's length (which is shorter: no comments). Byte length,
+      // not JS string length: the source contains multi-byte characters.
       expect(entry.functions[0].ranges[0]).toEqual({
         startOffset: 0,
-        endOffset: moduleSource.length,
+        endOffset: Buffer.byteLength(moduleSource),
         count: 1,
       });
 
@@ -663,14 +665,20 @@ console.log(JSON.stringify(entry));
       // are line-granular (the closing brace has no sourcemap entry of its own),
       // so the slice may extend to the end of the line like Node's ranges do
       // for wrapped CJS modules.
-      const slice = (fn: any) => moduleSource.slice(fn.ranges[0].startOffset, fn.ranges[0].endOffset);
+      const bytes = Buffer.from(moduleSource);
+      const slice = (fn: any) => bytes.toString("utf8", fn.ranges[0].startOffset, fn.ranges[0].endOffset);
       expect(slice(byName("alpha"))).toStartWith("function alpha() { return 'A'; }");
       expect(slice(byName("beta"))).toStartWith("function beta() { return 'B'; }");
       expect(slice(byName("m"))).toStartWith("m() { return 'Z'; }");
+      // The line before café() has non-ASCII bytes (é is 2 UTF-8 bytes, 🎉 is 4)
+      // before the function; the remap must convert the sourcemap's UTF-16
+      // column back to a byte column so startOffset lands on the function.
+      expect(slice(byName("caf\u00e9"))).toStartWith("function caf\u00e9() { return tag; }");
       // Before the offset remap, the class-hoisted transpiled offsets for m()
       // landed inside the header comment when sliced out of the on-disk file.
-      expect(byName("alpha").ranges[0].startOffset).toBe(moduleSource.indexOf("function alpha"));
-      expect(byName("m").ranges[0].startOffset).toBe(moduleSource.indexOf("m() {"));
+      expect(byName("alpha").ranges[0].startOffset).toBe(bytes.indexOf("function alpha"));
+      expect(byName("m").ranges[0].startOffset).toBe(bytes.indexOf("m() {"));
+      expect(byName("caf\u00e9").ranges[0].startOffset).toBe(bytes.indexOf("function caf\u00e9"));
     });
   });
 

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -549,10 +549,12 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       // neverCalled() reports a single function-granularity range with count 0.
       const neverCalledEntry = entryCoveringOffset(entry.functions, offsets.neverCalledBody);
       expect(neverCalledEntry).toEqual({
-        functionName: "",
+        functionName: "neverCalled",
         isBlockCoverage: false,
         ranges: [{ startOffset: expect.any(Number), endOffset: expect.any(Number), count: 0 }],
       });
+      expect(addEntry.functionName).toBe("add");
+      expect(classifyEntry.functionName).toBe("classify");
     });
 
     test.concurrent("respects callCount: false and detailed: false", async () => {
@@ -605,6 +607,70 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       // double() ran twice, neverCalled() never ran.
       expect(functionCounts).toContain(2);
       expect(functionCounts).toContain(0);
+    });
+
+    // The runtime transpiler strips comments and hoists class declarations, so
+    // JSC's coverage offsets index a text that differs from the file on disk.
+    // V8-coverage consumers (c8, v8-to-istanbul) slice the on-disk file by
+    // offset, so the reported ranges must be remapped to original-file bytes.
+    test.concurrent("offsets and functionName address the original file for Bun-transpiled modules", async () => {
+      const moduleSource = [
+        "// header comment that the runtime transpiler strips",
+        "export function alpha() { return 'A'; }   // called 3x",
+        "export function beta() { return 'B'; }    // called 1x",
+        "export class Zed { m() { return 'Z'; } }   // hoisted in the transpiled text",
+        "",
+      ].join("\n");
+      using dir = tempDir("inspector-coverage-original", {
+        "m.mjs": moduleSource,
+        "fixture.mjs": `
+import { Session } from "node:inspector/promises";
+const session = new Session();
+session.connect();
+await session.post("Profiler.enable");
+await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+const M = await import("./m.mjs");
+M.alpha(); M.alpha(); M.alpha(); M.beta(); new M.Zed().m();
+const coverage = await session.post("Profiler.takePreciseCoverage");
+await session.post("Profiler.stopPreciseCoverage");
+session.disconnect();
+const entry = coverage.result.find(s => s.url.endsWith("m.mjs"));
+console.log(JSON.stringify(entry));
+`,
+      });
+      await using proc = Bun.spawn({ cmd: [bunExe(), "fixture.mjs"], env: bunEnv, cwd: String(dir), stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+      const entry = JSON.parse(stdout.trim());
+
+      const byName = (name: string) => entry.functions.find((f: any) => f.functionName === name);
+      expect({
+        alpha: byName("alpha")?.ranges[0].count,
+        beta: byName("beta")?.ranges[0].count,
+        m: byName("m")?.ranges[0].count,
+      }).toEqual({ alpha: 3, beta: 1, m: 1 });
+
+      // The whole-script range must cover the on-disk file length, not the
+      // transpiled text's length (which is shorter: no comments).
+      expect(entry.functions[0].ranges[0]).toEqual({
+        startOffset: 0,
+        endOffset: moduleSource.length,
+        count: 1,
+      });
+
+      // Each function's primary range, sliced out of the on-disk file, must
+      // start at the function's own text and contain its full body. End offsets
+      // are line-granular (the closing brace has no sourcemap entry of its own),
+      // so the slice may extend to the end of the line like Node's ranges do
+      // for wrapped CJS modules.
+      const slice = (fn: any) => moduleSource.slice(fn.ranges[0].startOffset, fn.ranges[0].endOffset);
+      expect(slice(byName("alpha"))).toStartWith("function alpha() { return 'A'; }");
+      expect(slice(byName("beta"))).toStartWith("function beta() { return 'B'; }");
+      expect(slice(byName("m"))).toStartWith("m() { return 'Z'; }");
+      // Before the offset remap, the class-hoisted transpiled offsets for m()
+      // landed inside the header comment when sliced out of the on-disk file.
+      expect(byName("alpha").ranges[0].startOffset).toBe(moduleSource.indexOf("function alpha"));
+      expect(byName("m").ranges[0].startOffset).toBe(moduleSource.indexOf("m() {"));
     });
   });
 


### PR DESCRIPTION
`Profiler.takePreciseCoverage` on the in-process `node:inspector` Session now reports real `FunctionCoverage.functionName` values and byte offsets that index the original source file on disk, instead of empty names and offsets into Bun's runtime-transpiled module text.

## Repro

```js
import inspector from "node:inspector";
import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
import { join } from "node:path"; import { tmpdir } from "node:os"; import { pathToFileURL } from "node:url";
const dir = mkdtempSync(join(tmpdir(), "cov-")); const mod = join(dir, "m.mjs");
writeFileSync(mod, ["// header comment that the runtime transpiler strips",
  "export function alpha() { return 'A'; }   // called 3x",
  "export function beta() { return 'B'; }    // called 1x",
  "export class Zed { m() { return 'Z'; } }   // hoisted to the top of the transpiled text", ""].join("\n"));
const s = new inspector.Session(); s.connect();
const post = (m, p) => new Promise((res, rej) => s.post(m, p ?? {}, (e, r) => (e ? rej(e) : res(r))));
await post("Profiler.enable");
await post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
const M = await import(pathToFileURL(mod)); M.alpha(); M.alpha(); M.alpha(); M.beta(); new M.Zed().m();
const { result } = await post("Profiler.takePreciseCoverage");
const sc = result.find(x => /m\.mjs$/.test(x.url)); const file = readFileSync(mod, "utf8");
for (const f of sc.functions) { const r = f.ranges[0];
  console.log(JSON.stringify(f.functionName), r.count, JSON.stringify(file.slice(r.startOffset, r.endOffset).slice(0, 40))); }
```

Before: every `functionName` is `""`; the count-3 range slices to `"ort function alpha() { return 'A'"` because the offsets index the transpiled text (class hoisted above the functions, comments gone) while the url names the on-disk file.

After:
```
"" 1 "// header comment that the runtime trans"
"alpha" 3 "function alpha() { return 'A'; }   // ca"
"beta" 1 "function beta() { return 'B'; }    // ca"
"m" 1 "m() { return 'Z'; } }   // hoisted to th"
```

Node for comparison:
```
"" 1 "// header comment that the runtime trans"
"alpha" 3 "function alpha() { return 'A'; }"
"beta" 1 "function beta() { return 'B'; }"
"m" 1 "m() { return 'Z'; }"
```

## Cause

JSC's `ControlFlowProfiler` and `FunctionHasExecutedCache` report byte offsets into the text the VM compiled, which for Bun-loaded modules is the runtime-transpiled output. Any V8-coverage consumer that reads the file named by `url` from disk (c8, v8-to-istanbul) slices the wrong bytes. And `FunctionHasExecutedCache` carries no names, so `functionName` was always `""`.

## Fix

- **Names**: during the existing `ScriptExecutable` heap walk, index every live `FunctionExecutable`'s `ecmaName()` by `(functionStart, functionEnd)` (the same offsets `FunctionHasExecutedCache` stores, so the join is exact) and emit it alongside each function range.
- **Offsets**: a new `InspectorCoverage__remapOffsets` FFI looks up the module's sourcemap in `SavedSourceMap` (the same map error-stack remapping uses), reads the original file, and maps each `(start, end)` back through transpiled byte → (line, col) → sourcemap → original (line, col) → original byte. End offsets extend to the end of the mapped original line because the printer emits no explicit mapping at a function body's closing `}` (`FnBody` has no `close_brace_loc`), so the nearest mapping is the last statement's start. Block-to-function assignment in the JS layer still uses the raw transpiled offsets so containment holds across the class-hoisting reorder; only the emitted `CoverageRange` values are remapped. `vm.Script` / `eval` / builtins have no saved sourcemap and keep their offsets unchanged, which already index the text the caller gave.

## Verification

`test/js/node/inspector/inspector-profiler.test.ts` gains a spawned fixture with a header comment, two named functions, and a class (the same shapes the runtime transpiler reorders), asserting `functionName` is `alpha`/`beta`/`m` with the right call counts and that `startOffset` lands on each function's text when slicing the on-disk file. The existing vm-script test now asserts real names too. `test/cli/test/coverage.test.ts` (bun's own lcov coverage, which shares the control-flow profiler) still passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (a15832307)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [24.95ms]
(pass) node:inspector > Session > Session extends EventEmitter [5.00ms]
(pass) node:inspector > Session > connect() establishes connection [10.43ms]
(pass) node:inspector > Session > connect() throws if already connected [7.87ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [9.09ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [4.93ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [4.45ms]
(pass) node:inspector > Session > post() throws if not connected [15.00ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [17.23ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [36.52ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [5.33ms]
(pass) node:inspe
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [0.32ms]
(pass) node:inspector > Session > Session extends EventEmitter [0.06ms]
(pass) node:inspector > Session > connect() establishes connection [0.39ms]
(pass) node:inspector > Session > connect() throws if already connected [0.11ms]
151 |       session.connect();
152 |       expect(() => session.connect()).toThrow("already connected");
153 |     });
154 | 
155 |     test("connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread", () => {
156 |       expect(() => session.connectToMainThread()).toThrow(
                                                        ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: undefined

      at <anonymous> (/workspace/bun/test/js/node/inspector/inspector-profiler.test.ts:156:51)
(fail) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [0.40ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [0.08ms]
(pass) no
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (a15832307)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [17.72ms]
(pass) node:inspector > Session > Session extends EventEmitter [4.13ms]
(pass) node:inspector > Session > connect() establishes connection [8.49ms]
(pass) node:inspector > Session > connect() throws if already connected [4.91ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [6.24ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [2.96ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.58ms]
(pass) node:inspector > Session > post() throws if not connected [8.29ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [11.85ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [24.17ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [2.76ms]
(pass) node:inspect
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a15832307b
  features     baseline

22 deps, 108 codegen, 1171 objects in 3465ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch picohttpparser
[picohttpparser] up to date
[2/1234] fetch zlib
[zlib] up to date
[3/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1234] fetch tinycc
[tinycc] up to date
[5/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1234] subst deps/zlib/zlib.h
[7/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1234] gen bindgenv2
[9/1234] gen ErrorCode+*.h
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] subst deps/zlib/zconf.h
[12/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[13/1234] fetch zstd
[zstd] up to date
[14/1234] subst deps/libjpeg-turbo/jconfigint.h
[15/1234] subst deps/libjpeg-turbo/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
Cargo.lock                                        |   1 +
 src/js/node/inspector.ts                          |  36 +++---
 src/jsc/bindings/JSInspectorProfiler.cpp          |  82 ++++++++++---
 src/sourcemap_jsc/Cargo.toml                      |   1 +
 src/sourcemap_jsc/CodeCoverage.rs                 | 133 ++++++++++++++++++++++
 test/js/node/inspector/inspector-profiler.test.ts |  80 ++++++++++++-
 6 files changed, 302 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
Cargo.lock                                             0      0      0
src/js/node/inspector.ts                               3      6      0
src/jsc/bindings/JSInspectorProfiler.cpp               2     12      0
src/sourcemap_jsc/Cargo.toml                           1      1      0
src/sourcemap_jsc/CodeCoverage.rs                      5     10      0
test/js/node/inspector/inspector-profiler.test.ts      4     11      0
```

</details>

<!-- robobun:evidence:end -->