### PR TITLE
Bun.serve(http3): lift the 64 KB QPACK prepare_decode cap so a large request header does not abort the connection

### DIFF
--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -185,6 +185,11 @@ static void nq_on_path_switch(lsquic_conn_t *c, int validated, int is_preferred,
 }
 
 #define US_NQ_HSET_MIN_BUF 256
+/* Fallback ceiling for nq_hsi_prepare_decode when maxHeaderLength is
+ * unlimited: lsqpack requests the decode buffer from the peer-declared
+ * length varint before any value bytes arrive, so this bounds how much a
+ * few wire bytes can reserve per stream. */
+#define US_NQ_HSET_MAX_BUF (128 * 1024)
 
 struct nq_hset {
     struct lsxpack_header xhdr;
@@ -216,7 +221,12 @@ static struct lsxpack_header *nq_hsi_prepare_decode(void *hset,
                                                     struct lsxpack_header *hdr,
                                                     size_t space) {
     struct nq_hset *h = hset;
-    if (space > LSXPACK_MAX_STRLEN)
+    /* 2x max_bytes covers the Huffman decode-window headroom for a single
+     * header that is itself the whole configured maxHeaderLength; without a
+     * cap the peer's length varint alone drives the realloc (see
+     * US_NQ_HSET_MAX_BUF). */
+    size_t cap = h->max_bytes ? (size_t) h->max_bytes * 2 : US_NQ_HSET_MAX_BUF;
+    if (space > LSXPACK_MAX_STRLEN || space > cap)
         return NULL;
     if (space > h->decode_cap) {
         size_t want = space < US_NQ_HSET_MIN_BUF ? US_NQ_HSET_MIN_BUF : space;

--- a/packages/bun-usockets/src/node_quic_shim.c
+++ b/packages/bun-usockets/src/node_quic_shim.c
@@ -222,10 +222,12 @@ static struct lsxpack_header *nq_hsi_prepare_decode(void *hset,
                                                     size_t space) {
     struct nq_hset *h = hset;
     /* 2x max_bytes covers the Huffman decode-window headroom for a single
-     * header that is itself the whole configured maxHeaderLength; without a
-     * cap the peer's length varint alone drives the realloc (see
-     * US_NQ_HSET_MAX_BUF). */
-    size_t cap = h->max_bytes ? (size_t) h->max_bytes * 2 : US_NQ_HSET_MAX_BUF;
+     * header that is itself the whole configured maxHeaderLength; floored at
+     * US_NQ_HSET_MAX_BUF so a small or unset limit never lowers the abort
+     * threshold (a header over max_bytes is still silently dropped in
+     * process_header, which keeps the session alive). */
+    size_t cap = (size_t) h->max_bytes * 2;
+    if (cap < US_NQ_HSET_MAX_BUF) cap = US_NQ_HSET_MAX_BUF;
     if (space > LSXPACK_MAX_STRLEN || space > cap)
         return NULL;
     if (space > h->decode_cap) {

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -31,6 +31,15 @@ extern X509_STORE *us_get_default_ca_store(void);
 
 #define US_QUIC_READ_BUF (16 * 1024)
 
+/* Hard ceiling on the per-stream decoded header buffer. lsqpack calls
+ * prepare_decode with ~1.5x the peer-declared value length before a single
+ * value byte has arrived (DATA_STATE_READ_VAL_LEN -> guarantee_out_bytes),
+ * so without a cap a few wire bytes can reserve tens of MB; with 100 bidi
+ * streams that is a connection-level amplification attack. 128 KB covers a
+ * ~85 KB single header value (60 KB repros fine) while keeping the worst
+ * case at 128 KB x es_init_max_streams_bidi per connection. */
+#define US_QUIC_HSET_MAX_BUF (128 * 1024)
+
 /* Incoming header set: contiguous storage + index. Created before the
  * stream object exists (lsquic decodes headers ahead of on_new_stream),
  * so it lives standalone until on_read claims it via lsquic_stream_get_hset. */
@@ -430,9 +439,12 @@ static void *us_quic_hsi_create(void *hsi_ctx, lsquic_stream_t *s, int is_push) 
 static struct lsxpack_header *us_quic_hsi_prepare(void *hset_p, struct lsxpack_header *hdr, size_t space) {
     struct us_quic_hset *h = (struct us_quic_hset *) hset_p;
     /* NULL from this hook is connection-fatal in lsquic (LQRHS_ERROR ->
-     * HEC_QPACK_DECOMPRESSION_FAILED), so the only rejection is the
-     * structural limit of lsxpack_strlen_t; lsqpack never asks for more. */
-    if (space > LSXPACK_MAX_STRLEN) return NULL;
+     * HEC_QPACK_DECOMPRESSION_FAILED). The LSXPACK_MAX_STRLEN guard keeps the
+     * cast to lsxpack_strlen_t below from truncating; US_QUIC_HSET_MAX_BUF
+     * bounds the allocation a peer-declared length can force (see define). */
+    if (space > LSXPACK_MAX_STRLEN
+            || (size_t) h->len + space > US_QUIC_HSET_MAX_BUF)
+        return NULL;
     unsigned int need = h->len + (unsigned int) space;
     if (need > h->cap) {
         unsigned int ncap = h->cap ? h->cap : 512;
@@ -711,9 +723,10 @@ us_quic_socket_context_t *us_create_quic_socket_context(
     lsquic_engine_init_settings(&ctx->settings, LSENG_HTTP_SERVER);
     ctx->settings.es_versions = LSQUIC_DF_VERSIONS & LSQUIC_IETF_VERSIONS;
     ctx->settings.es_ecn = 0;
-    /* QPACK can expand small dynamic-table refs into large header lists; cap
-     * the post-decode size at the same order as uWS H1's MAX_FALLBACK_SIZE so
-     * a single request can't run hsi_prepare to OOM. */
+    /* Advisory only: lsquic writes this into the SETTINGS frame but never
+     * enforces it on decode. The actual allocation guard is
+     * US_QUIC_HSET_MAX_BUF in us_quic_hsi_prepare. Kept at uWS H1's default
+     * so well-behaved clients don't send more than we intend to buffer. */
     ctx->settings.es_max_header_list_size = 16 * 1024;
     ctx->settings.es_init_max_streams_bidi = 100;
     /* Static-table-only response encoding: skips the per-header dynamic

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -429,7 +429,10 @@ static void *us_quic_hsi_create(void *hsi_ctx, lsquic_stream_t *s, int is_push) 
 
 static struct lsxpack_header *us_quic_hsi_prepare(void *hset_p, struct lsxpack_header *hdr, size_t space) {
     struct us_quic_hset *h = (struct us_quic_hset *) hset_p;
-    if (space > 64 * 1024) return NULL;
+    /* NULL from this hook is connection-fatal in lsquic (LQRHS_ERROR ->
+     * HEC_QPACK_DECOMPRESSION_FAILED), so the only rejection is the
+     * structural limit of lsxpack_strlen_t; lsqpack never asks for more. */
+    if (space > LSXPACK_MAX_STRLEN) return NULL;
     unsigned int need = h->len + (unsigned int) space;
     if (need > h->cap) {
         unsigned int ncap = h->cap ? h->cap : 512;

--- a/packages/h3blast/Makefile
+++ b/packages/h3blast/Makefile
@@ -8,7 +8,11 @@ OBJ       := $(ROOT)/build/$(PROFILE)/obj/vendor
 VENDOR    := $(ROOT)/vendor
 
 CC        ?= clang
+# LSXPACK_MAX_STRLEN must match scripts/build/flags.ts: the linked
+# build/$(PROFILE)/obj/vendor/{lsquic,lsqpack,lshpack} objects are compiled
+# with the 32-bit lsxpack_strlen_t layout.
 CFLAGS    := -std=c11 -O3 -g -Wall -Wextra -Wno-unused-parameter \
+             -DLSXPACK_MAX_STRLEN=UINT32_MAX \
              -I$(VENDOR)/lsquic/include \
              -I$(VENDOR)/hdrhistogram/include \
              -I$(VENDOR)/boringssl/include

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -230,6 +230,16 @@ export const globalFlags: Flag[] = [
     when: c => c.windows,
     desc: "Undefine _DLL (we link statically)",
   },
+  {
+    // lsxpack_header.h (shared by lshpack/lsqpack/lsquic and bun's own
+    // quic.c/node_quic_shim.c/c-bindings.cpp) sizes lsxpack_strlen_t from
+    // this macro; the upstream default (UINT16_MAX) caps any single decoded
+    // HTTP/2/3 header at 64 KB and makes a ~44 KB H3 field section abort the
+    // whole connection with H3_QPACK_DECOMPRESSION_FAILED. The value is
+    // struct-layout ABI, so every TU that includes the header must agree.
+    flag: "-DLSXPACK_MAX_STRLEN=UINT32_MAX",
+    desc: "lshpack/lsqpack: 32-bit header lengths (struct ABI; must match across all consumers)",
+  },
 
   // ─── Optimization ───
   {

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -230,13 +230,16 @@ export const globalFlags: Flag[] = [
     when: c => c.windows,
     desc: "Undefine _DLL (we link statically)",
   },
+
+  // ─── lsxpack struct ABI (all platforms) ───
   {
     // lsxpack_header.h (shared by lshpack/lsqpack/lsquic and bun's own
     // quic.c/node_quic_shim.c/c-bindings.cpp) sizes lsxpack_strlen_t from
     // this macro; the upstream default (UINT16_MAX) caps any single decoded
     // HTTP/2/3 header at 64 KB and makes a ~44 KB H3 field section abort the
     // whole connection with H3_QPACK_DECOMPRESSION_FAILED. The value is
-    // struct-layout ABI, so every TU that includes the header must agree.
+    // struct-layout ABI, so every TU that includes the header must agree
+    // (packages/h3blast/Makefile sets it too for the same reason).
     flag: "-DLSXPACK_MAX_STRLEN=UINT32_MAX",
     desc: "lshpack/lsqpack: 32-bit header lengths (struct ABI; must match across all consumers)",
   },

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -525,6 +525,23 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
+  // A single ~60 KB value Huffman-encodes to ~45 KB, and the QPACK decoder
+  // reserves ~1.5x that, which used to hit quic.c's 64 KB prepare_decode
+  // ceiling and abort the whole connection with QPACK_DECOMPRESSION_FAILED.
+  test("single large request header value (>43 KB encoded) decodes without aborting the connection", async () => {
+    await withServer(async port => {
+      const big = Buffer.alloc(60000, "A").toString();
+      const res = await fetchH3(port, "/headers", { headers: { "x-big": big } });
+      expect(res.status).toBe(200);
+      const seen = (await res.json()) as Record<string, string>;
+      expect(seen["x-big"]?.length).toBe(60000);
+      expect(seen["x-big"]).toBe(big);
+      // The pooled session must still carry a follow-up request.
+      const after = await fetchH3(port, "/hello");
+      expect(await after.text()).toBe("hello over h3");
+    });
+  });
+
   test("8 MB POST body echoes byte-exact", async () => {
     await withServer(async port => {
       // Patterned (not crypto-random) so the test is deterministic but still


### PR DESCRIPTION
## What

A single request header whose decoded value is about 59 KB (about 44 KB of encoded QPACK) aborts the entire `Bun.serve({http3: true})` connection with `H3_QPACK_DECOMPRESSION_FAILED` (app error 0x200), taking every other in-flight stream on the session down with it.

```
error: HTTP3StreamReset fetching "https://127.0.0.1:.../headers"
  code: "HTTP3StreamReset"
```

## Cause

`us_quic_hsi_prepare` (`packages/bun-usockets/src/quic.c`, the server-side QPACK prepare_decode hook) rejected any per-header decode request above `64 * 1024` bytes by returning `NULL`. lsquic maps that to `LQRHS_ERROR` and calls `ci_abort_error(HEC_QPACK_DECOMPRESSION_FAILED)`, which is connection-fatal.

With a Huffman-encoded value lsqpack reserves about 1.5x the encoded length, so the practical ceiling was about `65536 / 1.5 ≈ 43.7 KB` of encoded bytes. A 60 KB value of `'A'` (6 bits/char Huffman) encodes to about 45 KB and requests about 67.5 KB of decode buffer, tripping the cap.

`es_max_header_list_size = 16 * 1024` (set on the server engine) is advisory only: lsquic writes it into the SETTINGS frame but never enforces it on decode, so it was not the guard the surrounding comment implied.

## Fix

* Build lshpack/lsqpack with `-DLSXPACK_MAX_STRLEN=UINT32_MAX` so `lsxpack_strlen_t` is 32-bit in every TU that includes `lsxpack_header.h` (lshpack, lsqpack, lsquic, `quic.c`, `node_quic_shim.c`, `c-bindings.cpp`, and the `h3blast` dev harness). The `flags.ts` and `packages/h3blast/Makefile` hunks are byte-identical to #35741 (the `node:quic` side of the same root cause), so whichever lands first the other resolves cleanly.
* Replace the per-request 64 KB `space` cap in `us_quic_hsi_prepare` with a 128 KB cap on the whole decoded header buffer (`h->len + space`). 128 KB admits a single header value up to about 85 KB (the 60 KB repro fits with room to spare) and bounds the per-stream buffer at 128 KB regardless of how many headers the peer sends. The `LSXPACK_MAX_STRLEN` check alongside it keeps the cast to `lsxpack_strlen_t` sound.
* Apply the same bound to the sibling `nq_hsi_prepare_decode` in `node_quic_shim.c`, since the build-flag change would otherwise turn its sole guard (`space > LSXPACK_MAX_STRLEN`) into a 4 GB no-op. The cap there is `max(2 × maxHeaderLength, 128 KB)`: users who opt into a larger `maxHeaderLength` get proportionally more decode headroom, and the 128 KB floor means a small or default limit never lowers the abort threshold below where it was (a header over `maxHeaderLength` is still silently dropped in `process_header`, which keeps the session alive).
* Correct the comment above `es_max_header_list_size` to say it is advisory and point at the actual guard.

## Why this cap, not `LSXPACK_MAX_STRLEN`

lsqpack requests the decode buffer from the peer-declared value-length varint before a single value byte has arrived (`DATA_STATE_READ_VAL_LEN` → `guarantee_out_bytes`), and that varint is 24-bit. Without a hard cap a dozen wire bytes reserve about 32 MB per stream, and with `es_init_max_streams_bidi = 100` one connection can pin about 3 GB of server heap for about 1 KB on the wire. The 128 KB cap keeps the `Bun.serve` worst case at about 12.8 MB per connection.

Exceeding the cap is still connection-fatal (same as before, at a higher threshold). Making it a per-stream reset per RFC 9114 §4.2.2 needs an lsquic patch: `NULL` from `hsi_prepare_decode` and any nonzero from `hsi_process_header` both end up in `ci_abort_error` via `qdh_header_read_results` / `qdh_hsi_process_wrapper` / `lsquic_stream.c`'s `HQFI_FLAG_ERROR` path. That and wiring a per-server `maxHeaderSize` through to the `Bun.serve` hook are tracked alongside the `node:quic` follow-ups in #35741.

## Verification

New case in `test/js/bun/http/serve-http3.test.ts` sends a 60 KB `x-big` header, asserts the handler receives the full value, and asserts a second request on the pooled session still succeeds.

Before: fetch rejects with `HTTP3StreamReset` (server never invokes the handler).
After: status 200, `x-big.length === 60000`, follow-up request served.

`test/js/bun/http/serve-http3.test.ts`, `test/js/node/quic/*`, and `test/js/node/http2/h2-conformance.test.ts` all pass with the new struct layout. #35741's new `quic-stream.test.ts` large-header case (`maxHeaderLength: 1 << 20`, 60 KB value) also passes under the `nq_hsi_prepare_decode` cap.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.0 (a17a87587)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [3241.99ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [3149.54ms]
(pass) Bun.serve HTTP/3 > 204 with no body [3025.98ms]
(pass) Bun.serve HTTP/3 > query string is preserved [2732.22ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [2638.93ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [2692.87ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [2447.74ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [2326.26ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [3533.80ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [2192.95ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [2646.96ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [2347.71ms]
(pass) Bun.serve
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (907cc02b9)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [496.01ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [294.95ms]
(pass) Bun.serve HTTP/3 > 204 with no body [258.72ms]
(pass) Bun.serve HTTP/3 > query string is preserved [185.69ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [259.13ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [174.52ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [214.30ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [195.43ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1101.45ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [288.56ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [213.95ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [255.99ms]
(pass) Bun.serve HTTP/3 > routes: per-method handler [204.26ms]
(pass) Bun.serve HTTP/3 > routes: method-specific '/*' falls through to fetch() on other methods [268.88ms]
(pass) Bun.serve H
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.0 (a17a87587)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [3001.30ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [3175.47ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1970.31ms]
(pass) Bun.serve HTTP/3 > query string is preserved [2040.21ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1994.48ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [2029.77ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [2215.62ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [2469.19ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [3272.20ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [2150.82ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [2239.88ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [2057.89ms]
(pass) Bun.serve
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2484ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[2/5] cc obj/packages/bun-usockets/src/quic.c.o
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+a17a87587
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (a17a87587)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [355.43ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [204.45ms]
(pass) Bun.serve HTTP/3 > 204 with no body [200.99ms]
(pass) Bun.serve HTTP/3 > query string is preserved [167.65ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [169.20ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [186.31ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [186.01ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [206.47ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1093.05ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/node_quic_shim.c | 14 +++++++++++++-
 packages/bun-usockets/src/quic.c           | 24 ++++++++++++++++++++----
 packages/h3blast/Makefile                  |  4 ++++
 scripts/build/flags.ts                     | 13 +++++++++++++
 test/js/bun/http/serve-http3.test.ts       | 17 +++++++++++++++++
 5 files changed, 67 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-usockets/src/node_quic_shim.c      4      3      0
packages/bun-usockets/src/quic.c                6      6      0
packages/h3blast/Makefile                       2      3      0
scripts/build/flags.ts                          1      2      0
test/js/bun/http/serve-http3.test.ts            4      1      0
```

</details>

<!-- robobun:evidence:end -->