### PR TITLE
node:fs: recursive rm passes through unmapped errnos instead of reporting EFAULT

### DIFF
--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -386,40 +386,6 @@ pub enum Error {
     BoringSSLError,
     #[error("WriteFailed")]
     WriteFailed,
-    #[error("FileNotFound")]
-    FileNotFound,
-    #[error("AccessDenied")]
-    AccessDenied,
-    #[error("PermissionDenied")]
-    PermissionDenied,
-    #[error("SymLinkLoop")]
-    SymLinkLoop,
-    #[error("NameTooLong")]
-    NameTooLong,
-    #[error("SystemResources")]
-    SystemResources,
-    #[error("ReadOnlyFileSystem")]
-    ReadOnlyFileSystem,
-    #[error("FileSystem")]
-    FileSystem,
-    #[error("FileBusy")]
-    FileBusy,
-    #[error("NotDir")]
-    NotDir,
-    #[error("IsDir")]
-    IsDir,
-    #[error("DirNotEmpty")]
-    DirNotEmpty,
-    #[error("SystemFdQuotaExceeded")]
-    SystemFdQuotaExceeded,
-    #[error("ProcessFdQuotaExceeded")]
-    ProcessFdQuotaExceeded,
-    #[error("BadPathName")]
-    BadPathName,
-    #[error("FileTooBig")]
-    FileTooBig,
-    #[error("NoDevice")]
-    NoDevice,
 
     #[error(transparent)]
     Core(#[from] bun_core::Error),
@@ -784,23 +750,6 @@ impl Error {
             Self::Unexpected => "Unexpected",
             Self::BoringSSLError => "BoringSSLError",
             Self::WriteFailed => "WriteFailed",
-            Self::FileNotFound => "FileNotFound",
-            Self::AccessDenied => "AccessDenied",
-            Self::PermissionDenied => "PermissionDenied",
-            Self::SymLinkLoop => "SymLinkLoop",
-            Self::NameTooLong => "NameTooLong",
-            Self::SystemResources => "SystemResources",
-            Self::ReadOnlyFileSystem => "ReadOnlyFileSystem",
-            Self::FileSystem => "FileSystem",
-            Self::FileBusy => "FileBusy",
-            Self::NotDir => "NotDir",
-            Self::IsDir => "IsDir",
-            Self::DirNotEmpty => "DirNotEmpty",
-            Self::SystemFdQuotaExceeded => "SystemFdQuotaExceeded",
-            Self::ProcessFdQuotaExceeded => "ProcessFdQuotaExceeded",
-            Self::BadPathName => "BadPathName",
-            Self::FileTooBig => "FileTooBig",
-            Self::NoDevice => "NoDevice",
             Self::Core(e) => e.name(),
             Self::Sys(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9542,12 +9542,44 @@ impl ReaddirEntry for Buffer {
     }
 }
 
+// Lossless `E` ↔ `SystemErrno` cast. On POSIX they are the same type; on
+// Windows they are distinct `#[repr(u16)]` enums with identical discriminant
+// sets (see `SystemErrno::to_e`).
+#[inline]
+const fn e_as_system_errno(e: E) -> SystemErrno {
+    #[cfg(windows)]
+    {
+        SystemErrno::from_raw(e as u16)
+    }
+    #[cfg(not(windows))]
+    {
+        e
+    }
+}
+#[inline]
+const fn system_errno_as_e(e: SystemErrno) -> E {
+    #[cfg(windows)]
+    {
+        e.to_e()
+    }
+    #[cfg(not(windows))]
+    {
+        e
+    }
+}
+
 // There are three distinct error→errno tables: rmdir-recursive,
 // rm-recursive, and rm non-recursive unlink/rmdir. An earlier draft
 // collapsed them into one, which silently mapped AccessDenied→EPERM for `rm`
 // (Node returns EACCES there) and widened the narrow table. Split back out
 // per call site.
 fn map_anyerror_to_errno(err: &crate::Error) -> E {
+    // `dt_err` packs any errno without a named variant as `Sys(errno)` so the
+    // round-trip is lossless; unwrap it here before falling back to the name
+    // table.
+    if let crate::Error::Sys(e) = err {
+        return system_errno_as_e(*e);
+    }
     match err.name() {
         "AccessDenied" => E::EPERM,
         "PermissionDenied" => E::EPERM,
@@ -9560,7 +9592,9 @@ fn map_anyerror_to_errno(err: &crate::Error) -> E {
         "ReadOnlyFileSystem" => E::EROFS,
         "FileSystem" => E::EIO,
         "FileBusy" | "DeviceBusy" => E::EBUSY,
+        "DirNotEmpty" => E::ENOTEMPTY,
         "NotDir" => E::ENOTDIR,
+        "NoDevice" => E::ENODEV,
         "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
         "FileNotFound" => E::ENOENT,
         "IsDir" => E::EISDIR,
@@ -9571,6 +9605,9 @@ fn map_anyerror_to_errno(err: &crate::Error) -> E {
 // `rm` recursive (zig_delete_tree) — same shape as the rmdir table above except
 // AccessDenied maps to EACCES, not EPERM.
 fn map_anyerror_to_errno_rm_tree(err: &crate::Error) -> E {
+    if let crate::Error::Sys(e) = err {
+        return system_errno_as_e(*e);
+    }
     match err.name() {
         "AccessDenied" => E::EACCES,
         "PermissionDenied" => E::EPERM,
@@ -9585,6 +9622,7 @@ fn map_anyerror_to_errno_rm_tree(err: &crate::Error) -> E {
         "FileSystem" => E::EIO,
         "FileBusy" | "DeviceBusy" => E::EBUSY,
         "NotDir" => E::ENOTDIR,
+        "NoDevice" => E::ENODEV,
         "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
         "FileNotFound" => E::ENOENT,
         "IsDir" => E::EISDIR,
@@ -9660,7 +9698,10 @@ fn dt_err(errno: E) -> crate::Error {
         E::EINVAL => "BadPathName",
         E::EFBIG => "FileTooBig",
         E::ENODEV => "NoDevice",
-        _ => "Unexpected",
+        // Any errno without a named variant is carried raw so the caller's
+        // `map_anyerror_to_errno*` returns it unchanged instead of EFAULT
+        // (e.g. ENOSPC from overlayfs whiteout writes, EDQUOT, ESTALE, ETXTBSY).
+        _ => return crate::Error::Sys(e_as_system_errno(errno)),
     })
 }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -402,33 +402,6 @@ fn encoding_to_node(e: Encoding) -> bun_core::NodeEncoding {
 /// `super::stat` swaps to `pub use bun_sys::PosixStat` this alias collapses.
 use super::stat::PosixStat;
 
-/// Node `fs.rm` mapping helper — maps an error-set *name* string back to a
-/// `crate::Error` variant so the callers' `map_anyerror_to_errno*` tables (which
-/// match on `err.name()`) keep round-tripping.
-#[inline]
-fn err_from_static(name: &'static str) -> crate::Error {
-    match name {
-        "FileNotFound" => crate::Error::FileNotFound,
-        "AccessDenied" => crate::Error::AccessDenied,
-        "PermissionDenied" => crate::Error::PermissionDenied,
-        "SymLinkLoop" => crate::Error::SymLinkLoop,
-        "NameTooLong" => crate::Error::NameTooLong,
-        "SystemResources" => crate::Error::SystemResources,
-        "ReadOnlyFileSystem" => crate::Error::ReadOnlyFileSystem,
-        "FileSystem" => crate::Error::FileSystem,
-        "FileBusy" => crate::Error::FileBusy,
-        "NotDir" => crate::Error::NotDir,
-        "IsDir" => crate::Error::IsDir,
-        "DirNotEmpty" => crate::Error::DirNotEmpty,
-        "SystemFdQuotaExceeded" => crate::Error::SystemFdQuotaExceeded,
-        "ProcessFdQuotaExceeded" => crate::Error::ProcessFdQuotaExceeded,
-        "BadPathName" => crate::Error::BadPathName,
-        "FileTooBig" => crate::Error::FileTooBig,
-        "NoDevice" => crate::Error::NoDevice,
-        _ => crate::Error::Unexpected,
-    }
-}
-
 /// `preallocate_supported` / `preallocate_length` — these consts have
 /// no equivalent in `bun_sys` (only `preallocate_file()` exists there), so
 /// define them locally so the write-file fast path keeps its 2 MiB guard.
@@ -7715,9 +7688,12 @@ impl NodeFS {
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]
             let resolved = args.path.slice();
-            if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::Directory)
+            if let Err(mut errno) =
+                zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::Directory)
             {
-                let mut errno: E = map_anyerror_to_errno(&err);
+                if errno == E::EACCES {
+                    errno = E::EPERM;
+                }
                 if cfg!(windows) && errno == E::ENOTDIR {
                     errno = E::ENOENT;
                 }
@@ -7753,8 +7729,8 @@ impl NodeFS {
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]
             let resolved = args.path.slice();
-            if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File) {
-                if matches!(err, crate::Error::FileNotFound) {
+            if let Err(errno) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File) {
+                if errno == E::ENOENT {
                     if args.force {
                         return Ok(());
                     }
@@ -7764,11 +7740,7 @@ impl NodeFS {
                     return Err(sys::Error::from_code(E::ENOENT, sys::Tag::lstat)
                         .with_path(args.path.slice()));
                 }
-                return Err(sys::Error::from_code(
-                    map_anyerror_to_errno_rm_tree(&err),
-                    sys::Tag::rm,
-                )
-                .with_path(args.path.slice()));
+                return Err(sys::Error::from_code(errno, sys::Tag::rm).with_path(args.path.slice()));
             }
             return Ok(());
         }
@@ -9542,94 +9514,6 @@ impl ReaddirEntry for Buffer {
     }
 }
 
-// Lossless `E` ↔ `SystemErrno` cast. On POSIX they are the same type; on
-// Windows they are distinct `#[repr(u16)]` enums with identical discriminant
-// sets (see `SystemErrno::to_e`).
-#[inline]
-const fn e_as_system_errno(e: E) -> SystemErrno {
-    #[cfg(windows)]
-    {
-        SystemErrno::from_raw(e as u16)
-    }
-    #[cfg(not(windows))]
-    {
-        e
-    }
-}
-#[inline]
-const fn system_errno_as_e(e: SystemErrno) -> E {
-    #[cfg(windows)]
-    {
-        e.to_e()
-    }
-    #[cfg(not(windows))]
-    {
-        e
-    }
-}
-
-// There are three distinct error→errno tables: rmdir-recursive,
-// rm-recursive, and rm non-recursive unlink/rmdir. An earlier draft
-// collapsed them into one, which silently mapped AccessDenied→EPERM for `rm`
-// (Node returns EACCES there) and widened the narrow table. Split back out
-// per call site.
-fn map_anyerror_to_errno(err: &crate::Error) -> E {
-    // `dt_err` packs any errno without a named variant as `Sys(errno)` so the
-    // round-trip is lossless; unwrap it here before falling back to the name
-    // table.
-    if let crate::Error::Sys(e) = err {
-        return system_errno_as_e(*e);
-    }
-    match err.name() {
-        "AccessDenied" => E::EPERM,
-        "PermissionDenied" => E::EPERM,
-        "FileTooBig" => E::EFBIG,
-        "SymLinkLoop" => E::ELOOP,
-        "ProcessFdQuotaExceeded" => E::ENFILE,
-        "NameTooLong" => E::ENAMETOOLONG,
-        "SystemFdQuotaExceeded" => E::EMFILE,
-        "SystemResources" => E::ENOMEM,
-        "ReadOnlyFileSystem" => E::EROFS,
-        "FileSystem" => E::EIO,
-        "FileBusy" | "DeviceBusy" => E::EBUSY,
-        "DirNotEmpty" => E::ENOTEMPTY,
-        "NotDir" => E::ENOTDIR,
-        "NoDevice" => E::ENODEV,
-        "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
-        "FileNotFound" => E::ENOENT,
-        "IsDir" => E::EISDIR,
-        _ => E::EFAULT,
-    }
-}
-
-// `rm` recursive (zig_delete_tree) — same shape as the rmdir table above except
-// AccessDenied maps to EACCES, not EPERM.
-fn map_anyerror_to_errno_rm_tree(err: &crate::Error) -> E {
-    if let crate::Error::Sys(e) = err {
-        return system_errno_as_e(*e);
-    }
-    match err.name() {
-        "AccessDenied" => E::EACCES,
-        "PermissionDenied" => E::EPERM,
-        "DirNotEmpty" => E::ENOTEMPTY,
-        "FileTooBig" => E::EFBIG,
-        "SymLinkLoop" => E::ELOOP,
-        "ProcessFdQuotaExceeded" => E::ENFILE,
-        "NameTooLong" => E::ENAMETOOLONG,
-        "SystemFdQuotaExceeded" => E::EMFILE,
-        "SystemResources" => E::ENOMEM,
-        "ReadOnlyFileSystem" => E::EROFS,
-        "FileSystem" => E::EIO,
-        "FileBusy" | "DeviceBusy" => E::EBUSY,
-        "NotDir" => E::ENOTDIR,
-        "NoDevice" => E::ENODEV,
-        "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
-        "FileNotFound" => E::ENOENT,
-        "IsDir" => E::EISDIR,
-        _ => E::EFAULT,
-    }
-}
-
 // `rm` non-recursive unlink/rmdir fallback — narrower table; anything not
 // listed here falls through to EFAULT.
 //
@@ -9665,45 +9549,14 @@ pub unsafe extern "C" fn Bun__mkdirp(global_this: &JSGlobalObject, path: *const 
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// zig_delete_tree — recursive delete-tree. Returns `FileNotFound`
-// instead of ignoring it, which is required to match the behavior of Node.js's
+// zig_delete_tree — recursive delete-tree. Returns `ENOENT` instead of
+// ignoring it, which is required to match the behavior of Node.js's
 // `fs.rm` { recursive: true, force: false }.
 // ──────────────────────────────────────────────────────────────────────────
 
-// Implemented on top of
-// `bun_sys` primitives (`openat` + `unlinkat`) and *errno* values, mapping the
-// errno back to the error-set name strings the callers'
-// `map_anyerror_to_errno*` tables expect. The structure: 16-slot stack,
-// treat_as_dir flip-flop, close-then-deleteDir, retry-on-DirNotEmpty.
-
-#[inline]
-fn dt_err(errno: E) -> crate::Error {
-    // Reverse of the `map_anyerror_to_errno*` tables above — round-trip through
-    // the error-set name so existing callers don't have to change.
-    err_from_static(match errno {
-        E::ENOENT => "FileNotFound",
-        E::EACCES => "AccessDenied",
-        E::EPERM => "PermissionDenied",
-        E::ELOOP => "SymLinkLoop",
-        E::ENAMETOOLONG => "NameTooLong",
-        E::ENOMEM => "SystemResources",
-        E::EROFS => "ReadOnlyFileSystem",
-        E::EIO => "FileSystem",
-        E::EBUSY => "FileBusy",
-        E::ENOTDIR => "NotDir",
-        E::EISDIR => "IsDir",
-        E::ENOTEMPTY => "DirNotEmpty",
-        E::EMFILE => "SystemFdQuotaExceeded",
-        E::ENFILE => "ProcessFdQuotaExceeded",
-        E::EINVAL => "BadPathName",
-        E::EFBIG => "FileTooBig",
-        E::ENODEV => "NoDevice",
-        // Any errno without a named variant is carried raw so the caller's
-        // `map_anyerror_to_errno*` returns it unchanged instead of EFAULT
-        // (e.g. ENOSPC from overlayfs whiteout writes, EDQUOT, ESTALE, ETXTBSY).
-        _ => return crate::Error::Sys(e_as_system_errno(errno)),
-    })
-}
+// Implemented on top of `bun_sys` primitives (`openat` + `unlinkat`) and raw
+// errno values. The structure: 16-slot stack, treat_as_dir flip-flop,
+// close-then-deleteDir, retry-on-ENOTEMPTY.
 
 #[inline]
 fn dt_open_dir(parent: &sys::Dir, name: &[u8]) -> Result<sys::Dir, E> {
@@ -9798,7 +9651,7 @@ pub fn zig_delete_tree(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<()> {
+) -> Result<(), E> {
     let initial_iterable_dir =
         match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint)? {
             Some(d) => d,
@@ -9832,7 +9685,7 @@ pub fn zig_delete_tree(
             let entry = match stack[top_idx].iter.next() {
                 Ok(Some(e)) => e,
                 Ok(None) => break,
-                Err(err) => return Err(dt_err(err.get_errno())),
+                Err(err) => return Err(err.get_errno()),
             };
             // `entry.name` borrows the iterator's internal buffer and
             // is invalidated by the next `next()` call. Copy it once here so
@@ -9878,11 +9731,11 @@ pub fn zig_delete_tree(
                                     ),
                                     Err(E::ENOTEMPTY | E::EEXIST)
                                 ) {
-                                    return Err(dt_err(E::ENOTEMPTY));
+                                    return Err(E::ENOTEMPTY);
                                 }
-                                return Err(dt_err(e));
+                                return Err(e);
                             }
-                            Err(e) => return Err(dt_err(e)),
+                            Err(e) => return Err(e),
                         }
                     } else {
                         let top_fd = stack[top_idx].iter.iter.dir;
@@ -9921,15 +9774,15 @@ pub fn zig_delete_tree(
                                 ),
                                 Err(E::ENOTEMPTY | E::EEXIST)
                             ) {
-                                return Err(dt_err(E::ENOTEMPTY));
+                                return Err(E::ENOTEMPTY);
                             }
-                            return Err(dt_err(e));
+                            return Err(e);
                         }
                         // "EPERM because it's a directory" is OS-dependent
                         // (Linux returns EISDIR; macOS returns EPERM). We only
                         // get errno, so forward EPERM as PermissionDenied —
                         // caller maps it.
-                        Err(e) => return Err(dt_err(e)),
+                        Err(e) => return Err(e),
                     }
                 }
             }
@@ -9975,12 +9828,12 @@ pub fn zig_delete_tree(
                         dt_delete_dir(sys::Dir::borrow(&ancestor.parent_dir), ancestor_name),
                         Err(E::ENOTEMPTY | E::EEXIST)
                     ) {
-                        return Err(dt_err(E::ENOTEMPTY));
+                        return Err(E::ENOTEMPTY);
                     }
                 }
-                return Err(dt_err(e));
+                return Err(e);
             }
-            Err(e) => return Err(dt_err(e)),
+            Err(e) => return Err(e),
         }
 
         if need_to_retry {
@@ -9999,7 +9852,7 @@ pub fn zig_delete_tree(
                             // That's fine, we were trying to remove this directory anyway.
                             continue 'process_stack;
                         }
-                        Err(e) => return Err(dt_err(e)),
+                        Err(e) => return Err(e),
                     }
                 } else {
                     match dt_delete_file(sys::Dir::borrow(&parent_dir), name) {
@@ -10009,14 +9862,10 @@ pub fn zig_delete_tree(
                             treat_as_dir = true;
                             continue 'handle_entry;
                         }
-                        Err(E::ENOTDIR) => {
-                            #[cfg(debug_assertions)]
-                            unreachable!();
-                            // "Unexpected" → caller's fallthrough arm = EFAULT.
-                            #[cfg(not(debug_assertions))]
-                            return Err(err_from_static("Unexpected"));
+                        Err(e) => {
+                            debug_assert_ne!(e, E::ENOTDIR);
+                            return Err(e);
                         }
-                        Err(e) => return Err(dt_err(e)),
                     }
                 }
             };
