### PR TITLE
plugin: preserve raw bytes when onLoad/build.module returns an ArrayBufferView

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -301,7 +301,10 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
                 result.value.sourceText.value = contentsValue;
             }
         } else if (JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(contentsValue)) {
-            result.value.sourceText.string = ZigString { reinterpret_cast<const unsigned char*>(view->vector()), view->byteLength() };
+            // Raw bytes from a typed array are opaque to us: tag as UTF-8 so the
+            // Rust side's ZigString::to_slice() does not Latin-1 -> UTF-8 transcode
+            // bytes >= 0x80 (which would corrupt UTF-8 source and binary payloads).
+            result.value.sourceText.string = ZigString { Zig::taggedUTF8Ptr(reinterpret_cast<const unsigned char*>(view->vector())), view->byteLength() };
             result.value.sourceText.value = contentsValue;
         }
     }

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -268,6 +268,11 @@ static const unsigned char* taggedUTF16Ptr(const char16_t* ptr)
     return reinterpret_cast<const unsigned char*>(reinterpret_cast<uintptr_t>(ptr) | (static_cast<uint64_t>(1) << 63));
 }
 
+static const unsigned char* taggedUTF8Ptr(const unsigned char* ptr)
+{
+    return reinterpret_cast<const unsigned char*>(reinterpret_cast<uintptr_t>(ptr) | (static_cast<uint64_t>(1) << 61));
+}
+
 static ZigString toZigString(WTF::String* str)
 {
     return str->isEmpty()

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -196,6 +196,39 @@ plugin({
   },
 });
 
+plugin({
+  name: "typed array contents",
+  setup(builder) {
+    // UTF-8 source with a non-ASCII literal. The UTF-8 bytes for "é" are
+    // [0xC3, 0xA9]; if those bytes were (wrongly) Latin-1 decoded and then
+    // re-encoded as UTF-8 the parser would see "Ã©" instead.
+    const jsWithUtf8 = Buffer.from('export default "é";\n', "utf8");
+
+    builder.module("buffer-module-sync", () => ({
+      contents: jsWithUtf8,
+      loader: "js",
+    }));
+
+    builder.module("buffer-module-async", async () => {
+      await 1;
+      return { contents: new Uint8Array(jsWithUtf8), loader: "js" };
+    });
+
+    builder.onResolve({ filter: /.*/, namespace: "buffer-contents" }, ({ path }) => ({
+      path,
+      namespace: "buffer-contents",
+    }));
+    builder.onLoad({ filter: /^sync$/, namespace: "buffer-contents" }, () => ({
+      contents: jsWithUtf8,
+      loader: "js",
+    }));
+    builder.onLoad({ filter: /^async$/, namespace: "buffer-contents" }, async () => {
+      await 1;
+      return { contents: jsWithUtf8, loader: "js" };
+    });
+  },
+});
+
 // This is to test that it works when imported from a separate file
 import { bunEnv, bunExe, tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
@@ -300,6 +333,19 @@ describe("module", () => {
       expect(hello).toBeUndefined();
       expect(there).toBeUndefined();
     }
+  });
+});
+
+describe("typed array contents", () => {
+  it.each([
+    ["build.module sync", "buffer-module-sync"],
+    ["build.module async", "buffer-module-async"],
+    ["onLoad sync", "buffer-contents:sync"],
+    ["onLoad async", "buffer-contents:async"],
+  ])("passes raw bytes through for %s", async (_, specifier) => {
+    const { default: value } = await import(specifier);
+    expect(value).toBe("é");
+    expect([...Buffer.from(value, "utf8")]).toEqual([0xc3, 0xa9]);
   });
 });
 


### PR DESCRIPTION
## What

Runtime `Bun.plugin` callbacks (`build.module(...)` and `onLoad(...)`) that return `contents` as a `Buffer`/`Uint8Array` had any byte `>= 0x80` expanded to its two-byte UTF-8 encoding before the loader saw it.

```js
Bun.plugin({
  setup(build) {
    build.module("virtual:x", () => ({
      contents: Buffer.from('export default "é"', "utf8"),
      loader: "js",
    }));
  },
});
(await import("virtual:x")).default;
// before: "Ã©"  (bytes c3 a9 became c3 83 c2 a9)
// after:  "é"
```

