### PR TITLE
node:quic: wire validateAddress through to a Retry flow

### DIFF
--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -479,6 +479,8 @@ NQ_SET(scid_len, unsigned)
 NQ_SET(silent_close, int)
 NQ_SET(cc_algo, unsigned)
 NQ_SET(delay_onclose, int)
+NQ_SET(force_retry, int)
+NQ_SET(retry_token_duration, unsigned)
 
 #define NQ_GET(f, ty) \
     ty us_nq_settings_get_##f(const struct lsquic_engine_settings *s) { return s->es_##f; }

--- a/patches/lsquic/node-quic-retry.patch
+++ b/patches/lsquic/node-quic-retry.patch
@@ -1,0 +1,86 @@
+--- a/include/lsquic.h
++++ b/include/lsquic.h
+@@ -1276,6 +1276,13 @@
+      * maxIdleTimeout transport parameter is specified in milliseconds).
+      */
+     unsigned        es_idle_timeout_ms;
++
++    /**
++     * bun: when nonzero, the server answers every tokenless Initial with a
++     * Retry packet (RFC 9000 Section 8.1 address validation).  Implies
++     * @ref es_support_srej.  node:quic's validateAddress.
++     */
++    int             es_force_retry;
+ };
+ 
+ /* Initialize `settings' to default values */
+@@ -2175,6 +2182,12 @@
+                             uint64_t *limited);
+ 
+ /**
++ * Retry packets this (server) engine has scheduled so far.
++ */
++uint64_t
++lsquic_engine_retry_count (const lsquic_engine_t *);
++
++/**
+  * PING frames received on this connection.
+  */
+ uint64_t
+--- a/src/liblsquic/lsquic_engine.c
++++ b/src/liblsquic/lsquic_engine.c
+@@ -223,6 +223,8 @@
+     uint64_t                           sreset_limited;
+     double                             sreset_tokens;
+     lsquic_time_t                      sreset_refill;
++    /* bun: Retry packets scheduled (address-validation counter). */
++    uint64_t                           retry_sent;
+     enum {
+         ENG_SERVER      = LSENG_SERVER,
+         ENG_HTTP        = LSENG_HTTP,
+@@ -759,6 +761,15 @@
+             return NULL;
+         }
+     }
++    /* bun: es_force_retry makes a server answer every tokenless Initial with
++     * a Retry (RFC 9000 Section 8.1), in release builds and without the env
++     * hook.  Implies es_support_srej so the token check on the follow-up
++     * Initial runs. */
++    if ((flags & LSENG_SERVER) && engine->pub.enp_settings.es_force_retry)
++    {
++        engine->flags |= ENG_FORCE_RETRY;
++        engine->pub.enp_settings.es_support_srej = 1;
++    }
+     engine->attq = lsquic_attq_create();
+     eng_hist_init(&engine->history);
+     if (engine->pub.enp_settings.es_max_batch_size)
+@@ -1518,6 +1529,13 @@
+ }
+ 
+ 
++uint64_t
++lsquic_engine_retry_count (const lsquic_engine_t *engine)
++{
++    return engine->retry_sent;
++}
++
++
+ static lsquic_conn_t *
+ find_or_create_conn (lsquic_engine_t *engine, lsquic_packet_in_t *packet_in,
+          struct packin_parse_state *ppstate, const struct sockaddr *sa_local,
+@@ -1686,6 +1704,7 @@
+             case (1 << 1) | 0:
+                 break;
+             }
++            ++engine->retry_sent;
+             schedule_req_packet(engine, PACKET_REQ_RETRY, packet_in, sa_local,
+                                                             sa_peer, peer_ctx);
+             return NULL;
+@@ -3286,6 +3305,7 @@
+         if (tick_st & TICK_RETRY)
+         {
+             assert(conn->cn_flags & LSCONN_MINI);
++            ++engine->retry_sent;
+             schedule_mini_retry(engine, conn, now);
+         }
+         if (tick_st & TICK_SEND)

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -128,6 +128,9 @@ export const lsquic: Dependency = {
     // never be encrypted and the peer idled out instead of learning of the
     // close. Select the PNS by handshake progress, as ngtcp2 does.
     "patches/lsquic/connection-close-pns.patch",
+    // node:quic validateAddress: ENG_FORCE_RETRY from a settings field
+    // (release-safe) plus a Retry counter the endpoint stats can read.
+    "patches/lsquic/node-quic-retry.patch",
   ],
 
   fetchDeps: ["zlib", "lshpack", "lsqpack", "boringssl"],

