### PR TITLE
verify-baseline-static: treat RTM as data-in-.text; regroup CRT strspn-family allowlist

### DIFF
--- a/scripts/verify-baseline-static/CLAUDE.md
+++ b/scripts/verify-baseline-static/CLAUDE.md
@@ -269,5 +269,6 @@ See `src/main.rs:94-135` and `src/aarch64.rs`:
   SETSSBSY etc.) IS flagged — dedicated opcode slots that #UD on pre-CET.
 - **PACIASP/AUTIASP/BTI** (aarch64) — HINT-space, architecturally NOP on
   pre-PAC CPUs. (`LDRAA`/`LDRAB` are _not_ HINT-space and _are_ reported.)
-- **3DNow!, SMM, Cyrix, VIA** (x64) — no toolchain targeting x86-64 emits
-  these. When their `0f xx` encodings show up, it's data.
+- **3DNow!, SMM, Cyrix, VIA, RTM/TSX** (x64) — no toolchain targeting x86-64
+  emits these without explicit intrinsics. When their encodings show up
+  (`0f 0f` 3DNow!, `C7/C6 F8` XBEGIN/XABORT), it's data.

--- a/scripts/verify-baseline-static/README.md
+++ b/scripts/verify-baseline-static/README.md
@@ -67,8 +67,8 @@ the decoder reports it.
 extensions no toolchain targeting x86-64 emits without explicit intrinsics.
 Their encodings (`0f xx` for the defunct extensions, `C7/C6 F8` for
 XBEGIN/XABORT) surface when a jump table's bytes happen to line up; the MSVC
-CRT `strspn.asm` family's image-relative RVA tables are the observed source
-of the latter.
+CRT strspn/strcspn/strpbrk switch tables are the observed source of the
+latter.
 
 **Not filtered (very rare):** a table whose bytes form a valid
 VEX/EVEX-prefixed encoding. Looks like a real AVX hit. Triage the same way:

--- a/scripts/verify-baseline-static/README.md
+++ b/scripts/verify-baseline-static/README.md
@@ -63,10 +63,12 @@ after the function that uses them (LLVM puts them in `.rodata`, so ELF builds
 are typically clean). When those bytes form a valid instruction encoding,
 the decoder reports it.
 
-**Filtered automatically:** 3DNow!, SMM, Cyrix, VIA Padlock — ISA extensions
-no toolchain targeting x86-64 emits in any configuration. Their two-byte
-`0f xx` encodings tend to surface when a lookup table uses `0x0f` as a
-sentinel value.
+**Filtered automatically:** 3DNow!, SMM, Cyrix, VIA Padlock, RTM/TSX — ISA
+extensions no toolchain targeting x86-64 emits without explicit intrinsics.
+Their encodings (`0f xx` for the defunct extensions, `C7/C6 F8` for
+XBEGIN/XABORT) surface when a jump table's bytes happen to line up; the MSVC
+CRT `strspn.asm` family's image-relative RVA tables are the observed source
+of the latter.
 
 **Not filtered (very rare):** a table whose bytes form a valid
 VEX/EVEX-prefixed encoding. Looks like a real AVX hit. Triage the same way:

--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -830,7 +830,7 @@ __std_minmax_8i                                                                 
 
 # ----------------------------------------------------------------------------
 # MSVC CRT libm + mem*/str* SIMD variants. Gate: __isa_available.
-# (45 symbols)
+# (44 symbols)
 # ----------------------------------------------------------------------------
 __remainder_piby2_fma3      [AVX, FMA]
 __remainder_piby2_fma3_bdl  [AVX, FMA]
@@ -873,13 +873,31 @@ sinf                        [AVX, FMA]
 sinh_fma                    [AVX, FMA]
 sinhf_fma                   [AVX, FMA]
 strnlen                     [AVX, AVX2]
-strpbrk                     [AVX, AVX2]   # UCRT vectorized str routine, runtime-gated on __isa_available
 tan                         [AVX, FMA]
 tanf                        [AVX, FMA]
 tanh_fma                    [AVX, FMA]
 tanhf_fma                   [AVX, FMA]
 wcslen                      [AVX, AVX2]
 wcsnlen                     [AVX, AVX2]