For binary contents (e.g. a `.wasm` buffer supplied through a plugin, as in #35587) every high byte shifted the rest of the stream, which surfaces as a parse error at the wrong offset.

## Why

`handleOnLoadResultNotPromise` built the `ZigString` for the ArrayBufferView case with no encoding tag:

```cpp
result.value.sourceText.string =
    ZigString { reinterpret_cast<const unsigned char*>(view->vector()), view->byteLength() };
```

An untagged `ZigString` is Latin-1 to `ZigString::to_slice()` in `transpile_virtual_module`, which re-encodes any non-ASCII byte as UTF-8. A typed array of source bytes is already UTF-8 (or opaque binary), so that transcode is data corruption.

The string branch right above it goes through `toZigString(JSString*, ...)`, which correctly tags Latin-1/UTF-16, so the transcode there is intentional and is left alone.

## Fix

Tag the ArrayBufferView-backed pointer with the UTF-8 bit so `to_slice()` borrows the bytes verbatim. Adds a `taggedUTF8Ptr()` helper alongside the existing `taggedUTF16Ptr()` in `helpers.h`.

## Tests

`test/js/bun/plugin/plugins.test.ts` gains four cases covering `build.module` and `onLoad`, each sync and async, asserting that a UTF-8 `é` in a `Buffer` round-trips unchanged. All four fail on main with `"Ã©"`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (4523f8d5f)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1199.57ms]
(pass) require > beep:boop returns 42 [9.96ms]
(pass) require > object module works [9.33ms]
(pass) module > throws with require() [13.37ms]
(pass) module > async module works with async import [26.85ms]
(pass) module > sync module module works with require() [4.87ms]
(pass) module > sync module module works with require.resolve() [3.20ms]
(pass) module > sync module module works with import [5.23ms]
(pass) module > modules are overridable [18.95ms]
342 |     ["build.module async", "buffer-module-async"],
343 |     ["onLoad sync", "buffer-contents:sync"],
344 |     ["onLoad async", "buffer-contents:async"],
345 |   ])(
... (truncated)

release without fix: 7 FAILED
bun test v1.3.14 (0d9b296a)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [37.52ms]
(pass) require > beep:boop returns 42 [0.40ms]
(pass) require > object module works [0.14ms]
(pass) module > throws with require() [2.39ms]
(pass) module > async module works with async import [3.13ms]
(pass) module > sync module module works with require() [0.13ms]
(pass) module > sync module module works with require.resolve() [0.06ms]
(pass) module > sync module module works with import [0.10ms]
(pass) module > modules are overridable [2.43ms]
342 |     ["build.module async", "buffer-module-async"],
343 |     ["onLoad sync", "buffer-contents:sync"],
344 |     ["onLoad async", "buffer-contents:async"],
345 |   ])("passes raw bytes through for %s", async (_, specifier) => {
346 |     const { default: value } = await import(specifier);
347 |     expect(value).toBe("é");
              
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (4523f8d5f)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1166.28ms]
(pass) require > beep:boop returns 42 [10.15ms]
(pass) require > object module works [9.19ms]
(pass) module > throws with require() [13.84ms]
(pass) module > async module works with async import [29.84ms]
(pass) module > sync module module works with require() [4.73ms]
(pass) module > sync module module works with require.resolve() [3.58ms]
(pass) module > sync module module works with import [5.58ms]
(pass) module > modules are overridable [89.70ms]
(pass) typed array contents > passes raw bytes through for build.module sync [13.75ms]
(pass) typed array contents > passes raw bytes through for build.module async [9.89m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4523f8d5fd
  features     baseline

22 deps, 108 codegen, 1171 objects in 1863ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] mkdir codegen
[2/1238] mkdir stamps
[3/1238] mkdir pch
[4/1238] mkdir obj
[5/1238] gen ErrorCode+*.h
[6/1238] fetch picohttpparser
[picohttpparser] up to date
[7/1238] gen bindgenv2
[8/1238] fetch zlib
[zlib] up to date
[9/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1238] fetch tinycc
[tinycc] up to date
[11/1238] gen .bind.ts → GeneratedBindings.cpp
[12/1238] subst deps/zlib/zlib.h
[13/1238] fetch nodejs (prebuilt)
[nodejs] up to date
[14/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[15/1238] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[16/1238] subst deps/zlib/zconf.h
[17/1238] fetch zstd
[zstd] up t
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ModuleLoader.cpp  |  5 ++++-
 src/jsc/bindings/helpers.h         |  5 +++++
 test/js/bun/plugin/plugins.test.ts | 46 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 55 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/ModuleLoader.cpp       2      1      0
src/jsc/bindings/helpers.h              1      1      0
test/js/bun/plugin/plugins.test.ts      2      2      0
```

</details>

**self-review** · no surviving concerns

32 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->