### PR TITLE
node:quic: detach lsquic ctx pointers before the finalize-order sweep at worker VM teardown

### DIFF
--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -2619,6 +2619,29 @@ impl QuicEndpoint {
         Ok(JSValue::UNDEFINED)
     }
 
+    /// `lastChanceToFinalize` sweeps the endpoint / session / stream wrappers
+    /// in unspecified order, so by the time `release_native` runs
+    /// `lsquic_engine_destroy` the raw `*mut QuicSession` registries and the
+    /// session/stream boxes the vtable callbacks reach may already be freed.
+    /// This drops the registries, nulls `vtable.owner` so every owner-keyed
+    /// callback short-circuits in `ctx_ref`, and points `on_stream_close` /
+    /// `on_conn_closed` at variants that never follow a session or endpoint
+    /// back-pointer; the session/stream `finalize` methods null their own
+    /// lsquic ctx, which is how already-freed boxes stay out of the shim.
+    fn detach_for_finalize(&self) {
+        self.sessions.with_mut(Vec::clear);
+        self.pending_new_sessions.with_mut(Vec::clear);
+        self.provisional.with_mut(Vec::clear);
+        self.pending_verneg.with_mut(Vec::clear);
+        self.vtable.with_mut(|vt| {
+            if let Some(vt) = vt.as_mut() {
+                vt.owner = null_mut();
+                vt.on_stream_close = stream::QuicStream::on_close_detached;
+                vt.on_conn_closed = QuicSession::on_closed_detached;
+            }
+        });
+    }
+
     #[expect(
         clippy::boxed_local,
         reason = "codegen's host_fn_finalize calls this as `|b| QuicEndpoint::finalize(b)` and requires `self: Box<Self>`"
@@ -2629,29 +2652,7 @@ impl QuicEndpoint {
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
             timer_all().remove(self.event_loop_timer.as_ptr());
         }
-        // `lastChanceToFinalize` sweeps wrappers in unspecified order, so the
-        // raw `*mut QuicSession` registries and the session/stream boxes the
-        // vtable callbacks reach may already be freed. `release_native` ->
-        // `lsquic_engine_destroy` fires `on_close` / `on_conn_closed` /
-        // `on_mini_conn_failed` on every live conn: make those safe first.
-        self.sessions.with_mut(Vec::clear);
-        self.pending_new_sessions.with_mut(Vec::clear);
-        self.provisional.with_mut(Vec::clear);
-        self.pending_verneg.with_mut(Vec::clear);
-        self.vtable.with_mut(|vt| {
-            if let Some(vt) = vt.as_mut() {
-                // Owner-keyed callbacks (`on_mini_conn_failed`, `packets_out`,
-                // `on_new_conn`/`on_new_stream`, the SSL_CTX lookups) now see
-                // a null owner and `ctx_ref` returns `None`.
-                vt.owner = null_mut();
-                // ctx-keyed callbacks reach a live stream/session box (their
-                // own `finalize` nulls the ctx otherwise), but its session /
-                // endpoint back-pointer may be a freed box: swap in variants
-                // that only clear the lsquic back-reference.
-                vt.on_stream_close = stream::QuicStream::on_close_detached;
-                vt.on_conn_closed = QuicSession::on_closed_detached;
-            }
-        });
+        self.detach_for_finalize();
         self.release_native();
     }
 }

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -2629,6 +2629,29 @@ impl QuicEndpoint {
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
             timer_all().remove(self.event_loop_timer.as_ptr());
         }
+        // `lastChanceToFinalize` sweeps wrappers in unspecified order, so the
+        // raw `*mut QuicSession` registries and the session/stream boxes the
+        // vtable callbacks reach may already be freed. `release_native` ->
+        // `lsquic_engine_destroy` fires `on_close` / `on_conn_closed` /
+        // `on_mini_conn_failed` on every live conn: make those safe first.
+        self.sessions.with_mut(Vec::clear);
+        self.pending_new_sessions.with_mut(Vec::clear);
+        self.provisional.with_mut(Vec::clear);
+        self.pending_verneg.with_mut(Vec::clear);
+        self.vtable.with_mut(|vt| {
+            if let Some(vt) = vt.as_mut() {
+                // Owner-keyed callbacks (`on_mini_conn_failed`, `packets_out`,
+                // `on_new_conn`/`on_new_stream`, the SSL_CTX lookups) now see
+                // a null owner and `ctx_ref` returns `None`.
+                vt.owner = null_mut();
+                // ctx-keyed callbacks reach a live stream/session box (their
+                // own `finalize` nulls the ctx otherwise), but its session /
+                // endpoint back-pointer may be a freed box: swap in variants
+                // that only clear the lsquic back-reference.
+                vt.on_stream_close = stream::QuicStream::on_close_detached;
+                vt.on_conn_closed = QuicSession::on_closed_detached;
+            }
+        });
         self.release_native();
     }
 }

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -2358,11 +2358,36 @@ impl QuicSession {
         Self::transport_params_to_js(global, &tp)
     }
 
