### PR TITLE
node:quic: drop rejected 0-RTT packets instead of retransmitting at 1-RTT

### DIFF
--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -162,6 +162,11 @@ static void nq_on_early_data_failed(lsquic_conn_t *c) {
         struct us_nq_vtable *vt = *(struct us_nq_vtable **) ctx;
         vt->on_early_data_failed(ctx);
     }
+    /* node:quic destroys every 0-RTT stream and the application re-opens;
+     * lsquic's transparent stash-and-retransmit-at-1-RTT would deliver the
+     * rejected payload to the server on a stream the client already reported
+     * as failed, so the documented re-open delivers it a second time. */
+    lsquic_conn_drop_0rtt_packets(c);
 }
 static void nq_on_origin(lsquic_conn_t *c, const unsigned char *chunk,
                          size_t len, int fin) {

--- a/patches/lsquic/node-quic-accessors.patch
+++ b/patches/lsquic/node-quic-accessors.patch
@@ -1391,7 +1391,7 @@
      if (0 == (conn->ifc_flags & IFC_IMMEDIATE_CLOSE_FLAGS))
          if (0 != conn->ifc_process_incoming_packet(conn, packet_in))
              conn->ifc_flags |= IFC_ERROR;
-@@ -8342,10 +8642,28 @@
+@@ -8342,10 +8642,32 @@
      struct ietf_full_conn *conn = (struct ietf_full_conn *) lconn;
  
      LSQ_DEBUG("early data failed");
@@ -1412,7 +1412,11 @@
 +void
 +lsquic_conn_drop_0rtt_packets (struct lsquic_conn *lconn)
 +{
-+    struct ietf_full_conn *conn = (struct ietf_full_conn *) lconn;
++    struct ietf_full_conn *conn;
++
++    if ((lconn->cn_flags & (LSCONN_MINI|LSCONN_IETF)) != LSCONN_IETF)
++        return;
++    conn = (struct ietf_full_conn *) lconn;
 +    lsquic_send_ctl_drop_0rtt_packets(&conn->ifc_send_ctl);
 +}
 +

--- a/patches/lsquic/node-quic-accessors.patch
+++ b/patches/lsquic/node-quic-accessors.patch
@@ -160,7 +160,7 @@
   * Refuse pushed stream.  Call it from @ref on_new_stream.
   *
   * No need to call lsquic_stream_close() after this.  on_close will be called.
-@@ -2031,6 +2154,112 @@
+@@ -2031,6 +2154,120 @@
  unsigned lsquic_engine_quic_versions (const lsquic_engine_t *);
  
  /**
@@ -232,6 +232,14 @@
 + */
 +void
 +lsquic_conn_abort_silent (lsquic_conn_t *);
++
++/**
++ * Destroy every sent-but-unacked 0-RTT packet so rejected early stream
++ * data is never retransmitted at 1-RTT.  Only valid from inside the
++ * @ref on_early_data_failed callback.
++ */
++void
++lsquic_conn_drop_0rtt_packets (lsquic_conn_t *);
 +
 +/**
 + * Per-connection SSL object (IETF QUIC only). Returns NULL for gQUIC or
@@ -1383,7 +1391,7 @@
      if (0 == (conn->ifc_flags & IFC_IMMEDIATE_CLOSE_FLAGS))
          if (0 != conn->ifc_process_incoming_packet(conn, packet_in))
              conn->ifc_flags |= IFC_ERROR;
-@@ -8342,6 +8642,9 @@
+@@ -8342,10 +8642,28 @@
      struct ietf_full_conn *conn = (struct ietf_full_conn *) lconn;
  
      LSQ_DEBUG("early data failed");
@@ -1393,6 +1401,25 @@
      lsquic_send_ctl_stash_0rtt_packets(&conn->ifc_send_ctl);
  }
  
+ 
++/* bun: destroy the unacked 0-RTT packets so a rejected early stream's
++ * STREAM frames are never retransmitted at 1-RTT.  node:quic tears every
++ * 0-RTT stream down and the application re-opens; without this the stashed
++ * packets reach the server on a stream the client already reported as
++ * failed, and the documented re-open delivers the payload a second time.
++ * Called from node:quic's on_early_data_failed callback (before this
++ * function's one caller stashes, so the stash finds nothing). */
++void
++lsquic_conn_drop_0rtt_packets (struct lsquic_conn *lconn)
++{
++    struct ietf_full_conn *conn = (struct ietf_full_conn *) lconn;
++    lsquic_send_ctl_drop_0rtt_packets(&conn->ifc_send_ctl);
++}
++
++
+ static size_t
+ ietf_full_conn_ci_get_min_datagram_size (struct lsquic_conn *lconn)
+ {
 @@ -8401,6 +8704,11 @@
      packet_out = get_writeable_packet(conn, need);
      if (!packet_out)
@@ -2035,3 +2062,56 @@
                  LSQ_DEBUG("acking via regular record #%"PRIu64,
                                                          packet_out->po_packno);
              }
+@@ -4420,6 +4436,40 @@
+ }
+ 
+ 
++/* bun: the node:quic early-data-rejected counterpart of the stash function
++ * above.  node:quic destroys every 0-RTT stream and the application
++ * re-opens, so the stashed packets must not be retransmitted at 1-RTT:
++ * the server (which rejected 0-RTT, so never processed them) would receive
++ * the payload on a stream the client already reported as failed.  Destroy
++ * the packets instead.  lsquic_packet_out_ack_streams releases each
++ * stream's n_unacked so the subsequent shutdown can finish it.
++ */
++void
++lsquic_send_ctl_drop_0rtt_packets (struct lsquic_send_ctl *ctl)
++{
++    struct lsquic_packet_out *packet_out, *next;
++    unsigned count, packet_sz;
++
++    count = 0;
++    for (packet_out = TAILQ_FIRST(&ctl->sc_unacked_packets[PNS_APP]);
++                                                packet_out; packet_out = next)
++    {
++        next = TAILQ_NEXT(packet_out, po_next);
++        if (packet_out->po_header_type == HETY_0RTT)
++        {
++            packet_sz = packet_out_sent_sz(packet_out);
++            send_ctl_unacked_remove(ctl, packet_out, packet_sz);
++            lsquic_packet_out_ack_streams(packet_out);
++            send_ctl_destroy_chain(ctl, packet_out, &next);
++            send_ctl_destroy_packet(ctl, packet_out);
++            ++count;
++        }
++    }
++
++    LSQ_DEBUG("dropped %u 0-RTT packet%.*s", count, count != 1, "s");
++}
++
++
+ uint64_t
+ lsquic_send_ctl_get_bw (struct lsquic_send_ctl *ctl)
+ {
+--- a/src/liblsquic/lsquic_send_ctl.h
++++ b/src/liblsquic/lsquic_send_ctl.h
+@@ -524,6 +524,9 @@
+ lsquic_send_ctl_stash_0rtt_packets (struct lsquic_send_ctl *);
+ 
+ void
++lsquic_send_ctl_drop_0rtt_packets (struct lsquic_send_ctl *);
++
++void
+ lsquic_send_ctl_set_bw_sampler (struct lsquic_send_ctl *, int enable);
+ 
+ int

--- a/patches/lsquic/node-quic-accessors.patch
+++ b/patches/lsquic/node-quic-accessors.patch
@@ -234,9 +234,9 @@
 +lsquic_conn_abort_silent (lsquic_conn_t *);
 +
 +/**
-+ * Destroy every sent-but-unacked 0-RTT packet so rejected early stream
-+ * data is never retransmitted at 1-RTT.  Only valid from inside the
-+ * @ref on_early_data_failed callback.
++ * Destroy every queued 0-RTT packet so rejected early stream data is
++ * never retransmitted at 1-RTT.  Only valid from inside the
++ * @ref on_early_data_failed callback.  No-op for HTTP/3 connections.
 + */
 +void
 +lsquic_conn_drop_0rtt_packets (lsquic_conn_t *);
@@ -1391,7 +1391,7 @@
      if (0 == (conn->ifc_flags & IFC_IMMEDIATE_CLOSE_FLAGS))
          if (0 != conn->ifc_process_incoming_packet(conn, packet_in))
              conn->ifc_flags |= IFC_ERROR;
-@@ -8342,10 +8642,32 @@
+@@ -8342,10 +8642,37 @@
      struct ietf_full_conn *conn = (struct ietf_full_conn *) lconn;
  
      LSQ_DEBUG("early data failed");
@@ -1402,13 +1402,16 @@
  }
  
  
