### PR TITLE
build(linux): enable full RELRO, stack canaries, and _FORTIFY_SOURCE=3

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1306,7 +1306,7 @@ static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, 
             memcpy(dirname_buf, path, dirname_len);
             dirname_buf[dirname_len] = 0;
 
-            int socket_dir_fd = open(dirname_buf, O_CLOEXEC | O_PATH | O_DIRECTORY, 0700);
+            int socket_dir_fd = open(dirname_buf, O_CLOEXEC | O_PATH | O_DIRECTORY);
             if (socket_dir_fd == -1) {
                 errno = ENAMETOOLONG;
                 return LIBUS_SOCKET_ERROR;

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -439,8 +439,9 @@ export interface Toolchain {
   rustHostTriple: string | undefined;
   strip: string;
   /**
-   * llvm-strip. On Linux hosts GNU strip is the default (`strip` above) but
-   * can't read Mach-O, so darwin cross-compiles swap this in as `cfg.strip`.
+   * llvm-strip. Preferred as `cfg.strip` on Linux (GNU strip's -R drops
+   * PT_GNU_RELRO) and for darwin cross-compiles (GNU strip can't read
+   * Mach-O). Optional: GNU strip remains the fallback.
    */
   llvmStrip: string | undefined;
   dsymutil: string | undefined;
@@ -1227,16 +1228,21 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     rustLld: toolchain.rustLld,
     rustLlvmVersion: toolchain.rustLlvmVersion,
     rustSysroot: toolchain.rustSysroot,
-    // Cross strips: linux-gnu uses <triple>-strip (GNU, handles -R .eh_frame
-    // fully; host strip rejects foreign-arch ELF); other cross targets use
-    // llvm-strip.
+    // Linux strips with llvm-strip whenever it's available. GNU strip's
+    // `-R <section>` (stripFlags on release-gnu) rewrites program headers
+    // from the section table and drops PT_GNU_RELRO in the process, silently
+    // undoing `-z relro -z now` on the shipped binary. llvm-strip keeps
+    // PT_GNU_RELRO; it leaves the removed sections' file extent as a zero
+    // gap in LOAD[0] instead of compacting it (~+0.8 MB on-disk, no RSS
+    // cost since nothing reads that range). Non-linux targets already use
+    // llvm-strip. GNU strip stays the last-resort fallback.
     strip:
       ld64StripSwap?.strip ??
-      (crossTarget !== undefined
-        ? linux && abi === "gnu" && existsSync(`/usr/bin/${crossTarget}-strip`)
-          ? `/usr/bin/${crossTarget}-strip`
-          : (toolchain.llvmStrip ?? toolchain.strip)
-        : toolchain.strip),
+      (linux
+        ? (toolchain.llvmStrip ?? toolchain.strip)
+        : crossTarget !== undefined
+          ? (toolchain.llvmStrip ?? toolchain.strip)
+          : toolchain.strip),
     dsymutil: toolchain.dsymutil,
     bun: toolchain.bun,
     jsRuntime: toolchain.jsRuntime,

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -435,11 +435,33 @@ export const globalFlags: Flag[] = [
     desc: "Assume no symbol interposition (enables more inlining across TUs)",
   },
 
-  // ─── Hardening (assertions builds) ───
+  // ─── Hardening ───
+  // Tranche 1: mitigations that work unchanged under the existing -no-pie
+  // link. PIE/ASLR is intentionally NOT here: flipping it moves JSC/WTF
+  // const-pointer tables from .rodata into .data.rel.ro (see
+  // deps/webkit.ts for the ~550 KB RW-vtable trade) and forces every
+  // direct dep to rebuild -fPIC. That is a separate change with its own
+  // size/RSS/rebuild cost to measure.
   {
     flag: "-fno-delete-null-pointer-checks",
     when: c => c.assertions,
     desc: "Don't optimize out null checks (hardening)",
+  },
+  {
+    flag: "-fstack-protector-strong",
+    when: c => c.unix,
+    desc: "Stack canaries on functions with local arrays / address-taken locals (C/C++ only; Rust side needs -Zstack-protector separately)",
+  },
+  {
+    // -U first: distro toolchains (and glibc's own features.h under -O) may
+    // predefine it, and redefining at a different level is a hard error.
+    // Level 3 adds _FORTIFY_SOURCE dynamic __builtin_dynamic_object_size
+    // checks (glibc ≥ 2.34); older glibc transparently falls back to 2.
+    // Release-only because it requires -O1+; !asan because ASAN already
+    // interposes the same libc entry points and the two fight.
+    flag: ["-U_FORTIFY_SOURCE", "-D_FORTIFY_SOURCE=3"],
+    when: c => c.linux && c.release && !c.asan,
+    desc: "glibc fortified libc wrappers (compile-time + runtime bounds on memcpy/sprintf/...)",
   },
 
   // ─── Diagnostics ───
@@ -1234,8 +1256,12 @@ export const linkerFlags: Flag[] = [
     flag: [
       "-Wl,--as-needed",
       "-Wl,-z,stack-size=12800000",
-      "-Wl,-z,lazy",
-      "-Wl,-z,norelro",
+      // Full RELRO. We link ~428 PLT slots; eager-binding them at startup
+      // is unmeasurable against a JSC VM init, and it lets ld.so remap
+      // .got/.got.plt/.data.rel.ro read-only so a write-what-where can't
+      // retarget a libc call. Replaces the historical -z lazy / -z norelro.
+      "-Wl,-z,relro",
+      "-Wl,-z,now",
       // (no --pack-dyn-relocs=relr: DT_RELR needs glibc ≥ 2.36 to load,
       // and we wrap symbols for portability down to 2.17. With -no-pie
       // there are <500 R_*_RELATIVE entries anyway — not worth the compat
@@ -1254,7 +1280,7 @@ export const linkerFlags: Flag[] = [
       "-Wl,--build-id=sha1",
     ],
     when: c => c.linux,
-    desc: "Linux linker tuning: lazy binding, large stack, fast gdb loading",
+    desc: "Linux linker tuning: full RELRO, large stack, fast gdb loading",
   },
   {
     flag: "-Wl,--gc-sections",
@@ -1485,17 +1511,19 @@ export const stripFlags: Flag[] = [
     // musl: no eh_frame handling differences, but CMake gates on NOT musl so we do too.
     //
     // Gated on release to match -Wl,--no-eh-frame-hdr in linkerFlags above
-    // (both fire on `c.linux && c.abi === "gnu" && c.release`). GNU strip
-    // does not rewrite the program header table, so the PT_GNU_EH_FRAME
-    // phdr must already be absent at link time — which the matching
-    // --no-eh-frame-hdr above guarantees. Nothing unwinds at runtime
-    // (`panic = "abort"`, `-fno-exceptions`); release backtraces use frame
-    // pointers. Saves ~962 KB of R-segment (.eh_frame 806 KB +
-    // .eh_frame_hdr 142 KB + .gcc_except_table 13 KB) that otherwise gets
-    // dragged into RSS via 64 KB fault-around on adjacent .rodata reads.
+    // (both fire on `c.linux && c.abi === "gnu" && c.release`). Nothing
+    // unwinds at runtime (`panic = "abort"`, `-fno-exceptions`); release
+    // backtraces use frame pointers.
+    //
+    // Runs under llvm-strip (see config.ts `strip:`), which zeroes these
+    // sections in place rather than compacting LOAD[0], so the on-disk win
+    // is smaller than GNU strip's (~0.8 MB of zero gap left behind). We
+    // accept that because GNU strip's -R rewrites the program-header table
+    // from sections and drops PT_GNU_RELRO, undoing full RELRO on the
+    // shipped binary. The zero gap is never faulted at runtime.
     flag: ["-R", ".eh_frame", "-R", ".eh_frame_hdr", "-R", ".gcc_except_table"],
     when: c => c.linux && c.abi === "gnu" && c.release,
-    desc: "Remove unwind sections (GNU strip required — llvm-strip leaves [LOAD #2 [R]])",
+    desc: "Remove unwind sections (llvm-strip; GNU strip's -R drops PT_GNU_RELRO)",
   },
 ];
 

--- a/scripts/verify-hardening.sh
+++ b/scripts/verify-hardening.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Usage: scripts/verify-hardening.sh <path-to-bun>
+#
+# Prints a hardening truth table for a Linux bun binary using readelf and a
+# live /proc/<pid>/maps probe, then a PASS/FAIL line per control. Exit status
+# is the FAIL count.
+#
+# Controls checked:
+#   PIE       ET_DYN (image participates in ASLR)
+#   RELRO     GNU_RELRO segment present + DT_BIND_NOW (full RELRO)
+#   CANARY    __stack_chk_fail imported
+#   FORTIFY   at least one __*_chk@ libc import
+#   CET       x86 IBT/SHSTK feature bits in .note.gnu.property
+#   NX        GNU_STACK is RW, not RWE
+#   JIT-W^X   no rwx mapping in a live process
+#
+# PIE/CET/JIT-W^X are expected FAIL today (tranche 2+). RELRO/CANARY/FORTIFY
+# are the tranche-1 targets this patch flips to PASS.
+
+set -uo pipefail
+
+BIN=${1:?"usage: $0 <binary>"}
+[[ -r "$BIN" ]] || { echo "error: cannot read $BIN" >&2; exit 64; }
+
+readelf=${READELF:-readelf}
+hdr=$("$readelf" -hW "$BIN" 2>/dev/null)
+seg=$("$readelf" -lW "$BIN" 2>/dev/null)
+dyn=$("$readelf" -dW "$BIN" 2>/dev/null)
+dynsym=$("$readelf" --dyn-syms -W "$BIN" 2>/dev/null)
+notes=$("$readelf" -nW "$BIN" 2>/dev/null)
+
+elf_type=$(grep -oE 'Type:[[:space:]]+[A-Z]+' <<<"$hdr" | awk '{print $2}')
+has_relro=$(grep -c 'GNU_RELRO' <<<"$seg")
+has_bindnow=$(grep -cE 'BIND_NOW|FLAGS_1.*\bNOW\b' <<<"$dyn")
+stack_perm=$(grep 'GNU_STACK' <<<"$seg" | grep -oE 'RW[E ]' | tr -d ' ')
+n_canary=$(grep -c '__stack_chk_fail' <<<"$dynsym")
+n_fortify=$(grep -cE '__[a-z_]+_chk(@|$)' <<<"$dynsym")
+has_cet=$(grep -cE 'IBT|SHSTK|x86 feature:' <<<"$notes")
+n_plt=$("$readelf" -rW "$BIN" 2>/dev/null | grep -c JUMP_SLOT)
+
+# Live probe: start the binary, read its maps, look for rwx and record the
+# image base (so repeated invocations show whether ASLR moved it).
+rwx_count="n/a"
+rwx_detail=""
+image_base="n/a"
+if [[ -x "$BIN" ]]; then
+  maps=$("$BIN" -e '
+    const fs = require("fs");
+    process.stdout.write(fs.readFileSync("/proc/self/maps","utf8"));
+  ' 2>/dev/null)
+  if [[ -n "$maps" ]]; then
+    rwx_count=$(grep -cE '\brwx' <<<"$maps")
+    rwx_detail=$(grep -E '\brwx' <<<"$maps" | head -1 | awk '{print $1, $NF}')
+    image_base=$(head -1 <<<"$maps" | cut -d- -f1)
+  fi
+fi
+
+row() { printf '  %-10s %-6s %s\n' "$1" "$2" "$3"; }
+off_on() { [[ "$1" -gt 0 ]] && echo ON || echo OFF; }
+
+echo "hardening: $BIN"
+echo
+row CONTROL STATE EVIDENCE
+row PIE     "$([[ "$elf_type" == DYN ]] && echo ON || echo OFF)" "ELF type=$elf_type, image base=$image_base"
+row RELRO   "$([[ "$has_relro" -gt 0 && "$has_bindnow" -gt 0 ]] && echo full || { [[ "$has_relro" -gt 0 ]] && echo part || echo OFF; })" "GNU_RELRO=$has_relro BIND_NOW=$has_bindnow PLT=$n_plt"
+row CANARY  "$(off_on "$n_canary")" "__stack_chk_fail imports=$n_canary"
+row FORTIFY "$(off_on "$n_fortify")" "*_chk imports=$n_fortify"
+row CET     "$(off_on "$has_cet")" "$([[ "$has_cet" -gt 0 ]] && grep -E 'IBT|SHSTK' <<<"$notes" | head -1 | xargs || echo 'no .note.gnu.property x86 feature')"
+row NX      "$([[ "$stack_perm" == RW ]] && echo ON || echo OFF)" "GNU_STACK=$stack_perm"
+row JIT-W^X "$([[ "$rwx_count" == 0 ]] && echo ON || echo OFF)" "rwx maps=$rwx_count${rwx_detail:+ ($rwx_detail)}"
+echo
+
+fails=()
+[[ "$elf_type" == DYN ]]                               || fails+=(PIE)
+[[ "$has_relro" -gt 0 && "$has_bindnow" -gt 0 ]]       || fails+=(RELRO)
+[[ "$n_canary" -gt 0 ]]                                || fails+=(CANARY)
+[[ "$n_fortify" -gt 0 ]]                               || fails+=(FORTIFY)
+[[ "$has_cet" -gt 0 ]]                                 || fails+=(CET)
+[[ "$stack_perm" == RW ]]                              || fails+=(NX)
+[[ "$rwx_count" == 0 || "$rwx_count" == "n/a" ]]       || fails+=(JIT-W^X)
+
+if [[ ${#fails[@]} -eq 0 ]]; then
+  echo "PASS: all controls"
+else
+  echo "FAIL: ${fails[*]}"
+fi
+exit ${#fails[@]}

--- a/src/exe_format/elf.rs
+++ b/src/exe_format/elf.rs
@@ -30,6 +30,8 @@ pub enum ElfError {
     BunSectionNotFound,
     #[error("NoWritableLoadSegment")]
     NoWritableLoadSegment,
+    #[error("LoadSegmentPastWritableSegment")]
+    LoadSegmentPastWritableSegment,
     #[error("NewVaddrCollides")]
     NewVaddrCollides,
 }
@@ -223,14 +225,8 @@ impl ElfFile {
         // flags). Growing an existing PT_LOAD is the layout a linker would
         // naturally produce; WSL1's kernel loader rejects binaries that
         // instead add a late PT_LOAD by repurposing PT_GNU_STACK (#29963).
-        //
-        // With `-z relro -z now` lld emits TWO PF_W PT_LOADs: the RELRO
-        // segment (.data.rel.ro/.got/.got.plt) first, then the regular
-        // .data/.bss segment. .bun is mutable initialized data so it is in
-        // the second one. We therefore select the PF_W PT_LOAD whose file
-        // extent ends last, and assert it is also the last PT_LOAD overall
-        // so the "everything past its file bytes is non-ALLOC tail" move
-        // below is sound.
+        // `-z relro` links have two PF_W PT_LOADs (RELRO then .data/.bss);
+        // .bun is mutable data so it's in the one with the highest file end.
         let phdr_size = size_of::<Elf64_Phdr>();
         let mut rw_phdr_index: Option<usize> = None;
         let mut rw_phdr: Elf64_Phdr = Elf64_Phdr::ZEROED;
@@ -265,9 +261,7 @@ impl ElfFile {
             return Err(ElfError::NoWritableLoadSegment);
         };
         if rw_phdr.p_offset + rw_phdr.p_filesz != max_load_file_end {
-            // A PT_LOAD with file bytes past the selected RW segment would be
-            // clobbered by the tail relocation below.
-            return Err(ElfError::InvalidElfFile);
+            return Err(ElfError::LoadSegmentPastWritableSegment);
         }
 
         // Place the new data at a page-aligned virtual address past every

--- a/src/exe_format/elf.rs
+++ b/src/exe_format/elf.rs
@@ -225,8 +225,7 @@ impl ElfFile {
         // flags). Growing an existing PT_LOAD is the layout a linker would
         // naturally produce; WSL1's kernel loader rejects binaries that
         // instead add a late PT_LOAD by repurposing PT_GNU_STACK (#29963).
-        // `-z relro` links have two PF_W PT_LOADs (RELRO then .data/.bss);
-        // .bun is mutable data so it's in the one with the highest file end.
+        // `-z relro` emits two PF_W loads; .bun is in the one that ends last.
         let phdr_size = size_of::<Elf64_Phdr>();
         let mut rw_phdr_index: Option<usize> = None;
         let mut rw_phdr: Elf64_Phdr = Elf64_Phdr::ZEROED;

--- a/src/exe_format/elf.rs
+++ b/src/exe_format/elf.rs
@@ -223,10 +223,19 @@ impl ElfFile {
         // flags). Growing an existing PT_LOAD is the layout a linker would
         // naturally produce; WSL1's kernel loader rejects binaries that
         // instead add a late PT_LOAD by repurposing PT_GNU_STACK (#29963).
+        //
+        // With `-z relro -z now` lld emits TWO PF_W PT_LOADs: the RELRO
+        // segment (.data.rel.ro/.got/.got.plt) first, then the regular
+        // .data/.bss segment. .bun is mutable initialized data so it is in
+        // the second one. We therefore select the PF_W PT_LOAD whose file
+        // extent ends last, and assert it is also the last PT_LOAD overall
+        // so the "everything past its file bytes is non-ALLOC tail" move
+        // below is sound.
         let phdr_size = size_of::<Elf64_Phdr>();
         let mut rw_phdr_index: Option<usize> = None;
         let mut rw_phdr: Elf64_Phdr = Elf64_Phdr::ZEROED;
         let mut max_vaddr_end: u64 = 0;
+        let mut max_load_file_end: u64 = 0;
         for i in 0..ehdr.e_phnum as usize {
             let phdr_offset = usize::try_from(ehdr.e_phoff).expect("int cast") + i * phdr_size;
             let phdr: Elf64_Phdr = read_struct(&self.data[phdr_offset..][..phdr_size]);
@@ -239,7 +248,14 @@ impl ElfFile {
                 max_vaddr_end = vaddr_end;
             }
 
-            if (phdr.p_flags & PF_W) != 0 && rw_phdr_index.is_none() {
+            let file_end = phdr.p_offset + phdr.p_filesz;
+            if file_end > max_load_file_end {
+                max_load_file_end = file_end;
+            }
+
+            if (phdr.p_flags & PF_W) != 0
+                && rw_phdr_index.is_none_or(|_| file_end > rw_phdr.p_offset + rw_phdr.p_filesz)
+            {
                 rw_phdr_index = Some(i);
                 rw_phdr = phdr;
             }
@@ -248,6 +264,11 @@ impl ElfFile {
         let Some(rw_index) = rw_phdr_index else {
             return Err(ElfError::NoWritableLoadSegment);
         };
+        if rw_phdr.p_offset + rw_phdr.p_filesz != max_load_file_end {
+            // A PT_LOAD with file bytes past the selected RW segment would be
+            // clobbered by the tail relocation below.
+            return Err(ElfError::InvalidElfFile);
+        }
 
         // Place the new data at a page-aligned virtual address past every
         // existing mapping. page_size is ≥ 128 so this also guarantees the

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3057,16 +3057,20 @@ JSC_DEFINE_HOST_FUNCTION(Process_functiongetgid, (JSGlobalObject * globalObject,
 JSC_DEFINE_HOST_FUNCTION(Process_functiongetgroups, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
-    int ngroups = getgroups(0, nullptr);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    int ngroups = getgroups(0, nullptr);
+    if (ngroups == -1) {
+        throwSystemError(throwScope, globalObject, "getgroups"_s, errno);
+        return {};
+    }
+    Vector<gid_t> groupVector(ngroups);
+    ngroups = getgroups(ngroups, groupVector.begin());
     if (ngroups == -1) {
         throwSystemError(throwScope, globalObject, "getgroups"_s, errno);
         return {};
     }
     JSArray* groups = constructEmptyArray(globalObject, nullptr, ngroups);
     RETURN_IF_EXCEPTION(throwScope, {});
-    Vector<gid_t> groupVector(ngroups);
-    getgroups(ngroups, groupVector.begin());
     for (unsigned i = 0; i < ngroups; i++) {
         groups->putDirectIndex(globalObject, i, jsNumber(groupVector[i]));
     }

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync } from "node:fs";
+import { chmodSync, realpathSync } from "node:fs";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -441,8 +441,19 @@ if (isLinux) {
       // #29963: the writable PT_LOAD must have been grown to cover .bun,
       // rather than a new late PT_LOAD being appended.
       expect(writableLoadCoversBun).toBe(true);
-      // A stock bun has 3 PT_LOAD segments; the fix must not add a 4th.
-      expect(loadCount).toBe(3);
+      // The compiled binary must have the same PT_LOAD count as the bun
+      // binary it was produced from (3 without `-z relro`, 4 with).
+      const srcHeader = new Uint8Array(
+        await Bun.file(realpathSync(bunExe())).slice(0, 4096).arrayBuffer(),
+      );
+      const srcView = new DataView(srcHeader.buffer);
+      const srcPhoff = Number(srcView.getBigUint64(32, true));
+      const srcPhnum = srcView.getUint16(56, true);
+      let srcLoadCount = 0;
+      for (let i = 0; i < srcPhnum; i++) {
+        if (srcView.getUint32(srcPhoff + i * phentsize, true) === PT_LOAD) srcLoadCount++;
+      }
+      expect(loadCount).toBe(srcLoadCount);
       // JSC bytecode cache requires 128-byte-aligned deserialization input.
       // StandaloneModuleGraph writes bytecode at payload offset 120 assuming
       // the `[u64 size]` header sits at a 128-byte-aligned vaddr (so bytecode

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -443,9 +443,7 @@ if (isLinux) {
       expect(writableLoadCoversBun).toBe(true);
       // The compiled binary must have the same PT_LOAD count as the bun
       // binary it was produced from (3 without `-z relro`, 4 with).
-      const srcHeader = new Uint8Array(
-        await Bun.file(realpathSync(bunExe())).slice(0, 4096).arrayBuffer(),
-      );
+      const srcHeader = new Uint8Array(await Bun.file(realpathSync(bunExe())).slice(0, 4096).arrayBuffer());
       const srcView = new DataView(srcHeader.buffer);
       const srcPhoff = Number(srcView.getBigUint64(32, true));
       const srcPhnum = srcView.getUint16(56, true);

--- a/test/cli/binary-hardening.test.ts
+++ b/test/cli/binary-hardening.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { bunExe, isLinux } from "harness";
+import { realpathSync } from "node:fs";
+
+// Linux-only: asserts the ELF hardening properties that scripts/build/flags.ts
+// is expected to produce. Kept in the test suite so a flag regression (e.g.
+// reintroducing -z norelro, or a strip tool that drops PT_GNU_RELRO) fails CI
+// rather than shipping silently. See scripts/verify-hardening.sh for the full
+// audit including the controls this change does not flip (PIE/CET/JIT W^X).
+
+async function readelf(args: string[]): Promise<string> {
+  const bin = realpathSync(bunExe());
+  await using proc = Bun.spawn({
+    cmd: ["readelf", ...args, bin],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, exited] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(exited).toBe(0);
+  return out;
+}
+
+describe.skipIf(!isLinux)("binary hardening (linux ELF)", () => {
+  test("link: full RELRO", async () => {
+    const seg = await readelf(["-lW"]);
+    // -Wl,-z,relro: PT_GNU_RELRO segment must survive strip.
+    expect(seg).toContain("GNU_RELRO");
+
+    // -Wl,-z,now: DT_BIND_NOW or DF_1_NOW so ld.so eagerly binds and then
+    // mprotects the RELRO segment read-only.
+    const dyn = await readelf(["-dW"]);
+    expect(dyn).toMatch(/BIND_NOW|\bNOW\b/);
+  });
+
+  test("compile: stack canaries", async () => {
+    // -fstack-protector-strong on the C/C++ side pulls in __stack_chk_fail.
+    const syms = await readelf(["--dyn-syms", "-W"]);
+    expect(syms).toContain("__stack_chk_fail");
+  });
+});


### PR DESCRIPTION
Tranche 1 of Linux binary hardening: the three mitigations that work unchanged under the existing `-no-pie` link. PIE/ASLR is intentionally left out (separate change; see the tranche header comment added to `flags.ts` for the `.rodata` vtable / deps-rebuild trade to measure).

## Truth table

`scripts/verify-hardening.sh build/release/bun` on stock `1.4.0-canary.1+df6c7eed6` (readelf + live `/proc/self/maps`):

```
  CONTROL    STATE  EVIDENCE
  PIE        OFF    ELF type=EXEC, image base=00200000 (identical across runs)
  RELRO      OFF    GNU_RELRO=0 BIND_NOW=0 PLT=428
  CANARY     OFF    __stack_chk_fail imports=0
  FORTIFY    OFF    *_chk imports=0
  CET        OFF    no .note.gnu.property x86 feature
  NX         ON     GNU_STACK=RW
  JIT-W^X    OFF    rwx maps=1 (1024 MB [anon:JSJITCode])

FAIL: PIE RELRO CANARY FORTIFY CET JIT-W^X
```

Source anchors: `-fno-pic/-fno-pie` at `scripts/build/flags.ts:639`; `-fno-pic/-Wl,-no-pie` at `:1224` (desc "No PIE (we don't need ASLR; simpler codegen)"); `-z lazy`/`-z norelro` at `:1237-1238`; ASLR-off rationale at `scripts/build/deps/webkit.ts:240-248`. No `-fstack-protector*`, `_FORTIFY_SOURCE`, or `-fcf-protection` anywhere in `scripts/build/`.

## Changes

- **Link**: `-Wl,-z,relro -Wl,-z,now` instead of `-Wl,-z,lazy -Wl,-z,norelro`. 428 PLT slots + 59 non-PLT RELA eager-bound at startup; `ld.so` then remaps `.got`/`.got.plt`/`.data.rel.ro` read-only so a write-what-where can't retarget a libc call.
- **Compile** (globalFlags, so direct deps like boringssl/libarchive get coverage too): `-fstack-protector-strong` on unix; `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3` on linux release `!asan`. Rust side is unchanged (would need `-Zstack-protector` separately).
- **Strip**: linux now uses `llvm-strip` instead of GNU strip. GNU strip's `-R <section>` rewrites the program-header table from sections and drops `PT_GNU_RELRO`, so without this the shipped binary shows `BIND_NOW` but no `GNU_RELRO` segment and `ld.so` never does the RO remap. `llvm-strip` keeps `PT_GNU_RELRO`; the cost is that it zeroes removed sections in place rather than compacting LOAD[0], leaving ~828 KB of zero-filled RO gap where `.eh_frame` was. That gap is never faulted at runtime.
- **`scripts/verify-hardening.sh <binary>`**: prints the table above + a PASS/FAIL set (exit status = FAIL count). The thing to run against release builds.

## After

```
  CONTROL    STATE  EVIDENCE
  PIE        OFF    ELF type=EXEC, image base=00200000
  RELRO      full   GNU_RELRO=1 BIND_NOW=2 PLT=403
  CANARY     ON     __stack_chk_fail imports=1
  FORTIFY    ON     *_chk imports=17
  CET        OFF    no .note.gnu.property x86 feature
  NX         ON     GNU_STACK=RW
  JIT-W^X    OFF    rwx maps=1 ([anon:JSJITCode])

FAIL: PIE CET JIT-W^X
```

Binary size 72.5 MB -> 73.3 MB (+1.1%, entirely the llvm-strip gap). `bun --revision`, a fetch smoke, and `test/js/bun/util/which.test.ts` pass on the patched release build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts test/cli/binary-hardening.test.ts

<!-- robobun:evidence:end -->

## Code fixed along the way

Enabling these flags surfaced three latent issues; each is fixed here rather than suppressed.

- **`packages/bun-usockets/src/bsd.c`**: bionic's fortified `open()` wrapper flags a mode argument passed without `O_CREAT`. Dropped the superfluous `0700` on an `O_PATH|O_DIRECTORY` open.
- **`src/jsc/bindings/BunProcess.cpp`**: `getgroups()` gains `warn_unused_result` under `_FORTIFY_SOURCE`. The fill call's return was discarded, which also meant a TOCTOU between the size probe and the fill would read uninitialized `gid_t`s. Now checked and the result array is sized from the actual count.
- **`src/exe_format/elf.rs`**: `-z relro -z now` makes lld emit two `PF_W` `PT_LOAD` segments (RELRO first, `.data`/`.bss` second). `write_bun_section()` picked the first, then relocated and zero-filled everything past it as non-ALLOC tail, which destroyed the entire `.data` segment and left its `p_offset` stale. `bun build --compile` output segfaulted in the first constructor touching a `.data` static (`pthread_mutex_lock(m=0x598)` in mimalloc init). Now selects the `PF_W` `PT_LOAD` with the highest file end and asserts it is the last `PT_LOAD`. Single-RW-segment binaries behave as before.

## Binary size (CI, build #82220 vs canary #79916)

| target | delta | attribution |
|---|---|---|
| windows-x64 / windows-aarch64 | +570 / +533 KB | none of these flags apply; this is main's own growth between the size baseline (ae4b17de) and this branch's base (df6c7eed, 8 commits later, including #31823 and #34598) |
| darwin-aarch64 / darwin-x64 | +1.01 / +1.14 MB | `-fstack-protector-strong` prologues/epilogues + the same baseline drift |
| linux-x64 / aarch64 (gnu) | +1.02 MB / +917 KB | llvm-strip zero gap (~828 KB) + stack-protector + baseline drift |
| linux-x64 / aarch64 (musl) | +1.06 MB / +891 KB | same as gnu |
| linux android x64 / aarch64 | +1.08 MB / +864 KB | stack-protector + FORTIFY + baseline drift (android was already PIE, no strip change) |
| freebsd x64 / aarch64 | +1.06 MB / +928 KB | stack-protector + baseline drift |

Subtracting the Windows number as baseline drift puts the per-target hardening cost at roughly +350 KB to +500 KB, plus the one-off ~828 KB llvm-strip gap on linux-gnu/musl.