### PR TITLE
node:quic(h3): reject in-flight requests above the GOAWAY id instead of a clean EOF

### DIFF
--- a/patches/lsquic/goaway-stream-id.patch
+++ b/patches/lsquic/goaway-stream-id.patch
@@ -52,3 +52,16 @@
      conn->ifc_conn.cn_flags |= LSCONN_PEER_GOING_AWAY;
      LSQ_DEBUG("received GOAWAY frame, last good stream ID: %"PRIu64, stream_id);
      if (conn->ifc_enpub->enp_stream_if->on_goaway_received)
+@@ -9907,6 +9928,12 @@
+                 conn->ifc_u.cli.ifcli_min_goaway_stream_id);
+             return;
+         }
++        /* bun: lower id (RFC 9114 sec 5.2 two-phase shutdown).  Record it and
++         * re-notify so the application can reject the newly-abandoned range
++         * instead of seeing it as a clean EOF from the walk below. */
++        conn->ifc_u.cli.ifcli_min_goaway_stream_id = stream_id;
++        if (conn->ifc_enpub->enp_stream_if->on_goaway_received)
++            conn->ifc_enpub->enp_stream_if->on_goaway_received(&conn->ifc_conn);
+     }
+     else
+     {

--- a/patches/lsquic/goaway-stream-id.patch
+++ b/patches/lsquic/goaway-stream-id.patch
@@ -1,0 +1,54 @@
+--- a/include/lsquic.h
++++ b/include/lsquic.h
+@@ -2202,6 +2202,14 @@
+ lsquic_conn_ack_now (lsquic_conn_t *);
+ 
+ /**
++ * Read the Stream ID from the peer's HTTP/3 GOAWAY frame (RFC 9114 sec 5.2)
++ * once LSCONN_PEER_GOING_AWAY is set on a client connection.  Returns 1 and
++ * writes *out on success, 0 otherwise.  bun addition.
++ */
++int
++lsquic_conn_get_min_goaway_stream_id (const lsquic_conn_t *, uint64_t *out);
++
++/**
+  * Update the millisecond idle timeout applied to connections created
+  * after this call (see @ref es_idle_timeout_ms).
+  */
+--- a/src/liblsquic/lsquic_full_conn_ietf.c
++++ b/src/liblsquic/lsquic_full_conn_ietf.c
+@@ -3135,6 +3135,26 @@
+ }
+ 
+ 
++/* bun: expose the Stream ID from the peer's GOAWAY frame (RFC 9114 sec 5.2)
++ * so on_goaway_received can report it to the application and reject in-flight
++ * requests above it instead of surfacing lsquic's fake-reset as a clean EOF.
++ */
++int
++lsquic_conn_get_min_goaway_stream_id (const struct lsquic_conn *lconn,
++                                      uint64_t *out)
++{
++    const struct ietf_full_conn *conn;
++
++    if ((lconn->cn_flags & (LSCONN_MINI|LSCONN_IETF|LSCONN_SERVER))
++                                                            != LSCONN_IETF
++            || !(lconn->cn_flags & LSCONN_PEER_GOING_AWAY))
++        return 0;
++    conn = (const struct ietf_full_conn *) lconn;
++    *out = conn->ifc_u.cli.ifcli_min_goaway_stream_id;
++    return 1;
++}
++
++
+ static void
+ retire_dcid (struct ietf_full_conn *conn, struct dcid_elem **dce)
+ {
+@@ -9856,6 +9876,7 @@
+         return;
+     }
+ 
++    conn->ifc_u.cli.ifcli_min_goaway_stream_id = stream_id;
+     conn->ifc_conn.cn_flags |= LSCONN_PEER_GOING_AWAY;
+     LSQ_DEBUG("received GOAWAY frame, last good stream ID: %"PRIu64, stream_id);
+     if (conn->ifc_enpub->enp_stream_if->on_goaway_received)

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -128,6 +128,13 @@ export const lsquic: Dependency = {
     // never be encrypted and the peer idled out instead of learning of the
     // close. Select the PNS by handshake progress, as ngtcp2 does.
     "patches/lsquic/connection-close-pns.patch",
+    // on_goaway_received has no access to the GOAWAY Stream ID (RFC 9114
+    // sec 5.2), so node:quic reported ongoaway(-1n) and had no way to reject
+    // in-flight requests above it; lsquic's fake_reset path then surfaced them
+    // as a clean EOF (silent truncation). Expose the id via
+    // lsquic_conn_get_min_goaway_stream_id so the session can deliver it and
+    // mark affected streams H3_REQUEST_REJECTED.
+    "patches/lsquic/goaway-stream-id.patch",
   ],
 
   fetchDeps: ["zlib", "lshpack", "lsqpack", "boringssl"],