+
+
+# ----------------------------------------------------------------------------
+# MSVC CRT strspn family. Data-in-.text false positive, NOT a gate.
+#
+# The UCRT's x64 strspn.asm (assembled once each for strspn/strcspn/strpbrk)
+# is SSE2-only; the psrldq/pslldq byte-shift ladder is dispatched through an
+# indirect `jmp *table[rbp + rax*4]` where the table is three arrays of 4-byte
+# image-relative RVAs stored in .text right after the function's `ret`. Those
+# RVAs change with link layout, and linear sweep desyncs into them: entry
+# bytes `C7 F8 xx xx` / `C6 F8 xx` decode as XBEGIN/XABORT (handled in
+# is_impossible_feature), and `C4/C5 xx ..` can decode as stray VEX. The SDE
+# -nhm step in this job calls strcspn (libarchive mtree, sqlite3) and passes,
+# confirming no post-SSE2 code runs.
+# (3 symbols)
+# ----------------------------------------------------------------------------
+strcspn                     [AVX, AVX2]
+strpbrk                     [AVX, AVX2]
+strspn                      [AVX, AVX2]
 
 
 # ----------------------------------------------------------------------------

--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -884,15 +884,15 @@ wcsnlen                     [AVX, AVX2]
 # ----------------------------------------------------------------------------
 # MSVC CRT strspn family. Data-in-.text false positive, NOT a gate.
 #
-# The UCRT's x64 strspn.asm (assembled once each for strspn/strcspn/strpbrk)
-# is SSE2-only; the psrldq/pslldq byte-shift ladder is dispatched through an
-# indirect `jmp *table[rbp + rax*4]` where the table is three arrays of 4-byte
-# image-relative RVAs stored in .text right after the function's `ret`. Those
-# RVAs change with link layout, and linear sweep desyncs into them: entry
-# bytes `C7 F8 xx xx` / `C6 F8 xx` decode as XBEGIN/XABORT (handled in
-# is_impossible_feature), and `C4/C5 xx ..` can decode as stray VEX. The SDE
-# -nhm step in this job calls strcspn (libarchive mtree, sqlite3) and passes,
-# confirming no post-SSE2 code runs.
+# ucrt/string/amd64/strspn.c (compiled 3x for strspn/strcspn/strpbrk) is
+# SSE2-only; its `switch (shift)` over _mm_srli_si128/_mm_slli_si128 lowers
+# to an indirect `jmp *table[rbp + rax*4]` where MSVC stores the table as
+# three arrays of 4-byte image-relative RVAs in .text right after the
+# function's `ret`. Those RVAs change with link layout, and linear sweep
+# desyncs into them: entry bytes `C7 F8 xx xx` / `C6 F8 xx` decode as
+# XBEGIN/XABORT (handled in is_impossible_feature), and `C4/C5 xx ..` can
+# decode as stray VEX. The SDE -nhm step in this job calls strcspn
+# (libarchive mtree, sqlite3) and passes, confirming no post-SSE2 code runs.
 # (3 symbols)
 # ----------------------------------------------------------------------------
 strcspn                     [AVX, AVX2]

