### PR TITLE
test(websocket): host proxy-tunnel-upgrade-leak servers in the test process

### DIFF
--- a/test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak-fixture.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak-fixture.ts
@@ -5,89 +5,19 @@
 // and therefore never calls cancel() to drop it, so when the socket finally
 // closed, handleClose's single deref left the struct at refcount 1 forever.
 //
-// The wss:// endpoint and the CONNECT proxy are both node:net/tls-based so
-// everything stays on the JS thread — using Bun.serve here races the debug
-// scoped logger's per-scope mutex against the server's own allocations and
-// sporadically deadlocks the fixture (unrelated to the leak under test).
+// The wss:// endpoint and CONNECT proxy run in the parent test process so this
+// subprocess stays as small as possible (debug+ASAN subprocess startup is the
+// dominant cost). After each `onopen` we signal the parent over IPC; the parent
+// tears down the proxy's client socket, which drives the upgrade client's
+// handleEnd/handleClose path — the same sequencing the original in-process
+// fixture used.
 //
 // Runs under BUN_DEBUG_alloc=1 so the test can count
 //   new(…NewHTTPUpgradeClient(…))   vs   destroy(…NewHTTPUpgradeClient(…))
 // emitted by `bun.new`/`bun.destroy` on debug builds.
-import net from "node:net";
-import tls from "node:tls";
-import crypto from "node:crypto";
-import { tls as tlsCerts } from "../../../harness";
 
