### PR TITLE
test: speed up zlib leak.test.ts by cutting redundant iterations

### DIFF
--- a/test/js/node/zlib/leak.test.ts
+++ b/test/js/node/zlib/leak.test.ts
@@ -3,135 +3,70 @@ import { isASAN } from "harness";
 import { promisify } from "node:util";
 import zlib from "node:zlib";
 
-const input = Buffer.alloc(50000);
-for (let i = 0; i < input.length; i++) input[i] = Math.random();
+const input = Buffer.alloc(50_000);
 
+// Each compressor allocates hundreds of KB of native state per call (deflate
+// window ~256KB, brotli/zstd larger). A few thousand calls is enough for a
+// leak of that state, or of a retained 50KB input buffer, to grow RSS by
+// >100MB, far above the threshold below.
 const upper = 1024 * 1024 * (isASAN ? 20 : 10);
 
-// The leak assertion (RSS stable across iterations) is quality-agnostic; the
-// default quality (11) makes each brotli test take multiple seconds in CI.
+// Quality is irrelevant to the leak assertion; the default (11) is ~40x slower.
 const brotliOpts = { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 2 } };
+
+type Sync = (buf: Buffer) => Buffer;
+type Async = (buf: Buffer) => Promise<Buffer>;
+const codecs: Array<[name: string, iters: number, compress: Sync | Async, sync: boolean]> = [
+  ["deflate", 2_000, promisify(zlib.deflate), false],
+  ["gzip", 2_000, promisify(zlib.gzip), false],
+  ["deflateSync", 2_000, zlib.deflateSync, true],
+  ["gzipSync", 2_000, zlib.gzipSync, true],
+  ["brotliCompress", 1_000, b => promisify(zlib.brotliCompress)(b, brotliOpts), false],
+  ["brotliCompressSync", 1_000, b => zlib.brotliCompressSync(b, brotliOpts), true],
+  ["zstdCompress", 1_000, promisify(zlib.zstdCompress), false],
+  ["zstdCompressSync", 1_000, zlib.zstdCompressSync, true],
+];
 
 describe("zlib compression does not leak memory", () => {
   beforeAll(() => {
-    for (let index = 0; index < 10_000; index++) {
-      zlib.deflateSync(input);
-    }
+    // Reach allocator steady state once so the first codec's baseline is not
+    // skewed by startup page faults.
+    for (let i = 0; i < 500; i++) zlib.deflateSync(input);
     Bun.gc(true);
-    console.log("beforeAll done");
   });
 
-  for (const compress of ["deflate", "gzip"] as const) {
-    test(
-      compress,
-      async () => {
-        for (let index = 0; index < 10_000; index++) {
-          await promisify(zlib[compress])(input);
-        }
-        const baseline = process.memoryUsage.rss();
-        console.log(baseline);
-        for (let index = 0; index < 10_000; index++) {
-          await promisify(zlib[compress])(input);
-        }
-        Bun.gc(true);
-        const after = process.memoryUsage.rss();
-        console.log(after);
-        console.log("-", after - baseline);
-        console.log("-", upper);
-        expect(after - baseline).toBeLessThan(upper);
-      },
-      0,
-    );
-  }
+  test.each(codecs)(
+    "%s",
+    async (name, iters, compress, sync) => {
+      const run = sync
+        ? (n: number) => {
+            let out: Buffer;
+            for (let i = 0; i < n; i++) out = (compress as Sync)(input);
+            return out!;
+          }
+        : async (n: number) => {
+            let out: Buffer;
+            for (let i = 0; i < n; i++) out = await (compress as Async)(input);
+            return out!;
+          };
 
-  for (const compress of ["deflateSync", "gzipSync"] as const) {
-    test(
-      compress,
-      async () => {
-        for (let index = 0; index < 10_000; index++) {
-          zlib[compress](input);
-        }
-        const baseline = process.memoryUsage.rss();
-        console.log(baseline);
-        for (let index = 0; index < 10_000; index++) {
-          zlib[compress](input);
-        }
-        Bun.gc(true);
-        const after = process.memoryUsage.rss();
-        console.log(after);
-        console.log("-", after - baseline);
-        console.log("-", upper);
-        expect(after - baseline).toBeLessThan(upper);
-      },
-      0,
-    );
-  }
+      const sample = await run(1);
+      expect(sample.length).toBeGreaterThan(0);
 
-  test("brotliCompress", async () => {
-    for (let index = 0; index < 1_000; index++) {
-      await promisify(zlib.brotliCompress)(input, brotliOpts);
-    }
-    const baseline = process.memoryUsage.rss();
-    console.log(baseline);
-    for (let index = 0; index < 1_000; index++) {
-      await promisify(zlib.brotliCompress)(input, brotliOpts);
-    }
-    Bun.gc(true);
-    const after = process.memoryUsage.rss();
-    console.log(after);
-    console.log("-", after - baseline);
-    console.log("-", upper);
-    expect(after - baseline).toBeLessThan(upper);
-  }, 0);
+      await run(iters);
+      Bun.gc(true);
+      const baseline = process.memoryUsage.rss();
 
-  test("brotliCompressSync", async () => {
-    for (let index = 0; index < 1_000; index++) {
-      zlib.brotliCompressSync(input, brotliOpts);
-    }
-    const baseline = process.memoryUsage.rss();
-    console.log(baseline);
-    for (let index = 0; index < 1_000; index++) {
-      zlib.brotliCompressSync(input, brotliOpts);
-    }
-    Bun.gc(true);
-    const after = process.memoryUsage.rss();
-    console.log(after);
-    console.log("-", after - baseline);
-    console.log("-", upper);
-    expect(after - baseline).toBeLessThan(upper);
-  }, 0);
+      await run(iters);
+      Bun.gc(true);
+      const after = process.memoryUsage.rss();
 
-  test("zstdCompress", async () => {
-    for (let index = 0; index < 1_000; index++) {
-      await promisify(zlib.zstdCompress)(input);
-    }
-    const baseline = process.memoryUsage.rss();
-    console.log(baseline);
-    for (let index = 0; index < 1_000; index++) {
-      await promisify(zlib.zstdCompress)(input);
-    }
-    Bun.gc(true);
-    const after = process.memoryUsage.rss();
-    console.log(after);
-    console.log("-", after - baseline);
-    console.log("-", upper);
-    expect(after - baseline).toBeLessThan(upper);
-  }, 0);
-
-  test("zstdCompressSync", async () => {
-    for (let index = 0; index < 1_000; index++) {
-      zlib.zstdCompressSync(input);
-    }
-    const baseline = process.memoryUsage.rss();
-    console.log(baseline);
-    for (let index = 0; index < 1_000; index++) {
-      zlib.zstdCompressSync(input);
-    }
-    Bun.gc(true);
-    const after = process.memoryUsage.rss();
-    console.log(after);
-    console.log("-", after - baseline);
-    console.log("-", upper);
-    expect(after - baseline).toBeLessThan(upper);
-  }, 0);
+      const delta = after - baseline;
+      expect(
+        delta,
+        `${name}: RSS grew ${(delta / 1024 / 1024).toFixed(1)}MB over ${iters} calls (limit ${(upper / 1024 / 1024).toFixed(0)}MB)`,
+      ).toBeLessThan(upper);
+    },
+    60_000,
+  );
 });