+    /// Clears `conn` without touching `endpoint`/`streams`:
+    /// `lastChanceToFinalize` sweeps wrappers in unspecified order, so those
+    /// back-pointers may already be freed.
+    pub(super) unsafe extern "C" fn on_closed_detached(ctx: *mut c_void) {
+        // SAFETY: `ctx_ref` documents the shim's context-pointer contract;
+        // `finalize` below nulls the ctx, so a non-null ctx is a live box.
+        if let Some(session) = unsafe { super::ffi::ctx_ref::<QuicSession>(ctx) } {
+            session.conn.set(null_mut());
+        }
+    }
+
     #[expect(
         clippy::boxed_local,
         reason = "codegen's host_fn_finalize calls this as `|b| QuicSession::finalize(b)` and requires `self: Box<Self>`"
     )]
-    pub(crate) fn finalize(self: Box<Self>) {}
+    pub(crate) fn finalize(self: Box<Self>) {
+        // `lastChanceToFinalize` sweeps wrappers in unspecified order: when
+        // this box drops before its endpoint, `QuicEndpoint::finalize` ->
+        // `lsquic_engine_destroy` still fires `on_conn_closed` with this
+        // pointer as the conn ctx. `conn` non-null means the lsquic conn is
+        // still live (`on_conn_closed` nulls it before lsquic frees the conn,
+        // and teardown clears it explicitly), so clearing the ctx here is the
+        // remaining obligation before the box is freed.
+        let conn = self.conn.get();
+        if !conn.is_null() {
+            // SAFETY: `conn` is live per the invariant above; null is always a
+            // valid ctx and makes the shim skip every conn callback.
+            unsafe { lsquic::lsquic_conn_set_ctx(conn, null_mut()) };
+        }
+    }
 }
 
 lsquic_callback! {

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -2358,12 +2358,10 @@ impl QuicSession {
         Self::transport_params_to_js(global, &tp)
     }
 
-    /// Clears `conn` without touching `endpoint`/`streams`:
-    /// `lastChanceToFinalize` sweeps wrappers in unspecified order, so those
-    /// back-pointers may already be freed.
+    /// `on_conn_closed` for [`QuicEndpoint::detach_for_finalize`]: clears
+    /// `conn` and nothing else, since `endpoint`/`streams` may already be freed.
     pub(super) unsafe extern "C" fn on_closed_detached(ctx: *mut c_void) {
-        // SAFETY: `ctx_ref` documents the shim's context-pointer contract;
-        // `finalize` below nulls the ctx, so a non-null ctx is a live box.
+        // SAFETY: `finalize` nulls the lsquic ctx, so a non-null one is live.
         if let Some(session) = unsafe { super::ffi::ctx_ref::<QuicSession>(ctx) } {
             session.conn.set(null_mut());
         }
@@ -2374,17 +2372,11 @@ impl QuicSession {
         reason = "codegen's host_fn_finalize calls this as `|b| QuicSession::finalize(b)` and requires `self: Box<Self>`"
     )]
     pub(crate) fn finalize(self: Box<Self>) {
-        // `lastChanceToFinalize` sweeps wrappers in unspecified order: when
-        // this box drops before its endpoint, `QuicEndpoint::finalize` ->
-        // `lsquic_engine_destroy` still fires `on_conn_closed` with this
-        // pointer as the conn ctx. `conn` non-null means the lsquic conn is
-        // still live (`on_conn_closed` nulls it before lsquic frees the conn,
-        // and teardown clears it explicitly), so clearing the ctx here is the
-        // remaining obligation before the box is freed.
+        // See [`QuicEndpoint::detach_for_finalize`]. A non-null `conn` is live
+        // (on_conn_closed / teardown null it), and null is always a valid ctx.
         let conn = self.conn.get();
         if !conn.is_null() {
-            // SAFETY: `conn` is live per the invariant above; null is always a
-            // valid ctx and makes the shim skip every conn callback.
+            // SAFETY: as above.
             unsafe { lsquic::lsquic_conn_set_ctx(conn, null_mut()) };
         }
     }

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -2358,10 +2358,10 @@ impl QuicSession {
         Self::transport_params_to_js(global, &tp)
     }
 
-    /// `on_conn_closed` for [`QuicEndpoint::detach_for_finalize`]: clears
-    /// `conn` and nothing else, since `endpoint`/`streams` may already be freed.
+    /// `on_conn_closed` for `QuicEndpoint::detach_for_finalize`.
     pub(super) unsafe extern "C" fn on_closed_detached(ctx: *mut c_void) {
-        // SAFETY: `finalize` nulls the lsquic ctx, so a non-null one is live.
+        // SAFETY: `finalize` nulls the lsquic ctx, so a non-null one is live;
+        // only `conn` is touched because `endpoint`/`streams` may be freed.
         if let Some(session) = unsafe { super::ffi::ctx_ref::<QuicSession>(ctx) } {
             session.conn.set(null_mut());
         }
@@ -2372,11 +2372,11 @@ impl QuicSession {
         reason = "codegen's host_fn_finalize calls this as `|b| QuicSession::finalize(b)` and requires `self: Box<Self>`"
     )]
     pub(crate) fn finalize(self: Box<Self>) {
-        // See [`QuicEndpoint::detach_for_finalize`]. A non-null `conn` is live
-        // (on_conn_closed / teardown null it), and null is always a valid ctx.
         let conn = self.conn.get();
         if !conn.is_null() {
-            // SAFETY: as above.
+            // SAFETY: see `QuicEndpoint::detach_for_finalize`; a non-null
+            // `conn` is live (on_conn_closed / teardown null it), and null is
+            // always a valid ctx.
             unsafe { lsquic::lsquic_conn_set_ctx(conn, null_mut()) };
         }
     }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -587,13 +587,13 @@ impl QuicStream {
         self.this_value.with_mut(|r| r.downgrade());
     }
 
-    /// `on_stream_close` for [`QuicEndpoint::detach_for_finalize`]: clears
-    /// `raw` and nothing else, since `session` may already be freed.
+    /// `on_stream_close` for `QuicEndpoint::detach_for_finalize`.
     pub(super) unsafe extern "C" fn on_close_detached(
         ctx: *mut c_void,
         _s: *mut lsquic::lsquic_stream,
     ) {
-        // SAFETY: `finalize` nulls the lsquic ctx, so a non-null one is live.
+        // SAFETY: `finalize` nulls the lsquic ctx, so a non-null one is live;
+        // only `raw` is touched because `session` may already be freed.
         if let Some(qs) = unsafe { super::ffi::ctx_ref::<QuicStream>(ctx) } {
             qs.raw.set(null_mut());
         }
@@ -604,10 +604,9 @@ impl QuicStream {
         reason = "codegen's host_fn_finalize calls this as `|b| QuicStream::finalize(b)` and requires `self: Box<Self>`"
     )]
     pub(crate) fn finalize(self: Box<Self>) {
-        // See [`QuicEndpoint::detach_for_finalize`]. A non-null `raw` is live
-        // by the `ls()` invariant, and null is always a valid ctx.
         if let Some(s) = self.ls() {
-            // SAFETY: as above.
+            // SAFETY: see `QuicEndpoint::detach_for_finalize`; a non-null `raw`
+            // is live by the `ls()` invariant, and null is always a valid ctx.
             unsafe { s.set_ctx(null_mut()) };
         }
     }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -587,11 +587,37 @@ impl QuicStream {
         self.this_value.with_mut(|r| r.downgrade());
     }
 
+    /// Clears `raw` without touching `session`: `lastChanceToFinalize` sweeps
+    /// wrappers in unspecified order, so by the time `QuicEndpoint::finalize`
+    /// runs `lsquic_engine_destroy` the session box may already be freed.
+    pub(super) unsafe extern "C" fn on_close_detached(
+        ctx: *mut c_void,
+        _s: *mut lsquic::lsquic_stream,
+    ) {
+        // SAFETY: `ctx_ref` documents the shim's context-pointer contract;
+        // `finalize` below nulls the ctx, so a non-null ctx is a live box.
+        if let Some(qs) = unsafe { super::ffi::ctx_ref::<QuicStream>(ctx) } {
+            qs.raw.set(null_mut());
+        }
+    }
+
     #[expect(
         clippy::boxed_local,
         reason = "codegen's host_fn_finalize calls this as `|b| QuicStream::finalize(b)` and requires `self: Box<Self>`"
     )]
