### PR TITLE
node:quic h3: deliver response trailers when only ontrailers is set

### DIFF
--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -1804,13 +1804,12 @@ class QuicStream {
     const inner = this.#inner;
     if (fn === undefined) {
       inner.onheaders = undefined;
-      inner.state.wantsHeaders = false;
     } else {
       validateFunction(fn, "onheaders");
       assertHeadersSupported(inner.session);
       inner.onheaders = FunctionPrototypeBind(fn, this);
-      inner.state.wantsHeaders = true;
     }
+    inner.state.wantsHeaders = inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
   }
 
   /** @type {Function|undefined} */
@@ -1829,6 +1828,7 @@ class QuicStream {
       assertHeadersSupported(inner.session);
       inner.oninfo = FunctionPrototypeBind(fn, this);
     }
+    inner.state.wantsHeaders = inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
   }
 
   /** @type {Function|undefined} */
@@ -1847,6 +1847,7 @@ class QuicStream {
       assertHeadersSupported(inner.session);
       inner.ontrailers = FunctionPrototypeBind(fn, this);
     }
+    inner.state.wantsHeaders = inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
   }
 
   /** @type {Function|undefined} */
@@ -2525,7 +2526,6 @@ class QuicStream {
 
     switch (kindName) {
       case "initial":
-        assert(inner.onheaders, "Unexpected stream headers event");
         inner.headers ??= block;
         if (onStreamHeadersChannel.hasSubscribers) {
           onStreamHeadersChannel.publish({
@@ -2535,7 +2535,12 @@ class QuicStream {
             headers: block,
           });
         }
-        safeCallbackInvoke(inner.onheaders, this, block);
+        {
+          // wantsHeaders is shared with ontrailers/oninfo, so the initial
+          // block can arrive with only one of those set.
+          const { onheaders } = inner;
+          if (onheaders) safeCallbackInvoke(onheaders, this, block);
+        }
         break;
       case "trailing":
         if (onStreamTrailersChannel.hasSubscribers) {

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -1809,7 +1809,8 @@ class QuicStream {
       assertHeadersSupported(inner.session);
       inner.onheaders = FunctionPrototypeBind(fn, this);
     }
-    inner.state.wantsHeaders = inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
+    inner.state.wantsHeaders =
+      inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
   }
 
   /** @type {Function|undefined} */
@@ -1828,7 +1829,8 @@ class QuicStream {
       assertHeadersSupported(inner.session);
       inner.oninfo = FunctionPrototypeBind(fn, this);
     }
-    inner.state.wantsHeaders = inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
+    inner.state.wantsHeaders =
+      inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
   }
 
   /** @type {Function|undefined} */
@@ -1847,7 +1849,8 @@ class QuicStream {
       assertHeadersSupported(inner.session);
       inner.ontrailers = FunctionPrototypeBind(fn, this);
     }
-    inner.state.wantsHeaders = inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
+    inner.state.wantsHeaders =
+      inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
   }
 
   /** @type {Function|undefined} */

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -1324,6 +1324,11 @@ function parseHeaderPairs(pairs) {
   return block;
 }
 
+function syncWantsHeaders(inner) {
+  inner.state.wantsHeaders =
+    inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
+}
+
 /**
  * Applies session and stream callbacks from an options object to a session.
  * @param {QuicSession} session
@@ -1809,8 +1814,7 @@ class QuicStream {
       assertHeadersSupported(inner.session);
       inner.onheaders = FunctionPrototypeBind(fn, this);
     }
-    inner.state.wantsHeaders =
-      inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
+    syncWantsHeaders(inner);
   }
 
   /** @type {Function|undefined} */
@@ -1829,8 +1833,7 @@ class QuicStream {
       assertHeadersSupported(inner.session);
       inner.oninfo = FunctionPrototypeBind(fn, this);
     }
-    inner.state.wantsHeaders =
-      inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
+    syncWantsHeaders(inner);
   }
 
   /** @type {Function|undefined} */
@@ -1849,8 +1852,7 @@ class QuicStream {
       assertHeadersSupported(inner.session);
       inner.ontrailers = FunctionPrototypeBind(fn, this);
     }
-    inner.state.wantsHeaders =
-      inner.onheaders !== undefined || inner.ontrailers !== undefined || inner.oninfo !== undefined;
+    syncWantsHeaders(inner);
   }
 
   /** @type {Function|undefined} */
