### PR TITLE
node:http2: don't let a malformed peer frame terminate the server process

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2689,9 +2689,7 @@ class Http2Stream extends Duplex {
     // seamless compatibility with http1. When the session is being torn down with an error
     // (closeSession in node passes the session error to every stream), surface that error
     // instead of a generic stream error so the same error reaches both client.on('error')
-    // and req.on('error') regardless of which dispatch path reached _destroy first. Same
-    // listenerCount guard as destroyStreamForSessionDestroy/emitStreamErrorNT: a stream that was
-    // never surfaced to user code has no possible 'error' listener.
+    // and req.on('error') regardless of which dispatch path reached _destroy first.
     if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL && this.listenerCount("error") > 0) {
       err = session?.[kSessionDestroyError] ?? $ERR_HTTP2_STREAM_ERROR(nameForErrorCode[rstCode] || rstCode);
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2690,7 +2690,11 @@ class Http2Stream extends Duplex {
     // (closeSession in node passes the session error to every stream), surface that error
     // instead of a generic stream error so the same error reaches both client.on('error')
     // and req.on('error') regardless of which dispatch path reached _destroy first.
-    if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL) {
+    // Gated on an 'error' listener being present, exactly like destroyStreamForSessionDestroy
+    // and emitStreamErrorNT: a stream user code never received (half-parsed before the 'stream'
+    // event fired) has no possible listener, and re-synthesizing the error here would land as
+    // an uncaughtException and terminate the process for a peer protocol violation.
+    if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL && this.listenerCount("error") > 0) {
       err = session?.[kSessionDestroyError] ?? $ERR_HTTP2_STREAM_ERROR(nameForErrorCode[rstCode] || rstCode);
     }
 

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2689,11 +2689,9 @@ class Http2Stream extends Duplex {
     // seamless compatibility with http1. When the session is being torn down with an error
     // (closeSession in node passes the session error to every stream), surface that error
     // instead of a generic stream error so the same error reaches both client.on('error')
-    // and req.on('error') regardless of which dispatch path reached _destroy first.
-    // Gated on an 'error' listener being present, exactly like destroyStreamForSessionDestroy
-    // and emitStreamErrorNT: a stream user code never received (half-parsed before the 'stream'
-    // event fired) has no possible listener, and re-synthesizing the error here would land as
-    // an uncaughtException and terminate the process for a peer protocol violation.
+    // and req.on('error') regardless of which dispatch path reached _destroy first. Same
+    // listenerCount guard as destroyStreamForSessionDestroy/emitStreamErrorNT: a stream that was
+    // never surfaced to user code has no possible 'error' listener.
     if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL && this.listenerCount("error") > 0) {
       err = session?.[kSessionDestroyError] ?? $ERR_HTTP2_STREAM_ERROR(nameForErrorCode[rstCode] || rstCode);
     }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1472,84 +1472,88 @@ describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
 
   const fixture = require.resolve("./h2-malformed-frame-survival-fixture.ts");
 
-  test.concurrent.each(killingFrames)("%s closes only the connection", async (_name, payload) => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), fixture],
-      env: bunEnv,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    const reader = proc.stdout.getReader();
-    let buffered = "";
-    while (!buffered.includes("\n")) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      buffered += Buffer.from(value).toString("latin1");
-    }
-    reader.releaseLock();
-    const m = buffered.match(/PORT:(\d+)/);
-    expect(m?.[1]).toBeDefined();
-    const childPort = Number(m![1]);
-
-    // Send the malformed bytes on one connection and wait for the server to tear it down.
-    {
-      const s = net.connect(childPort, "127.0.0.1");
-      s.on("error", () => {});
-      s.resume();
-      await once(s, "connect");
-      s.write(Buffer.concat([PREFACE, encodeFrame(FrameType.SETTINGS, 0, 0), payload]));
-      await once(s, "close");
-    }
-
-    // The child's default uncaughtException handler would have terminated it by now; a fresh
-    // connection succeeding is the liveness proof.
-    const probe = net.connect(childPort, "127.0.0.1");
-    const probeResult = await Promise.race([
-      once(probe, "connect").then(() => "connected" as const),
-      once(probe, "error").then(([e]) => e as Error),
-      proc.exited.then(code => `exited:${code}` as const),
-    ]);
-    if (probeResult !== "connected") {
-      const stderr = await proc.stderr.text();
-      expect({ probeResult: String(probeResult), stderr }).toEqual({ probeResult: "connected", stderr: "" });
-    }
-
-    // Liveness means a well-formed request on the fresh connection completes.
-    const frames: Frame[] = [];
-    const gotResponse = Promise.withResolvers<void>();
-    let buf = Buffer.alloc(0);
-    probe.on("data", d => {
-      buf = Buffer.concat([buf, d]);
-      while (buf.length >= 9) {
-        const len = buf.readUIntBE(0, 3);
-        if (buf.length < 9 + len) break;
-        const f: Frame = {
-          length: len,
-          type: buf.readUInt8(3),
-          flags: buf.readUInt8(4),
-          streamId: buf.readUInt32BE(5) & 0x7fffffff,
-          payload: buf.subarray(9, 9 + len),
-        };
-        frames.push(f);
-        buf = buf.subarray(9 + len);
-        if (f.streamId === 1 && (f.flags & 0x1) !== 0) gotResponse.resolve();
-        if (f.type === FrameType.GOAWAY) gotResponse.resolve();
+  test.concurrent.each(killingFrames)(
+    "%s closes only the connection",
+    async (_name, payload) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture],
+        env: bunEnv,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const reader = proc.stdout.getReader();
+      let buffered = "";
+      while (!buffered.includes("\n")) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffered += Buffer.from(value).toString("latin1");
       }
-    });
-    probe.on("close", () => gotResponse.resolve());
-    probe.write(
-      Buffer.concat([
-        PREFACE,
-        encodeFrame(FrameType.SETTINGS, 0, 0),
-        encodeFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET")),
-      ]),
-    );
-    await gotResponse.promise;
-    const data = frames.filter(f => f.type === FrameType.DATA && f.streamId === 1);
-    expect(Buffer.concat(data.map(f => f.payload)).toString()).toBe("ok");
-    probe.destroy();
+      reader.releaseLock();
+      const m = buffered.match(/PORT:(\d+)/);
+      expect(m?.[1]).toBeDefined();
+      const childPort = Number(m![1]);
 
