### PR TITLE
node:quic: emit CONNECTION_CLOSE from endpoint.destroy() when no error is given

### DIFF
--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -4421,10 +4421,8 @@ class QuicEndpoint {
     debug("destroying the endpoint");
     const inner = this.#inner;
     if (error !== undefined) inner.pendingError ??= error;
-    // With no error the cascaded sessions still get close options so a
-    // NO_ERROR CONNECTION_CLOSE reaches the peer; `session.destroy()`
-    // with no options is silent (Node parity), so without this the peer
-    // would only learn via its idle timer.
+    // session.destroy() with no options is silent; pass {} so the peer
+    // gets a NO_ERROR CONNECTION_CLOSE instead of waiting on idle.
     const closeOptions = errorToCloseOptions(error) ?? kEmptyObject;
     // Node's Endpoint::Send drops packets in the closing state.
     const alreadyClosing = this.#isClosedOrClosing;

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -4421,7 +4421,11 @@ class QuicEndpoint {
     debug("destroying the endpoint");
     const inner = this.#inner;
     if (error !== undefined) inner.pendingError ??= error;
-    const closeOptions = errorToCloseOptions(error);
+    // With no error the cascaded sessions still get close options so a
+    // NO_ERROR CONNECTION_CLOSE reaches the peer; `session.destroy()`
+    // with no options is silent (Node parity), so without this the peer
+    // would only learn via its idle timer.
+    const closeOptions = errorToCloseOptions(error) ?? kEmptyObject;
     // Node's Endpoint::Send drops packets in the closing state.
     const alreadyClosing = this.#isClosedOrClosing;
     for (const session of inner.sessions) {

--- a/src/js/internal/quic/quic.ts
+++ b/src/js/internal/quic/quic.ts
@@ -4421,8 +4421,7 @@ class QuicEndpoint {
     debug("destroying the endpoint");
     const inner = this.#inner;
     if (error !== undefined) inner.pendingError ??= error;
-    // session.destroy() with no options is silent; pass {} so the peer
-    // gets a NO_ERROR CONNECTION_CLOSE instead of waiting on idle.
+    // session.destroy() with no options is silent; {} emits a NO_ERROR CONNECTION_CLOSE.
     const closeOptions = errorToCloseOptions(error) ?? kEmptyObject;
     // Node's Endpoint::Send drops packets in the closing state.
     const alreadyClosing = this.#isClosedOrClosing;

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -1897,12 +1897,6 @@ impl QuicSession {
         }
     }
 
-    fn close_with_options(&self, global: &JSGlobalObject, options: JSValue) -> JsResult<()> {
-        let (app, code, reason) = self.parse_close_options(global, options)?;
-        self.apply_close(app, code, &reason);
-        Ok(())
-    }
-
     fn any_stream_undelivered(&self) -> bool {
         self.streams.get().iter().any(|&s| {
             // SAFETY: pointers in `streams` are unregistered before their
@@ -1980,8 +1974,23 @@ impl QuicSession {
                 // `inner.destroying` and finished its half before reaching
                 // here, so teardown() MUST run; report a parse failure
                 // instead of propagating past it.
-                if let Err(e) = self.close_with_options(global, options) {
-                    global.report_uncaught_exception_from_error(e);
+                match self.parse_close_options(global, options) {
+                    Ok((app, code, reason)) => {
+                        if let Some(c) = self.conn() {
+                            if app || code != 0 || reason.len() > 1 {
+                                let r = core::ffi::CStr::from_bytes_until_nul(&reason)
+                                    .unwrap_or(c"close");
+                                c.abort_error(app, code.min(u32::MAX as u64) as c_uint, r);
+                            } else {
+                                // apply_close's c.close() stalls on a server
+                                // conn with live bidi streams; destroy() must
+                                // always reach the wire, so take lsquic's
+                                // immediate-close NO_ERROR path.
+                                c.abort();
+                            }
+                        }
+                    }
+                    Err(e) => global.report_uncaught_exception_from_error(e),
                 }
                 if let Some(endpoint) = self.endpoint_ref() {
                     endpoint.drive_engines_once();

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -1867,7 +1867,7 @@ impl QuicSession {
             self.deferred_close
                 .with_mut(|d| *d = Some((app, code, reason)));
         } else {
-            self.apply_close(app, code, &reason);
+            self.apply_close(app, code, &reason, false);
         }
     }
 
@@ -1887,11 +1887,13 @@ impl QuicSession {
         false
     }
 
-    fn apply_close(&self, app: bool, code: u64, reason: &[u8]) {
+    fn apply_close(&self, app: bool, code: u64, reason: &[u8], immediate: bool) {
         let Some(c) = self.conn() else { return };
         if app || code != 0 || reason.len() > 1 {
             let creason = core::ffi::CStr::from_bytes_until_nul(reason).unwrap_or(c"close");
             c.abort_error(app, code.min(u32::MAX as u64) as core::ffi::c_uint, creason);
+        } else if immediate {
+            c.abort();
         } else {
             c.close();
         }
@@ -1916,7 +1918,7 @@ impl QuicSession {
             return;
         }
         if let Some((app, code, reason)) = self.deferred_close.with_mut(Option::take) {
-            self.apply_close(app, code, &reason);
+            self.apply_close(app, code, &reason, false);
             self.schedule_process();
         }
     }
@@ -1975,18 +1977,7 @@ impl QuicSession {
                 // here, so teardown() MUST run; report a parse failure
                 // instead of propagating past it.
                 match self.parse_close_options(global, options) {
-                    Ok((app, code, reason)) => {
-                        if let Some(c) = self.conn() {
-                            if app || code != 0 || reason.len() > 1 {
-                                let r = core::ffi::CStr::from_bytes_until_nul(&reason)
-                                    .unwrap_or(c"close");
-                                c.abort_error(app, code.min(u32::MAX as u64) as c_uint, r);
-                            } else {
-                                // close() defers on server bidi streams; abort() emits NO_ERROR now.
-                                c.abort();
-                            }
-                        }
-                    }
+                    Ok((app, code, reason)) => self.apply_close(app, code, &reason, true),
                     Err(e) => global.report_uncaught_exception_from_error(e),
                 }
                 if let Some(endpoint) = self.endpoint_ref() {

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -1982,10 +1982,8 @@ impl QuicSession {
                                     .unwrap_or(c"close");
                                 c.abort_error(app, code.min(u32::MAX as u64) as c_uint, r);
                             } else {
-                                // apply_close's c.close() stalls on a server
-                                // conn with live bidi streams; destroy() must
-                                // always reach the wire, so take lsquic's
-                                // immediate-close NO_ERROR path.
+                                // abort() is lsquic's immediate-close NO_ERROR;
+                                // close() defers until server bidi streams drain.
                                 c.abort();
                             }
                         }

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -1982,8 +1982,7 @@ impl QuicSession {
                                     .unwrap_or(c"close");
                                 c.abort_error(app, code.min(u32::MAX as u64) as c_uint, r);
                             } else {
-                                // abort() is lsquic's immediate-close NO_ERROR;
-                                // close() defers until server bidi streams drain.
+                                // close() defers on server bidi streams; abort() emits NO_ERROR now.
                                 c.abort();
                             }
                         }

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -267,3 +267,36 @@ describe("endpoint.close() while a session is live", () => {
     expect({ announced, resolved }).toEqual({ announced: 1, resolved: true });
   });
 });
+
+// endpoint.destroy() without an error used to cascade as a bare
+// session.destroy(), which aborts silently (no CONNECTION_CLOSE on the
+// wire), so the peer only learned via its idle timer. With a 30s idle
+// timeout the await below hangs well past the test's default timeout.
+describe("endpoint.destroy() without an error", () => {
+  test("emits CONNECTION_CLOSE so the connected peer's session.closed settles", async () => {
+    const tp = { maxIdleTimeout: 30 };
+    const serverHs = Promise.withResolvers<void>();
+    const server = await listen(
+      (s: any) => {
+        s.onerror = () => {};
+        s.closed.catch(() => {});
+        s.onhandshake = () => serverHs.resolve();
+      },
+      { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["echo"], transportParams: tp },
+    );
+    await using endpoint = new QuicEndpoint();
+    const client = await connect(server.address, {
+      endpoint,
+      alpn: "echo",
+      verifyPeer: "manual",
+      transportParams: tp,
+    });
+    client.closed.catch(() => {});
+    await client.opened;
+    await serverHs.promise;
+
+    server.destroy();
+    await client.closed;
+    expect(client.destroyed).toBe(true);
+  });
+});

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -276,7 +276,7 @@ describe("endpoint.destroy() without an error", () => {
   test("emits CONNECTION_CLOSE so the connected peer's session.closed settles", async () => {
     const tp = { maxIdleTimeout: 30 };
     const serverHs = Promise.withResolvers<void>();
-    const server = await listen(
+    await using server = await listen(
       (s: any) => {
         s.onerror = () => {};
         s.closed.catch(() => {});


### PR DESCRIPTION
## Problem

`endpoint.destroy()` (no error argument) left connected peers in the dark: their `session.closed` never settled and `session.destroyed` stayed `false` until the peer's own idle timer fired. A server tearing down with `srv.destroy()` looked alive to every client for the full `maxIdleTimeout`.

```js
const srv = await listen(s => {...}, { ..., transportParams: { maxIdleTimeout: 6 } });
const cli = await connect(srv.address, { ..., transportParams: { maxIdleTimeout: 6 } });
await cli.opened;
srv.destroy();
// cli.closed stays pending ~6s, cli.destroyed stays false
```

## Cause

`QuicEndpoint.destroy(error)` cascades to every live session as `session.destroy(error, closeOptions)`, where `closeOptions = errorToCloseOptions(error)`. With `error === undefined` that returns `undefined`, so every cascaded session hit the no-options path in the native `destroy()`, which aborts silently (`lsquic_conn_abort_silent`, no CONNECTION_CLOSE on the wire). The peer only learned via its idle timer or a later stateless reset.

A secondary bug in the with-options path: the NO_ERROR case went through `lsquic_conn_close()`, which on a server connection with live bidi streams defers the close until the streams drain, so even an explicit `session.destroy(undefined, {})` could stall.

## Fix

- `QuicEndpoint.destroy()` now passes an empty close-options object when no error is supplied, so every handshake-complete session emits a transport NO_ERROR CONNECTION_CLOSE and the peer's `session.closed` resolves at once.
- The native `QuicSession::destroy` with-options path now dispatches inline: NO_ERROR uses `lsquic_conn_abort()` (immediate-close path, always emits), non-zero codes keep using `lsquic_conn_abort_error()`. The shared `apply_close` used by graceful close is unchanged.

`session.destroy()` with no options stays silent (Node parity). The vendored Node stateless-reset tests (`test-quic-stateless-reset.mjs`, `test-quic-shared-endpoint-stream-close.mjs`) depend on that to exercise the reset path.

## Verification

Before:
```
client session.closed: STILL PENDING after 2000ms | destroyed: false
```

After:
```
client session.closed: settled (66ms) | destroyed: true
```

New test in `test/js/node/quic/quic-endpoint.test.ts` uses `maxIdleTimeout: 30` so without the fix `await client.closed` hangs past the 5s test timeout. The 13 directly-related Node parallel tests (`test-quic-endpoint-destroy-cascade-close-frame`, `test-quic-session-destroy`, `test-quic-stateless-reset`, `test-quic-shared-endpoint-stream-close`, etc.) and all 15 `test/js/node/quic/*.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-endpoint.test.ts
bun test v1.4.0 (69a308f8f)

test/js/node/quic/quic-endpoint.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [516.85ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [81.59ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [7015.43ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [327.90ms]
(pass) transportParams.maxIdleTimeout > 0 disables the idle timeout instead of falling back to the default [239.49ms]
(pass) endpoint.close() while a session is live > stops accepting new sessions so closed can resolve [150.02ms]
(fail) endpoint.destroy() without an error > emits CONNECTION_CLOSE so the connected peer's session.closed settles [5008.95ms]
  ^ this test timed out after 5000ms.

 6 pass
 1 fail
 1 snapsh
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8ec4c65dc)

test/js/node/quic/quic-endpoint.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:15:20)

(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [48.25ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [6.56ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [151.27ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [18.99ms]
(pass) transportParams.maxIdleTimeout > 0 disables the idle timeout instead of falling back to the default [16.09ms]
(pass) endpoint.close() while a session is live > stops accepting new sessions so closed can resolve [13.33ms]
(pass) endpoint.destroy() without an error > emits CONNECTION_CLOSE so the connected peer's session.closed settles [7.50ms]

 7 pass
 0 fail
 1 snapshots, 12 expect() calls
Ran 7 tests across 1 file. [652.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/quic/quic-endpoint.test.ts
bun test v1.4.0 (69a308f8f)

test/js/node/quic/quic-endpoint.test.ts:
ExperimentalWarning: quic is an experimental feature and might change at any time
      at node:quic (node:quic:16:20)

(pass) QuicEndpoint client-engine mode > an explicit endpoint rejects a connect() in the other mode [512.65ms]
(pass) server ALPN list > rejects a list mixing HTTP/3 and non-HTTP/3 protocols [145.57ms]
(pass) node:quic under --isolate > a second test file in the same process gets its own callbacks [8488.69ms]
(pass) dual-mode endpoint > does not stateless-reset its own client connection [528.08ms]
(pass) transportParams.maxIdleTimeout > 0 disables the idle timeout instead of falling back to the default [252.02ms]
(pass) endpoint.close() while a session is live > stops accepting new sessions so closed can resolve [263.25ms]
(pass) endpoint.destroy() without an error > emits CONNECTION_CLOSE so the connected peer's session.closed settles [146.38ms]

 7 pass
 0 fail
 1 snapshots, 12 expect() calls
Ran 7 tests acr
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1836ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (22464ms)
Bundle modules (1045ms)
Postprocesss modules (2024ms)
Bundle Functions (2569ms)
Generate Code (128ms)

[28.30s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/quic/quic.ts            |  3 ++-
 src/runtime/node/quic/session.rs        | 19 ++++++++-----------
 test/js/node/quic/quic-endpoint.test.ts | 33 +++++++++++++++++++++++++++++++++
 3 files changed, 43 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js/internal/quic/quic.ts                 6      4      0
src/runtime/node/quic/session.rs             9      8      0
test/js/node/quic/quic-endpoint.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->