### PR TITLE
node:quic(h3): scope malformed-message failures to one stream instead of CONNECTION_CLOSE

### DIFF
--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -197,6 +197,10 @@ struct nq_hset {
     unsigned max_bytes;
     unsigned n_pairs;
     size_t total_bytes;
+    /* RFC 9114 sec 4.1.2 malformed-message flag.  Set instead of returning -1
+     * so lsqpack keeps decoding and the application can RESET_STREAM the one
+     * stream rather than lsquic taking the whole connection down. */
+    int malformed;
 };
 
 #define NQ_HSI_CTX_PACK(pairs, bytes) \
@@ -247,10 +251,19 @@ static int nq_hsi_process_header(void *hset, struct lsxpack_header *hdr) {
     h->total_bytes += (size_t) hdr->name_len + hdr->val_len;
     const char *name = lsxpack_header_get_name(hdr);
     const char *val = lsxpack_header_get_value(hdr);
-    /* RFC 9114 4.1.2 makes such a field invalid. */
-    if ((hdr->name_len && memchr(name, 0, hdr->name_len))
-            || (hdr->val_len && memchr(val, 0, hdr->val_len)))
-        return -1;
+    /* RFC 9114 sec 4.1.2: NUL in a field name/value, and RFC 9110 sec 5.1: an
+     * empty field name, make the message malformed.  Returning -1 here makes
+     * lsqpack bubble LQRHS_ERROR up to qdh_header_read_results, which used to
+     * CONNECTION_CLOSE; with message-error-stream-reset.patch it now resets
+     * only this stream, but it still drops the rest of the field section on
+     * the floor.  Flagging and returning 0 lets the application see the whole
+     * header set and RESET_STREAM(H3_MESSAGE_ERROR) itself (stream.rs). */
+    if (hdr->name_len == 0
+            || memchr(name, 0, hdr->name_len)
+            || (hdr->val_len && memchr(val, 0, hdr->val_len))) {
+        h->malformed = 1;
+        return 0;
+    }
     size_t need = h->pairs_len + (size_t) hdr->name_len + 1
                 + (size_t) hdr->val_len + 1;
     if (need > h->pairs_cap) {
@@ -291,6 +304,10 @@ const char *us_nq_hset_pairs(void *hset, size_t *len) {
     struct nq_hset *h = hset;
     *len = h ? h->pairs_len : 0;
     return h ? h->pairs : NULL;
+}
+int us_nq_hset_malformed(void *hset) {
+    struct nq_hset *h = hset;
+    return h ? h->malformed : 0;
 }
 void us_nq_hset_free(void *hset) { nq_hsi_discard_header_set(hset); }
 
@@ -432,6 +449,10 @@ void us_nq_settings_init(struct lsquic_engine_settings *s, int is_server,
      * grant while that stream has unsent data (lsquic_qdh_arm_if_unsent). */
     s->es_qpack_enc_max_size = 0;
     s->es_qpack_enc_max_blocked = 0;
+    /* RFC 9114 sec 4.1.2: one malformed request is a stream error, not a
+     * CONNECTION_CLOSE that takes every concurrent request down with it
+     * (patches/lsquic/message-error-stream-reset.patch). */
+    s->es_message_error_is_stream = 1;
 }
 
 #define NQ_SET(field, ctype) \

--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -451,7 +451,11 @@ void us_nq_settings_init(struct lsquic_engine_settings *s, int is_server,
     s->es_qpack_enc_max_blocked = 0;
     /* RFC 9114 sec 4.1.2: one malformed request is a stream error, not a
      * CONNECTION_CLOSE that takes every concurrent request down with it
-     * (patches/lsquic/message-error-stream-reset.patch). */
+     * (patches/lsquic/message-error-stream-reset.patch).  Advertising a zero
+     * QPACK dynamic table keeps the RFC 9204 sec 2.2.3 connection-error class
+     * unreachable, so a field-section decode failure is stream-local. */
+    s->es_qpack_dec_max_size = 0;
+    s->es_qpack_dec_max_blocked = 0;
     s->es_message_error_is_stream = 1;
 }
 

--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -563,6 +563,11 @@ void us_nq_stream_reset(lsquic_stream_t *s, uint64_t code) {
     lsquic_stream_force_reset_ext(s, code);
 }
 
+extern void lsquic_stream_msg_error(lsquic_stream_t *, uint64_t);
+void us_nq_stream_msg_error(lsquic_stream_t *s, uint64_t code) {
+    lsquic_stream_msg_error(s, code);
+}
+
 /* ───── node:quic loop driver ─────
  *
  * The corking model quic.c uses for Bun.serve's HTTP/3 listener: JS marks the

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -724,7 +724,11 @@ us_quic_socket_context_t *us_create_quic_socket_context(
      * stream-hash walk on every write. */
     ctx->settings.es_ext_http_prio = 0;
     /* RFC 9114 sec 4.1.2: one malformed request is a stream error, not a
-     * CONNECTION_CLOSE that takes every concurrent request down with it. */
+     * CONNECTION_CLOSE that takes every concurrent request down with it.
+     * A zero QPACK dynamic table keeps the RFC 9204 sec 2.2.3 connection-
+     * error class unreachable, so decode failures are stream-local. */
+    ctx->settings.es_qpack_dec_max_size = 0;
+    ctx->settings.es_qpack_dec_max_blocked = 0;
     ctx->settings.es_message_error_is_stream = 1;
     if (idle_timeout_s) ctx->settings.es_idle_timeout = idle_timeout_s > 600 ? 600 : idle_timeout_s;
 
@@ -1177,6 +1181,8 @@ us_quic_socket_context_t *us_create_quic_client_context(
     ctx->settings.es_ecn = 0;
     ctx->settings.es_max_header_list_size = 64 * 1024;
     ctx->settings.es_ext_http_prio = 0;
+    ctx->settings.es_qpack_dec_max_size = 0;
+    ctx->settings.es_qpack_dec_max_blocked = 0;
     ctx->settings.es_message_error_is_stream = 1;
 
     struct lsquic_engine_api api;

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -723,6 +723,9 @@ us_quic_socket_context_t *us_create_quic_socket_context(
      * 9218 scheduler and the patched determine_bpt short-circuits the O(N)
      * stream-hash walk on every write. */
     ctx->settings.es_ext_http_prio = 0;
+    /* RFC 9114 sec 4.1.2: one malformed request is a stream error, not a
+     * CONNECTION_CLOSE that takes every concurrent request down with it. */
+    ctx->settings.es_message_error_is_stream = 1;
     if (idle_timeout_s) ctx->settings.es_idle_timeout = idle_timeout_s > 600 ? 600 : idle_timeout_s;
 
     struct lsquic_engine_api api;
@@ -1174,6 +1177,7 @@ us_quic_socket_context_t *us_create_quic_client_context(
     ctx->settings.es_ecn = 0;
     ctx->settings.es_max_header_list_size = 64 * 1024;
     ctx->settings.es_ext_http_prio = 0;
+    ctx->settings.es_message_error_is_stream = 1;
 
     struct lsquic_engine_api api;
     memset(&api, 0, sizeof(api));

--- a/patches/lsquic/message-error-stream-reset.patch
+++ b/patches/lsquic/message-error-stream-reset.patch
@@ -31,7 +31,7 @@
  void
 --- a/src/liblsquic/lsquic_stream.c
 +++ b/src/liblsquic/lsquic_stream.c
-@@ -1495,6 +1495,62 @@
+@@ -1495,6 +1495,66 @@
  }
  
  
@@ -59,7 +59,11 @@
 +        if (!(stream->sm_qflags & SMQF_SENDING_FLAGS))
 +            TAILQ_INSERT_TAIL(&stream->conn_pub->sending_streams, stream,
 +                                                        next_send_stream);
-+        stream->sm_qflags |= SMQF_SEND_STOP_SENDING|SMQF_WAIT_FIN_OFF;
++        /* No SMQF_WAIT_FIN_OFF: STREAM_RST_RECVD is synthesized below, so
++         * the peer's RESET_STREAM hits lsquic_stream_rst_in's duplicate guard
++         * before the line that would clear it, and stream_is_finished()'s
++         * SMQF_SELF_FLAGS check would keep the stream alive forever. */
++        stream->sm_qflags |= SMQF_SEND_STOP_SENDING;
 +    }
 +    /* stream_reset() clears every SMQF_SENDING flag; re-arm the STOP_SENDING
 +     * we just queued so both frames reach the peer. */
@@ -94,7 +98,7 @@
  static void
  verify_cl_on_fin (struct lsquic_stream *stream)
  {
-@@ -1506,6 +1562,11 @@
+@@ -1506,6 +1566,11 @@
       */
      if (stream->sm_data_in != 0 && stream->sm_cont_len != stream->sm_data_in)
      {
@@ -106,7 +110,7 @@
          lconn = stream->conn_pub->lconn;
          lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
              "number of bytes in DATA frames of stream %"PRIu64" is %llu, "
-@@ -4977,9 +5038,14 @@
+@@ -4977,9 +5042,14 @@
      stream->sm_data_in += filter->hqfi_left;
      if (stream->sm_data_in > stream->sm_cont_len)
      {
@@ -122,15 +126,20 @@
          lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
              "number of bytes in DATA frames of stream %"PRIu64" exceeds "
              "content-length limit of %llu", stream->id, stream->sm_cont_len);
-@@ -5139,6 +5205,11 @@
+@@ -5139,6 +5209,16 @@
                      goto end;
                  default:
                      assert(LQRHS_ERROR == rhs);
-+                    /* bun: qdh_header_read_results already reset this stream
-+                     * (or aborted the connection for a QPACK-fatal error). */
 +                    if (stream->conn_pub->enpub
 +                                ->enp_settings.es_message_error_is_stream)
++                    {
++                        /* bun: qdec already reset this stream for the peer-
++                         * triggerable cases; the fallback covers the handful
++                         * of LQRHS_ERROR paths (OOM, !QDH_INITIALIZED) that
++                         * return early without reaching qdec's reset. */
++                        lsquic_stream_msg_error(stream, HEC_INTERNAL_ERROR);
 +                        goto end;
++                    }
                      stream->sm_qflags &= ~SMQF_QPACK_DEC;
                      filter->hqfi_flags |= HQFI_FLAG_ERROR;
                      LSQ_INFO("error processing header block");

--- a/patches/lsquic/message-error-stream-reset.patch
+++ b/patches/lsquic/message-error-stream-reset.patch
@@ -126,13 +126,17 @@
          lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
              "number of bytes in DATA frames of stream %"PRIu64" exceeds "
              "content-length limit of %llu", stream->id, stream->sm_cont_len);
-@@ -5139,6 +5209,16 @@
+@@ -5139,6 +5209,20 @@
                      goto end;
                  default:
                      assert(LQRHS_ERROR == rhs);
 +                    if (stream->conn_pub->enpub
 +                                ->enp_settings.es_message_error_is_stream)
 +                    {
++                        stream->sm_qflags &= ~SMQF_QPACK_DEC;
++                        /* hq_filter_df needs HQFI_FLAG_ERROR to force-drain
++                         * the frame; lsqpack may have left p == prev. */
++                        filter->hqfi_flags |= HQFI_FLAG_ERROR;
 +                        /* bun: qdec already reset this stream for the peer-
 +                         * triggerable cases; the fallback covers the handful
 +                         * of LQRHS_ERROR paths (OOM, !QDH_INITIALIZED) that
@@ -197,7 +201,7 @@
              {
                  LSQ_DEBUG("finishing hset failed");
                  free(uh);
-@@ -696,10 +706,18 @@
+@@ -696,10 +706,19 @@
      {
          qdh_maybe_destroy_hblock_ctx(qdh, stream);
          qerr = lsqpack_dec_get_err_info(&qdh->qdh_decoder);
@@ -205,11 +209,12 @@
 -            HEC_QPACK_DECOMPRESSION_FAILED, "QPACK decompression error; "
 -            "stream %"PRIu64", offset %"PRIu64", line %d", qerr->stream_id,
 -            qerr->off, qerr->line);
-+        /* bun: a QPACK decode failure on a request stream is confined to that
-+         * stream's field section (RFC 9114 sec 4.1.2 / RFC 9204 sec 6); the
-+         * dynamic table state is only touched by the encoder stream, whose
-+         * errors are handled in qdh_read_encoder_stream and remain
-+         * connection-fatal. */
++        /* bun: RFC 9204 sec 2.2.3/4.5.1 mandate CONNECTION_CLOSE for a bad
++         * dynamic-table reference or Required Insert Count, but bun advertises
++         * es_qpack_dec_max_size=0 so there is no cross-stream decoder state a
++         * per-stream reset could desynchronize; that leaves the local-limit
++         * case (need > LSXPACK_MAX_STRLEN, RFC 9114 sec 4.2.2) which is
++         * stream-scoped.  qdh_read_encoder_stream stays connection-fatal. */
 +        if (qdh->qdh_enpub->enp_settings.es_message_error_is_stream)
 +            lsquic_stream_msg_error(stream, HEC_QPACK_DECOMPRESSION_FAILED);
 +        else

--- a/patches/lsquic/message-error-stream-reset.patch
+++ b/patches/lsquic/message-error-stream-reset.patch
@@ -1,0 +1,214 @@
+--- a/include/lsquic.h
++++ b/include/lsquic.h
+@@ -1276,6 +1276,16 @@
+      * maxIdleTimeout transport parameter is specified in milliseconds).
+      */
+     unsigned        es_idle_timeout_ms;
++
++    /**
++     * bun: when nonzero, a malformed HTTP/3 message (content-length
++     * mismatch, hsi_process_header rejection, or a field section QPACK
++     * cannot decode) resets only that stream per RFC 9114 sec 4.1.2
++     * (RESET_STREAM + STOP_SENDING H3_MESSAGE_ERROR, on_reset fired
++     * locally) instead of closing the connection.  Default 0 preserves
++     * the stock CONNECTION_CLOSE behavior.
++     */
++    int             es_message_error_is_stream;
+ };
+ 
+ /* Initialize `settings' to default values */
+--- a/src/liblsquic/lsquic_stream.h
++++ b/src/liblsquic/lsquic_stream.h
+@@ -524,6 +524,9 @@
+ lsquic_stream_maybe_reset (struct lsquic_stream *, uint64_t error_code, int);
+ 
+ void
++lsquic_stream_msg_error (struct lsquic_stream *, uint64_t error_code);
++
++void
+ lsquic_stream_call_on_close (lsquic_stream_t *);
+ 
+ void
+--- a/src/liblsquic/lsquic_stream.c
++++ b/src/liblsquic/lsquic_stream.c
+@@ -1495,6 +1495,62 @@
+ }
+ 
+ 
++/* bun: RFC 9114 sec 4.1.2 treats a malformed message as a *stream* error
++ * (H3_MESSAGE_ERROR on RESET_STREAM + STOP_SENDING), not a CONNECTION_CLOSE.
++ * The stock library wired every caller to ci_abort_error(), so one bad request
++ * tore down every concurrent stream on the connection.  This queues the
++ * per-stream frames, marks the read side as reset so further reads return
++ * ECONNRESET, and fires on_reset(how=0) so the application learns the failure
++ * the same way it would learn of a peer RESET_STREAM. */
++void
++lsquic_stream_msg_error (struct lsquic_stream *stream, uint64_t error_code)
++{
++    if (stream->stream_flags & STREAM_RST_RECVD)
++        return;
++    LSQ_INFO("message-level error 0x%"PRIX64" on stream %"PRIu64"; resetting "
++             "stream instead of connection", error_code, stream->id);
++    stream->error_code = error_code;
++    stream->ss_error_code = error_code;
++    stream->sm_bflags &= ~SMBF_VERIFY_CL;
++    if (!(stream->stream_flags & (STREAM_FIN_RECVD|STREAM_RST_RECVD))
++                            && !(stream->stream_flags & STREAM_SS_SENT)
++                            && !(stream->sm_qflags & SMQF_SEND_STOP_SENDING))
++    {
++        if (!(stream->sm_qflags & SMQF_SENDING_FLAGS))
++            TAILQ_INSERT_TAIL(&stream->conn_pub->sending_streams, stream,
++                                                        next_send_stream);
++        stream->sm_qflags |= SMQF_SEND_STOP_SENDING|SMQF_WAIT_FIN_OFF;
++    }
++    /* stream_reset() clears every SMQF_SENDING flag; re-arm the STOP_SENDING
++     * we just queued so both frames reach the peer. */
++    {
++        const enum stream_q_flags had_ss =
++                            stream->sm_qflags & SMQF_SEND_STOP_SENDING;
++        if (!(stream->stream_flags & (STREAM_RST_SENT|STREAM_FIN_SENT))
++                                    && !(stream->sm_qflags & SMQF_SEND_RST))
++            stream_reset(stream, error_code, 0);
++        if (had_ss)
++            stream->sm_qflags |= SMQF_SEND_STOP_SENDING;
++    }
++    stream->stream_flags |= STREAM_RST_RECVD;
++    if (stream->stream_if->on_reset
++                        && !(stream->stream_flags & STREAM_ONCLOSE_DONE)
++                        && !(stream->sm_dflags & SMDF_ONRESET0))
++    {
++        stream->sm_dflags |= SMDF_ONRESET0;
++        stream->stream_if->on_reset(stream, stream->st_ctx, 0);
++    }
++    /* The peer has not reset its write side, so reordered or retransmitted
++     * STREAM frames can still arrive; dropping data_in here would turn the
++     * next lsquic_stream_frame_in() into an INS_FRAME_ERR and abort the
++     * connection.  The stream is destroyed (and data_in freed) once the
++     * queued RESET_STREAM/STOP_SENDING reaches the wire and on_close fires. */
++    maybe_finish_stream(stream);
++    maybe_schedule_call_on_close(stream);
++    maybe_conn_to_tickable_if_writeable(stream, 1);
++}
++
++
+ static void
+ verify_cl_on_fin (struct lsquic_stream *stream)
+ {
+@@ -1506,6 +1562,11 @@
+      */
+     if (stream->sm_data_in != 0 && stream->sm_cont_len != stream->sm_data_in)
+     {
++        if (stream->conn_pub->enpub->enp_settings.es_message_error_is_stream)
++        {
++            lsquic_stream_msg_error(stream, HEC_MESSAGE_ERROR);
++            return;
++        }
+         lconn = stream->conn_pub->lconn;
+         lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
+             "number of bytes in DATA frames of stream %"PRIu64" is %llu, "
+@@ -4977,9 +5038,14 @@
+     stream->sm_data_in += filter->hqfi_left;
+     if (stream->sm_data_in > stream->sm_cont_len)
+     {
+-        lconn = stream->conn_pub->lconn;
+         filter->hqfi_flags |= HQFI_FLAG_ERROR;
+         stream->sm_bflags &= ~SMBF_VERIFY_CL;
++        if (stream->conn_pub->enpub->enp_settings.es_message_error_is_stream)
++        {
++            lsquic_stream_msg_error(stream, HEC_MESSAGE_ERROR);
++            return;
++        }
++        lconn = stream->conn_pub->lconn;
+         lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
+             "number of bytes in DATA frames of stream %"PRIu64" exceeds "
+             "content-length limit of %llu", stream->id, stream->sm_cont_len);
+@@ -5142,7 +5208,11 @@
+                     stream->sm_qflags &= ~SMQF_QPACK_DEC;
+                     filter->hqfi_flags |= HQFI_FLAG_ERROR;
+                     LSQ_INFO("error processing header block");
+-                    abort_connection(stream);   /* XXX Overkill? */
++                    /* bun: qdh_header_read_results already reset this stream
++                     * (or aborted the connection for a QPACK-fatal error). */
++                    if (!stream->conn_pub->enpub
++                                ->enp_settings.es_message_error_is_stream)
++                        abort_connection(stream);
+                     goto end;
+                 }
+                 break;
+--- a/src/liblsquic/lsquic_qdec_hdl.c
++++ b/src/liblsquic/lsquic_qdec_hdl.c
+@@ -551,18 +551,28 @@
+ 
+ /* Intercept header errors so that upper-layer errors do not get
+  * misinterpreted as QPACK errors.
++ *
++ * bun: the stock library called ci_abort_error(HEC_MESSAGE_ERROR) here, so a
++ * single rejected header took the whole connection down.  RFC 9114 sec 4.1.2
++ * scopes malformed-message handling to the stream; reset that stream and
++ * propagate the failure so lsqpack stops decoding this field section.
+  */
+ static int
+-qdh_hsi_process_wrapper (struct qpack_dec_hdl *qdh, void *hset,
+-                                                struct lsxpack_header *xhdr)
++qdh_hsi_process_wrapper (struct qpack_dec_hdl *qdh,
++                struct lsquic_stream *stream, void *hset,
++                struct lsxpack_header *xhdr)
+ {
+     int retval;
+ 
+     retval = qdh->qdh_enpub->enp_hsi_if->hsi_process_header(hset, xhdr);
+     if (0 != retval)
+-        qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
+-            HEC_MESSAGE_ERROR,
+-            "error processing headers");
++    {
++        if (qdh->qdh_enpub->enp_settings.es_message_error_is_stream)
++            lsquic_stream_msg_error(stream, HEC_MESSAGE_ERROR);
++        else
++            qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
++                HEC_MESSAGE_ERROR, "error processing headers");
++    }
+ 
+     return retval;
+ }
+@@ -599,7 +609,7 @@
+     else if ((qdh->qdh_flags & QDH_SAVE_UA) && !qdh->qdh_ua)
+         qdh_maybe_set_user_agent(qdh, xhdr, &qdh->qdh_ua);
+ 
+-    return qdh_hsi_process_wrapper(qdh, u->ctx.hset, xhdr);
++    return qdh_hsi_process_wrapper(qdh, stream, u->ctx.hset, xhdr);
+ }
+ 
+ 
+@@ -658,7 +668,7 @@
+             uh->uh_exclusive = -1;
+             if (qdh->qdh_enpub->enp_hsi_if == lsquic_http1x_if)
+                 uh->uh_flags    |= UH_H1H;
+-            if (0 != qdh_hsi_process_wrapper(qdh, hset, NULL))
++            if (0 != qdh_hsi_process_wrapper(qdh, stream, hset, NULL))
+             {
+                 LSQ_DEBUG("finishing hset failed");
+                 free(uh);
+@@ -696,10 +706,18 @@
+     {
+         qdh_maybe_destroy_hblock_ctx(qdh, stream);
+         qerr = lsqpack_dec_get_err_info(&qdh->qdh_decoder);
+-        qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
+-            HEC_QPACK_DECOMPRESSION_FAILED, "QPACK decompression error; "
+-            "stream %"PRIu64", offset %"PRIu64", line %d", qerr->stream_id,
+-            qerr->off, qerr->line);
++        /* bun: a QPACK decode failure on a request stream is confined to that
++         * stream's field section (RFC 9114 sec 4.1.2 / RFC 9204 sec 6); the
++         * dynamic table state is only touched by the encoder stream, whose
++         * errors are handled in qdh_read_encoder_stream and remain
++         * connection-fatal. */
++        if (qdh->qdh_enpub->enp_settings.es_message_error_is_stream)
++            lsquic_stream_msg_error(stream, HEC_QPACK_DECOMPRESSION_FAILED);
++        else
++            qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
++                HEC_QPACK_DECOMPRESSION_FAILED, "QPACK decompression error; "
++                "stream %"PRIu64", offset %"PRIu64", line %d", qerr->stream_id,
++                qerr->off, qerr->line);
+     }
+ 
+     return rhs;

