### PR TITLE
node:quic(h3): build lshpack/lsqpack with 32-bit header lengths so large request headers don't abort the connection

### DIFF
--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -212,11 +212,21 @@ static void *nq_hsi_create_header_set(void *ctx, lsquic_stream_t *s,
     }
     return h;
 }
+/* The largest decode window one header may ask for. lsqpack reserves 1.5x a
+ * Huffman string's declared length (up to 2^24) before its bytes arrive, so
+ * the peer chooses `space`; tie it to the configured maxHeaderLength, with a
+ * 64 KB floor for when none is set. */
+static size_t nq_hset_max_window(const struct nq_hset *h) {
+    size_t cap = (size_t) h->max_bytes * 2;
+    if (cap < UINT16_MAX) cap = UINT16_MAX;
+    if (cap > LSXPACK_MAX_STRLEN) cap = LSXPACK_MAX_STRLEN;
+    return cap;
+}
 static struct lsxpack_header *nq_hsi_prepare_decode(void *hset,
                                                     struct lsxpack_header *hdr,
                                                     size_t space) {
     struct nq_hset *h = hset;
-    if (space > LSXPACK_MAX_STRLEN)
+    if (space > nq_hset_max_window(h))
         return NULL;
     if (space > h->decode_cap) {
         size_t want = space < US_NQ_HSET_MIN_BUF ? US_NQ_HSET_MIN_BUF : space;

--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -185,6 +185,11 @@ static void nq_on_path_switch(lsquic_conn_t *c, int validated, int is_preferred,
 }
 
 #define US_NQ_HSET_MIN_BUF 256
+/* Fallback ceiling for nq_hsi_prepare_decode when maxHeaderLength is
+ * unlimited: lsqpack requests the decode buffer from the peer-declared
+ * length varint before any value bytes arrive, so this bounds how much a
+ * few wire bytes can reserve per stream. */
+#define US_NQ_HSET_MAX_BUF (128 * 1024)
 
 struct nq_hset {
     struct lsxpack_header xhdr;
@@ -212,21 +217,18 @@ static void *nq_hsi_create_header_set(void *ctx, lsquic_stream_t *s,
     }
     return h;
 }
-/* The largest decode window one header may ask for. lsqpack reserves 1.5x a
- * Huffman string's declared length (up to 2^24) before its bytes arrive, so
- * the peer chooses `space`; tie it to the configured maxHeaderLength, with a
- * 64 KB floor for when none is set. */
-static size_t nq_hset_max_window(const struct nq_hset *h) {
-    size_t cap = (size_t) h->max_bytes * 2;
-    if (cap < UINT16_MAX) cap = UINT16_MAX;
-    if (cap > LSXPACK_MAX_STRLEN) cap = LSXPACK_MAX_STRLEN;
-    return cap;
-}
 static struct lsxpack_header *nq_hsi_prepare_decode(void *hset,
                                                     struct lsxpack_header *hdr,
                                                     size_t space) {
     struct nq_hset *h = hset;
-    if (space > nq_hset_max_window(h))
+    /* 2x max_bytes covers the Huffman decode-window headroom for a single
+     * header that is itself the whole configured maxHeaderLength; floored at
+     * US_NQ_HSET_MAX_BUF so a small or unset limit never lowers the abort
+     * threshold (a header over max_bytes is still silently dropped in
+     * process_header, which keeps the session alive). */
+    size_t cap = (size_t) h->max_bytes * 2;
+    if (cap < US_NQ_HSET_MAX_BUF) cap = US_NQ_HSET_MAX_BUF;
+    if (space > LSXPACK_MAX_STRLEN || space > cap)
         return NULL;
     if (space > h->decode_cap) {
         size_t want = space < US_NQ_HSET_MIN_BUF ? US_NQ_HSET_MIN_BUF : space;

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -99,6 +99,10 @@ static constexpr unsigned MAX_CONTINUATION_FRAMES = 32;
  * is closed rather than the stream answered 431. */
 static constexpr unsigned HEADER_BLOCK_HARD_CAP_FACTOR = 2;
 static constexpr uint32_t DEFAULT_MAX_HEADER_LIST_SIZE = 64 * 1024;
+/* ls-hpack's per-string bound: its decoder answers LSHPACK_ERR_TOO_LARGE for
+ * a longer name or value, whatever width LSXPACK_MAX_STRLEN gives
+ * lsxpack_strlen_t (32 bits in this build, for QPACK). */
+static constexpr size_t HPACK_MAX_STRLEN = UINT16_MAX;
 /* Stop generating DATA frames once this much is queued on the socket; the
  * remainder waits for on_writable like an HttpResponse<SSL> would. */
 static constexpr size_t SOCKET_BACKPRESSURE_HIGH_WATER = 256 * 1024;
@@ -1098,7 +1102,7 @@ inline void Http2Connection::writeHeaderBlock(Http2Response *stream, bool endStr
             p = buf.data() + used;
             end = buf.data() + buf.size();
         }
-        if (h.nameLen > LSXPACK_MAX_STRLEN / 2 || h.valueLen > LSXPACK_MAX_STRLEN / 2) {
+        if (h.nameLen > http2::HPACK_MAX_STRLEN / 2 || h.valueLen > http2::HPACK_MAX_STRLEN / 2) {
             /* Beyond ls-hpack's 16-bit lengths: literal without indexing, no Huffman. */
             *p++ = 0x00;
             p = http2::hpackEncodeInteger(p, 0x00, 7, h.nameLen);
@@ -1576,11 +1580,11 @@ inline bool Http2Connection::handleHeaderBlock(uint32_t streamId, uint8_t flags,
     while (p < end) {
         lsxpack_header_t x;
         size_t room = buf.size() - used;
-        lsxpack_header_prepare_decode(&x, buf.data() + used, 0, room > LSXPACK_MAX_STRLEN ? LSXPACK_MAX_STRLEN : room);
+        lsxpack_header_prepare_decode(&x, buf.data() + used, 0, room > http2::HPACK_MAX_STRLEN ? http2::HPACK_MAX_STRLEN : room);
         int rc = lshpack_dec_decode(&dec, &p, end, &x);
         if (rc == LSHPACK_ERR_MORE_BUF) {
             size_t need = used + x.val_len + 64;
-            if (x.val_len > LSXPACK_MAX_STRLEN || buf.size() >= hardCap || room >= LSXPACK_MAX_STRLEN) {
+            if (x.val_len > http2::HPACK_MAX_STRLEN || buf.size() >= hardCap || room >= http2::HPACK_MAX_STRLEN) {
                 return connectionError(http2::ERR_ENHANCE_YOUR_CALM);
             }
             buf.resize(std::min(hardCap, std::max(buf.size() * 2, need)));

--- a/packages/h3blast/Makefile
+++ b/packages/h3blast/Makefile
@@ -8,7 +8,11 @@ OBJ       := $(ROOT)/build/$(PROFILE)/obj/vendor
 VENDOR    := $(ROOT)/vendor
 
 CC        ?= clang
+# LSXPACK_MAX_STRLEN must match scripts/build/flags.ts: the linked
+# build/$(PROFILE)/obj/vendor/{lsquic,lsqpack,lshpack} objects are compiled
+# with the 32-bit lsxpack_strlen_t layout.
 CFLAGS    := -std=c11 -O3 -g -Wall -Wextra -Wno-unused-parameter \
+             -DLSXPACK_MAX_STRLEN=UINT32_MAX \
              -I$(VENDOR)/lsquic/include \
              -I$(VENDOR)/hdrhistogram/include \
              -I$(VENDOR)/boringssl/include

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -230,6 +230,16 @@ export const globalFlags: Flag[] = [
     when: c => c.windows,
     desc: "Undefine _DLL (we link statically)",
   },
+  {
+    // lsxpack_header.h (shared by lshpack/lsqpack/lsquic and bun's own
+    // quic.c/node_quic_shim.c/c-bindings.cpp) sizes lsxpack_strlen_t from
+    // this macro; the upstream default (UINT16_MAX) caps any single decoded
+    // HTTP/2/3 header at 64 KB and makes a ~44 KB H3 field section abort the
+    // whole connection with H3_QPACK_DECOMPRESSION_FAILED. The value is
+    // struct-layout ABI, so every TU that includes the header must agree.
+    flag: "-DLSXPACK_MAX_STRLEN=UINT32_MAX",
+    desc: "lshpack/lsqpack: 32-bit header lengths (struct ABI; must match across all consumers)",
+  },
 
   // ─── Optimization ───
   {

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -230,13 +230,16 @@ export const globalFlags: Flag[] = [
     when: c => c.windows,
     desc: "Undefine _DLL (we link statically)",
   },
+
+  // ─── lsxpack struct ABI (all platforms) ───
   {
     // lsxpack_header.h (shared by lshpack/lsqpack/lsquic and bun's own
     // quic.c/node_quic_shim.c/c-bindings.cpp) sizes lsxpack_strlen_t from
     // this macro; the upstream default (UINT16_MAX) caps any single decoded
     // HTTP/2/3 header at 64 KB and makes a ~44 KB H3 field section abort the
     // whole connection with H3_QPACK_DECOMPRESSION_FAILED. The value is
-    // struct-layout ABI, so every TU that includes the header must agree.
+    // struct-layout ABI, so every TU that includes the header must agree
+    // (packages/h3blast/Makefile sets it too for the same reason).
     flag: "-DLSXPACK_MAX_STRLEN=UINT32_MAX",
     desc: "lshpack/lsqpack: 32-bit header lengths (struct ABI; must match across all consumers)",
   },

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -234,14 +234,17 @@ export const globalFlags: Flag[] = [
   // ─── lsxpack struct ABI (all platforms) ───
   {
     // lsxpack_header.h (shared by lshpack/lsqpack/lsquic and bun's own
-    // quic.c/node_quic_shim.c/c-bindings.cpp) sizes lsxpack_strlen_t from
-    // this macro; the upstream default (UINT16_MAX) caps any single decoded
-    // HTTP/2/3 header at 64 KB and makes a ~44 KB H3 field section abort the
-    // whole connection with H3_QPACK_DECOMPRESSION_FAILED. The value is
-    // struct-layout ABI, so every TU that includes the header must agree
+    // quic.c, node_quic_shim.c, Http2Context.h, c-bindings.cpp) sizes
+    // lsxpack_strlen_t from this macro. With the upstream default
+    // (UINT16_MAX) lsqpack cannot hold a decode window past 64 KB, and it
+    // reserves 1.5x a Huffman value's encoded length, so a ~44 KB encoded H3
+    // header aborts the whole connection with H3_QPACK_DECOMPRESSION_FAILED
+    // whatever limit the application configured. lshpack (HPACK) keeps its
+    // own UINT16_MAX per-string cap either way. The value is struct-layout
+    // ABI, so every TU that includes the header must agree
     // (packages/h3blast/Makefile sets it too for the same reason).
     flag: "-DLSXPACK_MAX_STRLEN=UINT32_MAX",
-    desc: "lshpack/lsqpack: 32-bit header lengths (struct ABI; must match across all consumers)",
+    desc: "lsqpack/lshpack: 32-bit header lengths (struct ABI; must match across all consumers)",
   },
 
   // ─── Optimization ───

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -178,6 +178,90 @@ describe("HTTP/3 header encoding", () => {
     expect(seen.length).toBe(1);
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
+
+  // A single header whose decoded size is well under the configured
+  // maxHeaderLength must decode cleanly; the QPACK decoder must not abort the
+  // whole connection at the lsxpack 16-bit buffer ceiling.
+  test("accepts a large header value under the configured limit and keeps the session alive", async () => {
+    const app = { maxHeaderPairs: 1000, maxHeaderLength: 1 << 20, maxFieldSectionSize: 1 << 20 };
+    let serverSessionError: any;
+    let received: number | undefined;
+    await using server = await listen(
+      async serverSession => {
+        serverSession.onerror = (e: any) => {
+          serverSessionError = e;
+        };
+        serverSession.onstream = (stream: any) => {
+          stream.closed.catch(() => {});
+        };
+        await serverSession.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        alpn: ["h3"],
+        application: app,
+        transportParams: { maxIdleTimeout: 1 },
+        onheaders(this: any, headers: Record<string, string>) {
+          received = headers["x-big"]?.length;
+          this.sendHeaders({ ":status": "200" });
+          this.writer.endSync();
+        },
+      },
+    );
+
+    const client = await connect(server.address, {
+      servername: "localhost",
+      alpn: "h3",
+      verifyPeer: "manual",
+      application: app,
+      transportParams: { maxIdleTimeout: 1 },
+    });
+    let clientSessionError: any;
+    client.onerror = (e: any) => {
+      clientSessionError = e;
+    };
+    client.closed.catch(() => {});
+    await client.opened;
+
+    // ~60 KB: Huffman-encodes to ~45 KB, and the decoder reserves 1.5x that,
+    // which previously overflowed the 16-bit lsxpack length and aborted the
+    // connection with H3_QPACK_DECOMPRESSION_FAILED.
+    const BIG = Buffer.alloc(60000, "A").toString();
+    const first = Promise.withResolvers<string>();
+    const sessionDied = client.closed.then(
+      () => Promise.reject(new Error("session closed before the large-header request was answered")),
+      e => Promise.reject(e),
+    );
+    sessionDied.catch(() => {});
+    const st1 = await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost", "x-big": BIG },
+      onheaders(headers: Record<string, string>) {
+        first.resolve(headers[":status"]);
+      },
+    });
+    st1.closed.catch(() => {});
+
+    expect(await Promise.race([first.promise, sessionDied])).toBe("200");
+    expect(received).toBe(BIG.length);
+    expect(client.destroyed).toBe(false);
+
+    // The session must still carry a second request.
+    const second = Promise.withResolvers<string>();
+    const st2 = await client.createBidirectionalStream({
+      headers: { ":method": "GET", ":path": "/2", ":scheme": "https", ":authority": "localhost" },
+      onheaders(headers: Record<string, string>) {
+        second.resolve(headers[":status"]);
+      },
+    });
+    st2.closed.catch(() => {});
+    expect(await Promise.race([second.promise, sessionDied])).toBe("200");
+
+    client.close();
+    await client.closed.catch(() => {});
+
+    expect(serverSessionError).toBeUndefined();
+    expect(clientSessionError).toBeUndefined();
+  });
 });
 
 describe("verifyClient", () => {

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -223,38 +223,40 @@ describe("HTTP/3 header encoding", () => {
     client.closed.catch(() => {});
     await client.opened;
 
-    // ~60 KB: Huffman-encodes to ~45 KB, and the decoder reserves 1.5x that,
-    // which previously overflowed the 16-bit lsxpack length and aborted the
-    // connection with H3_QPACK_DECOMPRESSION_FAILED.
-    const BIG = Buffer.alloc(60000, "A").toString();
-    const first = Promise.withResolvers<string>();
     const sessionDied = client.closed.then(
-      () => Promise.reject(new Error("session closed before the large-header request was answered")),
+      () => Promise.reject(new Error("session closed before the request was answered")),
       e => Promise.reject(e),
     );
     sessionDied.catch(() => {});
-    const st1 = await client.createBidirectionalStream({
-      headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost", "x-big": BIG },
-      onheaders(headers: Record<string, string>) {
-        first.resolve(headers[":status"]);
-      },
-    });
-    st1.closed.catch(() => {});
 
-    expect(await Promise.race([first.promise, sessionDied])).toBe("200");
-    expect(received).toBe(BIG.length);
-    expect(client.destroyed).toBe(false);
+    // "A" Huffman-codes to 6 bits, and the QPACK decoder reserves 1.5x the
+    // encoded length before it decodes. 60000 bytes is ~45 KB encoded, ~67 KB
+    // reserved: past a 16-bit lsxpack length, which aborted the connection with
+    // H3_QPACK_DECOMPRESSION_FAILED. 70000 bytes is past 16 bits decoded too,
+    // and ~52 KB encoded still fits the 64 KB block lsquic's sender builds.
+    // The last request has no large header: the session must still carry it.
+    for (const size of [60000, 70000, 0]) {
+      received = undefined;
+      const headers: Record<string, string> = {
+        ":method": "GET",
+        ":path": "/" + size,
+        ":scheme": "https",
+        ":authority": "localhost",
+      };
+      if (size) headers["x-big"] = Buffer.alloc(size, "A").toString();
+      const status = Promise.withResolvers<string>();
+      const stream = await client.createBidirectionalStream({
+        headers,
+        onheaders(responseHeaders: Record<string, string>) {
+          status.resolve(responseHeaders[":status"]);
+        },
+      });
+      stream.closed.catch(() => {});
 
-    // The session must still carry a second request.
-    const second = Promise.withResolvers<string>();
-    const st2 = await client.createBidirectionalStream({
-      headers: { ":method": "GET", ":path": "/2", ":scheme": "https", ":authority": "localhost" },
-      onheaders(headers: Record<string, string>) {
-        second.resolve(headers[":status"]);
-      },
-    });
-    st2.closed.catch(() => {});
-    expect(await Promise.race([second.promise, sessionDied])).toBe("200");
+      expect(await Promise.race([status.promise, sessionDied])).toBe("200");
+      expect(received).toBe(size || undefined);
+      expect(client.destroyed).toBe(false);
+    }
 
     client.close();
     await client.closed.catch(() => {});


### PR DESCRIPTION
### Problem
- A request header of about 44 KB encoded closes the whole HTTP/3 connection: `QUIC application error 512: QPACK decompression error; stream 0, offset 1243, line 3702` (`H3_QPACK_DECOMPRESSION_FAILED`). A configured `maxHeaderLength` of 1 MB does not help.
- `LSXPACK_MAX_STRLEN` defaults to `UINT16_MAX`, so one header's decode window stops at 65535 bytes. lsqpack reserves 1.5x a Huffman value's encoded length. `nq_hsi_prepare_decode` (`packages/bun-usockets/src/node_quic_shim.c`) returns `NULL` and lsquic aborts the connection.

### Fix
- `scripts/build/flags.ts` defines `LSXPACK_MAX_STRLEN=UINT32_MAX` for every translation unit. `packages/h3blast/Makefile` links the same objects and sets it too.
- `nq_hsi_prepare_decode` caps the window at twice the configured `maxHeaderLength`, with a 128 KB floor. The peer declares the length (up to 2^24) before it sends the bytes, so the window needs a bound. #35763 has the identical hunk.
- `Http2Context.h` used the macro as ls-hpack's string limit. It now has its own `HPACK_MAX_STRLEN = UINT16_MAX`, so `Bun.serve` HTTP/2 is unchanged.
- Verified: `test/js/node/quic/quic-stream.test.ts` fails with the error above without the define. Also ran the node:quic, node:http2, `serve-http2*`, `serve-http3`, and fetch HTTP/2 and HTTP/3 suites.

### Background
- QPACK is HTTP/3 header compression. lsqpack decodes each header into a buffer the application supplies through a `prepare_decode` callback. That buffer is the decode window.
- `struct lsxpack_header` describes one header with lengths of type `lsxpack_strlen_t`. ls-hpack, ls-qpack, lsquic, and bun's own C and C++ share it.
- The macro sets the width of `lsxpack_strlen_t`, so it is struct layout. Every file that includes the header must agree.

<details><summary>Notes</summary>

**Threshold.** `"A"` Huffman-codes to 6 bits. 60000 bytes is about 45000 encoded, and lsqpack asks `prepare_decode` for `45000 * 3/2 = 67500` bytes, which is more than 65535. The reported bisect (58000 passes, 59000 fails) matches `65535 / 1.5 = 43690` encoded bytes. With the older lsqpack pin the error said `line 3693`. After the lsqpack bump on main it says `line 3702`.

**Upstream supports both widths.** `lsxpack_header.h` accepts exactly `UINT16_MAX` or `UINT32_MAX`, and the current ls-qpack has `#if LSXPACK_MAX_STRLEN == UINT16_MAX` guards around its early length checks.

**Consumers of the struct.** lshpack, lsqpack, and lsquic are `direct` deps and get `globalFlags` through `computeDepFlags()`. `quic.c`, `node_quic_shim.c`, `c-bindings.cpp`, and the files that include `Http2Context.h` (`NodeHTTP.cpp`, `CookieMap.cpp`) get it through `computeFlags()`. `src/http/lshpack.rs` talks to C through a separate `lshpack_header` struct with `size_t` fields, so the Rust FFI does not change. In `c-bindings.cpp`, `lsxpack_header_prepare_decode(..., 65536)` now yields `val_len = 65536` where it was clamped to 65535. The buffer is 65536 bytes.

**Why the window cap.** `lsqpack_dec_int24` accepts a declared string length up to 2^24 - 1, and the Huffman path calls `guarantee_out_bytes(left + left / 2)` before any string byte arrives. Without a cap, a few bytes on the wire make the server `realloc` about 25 MB for each stream. Twice `maxHeaderLength` covers every header that fits the limit: name plus 1.5x the encoded value, and an encoder uses Huffman only when it is shorter.

**HTTP/2.** ls-hpack's decoder returns `LSHPACK_ERR_TOO_LARGE` for a name or value past `UINT16_MAX` at either struct width, and its encoder's length prefix is four bytes (about 2 MB). `Http2Context.h` keeps its 32 KB literal fallback on encode and its 64 KB window on decode. One difference: `x.val_len > HPACK_MAX_STRLEN` was always false with a 16-bit `val_len`. It is now live, and it answers `ENHANCE_YOUR_CALM` one loop iteration earlier for a header that could not fit anyway.

**What the test sends.** 60000 and 70000 byte values, then a plain request, all on one session with `maxHeaderLength: 1 << 20` on both peers. 70000 bytes is past 16 bits decoded as well. lsquic's sender builds an encoded header block of at most 64 KB (`MAX_HEADERS_SIZE` in `lsquic_stream.c`), so bun's own client cannot send more than that. A value of 100000 bytes fails on the sending side for that reason.

**Not changed here.**
- A header whose window passes the cap still aborts the connection. With no `maxHeaderLength` set the cap is 128 KB (it was 64 KB), so the 60000 byte repro now reaches the session and the JS layer drops the header under its default limit. To reject an oversize header on its stream only needs a change in lsquic: `qdh_hsi_process_wrapper` and the `LQRHS_ERROR` path both call `ci_abort_error`.
- The side that aborts reports `ERR_QUIC_TRANSPORT_ERROR` code 1 through `map_conn_status(LSCONN_ST_ERROR)`, because lsquic does not expose `ifc_error`. The peer sees the correct application code 0x200.
- `packages/bun-usockets/src/quic.c` (`Bun.serve` with `http3: true`) keeps its own fixed `64 * 1024` cap in `us_quic_hsi_prepare`. #35763 changes that one. It carries the same `flags.ts` define, so it also needs the `Http2Context.h` change from this PR.

**Suites run (debug + ASAN, rebased on f04caca828).** `test/js/node/quic/`, `test/js/node/http2/h2-conformance.test.ts`, `node-http2-continuation.test.ts`, `node-http2.test.js`, `test/js/bun/http/serve-http2.test.ts`, `serve-http2-protocol.test.ts`, `serve-http2-lifecycle.test.ts`, `serve-http3.test.ts`, `test/js/web/fetch/fetch-http2-client.test.ts`, `fetch-http3-client.test.ts`, `fetch-http3-adversarial.test.ts`. The three `serve-http2*` files ran together four times. One run timed out at 30 s in the h2 + h3 lifecycle test. The other three runs passed, four runs of that file alone passed, and one combined run on the base build passed.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 5 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/quic/quic-stream.test.ts:
(node:41608) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [486.01ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [68.76ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1085.25ms]
(pass) HTTP/3 header encoding > accepts a large header value under the configured limit and keeps the session alive [121.67ms]
(pass) verifyClient > a server requiring a client certificate never surfaces streams from a client that presented none [71.31ms]

 5 pass
 0 fail
 19 expect() calls
Ran 5 tests across 1 file. [4.56s]
__F:0:S:0

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/node/quic/quic-stream.test.ts:
(node:41636) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun --trace-warnings ...` to show where the warning was created)
(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [13.24ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [5.65ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1008.23ms]
1729 |     }
1730 |     switch (errorType) {
1731 |       case 0:
1732 |         this.destroy(makeQuicError("ERR_QUIC_TRANSPORT_ERROR", "QUIC transport error", "transport", code, reason, errorName));
1733 |         break;
1734 |         this.destroy(makeQuicError("ERR_QUIC_APPLICATION_ERROR", "QUIC application error", "application", code, reason, errorName));
                                         ^
error: QUIC application error 512: QPACK decompression error; stream 0, offset 1243, line 3693
 reason: "QPACK decompression error; stream 0, offset 1243, line 3693",
   code: "ERR_QUIC_APP
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/quic/quic-stream.test.ts:
(node:41820) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [697.02ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [68.61ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1074.41ms]
(pass) HTTP/3 header encoding > accepts a large header value under the configured limit and keeps the session alive [122.59ms]
(pass) verifyClient > a server requiring a client certificate never surfaces streams from a client that presented none [105.74ms]

 5 pass
 0 fail
 19 expect() calls
Ran 5 tests across 1 file. [4.76s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 647ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/13] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 34s
[9/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[10/13] link bun-profile
[12/13] strip bun
[12/13] bun-profile --revision
1.4.3-canary.1+a6422722f
[build] done
bun test v1.4.3-canary.1 (a6422722f)

test/js/node/quic/quic-stream.test.ts:
(node:42150) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-profile --trace-warnings ...` to show where the warning was created)
(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [12.67ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [5.10ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1006.71ms]
(pass) HTTP/3 header encoding > accepts a
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/node_quic_shim.c | 14 ++++-
 packages/bun-uws/src/Http2Context.h        | 10 ++--
 packages/h3blast/Makefile                  |  4 ++
 scripts/build/flags.ts                     | 16 ++++++
 test/js/node/quic/quic-stream.test.ts      | 86 ++++++++++++++++++++++++++++++
 5 files changed, 126 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-usockets/src/node_quic_shim.c      4      3     32
packages/bun-uws/src/Http2Context.h             2      3     33
packages/h3blast/Makefile                       1      1     32
scripts/build/flags.ts                          7      3     32
test/js/node/quic/quic-stream.test.ts           3      5     32
```

</details>

<!-- robobun:evidence:end -->