-    proc.stdin.write("quit\n");
-    const exitCode = await proc.exited;
-    expect(exitCode).toBe(0);
-  }, 15_000);
+      // Send the malformed bytes on one connection and wait for the server to tear it down.
+      {
+        const s = net.connect(childPort, "127.0.0.1");
+        s.on("error", () => {});
+        s.resume();
+        await once(s, "connect");
+        s.write(Buffer.concat([PREFACE, encodeFrame(FrameType.SETTINGS, 0, 0), payload]));
+        await once(s, "close");
+      }
+
+      // The child's default uncaughtException handler would have terminated it by now; a fresh
+      // connection succeeding is the liveness proof.
+      const probe = net.connect(childPort, "127.0.0.1");
+      const probeResult = await Promise.race([
+        once(probe, "connect").then(() => "connected" as const),
+        once(probe, "error").then(([e]) => e as Error),
+        proc.exited.then(code => `exited:${code}` as const),
+      ]);
+      if (probeResult !== "connected") {
+        const stderr = await proc.stderr.text();
+        expect({ probeResult: String(probeResult), stderr }).toEqual({ probeResult: "connected", stderr: "" });
+      }
+
+      // Liveness means a well-formed request on the fresh connection completes.
+      const frames: Frame[] = [];
+      const gotResponse = Promise.withResolvers<void>();
+      let buf = Buffer.alloc(0);
+      probe.on("data", d => {
+        buf = Buffer.concat([buf, d]);
+        while (buf.length >= 9) {
+          const len = buf.readUIntBE(0, 3);
+          if (buf.length < 9 + len) break;
+          const f: Frame = {
+            length: len,
+            type: buf.readUInt8(3),
+            flags: buf.readUInt8(4),
+            streamId: buf.readUInt32BE(5) & 0x7fffffff,
+            payload: buf.subarray(9, 9 + len),
+          };
+          frames.push(f);
+          buf = buf.subarray(9 + len);
+          if (f.streamId === 1 && (f.flags & 0x1) !== 0) gotResponse.resolve();
+          if (f.type === FrameType.GOAWAY) gotResponse.resolve();
+        }
+      });
+      probe.on("close", () => gotResponse.resolve());
+      probe.write(
+        Buffer.concat([
+          PREFACE,
+          encodeFrame(FrameType.SETTINGS, 0, 0),
+          encodeFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET")),
+        ]),
+      );
+      await gotResponse.promise;
+      const data = frames.filter(f => f.type === FrameType.DATA && f.streamId === 1);
+      expect(Buffer.concat(data.map(f => f.payload)).toString()).toBe("ok");
+      probe.destroy();
+
+      proc.stdin.write("quit\n");
+      const exitCode = await proc.exited;
+      expect(exitCode).toBe(0);
+    },
+    15_000,
+  );
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1504,10 +1504,10 @@ describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
 
       // The child's default uncaughtException handler would have terminated it by now; a fresh
       // connection succeeding is the liveness proof.