-    pub(crate) fn finalize(self: Box<Self>) {}
+    pub(crate) fn finalize(self: Box<Self>) {
+        // `lastChanceToFinalize` sweeps wrappers in unspecified order: when
+        // this box drops before its endpoint, `QuicEndpoint::finalize` ->
+        // `lsquic_engine_destroy` still fires `on_close` with this pointer as
+        // the stream ctx. `raw` non-null means the lsquic stream is still live
+        // (`on_close` nulls it before lsquic frees the stream, and teardown
+        // clears it explicitly), so clearing the ctx here is the remaining
+        // obligation before the box is freed.
+        if let Some(s) = self.ls() {
+            // SAFETY: null is always a valid ctx; the shim skips the callback.
+            unsafe { s.set_ctx(null_mut()) };
+        }
+    }
 
     pub(crate) fn get_reader(&self, _g: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         self.with_state(|s| s.has_reader = 1);

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -587,15 +587,13 @@ impl QuicStream {
         self.this_value.with_mut(|r| r.downgrade());
     }
 
-    /// Clears `raw` without touching `session`: `lastChanceToFinalize` sweeps
-    /// wrappers in unspecified order, so by the time `QuicEndpoint::finalize`
-    /// runs `lsquic_engine_destroy` the session box may already be freed.
+    /// `on_stream_close` for [`QuicEndpoint::detach_for_finalize`]: clears
+    /// `raw` and nothing else, since `session` may already be freed.
     pub(super) unsafe extern "C" fn on_close_detached(
         ctx: *mut c_void,
         _s: *mut lsquic::lsquic_stream,
     ) {
-        // SAFETY: `ctx_ref` documents the shim's context-pointer contract;
-        // `finalize` below nulls the ctx, so a non-null ctx is a live box.
+        // SAFETY: `finalize` nulls the lsquic ctx, so a non-null one is live.
         if let Some(qs) = unsafe { super::ffi::ctx_ref::<QuicStream>(ctx) } {
             qs.raw.set(null_mut());
         }
@@ -606,15 +604,10 @@ impl QuicStream {
         reason = "codegen's host_fn_finalize calls this as `|b| QuicStream::finalize(b)` and requires `self: Box<Self>`"
     )]
     pub(crate) fn finalize(self: Box<Self>) {
-        // `lastChanceToFinalize` sweeps wrappers in unspecified order: when
-        // this box drops before its endpoint, `QuicEndpoint::finalize` ->
-        // `lsquic_engine_destroy` still fires `on_close` with this pointer as
-        // the stream ctx. `raw` non-null means the lsquic stream is still live
-        // (`on_close` nulls it before lsquic frees the stream, and teardown
-        // clears it explicitly), so clearing the ctx here is the remaining
-        // obligation before the box is freed.
+        // See [`QuicEndpoint::detach_for_finalize`]. A non-null `raw` is live
+        // by the `ls()` invariant, and null is always a valid ctx.
         if let Some(s) = self.ls() {
-            // SAFETY: null is always a valid ctx; the shim skips the callback.
+            // SAFETY: as above.
             unsafe { s.set_ctx(null_mut()) };
         }
     }

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -291,5 +291,5 @@ describe("node:quic in a Worker", () => {
     // a clean run and the ASAN report on regression; keep it in the received
     // object so the failure diff shows which callback UAF'd.
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "PASS\n", stderr: expect.any(String), exitCode: 0 });
-  }, 120000);
+  }, 30000);
 });

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -267,3 +267,27 @@ describe("endpoint.close() while a session is live", () => {
     expect({ announced, resolved }).toEqual({ announced: 1, resolved: true });
   });
 });