@@ -10038,17 +9887,17 @@ fn zig_delete_tree_open_initial_subpath(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<Option<sys::Dir>> {
+) -> Result<Option<sys::Dir>, E> {
     // Treat as a file by default
     let mut treat_as_dir = kind_hint == sys::FileKind::Directory;
     loop {
         if treat_as_dir {
             return match dt_open_dir(self_, sub_path) {
                 Ok(d) => Ok(Some(d)),
-                // NotDir/FileNotFound surface here (no fall-through to
-                // deleteFile) — deliberate, so `FileNotFound` propagates
-                // (see the zig_delete_tree banner above).
-                Err(e) => Err(dt_err(e)),
+                // ENOTDIR/ENOENT surface here (no fall-through to deleteFile) —
+                // deliberate, so ENOENT propagates (see the zig_delete_tree
+                // banner above).
+                Err(e) => Err(e),
             };
         } else {
             match dt_delete_file(self_, sub_path) {
@@ -10057,7 +9906,7 @@ fn zig_delete_tree_open_initial_subpath(
                     treat_as_dir = true;
                     continue;
                 }
-                Err(e) => return Err(dt_err(e)),
+                Err(e) => return Err(e),
             }
         }
     }
@@ -10067,7 +9916,7 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<()> {
+) -> Result<(), E> {
     'start_over: loop {
         let mut dir = match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint)? {
             Some(d) => d,
@@ -10089,13 +9938,13 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
         // Here we must avoid recursion, in order to provide O(1) memory guarantee of this function.
         // Go through each entry and if it is not a directory, delete it. If it is a directory,
         // open it, and close the original directory. Repeat. Then start the entire operation over.
-        let result: crate::Result<()> = 'scan_dir: loop {
+        let result: Result<(), E> = 'scan_dir: loop {
             let mut dir_it = DirIterator::WrappedIterator::init(dir.fd);
             'dir_it: loop {
                 let entry = match dir_it.next() {
                     Ok(Some(e)) => e,
                     Ok(None) => break 'dir_it,
-                    Err(err) => break 'scan_dir Err(dt_err(err.get_errno())),
+                    Err(err) => break 'scan_dir Err(err.get_errno()),
                 };
                 let entry_name: Vec<u8> = entry.name.slice().to_vec();
                 let mut treat_as_dir = entry.kind == sys::FileKind::Directory;
@@ -10119,7 +9968,7 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                                 // That's fine, we were trying to remove this directory anyway.
                                 continue 'dir_it;
                             }
-                            Err(e) => break 'scan_dir Err(dt_err(e)),
+                            Err(e) => break 'scan_dir Err(e),
                         }
                     } else {
                         match dt_delete_file(&dir, &entry_name) {
@@ -10129,14 +9978,10 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                                 treat_as_dir = true;
                                 continue 'handle_entry;
                             }
-                            Err(E::ENOTDIR) => {
-                                #[cfg(debug_assertions)]
-                                unreachable!();
-                                // "Unexpected" → caller's fallthrough arm = EFAULT.
-                                #[cfg(not(debug_assertions))]
-                                break 'scan_dir Err(err_from_static("Unexpected"));
+                            Err(e) => {
+                                debug_assert_ne!(e, E::ENOTDIR);
+                                break 'scan_dir Err(e);
                             }
-                            Err(e) => break 'scan_dir Err(dt_err(e)),
                         }
                     }
                 }
