### PR TITLE
verify-baseline: allowlist UCRT strspn-family jump-table false positives on windows x64

### DIFF
--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -830,7 +830,7 @@ __std_minmax_8i                                                                 
 
 # ----------------------------------------------------------------------------
 # MSVC CRT libm + mem*/str* SIMD variants. Gate: __isa_available.
-# (45 symbols)
+# (44 symbols)
 # ----------------------------------------------------------------------------
 __remainder_piby2_fma3      [AVX, FMA]
 __remainder_piby2_fma3_bdl  [AVX, FMA]
@@ -873,13 +873,39 @@ sinf                        [AVX, FMA]
 sinh_fma                    [AVX, FMA]
 sinhf_fma                   [AVX, FMA]
 strnlen                     [AVX, AVX2]
-strpbrk                     [AVX, AVX2]   # UCRT vectorized str routine, runtime-gated on __isa_available
 tan                         [AVX, FMA]
 tanf                        [AVX, FMA]
 tanh_fma                    [AVX, FMA]
 tanhf_fma                   [AVX, FMA]
 wcslen                      [AVX, AVX2]
 wcsnlen                     [AVX, AVX2]
+
+
+# ----------------------------------------------------------------------------
+# MSVC CRT strspn/strcspn/strpbrk. Data-in-.text false positive, NOT a gate.
+#
+# Windows SDK source at ucrt/string/amd64/strspn.c (all three functions share
+# it) is plain SSE2 with three 16-way `switch (shift)` statements over
+# pslldq/psrldq immediates. MSVC lays each switch's jump table in .text right
+# after the function's ret. The 4-byte entries are image-relative RVAs of the
+# case handlers (read via `mov r, [base + 4*idx + OFF]; add r, base; jmp r`),
+# so their low bytes vary with link layout. The linear sweep falls into the
+# table and, depending on where a given case handler landed, can decode a
+# stray VEX (AVX/AVX2) or RTM opcode out of one entry:
+#
+#   build 80916, strcspn @0x14386f9e0: bytes `c7 f8 86 03 ce f8` are two
+#   consecutive table entries (RVAs 0x0386f8c7 / 0x0386f8ce → the `pslldq
+#   xmm2, 13/14` cases) that iced decodes as `xbegin rel32`. strpbrk has
+#   previously been flagged as `xabort imm8` (C6 F8 ib) for the same reason.
+#
+# There is no __isa_available dispatch in this file; the SSE2 path is taken
+# unconditionally and is baseline-safe. Ceiling covers the encodings observed
+# so far; a multi-feature hit here would still warrant a look.
+# (3 symbols)
+# ----------------------------------------------------------------------------
+strspn   [AVX, AVX2, RTM]
+strcspn  [AVX, AVX2, RTM]
+strpbrk  [AVX, AVX2, RTM]
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
The windows x64 static baseline scan intermittently flags one of the UCRT's `strspn` / `strcspn` / `strpbrk` as containing a single post-Nehalem instruction. Most recently on builds 80748, 80916, 80917, 80976, 80977:

```
strcspn  [RTM]  (1 insns)
    0x014386f9e0  Xbegin  (RTM)
```

These are data-in-.text false positives, not real instructions, and not a CPUID gate.

### Why it is a false positive

The Windows SDK source at `ucrt/string/amd64/strspn.c` (shared by all three functions via `#define SSTRCSPN` / `#define SSTRPBRK`) is plain SSE2: a `_mm_loadu_si128` / `_mm_cmpeq_epi8` scan with three 16-way `switch (shift)` statements over `pslldq`/`psrldq` immediates. There is no `__isa_available` dispatch in this file; the SSE2 path runs unconditionally and is baseline-safe.

MSVC lays each switch's jump table in `.text` right after the function body's `ret`. The 4-byte entries are image-relative RVAs of the case handlers (read via `mov r, [base + 4*idx + OFF]; add r, base; jmp r`), so their low bytes change every time the link layout moves `strcspn`. The linear-sweep decoder falls into the table and, depending on where a given case handler landed, can decode a stray VEX or RTM opcode out of one entry.

Disassembling build 80916's `bun-profile.exe` at the flagged address confirms it:

```
14386f931: c3                  ret              ; end of code
14386f932: 66 90               nop
14386f934: 69 f6 86 03 ...                      ; jump tables start
...
14386f9e0: c7 f8 86 03 ce f8   xbegin ...       ; <-- flagged
```

The bytes `c7 f8 86 03 ce f8` are two consecutive table entries, RVAs `0x0386f8c7` / `0x0386f8ce`, pointing at the `pslldq xmm2, 13` / `pslldq xmm2, 14` case labels. When a handler happens to land at an RVA whose little-endian encoding starts `c7 f8`, iced decodes it as `xbegin rel32`; `c6 f8` reads as `xabort imm8` (previously seen on `strpbrk`); a VEX-shaped prefix reads as an AVX op (the original `strpbrk [AVX, AVX2]` entry). Only a minority of link layouts hit one of those patterns, which is why this fails on some PR builds and not on main.

### Fix

Move `strpbrk` out of the `__isa_available`-gated CRT block (its comment was wrong: no such gate exists in `strspn.c`) into a new "Data-in-.text false positive" block that documents the jump-table mechanism, and add `strspn` / `strcspn` alongside it with a `[AVX, AVX2, RTM]` ceiling covering the encodings observed so far.

### Verification

Ran the built scanner against two CI artifacts with the updated allowlist:

- build 80916 (previously failing): `strcspn [RTM]` now suppressed, 0 violations, PASS
- build 80215 (main, previously passing): 0 violations, PASS (all three entries stale)

The same job's Intel SDE Nehalem emulation step already exercises `strcspn` in-process and passes.