--- a/src/lsquic_sys/lib.rs
+++ b/src/lsquic_sys/lib.rs
@@ -276,6 +276,9 @@ unsafe extern "C" {
     pub fn us_nq_settings_set_silent_close(s: *mut lsquic_engine_settings, v: c_int);
     pub fn us_nq_settings_set_cc_algo(s: *mut lsquic_engine_settings, v: c_uint);
     pub fn us_nq_settings_set_delay_onclose(s: *mut lsquic_engine_settings, v: c_int);
+    pub fn us_nq_settings_set_force_retry(s: *mut lsquic_engine_settings, v: c_int);
+    pub fn us_nq_settings_set_retry_token_duration(s: *mut lsquic_engine_settings, v: c_uint);
+    pub fn lsquic_engine_retry_count(e: *const lsquic_engine) -> u64;
 }
 
 pub struct Settings {
@@ -388,6 +391,8 @@ settings_setters! {
     silent_close => us_nq_settings_set_silent_close : c_int,
     cc_algo => us_nq_settings_set_cc_algo : c_uint,
     delay_onclose => us_nq_settings_set_delay_onclose : c_int,
+    force_retry => us_nq_settings_set_force_retry : c_int,
+    retry_token_duration => us_nq_settings_set_retry_token_duration : c_uint,
 }
 
 pub struct Engine(*mut lsquic_engine);

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -141,6 +141,16 @@ pub(super) fn stored_addr_from_sockaddr(ptr: *const c_void) -> StoredAddr {
     StoredAddr::from_raw(ptr.cast(), len)
 }
 
+/// RFC 9000 §17.2.2 Initial: SCID-len, SCID, then the token-length varint.
+fn initial_has_token(payload: &[u8], scid_off: usize) -> bool {
+    payload
+        .get(scid_off)
+        .map(|&l| l as usize)
+        .filter(|&l| l <= MAX_CID_LEN)
+        .and_then(|l| payload.get(scid_off + 1 + l))
+        .is_some_and(|&b| b != 0)
+}
+
 fn conn_peer_addr(conn: *mut lsquic::lsquic_conn) -> Option<StoredAddr> {
     let mut local: *const c_void = null();
     let mut peer: *const c_void = null();
@@ -1684,20 +1694,9 @@ impl QuicEndpoint {
         if self.provisional.get().iter().any(|p| p.dcid == dcid) {
             return;
         }
-        // Under address validation a tokenless Initial is answered with a
-        // Retry, not a mini-conn, so a provisional announced now would time
-        // out. RFC 9000 §17.2.2: SCID-len, SCID, then the token-length varint.
-        if self.validate_address.get() {
-            let scid_off = dcid_start + dcid_len;
-            let has_token = payload
-                .get(scid_off)
-                .map(|&l| l as usize)
-                .filter(|&l| l <= MAX_CID_LEN)
-                .and_then(|l| payload.get(scid_off + 1 + l))
-                .is_some_and(|&b| b != 0);
-            if !has_token {
-                return;
-            }
+        // Under address validation a tokenless Initial gets a Retry, not a mini-conn.
+        if self.validate_address.get() && !initial_has_token(payload, dcid_start + dcid_len) {
+            return;
         }
         // On a dual-mode endpoint the peer's Initial *response* carries our
         // client's SCID, which only the client engine hashes -- checking the

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -1684,11 +1684,9 @@ impl QuicEndpoint {
         if self.provisional.get().iter().any(|p| p.dcid == dcid) {
             return;
         }
-        // With address validation on, a tokenless Initial gets a Retry, not a
-        // session — announcing now would surface one that then times out.
-        // Initial layout after DCID (RFC 9000 §17.2.2): 1-byte SCID len, SCID,
-        // then the token-length varint. A single 0x00 byte encodes the empty
-        // token every compliant client sends on first contact.
+        // Under address validation a tokenless Initial is answered with a
+        // Retry, not a mini-conn, so a provisional announced now would time
+        // out. RFC 9000 §17.2.2: SCID-len, SCID, then the token-length varint.
         if self.validate_address.get() {
             let scid_off = dcid_start + dcid_len;
             let has_token = payload

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -141,14 +141,15 @@ pub(super) fn stored_addr_from_sockaddr(ptr: *const c_void) -> StoredAddr {
     StoredAddr::from_raw(ptr.cast(), len)
 }
 
-/// RFC 9000 §17.2.2 Initial: SCID-len, SCID, then the token-length varint.
+/// RFC 9000 §17.2.2 Initial: SCID-len, SCID, then the token-length varint (§16).
 fn initial_has_token(payload: &[u8], scid_off: usize) -> bool {
     payload
         .get(scid_off)
         .map(|&l| l as usize)
         .filter(|&l| l <= MAX_CID_LEN)
-        .and_then(|l| payload.get(scid_off + 1 + l))
-        .is_some_and(|&b| b != 0)
+        .and_then(|scid_len| payload.get(scid_off + 1 + scid_len..))
+        .and_then(|p| p.get(..1usize << (p.first()? >> 6)))
+        .is_some_and(|v| v[0] & 0x3F != 0 || v[1..].iter().any(|&b| b != 0))
 }
 
 fn conn_peer_addr(conn: *mut lsquic::lsquic_conn) -> Option<StoredAddr> {

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -61,6 +61,7 @@ pub(crate) const ENDPOINT_STATS_FIELDS: &[&str] = &[
     "PACKETS_BLOCKED",
 ];
 const IDX_STATS_SERVER_BUSY_COUNT: usize = 8;
+const IDX_STATS_RETRY_COUNT: usize = 9;
 const IDX_STATS_STATELESS_RESET_COUNT: usize = 13;
 const IDX_STATS_STATELESS_RESET_RATE_LIMITED: usize = 14;
 /// QUIC transport error code for CONNECTION_REFUSED (RFC 9000 §20.1).
@@ -223,6 +224,8 @@ pub struct QuicEndpoint {
     disable_stateless_reset: Cell<bool>,
     stateless_reset_burst: Cell<u32>,
     stateless_reset_rate: Cell<f64>,
+    validate_address: Cell<bool>,
+    retry_token_expiration: Cell<u32>,
     /// Pre-encoded HTTP/3 ORIGIN frame payload (RFC 9412). lsquic borrows
     /// the bytes for the engine's lifetime — set before engine creation,
     /// never mutated afterwards.
@@ -1137,6 +1140,8 @@ impl QuicEndpoint {
             origin_blob: JsCell::new(Vec::new()),
             stateless_reset_burst: Cell::new(0),
             stateless_reset_rate: Cell::new(0.0),
+            validate_address: Cell::new(false),
+            retry_token_expiration: Cell::new(0),
             client_is_http: Cell::new(false),
             processing: Cell::new(false),
             followup_due: Cell::new(false),
@@ -1281,6 +1286,21 @@ impl QuicEndpoint {
             {
                 // SAFETY: as above.
                 unsafe { (**raw).stateless_reset_rate.set(v.as_number().max(0.0)) };
+            }
+            if let Some(v) = options
+                .get(global, "validateAddress")?
+                .filter(|v| v.is_boolean())
+            {
+                // SAFETY: as above.
+                unsafe { (**raw).validate_address.set(v.to_boolean()) };
+            }
+            if let Some(v) = read_u64_option(global, options, "retryTokenExpiration")? {
+                // SAFETY: as above.
+                unsafe {
+                    (**raw)
+                        .retry_token_expiration
+                        .set(v.min(c_uint::MAX as u64) as u32)
+                };
             }
         }
 
@@ -1464,6 +1484,9 @@ impl QuicEndpoint {
             };
             self.write_stat(IDX_STATS_STATELESS_RESET_COUNT, sent);
             self.write_stat(IDX_STATS_STATELESS_RESET_RATE_LIMITED, limited);
+            // SAFETY: engine is live while the endpoint is.
+            let retries = unsafe { lsquic::lsquic_engine_retry_count(server_engine) };
+            self.write_stat(IDX_STATS_RETRY_COUNT, retries);
         }
 
         // Every callback below runs user JS that can synchronously destroy
@@ -1660,6 +1683,23 @@ impl QuicEndpoint {
         let dcid = &payload[dcid_start..dcid_start + dcid_len];
         if self.provisional.get().iter().any(|p| p.dcid == dcid) {
             return;
+        }
+        // With address validation on, a tokenless Initial gets a Retry, not a
+        // session — announcing now would surface one that then times out.
+        // Initial layout after DCID (RFC 9000 §17.2.2): 1-byte SCID len, SCID,
+        // then the token-length varint. A single 0x00 byte encodes the empty
+        // token every compliant client sends on first contact.
+        if self.validate_address.get() {
+            let scid_off = dcid_start + dcid_len;
+            let has_token = payload
+                .get(scid_off)
+                .map(|&l| l as usize)
+                .filter(|&l| l <= MAX_CID_LEN)
+                .and_then(|l| payload.get(scid_off + 1 + l))
+                .is_some_and(|&b| b != 0);
+            if !has_token {
+                return;
+            }
         }
         // On a dual-mode endpoint the peer's Initial *response* carries our
         // client's SCID, which only the client engine hashes -- checking the
@@ -1993,6 +2033,13 @@ impl QuicEndpoint {
             let origin_blob = self.origin_blob.get();
             if !origin_blob.is_empty() {
                 settings.origin_blob(origin_blob);
+            }
+            if self.validate_address.get() {
+                settings.force_retry(1);
+            }
+            let retry_exp = self.retry_token_expiration.get();
+            if retry_exp > 0 {
+                settings.retry_token_duration(retry_exp);
             }
         }
         let mut local_tp = lsquic::NqTransportParams::default();

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { createPrivateKey } from "node:crypto";
+import dgram from "node:dgram";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { connect, listen, QuicEndpoint } from "node:quic";
@@ -206,6 +207,82 @@ describe("transportParams.maxIdleTimeout", () => {
     };
 
     expect({ zero: await advertised(0), seven: await advertised(7) }).toEqual({ zero: 0n, seven: 7n });
+  });
+});
+
+// RFC 9000 §8.1: address validation via Retry. node:quic's validateAddress was
+// accepted and validated in JS but never reached the lsquic engine, so the
+// server handshook immediately with zero Retry packets and retryCount stayed 0.
+describe("QuicEndpoint validateAddress", () => {
+  const sniOpt = { "*": { keys: [key], certs: [cert] } };
+  const tp = { maxIdleTimeout: 5 };
+  const onSession = async (s: any) => {
+    s.onerror = () => {};
+    await s.closed.catch(() => {});
+  };
+
+  // Long header with bit7 set and version != 0; Retry type bits are 0b11 (v1)
+  // or 0b00 (v2). RFC 8999 §5.1 / RFC 9000 §17.2 / RFC 9369 §3.2.
+  const isRetry = (m: Buffer) => {
+    if (m.length < 5 || (m[0] & 0x80) === 0) return false;
+    const ver = m.readUInt32BE(1);
+    const type = (m[0] >> 4) & 0x3;
+    return (ver === 1 && type === 0b11) || (ver === 0x6b3343cf && type === 0b00);
+  };
+
+  const bind = () =>
+    new Promise<dgram.Socket>(resolve => {
+      const s = dgram.createSocket("udp4");
+      s.bind(0, "127.0.0.1", () => resolve(s));
+    });
+
+  const handshakeWith = async (validateAddress: boolean) => {
+    const ep = new QuicEndpoint({ validateAddress });
+    const server = await listen(onSession, { endpoint: ep, sni: sniOpt, alpn: ["test"], transportParams: tp });
+    const serverPort = server.address.port;
+
+    // Two-socket relay so we can observe the server→client flight: the client
+    // talks to `front`, the server sees `back` as its peer.
+    const front = await bind();
+    const back = await bind();
+    front.on("error", () => {});
+    back.on("error", () => {});
+    let clientPort = 0;
+    let sawRetry = false;
+    let relaying = true;
+    front.on("message", (m, ri) => {
+      if (!relaying) return;
+      clientPort = ri.port;
+      back.send(m, serverPort, "127.0.0.1");
+    });
+    back.on("message", m => {
+      if (isRetry(m)) sawRetry = true;
+      if (relaying && clientPort) front.send(m, clientPort, "127.0.0.1");
+    });
+
+    await using clientEp = new QuicEndpoint();
+    const client = await connect(
+      { address: "127.0.0.1", port: front.address().port, family: "ipv4" },
+      { endpoint: clientEp, alpn: "test", verifyPeer: "manual", servername: "localhost", transportParams: tp },
+    );
+    await client.opened;
+    const retryCount = ep.stats.retryCount;
+    const serverSessions = ep.stats.serverSessions;
+    client.close();
+    await client.closed.catch(() => {});
+    await server.close();
+    relaying = false;
+    front.close();
+    back.close();
+    return { retryCount, serverSessions, sawRetry };
+  };
+
+  test("true sends a Retry before accepting; false does not", async () => {
+    const [off, on] = await Promise.all([handshakeWith(false), handshakeWith(true)]);
+    expect({ off, on: { ...on, retryCount: on.retryCount > 0n } }).toEqual({
+      off: { retryCount: 0n, serverSessions: 1n, sawRetry: false },
+      on: { retryCount: true, serverSessions: 1n, sawRetry: true },
+    });
   });
 });
 

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -237,7 +237,7 @@ describe("QuicEndpoint validateAddress", () => {
     });
 
   const handshakeWith = async (validateAddress: boolean) => {
-    const ep = new QuicEndpoint({ validateAddress });
+    const ep = new QuicEndpoint({ validateAddress, retryTokenExpiration: 30 });
     const server = await listen(onSession, { endpoint: ep, sni: sniOpt, alpn: ["test"], transportParams: tp });
     const serverPort = server.address.port;
 
@@ -261,20 +261,25 @@ describe("QuicEndpoint validateAddress", () => {
     });
 
     await using clientEp = new QuicEndpoint();
-    const client = await connect(
-      { address: "127.0.0.1", port: front.address().port, family: "ipv4" },
-      { endpoint: clientEp, alpn: "test", verifyPeer: "manual", servername: "localhost", transportParams: tp },
-    );
-    await client.opened;
-    const retryCount = ep.stats.retryCount;
-    const serverSessions = ep.stats.serverSessions;
-    client.close();
-    await client.closed.catch(() => {});
-    await server.close();
-    relaying = false;
-    front.close();
-    back.close();
-    return { retryCount, serverSessions, sawRetry };
+    try {
+      const client = await connect(
+        { address: "127.0.0.1", port: front.address().port, family: "ipv4" },
+        { endpoint: clientEp, alpn: "test", verifyPeer: "manual", servername: "localhost", transportParams: tp },
+      );
+      await client.opened;
+      const retryCount = ep.stats.retryCount;
+      const serverSessions = ep.stats.serverSessions;
+      client.close();
+      await client.closed.catch(() => {});
+      return { retryCount, serverSessions, sawRetry };
+    } finally {
+      // Drain while the relay is still open; the endpoint's asyncDispose is a
+      // graceful close that would otherwise wait out the idle timeout.
+      await server.close().catch(() => {});
+      relaying = false;
+      front.close();
+      back.close();
+    }
   };
 
   test("true sends a Retry before accepting; false does not", async () => {

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -231,8 +231,9 @@ describe("QuicEndpoint validateAddress", () => {
   };
 
   const bind = () =>
-    new Promise<dgram.Socket>(resolve => {
+    new Promise<dgram.Socket>((resolve, reject) => {
       const s = dgram.createSocket("udp4");
+      s.once("error", reject);
       s.bind(0, "127.0.0.1", () => resolve(s));
     });
 


### PR DESCRIPTION
The `validateAddress` option was validated in JS then dropped before reaching the native endpoint, so a server with `validateAddress: true` handshook on the first Initial exactly as one without it: zero Retry packets on the wire and `endpoint.stats.retryCount` stuck at 0. The RFC 9000 §8.1 anti-spoof / anti-amplification knob was inert.

#### Repro

```js
const ep = new QuicEndpoint({ validateAddress: true });
await listen(..., { endpoint: ep, ... });
await connect(ep.address, ...).opened;
ep.stats.retryCount;   // 0n; should be >= 1n
```

A UDP relay logging every server→client packet type shows the same flight (`Initial,Handshake,SHORT`) for both `true` and `false`, with no Retry.

#### Cause

None of `validateAddress` / `retryTokenExpiration` / `tokenSecret` / `retryRate` / etc. are ever read by the Rust constructor; they fall through JS validation and are discarded. lsquic has the Retry machinery behind `ENG_FORCE_RETRY`, but that flag was only reachable via the `LSQUIC_FORCE_RETRY` env var, and only when built with `!NDEBUG || LSQUIC_QIR`, so it is dead in release.

#### Fix

* Add an `es_force_retry` settings field and a `retry_sent` counter to lsquic via a new patch (`patches/lsquic/node-quic-retry.patch`): when set on a server engine it enables `ENG_FORCE_RETRY` (release-safe) and forces `es_support_srej` on so the follow-up token is actually checked. The counter is bumped at both Retry schedule sites and exposed via `lsquic_engine_retry_count()`.
* Shim setters for `force_retry` and the existing `retry_token_duration`, plus the corresponding Rust FFI and `Settings` methods.
* `QuicEndpoint` constructor now reads `validateAddress` and `retryTokenExpiration` and applies them when building the server engine. The process pass polls `lsquic_engine_retry_count()` into `IDX_STATS_RETRY_COUNT` alongside the stateless-reset stats.
* `maybe_announce_provisional` skips a tokenless Initial when address validation is on: the engine answers that with a Retry instead of creating a mini-conn, so the provisional session would otherwise wait out the 10 s timeout before expiring.

#### Verification

New test in `test/js/node/quic/quic-endpoint.test.ts` runs a handshake through a two-socket dgram relay for both `validateAddress: false` and `true`, asserting that `true` produces a Retry packet on the wire, a nonzero `retryCount`, and still exactly one announced server session, while `false` produces none of the above. Fails on main (`retryCount` 0, no Retry seen), passes with this change.

The rest of the inert endpoint-option family (`tokenSecret`, `resetTokenSecret`, `retryRate/Burst`, `sessionCreationRate/Burst`, `udp*`, `ipv6Only`, `reusePort`, `addressLRUSize`) is still not wired; this PR covers the address-validation knob and its observable stat.