### PR TITLE
test(cron): run cron-local-time assertions in-process instead of per-test subprocess

### DIFF
--- a/test/js/bun/cron/cron-local-time.test.ts
+++ b/test/js/bun/cron/cron-local-time.test.ts
@@ -1,110 +1,124 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, jest, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Bun.cron.parse() and the in-process Bun.cron(schedule, handler) interpret
 // cron expressions in the system's local time zone — matching the OS-level
 // overload (crontab/launchd/schtasks all use local time).
 //
-// Each test spawns a subprocess with a fixed TZ so the assertions are
-// independent of the host's zone.
+// Assigning process.env.TZ at runtime updates WTF's time-zone override
+// immediately (see cron.test.ts's "Bun.cron.parse" suite for the same
+// pattern), so these tests pin the zone per assertion instead of spawning a
+// subprocess per case. One spawned case below still covers the startup-env
+// path explicitly.
 
-async function evalInTZ(tz: string, src: string): Promise<string> {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: { ...bunEnv, TZ: tz },
-    stderr: "pipe",
+const savedTZ = process.env.TZ;
+// Leave the process in a known zone between tests; each helper restores it.
+beforeAll(() => void (process.env.TZ = "UTC"));
+afterAll(() => void (process.env.TZ = savedTZ ?? ""));
+
+function withTZ<T>(tz: string, fn: () => T): T {
+  const old = process.env.TZ;
+  process.env.TZ = tz;
+  try {
+    return fn();
+  } finally {
+    process.env.TZ = old ?? "";
+  }
+}
+
+function parseInTZ(tz: string, expr: string, fromISO: string, opts?: { tz?: string }): string {
+  return withTZ(tz, () => Bun.cron.parse(expr, new Date(fromISO), opts)!.toISOString());
+}
+
+function chainInTZ(tz: string, expr: string, fromISO: string, steps: number, opts?: { tz?: string }): string[] {
+  return withTZ(tz, () => {
+    let t = new Date(fromISO);
+    const seq: string[] = [];
+    for (let i = 0; i < steps; i++) {
+      t = Bun.cron.parse(expr, t, opts)!;
+      seq.push(t.toISOString());
+    }
+    return seq;
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-  return stdout;
 }
 
-async function parseInTZ(tz: string, expr: string, fromISO: string): Promise<string> {
-  return evalInTZ(
-    tz,
-    `process.stdout.write(Bun.cron.parse(${JSON.stringify(expr)}, new Date(${JSON.stringify(fromISO)})).toISOString())`,
-  );
-}
+// These suites mutate process.env.TZ, so they must not be describe.concurrent.
+// Each in-process test is pure computation, so sequential is still fast.
 
-async function chainInTZ(tz: string, expr: string, fromISO: string, steps: number): Promise<string[]> {
-  const out = await evalInTZ(
-    tz,
-    `let t = new Date(${JSON.stringify(fromISO)});
-     const seq = [];
-     for (let i = 0; i < ${steps}; i++) { t = Bun.cron.parse(${JSON.stringify(expr)}, t); seq.push(t.toISOString()); }
-     process.stdout.write(JSON.stringify(seq))`,
-  );
-  return JSON.parse(out);
-}
-
-describe.concurrent("Bun.cron.parse — local time zone", () => {
-  test("0 9 * * * in America/Los_Angeles is 9am Pacific (PDT = UTC-7)", async () => {
-    const next = await parseInTZ("America/Los_Angeles", "0 9 * * *", "2026-06-15T00:00:00Z");
+describe("Bun.cron.parse — local time zone", () => {
+  test("0 9 * * * in America/Los_Angeles is 9am Pacific (PDT = UTC-7)", () => {
     // 2026-06-15 00:00 UTC = 2026-06-14 17:00 PDT; next 9am PDT = 2026-06-15 09:00 PDT = 16:00 UTC
-    expect(next).toBe("2026-06-15T16:00:00.000Z");
+    expect(parseInTZ("America/Los_Angeles", "0 9 * * *", "2026-06-15T00:00:00Z")).toBe("2026-06-15T16:00:00.000Z");
   });
 
-  test("0 9 * * * in UTC is 9am UTC", async () => {
-    const next = await parseInTZ("UTC", "0 9 * * *", "2026-06-15T00:00:00Z");
-    expect(next).toBe("2026-06-15T09:00:00.000Z");
+  test("0 9 * * * in UTC is 9am UTC", () => {
+    expect(parseInTZ("UTC", "0 9 * * *", "2026-06-15T00:00:00Z")).toBe("2026-06-15T09:00:00.000Z");
   });
 
-  test("0 9 * * * in Asia/Tokyo is 9am JST (UTC+9, no DST)", async () => {
-    const next = await parseInTZ("Asia/Tokyo", "0 9 * * *", "2026-06-15T00:00:00Z");
+  test("0 9 * * * in Asia/Tokyo is 9am JST (UTC+9, no DST)", () => {
     // 2026-06-15 00:00 UTC = 2026-06-15 09:00 JST → already at 09:00 but parse() returns the
     // NEXT occurrence strictly after, so next is 2026-06-16 09:00 JST = 2026-06-16 00:00 UTC
-    expect(next).toBe("2026-06-16T00:00:00.000Z");
+    expect(parseInTZ("Asia/Tokyo", "0 9 * * *", "2026-06-15T00:00:00Z")).toBe("2026-06-16T00:00:00.000Z");
   });
 
-  test("weekday matching uses local day-of-week (0 12 * * MON across the dateline)", async () => {
+  test("weekday matching uses local day-of-week (0 12 * * MON across the dateline)", () => {
     // Pacific/Auckland is UTC+12 (NZST in June). 2026-06-15 is a Monday in NZST.
-    // 12:00 NZST = 00:00 UTC same date.
-    const next = await parseInTZ("Pacific/Auckland", "0 12 * * MON", "2026-06-14T23:00:00Z");
     // 2026-06-14 23:00 UTC = 2026-06-15 11:00 NZST (Mon); next Mon 12:00 NZST = 2026-06-15 00:00 UTC
-    expect(next).toBe("2026-06-15T00:00:00.000Z");
+    expect(parseInTZ("Pacific/Auckland", "0 12 * * MON", "2026-06-14T23:00:00Z")).toBe("2026-06-15T00:00:00.000Z");
+  });
+
+  test("TZ set in the spawned process's environment is honored at startup", async () => {
+    // Covers the startup-env path that the in-process withTZ() helper does not:
+    // a fresh process with TZ in its env must parse in that zone from the
+    // first call, before any process.env.TZ assignment.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write(Bun.cron.parse("0 9 * * *", new Date("2026-06-15T00:00:00Z")).toISOString())`,
+      ],
+      env: { ...bunEnv, TZ: "America/Los_Angeles" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "2026-06-15T16:00:00.000Z", stderr: "", exitCode: 0 });
   });
 });
 
-describe.concurrent("Bun.cron.parse — DST transitions", () => {
-  test("spring-forward: schedule in the missing hour fires shifted forward (same day)", async () => {
+describe("Bun.cron.parse — DST transitions", () => {
+  test("spring-forward: schedule in the missing hour fires shifted forward (same day)", () => {
     // US 2025 spring-forward: 2025-03-09 02:00 EST → 03:00 EDT (2:00-2:59 don't exist).
     // "30 2 * * *" fires at 03:30 EDT — the gap-shifted instant. Matches croner and cron-parser.
-    const next = await parseInTZ("America/New_York", "30 2 * * *", "2025-03-09T05:00:00Z"); // = 00:00 EST
-    expect(next).toBe("2025-03-09T07:30:00.000Z"); // 03:30 EDT
+    expect(parseInTZ("America/New_York", "30 2 * * *", "2025-03-09T05:00:00Z")).toBe("2025-03-09T07:30:00.000Z");
   });
 
-  test("fall-back: schedule in the duplicated hour fires at the first occurrence", async () => {
+  test("fall-back: schedule in the duplicated hour fires at the first occurrence", () => {
     // US 2025 fall-back: 2025-11-02 02:00 EDT → 01:00 EST (1:00-1:59 occurs twice).
     // Starting from 00:30 EDT (= 04:30 UTC), next "30 1 * * *" is the first 01:30 (EDT) = 05:30 UTC.
-    const next = await parseInTZ("America/New_York", "30 1 * * *", "2025-11-02T04:30:00Z");
-    expect(next).toBe("2025-11-02T05:30:00.000Z");
+    expect(parseInTZ("America/New_York", "30 1 * * *", "2025-11-02T04:30:00Z")).toBe("2025-11-02T05:30:00.000Z");
   });
 
-  test("fall-back: starting from the second occurrence does not return a time before from", async () => {
+  test("fall-back: starting from the second occurrence does not return a time before from", () => {
     // 06:30 UTC = 01:30 EST (the SECOND 01:30). next() must not return the first 01:30 (05:30 UTC).
-    const next = await parseInTZ("America/New_York", "30 1 * * *", "2025-11-02T06:30:00Z");
     // Next valid 01:30 is the following day (EST): 2025-11-03 01:30 EST = 06:30 UTC.
-    expect(next).toBe("2025-11-03T06:30:00.000Z");
+    expect(parseInTZ("America/New_York", "30 1 * * *", "2025-11-02T06:30:00Z")).toBe("2025-11-03T06:30:00.000Z");
   });
 
-  test("fall-back: wildcard hour fires through both occurrences (cronie semantics)", async () => {
+  test("fall-back: wildcard hour fires through both occurrences (cronie semantics)", () => {
     // After the first 1:00 (05:00Z), next() returns the SECOND 1:00 (06:00Z).
     // Matches cronie/Vixie and cron-parser. Fixed-time schedules (30 1 * * *)
     // still fire once — only `*` minute or `*` hour schedules run through.
-    const next = await parseInTZ("America/New_York", "0 * * * *", "2025-11-02T05:00:01Z");
-    expect(next).toBe("2025-11-02T06:00:00.000Z");
+    expect(parseInTZ("America/New_York", "0 * * * *", "2025-11-02T05:00:01Z")).toBe("2025-11-02T06:00:00.000Z");
   });
 
-  test("fall-back: every-minute fires through both occurrences", async () => {
-    const next = await parseInTZ("America/New_York", "* * * * *", "2025-11-02T05:59:01Z");
-    expect(next).toBe("2025-11-02T06:00:00.000Z");
+  test("fall-back: every-minute fires through both occurrences", () => {
+    expect(parseInTZ("America/New_York", "* * * * *", "2025-11-02T05:59:01Z")).toBe("2025-11-02T06:00:00.000Z");
   });
 
-  test("fall-back: every-minute chained from the transition walks the repeated hour", async () => {
+  test("fall-back: every-minute chained from the transition walks the repeated hour", () => {
     // From 05:59Z, chaining * * * * * must hit every real-time minute through
     // the repeated 1:xx EST window (06:00Z..06:59Z), not jump to 07:00Z.
-    expect(await chainInTZ("America/New_York", "* * * * *", "2025-11-02T05:59:00Z", 4)).toEqual([
+    expect(chainInTZ("America/New_York", "* * * * *", "2025-11-02T05:59:00Z", 4)).toEqual([
       "2025-11-02T06:00:00.000Z",
       "2025-11-02T06:01:00.000Z",
       "2025-11-02T06:02:00.000Z",
@@ -112,8 +126,8 @@ describe.concurrent("Bun.cron.parse — DST transitions", () => {
     ]);
   });
 
-  test("fall-back: */15 chained from the transition fires at each quarter-hour", async () => {
-    expect(await chainInTZ("America/New_York", "*/15 * * * *", "2025-11-02T05:59:00Z", 5)).toEqual([
+  test("fall-back: */15 chained from the transition fires at each quarter-hour", () => {
+    expect(chainInTZ("America/New_York", "*/15 * * * *", "2025-11-02T05:59:00Z", 5)).toEqual([
       "2025-11-02T06:00:00.000Z",
       "2025-11-02T06:15:00.000Z",
       "2025-11-02T06:30:00.000Z",
@@ -122,39 +136,40 @@ describe.concurrent("Bun.cron.parse — DST transitions", () => {
     ]);
   });
 
-  test("spring-forward: only the first match in the gap fires shifted (croner semantics)", async () => {
+  test("spring-forward: only the first match in the gap fires shifted (croner semantics)", () => {
     // "*/15 2 * * *" has 4 occurrences in the missing hour. Bun fires the first
     // shifted to 3:00, then skips to next day. cron-parser shifts all four.
-    const first = await parseInTZ("America/New_York", "*/15 2 * * *", "2025-03-09T06:59:00Z");
-    expect(first).toBe("2025-03-09T07:00:00.000Z"); // 03:00 EDT
-    const second = await parseInTZ("America/New_York", "*/15 2 * * *", "2025-03-09T07:00:00Z");
-    expect(second).toBe("2025-03-10T06:00:00.000Z"); // next day 02:00 EDT
+    expect(chainInTZ("America/New_York", "*/15 2 * * *", "2025-03-09T06:59:00Z", 2)).toEqual([
+      "2025-03-09T07:00:00.000Z", // 03:00 EDT
+      "2025-03-10T06:00:00.000Z", // next day 02:00 EDT
+    ]);
   });
 
-  test("Lord Howe: 30-minute spring-forward gap shifts by 30 min", async () => {
+  test("Lord Howe: 30-minute spring-forward gap shifts by 30 min", () => {
     // Australia/Lord_Howe 2025-10-05 02:00→02:30. "15 2 * * *" → 02:45 LHDT.
-    const next = await parseInTZ("Australia/Lord_Howe", "15 2 * * *", "2025-10-04T14:30:00Z");
-    expect(next).toBe("2025-10-04T15:45:00.000Z");
+    expect(parseInTZ("Australia/Lord_Howe", "15 2 * * *", "2025-10-04T14:30:00Z")).toBe("2025-10-04T15:45:00.000Z");
   });
 
-  test("Lord Howe: 30-minute fall-back — wildcard fires through repeated half-hour", async () => {
+  test("Lord Howe: 30-minute fall-back — wildcard fires through repeated half-hour", () => {
     // 2025-04-06 02:00 LHDT (+11) → 01:30 LHST (+10:30); 1:30-1:59 repeats.
-    // After first 1:59 (14:59Z), every-minute → second 1:30 (15:00Z).
-    const a = await parseInTZ("Australia/Lord_Howe", "* * * * *", "2025-04-05T14:59:01Z");
-    expect(a).toBe("2025-04-05T15:00:00.000Z");
-    // After first 1:45, "45 *" → second 1:45.
-    const b = await parseInTZ("Australia/Lord_Howe", "45 * * * *", "2025-04-05T14:45:01Z");
-    expect(b).toBe("2025-04-05T15:15:00.000Z");
+    expect({
+      // After first 1:59 (14:59Z), every-minute → second 1:30 (15:00Z).
+      everyMinute: parseInTZ("Australia/Lord_Howe", "* * * * *", "2025-04-05T14:59:01Z"),
+      // After first 1:45, "45 *" → second 1:45.
+      wildcardHour: parseInTZ("Australia/Lord_Howe", "45 * * * *", "2025-04-05T14:45:01Z"),
+    }).toEqual({
+      everyMinute: "2025-04-05T15:00:00.000Z",
+      wildcardHour: "2025-04-05T15:15:00.000Z",
+    });
   });
 
-  test("Lord Howe: 30-minute fall-back — fixed-time fires once", async () => {
+  test("Lord Howe: 30-minute fall-back — fixed-time fires once", () => {
     // After first 1:45, "45 1" (fixed) → next day, not the second 1:45.
-    const next = await parseInTZ("Australia/Lord_Howe", "45 1 * * *", "2025-04-05T14:45:01Z");
-    expect(next).toBe("2025-04-06T15:15:00.000Z");
+    expect(parseInTZ("Australia/Lord_Howe", "45 1 * * *", "2025-04-05T14:45:01Z")).toBe("2025-04-06T15:15:00.000Z");
   });
 
-  test("fall-back: hourly chain walks 0→1→1→2 (both occurrences)", async () => {
-    expect(await chainInTZ("America/New_York", "0 * * * *", "2025-11-02T03:59:00Z", 4)).toEqual([
+  test("fall-back: hourly chain walks 0→1→1→2 (both occurrences)", () => {
+    expect(chainInTZ("America/New_York", "0 * * * *", "2025-11-02T03:59:00Z", 4)).toEqual([
       "2025-11-02T04:00:00.000Z", // 0:00 EDT
       "2025-11-02T05:00:00.000Z", // 1st 1:00 EDT
       "2025-11-02T06:00:00.000Z", // 2nd 1:00 EST
@@ -162,85 +177,69 @@ describe.concurrent("Bun.cron.parse — DST transitions", () => {
     ]);
   });
 
-  test("spring-forward: hourly chain walks 1→3→4 (no double-fire at 3)", async () => {
-    expect(await chainInTZ("America/New_York", "0 * * * *", "2025-03-09T05:59:00Z", 3)).toEqual([
+  test("spring-forward: hourly chain walks 1→3→4 (no double-fire at 3)", () => {
+    expect(chainInTZ("America/New_York", "0 * * * *", "2025-03-09T05:59:00Z", 3)).toEqual([
       "2025-03-09T06:00:00.000Z", // 1:00 EST
       "2025-03-09T07:00:00.000Z", // 3:00 EDT (2:00 doesn't exist)
       "2025-03-09T08:00:00.000Z", // 4:00 EDT
     ]);
   });
 
-  test("Santiago: midnight spring-forward gap shifts to 01:00 same day", async () => {
+  test("Santiago: midnight spring-forward gap shifts to 01:00 same day", () => {
     // America/Santiago 2025-09-07 00:00→01:00. "0 0 * * *" → 01:00 CLST.
-    const next = await parseInTZ("America/Santiago", "0 0 * * *", "2025-09-06T23:00:00-04:00");
-    expect(next).toBe("2025-09-07T04:00:00.000Z");
+    expect(parseInTZ("America/Santiago", "0 0 * * *", "2025-09-06T23:00:00-04:00")).toBe("2025-09-07T04:00:00.000Z");
   });
 });
 
-describe.concurrent("Bun.cron.parse — { tz } option", () => {
-  test("overrides process TZ (UTC opt under LA process)", async () => {
-    const next = await evalInTZ(
-      "America/Los_Angeles",
-      `process.stdout.write(Bun.cron.parse("0 9 * * *", new Date("2026-06-15T00:00:00Z"), {tz: "UTC"}).toISOString())`,
+describe("Bun.cron.parse — { tz } option", () => {
+  test("overrides process TZ (UTC opt under LA process)", () => {
+    expect(parseInTZ("America/Los_Angeles", "0 9 * * *", "2026-06-15T00:00:00Z", { tz: "UTC" })).toBe(
+      "2026-06-15T09:00:00.000Z",
     );
-    expect(next).toBe("2026-06-15T09:00:00.000Z");
   });
 
-  test("named zone (America/New_York under UTC process)", async () => {
-    const next = await evalInTZ(
-      "UTC",
-      `process.stdout.write(Bun.cron.parse("0 9 * * *", new Date("2026-06-15T00:00:00Z"), {tz: "America/New_York"}).toISOString())`,
-    );
+  test("named zone (America/New_York under UTC process)", () => {
     // 9am EDT (UTC-4) = 13:00 UTC
-    expect(next).toBe("2026-06-15T13:00:00.000Z");
-  });
-
-  test("tz option matches the same zone set as process TZ", async () => {
-    const zones = ["America/Los_Angeles", "Asia/Tokyo", "Pacific/Auckland", "Australia/Lord_Howe"];
-    const out = await evalInTZ(
-      "UTC",
-      `const zones = ${JSON.stringify(zones)};
-       const r = {};
-       for (const z of zones) {
-         const viaOpt = Bun.cron.parse("0 9 * * *", new Date("2026-06-15T00:00:00Z"), {tz: z}).toISOString();
-         process.env.TZ = z;
-         const viaEnv = Bun.cron.parse("0 9 * * *", new Date("2026-06-15T00:00:00Z")).toISOString();
-         process.env.TZ = "UTC";
-         r[z] = { viaOpt, viaEnv };
-       }
-       process.stdout.write(JSON.stringify(r))`,
+    expect(parseInTZ("UTC", "0 9 * * *", "2026-06-15T00:00:00Z", { tz: "America/New_York" })).toBe(
+      "2026-06-15T13:00:00.000Z",
     );
-    const r = JSON.parse(out);
-    for (const z of zones) expect({ zone: z, ...r[z] }).toEqual({ zone: z, viaOpt: r[z].viaEnv, viaEnv: r[z].viaEnv });
   });
 
-  test("DST via tz option matches DST via process TZ (spring-forward)", async () => {
+  test("tz option matches the same zone set as process TZ", () => {
+    const expected = {
+      "America/Los_Angeles": "2026-06-15T16:00:00.000Z",
+      "Asia/Tokyo": "2026-06-16T00:00:00.000Z",
+      "Pacific/Auckland": "2026-06-15T21:00:00.000Z",
+      "Australia/Lord_Howe": "2026-06-15T22:30:00.000Z",
+    };
+    const actual: Record<string, { viaOpt: string; viaEnv: string }> = {};
+    for (const z of Object.keys(expected)) {
+      actual[z] = {
+        viaOpt: parseInTZ("UTC", "0 9 * * *", "2026-06-15T00:00:00Z", { tz: z }),
+        viaEnv: parseInTZ(z, "0 9 * * *", "2026-06-15T00:00:00Z"),
+      };
+    }
+    expect(actual).toEqual(
+      Object.fromEntries(Object.entries(expected).map(([z, iso]) => [z, { viaOpt: iso, viaEnv: iso }])),
+    );
+  });
+
+  test("DST via tz option matches DST via process TZ (spring-forward)", () => {
     // US 2025 spring-forward: "30 2 * * *" → 03:30 EDT on 2025-03-09.
-    const next = await evalInTZ(
-      "UTC",
-      `process.stdout.write(Bun.cron.parse("30 2 * * *", new Date("2025-03-09T05:00:00Z"), {tz: "America/New_York"}).toISOString())`,
+    expect(parseInTZ("UTC", "30 2 * * *", "2025-03-09T05:00:00Z", { tz: "America/New_York" })).toBe(
+      "2025-03-09T07:30:00.000Z",
     );
-    expect(next).toBe("2025-03-09T07:30:00.000Z");
   });
 
-  test("DST via tz option matches DST via process TZ (fall-back, fixed fires once)", async () => {
+  test("DST via tz option matches DST via process TZ (fall-back, fixed fires once)", () => {
     // From the second 01:30 (EST), "30 1 * * *" → next day.
-    const next = await evalInTZ(
-      "UTC",
-      `process.stdout.write(Bun.cron.parse("30 1 * * *", new Date("2025-11-02T06:30:00Z"), {tz: "America/New_York"}).toISOString())`,
+    expect(parseInTZ("UTC", "30 1 * * *", "2025-11-02T06:30:00Z", { tz: "America/New_York" })).toBe(
+      "2025-11-03T06:30:00.000Z",
     );
-    expect(next).toBe("2025-11-03T06:30:00.000Z");
   });
 
-  test("DST via tz option (fall-back, wildcard hour fires through both occurrences)", async () => {
-    const out = await evalInTZ(
-      "UTC",
-      `let t = new Date("2025-11-02T03:59:00Z");
-       const seq = [];
-       for (let i = 0; i < 4; i++) { t = Bun.cron.parse("0 * * * *", t, {tz: "America/New_York"}); seq.push(t.toISOString()); }
-       process.stdout.write(JSON.stringify(seq))`,
-    );
-    expect(JSON.parse(out)).toEqual([
+  test("DST via tz option (fall-back, wildcard hour fires through both occurrences)", () => {
+    expect(chainInTZ("UTC", "0 * * * *", "2025-11-02T03:59:00Z", 4, { tz: "America/New_York" })).toEqual([
       "2025-11-02T04:00:00.000Z", // 0:00 EDT
       "2025-11-02T05:00:00.000Z", // 1st 1:00 EDT
       "2025-11-02T06:00:00.000Z", // 2nd 1:00 EST
@@ -271,27 +270,25 @@ describe.concurrent("Bun.cron.parse — { tz } option", () => {
     expect(() => Bun.cron.parse("* * * * *", Date.now(), { tz: 42 })).toThrow(/options\.tz must be a string/);
   });
 
-  test("tz: undefined falls back to local", async () => {
-    const next = await evalInTZ(
-      "Asia/Tokyo",
-      `process.stdout.write(Bun.cron.parse("0 9 * * *", new Date("2026-06-15T00:00:00Z"), {tz: undefined}).toISOString())`,
+  test("tz: undefined falls back to local", () => {
+    expect(parseInTZ("Asia/Tokyo", "0 9 * * *", "2026-06-15T00:00:00Z", { tz: undefined })).toBe(
+      "2026-06-16T00:00:00.000Z",
     );
-    expect(next).toBe("2026-06-16T00:00:00.000Z");
   });
 
-  test("in-process Bun.cron(schedule, handler, { tz }) uses the override", async () => {
-    const out = await evalInTZ(
-      "UTC",
-      `const { jest } = await import("bun:test");
-       jest.useFakeTimers();
-       jest.setSystemTime(new Date("2026-06-15T00:00:00Z"));
-       const fired = [];
-       using job = Bun.cron("0 9 * * *", () => fired.push(new Date().toISOString()), { tz: "America/New_York" });
-       jest.advanceTimersByTime(14 * 60 * 60 * 1000);
-       jest.useRealTimers();
-       process.stdout.write(JSON.stringify(fired));`,
-    );
-    // 9am EDT = 13:00 UTC; advancing 14h from 00:00Z fires exactly once at 13:00Z.
-    expect(JSON.parse(out)).toEqual(["2026-06-15T13:00:00.000Z"]);
+  test("in-process Bun.cron(schedule, handler, { tz }) uses the override", () => {
+    withTZ("UTC", () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(new Date("2026-06-15T00:00:00Z"));
+        const fired: string[] = [];
+        using _job = Bun.cron("0 9 * * *", () => fired.push(new Date().toISOString()), { tz: "America/New_York" });
+        jest.advanceTimersByTime(14 * 60 * 60 * 1000);
+        // 9am EDT = 13:00 UTC; advancing 14h from 00:00Z fires exactly once at 13:00Z.
+        expect(fired).toEqual(["2026-06-15T13:00:00.000Z"]);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 });


### PR DESCRIPTION
## What

`test/js/bun/cron/cron-local-time.test.ts` spawned 28 `bun -e` subprocesses, one per `(tz, expr, from)` assertion, solely to pin the process time zone. On debug+ASAN each spawn is roughly a second of startup, so the file took ~25s wall in CI (build #80083, debian-13 x64-asan) and tests that did two sequential spawns (e.g. the Lord Howe fall-back case) regularly hit the 5s default timeout.

## Change

Assigning `process.env.TZ` at runtime updates WTF's time-zone override immediately; `cron.test.ts`'s `Bun.cron.parse` suite already relies on this. So the helpers now set `process.env.TZ` in-process behind a small `withTZ()` wrapper and call `Bun.cron.parse` directly:

```ts
function parseInTZ(tz, expr, from, opts?) {
  return withTZ(tz, () => Bun.cron.parse(expr, new Date(from), opts)!.toISOString());
}
```

One subprocess is kept (`TZ set in the spawned process's environment is honored at startup`) to keep explicit coverage of the startup-env path that `withTZ()` does not exercise. The fake-timers case now uses in-process `jest.useFakeTimers()` the same way `in-process-cron.test.ts` does.

The `describe` blocks drop `.concurrent` since they now mutate global `process.env.TZ`; each in-process test is a few ms so sequential is still fast.

## Assertion improvements

- `tz option matches the same zone set as process TZ` now asserts the concrete expected ISO string per zone rather than only `viaOpt === viaEnv`, so a drift in both paths would be caught.
- `spring-forward: only the first match in the gap fires shifted` uses a single `chainInTZ` + `toEqual` instead of two separate awaited spawns.
- `Lord Howe: 30-minute fall-back` groups both sub-cases into one `toEqual` for a clearer diff on failure.
- The new startup-env spawn asserts `{ stdout, stderr, exitCode }` with `toEqual` rather than separate `toBe` calls.

No tests were deleted or skipped; the 30 original cases are all present plus the one new startup-env case (31 total).

## Timing (local, debug+ASAN, `./build/debug/bun-debug test`)

| | before | after |
| --- | --- | --- |
| wall time | ~35s | ~4-8s |
| result | 4 pass / 26 fail (5s timeouts) | 31 pass / 0 fail |
| subprocess spawns | 28 | 1 |

The before/after variance is FS-dependent; CI's 25s maps to the same 28-spawn cost.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/cron/cron-local-time.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/cron/cron-local-time.test.ts
bun test v1.4.0 (3beb38990)

test/js/bun/cron/cron-local-time.test.ts:
(pass) Bun.cron.parse — local time zone > 0 9 * * * in America/Los_Angeles is 9am Pacific (PDT = UTC-7) [279.43ms]
(pass) Bun.cron.parse — local time zone > 0 9 * * * in UTC is 9am UTC [4.68ms]
(pass) Bun.cron.parse — local time zone > 0 9 * * * in Asia/Tokyo is 9am JST (UTC+9, no DST) [3.94ms]
(pass) Bun.cron.parse — local time zone > weekday matching uses local day-of-week (0 12 * * MON across the dateline) [2.91ms]
(pass) Bun.cron.parse — local time zone > TZ set in the spawned process's environment is honored at startup [2292.89ms]
(pass) Bun.cron.parse — DST transitions > spring-forward: schedule in the missing hour fires shifted forward (same day) [5.78ms]
(pass) Bun.cron.parse — DST transitions > fall-back: schedule in the duplicated hour fires at the first occurrence [3.39ms]
(pass) Bun.cron.parse — DST transitions > fall-back: starting from the second occurrence does not return a time before from [3.88ms]
(pass) Bun.cron.parse — DST transitions > fall-back: wildcard hour fires through both occurrences (cronie semantics) [4.02ms]
(pass) Bun.cron.parse — DST transitions > fall-back: every-minute fires through both occurrences [3.92ms]
(pass) Bun.cron.parse — DST transitions > fall-back: every-minute chained from the transition walks the repeated hour [11.19ms]
(pass) Bun.cron.parse — DST transitions > fall-back: */15 chained from the transition fires at each quarter-hour [5.51ms]
(pass) Bun.cron.parse — DST transitions > spring-forward: only the first match in the gap fires shifted (croner semantics) [4.73ms]
(pass) Bun.cron.parse — DST transitions > Lord Howe: 30-minute spring-forward gap shifts by 30 min [3.89ms]
(pass) Bun.cron.parse — DST transitions > Lord Howe: 30-minute fall-back — wildcard fires through repeated half-hou
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/cron/cron-local-time.test.ts | 311 +++++++++++++++----------------
 1 file changed, 154 insertions(+), 157 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/bun/cron/cron-local-time.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->