### PR TITLE
node:quic: key shared-client-endpoint reuse on engine-baked connect() options

### DIFF
--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -166,8 +166,8 @@ function ERR_QUIC_VERSION_NEGOTIATION_ERROR() {
   return $ERR_QUIC_VERSION_NEGOTIATION_ERROR("The QUIC session requires version negotiation");
 }
 
-const kClientHttp = Symbol("kClientHttp");
-const kNoteClientHttp = Symbol("kNoteClientHttp");
+const kClientEngineKey = Symbol("kClientEngineKey");
+const kNoteClientEngine = Symbol("kNoteClientEngine");
 
 const kSocketAddressHandle = Symbol("kSocketAddressHandle");
 Object.defineProperty(SocketAddress.prototype, kSocketAddressHandle, {
@@ -3918,7 +3918,7 @@ class QuicEndpoint {
     busy: false,
     isPendingClose: false,
     listening: false,
-    clientHttp: undefined,
+    clientEngineKey: undefined,
     pendingClose: PromiseWithResolvers(),
     pendingError: undefined,
     sessions: new SafeSet(),
@@ -4394,12 +4394,12 @@ class QuicEndpoint {
     return this.#inner.listening;
   }
 
-  get [kClientHttp]() {
-    return this.#inner.clientHttp;
+  get [kClientEngineKey]() {
+    return this.#inner.clientEngineKey;
   }
 
-  [kNoteClientHttp](wantHttp) {
-    this.#inner.clientHttp ??= wantHttp;
+  [kNoteClientEngine](key) {
+    this.#inner.clientEngineKey ??= key;
   }
 
   /** @type {boolean} */
@@ -4606,11 +4606,43 @@ function alpnWantsHttp(alpn) {
   return typeof first !== "string" || first === "h3" || StringPrototypeStartsWith(first, "h3-");
 }
 
-function findSuitableEndpoint(wantHttp) {
+/**
+ * lsquic bakes these into the per-engine settings at `build_engine` time
+ * (src/runtime/node/quic/endpoint.rs), so a shared client endpoint is only
+ * reusable when a later connect()'s values match the first. keepAlive,
+ * maxIdleTimeout and preferredAddressPolicy are re-applied per connect()
+ * there and so stay out of this key.
+ * @param {boolean} wantHttp
+ * @param {*} handshakeTimeout
+ * @param {object} tp transportParams
+ * @param {object} app normalized application options
+ * @returns {string}
+ */
+function clientEngineKey(wantHttp, handshakeTimeout, tp, app) {
+  return (
+    `${wantHttp ? "h" : "r"}` +
+    `|${handshakeTimeout}` +
+    `|${tp.initialMaxStreamDataBidiLocal}` +
+    `|${tp.initialMaxStreamDataBidiRemote}` +
+    `|${tp.initialMaxStreamDataUni}` +
+    `|${tp.initialMaxData}` +
+    `|${tp.initialMaxStreamsBidi}` +
+    `|${tp.initialMaxStreamsUni}` +
+    `|${tp.maxUdpPayloadSize}` +
+    `|${tp.disableActiveMigration}` +
+    `|${tp.maxDatagramFrameSize}` +
+    `|${app.maxHeaderPairs}` +
+    `|${app.maxHeaderLength}` +
+    `|${app.enableConnectProtocol}` +
+    `|${app.enableDatagrams}`
+  );
+}
+
+function findSuitableEndpoint(engineKey) {
   for (const endpoint of endpointRegistry) {
     if (!endpoint.destroyed && !endpoint.closing && !endpoint.busy) {
-      const mode = endpoint[kClientHttp];
-      if (mode !== undefined && mode !== wantHttp) {
+      const key = endpoint[kClientEngineKey];
+      if (key !== undefined && key !== engineKey) {
         continue;
       }
       if (endpoint.listening) {
@@ -4628,7 +4660,7 @@ function findSuitableEndpoint(wantHttp) {
  * @param {boolean} forServer
  * @returns {QuicEndpoint}
  */
-function processEndpointOption(endpoint, reuseEndpoint = true, forServer = false, wantHttp = true) {
+function processEndpointOption(endpoint, reuseEndpoint, forServer, engineKey) {
   if (isQuicEndpoint(endpoint)) {
     return endpoint;
   }
@@ -4636,7 +4668,7 @@ function processEndpointOption(endpoint, reuseEndpoint = true, forServer = false
     return new QuicEndpoint(endpoint);
   }
   if (reuseEndpoint && !forServer) {
-    const existing = findSuitableEndpoint(wantHttp);
+    const existing = findSuitableEndpoint(engineKey);
     if (existing !== undefined) return existing;
   }
   return new QuicEndpoint();
@@ -5028,9 +5060,6 @@ function processSessionOptions(options, config = kEmptyObject) {
     }
   }
 
-  const wantHttp = forServer || alpnWantsHttp(options.alpn);
-  const actualEndpoint = processEndpointOption(endpoint, reuseEndpoint, forServer, wantHttp);
-
   // Normalize into the shape Node stores and returns from `session.applicationOptions`.
   const {
     maxHeaderPairs = 128n,
@@ -5042,6 +5071,23 @@ function processSessionOptions(options, config = kEmptyObject) {
     enableConnectProtocol = false,
     enableDatagrams = true,
   } = application;
+  const normalizedApplication = {
+    __proto__: null,
+    maxHeaderPairs: BigInt(maxHeaderPairs),
+    maxHeaderLength: BigInt(maxHeaderLength),
+    maxFieldSectionSize: BigInt(maxFieldSectionSize),
+    qpackMaxDtableCapacity: BigInt(qpackMaxDTableCapacity),
+    qpackEncoderMaxDtableCapacity: BigInt(qpackEncoderMaxDTableCapacity),
+    qpackBlockedStreams: BigInt(qpackBlockedStreams),
+    enableConnectProtocol: !!enableConnectProtocol,
+    enableDatagrams: !!enableDatagrams,
+  };
+
+  const engineKey = forServer
+    ? undefined
+    : clientEngineKey(alpnWantsHttp(options.alpn), handshakeTimeout, transportParams, normalizedApplication);
+  const actualEndpoint = processEndpointOption(endpoint, reuseEndpoint, forServer, engineKey);
+
   if (sessionTicket !== undefined) {
     if (!isArrayBufferView(sessionTicket)) {
       throw new ERR_INVALID_ARG_TYPE("options.sessionTicket", ["ArrayBufferView"], sessionTicket);
@@ -5061,21 +5107,10 @@ function processSessionOptions(options, config = kEmptyObject) {
     }
   }
 
-  const normalizedApplication = {
-    __proto__: null,
-    maxHeaderPairs: BigInt(maxHeaderPairs),
-    maxHeaderLength: BigInt(maxHeaderLength),
-    maxFieldSectionSize: BigInt(maxFieldSectionSize),
-    qpackMaxDtableCapacity: BigInt(qpackMaxDTableCapacity),
-    qpackEncoderMaxDtableCapacity: BigInt(qpackEncoderMaxDTableCapacity),
-    qpackBlockedStreams: BigInt(qpackBlockedStreams),
-    enableConnectProtocol: !!enableConnectProtocol,
-    enableDatagrams: !!enableDatagrams,
-  };
-
   return {
     __proto__: null,
     endpoint: actualEndpoint,
+    engineKey,
     version,
     minVersion,
     preferredAddressPolicy: getPreferredAddressPolicy(preferredAddressPolicy),
@@ -5134,7 +5169,7 @@ function processSessionOptions(options, config = kEmptyObject) {
  */
 async function listen(callback, options = kEmptyObject) {
   validateFunction(callback, "callback");
-  const { endpoint, ...sessionOptions } = processSessionOptions(options, { forServer: true });
+  const { endpoint, engineKey: _, ...sessionOptions } = processSessionOptions(options, { forServer: true });
   endpoint[kListen](callback, sessionOptions);
 
   if (onEndpointListeningChannel.hasSubscribers) {
@@ -5165,7 +5200,7 @@ async function connect(address, options = kEmptyObject) {
     address = new SocketAddress(address);
   }
 
-  const { endpoint, ...rest } = processSessionOptions(options);
+  const { endpoint, engineKey, ...rest } = processSessionOptions(options);
 
   if (onEndpointConnectChannel.hasSubscribers) {
     onEndpointConnectChannel.publish({
@@ -5178,7 +5213,7 @@ async function connect(address, options = kEmptyObject) {
 
   const session = endpoint[kConnect](address[kSocketAddressHandle], rest);
 
-  endpoint[kNoteClientHttp](alpnWantsHttp(options.alpn));
+  endpoint[kNoteClientEngine](engineKey);
 
   if (onEndpointClientSessionChannel.hasSubscribers) {
     onEndpointClientSessionChannel.publish({

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -4607,19 +4607,9 @@ function alpnWantsHttp(alpn) {
 }
 
 /**
- * lsquic bakes these into the per-engine settings at `build_engine` time
- * (src/runtime/node/quic/endpoint.rs), so a shared client endpoint is only
- * reusable when a later connect()'s values match the first. keepAlive and
- * preferredAddressPolicy are applied per conn there and so stay out of this
- * key. maxIdleTimeout is re-applied via `lsquic_engine_set_idle_timeout_ms`
- * but that mutates the shared settings a conn reads through a pointer at
- * handshake_ok, so it belongs in the key too.
- * @param {boolean} wantHttp
- * @param {*} handshakeTimeout
- * @param {*} cc
- * @param {object} tp transportParams
- * @param {object} app normalized application options
- * @returns {string}
+ * Every option `build_engine` (src/runtime/node/quic/endpoint.rs) bakes into
+ * lsquic's per-engine settings. Only keepAlive and preferredAddressPolicy are
+ * applied per conn there and so stay out of this key.
  */
 function clientEngineKey(wantHttp, handshakeTimeout, cc, tp, app) {
   return (

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -5206,9 +5206,7 @@ async function connect(address, options = kEmptyObject) {
     });
   }
 
-  // Stamp before kConnect: the native side may build_engine and then throw,
-  // leaving a baked engine on an endpoint whose key would otherwise stay
-  // undefined and so match any later connect().
+  // Before kConnect: build_engine may run and then throw, leaving a baked engine whose key must already be set.
   endpoint[kNoteClientEngine](engineKey);
 
   const session = endpoint[kConnect](address[kSocketAddressHandle], rest);

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -4609,25 +4609,30 @@ function alpnWantsHttp(alpn) {
 /**
  * lsquic bakes these into the per-engine settings at `build_engine` time
  * (src/runtime/node/quic/endpoint.rs), so a shared client endpoint is only
- * reusable when a later connect()'s values match the first. keepAlive,
- * maxIdleTimeout and preferredAddressPolicy are re-applied per connect()
- * there and so stay out of this key.
+ * reusable when a later connect()'s values match the first. keepAlive and
+ * preferredAddressPolicy are applied per conn there and so stay out of this
+ * key. maxIdleTimeout is re-applied via `lsquic_engine_set_idle_timeout_ms`
+ * but that mutates the shared settings a conn reads through a pointer at
+ * handshake_ok, so it belongs in the key too.
  * @param {boolean} wantHttp
  * @param {*} handshakeTimeout
+ * @param {*} cc
  * @param {object} tp transportParams
  * @param {object} app normalized application options
  * @returns {string}
  */
-function clientEngineKey(wantHttp, handshakeTimeout, tp, app) {
+function clientEngineKey(wantHttp, handshakeTimeout, cc, tp, app) {
   return (
     `${wantHttp ? "h" : "r"}` +
     `|${handshakeTimeout}` +
+    `|${cc}` +
     `|${tp.initialMaxStreamDataBidiLocal}` +
     `|${tp.initialMaxStreamDataBidiRemote}` +
     `|${tp.initialMaxStreamDataUni}` +
     `|${tp.initialMaxData}` +
     `|${tp.initialMaxStreamsBidi}` +
     `|${tp.initialMaxStreamsUni}` +
+    `|${tp.maxIdleTimeout}` +
     `|${tp.maxUdpPayloadSize}` +
     `|${tp.disableActiveMigration}` +
     `|${tp.maxDatagramFrameSize}` +
@@ -5085,7 +5090,7 @@ function processSessionOptions(options, config = kEmptyObject) {
 
   const engineKey = forServer
     ? undefined
-    : clientEngineKey(alpnWantsHttp(options.alpn), handshakeTimeout, transportParams, normalizedApplication);
+    : clientEngineKey(alpnWantsHttp(options.alpn), handshakeTimeout, cc, transportParams, normalizedApplication);
   const actualEndpoint = processEndpointOption(endpoint, reuseEndpoint, forServer, engineKey);
 
   if (sessionTicket !== undefined) {

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -5206,9 +5206,12 @@ async function connect(address, options = kEmptyObject) {
     });
   }
 
-  const session = endpoint[kConnect](address[kSocketAddressHandle], rest);
-
+  // Stamp before kConnect: the native side may build_engine and then throw,
+  // leaving a baked engine on an endpoint whose key would otherwise stay
+  // undefined and so match any later connect().
   endpoint[kNoteClientEngine](engineKey);
+
+  const session = endpoint[kConnect](address[kSocketAddressHandle], rest);
 
   if (onEndpointClientSessionChannel.hasSubscribers) {
     onEndpointClientSessionChannel.publish({

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -129,6 +129,69 @@ describe("node:quic under --isolate", () => {
   }, 30000);
 });
 
+// lsquic also bakes application/transport-param settings into the per-engine
+// config at build_engine time, so a shared client endpoint whose engine was
+// built for one connect()'s options cannot honour a later connect()'s. Node
+// applies these per session, so default reuse must be keyed on them too; a
+// subprocess keeps the endpoint registry clean of this file's other tests.
+describe("default connect() endpoint reuse", () => {
+  test("per-session engine options apply on a later connect() with different values", async () => {
+    const fixture = `
+      import { connect, listen } from "node:quic";
+      import { createPrivateKey } from "node:crypto";
+      import { readFileSync } from "node:fs";
+      const key = createPrivateKey(readFileSync(${JSON.stringify(join(keysDir, "agent1-key.pem"))}));
+      const cert = readFileSync(${JSON.stringify(join(keysDir, "agent1-cert.pem"))});
+      const server = await listen(async s => { await s.closed.catch(() => {}); }, {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 3 },
+      });
+      async function dial(opts) {
+        const c = await connect(server.address, {
+          servername: "localhost", verifyPeer: "manual",
+          transportParams: { maxIdleTimeout: 3 }, ...opts,
+        });
+        c.closed.catch(() => {});
+        await c.opened;
+        const tp = c.localTransportParams;
+        const ep = c.endpoint;
+        c.close();
+        return { tp, ep };
+      }
+      const a = await dial({ transportParams: { maxIdleTimeout: 3, initialMaxStreamsBidi: 10 } });
+      const b = await dial({ transportParams: { maxIdleTimeout: 3, initialMaxStreamsBidi: 50 } });
+      const c = await dial({ transportParams: { maxIdleTimeout: 3, initialMaxStreamsBidi: 50 } });
+      const d = await dial({ application: { maxHeaderPairs: 1024 } });
+      const e = await dial({});
+      console.log(JSON.stringify({
+        a_eq_b: a.ep === b.ep,
+        b_eq_c: b.ep === c.ep,
+        d_eq_e: d.ep === e.ep,
+        a_streams: String(a.tp.initialMaxStreamsBidi),
+        b_streams: String(b.tp.initialMaxStreamsBidi),
+      }));
+      server.destroy();
+      await a.ep?.close?.(); await b.ep?.close?.(); await d.ep?.close?.(); await e.ep?.close?.();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr.includes("ERR_") ? stderr : "").toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      a_eq_b: false,
+      b_eq_c: true,
+      d_eq_e: false,
+      a_streams: "10",
+      b_streams: "50",
+    });
+    expect(exitCode).toBe(0);
+  }, 30000);
+});
+
 // An endpoint that both listens and dials keeps two lsquic engines on one
 // socket. A 1-RTT packet for the client leg that also reaches the server
 // engine misses its conns_hash, and the server engine answers unknown packets

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -163,15 +163,17 @@ describe("default connect() endpoint reuse", () => {
       const c = await dial({ transportParams: { maxIdleTimeout: 3, initialMaxStreamsBidi: 50 } });
       const d = await dial({ application: { maxHeaderPairs: 1024 } });
       const e = await dial({});
+      const f = await dial({ cc: "bbr" });
       console.log(JSON.stringify({
         a_eq_b: a.ep === b.ep,
         b_eq_c: b.ep === c.ep,
         d_eq_e: d.ep === e.ep,
+        e_eq_f: e.ep === f.ep,
         a_streams: String(a.tp.initialMaxStreamsBidi),
         b_streams: String(b.tp.initialMaxStreamsBidi),
       }));
       server.destroy();
-      await a.ep?.close?.(); await b.ep?.close?.(); await d.ep?.close?.(); await e.ep?.close?.();
+      for (const x of [a, b, d, e, f]) await x.ep?.close?.();
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
@@ -185,6 +187,7 @@ describe("default connect() endpoint reuse", () => {
       a_eq_b: false,
       b_eq_c: true,
       d_eq_e: false,
+      e_eq_f: false,
       a_streams: "10",
       b_streams: "50",
     });


### PR DESCRIPTION
## Problem

`connect()`'s default shared-client-endpoint reuse only keyed on HTTP/3-vs-raw ALPN. A second `connect()` in the same process with different `application`, `transportParams`, or `cc` options reused the first call's endpoint, whose lsquic client engine was already built, so the new options were silently dropped and the session ran with the first call's settings.

```js
const a = await connect(addr, { transportParams: { initialMaxStreamsBidi: 10 } });
const b = await connect(addr, { transportParams: { initialMaxStreamsBidi: 50 } });
b.endpoint === a.endpoint;                        // true
b.localTransportParams.initialMaxStreamsBidi;     // 10n, not 50n
```

Observed while testing the outbound H3 header cap: a later `connect()` with `application: { maxHeaderPairs: 1024 }` still decoded at most 128 response headers because an earlier default `connect()` in the same process had already built the engine at 128.

## Cause

`src/runtime/node/quic/endpoint.rs` `connect()` builds the lsquic client engine only once per endpoint; subsequent connects swap the TLS context but leave the engine settings (`es_max_h3_header_pairs`, `es_init_max_*`, `es_cc_algo`, `es_handshake_to`, H3 datagram/CONNECT, etc.) as first built. `findSuitableEndpoint` in `src/js/internal/quic/quic.ts` returned the first open non-listening endpoint whose ALPN mode matched, ignoring every other engine-baked option.

## Fix

Node applies these per session, so default reuse now keys on the full set of options `build_engine` reads: ALPN mode, `handshakeTimeout`, `cc`, the `transportParams` fields (`initialMaxStreamData*`, `initialMaxData`, `initialMaxStreams*`, `maxIdleTimeout`, `maxUdpPayloadSize`, `disableActiveMigration`, `maxDatagramFrameSize`), and the `application` fields (`maxHeaderPairs`, `maxHeaderLength`, `enableConnectProtocol`, `enableDatagrams`). Only `keepAlive` and `preferredAddressPolicy` are applied per conn in the Rust layer and stay out of the key. `maxIdleTimeout` is included despite the per-connect `lsquic_engine_set_idle_timeout_ms` call: that mutates the engine-wide settings a conn re-reads at `handshake_ok`, so a concurrent second connect would otherwise clobber the first session's effective idle timeout.

Matching options still pool onto one endpoint; differing ones get a fresh endpoint whose engine honours them. An explicit `endpoint` argument is untouched and keeps the existing ERR_INVALID_STATE on ALPN-mode mismatch.

## Verification

New test in `test/js/node/quic/quic-endpoint.test.ts` runs six connects in a subprocess and asserts (a) differing `initialMaxStreamsBidi` / `application.maxHeaderPairs` / `cc` land on distinct endpoints, (b) identical options still share one, and (c) `localTransportParams.initialMaxStreamsBidi` reports the requested value on the second session. Without the fix it reports the first session's value and all sessions share one endpoint. The 232 previously-passing `test/js/node/test/parallel/test-quic-*.mjs` stay passing.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-endpoint.test.ts
bun test v1.4.0 (48689dc6d)

test/js/node/quic/quic-endpoint.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [345.16ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [84.71ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [5105.04ms]
181 |       stdout: "pipe",
182 |       stderr: "pipe",
183 |     });
184 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
185 |     expect(stderr.includes("ERR_") ? stderr : "").toBe("");
186 |     expect(JSON.parse(stdout.trim())).toEqual({
                                            ^
error: expect(received).toEqual(expected)

  {
-   "a_eq_b": false,
+   "a_eq_b": true,
    "a_streams": "10",
    "b_eq_c": true,
-   "b_streams": "50",
- 
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/quic/quic-endpoint.test.ts:

# Unhandled error between tests
-------------------------------
9 | import { connect, listen, QuicEndpoint } from "node:quic";
                                                  ^
error: Could not resolve: "node:quic". Maybe you need to "bun install"?
    at /workspace/bun/test/js/node/quic/quic-endpoint.test.ts:9:47
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [227.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-endpoint.test.ts
bun test v1.4.0 (48689dc6d)

test/js/node/quic/quic-endpoint.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [542.45ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [118.52ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [6072.62ms]
(pass) default connect() endpoint reuse > per-session engine options apply on a later connect() with different values [2720.67ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [283.52ms]
(pass) transportParams.maxIdleTimeout > 0 disables the idle timeout instead of falling back to the default [190.88ms]
(pass) endpoint.close() while a session is live > stops accepting new sessions so closed can resolve [227.14ms]

 7 pass
 0 fail
 1 snapshots, 14 expect() calls
Ran 7 tests
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     48689dc6d0
  features     baseline

22 deps, 108 codegen, 1171 objects in 2589ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch tinycc
[tinycc] up to date
[2/1234] fetch zlib
[zlib] up to date
[3/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1234] gen bindgenv2
[5/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[6/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[9/1234] subst deps/zlib/zlib.h
[10/1234] subst deps/zlib/zconf.h
[11/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[12/1234] fetch zstd

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/quic/quic.ts            | 93 ++++++++++++++++++++++-----------
 test/js/node/quic/quic-endpoint.test.ts | 66 +++++++++++++++++++++++
 2 files changed, 128 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js/internal/quic/quic.ts                13     16      0
test/js/node/quic/quic-endpoint.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->