### PR TITLE
node:quic: auto-close client endpoints created by connect() when idle

### DIFF
--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -4554,17 +4554,18 @@ class QuicEndpoint {
       return;
     }
     // Node parity: idle endpoints are unref'd, not destroyed — see test-quic-endpoint-idle-timeout.
-    if (inner.idleTimeout) {
+    const { idleTimeout, closeOnIdle } = inner;
+    if (idleTimeout) {
       const timer = setTimeout(() => {
         if (!this.destroyed && !inner.listening && inner.sessions.size === 0) {
           inner.suppressCloseChannels = true;
           this.destroy();
         }
-      }, inner.idleTimeout * 1000);
+      }, idleTimeout * 1000);
       if (typeof timer?.unref === "function") timer.unref();
       return;
     }
-    if (inner.closeOnIdle) {
+    if (closeOnIdle) {
       // Deferred: session.destroy() calls us before #handle.destroy() has
       // queued the session's CONNECTION_CLOSE.
       queueMicrotask(() => {

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -394,6 +394,7 @@ const kNilDatagramId = 0n;
 const endpointRegistry = new SafeSet();
 
 let releaseEndpointSocket;
+let markEndpointCloseOnIdle;
 process.on("exit", () => {
   for (const endpoint of endpointRegistry) {
     releaseEndpointSocket(endpoint);
@@ -3918,6 +3919,7 @@ class QuicEndpoint {
     busy: false,
     isPendingClose: false,
     listening: false,
+    closeOnIdle: false,
     clientHttp: undefined,
     pendingClose: PromiseWithResolvers(),
     pendingError: undefined,
@@ -3946,6 +3948,10 @@ class QuicEndpoint {
 
     releaseEndpointSocket = function (endpoint) {
       endpoint.#handle?.releaseSocket();
+    };
+
+    markEndpointCloseOnIdle = function (endpoint) {
+      endpoint.#inner.closeOnIdle = true;
     };
 
     assertEndpointNotClosedOrClosing = function (endpoint) {
@@ -4548,16 +4554,29 @@ class QuicEndpoint {
       return;
     }
     // Node parity: idle endpoints are unref'd, not destroyed — see test-quic-endpoint-idle-timeout.
-    if (!inner.idleTimeout) {
+    if (inner.idleTimeout) {
+      const timer = setTimeout(() => {
+        if (!this.destroyed && !inner.listening && inner.sessions.size === 0) {
+          inner.suppressCloseChannels = true;
+          this.destroy();
+        }
+      }, inner.idleTimeout * 1000);
+      if (typeof timer?.unref === "function") timer.unref();
       return;
     }
-    const timer = setTimeout(() => {
-      if (!this.destroyed && !inner.listening && inner.sessions.size === 0) {
-        inner.suppressCloseChannels = true;
-        this.destroy();
-      }
-    }, inner.idleTimeout * 1000);
-    if (typeof timer?.unref === "function") timer.unref();
+    // connect() created this endpoint and the caller holds no reference to it
+    // past session.close(): endpointRegistry is the only root, so without this
+    // the bound UDP fd and native engine leak for the life of the process.
+    // Deferred because session.destroy() calls us before it reaches
+    // #handle.destroy(), which is what queues the session's CONNECTION_CLOSE.
+    if (inner.closeOnIdle) {
+      queueMicrotask(() => {
+        if (!this.destroyed && !inner.isPendingClose && !inner.listening && inner.sessions.size === 0) {
+          inner.suppressCloseChannels = true;
+          this.destroy();
+        }
+      });
+    }
   }
 
   [kInspect](depth, options) {
@@ -4633,13 +4652,17 @@ function processEndpointOption(endpoint, reuseEndpoint = true, forServer = false
     return endpoint;
   }
   if (endpoint !== undefined) {
-    return new QuicEndpoint(endpoint);
+    const created = new QuicEndpoint(endpoint);
+    if (!forServer) markEndpointCloseOnIdle(created);
+    return created;
   }
   if (reuseEndpoint && !forServer) {
     const existing = findSuitableEndpoint(wantHttp);
     if (existing !== undefined) return existing;
   }
-  return new QuicEndpoint();
+  const created = new QuicEndpoint();
+  if (!forServer) markEndpointCloseOnIdle(created);
+  return created;
 }
 
 /**

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -4564,12 +4564,9 @@ class QuicEndpoint {
       if (typeof timer?.unref === "function") timer.unref();
       return;
     }
-    // connect() created this endpoint and the caller holds no reference to it
-    // past session.close(): endpointRegistry is the only root, so without this
-    // the bound UDP fd and native engine leak for the life of the process.
-    // Deferred because session.destroy() calls us before it reaches
-    // #handle.destroy(), which is what queues the session's CONNECTION_CLOSE.
     if (inner.closeOnIdle) {
+      // Deferred: session.destroy() calls us before #handle.destroy() has
+      // queued the session's CONNECTION_CLOSE.
       queueMicrotask(() => {
         if (!this.destroyed && !inner.isPendingClose && !inner.listening && inner.sessions.size === 0) {
           inner.suppressCloseChannels = true;

--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -62,6 +62,18 @@ test/js/node/test/parallel/test-stream-wrap-encoding.js [ FAIL ] # needs interna
 # test-http-max-http-headers.js is vendored.
 test/js/node/test/parallel/test-set-http-max-http-headers.js [ FAIL ] # spawns test-http-max-http-headers.js which is not vendored
 
+# The server-side assertion expects serverSession.closed to reject with
+# ERR_QUIC_TRANSPORT_ERROR after the client's onpathvalidation throws. That
+# rejection is a stateless reset FROM the client's endpoint, which only arrives
+# because Node leaks every per-connect client endpoint in endpointRegistry
+# (upstream's [kRemoveSession] only does sessions.delete). Bun auto-closes
+# those endpoints when their last session ends (otherwise each reuseEndpoint:
+# false connect leaks one bound UDP fd for the process lifetime, EMFILE at the
+# nofile limit). The client-side behavior this test was written for (onerror
+# fires with the thrown error, session.closed rejects with it) is unchanged and
+# is exercised by the sibling test-quic-callback-error-* files.
+test/js/node/test/parallel/test-quic-callback-error-onpathvalidation.mjs [ FAIL ] # server-side stateless reset only happens because Node leaks the client endpoint; Bun auto-closes it
+
 # Tests that are flaky
 test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -267,3 +267,64 @@ describe("endpoint.close() while a session is live", () => {
     expect({ announced, resolved }).toEqual({ announced: 1, resolved: true });
   });
 });
+
+// connect() that creates its own endpoint (reuseEndpoint:false or an
+// endpoint-options object) must not leave that endpoint rooted in the module's
+// endpointRegistry after the session closes: each one holds a bound UDP fd and
+// a native lsquic engine, so a long-lived client leaked one per connection and
+// hit EMFILE at the nofile limit.
+describe("connect() implicit client endpoint lifecycle", () => {
+  test.each([
+    ["reuseEndpoint:false", { reuseEndpoint: false } as const],
+    ["endpoint:{} options object", { endpoint: {} } as const],
+  ])("%s: the endpoint closes when its only session closes", async (_label, extra) => {
+    await using server = await listen(
+      async s => {
+        s.onerror = () => {};
+        await s.closed.catch(() => {});
+      },
+      { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["echo"], transportParams: { maxIdleTimeout: 5 } },
+    );
+
+    const client = await connect(server.address, {
+      alpn: "echo",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 5 },
+      ...extra,
+    });
+    await client.opened;
+    const endpoint = client.endpoint;
+    expect(endpoint.closing || endpoint.destroyed).toBe(false);
+
+    await client.close();
+
+    // Session.destroy() calls [kRemoveSession] before resolving `closed`, so by
+    // the time the await above returns, auto-close has already run.
+    expect(endpoint.closing || endpoint.destroyed).toBe(true);
+    await endpoint.closed;
+    expect(endpoint.destroyed).toBe(true);
+  });
+
+  test("an explicit QuicEndpoint instance is not auto-closed", async () => {
+    await using server = await listen(
+      async s => {
+        s.onerror = () => {};
+        await s.closed.catch(() => {});
+      },
+      { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["echo"], transportParams: { maxIdleTimeout: 5 } },
+    );
+
+    const endpoint = new QuicEndpoint();
+    const client = await connect(server.address, {
+      endpoint,
+      alpn: "echo",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 5 },
+    });
+    await client.opened;
+    await client.close();
+
+    expect({ closing: endpoint.closing, destroyed: endpoint.destroyed }).toEqual({ closing: false, destroyed: false });
+    await endpoint.close();
+  });
+});


### PR DESCRIPTION
## Problem

Every `connect()` that creates its own `QuicEndpoint` (via `reuseEndpoint: false` or an `endpoint: {...}` options object) leaked that endpoint for the life of the process after the session closed: one bound UDP fd plus the endpoint's lsquic engines and TLS context per connection. A long-lived client doing ~1000 connects hit `EMFILE` at the common 1024 nofile limit.

n=100 connect+close cycles under release-asan, fd count before/after:

```
reuseEndpoint:true   fds 13 -> 14  (+1)    shared default endpoint
reuseEndpoint:false  fds 14 -> 114 (+100)  one leaked endpoint per connect
endpoint:{} options  fds 14 -> 114 (+100)  one leaked endpoint per connect
```

n=1000: fds 10→1010, RSS 260→1626 MB, perfectly linear through `Bun.gc(true)` + idle. LSan at clean exit reports only the `SocketAddress` boxes of those endpoints (`to_js_socket_address` session.rs:176 ← `endpoint.address` endpoint.rs:2532): reachable retention, not an unreachable malloc leak.

## Cause

The module-level `endpointRegistry` is a strong `SafeSet` (quic.ts:394). Endpoints are added at construction (:4145) and removed only in `[kFinishClose]` (:4473). `[kRemoveSession]` (:4544) returns early when `idleTimeout` is unset (default `?? 0`, :4142), so a client endpoint whose last session closed was never closed and never GC-collectable.

Upstream Node.js has the same leak: its `[kRemoveSession]` is just `sessions.delete(session)`.

## Fix

Endpoints that `connect()` creates itself (not a user-supplied `QuicEndpoint` instance, not for `listen()`) are marked `closeOnIdle`. When their last session is removed and `idleTimeout` is unset, the endpoint is destroyed on the next microtask. Deferred so `session.destroy()` reaches `#handle.destroy()` first and the session's CONNECTION_CLOSE goes out before the socket closes.

User-owned `QuicEndpoint` instances and listening endpoints are unchanged. A user-configured `idleTimeout` still takes precedence.

## Verification

```
reuseEndpoint:true (control)   n=30 fds 10 -> 10 (+0)
reuseEndpoint:false            n=30 fds 10 -> 10 (+0)
endpoint:{} options            n=30 fds 10 -> 10 (+0)
```

`bun bd test test/js/node/quic/` passes (17/17). 234/235 vendored `test-quic-*` parallel tests pass; `test-quic-callback-error-onpathvalidation.mjs` is added to `test/expectations.txt` because its server-side `ERR_QUIC_TRANSPORT_ERROR` assertion relied on a stateless reset from the leaked client endpoint. The client-side behavior it was written for (onerror fires, `closed` rejects with the thrown error) is unchanged and covered by the sibling callback-error tests.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-endpoint.test.ts
error: bindgenv2 list-outputs failed (exit undefined)
  at: /workspace/bun/src/codegen/bindgenv2/script.ts
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: BUILD FAILED (no junit output)
bun test v1.3.14 (0d9b296a)

test/js/node/quic/quic-endpoint.test.ts:

# Unhandled error between tests
-------------------------------
9 | import { connect, listen, QuicEndpoint } from "node:quic";
                                                  ^
error: Could not resolve: "node:quic". Maybe you need to "bun install"?
    at /workspace/bun/test/js/node/quic/quic-endpoint.test.ts:9:47
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [1.62s]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-endpoint.test.ts
bun test v1.4.0 (21ea8ea35)

test/js/node/quic/quic-endpoint.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [870.01ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [94.50ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [9150.85ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [522.66ms]
(pass) transportParams.maxIdleTimeout > 0 disables the idle timeout instead of falling back to the default [279.10ms]
(pass) endpoint.close() while a session is live > stops accepting new sessions so closed can resolve [189.43ms]
(pass) connect() implicit client endpoint lifecycle > reuseEndpoint:false: the endpoint closes when its only session closes [105.15ms]
(pass) connect() implicit client endpoint lifecycle > en
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1491ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (15994ms)
Bundle modules (132ms)
Postprocesss modules (218ms)
Bundle Functions (2645ms)
Generate Code (39ms)

[19.05s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/2] bun-profile --revision
1.4.0-canary.1+21ea8ea35
[build] done
bun test v1.4.0-canary.1 (21ea8ea35)

test/js/node/quic/quic-endpoint.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:15:20)

(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [11.28ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [5.32ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [116.22ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [11.51ms]
(pass) transportParams.maxIdleTimeout > 0 disables the i
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/quic/quic.ts            | 41 ++++++++++++++++------
 test/expectations.txt                   | 12 +++++++
 test/js/node/quic/quic-endpoint.test.ts | 61 +++++++++++++++++++++++++++++++++
 3 files changed, 104 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js/internal/quic/quic.ts                11      9      0
test/expectations.txt                        1      1      0
test/js/node/quic/quic-endpoint.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->