### PR TITLE
webcrypto: fence ConcurrentCppTask's post-body unref against worker.terminate() freeing the VM

### DIFF
--- a/src/jsc/CppTask.rs
+++ b/src/jsc/CppTask.rs
@@ -11,9 +11,7 @@ unsafe extern "C" {
         task: &EventLoopTaskNoContext,
     ) -> *mut VirtualMachine;
     safe fn Bun__EventLoopTaskNoContext__contextIdentifier(task: &EventLoopTaskNoContext) -> u32;
-    // safe: by-value `u32` in; resolves the context under the C++ contexts-map
-    // lock (same fence as `postTaskTo`/`markTerminating`) and no-ops if the
-    // context is gone or terminating.
+    // safe: u32 in; resolves under the contexts-map lock, no-op if gone/terminating.
     safe fn ScriptExecutionContext__unrefEventLoopConcurrently(id: u32);
 }
 
@@ -53,18 +51,13 @@ impl EventLoopTaskNoContext {
     }
 
     /// The VM that created this task. Only safe to dereference on that VM's JS
-    /// thread (worker VMs are freed by `terminate()`); the pool-thread
-    /// completion uses [`Self::context_identifier`] instead.
+    /// thread; worker VMs are freed by `terminate()`.
     pub fn get_vm(&self) -> Option<bun_ptr::BackRef<VirtualMachine>> {
         NonNull::new(Bun__EventLoopTaskNoContext__createdInBunVm(self)).map(bun_ptr::BackRef::from)
     }
 
-    /// The creating VM's [`ScriptExecutionContextIdentifier`], captured at
-    /// construction so the pool-thread completion can unref the event loop
-    /// under the contexts-map lock instead of dereferencing the (possibly
-    /// freed) VM pointer.
-    ///
-    /// [`ScriptExecutionContextIdentifier`]: crate::JSGlobalObject::ScriptExecutionContextIdentifier
+    /// The creating context's `ScriptExecutionContextIdentifier`, for the
+    /// pool-thread checked unref in [`ConcurrentCppTask::run_owned`].
     pub fn context_identifier(&self) -> u32 {
         Bun__EventLoopTaskNoContext__contextIdentifier(self)
     }
@@ -91,11 +84,8 @@ impl ConcurrentCppTask {
         // SAFETY: `cpp_task` is the valid C++ handle stored by `ConcurrentCppTask__createAndRun`;
         // `opaque_ref` above proved it non-null and it has not yet been freed — `run` consumes it here.
         unsafe { EventLoopTaskNoContext::run(cpp_task) };
-        // Runs on a work-pool thread: the creating VM may be a worker freed by
-        // terminate() while `run` (the crypto op) ran. The identifier-keyed
-        // unref takes the contexts-map lock (serializing with the shutdown
-        // path's `markTerminating()`, which is called before the VM box is
-        // freed) and no-ops if the context is gone or terminating.
+        // Checked unref: the creating VM may be a worker freed by terminate()
+        // while `run` ran; the contexts-map lock serializes with markTerminating().
         ScriptExecutionContext__unrefEventLoopConcurrently(context_id);
     }
 }