-+/* bun: destroy the unacked 0-RTT packets so a rejected early stream's
++/* bun: destroy the queued 0-RTT packets so a rejected early stream's
 + * STREAM frames are never retransmitted at 1-RTT.  node:quic tears every
 + * 0-RTT stream down and the application re-opens; without this the stashed
 + * packets reach the server on a stream the client already reported as
 + * failed, and the documented re-open delivers the payload a second time.
 + * Called from node:quic's on_early_data_failed callback (before this
-+ * function's one caller stashes, so the stash finds nothing). */
++ * function's one caller stashes, so the stash finds nothing).  No-op in
++ * HTTP/3 mode: init_http packetized the H3 control and QPACK streams at
++ * 0-RTT, and those must be retransmitted (IFC_HTTP_INITED is already set
++ * so handshake_ok will not re-run init_http). */
 +void
 +lsquic_conn_drop_0rtt_packets (struct lsquic_conn *lconn)
 +{
@@ -1417,6 +1420,8 @@
 +    if ((lconn->cn_flags & (LSCONN_MINI|LSCONN_IETF)) != LSCONN_IETF)
 +        return;
 +    conn = (struct ietf_full_conn *) lconn;
++    if (conn->ifc_flags & IFC_HTTP)
++        return;
 +    lsquic_send_ctl_drop_0rtt_packets(&conn->ifc_send_ctl);
 +}
 +