@@ -10157,14 +10002,14 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                         continue 'start_over;
                     }
                     Err(e) => {
-                        return Err(dt_err(e));
+                        return Err(e);
                     }
                 }
             } else {
                 match dt_delete_dir(self_, sub_path) {
                     Ok(()) | Err(E::ENOENT) => return Ok(()),
                     Err(E::ENOTEMPTY) | Err(E::EEXIST) => continue 'start_over,
-                    Err(e) => return Err(dt_err(e)),
+                    Err(e) => return Err(e),
                 }
             }
         };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9779,9 +9779,9 @@ pub fn zig_delete_tree(
                             return Err(e);
                         }
                         // "EPERM because it's a directory" is OS-dependent
-                        // (Linux returns EISDIR; macOS returns EPERM). We only
-                        // get errno, so forward EPERM as PermissionDenied —
-                        // caller maps it.
+                        // (Linux returns EISDIR; macOS returns EPERM), so at
+                        // this layer EPERM-on-directory is indistinguishable
+                        // from a real permission error.
                         Err(e) => return Err(e),
                     }
                 }

--- a/test/js/node/fs/rm-recursive-errno-passthrough.test.ts
+++ b/test/js/node/fs/rm-recursive-errno-passthrough.test.ts
@@ -5,8 +5,8 @@
 // errnos the errno→name table did not list) deterministically.
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
-import { join } from "node:path";
 import { constants as osConstants } from "node:os";
