### PR TITLE
node:inspector: drop JSC-internal synthetics from precise coverage output

### DIFF
--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -274,9 +274,6 @@ function removeConsoleHooks() {
 
 // Reshapes the raw control-flow-profiler data from jsFunction_collectPreciseCoverage
 // into the V8 ScriptCoverage list returned by Profiler.takePreciseCoverage.
-// Each surviving function gets an entry whose first range spans the function
-// source with its call count, followed by the basic-block sub-ranges inside it
-// whose count differs from the call count.
 function buildScriptCoverageList(
   rawScripts: Array<{
     url: string;
@@ -301,26 +298,21 @@ function buildScriptCoverageList(
       url = pathToFileURL(url).href;
     }
 
-    // Index FunctionExecutable metadata by JSC's (functionStart, functionEnd),
-    // which is the same key FunctionHasExecutedCache uses.
+    // Keyed by (functionStart, functionEnd): the same key FunctionHasExecutedCache uses.
     const execByRange = new Map<number, { end: number; sourceEnd: number; name: string; skip: boolean }>();
     for (const [start, end, sourceEnd, name, skip] of script.executables) {
       const key = start * 0x100000000 + end;
       const prev = execByRange.$get(key);
-      // Recompilation can yield multiple FunctionExecutables for one range;
-      // one non-skip instance is enough to keep the range.
       if (prev === undefined || (prev.skip && !skip)) {
         execByRange.$set(key, { end, sourceEnd, name, skip });
       }
     }
 
-    // Build the V8 function list from FunctionHasExecutedCache (which records
-    // every inner function of every compiled CodeBlock). Drop synthetic
-    // entries that have no user-visible source: the program/module range, any
-    // range marked skip by its executable (generator/async bodies, class
-    // field initializers), and ranges with no executable under this sourceID
-    // at all (JSC's builtin default class constructors register their offsets
-    // against the enclosing script but link against the builtin provider).
+    // Drop FunctionHasExecutedCache ranges with no user-visible source: the
+    // program/module range, skip-marked executables (generator/async bodies,
+    // class-field initializers), and ranges with no executable on this
+    // sourceID (builtin default class constructors link against their own
+    // provider but register offsets under the enclosing script's sourceID).
     type Fn = { start: number; end: number; sourceEnd: number; name: string; executed: boolean };
     const seenFns = new Set<number>();
     const functions: Fn[] = [];
@@ -340,9 +332,8 @@ function buildScriptCoverageList(
 
     const blocks = script.blocks.filter(([start, end]) => start >= 0 && end >= start).sort((a, b) => a[0] - b[0]);
 
-    // Assign each basic block to the innermost surviving function range that
-    // contains it. Blocks from skipped inner executables (generator/async
-    // bodies) naturally fall through to the enclosing wrapper.
+    // Assign each basic block to the innermost surviving function; blocks from
+    // skipped generator/async bodies fall through to the enclosing wrapper.
     const blocksPerFunction: Array<Array<[number, number, number, boolean]>> = functions.map(() => []);
     const topLevelBlocks: Array<[number, number, number, boolean]> = [];
     const stack: number[] = [];
@@ -376,14 +367,9 @@ function buildScriptCoverageList(
 
     const clampCount = (c: number) => (callCount ? c : c > 0 ? 1 : 0);
 
-    // V8 emits sub-ranges as deltas from the enclosing range's count, so a
-    // block whose count equals the owner's call count is redundant. This also
-    // removes the function entry block (count == call count). JSC inserts a
-    // profile point after every return/throw; when that is the last statement
-    // the resulting count-0 block either spans only whitespace and the closing
-    // brace, or collapses to a single position at the owner's last source
-    // character (arrow expression bodies). V8 never emits that block, and
-    // coverage tools render it as a spurious uncovered line.
+    // V8 sub-ranges are deltas from the owner's count, so skip blocks with that
+    // count. Also skip JSC's post-return/throw block when it spans no code or
+    // collapses onto the owner's last character (arrow-body case).
     const subRanges = (ownBlocks: Array<[number, number, number, boolean]>, ownerCount: number, ownerEnd: number) => {
       const ranges: object[] = [];
       for (const [start, end, count, hasCode] of ownBlocks) {
@@ -400,13 +386,10 @@ function buildScriptCoverageList(
     const scriptExecuted = blocks.some(([, , count]) => count > 0) ? 1 : 0;
     const entries: object[] = [];
 
-    // The script's entry block is the first piece of the program/module code
-    // block after gap splitting. JSC keys BasicBlockLocations by (sourceID,
-    // start, end), so a class-field-initializer function (whose source JSC
-    // sets to the enclosing scope) aliases and increments the same counter.
-    // Treat that possibly-inflated count as the top-level baseline so the
-    // entry-block pieces are filtered out while real top-level branches
-    // (whose counts differ) survive.
+    // JSC keys BasicBlockLocations by (sourceID, start, end), so a class-field
+    // initializer (whose source is the enclosing scope) aliases the script
+    // entry block and inflates its counter; use that counter as the top-level
+    // baseline so only real branches survive.
     let scriptEntryCount = scriptExecuted;
     if (topLevelBlocks.length > 0) {
       let entry = topLevelBlocks[0];
@@ -436,10 +419,9 @@ function buildScriptCoverageList(
       }
 
       const ownBlocks = blocksPerFunction[i];
-      // The block with the smallest start offset is the function's entry
-      // block; it runs exactly once per invocation, so its execution count is
-      // the call count. Generator/async bodies were filtered above, so the
-      // wrapper's entry block (which counts user-visible calls) is selected.
+      // The smallest-start block is the function's entry block; its count is
+      // the call count (the wrapper's, since generator/async bodies were
+      // filtered above).
       let count = 1;
       if (ownBlocks.length > 0) {
         let entryBlock = ownBlocks[0];

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -299,12 +299,12 @@ function buildScriptCoverageList(
     }
 
     // Keyed by (functionStart, functionEnd): the same key FunctionHasExecutedCache uses.
-    const execByRange = new Map<string, { end: number; sourceEnd: number; name: string; skip: boolean }>();
+    const execByRange = new Map<string, { sourceEnd: number; name: string; skip: boolean }>();
     for (const [start, end, sourceEnd, name, skip] of script.executables) {
       const key = `${start}:${end}`;
       const prev = execByRange.$get(key);
       if (prev === undefined || (prev.skip && !skip)) {
-        execByRange.$set(key, { end, sourceEnd, name, skip });
+        execByRange.$set(key, { sourceEnd, name, skip });
       }
     }
 

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -273,18 +273,18 @@ function removeConsoleHooks() {
 }
 
 // Reshapes the raw control-flow-profiler data from jsFunction_collectPreciseCoverage
-// ([{ url, scriptId, sourceLength, blocks: [[start, end, count]], functions: [[start, end, executed]] }])
-// into the V8 ScriptCoverage list returned by Profiler.takePreciseCoverage:
-// each function gets an entry whose first range spans the whole function with its
-// call count, followed by the basic-block ranges inside it; blocks outside any
-// function go on a synthetic whole-script entry.
+// into the V8 ScriptCoverage list returned by Profiler.takePreciseCoverage.
+// Each surviving function gets an entry whose first range spans the function
+// source with its call count, followed by the basic-block sub-ranges inside it
+// whose count differs from the call count.
 function buildScriptCoverageList(
   rawScripts: Array<{
     url: string;
     scriptId: number;
     sourceLength: number;
-    blocks: Array<[number, number, number]>;
+    blocks: Array<[number, number, number, boolean]>;
     functions: Array<[number, number, boolean]>;
+    executables: Array<[number, number, number, string, boolean]>;
   }>,
   callCount: boolean,
   detailed: boolean,
@@ -301,26 +301,60 @@ function buildScriptCoverageList(
       url = pathToFileURL(url).href;
     }
 
+    // Index FunctionExecutable metadata by JSC's (functionStart, functionEnd),
+    // which is the same key FunctionHasExecutedCache uses.
+    const execByRange = new Map<number, { end: number; sourceEnd: number; name: string; skip: boolean }>();
+    for (const [start, end, sourceEnd, name, skip] of script.executables) {
+      const key = start * 0x100000000 + end;
+      const prev = execByRange.$get(key);
+      // Recompilation can yield multiple FunctionExecutables for one range;
+      // one non-skip instance is enough to keep the range.
+      if (prev === undefined || (prev.skip && !skip)) {
+        execByRange.$set(key, { end, sourceEnd, name, skip });
+      }
+    }
+
+    // Build the V8 function list from FunctionHasExecutedCache (which records
+    // every inner function of every compiled CodeBlock). Drop synthetic
+    // entries that have no user-visible source: the program/module range, any
+    // range marked skip by its executable (generator/async bodies, class
+    // field initializers), and ranges with no executable under this sourceID
+    // at all (JSC's builtin default class constructors register their offsets
+    // against the enclosing script but link against the builtin provider).
+    type Fn = { start: number; end: number; sourceEnd: number; name: string; executed: boolean };
+    const seenFns = new Set<number>();
+    const functions: Fn[] = [];
+    for (const [start, end, executed] of script.functions) {
+      if (start < 0 || end < start) continue;
+      if (start === 0 && end >= sourceLength - 1) continue;
+      const key = start * 0x100000000 + end;
+      if (seenFns.$has(key)) continue;
+      seenFns.$add(key);
+      const meta = execByRange.$get(key);
+      if (meta === undefined || meta.skip) continue;
+      functions.push({ start, end, sourceEnd: meta.sourceEnd, name: meta.name, executed });
+    }
     // Outer functions before nested ones, so a stack-based sweep below sees
     // enclosing ranges first.
-    const functions = script.functions
-      .filter(([start, end]) => start >= 0 && end >= start)
-      .sort((a, b) => a[0] - b[0] || b[1] - a[1]);
+    functions.sort((a, b) => a.start - b.start || b.end - a.end);
+
     const blocks = script.blocks.filter(([start, end]) => start >= 0 && end >= start).sort((a, b) => a[0] - b[0]);
 
-    // Assign each basic block to the innermost function range containing it.
-    const blocksPerFunction: Array<Array<[number, number, number]>> = functions.map(() => []);
-    const topLevelBlocks: Array<[number, number, number]> = [];
+    // Assign each basic block to the innermost surviving function range that
+    // contains it. Blocks from skipped inner executables (generator/async
+    // bodies) naturally fall through to the enclosing wrapper.
+    const blocksPerFunction: Array<Array<[number, number, number, boolean]>> = functions.map(() => []);
+    const topLevelBlocks: Array<[number, number, number, boolean]> = [];
     const stack: number[] = [];
     let nextFunction = 0;
     for (const block of blocks) {
-      while (nextFunction < functions.length && functions[nextFunction][0] <= block[0]) {
+      while (nextFunction < functions.length && functions[nextFunction].start <= block[0]) {
         stack.push(nextFunction);
         nextFunction++;
       }
       // Functions that ended before this block started can no longer contain
       // this block or any later one (blocks are sorted by start).
-      while (stack.length > 0 && functions[stack[stack.length - 1]][1] < block[0]) {
+      while (stack.length > 0 && functions[stack[stack.length - 1]].end < block[0]) {
         stack.pop();
       }
       // The stack is a nesting chain (siblings get popped above), so ends
@@ -328,7 +362,7 @@ function buildScriptCoverageList(
       // covers the block's end is the innermost containing function.
       let owner = -1;
       for (let i = stack.length - 1; i >= 0; i--) {
-        if (functions[stack[i]][1] >= block[1]) {
+        if (functions[stack[i]].end >= block[1]) {
           owner = stack[i];
           break;
         }
@@ -340,44 +374,72 @@ function buildScriptCoverageList(
       }
     }
 
+    const clampCount = (c: number) => (callCount ? c : c > 0 ? 1 : 0);
+
+    // V8 emits sub-ranges as deltas from the enclosing range's count, so a
+    // block whose count equals the owner's call count is redundant. This also
+    // removes the function entry block (count == call count). JSC inserts a
+    // profile point after every return/throw; when that is the last statement
+    // the resulting count-0 block either spans only whitespace and the closing
+    // brace, or collapses to a single position at the owner's last source
+    // character (arrow expression bodies). V8 never emits that block, and
+    // coverage tools render it as a spurious uncovered line.
+    const subRanges = (ownBlocks: Array<[number, number, number, boolean]>, ownerCount: number, ownerEnd: number) => {
+      const ranges: object[] = [];
+      for (const [start, end, count, hasCode] of ownBlocks) {
+        if (count === ownerCount) continue;
+        if (count === 0 && (!hasCode || start >= ownerEnd)) continue;
+        ranges.push({ startOffset: start, endOffset: end + 1, count: clampCount(count) });
+      }
+      return ranges;
+    };
+
     // Derived from the (delta-subtracted) block counts only: the function
     // `executed` flag is cumulative and would make a second takePreciseCoverage
     // report 1 even when nothing ran since the first.
     const scriptExecuted = blocks.some(([, , count]) => count > 0) ? 1 : 0;
     const entries: object[] = [];
 
-    const toRange = ([startOffset, endOffset, count]: [number, number, number]) => ({
-      startOffset,
-      endOffset,
-      count: callCount ? count : count > 0 ? 1 : 0,
-    });
+    // The script's entry block is the first piece of the program/module code
+    // block after gap splitting. JSC keys BasicBlockLocations by (sourceID,
+    // start, end), so a class-field-initializer function (whose source JSC
+    // sets to the enclosing scope) aliases and increments the same counter.
+    // Treat that possibly-inflated count as the top-level baseline so the
+    // entry-block pieces are filtered out while real top-level branches
+    // (whose counts differ) survive.
+    let scriptEntryCount = scriptExecuted;
+    if (topLevelBlocks.length > 0) {
+      let entry = topLevelBlocks[0];
+      for (const b of topLevelBlocks) if (b[0] < entry[0]) entry = b;
+      scriptEntryCount = entry[2];
+    }
 
     // Whole-script entry. V8 always reports one covering the entire source.
     entries.push({
       functionName: "",
       ranges: [
         { startOffset: 0, endOffset: sourceLength, count: scriptExecuted },
-        ...(detailed ? topLevelBlocks.map(toRange) : []),
+        ...(detailed ? subRanges(topLevelBlocks, scriptEntryCount, sourceLength - 1) : []),
       ],
       isBlockCoverage: detailed,
     });
 
     for (let i = 0; i < functions.length; i++) {
-      const [startOffset, endOffset, executed] = functions[i];
-      if (!executed) {
+      const fn = functions[i];
+      if (!fn.executed) {
         entries.push({
-          functionName: "",
-          ranges: [{ startOffset, endOffset, count: 0 }],
+          functionName: fn.name,
+          ranges: [{ startOffset: fn.start, endOffset: fn.sourceEnd, count: 0 }],
           isBlockCoverage: false,
         });
         continue;
       }
 
       const ownBlocks = blocksPerFunction[i];
-      // Approximate the call count from the entry block (the one with the
-      // smallest start offset). Diverges from V8 for generators/async
-      // functions, which JSC compiles as two nested CodeBlocks whose body
-      // entry counts state-0 resumes rather than user-visible calls.
+      // The block with the smallest start offset is the function's entry
+      // block; it runs exactly once per invocation, so its execution count is
+      // the call count. Generator/async bodies were filtered above, so the
+      // wrapper's entry block (which counts user-visible calls) is selected.
       let count = 1;
       if (ownBlocks.length > 0) {
         let entryBlock = ownBlocks[0];
@@ -387,10 +449,10 @@ function buildScriptCoverageList(
         count = entryBlock[2];
       }
       entries.push({
-        functionName: "",
+        functionName: fn.name,
         ranges: [
-          { startOffset, endOffset, count: callCount ? count : count > 0 ? 1 : 0 },
-          ...(detailed ? ownBlocks.map(toRange) : []),
+          { startOffset: fn.start, endOffset: fn.sourceEnd, count: clampCount(count) },
+          ...(detailed ? subRanges(ownBlocks, count, fn.end) : []),
         ],
         isBlockCoverage: detailed,
       });

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -299,30 +299,25 @@ function buildScriptCoverageList(
     }
 
     // Keyed by (functionStart, functionEnd): the same key FunctionHasExecutedCache uses.
-    const execByRange = new Map<number, { end: number; sourceEnd: number; name: string; skip: boolean }>();
+    const execByRange = new Map<string, { end: number; sourceEnd: number; name: string; skip: boolean }>();
     for (const [start, end, sourceEnd, name, skip] of script.executables) {
-      const key = start * 0x100000000 + end;
+      const key = `${start}:${end}`;
       const prev = execByRange.$get(key);
       if (prev === undefined || (prev.skip && !skip)) {
         execByRange.$set(key, { end, sourceEnd, name, skip });
       }
     }
 
-    // Drop FunctionHasExecutedCache ranges with no user-visible source: the
-    // program/module range, skip-marked executables (generator/async bodies,
-    // class-field initializers), and ranges with no executable on this
-    // sourceID (builtin default class constructors link against their own
-    // provider but register offsets under the enclosing script's sourceID).
     type Fn = { start: number; end: number; sourceEnd: number; name: string; executed: boolean };
-    const seenFns = new Set<number>();
+    const seenFns = new Set<string>();
     const functions: Fn[] = [];
     for (const [start, end, executed] of script.functions) {
       if (start < 0 || end < start) continue;
-      if (start === 0 && end >= sourceLength - 1) continue;
-      const key = start * 0x100000000 + end;
+      const key = `${start}:${end}`;
       if (seenFns.$has(key)) continue;
       seenFns.$add(key);
       const meta = execByRange.$get(key);
+      // Program/module/eval and default-ctor ranges have no FunctionExecutable on this sourceID; gen/async bodies are skip.
       if (meta === undefined || meta.skip) continue;
       functions.push({ start, end, sourceEnd: meta.sourceEnd, name: meta.name, executed });
     }
@@ -332,8 +327,7 @@ function buildScriptCoverageList(
 
     const blocks = script.blocks.filter(([start, end]) => start >= 0 && end >= start).sort((a, b) => a[0] - b[0]);
 
-    // Assign each basic block to the innermost surviving function; blocks from
-    // skipped generator/async bodies fall through to the enclosing wrapper.
+    // Assign each block to the innermost surviving function; skipped generator/async body blocks fall to the wrapper.
     const blocksPerFunction: Array<Array<[number, number, number, boolean]>> = functions.map(() => []);
     const topLevelBlocks: Array<[number, number, number, boolean]> = [];
     const stack: number[] = [];
@@ -367,13 +361,12 @@ function buildScriptCoverageList(
 
     const clampCount = (c: number) => (callCount ? c : c > 0 ? 1 : 0);
 
-    // V8 sub-ranges are deltas from the owner's count, so skip blocks with that
-    // count. Also skip JSC's post-return/throw block when it spans no code or
-    // collapses onto the owner's last character (arrow-body case).
     const subRanges = (ownBlocks: Array<[number, number, number, boolean]>, ownerCount: number, ownerEnd: number) => {
       const ranges: object[] = [];
       for (const [start, end, count, hasCode] of ownBlocks) {
+        // V8 sub-ranges are deltas from the owner's count, so the entry block (same count) is redundant.
         if (count === ownerCount) continue;
+        // JSC's post-return/throw block: whitespace/comment/`}` only, or a single position at ownerEnd for arrow bodies.
         if (count === 0 && (!hasCode || start >= ownerEnd)) continue;
         ranges.push({ startOffset: start, endOffset: end + 1, count: clampCount(count) });
       }
@@ -386,10 +379,7 @@ function buildScriptCoverageList(
     const scriptExecuted = blocks.some(([, , count]) => count > 0) ? 1 : 0;
     const entries: object[] = [];
 
-    // JSC keys BasicBlockLocations by (sourceID, start, end), so a class-field
-    // initializer (whose source is the enclosing scope) aliases the script
-    // entry block and inflates its counter; use that counter as the top-level
-    // baseline so only real branches survive.
+    // A class-field initializer shares the script's entry BasicBlockLocation and inflates its counter; use that as baseline.
     let scriptEntryCount = scriptExecuted;
     if (topLevelBlocks.length > 0) {
       let entry = topLevelBlocks[0];
@@ -409,7 +399,9 @@ function buildScriptCoverageList(
 
     for (let i = 0; i < functions.length; i++) {
       const fn = functions[i];
-      if (!fn.executed) {
+      const ownBlocks = blocksPerFunction[i];
+      // No entry block means not actually called (the executed bit can alias the program's when they share (start,end)).
+      if (!fn.executed || ownBlocks.length === 0) {
         entries.push({
           functionName: fn.name,
           ranges: [{ startOffset: fn.start, endOffset: fn.sourceEnd, count: 0 }],
@@ -418,18 +410,12 @@ function buildScriptCoverageList(
         continue;
       }
 
-      const ownBlocks = blocksPerFunction[i];
-      // The smallest-start block is the function's entry block; its count is
-      // the call count (the wrapper's, since generator/async bodies were
-      // filtered above).
-      let count = 1;
-      if (ownBlocks.length > 0) {
-        let entryBlock = ownBlocks[0];
-        for (const block of ownBlocks) {
-          if (block[0] < entryBlock[0]) entryBlock = block;
-        }
-        count = entryBlock[2];
+      // The smallest-start block is the entry block; its count is the call count (wrapper's, since bodies were skipped).
+      let entryBlock = ownBlocks[0];
+      for (const block of ownBlocks) {
+        if (block[0] < entryBlock[0]) entryBlock = block;
       }
+      const count = entryBlock[2];
       entries.push({
         functionName: fn.name,
         ranges: [

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -77,8 +77,9 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_stopPreciseCoverage, (JSGlobalObject * globa
 }
 
 // Returns a JSON string describing every script the control flow profiler has
-// data for. The JS layer in node/inspector.ts reshapes this into the V8
-// ScriptCoverage format returned by Profiler.takePreciseCoverage.
+// data for: [{ url, scriptId, sourceLength, blocks: [[start, end, count]],
+// functions: [[start, end, executed]] }]. The JS layer in node/inspector.ts
+// reshapes this into the V8 ScriptCoverage format.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_collectPreciseCoverage);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
 {
@@ -91,8 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
     // (not the whole heap). Providers whose executables were all GC'd are not
     // reported, and offsets index the transpiled source for Bun-loaded modules;
     // Bun appends an inline //# sourceMappingURL, so consumers that read the
-    // script source (v8-to-istanbul) can remap. FunctionExecutable metadata is
-    // collected alongside so the JS layer can drop JSC-internal synthetics.
+    // script source (v8-to-istanbul) can remap.
     struct ExecutableInfo {
         unsigned functionStart;
         unsigned functionEnd;
@@ -118,23 +118,18 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
                     return;
 
                 auto* fn = static_cast<FunctionExecutable*>(executable);
+                if (fn->isBuiltinFunction() || fn->implementationVisibility() != ImplementationVisibility::Public)
+                    return;
                 SourceParseMode mode = fn->parseMode();
-                // These have no distinct user-visible source: generator/async
-                // bodies alias the wrapper, and default constructors and
-                // class-field initializers carry offsets into a different
-                // provider. Emit them only as a skip marker.
-                bool skip = fn->isBuiltinFunction()
-                    || fn->implementationVisibility() != ImplementationVisibility::Public
-                    || mode == SourceParseMode::ClassFieldInitializerMode
-                    || isGeneratorOrAsyncFunctionBodyParseMode(mode);
-                ExecutableInfo info {
+                // Synthetics with no distinct user-visible source: gen/async bodies, field initializers.
+                bool skip = mode == SourceParseMode::ClassFieldInitializerMode || isGeneratorOrAsyncFunctionBodyParseMode(mode);
+                executablesPerSource.ensure(sourceID, [] { return Vector<ExecutableInfo> {}; }).iterator->value.append(ExecutableInfo {
                     fn->functionStart(),
                     fn->functionEnd(),
                     static_cast<unsigned>(executable->source().endOffset()),
                     fn->ecmaName().string(),
                     skip,
-                };
-                executablesPerSource.ensure(sourceID, [] { return Vector<ExecutableInfo> {}; }).iterator->value.append(WTF::move(info));
+                });
             });
         });
     }
@@ -157,17 +152,28 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
 
         StringView source = provider->source();
         unsigned providerLen = source.length();
-        // Tag each block so the JS layer can drop JSC's post-return/throw
-        // block when it spans only whitespace and the closing brace.
+        // Lets the JS layer drop JSC's post-return/throw block when it spans only whitespace, comments, and `}`.
         auto rangeHasCode = [&](int start, int end) -> bool {
-            unsigned s = start < 0 ? 0 : static_cast<unsigned>(start);
+            unsigned i = start < 0 ? 0 : static_cast<unsigned>(start);
             unsigned e = end < 0 ? 0 : static_cast<unsigned>(end);
             if (e >= providerLen)
                 e = providerLen ? providerLen - 1 : 0;
-            for (unsigned i = s; i <= e && i < providerLen; i++) {
+            while (i <= e && i < providerLen) {
                 char16_t c = source[i];
-                if (c != ' ' && c != '\t' && c != '\r' && c != '\n' && c != '}' && c != ';')
+                if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '}' || c == ';' || c == 0x00A0 || c == 0x2028 || c == 0x2029 || c == 0xFEFF) {
+                    i++;
+                } else if (c == '/' && i + 1 < providerLen && source[i + 1] == '/') {
+                    i += 2;
+                    while (i < providerLen && source[i] != '\n' && source[i] != '\r' && source[i] != 0x2028 && source[i] != 0x2029)
+                        i++;
+                } else if (c == '/' && i + 1 < providerLen && source[i + 1] == '*') {
+                    i += 2;
+                    while (i + 1 < providerLen && !(source[i] == '*' && source[i + 1] == '/'))
+                        i++;
+                    i += 2;
+                } else {
                     return true;
+                }
             }
             return false;
         };
@@ -178,7 +184,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
             range->pushInteger(block.m_startOffset);
             range->pushInteger(block.m_endOffset);
             range->pushDouble(static_cast<double>(block.m_executionCount));
-            range->pushBoolean(rangeHasCode(block.m_startOffset, block.m_endOffset));
+            range->pushBoolean(block.m_executionCount == 0 && rangeHasCode(block.m_startOffset, block.m_endOffset));
             blockArray->pushValue(WTF::move(range));
         }
         script->setValue("blocks"_s, WTF::move(blockArray));

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -184,7 +184,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
             range->pushInteger(block.m_startOffset);
             range->pushInteger(block.m_endOffset);
             range->pushDouble(static_cast<double>(block.m_executionCount));
-            range->pushBoolean(block.m_executionCount == 0 && rangeHasCode(block.m_startOffset, block.m_endOffset));
+            // JS delta-subtracts the count; a block that ever ran has code, so don't scan it.
+            range->pushBoolean(block.m_executionCount > 0 || rangeHasCode(block.m_startOffset, block.m_endOffset));
             blockArray->pushValue(WTF::move(range));
         }
         script->setValue("blocks"_s, WTF::move(blockArray));

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -91,10 +91,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
     // (not the whole heap). Providers whose executables were all GC'd are not
     // reported, and offsets index the transpiled source for Bun-loaded modules;
     // Bun appends an inline //# sourceMappingURL, so consumers that read the
-    // script source (v8-to-istanbul) can remap. FunctionExecutable metadata
-    // (name, source span, parse mode) is collected alongside so the JS layer
-    // can drop JSC-internal synthetic functions that would otherwise surface
-    // as phantom V8 FunctionCoverage entries.
+    // script source (v8-to-istanbul) can remap. FunctionExecutable metadata is
+    // collected alongside so the JS layer can drop JSC-internal synthetics.
     struct ExecutableInfo {
         unsigned functionStart;
         unsigned functionEnd;
@@ -121,12 +119,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
 
                 auto* fn = static_cast<FunctionExecutable*>(executable);
                 SourceParseMode mode = fn->parseMode();
-                // These compile as inner FunctionExecutables but have no direct
-                // source representation a V8 consumer would recognise. Their
-                // ranges either alias the wrapper (generator/async bodies) or
-                // carry offsets into a different SourceProvider (default
-                // constructors, class-field initializers), so emit them only
-                // as a skip marker.
+                // These have no distinct user-visible source: generator/async
+                // bodies alias the wrapper, and default constructors and
+                // class-field initializers carry offsets into a different
+                // provider. Emit them only as a skip marker.
                 bool skip = fn->isBuiltinFunction()
                     || fn->implementationVisibility() != ImplementationVisibility::Public
                     || mode == SourceParseMode::ClassFieldInitializerMode
@@ -161,10 +157,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
 
         StringView source = provider->source();
         unsigned providerLen = source.length();
-        // JSC emits a profile point after every return/throw; when that's the
-        // function's last statement the resulting block spans only whitespace
-        // and the closing brace. Tag each block so the JS layer can drop those
-        // without shipping full source text over the wire.
+        // Tag each block so the JS layer can drop JSC's post-return/throw
+        // block when it spans only whitespace and the closing brace.
         auto rangeHasCode = [&](int start, int end) -> bool {
             unsigned s = start < 0 ? 0 : static_cast<unsigned>(start);
             unsigned e = end < 0 ? 0 : static_cast<unsigned>(end);

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -6,9 +6,11 @@
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ControlFlowProfiler.h>
+#include <JavaScriptCore/FunctionExecutable.h>
 #include <JavaScriptCore/FunctionHasExecutedCache.h>
 #include <JavaScriptCore/HeapIterationScope.h>
 #include <JavaScriptCore/MarkedSpaceInlines.h>
+#include <JavaScriptCore/ParserModes.h>
 #include <JavaScriptCore/ScriptExecutable.h>
 #include <JavaScriptCore/SourceProvider.h>
 #include <JavaScriptCore/SubspaceInlines.h>
@@ -75,9 +77,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_stopPreciseCoverage, (JSGlobalObject * globa
 }
 
 // Returns a JSON string describing every script the control flow profiler has
-// data for: [{ url, scriptId, sourceLength, blocks: [[start, end, count]],
-// functions: [[start, end, executed]] }]. The JS layer in node/inspector.ts
-// reshapes this into the V8 ScriptCoverage format.
+// data for. The JS layer in node/inspector.ts reshapes this into the V8
+// ScriptCoverage format returned by Profiler.takePreciseCoverage.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_collectPreciseCoverage);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
 {
@@ -90,9 +91,20 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
     // (not the whole heap). Providers whose executables were all GC'd are not
     // reported, and offsets index the transpiled source for Bun-loaded modules;
     // Bun appends an inline //# sourceMappingURL, so consumers that read the
-    // script source (v8-to-istanbul) can remap.
+    // script source (v8-to-istanbul) can remap. FunctionExecutable metadata
+    // (name, source span, parse mode) is collected alongside so the JS layer
+    // can drop JSC-internal synthetic functions that would otherwise surface
+    // as phantom V8 FunctionCoverage entries.
+    struct ExecutableInfo {
+        unsigned functionStart;
+        unsigned functionEnd;
+        unsigned sourceEnd;
+        String name;
+        bool skip;
+    };
     Vector<Ref<JSC::SourceProvider>> providers;
     HashSet<SourceID> seenSourceIDs;
+    UncheckedKeyHashMap<SourceID, Vector<ExecutableInfo>> executablesPerSource;
     {
         HeapIterationScope iterationScope(vm.heap);
         vm.heap.forEachScriptExecutableSpace([&](auto& spaceAndSet) {
@@ -101,9 +113,32 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
                 auto* provider = executable->source().provider();
                 if (!provider)
                     return;
-                if (!seenSourceIDs.add(provider->asID()).isNewEntry)
+                SourceID sourceID = provider->asID();
+                if (seenSourceIDs.add(sourceID).isNewEntry)
+                    providers.append(*provider);
+                if (executable->type() != FunctionExecutableType)
                     return;
-                providers.append(*provider);
+
+                auto* fn = static_cast<FunctionExecutable*>(executable);
+                SourceParseMode mode = fn->parseMode();
+                // These compile as inner FunctionExecutables but have no direct
+                // source representation a V8 consumer would recognise. Their
+                // ranges either alias the wrapper (generator/async bodies) or
+                // carry offsets into a different SourceProvider (default
+                // constructors, class-field initializers), so emit them only
+                // as a skip marker.
+                bool skip = fn->isBuiltinFunction()
+                    || fn->implementationVisibility() != ImplementationVisibility::Public
+                    || mode == SourceParseMode::ClassFieldInitializerMode
+                    || isGeneratorOrAsyncFunctionBodyParseMode(mode);
+                ExecutableInfo info {
+                    fn->functionStart(),
+                    fn->functionEnd(),
+                    static_cast<unsigned>(executable->source().endOffset()),
+                    fn->ecmaName().string(),
+                    skip,
+                };
+                executablesPerSource.ensure(sourceID, [] { return Vector<ExecutableInfo> {}; }).iterator->value.append(WTF::move(info));
             });
         });
     }
@@ -124,12 +159,32 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
         script->setDouble("scriptId"_s, static_cast<double>(sourceID));
         script->setDouble("sourceLength"_s, static_cast<double>(provider->source().length()));
 
+        StringView source = provider->source();
+        unsigned providerLen = source.length();
+        // JSC emits a profile point after every return/throw; when that's the
+        // function's last statement the resulting block spans only whitespace
+        // and the closing brace. Tag each block so the JS layer can drop those
+        // without shipping full source text over the wire.
+        auto rangeHasCode = [&](int start, int end) -> bool {
+            unsigned s = start < 0 ? 0 : static_cast<unsigned>(start);
+            unsigned e = end < 0 ? 0 : static_cast<unsigned>(end);
+            if (e >= providerLen)
+                e = providerLen ? providerLen - 1 : 0;
+            for (unsigned i = s; i <= e && i < providerLen; i++) {
+                char16_t c = source[i];
+                if (c != ' ' && c != '\t' && c != '\r' && c != '\n' && c != '}' && c != ';')
+                    return true;
+            }
+            return false;
+        };
+
         auto blockArray = JSON::Array::create();
         for (const auto& block : blocks) {
             auto range = JSON::Array::create();
             range->pushInteger(block.m_startOffset);
             range->pushInteger(block.m_endOffset);
             range->pushDouble(static_cast<double>(block.m_executionCount));
+            range->pushBoolean(rangeHasCode(block.m_startOffset, block.m_endOffset));
             blockArray->pushValue(WTF::move(range));
         }
         script->setValue("blocks"_s, WTF::move(blockArray));
@@ -143,6 +198,21 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
             functionArray->pushValue(WTF::move(range));
         }
         script->setValue("functions"_s, WTF::move(functionArray));
+
+        auto executableArray = JSON::Array::create();
+        auto execIt = executablesPerSource.find(sourceID);
+        if (execIt != executablesPerSource.end()) {
+            for (const auto& info : execIt->value) {
+                auto entry = JSON::Array::create();
+                entry->pushDouble(static_cast<double>(info.functionStart));
+                entry->pushDouble(static_cast<double>(info.functionEnd));
+                entry->pushDouble(static_cast<double>(info.sourceEnd));
+                entry->pushString(info.name);
+                entry->pushBoolean(info.skip);
+                executableArray->pushValue(WTF::move(entry));
+            }
+        }
+        script->setValue("executables"_s, WTF::move(executableArray));
 
         scripts->pushValue(WTF::move(script));
     }

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -77,9 +77,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_stopPreciseCoverage, (JSGlobalObject * globa
 }
 
 // Returns a JSON string describing every script the control flow profiler has
-// data for: [{ url, scriptId, sourceLength, blocks: [[start, end, count]],
-// functions: [[start, end, executed]] }]. The JS layer in node/inspector.ts
-// reshapes this into the V8 ScriptCoverage format.
+// data for; the shape is buildScriptCoverageList's parameter type in node/inspector.ts.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_collectPreciseCoverage);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * globalObject, CallFrame*))
 {

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -657,7 +657,6 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       expect(functionCounts).toContain(0);
     });
 
-    // https://github.com/oven-sh/bun/issues/3372
     // Sequential: the three concurrent subprocess tests above already saturate
     // the debug-ASAN process budget; a fourth pushes them past the default
     // timeout on constrained runners.

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -537,29 +537,35 @@ session.connect();
 await session.post("Profiler.enable");
 await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
 const url = "file:///delta-fixture/virtual.js";
-const f = vm.runInThisContext("function f(){return 1}; f", { filename: url });
-f(); f(); f();
+const code = "function f(n){ if(n<0) return 'neg'; return 'pos'; }; f";
+const negOffset = code.indexOf("'neg'");
+const f = vm.runInThisContext(code, { filename: url });
+f(-1); f(-1); f(-1);
 const first = await session.post("Profiler.takePreciseCoverage");
-f();
+f(1);
 const second = await session.post("Profiler.takePreciseCoverage");
 await session.post("Profiler.stopPreciseCoverage");
 session.disconnect();
-const bodyOffset = "function f(){".length;
-const countFor = c => {
+const rangesFor = c => {
   const entry = c.result.find(s => s.url === url);
-  // Innermost function entry that covers the body of f().
-  const fn = entry?.functions
-    .filter(f => f.ranges[0].startOffset <= bodyOffset && bodyOffset < f.ranges[0].endOffset)
-    .sort((a, b) => a.ranges[0].endOffset - b.ranges[0].endOffset)[0];
-  return fn?.ranges[0].count;
+  const fn = entry?.functions.find(f => f.functionName === "f");
+  return fn?.ranges.map(r => [r.startOffset, r.endOffset, r.count]);
 };
-console.log(JSON.stringify({ first: countFor(first), second: countFor(second) }));
+console.log(JSON.stringify({ negOffset, first: rangesFor(first), second: rangesFor(second) }));
 `,
       });
       await using proc = Bun.spawn({ cmd: [bunExe(), "fixture.mjs"], env: bunEnv, cwd: String(dir), stderr: "pipe" });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
-      expect(JSON.parse(stdout.trim())).toEqual({ first: 3, second: 1 });
+      const { negOffset, first, second } = JSON.parse(stdout.trim());
+      // Window 1: all 3 calls took the negative branch, so no sub-range (branch count equals call count).
+      expect(first[0][2]).toBe(3);
+      // Window 2: one call took the positive branch; the negative branch ran 0 times
+      // in this window and must appear as a count-0 sub-range (not be dropped as a
+      // no-code tail because its cumulative raw count is > 0).
+      expect(second[0][2]).toBe(1);
+      const negRange = second.find(([s, e, c]) => s <= negOffset && negOffset < e && c === 0);
+      expect(negRange).toBeDefined();
     });
 
     test.concurrent("collects block coverage with call counts for vm scripts", async () => {

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -62,6 +62,56 @@ console.log(
 );
 `;
 
+const coverageShapeFixture = `
+import { Session } from "node:inspector/promises";
+import vm from "node:vm";
+
+const session = new Session();
+session.connect();
+await session.post("Profiler.enable");
+await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+
+const code = [
+  "class K { m() { return 1; } }",
+  "class D extends K { }",
+  "class F { f = 1; g() {} }",
+  "function* gen() { yield 1; yield 2; }",
+  "async function af() { return 1; }",
+  "function andop(a, b) { return a && b; }",
+  "function f() { return 42; }",
+  "function dead() { return 1; 0xdead; }",
+  "({ K, D, F, gen, af, andop, f, dead });",
+].join("\\n");
+const url = "file:///inspector-coverage-shape/virtual.js";
+const exported = vm.runInThisContext(code, { filename: url });
+new exported.K().m();
+new exported.D();
+new exported.F();
+for (const _ of exported.gen()) {}
+await exported.af();
+exported.andop(0, 1);
+exported.andop(1, 1);
+exported.f();
+exported.f();
+exported.dead();
+
+const coverage = await session.post("Profiler.takePreciseCoverage");
+session.disconnect();
+
+const entry = coverage.result.find(script => script.url === url);
+// Normalise: sort by first-range start so order is stable, and collapse ranges
+// to [start, end, count] triples for a compact equality check.
+const normalised = entry.functions
+  .slice()
+  .sort((a, b) => a.ranges[0].startOffset - b.ranges[0].startOffset)
+  .map(fn => ({
+    name: fn.functionName,
+    block: fn.isBlockCoverage,
+    ranges: fn.ranges.map(r => [r.startOffset, r.endOffset, r.count]),
+  }));
+console.log(JSON.stringify({ codeLength: code.length, entry: normalised }));
+`;
+
 const coverageImportFixture = `
 import { Session } from "node:inspector/promises";
 
@@ -549,7 +599,7 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       // neverCalled() reports a single function-granularity range with count 0.
       const neverCalledEntry = entryCoveringOffset(entry.functions, offsets.neverCalledBody);
       expect(neverCalledEntry).toEqual({
-        functionName: "",
+        functionName: "neverCalled",
         isBlockCoverage: false,
         ranges: [{ startOffset: expect.any(Number), endOffset: expect.any(Number), count: 0 }],
       });
@@ -605,6 +655,61 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       // double() ran twice, neverCalled() never ran.
       expect(functionCounts).toContain(2);
       expect(functionCounts).toContain(0);
+    });
+
+    // https://github.com/oven-sh/bun/issues/3372
+    // Sequential: the three concurrent subprocess tests above already saturate
+    // the debug-ASAN process budget; a fourth pushes them past the default
+    // timeout on constrained runners.
+    test("FunctionCoverage list has no JSC-shaped artifacts", async () => {
+      using dir = tempDir("inspector-coverage-shape", {
+        "fixture.mjs": coverageShapeFixture,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+      const { codeLength, entry } = JSON.parse(stdout);
+      const byName: Record<string, { name: string; block: boolean; ranges: [number, number, number][] }> = {};
+      for (const fn of entry) byName[fn.name] = fn;
+
+      // (a) Exactly one whole-script entry, spanning the full source.
+      const scriptEntries = entry.filter((fn: any) => fn.ranges[0][0] === 0);
+      expect(scriptEntries).toEqual([{ name: "", block: true, ranges: [[0, codeLength, 1]] }]);
+
+      // (b)/(f) No phantom default-constructor entry: JSC's builtin default
+      // constructor registers offsets [1, 14] under the user script's
+      // sourceID, but it must not surface as a FunctionCoverage entry.
+      expect(entry.filter((fn: any) => fn.ranges[0][0] === 1)).toEqual([]);
+
+      // (c) Generator and async functions appear exactly once (wrapper only,
+      // no inner-body duplicate).
+      expect(entry.filter((fn: any) => fn.name === "gen")).toHaveLength(1);
+      expect(entry.filter((fn: any) => fn.name === "af")).toHaveLength(1);
+      expect(byName.gen).toEqual({ name: "gen", block: true, ranges: [[78, 115, 1]] });
+      expect(byName.af).toEqual({ name: "af", block: true, ranges: [[116, 149, 1]] });
+
+      // (d) Functions whose last statement is a return have no trailing
+      // count-0 sub-range over the closing brace; but real dead code after a
+      // return is still reported.
+      expect(byName.f).toEqual({ name: "f", block: true, ranges: [[190, 217, 2]] });
+      expect(byName.m).toEqual({ name: "m", block: true, ranges: [[10, 27, 1]] });
+      expect(byName.andop.ranges[0]).toEqual([150, 189, 2]);
+      expect(byName.andop.ranges.some(([, , c]) => c === 0)).toBe(false);
+      expect(byName.dead.ranges[0]).toEqual([218, 255, 1]);
+      expect(byName.dead.ranges.some(([s, , c]) => s === 245 && c === 0)).toBe(true);
+
+      // Never-called method reported with count 0 and isBlockCoverage:false.
+      expect(byName.g).toEqual({ name: "g", block: false, ranges: [[69, 75, 0]] });
+
+      // One entry per declared function (plus the script entry); no extras
+      // from module-program, generator bodies, default constructors or
+      // class-field initializers.
+      expect(entry.map((fn: any) => fn.name).sort()).toEqual(["", "af", "andop", "dead", "f", "g", "gen", "m"]);
     });
   });
 

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -80,10 +80,12 @@ const code = [
   "function andop(a, b) { return a && b; }",
   "function f() { return 42; }",
   "function dead() { return 1; 0xdead; }",
-  "({ K, D, F, gen, af, andop, f, dead });",
+  "function tc() { return 1; /* done */ } // eol",
+  "({ K, D, F, gen, af, andop, f, dead, tc });",
 ].join("\\n");
 const url = "file:///inspector-coverage-shape/virtual.js";
 const exported = vm.runInThisContext(code, { filename: url });
+const lone = vm.runInThisContext("function lone(){return 1}", { filename: "file:///inspector-coverage-shape/lone.js" });
 new exported.K().m();
 new exported.D();
 new exported.F();
@@ -94,22 +96,28 @@ exported.andop(1, 1);
 exported.f();
 exported.f();
 exported.dead();
+exported.tc();
+exported.tc();
 
 const coverage = await session.post("Profiler.takePreciseCoverage");
 session.disconnect();
 
-const entry = coverage.result.find(script => script.url === url);
 // Normalise: sort by first-range start so order is stable, and collapse ranges
 // to [start, end, count] triples for a compact equality check.
-const normalised = entry.functions
-  .slice()
-  .sort((a, b) => a.ranges[0].startOffset - b.ranges[0].startOffset)
-  .map(fn => ({
-    name: fn.functionName,
-    block: fn.isBlockCoverage,
-    ranges: fn.ranges.map(r => [r.startOffset, r.endOffset, r.count]),
-  }));
-console.log(JSON.stringify({ codeLength: code.length, entry: normalised }));
+const normalise = list =>
+  list
+    .slice()
+    .sort((a, b) => a.ranges[0].startOffset - b.ranges[0].startOffset)
+    .map(fn => ({
+      name: fn.functionName,
+      block: fn.isBlockCoverage,
+      ranges: fn.ranges.map(r => [r.startOffset, r.endOffset, r.count]),
+    }));
+const entry = normalise(coverage.result.find(script => script.url === url).functions);
+const loneEntry = normalise(
+  coverage.result.find(script => script.url === "file:///inspector-coverage-shape/lone.js").functions,
+);
+console.log(JSON.stringify({ codeLength: code.length, entry, loneEntry }));
 `;
 
 const coverageImportFixture = `
@@ -672,7 +680,7 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
-      const { codeLength, entry } = JSON.parse(stdout);
+      const { codeLength, entry, loneEntry } = JSON.parse(stdout);
       const byName: Record<string, { name: string; block: boolean; ranges: [number, number, number][] }> = {};
       for (const fn of entry) byName[fn.name] = fn;
 
@@ -693,10 +701,11 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       expect(byName.af).toEqual({ name: "af", block: true, ranges: [[116, 149, 1]] });
 
       // (d) Functions whose last statement is a return have no trailing
-      // count-0 sub-range over the closing brace; but real dead code after a
-      // return is still reported.
+      // count-0 sub-range over the closing brace or over a trailing comment;
+      // real dead code after a return is still reported.
       expect(byName.f).toEqual({ name: "f", block: true, ranges: [[190, 217, 2]] });
       expect(byName.m).toEqual({ name: "m", block: true, ranges: [[10, 27, 1]] });
+      expect(byName.tc).toEqual({ name: "tc", block: true, ranges: [[256, 294, 2]] });
       expect(byName.andop.ranges[0]).toEqual([150, 189, 2]);
       expect(byName.andop.ranges.some(([, , c]) => c === 0)).toBe(false);
       expect(byName.dead.ranges[0]).toEqual([218, 255, 1]);
@@ -708,7 +717,15 @@ console.log(JSON.stringify({ first: countFor(first), second: countFor(second) })
       // One entry per declared function (plus the script entry); no extras
       // from module-program, generator bodies, default constructors or
       // class-field initializers.
-      expect(entry.map((fn: any) => fn.name).sort()).toEqual(["", "af", "andop", "dead", "f", "g", "gen", "m"]);
+      expect(entry.map((fn: any) => fn.name).sort()).toEqual(["", "af", "andop", "dead", "f", "g", "gen", "m", "tc"]);
+
+      // A function declaration that spans the entire script still gets its own
+      // entry and reports count 0 when never called.
+      expect(loneEntry.find((fn: any) => fn.name === "lone")).toEqual({
+        name: "lone",
+        block: false,
+        ranges: [[0, 25, 0]],
+      });
     });
   });
 


### PR DESCRIPTION
`Profiler.takePreciseCoverage` now returns a `FunctionCoverage` list whose shape matches V8's. The raw JSC control-flow-profiler data carried several JSC-internal entries that a V8 coverage consumer (c8, istanbul, `@vitest/coverage-v8`) misreads as uncovered code or phantom functions.

## Repro

```js
import { Session } from 'node:inspector/promises';
import vm from 'node:vm';
const s = new Session(); s.connect();
await s.post('Profiler.enable');
await s.post('Profiler.startPreciseCoverage', { callCount: true, detailed: true });
const code = [
  'class K { m() { return 1; } }',
  'function* gen() { yield 1; yield 2; }',
  'function f() { return 42; }',
  '({ K, gen, f });',
].join('\n');
const M = vm.runInThisContext(code, { filename: 'file:///x.js' });
new M.K().m(); for (const _ of M.gen()) {} M.f(); M.f();
const { result } = await s.post('Profiler.takePreciseCoverage');
for (const fn of result.find(e => e.url === 'file:///x.js').functions)
  console.log(JSON.stringify(fn.ranges.map(r => [r.startOffset, r.endOffset, r.count])), fn.functionName, fn.isBlockCoverage);
```

Before (8 entries, functionName always empty):
```
[[0,112,1],[27,29,1],[67,67,1],[95,111,1]]  true
[[0,111,1],[0,9,1],[27,29,1],[67,67,1],[95,111,1]]  true
[[1,15,0]]  false
[[10,26,1],[11,25,1],[24,25,0]]  true
[[30,66,1],[47,65,1],[64,65,0]]  true
[[48,65,3],[48,55,3],[57,65,3],[64,65,0]]  true
[[68,94,2],[82,93,2],[92,93,0]]  true
```

After (matches Node v26.3.0 exactly):
```
[[0,112,1]]  true
[[10,27,1]] m true
[[30,67,1]] gen true
[[68,95,2]] f true
```

## Cause

- **duplicate whole-script entry**: the module-program executable registers `[0, sourceLength-1]` in `FunctionHasExecutedCache`, and the reshaper also emitted a synthetic `[0, sourceLength]` entry.
- **phantom count-0 entry at `[1, 15)` for every class without an explicit constructor**: JSC synthesises a default constructor from the builtin source `"(function () { })"`; `CodeBlock::finishCreation` inserts that executable's `unlinkedFunctionStart/End` (1, 14) into `FunctionHasExecutedCache` under the *enclosing script's* sourceID, but `UnlinkedFunctionExecutable::linkedSourceCode` links it against the builtin's provider, so the offsets point into the wrong source.
- **generator/async listed twice**: JSC compiles these as a wrapper + body pair; both CodeBlocks register in `FunctionHasExecutedCache`.
- **trailing count-0 sub-range over the closing brace**: JSC emits a profile point after every `return`/`throw`; when that is the last statement the resulting block spans only whitespace and `}`.
- **class-field initializer aliases the script entry block**: its synthetic function takes `m_scopeNode->source()` as its source, so its entry block shares the module's `BasicBlockLocation` key and inflates the top-level counter.

## Fix

`jsFunction_collectPreciseCoverage` now also collects per-script `FunctionExecutable` metadata (name, `source().endOffset()`, parse mode, builtin/visibility flags) during the existing script-executable subspace walk, and tags each basic-block range with whether it contains any non-whitespace non-`}` source.

`buildScriptCoverageList` uses that to:
- derive the function list from `FunctionHasExecutedCache` ranges that have a matching public `FunctionExecutable` on the same source, dropping the module-program range, generator/async bodies, class-field initializers, and the phantom default-constructor range (which has no matching executable under the user's sourceID);
- populate `functionName` from `ecmaName()`;
- emit V8-style half-open `endOffset` (past the closing `}`) from `source().endOffset()`;
- emit only sub-ranges whose count differs from the owner's call count, dropping the entry block and any count-0 block that contains no code (or collapsed onto the owner's last character, for arrow expression bodies);
- use the script's own entry-block count as the top-level baseline, so a class-field initializer aliasing that counter does not surface as a spurious sub-range.

## Not addressed

Short-circuit operand coverage (the RHS of `a && b` / `a || b` / `a ?? b`) is unchanged: JSC's `LogicalOpNode::emitBytecode` and `CoalesceNode::emitBytecode` never call `emitProfileControlFlow`, so the RHS count is not recorded and cannot be reconstructed without a WebKit-side change.

## Verification

`bun bd test test/js/node/inspector/inspector-profiler.test.ts` (45 pass). New test `FunctionCoverage list has no JSC-shaped artifacts` asserts the exact entry list for a vm script covering all of the above constructs; it fails on main at the first assertion (two whole-script entries with a `[1, 15)` phantom).