--- a/patches/lsquic/node-quic-accessors.patch
+++ b/patches/lsquic/node-quic-accessors.patch
@@ -2066,7 +2066,7 @@
                  LSQ_DEBUG("acking via regular record #%"PRIu64,
                                                          packet_out->po_packno);
              }
-@@ -4420,6 +4436,40 @@
+@@ -4420,6 +4436,95 @@
  }
  
  
@@ -2075,14 +2075,34 @@
 + * re-opens, so the stashed packets must not be retransmitted at 1-RTT:
 + * the server (which rejected 0-RTT, so never processed them) would receive
 + * the payload on a stream the client already reported as failed.  Destroy
-+ * the packets instead.  lsquic_packet_out_ack_streams releases each
-+ * stream's n_unacked so the subsequent shutdown can finish it.
++ * the packets instead.  Covers the same queue set as
++ * lsquic_send_ctl_0rtt_to_1rtt, which would otherwise relabel survivors
++ * HETY_SHORT and send them.  lsquic_packet_out_ack_streams releases each
++ * stream's n_unacked so the subsequent shutdown can finish it;
++ * on_datagram_status reports carried DATAGRAM frames as lost so the
++ * application's inflight-id FIFO stays aligned.
 + */
++static void
++send_ctl_discard_0rtt_packet (struct lsquic_send_ctl *ctl,
++                              struct lsquic_packet_out *packet_out,
++                              struct lsquic_packet_out **next)
++{
++    lsquic_packet_out_ack_streams(packet_out);
++    if ((packet_out->po_frame_types & QUIC_FTBIT_DATAGRAM)
++            && ctl->sc_enpub->enp_stream_if->on_datagram_status)
++        ctl->sc_enpub->enp_stream_if->on_datagram_status(
++            ctl->sc_conn_pub->lconn,
++            lsquic_packet_out_count_datagram_frames(packet_out), 0);
++    send_ctl_destroy_chain(ctl, packet_out, next);
++    send_ctl_destroy_packet(ctl, packet_out);
++}
++
++
 +void
 +lsquic_send_ctl_drop_0rtt_packets (struct lsquic_send_ctl *ctl)
 +{
 +    struct lsquic_packet_out *packet_out, *next;
-+    unsigned count, packet_sz;
++    unsigned count, packet_sz, n;
 +
 +    count = 0;
 +    for (packet_out = TAILQ_FIRST(&ctl->sc_unacked_packets[PNS_APP]);
@@ -2093,12 +2113,47 @@
 +        {
 +            packet_sz = packet_out_sent_sz(packet_out);
 +            send_ctl_unacked_remove(ctl, packet_out, packet_sz);
-+            lsquic_packet_out_ack_streams(packet_out);
-+            send_ctl_destroy_chain(ctl, packet_out, &next);
-+            send_ctl_destroy_packet(ctl, packet_out);
++            send_ctl_discard_0rtt_packet(ctl, packet_out, &next);
 +            ++count;
 +        }
 +    }
++    for (packet_out = TAILQ_FIRST(&ctl->sc_scheduled_packets);
++                                                packet_out; packet_out = next)
++    {
++        next = TAILQ_NEXT(packet_out, po_next);
++        if (packet_out->po_header_type == HETY_0RTT)
++        {
++            send_ctl_sched_remove(ctl, packet_out);
++            send_ctl_discard_0rtt_packet(ctl, packet_out, NULL);
++            ++count;
++        }
++    }
++    for (packet_out = TAILQ_FIRST(&ctl->sc_lost_packets);
++                                                packet_out; packet_out = next)
++    {
++        next = TAILQ_NEXT(packet_out, po_next);
++        if (packet_out->po_header_type == HETY_0RTT)
++        {
++            TAILQ_REMOVE(&ctl->sc_lost_packets, packet_out, po_next);
++            packet_out->po_flags &= ~PO_LOST;
++            send_ctl_discard_0rtt_packet(ctl, packet_out, NULL);
++            ++count;
++        }
++    }
++    for (n = 0; n < 2; ++n)
++        for (packet_out = TAILQ_FIRST(&ctl->sc_buffered_packets[n].bpq_packets);
++                                                packet_out; packet_out = next)
++        {
++            next = TAILQ_NEXT(packet_out, po_next);
++            if (packet_out->po_header_type == HETY_0RTT)
++            {
++                TAILQ_REMOVE(&ctl->sc_buffered_packets[n].bpq_packets,
++                             packet_out, po_next);
++                --ctl->sc_buffered_packets[n].bpq_count;
++                send_ctl_discard_0rtt_packet(ctl, packet_out, NULL);
++                ++count;
++            }
++        }
 +
 +    LSQ_DEBUG("dropped %u 0-RTT packet%.*s", count, count != 1, "s");
 +}

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -1565,6 +1565,17 @@ impl QuicSession {
             ),
             None => (JSValue::UNDEFINED, JSValue::UNDEFINED),
         };
