### PR TITLE
node:repl: enumerate let/const/class bindings for completion; render the input preview

### DIFF
--- a/src/js/internal/repl/completion.js
+++ b/src/js/internal/repl/completion.js
@@ -35,14 +35,13 @@ const {
 } = primordials;
 
 const {
-  kContextId,
   getREPLResourceName,
   globalBuiltins,
   getReplBuiltinLibs,
   fixReplRequire,
 } = require("internal/repl/utils");
 
-const { sendInspectorCommand } = require("internal/repl/node-shims");
+const { getGlobalLexicalScopeNames } = require("internal/repl/node-shims");
 
 const { isProxy } = require("internal/repl/node-shims");
 
@@ -104,25 +103,6 @@ function isNotLegacyObjectPrototypeMethod(str) {
     str !== "__defineSetter__" &&
     str !== "__lookupGetter__" &&
     str !== "__lookupSetter__"
-  );
-}
-
-function getGlobalLexicalScopeNames(contextId) {
-  return sendInspectorCommand(
-    session => {
-      let names = [];
-      session.post(
-        "Runtime.globalLexicalScopeNames",
-        {
-          executionContextId: contextId,
-        },
-        (error, result) => {
-          if (!error) names = result.names;
-        },
-      );
-      return names;
-    },
-    () => [],
   );
 }
 
