### PR TITLE
test(sql): drive postgres-datestyle from a scripted backend instead of a docker container

### DIFF
--- a/test/js/sql/postgres-datestyle.test.ts
+++ b/test/js/sql/postgres-datestyle.test.ts
@@ -5,10 +5,40 @@
 // in the StartupMessage (as libpq clients, node-postgres and postgres.js do) so
 // the server always sends the ISO form the decoder expects, regardless of
 // postgresql.conf / ALTER DATABASE / ALTER ROLE defaults.
+//
+// Both tests run against a scripted v3 backend so the exact wire bytes are
+// deterministic and no docker container is needed. The second test's mock
+// honours the StartupMessage DateStyle the same way a real server does (a
+// startup-packet parameter is GUC source PGC_S_CLIENT and outranks every
+// server-side default): when DateStyle=ISO arrives in the startup packet the
+// mock emits ISO text, otherwise it emits the SQL,DMY text a
+// `ALTER DATABASE ... SET datestyle = 'SQL, DMY'` default would produce.
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
-import { describeWithContainer } from "harness";
-import { listeningServer, pgAuthenticationOk, pgParameterStatus, pgReadyForQuery } from "./wire-frames";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgParameterDescription,
+  pgParameterStatus,
+  pgParseComplete,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const OID_date = 1082;
+
+function parseStartupParams(bytes: Buffer): Record<string, string> {
+  // StartupMessage body is key\0value\0 pairs after the 8-byte header.
+  const body = bytes.subarray(8).toString("latin1");
+  const params: Record<string, string> = {};
+  const parts = body.split("\0");
+  for (let i = 0; i + 1 < parts.length && parts[i] !== ""; i += 2) params[parts[i]] = parts[i + 1];
+  return params;
+}
 
 // ---------------------------------------------------------------------------
 // Protocol-level: the StartupMessage must carry DateStyle=ISO so server-side
@@ -28,12 +58,7 @@ test("StartupMessage pins DateStyle=ISO so server-side datestyle defaults cannot
   try {
     await using sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 5 });
     await sql.connect();
-    const bytes = await startup.promise;
-    // StartupMessage body is key\0value\0 pairs after the 8-byte header.
-    const body = bytes.subarray(8).toString("latin1");
-    const params: Record<string, string> = {};
-    const parts = body.split("\0");
-    for (let i = 0; i + 1 < parts.length && parts[i] !== ""; i += 2) params[parts[i]] = parts[i + 1];
+    const params = parseStartupParams(await startup.promise);
     // client_encoding was already pinned; DateStyle must be too.
     expect(params.client_encoding).toBe("UTF8");
     expect(params.DateStyle).toMatch(/^ISO\b/);
@@ -43,40 +68,104 @@ test("StartupMessage pins DateStyle=ISO so server-side datestyle defaults cannot
 });
 
 // ---------------------------------------------------------------------------
-// End-to-end against a real server: force a non-ISO default on the database,
-// reconnect, and read a date back. Without DateStyle in the StartupMessage the
-// server honours the ALTER DATABASE default and emits `03/04/2026`, which the
-// old decode path turns into 4 March (or null for day > 12).
+// End-to-end against a scripted backend whose default DateStyle is 'SQL, DMY':
+// without DateStyle in the StartupMessage the server emits `03/04/2026` /
+// `22/07/2026` for the two probe dates, which the old decode path turns into
+// 4 March (month/day swapped) and null (day > 12). With the startup parameter
+// the mock emits ISO text, exactly as a real server does, and the decoder
+// produces the right Date on both the simple and extended query paths.
 // ---------------------------------------------------------------------------
