### PR TITLE
Enable WebAssembly Memory64 by default

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -300,6 +300,9 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         // allow_user_segv_handler=1, so we don't force it off here.
         JSC::initialize([&] {
             JSC::Options::useWasm() = true;
+            // Memory64 is implemented in every Wasm tier; 64-bit memories never
+            // take the fast-memory (Signaling) path, so tier-up is safe.
+            JSC::Options::useWasmMemory64() = true;
             JSC::Options::useJIT() = true;
             JSC::Options::useBBQJIT() = true;
             JSC::Options::useConcurrentJIT() = true;

--- a/test/js/bun/wasm/memory64.test.ts
+++ b/test/js/bun/wasm/memory64.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+
+// Memory64 module (issue #35706). Equivalent .wat:
+//
+//   (module
+//     (memory (export "mem") i64 1)
+//     (func (export "storeLoad") (param $addr i64) (param $val i32) (result i32)
+//       local.get $addr
+//       local.get $val
+//       i32.store
+//       local.get $addr
+//       i32.load)
+//     (func (export "size") (result i64)
+//       memory.size))
+const memory64Wasm = Uint8Array.fromBase64(
+  "AGFzbQEAAAABCwJgAn5/AX9gAAF+AwMCAAEFAwEEAQcaAwNtZW0CAAlzdG9yZUxvYWQAAARzaXplAAEKFQIOACAAIAE2AgAgACgCAAsEAD8ACw==",
+);
+
+test("memory64 module validates", () => {
+  expect(WebAssembly.validate(memory64Wasm)).toBe(true);
+});
+
+test("memory64 module instantiates and uses i64 addresses", async () => {
+  const { instance } = await WebAssembly.instantiate(memory64Wasm, {});
+  const mem = instance.exports.mem as WebAssembly.Memory;
+  const storeLoad = instance.exports.storeLoad as (addr: bigint, val: number) => number;
+  const size = instance.exports.size as () => bigint;
+
+  expect(mem.buffer.byteLength).toBe(65536);
+  expect(size()).toBe(1n);
+  expect(storeLoad(0n, 42)).toBe(42);
+  expect(storeLoad(65532n, 1234)).toBe(1234);
+
+  // Out-of-bounds i64 address traps instead of wrapping.
+  expect(() => storeLoad(65536n, 1)).toThrow(WebAssembly.RuntimeError);
+  expect(() => storeLoad(2n ** 33n, 1)).toThrow(WebAssembly.RuntimeError);
+
+  // Growing an i64-addressed memory takes BigInt page counts.
+  expect(mem.grow(1n)).toBe(1n);
+  expect(mem.buffer.byteLength).toBe(131072);
+  expect(size()).toBe(2n);
+  expect(storeLoad(131068n, 7)).toBe(7);
+});


### PR DESCRIPTION
Fixes #35706

### Repro

Any wasm module declaring an i64-addressed memory (e.g. emscripten `-sMEMORY64`) failed to compile:

```
CompileError: WebAssembly.Module doesn't parse at byte 30: Memory64 is not enabled
```

Node ships memory64 by default, and the JS-side `new WebAssembly.Memory({ address: "i64" })` already worked in Bun; only module parsing was gated.

### Cause

JSC implements the memory64 proposal but the `useWasmMemory64` option defaults to false (`OptionsList.h`), and Bun never enabled it. The parser gate in `WasmSectionParser.cpp` (`parseResizableLimits`) rejects 64-bit limits for both memories and tables, so the one flag covers the whole proposal.

### Fix

Set `JSC::Options::useWasmMemory64() = true` in `JSCInitialize` alongside the other option defaults.

The option's description says memory64 is "only supported in the IPInt tier", but that is stale: BBQ and OMG both carry full `isMemory64()` codepaths, and 64-bit memories are excluded from the fast-memory (Signaling) path (`WasmMemory.cpp`), whose `RELEASE_ASSERT(!isMemory64())` is the only tier hazard. Verified empirically on the debug (ASAN) build with lowered tier-up thresholds and `BUN_JSC_logJIT=1`: a hot i64-addressed load/store loop tiers through BBQ and OMGForOSREntry, keeps producing correct results after `memory.grow`, and out-of-bounds i64 addresses still trap.

### Verification

New test `test/js/bun/wasm/memory64.test.ts` validates and instantiates a memory64 module, exercises i64 load/store addresses, OOB traps, and BigInt `grow`. Fails on current bun with the CompileError above, passes with this change. The reporter's repro (https://github.com/Valle12/bun-issue3) prints "memory64 is supported" with the fixed build.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/wasm/memory64.test.ts"
bun test v1.4.0 (8c218e79a)

test/js/bun/wasm/memory64.test.ts:
15 | const memory64Wasm = Uint8Array.fromBase64(
16 |   "AGFzbQEAAAABCwJgAn5/AX9gAAF+AwMCAAEFAwEEAQcaAwNtZW0CAAlzdG9yZUxvYWQAAARzaXplAAEKFQIOACAAIAE2AgAgACgCAAsEAD8ACw==",
17 | );
18 | 
19 | test("memory64 module validates", () => {
20 |   expect(WebAssembly.validate(memory64Wasm)).toBe(true);
                                                  ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/js/bun/wasm/memory64.test.ts:20:46)
(fail) memory64 module validates [9.35ms]
CompileError: WebAssembly.Module doesn't parse at byte 30: Memory64 is not enabled
(fail) memory64 module instantiates and uses i64 addresses [13.32ms]

 0 pass
 2 fail
 1 expect() calls
Ran 2 tests across 1 file. [2.48s]
error: script "bd" exited with code 1
__F:2:S:0

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/wasm/memory64.test.ts:
15 | const memory64Wasm = Uint8Array.fromBase64(
16 |   "AGFzbQEAAAABCwJgAn5/AX9gAAF+AwMCAAEFAwEEAQcaAwNtZW0CAAlzdG9yZUxvYWQAAARzaXplAAEKFQIOACAAIAE2AgAgACgCAAsEAD8ACw==",
17 | );
18 | 
19 | test("memory64 module validates", () => {
20 |   expect(WebAssembly.validate(memory64Wasm)).toBe(true);
                                                  ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/js/bun/wasm/memory64.test.ts:20:46)
(fail) memory64 module validates [5.71ms]
CompileError: WebAssembly.Module doesn't parse at byte 30: Memory64 is not enabled
(fail) memory64 module instantiates and uses i64 addresses [2.32ms]

 0 pass
 2 fail
 1 expect() calls
Ran 2 tests across 1 file. [232.00ms]
__F:2:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/wasm/memory64.test.ts"
bun test v1.4.0 (8c218e79a)

test/js/bun/wasm/memory64.test.ts:
(pass) memory64 module validates [33.33ms]
(pass) memory64 module instantiates and uses i64 addresses [29.93ms]

 2 pass
 0 fail
 11 expect() calls
Ran 2 tests across 1 file. [2.38s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1245ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen cpp.rs (cppbind)
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 39s
[2/6] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[3/6] link bun-profile
[4/6] bun-profile --revision
1.4.0-canary.1+8c218e79a
[6/6] strip bun
[build] done
bun test v1.4.0-canary.1 (8c218e79a)

test/js/bun/wasm/memory64.test.ts:
(pass) memory64 module validates [0.62ms]
(pass) memory64 module instantiates and uses i64 addresses [0.64ms]

 2 pass
 0 fail
 11 expect() calls
Ran 2 tests across 1 file. [255.00ms]
__F:0:S:0
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp |  3 +++
 test/js/bun/wasm/memory64.test.ts    | 43 ++++++++++++++++++++++++++++++++++++
 2 files changed, 46 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp      1      1      0
test/js/bun/wasm/memory64.test.ts         0      1      0
```

</details>

**root cause** · written by the author bot

Bun initializes JavaScriptCore with its own set of option defaults, and JSC's useWasmMemory64 option is off by default, so WebAssembly modules declaring 64-bit memories failed to validate or instantiate even though the engine fully supports them. The fix enables useWasmMemory64 in JSCInitialize alongside the existing useWasm default, matching the behavior Node.js already ships. The environment variable override still runs afterward, so BUN_JSC_useWasmMemory64=0 remains available as an escape hatch.

<!-- robobun:evidence:end -->