-// Minimal wss:// endpoint: completes the RFC 6455 handshake and then idles.
-// The proxy force-closes the client socket right after `onopen`, so no
-// data frames are needed.
-const wss = tls.createServer({ cert: tlsCerts.cert, key: tlsCerts.key }, sock => {
-  let buf = Buffer.alloc(0);
-  sock.on("data", chunk => {
-    buf = Buffer.concat([buf, chunk]);
-    const end = buf.indexOf("\r\n\r\n");
-    if (end === -1) return;
-    const head = buf.subarray(0, end).toString("latin1");
-    const m = /Sec-WebSocket-Key:\s*([A-Za-z0-9+/=]+)/i.exec(head);
-    if (!m) {
-      sock.destroy();
-      return;
-    }
-    const accept = crypto
-      .createHash("sha1")
-      .update(m[1] + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
-      .digest("base64");
-    sock.write(
-      "HTTP/1.1 101 Switching Protocols\r\n" +
-        "Upgrade: websocket\r\n" +
-        "Connection: Upgrade\r\n" +
-        `Sec-WebSocket-Accept: ${accept}\r\n` +
-        "\r\n",
-    );
-    sock.removeAllListeners("data");
-    sock.on("data", () => {});
-  });
-  sock.on("error", () => {});
-});
-await new Promise<void>(r => wss.listen(0, "127.0.0.1", () => r()));
-const wssPort = (wss.address() as net.AddressInfo).port;
-
-// HTTP CONNECT proxy that holds onto the client sockets so we can
-// hard-close them once the WebSocket upgrade has completed — that drives
-// the upgrade client's handleEnd/handleClose path, which is where the leaked
-// ref would otherwise go unreleased.
-const clientSockets: net.Socket[] = [];
-const proxy = net.createServer(clientSocket => {
-  clientSockets.push(clientSocket);
-  let buf = Buffer.alloc(0);
-  let serverSocket: net.Socket | null = null;
-  clientSocket.on("data", chunk => {
-    if (serverSocket) {
-      serverSocket.write(chunk);
-      return;
-    }
-    buf = Buffer.concat([buf, chunk]);
-    const end = buf.indexOf("\r\n\r\n");
-    if (end === -1) return;
-    const m = /^CONNECT\s+([^:]+):(\d+)\s+HTTP/.exec(buf.toString("latin1"));
-    if (!m) {
-      clientSocket.destroy();
-      return;
-    }
-    const rest = buf.subarray(end + 4);
-    serverSocket = net.createConnection({ host: m[1], port: Number(m[2]) }, () => {
-      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
-      if (rest.length) serverSocket!.write(rest);
-      serverSocket!.on("data", d => clientSocket.write(d));
-    });
-    serverSocket.on("error", () => clientSocket.destroy());
-    serverSocket.on("close", () => clientSocket.destroy());
-    clientSocket.on("close", () => serverSocket?.destroy());
-  });
-  clientSocket.on("error", () => serverSocket?.destroy());
-});
-await new Promise<void>(r => proxy.listen(0, "127.0.0.1", () => r()));
-const proxyPort = (proxy.address() as net.AddressInfo).port;
+const wssPort = Number(process.env.WSS_PORT);
+const proxyPort = Number(process.env.PROXY_PORT);
 
 async function roundTrip() {
   const ws = new WebSocket(`wss://127.0.0.1:${wssPort}/`, {
@@ -97,18 +27,27 @@ async function roundTrip() {
   });
   const opened = Promise.withResolvers<void>();
   const closed = Promise.withResolvers<void>();
-  ws.onopen = () => opened.resolve();
-  ws.onclose = () => closed.resolve();
-  // Errors are expected once we hard-close the proxy socket; onclose still fires.
+  let didOpen = false;
+  ws.onopen = () => {
+    didOpen = true;
+    opened.resolve();
+  };
+  ws.onclose = ev => {
+    if (!didOpen) opened.reject(new Error(`closed before open: ${ev.code} ${ev.reason}`));
+    closed.resolve();
+  };
+  // Errors are expected once the parent hard-closes the proxy socket; onclose
+  // still fires.
   ws.onerror = () => {};
   await opened.promise;
-  // Tunnel-mode upgrade has completed (state == .done). Tear down the proxy
-  // connection so handleEnd/handleClose run on the upgrade client.
-  for (const s of clientSockets.splice(0)) s.destroy();
+  // Tunnel-mode upgrade has completed (state == .done). Ask the parent to
+  // tear down the proxy connection so handleEnd/handleClose run on the
+  // upgrade client.
+  process.send!("open");
   await closed.promise;
 }
 
-for (let i = 0; i < 3; i++) {
+for (let i = 0; i < 2; i++) {
   await roundTrip();
 }
 

--- a/test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug } from "harness";
+import { bunEnv, bunExe, isDebug, tls as tlsCerts } from "harness";
+import crypto from "node:crypto";
+import net from "node:net";
+import tls from "node:tls";
 import path from "node:path";
 
 // The tunnel-mode success branch in WebSocketUpgradeClient.processResponse()
@@ -12,44 +15,136 @@ import path from "node:path";
 // The assertion counts `[alloc] new(…NewHTTPUpgradeClient(…))` vs
 // `[alloc] destroy(…NewHTTPUpgradeClient(…))` in the alloc debug scope, which
 // is only emitted by debug builds (Environment.allow_assert).
+//
+// The wss:// endpoint and CONNECT proxy run in THIS process so the debug
+// subprocess only pays for the WebSocket client round-trips (no TLS server
+// startup, no harness import, no scoped-logger lock contention with the
+// server thread under BUN_DEBUG_alloc=1).
 test.skipIf(!isDebug)(
   "wss:// through HTTP proxy does not leak HTTPUpgradeClient",
   async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "websocket-proxy-tunnel-upgrade-leak-fixture.ts")],
-      env: {
-        ...bunEnv,
-        BUN_DEBUG_alloc: "1",
-        // NO_PROXY in CI environments short-circuits the explicit `proxy:` option
-        // for 127.0.0.1, so the fixture would bypass tunnel mode entirely.
-        NO_PROXY: undefined,
-        no_proxy: undefined,
-        HTTP_PROXY: undefined,
-        HTTPS_PROXY: undefined,
-      },
-      stderr: "pipe",
-      stdout: "pipe",
+    // Minimal wss:// endpoint: completes the RFC 6455 handshake and then idles.
+    // The proxy force-closes the client socket right after `onopen`, so no
+    // data frames are needed.
+    const wss = tls.createServer({ cert: tlsCerts.cert, key: tlsCerts.key }, sock => {
+      let buf = Buffer.alloc(0);
+      sock.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        const end = buf.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        const head = buf.subarray(0, end).toString("latin1");
+        const m = /Sec-WebSocket-Key:\s*([A-Za-z0-9+/=]+)/i.exec(head);
+        if (!m) {
+          sock.destroy();
+          return;
+        }
+        const accept = crypto
+          .createHash("sha1")
+          .update(m[1] + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n` +
+            "\r\n",
+        );
+        sock.removeAllListeners("data");
+        sock.on("data", () => {});
+      });
+      sock.on("error", () => {});
     });
+    await new Promise<void>(r => wss.listen(0, "127.0.0.1", () => r()));
+    const wssPort = (wss.address() as net.AddressInfo).port;
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // HTTP CONNECT proxy that holds onto the client sockets so we can
+    // hard-close them once the WebSocket upgrade has completed — that drives
+    // the upgrade client's handleEnd/handleClose path, which is where the
+    // leaked ref would otherwise go unreleased.
+    const clientSockets: net.Socket[] = [];
+    const proxy = net.createServer(clientSocket => {
+      clientSockets.push(clientSocket);
+      let buf = Buffer.alloc(0);
+      let serverSocket: net.Socket | null = null;
+      clientSocket.on("data", chunk => {
+        if (serverSocket) {
+          serverSocket.write(chunk);
+          return;
+        }
+        buf = Buffer.concat([buf, chunk]);
+        const end = buf.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        const m = /^CONNECT\s+([^:]+):(\d+)\s+HTTP/.exec(buf.toString("latin1"));
+        if (!m) {
+          clientSocket.destroy();
+          return;
+        }
+        const rest = buf.subarray(end + 4);
+        serverSocket = net.createConnection({ host: m[1], port: Number(m[2]) }, () => {
+          clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+          if (rest.length) serverSocket!.write(rest);
+          serverSocket!.on("data", d => clientSocket.write(d));
+        });
+        serverSocket.on("error", () => clientSocket.destroy());
+        serverSocket.on("close", () => clientSocket.destroy());
+        clientSocket.on("close", () => serverSocket?.destroy());
+      });
+      clientSocket.on("error", () => serverSocket?.destroy());
+    });
+    await new Promise<void>(r => proxy.listen(0, "127.0.0.1", () => r()));
+    const proxyPort = (proxy.address() as net.AddressInfo).port;
 
-    // `bun.new`/`bun.destroy` log via Output.scoped(.alloc) in debug builds:
-    //   [alloc] new(http.websocket_client.WebSocketUpgradeClient.NewHTTPUpgradeClient(false)) = …
-    //   [alloc] destroy(http.websocket_client.WebSocketUpgradeClient.NewHTTPUpgradeClient(false)) = …
-    // Scoped debug output writes to the raw stdout stream, but search both
-    // streams in case that ever changes.
-    const lines = (stdout + stderr)
-      .split("\n")
-      .filter(l => l.startsWith("[alloc] ") && l.includes("NewHTTPUpgradeClient"));
-    const created = lines.filter(l => l.startsWith("[alloc] new(")).length;
-    const destroyed = lines.filter(l => l.startsWith("[alloc] destroy(")).length;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "websocket-proxy-tunnel-upgrade-leak-fixture.ts")],
+        env: {
+          ...bunEnv,
+          BUN_DEBUG_alloc: "1",
+          WSS_PORT: String(wssPort),
+          PROXY_PORT: String(proxyPort),
+          // NO_PROXY in CI environments short-circuits the explicit `proxy:`
+          // option for 127.0.0.1, so the fixture would bypass tunnel mode.
+          NO_PROXY: undefined,
+          no_proxy: undefined,
+          HTTP_PROXY: undefined,
+          HTTPS_PROXY: undefined,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+        ipc(message) {
+          // Fixture signals once the tunnel-mode upgrade has completed; tear
+          // down the proxy's client socket(s) so handleClose runs.
+          if (message === "open") for (const s of clientSockets.splice(0)) s.destroy();
+        },
+      });
 
-    // Must have exercised the tunnel path at all — guards against NO_PROXY or
-    // a fixture regression silently skipping the scenario.
-    expect(created).toBeGreaterThan(0);
-    expect({ created, destroyed }).toEqual({ created, destroyed: created });
-    if (exitCode !== 0) console.error(stderr);
-    expect(exitCode).toBe(0);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // `bun.new`/`bun.destroy` log via Output.scoped(.alloc) in debug builds:
+      //   [alloc] new(http.websocket_client.WebSocketUpgradeClient.NewHTTPUpgradeClient(false)) = …
+      //   [alloc] destroy(http.websocket_client.WebSocketUpgradeClient.NewHTTPUpgradeClient(false)) = …
+      // Scoped debug output writes to the raw stdout stream, but search both
+      // streams in case that ever changes.
+      const lines = (stdout + stderr)
+        .split("\n")
+        .filter(l => l.startsWith("[alloc] ") && l.includes("NewHTTPUpgradeClient"));
+      const created = lines.filter(l => l.startsWith("[alloc] new(")).length;
+      const destroyed = lines.filter(l => l.startsWith("[alloc] destroy(")).length;
+
+      // Fixture errors surface here first so the diff in a failure is useful.
+      const errors = stderr
+        .split("\n")
+        .filter(l => l && !l.startsWith("[alloc] "))
+        .join("\n");
+      expect(errors).toBe("");
+      // Must have exercised the tunnel path at all — guards against NO_PROXY or
+      // a fixture regression silently skipping the scenario.
+      expect({ created, destroyed }).toEqual({ created: 2, destroyed: 2 });
+      expect(exitCode).toBe(0);
+    } finally {
+      await new Promise<void>(r => wss.close(() => r()));
+      await new Promise<void>(r => proxy.close(() => r()));
+    }
   },
-  30_000,
+  20_000,
 );

--- a/test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts
@@ -17,9 +17,8 @@ import tls from "node:tls";
 // is only emitted by debug builds (Environment.allow_assert).
 //
 // The wss:// endpoint and CONNECT proxy run in THIS process so the debug
-// subprocess only pays for the WebSocket client round-trips (no TLS server
-// startup, no harness import, no scoped-logger lock contention with the
-// server thread under BUN_DEBUG_alloc=1).
+// subprocess only pays for the WebSocket client round-trips — no TLS server
+// startup and no harness import in the BUN_DEBUG_alloc=1 child.
 test.skipIf(!isDebug)(
   "wss:// through HTTP proxy does not leak HTTPUpgradeClient",
   async () => {

--- a/test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tls as tlsCerts } from "harness";
 import crypto from "node:crypto";
 import net from "node:net";
-import tls from "node:tls";
 import path from "node:path";
+import tls from "node:tls";
 
 // The tunnel-mode success branch in WebSocketUpgradeClient.processResponse()
 // took `outgoing_websocket` without releasing the ref that paired with C++'s


### PR DESCRIPTION
## What

Speed up `test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts` for local `bun bd test` runs, and tighten its assertions.

The test is `test.skipIf(!isDebug)` and therefore skips on every CI lane (release binaries), so this has no effect on CI wall time. It does make the test roughly 2x faster when you run it from a debug build locally.

## Why it was slow

The test spawns a subprocess under `BUN_DEBUG_alloc=1` to count `new(…NewHTTPUpgradeClient…)` vs `destroy(…)` log lines. The subprocess was doing all of the setup work:

- starting a `node:tls` server and a `node:net` CONNECT proxy
- importing `../../../harness` just for the TLS cert/key strings (the harness pulls in `bun:jsc`, `bun:test`, `child_process`, etc.)
- three sequential wss://-through-proxy round trips

On a debug+ASAN build the harness import and `tls.createServer` are each several hundred ms to seconds inside the timed subprocess.

## Change

Host the wss endpoint and CONNECT proxy in the **test process** and pass their ports to a minimal fixture that only runs the WebSocket client. The fixture signals each `onopen` over Bun's `ipc` channel; the parent then destroys the proxy's client socket, which is exactly the handleEnd/handleClose trigger the original in-process fixture used. Two round trips instead of three (the leak is a deterministic refcount miss, not a race).

Assertion changes:
- assert the fixture's non-`[alloc]` stderr is empty before the counts, so a fixture error reads as the actual error instead of a confusing count mismatch
- pin the expected counts to `{created: 2, destroyed: 2}` instead of `{created, destroyed: created}` so a fixture regression that skips a round trip fails the assertion
- reject `opened` with the close code if `onclose` fires before `onopen`, so a handshake failure surfaces as an error instead of hanging

## Verification

Local debug+ASAN, warm cache, 5 runs each (test body time):

| | test body |
| --- | --- |
| before | 3212 / 3236 / 3251 / 3383 / 4431 ms |
| after | 1460 / 1470 / 1501 / 1662 / 1671 ms |

25/25 consecutive passes across default and CI-like (`BUN_GARBAGE_COLLECTOR_LEVEL=1 BUN_JSC_randomIntegrityAuditRate=1.0`) env.

**Fail-before check**: with the tunnel-branch `deref` in `WebSocketUpgradeClient.processResponse()` commented out, the new test fails with `{created: 2, destroyed: 0}` (the original #29874 leak), same as the old test.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts
bun test v1.4.0 (0a3787abe)

test/js/web/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts:
(pass) wss:// through HTTP proxy does not leak HTTPUpgradeClient [1607.83ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [4.86s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../websocket-proxy-tunnel-upgrade-leak-fixture.ts | 109 ++++----------
 .../websocket-proxy-tunnel-upgrade-leak.test.ts    | 160 ++++++++++++++++-----
 2 files changed, 151 insertions(+), 118 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…ebsocket/websocket-proxy-tunnel-upgrade-leak-fixture.ts      2      3      0
…b/websocket/websocket-proxy-tunnel-upgrade-leak.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->