-describeWithContainer("postgres", { image: "postgres_plain" }, container => {
-  test("database-level non-ISO DateStyle default does not corrupt date values", async () => {
-    await container.ready;
-    const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
-    {
-      await using setup = new SQL({ url, max: 1 });
-      await setup.unsafe(`ALTER DATABASE bun_sql_test SET datestyle = 'SQL, DMY'`);
-    }
-    try {
-      await using sql = new SQL({ url, max: 1 });
-      const [[style], [row], ext] = await Promise.all([
-        sql`select current_setting('datestyle') as ds`.simple(),
-        sql`select '2026-04-03'::date as d, '2026-07-22'::date as d2`.simple(),
-        sql`select '2026-04-03'::date as d`,
-      ]);
-      // DateStyle in the startup packet overrides the database default.
-      expect(style.ds).toMatch(/^ISO\b/);
-      expect({
-        d: row.d.toISOString(),
-        d2: row.d2.toISOString(),
-        ext: ext[0].d.toISOString(),
-      }).toEqual({
-        d: "2026-04-03T00:00:00.000Z",
-        d2: "2026-07-22T00:00:00.000Z",
-        ext: "2026-04-03T00:00:00.000Z",
+test("database-level non-ISO DateStyle default does not corrupt date values", async () => {
+  // 3 April (swaps to 4 March under an MDY reader) and 22 July (day > 12, so
+  // an MDY reader yields Invalid Date) are the two diagnostic probe values.
+  const dateStyles = {
+    ISO: { d: "2026-04-03", d2: "2026-07-22", ds: "ISO, MDY" },
+    SQL: { d: "03/04/2026", d2: "22/07/2026", ds: "SQL, DMY" },
+  } as const;
+
+  let seenDateStyle = "";
+  const { port, server } = await listeningServer(socket => {
+    let pending = Buffer.alloc(0);
+    let sawStartup = false;
+    let style: (typeof dateStyles)[keyof typeof dateStyles];
+    socket.on("data", chunk => {
+      pending = Buffer.concat([pending, chunk]);
+      if (!sawStartup) {
+        if (pending.length < 4) return;
+        const len = pending.readInt32BE(0);
+        if (pending.length < len) return;
+        const params = parseStartupParams(pending.subarray(0, len));
+        pending = pending.subarray(len);
+        sawStartup = true;
+        seenDateStyle = params.DateStyle ?? "";
+        // Honour the startup parameter the way a real server does; fall back
+        // to the database default ('SQL, DMY') when the client didn't send one.
+        style = /^ISO\b/.test(seenDateStyle) ? dateStyles.ISO : dateStyles.SQL;
+        socket.write(
+          Buffer.concat([pgAuthenticationOk(), pgParameterStatus("DateStyle", style.ds), pgReadyForQuery()]),
+        );
+      }
+      pending = pgReadFrontendMessages(pending, type => {
+        if (type === 0x51 /* Q: simple query */) {
+          socket.write(
+            Buffer.concat([
+              pgRowDescription([
+                { name: "ds", typeOid: 25 /* text */ },
+                { name: "d", typeOid: OID_date },
+                { name: "d2", typeOid: OID_date },
+              ]),
+              pgDataRow([Buffer.from(style.ds), Buffer.from(style.d), Buffer.from(style.d2)]),
+              pgCommandComplete("SELECT 1"),
+              pgReadyForQuery(),
+            ]),
+          );
+        } else if (type === 0x50 /* P: Parse */) {
+          socket.write(
+            Buffer.concat([
+              pgParseComplete(),
+              pgParameterDescription([]),
+              pgRowDescription([{ name: "d", typeOid: OID_date }]),
+              pgReadyForQuery(),
+            ]),
+          );
+        } else if (type === 0x42 /* B: Bind */) {
+          socket.write(
+            Buffer.concat([
+              pgBindComplete(),
+              pgDataRow([Buffer.from(style.d)]),
+              pgCommandComplete("SELECT 1"),
+              pgReadyForQuery(),
+            ]),
+          );
+        }
       });
-    } finally {
-      await using cleanup = new SQL({ url, max: 1 });
-      await cleanup.unsafe(`ALTER DATABASE bun_sql_test RESET datestyle`);
-    }
+    });
+    socket.on("error", () => {});
   });
+
+  try {
+    await using sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 5 });
+    const [[row], ext] = await Promise.all([
+      sql`select current_setting('datestyle'), '2026-04-03'::date, '2026-07-22'::date`.simple(),
+      sql`select '2026-04-03'::date`,
+    ]);
+    const iso = (v: unknown) => (v instanceof Date && !Number.isNaN(v.getTime()) ? v.toISOString() : String(v));
+    expect({
+      // DateStyle in the startup packet overrides the database default; the
+      // mock reports it back the same way `current_setting('datestyle')` would.
+      seenDateStyle,
+      ds: row.ds,
+      d: iso(row.d),
+      d2: iso(row.d2),
+      ext: iso(ext[0].d),
+    }).toEqual({
+      seenDateStyle: "ISO, MDY",
+      ds: "ISO, MDY",
+      d: "2026-04-03T00:00:00.000Z",
+      d2: "2026-07-22T00:00:00.000Z",
+      ext: "2026-04-03T00:00:00.000Z",
+    });
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
 });


### PR DESCRIPTION
## What

`test/js/sql/postgres-datestyle.test.ts` was taking ~34s on `darwin 14 aarch64` in CI (build #80083). All of that was the `postgres_plain` container cold-start inside `describeWithContainer`; the two tests themselves run in about a second.

This replaces the container-backed end-to-end test with a scripted v3 backend (the same `wire-frames.ts` helpers `postgres-infinity-date.test.ts` already uses), so the file no longer needs docker at all.

## Why this is equivalent coverage

The container test did three things:

1. `ALTER DATABASE bun_sql_test SET datestyle = 'SQL, DMY'`, then opened a new connection and checked `current_setting('datestyle')` was ISO. That proves a StartupMessage `DateStyle` parameter outranks an `ALTER DATABASE` default, which is Postgres's documented GUC precedence (`PGC_S_CLIENT` > `PGC_S_DATABASE`); it is not Bun behaviour.
2. Selected `'2026-04-03'::date` and `'2026-07-22'::date` via `.simple()` and checked the decoded `Date` objects.
3. Selected `'2026-04-03'::date` via the extended protocol and checked the decoded `Date`.

The scripted backend covers the same ground from Bun's side:

- It parses the StartupMessage and, like a real server, honours the `DateStyle` the client sent. If `DateStyle=ISO` is present it emits ISO date text; if not it emits the `SQL, DMY` text (`03/04/2026`, `22/07/2026`) that an `ALTER DATABASE ... SET datestyle = 'SQL, DMY'` default would produce.
- It serves the simple query (`Q`) with three columns (`current_setting`, two dates) and the extended query (`P`/`B`) with one date column.
- The assertions are the same dates, the same `.toISOString()` values, plus the session `DateStyle` the client observed.

Because the mock reacts to what Bun actually sends, the test still fails-before the `StartupMessage.rs` fix: on a build without the `DateStyle` startup parameter the mock falls through to `SQL, DMY`, and the decoder produces `2026-03-04` (month/day swapped) and `Invalid Date`, which the single `toEqual` shows as a clean diff.

The first test (StartupMessage bytes contain `DateStyle=ISO`) is unchanged apart from hoisting the key/value-pair parser into a shared `parseStartupParams` helper.

## Side benefit

Without docker and without a `BUN_TEST_SERVICE_postgres_plain` env override, the old end-to-end test was `describe.todo`'d (0 coverage). The wire-mock version always runs.

## Timing

- CI `darwin 14 aarch64` (build #80083): **34s** wall time, entirely container cold-start. After: no container, so that cost is gone; the test body is <1s.
- Local `bun bd test` (debug+ASAN, warm Postgres via env var): before ~4–8s, after ~4–8s. Unchanged here because the env-var path never paid the cold-start cost; the whole file is dominated by debug-runner startup either way.
- Local `bun bd test` with no Postgres / docker: before ran **1** test (container block todo'd), after runs **2** tests in the same ~4s.

## Verification

```
$ bun bd test test/js/sql/postgres-datestyle.test.ts
(pass) StartupMessage pins DateStyle=ISO so server-side datestyle defaults cannot corrupt dates
(pass) database-level non-ISO DateStyle default does not corrupt date values
 2 pass, 0 fail
```

<details>
<summary>fail-before on a build without the StartupMessage fix</summary>

```
error: expect(received).toEqual(expected)
  {
-   "d": "2026-04-03T00:00:00.000Z",
-   "d2": "2026-07-22T00:00:00.000Z",
-   "ds": "ISO, MDY",
-   "ext": "2026-04-03T00:00:00.000Z",
-   "seenDateStyle": "ISO, MDY",
+   "d": "2026-03-04T00:00:00.000Z",
+   "d2": "Invalid Date",
+   "ds": "SQL, DMY",
+   "ext": "2026-03-04T00:00:00.000Z",
+   "seenDateStyle": "",
  }
```
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/sql/postgres-datestyle.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/sql/postgres-datestyle.test.ts
bun test v1.4.0 (3ed2e0fa8)

test/js/sql/postgres-datestyle.test.ts:
(pass) StartupMessage pins DateStyle=ISO so server-side datestyle defaults cannot corrupt dates [692.62ms]
(pass) database-level non-ISO DateStyle default does not corrupt date values [321.71ms]

 2 pass
 0 fail
 3 expect() calls
Ran 2 tests across 1 file. [4.23s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/sql/postgres-datestyle.test.ts | 171 +++++++++++++++++++++++++--------
 1 file changed, 130 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
test/js/sql/postgres-datestyle.test.ts      3      3      0
```

</details>

**self-review** · no surviving concerns

28 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->