+import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 

--- a/test/js/node/fs/rm-recursive-errno-passthrough.test.ts
+++ b/test/js/node/fs/rm-recursive-errno-passthrough.test.ts
@@ -31,33 +31,34 @@ int unlinkat(int dirfd, const char *path, int flags) {
 }
 `;
 
-// The child builds a small tree, calls all three rm entry points (sync / promise /
-// callback) with { recursive: true, force: true }, and prints each error code.
+// The child builds a small tree under $TREE_ROOT (inside the parent test's
+// tempDir, so afterAll cleans up whatever the failing rm leaves behind), calls
+// all three rm entry points with { recursive: true, force: true }, and prints
+// each result as `<label> <code> <errno>`.
 const FIXTURE = /* js */ `
 import fs from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const make = () => {
-  const root = fs.mkdtempSync(join(tmpdir(), "rm-errno-"));
-  fs.mkdirSync(join(root, "sub"));
+const make = name => {
+  const root = join(process.env.TREE_ROOT, name);
+  fs.mkdirSync(join(root, "sub"), { recursive: true });
   fs.writeFileSync(join(root, "sub", "POISON_FILE"), "x");
   fs.writeFileSync(join(root, "sub", "ok.txt"), "x");
   return root;
 };
-const report = e => JSON.stringify({ code: e?.code ?? null, errno: e?.errno ?? null });
+const report = (label, e) => console.log(label, e ? e.code + " " + e.errno : "ok");
 
-let root = make();
-try { fs.rmSync(root, { recursive: true, force: true }); console.log("sync", report(null)); }
-catch (e) { console.log("sync", report(e)); }
+let root = make("sync");
+try { fs.rmSync(root, { recursive: true, force: true }); report("sync", null); }
+catch (e) { report("sync", e); }
 
-root = make();
+root = make("promise");
 await fs.promises.rm(root, { recursive: true, force: true })
-  .then(() => console.log("promise", report(null)), e => console.log("promise", report(e)));
+  .then(() => report("promise", null), e => report("promise", e));
 
-root = make();
+root = make("callback");
 await new Promise(done => fs.rm(root, { recursive: true, force: true },
-  e => { console.log("callback", report(e)); done(); }));
+  e => { report("callback", e); done(); }));
 `;
 
 let dir: ReturnType<typeof tempDir>;
@@ -94,54 +95,36 @@ const run = async (errno: number) => {
       LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
       FAIL_UNLINKAT_NEEDLE: "POISON_FILE",
       FAIL_UNLINKAT_ERRNO: String(errno),
+      TREE_ROOT: join(String(dir), `trees-${errno}`),
     },
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const lines: Record<string, { code: string | null; errno: number | null }> = {};
-  for (const line of stdout.trim().split("\n")) {
-    const [label, json] = line.split(" ", 2);
-    lines[label] = JSON.parse(json);
-  }
-  return { lines, stderr, exitCode };
+  return { stdout, stderr, exitCode };
 };
 
 describe.skipIf(!isLinux || !cc)("rm({recursive:true}) reports the kernel errno, not EFAULT", () => {
-  // ENOSPC / ETXTBSY are defined on every Linux; EDQUOT / ESTALE are present on
-  // every glibc/musl target CI runs but guarded for completeness.
+  // First five were collapsed to EFAULT on main; EACCES/EBUSY/EROFS already
+  // worked and are here as a regression guard. Defined on every Linux target
+  // CI runs; the filter is defensive.
   const cases = (
     [
       ["ENOSPC", osConstants.errno.ENOSPC],
       ["ETXTBSY", osConstants.errno.ETXTBSY],
       ["EDQUOT", osConstants.errno.EDQUOT],
       ["ESTALE", osConstants.errno.ESTALE],
+      ["ENODEV", osConstants.errno.ENODEV],
+      ["EACCES", osConstants.errno.EACCES],
+      ["EBUSY", osConstants.errno.EBUSY],
+      ["EROFS", osConstants.errno.EROFS],
     ] as const
   ).filter(([, n]) => typeof n === "number");
 
   test.concurrent.each(cases)("%s", async (name, errno) => {
-    const { lines, stderr, exitCode } = await run(errno);
-    const want = { code: name, errno: -errno };
-    expect({ lines, stderr, exitCode }).toEqual({
-      lines: { sync: want, promise: want, callback: want },
-      stderr: "",
-      exitCode: 0,
-    });
-  });
-
-  // Errnos that already had a named variant must keep round-tripping unchanged.
-  const namedCases = [
-    ["ENOENT", osConstants.errno.ENOENT, null], // force:true swallows ENOENT
-    ["EACCES", osConstants.errno.EACCES, "EACCES"],
-    ["EBUSY", osConstants.errno.EBUSY, "EBUSY"],
-    ["EROFS", osConstants.errno.EROFS, "EROFS"],
-  ] as const;
-
-  test.concurrent.each(namedCases)("%s (named variant still round-trips)", async (_name, errno, wantCode) => {
-    const { lines, stderr, exitCode } = await run(errno);
-    const want = wantCode === null ? { code: null, errno: null } : { code: wantCode, errno: -errno };
-    expect({ lines, stderr, exitCode }).toEqual({
-      lines: { sync: want, promise: want, callback: want },
+    const line = `${name} ${-errno}`;
+    expect(await run(errno)).toEqual({
+      stdout: `sync ${line}\npromise ${line}\ncallback ${line}\n`,
       stderr: "",
       exitCode: 0,
     });

--- a/test/js/node/fs/rm-recursive-errno-passthrough.test.ts
+++ b/test/js/node/fs/rm-recursive-errno-passthrough.test.ts
@@ -1,0 +1,149 @@
+// Recursive fs.rm must report the errno the kernel actually returned, not
+// EFAULT. The original field repro was overlayfs at 100% disk: deleting a
+// lower-layer file requires writing a whiteout in the upper layer, which fails
+// with ENOSPC. An LD_PRELOAD shim reproduces that (and a handful of other
+// errnos the errno→name table did not list) deterministically.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+import { constants as osConstants } from "node:os";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int (*real_unlinkat)(int, const char *, int);
+
+int unlinkat(int dirfd, const char *path, int flags) {
+  if (!real_unlinkat) real_unlinkat = dlsym(RTLD_NEXT, "unlinkat");
+  const char *needle = getenv("FAIL_UNLINKAT_NEEDLE");
+  if (needle && path && strstr(path, needle)) {
+    const char *e = getenv("FAIL_UNLINKAT_ERRNO");
+    errno = e ? atoi(e) : ENOSPC;
+    return -1;
+  }
+  return real_unlinkat(dirfd, path, flags);
+}
+`;
+
+// The child builds a small tree, calls all three rm entry points (sync / promise /
+// callback) with { recursive: true, force: true }, and prints each error code.
+const FIXTURE = /* js */ `
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const make = () => {
+  const root = fs.mkdtempSync(join(tmpdir(), "rm-errno-"));
+  fs.mkdirSync(join(root, "sub"));
+  fs.writeFileSync(join(root, "sub", "POISON_FILE"), "x");
+  fs.writeFileSync(join(root, "sub", "ok.txt"), "x");
+  return root;
+};
+const report = e => JSON.stringify({ code: e?.code ?? null, errno: e?.errno ?? null });
+
+let root = make();
+try { fs.rmSync(root, { recursive: true, force: true }); console.log("sync", report(null)); }
+catch (e) { console.log("sync", report(e)); }
+
+root = make();
+await fs.promises.rm(root, { recursive: true, force: true })
+  .then(() => console.log("promise", report(null)), e => console.log("promise", report(e)));
+
+root = make();
+await new Promise(done => fs.rm(root, { recursive: true, force: true },
+  e => { console.log("callback", report(e)); done(); }));
+`;
+
+let dir: ReturnType<typeof tempDir>;
+let shimPath: string;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  dir = tempDir("rm-errno-fault", {
+    "shim.c": SHIM_C,
+    "fixture.js": FIXTURE,
+  });
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr}`);
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+const run = async (errno: number) => {
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+      FAIL_UNLINKAT_NEEDLE: "POISON_FILE",
+      FAIL_UNLINKAT_ERRNO: String(errno),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const lines: Record<string, { code: string | null; errno: number | null }> = {};
+  for (const line of stdout.trim().split("\n")) {
+    const [label, json] = line.split(" ", 2);
+    lines[label] = JSON.parse(json);
+  }
+  return { lines, stderr, exitCode };
+};
+
+describe.skipIf(!isLinux || !cc)("rm({recursive:true}) reports the kernel errno, not EFAULT", () => {
+  // ENOSPC / ETXTBSY are defined on every Linux; EDQUOT / ESTALE are present on
+  // every glibc/musl target CI runs but guarded for completeness.
+  const cases = (
+    [
+      ["ENOSPC", osConstants.errno.ENOSPC],
+      ["ETXTBSY", osConstants.errno.ETXTBSY],
+      ["EDQUOT", osConstants.errno.EDQUOT],
+      ["ESTALE", osConstants.errno.ESTALE],
+    ] as const
+  ).filter(([, n]) => typeof n === "number");
+
+  test.concurrent.each(cases)("%s", async (name, errno) => {
+    const { lines, stderr, exitCode } = await run(errno);
+    const want = { code: name, errno: -errno };
+    expect({ lines, stderr, exitCode }).toEqual({
+      lines: { sync: want, promise: want, callback: want },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Errnos that already had a named variant must keep round-tripping unchanged.
+  const namedCases = [
+    ["ENOENT", osConstants.errno.ENOENT, null], // force:true swallows ENOENT
+    ["EACCES", osConstants.errno.EACCES, "EACCES"],
+    ["EBUSY", osConstants.errno.EBUSY, "EBUSY"],
+    ["EROFS", osConstants.errno.EROFS, "EROFS"],
+  ] as const;
+
+  test.concurrent.each(namedCases)("%s (named variant still round-trips)", async (_name, errno, wantCode) => {
+    const { lines, stderr, exitCode } = await run(errno);
+    const want = wantCode === null ? { code: null, errno: null } : { code: wantCode, errno: -errno };
+    expect({ lines, stderr, exitCode }).toEqual({
+      lines: { sync: want, promise: want, callback: want },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
## What

`fs.rmSync` / `fs.promises.rm` / `fs.rm` with `{ recursive: true }` reported

```
EFAULT: bad address in system call argument, rm '<path>'
```

when any syscall in the recursive walk failed with an errno the internal mapping table did not list. No bad pointer ever reached the kernel; the real errno was discarded and replaced with `EFAULT`.

## Repro

The field report was `rmSync('/workspace/bun/vendor/tinycc', { recursive: true, force: true })` on an overlayfs mount near 100% disk. Deleting a file that exists in the lower layer requires writing a whiteout entry in the upper layer; with the upper filesystem full, `unlinkat(2)` returns **ENOSPC**.

Reproducible deterministically with an LD_PRELOAD shim that makes `unlinkat` fail with a chosen errno for a marked filename (what the new test does):

```
$ FAIL_UNLINKAT_ERRNO=28 bun -e '... fs.rmSync(root,{recursive:true,force:true}) ...'
code=EFAULT errno=-14 msg=EFAULT: bad address in system call argument, rm '/tmp/rmf-...'
```

Bun's own `fs.unlinkSync` on the same path reports `ENOSPC`, and Node's `fs.promises.rm` / callback `fs.rm` both report `ENOSPC`.

## Cause

`zig_delete_tree` (the recursive walk) round-tripped every syscall errno through a Zig-port artifact: `E -> dt_err -> name string -> err_from_static -> crate::Error -> err.name() -> map_anyerror_to_errno* -> E`. `dt_err` listed 17 errnos and mapped everything else to `"Unexpected"`; the reverse tables mapped any unlisted name to `E::EFAULT`. So `ENOSPC -> "Unexpected" -> EFAULT`, and likewise for `EDQUOT`, `ESTALE`, `ETXTBSY`, `ENODEV`, `EOPNOTSUPP` and anything else not in the list.

The four-table apparatus has exactly two callers, both in `node_fs.rs`, and after the identity rows cancel it encodes a single non-identity mapping: `rmdir`'s `EACCES -> EPERM`.

## Fix

`zig_delete_tree` (and its two helpers) now return `Result<(), E>` directly. `dt_err`, `err_from_static`, `map_anyerror_to_errno` and `map_anyerror_to_errno_rm_tree` are deleted; the `rmdir` caller keeps its one `EACCES -> EPERM` remap inline and the `rm` caller matches `E::ENOENT` for the `force` handling. The kernel errno now reaches the user unchanged, matching `fs.unlinkSync` and Node's `fs.promises.rm` / callback `fs.rm`.

Related: #33436 addresses the same `EFAULT` default on the **non**-recursive `unlink` branch (`map_rm_errno_narrow`); that table is untouched here so the two PRs do not overlap.

## Verification

New `test/js/node/fs/rm-recursive-errno-passthrough.test.ts` compiles an LD_PRELOAD shim that makes `unlinkat` on a marked child fail with each of `ENOSPC` / `ETXTBSY` / `EDQUOT` / `ESTALE` / `ENODEV`, and asserts all three entry points (`rmSync` / `promises.rm` / callback `rm`) report that exact `code`/`errno`. It also re-exercises `EACCES` / `EBUSY` / `EROFS` as a regression guard.

- 5 of 8 tests fail on `main` (all five errnos surface as `EFAULT`); 8/8 pass with this change.
- `test/js/node/fs/fs.test.ts -t '^rm'` and `test/js/node/test/parallel/test-fs-rm*` all pass.
- `bun run rust:check-all` green across all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/rm-recursive-errno-passthrough.test.ts

<!-- robobun:evidence:end -->