### PR TITLE
cli: refuse to start for unsupported Node.js security flags

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -307,11 +307,7 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--trace-exit"),
     parse_param!("--expose-internals"),
     parse_param!("--stack-trace-limit <STR>"),
-    // Node.js security-sensitive flags that Bun does not implement. Declaring
-    // them makes the parser consume the flag (and its value for the
-    // value-taking ones) so `reject_unsupported_security_flags` can refuse to
-    // start instead of running the application without the requested
-    // restriction. Hidden from `--help`.
+    // Node.js security flags Bun does not implement; see `reject_unsupported_security_flags`.
     parse_param!("--enable-fips"),
     parse_param!("--force-fips"),
     parse_param!("--tls-cipher-list <STR>"),
@@ -337,12 +333,7 @@ enum SecurityFlagKind {
     NodeLoader,
 }
 
-/// Node.js flags that restrict or harden runtime behavior which Bun does not
-/// implement. Accepting any of these silently would run the application
-/// *without* the restriction the caller asked for (FIPS, cipher pinning,
-/// loader hooks, permission model, ...), so they are refused at startup.
-/// Keep each entry's [`SecurityFlagKind`] in step with its `parse_param!`
-/// declaration in [`RUNTIME_PARAMS_`].
+/// Node.js hardening flags Bun refuses rather than ignores (fail-closed). Keep kinds in step with [`RUNTIME_PARAMS_`].
 const UNSUPPORTED_SECURITY_FLAGS: &[(&[u8], SecurityFlagKind)] = &[
     (b"--enable-fips", SecurityFlagKind::Flag),
     (b"--force-fips", SecurityFlagKind::Flag),
@@ -364,8 +355,7 @@ const UNSUPPORTED_SECURITY_FLAGS: &[(&[u8], SecurityFlagKind)] = &[
     (b"--experimental-permission", SecurityFlagKind::Flag),
 ];
 
-/// Refuse to start when any flag in [`UNSUPPORTED_SECURITY_FLAGS`] was passed.
-/// Exit code 9 matches Node's "invalid argument" code for a bad CLI option.
+/// Exits 9 (Node's bad-option code) if any [`UNSUPPORTED_SECURITY_FLAGS`] entry was passed, so the caller's hardening request fails closed instead of running unrestricted.
 fn reject_unsupported_security_flags(args: &clap::Args<clap::Help>, cmd: CommandTag) {
     for &(name, kind) in UNSUPPORTED_SECURITY_FLAGS {
         let present = match kind {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -307,7 +307,85 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--trace-exit"),
     parse_param!("--expose-internals"),
     parse_param!("--stack-trace-limit <STR>"),
+    // Node.js security-sensitive flags that Bun does not implement. Declaring
+    // them makes the parser consume the flag (and its value for the
+    // value-taking ones) so `reject_unsupported_security_flags` can refuse to
+    // start instead of running the application without the requested
+    // restriction. Hidden from `--help`.
+    parse_param!("--enable-fips"),
+    parse_param!("--force-fips"),
+    parse_param!("--tls-cipher-list <STR>"),
+    parse_param!("--experimental-loader <STR>..."),
+    parse_param!("--policy <STR>"),
+    parse_param!("--experimental-policy <STR>"),
+    parse_param!("--experimental-config-file <STR>"),
+    parse_param!("--frozen-intrinsics"),
+    parse_param!("--disallow-code-generation-from-strings"),
+    parse_param!("--disable-proto <STR>"),
+    parse_param!("--secure-heap <STR>"),
+    parse_param!("--secure-heap-min <STR>"),
+    parse_param!("--permission"),
+    parse_param!("--experimental-permission"),
 ];
+
+#[derive(Copy, Clone)]
+enum SecurityFlagKind {
+    Flag,
+    Option,
+    Options,
+    /// `--loader` under `node` emulation only (Bun owns `--loader` otherwise).
+    NodeLoader,
+}
+
+/// Node.js flags that restrict or harden runtime behavior which Bun does not
+/// implement. Accepting any of these silently would run the application
+/// *without* the restriction the caller asked for (FIPS, cipher pinning,
+/// loader hooks, permission model, ...), so they are refused at startup.
+/// Keep each entry's [`SecurityFlagKind`] in step with its `parse_param!`
+/// declaration in [`RUNTIME_PARAMS_`].
+const UNSUPPORTED_SECURITY_FLAGS: &[(&[u8], SecurityFlagKind)] = &[
+    (b"--enable-fips", SecurityFlagKind::Flag),
+    (b"--force-fips", SecurityFlagKind::Flag),
+    (b"--tls-cipher-list", SecurityFlagKind::Option),
+    (b"--experimental-loader", SecurityFlagKind::Options),
+    (b"--loader", SecurityFlagKind::NodeLoader),
+    (b"--policy", SecurityFlagKind::Option),
+    (b"--experimental-policy", SecurityFlagKind::Option),
+    (b"--experimental-config-file", SecurityFlagKind::Option),
+    (b"--frozen-intrinsics", SecurityFlagKind::Flag),
+    (
+        b"--disallow-code-generation-from-strings",
+        SecurityFlagKind::Flag,
+    ),
+    (b"--disable-proto", SecurityFlagKind::Option),
+    (b"--secure-heap", SecurityFlagKind::Option),
+    (b"--secure-heap-min", SecurityFlagKind::Option),
+    (b"--permission", SecurityFlagKind::Flag),
+    (b"--experimental-permission", SecurityFlagKind::Flag),
+];
+
+/// Refuse to start when any flag in [`UNSUPPORTED_SECURITY_FLAGS`] was passed.
+/// Exit code 9 matches Node's "invalid argument" code for a bad CLI option.
+#[cold]
+fn reject_unsupported_security_flags(args: &clap::Args<clap::Help>, cmd: CommandTag) {
+    for &(name, kind) in UNSUPPORTED_SECURITY_FLAGS {
+        let present = match kind {
+            SecurityFlagKind::Flag => args.flag(name),
+            SecurityFlagKind::Option => args.option(name).is_some(),
+            SecurityFlagKind::Options => !args.options(name).is_empty(),
+            SecurityFlagKind::NodeLoader => {
+                cmd == CommandTag::RunAsNodeCommand && !args.options(b"--loader").is_empty()
+            }
+        };
+        if present {
+            Output::err_generic(
+                "{} is not supported in Bun. Refusing to start because silently ignoring it would run without the security restriction it requests.",
+                format_args!("{}", BStr::new(name)),
+            );
+            Global::exit(9);
+        }
+    }
+}
 
 pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
     parse_param!(
@@ -925,6 +1003,8 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             | CommandTag::TestCommand
             | CommandTag::RunAsNodeCommand
     ) {
+        reject_unsupported_security_flags(&args, cmd);
+
         {
             let preloads = args.options(b"--preload");
             let preloads2 = args.options(b"--require");

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -366,7 +366,6 @@ const UNSUPPORTED_SECURITY_FLAGS: &[(&[u8], SecurityFlagKind)] = &[
 
 /// Refuse to start when any flag in [`UNSUPPORTED_SECURITY_FLAGS`] was passed.
 /// Exit code 9 matches Node's "invalid argument" code for a bad CLI option.
-#[cold]
 fn reject_unsupported_security_flags(args: &clap::Args<clap::Help>, cmd: CommandTag) {
     for &(name, kind) in UNSUPPORTED_SECURITY_FLAGS {
         let present = match kind {
@@ -378,13 +377,19 @@ fn reject_unsupported_security_flags(args: &clap::Args<clap::Help>, cmd: Command
             }
         };
         if present {
-            Output::err_generic(
-                "{} is not supported in Bun. Refusing to start because silently ignoring it would run without the security restriction it requests.",
-                format_args!("{}", BStr::new(name)),
-            );
-            Global::exit(9);
+            refuse_security_flag(name);
         }
     }
+}
+
+#[cold]
+#[inline(never)]
+fn refuse_security_flag(name: &[u8]) -> ! {
+    Output::err_generic(
+        "{} is not supported in Bun. Refusing to start because silently ignoring it would run without the security restriction it requests.",
+        format_args!("{}", BStr::new(name)),
+    );
+    Global::exit(9);
 }
 
 pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "path";
-import { bunEnv, bunExe, fakeNodeRun, tempDirWithFiles } from "../../harness";
+import { bunEnv, bunExe, fakeNodeRun, tempDir, tempDirWithFiles } from "../../harness";
 
 describe("fake node cli", () => {
   test("the node cli actually works", () => {
@@ -110,5 +110,109 @@ describe("fake node cli", () => {
     });
     expect(result.stderr.toString()).toContain("Missing script");
     expect(result.success).toBe(false);
+  });
+});
+
+describe("unsupported Node.js security flags are refused at startup", () => {
+  // Each of these flags asks for a security restriction Bun does not implement.
+  // Before this was fixed, Bun echoed the flag in process.execArgv and ran the
+  // application unrestricted; now it must refuse to start so the failure is
+  // visible instead of silent.
+  const cases: [flag: string, probe: string, failOpenMarker: string][] = [
+    ["--enable-fips", `"fips=" + require("crypto").getFips()`, "fips=0"],
+    ["--force-fips", `"fips=" + require("crypto").getFips()`, "fips=0"],
+    [
+      "--tls-cipher-list=ECDHE-RSA-AES128-GCM-SHA256",
+      `"ciphers=" + require("tls").DEFAULT_CIPHERS.split(":").length`,
+      "ciphers=19",
+    ],
+    ["--experimental-loader=./hooks.mjs", `"ran"`, "ran"],
+    ["--policy=./policy.json", `"ran"`, "ran"],
+    ["--experimental-policy=./policy.json", `"ran"`, "ran"],
+    ["--experimental-config-file=./node.config.json", `"ran"`, "ran"],
+    ["--frozen-intrinsics", `(Object.assign = 1, "assign=" + typeof Object.assign)`, "assign=number"],
+    ["--disallow-code-generation-from-strings", `"eval=" + eval("1+1")`, "eval=2"],
+    ["--disable-proto=throw", `"proto=" + (({}).__proto__ !== undefined)`, "proto=true"],
+    ["--secure-heap=65536", `"ran"`, "ran"],
+    ["--secure-heap-min=4096", `"ran"`, "ran"],
+    ["--permission", `require("fs").readdirSync("."), "fs=allowed"`, "fs=allowed"],
+    ["--experimental-permission", `"ran"`, "ran"],
+  ];
+
+  async function run(cmd: string[], cwd: string) {
+    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  describe.each([
+    ["bun", (flag: string, app: string) => [bunExe(), flag, app]],
+    ["bun run", (flag: string, app: string) => [bunExe(), "run", flag, app]],
+    ["bun-as-node", (flag: string, app: string) => [bunExe(), "--bun", "node", flag, app]],
+  ] as const)("%s", (_, cmd) => {
+    test.concurrent.each(cases)("%s refuses to start", async (flag, probe, failOpenMarker) => {
+      const flagName = flag.split("=")[0];
+      using dir = tempDir("security-flag", {
+        "app.mjs": `console.log(${probe}, JSON.stringify(process.execArgv));`,
+        "hooks.mjs": `throw new Error("loader hooks file should not have been executed as the entrypoint");`,
+      });
+      const { stdout, stderr, exitCode } = await run(cmd(flag, "app.mjs"), String(dir));
+      // The application must not have started: no fail-open marker on stdout,
+      // and the flag must not appear in a printed execArgv receipt.
+      expect(stdout).not.toContain(failOpenMarker);
+      expect(stdout).not.toContain(flagName);
+      expect(stderr).toContain(`${flagName} is not supported in Bun`);
+      expect(exitCode).toBe(9);
+    });
+  });
+
+  test.concurrent("--experimental-loader <value> (space form) does not run the value as the entrypoint", async () => {
+    using dir = tempDir("security-flag", {
+      "hooks.mjs": `console.log("HOOKS_RAN");`,
+      "app.mjs": `console.log("APP_RAN");`,
+    });
+    const { stdout, stderr, exitCode } = await run(
+      [bunExe(), "--experimental-loader", "./hooks.mjs", "app.mjs"],
+      String(dir),
+    );
+    expect(stdout).not.toContain("HOOKS_RAN");
+    expect(stdout).not.toContain("APP_RAN");
+    expect(stderr).toContain("--experimental-loader is not supported in Bun");
+    expect(exitCode).toBe(9);
+  });
+
+  test.concurrent("bun-as-node --loader=./hooks.mjs is refused (Node's loader, not Bun's)", async () => {
+    using dir = tempDir("security-flag", {
+      "hooks.mjs": `throw new Error("should not run");`,
+      "app.mjs": `console.log("APP_RAN");`,
+    });
+    const { stdout, stderr, exitCode } = await run(
+      [bunExe(), "--bun", "node", "--loader=./hooks.mjs", "app.mjs"],
+      String(dir),
+    );
+    expect(stdout).not.toContain("APP_RAN");
+    expect(stderr).toContain("--loader is not supported in Bun");
+    expect(exitCode).toBe(9);
+  });
+
+  test.concurrent("bun --loader .ext:loader (Bun's own option) is still accepted", async () => {
+    using dir = tempDir("security-flag", {
+      "data.xyz": `hello`,
+      "app.mjs": `import data from "./data.xyz"; console.log("text=" + data);`,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "--loader", ".xyz:text", "app.mjs"], String(dir));
+    expect(stderr).not.toContain("is not supported in Bun");
+    expect(stdout.trim()).toBe("text=hello");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("flags Bun does implement still work", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      [bunExe(), "--zero-fill-buffers", "--no-addons", "--tls-min-v1.2", "-e", `console.log("ok")`],
+      process.cwd(),
+    );
+    expect(stderr).not.toContain("is not supported in Bun");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -139,24 +139,29 @@ describe("unsupported Node.js security flags are refused at startup", () => {
     ["--experimental-permission", `"ran"`, "ran"],
   ];
 
-  async function run(cmd: string[], cwd: string) {
-    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
+  async function run(cmd: string[], cwd: string, env: Record<string, string | undefined> = {}) {
+    await using proc = Bun.spawn({ cmd, env: { ...bunEnv, ...env }, cwd, stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stdout, stderr, exitCode };
   }
 
+  type Invocation = (flag: string, app: string) => { cmd: string[]; env?: Record<string, string> };
   describe.each([
-    ["bun", (flag: string, app: string) => [bunExe(), flag, app]],
-    ["bun run", (flag: string, app: string) => [bunExe(), "run", flag, app]],
-    ["bun-as-node", (flag: string, app: string) => [bunExe(), "--bun", "node", flag, app]],
-  ] as const)("%s", (_, cmd) => {
+    ["bun", (flag, app) => ({ cmd: [bunExe(), flag, app] })],
+    ["bun run", (flag, app) => ({ cmd: [bunExe(), "run", flag, app] })],
+    ["bun-as-node", (flag, app) => ({ cmd: [bunExe(), "--bun", "node", flag, app] })],
+    ["bun test", (flag, app) => ({ cmd: [bunExe(), "test", flag, app] })],
+    ["BUN_OPTIONS", (flag, app) => ({ cmd: [bunExe(), app], env: { BUN_OPTIONS: flag } })],
+  ] satisfies [string, Invocation][])("%s", (label, inv) => {
     test.concurrent.each(cases)("%s refuses to start", async (flag, probe, failOpenMarker) => {
       const flagName = flag.split("=")[0];
       using dir = tempDir("security-flag", {
         "app.mjs": `console.log(${probe}, JSON.stringify(process.execArgv));`,
+        "app.test.mjs": `import {test} from "bun:test"; test("probe", () => console.log(${probe}, JSON.stringify(process.execArgv)));`,
         "hooks.mjs": `throw new Error("loader hooks file should not have been executed as the entrypoint");`,
       });
-      const { stdout, stderr, exitCode } = await run(cmd(flag, "app.mjs"), String(dir));
+      const { cmd, env } = inv(flag, label === "bun test" ? "app.test.mjs" : "app.mjs");
+      const { stdout, stderr, exitCode } = await run(cmd, String(dir), env);
       // The application must not have started: no fail-open marker on stdout,
       // and the flag must not appear in a printed execArgv receipt.
       expect(stdout).not.toContain(failOpenMarker);

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -177,6 +177,13 @@ if (process.argv.length === 2 &&
         // does not exist, so don't re-spawn just to pass the flag through.
         continue;
       }
+      if ((flag === "--permission" || flag === "--experimental-permission") && process.versions.bun) {
+        // Bun has no permission model and refuses to start with --permission
+        // rather than running unrestricted, so a test written to exercise
+        // permission-model behaviour cannot run meaningfully here.
+        console.log(`1..0 # Skipped: Bun does not implement ${flag}`);
+        process.exit(0);
+      }
       if (flag === "test") {
         process.env.SKIP_FLAG_CHECK = "1";
         break;


### PR DESCRIPTION
## Problem

Bun silently accepts a set of Node.js flags that request a security restriction it does not implement. The flag appears in `process.execArgv`, and the process runs without the restriction:

```console
$ bun --enable-fips -e 'console.log(require("crypto").getFips(), process.execArgv)'
0 [ "--enable-fips", ... ]            # node: process never starts (OpenSSL error, exit 1)

$ bun --tls-cipher-list=AES256-SHA -e 'console.log(require("tls").DEFAULT_CIPHERS.split(":").length)'
19                                      # node: 1 (exactly the requested cipher)

$ bun --permission -e 'require("fs").readdirSync("."); console.log("fs=allowed")'
fs=allowed                              # node: ERR_ACCESS_DENIED

$ bun --experimental-loader=./hooks.mjs app.mjs
# app runs; hooks never load. node runs the resolve/load hooks on every import.
```

Each is a fail-open: a caller hardening their deployment sees the flag echoed back and never learns the restriction was not applied.

## Cause

`StreamingClap::normal()` in `src/clap/streaming.rs` skips past any unrecognized `--long` flag and continues parsing. `process.execArgv` is rebuilt from raw `argv` in `node_process.rs`, so the skipped flag still shows up there.

## Fix

Declare the security-sensitive flag set in `RUNTIME_PARAMS_` (empty help text keeps them out of `--help`) so the parser consumes each flag and any value, then check for them at the top of the runtime-commands branch of `Arguments::parse` and exit 9 with an explicit error before any user code runs:

```
error: --enable-fips is not supported in Bun. Refusing to start because silently ignoring it would run without the security restriction it requests.
```

The set covered (`UNSUPPORTED_SECURITY_FLAGS` in `Arguments.rs`):

`--enable-fips`, `--force-fips`, `--tls-cipher-list`, `--experimental-loader`, `--loader` (under bun-as-node only; `bun`/`bun run` keep Bun's own `ext:loader` option), `--policy`, `--experimental-policy`, `--experimental-config-file`, `--frozen-intrinsics`, `--disallow-code-generation-from-strings`, `--disable-proto`, `--secure-heap`, `--secure-heap-min`, `--permission`, `--experimental-permission`.

Declaring the value-taking ones also fixes the space form (`bun --experimental-loader ./hooks.mjs app.mjs` previously ran `hooks.mjs` as the entrypoint).

Applies to `bun`, `bun run`, `bun test`, bun-as-node, and `BUN_OPTIONS`. Not applied to `NODE_OPTIONS` (Bun does not parse it into argv) `new Worker({ execArgv })` (separate parser that only reads `--no-addons`), or the underscore spellings Node also accepts (`--enable_fips` etc.; Bun's parser has no `_`/`-` normalization for any flag). All left for follow-up.

## Overlap with open PRs

- #35766 implements `--disable-proto`, `--disallow-code-generation-from-strings`, and `--frozen-intrinsics`, and warns on `--secure-heap`. When that lands, those five entries (and their test rows) should be dropped from `UNSUPPORTED_SECURITY_FLAGS`; until then this PR keeps them failing closed on `main`.
- #35143 adds warn-once for unknown long flags on `run`/`test`, which covers the non-security tier.
- #34100 declares Node's other value-taking flags so their argument is not parsed as the entrypoint.

## Verification

`test/cli/run/as-node.test.ts` gains a parameterized block that, for each flag and for each of `bun`, `bun run`, and bun-as-node, asserts the application never prints its fail-open probe (`getFips()==0`, default cipher count, mutable `Object.assign`, filesystem reachable under `--permission`, etc.), stderr names the flag, and exit is 9. Also covers the space-form `--experimental-loader`, bun-as-node `--loader`, and two positives: Bun's own `--loader .ext:text` still works, and honored flags (`--zero-fill-buffers`, `--no-addons`, `--tls-min-v1.2`) are unaffected. 44/57 cases fail on the released binary; all 57 pass with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 72 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/as-node.test.ts
bun test v1.4.0 (01a31d5e0)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [904.97ms]
(pass) fake node cli > doesnt resolve bins [896.10ms]
(pass) fake node cli > doesnt resolve scripts [946.39ms]
(pass) fake node cli > can run a script named run.js [1083.41ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [823.14ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [713.49ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [889.37ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [759.59ms]
(pass) fake node cli > node -e  [714.74ms]
(pass) fake node cli > process args work [735.98ms]
(pass) fake node cli > no args with piped stdin errors with 'Missing script' [512.42ms]
162 |       });
163 |       const { cmd, env } = inv(flag, label === "bun test" ? "app.test.mjs" : "app.mjs");
164 |       const { stdout, stderr, exitCode } = await run(cm
... (truncated)

release without fix: 72 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [196.69ms]
(pass) fake node cli > doesnt resolve bins [103.38ms]
(pass) fake node cli > doesnt resolve scripts [134.91ms]
(pass) fake node cli > can run a script named run.js [92.68ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [75.54ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [86.74ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [41.58ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [75.35ms]
(pass) fake node cli > node -e  [40.27ms]
(pass) fake node cli > process args work [67.27ms]
(pass) fake node cli > no args with piped stdin errors with 'Missing script' [44.49ms]
162 |       });
163 |       const { cmd, env } = inv(flag, label === "bun test" ? "app.test.mjs" : "app.mjs");
164 |       const { stdout, stderr, exitCode } = await run(cmd, String(dir), env);
165 |       // The application must not have started: no fail-open marker on stdout,
166 |       // and the flag must not appear in a printe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/as-node.test.ts
bun test v1.4.0 (01a31d5e0)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [683.32ms]
(pass) fake node cli > doesnt resolve bins [542.68ms]
(pass) fake node cli > doesnt resolve scripts [895.10ms]
(pass) fake node cli > can run a script named run.js [482.25ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [529.99ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [446.04ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [623.03ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [473.57ms]
(pass) fake node cli > node -e  [519.37ms]
(pass) fake node cli > process args work [553.03ms]
(pass) fake node cli > no args with piped stdin errors with 'Missing script' [345.39ms]
(pass) unsupported Node.js security flags are refused at startup > bun > --tls-cipher-list=ECDHE-RSA-AES128-GCM-SHA256 refuses to start [298.83ms]
(pass) unsupported Node.js
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     01a31d5e0a
  features     baseline

22 deps, 108 codegen, 1171 objects in 3325ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch picohttpparser
[picohttpparser] up to date
[2/1234] fetch zlib
[zlib] up to date
[3/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1234] gen .bind.ts → GeneratedBindings.cpp
[5/1234] gen ErrorCode+*.h
[6/1234] gen bindgenv2
[7/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1234] subst deps/zlib/zconf.h
[9/1234] fetch tinycc
[tinycc] up to date
[10/1234] subst deps/zlib/zlib.h
[11/1234] subst deps/libjpeg-turbo/jconfig.h
[12/1234] subst deps/libjpeg-turbo/jconfigint.h
[13/1234] fetch brotli
[brotli] up to date
[14/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[15/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/Arguments.rs      |  75 ++++++++++++++++++++++++++
 test/cli/run/as-node.test.ts      | 111 +++++++++++++++++++++++++++++++++++++-
 test/js/node/test/common/index.js |   7 +++
 3 files changed, 192 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/cli/Arguments.rs           6      8      0
test/cli/run/as-node.test.ts           2      4      0
test/js/node/test/common/index.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->
