### PR TITLE
Coerce later arguments before capturing input buffers in Bun.Transpiler, Bun.randomUUIDv5 and Bun.RedisClient

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -5,7 +5,7 @@ use bun_options_types::TargetExt as _;
 use std::io::Write as _;
 
 use crate::Error;
-use crate::node::{StringOrBuffer, ThreadIsolated};
+use crate::node::{StringOrBuffer, StringOrBufferKind, ThreadIsolated};
 use bun_alloc::{Arena, ArenaVec}; // bumpalo::Bump / bumpalo::collections::Vec re-exports
 use bun_ast::Expr;
 use bun_ast::Loader;
@@ -1270,12 +1270,10 @@ impl JSTranspiler {
         let Some(code_arg) = args.next() else {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
-
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+        args.eat();
+        let Some(code_kind) = StringOrBufferKind::of(code_arg) else {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
-        let code = code_holder.slice();
-        args.eat();
 
         let loader: Option<Loader> = 'brk: {
             if let Some(arg) = args.next() {
@@ -1284,6 +1282,9 @@ impl JSTranspiler {
             }
             break 'brk None;
         };
+
+        let code_holder = StringOrBuffer::from_js_with_kind(global, code_arg, code_kind)?;
+        let code = code_holder.slice();
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
@@ -1411,19 +1412,15 @@ impl JSTranspiler {
             ));
         };
 
-        let arena = Arena::new();
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+        args.eat();
+        let Some(code_kind) = StringOrBufferKind::of(code_arg) else {
             return Err(global.throw_invalid_argument_type(
                 "transformSync",
                 "code",
                 "string or Uint8Array",
             ));
         };
-        let code = code_holder.slice();
-        arguments[0].ensure_still_alive();
-        let _keep0 = bun_jsc::EnsureStillAlive(arguments[0]);
 
-        args.eat();
         let mut js_ctx_value: JSValue = JSValue::ZERO;
         let loader: Option<Loader> = 'brk: {
             if let Some(arg) = args.next() {
@@ -1439,6 +1436,12 @@ impl JSTranspiler {
             }
             break 'brk None;
         };
+
+        let arena = Arena::new();
+        let code_holder = StringOrBuffer::from_js_with_kind(global, code_arg, code_kind)?;
+        let code = code_holder.slice();
+        arguments[0].ensure_still_alive();
+        let _keep0 = bun_jsc::EnsureStillAlive(arguments[0]);
 
         if let Some(arg) = args.next_eat() {
             if arg.is_object() {
@@ -1615,15 +1618,14 @@ impl JSTranspiler {
             ));
         };
 
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+        args.eat();
+        let Some(code_kind) = StringOrBufferKind::of(code_arg) else {
             return Err(global.throw_invalid_argument_type(
                 "scanImports",
                 "code",
                 "string or Uint8Array",
             ));
         };
-        args.eat();
-        let code = code_holder.slice();
 
         let mut loader: Loader = self.config.get().default_loader;
         if let Some(arg) = args.next() {
@@ -1632,6 +1634,9 @@ impl JSTranspiler {
             }
             args.eat();
         }
+
+        let code_holder = StringOrBuffer::from_js_with_kind(global, code_arg, code_kind)?;
+        let code = code_holder.slice();
 
         if !loader.is_java_script_like() {
             return Err(global.throw_invalid_arguments(format_args!(

--- a/src/runtime/node.rs
+++ b/src/runtime/node.rs
@@ -17,8 +17,8 @@ pub mod assert {
 pub mod types;
 pub use types::{
     BlobOrStringOrBuffer, Dirent, Encoding, FileBlobs, Flavor, PathLike, PathOrBlob,
-    PathOrFileDescriptor, StringObjects, StringOrBuffer, ThreadIsolated, ThreadIsolatedArg,
-    mode_from_js,
+    PathOrFileDescriptor, StringObjects, StringOrBuffer, StringOrBufferKind, ThreadIsolated,
+    ThreadIsolatedArg, mode_from_js,
 };
 
 pub use bun_jsc::MarkedArrayBuffer as Buffer;

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -290,6 +290,33 @@ impl Default for StringOrBuffer<'_> {
     }
 }
 
+/// Type-tag classification (no user JS); decode later via `from_js_with_kind`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum StringOrBufferKind {
+    String,
+    StringObject,
+    ArrayBuffer,
+}
+
+impl StringOrBufferKind {
+    #[inline]
+    pub fn of(value: JSValue) -> Option<Self> {
+        if !value.is_cell() {
+            return None;
+        }
+        let ty = value.js_type();
+        if ty.is_string() {
+            Some(Self::String)
+        } else if ty.is_string_object_like() {
+            Some(Self::StringObject)
+        } else if ty.is_array_buffer_like() {
+            Some(Self::ArrayBuffer)
+        } else {
+            None
+        }
+    }
+}
+
 impl<'a> StringOrBuffer<'a> {
     pub(crate) const EMPTY: Self = StringOrBuffer::Utf8(Utf8Bytes::EMPTY);
 
@@ -393,12 +420,38 @@ impl StringOrBuffer<'static> {
         flavor: Flavor,
         string_objects: StringObjects,
     ) -> JsResult<bool> {
-        use jsc::JSType;
-        match value.js_type() {
-            str_type @ (JSType::String | JSType::StringObject | JSType::DerivedStringObject) => {
-                if string_objects == StringObjects::Reject && str_type != JSType::String {
-                    return Ok(false);
-                }
+        let Some(kind) = StringOrBufferKind::of(value) else {
+            return Ok(false);
+        };
+        if string_objects == StringObjects::Reject && kind == StringOrBufferKind::StringObject {
+            return Ok(false);
+        }
+        Self::from_js_with_kind_into(out, global, value, kind, flavor)?;
+        Ok(true)
+    }
+
+    /// Decode a value already classified by [`StringOrBufferKind::of`].
+    #[inline]
+    pub fn from_js_with_kind(
+        global: &JSGlobalObject,
+        value: JSValue,
+        kind: StringOrBufferKind,
+    ) -> JsResult<Self> {
+        let mut out = Self::EMPTY;
+        Self::from_js_with_kind_into(&mut out, global, value, kind, Flavor::Sync)?;
+        Ok(out)
+    }
+
+    #[inline]
+    fn from_js_with_kind_into(
+        out: &mut Self,
+        global: &JSGlobalObject,
+        value: JSValue,
+        kind: StringOrBufferKind,
+        flavor: Flavor,
+    ) -> JsResult<()> {
+        match kind {
+            StringOrBufferKind::String | StringOrBufferKind::StringObject => {
                 let str = bun_core::String::from_js(value, global)?;
                 *out = if flavor == Flavor::Async {
                     shared_or_utf8(
@@ -410,28 +463,12 @@ impl StringOrBuffer<'static> {
                 } else {
                     Self::String(str.into_utf8_with_string())
                 };
-                Ok(true)
             }
-
-            JSType::ArrayBuffer
-            | JSType::Int8Array
-            | JSType::Uint8Array
-            | JSType::Uint8ClampedArray
-            | JSType::Int16Array
-            | JSType::Uint16Array
-            | JSType::Int32Array
-            | JSType::Uint32Array
-            | JSType::Float32Array
-            | JSType::Float16Array
-            | JSType::Float64Array
-            | JSType::BigInt64Array
-            | JSType::BigUint64Array
-            | JSType::DataView => {
+            StringOrBufferKind::ArrayBuffer => {
                 *out = Self::buffer_from_js(global, value, flavor)?;
-                Ok(true)
             }
-            _ => Ok(false),
         }
+        Ok(())
     }
 
     #[inline]

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -70,6 +70,12 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
         return JSArgument::from_js_maybe_file(global, str.to_js(), FileBlobs::Reject);
     }
 
+    if let Some(ab) = value.as_array_buffer(global) {
+        return Ok(Some(JSArgument::StringOrBuffer(
+            crate::node::StringOrBuffer::owned(ab.byte_slice().to_vec()),
+        )));
+    }
+
     JSArgument::from_js_maybe_file(global, value, FileBlobs::Allow)
 }
 

--- a/src/runtime/webcore/Crypto.rs
+++ b/src/runtime/webcore/Crypto.rs
@@ -2,7 +2,7 @@ use bun_core::String as BunString;
 use bun_jsc::uuid::{self, UUID, UUID5, UUID7};
 use bun_jsc::{CallFrame, JSGlobalObject, JSType, JSValue, JsClass, JsResult, StringJsc};
 
-use crate::node::Encoding;
+use crate::node::{Encoding, StringOrBuffer, StringOrBufferKind};
 
 // `.classes.ts`-backed type: the C++ JSCell wrapper stays generated C++.
 // This struct is the `m_ctx` payload. `toJS`/`fromJS`/`fromJSDirect` are
@@ -280,21 +280,13 @@ fn bun_random_uuid_v5(global: &JSGlobalObject, callframe: &CallFrame) -> JsResul
     let name_value = arguments.ptr[0];
     let namespace_value = arguments.ptr[1];
 
-    let name_buffer;
-    let name: bun_core::Utf8Bytes = 'brk: {
-        if name_value.is_string() {
-            break 'brk name_value.to_utf8(global)?;
-        } else if let Some(array_buffer) = name_value.as_array_buffer(global) {
-            name_buffer = array_buffer;
-            break 'brk bun_core::Utf8Bytes::Borrowed(name_buffer.byte_slice());
-        } else {
-            return Err(global
-                .err(
-                    bun_jsc::ErrorCode::INVALID_ARG_TYPE,
-                    format_args!("The \"name\" argument must be of type string or BufferSource"),
-                )
-                .throw());
-        }
+    let Some(name_kind) = StringOrBufferKind::of(name_value) else {
+        return Err(global
+            .err(
+                bun_jsc::ErrorCode::INVALID_ARG_TYPE,
+                format_args!("The \"name\" argument must be of type string or BufferSource"),
+            )
+            .throw());
     };
 
     let namespace: [u8; 16] = 'brk: {
@@ -344,6 +336,8 @@ fn bun_random_uuid_v5(global: &JSGlobalObject, callframe: &CallFrame) -> JsResul
             )
             .throw());
     };
+
+    let name = StringOrBuffer::from_js_with_kind(global, name_value, name_kind)?;
 
     let uuid = UUID5::init(&namespace, name.slice());
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5700,6 +5700,61 @@ it("transform() result is unaffected by detaching the input ArrayBuffer while th
   expect(exitCode).toBe(0);
 });
 
+// A boxed `String` loader's `toString()` runs user JS; detaching the code buffer
+// from there left the parser reading freed heap. With the loader coerced before
+// the code buffer is captured, the detached buffer is seen as empty.
+it("transformSync/scan/scanImports coerce the loader before capturing the code buffer", async () => {
+  const script = `
+    const transpiler = new Bun.Transpiler({ loader: "js" });
+    const size = 1 << 16;
+    const keep = [];
+    function mkSrc() {
+      const bytes = new Uint8Array(new ArrayBuffer(size)).fill(0x20);
+      new TextEncoder().encodeInto("export const ORIGINAL = 1;//", bytes);
+      return bytes;
+    }
+    function hostile(src) {
+      return Object.assign(new String("js"), {
+        toString() {
+          src.buffer.transfer(0);
+          Bun.gc(true);
+          for (let i = 0; i < 64; i++) {
+            const x = new Uint8Array(size).fill(0x20);
+            new TextEncoder().encodeInto('import "recycled"; export const RECYCLED = 2;//', x);
+            keep.push(x);
+          }
+          Bun.gc(true);
+          return "js";
+        },
+      });
+    }
+    const results = {};
+    { const src = mkSrc(); results.transformSync = transpiler.transformSync(src, hostile(src)); }
+    { const src = mkSrc(); results.scan = transpiler.scan(src, hostile(src)); }
+    { const src = mkSrc(); results.scanImports = transpiler.scanImports(src, hostile(src)); }
+    console.log(JSON.stringify(results));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const results = JSON.parse(stdout.trim());
+  expect(results).toEqual({
+    transformSync: "",
+    scan: { imports: [], exports: [] },
+    scanImports: [],
+  });
+  expect(stdout).not.toContain("RECYCLED");
+  expect(stdout).not.toContain("recycled");
+  expect(exitCode).toBe(0);
+});
+
 // A numeric literal property name like `1e999` overflows to the number Infinity, which the
 // printer emits as "1/0" / "1 / 0". That is not valid syntax in property-name position, so such
 // keys must be printed as computed properties instead.

--- a/test/js/bun/util/randomUUIDv5.test.ts
+++ b/test/js/bun/util/randomUUIDv5.test.ts
@@ -379,4 +379,28 @@ describe("randomUUIDv5", () => {
       expect(result).toBe(first);
     }
   });
+
+  // A boxed `String` namespace's `toString()` runs user JS; detaching the name
+  // buffer from there left the hash reading freed heap. With namespace coerced
+  // before the name buffer is snapshotted, the name is seen as detached (empty).
+  test("coerces namespace before snapshotting the name buffer", () => {
+    const size = 1 << 16;
+    const keep: Uint8Array[] = [];
+    const name = Buffer.from(new ArrayBuffer(size));
+    name.fill(0x41);
+    const wantRecycled = Bun.randomUUIDv5(Buffer.alloc(size, 0x5a), dnsNamespace);
+    const wantEmpty = Bun.randomUUIDv5(new Uint8Array(0), dnsNamespace);
+    const evilNs = Object.assign(new String(dnsNamespace), {
+      toString() {
+        name.buffer.transfer(0);
+        Bun.gc(true);
+        for (let i = 0; i < 96; i++) keep.push(Buffer.alloc(size, 0x5a));
+        Bun.gc(true);
+        return dnsNamespace;
+      },
+    });
+    const got = Bun.randomUUIDv5(name, evilNs as any);
+    expect({ got, detached: name.buffer.detached }).toEqual({ got: wantEmpty, detached: true });
+    expect(got).not.toBe(wantRecycled);
+  });
 });

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -494,6 +494,111 @@ test.concurrent("RedisClient survives GC after a command throws during argument 
   expect(exitCode).toBe(0);
 });
 
+// A later argument's toString() can detach an earlier ArrayBuffer argument
+// (transfer() frees its store synchronously), so the earlier captured slice
+// pointed at freed heap by the time the command was serialized onto the wire.
+test("set/send serialize ArrayBuffer arguments before a later toString() can free them", async () => {
+  const src = `
+    const net = require("node:net");
+
+    const TAIL = Buffer.from("$1\\r\\nv\\r\\n");
+    let wire = Buffer.alloc(0);
+    let want = 0;
+    let resolveFrame;
+    let saidHello = false;
+    function tails() {
+      let n = 0, i = -1;
+      while ((i = wire.indexOf(TAIL, i + 1)) !== -1) n++;
+      return n;
+    }
+    const server = net.createServer(socket => {
+      socket.on("data", data => {
+        if (!saidHello) {
+          if (data.includes("HELLO")) { saidHello = true; socket.write("+OK\\r\\n"); }
+          return;
+        }
+        wire = Buffer.concat([wire, data]);
+        if (resolveFrame && tails() >= want) {
+          socket.write("+OK\\r\\n");
+          const r = resolveFrame; resolveFrame = null; r();
+        }
+      });
+      socket.on("error", () => {});
+    });
+    await new Promise((resolve, reject) => {
+      server.listen(0, "127.0.0.1", resolve);
+      server.on("error", reject);
+    });
+
+    const client = new Bun.RedisClient("redis://127.0.0.1:" + server.address().port, {
+      autoReconnect: false,
+      connectionTimeout: 5000,
+    });
+    await client.connect();
+
+    const keep = [];
+    function evilValue(key) {
+      return Object.assign(new String("v"), {
+        toString() {
+          key.buffer.transfer(0);
+          for (let i = 0; i < 24; i++) {
+            const x = new Uint8Array(4096);
+            x.fill(0x5a);
+            Buffer.from(x.buffer).write("RECYCLEDKEY");
+            keep.push(x);
+          }
+          Bun.gc(true);
+          return "v";
+        },
+      });
+    }
+
+    {
+      const key = Buffer.from(new ArrayBuffer(4096));
+      key.write("ORIGINALKEY");
+      want = 1;
+      const done = new Promise(r => (resolveFrame = r));
+      client.set(key, evilValue(key)).catch(() => {});
+      await done;
+    }
+
+    {
+      const key = Buffer.from(new ArrayBuffer(4096));
+      key.write("ORIGINAL2KEY");
+      want = 2;
+      const done = new Promise(r => (resolveFrame = r));
+      client.send("LPUSH", [key, evilValue(key)]).catch(() => {});
+      await done;
+    }
+
+    client.close();
+    server.close();
+
+    const text = wire.toString("latin1");
+    if (text.includes("RECYCLEDKEY")) {
+      throw new Error("freed/recycled heap reached the wire: " + JSON.stringify(text.slice(0, 80)));
+    }
+    if (!text.includes("ORIGINALKEY") || !text.includes("ORIGINAL2KEY")) {
+      throw new Error("original key bytes missing from the wire: " + JSON.stringify(text.slice(0, 80)));
+    }
+    console.log("OK");
+    process.exit(0);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
 // Fuzzer found heap corruption (zapped cell during GC marking) when a custom
 // setter on a generated class was invoked with a receiver that is not an
 // instance of that class (e.g. through a Proxy wrapping the instance, or an


### PR DESCRIPTION
### Problem
- A later argument's coercion runs user JS (a `String` object's `toString`). If that JS detaches an earlier `ArrayBuffer` argument with `transfer()`, the slice bun already captured points at freed memory. ASAN reports `heap-use-after-free`. A release build reads whatever the allocator put there next, and `RedisClient` sends it on the wire.
- Three sites capture first and coerce second: `Bun.Transpiler#transformSync`, `scan` and `scanImports` (code, then loader, `src/runtime/api/JSTranspiler.rs`), `Bun.randomUUIDv5` (name, then namespace, `src/runtime/webcore/Crypto.rs`), and every `Bun.RedisClient` command (`from_js` in `src/runtime/valkey_jsc/js_valkey_functions.rs` borrows each buffer, and serialization runs after all arguments are collected).

### Fix
- Transpiler and `randomUUIDv5` classify the first argument by its cell type, which runs no JS, then coerce the later argument, then capture the bytes. A bad first argument still throws first. A buffer the coercion detached reads as empty.
- `RedisClient` copies `ArrayBuffer` arguments when it collects them. A borrow cannot work there.
- `StringOrBufferKind::of` reads the type tag once and `StringOrBuffer::from_js_with_kind` decodes later. `from_js_maybe_async_into` uses the same two steps, so there is one classification.
- Verified: the new tests in `transpiler.test.js`, `randomUUIDv5.test.ts` and `valkey-gc.test.ts` fail with `src/` at main and pass with the fix. Also `fs.test.ts`.

### Background
- `ArrayBuffer.prototype.transfer()` moves the bytes to a new buffer and detaches the old one, which frees its store.
- `StringOrBuffer` is the parsed form of a string-or-buffer argument. For a synchronous call its `Buffer` arm borrows the JS buffer's memory without pinning it.
- #36165 fixed this pattern for the crypto, KDF and `indexOfLine` paths.

<details>
<summary>Notes</summary>

Rebased onto main at a749e0a9 as one commit. `StringOrBuffer` changed shape on main (`StringOrBuffer<'a>`, `Flavor`, `StringObjects`), so `from_js_with_kind_into` now takes a `Flavor` and its body is main's decode arms unchanged. The Redis copy uses `StringOrBuffer::owned`. `scan` no longer has the `has_exception` check, because main removed it.

Two tests in `valkey-gc.test.ts` (`RESP map keys are not leaked`, `new RedisClient(url) does not leak the URL and its components`) time out at 5 s on a local debug ASAN build. They time out the same way with `src/` reset to main.

The text below is the previous revision of this description.

---

A later argument's user-visible coercion (`toString`, `Symbol.toPrimitive`, property getter) runs after an earlier ArrayBuffer-backed argument's raw `(ptr,len)` slice is captured. If that coercion detaches the earlier buffer via `ArrayBuffer.prototype.transfer`, the captured slice points at freed heap and the call reads whatever the allocator hands back next, including another Worker's freshly freed blocks.

#36165 already fixed this pattern for the crypto/KDF/`indexOfLine` paths via a post-coercion buffer re-snapshot. This change covers the three remaining call sites.

## Reproduction

```js
const code = new Uint8Array(new ArrayBuffer(1 << 16)).fill(0x20);
new TextEncoder().encodeInto("export const ORIGINAL = 1;//", code);
const loader = Object.assign(new String("js"), {
  toString() {
    code.buffer.transfer(0);       // free the store the transpiler already borrowed
    /* respray the freed block */ return "js";
  },
});
new Bun.Transpiler().transformSync(code, loader);   // emits the resprayed bytes, not `code`
```

On the shipping canary this recovers a planted marker at 100% for `Bun.Transpiler#transformSync` and `Bun.randomUUIDv5`, and at ~90% for `Bun.RedisClient#set`/`send` (the resprayed key reaches the wire).

## Fix

- `Bun.Transpiler#{transformSync,scan,scanImports}`: the loader argument is now coerced before the code buffer is captured. A boxed-`String` loader whose `toString` detaches the code buffer sees the buffer as empty.
- `Bun.randomUUIDv5`: the namespace argument is now coerced before the name buffer is snapshotted. A type-tag guard on the name argument preserves the previous error-message precedence when both are invalid.
- `Bun.RedisClient` (every `cmd_*` command and `send`): ArrayBuffer-backed arguments are now copied into an owned slice in the argument-collection helper, so a later argument's `toString` cannot free the bytes before the command is serialized onto the wire. A borrowed slice is not safe here because the command serializer runs after all arguments are collected.

## Verification

Each new test plants a distinguishing byte pattern in the freed block and asserts the call's result does not reflect the resprayed bytes. Every test fails on the released `bun` and passes with this change.

Supersedes #34969, #34970. (The crypto/KDF sites covered by #34964 and #34966 were fixed in #36165.)

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/valkey/valkey-gc.test.ts

<!-- robobun:evidence:end -->