@@ -2539,8 +2541,6 @@ class QuicStream {
           });
         }
         {
-          // wantsHeaders is shared with ontrailers/oninfo, so the initial
-          // block can arrive with only one of those set.
           const { onheaders } = inner;
           if (onheaders) safeCallbackInvoke(onheaders, this, block);
         }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -1023,49 +1023,66 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
     }
     // SAFETY: `ctx` is the live QuicStream we returned from on_new_stream.
     let qs = unsafe { &*ctx.cast::<QuicStream>() };
-    if let Some(hset) = stream.take_header_set() {
-        let pairs = hset.pairs();
-        /// RFC 9114 §8.1 H3_MESSAGE_ERROR — malformed message (a request
-        /// carrying :status). Matches lsquic's `HEC_MESSAGE_ERROR`
-        /// (lsquic_hq.h:82); 0x105 is H3_FRAME_UNEXPECTED, a different code.
-        const H3_MESSAGE_ERROR: u64 = 0x10e;
-        let has_status = pairs
-            .as_chunks::<2>()
-            .0
-            .iter()
-            .find(|kv| kv[0] == b":status")
-            .map(|kv| kv[1].len() == 3 && kv[1][0] == b'1');
-        // A :status in a request is malformed: node's nghttp3 resets the
-        // stream (RFC 9114 §4.1.2), and routing it to `oninfo` would leave
-        // the request unanswered until the idle timeout.
-        let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
-        if peer_is_client && has_status.is_some() {
-            if let Some(s) = qs.ls() {
-                // reset() only ends the read side when the peer already
-                // FIN'd/RST'd, so STOP_SENDING is what stops a malformed
-                // request streaming a body into a stream nothing will answer.
-                s.reset(H3_MESSAGE_ERROR);
-                s.stop_sending(H3_MESSAGE_ERROR);
+    let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
+    // `stream->uh` is a linked list (1xx*, final, trailers): drain it, not
+    // pop once. The HQ filter can decode a trailing block while we read DATA
+    // below, so re-drain on -1 too.
+    enum Claimed {
+        None,
+        Some,
+        Malformed,
+    }
+    let claim_hsets = |qs: &QuicStream| -> Claimed {
+        let mut out = Claimed::None;
+        while let Some(hset) = stream.take_header_set() {
+            out = Claimed::Some;
+            let pairs = hset.pairs();
+            let has_status = pairs
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .find(|kv| kv[0] == b":status")
+                .map(|kv| kv[1].len() == 3 && kv[1][0] == b'1');
+            // A :status in a request is malformed: node's nghttp3 resets the
+            // stream (RFC 9114 §4.1.2), and routing it to `oninfo` would leave
+            // the request unanswered until the idle timeout.
+            if peer_is_client && has_status.is_some() {
+                /// RFC 9114 §8.1 H3_MESSAGE_ERROR — malformed message (a
+                /// request carrying :status). Matches lsquic's
+                /// `HEC_MESSAGE_ERROR` (lsquic_hq.h:82); 0x105 is
+                /// H3_FRAME_UNEXPECTED, a different code.
+                const H3_MESSAGE_ERROR: u64 = 0x10e;
+                if let Some(s) = qs.ls() {
+                    // reset() only ends the read side when the peer already
+                    // FIN'd/RST'd, so STOP_SENDING is what stops a malformed
+                    // request streaming a body into a stream nothing will answer.
+                    s.reset(H3_MESSAGE_ERROR);
+                    s.stop_sending(H3_MESSAGE_ERROR);
+                }
+                qs.mark_reset(H3_MESSAGE_ERROR);
+                return Claimed::Malformed;
             }
-            qs.mark_reset(H3_MESSAGE_ERROR);
-            return;
+            // 1xx interim responses are HINTS (RFC 9114 §4.1).
+            let is_interim = has_status.unwrap_or(false);
+            let kind = if is_interim {
+                QUIC_STREAM_HEADERS_KIND_HINTS
+            } else if qs.mark_headers_received() {
+                QUIC_STREAM_HEADERS_KIND_INITIAL
+            } else {
+                QUIC_STREAM_HEADERS_KIND_TRAILING
+            };
+            if let Some(session) = qs.session_ref() {
+                session.push_event(SessionEvent::StreamHeaders {
+                    stream: ctx.cast(),
+                    pairs,
+                    kind,
+                });
+            }
         }
-        // 1xx interim responses are HINTS (RFC 9114 §4.1).
-        let is_interim = has_status.unwrap_or(false);
-        let kind = if is_interim {
-            QUIC_STREAM_HEADERS_KIND_HINTS
-        } else if qs.mark_headers_received() {
-            QUIC_STREAM_HEADERS_KIND_INITIAL
-        } else {
-            QUIC_STREAM_HEADERS_KIND_TRAILING
-        };
-        if let Some(session) = qs.session_ref() {
-            session.push_event(SessionEvent::StreamHeaders {
-                stream: ctx.cast(),
-                pairs,
-                kind,
-            });
-        }
+        out
+    };
+    if matches!(claim_hsets(qs), Claimed::Malformed) {
+        return;
     }
     if stream.received_early_data() {
         qs.with_state(|s| s.received_early_data = 1);
@@ -1091,7 +1108,16 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
                 got_any = true;
                 break;
             }
-            _ => break,
+            _ => {
+                // `stream_readf` returns -1 for EWOULDBLOCK and for "header
+                // set not claimed" alike; the HQ filter decodes trailers as
+                // it drains past DATA, so an unclaimed set here is the
+                // trailing block — claim and re-read for the FIN behind it.
+                if matches!(claim_hsets(qs), Claimed::Some) {
+                    continue;
+                }
+                break;
+            }
         }
     }
     if got_any {

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -1024,9 +1024,7 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
     // SAFETY: `ctx` is the live QuicStream we returned from on_new_stream.
     let qs = unsafe { &*ctx.cast::<QuicStream>() };
     let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
-    // `stream->uh` is a linked list (1xx*, final, trailers): drain it, not
-    // pop once. The HQ filter can decode a trailing block while we read DATA
-    // below, so re-drain on -1 too.
+    // `stream->uh` is a list (1xx*, final, trailers): drain, don't pop once.
     enum Claimed {
         None,
         Some,
@@ -1109,10 +1107,9 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
                 break;
             }
             _ => {
-                // `stream_readf` returns -1 for EWOULDBLOCK and for "header
-                // set not claimed" alike; the HQ filter decodes trailers as
-                // it drains past DATA, so an unclaimed set here is the
-                // trailing block — claim and re-read for the FIN behind it.
+                // -1 is EWOULDBLOCK or "header set not claimed": the HQ
+                // filter decodes trailers while draining DATA, so claim and
+                // re-read for the FIN behind them.
                 if matches!(claim_hsets(qs), Claimed::Some) {
                     continue;
                 }

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -111,6 +111,48 @@ describe("HTTP/3 response trailers", () => {
   });
 });
 
+// Same gate: `oninfo` alone must enable HEADERS dispatch for 1xx interim
+// responses (RFC 9114 §4.1).
+test("HTTP/3 1xx interim responses are delivered when only oninfo is set", async () => {
+  await using server = await listen(
+    async serverSession => {
+      serverSession.onstream = (stream: any) => {
+        stream.closed.catch(() => {});
+      };
+      await serverSession.closed.catch(() => {});
+    },
+    {
+      sni: { "*": { keys: [key], certs: [cert] } },
+      transportParams: { maxIdleTimeout: 2 },
+      onheaders(this: any) {
+        this.sendInformationalHeaders({ ":status": "103", "link": "</a>; rel=preload" });
+        this.sendHeaders({ ":status": "200" }, { terminal: true });
+      },
+    },
+  );
+
+  const client = await connect(server.address, {
+    servername: "localhost",
+    verifyPeer: "manual",
+    transportParams: { maxIdleTimeout: 2 },
+  });
+  await client.opened;
+
+  const hints = Promise.withResolvers<Record<string, string>>();
+  const stream = await client.createBidirectionalStream({
+    headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost" },
+  });
+  stream.oninfo = (h: Record<string, string>) => hints.resolve(h);
+
+  for await (const _ of stream) {
+  }
+  const result = await Promise.race([hints.promise, stream.closed.then(() => "dropped")]);
+
+  client.close();
+  expect(result).toEqual({ ":status": "103", "link": "</a>; rel=preload" });
+  expect(stream.headers?.[":status"]).toBe("200");
+});
+
 // `destroy()` after the app committed AND ended a response (which, under
 // `onwanttrailers`, records `trailers_pending` rather than `fin_pending`)
 // must deliver it with a FIN, never retract it with a RESET_STREAM.

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -1,6 +1,3 @@
-// `destroy()` after the app committed AND ended a response (which, under
-// `onwanttrailers`, records `trailers_pending` rather than `fin_pending`)
-// must deliver it with a FIN, never retract it with a RESET_STREAM.
 import { describe, expect, test } from "bun:test";
 import { createPrivateKey } from "node:crypto";
 import { readFileSync } from "node:fs";
@@ -11,6 +8,112 @@ const keysDir = join(import.meta.dir, "..", "test", "fixtures", "keys");
 const key = createPrivateKey(readFileSync(join(keysDir, "agent1-key.pem")));
 const cert = readFileSync(join(keysDir, "agent1-cert.pem"));
 
+// A client that sets only `ontrailers` (no `onheaders`) must still receive
+// trailing HEADERS: the `wantsHeaders` state flag gates the native dispatch
+// of every HEADERS kind, so tying it to `onheaders` alone drops trailers
+// silently.
+describe("HTTP/3 response trailers", () => {
+  test("are delivered when only ontrailers is set", async () => {
+    await using server = await listen(
+      async serverSession => {
+        serverSession.onstream = (stream: any) => {
+          stream.closed.catch(() => {});
+        };
+        await serverSession.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 2 },
+        onheaders(this: any) {
+          this.sendHeaders({ ":status": "200" });
+          this.writer.writeSync(new TextEncoder().encode("body"));
+          this.writer.endSync();
+        },
+        onwanttrailers(this: any) {
+          this.sendTrailers({ "x-tr-a": "1", "x-tr-b": "two" });
+        },
+      },
+    );
+
+    const client = await connect(server.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 2 },
+    });
+    await client.opened;
+
+    const trailers = Promise.withResolvers<Record<string, string>>();
+    const stream = await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost" },
+    });
+    stream.ontrailers = (t: Record<string, string>) => trailers.resolve(t);
+
+    let body = "";
+    for await (const c of stream) for (const b of [c].flat()) body += Buffer.from(b);
+    // The stream FIN follows the trailing HEADERS on the wire (RFC 9114
+    // §4.1), so by the time the body iterator ends, trailers have been
+    // dispatched or never will be.
+    const result = await Promise.race([trailers.promise, stream.closed.then(() => "dropped")]);
+
+    client.close();
+    expect(body).toBe("body");
+    expect(result).toEqual({ "x-tr-a": "1", "x-tr-b": "two" });
+    // The initial :status block was stashed even without onheaders.
+    expect(stream.headers?.[":status"]).toBe("200");
+  });
+
+  // The response HEADERS + DATA + trailing HEADERS + FIN decoded in a single
+  // on_read callback: lsquic's HQ filter appends the trailer set to
+  // `stream->uh` while draining DATA, and lsquic_stream_read then returns -1
+  // ("header set not claimed") instead of 0 for FIN. The read path has to
+  // claim that set itself and re-read for the FIN behind it.
+  test("are delivered when decoded in the same read callback as the body", async () => {
+    await using server = await listen(
+      async serverSession => {
+        serverSession.onstream = (stream: any) => {
+          stream.closed.catch(() => {});
+        };
+        await serverSession.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 2 },
+        onheaders(this: any) {
+          this.sendHeaders({ ":status": "200" });
+          // No DATA: both HEADERS blocks go out in one lsquic write, so the
+          // client's `on_read` sees both in `stream->uh` at once.
+          this.sendTrailers({ "x-tr-a": "1", "x-tr-b": "two" });
+        },
+      },
+    );
+
+    const client = await connect(server.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 2 },
+    });
+    await client.opened;
+
+    const trailers = Promise.withResolvers<Record<string, string>>();
+    const stream = await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost" },
+      ontrailers(t: Record<string, string>) {
+        trailers.resolve(t);
+      },
+    });
+
+    for await (const _ of stream) {
+    }
+    const result = await Promise.race([trailers.promise, stream.closed.then(() => "dropped")]);
+
+    client.close();
+    expect(result).toEqual({ "x-tr-a": "1", "x-tr-b": "two" });
+  });
+});
+
+// `destroy()` after the app committed AND ended a response (which, under
+// `onwanttrailers`, records `trailers_pending` rather than `fin_pending`)
+// must deliver it with a FIN, never retract it with a RESET_STREAM.
 describe("QuicStream.destroy after the app ended the send side", () => {
   test("delivers the committed response instead of retracting it with RESET_STREAM", async () => {
     await using server = await listen(


### PR DESCRIPTION
## Problem

A `node:quic` HTTP/3 client that sets only `ontrailers` (no `onheaders`) never receives trailing headers: the body reads fine, `ontrailers` never fires, no error.

```js
const st = await client.createBidirectionalStream({
  headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost" },
});
st.ontrailers = t => console.log("TRAILERS", t);   // never called
for await (const c of st) { ... }                  // body reads fine
```

This is the common shape for gRPC-over-h3 and any client that cares about trailers but not the initial `:status` block.

## Cause

The native `StreamHeaders` dispatch is gated on `stream.state.wantsHeaders`, which is the one flag for every HEADERS kind (initial, trailing, hints). Only the `onheaders` setter wrote it. Setting `ontrailers` or `oninfo` alone left `wantsHeaders = 0`, so the native side dropped every decoded block.

Separately, `on_stream_read` claimed `lsquic_stream_get_hset()` once per callback. `stream->uh` is a linked list, and when a peer emits `HEADERS + DATA + HEADERS(trailers) + FIN` in one STREAM frame, lsquic's HQ filter decodes the trailing block as a side effect of draining DATA; `lsquic_stream_read` then returns `-1` ("header set not claimed: cannot read from stream") instead of `0` for the FIN.

## Fix

- `set ontrailers` / `set oninfo` / `set onheaders` now compute `wantsHeaders` from the OR of all three handlers.
- `[kHeaders]` no longer asserts `onheaders` on an initial block: the block is stashed to `stream.headers` (unchanged) and the callback is optional, matching the trailing/hints cases.
- `on_stream_read` drains `stream->uh` as a list and re-checks it when `lsquic_stream_read` returns `-1`; if a new block appeared it claims it and re-reads for the FIN behind it.

## Verification

```
# fail-before (src/ stashed)
(fail) HTTP/3 response trailers > are delivered when only ontrailers is set
(fail) HTTP/3 response trailers > are delivered when decoded in the same read callback as the body

# pass-after
(pass) HTTP/3 response trailers > are delivered when only ontrailers is set
(pass) HTTP/3 response trailers > are delivered when decoded in the same read callback as the body
```

Existing `test/js/node/quic/*.test.ts` and `test/js/node/test/parallel/test-quic-h3-*` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (8224b855b)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

55 |     // dispatched or never will be.
56 |     const result = await Promise.race([trailers.promise, stream.closed.then(() => "dropped")]);
57 | 
58 |     client.close();
59 |     expect(body).toBe("body");
60 |     expect(result).toEqual({ "x-tr-a": "1", "x-tr-b": "two" });
                        ^
error: expect(received).toEqual(expected)

- {
-   "x-tr-a": "1",
-   "x-tr-b": "two",
- }
+ "dropped"

- Expected  - 4
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/quic/quic-stream.test.ts:60:20)
(fail) HTTP/3 response trailers > are delivered when only ontrailers is set [1063.37ms]
105 |     for await (const _ of stream) {
106 |     }
107 |     const result = await Promise.race([trailers.promise, stream.closed.then(() => "dropped")]);
108 | 
109 |     client.close();
110 |     expect(result).
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a353fd654)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:15:20)

(pass) HTTP/3 response trailers > are delivered when only ontrailers is set [56.43ms]
(pass) HTTP/3 response trailers > are delivered when decoded in the same read callback as the body [7.97ms]
(pass) HTTP/3 1xx interim responses are delivered when only oninfo is set [8.59ms]
(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [10.08ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [8.64ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1008.33ms]

 6 pass
 0 fail
 13 expect() calls
Ran 6 tests across 1 file. [1413.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (8224b855b)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) HTTP/3 response trailers > are delivered when only ontrailers is set [892.24ms]
(pass) HTTP/3 response trailers > are delivered when decoded in the same read callback as the body [192.30ms]
(pass) HTTP/3 1xx interim responses are delivered when only oninfo is set [209.72ms]
(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [257.58ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [203.11ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1187.25ms]

 6 pass
 0 fail
 13 expect() calls
Ran 6 tests across 1 file. [9.80s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1385ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (22369ms)
Bundle modules (829ms)
Postprocesss modules (806ms)
Bundle Functions (2028ms)
Generate Code (76ms)

[26.18s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/quic/quic.ts          |  16 +++-
 src/runtime/node/quic/stream.rs       | 107 ++++++++++++++----------
 test/js/node/quic/quic-stream.test.ts | 151 +++++++++++++++++++++++++++++++++-
 3 files changed, 225 insertions(+), 49 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/internal/quic/quic.ts               5      7      0
src/runtime/node/quic/stream.rs            4     12      0
test/js/node/quic/quic-stream.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->