### PR TITLE
node:quic: reject RFC 9114 malformed H3 field sections with H3_MESSAGE_ERROR

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -225,6 +225,8 @@ export const isolatedModuleCacheSourceType: (specifier: string) => string | null
 );
 export const Dequeue = require("internal/fifo");
 
+export const quicSendRawHeaders: unique symbol = require("internal/quic/symbols").kSendRawHeaders;
+
 // Userland access to node-internal modules for vendored node tests that
 // declare `// Flags: --expose-internals` (served via the require interceptor
 // in test/js/node/test/common/index.js). Static requires only — the builtin

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -64,6 +64,7 @@ const PromiseWithResolvers = () => Promise.withResolvers();
 const SymbolAsyncDispose = Symbol.asyncDispose;
 const SymbolAsyncIterator = Symbol.asyncIterator;
 const SymbolDispose = Symbol.dispose;
+const SymbolFor = Symbol.for;
 const SymbolIterator = Symbol.iterator;
 const DataViewPrototypeGetByteLength = uncurryThis(
   Object.getOwnPropertyDescriptor(DataView.prototype, "byteLength").get,
@@ -2429,6 +2430,15 @@ class QuicStream {
     }
     const headerString = buildNgHeaderString(headers, assertValidPseudoHeader, true);
     return this.#handle.sendHeaders(kind, headerString, flags);
+  }
+
+  // Test hook for RFC 9114 malformed-receive coverage: the public paths all
+  // route through `buildNgHeaderString`, which rejects every malformed shape
+  // the receive-side validator must be shown to catch.
+  [SymbolFor("bun.internal.quic.sendRawHeaders")](pairs, kind = kHeadersKindInitial, flags = kHeadersFlagsNone) {
+    let s = "";
+    for (let i = 0; i + 1 < pairs.length; i += 2) s += `${pairs[i]}\0${pairs[i + 1]}\0\0`;
+    return this.#handle.sendHeaders(kind, [s, pairs.length >> 1], flags);
   }
 
   [kFinishClose](error) {

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -64,7 +64,6 @@ const PromiseWithResolvers = () => Promise.withResolvers();
 const SymbolAsyncDispose = Symbol.asyncDispose;
 const SymbolAsyncIterator = Symbol.asyncIterator;
 const SymbolDispose = Symbol.dispose;
-const SymbolFor = Symbol.for;
 const SymbolIterator = Symbol.iterator;
 const DataViewPrototypeGetByteLength = uncurryThis(
   Object.getOwnPropertyDescriptor(DataView.prototype, "byteLength").get,
@@ -279,6 +278,7 @@ const {
   kPrivateConstructor,
   kReset,
   kSendHeaders,
+  kSendRawHeaders,
   kSessionTicket,
   kTrailers,
   kVersionNegotiation,
@@ -2432,10 +2432,8 @@ class QuicStream {
     return this.#handle.sendHeaders(kind, headerString, flags);
   }
 
-  // Test hook for RFC 9114 malformed-receive coverage: the public paths all
-  // route through `buildNgHeaderString`, which rejects every malformed shape
-  // the receive-side validator must be shown to catch.
-  [SymbolFor("bun.internal.quic.sendRawHeaders")](pairs, kind = kHeadersKindInitial, flags = kHeadersFlagsNone) {
+  // Bypasses `buildNgHeaderString`; re-exported through bun:internal-for-testing.
+  [kSendRawHeaders](pairs, kind = kHeadersKindInitial, flags = kHeadersFlagsNone) {
     let s = "";
     for (let i = 0; i + 1 < pairs.length; i += 2) s += `${pairs[i]}\0${pairs[i + 1]}\0\0`;
     return this.#handle.sendHeaders(kind, [s, pairs.length >> 1], flags);

--- a/src/js/internal/quic/symbols.ts
+++ b/src/js/internal/quic/symbols.ts
@@ -31,6 +31,7 @@ const kRemoveSession = Symbol("kRemoveSession");
 const kRemoveStream = Symbol("kRemoveStream");
 const kReset = Symbol("kReset");
 const kSendHeaders = Symbol("kSendHeaders");
+const kSendRawHeaders = Symbol("kSendRawHeaders");
 const kSessionTicket = Symbol("kSessionTicket");
 const kTrailers = Symbol("kTrailers");
 const kVersionNegotiation = Symbol("kVersionNegotiation");
@@ -66,6 +67,7 @@ export default {
   kRemoveStream,
   kReset,
   kSendHeaders,
+  kSendRawHeaders,
   kSessionTicket,
   kTrailers,
   kVersionNegotiation,

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -120,9 +120,7 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
                     if bit != PSEUDO_STATUS {
                         return Err(());
                     }
-                    if value.len() != 3
-                        || !value.iter().all(u8::is_ascii_digit)
-                        || value[0] == b'0'
+                    if value.len() != 3 || !value.iter().all(u8::is_ascii_digit) || value[0] == b'0'
                     {
                         return Err(());
                     }
@@ -140,7 +138,9 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
                 b"content-length" => {
                     if value.is_empty()
                         || !value.iter().all(u8::is_ascii_digit)
-                        || content_length.replace(value).is_some_and(|prev| prev != value)
+                        || content_length
+                            .replace(value)
+                            .is_some_and(|prev| prev != value)
                     {
                         return Err(());
                     }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -52,7 +52,9 @@ fn is_valid_h3_field_name(name: &[u8]) -> bool {
 
 /// RFC 9110 §5.5. NUL is the pair delimiter, already rejected in C.
 fn is_valid_h3_field_value(value: &[u8]) -> bool {
-    !value.iter().any(|&c| matches!(c, b'\r' | b'\n'))
+    !matches!(value.first(), Some(b' ' | b'\t'))
+        && !matches!(value.last(), Some(b' ' | b'\t'))
+        && !value.iter().any(|&c| matches!(c, b'\r' | b'\n'))
 }
 
 /// RFC 9114 §4.2.1.
@@ -83,10 +85,11 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
     let mut seen_pseudo: u8 = 0;
     let mut seen_regular = false;
     let mut saw_host = false;
+    let mut content_length: Option<&[u8]> = None;
     let mut method_is_connect = false;
     let mut is_interim = false;
-    for kv in pairs.chunks_exact(2) {
-        let (name, value) = (kv[0].as_slice(), kv[1].as_slice());
+    for [name, value] in pairs.as_chunks::<2>().0 {
+        let (name, value) = (name.as_slice(), value.as_slice());
         if !is_valid_h3_field_value(value) {
             return Err(());
         }
@@ -117,7 +120,10 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
                     if bit != PSEUDO_STATUS {
                         return Err(());
                     }
-                    if value.len() != 3 || !value.iter().all(u8::is_ascii_digit) {
+                    if value.len() != 3
+                        || !value.iter().all(u8::is_ascii_digit)
+                        || value[0] == b'0'
+                    {
                         return Err(());
                     }
                     is_interim = value[0] == b'1';
@@ -129,7 +135,18 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
             if !is_valid_h3_field_name(name) || is_connection_specific(name, value) {
                 return Err(());
             }
-            saw_host |= name == b"host";
+            match name {
+                b"host" => saw_host |= !value.is_empty(),
+                b"content-length" => {
+                    if value.is_empty()
+                        || !value.iter().all(u8::is_ascii_digit)
+                        || content_length.replace(value).is_some_and(|prev| prev != value)
+                    {
+                        return Err(());
+                    }
+                }
+                _ => {}
+            }
         }
     }
     match role {
@@ -1180,6 +1197,7 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
         };
         match validate_h3_field_section(&pairs, role) {
             Err(()) => {
+                stream.want_read(false);
                 if let Some(s) = qs.ls() {
                     s.reset(H3_MESSAGE_ERROR);
                     // reset() alone leaves the peer free to keep writing.

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -123,9 +123,9 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
                     }
                     PSEUDO_SCHEME => {
                         if !value[0].is_ascii_alphabetic()
-                            || !value[1..]
-                                .iter()
-                                .all(|&c| c.is_ascii_alphanumeric() || matches!(c, b'+' | b'-' | b'.'))
+                            || !value[1..].iter().all(|&c| {
+                                c.is_ascii_alphanumeric() || matches!(c, b'+' | b'-' | b'.')
+                            })
                         {
                             return Err(());
                         }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -63,11 +63,9 @@ fn is_valid_h3_field_value(value: &[u8]) -> bool {
 /// with the value `trailers`.
 fn is_connection_specific(name: &[u8], value: &[u8]) -> bool {
     match name {
-        b"connection"
-        | b"keep-alive"
-        | b"proxy-connection"
-        | b"transfer-encoding"
-        | b"upgrade" => true,
+        b"connection" | b"keep-alive" | b"proxy-connection" | b"transfer-encoding" | b"upgrade" => {
+            true
+        }
         b"te" => value != b"trailers",
         _ => false,
     }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -110,14 +110,28 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
             }
             seen_pseudo |= bit;
             match role {
-                H3HeaderRole::Request => {
-                    if bit == PSEUDO_STATUS {
-                        return Err(());
-                    }
-                    if bit == PSEUDO_METHOD {
+                H3HeaderRole::Request => match bit {
+                    PSEUDO_STATUS => return Err(()),
+                    PSEUDO_METHOD => {
+                        if !value
+                            .iter()
+                            .all(|c| is_valid_h3_field_name(&[c.to_ascii_lowercase()]))
+                        {
+                            return Err(());
+                        }
                         method_is_connect = value == b"CONNECT";
                     }
-                }
+                    PSEUDO_SCHEME => {
+                        if !value[0].is_ascii_alphabetic()
+                            || !value[1..]
+                                .iter()
+                                .all(|&c| c.is_ascii_alphanumeric() || matches!(c, b'+' | b'-' | b'.'))
+                        {
+                            return Err(());
+                        }
+                    }
+                    _ => {}
+                },
                 H3HeaderRole::Response => {
                     if bit != PSEUDO_STATUS {
                         return Err(());

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -18,8 +18,7 @@ const QUIC_STREAM_HEADERS_KIND_INITIAL: u32 = 1;
 const QUIC_STREAM_HEADERS_KIND_TRAILING: u32 = 2;
 const QUIC_STREAM_HEADERS_FLAGS_TERMINAL: u32 = 1;
 
-/// RFC 9114 §8.1 H3_MESSAGE_ERROR. Matches lsquic's `HEC_MESSAGE_ERROR`
-/// (lsquic_hq.h:82).
+/// RFC 9114 §8.1; lsquic `HEC_MESSAGE_ERROR`.
 const H3_MESSAGE_ERROR: u64 = 0x10e;
 
 const PSEUDO_METHOD: u8 = 1 << 0;
@@ -37,8 +36,7 @@ enum H3HeaderRole {
     Trailer,
 }
 
-/// RFC 9110 token characters, lowercase-only per RFC 9114 §4.2 ("characters in
-/// field names MUST be converted to lowercase prior to their encoding").
+/// RFC 9110 token chars, lowercase-only (RFC 9114 §4.2).
 fn is_valid_h3_field_name(name: &[u8]) -> bool {
     !name.is_empty()
         && name.iter().all(|&c| {
@@ -52,21 +50,18 @@ fn is_valid_h3_field_name(name: &[u8]) -> bool {
         })
 }
 
-/// RFC 9114 §4.2 applies RFC 9110 §5.5: field values must not contain NUL, CR,
-/// or LF. NUL is checked earlier in `nq_hsi_process_header` (it doubles as the
-/// pair delimiter).
+/// RFC 9110 §5.5. NUL is the pair delimiter, already rejected in C.
 fn is_valid_h3_field_value(value: &[u8]) -> bool {
     !value.iter().any(|&c| matches!(c, b'\r' | b'\n'))
 }
 
-/// RFC 9114 §4.2.1 prohibited connection-specific fields. `te` is allowed only
-/// with the value `trailers`.
+/// RFC 9114 §4.2.1.
 fn is_connection_specific(name: &[u8], value: &[u8]) -> bool {
     match name {
         b"connection" | b"keep-alive" | b"proxy-connection" | b"transfer-encoding" | b"upgrade" => {
             true
         }
-        b"te" => value != b"trailers",
+        b"te" => !value.eq_ignore_ascii_case(b"trailers"),
         _ => false,
     }
 }
@@ -83,11 +78,8 @@ fn pseudo_header_bit(name: &[u8]) -> Option<u8> {
     }
 }
 
-/// RFC 9114 §4.1.2/§4.2/§4.3 malformed-message checks. nghttp3, which Node
-/// builds on, performs all of these in `nghttp3_http_on_header`; lsquic's
-/// QPACK decoder does not, so every decoded field section passes through here
-/// before reaching `onheaders`. Returns the classified kind on success, or
-/// `Err(())` if the section MUST be treated as a stream error.
+/// RFC 9114 §4.1.2/§4.2/§4.3. lsquic's QPACK decoder does not validate these
+/// (nghttp3 does), so every inbound field section is checked here.
 fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u32, ()> {
     let mut seen_pseudo: u8 = 0;
     let mut seen_regular = false;
@@ -99,18 +91,15 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
             return Err(());
         }
         if let Some((b':', rest)) = name.split_first() {
-            // §4.3: pseudo-headers MUST precede regular fields, and trailers
-            // contain none.
             if seen_regular || matches!(role, H3HeaderRole::Trailer) {
                 return Err(());
             }
-            if !is_valid_h3_field_name(rest) {
+            if value.is_empty() || !is_valid_h3_field_name(rest) {
                 return Err(());
             }
             let Some(bit) = pseudo_header_bit(name) else {
                 return Err(());
             };
-            // §4.3.1/§4.3.2: each defined pseudo-header appears at most once.
             if seen_pseudo & bit != 0 {
                 return Err(());
             }
@@ -128,7 +117,6 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
                     if bit != PSEUDO_STATUS {
                         return Err(());
                     }
-                    // §4.3.2: `:status` carries the RFC 9110 3-digit code.
                     if value.len() != 3 || !value.iter().all(u8::is_ascii_digit) {
                         return Err(());
                     }
@@ -156,20 +144,23 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
             })
         }
         H3HeaderRole::Request => {
-            // §4.3.1: CONNECT omits :scheme and :path; otherwise all three are
-            // mandatory. :protocol is only defined with CONNECT (RFC 9220).
-            let required = if method_is_connect {
-                PSEUDO_METHOD
+            let extended = seen_pseudo & PSEUDO_PROTOCOL != 0;
+            if extended && !method_is_connect {
+                return Err(());
+            }
+            let ok = if method_is_connect && !extended {
+                // §4.4: plain CONNECT carries only :method and :authority.
+                seen_pseudo == PSEUDO_METHOD | PSEUDO_AUTHORITY
             } else {
-                PSEUDO_REQUIRED_REQUEST
+                // §4.3.1; RFC 9220 extended CONNECT also requires :authority.
+                let req = PSEUDO_REQUIRED_REQUEST | if extended { PSEUDO_AUTHORITY } else { 0 };
+                seen_pseudo & req == req
             };
-            if seen_pseudo & required != required {
-                return Err(());
+            if ok {
+                Ok(QUIC_STREAM_HEADERS_KIND_INITIAL)
+            } else {
+                Err(())
             }
-            if !method_is_connect && seen_pseudo & PSEUDO_PROTOCOL != 0 {
-                return Err(());
-            }
-            Ok(QUIC_STREAM_HEADERS_KIND_INITIAL)
         }
     }
 }
@@ -1189,11 +1180,8 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
         match validate_h3_field_section(&pairs, role) {
             Err(()) => {
                 if let Some(s) = qs.ls() {
-                    // reset() only ends the read side when the peer already
-                    // FIN'd/RST'd, so STOP_SENDING is what stops a malformed
-                    // message streaming a body into a stream nothing will
-                    // answer.
                     s.reset(H3_MESSAGE_ERROR);
+                    // reset() alone leaves the peer free to keep writing.
                     s.stop_sending(H3_MESSAGE_ERROR);
                 }
                 qs.mark_reset(H3_MESSAGE_ERROR);

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -50,11 +50,11 @@ fn is_valid_h3_field_name(name: &[u8]) -> bool {
         })
 }
 
-/// RFC 9110 §5.5. NUL is the pair delimiter, already rejected in C.
+/// RFC 9110 §5.5 field-vchar; matches nghttp3_check_header_value.
 fn is_valid_h3_field_value(value: &[u8]) -> bool {
     !matches!(value.first(), Some(b' ' | b'\t'))
         && !matches!(value.last(), Some(b' ' | b'\t'))
-        && !value.iter().any(|&c| matches!(c, b'\r' | b'\n'))
+        && !value.iter().any(|&c| matches!(c, 0..=8 | 0x0a..=0x1f | 0x7f))
 }
 
 /// RFC 9114 §4.2.1.

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -78,11 +78,11 @@ fn pseudo_header_bit(name: &[u8]) -> Option<u8> {
     }
 }
 
-/// RFC 9114 §4.1.2/§4.2/§4.3. lsquic's QPACK decoder does not validate these
-/// (nghttp3 does), so every inbound field section is checked here.
+/// RFC 9114 §4.1.2/§4.2/§4.3. lsquic's QPACK decoder leaves these to the caller.
 fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u32, ()> {
     let mut seen_pseudo: u8 = 0;
     let mut seen_regular = false;
+    let mut saw_host = false;
     let mut method_is_connect = false;
     let mut is_interim = false;
     for kv in pairs.chunks_exact(2) {
@@ -129,6 +129,7 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
             if !is_valid_h3_field_name(name) || is_connection_specific(name, value) {
                 return Err(());
             }
+            saw_host |= name == b"host";
         }
     }
     match role {
@@ -152,9 +153,9 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
                 // §4.4: plain CONNECT carries only :method and :authority.
                 seen_pseudo == PSEUDO_METHOD | PSEUDO_AUTHORITY
             } else {
-                // §4.3.1; RFC 9220 extended CONNECT also requires :authority.
+                // §4.3.1: one of :authority or Host is required for http/https.
                 let req = PSEUDO_REQUIRED_REQUEST | if extended { PSEUDO_AUTHORITY } else { 0 };
-                seen_pseudo & req == req
+                seen_pseudo & req == req && (seen_pseudo & PSEUDO_AUTHORITY != 0 || saw_host)
             };
             if ok {
                 Ok(QUIC_STREAM_HEADERS_KIND_INITIAL)

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -18,6 +18,164 @@ const QUIC_STREAM_HEADERS_KIND_INITIAL: u32 = 1;
 const QUIC_STREAM_HEADERS_KIND_TRAILING: u32 = 2;
 const QUIC_STREAM_HEADERS_FLAGS_TERMINAL: u32 = 1;
 
+/// RFC 9114 §8.1 H3_MESSAGE_ERROR. Matches lsquic's `HEC_MESSAGE_ERROR`
+/// (lsquic_hq.h:82).
+const H3_MESSAGE_ERROR: u64 = 0x10e;
+
+const PSEUDO_METHOD: u8 = 1 << 0;
+const PSEUDO_SCHEME: u8 = 1 << 1;
+const PSEUDO_AUTHORITY: u8 = 1 << 2;
+const PSEUDO_PATH: u8 = 1 << 3;
+const PSEUDO_PROTOCOL: u8 = 1 << 4;
+const PSEUDO_STATUS: u8 = 1 << 5;
+const PSEUDO_REQUIRED_REQUEST: u8 = PSEUDO_METHOD | PSEUDO_SCHEME | PSEUDO_PATH;
+
+#[derive(Clone, Copy)]
+enum H3HeaderRole {
+    Request,
+    Response,
+    Trailer,
+}
+
+/// RFC 9110 token characters, lowercase-only per RFC 9114 §4.2 ("characters in
+/// field names MUST be converted to lowercase prior to their encoding").
+fn is_valid_h3_field_name(name: &[u8]) -> bool {
+    !name.is_empty()
+        && name.iter().all(|&c| {
+            matches!(
+                c,
+                b'a'..=b'z'
+                    | b'0'..=b'9'
+                    | b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*'
+                    | b'+' | b'-' | b'.' | b'^' | b'_' | b'`' | b'|' | b'~'
+            )
+        })
+}
+
+/// RFC 9114 §4.2 applies RFC 9110 §5.5: field values must not contain NUL, CR,
+/// or LF. NUL is checked earlier in `nq_hsi_process_header` (it doubles as the
+/// pair delimiter).
+fn is_valid_h3_field_value(value: &[u8]) -> bool {
+    !value.iter().any(|&c| matches!(c, b'\r' | b'\n'))
+}
+
+/// RFC 9114 §4.2.1 prohibited connection-specific fields. `te` is allowed only
+/// with the value `trailers`.
+fn is_connection_specific(name: &[u8], value: &[u8]) -> bool {
+    match name {
+        b"connection"
+        | b"keep-alive"
+        | b"proxy-connection"
+        | b"transfer-encoding"
+        | b"upgrade" => true,
+        b"te" => value != b"trailers",
+        _ => false,
+    }
+}
+
+fn pseudo_header_bit(name: &[u8]) -> Option<u8> {
+    match name {
+        b":method" => Some(PSEUDO_METHOD),
+        b":scheme" => Some(PSEUDO_SCHEME),
+        b":authority" => Some(PSEUDO_AUTHORITY),
+        b":path" => Some(PSEUDO_PATH),
+        b":protocol" => Some(PSEUDO_PROTOCOL),
+        b":status" => Some(PSEUDO_STATUS),
+        _ => None,
+    }
+}
+
+/// RFC 9114 §4.1.2/§4.2/§4.3 malformed-message checks. nghttp3, which Node
+/// builds on, performs all of these in `nghttp3_http_on_header`; lsquic's
+/// QPACK decoder does not, so every decoded field section passes through here
+/// before reaching `onheaders`. Returns the classified kind on success, or
+/// `Err(())` if the section MUST be treated as a stream error.
+fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u32, ()> {
+    let mut seen_pseudo: u8 = 0;
+    let mut seen_regular = false;
+    let mut method_is_connect = false;
+    let mut is_interim = false;
+    for kv in pairs.chunks_exact(2) {
+        let (name, value) = (kv[0].as_slice(), kv[1].as_slice());
+        if !is_valid_h3_field_value(value) {
+            return Err(());
+        }
+        if let Some((b':', rest)) = name.split_first() {
+            // §4.3: pseudo-headers MUST precede regular fields, and trailers
+            // contain none.
+            if seen_regular || matches!(role, H3HeaderRole::Trailer) {
+                return Err(());
+            }
+            if !is_valid_h3_field_name(rest) {
+                return Err(());
+            }
+            let Some(bit) = pseudo_header_bit(name) else {
+                return Err(());
+            };
+            // §4.3.1/§4.3.2: each defined pseudo-header appears at most once.
+            if seen_pseudo & bit != 0 {
+                return Err(());
+            }
+            seen_pseudo |= bit;
+            match role {
+                H3HeaderRole::Request => {
+                    if bit == PSEUDO_STATUS {
+                        return Err(());
+                    }
+                    if bit == PSEUDO_METHOD {
+                        method_is_connect = value == b"CONNECT";
+                    }
+                }
+                H3HeaderRole::Response => {
+                    if bit != PSEUDO_STATUS {
+                        return Err(());
+                    }
+                    // §4.3.2: `:status` carries the RFC 9110 3-digit code.
+                    if value.len() != 3 || !value.iter().all(u8::is_ascii_digit) {
+                        return Err(());
+                    }
+                    is_interim = value[0] == b'1';
+                }
+                H3HeaderRole::Trailer => unreachable!(),
+            }
+        } else {
+            seen_regular = true;
+            if !is_valid_h3_field_name(name) || is_connection_specific(name, value) {
+                return Err(());
+            }
+        }
+    }
+    match role {
+        H3HeaderRole::Trailer => Ok(QUIC_STREAM_HEADERS_KIND_TRAILING),
+        H3HeaderRole::Response => {
+            if seen_pseudo & PSEUDO_STATUS == 0 {
+                return Err(());
+            }
+            Ok(if is_interim {
+                QUIC_STREAM_HEADERS_KIND_HINTS
+            } else {
+                QUIC_STREAM_HEADERS_KIND_INITIAL
+            })
+        }
+        H3HeaderRole::Request => {
+            // §4.3.1: CONNECT omits :scheme and :path; otherwise all three are
+            // mandatory. :protocol is only defined with CONNECT (RFC 9220).
+            let required = if method_is_connect {
+                PSEUDO_METHOD
+            } else {
+                PSEUDO_REQUIRED_REQUEST
+            };
+            if seen_pseudo & required != required {
+                return Err(());
+            }
+            if !method_is_connect && seen_pseudo & PSEUDO_PROTOCOL != 0 {
+                return Err(());
+            }
+            Ok(QUIC_STREAM_HEADERS_KIND_INITIAL)
+        }
+    }
+}
+
 /// Mirrors Node's `Stream::State` (see `node_quic_binding.rs` for the
 /// `IDX_STATE_STREAM_*` offsets the JS layer reads).
 #[repr(C)]
@@ -435,9 +593,6 @@ impl QuicStream {
 
     pub(super) fn mark_close_reported(&self) -> bool {
         self.close_reported.replace(true)
-    }
-    pub(super) fn mark_headers_received(&self) -> bool {
-        !self.headers_received.replace(true)
     }
     pub(super) fn wants_headers(&self) -> bool {
         self.with_state(|s| s.wants_headers != 0)
@@ -1025,46 +1180,42 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
     let qs = unsafe { &*ctx.cast::<QuicStream>() };
     if let Some(hset) = stream.take_header_set() {
         let pairs = hset.pairs();
-        /// RFC 9114 §8.1 H3_MESSAGE_ERROR — malformed message (a request
-        /// carrying :status). Matches lsquic's `HEC_MESSAGE_ERROR`
-        /// (lsquic_hq.h:82); 0x105 is H3_FRAME_UNEXPECTED, a different code.
-        const H3_MESSAGE_ERROR: u64 = 0x10e;
-        let has_status = pairs
-            .as_chunks::<2>()
-            .0
-            .iter()
-            .find(|kv| kv[0] == b":status")
-            .map(|kv| kv[1].len() == 3 && kv[1][0] == b'1');
-        // A :status in a request is malformed: node's nghttp3 resets the
-        // stream (RFC 9114 §4.1.2), and routing it to `oninfo` would leave
-        // the request unanswered until the idle timeout.
         let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
-        if peer_is_client && has_status.is_some() {
-            if let Some(s) = qs.ls() {
-                // reset() only ends the read side when the peer already
-                // FIN'd/RST'd, so STOP_SENDING is what stops a malformed
-                // request streaming a body into a stream nothing will answer.
-                s.reset(H3_MESSAGE_ERROR);
-                s.stop_sending(H3_MESSAGE_ERROR);
-            }
-            qs.mark_reset(H3_MESSAGE_ERROR);
-            return;
-        }
-        // 1xx interim responses are HINTS (RFC 9114 §4.1).
-        let is_interim = has_status.unwrap_or(false);
-        let kind = if is_interim {
-            QUIC_STREAM_HEADERS_KIND_HINTS
-        } else if qs.mark_headers_received() {
-            QUIC_STREAM_HEADERS_KIND_INITIAL
+        let role = if qs.headers_received.get() {
+            H3HeaderRole::Trailer
+        } else if peer_is_client {
+            H3HeaderRole::Request
         } else {
-            QUIC_STREAM_HEADERS_KIND_TRAILING
+            H3HeaderRole::Response
         };
-        if let Some(session) = qs.session_ref() {
-            session.push_event(SessionEvent::StreamHeaders {
-                stream: ctx.cast(),
-                pairs,
-                kind,
-            });
+        match validate_h3_field_section(&pairs, role) {
+            Err(()) => {
+                if let Some(s) = qs.ls() {
+                    // reset() only ends the read side when the peer already
+                    // FIN'd/RST'd, so STOP_SENDING is what stops a malformed
+                    // message streaming a body into a stream nothing will
+                    // answer.
+                    s.reset(H3_MESSAGE_ERROR);
+                    s.stop_sending(H3_MESSAGE_ERROR);
+                }
+                qs.mark_reset(H3_MESSAGE_ERROR);
+                if let Some(session) = qs.session_ref() {
+                    session.push_event(SessionEvent::StreamWake { stream: ctx.cast() });
+                }
+                return;
+            }
+            Ok(kind) => {
+                if kind != QUIC_STREAM_HEADERS_KIND_HINTS {
+                    qs.headers_received.set(true);
+                }
+                if let Some(session) = qs.session_ref() {
+                    session.push_event(SessionEvent::StreamHeaders {
+                        stream: ctx.cast(),
+                        pairs,
+                        kind,
+                    });
+                }
+            }
         }
     }
     if stream.received_early_data() {

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -54,7 +54,9 @@ fn is_valid_h3_field_name(name: &[u8]) -> bool {
 fn is_valid_h3_field_value(value: &[u8]) -> bool {
     !matches!(value.first(), Some(b' ' | b'\t'))
         && !matches!(value.last(), Some(b' ' | b'\t'))
-        && !value.iter().any(|&c| matches!(c, 0..=8 | 0x0a..=0x1f | 0x7f))
+        && !value
+            .iter()
+            .any(|&c| matches!(c, 0..=8 | 0x0a..=0x1f | 0x7f))
 }
 
 /// RFC 9114 §4.2.1.

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -87,7 +87,7 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
     let mut seen_pseudo: u8 = 0;
     let mut seen_regular = false;
     let mut saw_host = false;
-    let mut content_length: Option<&[u8]> = None;
+    let mut content_length: Option<u64> = None;
     let mut method_is_connect = false;
     let mut is_interim = false;
     for [name, value] in pairs.as_chunks::<2>().0 {
@@ -136,14 +136,21 @@ fn validate_h3_field_section(pairs: &[Vec<u8>], role: H3HeaderRole) -> Result<u3
                 return Err(());
             }
             match name {
-                b"host" => saw_host |= !value.is_empty(),
+                b"host" => {
+                    if value.is_empty() {
+                        return Err(());
+                    }
+                    saw_host = true;
+                }
                 b"content-length" => {
-                    if value.is_empty()
-                        || !value.iter().all(u8::is_ascii_digit)
-                        || content_length
-                            .replace(value)
-                            .is_some_and(|prev| prev != value)
-                    {
+                    let Some(n) = value.iter().try_fold(0u64, |acc, &d| {
+                        d.is_ascii_digit()
+                            .then(|| acc.checked_mul(10)?.checked_add((d - b'0').into()))
+                            .flatten()
+                    }) else {
+                        return Err(());
+                    };
+                    if value.is_empty() || content_length.replace(n).is_some_and(|p| p != n) {
                         return Err(());
                     }
                 }

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -219,8 +219,10 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: "plain CONNECT with :path", pairs: [":method", "CONNECT", ":authority", "h", ":path", "/"] },
     { name: "no :authority and no Host", pairs: [":method", "GET", ":scheme", "https", ":path", "/"] },
     { name: "empty Host without :authority", pairs: [":method", "GET", ":scheme", "https", ":path", "/", "host", ""] },
+    { name: "empty Host with :authority", pairs: [...valid, "host", ""] },
     { name: "non-numeric content-length", pairs: [...valid, "content-length", "abc"] },
     { name: "conflicting content-length", pairs: [...valid, "content-length", "5", "content-length", "100"] },
+    { name: "content-length overflow", pairs: [...valid, "content-length", "99999999999999999999"] },
   ];
 
   const malformedResponses: Row[] = [

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -179,3 +179,238 @@ describe("HTTP/3 header encoding", () => {
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
 });
+
+// RFC 9114 §4.1.2/§4.2/§4.3: a peer that sends a malformed field section MUST
+// receive a stream error of type H3_MESSAGE_ERROR (0x10e). Bun's own client
+// validates outbound headers in `buildNgHeaderString`, so the receive-side
+// checks have to be exercised through a raw send hook that bypasses it.
+describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
+  const kSendRaw = Symbol.for("bun.internal.quic.sendRawHeaders");
+  const H3_MESSAGE_ERROR = 0x10en;
+
+  const valid = [":method", "GET", ":scheme", "https", ":authority", "localhost", ":path", "/"];
+
+  type Row = { name: string; pairs: string[] };
+  // Each of these is a MUST-reject per §4.1.2/§4.2/§4.3.
+  const malformedRequests: Row[] = [
+    { name: "duplicate :path", pairs: [...valid, ":path", "/b"] },
+    { name: "duplicate :method", pairs: [":method", "GET", ...valid] },
+    { name: "unknown pseudo-header", pairs: [...valid, ":foo", "bar"] },
+    { name: ":status in request", pairs: [...valid, ":status", "200"] },
+    { name: "pseudo-header after regular", pairs: [...valid, "x-ok", "v", ":path", "/c"] },
+    { name: "uppercase field name", pairs: [...valid, "X-Upper", "v"] },
+    { name: "non-token field name", pairs: [...valid, "bad name", "v"] },
+    { name: "CR in field value", pairs: [...valid, "x-crlf", "a\r\nb"] },
+    { name: "transfer-encoding", pairs: [...valid, "transfer-encoding", "chunked"] },
+    { name: "connection", pairs: [...valid, "connection", "close"] },
+    { name: "keep-alive", pairs: [...valid, "keep-alive", "timeout=5"] },
+    { name: "upgrade", pairs: [...valid, "upgrade", "h2c"] },
+    { name: "te not trailers", pairs: [...valid, "te", "gzip"] },
+    { name: "missing :method", pairs: [":scheme", "https", ":authority", "localhost", ":path", "/"] },
+    { name: "missing :path", pairs: [":method", "GET", ":scheme", "https", ":authority", "localhost"] },
+    { name: "missing :scheme", pairs: [":method", "GET", ":authority", "localhost", ":path", "/"] },
+    { name: ":protocol without CONNECT", pairs: [...valid, ":protocol", "websocket"] },
+  ];
+
+  const malformedResponses: Row[] = [
+    { name: "missing :status", pairs: ["content-type", "text/plain"] },
+    { name: "duplicate :status", pairs: [":status", "200", ":status", "404"] },
+    { name: "non-numeric :status", pairs: [":status", "abc"] },
+    { name: "request pseudo in response", pairs: [":status", "200", ":path", "/"] },
+    { name: "uppercase field name", pairs: [":status", "200", "X-Upper", "v"] },
+    { name: "transfer-encoding", pairs: [":status", "200", "transfer-encoding", "chunked"] },
+    { name: "connection", pairs: [":status", "200", "connection", "close"] },
+    { name: "pseudo after regular", pairs: ["x-ok", "v", ":status", "200"] },
+  ];
+
+  async function withH3({ onServerHeaders }: { onServerHeaders?: (this: any, h: any) => void }) {
+    const seen: unknown[] = [];
+    const server = await listen(
+      async ss => {
+        ss.onstream = (s: any) => s.closed.catch(() => {});
+        await ss.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 1 },
+        onheaders:
+          onServerHeaders ??
+          function (this: any, h: any) {
+            seen.push(h);
+            this.sendHeaders({ ":status": "200" });
+            this.writer.endSync();
+          },
+      },
+    );
+    const client = await connect(server.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 1 },
+    });
+    await client.opened;
+    return {
+      server,
+      client,
+      seen,
+      done: async () => {
+        client.close();
+        await server.close();
+      },
+    };
+  }
+
+  test.concurrent.each(malformedRequests)(
+    "server rejects malformed request: $name",
+    async ({ pairs }) => {
+      const { client, seen, done } = await withH3({});
+      const stream = await client.createBidirectionalStream();
+      (stream as any)[kSendRaw](pairs, 1, 1);
+
+      // The server resets the stream with H3_MESSAGE_ERROR; the client learns
+      // it via the RESET_STREAM frame, which rejects `closed`.
+      const err = await stream.closed.then(
+        () => undefined,
+        (e: any) => e,
+      );
+      await done();
+
+      expect({ seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+        seen: [],
+        code: "ERR_QUIC_APPLICATION_ERROR",
+        errorCode: H3_MESSAGE_ERROR,
+      });
+    },
+  );
+
+  test.concurrent.each(malformedResponses)(
+    "client rejects malformed response: $name",
+    async ({ pairs }) => {
+      const clientSeen: unknown[] = [];
+      const { client, done } = await withH3({
+        onServerHeaders(this: any) {
+          (this as any)[kSendRaw](pairs, 1, 1);
+        },
+      });
+      const stream = await client.createBidirectionalStream({
+        headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
+        onheaders(h: any) {
+          clientSeen.push(h);
+        },
+      });
+      const err = await stream.closed.then(
+        () => undefined,
+        (e: any) => e,
+      );
+      await done();
+
+      expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+        clientSeen: [],
+        code: "ERR_QUIC_APPLICATION_ERROR",
+        errorCode: H3_MESSAGE_ERROR,
+      });
+    },
+  );
+
+  // Well-formed sections that live near a boundary must still be accepted.
+  test.concurrent.each([
+    { name: "te: trailers", pairs: [...valid, "te", "trailers"] },
+    { name: "CONNECT without :scheme/:path", pairs: [":method", "CONNECT", ":authority", "localhost:443"] },
+  ])("server accepts well-formed request: $name", async ({ pairs }) => {
+    const { client, seen, done } = await withH3({});
+    const stream = await client.createBidirectionalStream();
+    (stream as any)[kSendRaw](pairs, 1, 1);
+    await stream.closed.catch(() => {});
+    const accepted = seen.length;
+    await done();
+    expect(accepted).toBe(1);
+  });
+
+  // These cases go through the public `sendHeaders` path (no raw hook), so
+  // they demonstrate the gap is reachable from the documented API surface:
+  // `buildNgHeaderString` does not enforce role-appropriate pseudo-headers or
+  // the presence of the mandatory ones.
+  test.concurrent("client rejects response missing :status (public sendHeaders)", async () => {
+    const clientSeen: unknown[] = [];
+    const { client, done } = await withH3({
+      onServerHeaders(this: any) {
+        this.sendHeaders({ "content-type": "text/plain" }, { terminal: true });
+      },
+    });
+    const stream = await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
+      onheaders: (h: any) => clientSeen.push(h),
+    });
+    const err = await stream.closed.then(
+      () => undefined,
+      (e: any) => e,
+    );
+    await done();
+    expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+      clientSeen: [],
+      code: "ERR_QUIC_APPLICATION_ERROR",
+      errorCode: H3_MESSAGE_ERROR,
+    });
+  });
+
+  test.concurrent("client rejects response carrying :method (public sendHeaders)", async () => {
+    const clientSeen: unknown[] = [];
+    const { client, done } = await withH3({
+      onServerHeaders(this: any) {
+        this.sendHeaders({ ":status": "200", ":method": "GET" }, { terminal: true });
+      },
+    });
+    const stream = await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
+      onheaders: (h: any) => clientSeen.push(h),
+    });
+    const err = await stream.closed.then(
+      () => undefined,
+      (e: any) => e,
+    );
+    await done();
+    expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+      clientSeen: [],
+      code: "ERR_QUIC_APPLICATION_ERROR",
+      errorCode: H3_MESSAGE_ERROR,
+    });
+  });
+
+  test.concurrent("server rejects request missing :scheme (public sendHeaders)", async () => {
+    const { client, seen, done } = await withH3({});
+    const stream = await client.createBidirectionalStream();
+    stream.sendHeaders({ ":method": "GET", ":authority": "localhost", ":path": "/" }, { terminal: true });
+    const err = await stream.closed.then(
+      () => undefined,
+      (e: any) => e,
+    );
+    await done();
+    expect({ seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+      seen: [],
+      code: "ERR_QUIC_APPLICATION_ERROR",
+      errorCode: H3_MESSAGE_ERROR,
+    });
+  });
+
+  test.concurrent("server rejects pseudo-header in trailers", async () => {
+    let trailersSeen = 0;
+    const { client, done } = await withH3({
+      onServerHeaders(this: any) {
+        this.ontrailers = () => trailersSeen++;
+        this.sendHeaders({ ":status": "200" }, { terminal: true });
+      },
+    });
+    const stream = await client.createBidirectionalStream();
+    (stream as any)[kSendRaw](valid, 1, 0);
+    (stream as any)[kSendRaw]([":path", "/t"], 2, 1);
+    const err = await stream.closed.then(
+      () => undefined,
+      (e: any) => e,
+    );
+    await done();
+    expect({ trailersSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+      trailersSeen: 0,
+      code: "ERR_QUIC_APPLICATION_ERROR",
+      errorCode: H3_MESSAGE_ERROR,
+    });
+  });
+});

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -223,6 +223,8 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: "non-numeric content-length", pairs: [...valid, "content-length", "abc"] },
     { name: "conflicting content-length", pairs: [...valid, "content-length", "5", "content-length", "100"] },
     { name: "content-length overflow", pairs: [...valid, "content-length", "99999999999999999999"] },
+    { name: ":method with space", pairs: [":method", "GET POST", ":scheme", "https", ":authority", "h", ":path", "/"] },
+    { name: ":scheme with space", pairs: [":method", "GET", ":scheme", "ht tp", ":authority", "h", ":path", "/"] },
   ];
 
   const malformedResponses: Row[] = [

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -259,57 +259,51 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     };
   }
 
-  test.concurrent.each(malformedRequests)(
-    "server rejects malformed request: $name",
-    async ({ pairs }) => {
-      const { client, seen, done } = await withH3({});
-      const stream = await client.createBidirectionalStream();
-      (stream as any)[kSendRaw](pairs, 1, 1);
+  test.concurrent.each(malformedRequests)("server rejects malformed request: $name", async ({ pairs }) => {
+    const { client, seen, done } = await withH3({});
+    const stream = await client.createBidirectionalStream();
+    (stream as any)[kSendRaw](pairs, 1, 1);
 
-      // The server resets the stream with H3_MESSAGE_ERROR; the client learns
-      // it via the RESET_STREAM frame, which rejects `closed`.
-      const err = await stream.closed.then(
-        () => undefined,
-        (e: any) => e,
-      );
-      await done();
+    // The server resets the stream with H3_MESSAGE_ERROR; the client learns
+    // it via the RESET_STREAM frame, which rejects `closed`.
+    const err = await stream.closed.then(
+      () => undefined,
+      (e: any) => e,
+    );
+    await done();
 
-      expect({ seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
-        seen: [],
-        code: "ERR_QUIC_APPLICATION_ERROR",
-        errorCode: H3_MESSAGE_ERROR,
-      });
-    },
-  );
+    expect({ seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+      seen: [],
+      code: "ERR_QUIC_APPLICATION_ERROR",
+      errorCode: H3_MESSAGE_ERROR,
+    });
+  });
 
-  test.concurrent.each(malformedResponses)(
-    "client rejects malformed response: $name",
-    async ({ pairs }) => {
-      const clientSeen: unknown[] = [];
-      const { client, done } = await withH3({
-        onServerHeaders(this: any) {
-          (this as any)[kSendRaw](pairs, 1, 1);
-        },
-      });
-      const stream = await client.createBidirectionalStream({
-        headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
-        onheaders(h: any) {
-          clientSeen.push(h);
-        },
-      });
-      const err = await stream.closed.then(
-        () => undefined,
-        (e: any) => e,
-      );
-      await done();
+  test.concurrent.each(malformedResponses)("client rejects malformed response: $name", async ({ pairs }) => {
+    const clientSeen: unknown[] = [];
+    const { client, done } = await withH3({
+      onServerHeaders(this: any) {
+        (this as any)[kSendRaw](pairs, 1, 1);
+      },
+    });
+    const stream = await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
+      onheaders(h: any) {
+        clientSeen.push(h);
+      },
+    });
+    const err = await stream.closed.then(
+      () => undefined,
+      (e: any) => e,
+    );
+    await done();
 
-      expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
-        clientSeen: [],
-        code: "ERR_QUIC_APPLICATION_ERROR",
-        errorCode: H3_MESSAGE_ERROR,
-      });
-    },
-  );
+    expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+      clientSeen: [],
+      code: "ERR_QUIC_APPLICATION_ERROR",
+      errorCode: H3_MESSAGE_ERROR,
+    });
+  });
 
   // Well-formed sections that live near a boundary must still be accepted.
   test.concurrent.each([

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -1,6 +1,7 @@
 // `destroy()` after the app committed AND ended a response (which, under
 // `onwanttrailers`, records `trailers_pending` rather than `fin_pending`)
 // must deliver it with a FIN, never retract it with a RESET_STREAM.
+import { quicSendRawHeaders as kSendRaw } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { createPrivateKey } from "node:crypto";
 import { readFileSync } from "node:fs";
@@ -185,7 +186,6 @@ describe("HTTP/3 header encoding", () => {
 // validates outbound headers in `buildNgHeaderString`, so the receive-side
 // checks have to be exercised through a raw send hook that bypasses it.
 describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
-  const kSendRaw = Symbol.for("bun.internal.quic.sendRawHeaders");
   const H3_MESSAGE_ERROR = 0x10en;
 
   const valid = [":method", "GET", ":scheme", "https", ":authority", "localhost", ":path", "/"];
@@ -209,7 +209,10 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: "missing :method", pairs: [":scheme", "https", ":authority", "localhost", ":path", "/"] },
     { name: "missing :path", pairs: [":method", "GET", ":scheme", "https", ":authority", "localhost"] },
     { name: "missing :scheme", pairs: [":method", "GET", ":authority", "localhost", ":path", "/"] },
+    { name: "empty :path", pairs: [":method", "GET", ":scheme", "https", ":authority", "localhost", ":path", ""] },
     { name: ":protocol without CONNECT", pairs: [...valid, ":protocol", "websocket"] },
+    { name: "CONNECT without :authority", pairs: [":method", "CONNECT"] },
+    { name: "plain CONNECT with :path", pairs: [":method", "CONNECT", ":authority", "h", ":path", "/"] },
   ];
 
   const malformedResponses: Row[] = [
@@ -242,26 +245,30 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
           },
       },
     );