--- a/patches/lsquic/message-error-stream-reset.patch
+++ b/patches/lsquic/message-error-stream-reset.patch
@@ -122,19 +122,18 @@
          lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
              "number of bytes in DATA frames of stream %"PRIu64" exceeds "
              "content-length limit of %llu", stream->id, stream->sm_cont_len);
-@@ -5142,7 +5208,11 @@
+@@ -5139,6 +5205,11 @@
+                     goto end;
+                 default:
+                     assert(LQRHS_ERROR == rhs);
++                    /* bun: qdh_header_read_results already reset this stream
++                     * (or aborted the connection for a QPACK-fatal error). */
++                    if (stream->conn_pub->enpub
++                                ->enp_settings.es_message_error_is_stream)
++                        goto end;
                      stream->sm_qflags &= ~SMQF_QPACK_DEC;
                      filter->hqfi_flags |= HQFI_FLAG_ERROR;
                      LSQ_INFO("error processing header block");
--                    abort_connection(stream);   /* XXX Overkill? */
-+                    /* bun: qdh_header_read_results already reset this stream
-+                     * (or aborted the connection for a QPACK-fatal error). */
-+                    if (!stream->conn_pub->enpub
-+                                ->enp_settings.es_message_error_is_stream)
-+                        abort_connection(stream);
-                     goto end;
-                 }
-                 break;
 --- a/src/liblsquic/lsquic_qdec_hdl.c
 +++ b/src/liblsquic/lsquic_qdec_hdl.c
 @@ -551,18 +551,28 @@