-      const probe = net.connect(childPort, "127.0.0.1");
+      const probe = new RawH2(childPort);
       const probeResult = await Promise.race([
-        once(probe, "connect").then(() => "connected" as const),
-        once(probe, "error").then(([e]) => e as Error),
+        once(probe.socket, "connect").then(() => "connected" as const),
+        once(probe.socket, "error").then(([e]) => e as Error),
         proc.exited.then(code => `exited:${code}` as const),
       ]);
       if (probeResult !== "connected") {
@@ -1516,37 +1516,14 @@ describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
       }
 
       // Liveness means a well-formed request on the fresh connection completes.
-      const frames: Frame[] = [];
-      const gotResponse = Promise.withResolvers<void>();
-      let buf = Buffer.alloc(0);
-      probe.on("data", d => {
-        buf = Buffer.concat([buf, d]);
-        while (buf.length >= 9) {
-          const len = buf.readUIntBE(0, 3);
-          if (buf.length < 9 + len) break;
-          const f: Frame = {
-            length: len,
-            type: buf.readUInt8(3),
-            flags: buf.readUInt8(4),
-            streamId: buf.readUInt32BE(5) & 0x7fffffff,
-            payload: buf.subarray(9, 9 + len),
-          };
-          frames.push(f);
-          buf = buf.subarray(9 + len);
-          if (f.streamId === 1 && (f.flags & 0x1) !== 0) gotResponse.resolve();
-          if (f.type === FrameType.GOAWAY) gotResponse.resolve();
-        }
-      });
-      probe.on("close", () => gotResponse.resolve());
-      probe.write(
-        Buffer.concat([
-          PREFACE,
-          encodeFrame(FrameType.SETTINGS, 0, 0),
-          encodeFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET")),
-        ]),
-      );
-      await gotResponse.promise;
-      const data = frames.filter(f => f.type === FrameType.DATA && f.streamId === 1);
+      probe.sendPreface();
+      probe.sendEmptySettings();
+      probe.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
+      await Promise.race([
+        probe.waitFor(f => (f.streamId === 1 && (f.flags & 0x1) !== 0) || f.type === FrameType.GOAWAY),
+        probe.waitClosed(),
+      ]);
+      const data = probe.frames.filter(f => f.type === FrameType.DATA && f.streamId === 1);
       expect(Buffer.concat(data.map(f => f.payload)).toString()).toBe("ok");
       probe.destroy();
 

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1423,8 +1423,6 @@ describe("inbound stream lifecycle", () => {
 // and so could not have an 'error' listener on — and the unhandled stream 'error' became an
 // uncaughtException.
 describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
-  const wellFormedGet = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
-
   // Each case is the raw bytes to send after the client preface + SETTINGS; every one is a
   // connection error the server must tear down that one connection for, and nothing else.
   const killingFrames: [string, Buffer][] = [
@@ -1458,7 +1456,7 @@ describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
     [
       "PING inside a header block",
       Buffer.concat([
-        encodeFrame(FrameType.HEADERS, 0x1 /* END_STREAM, no END_HEADERS */, 1, wellFormedGet),
+        encodeFrame(FrameType.HEADERS, 0x1 /* END_STREAM, no END_HEADERS */, 1, requestHeaderBlock("GET")),
         encodeFrame(FrameType.PING, 0, 0, Buffer.alloc(8)),
       ]),
     ],
@@ -1466,8 +1464,8 @@ describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
     [
       "other-stream HEADERS inside a header block",
       Buffer.concat([
-        encodeFrame(FrameType.HEADERS, 0x1 /* END_STREAM, no END_HEADERS */, 1, wellFormedGet),
-        encodeFrame(FrameType.HEADERS, 0x5, 3, wellFormedGet),
+        encodeFrame(FrameType.HEADERS, 0x1 /* END_STREAM, no END_HEADERS */, 1, requestHeaderBlock("GET")),
+        encodeFrame(FrameType.HEADERS, 0x5, 3, requestHeaderBlock("GET")),
       ]),
     ],
   ];
@@ -1542,7 +1540,7 @@ describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
       Buffer.concat([
         PREFACE,
         encodeFrame(FrameType.SETTINGS, 0, 0),
-        encodeFrame(FrameType.HEADERS, 0x5, 1, wellFormedGet),
+        encodeFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET")),
       ]),
     );
     await gotResponse.promise;
@@ -1553,5 +1551,5 @@ describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
     proc.stdin.write("quit\n");
     const exitCode = await proc.exited;
     expect(exitCode).toBe(0);
-  });
+  }, 15_000);
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1506,8 +1506,10 @@ describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
       // connection succeeding is the liveness proof.
       const probe = new RawH2(childPort);
       const probeResult = await Promise.race([
-        once(probe.socket, "connect").then(() => "connected" as const),
-        once(probe.socket, "error").then(([e]) => e as Error),
+        once(probe.socket, "connect").then(
+          () => "connected" as const,
+          e => e as Error,
+        ),
         proc.exited.then(code => `exited:${code}` as const),
       ]);
       if (probeResult !== "connected") {

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1414,3 +1414,144 @@ describe("inbound stream lifecycle", () => {
     }
   });
 });