--- a/src/lsquic_sys/lib.rs
+++ b/src/lsquic_sys/lib.rs
@@ -622,6 +622,17 @@ impl Conn {
         // SAFETY: as above.
         unsafe { lsquic_conn_get_ssl(self.0) }
     }
+    /// The Stream ID from the peer's GOAWAY frame (RFC 9114 §5.2).
+    /// `None` until one arrives; client-only.
+    pub fn min_goaway_stream_id(&self) -> Option<u64> {
+        unsafe extern "C" {
+            fn lsquic_conn_get_min_goaway_stream_id(c: *const lsquic_conn, out: *mut u64) -> c_int;
+        }
+        let mut id: u64 = 0;
+        // SAFETY: `self.0` is live; `id` is a stack out-param.
+        (unsafe { lsquic_conn_get_min_goaway_stream_id(self.0, core::ptr::from_mut(&mut id)) } != 0)
+            .then_some(id)
+    }
     pub fn sockaddr(&self) -> Option<(*const sockaddr, *const sockaddr)> {
         let mut local: *const sockaddr = core::ptr::null();
         let mut peer: *const sockaddr = core::ptr::null();

--- a/src/lsquic_sys/lib.rs
+++ b/src/lsquic_sys/lib.rs
@@ -622,8 +622,7 @@ impl Conn {
         // SAFETY: as above.
         unsafe { lsquic_conn_get_ssl(self.0) }
     }
-    /// The Stream ID from the peer's GOAWAY frame (RFC 9114 §5.2).
-    /// `None` until one arrives; client-only.
+    /// Stream ID from the peer's GOAWAY (RFC 9114 §5.2); client-only.
     pub fn min_goaway_stream_id(&self) -> Option<u64> {
         unsafe extern "C" {
             fn lsquic_conn_get_min_goaway_stream_id(c: *const lsquic_conn, out: *mut u64) -> c_int;

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -2389,12 +2389,7 @@ lsquic_callback! {
         session.push_event(SessionEvent::GoawayReceived {
             last_stream_id: stream_id,
         });
-        // RFC 9114 §5.2: client requests above the GOAWAY id were not
-        // processed and are safe to retry. lsquic is about to fake-reset or
-        // shutdown-internal those streams without firing on_reset, which would
-        // surface here as a clean EOF; mark them rejected first so the reader
-        // sees an error instead of a truncated body. The `>` matches lsquic's
-        // own walk (on_goaway_client in lsquic_full_conn_ietf.c).
+        // lsquic fake-resets id>goaway_id with no on_reset (→clean EOF); reject so readers error.
         let Some(stream_id) = stream_id.filter(|_| !session.is_server()) else {
             return;
         };
@@ -2404,9 +2399,7 @@ lsquic_callback! {
                 continue;
             };
             let id = stream.stream_id();
-            // Client-initiated bidirectional streams have the two low bits
-            // clear (RFC 9000 §2.1); pending streams report id < 0. A stream
-            // already reset was handled by a previous GOAWAY with a higher id.
+            // Low 2 bits 0 = client-bidi (RFC 9000 §2.1); id<0 = pending.
             if id < 0
                 || id as u64 & 0x3 != 0
                 || id as u64 <= stream_id

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -51,6 +51,7 @@ const STREAM_ID_UNI_BIT: u64 = 0x2;
 /// HTTP/3 application error codes (RFC 9114 §8.1).
 const H3_NO_ERROR: u64 = 0x100;
 const H3_INTERNAL_ERROR: u64 = 0x102;
+const H3_REQUEST_REJECTED: u64 = 0x10b;
 
 /// Node's DefaultApplication normalized option defaults
 /// (node/src/quic/session.cc).
@@ -312,7 +313,9 @@ pub(super) enum SessionEvent {
         stream: *mut super::stream::QuicStream,
     },
     HandshakeConfirmed,
-    GoawayReceived,
+    GoawayReceived {
+        last_stream_id: Option<u64>,
+    },
     Datagram {
         payload: Vec<u8>,
         early: bool,
@@ -893,7 +896,10 @@ impl QuicSession {
             // SAFETY: teardown clears `endpoint` before the endpoint can die.
             let defer_closes = !endpoint.is_null() && unsafe { (*endpoint).defer_closes.get() };
             if (dispatched_js || defer_closes)
-                && matches!(event, SessionEvent::Closed | SessionEvent::GoawayReceived)
+                && matches!(
+                    event,
+                    SessionEvent::Closed | SessionEvent::GoawayReceived { .. }
+                )
             {
                 self.events.with_mut(|e| e.insert(0, event));
                 self.schedule_process();
@@ -1073,10 +1079,12 @@ impl QuicSession {
                         }
                     }
                 }
-                SessionEvent::GoawayReceived => {
-                    // lsquic doesn't surface the GOAWAY stream-id; Node
-                    // reports -1n when the id is unavailable.
-                    let last_stream_id = match JSValue::from_int64_no_truncate(global, -1) {
+                SessionEvent::GoawayReceived { last_stream_id } => {
+                    // -1n is Node's "id unavailable" (session.cc EmitGoaway).
+                    let last_stream_id = match last_stream_id.map_or_else(
+                        || JSValue::from_int64_no_truncate(global, -1),
+                        |id| JSValue::from_uint64_no_truncate(global, id),
+                    ) {
                         Ok(v) => v,
                         Err(e) => {
                             global.report_uncaught_exception_from_error(e);
@@ -2377,7 +2385,37 @@ lsquic_callback! {
     }
 
     pub(super) fn on_goaway_received(session: &QuicSession) {
-        session.push_event(SessionEvent::GoawayReceived);
+        let stream_id = session.conn().and_then(|c| c.min_goaway_stream_id());
+        session.push_event(SessionEvent::GoawayReceived {
+            last_stream_id: stream_id,
+        });
+        // RFC 9114 §5.2: client requests above the GOAWAY id were not
+        // processed and are safe to retry. lsquic is about to fake-reset or
+        // shutdown-internal those streams without firing on_reset, which would
+        // surface here as a clean EOF; mark them rejected first so the reader
+        // sees an error instead of a truncated body. The `>` matches lsquic's
+        // own walk (on_goaway_client in lsquic_full_conn_ietf.c).
+        let Some(stream_id) = stream_id.filter(|_| !session.is_server()) else {
+            return;
+        };
+        let streams: Vec<*mut super::stream::QuicStream> = session.streams.get().clone();
+        for sp in streams {
+            let Some(stream) = session.live_stream(sp) else {
+                continue;
+            };
+            let id = stream.stream_id();
+            // Client-initiated bidirectional streams have the two low bits
+            // clear (RFC 9000 §2.1); pending streams report id < 0.
+            if id < 0 || id as u64 & 0x3 != 0 || id as u64 <= stream_id {
+                continue;
+            }
+            stream.mark_reset(H3_REQUEST_REJECTED);
+            session.push_event(SessionEvent::StreamReset {
+                stream: sp,
+                code: H3_REQUEST_REJECTED,
+            });
+            session.push_event(SessionEvent::StreamWake { stream: sp });
+        }
     }
 
     pub(super) fn on_hsk_confirmed(session: &QuicSession) {

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -2405,8 +2405,13 @@ lsquic_callback! {
             };
             let id = stream.stream_id();
             // Client-initiated bidirectional streams have the two low bits
-            // clear (RFC 9000 §2.1); pending streams report id < 0.
-            if id < 0 || id as u64 & 0x3 != 0 || id as u64 <= stream_id {
+            // clear (RFC 9000 §2.1); pending streams report id < 0. A stream
+            // already reset was handled by a previous GOAWAY with a higher id.
+            if id < 0
+                || id as u64 & 0x3 != 0
+                || id as u64 <= stream_id
+                || stream.with_state(|s| s.reset != 0)
+            {
                 continue;
             }
             stream.mark_reset(H3_REQUEST_REJECTED);

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -313,9 +313,7 @@ pub(super) enum SessionEvent {
         stream: *mut super::stream::QuicStream,
     },
     HandshakeConfirmed,
-    GoawayReceived {
-        last_stream_id: Option<u64>,
-    },
+    GoawayReceived,
     Datagram {
         payload: Vec<u8>,
         early: bool,
@@ -896,10 +894,7 @@ impl QuicSession {
             // SAFETY: teardown clears `endpoint` before the endpoint can die.
             let defer_closes = !endpoint.is_null() && unsafe { (*endpoint).defer_closes.get() };
             if (dispatched_js || defer_closes)
-                && matches!(
-                    event,
-                    SessionEvent::Closed | SessionEvent::GoawayReceived { .. }
-                )
+                && matches!(event, SessionEvent::Closed | SessionEvent::GoawayReceived)
             {
                 self.events.with_mut(|e| e.insert(0, event));
                 self.schedule_process();
@@ -1079,12 +1074,9 @@ impl QuicSession {
                         }
                     }
                 }
-                SessionEvent::GoawayReceived { last_stream_id } => {
-                    // -1n is Node's "id unavailable" (session.cc EmitGoaway).
-                    let last_stream_id = match last_stream_id.map_or_else(
-                        || JSValue::from_int64_no_truncate(global, -1),
-                        |id| JSValue::from_uint64_no_truncate(global, id),
-                    ) {
+                SessionEvent::GoawayReceived => {
+                    // Node v26 reports -1n here; the id is read internally for rejection.
+                    let last_stream_id = match JSValue::from_int64_no_truncate(global, -1) {
                         Ok(v) => v,
                         Err(e) => {
                             global.report_uncaught_exception_from_error(e);
@@ -2385,12 +2377,13 @@ lsquic_callback! {
     }
 
     pub(super) fn on_goaway_received(session: &QuicSession) {
-        let stream_id = session.conn().and_then(|c| c.min_goaway_stream_id());
-        session.push_event(SessionEvent::GoawayReceived {
-            last_stream_id: stream_id,
-        });
+        session.push_event(SessionEvent::GoawayReceived);
         // lsquic fake-resets id>goaway_id with no on_reset (→clean EOF); reject so readers error.
-        let Some(stream_id) = stream_id.filter(|_| !session.is_server()) else {
+        let Some(stream_id) = session
+            .conn()
+            .and_then(|c| c.min_goaway_stream_id())
+            .filter(|_| !session.is_server())
+        else {
             return;
         };
         let streams: Vec<*mut super::stream::QuicStream> = session.streams.get().clone();

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -179,3 +179,109 @@ describe("HTTP/3 header encoding", () => {
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
 });
+
+// RFC 9114 §5.2: GOAWAY carries the lowest Stream ID the server did NOT
+// process. Requests above it were never handled and may be retried. The id
+// must reach `ongoaway`, and those streams must fail loudly: a clean EOF on a
+// body that had already delivered `:status 200` is silent data corruption.
+describe("HTTP/3 GOAWAY on the client", () => {
+  test("delivers the stream id and rejects in-flight requests above it", async () => {
+    const serverReady = Promise.withResolvers<void>();
+    let serverSessionRef: any;
+    const server = await listen(
+      async serverSession => {
+        serverSessionRef = serverSession;
+        serverSession.onstream = (stream: any) => {
+          stream.closed.catch(() => {});
+        };
+        await serverSession.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 2 },
+        onheaders(this: any) {
+          this.sendHeaders({ ":status": "200" });
+          this.writer.writeSync(new TextEncoder().encode("partial"));
+          serverReady.resolve();
+        },
+      },
+    );
+
+    const client = await connect(server.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 2 },
+    });
+    let id: bigint, bError: any, bReset: any, streamAId: bigint, streamBId: bigint;
+    try {
+      await client.opened;
+
+      const goawayId = Promise.withResolvers<bigint>();
+      client.ongoaway = (i: bigint) => goawayId.resolve(i);
+
+      // Stream A sends a request (server sees it, max_req_id = A.id).
+      // Stream B is created locally with a higher id but writes nothing, so
+      // the server never learns of it: GOAWAY carries A.id and B is strictly
+      // above it.
+      const gotFirstChunk = Promise.withResolvers<void>();
+      const streamA = await client.createBidirectionalStream({
+        headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost" },
+        onheaders() {},
+      });
+      streamAId = streamA.id;
+      const streamB = await client.createBidirectionalStream();
+      streamBId = streamB.id;
+      streamB.onreset = (e: any) => {
+        bReset = e;
+      };
+      streamB.closed.catch(() => {});
+      const readB = (async () => {
+        try {
+          for await (const _ of streamB) {
+          }
+          return undefined;
+        } catch (e: any) {
+          return e;
+        }
+      })();
+      (async () => {
+        for await (const _ of streamA) gotFirstChunk.resolve();
+      })().catch(() => {});
+
+      await serverReady.promise;
+      await gotFirstChunk.promise;
+      // Server has seen only stream A (B never hit the wire) and sends
+      // GOAWAY(A.id) on graceful close.
+      serverSessionRef.close();
+
+      id = await goawayId.promise;
+      // ongoaway and the per-stream onreset dispatch from the same event
+      // batch; let that batch finish before tearing the client down so
+      // bReset is observable. Without the fix B is never closed at all, so
+      // the destroy is what settles readB deterministically.
+      await new Promise<void>(resolve => setImmediate(resolve));
+      client.destroy();
+      bError = await readB;
+    } finally {
+      client.destroy?.();
+      serverSessionRef?.destroy?.();
+      server.close?.({ force: true });
+    }
+
+    // Before the fix this was always -1n.
+    expect(id).toBe(streamAId);
+    expect(id).toBeGreaterThanOrEqual(0n);
+    expect(streamBId).toBeGreaterThan(streamAId);
+    // Before the fix lsquic fake-resets B without an on_reset, which used to
+    // surface as a clean end-of-iteration here with no onreset: silent
+    // truncation. H3_REQUEST_REJECTED = 0x10b (RFC 9114 §8.1).
+    expect({
+      iterator: bError?.code,
+      onreset: bReset && { code: bReset.code, errorCode: bReset.errorCode },
+    }).toEqual({
+      iterator: "ERR_QUIC_STREAM_RESET",
+      onreset: { code: "ERR_QUIC_APPLICATION_ERROR", errorCode: 0x10bn },
+    });
+    expect(bError?.message).toContain(String(0x10b));
+  });
+});

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -188,7 +188,7 @@ describe("HTTP/3 GOAWAY on the client", () => {
   test("delivers the stream id and rejects in-flight requests above it", async () => {
     const serverReady = Promise.withResolvers<void>();
     let serverSessionRef: any;
-    const server = await listen(
+    await using server = await listen(
       async serverSession => {
         serverSessionRef = serverSession;
         serverSession.onstream = (stream: any) => {
@@ -207,13 +207,14 @@ describe("HTTP/3 GOAWAY on the client", () => {
       },
     );
 
-    const client = await connect(server.address, {
-      servername: "localhost",
-      verifyPeer: "manual",
-      transportParams: { maxIdleTimeout: 2 },
-    });
+    let client: any;
     let id: bigint, bError: any, bReset: any, streamAId: bigint, streamBId: bigint;
     try {
+      client = await connect(server.address, {
+        servername: "localhost",
+        verifyPeer: "manual",
+        transportParams: { maxIdleTimeout: 2 },
+      });
       await client.opened;
 
       const goawayId = Promise.withResolvers<bigint>();
@@ -263,9 +264,8 @@ describe("HTTP/3 GOAWAY on the client", () => {
       client.destroy();
       bError = await readB;
     } finally {
-      client.destroy?.();
+      client?.destroy?.();
       serverSessionRef?.destroy?.();
-      server.close?.({ force: true });
     }
 
     // Before the fix this was always -1n.

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -180,12 +180,11 @@ describe("HTTP/3 header encoding", () => {
   });
 });
 
-// RFC 9114 §5.2: GOAWAY carries the lowest Stream ID the server did NOT
-// process. Requests above it were never handled and may be retried. The id
-// must reach `ongoaway`, and those streams must fail loudly: a clean EOF on a
-// body that had already delivered `:status 200` is silent data corruption.
+// RFC 9114 §5.2: requests above the GOAWAY Stream ID were never handled and
+// may be retried. Those streams must fail loudly: a clean EOF on a body that
+// had already delivered `:status 200` is silent data corruption.
 describe("HTTP/3 GOAWAY on the client", () => {
-  test("delivers the stream id and rejects in-flight requests above it", async () => {
+  test("rejects in-flight requests above the GOAWAY id instead of a clean EOF", async () => {
     const serverReady = Promise.withResolvers<void>();
     let serverSessionRef: any;
     await using server = await listen(
@@ -268,9 +267,8 @@ describe("HTTP/3 GOAWAY on the client", () => {
       serverSessionRef?.destroy?.();
     }
 
-    // Before the fix this was always -1n.
-    expect(id).toBe(streamAId);
-    expect(id).toBeGreaterThanOrEqual(0n);
+    // Node v26 still reports -1n here; the id is read internally for rejection.
+    expect(id).toBe(-1n);
     expect(streamBId).toBeGreaterThan(streamAId);
     // Before the fix lsquic fake-resets B without an on_reset, which used to
     // surface as a clean end-of-iteration here with no onreset: silent

--- a/test/js/node/test/parallel/test-quic-h3-goaway.mjs
+++ b/test/js/node/test/parallel/test-quic-h3-goaway.mjs
@@ -74,7 +74,7 @@ dc.subscribe('quic.session.goaway', mustCall((msg) => {
     verifyPeer: 'manual',
     // Ongoaway fires when the peer sends GOAWAY.
     ongoaway: mustCall(function(lastStreamId) {
-      strictEqual(lastStreamId, -1n);
+      strictEqual(lastStreamId, 4n);
       goawayReceived.resolve();
     }),
   });

--- a/test/js/node/test/parallel/test-quic-h3-goaway.mjs
+++ b/test/js/node/test/parallel/test-quic-h3-goaway.mjs
@@ -74,7 +74,7 @@ dc.subscribe('quic.session.goaway', mustCall((msg) => {
     verifyPeer: 'manual',
     // Ongoaway fires when the peer sends GOAWAY.
     ongoaway: mustCall(function(lastStreamId) {
-      strictEqual(lastStreamId, 4n);
+      strictEqual(lastStreamId, -1n);
       goawayReceived.resolve();
     }),
   });


### PR DESCRIPTION
## Problem

An HTTP/3 server sending `GOAWAY(id)` while responses are in flight causes silent body truncation on the client. With 5 concurrent requests (stream ids 0,4,8,12,16) and `GOAWAY(0)`:

```
ongoaway id = -1n
stream id=4  :status=200 body="c0;c1;c2;" complete=false reset=null err=null
stream id=8  :status=200 body="c0;c1;c2;" complete=false reset=null err=null
...
```

The body iterator completes cleanly (`for await` ends, no `onreset`, no error) after 3 of 11 chunks, with `:status 200` already delivered: the app consumes a short read as success.

## Cause

After `on_goaway_received` returns, lsquic's `on_goaway_client` walks client-bidi streams with `id > goaway_id` and calls `lsquic_stream_received_goaway`, which either `fake_reset_unused_stream` (no data yet) or `lsquic_stream_shutdown_internal` (data already received). Neither fires `on_reset`; both only schedule `on_close`. Bun's `on_stream_close` then runs `end_read_side`, which sets `inbound.ended = true`, so `pull()` returns `EOS` and the iterator completes as if the server FIN'd. lsquic's `on_goaway_received(lsquic_conn_t *)` callback itself does not carry the GOAWAY frame's Stream ID, so the session had no way to know which streams to reject.

## Fix

- **lsquic patch** (`patches/lsquic/goaway-stream-id.patch`): add `lsquic_conn_get_min_goaway_stream_id(conn, *out)`, which returns the Stream ID from the peer's GOAWAY once `LSCONN_PEER_GOING_AWAY` is set on a client connection. Also record the id in `on_goaway_client_27` (the draft-29 variant), and in `on_goaway_client`'s decreasing-id fall-through (RFC 9114 §5.2 two-phase shutdown) update the stored id and re-invoke the callback so the newly-abandoned range is rejected. Additive only; no signature changes.
- **`session.rs` `on_goaway_received`**: read the id via the new accessor, walk live client-bidi streams and for each with `id > goaway_id` (matching lsquic's own walk) that is not already reset, call `mark_reset(H3_REQUEST_REJECTED)` and queue `StreamReset`/`StreamWake` so `onreset` fires and the reader errors.

`ongoaway(lastStreamId)` stays at `-1n`, matching Node v26's current behaviour (Node's `test-quic-h3-goaway.mjs` asserts `-1n`); the id is used internally only. RFC 9114 §5.2: requests above the GOAWAY id were not processed and may be retried; §8.1 `H3_REQUEST_REJECTED (0x10b)` is the retryable signal.

## Verification

`test/js/node/quic/quic-stream.test.ts` "HTTP/3 GOAWAY on the client": stream A sends a request, stream B is created locally with a higher id but never writes, so the server's graceful close carries `GOAWAY(A.id)` with B strictly above it. Before: B's iterator ends cleanly, no `onreset`. After: B's iterator throws `ERR_QUIC_STREAM_RESET` and `onreset` fires with `{ code: 'ERR_QUIC_APPLICATION_ERROR', errorCode: 0x10bn }`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (63424f305)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [519.76ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [119.78ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1098.09ms]
274 |     // surface as a clean end-of-iteration here with no onreset: silent
275 |     // truncation. H3_REQUEST_REJECTED = 0x10b (RFC 9114 §8.1).
276 |     expect({
277 |       iterator: bError?.code,
278 |       onreset: bReset && { code: bReset.code, errorCode: bReset.errorCode },
279 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
-   "iterator": "ERR_QUIC_STREAM_RESET",
-   "onreset": {
-     "code": "ERR_QUIC_APPLICATION_ERROR",
-
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (ee3af8c8e)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:15:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [37.67ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [5.15ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1005.33ms]
266 |       client?.destroy?.();
267 |       serverSessionRef?.destroy?.();
268 |     }
269 | 
270 |     // Node v26 still reports -1n here; the id is read internally for rejection.
271 |     expect(id).toBe(-1n);
                     ^
error: expect(received).toBe(expected)

Expected: -1n
Received: 0n

      at <anonymous> (/workspace/bun/test/js/node/quic/quic-stream.test.ts:271:16)
(fail) HTTP/3 GOAWAY on the client > rejects in-flight requests above the GOAWAY id instead of a clean EOF [9.06ms]

 3 pass
 1 fail
 8 expect() calls
Ran 4 tests across 1 file. [1312.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-stream.test.ts
bun test v1.4.0 (63424f305)

test/js/node/quic/quic-stream.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicStream.destroy after the app ended the send side > delivers the committed response instead of retracting it with RESET_STREAM [514.07ms]
(pass) HTTP/3 header encoding > round-trips non-ASCII header values byte-for-byte [111.42ms]
(pass) HTTP/3 header encoding > rejects a value whose latin1 encoding splices in an extra header [1099.02ms]
(pass) HTTP/3 GOAWAY on the client > rejects in-flight requests above the GOAWAY id instead of a clean EOF [198.12ms]

 4 pass
 0 fail
 11 expect() calls
Ran 4 tests across 1 file. [4.83s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 718ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/32] gen cpp.rs (cppbind)
[2/32] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/32] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameP
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
patches/lsquic/goaway-stream-id.patch |  67 ++++++++++++++++++++++
 scripts/build/deps/lsquic.ts          |   7 +++
 src/lsquic_sys/lib.rs                 |  10 ++++
 src/runtime/node/quic/session.rs      |  33 ++++++++++-
 test/js/node/quic/quic-stream.test.ts | 104 ++++++++++++++++++++++++++++++++++
 5 files changed, 219 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
patches/lsquic/goaway-stream-id.patch      0      1      0
scripts/build/deps/lsquic.ts               1      3      0
src/lsquic_sys/lib.rs                      2      5      0
src/runtime/node/quic/session.rs           8     13      0
test/js/node/quic/quic-stream.test.ts      4     12      0
```

</details>

<!-- robobun:evidence:end -->