+        // Fire before `opened` resolves: the early streams were already torn
+        // down during `EarlyDataFailed`, and the application's re-open
+        // decision keys off this callback having run by the time it awaits
+        // `opened`.
+        if early_data.0 && !early_data.1 && !self.is_server.get() {
+            if let Some(callback) = callbacks::get(global, "onSessionEarlyDataRejected") {
+                let vm = global.bun_vm().as_mut();
+                vm.event_loop_ref()
+                    .run_callback(callback, global, self.handle(), &[]);
+            }
+        }
         if let Some(callback) = callbacks::get(global, "onSessionHandshake") {
             let vm = global.bun_vm().as_mut();
             vm.event_loop_ref().run_callback(
@@ -1590,16 +1601,6 @@ impl QuicSession {
                 "\u{1e}{{\"qlog_version\":\"0.3\",\"qlog_format\":\"JSON-SEQ\",\"title\":\"bun node:quic\"}}\n\u{1e}{{\"time\":{t},\"name\":\"connectivity:connection_started\",\"data\":{{}}}}\n"
             );
             self.emit_qlog(global, &chunk, false);
-        }
-
-        // Node destroys the early streams and fires `onearlyrejected` — on
-        // the CLIENT only.
-        if early_data.0 && !early_data.1 && !self.is_server.get() {
-            if let Some(callback) = callbacks::get(global, "onSessionEarlyDataRejected") {
-                let vm = global.bun_vm().as_mut();
-                vm.event_loop_ref()
-                    .run_callback(callback, global, self.handle(), &[]);
-            }
         }
 
         // Matching Node: the server session exists and then closes with a

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -1565,8 +1565,7 @@ impl QuicSession {
             ),
             None => (JSValue::UNDEFINED, JSValue::UNDEFINED),
         };