--- a/scripts/verify-baseline-static/src/main.rs
+++ b/scripts/verify-baseline-static/src/main.rs
@@ -172,9 +172,15 @@ fn is_allowed(feat: CpuidFeature) -> bool {
 /// instruction from a defunct or privileged ISA extension.
 ///
 /// 3DNow! was removed from silicon by 2010. SMM's RSM is ring-0. Cyrix/Geode/
-/// Padlock never had a mainstream toolchain. No compiler targeting x86-64 in
-/// any configuration emits these — their presence in a scan means a linear
-/// sweep walked through inline data.
+/// Padlock never had a mainstream toolchain. TSX (RTM XBEGIN/XABORT/XEND,
+/// and XTEST which iced tags HLE_or_RTM) is never compiler-emitted without
+/// `_xbegin()` intrinsics, no Bun dependency uses it, and Intel deprecated it
+/// (SDM vol. 1 2.5: future parts drop it; existing parts disable it via
+/// microcode for TAA). When a scan sees RTM it is the MSVC CRT's inline RVA
+/// jump tables decoding as `C7 F8` XBEGIN / `C6 F8` XABORT — see the
+/// strcspn/strspn/strpbrk note in allowlist-x64-windows.txt. No compiler
+/// targeting x86-64 in any configuration emits these — their presence in a
+/// scan means a linear sweep walked through inline data.
 ///
 /// MSVC inlines jump tables in .text (LLVM puts them in .rodata), so this
 /// matters on PE more than ELF.
@@ -200,6 +206,8 @@ fn is_impossible_feature(feat: CpuidFeature) -> bool {
             | F::PADLOCK_RNG
             | F::PADLOCK_GMI
             | F::PADLOCK_UNDOC
+            | F::RTM
+            | F::HLE_or_RTM
     )
 }
 


### PR DESCRIPTION
Fixes the `verify-baseline` Windows x64 step going red on unrelated PR branches (seen in builds [80748](https://buildkite.com/bun/bun/builds/80748) and [80917](https://buildkite.com/bun/bun/builds/80917), both based on 65f3fe3e):

```
strcspn  [RTM]  (1 insns)
    0x014386f9e0  Xbegin  (RTM)
```

## Cause

The UCRT's x64 `strspn.asm` (built once each as `strspn`, `strcspn`, `strpbrk`) is SSE2-only. It dispatches a `psrldq`/`pslldq` byte-shift ladder through `jmp *table[rbp + rax*4]`, where `table` is three arrays of 4-byte image-relative RVAs stored in `.text` immediately after the function's `ret`. The linear-sweep decoder walks past the `ret` into those RVAs.

Because the table entries are absolute RVAs, their byte values change with link layout. In the failing builds the 13th entry of the third `pslldq` table is RVA `0x0386f8c7`, whose first two bytes `C7 F8` are the `XBEGIN rel32` opcode. Disassembly of `bun-profile.exe` from build 80917 around `0x14386f9e0`:

```
14386f931: c3                 retq
14386f932: 66 90              nop
14386f934: 69 f6 86 03 70 f6  ...    <- jump table begins (RVA 0x0386f669, 0x0386f670, ...)
...
14386f9e0: c7 f8 86 03 ce f8  xbegin 0x13c54fd6c   <- RVA 0x0386f8c7 = pslldq $0xd target
```

Current main (df6c7eed, build 80215) passes only because the three commits merged after 65f3fe3e shift `.text` enough that this table slot's low bytes are no longer `C7 F8`. The next layout perturbation can bring it back in any of the three routines (it already hit `strpbrk` once on a branch as `xabort`, `C6 F8 ib`).

## Fix

- `is_impossible_feature`: add `RTM` and `HLE_or_RTM` (XTEST). No compiler emits TSX without `_xbegin()` intrinsics, no Bun dependency uses it (grepped `src/` and `vendor/`), and Intel deprecated the extension (SDM vol. 1 2.5). An RTM hit is always data.
- `allowlist-x64-windows.txt`: move `strpbrk` out of the `__isa_available`-gated section (it was never gated; the routines have no AVX path) into a new data-in-.text section with `strcspn`/`strspn`, ceilinged at `[AVX, AVX2]` for the `C4/C5` VEX-prefix case, matching the `llint_entry` precedent.
- `CLAUDE.md`: list RTM/TSX under deliberately-ignored features.

## Verification

Rebuilt the scanner and ran it against the `bun-windows-x64-profile` artifact from build 80917:

| | before | after |
|-|-|-|
| violations | 1 symbol, 1 insn (`strcspn [RTM]`) | 0 |
| result | FAIL | PASS |

The SDE `-nhm` emulated phase in the same step already exercises `strcspn` (via sqlite3 and libarchive mtree parsing in the SIMD baseline tests) and passes, confirming no post-SSE2 instruction actually executes.