### PR TITLE
node:inspector: emit full RemoteObject, stackTrace, and count/time*/assert/dirxml/clear for in-process Session consoleAPICalled

### DIFF
--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -187,7 +187,8 @@ let nextRemoteObjectId = 1;
 function constructorName(value: object): string | undefined {
   try {
     let proto: object | null = value;
-    while (proto !== null) {
+    // Bounded: a Proxy getPrototypeOf trap may return itself (legal ES), which would loop forever.
+    for (let i = 0; proto !== null && i < 100; i++) {
       const descriptor = Object.getOwnPropertyDescriptor(proto, "constructor");
       if (descriptor !== undefined) {
         const ctor = descriptor.value;
@@ -587,7 +588,10 @@ function makeSpecialConsoleHook(method: string, original: Function): Function {
   switch (method) {
     case "assert": {
       const hook = function (this: unknown, ...args: unknown[]) {
-        if (!args[0]) emitConsoleAPICalled("assert", ArrayPrototypeSlice.$call(args, 1), hook);
+        if (!args[0]) {
+          const rest = ArrayPrototypeSlice.$call(args, 1);
+          emitConsoleAPICalled("assert", rest.length > 0 ? rest : ["console.assert"], hook);
+        }
         return original.$apply(this, args);
       };
       return hook;
@@ -614,13 +618,15 @@ function makeSpecialConsoleHook(method: string, original: Function): Function {
         return original.$call(this, label);
       };
     case "timeLog": {
-      const hook = function (this: unknown, label?: unknown, ...extra: unknown[]) {
-        const key = toLabel(label);
+      const hook = function (this: unknown) {
+        const key = toLabel(arguments[0]);
         const start = consoleTimers.get(key);
         if (start !== undefined) {
-          emitConsoleAPICalled("log", [`${key}: ${PerformanceNow() - start} ms`, ...extra], hook);
+          const emitArgs = ArrayPrototypeSlice.$call(arguments);
+          emitArgs[0] = `${key}: ${PerformanceNow() - start} ms`;
+          emitConsoleAPICalled("log", emitArgs, hook);
         }
-        return original.$call(this, label, ...extra);
+        return original.$apply(this, arguments);
       };
       return hook;
     }

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -544,7 +544,11 @@ function emitConsoleAPICalled(type: string, args: unknown[], hook: Function) {
           executionContextId: 1,
           timestamp,
         };
-        if (callFrames !== undefined) params.stackTrace = { callFrames: ArrayPrototypeSlice.$call(callFrames) };
+        if (callFrames !== undefined) {
+          const frames: object[] = [];
+          for (let i = 0; i < callFrames.length; i++) frames.push({ ...(callFrames[i] as AnyRecord) });
+          params.stackTrace = { callFrames: frames };
+        }
         const message = { method: "Runtime.consoleAPICalled", params };
         // Node's Session#onMessage emits the method-specific event first,
         // then the generic "inspectorNotification".
@@ -602,31 +606,34 @@ function makeSpecialConsoleHook(method: string, original: Function): Function {
         const next = (consoleCounts.get(key) ?? 0) + 1;
         consoleCounts.set(key, next);
         emitConsoleAPICalled("count", [`${key}: ${next}`], hook);
-        return original.$call(this, label);
+        return original.$call(this, key);
       };
       return hook;
     }
     case "countReset":
       return function (this: unknown, label?: unknown) {
-        consoleCounts.delete(toLabel(label));
-        return original.$call(this, label);
+        const key = toLabel(label);
+        consoleCounts.delete(key);
+        return original.$call(this, key);
       };
     case "time":
       return function (this: unknown, label?: unknown) {
         const key = toLabel(label);
         if (!consoleTimers.has(key)) consoleTimers.set(key, PerformanceNow());
-        return original.$call(this, label);
+        return original.$call(this, key);
       };
     case "timeLog": {
       const hook = function (this: unknown) {
-        const key = toLabel(arguments[0]);
+        const forward = ArrayPrototypeSlice.$call(arguments);
+        const key = toLabel(forward[0]);
+        forward[0] = key;
         const start = consoleTimers.get(key);
         if (start !== undefined) {
-          const emitArgs = ArrayPrototypeSlice.$call(arguments);
+          const emitArgs = ArrayPrototypeSlice.$call(forward);
           emitArgs[0] = `${key}: ${PerformanceNow() - start} ms`;
           emitConsoleAPICalled("log", emitArgs, hook);
         }
-        return original.$apply(this, arguments);
+        return original.$apply(this, forward);
       };
       return hook;
     }
@@ -638,7 +645,7 @@ function makeSpecialConsoleHook(method: string, original: Function): Function {
           consoleTimers.delete(key);
           emitConsoleAPICalled("timeEnd", [`${key}: ${PerformanceNow() - start} ms`], hook);
         }
-        return original.$call(this, label);
+        return original.$call(this, key);
       };
       return hook;
     }
@@ -657,7 +664,8 @@ function installConsoleHooks() {
     hookedConsoleMethods.push([method, original, hook]);
     consoleObject[method] = hook;
   }
-  for (const method of CONSOLE_API_SPECIAL) {
+  for (let i = 0; i < CONSOLE_API_SPECIAL.length; i++) {
+    const method = CONSOLE_API_SPECIAL[i];
     const original = consoleObject[method];
     if (typeof original !== "function") continue;
     const hook = makeSpecialConsoleHook(method, original);
@@ -677,8 +685,6 @@ function removeConsoleHooks() {
     }
   }
   hookedConsoleMethods.length = 0;
-  consoleCounts.clear();
-  consoleTimers.clear();
 }
 
 // Reshapes the raw control-flow-profiler data from jsFunction_collectPreciseCoverage

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -13,23 +13,22 @@ const types = require("node:util/types");
 const DateNow = Date.now;
 const PerformanceNow = performance.now.bind(performance);
 const ObjectKeys = Object.keys;
+const ObjectIs = Object.is;
 const ObjectGetPrototypeOf = Object.getPrototypeOf;
+const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const ObjectPrototypeToString = Object.prototype.toString;
 const ArrayPrototypeSlice = Array.prototype.slice;
 const FunctionPrototypeToString = Function.prototype.toString;
 const DatePrototypeToString = Date.prototype.toString;
 const RegExpPrototypeToString = RegExp.prototype.toString;
 const ErrorPrototypeToString = Error.prototype.toString;
-const MapPrototypeGetSize = Object.getOwnPropertyDescriptor(Map.prototype, "size")!.get!;
-const SetPrototypeGetSize = Object.getOwnPropertyDescriptor(Set.prototype, "size")!.get!;
+const MapPrototypeGetSize = ObjectGetOwnPropertyDescriptor(Map.prototype, "size")!.get!;
+const SetPrototypeGetSize = ObjectGetOwnPropertyDescriptor(Set.prototype, "size")!.get!;
 const MapPrototypeEntries = Map.prototype.entries;
 const SetPrototypeValues = Set.prototype.values;
 const TypedArrayPrototype = ObjectGetPrototypeOf(Uint8Array.prototype);
-const TypedArrayPrototypeGetLength = Object.getOwnPropertyDescriptor(TypedArrayPrototype, "length")!.get!;
-const TypedArrayPrototypeGetToStringTag = Object.getOwnPropertyDescriptor(
-  TypedArrayPrototype,
-  Symbol.toStringTag,
-)!.get!;
+const TypedArrayPrototypeGetLength = ObjectGetOwnPropertyDescriptor(TypedArrayPrototype, "length")!.get!;
+const TypedArrayPrototypeGetToStringTag = ObjectGetOwnPropertyDescriptor(TypedArrayPrototype, Symbol.toStringTag)!.get!;
 const ErrorCaptureStackTrace = Error.captureStackTrace;
 
 // #handleMethod return marker for inspector-protocol errors: the callback
@@ -189,7 +188,7 @@ function constructorName(value: object): string | undefined {
     let proto: object | null = value;
     // Bounded: a Proxy getPrototypeOf trap may return itself (legal ES), which would loop forever.
     for (let i = 0; proto !== null && i < 100; i++) {
-      const descriptor = Object.getOwnPropertyDescriptor(proto, "constructor");
+      const descriptor = ObjectGetOwnPropertyDescriptor(proto, "constructor");
       if (descriptor !== undefined) {
         const ctor = descriptor.value;
         if ($isCallable(ctor)) {
@@ -305,7 +304,7 @@ function previewValue(value: unknown): { type: string; value: string; subtype?: 
     case "string":
       return { type: "string", value: truncate(value) };
     case "number":
-      return { type: "number", value: Object.is(value, -0) ? "-0" : `${value}` };
+      return { type: "number", value: ObjectIs(value, -0) ? "-0" : `${value}` };
     case "boolean":
       return { type: "boolean", value: `${value}` };
     case "undefined":
@@ -411,7 +410,7 @@ function toRemoteObject(arg: unknown): object {
     case "string":
       return { type: "string", value: arg };
     case "number":
-      if (Object.is(arg, -0)) return { type: "number", unserializableValue: "-0", description: "-0" };
+      if (ObjectIs(arg, -0)) return { type: "number", unserializableValue: "-0", description: "-0" };
       return Number.isFinite(arg)
         ? { type: "number", value: arg, description: String(arg) }
         : {

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -175,23 +175,16 @@ const CONSOLE_API_TYPES: Record<string, string> = {
   groupEnd: "endGroup",
 };
 
-// Methods whose CDP semantics differ from "emit the JS arguments as-is":
-// assert is conditional, count/time* carry derived strings rather than the
-// raw args, and time/countReset emit nothing. These get bespoke hooks.
+// Methods whose event args are derived (not the raw JS args) and so need bespoke hooks below.
 const CONSOLE_API_SPECIAL = ["assert", "count", "countReset", "time", "timeLog", "timeEnd"];
 
 const PREVIEW_MAX_PROPERTIES = 5;
 const MAX_DESCRIPTION_LENGTH = 100;
 
-// Synthetic RemoteObject.objectId so the shape matches V8. The in-process
-// Session has no Runtime.getProperties backend to dereference these, but
-// consumers commonly test for the field's presence to distinguish primitives
-// from objects.
+// Synthetic objectId for shape parity with V8; there is no Runtime.getProperties backend to dereference it.
 let nextRemoteObjectId = 1;
 
 function constructorName(value: object): string | undefined {
-  // Every property read on a user value can throw (Proxy traps, hostile
-  // getters). A failure here falls back to the subtype-derived name.
   try {
     let proto: object | null = value;
     while (proto !== null) {
@@ -218,8 +211,6 @@ function truncate(text: string): string {
 }
 
 function classifyObject(value: object): { subtype?: string; className: string; description: string } {
-  // util.types predicates read internal slots and do not invoke user code, so
-  // the classification itself cannot throw even on hostile Proxies / getters.
   if ($isProxyObject(value)) {
     const className = constructorName(value) ?? "Object";
     return { subtype: "proxy", className, description: `Proxy(${className})` };
@@ -410,10 +401,7 @@ function buildPreview(value: object, subtype: string | undefined, description: s
       }
       if (keys.length > shown) preview.overflow = true;
     }
-  } catch {
-    // A hostile getter or Proxy trap threw mid-enumeration; keep whatever was
-    // collected so far.
-  }
+  } catch {}
   return preview;
 }
 
@@ -500,9 +488,7 @@ function prepareCDPCallFrames(_err: unknown, callSites: any[]): object[] {
 const CONSOLE_STACK_TRACE_LIMIT = 30;
 
 function captureCDPStackTrace(skipAbove: Function): object[] | undefined {
-  // User code can install throwing getters/setters or make these non-writable
-  // in strict mode; best-effort at every touch so console.* itself never
-  // throws from the hook.
+  // Every Error.* touch is guarded so hostile getters/setters/freeze cannot make console.* itself throw.
   const target: { stack?: object[] } = {};
   let savedPrepare: unknown;
   let savedLimit: unknown;
@@ -581,10 +567,7 @@ function emitConsoleAPICalled(type: string, args: unknown[], hook: Function) {
   }
 }
 
-// Shadow state for count()/time*(): Bun's native console keeps its own
-// counters and timers, but those live in C++ and are not readable from here,
-// so the hook maintains a parallel map to synthesize the formatted string V8
-// puts in the event args.
+// Shadow counters/timers parallel to Bun's native C++ console state, which is not readable from JS.
 const consoleCounts: Map<string, number> = new SafeMap();
 const consoleTimers: Map<string, number> = new SafeMap();
 

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -15,6 +15,7 @@ const PerformanceNow = performance.now.bind(performance);
 const ObjectKeys = Object.keys;
 const ObjectGetPrototypeOf = Object.getPrototypeOf;
 const ObjectPrototypeToString = Object.prototype.toString;
+const ArrayPrototypeSlice = Array.prototype.slice;
 const FunctionPrototypeToString = Function.prototype.toString;
 const DatePrototypeToString = Date.prototype.toString;
 const RegExpPrototypeToString = RegExp.prototype.toString;
@@ -195,9 +196,12 @@ function constructorName(value: object): string | undefined {
     let proto: object | null = value;
     while (proto !== null) {
       const descriptor = Object.getOwnPropertyDescriptor(proto, "constructor");
-      if (descriptor !== undefined && $isCallable(descriptor.value)) {
-        const name = descriptor.value.name;
-        if (typeof name === "string" && name.length > 0) return name;
+      if (descriptor !== undefined) {
+        const ctor = descriptor.value;
+        if ($isCallable(ctor)) {
+          const name = ctor.name;
+          if (typeof name === "string" && name.length > 0) return name;
+        }
       }
       proto = ObjectGetPrototypeOf(proto);
     }
@@ -206,7 +210,11 @@ function constructorName(value: object): string | undefined {
 }
 
 function truncate(text: string): string {
-  return text.length > MAX_DESCRIPTION_LENGTH ? text.slice(0, MAX_DESCRIPTION_LENGTH) + "…" : text;
+  if (text.length <= MAX_DESCRIPTION_LENGTH) return text;
+  let end = MAX_DESCRIPTION_LENGTH;
+  const code = text.charCodeAt(end - 1);
+  if (code >= 0xd800 && code <= 0xdbff) end--;
+  return text.slice(0, end) + "…";
 }
 
 function classifyObject(value: object): { subtype?: string; className: string; description: string } {
@@ -324,20 +332,21 @@ function previewValue(value: unknown): { type: string; value: string; subtype?: 
       } catch {
         return { type: "object", value: "Object" };
       }
+      const { subtype, description } = info;
       const entry: { type: string; value: string; subtype?: string } = {
         type: "object",
-        value: truncate(info.description),
+        value: truncate(description),
       };
-      if (info.subtype !== undefined) entry.subtype = info.subtype;
+      if (subtype !== undefined) entry.subtype = subtype;
       return entry;
     }
   }
 }
 
 function entryPreview(value: unknown): object {
-  const p = previewValue(value);
-  const out: AnyRecord = { type: p.type, description: p.value, overflow: false, properties: [] };
-  if (p.subtype !== undefined) out.subtype = p.subtype;
+  const { type, value: description, subtype } = previewValue(value);
+  const out: AnyRecord = { type, description, overflow: false, properties: [] };
+  if (subtype !== undefined) out.subtype = subtype;
   return out;
 }
 
@@ -455,14 +464,15 @@ function toRemoteObject(arg: unknown): object {
       } catch {
         info = { className: "Object", description: ObjectPrototypeToString.$call(arg) };
       }
+      const { subtype, className, description } = info;
       const remote: AnyRecord = {
         type: "object",
-        className: info.className,
-        description: info.description,
+        className,
+        description,
         objectId: `bun.1.${nextRemoteObjectId++}`,
-        preview: buildPreview(arg, info.subtype, info.description),
+        preview: buildPreview(arg, subtype, description),
       };
-      if (info.subtype !== undefined) remote.subtype = info.subtype;
+      if (subtype !== undefined) remote.subtype = subtype;
       return remote;
     }
   }
@@ -487,28 +497,38 @@ function prepareCDPCallFrames(_err: unknown, callSites: any[]): object[] {
   return frames;
 }
 
-function captureCDPStackTrace(skipAbove: Function): object | undefined {
+const CONSOLE_STACK_TRACE_LIMIT = 30;
+
+function captureCDPStackTrace(skipAbove: Function): object[] | undefined {
+  // User code can install throwing getters/setters or make these non-writable
+  // in strict mode; best-effort at every touch so console.* itself never
+  // throws from the hook.
   const target: { stack?: object[] } = {};
-  const savedPrepare = Error.prepareStackTrace;
-  const savedLimit = Error.stackTraceLimit;
+  let savedPrepare: unknown;
+  let savedLimit: unknown;
+  try {
+    savedPrepare = Error.prepareStackTrace;
+    savedLimit = Error.stackTraceLimit;
+  } catch {
+    return undefined;
+  }
   try {
     Error.prepareStackTrace = prepareCDPCallFrames;
     try {
-      Error.stackTraceLimit = 200;
+      Error.stackTraceLimit = CONSOLE_STACK_TRACE_LIMIT;
     } catch {}
     ErrorCaptureStackTrace(target, skipAbove);
-    const callFrames = target.stack;
-    if ($isArray(callFrames)) return { callFrames };
   } catch {
-    // Best-effort: a user-installed prepareStackTrace setter or a non-writable
-    // stackTraceLimit must not make console.* itself throw.
   } finally {
-    Error.prepareStackTrace = savedPrepare;
     try {
-      Error.stackTraceLimit = savedLimit;
+      Error.prepareStackTrace = savedPrepare as any;
+    } catch {}
+    try {
+      Error.stackTraceLimit = savedLimit as number;
     } catch {}
   }
-  return undefined;
+  const callFrames = target.stack;
+  return $isArray(callFrames) ? callFrames : undefined;
 }
 
 // Node delivers consoleAPICalled through V8's message pump, so a listener
@@ -522,7 +542,7 @@ function emitConsoleAPICalled(type: string, args: unknown[], hook: Function) {
   emittingConsoleAPI = true;
   try {
     const timestamp = DateNow();
-    const stackTrace = captureCDPStackTrace(hook);
+    const callFrames = captureCDPStackTrace(hook);
     for (const session of runtimeEnabledSessions) {
       // Neither a throwing listener nor a throwing argument serialization
       // (toRemoteObject reads user-controlled getters) may make the console
@@ -537,7 +557,7 @@ function emitConsoleAPICalled(type: string, args: unknown[], hook: Function) {
           executionContextId: 1,
           timestamp,
         };
-        if (stackTrace !== undefined) params.stackTrace = stackTrace;
+        if (callFrames !== undefined) params.stackTrace = { callFrames: ArrayPrototypeSlice.$call(callFrames) };
         const message = { method: "Runtime.consoleAPICalled", params };
         // Node's Session#onMessage emits the method-specific event first,
         // then the generic "inspectorNotification".
@@ -584,7 +604,7 @@ function makeSpecialConsoleHook(method: string, original: Function): Function {
   switch (method) {
     case "assert": {
       const hook = function (this: unknown, ...args: unknown[]) {
-        if (!args[0]) emitConsoleAPICalled("assert", args.slice(1), hook);
+        if (!args[0]) emitConsoleAPICalled("assert", ArrayPrototypeSlice.$call(args, 1), hook);
         return original.$apply(this, args);
       };
       return hook;

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -5,11 +5,31 @@
 // Protocol WebSocket server with breakpoint pausing.
 const { hideFromStack } = require("internal/shared");
 const { validateString, validateFunction } = require("internal/validators");
-const { SafeSet } = require("internal/primordials");
+const { SafeSet, SafeMap } = require("internal/primordials");
 const EventEmitter = require("node:events");
 const { pathToFileURL } = require("node:url");
 const { isAbsolute } = require("node:path");
+const types = require("node:util/types");
 const DateNow = Date.now;
+const PerformanceNow = performance.now.bind(performance);
+const ObjectKeys = Object.keys;
+const ObjectGetPrototypeOf = Object.getPrototypeOf;
+const ObjectPrototypeToString = Object.prototype.toString;
+const FunctionPrototypeToString = Function.prototype.toString;
+const DatePrototypeToString = Date.prototype.toString;
+const RegExpPrototypeToString = RegExp.prototype.toString;
+const ErrorPrototypeToString = Error.prototype.toString;
+const MapPrototypeGetSize = Object.getOwnPropertyDescriptor(Map.prototype, "size")!.get!;
+const SetPrototypeGetSize = Object.getOwnPropertyDescriptor(Set.prototype, "size")!.get!;
+const MapPrototypeEntries = Map.prototype.entries;
+const SetPrototypeValues = Set.prototype.values;
+const TypedArrayPrototype = ObjectGetPrototypeOf(Uint8Array.prototype);
+const TypedArrayPrototypeGetLength = Object.getOwnPropertyDescriptor(TypedArrayPrototype, "length")!.get!;
+const TypedArrayPrototypeGetToStringTag = Object.getOwnPropertyDescriptor(
+  TypedArrayPrototype,
+  Symbol.toStringTag,
+)!.get!;
+const ErrorCaptureStackTrace = Error.captureStackTrace;
 
 // #handleMethod return marker for inspector-protocol errors: the callback
 // receives the plain `{ code, message }` object (Node delivers protocol
@@ -129,13 +149,14 @@ function waitForDebugger() {
 
 // Sessions with Runtime enabled receive Runtime.consoleAPICalled for console
 // calls. This monkey-patches globalThis.console (not JSC's ConsoleClient as
-// cdp.ts does), so pre-captured refs bypass it and no stackTrace is emitted.
+// cdp.ts does), so pre-captured refs bypass it.
 // SafeSet iteration is tamper-proof (own frozen Symbol.iterator), so a hostile
 // Set.prototype[Symbol.iterator] cannot make console.log itself throw from
 // inside the hook's for-of loop head.
 const runtimeEnabledSessions: Set<Session> = new SafeSet();
 const hookedConsoleMethods: Array<[string, Function, Function]> = [];
 
+// Methods whose arguments are forwarded verbatim as the event args.
 const CONSOLE_API_TYPES: Record<string, string> = {
   __proto__: null,
   log: "log",
@@ -145,11 +166,247 @@ const CONSOLE_API_TYPES: Record<string, string> = {
   debug: "debug",
   trace: "trace",
   dir: "dir",
+  dirxml: "dirxml",
   table: "table",
+  clear: "clear",
   group: "startGroup",
   groupCollapsed: "startGroupCollapsed",
   groupEnd: "endGroup",
 };
+
+// Methods whose CDP semantics differ from "emit the JS arguments as-is":
+// assert is conditional, count/time* carry derived strings rather than the
+// raw args, and time/countReset emit nothing. These get bespoke hooks.
+const CONSOLE_API_SPECIAL = ["assert", "count", "countReset", "time", "timeLog", "timeEnd"];
+
+const PREVIEW_MAX_PROPERTIES = 5;
+const MAX_DESCRIPTION_LENGTH = 100;
+
+// Synthetic RemoteObject.objectId so the shape matches V8. The in-process
+// Session has no Runtime.getProperties backend to dereference these, but
+// consumers commonly test for the field's presence to distinguish primitives
+// from objects.
+let nextRemoteObjectId = 1;
+
+function constructorName(value: object): string | undefined {
+  // Every property read on a user value can throw (Proxy traps, hostile
+  // getters). A failure here falls back to the subtype-derived name.
+  try {
+    let proto: object | null = value;
+    while (proto !== null) {
+      const descriptor = Object.getOwnPropertyDescriptor(proto, "constructor");
+      if (descriptor !== undefined && $isCallable(descriptor.value)) {
+        const name = descriptor.value.name;
+        if (typeof name === "string" && name.length > 0) return name;
+      }
+      proto = ObjectGetPrototypeOf(proto);
+    }
+  } catch {}
+  return undefined;
+}
+
+function truncate(text: string): string {
+  return text.length > MAX_DESCRIPTION_LENGTH ? text.slice(0, MAX_DESCRIPTION_LENGTH) + "…" : text;
+}
+
+function classifyObject(value: object): { subtype?: string; className: string; description: string } {
+  // util.types predicates read internal slots and do not invoke user code, so
+  // the classification itself cannot throw even on hostile Proxies / getters.
+  if ($isProxyObject(value)) {
+    const className = constructorName(value) ?? "Object";
+    return { subtype: "proxy", className, description: `Proxy(${className})` };
+  }
+  if ($isJSArray(value) || $isArray(value)) {
+    const className = constructorName(value) ?? "Array";
+    return { subtype: "array", className, description: `${className}(${(value as unknown[]).length})` };
+  }
+  if (types.isNativeError(value)) {
+    let description;
+    try {
+      const stack = (value as Error).stack;
+      description = typeof stack === "string" && stack.length > 0 ? stack : ErrorPrototypeToString.$call(value);
+    } catch {
+      description = "Error";
+    }
+    return { subtype: "error", className: constructorName(value) ?? "Error", description };
+  }
+  if ($isRegExpObject(value)) {
+    let description;
+    try {
+      description = RegExpPrototypeToString.$call(value);
+    } catch {
+      description = "RegExp";
+    }
+    return { subtype: "regexp", className: constructorName(value) ?? "RegExp", description };
+  }
+  if (types.isDate(value)) {
+    let description;
+    try {
+      description = DatePrototypeToString.$call(value);
+    } catch {
+      description = "Date";
+    }
+    return { subtype: "date", className: constructorName(value) ?? "Date", description };
+  }
+  if ($isMap(value)) {
+    const className = constructorName(value) ?? "Map";
+    return { subtype: "map", className, description: `${className}(${MapPrototypeGetSize.$call(value)})` };
+  }
+  if ($isSet(value)) {
+    const className = constructorName(value) ?? "Set";
+    return { subtype: "set", className, description: `${className}(${SetPrototypeGetSize.$call(value)})` };
+  }
+  if (types.isWeakMap(value))
+    return { subtype: "weakmap", className: constructorName(value) ?? "WeakMap", description: "WeakMap" };
+  if (types.isWeakSet(value))
+    return { subtype: "weakset", className: constructorName(value) ?? "WeakSet", description: "WeakSet" };
+  if ($isPromise(value))
+    return { subtype: "promise", className: constructorName(value) ?? "Promise", description: "Promise" };
+  if (types.isTypedArray(value)) {
+    const className = TypedArrayPrototypeGetToStringTag.$call(value) ?? constructorName(value) ?? "TypedArray";
+    return {
+      subtype: "typedarray",
+      className,
+      description: `${className}(${TypedArrayPrototypeGetLength.$call(value)})`,
+    };
+  }
+  if (types.isDataView(value))
+    return {
+      subtype: "dataview",
+      className: constructorName(value) ?? "DataView",
+      description: `DataView(${(value as DataView).byteLength})`,
+    };
+  if (types.isArrayBuffer(value))
+    return {
+      subtype: "arraybuffer",
+      className: constructorName(value) ?? "ArrayBuffer",
+      description: `ArrayBuffer(${(value as ArrayBuffer).byteLength})`,
+    };
+  if (types.isSharedArrayBuffer(value))
+    return {
+      subtype: "arraybuffer",
+      className: constructorName(value) ?? "SharedArrayBuffer",
+      description: `SharedArrayBuffer(${(value as SharedArrayBuffer).byteLength})`,
+    };
+  if (types.isGeneratorObject(value)) {
+    const className = constructorName(value) ?? "Generator";
+    return { subtype: "generator", className, description: className };
+  }
+  if (types.isMapIterator(value) || types.isSetIterator(value)) {
+    const className = constructorName(value) ?? "Iterator";
+    return { subtype: "iterator", className, description: className };
+  }
+  const className = constructorName(value) ?? "Object";
+  return { className, description: className };
+}
+
+function previewValue(value: unknown): { type: string; value: string; subtype?: string } {
+  switch (typeof value) {
+    case "string":
+      return { type: "string", value: truncate(value) };
+    case "number":
+      return { type: "number", value: Object.is(value, -0) ? "-0" : `${value}` };
+    case "boolean":
+      return { type: "boolean", value: `${value}` };
+    case "undefined":
+      return { type: "undefined", value: "undefined" };
+    case "bigint":
+      return { type: "bigint", value: `${value}n` };
+    case "symbol":
+      return { type: "symbol", value: String(value) };
+    case "function":
+      return { type: "function", value: "" };
+    default: {
+      if (value === null) return { type: "object", subtype: "null", value: "null" };
+      let info;
+      try {
+        info = classifyObject(value);
+      } catch {
+        return { type: "object", value: "Object" };
+      }
+      const entry: { type: string; value: string; subtype?: string } = {
+        type: "object",
+        value: truncate(info.description),
+      };
+      if (info.subtype !== undefined) entry.subtype = info.subtype;
+      return entry;
+    }
+  }
+}
+
+function entryPreview(value: unknown): object {
+  const p = previewValue(value);
+  const out: AnyRecord = { type: p.type, description: p.value, overflow: false, properties: [] };
+  if (p.subtype !== undefined) out.subtype = p.subtype;
+  return out;
+}
+
+type AnyRecord = Record<string, any>;
+
+function buildPreview(value: object, subtype: string | undefined, description: string): object {
+  const preview: AnyRecord = { type: "object", description, overflow: false, properties: [] };
+  if (subtype !== undefined) preview.subtype = subtype;
+  const properties: AnyRecord[] = preview.properties;
+
+  try {
+    if (subtype === "array" || subtype === "typedarray") {
+      const length = subtype === "typedarray" ? TypedArrayPrototypeGetLength.$call(value) : (value as unknown[]).length;
+      const shown = length > PREVIEW_MAX_PROPERTIES ? PREVIEW_MAX_PROPERTIES : length;
+      for (let i = 0; i < shown; i++) properties.push({ name: `${i}`, ...previewValue((value as any)[i]) });
+      if (length > shown) preview.overflow = true;
+    } else if (subtype === "map") {
+      const entries: AnyRecord[] = [];
+      let count = 0;
+      for (const [k, v] of MapPrototypeEntries.$call(value)) {
+        if (count >= PREVIEW_MAX_PROPERTIES) {
+          preview.overflow = true;
+          break;
+        }
+        entries.push({ key: entryPreview(k), value: entryPreview(v) });
+        count++;
+      }
+      preview.entries = entries;
+    } else if (subtype === "set") {
+      const entries: AnyRecord[] = [];
+      let count = 0;
+      for (const v of SetPrototypeValues.$call(value)) {
+        if (count >= PREVIEW_MAX_PROPERTIES) {
+          preview.overflow = true;
+          break;
+        }
+        entries.push({ value: entryPreview(v) });
+        count++;
+      }
+      preview.entries = entries;
+    } else if (subtype === "error") {
+      const message = (value as Error).message;
+      const stack = (value as Error).stack;
+      if (typeof stack === "string") properties.push({ name: "stack", type: "string", value: truncate(stack) });
+      if (typeof message === "string") properties.push({ name: "message", type: "string", value: truncate(message) });
+    } else if (
+      subtype === "regexp" ||
+      subtype === "date" ||
+      subtype === "weakmap" ||
+      subtype === "weakset" ||
+      subtype === "promise" ||
+      subtype === "proxy"
+    ) {
+      // No property preview for these subtypes.
+    } else {
+      const keys = ObjectKeys(value);
+      const shown = keys.length > PREVIEW_MAX_PROPERTIES ? PREVIEW_MAX_PROPERTIES : keys.length;
+      for (let i = 0; i < shown; i++) {
+        const name = keys[i];
+        properties.push({ name, ...previewValue((value as AnyRecord)[name]) });
+      }
+      if (keys.length > shown) preview.overflow = true;
+    }
+  } catch {
+    // A hostile getter or Proxy trap threw mid-enumeration; keep whatever was
+    // collected so far.
+  }
+  return preview;
+}
 
 function toRemoteObject(arg: unknown): object {
   switch (typeof arg) {
@@ -176,18 +433,82 @@ function toRemoteObject(arg: unknown): object {
       };
     case "symbol":
       return { type: "symbol", description: String(arg) };
-    case "function":
+    case "function": {
+      let description;
+      try {
+        description = FunctionPrototypeToString.$call(arg);
+      } catch {
+        description = "function () {}";
+      }
       return {
         type: "function",
-        description: Function.prototype.toString.$call(arg),
+        className: constructorName(arg as object) ?? "Function",
+        description,
+        objectId: `bun.1.${nextRemoteObjectId++}`,
       };
-    default:
+    }
+    default: {
       if (arg === null) return { type: "object", subtype: "null", value: null };
-      return {
+      let info: { subtype?: string; className: string; description: string };
+      try {
+        info = classifyObject(arg);
+      } catch {
+        info = { className: "Object", description: ObjectPrototypeToString.$call(arg) };
+      }
+      const remote: AnyRecord = {
         type: "object",
-        description: Object.prototype.toString.$call(arg),
+        className: info.className,
+        description: info.description,
+        objectId: `bun.1.${nextRemoteObjectId++}`,
+        preview: buildPreview(arg, info.subtype, info.description),
       };
+      if (info.subtype !== undefined) remote.subtype = info.subtype;
+      return remote;
+    }
   }
+}
+
+function prepareCDPCallFrames(_err: unknown, callSites: any[]): object[] {
+  const frames: object[] = [];
+  for (let i = 0; i < callSites.length; i++) {
+    const site = callSites[i];
+    const line = site.getLineNumber();
+    const column = site.getColumnNumber();
+    const url = site.getFileName() ?? "";
+    frames.push({
+      functionName: site.getFunctionName() ?? "",
+      scriptId: `${site.getScriptId() ?? ""}`,
+      url: typeof url === "string" && isAbsolute(url) ? pathToFileURL(url).href : url,
+      // CDP positions are 0-based; CallSite line numbers are 1-based.
+      lineNumber: typeof line === "number" && line > 0 ? line - 1 : 0,
+      columnNumber: typeof column === "number" && column >= 0 ? column : 0,
+    });
+  }
+  return frames;
+}
+
+function captureCDPStackTrace(skipAbove: Function): object | undefined {
+  const target: { stack?: object[] } = {};
+  const savedPrepare = Error.prepareStackTrace;
+  const savedLimit = Error.stackTraceLimit;
+  try {
+    Error.prepareStackTrace = prepareCDPCallFrames;
+    try {
+      Error.stackTraceLimit = 200;
+    } catch {}
+    ErrorCaptureStackTrace(target, skipAbove);
+    const callFrames = target.stack;
+    if ($isArray(callFrames)) return { callFrames };
+  } catch {
+    // Best-effort: a user-installed prepareStackTrace setter or a non-writable
+    // stackTraceLimit must not make console.* itself throw.
+  } finally {
+    Error.prepareStackTrace = savedPrepare;
+    try {
+      Error.stackTraceLimit = savedLimit;
+    } catch {}
+  }
+  return undefined;
 }
 
 // Node delivers consoleAPICalled through V8's message pump, so a listener
@@ -196,28 +517,28 @@ function toRemoteObject(arg: unknown): object {
 // original method but are not re-emitted.
 let emittingConsoleAPI = false;
 
-function emitConsoleAPICalled(type: string, args: unknown[]) {
+function emitConsoleAPICalled(type: string, args: unknown[], hook: Function) {
   if (emittingConsoleAPI) return;
   emittingConsoleAPI = true;
   try {
     const timestamp = DateNow();
+    const stackTrace = captureCDPStackTrace(hook);
     for (const session of runtimeEnabledSessions) {
       // Neither a throwing listener nor a throwing argument serialization
-      // (toRemoteObject reads user-controlled toString) may make the console
+      // (toRemoteObject reads user-controlled getters) may make the console
       // call itself throw, suppress the underlying output, or starve later
       // sessions; Node surfaces listener exceptions as process warnings.
       try {
         // A fresh message per session: a listener that mutates its payload
         // must not contaminate what the next session receives.
-        const message = {
-          method: "Runtime.consoleAPICalled",
-          params: {
-            type,
-            args: args.map(toRemoteObject),
-            executionContextId: 1,
-            timestamp,
-          },
+        const params: AnyRecord = {
+          type,
+          args: args.map(toRemoteObject),
+          executionContextId: 1,
+          timestamp,
         };
+        if (stackTrace !== undefined) params.stackTrace = stackTrace;
+        const message = { method: "Runtime.consoleAPICalled", params };
         // Node's Session#onMessage emits the method-specific event first,
         // then the generic "inspectorNotification".
         session.emit("Runtime.consoleAPICalled", message);
@@ -240,11 +561,81 @@ function emitConsoleAPICalled(type: string, args: unknown[]) {
   }
 }
 
+// Shadow state for count()/time*(): Bun's native console keeps its own
+// counters and timers, but those live in C++ and are not readable from here,
+// so the hook maintains a parallel map to synthesize the formatted string V8
+// puts in the event args.
+const consoleCounts: Map<string, number> = new SafeMap();
+const consoleTimers: Map<string, number> = new SafeMap();
+
+function toLabel(label: unknown): string {
+  return label === undefined ? "default" : `${label}`;
+}
+
 function makeConsoleHook(type: string, original: Function): Function {
-  return function (this: unknown, ...args: unknown[]) {
-    emitConsoleAPICalled(type, args);
+  const hook = function (this: unknown, ...args: unknown[]) {
+    emitConsoleAPICalled(type, args, hook);
     return original.$apply(this, args);
   };
+  return hook;
+}
+
+function makeSpecialConsoleHook(method: string, original: Function): Function {
+  switch (method) {
+    case "assert": {
+      const hook = function (this: unknown, ...args: unknown[]) {
+        if (!args[0]) emitConsoleAPICalled("assert", args.slice(1), hook);
+        return original.$apply(this, args);
+      };
+      return hook;
+    }
+    case "count": {
+      const hook = function (this: unknown, label?: unknown) {
+        const key = toLabel(label);
+        const next = (consoleCounts.get(key) ?? 0) + 1;
+        consoleCounts.set(key, next);
+        emitConsoleAPICalled("count", [`${key}: ${next}`], hook);
+        return original.$call(this, label);
+      };
+      return hook;
+    }
+    case "countReset":
+      return function (this: unknown, label?: unknown) {
+        consoleCounts.delete(toLabel(label));
+        return original.$call(this, label);
+      };
+    case "time":
+      return function (this: unknown, label?: unknown) {
+        const key = toLabel(label);
+        if (!consoleTimers.has(key)) consoleTimers.set(key, PerformanceNow());
+        return original.$call(this, label);
+      };
+    case "timeLog": {
+      const hook = function (this: unknown, label?: unknown, ...extra: unknown[]) {
+        const key = toLabel(label);
+        const start = consoleTimers.get(key);
+        if (start !== undefined) {
+          emitConsoleAPICalled("log", [`${key}: ${PerformanceNow() - start} ms`, ...extra], hook);
+        }
+        return original.$call(this, label, ...extra);
+      };
+      return hook;
+    }
+    case "timeEnd": {
+      const hook = function (this: unknown, label?: unknown) {
+        const key = toLabel(label);
+        const start = consoleTimers.get(key);
+        if (start !== undefined) {
+          consoleTimers.delete(key);
+          emitConsoleAPICalled("timeEnd", [`${key}: ${PerformanceNow() - start} ms`], hook);
+        }
+        return original.$call(this, label);
+      };
+      return hook;
+    }
+    default:
+      return original;
+  }
 }
 
 function installConsoleHooks() {
@@ -254,6 +645,13 @@ function installConsoleHooks() {
     const original = consoleObject[method];
     if (typeof original !== "function") continue;
     const hook = makeConsoleHook(CONSOLE_API_TYPES[method], original);
+    hookedConsoleMethods.push([method, original, hook]);
+    consoleObject[method] = hook;
+  }
+  for (const method of CONSOLE_API_SPECIAL) {
+    const original = consoleObject[method];
+    if (typeof original !== "function") continue;
+    const hook = makeSpecialConsoleHook(method, original);
     hookedConsoleMethods.push([method, original, hook]);
     consoleObject[method] = hook;
   }
@@ -270,6 +668,8 @@ function removeConsoleHooks() {
     }
   }
   hookedConsoleMethods.length = 0;
+  consoleCounts.clear();
+  consoleTimers.clear();
 }
 
 // Reshapes the raw control-flow-profiler data from jsFunction_collectPreciseCoverage

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -863,7 +863,6 @@ describe("node:inspector Runtime.consoleAPICalled", () => {
     `);
     const byType = (t: string) => events.filter(e => e.type === t);
 
-    // count
     const counts = byType("count");
     expect(counts.map(e => e.args[0].value)).toEqual(["cnt: 1", "cnt: 2", "cnt: 1"]);
 
@@ -881,7 +880,6 @@ describe("node:inspector Runtime.consoleAPICalled", () => {
     expect(asserts).toHaveLength(1);
     expect(asserts[0].args).toEqual([{ type: "string", value: "loud" }]);
 
-    // dirxml carries the argument as a RemoteObject.
     const dirxml = byType("dirxml");
     expect(dirxml).toHaveLength(1);
     expect(dirxml[0].args[0]).toMatchObject({ type: "object", className: "Object" });
@@ -897,12 +895,9 @@ describe("node:inspector Runtime.consoleAPICalled", () => {
       process.stderr.write("reached\\n");
     `);
     expect(events).toHaveLength(1);
-    expect(events[0].args).toHaveLength(3);
-    // Revoked proxy: classification fell back but a RemoteObject was still produced.
-    expect(events[0].args[0].type).toBe("object");
-    // Null-prototype object.
-    expect(events[0].args[1]).toMatchObject({ type: "object", className: "Object", description: "Object" });
-    // Proxy over an array.
-    expect(events[0].args[2]).toMatchObject({ type: "object", subtype: "proxy" });
+    const [revoked, nullProto, arrayProxy] = events[0].args;
+    expect(revoked.type).toBe("object");
+    expect(nullProto).toMatchObject({ type: "object", className: "Object", description: "Object" });
+    expect(arrayProxy).toMatchObject({ type: "object", subtype: "proxy" });
   });
 });

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -858,6 +858,7 @@ describe("node:inspector Runtime.consoleAPICalled", () => {
       console.timeEnd("tm");
       console.assert(true, "quiet");
       console.assert(false, "loud");
+      console.assert(false);
       console.dirxml({ x: 1 });
       console.clear();
     `);
@@ -875,10 +876,11 @@ describe("node:inspector Runtime.consoleAPICalled", () => {
     expect(timeEnd).toHaveLength(1);
     expect(timeEnd[0].args[0].value).toMatch(/^tm: [\d.]+ ms$/);
 
-    // assert only fires on falsy condition, args are the message arguments.
+    // assert: only on falsy; V8 substitutes "console.assert" when no message args were given.
     const asserts = byType("assert");
-    expect(asserts).toHaveLength(1);
+    expect(asserts).toHaveLength(2);
     expect(asserts[0].args).toEqual([{ type: "string", value: "loud" }]);
+    expect(asserts[1].args).toEqual([{ type: "string", value: "console.assert" }]);
 
     const dirxml = byType("dirxml");
     expect(dirxml).toHaveLength(1);
@@ -891,13 +893,15 @@ describe("node:inspector Runtime.consoleAPICalled", () => {
     const events = await collect(`
       const revoked = Proxy.revocable({}, {});
       revoked.revoke();
-      console.log(revoked.proxy, Object.create(null), new Proxy([1], {}));
+      let cyclic; cyclic = new Proxy({}, { getPrototypeOf: () => cyclic });
+      console.log(revoked.proxy, Object.create(null), new Proxy([1], {}), cyclic);
       process.stderr.write("reached\\n");
     `);
     expect(events).toHaveLength(1);
-    const [revoked, nullProto, arrayProxy] = events[0].args;
+    const [revoked, nullProto, arrayProxy, cyclic] = events[0].args;
     expect(revoked.type).toBe("object");
     expect(nullProto).toMatchObject({ type: "object", className: "Object", description: "Object" });
     expect(arrayProxy).toMatchObject({ type: "object", subtype: "proxy" });
+    expect(cyclic).toMatchObject({ type: "object", subtype: "proxy" });
   });
 });

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -686,3 +686,223 @@ describe("node:inspector/promises", () => {
     expect(inspectorPromises.waitForDebugger).toBe(inspector.waitForDebugger);
   });
 });
+
+// Runtime.consoleAPICalled mirroring runs in a subprocess so its console
+// hooks do not interfere with the test runner's own console, and so assertion
+// output is not interleaved with the calls being mirrored.
+describe("node:inspector Runtime.consoleAPICalled", () => {
+  type Event = {
+    type: string;
+    args: any[];
+    stackTrace?: { callFrames: { functionName: string; scriptId: string; url: string; lineNumber: number }[] };
+  };
+
+  async function collect(script: string): Promise<Event[]> {
+    // The mirrored console calls also write to the child's stdout, so the JSON
+    // result is tagged with a marker and split off on the parent side.
+    const marker = "\n<<<RESULT>>>\n";
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const s = new (require("node:inspector").Session)();
+         s.connect();
+         const events = [];
+         s.on("Runtime.consoleAPICalled", m => events.push(m.params));
+         await new Promise((ok, no) => s.post("Runtime.enable", {}, e => (e ? no(e) : ok())));
+         ${script}
+         await new Promise(r => setImmediate(r));
+         s.disconnect();
+         process.stdout.write(${JSON.stringify(marker)} + JSON.stringify(events));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(`subprocess failed (${exitCode}): ${stderr}`);
+    const at = stdout.lastIndexOf(marker);
+    if (at < 0) throw new Error(`no result marker; stdout:\n${stdout}\nstderr:\n${stderr}`);
+    return JSON.parse(stdout.slice(at + marker.length));
+  }
+
+  test.concurrent("object args carry subtype, className, description, objectId and preview", async () => {
+    const events = await collect(`
+      console.log([1, 2, 3]);
+      console.error(new TypeError("boom"));
+      console.log(new Map([["k", 7]]), new Set([1, 2]));
+      console.log(new Uint8Array([9, 8]));
+      console.log(new Date(0));
+      console.log(/abc/g);
+      console.log(Promise.resolve(1));
+      console.log({ a: 1, b: { c: 2 } });
+      console.log(function foo() {});
+    `);
+
+    const arr = events[0].args[0];
+    expect(arr).toMatchObject({
+      type: "object",
+      subtype: "array",
+      className: "Array",
+      description: "Array(3)",
+    });
+    expect(typeof arr.objectId).toBe("string");
+    expect(arr.preview).toMatchObject({
+      type: "object",
+      subtype: "array",
+      description: "Array(3)",
+      overflow: false,
+      properties: [
+        { name: "0", type: "number", value: "1" },
+        { name: "1", type: "number", value: "2" },
+        { name: "2", type: "number", value: "3" },
+      ],
+    });
+
+    const err = events[1].args[0];
+    expect(err).toMatchObject({ type: "object", subtype: "error", className: "TypeError" });
+    expect(err.description).toStartWith("TypeError: boom");
+    expect(err.description).toContain("\n    at "); // carries the stack, not just "[object Error]"
+    const propNames = err.preview.properties.map((p: any) => p.name);
+    expect(propNames).toContain("message");
+    expect(propNames).toContain("stack");
+
+    const [mapArg, setArg] = events[2].args;
+    expect(mapArg).toMatchObject({ type: "object", subtype: "map", className: "Map", description: "Map(1)" });
+    expect(mapArg.preview.entries).toEqual([
+      {
+        key: expect.objectContaining({ type: "string", description: "k" }),
+        value: expect.objectContaining({ type: "number", description: "7" }),
+      },
+    ]);
+    expect(setArg).toMatchObject({ type: "object", subtype: "set", className: "Set", description: "Set(2)" });
+    expect(setArg.preview.entries).toEqual([
+      { value: expect.objectContaining({ type: "number", description: "1" }) },
+      { value: expect.objectContaining({ type: "number", description: "2" }) },
+    ]);
+
+    expect(events[3].args[0]).toMatchObject({
+      type: "object",
+      subtype: "typedarray",
+      className: "Uint8Array",
+      description: "Uint8Array(2)",
+      preview: expect.objectContaining({
+        properties: [
+          { name: "0", type: "number", value: "9" },
+          { name: "1", type: "number", value: "8" },
+        ],
+      }),
+    });
+
+    expect(events[4].args[0]).toMatchObject({ type: "object", subtype: "date", className: "Date" });
+    expect(events[4].args[0].description).toContain("1970");
+    expect(events[5].args[0]).toMatchObject({
+      type: "object",
+      subtype: "regexp",
+      className: "RegExp",
+      description: "/abc/g",
+    });
+    expect(events[6].args[0]).toMatchObject({
+      type: "object",
+      subtype: "promise",
+      className: "Promise",
+      description: "Promise",
+    });
+
+    const obj = events[7].args[0];
+    expect(obj).toMatchObject({ type: "object", className: "Object", description: "Object" });
+    expect(obj.subtype).toBeUndefined();
+    expect(obj.preview.properties).toEqual([
+      { name: "a", type: "number", value: "1" },
+      { name: "b", type: "object", value: "Object" },
+    ]);
+
+    const fn = events[8].args[0];
+    expect(fn).toMatchObject({ type: "function", className: "Function" });
+    expect(fn.description).toContain("function foo");
+    expect(typeof fn.objectId).toBe("string");
+  });
+
+  test.concurrent("every event carries a stackTrace with CDP call frames", async () => {
+    const events = await collect(`
+      function outer() { console.trace("t"); }
+      outer();
+      console.log("plain");
+    `);
+    expect(events.map(e => e.type)).toEqual(["trace", "log"]);
+    for (const e of events) {
+      expect(e.stackTrace).toBeDefined();
+      expect(Array.isArray(e.stackTrace!.callFrames)).toBe(true);
+      expect(e.stackTrace!.callFrames.length).toBeGreaterThan(0);
+      const top = e.stackTrace!.callFrames[0];
+      expect(top).toEqual({
+        functionName: expect.any(String),
+        scriptId: expect.any(String),
+        url: expect.any(String),
+        lineNumber: expect.any(Number),
+        columnNumber: expect.any(Number),
+      });
+    }
+    // The trace call's top frame is the user function, not the inspector hook.
+    expect(events[0].stackTrace!.callFrames[0].functionName).toBe("outer");
+  });
+
+  test.concurrent("count, time/timeLog/timeEnd, assert, dirxml and clear emit events", async () => {
+    const events = await collect(`
+      console.count("cnt");
+      console.count("cnt");
+      console.countReset("cnt");
+      console.count("cnt");
+      console.time("tm");
+      console.timeLog("tm", "extra");
+      console.timeEnd("tm");
+      console.assert(true, "quiet");
+      console.assert(false, "loud");
+      console.dirxml({ x: 1 });
+      console.clear();
+    `);
+    const byType = (t: string) => events.filter(e => e.type === t);
+
+    // count
+    const counts = byType("count");
+    expect(counts.map(e => e.args[0].value)).toEqual(["cnt: 1", "cnt: 2", "cnt: 1"]);
+
+    // timeLog emits as "log" per CDP, timeEnd as "timeEnd"; both formatted label: ms.
+    const timeLog = byType("log").find(e => typeof e.args[0]?.value === "string" && e.args[0].value.startsWith("tm: "));
+    expect(timeLog).toBeDefined();
+    expect(timeLog!.args[0].value).toMatch(/^tm: [\d.]+ ms$/);
+    expect(timeLog!.args[1]).toEqual({ type: "string", value: "extra" });
+    const timeEnd = byType("timeEnd");
+    expect(timeEnd).toHaveLength(1);
+    expect(timeEnd[0].args[0].value).toMatch(/^tm: [\d.]+ ms$/);
+
+    // assert only fires on falsy condition, args are the message arguments.
+    const asserts = byType("assert");
+    expect(asserts).toHaveLength(1);
+    expect(asserts[0].args).toEqual([{ type: "string", value: "loud" }]);
+
+    // dirxml carries the argument as a RemoteObject.
+    const dirxml = byType("dirxml");
+    expect(dirxml).toHaveLength(1);
+    expect(dirxml[0].args[0]).toMatchObject({ type: "object", className: "Object" });
+
+    expect(byType("clear")).toHaveLength(1);
+  });
+
+  test.concurrent("hostile arguments do not make console.log throw", async () => {
+    const events = await collect(`
+      const revoked = Proxy.revocable({}, {});
+      revoked.revoke();
+      console.log(revoked.proxy, Object.create(null), new Proxy([1], {}));
+      process.stderr.write("reached\\n");
+    `);
+    expect(events).toHaveLength(1);
+    expect(events[0].args).toHaveLength(3);
+    // Revoked proxy: classification fell back but a RemoteObject was still produced.
+    expect(events[0].args[0].type).toBe("object");
+    // Null-prototype object.
+    expect(events[0].args[1]).toMatchObject({ type: "object", className: "Object", description: "Object" });
+    // Proxy over an array.
+    expect(events[0].args[2]).toMatchObject({ type: "object", subtype: "proxy" });
+  });
+});

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -752,14 +752,14 @@ test("Object.prototype pollution does not cause Runtime.enable to hook extra con
   const session = new inspector.Session();
   session.connect();
   // @ts-expect-error deliberate prototype pollution
-  Object.prototype.count = "log";
-  const savedCount = console.count;
+  Object.prototype.profile = "log";
+  const savedProfile = console.profile;
   try {
     session.post("Runtime.enable");
-    expect(console.count).toBe(savedCount);
+    expect(console.profile).toBe(savedProfile);
   } finally {
     // @ts-expect-error cleanup
-    delete Object.prototype.count;
+    delete Object.prototype.profile;
     session.disconnect();
   }
 });
@@ -767,16 +767,22 @@ test("Object.prototype pollution does not cause Runtime.enable to hook extra con
 test("a console argument whose toString throws does not break console.log", async () => {
   const session = new inspector.Session();
   session.connect();
+  const events: any[] = [];
   const warnings: Error[] = [];
   const onWarning = (w: Error) => warnings.push(w);
   process.on("warning", onWarning);
+  session.on("Runtime.consoleAPICalled", m => events.push(m.params));
   try {
     session.post("Runtime.enable");
     const { proxy, revoke } = Proxy.revocable({}, {});
     revoke();
     expect(() => console.log(proxy)).not.toThrow();
     await new Promise(resolve => setImmediate(resolve));
-    expect(warnings).toHaveLength(1);
+    // The RemoteObject builder handles revoked proxies, so the event is
+    // delivered with a proxy-subtype arg and no warning is emitted.
+    expect(warnings).toHaveLength(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].args[0]).toMatchObject({ type: "object", subtype: "proxy" });
   } finally {
     process.off("warning", onWarning);
     session.disconnect();


### PR DESCRIPTION
### Repro

```js
import inspector from "node:inspector";
const s = new inspector.Session(); s.connect();
const events = []; s.on("Runtime.consoleAPICalled", m => events.push(m.params));
await new Promise((ok, no) => s.post("Runtime.enable", {}, e => (e ? no(e) : ok())));
console.log([1, 2, 3]); console.error(new Error("boom")); console.trace("t");
console.count("cnt"); console.time("tm"); console.timeEnd("tm");
console.assert(false, "msg"); console.dirxml({ x: 1 });
await new Promise(r => setImmediate(r)); s.disconnect();
console.log(events.map(e => e.type));
console.log(JSON.stringify(events[0].args[0]));
console.log("stackTrace:", !!events[2].stackTrace);
// bun before: ["log","error","trace"]
//             {"type":"object","description":"[object Array]"}
//             stackTrace: false
// node:       ["log","error","trace","count","timeEnd","assert","dirxml"]
//             {"type":"object","subtype":"array","className":"Array",
//              "description":"Array(3)","objectId":"...","preview":{...}}
//             stackTrace: true
```

### Cause

The in-process `Session`'s console hook in `src/js/node/inspector.ts` built each argument with a fall-through `Object.prototype.toString.call(arg)` description and nothing else, never captured a stack, and only hooked the methods whose CDP args are the raw JS args (`log`/`error`/`trace`/...). This is a separate implementation from the WebSocket CDP path in `src/js/internal/inspector/cdp.ts`, which gets subtype/className/preview/objectId/stackTrace from JSC's `Console.messageAdded`.

### Fix

- **RemoteObject builder:** `classifyObject()` detects subtype/className via `node:util/types` predicates and JSC intrinsics (so a hostile Proxy or getter cannot derail classification), builds a per-subtype description (`Array(3)`, `Map(1)`, `Uint8Array(2)`, the error's stack, the regexp's source, ...), and `buildPreview()` fills a bounded `preview.properties` / `preview.entries` (5-item cap, `overflow` set past that). Objects and functions get a synthetic `objectId` so the shape matches V8; the in-process Session has no `Runtime.getProperties` backend to dereference it, but consumers commonly test for the field to tell primitives from objects.
- **stackTrace:** `captureCDPStackTrace()` uses `Error.captureStackTrace` with a `prepareStackTrace` that emits CDP `{functionName, scriptId, url, lineNumber, columnNumber}` frames (0-based), starting above the hook so the top frame is the user's call site.
- **Missing methods:** `dirxml`/`clear` are added to the pass-through table; `assert` emits only on a falsy condition; `count`/`countReset`/`time`/`timeLog`/`timeEnd` get bespoke hooks backed by `SafeMap`-tracked shadow counters/timers so the `"label: N"` / `"label: X ms"` strings match what V8's inspector emits.

### Verification

`bun bd test test/js/node/inspector/` passes 71/71. Four new subprocess tests in `inspector-profiler.test.ts` cover the RemoteObject shape across array/error/map/set/typed-array/date/regexp/promise/plain-object/function, the stackTrace frame shape, the count/time*/assert/dirxml/clear event stream, and robustness against revoked proxies / null-prototype objects. With `src/js/node/inspector.ts` reverted to `main` those four fail on subtype/stackTrace/missing-events while the rest of the suite still passes.

Two existing `inspector.test.ts` cases are updated to match the new behavior: the prototype-pollution guard now checks `console.profile` (since `count` is legitimately hooked), and the revoked-proxy case now asserts the event is delivered with `subtype:"proxy"` and no process warning (the builder handles it instead of throwing).

Related: #35736 fixes the WebSocket CDP path's timestamp unit and its count/time forwarding in `ConsoleObject.cpp`; this PR is the in-process `Session` path and does not overlap at the file level.