@@ -388,8 +368,11 @@ function complete(line, callback) {
 
     // Resolve expr and get its completions.
     if (!expr) {
-      // Get global vars synchronously
-      ArrayPrototypePush(completionGroups, getGlobalLexicalScopeNames(this[kContextId]));
+      // let/const/class bindings live in the target global's lexical
+      // environment, not on `this.context`, so the property walk below never
+      // sees them. Node reads them via V8's Runtime.globalLexicalScopeNames;
+      // Bun reads the JSGlobalLexicalEnvironment symbol table directly.
+      ArrayPrototypePush(completionGroups, getGlobalLexicalScopeNames(this.useGlobal ? undefined : this.context));
       let contextProto = this.context;
       while ((contextProto = ObjectGetPrototypeOf(contextProto)) !== null) {
         ArrayPrototypePush(completionGroups, filteredOwnPropertyNames(contextProto));

--- a/src/js/internal/repl/node-shims.js
+++ b/src/js/internal/repl/node-shims.js
@@ -75,11 +75,28 @@ function debuglog(set, cb) {
 
 // ---- internal/util/inspector ----------------------------------------------
 
+// The three Node-side callers each need a different V8 inspector method, and
+// JSC's backend speaks none of them in-process. Two are replaced by direct
+// bindings (getGlobalLexicalScopeNames below; the input preview's AST-gated
+// eval in internal/repl/utils.js); the remaining caller — createContext()'s
+// Runtime.executionContextCreated capture — only recorded a contextId for the
+// two replaced callers, so falling through to onError there is correct.
 function sendInspectorCommand(cb, onError) {
-  // JSC's inspector protocol has no `Runtime.globalLexicalScopeNames` (V8-only),
-  // so let/const/class tab-completion in useGlobal:true mode is inert until a
-  // native binding enumerates JSGlobalObject::globalLexicalEnvironment().
   return onError();
+}
+
+const nativeGlobalLexicalScopeNames = $newCppFunction("NodeVM.cpp", "jsFunction_getGlobalLexicalScopeNames", 1);
+
+// Enumerates let/const/class bindings of a vm context's (or, with no context,
+// the main realm's) global lexical environment. Those bindings are not own
+// properties of the context object, so the REPL's property walk cannot see
+// them; Node surfaces them via V8's Runtime.globalLexicalScopeNames.
+function getGlobalLexicalScopeNames(context) {
+  try {
+    return nativeGlobalLexicalScopeNames(context);
+  } catch {
+    return [];
+  }
 }
 
 // ---- internal/util/types ----------------------------------------------
@@ -427,6 +444,7 @@ export default {
   debuglog,
   // internal/util/inspector
   sendInspectorCommand,
+  getGlobalLexicalScopeNames,
   // internal/util/types
   isProxy,
   // internal/options

--- a/src/js/internal/repl/utils.js
+++ b/src/js/internal/repl/utils.js
@@ -26,10 +26,9 @@ const {
 // Lazy: don't destructure — the vm.Script parse of acorn's ~122 KB source
 // stays deferred until isRecoverableError/isValidSyntax first runs.
 const acorn = require("internal/repl/acorn");
+const acornWalk = require("internal/repl/acorn-walk");
 
-const { sendInspectorCommand, getBuiltinLibs } = require("internal/repl/node-shims");
-
-const { ERR_INSPECTOR_NOT_AVAILABLE } = require("internal/repl/node-errors").codes;
+const { getBuiltinLibs } = require("internal/repl/node-shims");
 
 const { clearLine, clearScreenDown, cursorTo, moveCursor } = require("internal/readline/callbacks");
 
@@ -274,7 +273,10 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
     );
   }
 
-  // This returns a code preview for arbitrary input code.
+  // This returns a code preview for arbitrary input code. Node runs
+  // V8's Runtime.evaluate with throwOnSideEffect:true, which aborts at the
+  // first write/call at runtime; JSC has no equivalent, so gate on an AST
+  // side-effect scan before evaluating in the REPL's own context.
   function getInputPreview(input, callback) {
     // For similar reasons as `defaultEval`, wrap expressions starting with a
     // curly brace with parenthesis.
@@ -282,78 +284,78 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
       input = `(${input})`;
       wrapped = true;
     }
-    sendInspectorCommand(
-      session => {
-        session.post(
-          "Runtime.evaluate",
-          {
-            expression: input,
-            throwOnSideEffect: true,
-            timeout: 333,
-            contextId: repl[contextSymbol],
-          },
-          (error, preview) => {
-            if (error) {
-              callback(error);
-              return;
-            }
-            const { result } = preview;
-            if (result.value !== undefined) {
-              callback(null, inspect(result.value, previewOptions));
-              // Ignore EvalErrors, SyntaxErrors and ReferenceErrors. It is not clear
-              // where they came from and if they are recoverable or not. Other errors
-              // may be inspected.
-            } else if (
-              preview.exceptionDetails &&
-              (result.className === "EvalError" ||
-                result.className === "SyntaxError" ||
-                // Report ReferenceError in case the strict mode is active
-                // for input that has no completions.
-                (result.className === "ReferenceError" && (hasCompletions || !isInStrictMode(repl))))
-            ) {
-              callback(null, null);
-            } else if (result.objectId) {
-              // The writer options might change and have influence on the inspect
-              // output. The user might change e.g., `showProxy`, `getters` or
-              // `showHidden`. Use `inspect` instead of `JSON.stringify` to keep
-              // `Infinity` and similar intact.
-              const inspectOptions = inspect(
-                {
-                  ...repl.writer.options,
-                  colors: false,
-                  depth: 1,
-                  compact: true,
-                  breakLength: Infinity,
-                },
-                previewOptions,
-              );
-              session.post(
-                "Runtime.callFunctionOn",
-                {
-                  functionDeclaration: `(v) =>
-                    Reflect
-                    .getOwnPropertyDescriptor(globalThis, 'util')
-                    .get().inspect(v, ${inspectOptions})`,
-                  objectId: result.objectId,
-                  arguments: [result],
-                },
-                (error, preview) => {
-                  if (error) {
-                    callback(error);
-                  } else {
-                    callback(null, preview.result.value);
-                  }
-                },
-              );
-            } else {
-              // Either not serializable or undefined.
-              callback(null, result.unserializableValue || result.type);
-            }
-          },
-        );
-      },
-      () => callback(new ERR_INSPECTOR_NOT_AVAILABLE()),
-    );
+
+    let ast;
+    try {
+      ast = acorn.parse(input, { __proto__: null, ecmaVersion: "latest" });
+    } catch {
+      return callback(null, null);
+    }
+    // V8's throwOnSideEffect is a runtime trap; approximating it statically
+    // means any node kind that can run user code is a reject. A property get
+    // (MemberExpression) can run a user getter — that hole is accepted so the
+    // common case (`arr.length`, `Math.PI`) still previews.
+    let safe = true;
+    const reject = () => (safe = false);
+    try {
+      acornWalk.simple(ast, {
+        CallExpression: reject,
+        NewExpression: reject,
+        TaggedTemplateExpression: reject,
+        AssignmentExpression: reject,
+        UpdateExpression: reject,
+        AwaitExpression: reject,
+        YieldExpression: reject,
+        ImportExpression: reject,
+        SpreadElement: reject,
+        ThrowStatement: reject,
+        ForStatement: reject,
+        ForInStatement: reject,
+        ForOfStatement: reject,
+        WhileStatement: reject,
+        DoWhileStatement: reject,
+        VariableDeclaration: reject,
+        FunctionDeclaration: reject,
+        ClassDeclaration: reject,
+        UnaryExpression: node => {
+          if (node.operator === "delete") safe = false;
+        },
+      });
+    } catch {
+      safe = false;
+    }
+    if (!safe) return callback(null, null);
+
+    let result;
+    let threw = false;
+    try {
+      const script = new vm.Script(input, { filename: "REPLPreview", displayErrors: false });
+      result = repl.useGlobal
+        ? script.runInThisContext({ displayErrors: false })
+        : script.runInContext(repl.context, { displayErrors: false });
+    } catch (e) {
+      threw = true;
+      result = e;
+    }
+    if (threw) {
+      const name = result?.constructor?.name;
+      // Ignore EvalErrors, SyntaxErrors and ReferenceErrors. It is not clear
+      // where they came from and if they are recoverable or not. Other errors
+      // may be inspected.
+      if (
+        name === "EvalError" ||
+        name === "SyntaxError" ||
+        (name === "ReferenceError" && (hasCompletions || !isInStrictMode(repl)))
+      ) {
+        return callback(null, null);
+      }
+    }
+    if (result === undefined) return callback(null, "undefined");
+    const inspectOptions =
+      typeof result === "object" || typeof result === "function"
+        ? { ...repl.writer.options, colors: false, depth: 1, compact: true, breakLength: Infinity }
+        : previewOptions;
+    return callback(null, inspect(result, inspectOptions));
   }
 
   const showPreview = (showCompletion = true) => {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -50,6 +50,7 @@
 
 #include "AsyncContextFrame.h"
 #include "JavaScriptCore/JSCInlines.h"
+#include "JavaScriptCore/JSGlobalLexicalEnvironment.h"
 #include "JavaScriptCore/JSPromise.h"
 #include "JavaScriptCore/JSNativeStdFunction.h"
 #include "JavaScriptCore/BytecodeCacheError.h"
@@ -1810,6 +1811,45 @@ void NodeVMGlobalObject::getOwnPropertyNames(JSObject* cell, JSGlobalObject* glo
 JSC_DEFINE_HOST_FUNCTION(vmIsModuleNamespaceObject, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(jsBoolean(callFrame->argument(0).inherits(JSModuleNamespaceObject::info())));
+}
+
+// Returns the let/const/class binding names of a global's JSGlobalLexicalEnvironment
+// as a JS array. Those bindings are not own properties of the (vm sandbox) object, so
+// the REPL cannot enumerate them via Object.getOwnPropertyNames; V8 exposes them via
+// the Runtime.globalLexicalScopeNames inspector method, which JSC does not implement.
+// `context` is a contextified vm sandbox (resolved to its NodeVMGlobalObject); any
+// other value falls back to the calling realm's global.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_getGlobalLexicalScopeNames, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGlobalObject* target = globalObject;
+    JSValue contextArg = callFrame->argument(0);
+    if (contextArg.isObject()) {
+        if (auto* nodeVmGlobal = NodeVM::getGlobalObjectFromContext(globalObject, contextArg, false))
+            target = nodeVmGlobal;
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    Vector<Identifier, 8> names;
+    if (auto* lexicalEnv = target->globalLexicalEnvironment()) {
+        SymbolTable* symbolTable = lexicalEnv->symbolTable();
+        ConcurrentJSLocker locker(symbolTable->m_lock);
+        for (auto it = symbolTable->begin(locker), end = symbolTable->end(locker); it != end; ++it) {
+            if (it->key->isSymbol())
+                continue;
+            names.append(Identifier::fromUid(vm, it->key.get()));
+        }
+    }
+
+    JSArray* result = constructEmptyArray(globalObject, nullptr, names.size());
+    RETURN_IF_EXCEPTION(scope, {});
+    for (unsigned i = 0; i < names.size(); ++i) {
+        result->putDirectIndex(globalObject, i, jsString(vm, names[i].string()));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+    return JSValue::encode(result);
 }
 
 JSC::JSValue createNodeVMBinding(Zig::GlobalObject* globalObject)

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -45,6 +45,8 @@ bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JS
 
 } // namespace NodeVM
 
+JSC_DECLARE_HOST_FUNCTION(jsFunction_getGlobalLexicalScopeNames);
+
 class BaseVMOptions {
 public:
     String filename;

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1847,3 +1847,114 @@ describe.concurrent("node:repl prints a frozen thrown error and continues", () =
     interactiveTimeout,
   );
 });
+
+describe.concurrent("node:repl inspector-backed features", () => {
+  const env = { ...bunEnv, NO_COLOR: "1", NODE_REPL_HISTORY: "" };
+
+  // let/const/class bindings land in the REPL context's global lexical
+  // environment, not on the sandbox object, so the own-property walk in
+  // complete() never saw them. Node reads them via V8's
+  // Runtime.globalLexicalScopeNames; Bun reads the JSGlobalLexicalEnvironment
+  // symbol table directly (NodeVM.cpp jsFunction_getGlobalLexicalScopeNames).
+  test(
+    "complete() offers let/const/class bindings",
+    async () => {
+      const script = `
+      const repl = require("node:repl");
+      const { PassThrough } = require("node:stream");
+      const decls = "let qqLet = 1; var qqVar = 2; const qqConst = 3; qqImplicit = 4; function qqFn(){}; class qqCls{}\\n";
+      const complete = (r, line) => new Promise(res => r.complete(line, (e, [c]) => res(c.filter(Boolean).sort())));
+      // defaultEval finishes via queueMicrotask; wait one turn so the bindings
+      // exist before asking for completions.
+      const settle = () => new Promise(res => queueMicrotask(() => queueMicrotask(res)));
+      (async () => {
+        for (const useGlobal of [false, true]) {
+          const inp = new PassThrough(), out = new PassThrough(); out.resume();
+          const r = repl.start({ input: inp, output: out, terminal: false, prompt: "", useGlobal });
+          inp.write(decls);
+          await settle();
+          console.log("useGlobal=" + useGlobal + " " + JSON.stringify(await complete(r, "qq")));
+          r.close();
+        }
+        // User-facing face: after \`const x = ...\`, bare-identifier and member
+        // completion both reach it.
+        const inp = new PassThrough(), out = new PassThrough(); out.resume();
+        const r = repl.start({ input: inp, output: out, terminal: false, prompt: "" });
+        inp.write("const myUniqueArr = [9, 9, 9]\\n");
+        await settle();
+        console.log("ID " + JSON.stringify(await complete(r, "myUniqu")));
+        console.log("MEMBER " + JSON.stringify(await complete(r, "myUniqueArr.len")));
+        r.close();
+      })();
+    `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim().split("\n")).toEqual([
+        'useGlobal=false ["qqCls","qqConst","qqFn","qqImplicit","qqLet","qqVar"]',
+        'useGlobal=true ["qqCls","qqConst","qqFn","qqImplicit","qqLet","qqVar"]',
+        'ID ["myUniqueArr"]',
+        'MEMBER ["myUniqueArr.length"]',
+      ]);
+      expect(exitCode).toBe(0);
+    },
+    interactiveTimeout,
+  );
+
+  // The TTY eval-result preview (grey `10` under `5+5`) went through V8's
+  // Runtime.evaluate {throwOnSideEffect:true}; JSC has none, so Bun gates an
+  // in-context eval on an AST side-effect scan: pure expressions preview,
+  // anything that would run user code (calls, assignments, ...) does not.
+  test(
+    "terminal input preview renders for pure expressions and skips side-effectful ones",
+    async () => {
+      const script = `
+      const repl = require("node:repl");
+      const { Stream } = require("node:stream");
+      process.env.TERM = "xterm";
+      let buf = "";
+      class S extends Stream {
+        readable = true; writable = true;
+        write(c) { buf += c; return true; }
+        resume() {} pause() {}
+      }
+      const io = new S();
+      const r = repl.start({ prompt: "> ", stream: io, terminal: true, useColors: false, preview: true });
+      r.context.sideEffect = 0;
+      r.context.bump = () => r.context.sideEffect++;
+      // One emit() per input: readline inserts the whole string then refreshes
+      // once, so the captured preview is for the final line, not an
+      // intermediate keystroke. useColors:false renders it as "\\n// <value>".
+      const probe = input => {
+        buf = "";
+        io.emit("data", input);
+        const m = buf.match(/\\n\\/\\/ (.+?)\\x1b/);
+        console.log(JSON.stringify({ input, preview: m ? m[1] : null }));
+        io.emit("keypress", "", { ctrl: true, name: "u" });
+      };
+      probe("3+4");           // pure BinaryExpression
+      probe("[9,8].length");  // pure MemberExpression
+      probe("bump()");        // CallExpression: not evaluated
+      probe("sideEffect++");  // UpdateExpression: not evaluated
+      probe("sideEffect=9");  // AssignmentExpression: not evaluated
+      probe("qzqz_nope");     // ReferenceError: suppressed
+      console.log(JSON.stringify({ sideEffect: r.context.sideEffect }));
+      r.close();
+    `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim().split("\n").map(l => JSON.parse(l))).toEqual([
+        { input: "3+4", preview: "7" },
+        { input: "[9,8].length", preview: "2" },
+        { input: "bump()", preview: null },
+        { input: "sideEffect++", preview: null },
+        { input: "sideEffect=9", preview: null },
+        { input: "qzqz_nope", preview: null },
+        { sideEffect: 0 },
+      ]);
+      expect(exitCode).toBe(0);
+    },
+    interactiveTimeout,
+  );
+});

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1944,7 +1944,12 @@ describe.concurrent("node:repl inspector-backed features", () => {
       await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env, stdout: "pipe", stderr: "pipe" });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
-      expect(stdout.trim().split("\n").map(l => JSON.parse(l))).toEqual([
+      expect(
+        stdout
+          .trim()
+          .split("\n")
+          .map(l => JSON.parse(l)),
+      ).toEqual([
         { input: "3+4", preview: "7" },
         { input: "[9,8].length", preview: "2" },
         { input: "bump()", preview: null },


### PR DESCRIPTION
## What

Fixes two inert faces of the v26-vendored `node:repl` that both trace to `sendInspectorCommand` in `internal/repl/node-shims.js` being a stub that always takes the fallback path:

1. **Tab completion never offers `let`/`const`/`class` bindings.** Those declarations land in the target global's `JSGlobalLexicalEnvironment`, not on the context object, so `complete()`'s own-property walk never sees them. Node reads them via V8's `Runtime.globalLexicalScopeNames` inspector method, which JSC does not implement.
2. **The terminal eval-result preview never renders.** Typing `5+5` in a TTY REPL shows Node's grey `10` line; Bun showed nothing. Node uses `Runtime.evaluate` with `throwOnSideEffect:true`; JSC has no equivalent.

## Repro

```js
import repl from "node:repl";
import { PassThrough } from "node:stream";
const inp = new PassThrough(), out = new PassThrough(); out.resume();
const r = repl.start({ input: inp, output: out, terminal: false, prompt: "" });
inp.write("let qqLet = 1; var qqVar = 2; const qqConst = 3; qqImplicit = 4; function qqFn(){}; class qqCls{}\n");
setTimeout(() => r.complete("qq", (e, [c]) => { console.log(JSON.stringify(c)); r.close(); }), 300);
```

Before: `["qqFn","qqImplicit","qqVar"]`
After (matches Node v26.3.0): `["qqFn","qqImplicit","qqVar","","qqCls","qqConst","qqLet"]`

## Fix

**Completion**: add `jsFunction_getGlobalLexicalScopeNames` in `NodeVM.cpp` that resolves a vm sandbox (via `getGlobalObjectFromContext`) or falls back to the calling realm, then walks that global's `globalLexicalEnvironment()->symbolTable()` into a JS array. `completion.js` calls it directly in place of the inspector round-trip. Works for both `useGlobal:false` (vm context) and `useGlobal:true` (main realm).

**Preview**: replace the inspector path with an AST-gated in-context eval. `acorn.parse` + `acornWalk.simple` reject any node kind that can run user code (`CallExpression`, `NewExpression`, `AssignmentExpression`, `UpdateExpression`, `TaggedTemplateExpression`, loops, declarations, `delete`, spread, `await`/`yield`/`import()`). Accepted input is evaluated via `vm.Script#runInContext` in the REPL's own context and `util.inspect`ed with the same options Node uses. `MemberExpression` is intentionally allowed so `arr.length` / `Math.PI` preview; that means a getter can run, which V8's runtime trap would have caught (documented in the code).

## Tests

`test/js/bun/repl/repl.test.ts` (`node:repl inspector-backed features`):

- `complete()` offers all six `qq*` bindings in both `useGlobal` modes, and a `const`-declared identifier is offered for bare and member completion.
- The terminal preview renders `7` for `3+4` and `2` for `[9,8].length`, renders nothing for `bump()` / `sideEffect++` / `sideEffect=9` / an unresolved identifier, and leaves `sideEffect === 0`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->