@@ -104,13 +94,9 @@ impl ConcurrentCppTask {
 pub(crate) extern "C" fn ConcurrentCppTask__createAndRun(cpp_task: *mut EventLoopTaskNoContext) {
     crate::mark_binding!();
     // `EventLoopTaskNoContext` is an `opaque_ffi!` ZST handle; `opaque_ref` is
-    // the centralised non-null deref proof. C++ just handed it over.
-    //
-    // Called on the creating VM's JS thread (only caller is
-    // `PhonyWorkQueue::dispatch` from the SubtleCrypto IDL entry points), so
-    // dereferencing the captured VM here is safe. The matching unref happens
-    // on a work-pool thread in `run_owned` and goes through the context
-    // identifier instead.
+    // the centralised non-null deref proof. Runs on the creating VM's JS
+    // thread (only caller is `PhonyWorkQueue::dispatch`), so dereferencing
+    // the captured VM here is safe; `run_owned`'s unref is the checked one.
     if let Some(vm) = EventLoopTaskNoContext::opaque_ref(cpp_task).get_vm() {
         vm.event_loop_shared().ref_concurrently();
     }

--- a/src/jsc/CppTask.rs
+++ b/src/jsc/CppTask.rs
@@ -50,14 +50,12 @@ impl EventLoopTaskNoContext {
         unsafe { Bun__EventLoopTaskNoContext__performTask(this) }
     }
 
-    /// The VM that created this task. Only safe to dereference on that VM's JS
-    /// thread; worker VMs are freed by `terminate()`.
+    /// The creating VM. Only safe to dereference on that VM's JS thread.
     pub fn get_vm(&self) -> Option<bun_ptr::BackRef<VirtualMachine>> {
         NonNull::new(Bun__EventLoopTaskNoContext__createdInBunVm(self)).map(bun_ptr::BackRef::from)
     }
 
-    /// The creating context's `ScriptExecutionContextIdentifier`, for the
-    /// pool-thread checked unref in [`ConcurrentCppTask::run_owned`].
+    /// The creating context's identifier, for the checked pool-thread unref.
     pub fn context_identifier(&self) -> u32 {
         Bun__EventLoopTaskNoContext__contextIdentifier(self)
     }
@@ -84,8 +82,7 @@ impl ConcurrentCppTask {
         // SAFETY: `cpp_task` is the valid C++ handle stored by `ConcurrentCppTask__createAndRun`;
         // `opaque_ref` above proved it non-null and it has not yet been freed — `run` consumes it here.
         unsafe { EventLoopTaskNoContext::run(cpp_task) };
-        // Checked unref: the creating VM may be a worker freed by terminate()
-        // while `run` ran; the contexts-map lock serializes with markTerminating().
+        // Checked: the creating VM may be a worker freed by terminate() while `run` ran.
         ScriptExecutionContext__unrefEventLoopConcurrently(context_id);
     }
 }
@@ -94,10 +91,9 @@ impl ConcurrentCppTask {
 pub(crate) extern "C" fn ConcurrentCppTask__createAndRun(cpp_task: *mut EventLoopTaskNoContext) {
     crate::mark_binding!();
     // `EventLoopTaskNoContext` is an `opaque_ffi!` ZST handle; `opaque_ref` is
-    // the centralised non-null deref proof. Runs on the creating VM's JS
-    // thread (only caller is `PhonyWorkQueue::dispatch`), so dereferencing
-    // the captured VM here is safe; `run_owned`'s unref is the checked one.
+    // the centralised non-null deref proof. C++ just handed it over.
     if let Some(vm) = EventLoopTaskNoContext::opaque_ref(cpp_task).get_vm() {
+        // Runs on the creating VM's JS thread (from `PhonyWorkQueue::dispatch`).
         vm.event_loop_shared().ref_concurrently();
     }
     WorkPool::schedule_new(ConcurrentCppTask {

--- a/src/jsc/CppTask.rs
+++ b/src/jsc/CppTask.rs
@@ -10,6 +10,11 @@ unsafe extern "C" {
     safe fn Bun__EventLoopTaskNoContext__createdInBunVm(
         task: &EventLoopTaskNoContext,
     ) -> *mut VirtualMachine;
+    safe fn Bun__EventLoopTaskNoContext__contextIdentifier(task: &EventLoopTaskNoContext) -> u32;
+    // safe: by-value `u32` in; resolves the context under the C++ contexts-map
+    // lock (same fence as `postTaskTo`/`markTerminating`) and no-ops if the
+    // context is gone or terminating.
+    safe fn ScriptExecutionContext__unrefEventLoopConcurrently(id: u32);
 }
 
 bun_opaque::opaque_ffi! {
@@ -47,13 +52,21 @@ impl EventLoopTaskNoContext {
         unsafe { Bun__EventLoopTaskNoContext__performTask(this) }
     }
 
-    /// Get the VM that created this task. `VirtualMachine` is process-lifetime
-    /// (PORTING.md §Global mutable state), so a [`BackRef`] is the right
-    /// non-owning handle: callers project `&VirtualMachine` via `Deref` and
-    /// route mutation through the VM's safe interior accessors (e.g.
-    /// `event_loop_shared()`).
+    /// The VM that created this task. Only safe to dereference on that VM's JS
+    /// thread (worker VMs are freed by `terminate()`); the pool-thread
+    /// completion uses [`Self::context_identifier`] instead.
     pub fn get_vm(&self) -> Option<bun_ptr::BackRef<VirtualMachine>> {
         NonNull::new(Bun__EventLoopTaskNoContext__createdInBunVm(self)).map(bun_ptr::BackRef::from)
+    }
+
+    /// The creating VM's [`ScriptExecutionContextIdentifier`], captured at
+    /// construction so the pool-thread completion can unref the event loop
+    /// under the contexts-map lock instead of dereferencing the (possibly
+    /// freed) VM pointer.
+    ///
+    /// [`ScriptExecutionContextIdentifier`]: crate::JSGlobalObject::ScriptExecutionContextIdentifier
+    pub fn context_identifier(&self) -> u32 {
+        Bun__EventLoopTaskNoContext__contextIdentifier(self)
     }
 }
 
@@ -73,14 +86,17 @@ impl ConcurrentCppTask {
         let cpp_task = self.cpp_task;
         // `EventLoopTaskNoContext` is an `opaque_ffi!` ZST handle; `opaque_ref`
         // is the centralised non-null deref proof. Valid until `run` consumes it.
-        let maybe_vm = EventLoopTaskNoContext::opaque_ref(cpp_task).get_vm();
+        let context_id = EventLoopTaskNoContext::opaque_ref(cpp_task).context_identifier();
         drop(self);
         // SAFETY: `cpp_task` is the valid C++ handle stored by `ConcurrentCppTask__createAndRun`;
         // `opaque_ref` above proved it non-null and it has not yet been freed — `run` consumes it here.
         unsafe { EventLoopTaskNoContext::run(cpp_task) };
-        if let Some(vm) = maybe_vm {
-            vm.event_loop_shared().unref_concurrently();
-        }
+        // Runs on a work-pool thread: the creating VM may be a worker freed by
+        // terminate() while `run` (the crypto op) ran. The identifier-keyed
+        // unref takes the contexts-map lock (serializing with the shutdown
+        // path's `markTerminating()`, which is called before the VM box is
+        // freed) and no-ops if the context is gone or terminating.
+        ScriptExecutionContext__unrefEventLoopConcurrently(context_id);
     }
 }
 
@@ -89,6 +105,12 @@ pub(crate) extern "C" fn ConcurrentCppTask__createAndRun(cpp_task: *mut EventLoo
     crate::mark_binding!();
     // `EventLoopTaskNoContext` is an `opaque_ffi!` ZST handle; `opaque_ref` is
     // the centralised non-null deref proof. C++ just handed it over.
+    //
+    // Called on the creating VM's JS thread (only caller is
+    // `PhonyWorkQueue::dispatch` from the SubtleCrypto IDL entry points), so
+    // dereferencing the captured VM here is safe. The matching unref happens
+    // on a work-pool thread in `run_owned` and goes through the context
+    // identifier instead.
     if let Some(vm) = EventLoopTaskNoContext::opaque_ref(cpp_task).get_vm() {
         vm.event_loop_shared().ref_concurrently();
     }

--- a/src/jsc/bindings/EventLoopTaskNoContext.cpp
+++ b/src/jsc/bindings/EventLoopTaskNoContext.cpp
@@ -12,4 +12,9 @@ extern "C" void* Bun__EventLoopTaskNoContext__createdInBunVm(const EventLoopTask
     return task->createdInBunVm();
 }
 
+extern "C" WebCore::ScriptExecutionContextIdentifier Bun__EventLoopTaskNoContext__contextIdentifier(const EventLoopTaskNoContext* task)
+{
+    return task->contextIdentifier();
+}
+
 } // namespace Bun

--- a/src/jsc/bindings/EventLoopTaskNoContext.h
+++ b/src/jsc/bindings/EventLoopTaskNoContext.h
@@ -29,9 +29,7 @@ public:
 
 private:
     void* m_createdInBunVm;
-    // Captured for the pool-thread completion: the creating VM may be a worker
-    // freed by terminate() while the task ran, so the unref goes through the
-    // contexts-map lock instead of dereferencing m_createdInBunVm.
+    // For ConcurrentCppTask's checked pool-thread unref.
     WebCore::ScriptExecutionContextIdentifier m_contextIdentifier;
     Function<void()> m_task;
 };

--- a/src/jsc/bindings/EventLoopTaskNoContext.h
+++ b/src/jsc/bindings/EventLoopTaskNoContext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ZigGlobalObject.h"
+#include "ScriptExecutionContext.h"
 #include "root.h"
 
 namespace Bun {
@@ -12,6 +13,7 @@ class EventLoopTaskNoContext {
 public:
     EventLoopTaskNoContext(JSC::JSGlobalObject* globalObject, Function<void()>&& task)
         : m_createdInBunVm(defaultGlobalObject(globalObject)->bunVM())
+        , m_contextIdentifier(defaultGlobalObject(globalObject)->scriptExecutionContext()->identifier())
         , m_task(WTF::move(task))
     {
     }
@@ -23,13 +25,19 @@ public:
     }
 
     void* createdInBunVm() const { return m_createdInBunVm; }
+    WebCore::ScriptExecutionContextIdentifier contextIdentifier() const { return m_contextIdentifier; }
 
 private:
     void* m_createdInBunVm;
+    // Captured for the pool-thread completion: the creating VM may be a worker
+    // freed by terminate() while the task ran, so the unref goes through the
+    // contexts-map lock instead of dereferencing m_createdInBunVm.
+    WebCore::ScriptExecutionContextIdentifier m_contextIdentifier;
     Function<void()> m_task;
 };
 
 extern "C" void Bun__EventLoopTaskNoContext__performTask(EventLoopTaskNoContext* task);
 extern "C" void* Bun__EventLoopTaskNoContext__createdInBunVm(const EventLoopTaskNoContext* task);
+extern "C" WebCore::ScriptExecutionContextIdentifier Bun__EventLoopTaskNoContext__contextIdentifier(const EventLoopTaskNoContext* task);
 
 } // namespace Bun

--- a/src/jsc/bindings/ScriptExecutionContext.cpp
+++ b/src/jsc/bindings/ScriptExecutionContext.cpp
@@ -308,4 +308,21 @@ extern "C" void ScriptExecutionContext__markTerminating(JSC::JSGlobalObject* glo
         context->markTerminating();
 }
 
+// Release one concurrent event-loop ref on the context's VM, if that context
+// is still live and not terminating. Called from a work-pool thread after a
+// ConcurrentCppTask's body has run; the creating VM may be a worker that
+// worker.terminate() freed while the task was running. Taking the map lock
+// serializes with markTerminating() (called from WebWorker::shutdown before
+// the VM box is freed), so either we observe the live context and unref under
+// the lock, or we observe it gone/terminating and drop the unref (the counter
+// of a freed event loop needs no balancing). Same fence as postTaskTo().
+extern "C" void ScriptExecutionContext__unrefEventLoopConcurrently(ScriptExecutionContextIdentifier id)
+{
+    Locker locker { allScriptExecutionContextsMapLock };
+    auto* context = allScriptExecutionContextsMap().get(id);
+    if (!context || context->isTerminating())
+        return;
+    Bun__eventLoop__incrementRefConcurrently(WebCore::clientData(context->vm())->bunVM, -1);
+}
+
 } // namespace WebCore

--- a/src/jsc/bindings/ScriptExecutionContext.cpp
+++ b/src/jsc/bindings/ScriptExecutionContext.cpp
@@ -308,21 +308,16 @@ extern "C" void ScriptExecutionContext__markTerminating(JSC::JSGlobalObject* glo
         context->markTerminating();
 }
 
-// Release one concurrent event-loop ref on the context's VM, if that context
-// is still live and not terminating. Called from a work-pool thread after a
-// ConcurrentCppTask's body has run; the creating VM may be a worker that
-// worker.terminate() freed while the task was running. Taking the map lock
-// serializes with markTerminating() (called from WebWorker::shutdown before
-// the VM box is freed), so either we observe the live context and unref under
-// the lock, or we observe it gone/terminating and drop the unref (the counter
-// of a freed event loop needs no balancing). Same fence as postTaskTo().
+// Checked unref for ConcurrentCppTask's pool-thread completion: the map lock
+// serializes with markTerminating() (called before the worker VM is freed), so
+// a terminated worker's VM is never dereferenced. Same fence as postTaskTo().
 extern "C" void ScriptExecutionContext__unrefEventLoopConcurrently(ScriptExecutionContextIdentifier id)
 {
     Locker locker { allScriptExecutionContextsMapLock };
     auto* context = allScriptExecutionContextsMap().get(id);
     if (!context || context->isTerminating())
         return;
-    Bun__eventLoop__incrementRefConcurrently(WebCore::clientData(context->vm())->bunVM, -1);
+    context->unrefEventLoop();
 }
 
 } // namespace WebCore

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -121,6 +121,55 @@ test(
   timeout,
 );
 