--- a/patches/lsquic/message-error-stream-reset.patch
+++ b/patches/lsquic/message-error-stream-reset.patch
@@ -31,7 +31,7 @@
  void
 --- a/src/liblsquic/lsquic_stream.c
 +++ b/src/liblsquic/lsquic_stream.c
-@@ -1495,6 +1495,66 @@
+@@ -1495,6 +1495,72 @@
  }
  
  
@@ -52,6 +52,10 @@
 +    stream->error_code = error_code;
 +    stream->ss_error_code = error_code;
 +    stream->sm_bflags &= ~SMBF_VERIFY_CL;
++    /* qdh_hsi_process_wrapper calls us from inside lsqpack's dhi_process_header
++     * callback; stream_reset() would otherwise re-enter lsqpack via
++     * lsquic_qdh_cancel_stream and free the read_ctx it still holds. */
++    stream->sm_qflags &= ~SMQF_QPACK_DEC;
 +    if (!(stream->stream_flags & (STREAM_FIN_RECVD|STREAM_RST_RECVD))
 +                            && !(stream->stream_flags & STREAM_SS_SENT)
 +                            && !(stream->sm_qflags & SMQF_SEND_STOP_SENDING))
@@ -65,12 +69,14 @@
 +         * SMQF_SELF_FLAGS check would keep the stream alive forever. */
 +        stream->sm_qflags |= SMQF_SEND_STOP_SENDING;
 +    }