### PR DESCRIPTION
## What does this PR do?

Speeds up `test/js/node/zlib/leak.test.ts` without weakening the leak assertion.

### Changes

- **deflate/gzip: 10,000 -> 2,000 iterations per phase.** Each `zlib.deflate`/`gzip` call allocates ~256KB of native deflate state; 2,000 calls is enough for a leak of that state (or of the retained 50KB input buffer) to push RSS >100MB past the 10/20MB threshold. The original 10k count was catching leaks >=1KB/call; 2k catches >=5KB/call, which still covers every realistic leak mode here (native state, input buffer, output buffer at this input size).
- **beforeAll warmup: 10,000 -> 500.** Every codec test already runs its own warmup loop before sampling the baseline, so the global warmup only needs to get the allocator past startup page faults.
- **Collapsed the eight near-identical test bodies** into a single `test.each` over a codec table.
- **GC before the baseline** as well as after the measure loop (the old code only GC'd after), so the baseline is taken against a swept heap.
- Dropped the no-op `input[i] = Math.random()` loop: `Math.random()` returns [0,1) and truncates to 0 when stored in a `Buffer` byte, so the input was already 50,000 zeros.
- Replaced the four `console.log` lines per test with a single descriptive assertion message that reports the actual RSS growth, iteration count and limit on failure.
- Added `expect(sample.length).toBeGreaterThan(0)` so the test also asserts the call path produced output at all.
- Bounded the per-test timeout at 60s (was `0` / unlimited).

brotli/zstd stay at 1,000 iterations (unchanged).

### How did you verify your code works?

`bun test test/js/node/zlib/leak.test.ts` on a release binary, three runs each:

| | before | after |
|---|---|---|
| run 1 | 5.80s | 2.73s |
| run 2 | 5.39s | 1.87s |
| run 3 | 5.11s | 1.95s |

`bun bd test` (debug+ASAN, `BUN_GARBAGE_COLLECTOR_LEVEL=1`): 483s -> 94s on the same machine. The debian-13 x64-asan CI lane should see a proportional drop.

Verified a simulated 50KB/call leak still fails the assertion at 2,000 iterations:

```
error: deflateSync-LEAKY: RSS grew 112.1MB over 2000 calls (limit 10MB)
```
