### PR TITLE
inspector: isolate Debugger/Runtime state between concurrent CDP clients

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -138,6 +138,7 @@ export default function (
       switch (parsed?.type) {
         case "close":
           try {
+            sessionAdapter?.dispose?.();
             sessionBackend?.close();
             sessionBackend = undefined;
             sessionAdapter = undefined;
@@ -160,6 +161,7 @@ export default function (
           // outlive it. Refcounted so one Session can't tear down another's.
           if (--sessionRefs > 0) return;
           sessionRefs = 0;
+          sessionAdapter?.dispose?.();
           sessionBackend?.close();
           sessionBackend = undefined;
           sessionAdapter = undefined;
@@ -599,14 +601,16 @@ class Debugger {
 
   #close(connection: ConnectionOwner): void {
     const { data } = connection;
-    const { backend } = data;
+    const { backend, adapter } = data;
+    adapter?.dispose?.();
     backend?.close();
   }
 
   #error(connection: ConnectionOwner, error: Error): void {
     const { data } = connection;
-    const { backend } = data;
+    const { backend, adapter } = data;
     console.error(error);
+    adapter?.dispose?.();
     backend?.close();
   }
 }

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -604,6 +604,8 @@ class Debugger {
     const { backend, adapter } = data;
     adapter?.dispose?.();
     backend?.close();
+    data.adapter = undefined;
+    data.backend = undefined;
   }
 
   #error(connection: ConnectionOwner, error: Error): void {
@@ -612,6 +614,8 @@ class Debugger {
     console.error(error);
     adapter?.dispose?.();
     backend?.close();
+    data.adapter = undefined;
+    data.backend = undefined;
   }
 }
 

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -658,7 +658,11 @@ class InspectorCDPAdapter {
           this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
           return;
         }
-        const state = params.state === "caught" ? "all" : typeof params.state === "string" ? params.state : "none";
+        const state = params.state === "caught" ? "all" : params.state;
+        if (typeof state !== "string" || !(state in PAUSE_ON_EXCEPTIONS_ORDER)) {
+          this.#replyErrorToClient(id, -32602, `Unknown pause on exceptions mode: ${params.state}`);
+          return;
+        }
         this.#flags.pauseOnExceptions = state;
         this.#syncBackendAggregate();
         this.#replyToClient(id, {});
@@ -701,7 +705,7 @@ class InspectorCDPAdapter {
           return;
         }
         const maxDepth = params.maxDepth;
-        this.#flags.asyncCallStackDepth = typeof maxDepth === "number" && maxDepth > 0 ? maxDepth : 0;
+        this.#flags.asyncCallStackDepth = Number.isFinite(maxDepth) && maxDepth > 0 ? maxDepth | 0 : 0;
         this.#syncBackendAggregate();
         this.#replyToClient(id, {});
         return;

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -226,9 +226,11 @@ class InspectorCDPAdapter {
 
   // JSC's InjectedScript keeps one process-global objectGroup→ids map, so
   // prefix client-supplied group names per session and another client's
-  // releaseObjectGroup cannot name this session's handles.
-  #sessionObjectGroup(name: unknown): string {
-    return this.#objectGroupPrefix + (typeof name === "string" ? name : "");
+  // releaseObjectGroup cannot name this session's handles. An omitted group
+  // stays omitted so the handle is not bound to any releasable group, as in V8.
+  #sessionObjectGroup(name: unknown): string | undefined {
+    if (typeof name !== "string") return undefined;
+    return this.#objectGroupPrefix + name;
   }
 
   handleClientMessage(message: string): void {
@@ -655,10 +657,18 @@ class InspectorCDPAdapter {
         return;
 
       case "Debugger.setAsyncCallStackDepth":
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         this.#sendToBackend("Debugger.setAsyncStackTraceDepth", { depth: params.maxDepth ?? 0 }, id, method);
         return;
 
       case "Debugger.setBreakpointByUrl": {
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         const { condition, urlRegex, url } = params;
         const options: AnyObject = {};
         if (condition) options.condition = condition;
@@ -687,6 +697,10 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.setBreakpoint": {
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         const { condition } = params;
         this.#sendToBackend(
           "Debugger.setBreakpoint",
@@ -702,6 +716,10 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.getPossibleBreakpoints": {
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         const start = params.start;
         let end = params.end;
         if (!end) {

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -616,12 +616,20 @@ class InspectorCDPAdapter {
         return;
 
       case "Debugger.setBreakpointsActive":
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         this.#flags.breakpointsActive = params.active !== false;
         this.#syncBackendAggregate();
         this.#replyToClient(id, {});
         return;
 
       case "Debugger.setPauseOnExceptions": {
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         const state = params.state === "caught" ? "all" : typeof params.state === "string" ? params.state : "none";
         this.#flags.pauseOnExceptions = state;
         this.#syncBackendAggregate();
@@ -630,9 +638,12 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.removeBreakpoint": {
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         const { breakpointId } = params;
-        const owner = breakpointOwner.$get(breakpointId);
-        if (owner !== undefined && owner !== this.#sessionId) {
+        if (breakpointOwner.$get(breakpointId) !== this.#sessionId) {
           // V8's per-session breakpoint store would have no entry here.
           this.#replyToClient(id, {});
           return;

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -122,18 +122,28 @@ type SessionFlags = {
   runtimeEnabled: boolean;
   breakpointsActive: boolean;
   pauseOnExceptions: string;
+  asyncCallStackDepth: number;
 };
 
 const sessionFlags: Map<number, SessionFlags> = new Map();
 const breakpointOwner: Map<string, number> = new Map();
 // Last values actually sent to the single backend so we only write on change.
-const backendAggregate = { breakpointsActive: false, pauseOnExceptions: "none" };
+const backendAggregate = { breakpointsActive: false, pauseOnExceptions: "none", asyncCallStackDepth: 0 };
 
 function aggregateBreakpointsActive(): boolean {
   for (const flags of sessionFlags.values()) {
     if (flags.debuggerEnabled && flags.breakpointsActive) return true;
   }
   return false;
+}
+
+function aggregateAsyncCallStackDepth(): number {
+  let max = 0;
+  for (const flags of sessionFlags.values()) {
+    const { asyncCallStackDepth } = flags;
+    if (flags.debuggerEnabled && asyncCallStackDepth > max) max = asyncCallStackDepth;
+  }
+  return max;
 }
 
 function aggregatePauseOnExceptions(): string {
@@ -213,13 +223,20 @@ class InspectorCDPAdapter {
   >();
   #scripts = new Map<string, { cdpUrl: string; endLine: number; endColumn: number }>();
   #flags: SessionFlags;
+  #usedObjectGroups = new Set<string>();
 
   constructor(writeToBackend: (message: string) => void, writeToClient: (message: string) => void) {
     this.#writeToBackend = writeToBackend;
     this.#writeToClient = writeToClient;
     this.#sessionId = nextSessionId++;
     this.#objectGroupPrefix = `bun-session-${this.#sessionId}:`;
-    this.#flags = { debuggerEnabled: false, runtimeEnabled: false, breakpointsActive: true, pauseOnExceptions: "none" };
+    this.#flags = {
+      debuggerEnabled: false,
+      runtimeEnabled: false,
+      breakpointsActive: true,
+      pauseOnExceptions: "none",
+      asyncCallStackDepth: 0,
+    };
     sessionFlags.$set(this.#sessionId, this.#flags);
     liveAdapters.$set(this.#sessionId, this);
   }
@@ -230,7 +247,9 @@ class InspectorCDPAdapter {
   // stays omitted so the handle is not bound to any releasable group, as in V8.
   #sessionObjectGroup(name: unknown): string | undefined {
     if (typeof name !== "string") return undefined;
-    return this.#objectGroupPrefix + name;
+    const prefixed = this.#objectGroupPrefix + name;
+    this.#usedObjectGroups.$add(prefixed);
+    return prefixed;
   }
 
   handleClientMessage(message: string): void {
@@ -288,6 +307,10 @@ class InspectorCDPAdapter {
   dispose(): void {
     if (!liveAdapters.$has(this.#sessionId)) return;
     this.#teardownDebuggerState();
+    for (const group of this.#usedObjectGroups) {
+      this.#sendToBackend("Runtime.releaseObjectGroup", { objectGroup: group });
+    }
+    this.#usedObjectGroups.clear();
     if (this.#flags.runtimeEnabled) {
       this.#flags.runtimeEnabled = false;
       if (!anyRuntimeEnabled()) {
@@ -306,17 +329,21 @@ class InspectorCDPAdapter {
   }
 
   #syncBackendAggregate(): void {
+    const writer = InspectorCDPAdapter.#backendWriter() ?? this;
     const active = aggregateBreakpointsActive();
     if (active !== backendAggregate.breakpointsActive) {
       backendAggregate.breakpointsActive = active;
-      const writer = InspectorCDPAdapter.#backendWriter() ?? this;
       writer.#sendToBackend("Debugger.setBreakpointsActive", { active });
     }
     const pauseState = aggregatePauseOnExceptions();
     if (pauseState !== backendAggregate.pauseOnExceptions) {
       backendAggregate.pauseOnExceptions = pauseState;
-      const writer = InspectorCDPAdapter.#backendWriter() ?? this;
       writer.#sendToBackend("Debugger.setPauseOnExceptions", { state: pauseState });
+    }
+    const depth = aggregateAsyncCallStackDepth();
+    if (depth !== backendAggregate.asyncCallStackDepth) {
+      backendAggregate.asyncCallStackDepth = depth;
+      writer.#sendToBackend("Debugger.setAsyncStackTraceDepth", { depth });
     }
   }
 
@@ -333,6 +360,7 @@ class InspectorCDPAdapter {
     this.#flags.debuggerEnabled = false;
     this.#flags.breakpointsActive = true;
     this.#flags.pauseOnExceptions = "none";
+    this.#flags.asyncCallStackDepth = 0;
     this.#syncBackendAggregate();
     if (!anyDebuggerEnabled()) this.#sendToBackend("Debugger.disable");
   }
@@ -667,13 +695,17 @@ class InspectorCDPAdapter {
         this.#sendToBackend(method, params, id, method);
         return;
 
-      case "Debugger.setAsyncCallStackDepth":
+      case "Debugger.setAsyncCallStackDepth": {
         if (!this.#flags.debuggerEnabled) {
           this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
           return;
         }
-        this.#sendToBackend("Debugger.setAsyncStackTraceDepth", { depth: params.maxDepth ?? 0 }, id, method);
+        const maxDepth = params.maxDepth;
+        this.#flags.asyncCallStackDepth = typeof maxDepth === "number" && maxDepth > 0 ? maxDepth : 0;
+        this.#syncBackendAggregate();
+        this.#replyToClient(id, {});
         return;
+      }
 
       case "Debugger.setBreakpointByUrl": {
         if (!this.#flags.debuggerEnabled) {
@@ -935,6 +967,9 @@ class InspectorCDPAdapter {
           case "Breakpoint": {
             const hitId = data?.breakpointId;
             if (hitId && breakpointOwner.$get(hitId) === this.#sessionId) cdpParams.hitBreakpoints = [hitId];
+            // V8 does not populate `data` for breakpoint pauses; JSC's is
+            // {breakpointId}, which the owner filter above covers.
+            cdpParams.data = undefined;
             break;
           }
         }

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -803,14 +803,15 @@ class InspectorCDPAdapter {
         return;
 
       // The deprecated CDP Console domain is fully managed via Runtime.enable/
-      // disable above; forwarding disable here would let one client tear the
-      // shared ConsoleAgent down under another.
+      // disable above; forwarding disable or clearMessages here would let one
+      // client tear the shared ConsoleAgent (and its "console" objectGroup)
+      // down under another.
       case "Console.enable":
       case "Console.disable":
+      case "Console.clearMessages":
         this.#replyToClient(id, {});
         return;
 
-      case "Console.clearMessages":
       case "Inspector.enable":
         this.#sendToBackend(method, undefined, id, method);
         return;
@@ -860,7 +861,16 @@ class InspectorCDPAdapter {
       return;
     }
     const { breakpointId } = result;
-    if (typeof breakpointId === "string") breakpointOwner.$set(breakpointId, this.#sessionId);
+    if (typeof breakpointId === "string") {
+      if (!this.#flags.debuggerEnabled || !liveAdapters.$has(this.#sessionId)) {
+        // Session tore down while this setBreakpoint was in flight and the
+        // shared backend stayed enabled for another session: remove the armed
+        // breakpoint instead of orphaning it under a dead owner.
+        this.#sendToBackend("Debugger.removeBreakpoint", { breakpointId });
+        return;
+      }
+      breakpointOwner.$set(breakpointId, this.#sessionId);
+    }
     this.#replyToClient(id, this.#translateResult(method, result));
   }
 

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -97,9 +97,12 @@ const CONSOLE_LEVEL_MAP: Record<string, string> = {
 // V8InspectorSession) is emulated at this layer. All adapters run on the one
 // debugger thread, so module-level state needs no locking.
 
-// Disjoint backend-command-id ranges per session so a broadcast response only
-// matches the sender's #pending map.
-const BACKEND_ID_STRIDE = 1_000_000_000;
+// One counter shared across adapters: FrontendRouter replays a response to
+// every channel, and BackendDispatcher echoes the id as a 32-bit int, so each
+// adapter drawing from the same counter keeps ids unique (a broadcast only
+// matches the sender's #pending map) without per-session ranges overflowing
+// that int.
+let nextBackendId = 1;
 
 const PAUSE_ON_EXCEPTIONS_ORDER: Record<string, number> = {
   __proto__: null as never,
@@ -160,6 +163,7 @@ function anyRuntimeEnabled(): boolean {
 // Tag every RemoteObject.objectId leaving this adapter with its session id so
 // a handle minted for one client cannot be presented by another. JSC emits the
 // fixed `{"injectedScriptId":N,"id":M}` shape (InjectedScriptSource.js).
+const INJECTED_SCRIPT_OBJECT_ID_PREFIX = '{"injectedScriptId":';
 function tagObjectIds(value: unknown, sessionId: number): void {
   if (value === null || typeof value !== "object") return;
   if ($isArray(value)) {
@@ -167,11 +171,15 @@ function tagObjectIds(value: unknown, sessionId: number): void {
     return;
   }
   const obj = value as AnyObject;
+  // RemoteObject.value (returnByValue:true) is arbitrary user JSON; never walk
+  // into it or a user property that happens to be named `objectId` is mutated.
+  const isRemoteObject = typeof obj.type === "string";
   for (const key in obj) {
     const child = obj[key];
-    if (key === "objectId" && typeof child === "string" && child.charCodeAt(0) === 123 /* '{' */) {
+    if (key === "objectId" && typeof child === "string" && child.startsWith(INJECTED_SCRIPT_OBJECT_ID_PREFIX)) {
       obj[key] = `{"bunSessionId":${sessionId},${child.slice(1)}`;
     } else if (child !== null && typeof child === "object") {
+      if (isRemoteObject && key === "value") continue;
       tagObjectIds(child, sessionId);
     }
   }
@@ -197,7 +205,7 @@ class InspectorCDPAdapter {
   #writeToBackend: (message: string) => void;
   #writeToClient: (message: string) => void;
   #sessionId: number;
-  #nextBackendId: number;
+  #objectGroupPrefix: string;
   #nextExceptionId = 1;
   #pending = new Map<
     number,
@@ -210,10 +218,17 @@ class InspectorCDPAdapter {
     this.#writeToBackend = writeToBackend;
     this.#writeToClient = writeToClient;
     this.#sessionId = nextSessionId++;
-    this.#nextBackendId = this.#sessionId * BACKEND_ID_STRIDE;
+    this.#objectGroupPrefix = `bun-session-${this.#sessionId}:`;
     this.#flags = { debuggerEnabled: false, runtimeEnabled: false, breakpointsActive: true, pauseOnExceptions: "none" };
     sessionFlags.$set(this.#sessionId, this.#flags);
     liveAdapters.$set(this.#sessionId, this);
+  }
+
+  // JSC's InjectedScript keeps one process-global objectGroup→ids map, so
+  // prefix client-supplied group names per session and another client's
+  // releaseObjectGroup cannot name this session's handles.
+  #sessionObjectGroup(name: unknown): string {
+    return this.#objectGroupPrefix + (typeof name === "string" ? name : "");
   }
 
   handleClientMessage(message: string): void {
@@ -342,7 +357,7 @@ class InspectorCDPAdapter {
     clientMethod = method,
     onResult?: (result: AnyObject, error?: AnyObject) => void,
   ): void {
-    const id = this.#nextBackendId++;
+    const id = nextBackendId++;
     this.#pending.$set(id, { clientId, method: clientMethod, onResult });
     this.#writeToBackend(JSON.stringify(params === undefined ? { id, method } : { id, method, params }));
   }
@@ -396,7 +411,7 @@ class InspectorCDPAdapter {
         // execution context"), so drop it even though CDP clients echo it.
         const jscParams = {
           expression: params.expression,
-          objectGroup: params.objectGroup,
+          objectGroup: this.#sessionObjectGroup(params.objectGroup),
           includeCommandLineAPI: params.includeCommandLineAPI,
           doNotPauseOnExceptionsAndMuteConsole: params.silent,
           returnByValue: params.returnByValue,
@@ -529,7 +544,7 @@ class InspectorCDPAdapter {
         // client's objectGroup so its releaseObjectGroup reclaims this handle.
         this.#sendToBackend(
           "Runtime.evaluate",
-          { expression: "globalThis", objectGroup: params.objectGroup },
+          { expression: "globalThis", objectGroup: this.#sessionObjectGroup(params.objectGroup) },
           null,
           method,
           (result, error) => {
@@ -555,7 +570,7 @@ class InspectorCDPAdapter {
       }
 
       case "Runtime.releaseObjectGroup":
-        this.#sendToBackend(method, params, id, method);
+        this.#sendToBackend(method, { objectGroup: this.#sessionObjectGroup(params.objectGroup) }, id, method);
         return;
 
       case "Runtime.getIsolateId":
@@ -632,6 +647,10 @@ class InspectorCDPAdapter {
       case "Debugger.stepOver":
       case "Debugger.continueToLocation":
       case "Debugger.getScriptSource":
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         this.#sendToBackend(method, params, id, method);
         return;
 
@@ -698,12 +717,16 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.evaluateOnCallFrame":
+        if (!this.#flags.debuggerEnabled) {
+          this.#replyErrorToClient(id, -32000, "Debugger agent is not enabled");
+          return;
+        }
         this.#sendToBackend(
           "Debugger.evaluateOnCallFrame",
           {
             callFrameId: params.callFrameId,
             expression: params.expression,
-            objectGroup: params.objectGroup,
+            objectGroup: this.#sessionObjectGroup(params.objectGroup),
             includeCommandLineAPI: params.includeCommandLineAPI,
             doNotPauseOnExceptionsAndMuteConsole: params.silent,
             returnByValue: params.returnByValue,
@@ -718,8 +741,14 @@ class InspectorCDPAdapter {
         this.#sendToBackend("Heap.gc", undefined, id, method);
         return;
 
+      // The deprecated CDP Console domain is fully managed via Runtime.enable/
+      // disable above; forwarding disable here would let one client tear the
+      // shared ConsoleAgent down under another.
       case "Console.enable":
       case "Console.disable":
+        this.#replyToClient(id, {});
+        return;
+
       case "Console.clearMessages":
       case "Inspector.enable":
         this.#sendToBackend(method, undefined, id, method);
@@ -874,9 +903,11 @@ class InspectorCDPAdapter {
           case "assert":
             cdpParams.reason = "assert";
             break;
-          case "Breakpoint":
-            if (data?.breakpointId) cdpParams.hitBreakpoints = [data.breakpointId];
+          case "Breakpoint": {
+            const hitId = data?.breakpointId;
+            if (hitId && breakpointOwner.$get(hitId) === this.#sessionId) cdpParams.hitBreakpoints = [hitId];
             break;
+          }
         }
         if (asyncStackTrace) cdpParams.asyncStackTrace = this.#translateStackTrace(asyncStackTrace);
         this.#emitToClient("Debugger.paused", cdpParams);
@@ -888,6 +919,7 @@ class InspectorCDPAdapter {
         return;
 
       case "Debugger.breakpointResolved":
+        if (breakpointOwner.$get(params.breakpointId) !== this.#sessionId) return;
         this.#emitToClient("Debugger.breakpointResolved", {
           breakpointId: params.breakpointId,
           location: params.location,

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -199,7 +199,7 @@ function untagObjectId(objectId: unknown, sessionId: number): string | null {
     return null;
   }
   if (parsed?.bunSessionId !== sessionId) return null;
-  const { bunSessionId, ...rest } = parsed;
+  const { bunSessionId: _bunSessionId, ...rest } = parsed;
   return JSON.stringify(rest);
 }
 
@@ -485,11 +485,11 @@ class InspectorCDPAdapter {
         let callArguments = params.arguments;
         if ($isArray(callArguments)) {
           callArguments = callArguments.map((arg: AnyObject) => {
-            if (arg && typeof arg === "object" && typeof arg.objectId === "string") {
-              const backendArgId = untagObjectId(arg.objectId, this.#sessionId);
-              return backendArgId === null ? arg : { ...arg, objectId: backendArgId };
-            }
-            return arg;
+            if (arg === null || typeof arg !== "object") return arg;
+            const { objectId: argObjectId } = arg;
+            if (typeof argObjectId !== "string") return arg;
+            const backendArgId = untagObjectId(argObjectId, this.#sessionId);
+            return backendArgId === null ? arg : { ...arg, objectId: backendArgId };
           });
         }
         const forward = (targetObjectId: unknown) =>

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -91,19 +91,14 @@ const CONSOLE_LEVEL_MAP: Record<string, string> = {
   debug: "debug",
 };
 
-// ── Per-session isolation ─────────────────────────────────────────────────────
-// JSC's JSGlobalObjectInspectorController has a single DebuggerAgent /
-// RuntimeAgent / InjectedScript, and its FrontendRouter broadcasts every
-// response and event to every attached FrontendChannel. Node gives each
-// inspector WebSocket a separate V8InspectorSession, so one client cannot
-// disable another's Debugger, flip its breakpointsActive / pauseOnExceptions,
-// delete its breakpoints, or read/release its Runtime.RemoteObject handles.
-// Every adapter runs on the one debugger thread, so module-level coordination
-// state needs no locking.
+// JSC has one DebuggerAgent/RuntimeAgent/InjectedScript per process and its
+// FrontendRouter broadcasts every response and event to every FrontendChannel,
+// so per-session isolation (Node gives each WebSocket its own
+// V8InspectorSession) is emulated at this layer. All adapters run on the one
+// debugger thread, so module-level state needs no locking.
 
-// Disjoint backend-command-id ranges per session: FrontendRouter replays a
-// response to every channel, so without this one adapter can claim another's
-// reply from its #pending map.
+// Disjoint backend-command-id ranges per session so a broadcast response only
+// matches the sender's #pending map.
 const BACKEND_ID_STRIDE = 1_000_000_000;
 
 const PAUSE_ON_EXCEPTIONS_ORDER: Record<string, number> = {
@@ -117,8 +112,6 @@ const PAUSE_ON_EXCEPTIONS_ORDER: Record<string, number> = {
 const FOREIGN_OBJECT_ID_ERROR = "Could not find object with given id";
 
 let nextSessionId = 1;
-// A Map (not a Set) so we can reach other adapters' sendToBackend for backend
-// aggregate updates even after an adapter has left.
 const liveAdapters: Map<number, InspectorCDPAdapter> = new Map();
 
 type SessionFlags = {
@@ -164,12 +157,9 @@ function anyRuntimeEnabled(): boolean {
   return false;
 }
 
-// Tag every RemoteObject handle leaving this adapter with its session id so a
-// handle minted for one client cannot be presented by another. JSC emits a
-// fixed `{"injectedScriptId":N,"id":M}` string (InjectedScriptSource.js), so a
-// recursive walk that rewrites every `objectId` string property covers
-// evaluate/callFunctionOn/getProperties results, paused scope chains and
-// consoleAPICalled args alike.
+// Tag every RemoteObject.objectId leaving this adapter with its session id so
+// a handle minted for one client cannot be presented by another. JSC emits the
+// fixed `{"injectedScriptId":N,"id":M}` shape (InjectedScriptSource.js).
 function tagObjectIds(value: unknown, sessionId: number): void {
   if (value === null || typeof value !== "object") return;
   if ($isArray(value)) {
@@ -484,13 +474,25 @@ class InspectorCDPAdapter {
         const { objectId, executionContextId } = params;
         let callArguments = params.arguments;
         if ($isArray(callArguments)) {
-          callArguments = callArguments.map((arg: AnyObject) => {
-            if (arg === null || typeof arg !== "object") return arg;
+          const rewritten: AnyObject[] = [];
+          for (const arg of callArguments as AnyObject[]) {
+            if (arg === null || typeof arg !== "object") {
+              rewritten.push(arg);
+              continue;
+            }
             const { objectId: argObjectId } = arg;
-            if (typeof argObjectId !== "string") return arg;
+            if (typeof argObjectId !== "string") {
+              rewritten.push(arg);
+              continue;
+            }
             const backendArgId = untagObjectId(argObjectId, this.#sessionId);
-            return backendArgId === null ? arg : { ...arg, objectId: backendArgId };
-          });
+            if (backendArgId === null) {
+              this.#replyErrorToClient(id, -32000, FOREIGN_OBJECT_ID_ERROR);
+              return;
+            }
+            rewritten.push({ ...arg, objectId: backendArgId });
+          }
+          callArguments = rewritten;
         }
         const forward = (targetObjectId: unknown) =>
           this.#sendToBackend(

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -871,6 +871,7 @@ class InspectorCDPAdapter {
         // shared backend stayed enabled for another session: remove the armed
         // breakpoint instead of orphaning it under a dead owner.
         this.#sendToBackend("Debugger.removeBreakpoint", { breakpointId });
+        this.#replyToClient(id, this.#translateResult(method, result));
         return;
       }
       breakpointOwner.$set(breakpointId, this.#sessionId);

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -91,20 +91,139 @@ const CONSOLE_LEVEL_MAP: Record<string, string> = {
   debug: "debug",
 };
 
+// ── Per-session isolation ─────────────────────────────────────────────────────
+// JSC's JSGlobalObjectInspectorController has a single DebuggerAgent /
+// RuntimeAgent / InjectedScript, and its FrontendRouter broadcasts every
+// response and event to every attached FrontendChannel. Node gives each
+// inspector WebSocket a separate V8InspectorSession, so one client cannot
+// disable another's Debugger, flip its breakpointsActive / pauseOnExceptions,
+// delete its breakpoints, or read/release its Runtime.RemoteObject handles.
+// Every adapter runs on the one debugger thread, so module-level coordination
+// state needs no locking.
+
+// Disjoint backend-command-id ranges per session: FrontendRouter replays a
+// response to every channel, so without this one adapter can claim another's
+// reply from its #pending map.
+const BACKEND_ID_STRIDE = 1_000_000_000;
+
+const PAUSE_ON_EXCEPTIONS_ORDER: Record<string, number> = {
+  __proto__: null as never,
+  none: 0,
+  uncaught: 1,
+  all: 2,
+};
+
+// V8's message when a session asks about a RemoteObject it never received.
+const FOREIGN_OBJECT_ID_ERROR = "Could not find object with given id";
+
+let nextSessionId = 1;
+// A Map (not a Set) so we can reach other adapters' sendToBackend for backend
+// aggregate updates even after an adapter has left.
+const liveAdapters: Map<number, InspectorCDPAdapter> = new Map();
+
+type SessionFlags = {
+  debuggerEnabled: boolean;
+  runtimeEnabled: boolean;
+  breakpointsActive: boolean;
+  pauseOnExceptions: string;
+};
+
+const sessionFlags: Map<number, SessionFlags> = new Map();
+const breakpointOwner: Map<string, number> = new Map();
+// Last values actually sent to the single backend so we only write on change.
+const backendAggregate = { breakpointsActive: false, pauseOnExceptions: "none" };
+
+function aggregateBreakpointsActive(): boolean {
+  for (const flags of sessionFlags.values()) {
+    if (flags.debuggerEnabled && flags.breakpointsActive) return true;
+  }
+  return false;
+}
+
+function aggregatePauseOnExceptions(): string {
+  let best = "none";
+  let bestRank = 0;
+  for (const flags of sessionFlags.values()) {
+    if (!flags.debuggerEnabled) continue;
+    const rank = PAUSE_ON_EXCEPTIONS_ORDER[flags.pauseOnExceptions] ?? 0;
+    if (rank > bestRank) {
+      bestRank = rank;
+      best = flags.pauseOnExceptions;
+    }
+  }
+  return best;
+}
+
+function anyDebuggerEnabled(): boolean {
+  for (const flags of sessionFlags.values()) if (flags.debuggerEnabled) return true;
+  return false;
+}
+
+function anyRuntimeEnabled(): boolean {
+  for (const flags of sessionFlags.values()) if (flags.runtimeEnabled) return true;
+  return false;
+}
+
+// Tag every RemoteObject handle leaving this adapter with its session id so a
+// handle minted for one client cannot be presented by another. JSC emits a
+// fixed `{"injectedScriptId":N,"id":M}` string (InjectedScriptSource.js), so a
+// recursive walk that rewrites every `objectId` string property covers
+// evaluate/callFunctionOn/getProperties results, paused scope chains and
+// consoleAPICalled args alike.
+function tagObjectIds(value: unknown, sessionId: number): void {
+  if (value === null || typeof value !== "object") return;
+  if ($isArray(value)) {
+    for (let i = 0; i < (value as unknown[]).length; i++) tagObjectIds((value as unknown[])[i], sessionId);
+    return;
+  }
+  const obj = value as AnyObject;
+  for (const key in obj) {
+    const child = obj[key];
+    if (key === "objectId" && typeof child === "string" && child.charCodeAt(0) === 123 /* '{' */) {
+      obj[key] = `{"bunSessionId":${sessionId},${child.slice(1)}`;
+    } else if (child !== null && typeof child === "object") {
+      tagObjectIds(child, sessionId);
+    }
+  }
+}
+
+// Inverse of tagObjectIds for a single id string: returns the backend id when
+// the tag matches this session, or null when it belongs to another (or has no
+// tag, i.e. a client guessing raw backend ids).
+function untagObjectId(objectId: unknown, sessionId: number): string | null {
+  if (typeof objectId !== "string") return null;
+  let parsed: AnyObject;
+  try {
+    parsed = JSON.parse(objectId);
+  } catch {
+    return null;
+  }
+  if (parsed?.bunSessionId !== sessionId) return null;
+  const { bunSessionId, ...rest } = parsed;
+  return JSON.stringify(rest);
+}
+
 class InspectorCDPAdapter {
   #writeToBackend: (message: string) => void;
   #writeToClient: (message: string) => void;
-  #nextBackendId = 1;
+  #sessionId: number;
+  #nextBackendId: number;
   #nextExceptionId = 1;
   #pending = new Map<
     number,
     { clientId: number | string | null; method: string; onResult?: (result: AnyObject, error?: AnyObject) => void }
   >();
   #scripts = new Map<string, { cdpUrl: string; endLine: number; endColumn: number }>();
+  #flags: SessionFlags;
 
   constructor(writeToBackend: (message: string) => void, writeToClient: (message: string) => void) {
     this.#writeToBackend = writeToBackend;
     this.#writeToClient = writeToClient;
+    this.#sessionId = nextSessionId++;
+    this.#nextBackendId = this.#sessionId * BACKEND_ID_STRIDE;
+    this.#flags = { debuggerEnabled: false, runtimeEnabled: false, breakpointsActive: true, pauseOnExceptions: "none" };
+    sessionFlags.$set(this.#sessionId, this.#flags);
+    liveAdapters.$set(this.#sessionId, this);
   }
 
   handleClientMessage(message: string): void {
@@ -137,8 +256,10 @@ class InspectorCDPAdapter {
       if (!pending) return;
       this.#pending.$delete(id);
       const { clientId, onResult } = pending;
+      const result = parsed.result || {};
+      tagObjectIds(result, this.#sessionId);
       if (onResult) {
-        onResult(parsed.result || {}, error);
+        onResult(result, error);
         return;
       }
       if (clientId === null || clientId === undefined) return;
@@ -146,12 +267,67 @@ class InspectorCDPAdapter {
         this.#replyErrorToClient(clientId, error.code ?? -32000, error.message ?? "Unknown error");
         return;
       }
-      this.#replyToClient(clientId, this.#translateResult(pending.method, parsed.result || {}));
+      this.#replyToClient(clientId, this.#translateResult(pending.method, result));
       return;
     }
     if (typeof method === "string") {
       this.#translateBackendEvent(method, parsed.params || {});
     }
+  }
+
+  // Drop this session's contribution to the shared backend state. Called when
+  // the WebSocket closes so a vanished client cannot keep breakpoints armed or
+  // hold Debugger enabled for everyone else.
+  dispose(): void {
+    if (!liveAdapters.$has(this.#sessionId)) return;
+    this.#teardownDebuggerState();
+    if (this.#flags.runtimeEnabled) {
+      this.#flags.runtimeEnabled = false;
+      if (!anyRuntimeEnabled()) {
+        this.#sendToBackend("Runtime.disable");
+        this.#sendToBackend("Console.disable");
+      }
+    }
+    sessionFlags.$delete(this.#sessionId);
+    liveAdapters.$delete(this.#sessionId);
+  }
+
+  // Any live adapter can deliver aggregate updates to the single backend.
+  static #backendWriter(): InspectorCDPAdapter | undefined {
+    for (const adapter of liveAdapters.values()) return adapter;
+    return undefined;
+  }
+
+  #syncBackendAggregate(): void {
+    const active = aggregateBreakpointsActive();
+    if (active !== backendAggregate.breakpointsActive) {
+      backendAggregate.breakpointsActive = active;
+      const writer = InspectorCDPAdapter.#backendWriter() ?? this;
+      writer.#sendToBackend("Debugger.setBreakpointsActive", { active });
+    }
+    const pauseState = aggregatePauseOnExceptions();
+    if (pauseState !== backendAggregate.pauseOnExceptions) {
+      backendAggregate.pauseOnExceptions = pauseState;
+      const writer = InspectorCDPAdapter.#backendWriter() ?? this;
+      writer.#sendToBackend("Debugger.setPauseOnExceptions", { state: pauseState });
+    }
+  }
+
+  #teardownDebuggerState(): void {
+    if (!this.#flags.debuggerEnabled) return;
+    const owned: string[] = [];
+    for (const [breakpointId, owner] of breakpointOwner) {
+      if (owner === this.#sessionId) owned.push(breakpointId);
+    }
+    for (const breakpointId of owned) {
+      breakpointOwner.$delete(breakpointId);
+      this.#sendToBackend("Debugger.removeBreakpoint", { breakpointId });
+    }
+    this.#flags.debuggerEnabled = false;
+    this.#flags.breakpointsActive = true;
+    this.#flags.pauseOnExceptions = "none";
+    this.#syncBackendAggregate();
+    if (!anyDebuggerEnabled()) this.#sendToBackend("Debugger.disable");
   }
 
   #replyToClient(id: number | string, result: AnyObject): void {
@@ -185,6 +361,7 @@ class InspectorCDPAdapter {
     switch (method) {
       // ── Runtime ──────────────────────────────────────────────────────────
       case "Runtime.enable":
+        this.#flags.runtimeEnabled = true;
         // JSGlobalObject inspection has a single execution context; CDP clients
         // need at least one announced for the console and evaluation to work.
         this.#emitToClient("Runtime.executionContextCreated", {
@@ -204,6 +381,13 @@ class InspectorCDPAdapter {
         return;
 
       case "Runtime.disable":
+        this.#flags.runtimeEnabled = false;
+        if (anyRuntimeEnabled()) {
+          // Another session still wants console events; keep the shared
+          // Console agent alive and just stop forwarding to this client.
+          this.#replyToClient(id, {});
+          return;
+        }
         this.#sendToBackend("Runtime.disable");
         // Runtime.enable also enabled the Console domain; mirror it here so a
         // client that disables Runtime stops receiving consoleAPICalled.
@@ -241,7 +425,7 @@ class InspectorCDPAdapter {
               return;
             }
             const remote = result.result;
-            const objectId = remote?.objectId;
+            const objectId = untagObjectId(remote?.objectId, this.#sessionId);
             if (!result.wasThrown && remote?.type === "object" && objectId) {
               // JSC's Runtime.awaitPromise resolves any thenable and returns
               // non-thenable objects as-is, so no subtype check is needed.
@@ -271,17 +455,22 @@ class InspectorCDPAdapter {
         return;
       }
 
-      case "Runtime.getProperties":
+      case "Runtime.getProperties": {
         if (params.accessorPropertiesOnly) {
           // JSC has no accessor-only query; DevTools issues this in addition to
           // the regular request, so an empty list keeps the merged view correct.
           this.#replyToClient(id, { result: [] });
           return;
         }
+        const backendObjectId = untagObjectId(params.objectId, this.#sessionId);
+        if (backendObjectId === null) {
+          this.#replyErrorToClient(id, -32000, FOREIGN_OBJECT_ID_ERROR);
+          return;
+        }
         this.#sendToBackend(
           "Runtime.getProperties",
           {
-            objectId: params.objectId,
+            objectId: backendObjectId,
             ownProperties: params.ownProperties,
             generatePreview: params.generatePreview,
           },
@@ -289,16 +478,27 @@ class InspectorCDPAdapter {
           method,
         );
         return;
+      }
 
       case "Runtime.callFunctionOn": {
         const { objectId, executionContextId } = params;
+        let callArguments = params.arguments;
+        if ($isArray(callArguments)) {
+          callArguments = callArguments.map((arg: AnyObject) => {
+            if (arg && typeof arg === "object" && typeof arg.objectId === "string") {
+              const backendArgId = untagObjectId(arg.objectId, this.#sessionId);
+              return backendArgId === null ? arg : { ...arg, objectId: backendArgId };
+            }
+            return arg;
+          });
+        }
         const forward = (targetObjectId: unknown) =>
           this.#sendToBackend(
             "Runtime.callFunctionOn",
             {
               objectId: targetObjectId,
               functionDeclaration: params.functionDeclaration,
-              arguments: params.arguments,
+              arguments: callArguments,
               doNotPauseOnExceptionsAndMuteConsole: params.silent,
               returnByValue: params.returnByValue,
               generatePreview: params.generatePreview,
@@ -309,7 +509,12 @@ class InspectorCDPAdapter {
             method,
           );
         if (objectId) {
-          forward(objectId);
+          const backendObjectId = untagObjectId(objectId, this.#sessionId);
+          if (backendObjectId === null) {
+            this.#replyErrorToClient(id, -32000, FOREIGN_OBJECT_ID_ERROR);
+            return;
+          }
+          forward(backendObjectId);
           return;
         }
         if (executionContextId === undefined) {
@@ -326,7 +531,7 @@ class InspectorCDPAdapter {
           null,
           method,
           (result, error) => {
-            const globalObjectId = result.result?.objectId;
+            const globalObjectId = untagObjectId(result.result?.objectId, this.#sessionId);
             if (error || !globalObjectId) {
               this.#replyErrorToClient(id, error?.code ?? -32000, error?.message ?? "Failed to resolve global object");
               return;
@@ -337,7 +542,16 @@ class InspectorCDPAdapter {
         return;
       }
 
-      case "Runtime.releaseObject":
+      case "Runtime.releaseObject": {
+        const backendObjectId = untagObjectId(params.objectId, this.#sessionId);
+        if (backendObjectId === null) {
+          this.#replyErrorToClient(id, -32000, FOREIGN_OBJECT_ID_ERROR);
+          return;
+        }
+        this.#sendToBackend(method, { objectId: backendObjectId }, id, method);
+        return;
+      }
+
       case "Runtime.releaseObjectGroup":
         this.#sendToBackend(method, params, id, method);
         return;
@@ -360,6 +574,10 @@ class InspectorCDPAdapter {
 
       // ── Debugger ─────────────────────────────────────────────────────────
       case "Debugger.enable":
+        this.#flags.debuggerEnabled = true;
+        this.#flags.breakpointsActive = true;
+        // The shared agent is idempotent and re-broadcasts scriptParsed on
+        // each enable, so a late-joining client still receives the script list.
         this.#sendToBackend("Debugger.enable");
         // V8's Debugger.enable activates breakpoints and pauses on `debugger;`
         // by default; JSC requires explicit opt-in for both. A client may run
@@ -368,30 +586,51 @@ class InspectorCDPAdapter {
         // commands instead of the first: the backend replies in order, so that
         // response is proof all three landed. #translateResult still builds
         // V8's { debuggerId } shape from the clientMethod passed here.
+        backendAggregate.breakpointsActive = true;
         this.#sendToBackend("Debugger.setBreakpointsActive", { active: true });
         this.#sendToBackend("Debugger.setPauseOnDebuggerStatements", { enabled: true }, id, method);
         return;
 
       case "Debugger.disable":
+        this.#teardownDebuggerState();
+        this.#replyToClient(id, {});
+        return;
+
+      case "Debugger.setBreakpointsActive":
+        this.#flags.breakpointsActive = params.active !== false;
+        this.#syncBackendAggregate();
+        this.#replyToClient(id, {});
+        return;
+
+      case "Debugger.setPauseOnExceptions": {
+        const state = params.state === "caught" ? "all" : typeof params.state === "string" ? params.state : "none";
+        this.#flags.pauseOnExceptions = state;
+        this.#syncBackendAggregate();
+        this.#replyToClient(id, {});
+        return;
+      }
+
+      case "Debugger.removeBreakpoint": {
+        const { breakpointId } = params;
+        const owner = breakpointOwner.$get(breakpointId);
+        if (owner !== undefined && owner !== this.#sessionId) {
+          // V8's per-session breakpoint store would have no entry here.
+          this.#replyToClient(id, {});
+          return;
+        }
+        breakpointOwner.$delete(breakpointId);
+        this.#sendToBackend(method, params, id, method);
+        return;
+      }
+
       case "Debugger.pause":
       case "Debugger.resume":
       case "Debugger.stepInto":
       case "Debugger.stepOut":
       case "Debugger.stepOver":
-      case "Debugger.setBreakpointsActive":
-      case "Debugger.removeBreakpoint":
       case "Debugger.continueToLocation":
       case "Debugger.getScriptSource":
         this.#sendToBackend(method, params, id, method);
-        return;
-
-      case "Debugger.setPauseOnExceptions":
-        this.#sendToBackend(
-          "Debugger.setPauseOnExceptions",
-          { state: params.state === "caught" ? "all" : params.state },
-          id,
-          method,
-        );
         return;
 
       case "Debugger.setAsyncCallStackDepth":
@@ -420,7 +659,9 @@ class InspectorCDPAdapter {
           this.#replyErrorToClient(id, -32602, "Either url or urlRegex must be specified.");
           return;
         }
-        this.#sendToBackend("Debugger.setBreakpointByUrl", jscParams, id, method);
+        this.#sendToBackend("Debugger.setBreakpointByUrl", jscParams, null, method, (result, error) =>
+          this.#forwardBreakpointResult(id, method, result, error),
+        );
         return;
       }
 
@@ -432,8 +673,9 @@ class InspectorCDPAdapter {
             location: params.location,
             options: condition ? { condition } : undefined,
           },
-          id,
+          null,
           method,
+          (result, error) => this.#forwardBreakpointResult(id, method, result, error),
         );
         return;
       }
@@ -520,6 +762,16 @@ class InspectorCDPAdapter {
     }
   }
 
+  #forwardBreakpointResult(id: number | string, method: string, result: AnyObject, error?: AnyObject): void {
+    if (error) {
+      this.#replyErrorToClient(id, error.code ?? -32000, error.message ?? "Unknown error");
+      return;
+    }
+    const { breakpointId } = result;
+    if (typeof breakpointId === "string") breakpointOwner.$set(breakpointId, this.#sessionId);
+    this.#replyToClient(id, this.#translateResult(method, result));
+  }
+
   #translateResult(method: string, result: AnyObject): AnyObject {
     switch (method) {
       case "Debugger.enable":
@@ -562,6 +814,14 @@ class InspectorCDPAdapter {
   }
 
   #translateBackendEvent(method: string, params: AnyObject): void {
+    // FrontendRouter broadcasts every event to every channel; only forward the
+    // ones this session opted into, so a never-enabled client cannot observe
+    // another's Debugger.paused frames or console output.
+    if (method.charCodeAt(0) === 68 /* 'D' */ && method.startsWith("Debugger.")) {
+      if (!this.#flags.debuggerEnabled) return;
+    } else if (method === "Console.messageAdded") {
+      if (!this.#flags.runtimeEnabled) return;
+    }
     switch (method) {
       case "Debugger.scriptParsed": {
         const url = params.sourceURL || params.url || "";
@@ -589,6 +849,7 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.paused": {
+        tagObjectIds(params, this.#sessionId);
         const callFrames = (params.callFrames ?? []).map((frame: AnyObject) => ({
           callFrameId: frame.callFrameId,
           functionName: frame.functionName ?? "",
@@ -636,6 +897,7 @@ class InspectorCDPAdapter {
         return;
 
       case "Console.messageAdded":
+        tagObjectIds(params, this.#sessionId);
         this.#translateConsoleMessage(params.message || {});
         return;
 

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1089,8 +1089,8 @@ for await (const line of rl) {
       stdoutText += decoder.decode(value);
     }
   }
-  await waitForStdout("URL ");
-  const wsUrl = stdoutText.match(/URL (\S+)/)![1];
+  await waitForStdout("\n");
+  const wsUrl = stdoutText.match(/URL (\S+)\n/)![1];
 
   type Pending = { resolve: (msg: any) => void; reject: (err: Error) => void; method: string };
   type Client = {
@@ -1134,9 +1134,16 @@ for await (const line of rl) {
           }
         }
       };
-      ws.onerror = e => (pending.size ? client.abandon(`ws ${name} errored`) : reject(e));
-      ws.onclose = () => client.abandon(`ws ${name} closed`);
-      ws.onopen = () => resolve(client);
+      let opened = false;
+      ws.onerror = e => (opened ? client.abandon(`ws ${name} errored`) : reject(e));
+      ws.onclose = () => {
+        if (!opened) reject(new Error(`ws ${name} closed before open; stderr: ${stderrText}`));
+        client.abandon(`ws ${name} closed`);
+      };
+      ws.onopen = () => {
+        opened = true;
+        resolve(client);
+      };
     });
   }
 
@@ -1169,10 +1176,24 @@ for await (const line of rl) {
   expect(A.pauseCount).toBe(pausesBefore + 1);
 
   // B never enabled Debugger; none of these may touch A's session.
-  await B.send("Debugger.setBreakpointsActive", { active: false });
-  await B.send("Debugger.setPauseOnExceptions", { state: "none" });
-  await B.send("Debugger.removeBreakpoint", { breakpointId });
-  await B.send("Debugger.disable");
+  const bActive = await B.send("Debugger.setBreakpointsActive", { active: false });
+  const bPause = await B.send("Debugger.setPauseOnExceptions", { state: "none" });
+  const bRemove = await B.send("Debugger.removeBreakpoint", { breakpointId });
+  const bSetBp = await B.send("Debugger.setBreakpointByUrl", { lineNumber: 8, urlRegex: "debuggee\\.mjs$" });
+  const bDisable = await B.send("Debugger.disable");
+  expect({
+    active: bActive.error?.message,
+    pause: bPause.error?.message,
+    remove: bRemove.error?.message,
+    setBp: bSetBp.error?.message,
+    disable: bDisable.error?.message ?? "no error",
+  }).toEqual({
+    active: "Debugger agent is not enabled",
+    pause: "Debugger agent is not enabled",
+    remove: "Debugger agent is not enabled",
+    setBp: "Debugger agent is not enabled",
+    disable: "no error",
+  });
 
   const pausesMid = A.pauseCount;
   await triggerHit();
@@ -1259,6 +1280,10 @@ for await (const line of rl) {
   B.ws.close();
   proc.stdin.write("exit\n");
   proc.stdin.flush();
-  expect(await proc.exited).toBe(0);
+  const exitCode = await proc.exited;
   await stderrDrained;
+  expect({ exitCode, stderr: stderrText }).toEqual({
+    exitCode: 0,
+    stderr: expect.stringContaining("Debugger listening on"),
+  });
 }, 20_000);

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1071,12 +1071,21 @@ for await (const line of rl) {
   });
 
   const decoder = new TextDecoder();
+  const stderrReader = proc.stderr.getReader();
+  let stderrText = "";
+  const stderrDrained = (async () => {
+    for (;;) {
+      const { value, done } = await stderrReader.read();
+      if (done) break;
+      stderrText += decoder.decode(value);
+    }
+  })();
   const stdoutReader = proc.stdout.getReader();
   let stdoutText = "";
   async function waitForStdout(marker: string) {
     while (!stdoutText.includes(marker)) {
       const { value, done } = await stdoutReader.read();
-      if (done) throw new Error(`stdout closed before "${marker}": ${stdoutText}`);
+      if (done) throw new Error(`stdout closed before "${marker}": ${stdoutText}\nstderr: ${stderrText}`);
       stdoutText += decoder.decode(value);
     }
   }
@@ -1167,16 +1176,33 @@ for await (const line of rl) {
   const objectId = evalA.result?.result?.objectId;
   expect(objectId).toBeString();
   const bProps = await B.send("Runtime.getProperties", { objectId, ownProperties: true });
+  // callFunctionOn: neither the target objectId nor an arguments[].objectId may
+  // reach the backend from another session.
+  const bCallTarget = await B.send("Runtime.callFunctionOn", {
+    objectId,
+    functionDeclaration: "function(){ return this.alpha }",
+    returnByValue: true,
+  });
+  const bCallArg = await B.send("Runtime.callFunctionOn", {
+    executionContextId: 1,
+    functionDeclaration: "function(x){ return x.alpha }",
+    arguments: [{ objectId }],
+    returnByValue: true,
+  });
   const bRelease = await B.send("Runtime.releaseObject", { objectId });
   const aProps = await A.send("Runtime.getProperties", { objectId, ownProperties: true });
   const alphaFromA = (aProps.result?.result || []).find((p: any) => p.name === "alpha")?.value?.value;
   expect({
     bProps: bProps.error?.message ?? "no error",
+    bCallTarget: bCallTarget.error?.message ?? "no error",
+    bCallArg: bCallArg.error?.message ?? "no error",
     bRelease: bRelease.error?.message ?? "no error",
     alphaFromA,
     aError: aProps.error?.message,
   }).toEqual({
     bProps: "Could not find object with given id",
+    bCallTarget: "Could not find object with given id",
+    bCallArg: "Could not find object with given id",
     bRelease: "Could not find object with given id",
     alphaFromA: "objA-secret",
     aError: undefined,
@@ -1202,4 +1228,5 @@ for await (const line of rl) {
   proc.stdin.write("exit\n");
   proc.stdin.flush();
   expect(await proc.exited).toBe(0);
+  await stderrDrained;
 }, 20_000);

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1092,32 +1092,39 @@ for await (const line of rl) {
   await waitForStdout("URL ");
   const wsUrl = stdoutText.match(/URL (\S+)/)![1];
 
+  type Pending = { resolve: (msg: any) => void; reject: (err: Error) => void; method: string };
   type Client = {
     ws: WebSocket;
     events: any[];
     pauseCount: number;
     send: (method: string, params?: unknown) => Promise<any>;
+    abandon: (why: string) => void;
   };
-  function attach(autoResume: boolean): Promise<Client> {
+  function attach(name: string, autoResume: boolean): Promise<Client> {
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(wsUrl);
-      const pending = new Map<number, (msg: any) => void>();
+      const pending = new Map<number, Pending>();
+      let nextId = 1;
       const client: Client = {
         ws,
         events: [],
         pauseCount: 0,
         send: (method, params) =>
-          new Promise(r => {
+          new Promise((res, rej) => {
             const id = nextId++;
-            pending.set(id, r);
+            pending.set(id, { resolve: res, reject: rej, method });
             ws.send(JSON.stringify({ id, method, params }));
           }),
+        abandon: why => {
+          for (const p of pending.values())
+            p.reject(new Error(`${why} while ${name} awaited ${p.method}; stderr: ${stderrText}`));
+          pending.clear();
+        },
       };
-      let nextId = 1;
       ws.onmessage = e => {
         const m = JSON.parse(String(e.data));
         if (m.id !== undefined) {
-          pending.get(m.id)?.(m);
+          pending.get(m.id)?.resolve(m);
           pending.delete(m.id);
         } else {
           client.events.push(m);
@@ -1127,7 +1134,8 @@ for await (const line of rl) {
           }
         }
       };
-      ws.onerror = reject;
+      ws.onerror = e => (pending.size ? client.abandon(`ws ${name} errored`) : reject(e));
+      ws.onclose = () => client.abandon(`ws ${name} closed`);
       ws.onopen = () => resolve(client);
     });
   }
@@ -1135,8 +1143,12 @@ for await (const line of rl) {
   // A auto-resumes every pause so each "hit" trigger always reaches the
   // "after-hit" marker; the pauseCount delta tells us whether the breakpoint
   // actually fired.
-  const A = await attach(true);
-  const B = await attach(false);
+  const A = await attach("A", true);
+  const B = await attach("B", false);
+  proc.exited.then(code => {
+    A.abandon(`child exited (code ${code})`);
+    B.abandon(`child exited (code ${code})`);
+  });
 
   await A.send("Runtime.enable");
   await A.send("Debugger.enable");
@@ -1167,12 +1179,21 @@ for await (const line of rl) {
   expect(A.pauseCount).toBe(pausesMid + 1);
 
   // B never enabled Debugger, so the FrontendRouter broadcast must have been
-  // dropped before reaching its socket.
+  // dropped before reaching its socket, and its Debugger commands are rejected.
   expect(B.events.filter(e => e.method === "Debugger.paused")).toEqual([]);
+  const bEval = await B.send("Debugger.evaluateOnCallFrame", {
+    callFrameId: '{"ordinal":0,"injectedScriptId":1}',
+    expression: "local",
+  });
+  expect(bEval.error?.message).toBe("Debugger agent is not enabled");
 
   // objectId isolation: B presenting A's handle is rejected, and B's
-  // releaseObject cannot invalidate it for A.
-  const evalA = await A.send("Runtime.evaluate", { expression: "globalThis.secretStore", returnByValue: false });
+  // releaseObject / releaseObjectGroup cannot invalidate it for A.
+  const evalA = await A.send("Runtime.evaluate", {
+    expression: "globalThis.secretStore",
+    objectGroup: "console",
+    returnByValue: false,
+  });
   const objectId = evalA.result?.result?.objectId;
   expect(objectId).toBeString();
   const bProps = await B.send("Runtime.getProperties", { objectId, ownProperties: true });
@@ -1190,6 +1211,7 @@ for await (const line of rl) {
     returnByValue: true,
   });
   const bRelease = await B.send("Runtime.releaseObject", { objectId });
+  await B.send("Runtime.releaseObjectGroup", { objectGroup: "console" });
   const aProps = await A.send("Runtime.getProperties", { objectId, ownProperties: true });
   const alphaFromA = (aProps.result?.result || []).find((p: any) => p.name === "alpha")?.value?.value;
   expect({
@@ -1208,9 +1230,19 @@ for await (const line of rl) {
     aError: undefined,
   });
 
+  // returnByValue user JSON with a property named `objectId` must round-trip
+  // unchanged (the adapter's session tagging must not descend into user data).
+  const userJson = await A.send("Runtime.evaluate", {
+    expression: 'JSON.parse(\'{"objectId":"{\\\\"k\\\\":1}","nested":{"objectId":"x"}}\')',
+    returnByValue: true,
+  });
+  expect(userJson.result?.result?.value).toEqual({ objectId: '{"k":1}', nested: { objectId: "x" } });
+
   // Runtime/Console refcounting: B's Runtime.disable must not silence A, and
-  // B (never enabled Runtime) must not have received A's console stream.
+  // B (never enabled Runtime) must not have received A's console stream. A
+  // direct Console.disable (deprecated CDP domain) must not bypass the guard.
   await B.send("Runtime.disable");
+  await B.send("Console.disable");
   A.events.length = 0;
   B.events.length = 0;
   proc.stdin.write("log\n");

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -311,7 +311,7 @@ test("inspector.close() followed by inspector.open() starts a new server", async
   expect(summary.secondUrl).not.toBe(summary.firstUrl);
   expect(summary.protocolVersion).toBe("1.1");
   expect(summary.finalUrl).toBeNull();
-});
+}, 20_000);
 
 // A failed inspector.open() (port already in use) must print Node's diagnostic
 // line and RETURN so a later open() can retry on the same debugger thread.
@@ -369,7 +369,7 @@ test("inspector.open() can be retried after a failed start", async () => {
   expect(summary.url).toStartWith("ws://127.0.0.1:");
   expect(summary.protocolVersion).toBe("1.1");
   expect(summary.finalUrl).toBeNull();
-});
+}, 20_000);
 
 // wait=true refs the event loop before the debugger thread attempts to bind;
 // on bind failure the ref must be released so the process can exit.
@@ -398,7 +398,7 @@ test("inspector.open() with wait=true does not hang the process after a bind fai
   expect(stderr).toContain(`Starting inspector on 127.0.0.1:${port} failed: address already in use`);
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
-});
+}, 20_000);
 
 // waitForDebugger() must block until a client sends Runtime.runIfWaitingForDebugger,
 // even when open() was called without `wait`. The client marks a global before
@@ -472,7 +472,7 @@ test("inspector.waitForDebugger() blocks until a client resumes the process", as
 
   expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ resumedByClient: true });
   expect(exitCode).toBe(0);
-});
+}, 20_000);
 
 // A second waitForDebugger() must block again for a fresh
 // Runtime.runIfWaitingForDebugger — Node blocks on every call, and it must be
@@ -562,7 +562,7 @@ test("inspector.waitForDebugger() blocks again on the second call after a fronte
 
   expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ first: 1, second: 2 });
   expect(exitCode).toBe(0);
-});
+}, 20_000);
 
 test("Runtime.consoleAPICalled is emitted while the Runtime domain is enabled", () => {
   const session = new inspector.Session();
@@ -886,7 +886,7 @@ export { after };
   expect(JSON.parse(stdoutText.trim().split("\n").at(-1)!)).toEqual({ after: 1, bump: 1, warm: 10 });
   expect(await proc.exited).toBe(0);
   await stderrDrained;
-});
+}, 20_000);
 
 // End-to-end pause/resume over the DevTools-protocol server started by
 // inspector.open(): the entry module is a top-level-await module that calls
@@ -1009,7 +1009,7 @@ export { after };
 
   expect(JSON.parse(stdoutText.trim().split("\n").at(-1)!)).toEqual({ after: 1, beforeOpen: 1 });
   expect(await proc.exited).toBe(0);
-});
+}, 20_000);
 
 test("disconnect does not clobber a console method reassigned by user code", () => {
   const session = new inspector.Session();

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1208,6 +1208,17 @@ for await (const line of rl) {
   });
   expect(bEval.error?.message).toBe("Debugger agent is not enabled");
 
+  // With B also debugger-enabled, B's setBreakpointsActive(false) must not
+  // lower the aggregate below A's true, and B cannot remove A's breakpoint.
+  await B.send("Debugger.enable");
+  await B.send("Debugger.setBreakpointsActive", { active: false });
+  const bRemoveOwned = await B.send("Debugger.removeBreakpoint", { breakpointId });
+  expect(bRemoveOwned).toEqual({ id: expect.any(Number), result: {} });
+  const pausesBoth = A.pauseCount;
+  await triggerHit();
+  expect(A.pauseCount).toBe(pausesBoth + 1);
+  await B.send("Debugger.disable");
+
   // objectId isolation: B presenting A's handle is rejected, and B's
   // releaseObject / releaseObjectGroup cannot invalidate it for A.
   const evalA = await A.send("Runtime.evaluate", {

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1025,3 +1025,181 @@ test("disconnect does not clobber a console method reassigned by user code", () 
     console.log = before;
   }
 });
+
+// JSC's JSGlobalObjectInspectorController has one DebuggerAgent / RuntimeAgent
+// / InjectedScript shared across every FrontendChannel, so two CDP clients on
+// the same inspector.open() server used to stomp on each other: B's
+// setBreakpointsActive(false) / Debugger.disable blinded A, B's Runtime.disable
+// silenced A's console stream, and B could read/release A's RemoteObject
+// handles by id. Node gives each WebSocket its own V8InspectorSession and is
+// per-session on every cell of that matrix.
+test("two inspector.open() clients have isolated Debugger/Runtime session state", async () => {
+  using dir = tempDir("inspector-multi-session", {
+    "debuggee.mjs": `
+import inspector from "node:inspector";
+import readline from "node:readline";
+inspector.open(0, "127.0.0.1", false);
+process.stdout.write("URL " + inspector.url() + "\\n");
+globalThis.secretStore = { alpha: "objA-secret" };
+globalThis.hitme = function hitme() {
+  const local = "hit";
+  return local;
+};
+let hits = 0, logs = 0;
+const rl = readline.createInterface({ input: process.stdin });
+for await (const line of rl) {
+  if (line === "hit") {
+    globalThis.hitme();
+    process.stdout.write("after-hit:" + (++hits) + "\\n");
+  } else if (line === "log") {
+    console.log("tagged-console-call");
+    process.stdout.write("after-log:" + (++logs) + "\\n");
+  } else if (line === "exit") {
+    process.exit(0);
+  }
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "debuggee.mjs"],
+    env: injectedScriptChildEnv,
+    cwd: String(dir),
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  const stdoutReader = proc.stdout.getReader();
+  let stdoutText = "";
+  async function waitForStdout(marker: string) {
+    while (!stdoutText.includes(marker)) {
+      const { value, done } = await stdoutReader.read();
+      if (done) throw new Error(`stdout closed before "${marker}": ${stdoutText}`);
+      stdoutText += decoder.decode(value);
+    }
+  }
+  await waitForStdout("URL ");
+  const wsUrl = stdoutText.match(/URL (\S+)/)![1];
+
+  type Client = {
+    ws: WebSocket;
+    events: any[];
+    pauseCount: number;
+    send: (method: string, params?: unknown) => Promise<any>;
+  };
+  function attach(autoResume: boolean): Promise<Client> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(wsUrl);
+      const pending = new Map<number, (msg: any) => void>();
+      const client: Client = {
+        ws,
+        events: [],
+        pauseCount: 0,
+        send: (method, params) =>
+          new Promise(r => {
+            const id = nextId++;
+            pending.set(id, r);
+            ws.send(JSON.stringify({ id, method, params }));
+          }),
+      };
+      let nextId = 1;
+      ws.onmessage = e => {
+        const m = JSON.parse(String(e.data));
+        if (m.id !== undefined) {
+          pending.get(m.id)?.(m);
+          pending.delete(m.id);
+        } else {
+          client.events.push(m);
+          if (m.method === "Debugger.paused") {
+            client.pauseCount++;
+            if (autoResume) ws.send(JSON.stringify({ id: nextId++, method: "Debugger.resume" }));
+          }
+        }
+      };
+      ws.onerror = reject;
+      ws.onopen = () => resolve(client);
+    });
+  }
+
+  // A auto-resumes every pause so each "hit" trigger always reaches the
+  // "after-hit" marker; the pauseCount delta tells us whether the breakpoint
+  // actually fired.
+  const A = await attach(true);
+  const B = await attach(false);
+
+  await A.send("Runtime.enable");
+  await A.send("Debugger.enable");
+  const bp = await A.send("Debugger.setBreakpointByUrl", { lineNumber: 8, urlRegex: "debuggee\\.mjs$" });
+  expect(bp.result?.breakpointId).toBeString();
+  const breakpointId = bp.result.breakpointId;
+
+  let hitSeq = 0;
+  async function triggerHit() {
+    const marker = `after-hit:${++hitSeq}\n`;
+    proc.stdin.write("hit\n");
+    proc.stdin.flush();
+    await waitForStdout(marker);
+  }
+
+  const pausesBefore = A.pauseCount;
+  await triggerHit();
+  expect(A.pauseCount).toBe(pausesBefore + 1);
+
+  // B never enabled Debugger; none of these may touch A's session.
+  await B.send("Debugger.setBreakpointsActive", { active: false });
+  await B.send("Debugger.setPauseOnExceptions", { state: "none" });
+  await B.send("Debugger.removeBreakpoint", { breakpointId });
+  await B.send("Debugger.disable");
+
+  const pausesMid = A.pauseCount;
+  await triggerHit();
+  expect(A.pauseCount).toBe(pausesMid + 1);
+
+  // B never enabled Debugger, so the FrontendRouter broadcast must have been
+  // dropped before reaching its socket.
+  expect(B.events.filter(e => e.method === "Debugger.paused")).toEqual([]);
+
+  // objectId isolation: B presenting A's handle is rejected, and B's
+  // releaseObject cannot invalidate it for A.
+  const evalA = await A.send("Runtime.evaluate", { expression: "globalThis.secretStore", returnByValue: false });
+  const objectId = evalA.result?.result?.objectId;
+  expect(objectId).toBeString();
+  const bProps = await B.send("Runtime.getProperties", { objectId, ownProperties: true });
+  const bRelease = await B.send("Runtime.releaseObject", { objectId });
+  const aProps = await A.send("Runtime.getProperties", { objectId, ownProperties: true });
+  const alphaFromA = (aProps.result?.result || []).find((p: any) => p.name === "alpha")?.value?.value;
+  expect({
+    bProps: bProps.error?.message ?? "no error",
+    bRelease: bRelease.error?.message ?? "no error",
+    alphaFromA,
+    aError: aProps.error?.message,
+  }).toEqual({
+    bProps: "Could not find object with given id",
+    bRelease: "Could not find object with given id",
+    alphaFromA: "objA-secret",
+    aError: undefined,
+  });
+
+  // Runtime/Console refcounting: B's Runtime.disable must not silence A, and
+  // B (never enabled Runtime) must not have received A's console stream.
+  await B.send("Runtime.disable");
+  A.events.length = 0;
+  B.events.length = 0;
+  proc.stdin.write("log\n");
+  proc.stdin.flush();
+  await waitForStdout("after-log:1\n");
+  // The console event and this evaluate result share A's backend→client
+  // queue and the console.log ran first, so once this reply arrives the
+  // consoleAPICalled has too.
+  await A.send("Runtime.evaluate", { expression: "1", returnByValue: true });
+  expect(A.events.filter(e => e.method === "Runtime.consoleAPICalled").length).toBeGreaterThan(0);
+  expect(B.events.filter(e => e.method === "Runtime.consoleAPICalled")).toEqual([]);
+
+  A.ws.close();
+  B.ws.close();
+  proc.stdin.write("exit\n");
+  proc.stdin.flush();
+  expect(await proc.exited).toBe(0);
+}, 20_000);


### PR DESCRIPTION
With two clients attached to one `inspector.open()` server, client B can silently hijack or blind client A: B's `Debugger.setBreakpointsActive{active:false}` or `Debugger.disable` stops A's breakpoints, B's `Runtime.disable` silences A's console stream, B receives A's `Debugger.paused` / `Runtime.consoleAPICalled` without ever enabling those domains, and B can read or `releaseObject` A's `Runtime.RemoteObject` handles by id. Node gives each WebSocket its own `V8InspectorSession` and is per-session on every cell of that matrix.

## Repro

```
A: Debugger.enable + setBreakpointByUrl; interval hits it (A.paused = 1)
B: Debugger.setBreakpointsActive{active:false}   // B never enabled Debugger
A: paused count after = 0  (node: still 1)

A: Runtime.evaluate 'globalThis.secretStore' -> objectId {"injectedScriptId":1,"id":34}
B: Runtime.getProperties(objectId) -> alpha = "objA-secret"  (node: "Could not find object with given id")
B: Runtime.releaseObject(objectId)
A: Runtime.getProperties(objectId) -> "Internal error"       (node: still valid)
```

## Cause

Every WebSocket client is a `FrontendChannel` on the one per-process `JSGlobalObjectInspectorController`, which owns a single `InspectorDebuggerAgent` / `InspectorRuntimeAgent` / `InjectedScript`. `FrontendRouter::sendResponse` / `sendEvent` broadcast to every channel (the `// FIXME: send responses to the appropriate frontend` in `InspectorFrontendRouter.cpp`), and `dispatchMessageFromRemote` carries no sender identity, so every agent's enable flags, breakpoints, `breakpointsActive`, `pauseOnExceptions` and RemoteObject id table are process-global across clients.

## Fix

The CDP adapter already sits between each WebSocket and the shared JSC backend, so do the per-session scoping there (no WebKit changes):

- **Shared backend command-id counter** across adapters, so a broadcast response only matches the sender's `#pending` map and ids stay within `BackendDispatcher`'s 32-bit int. (Same approach as #35701, which this PR subsumes.)
- **Per-adapter `debuggerEnabled` / `runtimeEnabled`** gating of broadcast events and of inbound Debugger commands (`pause`/`resume`/`step*`/`evaluateOnCallFrame` reply `Debugger agent is not enabled`), and **refcounted** `Debugger`/`Runtime`/`Console` enable so one client's `disable` does not tear the shared agent down under another. The deprecated `Console.enable`/`disable` are acknowledged locally.
- **Per-adapter `breakpointsActive` / `pauseOnExceptions`** with an aggregate written to the backend only on change; **per-adapter breakpoint ownership** so `removeBreakpoint` cannot delete another client's, and `breakpointResolved` / `Debugger.paused.hitBreakpoints` are filtered to the owner.
- **Session-tagged `objectId`s**: every outbound `RemoteObject.objectId` gets a `bunSessionId` field (skipping `RemoteObject.value`, which is user JSON under `returnByValue`); inbound ids without this adapter's tag are rejected with V8's `Could not find object with given id`, including `callFunctionOn` `arguments[].objectId`. `objectGroup` names are likewise prefixed per session so `releaseObjectGroup` cannot free another client's handles.
- **`dispose()`** on connection close removes the session's breakpoints and contribution to the aggregates.

## Verification

New test `two inspector.open() clients have isolated Debugger/Runtime session state` drives A's breakpoint before and after B's `setBreakpointsActive(false)` / `removeBreakpoint` / `Debugger.disable`, checks B can't read or release A's `objectId` via `getProperties` / `callFunctionOn` (target or `arguments[]`) / `releaseObject` / `releaseObjectGroup`, checks B's `Runtime.disable` / `Console.disable` doesn't silence A, checks B's `evaluateOnCallFrame` is rejected, and checks `returnByValue` user JSON with an `objectId` property round-trips unchanged. Fails on main at the second pause count (`Expected: 2, Received: 1`), passes with the fix. Full `test/js/node/inspector/inspector.test.ts` 24/24.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (72a2623a3)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [9.78ms]
(pass) inspector.console [10.52ms]
(pass) inspector.close() is a no-op when the inspector is not open [5.34ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [6.12ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [5007.48ms]
(pass) inspector.close() followed by inspector.open() starts a new server [1926.46ms]
(pass) inspector.open() can be retried after a failed start [2128.59ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [2067.17ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [2551.42ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [2396.46ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [72.54ms]
-0 NaN Infinity -Infinity 1
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (08b25a85a)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [3.99ms]
(pass) inspector.console [0.17ms]
(pass) inspector.close() is a no-op when the inspector is not open [1.93ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [0.23ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [900.36ms]
(pass) inspector.close() followed by inspector.open() starts a new server [89.07ms]
(pass) inspector.open() can be retried after a failed start [49.89ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [49.48ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [69.20ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [138.34ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [2.78ms]
-0 NaN Infinity -Infinity 1n
(pass) Runtime.consoleAPICalled encodes -0/NaN/Infinity/bigint as unserializableValue like Node [0.18ms]
(pass) Session errors carry Node's ERR_INSPECTOR_* codes and post() va
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (72a2623a3)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [9.53ms]
(pass) inspector.console [9.70ms]
(pass) inspector.close() is a no-op when the inspector is not open [5.41ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [5.87ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [5015.69ms]
(pass) inspector.close() followed by inspector.open() starts a new server [1981.41ms]
(pass) inspector.open() can be retried after a failed start [1932.95ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [2041.66ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [2826.94ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [2227.95ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [126.46ms]
-0 NaN Infinity -Infinity 1
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 904ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (16614ms)
Bundle modules (1111ms)
Postprocesss modules (403ms)
Bundle Functions (2349ms)
Generate Code (715ms)

[21.22s] Bundled "src/js" for production
  2582 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/debugger.ts              |  12 +-
 src/js/internal/inspector/cdp.ts         | 439 ++++++++++++++++++++++++++++---
 test/js/node/inspector/inspector.test.ts | 287 +++++++++++++++++++-
 3 files changed, 697 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/debugger.ts                   3      7      0
src/js/internal/inspector/cdp.ts             23     54      0
test/js/node/inspector/inspector.test.ts      5     27      0
```

</details>

<!-- robobun:evidence:end -->