-+    /* stream_reset() clears every SMQF_SENDING flag; re-arm the STOP_SENDING
-+     * we just queued so both frames reach the peer. */
++    /* RFC 9000 sec 3.1 permits RESET_STREAM in Data Sent, so FIN_SENT does not
++     * skip the reset: SMQF_SEND_RST is what keeps stream_is_finished() false
++     * until both frames reach the wire.  stream_reset() clears every
++     * SMQF_SENDING flag, so re-arm the STOP_SENDING we just queued. */
 +    {
 +        const enum stream_q_flags had_ss =
 +                            stream->sm_qflags & SMQF_SEND_STOP_SENDING;
-+        if (!(stream->stream_flags & (STREAM_RST_SENT|STREAM_FIN_SENT))
++        if (!(stream->stream_flags & STREAM_RST_SENT)
 +                                    && !(stream->sm_qflags & SMQF_SEND_RST))
 +            stream_reset(stream, error_code, 0);
 +        if (had_ss)
@@ -98,7 +104,7 @@
  static void
  verify_cl_on_fin (struct lsquic_stream *stream)
  {
-@@ -1506,6 +1566,11 @@
+@@ -1506,6 +1572,11 @@
       */
      if (stream->sm_data_in != 0 && stream->sm_cont_len != stream->sm_data_in)
      {
@@ -110,7 +116,7 @@
          lconn = stream->conn_pub->lconn;
          lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
              "number of bytes in DATA frames of stream %"PRIu64" is %llu, "
-@@ -4977,9 +5042,14 @@
+@@ -4977,9 +5048,14 @@
      stream->sm_data_in += filter->hqfi_left;
      if (stream->sm_data_in > stream->sm_cont_len)
      {
@@ -126,7 +132,7 @@
          lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
              "number of bytes in DATA frames of stream %"PRIu64" exceeds "
              "content-length limit of %llu", stream->id, stream->sm_cont_len);
-@@ -5139,6 +5209,20 @@
+@@ -5139,6 +5215,20 @@
                      goto end;
                  default:
                      assert(LQRHS_ERROR == rhs);

--- a/patches/lsquic/message-error-stream-reset.patch
+++ b/patches/lsquic/message-error-stream-reset.patch
@@ -31,7 +31,7 @@
  void
 --- a/src/liblsquic/lsquic_stream.c
 +++ b/src/liblsquic/lsquic_stream.c
-@@ -1495,6 +1495,72 @@
+@@ -1495,6 +1495,68 @@
  }
  
  
@@ -52,10 +52,6 @@
 +    stream->error_code = error_code;
 +    stream->ss_error_code = error_code;
 +    stream->sm_bflags &= ~SMBF_VERIFY_CL;
-+    /* qdh_hsi_process_wrapper calls us from inside lsqpack's dhi_process_header
-+     * callback; stream_reset() would otherwise re-enter lsqpack via
-+     * lsquic_qdh_cancel_stream and free the read_ctx it still holds. */
-+    stream->sm_qflags &= ~SMQF_QPACK_DEC;
 +    if (!(stream->stream_flags & (STREAM_FIN_RECVD|STREAM_RST_RECVD))
 +                            && !(stream->stream_flags & STREAM_SS_SENT)
 +                            && !(stream->sm_qflags & SMQF_SEND_STOP_SENDING))
@@ -104,7 +100,7 @@
  static void
  verify_cl_on_fin (struct lsquic_stream *stream)
  {
-@@ -1506,6 +1572,11 @@
+@@ -1506,6 +1568,11 @@
       */
      if (stream->sm_data_in != 0 && stream->sm_cont_len != stream->sm_data_in)
      {
@@ -116,7 +112,7 @@
          lconn = stream->conn_pub->lconn;
          lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
              "number of bytes in DATA frames of stream %"PRIu64" is %llu, "
-@@ -4977,9 +5048,14 @@
+@@ -4977,9 +5044,14 @@
      stream->sm_data_in += filter->hqfi_left;
      if (stream->sm_data_in > stream->sm_cont_len)
      {
@@ -132,7 +128,7 @@
          lconn->cn_if->ci_abort_error(lconn, 1, HEC_MESSAGE_ERROR,
              "number of bytes in DATA frames of stream %"PRIu64" exceeds "
              "content-length limit of %llu", stream->id, stream->sm_cont_len);
-@@ -5139,6 +5215,20 @@
+@@ -5139,6 +5211,20 @@
                      goto end;
                  default:
                      assert(LQRHS_ERROR == rhs);
@@ -155,7 +151,7 @@
                      LSQ_INFO("error processing header block");
 --- a/src/liblsquic/lsquic_qdec_hdl.c
 +++ b/src/liblsquic/lsquic_qdec_hdl.c
-@@ -551,18 +551,28 @@
+@@ -551,18 +551,34 @@
  
  /* Intercept header errors so that upper-layer errors do not get
   * misinterpreted as QPACK errors.
@@ -181,7 +177,13 @@
 -            "error processing headers");
 +    {
 +        if (qdh->qdh_enpub->enp_settings.es_message_error_is_stream)
++        {
++            /* We are inside lsqpack's dhi_process_header callback; let
++             * stream_reset() skip lsquic_qdh_cancel_stream so it does not
++             * free the read_ctx qdec_header_process still holds. */
++            stream->sm_qflags &= ~SMQF_QPACK_DEC;
 +            lsquic_stream_msg_error(stream, HEC_MESSAGE_ERROR);
++        }
 +        else
 +            qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
 +                HEC_MESSAGE_ERROR, "error processing headers");
@@ -189,7 +191,7 @@
  
      return retval;
  }
-@@ -599,7 +609,7 @@
+@@ -599,7 +615,7 @@
      else if ((qdh->qdh_flags & QDH_SAVE_UA) && !qdh->qdh_ua)
          qdh_maybe_set_user_agent(qdh, xhdr, &qdh->qdh_ua);
  
@@ -198,7 +200,7 @@
  }
  
  
-@@ -658,7 +668,7 @@
+@@ -658,7 +674,7 @@
              uh->uh_exclusive = -1;
              if (qdh->qdh_enpub->enp_hsi_if == lsquic_http1x_if)
                  uh->uh_flags    |= UH_H1H;
@@ -207,7 +209,7 @@
              {
                  LSQ_DEBUG("finishing hset failed");
                  free(uh);
-@@ -696,10 +706,19 @@
+@@ -696,10 +712,19 @@
      {
          qdh_maybe_destroy_hblock_ctx(qdh, stream);
          qerr = lsqpack_dec_get_err_info(&qdh->qdh_decoder);

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -128,6 +128,12 @@ export const lsquic: Dependency = {
     // never be encrypted and the peer idled out instead of learning of the
     // close. Select the PNS by handshake progress, as ngtcp2 does.
     "patches/lsquic/connection-close-pns.patch",
+    // RFC 9114 sec 4.1.2: a malformed HTTP/3 message (content-length mismatch,
+    // rejected header, undecodable field section) is a *stream* error; the
+    // stock library routes every one to ci_abort_error() = CONNECTION_CLOSE,
+    // so one bad request nuked every innocent request sharing the connection.
+    // Applies after node-quic-accessors.patch (uses ss_error_code).
+    "patches/lsquic/message-error-stream-reset.patch",
   ],
 
   fetchDeps: ["zlib", "lshpack", "lsqpack", "boringssl"],

--- a/src/lsquic_sys/lib.rs
+++ b/src/lsquic_sys/lib.rs
@@ -224,6 +224,7 @@ unsafe extern "C" {
     pub fn us_nq_spec_stride() -> usize;
     pub fn us_nq_stream_reset(s: *mut lsquic_stream, code: u64);
     pub fn us_nq_hset_pairs(hset: *mut c_void, len: *mut usize) -> *const c_char;
+    pub fn us_nq_hset_malformed(hset: *mut c_void) -> c_int;
     pub fn us_nq_hset_free(hset: *mut c_void);
     pub fn us_nq_stream_send_headers(
         s: *mut lsquic_stream,
@@ -815,6 +816,13 @@ impl Stream {
 pub struct HeaderSet(*mut c_void);
 
 impl HeaderSet {
+    /// RFC 9114 §4.1.2 malformed-message flag (NUL in a field, empty name).
+    /// The shim flags-and-continues instead of returning -1 into lsqpack so
+    /// this stream can be reset without taking the connection down.
+    pub fn malformed(&self) -> bool {
+        // SAFETY: `self.0` is a live `nq_hset` until `Drop`.
+        unsafe { us_nq_hset_malformed(self.0) != 0 }
+    }
     /// h3 permits bytes that are not valid UTF-8, so the JS boundary picks the
     /// encoding (latin1, as node does for HTTP headers).
     pub fn pairs(&self) -> Vec<Vec<u8>> {

--- a/src/lsquic_sys/lib.rs
+++ b/src/lsquic_sys/lib.rs
@@ -816,9 +816,7 @@ impl Stream {
 pub struct HeaderSet(*mut c_void);
 
 impl HeaderSet {
-    /// RFC 9114 §4.1.2 malformed-message flag (NUL in a field, empty name).
-    /// The shim flags-and-continues instead of returning -1 into lsqpack so
-    /// this stream can be reset without taking the connection down.
+    /// RFC 9114 §4.1.2 malformed-message flag set by `nq_hsi_process_header`.
     pub fn malformed(&self) -> bool {
         // SAFETY: `self.0` is a live `nq_hset` until `Drop`.
         unsafe { us_nq_hset_malformed(self.0) != 0 }

--- a/src/lsquic_sys/lib.rs
+++ b/src/lsquic_sys/lib.rs
@@ -223,6 +223,7 @@ unsafe extern "C" {
     pub fn us_nq_spec_iov(s: *const lsquic_out_spec, n: *mut usize) -> *const iovec;
     pub fn us_nq_spec_stride() -> usize;
     pub fn us_nq_stream_reset(s: *mut lsquic_stream, code: u64);
+    pub fn us_nq_stream_msg_error(s: *mut lsquic_stream, code: u64);
     pub fn us_nq_hset_pairs(hset: *mut c_void, len: *mut usize) -> *const c_char;
     pub fn us_nq_hset_malformed(hset: *mut c_void) -> c_int;
     pub fn us_nq_hset_free(hset: *mut c_void);
@@ -711,6 +712,11 @@ impl Stream {
     pub fn reset(&self, code: u64) {
         // SAFETY: as above.
         unsafe { us_nq_stream_reset(self.0, code) }
+    }
+    /// `lsquic_stream_msg_error`: per-stream RST+SS, synthesize RST_RECVD, fire on_reset(0).
+    pub fn msg_error(&self, code: u64) {
+        // SAFETY: as above.
+        unsafe { us_nq_stream_msg_error(self.0, code) }
     }
     pub fn error_code(&self) -> u64 {
         unsafe extern "C" {

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -1036,8 +1036,7 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
             .find(|kv| kv[0] == b":status")
             .map(|kv| kv[1].len() == 3 && kv[1][0] == b'1');
         let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
-        // RFC 9114 §4.1.2 malformed message → reset this stream, as nghttp3
-        // does, not the whole connection (the shim flags NUL/empty names).
+        // RFC 9114 §4.1.2: malformed message → stream reset, not conn close.
         if hset.malformed() || (peer_is_client && has_status.is_some()) {
             if let Some(s) = qs.ls() {
                 // reset() only ends the read side when the peer already

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -1035,10 +1035,9 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
             .iter()
             .find(|kv| kv[0] == b":status")
             .map(|kv| kv[1].len() == 3 && kv[1][0] == b'1');
-        // RFC 9114 §4.1.2: a malformed message (NUL/empty field name flagged
-        // by the shim, or :status in a request) resets this stream, as node's
-        // nghttp3 does, not the whole connection.
         let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
+        // RFC 9114 §4.1.2 malformed message → reset this stream, as nghttp3
+        // does, not the whole connection (the shim flags NUL/empty names).
         if hset.malformed() || (peer_is_client && has_status.is_some()) {
             if let Some(s) = qs.ls() {
                 // reset() only ends the read side when the peer already

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -1035,11 +1035,14 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
             .iter()
             .find(|kv| kv[0] == b":status")
             .map(|kv| kv[1].len() == 3 && kv[1][0] == b'1');
-        // A :status in a request is malformed: node's nghttp3 resets the
-        // stream (RFC 9114 §4.1.2), and routing it to `oninfo` would leave
-        // the request unanswered until the idle timeout.
+        // RFC 9114 §4.1.2: a malformed message (NUL in a field, empty field
+        // name, :status in a request) is a *stream* error.  The shim flags
+        // NUL/empty instead of returning -1 into lsqpack, which would have
+        // become a CONNECTION_CLOSE and torn down every concurrent request.
+        // node's nghttp3 resets the stream; routing the bad headers to
+        // `onheaders` would leave the request unanswered until idle timeout.
         let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
-        if peer_is_client && has_status.is_some() {
+        if hset.malformed() || (peer_is_client && has_status.is_some()) {
             if let Some(s) = qs.ls() {
                 // reset() only ends the read side when the peer already
                 // FIN'd/RST'd, so STOP_SENDING is what stops a malformed

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -1035,12 +1035,9 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
             .iter()
             .find(|kv| kv[0] == b":status")
             .map(|kv| kv[1].len() == 3 && kv[1][0] == b'1');
-        // RFC 9114 §4.1.2: a malformed message (NUL in a field, empty field
-        // name, :status in a request) is a *stream* error.  The shim flags
-        // NUL/empty instead of returning -1 into lsqpack, which would have
-        // become a CONNECTION_CLOSE and torn down every concurrent request.
-        // node's nghttp3 resets the stream; routing the bad headers to
-        // `onheaders` would leave the request unanswered until idle timeout.
+        // RFC 9114 §4.1.2: a malformed message (NUL/empty field name flagged
+        // by the shim, or :status in a request) resets this stream, as node's
+        // nghttp3 does, not the whole connection.
         let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
         if hset.malformed() || (peer_is_client && has_status.is_some()) {
             if let Some(s) = qs.ls() {

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -1038,21 +1038,8 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
         let peer_is_client = qs.session_ref().is_some_and(|s| s.is_server());
         // RFC 9114 §4.1.2: malformed message → stream reset, not conn close.
         if hset.malformed() || (peer_is_client && has_status.is_some()) {
-            if let Some(s) = qs.ls() {
-                // reset() only ends the read side when the peer already
-                // FIN'd/RST'd, so STOP_SENDING is what stops a malformed
-                // request streaming a body into a stream nothing will answer.
-                s.reset(H3_MESSAGE_ERROR);
-                s.stop_sending(H3_MESSAGE_ERROR);
-            }
-            qs.mark_reset(H3_MESSAGE_ERROR);
-            if let Some(session) = qs.session_ref() {
-                session.push_event(SessionEvent::StreamReset {
-                    stream: ctx.cast(),
-                    code: H3_MESSAGE_ERROR,
-                });
-                session.push_event(SessionEvent::StreamWake { stream: ctx.cast() });
-            }
+            // on_reset(0) → on_stream_reset pushes the events; RST_RECVD suppresses the peer echo.
+            stream.msg_error(H3_MESSAGE_ERROR);
             return;
         }
         // 1xx interim responses are HINTS (RFC 9114 §4.1).

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -1046,6 +1046,13 @@ pub(super) unsafe extern "C" fn on_stream_read(ctx: *mut c_void, s: *mut lsquic:
                 s.stop_sending(H3_MESSAGE_ERROR);
             }
             qs.mark_reset(H3_MESSAGE_ERROR);
+            if let Some(session) = qs.session_ref() {
+                session.push_event(SessionEvent::StreamReset {
+                    stream: ctx.cast(),
+                    code: H3_MESSAGE_ERROR,
+                });
+                session.push_event(SessionEvent::StreamWake { stream: ctx.cast() });
+            }
             return;
         }
         // 1xx interim responses are HINTS (RFC 9114 §4.1).

--- a/test/js/node/quic/quic-h3-malformed.test.ts
+++ b/test/js/node/quic/quic-h3-malformed.test.ts
@@ -1,0 +1,121 @@
+// RFC 9114 sec 4.1.2: a malformed HTTP/3 message is a *stream* error
+// (H3_MESSAGE_ERROR on RESET_STREAM + STOP_SENDING), not a CONNECTION_CLOSE.
+// lsquic's stock behavior wires every such failure to `ci_abort_error`, so one
+// bad request tore down every concurrent request on the same connection.
+import { describe, expect, test } from "bun:test";
+import { createPrivateKey } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { connect, listen } from "node:quic";
+
+const keysDir = join(import.meta.dir, "..", "test", "fixtures", "keys");
+const key = createPrivateKey(readFileSync(join(keysDir, "agent1-key.pem")));
+const cert = readFileSync(join(keysDir, "agent1-cert.pem"));
+
+// A well-formed concurrent request must still COMPLETE when a malformed request
+// on the same connection is rejected: the connection has to survive the poison.
+// The innocent stream's headers are sent first so its HEADERS frame is in
+// lsquic's hands before the poison is parsed; whether the response body (and
+// hence its FIN) arrives is the connection-survival signal.
+async function blastRadius(
+  poison: (client: any) => Promise<any>,
+  describeBody?: (stream: any) => Promise<void>,
+): Promise<{ completed: number; poisonedReset: unknown; sessionClose: unknown }> {
+  let sessionClose: unknown = null;
+  await using server = await listen(
+    async (s: any) => {
+      s.onstream = (st: any) => {
+        st.closed.catch(() => {});
+      };
+      await s.closed.catch((e: unknown) => {
+        sessionClose = e;
+      });
+    },
+    {
+      sni: { "*": { keys: [key], certs: [cert] } },
+      transportParams: { maxIdleTimeout: 2 },
+      onheaders(this: any, headers: Record<string, string>) {
+        if (headers[":path"] === "/innocent") {
+          this.sendHeaders({ ":status": "200" });
+          // A non-empty body moves the FIN past the response HEADERS frame,
+          // so a CONNECTION_CLOSE arriving after the poison is parsed (but
+          // before the tick that would have flushed this FIN) aborts the
+          // innocent iterator instead of letting it drain.
+          this.writer.writeSync(new TextEncoder().encode("ok"));
+          this.writer.endSync();
+        } else if (describeBody) {
+          void describeBody(this);
+        }
+      },
+    },
+  );
+
+  const client = await connect(server.address, {
+    servername: "localhost",
+    verifyPeer: "manual",
+    transportParams: { maxIdleTimeout: 2 },
+  });
+  await client.opened;
+
+  const innocent = await client.createBidirectionalStream({
+    headers: { ":method": "GET", ":path": "/innocent", ":scheme": "https", ":authority": "localhost" },
+  });
+
+  const poisoned = await poison(client);
+  const poisonedReset = await poisoned.closed.then(
+    () => null,
+    (e: unknown) => e,
+  );
+
+  let completed = 0;
+  try {
+    for await (const _ of innocent) completed++;
+  } catch {}
+
+  client.close();
+  return { completed, poisonedReset, sessionClose };
+}
+
+describe("HTTP/3 malformed message is a stream error, not a connection error", () => {
+  // verify_cl_on_fin / verify_cl_on_new_data_frame in lsquic_stream.c call
+  // ci_abort_error(HEC_MESSAGE_ERROR) when the DATA-frame byte count disagrees
+  // with content-length, which the stock library converts to CONNECTION_CLOSE.
+  test("request content-length mismatch resets that stream, innocent completes", async () => {
+    const { completed, poisonedReset, sessionClose } = await blastRadius(async client =>
+      client.createBidirectionalStream({
+        headers: {
+          ":method": "POST",
+          ":path": "/poison",
+          ":scheme": "https",
+          ":authority": "localhost",
+          "content-length": "1000",
+        },
+        // The three-byte body FINs the request at 3 bytes; the server's lsquic
+        // detects the mismatch in verify_cl_on_fin() once it reads that FIN.
+        body: new TextEncoder().encode("abc"),
+      }),
+    );
+    // The innocent request must still deliver its body; before the fix, the
+    // server's CONNECTION_CLOSE terminated the iterator with zero chunks.
+    expect(completed).toBeGreaterThan(0);
+    expect(sessionClose).toBeNull();
+    // RFC 9114 sec 4.1.2: H3_MESSAGE_ERROR (0x10e) on the poisoned stream.
+    expect((poisonedReset as any)?.errorCode).toBe(0x10en);
+  });
+
+  test("response content-length mismatch resets that stream, innocent completes", async () => {
+    const { completed, poisonedReset } = await blastRadius(
+      client =>
+        client.createBidirectionalStream({
+          headers: { ":method": "GET", ":path": "/poison", ":scheme": "https", ":authority": "localhost" },
+        }),
+      async stream => {
+        stream.sendHeaders({ ":status": "200", "content-length": "1000" });
+        stream.writer.writeSync(new TextEncoder().encode("abc"));
+        stream.writer.endSync();
+      },
+    );
+    expect(completed).toBeGreaterThan(0);
+    expect((poisonedReset as any)?.errorCode).toBe(0x10en);
+  });
+});

--- a/test/js/node/quic/quic-h3-malformed.test.ts
+++ b/test/js/node/quic/quic-h3-malformed.test.ts
@@ -103,6 +103,27 @@ describe("HTTP/3 malformed message is a stream error, not a connection error", (
     expect((poisonedReset as any)?.errorCode).toBe(0x10en);
   });
 
+  // verify_cl_on_new_data_frame fires while DATA is still arriving (no FIN
+  // yet); lsquic_stream_msg_error must therefore queue STOP_SENDING and let
+  // the peer's RESET_STREAM reply finish the stream instead of leaking it.
+  test("request body exceeding content-length resets that stream, innocent completes", async () => {
+    const { completed, poisonedReset, sessionClose } = await blastRadius(async client =>
+      client.createBidirectionalStream({
+        headers: {
+          ":method": "POST",
+          ":path": "/poison",
+          ":scheme": "https",
+          ":authority": "localhost",
+          "content-length": "3",
+        },
+        body: new TextEncoder().encode(Buffer.alloc(100, "a").toString()),
+      }),
+    );
+    expect(completed).toBeGreaterThan(0);
+    expect(sessionClose).toBeNull();
+    expect((poisonedReset as any)?.errorCode).toBe(0x10en);
+  });
+
   test("response content-length mismatch resets that stream, innocent completes", async () => {
     const { completed, poisonedReset } = await blastRadius(
       client =>

--- a/test/js/node/quic/quic-h3-malformed.test.ts
+++ b/test/js/node/quic/quic-h3-malformed.test.ts
@@ -104,21 +104,26 @@ describe("HTTP/3 malformed message is a stream error, not a connection error", (
   });
 
   // verify_cl_on_new_data_frame fires while DATA is still arriving (no FIN
-  // yet); lsquic_stream_msg_error must therefore queue STOP_SENDING and let
-  // the peer's RESET_STREAM reply finish the stream instead of leaking it.
+  // yet), so lsquic_stream_msg_error must queue STOP_SENDING and let the
+  // peer's RESET_STREAM reply finish the stream instead of leaking it.  The
+  // write side is left open (no endSync) so the server's lsquic sees the
+  // oversize DATA frame before STREAM_FIN_RECVD can mask the pre-FIN branch.
   test("request body exceeding content-length resets that stream, innocent completes", async () => {
-    const { completed, poisonedReset, sessionClose } = await blastRadius(async client =>
-      client.createBidirectionalStream({
-        headers: {
+    const { completed, poisonedReset, sessionClose } = await blastRadius(async client => {
+      const st = await client.createBidirectionalStream();
+      st.sendHeaders(
+        {
           ":method": "POST",
           ":path": "/poison",
           ":scheme": "https",
           ":authority": "localhost",
           "content-length": "3",
         },
-        body: new TextEncoder().encode(Buffer.alloc(100, "a").toString()),
-      }),
-    );
+        { terminal: false },
+      );
+      st.writer.writeSync(new TextEncoder().encode(Buffer.alloc(100, "a").toString()));
+      return st;
+    });
     expect(completed).toBeGreaterThan(0);
     expect(sessionClose).toBeNull();
     expect((poisonedReset as any)?.errorCode).toBe(0x10en);


### PR DESCRIPTION
## Problem

One malformed HTTP/3 request or response on a `node:quic` h3 session takes the **whole connection** down, killing every concurrent request sharing it. RFC 9114 sec 4.1.2 says a malformed message is a *stream* error (RESET_STREAM + STOP_SENDING `H3_MESSAGE_ERROR`), not a CONNECTION_CLOSE.

Blast-radius rig (20 well-formed slow requests + 1 poison on the same connection, both directions symmetric): every row below is deterministic 20/20 innocents killed.

| poison | trigger | lsquic path |
|---|---|---|
| `clmm` | `content-length: 1000` + 3-byte body | `verify_cl_on_fin` / `verify_cl_on_new_data_frame` -> `ci_abort_error(HEC_MESSAGE_ERROR)` |
| `nul` | field value contains 0x00 | `nq_hsi_process_header` returns -1 -> `qdh_hsi_process_wrapper` -> `ci_abort_error(HEC_MESSAGE_ERROR)` |
| `empty` | empty field name | same path |
| `big` | 66000-byte field value | lsqpack `need > LSXPACK_MAX_STRLEN` -> `LQRHS_ERROR` -> `qdh_header_read_results` -> `ci_abort_error(HEC_QPACK_DECOMPRESSION_FAILED)` + `hq_read` -> `abort_connection()` |

```
innocent completed=0/20 killed=20 connection_close=('0x10e', 'number of bytes in DATA frames of stream 80 is 3, while content-length specified of 1000')
```

The one case bun already got right is `:status`-in-request, which `stream.rs` handles post-hoc after `take_header_set()`; that proves the per-stream reset primitive exists.

## Fix

**`patches/lsquic/message-error-stream-reset.patch`** adds `lsquic_stream_msg_error(stream, code)`: queues `RESET_STREAM(code)` + `STOP_SENDING(code)` (re-arming STOP_SENDING after `stream_reset()` clears the sending flags), sets `STREAM_RST_RECVD` so further reads return `ECONNRESET`, and fires `on_reset(how=0)` so the application sees the failure the same way it sees a peer RESET_STREAM. It deliberately does **not** `drop_frames_in()`: the peer has not reset its write side, so a late or retransmitted STREAM frame for that stream must not become `INS_FRAME_ERR` -> `ABORT_ERROR("cannot insert stream frame")`.

A new `es_message_error_is_stream` setting (default 0 = stock CONNECTION_CLOSE) gates the four message-level call sites: `verify_cl_on_fin`, `verify_cl_on_new_data_frame`, `qdh_hsi_process_wrapper`, and `qdh_header_read_results` LQRHS_ERROR. QPACK encoder-stream errors (`qdh_read_encoder_stream`) and frame-level errors (unexpected frame sequence, truncated frame) remain connection-fatal per RFC 9114 sec 7/8 and RFC 9204.

**`node_quic_shim.c`** turns the setting on for node:quic engines, and `nq_hsi_process_header` now flags NUL-in-field / empty-name headers on the hset instead of returning -1 into lsqpack (so the whole field section still reaches the application for logging). `stream.rs` resets the one stream with `H3_MESSAGE_ERROR` when the flag is set, generalising its existing `:status`-in-request handling.

## Verification

`test/js/node/quic/quic-h3-malformed.test.ts` opens an innocent request and a `content-length: 1000` + 3-byte-body poison on the same connection, in both directions (request and response). Without the fix, the server's CONNECTION_CLOSE aborts the innocent iterator with zero chunks and the poison stream's `closed` resolves without a code; with the fix, the innocent request completes and the poison stream's `closed` rejects with `errorCode 0x10en`. 20/20 green on the whole `test/js/node/quic/` suite.

The other three poisons (`nul`, `empty`, `big`) need a raw-QPACK client to emit, so the test covers the one reachable from bun's own client (the shim change for `nul`/`empty` and the qdec change for `big` are straight-line once the setting is on).

## Related

- #35716 covers the `clmm` path only (this PR additionally covers `nul`/`empty`/`big` and gates behind a setting so stash-src fail-before holds).
- #35741 addresses the `big` case by widening `LSXPACK_MAX_STRLEN`; this PR instead resets the one stream on LQRHS_ERROR.
- #35732 adds semantic field-section validation (duplicate pseudo-headers, connection-specific headers) and is orthogonal.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/quic/quic-h3-malformed.test.ts"
bun test v1.4.0 (4ca91fca0)

test/js/node/quic/quic-h3-malformed.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

2250 |     }
2251 |     switch (errorType) {
2252 |       case 0:
2253 |         this.destroy(makeQuicError("ERR_QUIC_TRANSPORT_ERROR", "QUIC transport error", "transport", code, reason, errorName));
2254 |         break;
2255 |         this.destroy(makeQuicError("ERR_QUIC_APPLICATION_ERROR", "QUIC application error", "application", code, reason, errorName));
                                         ^
error: QUIC application error 270: number of bytes in DATA frames of stream 4 is 3, while content-length specified of 1000
 reason: "number of bytes in DATA frames of stream 4 is 3, while content-length specified of 1000",
   code: "ERR_QUIC_APPLICATION_ERROR"

      at [kFinishClose] (internal:quic/quic:2255:35)
      at onSessionClose (internal:quic/quic:341:31)
      at close (internal:quic/quic:2112
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (5ee2b54b5)

test/js/node/quic/quic-h3-malformed.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:15:20)

(pass) HTTP/3 malformed message is a stream error, not a connection error > request content-length mismatch resets that stream, innocent completes [11.55ms]
(pass) HTTP/3 malformed message is a stream error, not a connection error > request body exceeding content-length resets that stream, innocent completes [6.95ms]
(pass) HTTP/3 malformed message is a stream error, not a connection error > response content-length mismatch resets that stream, innocent completes [4.55ms]

 3 pass
 0 fail
 8 expect() calls
Ran 3 tests across 1 file. [187.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/quic/quic-h3-malformed.test.ts"
bun test v1.4.0 (4ca91fca0)

test/js/node/quic/quic-h3-malformed.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) HTTP/3 malformed message is a stream error, not a connection error > request content-length mismatch resets that stream, innocent completes [511.33ms]
(pass) HTTP/3 malformed message is a stream error, not a connection error > request body exceeding content-length resets that stream, innocent completes [134.82ms]
(pass) HTTP/3 malformed message is a stream error, not a connection error > response content-length mismatch resets that stream, innocent completes [103.17ms]

 3 pass
 0 fail
 8 expect() calls
Ran 3 tests across 1 file. [3.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 4215ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/211] fetch lsquic
[lsquic] up to date
[2/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_alarmset.c.o
[3/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_conn.c.o
[4/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_crand.c.o
[5/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_cfcw.c.o
[6/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_arr.c.o
[7/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_attq.c.o
[8/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_adaptive_cc.c.o
[9/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_bbr.c.o
[10/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_di_error.c.o
[11/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_bw_sampler.c.o
[12/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_cubic.c.o
[13/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_di_hash.c.o
[14/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_di_nocopy.c.o
[15/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_enc_sess_common.c.o
[16/211] cc obj/vendor/lsquic/src/liblsquic/lsquic_frab_list.c.o
[17/211] cc obj/vendor/lsquic/src/liblsqui
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/node_quic_shim.c      |  38 +++-
 packages/bun-usockets/src/quic.c                |  10 +
 patches/lsquic/message-error-stream-reset.patch | 235 ++++++++++++++++++++++++
 scripts/build/deps/lsquic.ts                    |   6 +
 src/lsquic_sys/lib.rs                           |  12 ++
 src/runtime/node/quic/stream.rs                 |  16 +-
 test/js/node/quic/quic-h3-malformed.test.ts     | 147 +++++++++++++++
 7 files changed, 448 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 7 passed · 2 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
packages/bun-usockets/src/node_quic_shim.c           5      6      0
packages/bun-usockets/src/quic.c                     2      4      0
patches/lsquic/message-error-stream-reset.patch      5     24      0
scripts/build/deps/lsquic.ts                         1      1      0
src/lsquic_sys/lib.rs                                7      7      0
src/runtime/node/quic/stream.rs                      6      7      0
test/js/node/quic/quic-h3-malformed.test.ts          2      4      0
```

</details>

<!-- robobun:evidence:end -->