+
+// Worker VM teardown runs lastChanceToFinalize, which sweeps the QUIC wrappers
+// in unspecified order. QuicEndpoint::finalize -> lsquic_engine_destroy drives
+// on_close/on_conn_closed into per-stream/per-session ctx pointers; when those
+// wrappers were swept first the ctx is a freed box and ASAN reports
+// heap-use-after-free at nq_on_stream_close / nq_on_conn_closed.
+describe("node:quic in a Worker", () => {
+  test("worker.terminate() with a live endpoint + session does not UAF at VM teardown", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        join(import.meta.dir, "quic-worker-terminate-fixture.ts"),
+        join(keysDir, "agent1-key.pem"),
+        join(keysDir, "agent1-cert.pem"),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "PASS\n", exitCode: 0 });
+    void stderr;
+  }, 60000);
+});

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -287,7 +287,9 @@ describe("node:quic in a Worker", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({ stdout: "PASS\n", exitCode: 0 });
-    void stderr;
-  }, 60000);
+    // stderr carries the per-worker ExperimentalWarning (random blob URLs) on
+    // a clean run and the ASAN report on regression; keep it in the received
+    // object so the failure diff shows which callback UAF'd.
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "PASS\n", stderr: expect.any(String), exitCode: 0 });
+  }, 120000);
 });