-        // Before onSessionHandshake so `onearlyrejected` has fired when the
-        // application's `await opened` continuation runs.
+        // Before onSessionHandshake: `onearlyrejected` must precede `await opened`.
         if early_data.0 && !early_data.1 && !self.is_server.get() {
             if let Some(callback) = callbacks::get(global, "onSessionEarlyDataRejected") {
                 let vm = global.bun_vm().as_mut();

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -1565,10 +1565,8 @@ impl QuicSession {
             ),
             None => (JSValue::UNDEFINED, JSValue::UNDEFINED),
         };
-        // Fire before `opened` resolves: the early streams were already torn
-        // down during `EarlyDataFailed`, and the application's re-open
-        // decision keys off this callback having run by the time it awaits
-        // `opened`.
+        // Before onSessionHandshake so `onearlyrejected` has fired when the
+        // application's `await opened` continuation runs.
         if early_data.0 && !early_data.1 && !self.is_server.get() {
             if let Some(callback) = callbacks::get(global, "onSessionEarlyDataRejected") {
                 let vm = global.bun_vm().as_mut();

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -179,3 +179,100 @@ describe("HTTP/3 header encoding", () => {
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
 });
+
+// A 0-RTT stream the server rejects must not reach the server at 1-RTT.
+// lsquic's default is to stash rejected 0-RTT packets and retransmit them
+// once 1-RTT keys exist, but node:quic destroys every early stream and the
+// application re-opens, so a retransmission delivers the payload twice.
+describe("0-RTT rejected", () => {
+  async function readAll(stream: any) {
+    const chunks: Buffer[] = [];
+    for await (const c of stream) for (const x of [].concat(c)) chunks.push(Buffer.from(x));
+    return Buffer.concat(chunks);
+  }
+
+  test("a rejected early stream's data never reaches the server", async () => {
+    // Server A issues a ticket, then a fresh server B (new ticket keys)
+    // rejects the early data.
+    const makeServer = async () => {
+      const got: string[] = [];
+      const barrier = Promise.withResolvers<void>();
+      const ep = await listen(
+        async s => {
+          s.onerror = () => {};
+          s.closed.catch(() => {});
+          s.onstream = async (st: any) => {
+            const body = await readAll(st).catch(() => Buffer.alloc(0));
+            got.push(body.toString());
+            if (body.length) {
+              st.writer.writeSync(body);
+              await st.writer.end();
+            }
+            barrier.resolve();
+          };
+        },
+        { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["echo"] },
+      );
+      return { ep, got, barrier };
+    };
+
+    const a = await makeServer();
+    const gotTicket = Promise.withResolvers<Buffer>();
+    let token: Buffer | undefined;
+    {
+      const c = await connect(a.ep.address, {
+        alpn: "echo",
+        verifyPeer: "manual",
+        reuseEndpoint: false,
+        onsessionticket: (t: Buffer) => gotTicket.resolve(t),
+        onnewtoken: (t: Buffer) => (token = t),
+      });
+      await c.opened;
+      await readAll(await c.createBidirectionalStream({ body: Buffer.from("first") }));
+      var ticket = await gotTicket.promise;
+      c.close();
+      await c.closed.catch(() => {});
+    }
+    await a.ep.close();
+
+    const b = await makeServer();
+    let earlyRejectedFired = false;
+    const c = await connect(b.ep.address, {
+      alpn: "echo",
+      verifyPeer: "manual",
+      reuseEndpoint: false,
+      sessionTicket: ticket,
+      token,
+      onearlyrejected: () => (earlyRejectedFired = true),
+    });
+    c.closed.catch(() => {});
+
+    // The 0-RTT stream: opened before the handshake, its payload must be
+    // discarded on rejection.
+    const early = await c.createBidirectionalStream({ body: Buffer.from("PAY-ORDER-42") });
+    const earlyClose = early.closed.catch((e: any) => e);
+
+    const info = await c.opened;
+    expect(info.earlyDataAttempted).toBe(true);
+    expect(info.earlyDataAccepted).toBe(false);
+
+    // The client-side early stream is destroyed with an application error.
+    const err = await earlyClose;
+    expect(err?.code).toBe("ERR_QUIC_APPLICATION_ERROR");
+    await expect(readAll(early)).rejects.toThrow();
+
+    // The documented re-open: this is the one delivery the server must see.
+    const echoed = await readAll(await c.createBidirectionalStream({ body: Buffer.from("PAY-ORDER-42") }));
+    expect(echoed.toString()).toBe("PAY-ORDER-42");
+
+    // The re-open reached the server; any retransmitted 0-RTT stream that
+    // was going to arrive has arrived by now (same path, lower stream id).
+    await b.barrier.promise;
+    c.close();
+    await c.closed.catch(() => {});
+    await b.ep.close();
+
+    expect(b.got).toEqual(["PAY-ORDER-42"]);
+    expect(earlyRejectedFired).toBe(true);
+  });
+});

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -213,14 +213,15 @@ describe("0-RTT rejected", () => {
         },
         { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["echo"] },
       );
-      return { ep, got, barrier };
+      return { ep, got, barrier, [Symbol.asyncDispose]: () => ep.close() };
     };
 
-    const a = await makeServer();
     const gotTicket = Promise.withResolvers<Buffer>();
+    let ticket: Buffer;
     let token: Buffer | undefined;
     {
-      const c = await connect(a.ep.address, {
+      await using a = await makeServer();
+      await using c = await connect(a.ep.address, {
         alpn: "echo",
         verifyPeer: "manual",
         reuseEndpoint: false,
@@ -229,15 +230,12 @@ describe("0-RTT rejected", () => {
       });
       await c.opened;
       await readAll(await c.createBidirectionalStream({ body: Buffer.from("first") }));
-      var ticket = await gotTicket.promise;
-      c.close();
-      await c.closed.catch(() => {});
+      ticket = await gotTicket.promise;
     }
-    await a.ep.close();
 
-    const b = await makeServer();
+    await using b = await makeServer();
     let earlyRejectedFired = false;
-    const c = await connect(b.ep.address, {
+    await using c = await connect(b.ep.address, {
       alpn: "echo",
       verifyPeer: "manual",
       reuseEndpoint: false,
@@ -259,7 +257,7 @@ describe("0-RTT rejected", () => {
     // The client-side early stream is destroyed with an application error.
     const err = await earlyClose;
     expect(err?.code).toBe("ERR_QUIC_APPLICATION_ERROR");
-    await expect(readAll(early)).rejects.toThrow();
+    await expect(readAll(early)).rejects.toThrow(expect.objectContaining({ code: "ERR_INVALID_STATE" }));
 
     // The documented re-open: this is the one delivery the server must see.
     const echoed = await readAll(await c.createBidirectionalStream({ body: Buffer.from("PAY-ORDER-42") }));
@@ -268,9 +266,6 @@ describe("0-RTT rejected", () => {
     // The re-open reached the server; any retransmitted 0-RTT stream that
     // was going to arrive has arrived by now (same path, lower stream id).
     await b.barrier.promise;
-    c.close();
-    await c.closed.catch(() => {});
-    await b.ep.close();
 
     expect(b.got).toEqual(["PAY-ORDER-42"]);
     expect(earlyRejectedFired).toBe(true);

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -251,6 +251,7 @@ describe("0-RTT rejected", () => {
     const earlyClose = early.closed.catch((e: any) => e);
 
     const info = await c.opened;
+    expect(earlyRejectedFired).toBe(true);
     expect(info.earlyDataAttempted).toBe(true);
     expect(info.earlyDataAccepted).toBe(false);
 
@@ -268,6 +269,5 @@ describe("0-RTT rejected", () => {
     await b.barrier.promise;
 
     expect(b.got).toEqual(["PAY-ORDER-42"]);
-    expect(earlyRejectedFired).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

A session ticket issued by server instance A is resumed against instance B (fresh ticket keys), so B rejects early data. The client's 0-RTT stream is destroyed with `ERR_QUIC_APPLICATION_ERROR: stream reset with code 1`, but the payload it carried is retransmitted at 1-RTT and B's `onstream` receives it anyway. The documented recovery (re-open and resend) then delivers the payload a second time:

```
early stream: ERR_QUIC_APPLICATION_ERROR
accepted: false
server delivered: [ "PAY-ORDER-42", "PAY-ORDER-42" ]
```

## Cause

On `SSL_ERROR_EARLY_DATA_REJECTED`, lsquic's `ietf_full_conn_ci_early_data_failed` calls `lsquic_send_ctl_stash_0rtt_packets`, moving every unacked 0-RTT packet to `sc_0rtt_stash`. When the handshake completes, `lsquic_send_ctl_0rtt_to_1rtt` drains the stash into `sc_lost_packets` (relabelled `HETY_SHORT`), and they are retransmitted.

That is lsquic's transparent 0-RTT fallback, correct for an application that keeps using the early streams. node:quic does the opposite: every 0-RTT stream is destroyed and the application re-opens. `cancel_early_rejected` clears Bun's own outbound buffer and calls `lsquic_stream_shutdown_internal`, but neither touches lsquic's send-controller queues, so the stashed STREAM frames still go out.

## Fix

Add `lsquic_conn_drop_0rtt_packets` (a public wrapper over a new `lsquic_send_ctl_drop_0rtt_packets`: mirror of `stash`, but destroy instead of move, releasing each stream's `n_unacked` via `lsquic_packet_out_ack_streams` so the subsequent shutdown can finish the stream) and call it from `nq_on_early_data_failed` in the node:quic shim. The stash step that follows finds nothing, and `0rtt_to_1rtt` has no stash to requeue.

Also fire `onSessionEarlyDataRejected` before `onSessionHandshake` so `onearlyrejected` has run by the time the application awaits `opened`.

## Verification

With the fix:

```
early stream: ERR_QUIC_APPLICATION_ERROR
onearlyrejected fired
accepted: false attempted: true earlyRejectedFired@opened: true
server delivered: ["PAY-ORDER-42"]
```

New test in `test/js/node/quic/quic-stream.test.ts` fails before (server receives `["PAY-ORDER-42","PAY-ORDER-42"]`) and passes after. All nine `test-quic-*zero-rtt*` / `test-quic-enable-early-data` node-parallel tests and the three `test/js/node/quic/*.test.ts` files pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (a2e7ff510)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [670.13ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [221.44ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1205.23ms]
249 |     // discarded on rejection.
250 |     const early = await c.createBidirectionalStream({ body: Buffer.from("PAY-ORDER-42") });
251 |     const earlyClose = early.closed.catch((e: any) => e);
252 | 
253 |     const info = await c.opened;
254 |     expect(earlyRejectedFired).toBe(true);
                                     ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/js/node/quic/quic-stream.tes
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ce68fdc0d)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:15:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [128.30ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [7.82ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1006.81ms]
(pass) 0-RTT rejected > a rejected early stream's data never reaches the server [21.02ms]

 4 pass
 0 fail
 14 expect() calls
Ran 4 tests across 1 file. [1.69s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (a2e7ff510)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [740.86ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [163.71ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1141.67ms]
(pass) 0-RTT rejected > a rejected early stream's data never reaches the server [564.76ms]

 4 pass
 0 fail
 14 expect() calls
Ran 4 tests across 1 file. [6.13s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1341ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/node_quic_shim.c |   5 +
 patches/lsquic/node-quic-accessors.patch   | 143 ++++++++++++++++++++++++++++-
 src/runtime/node/quic/session.rs           |  18 ++--
 test/js/node/quic/quic-stream.test.ts      |  92 +++++++++++++++++++
 4 files changed, 246 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-usockets/src/node_quic_shim.c      1      1      0
patches/lsquic/node-quic-accessors.patch        4     15      0
src/runtime/node/quic/session.rs                5      3      0
test/js/node/quic/quic-stream.test.ts           2      3      0
```

</details>

<!-- robobun:evidence:end -->