### PR TITLE
runtime transpiler cache: per-uid root, ownership check, mandatory payload hashes

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,9 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: section hashes are seeded with `input_hash` (not the fixed
+/// `SEED`) and a stored hash of 0 no longer skips verification.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a
@@ -297,11 +299,9 @@ impl Entry {
                     ..Default::default()
                 };
 
-                metadata.output_hash = hash(output_bytes);
-                metadata.sourcemap_hash = hash(sourcemap);
-                if !esm_record.is_empty() {
-                    metadata.esm_record_hash = hash(esm_record);
-                }
+                metadata.output_hash = Wyhash::hash(input_hash, output_bytes);
+                metadata.sourcemap_hash = Wyhash::hash(input_hash, sourcemap);
+                metadata.esm_record_hash = Wyhash::hash(input_hash, esm_record);
 
                 let mut metadata_stream = bun_io::FixedBufferStream::new_mut(&mut metadata_buf[..]);
                 metadata.encode(&mut metadata_stream)?;
@@ -393,6 +393,8 @@ impl Entry {
             return Err(crate::CrateError::MissingData);
         }
 
+        let section_seed = self.metadata.input_hash;
+
         debug_assert!(
             self.output_code.is_empty(),
             "this should be the default value"
@@ -433,7 +435,7 @@ impl Entry {
                         return Err(crate::CrateError::MissingData);
                     }
 
-                    if self.metadata.output_hash != 0 && hash(bytes) != self.metadata.output_hash {
+                    if Wyhash::hash(section_seed, bytes) != self.metadata.output_hash {
                         return Err(crate::CrateError::InvalidHash);
                     }
 
@@ -457,15 +459,12 @@ impl Entry {
                         return Err(crate::CrateError::Alloc(bun_alloc::AllocError));
                     }
                     let read_bytes = file.pread_all(bytes, self.metadata.output_byte_offset)?;
-
-                    if self.metadata.output_hash != 0 {
-                        if hash(latin1.latin1()) != self.metadata.output_hash {
-                            return Err(crate::CrateError::InvalidHash);
-                        }
-                    }
-
                     if read_bytes as u64 != self.metadata.output_byte_length {
                         return Err(crate::CrateError::MissingData);
+                    }
+
+                    if Wyhash::hash(section_seed, latin1.latin1()) != self.metadata.output_hash {
+                        return Err(crate::CrateError::InvalidHash);
                     }
 
                     latin1
@@ -488,11 +487,9 @@ impl Entry {
                         return Err(crate::CrateError::MissingData);
                     }
 
-                    if self.metadata.output_hash != 0 {
-                        let utf16_bytes: &[u8] = bytemuck::cast_slice(string.utf16());
-                        if hash(utf16_bytes) != self.metadata.output_hash {
-                            return Err(crate::CrateError::InvalidHash);
-                        }
+                    let utf16_bytes: &[u8] = bytemuck::cast_slice(string.utf16());
+                    if Wyhash::hash(section_seed, utf16_bytes) != self.metadata.output_hash {
+                        return Err(crate::CrateError::InvalidHash);
                     }
 
                     string
@@ -508,6 +505,9 @@ impl Entry {
                 self.metadata.sourcemap_byte_length as usize,
                 self.metadata.sourcemap_byte_offset,
             )?;
+            if Wyhash::hash(section_seed, &self.sourcemap) != self.metadata.sourcemap_hash {
+                return Err(crate::CrateError::InvalidHash);
+            }
         }
 
         if self.metadata.esm_record_byte_length > 0 {
@@ -517,10 +517,8 @@ impl Entry {
                 self.metadata.esm_record_byte_offset,
             )?;
 
-            if self.metadata.esm_record_hash != 0 {
-                if hash(&esm_record) != self.metadata.esm_record_hash {
-                    return Err(crate::CrateError::InvalidHash);
-                }
+            if Wyhash::hash(section_seed, &esm_record) != self.metadata.esm_record_hash {
+                return Err(crate::CrateError::InvalidHash);
             }
 
             self.esm_record = esm_record;
@@ -544,6 +542,55 @@ pub struct RuntimeTranspilerCache {
 
 pub(crate) fn hash(bytes: &[u8]) -> u64 {
     Wyhash::hash(SEED, bytes)
+}
+
+/// Effective uid: the identity the kernel checks file access against.
+#[cfg(unix)]
+#[inline]
+fn current_user_id() -> u32 {
+    bun_sys::c::geteuid() as u32
+}
+
+#[cfg(windows)]
+#[inline]
+fn current_user_id() -> u32 {
+    bun_sys::windows::user_unique_id()
+}
+
+#[cfg(unix)]
+fn is_trusted_dir_stat(st: &sys::Stat) -> bool {
+    (st.st_mode & libc::S_IFMT) == libc::S_IFDIR
+        && st.st_uid == bun_sys::c::geteuid()
+        && (st.st_mode & (libc::S_IWGRP | libc::S_IWOTH)) == 0
+}
+
+/// `true` when `path` lstat's as a directory owned by the current uid with no
+/// group/other write bits, or does not exist. Any other result fails closed.
+#[cfg(unix)]
+fn is_trusted_cache_root(path: &ZStr) -> bool {
+    match sys::lstat(path) {
+        Ok(st) => is_trusted_dir_stat(&st),
+        Err(e) if e.get_errno() == sys::E::ENOENT => true,
+        Err(_) => false,
+    }
+}
+
+/// Same predicate as `is_trusted_cache_root`, on the directory we opened.
+#[cfg(unix)]
+fn is_trusted_opened_cache_dir(fd: Fd) -> bool {
+    sys::fstat(fd).is_ok_and(|st| is_trusted_dir_stat(&st))
+}
+
+#[cfg(not(unix))]
+#[inline(always)]
+fn is_trusted_cache_root(_path: &ZStr) -> bool {
+    true
+}
+
+#[cfg(not(unix))]
+#[inline(always)]
+fn is_trusted_opened_cache_dir(_fd: Fd) -> bool {
+    true
 }
 
 /// Allocate `len` bytes and fill them via `pread_all` at `offset`, returning
@@ -635,8 +682,13 @@ impl RuntimeTranspilerCache {
         // that `absBufZ` used.
         let top = FileSystem::instance().top_level_dir;
 
+        let mut seg = [0u8; 4 + 10];
+        seg[..4].copy_from_slice(b"@t@-");
+        let n = bun_core::fmt::print_int(&mut seg[4..], current_user_id());
+        let tcache_seg: &[u8] = &seg[..4 + n];
+
         if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
-            let parts: &[&[u8]] = &[dir, b"bun", b"@t@"];
+            let parts: &[&[u8]] = &[dir, b"bun", tcache_seg];
             return path_handler::join_abs_string_buf_z::<platform::Loose>(
                 top,
                 &mut buf[..],
@@ -650,7 +702,7 @@ impl RuntimeTranspilerCache {
             // On a mac, default to ~/Library/Caches/bun/*
             // This is different than ~/.bun/install/cache, and not configurable by the user.
             if let Some(home) = env_var::HOME.get() {
-                let parts: &[&[u8]] = &[home, b"Library/", b"Caches/", b"bun", b"@t@"];
+                let parts: &[&[u8]] = &[home, b"Library/", b"Caches/", b"bun", tcache_seg];
                 return path_handler::join_abs_string_buf_z::<platform::Loose>(
                     top,
                     &mut buf[..],
@@ -661,7 +713,7 @@ impl RuntimeTranspilerCache {
         }
 
         if let Some(dir) = env_var::HOME.get() {
-            let parts: &[&[u8]] = &[dir, b".bun", b"install", b"cache", b"@t@"];
+            let parts: &[&[u8]] = &[dir, b".bun", b"install", b"cache", tcache_seg];
             return path_handler::join_abs_string_buf_z::<platform::Loose>(
                 top,
                 &mut buf[..],
@@ -693,8 +745,17 @@ impl RuntimeTranspilerCache {
         let path_len = match Self::RUNTIME_TRANSPILER_CACHE.with(|c| c.get()) {
             Some(len) => len,
             None => {
-                let len = Self::CACHE_DIR_BUF
-                    .with_borrow_mut(|tl_buf| Self::really_get_cache_dir(tl_buf));
+                let len = Self::CACHE_DIR_BUF.with_borrow_mut(|tl_buf| {
+                    let len = Self::really_get_cache_dir(tl_buf);
+                    if len > 0 && !is_trusted_cache_root(ZStr::from_buf(&tl_buf[..], len)) {
+                        bun_core::scoped_log!(
+                            cache,
+                            "transpiler cache root failed ownership/mode check, disabling"
+                        );
+                        return 0;
+                    }
+                    len
+                });
                 if len == 0 {
                     IS_DISABLED.store(true, Ordering::Relaxed);
                     return Err(crate::CrateError::CacheDisabled);
@@ -813,6 +874,11 @@ impl RuntimeTranspilerCache {
                 fd.close();
             }
         });
+
+        if cache_dir_fd != Fd::cwd() && !is_trusted_opened_cache_dir(cache_dir_fd) {
+            IS_DISABLED.store(true, Ordering::Relaxed);
+            return Err(crate::CrateError::CacheDisabled);
+        }
 
         Entry::save(
             cache_dir_fd,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4935,13 +4935,14 @@ pub mod c {
     use core::ffi::{c_char, c_void};
     #[cfg(unix)]
     pub use libc::fchmod;
-    // `getuid`/`getgid` take no args and read kernel
+    // `getuid`/`geteuid`/`getgid` take no args and read kernel
     // process state — no preconditions, never fail. Declared locally as
     // `safe fn` (instead of re-exporting the `libc` crate's raw decls) so
     // callers need no per-site proof.
     #[cfg(unix)]
     unsafe extern "C" {
         pub safe fn getuid() -> libc::uid_t;
+        pub safe fn geteuid() -> libc::uid_t;
         pub safe fn getgid() -> libc::gid_t;
     }
     #[cfg(unix)]

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, tmpdirSync } from "harness";
+import { bunEnv, bunExe, bunRun, isPosix, tmpdirSync } from "harness";
 import { join } from "path";
 
 function dummyFile(size: number, cache_bust: string, value: string | { code: string }) {
@@ -170,8 +170,8 @@ describe("transpiler cache", () => {
     // Stand-in for the shared, world-writable system temp dir. Pre-create
     // bun/@t@ inside it the way another local user could on a multi-user host.
     const shared_tmp = join(temp_dir, "shared-tmp");
-    const shared_cache = join(shared_tmp, "bun", "@t@");
-    mkdirSync(shared_cache, { recursive: true });
+    const shared_bun = join(shared_tmp, "bun");
+    mkdirSync(join(shared_bun, "@t@"), { recursive: true });
 
     // No per-user cache location is available (no BUN_RUNTIME_TRANSPILER_CACHE_PATH,
     // no XDG_CACHE_HOME, no HOME) — the only remaining candidate is the shared
@@ -190,16 +190,17 @@ describe("transpiler cache", () => {
       }),
     ).toSpawn("no-tmpdir-cache");
 
-    // No cache entry may be written into (or read back from) a directory that
-    // another local user could own and pre-populate.
-    expect(readdirSync(shared_cache)).toEqual([]);
+    // Nothing may be written under the shared dir, whatever leaf name a
+    // fallback would pick: only the pre-created decoy remains, and it is empty.
+    expect(readdirSync(shared_bun)).toEqual(["@t@"]);
+    expect(readdirSync(join(shared_bun, "@t@"))).toEqual([]);
 
     // A per-user cache location still works.
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("no-tmpdir-cache");
     expect(newCacheCount()).toBe(1);
   });
   test("works if the cache is not user-readable", async () => {
-    mkdirSync(cache_dir, { recursive: true });
+    mkdirSync(cache_dir, { recursive: true, mode: 0o755 });
     writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "b"));
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("b");
     expect(newCacheCount()).toBe(1);
@@ -322,6 +323,105 @@ describe("transpiler cache", () => {
       expect(newCacheCount()).toBe(0);
     });
   });
+
+  test("rejects a cache entry whose output was rewritten with a zeroed output_hash", async () => {
+    // Cache entry header (src/jsc/RuntimeTranspilerCache.rs, Metadata::encode):
+    //   0: cache_version u32, 4: module_type u8, 5: output_encoding u8,
+    //   6: features_hash u64, 14: input_byte_length u64, 22: input_hash u64,
+    //   30: output_byte_offset u64, 38: output_byte_length u64,
+    //   46: output_hash u64, ...; payload follows the 102-byte header.
+    const OUTPUT_BYTE_OFFSET = 30;
+    const OUTPUT_BYTE_LENGTH = 38;
+    const OUTPUT_HASH = 46;
+
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "forge", "GOOD"));
+
+    expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("GOOD");
+    const entries = readdirSync(cache_dir);
+    expect(entries.length).toBe(1);
+
+    // Tamper: rewrite the printed literal inside the stored output and clear
+    // output_hash so the (forgeable) self-check would have accepted it.
+    const pile = join(cache_dir, entries[0]);
+    const buf = Buffer.from(readFileSync(pile));
+    const outOff = Number(buf.readBigUInt64LE(OUTPUT_BYTE_OFFSET));
+    const outLen = Number(buf.readBigUInt64LE(OUTPUT_BYTE_LENGTH));
+    const region = buf.subarray(outOff, outOff + outLen);
+    const needle = region.indexOf("GOOD");
+    expect(needle).toBeGreaterThanOrEqual(0);
+    region.write("EVIL", needle, "latin1");
+    buf.writeBigUInt64LE(0n, OUTPUT_HASH);
+    writeFileSync(pile, buf);
+
+    // The tampered entry must be rejected and the source re-transpiled: the
+    // original output is observed and a fresh entry replaces the forged one.
+    expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("GOOD");
+    const after = readdirSync(cache_dir);
+    expect(after.length).toBe(1);
+    expect(Buffer.from(readFileSync(join(cache_dir, after[0]))).readBigUInt64LE(OUTPUT_HASH)).not.toBe(0n);
+  });
+
+  test("rejects a cache entry whose output_hash was recomputed with the fixed seed", async () => {
+    const OUTPUT_BYTE_OFFSET = 30;
+    const OUTPUT_BYTE_LENGTH = 38;
+    const OUTPUT_HASH = 46;
+
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "forge2", "GOOD"));
+    expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("GOOD");
+    const entries = readdirSync(cache_dir);
+    expect(entries.length).toBe(1);
+
+    // Section hashes are keyed on the per-entry input hash, not the fixed
+    // seed, so a wyhash(seed=42) over the tampered output must still be
+    // rejected.
+    const pile = join(cache_dir, entries[0]);
+    const buf = Buffer.from(readFileSync(pile));
+    const outOff = Number(buf.readBigUInt64LE(OUTPUT_BYTE_OFFSET));
+    const outLen = Number(buf.readBigUInt64LE(OUTPUT_BYTE_LENGTH));
+    const region = buf.subarray(outOff, outOff + outLen);
+    const needle = region.indexOf("GOOD");
+    expect(needle).toBeGreaterThanOrEqual(0);
+    region.write("EVIL", needle, "latin1");
+    buf.writeBigUInt64LE(Bun.hash.wyhash(region, 42n), OUTPUT_HASH);
+    writeFileSync(pile, buf);
+
+    expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("GOOD");
+  });
+
+  test.skipIf(!isPosix)("disables the cache when the cache root is writable by other users", async () => {
+    // An attacker-controlled cache root (group/other-writable) must not be
+    // read from or written to: the transpiler cache is disabled for the run.
+    mkdirSync(cache_dir, { recursive: true });
+    chmodSync(cache_dir, 0o777);
+    try {
+      writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "trust", "ok"));
+      expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("ok");
+      expect(readdirSync(cache_dir)).toEqual([]);
+    } finally {
+      chmodSync(cache_dir, 0o755);
+    }
+  });
+
+  test.skipIf(!isPosix)("stops writing when the cache root turns untrusted after the initial check", async () => {
+    // The root is validated once per process when it is first resolved. The
+    // directory actually opened for each write is re-validated, so a root that
+    // becomes group/other-writable later in the same process receives no
+    // further entries.
+    const filler = "\n//" + Buffer.alloc(50 * 1024, "f").toString();
+    writeFileSync(
+      join(temp_dir, "a.js"),
+      `require("fs").chmodSync(${JSON.stringify(cache_dir)}, 0o777);
+require("./b.js");${filler}`,
+    );
+    writeFileSync(join(temp_dir, "b.js"), dummyFile(50 * 1024, "late", "late-ok"));
+    try {
+      expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("late-ok");
+      // Only a.js (written while the root was still trusted) is cached.
+      expect(readdirSync(cache_dir).length).toBe(1);
+    } finally {
+      chmodSync(cache_dir, 0o755);
+    }
+  });
 });
 
 test("rejects cached module records containing out-of-range string indices", () => {
@@ -341,6 +441,7 @@ test("rejects cached module records containing out-of-range string indices", () 
   //   table: [offset_width u8][0;3][count u32][(count+1) offsets][pad to even][bytes]
   //   body:  [flags u8][id_width u8][0;2][n_requested u32][n_records u32]
   //          [n_records tag bytes][n_requested tag bytes][string ids @ id_width ...]
+  const INPUT_HASH_AT = 22;
   const ESM_RECORD_BYTE_OFFSET_AT = 78;
   const ESM_RECORD_BYTE_LENGTH_AT = 86;
   const ESM_RECORD_HASH_AT = 94;
@@ -370,10 +471,12 @@ test("rejects cached module records containing out-of-range string indices", () 
     // Point every string id in the body past the table (and past the two
     // sentinels count / count+1): all-ones at whatever width the ids use.
     data.fill(0xff, idsAt, end);
-    // The cache loader skips esm-record content verification when the stored
-    // hash field is zero, so whoever writes the cache file controls exactly
-    // what reaches the module record deserializer.
-    data.writeBigUInt64LE(0n, ESM_RECORD_HASH_AT);
+    // Section hashes are keyed on the input hash; recompute it for the
+    // rewritten record so the entry passes the loader's hash check and the
+    // corrupted indices reach the module-record deserializer under test.
+    const inputHash = data.readBigUInt64LE(INPUT_HASH_AT);
+    const esmHash = Bun.hash.wyhash(data.subarray(esmOff, esmOff + esmLen), inputHash);
+    data.writeBigUInt64LE(esmHash, ESM_RECORD_HASH_AT);
     writeFileSync(file, data);
     return true;
   }


### PR DESCRIPTION
## What

Hardens the on-disk runtime transpiler cache (`src/jsc/RuntimeTranspilerCache.rs`) against cross-user planting and self-attesting forgeries:

1. **Per-uid default root.** The default leaf becomes `@t@-<uid>` (unix `geteuid()`, Windows `user_unique_id()`) instead of `@t@`, so the default cache location under `XDG_CACHE_HOME` / `~/Library/Caches` / `~/.bun/install/cache` is no longer shared across users on a multi-tenant host. An explicit `BUN_RUNTIME_TRANSPILER_CACHE_PATH` is still used verbatim.
2. **Cache-root ownership check.** `get_cache_dir` lstat's the resolved root once per process: if it exists and is not a directory owned by the effective uid with no group/other write bits, the cache is disabled for the run instead of consumed. Only ENOENT is treated as benign; any other lstat error fails closed. `to_file` re-applies the same predicate with `fstat` on the directory it actually opened, so a root that appears or changes between the initial check and a write receives nothing (our own `mkdir` is 0755, so a root we create always passes).
3. **Input-keyed, mandatory section hashes.** `output_hash` / `sourcemap_hash` / `esm_record_hash` are seeded with `input_hash` instead of the fixed `SEED`, and the `hash != 0` bypass is gone (as is the missing `sourcemap_hash` check on load). A planted entry whose payload was rewritten with a zeroed hash, or whose hash was recomputed with the old fixed seed, is rejected with `InvalidHash` and re-transpiled. `EXPECTED_VERSION` bumps to 28 (24 through 27 were taken on main while this was open).

The section hash is still an unkeyed wyhash over bytes an attacker can observe (source and payload), so a same-uid writer who knows the target source can still recompute it; the uid namespacing and ownership check are the actual boundary. A 0600 per-user MAC key would close the remaining same-uid case and is a follow-up.

Reads still open `<root>/<hash>.pile` by pathname, so there is a small window between the per-process lstat and the first open if the root's parent is attacker-writable. Every default location has its parent inside `$HOME`; an explicit `BUN_RUNTIME_TRANSPILER_CACHE_PATH` under a shared parent is a user opt-in. Converting reads to a held directory fd plus `openat` is a larger change and is left as a follow-up; see the review thread on `is_trusted_cache_root` for the discussion.

Supersedes #35101 (which introduced the input-keyed section hashes and the zero-hash/fixed-seed tests adopted here).

## Rebase notes

Rebased onto current main four times. The first rebase dropped a shared `bun_sys` helper: bunx grew its own multi-segment cache-path walker in `bunx_command.rs`, so the ownership check is a private helper in `RuntimeTranspilerCache.rs` and `bunx_command.rs` is untouched; the test file was converted to the async `bunRun` / `toSpawn` harness. The second (after #40238) only dropped the `scopeguard` errdefers and `OutputCode::String` wrappers around the hash checks in `Entry::load`. The third (after #40509 changed the ModuleInfo wire format and took version 26) adopts main's new record parser in the module-record corruption test, swapping only its zero-hash write for the input-keyed recompute. The fourth (after #40677 took version 27) is a version-number-only conflict; the bump is now 28. The only `src/sys` change is declaring `geteuid` next to the existing `getuid`.

## Repro

Before this change, planting a tampered `.pile` with `output_hash = 0` is executed verbatim:

```
$ bun a.js                         # populates cache
GOOD
$ # rewrite "GOOD" -> "EVIL" in the .pile output region, zero output_hash
$ bun a.js
EVIL
```

And a cache root pre-created with mode `0777` is written to and read from without complaint.

## Cost

- One lstat on the cache root per process.
- The payload hashes were already computed on every honest cache hit (the writer always stamped them); only the `hash = 0` and seed-mismatch paths change behaviour.
- The per-uid leaf means existing `@t@` directories become dead on upgrade; `bun pm cache rm` still clears the parent.

## Tests

`test/cli/run/transpiler-cache.test.ts` (all fail on the released bun, pass with this change):
- `rejects a cache entry whose output was rewritten with a zeroed output_hash`
- `rejects a cache entry whose output_hash was recomputed with the fixed seed`
- `disables the cache when the cache root is writable by other users` (posix only)
- `stops writing when the cache root turns untrusted after the initial check` (posix only; the entry point chmods the root to 0777 and requires a second module, which must not be written)

The existing module-record corruption test now recomputes `esm_record_hash` via `Bun.hash.wyhash(bytes, input_hash)` so it still reaches the deserializer past the new guard.

The install extraction cache (`determine_preinstall_state` trust-by-dirname) is intentionally not in this PR; that change touches both extraction paths plus patch/github edges and will land separately.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts
bun test v1.4.1 (65362b53b)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [773.54ms]
(pass) transpiler cache > works with empty files [840.53ms]
(pass) transpiler cache > ignores files under the minimum cache size [304.42ms]
(pass) transpiler cache > does not cache a file whose parse logged an error [946.54ms]
(pass) transpiler cache > it is indeed content addressable [1049.82ms]
(pass) transpiler cache > doing 50 buns at once does not crash [1925.63ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [683.72ms]
(pass) transpiler cache > works if the cache is not user-readable [1015.83ms]
(pass) transpiler cache > works if the cache is not user-writable [353.32ms]
(pass) transpiler cache > does not inline process.env [706.82ms]
(pass) transpiler cache > --feature flag invalidates cache [1825.09ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > require.extensions is still consulted [63
... (truncated)

release without fix: 5 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [22.38ms]
(pass) transpiler cache > works with empty files [34.08ms]
(pass) transpiler cache > ignores files under the minimum cache size [18.64ms]
(pass) transpiler cache > does not cache a file whose parse logged an error [27.20ms]
(pass) transpiler cache > it is indeed content addressable [52.12ms]
(pass) transpiler cache > doing 50 buns at once does not crash [36.02ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [22.63ms]
(pass) transpiler cache > works if the cache is not user-readable [24.69ms]
(pass) transpiler cache > works if the cache is not user-writable [15.20ms]
(pass) transpiler cache > does not inline process.env [22.26ms]
(pass) transpiler cache > --feature flag invalidates cache [59.70ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > require.extensions is still consulted [33.29ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > unknown extensions still use the file loader [22.32ms]
353 |     buf.writeBigUInt6
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts
bun test v1.4.1 (65362b53b)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [827.18ms]
(pass) transpiler cache > works with empty files [646.54ms]
(pass) transpiler cache > ignores files under the minimum cache size [279.77ms]
(pass) transpiler cache > does not cache a file whose parse logged an error [1123.78ms]
(pass) transpiler cache > it is indeed content addressable [1165.55ms]
(pass) transpiler cache > doing 50 buns at once does not crash [1803.58ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [650.63ms]
(pass) transpiler cache > works if the cache is not user-readable [1111.77ms]
(pass) transpiler cache > works if the cache is not user-writable [327.37ms]
(pass) transpiler cache > does not inline process.env [720.43ms]
(pass) transpiler cache > --feature flag invalidates cache [2123.58ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > require.extensions is still consulted [5
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0a1816e560
  features     baseline

23 deps, 131 codegen, 1172 objects in 779ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [9.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch zlib
[zlib] up to date
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [15.00ms]
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 19ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/RuntimeTranspilerCache.rs     | 122 +++++++++++++++++++++++++--------
 src/sys/lib.rs                        |   3 +-
 test/cli/run/transpiler-cache.test.ts | 125 +++++++++++++++++++++++++++++++---
 3 files changed, 210 insertions(+), 40 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/RuntimeTranspilerCache.rs         17     33      0
src/sys/lib.rs                             5      4      0
test/cli/run/transpiler-cache.test.ts      6     10      0
```

</details>

<!-- robobun:evidence:end -->