--- a/test/js/node/quic/quic-worker-terminate-fixture.ts
+++ b/test/js/node/quic/quic-worker-terminate-fixture.ts
@@ -54,12 +54,15 @@ const src = `
   await new Promise(() => {});
 `;
 
-for (let round = 0; round < 6; round++) {
+for (let round = 0; round < 10; round++) {
   const w = new Worker(src, { eval: true, workerData });
   await new Promise<void>((resolve, reject) => {
     w.once("message", () => resolve());
     w.once("error", reject);
   });
+  // No observable signal to await: terminate() must land at a varied phase
+  // of the connect/stream churn so the sweep sees live wrappers; awaiting a
+  // specific worker event would collapse that distribution.
   await Bun.sleep(200 + ((round * 53) % 300));
   await w.terminate();
 }

--- a/test/js/node/quic/quic-worker-terminate-fixture.ts
+++ b/test/js/node/quic/quic-worker-terminate-fixture.ts
@@ -1,0 +1,67 @@
+// Terminating a Worker that owns live node:quic endpoints + sessions + streams
+// drives the VM's lastChanceToFinalize sweep, which finalizes the QUIC
+// wrappers in unspecified order. The endpoint finalizer runs
+// lsquic_engine_destroy, whose close path calls back into per-stream and
+// per-session context pointers; if the stream/session wrappers were swept
+// first, those contexts are freed and the callback is a use-after-free.
+import { Worker } from "node:worker_threads";
+import { readFileSync } from "node:fs";
+
+const [keyPath, certPath] = process.argv.slice(2);
+const workerData = {
+  key: readFileSync(keyPath, "utf8"),
+  cert: readFileSync(certPath, "utf8"),
+};
+
+const src = `
+  const { parentPort, workerData } = require("node:worker_threads");
+  const { listen, connect } = require("node:quic");
+  const { createPrivateKey } = require("node:crypto");
+
+  const key = createPrivateKey(workerData.key);
+  const cert = Buffer.from(workerData.cert);
+
+  const server = await listen(
+    session => {
+      session.onstream = stream => stream.closed.catch(() => {});
+      session.closed.catch(() => {});
+    },
+    { sni: { "*": { keys: [key], certs: [cert] } }, alpn: "wq", transportParams: { maxIdleTimeout: 30 } },
+  );
+
+  // Several concurrent sessions, each churning bidi streams with a large body
+  // so the lsquic stream is still open when terminate() lands. The sweep
+  // order between these wrappers and the endpoint is what the test exercises.
+  const payload = Buffer.alloc(1 << 20, 120);
+  for (let i = 0; i < 3; i++) (async () => {
+    for (;;) {
+      try {
+        const c = await connect(server.address, {
+          alpn: "wq",
+          servername: "localhost",
+          verifyPeer: "manual",
+          transportParams: { maxIdleTimeout: 30 },
+        });
+        c.closed.catch(() => {});
+        await c.createBidirectionalStream({ body: new Uint8Array(payload) });
+        await new Promise(r => setTimeout(r, 30));
+        try { c.close(); } catch {}
+      } catch {}
+    }
+  })();
+
+  parentPort.postMessage("up");
+  await new Promise(() => {});
+`;
+
+for (let round = 0; round < 6; round++) {
+  const w = new Worker(src, { eval: true, workerData });
+  await new Promise<void>((resolve, reject) => {
+    w.once("message", () => resolve());
+    w.once("error", reject);
+  });
+  await Bun.sleep(200 + ((round * 53) % 300));
+  await w.terminate();
+}
+
+console.log("PASS");

--- a/test/js/node/quic/quic-worker-terminate-fixture.ts
+++ b/test/js/node/quic/quic-worker-terminate-fixture.ts
@@ -29,41 +29,39 @@ const src = `
     { sni: { "*": { keys: [key], certs: [cert] } }, alpn: "wq", transportParams: { maxIdleTimeout: 30 } },
   );
 
-  // Several concurrent sessions, each churning bidi streams with a large body
-  // so the lsquic stream is still open when terminate() lands. The sweep
-  // order between these wrappers and the endpoint is what the test exercises.
-  const payload = Buffer.alloc(1 << 20, 120);
-  for (let i = 0; i < 3; i++) (async () => {
-    for (;;) {
-      try {
-        const c = await connect(server.address, {
-          alpn: "wq",
-          servername: "localhost",
-          verifyPeer: "manual",
-          transportParams: { maxIdleTimeout: 30 },
-        });
-        c.closed.catch(() => {});
-        await c.createBidirectionalStream({ body: new Uint8Array(payload) });
-        await new Promise(r => setTimeout(r, 30));
-        try { c.close(); } catch {}
-      } catch {}
-    }
-  })();
+  // IsoSubspace lower-tier puts the first numberOfLowerTierPreciseCells (8)
+  // cells of each wrapper type into PreciseAllocations and the rest into a
+  // MarkedBlock; lastChanceToFinalize sweeps MarkedBlocks first. Twelve
+  // live sessions (twenty-four with the server side) push session and
+  // stream wrappers past the lower tier so their blocks are swept before
+  // the two endpoints, whose finalizer then runs lsquic_engine_destroy.
+  const held = [];
+  for (let i = 0; i < 12; i++) {
+    const c = await connect(server.address, {
+      alpn: "wq",
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 30 },
+    });
+    c.closed.catch(() => {});
+    await c.opened;
+    const st = await c.createBidirectionalStream({
+      body: new Uint8Array(Buffer.alloc(1 << 16, 120)),
+    });
+    st.closed.catch(() => {});
+    held.push(c, st);
+  }
 
   parentPort.postMessage("up");
   await new Promise(() => {});
 `;
 
-for (let round = 0; round < 10; round++) {
+for (let round = 0; round < 2; round++) {
   const w = new Worker(src, { eval: true, workerData });
   await new Promise<void>((resolve, reject) => {
     w.once("message", () => resolve());
     w.once("error", reject);
   });
-  // No observable signal to await: terminate() must land at a varied phase
-  // of the connect/stream churn so the sweep sees live wrappers; awaiting a
-  // specific worker event would collapse that distribution.
-  await Bun.sleep(200 + ((round * 53) % 300));
   await w.terminate();
 }
 


### PR DESCRIPTION
### Problem
- A Worker that used `node:quic` crashes when it ends or is terminated. On a release build of main (fd8422ce4) the repro segfaults 3 of 3 runs: `panic: Segmentation fault at address 0x1`, exit 139. Under ASAN it is `heap-use-after-free` READ 8 on the Worker thread, top frame `nq_on_stream_close` (`packages/bun-usockets/src/node_quic_shim.c:127`), reached through `lsquic_stream_destroy` <- `ietf_full_conn_ci_destroy` <- `force_close_conn` <- `lsquic_engine_destroy` <- `QuicEndpoint::release_native` <- `QuicEndpoint::finalize`.
- `WebWorker::shutdown` -> `VM::~VM` -> `Heap::lastChanceToFinalize` sweeps the QUIC wrappers in unspecified order. `QuicStream` and `QuicSession` dropped their boxes without clearing the ctx pointer lsquic still held, so the endpoint finalizer's `lsquic_engine_destroy` called back into freed memory. The same root also shows as `nq_on_conn_closed` (shim.c:57) and as `QuicSession::push_event` via `on_conn_closed` or `on_mini_conn_failed`.

### Fix
- `QuicStream::finalize` and `QuicSession::finalize` clear lsquic's stream/conn ctx before the box drops. A non-null `raw`/`conn` always means the lsquic object is still live: `on_close`/`on_conn_closed` null it before lsquic frees the struct, and `teardown()` clears it on the orderly path. `QuicStream::create` now leaves `raw` null until `bind_raw`, after the fallible ArrayBuffer allocations, so a wrapper from a failed `create` never points at a stream lsquic still owns.
- `QuicEndpoint::detach_for_finalize` runs before `release_native`. It clears the raw `*mut QuicSession` registries and nulls `vtable.owner`, so owner-keyed callbacks (`on_mini_conn_failed`, `packets_out`, `on_new_conn`, the SSL_CTX lookups) short-circuit in `ctx_ref`. `on_new_stream` resolves its session through the conn ctx instead, which `QuicSession::finalize` nulls.
- It also swaps `on_stream_close` and `on_conn_closed` for variants that only clear the wrapper's own lsquic handle. A callback that reaches a wrapper the sweep has not freed yet then cannot follow that wrapper's `session`/`endpoint` back-pointer into a box that is already gone.
- Verified: `test/js/node/quic/quic-endpoint.test.ts` (`worker.terminate`). Debug+ASAN fails 3 of 3 with `src/` at main and passes 3 of 3 with the fix. `USE_SYSTEM_BUN=1` (release 1.4.3) fails with the segfault. All of `test/js/node/quic/` is 21/21.

### Background
- `lastChanceToFinalize` is the sweep `VM::~VM` runs so that every remaining cell's destructor runs before the heap goes away. It gives no ordering between cells, which is why an endpoint can outlive its own sessions here.
- lsquic stores one opaque `void*` per connection and per stream. `node_quic_shim.c` reads the vtable pointer out of the front of that context on every callback, so a freed context is a wild read on the first instruction of the callback.
- `lsquic_engine_destroy` is not passive. It force-closes every live connection, which drives `on_close` for each stream and `on_conn_closed` for each connection.
- `ctx_ref` (`src/runtime/node/quic/ffi.rs`) is the one audited deref for these callbacks. A null context is its whole liveness test, so nulling a context is what makes a late callback a no-op.

<details><summary>Notes</summary>

First opened 2026-07-25 and closed unmerged on 2026-09-13 by a stale-PR cleanup ("This is not a judgment on the fix itself"). This push merges current main and resolves two conflicts: #40516 deleted the empty `QuicStream::finalize` and `QuicSession::finalize` bodies in favour of the `JsFinalize` default, and this change fills those bodies in again. The `raw`/`conn` invariants the fix relies on are unchanged on main, as is the shim's null check.

What changed about the surface since the original post: `node:quic` ships in releases now, so this is no longer ASAN-lane only. 1.4.3 segfaults. 1.3.14 has no `node:quic`.

The fixture is deterministic rather than timing-based. JSC's `IsoSubspace` lower tier puts the first 8 cells of each wrapper type in `PreciseAllocation`s and the rest in a `MarkedBlock`, and `lastChanceToFinalize` sweeps `MarkedBlock`s first. Holding twelve live sessions plus their streams pushes those wrappers past the lower tier while the two endpoints stay in it, so the endpoint finalizer always runs after the session and stream boxes are freed. That is 8/8 fail-before where the earlier sleep-based version was about 4/8, and one run takes roughly 10s instead of 80s.

Callbacks reachable from `lsquic_engine_destroy`, from the vendored source: `destroy_conn` (`lsquic_engine.c:994-1014`) calls `on_mini_conn_failed` for a mini conn, then `ci_destroy`. `ietf_full_conn_ci_destroy` (`lsquic_full_conn_ietf.c:3202`) calls `lsquic_stream_destroy` for each stream, which calls `on_close` (`lsquic_stream.c:663`), and then `on_conn_closed` (line 3251). `on_hsk_done` and `on_hsk_confirmed` are reached only from the crypto stream's handshake progress (`lsquic_enc_sess_ietf.c:2044-2050` via `ci_hsk_done`), never from the destroy path. So the three callbacks the detach covers are the full set.

Four faces of the one root were observed while reducing it: `nq_on_stream_close` (stream ctx), `nq_on_conn_closed` (conn ctx), `QuicSession::push_event` from `on_conn_closed`, and `QuicSession::push_event` from `on_mini_conn_failed` reaching a freed session through the endpoint's `provisional` list.

Open #40220 (`node:quic`: remove unsafe from the endpoint, session, stream and TLS code) makes these contexts refcounted and lists a terminated-Worker hand test. It is a 26-file refactor, last pushed 2026-08-29, and currently conflicts with main, so it is not a near-term fix for this crash.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/quic/quic-endpoint.test.ts
bun test v1.4.3 (b52d51348)

test/js/node/quic/quic-endpoint.test.ts:
(node:12196) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [298.54ms]
(pass) endpoint blockList > applies to packets forwarded from a sibling endpoint on the same loop [377.27ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [74.40ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [4175.44ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [221.28ms]
(pass) transportParams.maxIdleTimeout > 0 disables the idle timeout instead of falling back to the default [92.23ms]
(pass) endpoint.close() while a session is live > stops accepting new sessions so closed can resolve [116.51ms]
332 |     });
333 |     const [s
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (b52d51348)

test/js/node/quic/quic-endpoint.test.ts:
(node:12256) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun --trace-warnings ...` to show where the warning was created)
(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [12.49ms]
(pass) endpoint blockList > applies to packets forwarded from a sibling endpoint on the same loop [9.54ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [3.76ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [73.51ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [8.10ms]
(pass) transportParams.maxIdleTimeout > 0 disables the idle timeout instead of falling back to the default [10.95ms]
(pass) endpoint.close() while a session is live > stops accepting new sessions so closed can resolve [10.42ms]
332 |     });
333 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
334 |     // stderr carries the per-worker ExperimentalWarning (random blob U
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/quic/quic-endpoint.test.ts
bun test v1.4.3 (b52d51348)

test/js/node/quic/quic-endpoint.test.ts:
(node:12846) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [389.01ms]
(pass) endpoint blockList > applies to packets forwarded from a sibling endpoint on the same loop [286.97ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [53.70ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [3865.60ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [182.42ms]
(pass) transportParams.maxIdleTimeout > 0 disables the idle timeout instead of falling back to the default [83.56ms]
(pass) endpoint.close() while a session is live > stops accepting new sessions so closed can resolve [85.40ms]
(pass) node:quic in a Worker > wo
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     971e764ec6
  features     lto, baseline

23 deps, 131 codegen, 1176 objects in 767ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1250] install /workspace/bun
bun install v1.4.3-canary.1 (b52d51348)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1250] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (b52d51348)

Checked 1 install across 2 packages (no changes) [5.00ms]
[3/1250] gen ErrorCode+*.h
[4/1250] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (b52d51348)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[5/1250] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 KB  (entry point)

[6/1250] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1223] fetch tinycc
[tinycc] up to date
[8/1222] fetch zlib
[zlib] up to date
[9/1222] gen bindgenv2
[10/1222] gen .bind.ts → GeneratedBindings.cpp
[11/1222] gen bake.{client,server,error}.js
-> bake.client.js, bake.s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/quic/endpoint.rs                  | 24 ++++++++
 src/runtime/node/quic/session.rs                   | 23 ++++++++
 src/runtime/node/quic/stream.rs                    | 24 ++++++++
 test/js/node/quic/quic-endpoint.test.ts            | 27 +++++++++
 test/js/node/quic/quic-worker-terminate-fixture.ts | 68 ++++++++++++++++++++++
 5 files changed, 166 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/runtime/node/quic/endpoint.rs                       0      0      0
src/runtime/node/quic/session.rs                        0      0      0
src/runtime/node/quic/stream.rs                         0      0      0
test/js/node/quic/quic-endpoint.test.ts                 0      0      0
test/js/node/quic/quic-worker-terminate-fixture.ts      0      0      0
```

</details>

**root cause** · written by the author bot

When a Worker's VM is torn down, the finalize-order sweep can run QUIC endpoint, session, and stream finalizers while lsquic still holds raw context pointers to those objects, so native callbacks fired during native release could dereference freed memory. The fix detaches those pointers before any native resource is released: the endpoint clears its callback-visible registries and vtable callbacks first, detached callbacks null out the native pointer slots, and the session and stream finalizers clear the lsquic connection and stream contexts. A regression test terminates a worker with activ…

<!-- robobun:evidence:end -->
