### PR TITLE
test/js/sql: drop duplicate pgParameterStatus export in wire-frames.ts

### DIFF
--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -122,11 +122,6 @@ export function pgErrorResponse(fields: { S: string; C: string; M: string; [k: s
   return buf;
 }
 
-// PostgreSQL FE/BE protocol §55.7 ParameterStatus: Byte1('S') Int32(len) String(name) String(value)
-export function pgParameterStatus(name: string, value: string): Buffer {
-  return pgRaw("S", Buffer.concat([pgCString(name), pgCString(value)]));
-}
-
 // PostgreSQL FE/BE protocol §55.7 NotificationResponse: Byte1('A') Int32(len) Int32(pid) String(channel) String(payload)
 export function pgNotificationResponse(pid: number, channel: string, payload: string): Buffer {
   return pgRaw("A", Buffer.concat([pgInt32(pid), pgCString(channel), pgCString(payload)]));


### PR DESCRIPTION
## What

`test/js/sql/wire-frames.ts` exported `pgParameterStatus` twice with identical bodies (lines 92 and 126 on main). Bun's transpiler silently accepts the second declaration so no test failed, but `tsc` flags it as TS2393 Duplicate function implementation, and anyone editing just one copy would be surprised.

## Cause

#35112 added `pgParameterStatus` to the shared wire-frames helper; #35114 then landed with its own copy of the same helper a few lines lower. Both merged and the file ended up with two.

## Fix

Delete the second copy (the one between `pgErrorResponse` and `pgNotificationResponse`). The first copy stays next to `pgAuthenticationOk` / `pgReadyForQuery` where the other startup-sequence builders live.

## Verification

```
bun bd test test/js/sql/postgres-datestyle.test.ts \
            test/js/sql/postgres-infinity-date.test.ts \
            test/js/sql/postgres-frame-boundary.test.ts
# 21 pass, 0 fail
```

All three importers of `wire-frames.ts` (including the two that call `pgParameterStatus` directly) still pass.

This is a test-helper cleanup with no `src/` change, so there is no fail-before state to demonstrate: the duplicate was silently accepted at runtime and the fix is purely removing dead duplication.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->