+// Regression: ConcurrentCppTask::run_owned (the work-pool wrapper for async
+// WebCrypto ops) dereferenced the raw bunVM pointer captured by the C++
+// EventLoopTaskNoContext to call unref_concurrently() after the crypto body
+// ran. When the creating VM was a worker freed by terminate() while the
+// crypto op was still running on the pool, that read the freed VM
+// allocation. The body itself already posts back via postTaskTo(contextId)
+// and so was safe; only the trailing unref was unfenced.
+test.skipIf(!isASAN)(
+  "terminate() while crypto.subtle async ops are in flight does not UAF in ConcurrentCppTask",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src = \`
+          const { parentPort } = require("node:worker_threads");
+          const s = crypto.subtle;
+          // Four lanes of PBKDF2 deriveBits on the work pool. The 200k-iteration
+          // SHA-512 body is long enough that terminate() reliably lands while
+          // at least one ConcurrentCppTask is still in run_owned.
+          for (let i = 0; i < 4; i++) (async () => {
+            const k = await s.importKey("raw", new TextEncoder().encode("pw-material-key"), "PBKDF2", false, ["deriveBits"]);
+            for (;;) try { await s.deriveBits({ name: "PBKDF2", salt: new Uint8Array(16), iterations: 200000, hash: "SHA-512" }, k, 512); } catch {}
+          })();
+          parentPort.postMessage("up");
+        \`;
+        for (let r = 0; r < ${rounds}; r++) {
+          const w = new Worker(src, { eval: true });
+          await new Promise(res => w.once("message", res));
+          // Let the pool lanes fill before terminating.
+          await Bun.sleep(60 + ((r * 41) % 220));
+          await w.terminate();
+        }
+        console.log("ok");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+  },
+  timeout,
+);
+
 // Regression: the per-VM c-ares channel was destroyed in deinit_runtime_state
 // (RuntimeState drop) AFTER JSC teardown and RareData.file_polls drop.
 // ares_destroy() synchronously fires EDESTRUCTION query callbacks and socket-

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -143,16 +143,22 @@ test.skipIf(!isASAN)(
           // Four lanes of PBKDF2 deriveBits on the work pool. The 200k-iteration
           // SHA-512 body is long enough that terminate() reliably lands while
           // at least one ConcurrentCppTask is still in run_owned.
+          const k = await s.importKey("raw", new TextEncoder().encode("pw-material-key"), "PBKDF2", false, ["deriveBits"]);
           for (let i = 0; i < 4; i++) (async () => {
-            const k = await s.importKey("raw", new TextEncoder().encode("pw-material-key"), "PBKDF2", false, ["deriveBits"]);
             for (;;) try { await s.deriveBits({ name: "PBKDF2", salt: new Uint8Array(16), iterations: 200000, hash: "SHA-512" }, k, 512); } catch {}
           })();
           parentPort.postMessage("up");
         \`;
         for (let r = 0; r < ${rounds}; r++) {
           const w = new Worker(src, { eval: true });
-          await new Promise(res => w.once("message", res));
-          // Let the pool lanes fill before terminating.
+          await new Promise((res, rej) => {
+            w.once("message", res);
+            w.once("error", rej);
+            w.once("exit", code => rej(new Error("worker exited early: " + code)));
+          });
+          // The deriveBits tasks are on the work-pool queue as of "up"; give the
+          // pool threads a moment to enter the PBKDF2 body so terminate() frees
+          // the VM mid-op (the condition the fence must handle).
           await Bun.sleep(60 + ((r * 41) % 220));
           await w.terminate();
         }


### PR DESCRIPTION
## Problem

`worker.terminate()` with async `crypto.subtle` ops in flight (`deriveBits` PBKDF2, `sign`, `digest`, etc.) is a cross-thread heap-use-after-free that kills the whole process:

```
==6462==ERROR: AddressSanitizer: heap-use-after-free on address 0x73db7d491230
READ of size 8 at 0x73db7d491230 thread T12 (Bun Pool 1)
    #0 in <VirtualMachine>::event_loop_shared VirtualMachine.rs:747
    #1 in <ConcurrentCppTask>::run_owned CppTask.rs:82
    #2 in ThreadPool.rs:1241
freed by thread T10 (Worker) here:
    #5 in <WebWorker>::shutdown web_worker.rs:1383
```

Stock release bun: `Segmentation fault (core dumped)`, 2/3 on the repro.

## Cause

`ConcurrentCppTask` wraps every `crypto.subtle` op that runs on the work pool (via `PhonyWorkQueue::dispatch`, the only caller of `ConcurrentCppTask__createAndRun`). After the C++ body finishes on the pool thread, `run_owned` dereferenced the raw `bunVM` pointer captured by `EventLoopTaskNoContext` to call `event_loop_shared().unref_concurrently()`. When the creating VM was a worker freed by `terminate()` while the crypto op was still running, that read the freed `VirtualMachine` allocation.

The crypto body itself was already safe: `dispatchAlgorithmOperation` captures the `ScriptExecutionContextIdentifier` and posts the result via `postTaskTo()`, which serializes with `markTerminating()` on the contexts-map lock. Only the trailing Rust-side unref was unfenced.

## Fix

`EventLoopTaskNoContext` now also captures the context identifier, and the pool-thread unref goes through a new `ScriptExecutionContext__unrefEventLoopConcurrently(id)` that resolves the context under the same contexts-map lock and no-ops if it is gone or terminating. `WebWorker::shutdown` already calls `markTerminating()` (under that lock) before any VM state is freed, so the unref either completes before shutdown begins or is dropped (the counter of a freed event loop needs no balancing).

The schedule-time `ref_concurrently()` in `ConcurrentCppTask__createAndRun` stays direct: it runs on the creating VM's JS thread.

## Verification

New ASAN-gated test in `test/js/web/workers/worker-terminate-lifetime.test.ts`: terminates a worker with four lanes of PBKDF2/SHA-512 200k-iteration `deriveBits` in flight.

- without this patch: 3/3 `heap-use-after-free ... event_loop_shared`
- with this patch: 3/3 pass (~21s under ASAN debug)

Sibling to #35154 / #35155 / #35156 / #35158 (same worker-teardown UAF class, different completion site).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->