+
+// Malformed frames from the wire must never terminate the server process. A connection error is
+// scoped to the connection (RFC 9113 §5.4.1): the session gets a GOAWAY, 'sessionError' fires,
+// the socket closes, and the server keeps serving other connections. Node (nghttp2) behaves this
+// way for every case here. Prior to this change, any HPACK decode failure or CONTINUATION-sequence
+// violation re-surfaced the session error on the half-parsed stream — which user code never saw
+// and so could not have an 'error' listener on — and the unhandled stream 'error' became an
+// uncaughtException.
+describe("malformed-frame process survival (RFC 9113 §5.4.1)", () => {
+  const wellFormedGet = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
+
+  // Each case is the raw bytes to send after the client preface + SETTINGS; every one is a
+  // connection error the server must tear down that one connection for, and nothing else.
+  const killingFrames: [string, Buffer][] = [
+    // HPACK §6.1: indexed representation with index 0 is a decoding error.
+    ["HPACK index 0", encodeFrame(FrameType.HEADERS, 0x5, 1, Buffer.from([0x80]))],
+    // HPACK §2.3.3: index past static + dynamic table bounds.
+    ["HPACK out-of-range index", encodeFrame(FrameType.HEADERS, 0x5, 1, Buffer.from([0xff, 0xff, 0x7f]))],
+    // HPACK §5.2: literal header whose string length exceeds the remaining block.
+    ["HPACK truncated literal", encodeFrame(FrameType.HEADERS, 0x5, 1, Buffer.from([0x00, 0x05, 0x78]))],
+    // Arbitrary bytes that cannot form a valid HPACK instruction sequence.
+    [
+      "HPACK junk bytes",
+      encodeFrame(FrameType.HEADERS, 0x5, 1, Buffer.from([0x40, 0x81, 0xff, 0xff, 0xff, 0xff, 0xff])),
+    ],
+    // HPACK §6.3: dynamic-table size update larger than SETTINGS_HEADER_TABLE_SIZE.
+    [
+      "HPACK dynamic-table size update over max",
+      encodeFrame(FrameType.HEADERS, 0x5, 1, Buffer.from([0x3f, 0xe2, 0xff, 0xff, 0xff, 0x07])),
+    ],
+    // HPACK §5.2: Huffman-coded literal with the 8-bit EOS symbol inside (decoding error).
+    [
+      "HPACK invalid Huffman sequence",
+      encodeFrame(FrameType.HEADERS, 0x5, 1, Buffer.from([0x00, 0x84, 0xff, 0xff, 0xff, 0xff, 0x00])),
+    ],
+    // HPACK §5.1: string-length varint that exceeds 32 bits.
+    [
+      "HPACK string length overflow",
+      encodeFrame(FrameType.HEADERS, 0x5, 1, Buffer.from([0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f])),
+    ],
+    // RFC 9113 §4.3: any frame other than CONTINUATION between HEADERS and END_HEADERS.
+    [
+      "PING inside a header block",
+      Buffer.concat([
+        encodeFrame(FrameType.HEADERS, 0x1 /* END_STREAM, no END_HEADERS */, 1, wellFormedGet),
+        encodeFrame(FrameType.PING, 0, 0, Buffer.alloc(8)),
+      ]),
+    ],
+    // RFC 9113 §6.10: CONTINUATION for a different stream while a header block is open.
+    [
+      "other-stream HEADERS inside a header block",
+      Buffer.concat([
+        encodeFrame(FrameType.HEADERS, 0x1 /* END_STREAM, no END_HEADERS */, 1, wellFormedGet),
+        encodeFrame(FrameType.HEADERS, 0x5, 3, wellFormedGet),
+      ]),
+    ],
+  ];
+
+  const fixture = require.resolve("./h2-malformed-frame-survival-fixture.ts");
+
+  test.concurrent.each(killingFrames)("%s closes only the connection", async (_name, payload) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture],
+      env: bunEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const reader = proc.stdout.getReader();
+    let buffered = "";
+    while (!buffered.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffered += Buffer.from(value).toString("latin1");
+    }
+    reader.releaseLock();
+    const m = buffered.match(/PORT:(\d+)/);
+    expect(m?.[1]).toBeDefined();
+    const childPort = Number(m![1]);
+
+    // Send the malformed bytes on one connection and wait for the server to tear it down.
+    {
+      const s = net.connect(childPort, "127.0.0.1");
+      s.on("error", () => {});
+      s.resume();
+      await once(s, "connect");
+      s.write(Buffer.concat([PREFACE, encodeFrame(FrameType.SETTINGS, 0, 0), payload]));
+      await once(s, "close");
+    }
+
+    // The child's default uncaughtException handler would have terminated it by now; a fresh
+    // connection succeeding is the liveness proof.
+    const probe = net.connect(childPort, "127.0.0.1");
+    const probeResult = await Promise.race([
+      once(probe, "connect").then(() => "connected" as const),
+      once(probe, "error").then(([e]) => e as Error),
+      proc.exited.then(code => `exited:${code}` as const),
+    ]);
+    if (probeResult !== "connected") {
+      const stderr = await proc.stderr.text();
+      expect({ probeResult: String(probeResult), stderr }).toEqual({ probeResult: "connected", stderr: "" });
+    }
+
+    // Liveness means a well-formed request on the fresh connection completes.
+    const frames: Frame[] = [];
+    const gotResponse = Promise.withResolvers<void>();
+    let buf = Buffer.alloc(0);
+    probe.on("data", d => {
+      buf = Buffer.concat([buf, d]);
+      while (buf.length >= 9) {
+        const len = buf.readUIntBE(0, 3);
+        if (buf.length < 9 + len) break;
+        const f: Frame = {
+          length: len,
+          type: buf.readUInt8(3),
+          flags: buf.readUInt8(4),
+          streamId: buf.readUInt32BE(5) & 0x7fffffff,
+          payload: buf.subarray(9, 9 + len),
+        };
+        frames.push(f);
+        buf = buf.subarray(9 + len);
+        if (f.streamId === 1 && (f.flags & 0x1) !== 0) gotResponse.resolve();
+        if (f.type === FrameType.GOAWAY) gotResponse.resolve();
+      }
+    });
+    probe.on("close", () => gotResponse.resolve());
+    probe.write(
+      Buffer.concat([
+        PREFACE,
+        encodeFrame(FrameType.SETTINGS, 0, 0),
+        encodeFrame(FrameType.HEADERS, 0x5, 1, wellFormedGet),
+      ]),
+    );
+    await gotResponse.promise;
+    const data = frames.filter(f => f.type === FrameType.DATA && f.streamId === 1);
+    expect(Buffer.concat(data.map(f => f.payload)).toString()).toBe("ok");
+    probe.destroy();
+
+    proc.stdin.write("quit\n");
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/http2/h2-malformed-frame-survival-fixture.ts
+++ b/test/js/node/http2/h2-malformed-frame-survival-fixture.ts
@@ -1,0 +1,32 @@
+// A bare node:http2 server for the malformed-frame survival test. It handles session-level errors
+// (sessionError + per-session 'error') exactly like a production server would, but leaves the
+// default uncaughtException behavior alone so a stray throw terminates the process — the test
+// parent observes that as a non-zero exit instead of a liveness probe succeeding.
+import http2 from "node:http2";
+
+const server = http2.createServer();
+
+server.on("sessionError", () => {});
+server.on("session", session => {
+  session.on("error", () => {});
+});
+server.on("stream", stream => {
+  stream.on("error", () => {});
+  stream.respond({ ":status": 200 });
+  stream.end("ok");
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const addr = server.address();
+  if (addr && typeof addr === "object") {
+    process.stdout.write(`PORT:${addr.port}\n`);
+  }
+});
+
+process.stdin.on("data", d => {
+  if (d.toString().includes("quit")) {
+    server.close();
+    process.exit(0);
+  }
+});
+process.stdin.resume();


### PR DESCRIPTION
A single malformed HEADERS/HPACK block or CONTINUATION-sequence violation sent to a bare `node:http2` server terminates the process.

### Repro

```js
import http2 from "node:http2"; import net from "node:net";
const srv = http2.createServer();
srv.on("sessionError", () => {});            // session-level errors handled
srv.on("session", s => s.on("error", () => {}));
srv.on("stream", s => { s.respond({ ":status": 200 }); s.end("ok"); });
srv.listen(0, "127.0.0.1", () => {
  const fr = (t,f,sid,pl=Buffer.alloc(0)) => { const b=Buffer.alloc(9+pl.length);
    b.writeUIntBE(pl.length,0,3); b[3]=t; b[4]=f; b.writeUInt32BE(sid,5); pl.copy(b,9); return b; };
  net.connect(srv.address().port, "127.0.0.1", function () {
    this.write(Buffer.concat([Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n","latin1"),
      fr(4,0,0), fr(1,0x5,1,Buffer.from([0x80]))]));  // HEADERS with HPACK index 0
  });
});
```

```
error: Protocol error
 code: "ERR_HTTP2_ERROR"
      at _destroy (node:http2)
      ...
```

The server process exits 1. Node.js v26 survives (GOAWAY + `sessionError` + socket close) and keeps serving.

### Cause

The engine detects the connection error, writes the RFC-code GOAWAY, and dispatches the server `error()` handler, which calls `session.destroy(new NghttpError(code))`. The destroy sweep reaches the half-parsed stream that was created when the HEADERS frame started but never surfaced to user code via the `stream` event. `destroyStreamForSessionDestroy` already gates the error on `listenerCount("error") > 0` and passes `undefined` for it, but `Http2Stream._destroy` then re-synthesizes `err = session[kSessionDestroyError]` and hands it to the Duplex callback. The Duplex emits `'error'` on a stream with no listener (and no possible listener, since user code never saw it), and the unhandled emit is an `uncaughtException`.

### Fix

Gate the re-synthesis in `_destroy` on an `'error'` listener being present, the same guard `destroyStreamForSessionDestroy` and `emitStreamErrorNT` already apply. A connection error then stays scoped to the connection (RFC 9113 5.4.1): GOAWAY, `sessionError`, socket close, server keeps serving.

### Verification

New `malformed-frame process survival` describe block in `test/js/node/http2/h2-conformance.test.ts` spawns a child `node:http2` server (no `uncaughtException` handler, session errors handled) and drives nine malformed-frame cases against it from a raw byte-level client: seven HPACK decode failures (index 0, out-of-range index, truncated literal, junk bytes, oversized dynamic-table update, invalid Huffman, length-varint overflow) and two CONTINUATION-sequence violations (PING inside a header block, HEADERS for another stream inside a header block). Each case asserts the malformed connection is torn down, a fresh connection then completes a well-formed request, and the child exits 0 on a clean `quit`.

Before: 9/9 fail (child exits 1 with the `ERR_HTTP2_ERROR` uncaught). After: 9/9 pass. `node-http2.test.js` (307 tests) and the rest of `h2-conformance.test.ts` unchanged.

The second GOAWAY carrying `INTERNAL_ERROR` instead of the engine's specific code is addressed separately in #34366.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (0e602039c)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [751.77ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [250.02ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [231.28ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [164.55ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [135.39ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [93.46ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [113.37ms]
(pass) PING (checklist §3.7) > a PING on a non-zer
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2e08bf54e)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [32.44ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [4.19ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [3.10ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [6.83ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [1.94ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [1.42ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.39ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [1.15ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [1.24ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (0e602039c)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [771.20ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [233.79ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [221.24ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [158.22ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [140.82ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [122.59ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [134.56ms]
(pass) PING (checklist §3.7) > a PING on a non-ze
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1785ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (19634ms)
Bundle modules (213ms)
Postprocesss modules (1265ms)
Bundle Functions (1696ms)
Generate Code (43ms)

[22.88s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                               |   2 +-
 test/js/node/http2/h2-conformance.test.ts          | 122 +++++++++++++++++++++
 .../http2/h2-malformed-frame-survival-fixture.ts   |  32 ++++++
 3 files changed, 155 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/http2.ts                                          7      3      0
test/js/node/http2/h2-conformance.test.ts                     8      7      0
…st/js/node/http2/h2-malformed-frame-survival-fixture.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->