-    const client = await connect(server.address, {
-      servername: "localhost",
-      verifyPeer: "manual",
-      transportParams: { maxIdleTimeout: 1 },
-    });
-    await client.opened;
-    return {
-      server,
-      client,
-      seen,
-      done: async () => {
-        client.close();
-        await server.close();
-      },
-    };
+    try {
+      const client = await connect(server.address, {
+        servername: "localhost",
+        verifyPeer: "manual",
+        transportParams: { maxIdleTimeout: 1 },
+      });
+      await client.opened;
+      return {
+        client,
+        seen,
+        [Symbol.asyncDispose]: async () => {
+          client.close();
+          await server.close();
+        },
+      };
+    } catch (e) {
+      await server.close();
+      throw e;
+    }
   }
 
   test.concurrent.each(malformedRequests)("server rejects malformed request: $name", async ({ pairs }) => {
-    const { client, seen, done } = await withH3({});
-    const stream = await client.createBidirectionalStream();
+    await using ctx = await withH3({});
+    const stream = await ctx.client.createBidirectionalStream();
     (stream as any)[kSendRaw](pairs, 1, 1);
 
     // The server resets the stream with H3_MESSAGE_ERROR; the client learns
@@ -270,9 +277,8 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
       () => undefined,
       (e: any) => e,
     );
-    await done();
 
-    expect({ seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+    expect({ seen: ctx.seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
       seen: [],
       code: "ERR_QUIC_APPLICATION_ERROR",
       errorCode: H3_MESSAGE_ERROR,
@@ -281,12 +287,12 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
 
   test.concurrent.each(malformedResponses)("client rejects malformed response: $name", async ({ pairs }) => {
     const clientSeen: unknown[] = [];
-    const { client, done } = await withH3({
+    await using ctx = await withH3({
       onServerHeaders(this: any) {
         (this as any)[kSendRaw](pairs, 1, 1);
       },
     });
-    const stream = await client.createBidirectionalStream({
+    const stream = await ctx.client.createBidirectionalStream({
       headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
       onheaders(h: any) {
         clientSeen.push(h);
@@ -296,7 +302,6 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
       () => undefined,
       (e: any) => e,
     );
-    await done();
 
     expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
       clientSeen: [],
@@ -308,29 +313,30 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
   // Well-formed sections that live near a boundary must still be accepted.
   test.concurrent.each([
     { name: "te: trailers", pairs: [...valid, "te", "trailers"] },
+    { name: "te: Trailers (mixed case)", pairs: [...valid, "te", "Trailers"] },
     { name: "CONNECT without :scheme/:path", pairs: [":method", "CONNECT", ":authority", "localhost:443"] },
+    {
+      name: "extended CONNECT",
+      pairs: [":method", "CONNECT", ":protocol", "websocket", ":scheme", "https", ":authority", "h", ":path", "/"],
+    },
   ])("server accepts well-formed request: $name", async ({ pairs }) => {
-    const { client, seen, done } = await withH3({});
-    const stream = await client.createBidirectionalStream();
+    await using ctx = await withH3({});
+    const stream = await ctx.client.createBidirectionalStream();
     (stream as any)[kSendRaw](pairs, 1, 1);
     await stream.closed.catch(() => {});
-    const accepted = seen.length;
-    await done();
-    expect(accepted).toBe(1);
+    expect(ctx.seen.length).toBe(1);
   });
 
-  // These cases go through the public `sendHeaders` path (no raw hook), so
-  // they demonstrate the gap is reachable from the documented API surface:
-  // `buildNgHeaderString` does not enforce role-appropriate pseudo-headers or
-  // the presence of the mandatory ones.
+  // These reach the server through public `sendHeaders`, which does not enforce
+  // role-appropriate or mandatory pseudo-headers: the gap was on the API surface.
   test.concurrent("client rejects response missing :status (public sendHeaders)", async () => {
     const clientSeen: unknown[] = [];
-    const { client, done } = await withH3({
+    await using ctx = await withH3({
       onServerHeaders(this: any) {
         this.sendHeaders({ "content-type": "text/plain" }, { terminal: true });
       },
     });
-    const stream = await client.createBidirectionalStream({
+    const stream = await ctx.client.createBidirectionalStream({
       headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
       onheaders: (h: any) => clientSeen.push(h),
     });
@@ -338,7 +344,6 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
       () => undefined,
       (e: any) => e,
     );
-    await done();
     expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
       clientSeen: [],
       code: "ERR_QUIC_APPLICATION_ERROR",
@@ -348,12 +353,12 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
 
   test.concurrent("client rejects response carrying :method (public sendHeaders)", async () => {
     const clientSeen: unknown[] = [];
-    const { client, done } = await withH3({
+    await using ctx = await withH3({
       onServerHeaders(this: any) {
         this.sendHeaders({ ":status": "200", ":method": "GET" }, { terminal: true });
       },
     });
-    const stream = await client.createBidirectionalStream({
+    const stream = await ctx.client.createBidirectionalStream({
       headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
       onheaders: (h: any) => clientSeen.push(h),
     });
@@ -361,7 +366,6 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
       () => undefined,
       (e: any) => e,
     );
-    await done();
     expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
       clientSeen: [],
       code: "ERR_QUIC_APPLICATION_ERROR",
@@ -370,15 +374,14 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
   });
 
   test.concurrent("server rejects request missing :scheme (public sendHeaders)", async () => {
-    const { client, seen, done } = await withH3({});
-    const stream = await client.createBidirectionalStream();
+    await using ctx = await withH3({});
+    const stream = await ctx.client.createBidirectionalStream();
     stream.sendHeaders({ ":method": "GET", ":authority": "localhost", ":path": "/" }, { terminal: true });
     const err = await stream.closed.then(
       () => undefined,
       (e: any) => e,
     );
-    await done();
-    expect({ seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+    expect({ seen: ctx.seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
       seen: [],
       code: "ERR_QUIC_APPLICATION_ERROR",
       errorCode: H3_MESSAGE_ERROR,
@@ -387,20 +390,19 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
 
   test.concurrent("server rejects pseudo-header in trailers", async () => {
     let trailersSeen = 0;
-    const { client, done } = await withH3({
+    await using ctx = await withH3({
       onServerHeaders(this: any) {
         this.ontrailers = () => trailersSeen++;
         this.sendHeaders({ ":status": "200" }, { terminal: true });
       },
     });
-    const stream = await client.createBidirectionalStream();
+    const stream = await ctx.client.createBidirectionalStream();
     (stream as any)[kSendRaw](valid, 1, 0);
     (stream as any)[kSendRaw]([":path", "/t"], 2, 1);
     const err = await stream.closed.then(
       () => undefined,
       (e: any) => e,
     );
-    await done();
     expect({ trailersSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
       trailersSeen: 0,
       code: "ERR_QUIC_APPLICATION_ERROR",

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -2,7 +2,7 @@
 // `onwanttrailers`, records `trailers_pending` rather than `fin_pending`)
 // must deliver it with a FIN, never retract it with a RESET_STREAM.
 import { quicSendRawHeaders as kSendRaw } from "bun:internal-for-testing";
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createPrivateKey } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -213,6 +213,7 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: ":protocol without CONNECT", pairs: [...valid, ":protocol", "websocket"] },
     { name: "CONNECT without :authority", pairs: [":method", "CONNECT"] },
     { name: "plain CONNECT with :path", pairs: [":method", "CONNECT", ":authority", "h", ":path", "/"] },
+    { name: "no :authority and no Host", pairs: [":method", "GET", ":scheme", "https", ":path", "/"] },
   ];
 
   const malformedResponses: Row[] = [
@@ -226,187 +227,176 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: "pseudo after regular", pairs: ["x-ok", "v", ":status", "200"] },
   ];
 
-  async function withH3({ onServerHeaders }: { onServerHeaders?: (this: any, h: any) => void }) {
-    const seen: unknown[] = [];
-    const server = await listen(
+  const wellFormedRequests: Row[] = [
+    { name: "te: trailers", pairs: [...valid, "te", "trailers"] },
+    { name: "te: Trailers (mixed case)", pairs: [...valid, "te", "Trailers"] },
+    { name: "Host without :authority", pairs: [":method", "GET", ":scheme", "https", ":path", "/", "host", "localhost"] },
+    { name: "CONNECT without :scheme/:path", pairs: [":method", "CONNECT", ":authority", "localhost:443"] },
+    {
+      name: "extended CONNECT",
+      pairs: [":method", "CONNECT", ":protocol", "websocket", ":scheme", "https", ":authority", "h", ":path", "/"],
+    },
+  ];
+
+  // One shared session: a fresh handshake per row is what made this flake under
+  // concurrent load. The server dispatches on x-case so response-side rows can
+  // pick their own malformed reply.
+  const serverSeen: Record<string, unknown[]> = {};
+  let server: any, client: any, serverSession: any;
+  beforeAll(async () => {
+    server = await listen(
+      ss => {
+        serverSession = ss;
+        ss.closed.catch(() => {});
+        ss.onstream = (s: any) => s.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 30 },
+        onheaders(this: any, h: any) {
+          this.closed.catch(() => {});
+          const tag = h["x-case"];
+          if (tag?.startsWith("resp/")) {
+            (this as any)[kSendRaw](malformedResponses[+tag.slice(5)].pairs, 1, 1);
+          } else {
+            (serverSeen[tag ?? h[":path"]] ??= []).push(h);
+            this.sendHeaders({ ":status": "200" }, { terminal: true });
+          }
+        },
+      },
+    );
+    client = await connect(server.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 30 },
+    });
+    client.closed.catch(() => {});
+    await client.opened;
+  });
+  afterAll(() => {
+    client?.close();
+    serverSession?.close();
+    server?.close().catch(() => {});
+  });
+
+  const closedErr = (s: any) =>
+    s.closed.then(
+      () => undefined,
+      (e: any) => e,
+    );
+
+  test.concurrent.each(malformedRequests)("server rejects malformed request: $name", async ({ name, pairs }) => {
+    const stream = await client.createBidirectionalStream();
+    (stream as any)[kSendRaw](pairs, 1, 1);
+    const err = await closedErr(stream);
+    expect({ seen: serverSeen[name], code: err?.code, errorCode: err?.errorCode }).toEqual({
+      seen: undefined,
+      code: "ERR_QUIC_APPLICATION_ERROR",
+      errorCode: H3_MESSAGE_ERROR,
+    });
+  });
+
+  test.concurrent.each(malformedResponses.map((r, i) => ({ ...r, i })))(
+    "client rejects malformed response: $name",
+    async ({ i }) => {
+      const clientSeen: unknown[] = [];
+      const stream = await client.createBidirectionalStream({
+        headers: { ":method": "GET", ":scheme": "https", ":authority": "h", ":path": "/", "x-case": `resp/${i}` },
+        onheaders: (h: any) => clientSeen.push(h),
+      });
+      const err = await closedErr(stream);
+      expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+        clientSeen: [],
+        code: "ERR_QUIC_APPLICATION_ERROR",
+        errorCode: H3_MESSAGE_ERROR,
+      });
+    },
+  );
+
+  test.concurrent.each(wellFormedRequests)("server accepts well-formed request: $name", async ({ name, pairs }) => {
+    const stream = await client.createBidirectionalStream();
+    (stream as any)[kSendRaw]([...pairs, "x-case", name], 1, 1);
+    const err = await closedErr(stream);
+    expect({ seen: serverSeen[name]?.length, err }).toEqual({ seen: 1, err: undefined });
+  });
+
+  // These reach the server through public `sendHeaders`, which does not enforce
+  // role-appropriate or mandatory pseudo-headers: the gap was on the API surface.
+  test.concurrent.each([
+    { name: "missing :status", headers: { "content-type": "text/plain" } },
+    { name: ":method in response", headers: { ":status": "200", ":method": "GET" } },
+  ])("client rejects response via public sendHeaders: $name", async ({ headers }) => {
+    const clientSeen: unknown[] = [];
+    await using server = await listen(
       async ss => {
         ss.onstream = (s: any) => s.closed.catch(() => {});
         await ss.closed.catch(() => {});
       },
       {
         sni: { "*": { keys: [key], certs: [cert] } },
-        transportParams: { maxIdleTimeout: 1 },
-        onheaders:
-          onServerHeaders ??
-          function (this: any, h: any) {
-            seen.push(h);
-            this.sendHeaders({ ":status": "200" });
-            this.writer.endSync();
-          },
-      },
-    );
-    try {
-      const client = await connect(server.address, {
-        servername: "localhost",
-        verifyPeer: "manual",
-        transportParams: { maxIdleTimeout: 1 },
-      });
-      await client.opened;
-      return {
-        client,
-        seen,
-        [Symbol.asyncDispose]: async () => {
-          client.close();
-          await server.close();
+        onheaders(this: any) {
+          this.sendHeaders(headers, { terminal: true });
         },
-      };
-    } catch (e) {
-      await server.close();
-      throw e;
+      },
+    );
+    const c = await connect(server.address, { servername: "localhost", verifyPeer: "manual" });
+    await c.opened;
+    try {
+      const stream = await c.createBidirectionalStream({
+        headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
+        onheaders: (h: any) => clientSeen.push(h),
+      });
+      const err = await closedErr(stream);
+      expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
+        clientSeen: [],
+        code: "ERR_QUIC_APPLICATION_ERROR",
+        errorCode: H3_MESSAGE_ERROR,
+      });
+    } finally {
+      c.close();
     }
-  }
-
-  test.concurrent.each(malformedRequests)("server rejects malformed request: $name", async ({ pairs }) => {
-    await using ctx = await withH3({});
-    const stream = await ctx.client.createBidirectionalStream();
-    (stream as any)[kSendRaw](pairs, 1, 1);
-
-    // The server resets the stream with H3_MESSAGE_ERROR; the client learns
-    // it via the RESET_STREAM frame, which rejects `closed`.
-    const err = await stream.closed.then(
-      () => undefined,
-      (e: any) => e,
-    );
-
-    expect({ seen: ctx.seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
-      seen: [],
-      code: "ERR_QUIC_APPLICATION_ERROR",
-      errorCode: H3_MESSAGE_ERROR,
-    });
-  });
-
-  test.concurrent.each(malformedResponses)("client rejects malformed response: $name", async ({ pairs }) => {
-    const clientSeen: unknown[] = [];
-    await using ctx = await withH3({
-      onServerHeaders(this: any) {
-        (this as any)[kSendRaw](pairs, 1, 1);
-      },
-    });
-    const stream = await ctx.client.createBidirectionalStream({
-      headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
-      onheaders(h: any) {
-        clientSeen.push(h);
-      },
-    });
-    const err = await stream.closed.then(
-      () => undefined,
-      (e: any) => e,
-    );
-
-    expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
-      clientSeen: [],
-      code: "ERR_QUIC_APPLICATION_ERROR",
-      errorCode: H3_MESSAGE_ERROR,
-    });
-  });
-
-  // Well-formed sections that live near a boundary must still be accepted.
-  test.concurrent.each([
-    { name: "te: trailers", pairs: [...valid, "te", "trailers"] },
-    { name: "te: Trailers (mixed case)", pairs: [...valid, "te", "Trailers"] },
-    { name: "CONNECT without :scheme/:path", pairs: [":method", "CONNECT", ":authority", "localhost:443"] },
-    {
-      name: "extended CONNECT",
-      pairs: [":method", "CONNECT", ":protocol", "websocket", ":scheme", "https", ":authority", "h", ":path", "/"],
-    },
-  ])("server accepts well-formed request: $name", async ({ pairs }) => {
-    await using ctx = await withH3({});
-    const stream = await ctx.client.createBidirectionalStream();
-    (stream as any)[kSendRaw](pairs, 1, 1);
-    await stream.closed.catch(() => {});
-    expect(ctx.seen.length).toBe(1);
-  });
-
-  // These reach the server through public `sendHeaders`, which does not enforce
-  // role-appropriate or mandatory pseudo-headers: the gap was on the API surface.
-  test.concurrent("client rejects response missing :status (public sendHeaders)", async () => {
-    const clientSeen: unknown[] = [];
-    await using ctx = await withH3({
-      onServerHeaders(this: any) {
-        this.sendHeaders({ "content-type": "text/plain" }, { terminal: true });
-      },
-    });
-    const stream = await ctx.client.createBidirectionalStream({
-      headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
-      onheaders: (h: any) => clientSeen.push(h),
-    });
-    const err = await stream.closed.then(
-      () => undefined,
-      (e: any) => e,
-    );
-    expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
-      clientSeen: [],
-      code: "ERR_QUIC_APPLICATION_ERROR",
-      errorCode: H3_MESSAGE_ERROR,
-    });
-  });
-
-  test.concurrent("client rejects response carrying :method (public sendHeaders)", async () => {
-    const clientSeen: unknown[] = [];
-    await using ctx = await withH3({
-      onServerHeaders(this: any) {
-        this.sendHeaders({ ":status": "200", ":method": "GET" }, { terminal: true });
-      },
-    });
-    const stream = await ctx.client.createBidirectionalStream({
-      headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
-      onheaders: (h: any) => clientSeen.push(h),
-    });
-    const err = await stream.closed.then(
-      () => undefined,
-      (e: any) => e,
-    );
-    expect({ clientSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
-      clientSeen: [],
-      code: "ERR_QUIC_APPLICATION_ERROR",
-      errorCode: H3_MESSAGE_ERROR,
-    });
   });
 
   test.concurrent("server rejects request missing :scheme (public sendHeaders)", async () => {
-    await using ctx = await withH3({});
-    const stream = await ctx.client.createBidirectionalStream();
+    const stream = await client.createBidirectionalStream();
     stream.sendHeaders({ ":method": "GET", ":authority": "localhost", ":path": "/" }, { terminal: true });
-    const err = await stream.closed.then(
-      () => undefined,
-      (e: any) => e,
-    );
-    expect({ seen: ctx.seen, code: err?.code, errorCode: err?.errorCode }).toEqual({
-      seen: [],
+    const err = await closedErr(stream);
+    expect({ code: err?.code, errorCode: err?.errorCode }).toEqual({
       code: "ERR_QUIC_APPLICATION_ERROR",
       errorCode: H3_MESSAGE_ERROR,
     });
   });
 
   test.concurrent("server rejects pseudo-header in trailers", async () => {
-    let trailersSeen = 0;
-    await using ctx = await withH3({
-      onServerHeaders(this: any) {
-        this.ontrailers = () => trailersSeen++;
-        this.sendHeaders({ ":status": "200" }, { terminal: true });
+    // Dedicated session: the assertion is on the server's stream lifetime,
+    // which the shared session does not surface.
+    const serverStreamDone = Promise.withResolvers<void>();
+    const trailersSeen: unknown[] = [];
+    await using server = await listen(
+      async ss => {
+        ss.onerror = () => {};
+        ss.onstream = (s: any) => s.closed.then(serverStreamDone.resolve, serverStreamDone.resolve);
+        await ss.closed.catch(() => {});
       },
-    });
-    const stream = await ctx.client.createBidirectionalStream();
-    (stream as any)[kSendRaw](valid, 1, 0);
-    (stream as any)[kSendRaw]([":path", "/t"], 2, 1);
-    const err = await stream.closed.then(
-      () => undefined,
-      (e: any) => e,
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        onheaders(this: any) {
+          this.ontrailers = (t: any) => trailersSeen.push(t);
+        },
+      },
     );
-    expect({ trailersSeen, code: err?.code, errorCode: err?.errorCode }).toEqual({
-      trailersSeen: 0,
-      code: "ERR_QUIC_APPLICATION_ERROR",
-      errorCode: H3_MESSAGE_ERROR,
-    });
+    const c = await connect(server.address, { servername: "localhost", verifyPeer: "manual" });
+    c.onerror = () => {};
+    await c.opened;
+    try {
+      const stream = await c.createBidirectionalStream();
+      stream.closed.catch(() => {});
+      (stream as any)[kSendRaw](valid, 1, 0);
+      (stream as any)[kSendRaw]([":path", "/t"], 2, 1);
+      await serverStreamDone.promise;
+    } finally {
+      c.close();
+    }
+    expect(trailersSeen).toEqual([]);
   });
 });

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -201,6 +201,8 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: "uppercase field name", pairs: [...valid, "X-Upper", "v"] },
     { name: "non-token field name", pairs: [...valid, "bad name", "v"] },
     { name: "CR in field value", pairs: [...valid, "x-crlf", "a\r\nb"] },
+    { name: "leading SP in field value", pairs: [...valid, "x-ws", " v"] },
+    { name: "trailing HTAB in field value", pairs: [...valid, "x-ws", "v\t"] },
     { name: "transfer-encoding", pairs: [...valid, "transfer-encoding", "chunked"] },
     { name: "connection", pairs: [...valid, "connection", "close"] },
     { name: "keep-alive", pairs: [...valid, "keep-alive", "timeout=5"] },
@@ -214,12 +216,16 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: "CONNECT without :authority", pairs: [":method", "CONNECT"] },
     { name: "plain CONNECT with :path", pairs: [":method", "CONNECT", ":authority", "h", ":path", "/"] },
     { name: "no :authority and no Host", pairs: [":method", "GET", ":scheme", "https", ":path", "/"] },
+    { name: "empty Host without :authority", pairs: [":method", "GET", ":scheme", "https", ":path", "/", "host", ""] },
+    { name: "non-numeric content-length", pairs: [...valid, "content-length", "abc"] },
+    { name: "conflicting content-length", pairs: [...valid, "content-length", "5", "content-length", "100"] },
   ];
 
   const malformedResponses: Row[] = [
     { name: "missing :status", pairs: ["content-type", "text/plain"] },
     { name: "duplicate :status", pairs: [":status", "200", ":status", "404"] },
     { name: "non-numeric :status", pairs: [":status", "abc"] },
+    { name: ":status < 100", pairs: [":status", "050"] },
     { name: "request pseudo in response", pairs: [":status", "200", ":path", "/"] },
     { name: "uppercase field name", pairs: [":status", "200", "X-Upper", "v"] },
     { name: "transfer-encoding", pairs: [":status", "200", "transfer-encoding", "chunked"] },
@@ -227,9 +233,15 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: "pseudo after regular", pairs: ["x-ok", "v", ":status", "200"] },
   ];
 
+  const publicBadResponses = [
+    { name: "missing :status", headers: { "content-type": "text/plain" } },
+    { name: ":method in response", headers: { ":status": "200", ":method": "GET" } },
+  ];
+
   const wellFormedRequests: Row[] = [
     { name: "te: trailers", pairs: [...valid, "te", "trailers"] },
     { name: "te: Trailers (mixed case)", pairs: [...valid, "te", "Trailers"] },
+    { name: "repeated content-length (same value)", pairs: [...valid, "content-length", "0", "content-length", "0"] },
     {
       name: "Host without :authority",
       pairs: [":method", "GET", ":scheme", "https", ":path", "/", "host", "localhost"],
@@ -261,6 +273,8 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
           const tag = h["x-case"];
           if (tag?.startsWith("resp/")) {
             (this as any)[kSendRaw](malformedResponses[+tag.slice(5)].pairs, 1, 1);
+          } else if (tag?.startsWith("pub/")) {
+            this.sendHeaders(publicBadResponses[+tag.slice(4)].headers, { terminal: true });
           } else {
             (serverSeen[tag ?? h[":path"]] ??= []).push(h);
             this.sendHeaders({ ":status": "200" }, { terminal: true });
@@ -288,12 +302,13 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
       (e: any) => e,
     );
 
-  test.concurrent.each(malformedRequests)("server rejects malformed request: $name", async ({ name, pairs }) => {
+  test.concurrent.each(malformedRequests)("server rejects malformed request: $name", async ({ pairs }) => {
     const stream = await client.createBidirectionalStream();
     (stream as any)[kSendRaw](pairs, 1, 1);
     const err = await closedErr(stream);
-    expect({ seen: serverSeen[name], code: err?.code, errorCode: err?.errorCode }).toEqual({
-      seen: undefined,
+    // The RESET_STREAM from the server is the observable proof: onheaders and
+    // the reset path are mutually exclusive in on_stream_read.
+    expect({ code: err?.code, errorCode: err?.errorCode }).toEqual({
       code: "ERR_QUIC_APPLICATION_ERROR",
       errorCode: H3_MESSAGE_ERROR,
     });
@@ -325,28 +340,12 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
 
   // These reach the server through public `sendHeaders`, which does not enforce
   // role-appropriate or mandatory pseudo-headers: the gap was on the API surface.
-  test.concurrent.each([
-    { name: "missing :status", headers: { "content-type": "text/plain" } },
-    { name: ":method in response", headers: { ":status": "200", ":method": "GET" } },
-  ])("client rejects response via public sendHeaders: $name", async ({ headers }) => {
-    const clientSeen: unknown[] = [];
-    await using server = await listen(
-      async ss => {
-        ss.onstream = (s: any) => s.closed.catch(() => {});
-        await ss.closed.catch(() => {});
-      },
-      {
-        sni: { "*": { keys: [key], certs: [cert] } },
-        onheaders(this: any) {
-          this.sendHeaders(headers, { terminal: true });
-        },
-      },
-    );
-    const c = await connect(server.address, { servername: "localhost", verifyPeer: "manual" });
-    await c.opened;
-    try {
-      const stream = await c.createBidirectionalStream({
-        headers: { ":method": "GET", ":scheme": "https", ":authority": "localhost", ":path": "/" },
+  test.concurrent.each(publicBadResponses.map((r, i) => ({ ...r, i })))(
+    "client rejects response via public sendHeaders: $name",
+    async ({ i }) => {
+      const clientSeen: unknown[] = [];
+      const stream = await client.createBidirectionalStream({
+        headers: { ":method": "GET", ":scheme": "https", ":authority": "h", ":path": "/", "x-case": `pub/${i}` },
         onheaders: (h: any) => clientSeen.push(h),
       });
       const err = await closedErr(stream);
@@ -355,10 +354,8 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
         code: "ERR_QUIC_APPLICATION_ERROR",
         errorCode: H3_MESSAGE_ERROR,
       });
-    } finally {
-      c.close();
-    }
-  });
+    },
+  );
 
   test.concurrent("server rejects request missing :scheme (public sendHeaders)", async () => {
     const stream = await client.createBidirectionalStream();

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -201,6 +201,8 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
     { name: "uppercase field name", pairs: [...valid, "X-Upper", "v"] },
     { name: "non-token field name", pairs: [...valid, "bad name", "v"] },
     { name: "CR in field value", pairs: [...valid, "x-crlf", "a\r\nb"] },
+    { name: "C0 control in field value", pairs: [...valid, "x-ctl", "a\x01b"] },
+    { name: "DEL in field value", pairs: [...valid, "x-ctl", "a\x7fb"] },
     { name: "leading SP in field value", pairs: [...valid, "x-ws", " v"] },
     { name: "trailing HTAB in field value", pairs: [...valid, "x-ws", "v\t"] },
     { name: "transfer-encoding", pairs: [...valid, "transfer-encoding", "chunked"] },

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -230,7 +230,10 @@ describe("HTTP/3 inbound field-section validation (RFC 9114)", () => {
   const wellFormedRequests: Row[] = [
     { name: "te: trailers", pairs: [...valid, "te", "trailers"] },
     { name: "te: Trailers (mixed case)", pairs: [...valid, "te", "Trailers"] },
-    { name: "Host without :authority", pairs: [":method", "GET", ":scheme", "https", ":path", "/", "host", "localhost"] },
+    {
+      name: "Host without :authority",
+      pairs: [":method", "GET", ":scheme", "https", ":path", "/", "host", "localhost"],
+    },
     { name: "CONNECT without :scheme/:path", pairs: [":method", "CONNECT", ":authority", "localhost:443"] },
     {
       name: "extended CONNECT",


### PR DESCRIPTION
Fixes #3341.

## Problem

The inbound H3 header path (`nq_hsi_process_header` -> `on_stream_read` -> `parseHeaderPairs`) validated only embedded NUL bytes and `:status`-in-request. Every other malformed field section that RFC 9114 4.1.2 / 4.2 / 4.3 says MUST be a stream error of type `H3_MESSAGE_ERROR` reached `onheaders` and was answered with 200:

- duplicate pseudo-headers (`:path` twice)
- uppercase or non-token field names
- connection-specific headers (`transfer-encoding`, `connection`, `keep-alive`, `proxy-connection`, `upgrade`, `te` != `trailers`)
- pseudo-headers appearing after regular headers
- unknown pseudo-headers
- requests missing `:method` / `:scheme` / `:path`
- responses missing `:status`, or with a non-numeric `:status`, or carrying request pseudo-headers
- pseudo-headers in trailers

The duplicate-pseudo-header and `transfer-encoding: chunked` cases are the request-smuggling-adjacent ones. A raw QPACK client (aioquic transport + hand-encoded field section) against `listen({alpn:["h3"]})` delivers `":path": ["/a","/b"]` and `"transfer-encoding": "chunked"` to `onheaders`, and the server responds 200.

## Cause

Node builds `node:quic` on nghttp3, whose `nghttp3_http_on_header` performs all of these checks before the application callback fires. Bun builds on lsquic, whose QPACK decoder only surfaces decoded name/value pairs and leaves semantic validation to the caller. The only caller-side check was the one-off `:status`-in-request guard in `on_stream_read`.

## Fix

`on_stream_read` now runs a full RFC 9114 4.1.2 / 4.2 / 4.3 validator (`validate_h3_field_section`) over every decoded field section, role-aware (request / response / trailer), before pushing `StreamHeaders`. A failure issues `RESET_STREAM` + `STOP_SENDING` with `H3_MESSAGE_ERROR` (0x10e), the same per-stream error nghttp3 produces. This mirrors the structure of the existing HTTP/2 receive-side validation in `h2_frame_parser.rs`.

## Testing

`buildNgHeaderString` rejects every malformed shape on the way out, so a bun-to-bun test cannot exercise most receive-side checks through the public API. A `Symbol.for`-keyed raw-send hook on `QuicStream` is added for that purpose. The test adds 31 cases (17 malformed requests, 8 malformed responses, 2 well-formed edge cases, pseudo-header-in-trailer, and 3 public-API cases that show the gap was reachable from documented surface).

```
# with fix
34 pass, 0 fail

# without fix (git stash -- src/)
0 pass, 31 fail

# sample fail-before output
{
  clientSeen: [{ "content-type": "text/plain" }],   // response missing :status delivered
  code: undefined,
  errorCode: undefined,
}
```

All `test-quic-h3-*.mjs` and `test-quic-stream-*.mjs` Node parallel tests still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (82d59a715)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)


# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'quicSendRawHeaders' not found in module 'bun:internal-for-testing'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [4.12s]
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/quic/quic-stream.test.ts:

# Unhandled error between tests
-------------------------------
9 | import { connect, listen } from "node:quic";
                                    ^
error: Could not resolve: "node:quic". Maybe you need to "bun install"?
    at /workspace/bun/test/js/node/quic/quic-stream.test.ts:9:33
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [291.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (82d59a715)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [532.44ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [127.36ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1134.47ms]
(pass) HTTP/3 inbound field-section validation (RFC 9114) > server rejects malformed request: duplicate :path [78.46ms]
(pass) HTTP/3 inbound field-section validation (RFC 9114) > server rejects malformed request: duplicate :method [84.33ms]
(pass) HTTP/3 inbound field-section validation (RFC 9114) > server rejects malformed request: unknown pseudo-header [84.12ms]
(pass) HTTP/3 inbound field-section validation (RFC 9114) > server rejects malformed request: :status in re
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     82d59a715a
  features     baseline

22 deps, 108 codegen, 1171 objects in 1449ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[3/1234] fetch picohttpparser
[picohttpparser] up to date
[4/1234] fetch tinycc
[tinycc] up to date
[5/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1234] fetch zlib
[zlib] up to date
[8/1234] subst deps/libjpeg-turbo/jconfig.h
[9/1234] gen .bind.ts → GeneratedBindings.cpp
[10/1234] subst deps/libjpeg-turbo/jconfigint.h
[11/1234] subst deps/zlib/zlib.h
[12/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[13/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/Pr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal-for-testing.ts        |   2 +
 src/js/internal/quic/quic.ts          |   8 ++
 src/js/internal/quic/symbols.ts       |   2 +
 src/runtime/node/quic/stream.rs       | 245 ++++++++++++++++++++++++++++------
 test/js/node/quic/quic-stream.test.ts | 227 ++++++++++++++++++++++++++++++-
 5 files changed, 443 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/internal-for-testing.ts             1      1      0
src/js/internal/quic/quic.ts              12      6      0
src/js/internal/quic/symbols.ts            2      2      0
src/runtime/node/quic/stream.rs           16     38      0
test/js/node/quic/quic-stream.test.ts      9     37      0
```

</details>

<!-- robobun:evidence:end -->