### PR TITLE
error: recover async stack frames dropped under AsyncLocalStorage

### DIFF
--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -225,7 +225,7 @@ void Bun::appendAsyncLocalStorageStackFrames(VM& vm, JSCell* owner, Vector<Stack
 
     auto promiseContext = [](JSPromise* p, bool unwrap) -> JSValue {
         if (!p)
-            return { };
+            return {};
         JSValue context = p->asyncStackTraceContext();
         return unwrap ? unwrapAsyncContextTuple(context) : context;
     };

--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -16,8 +16,71 @@
 #include <JavaScriptCore/Options.h>
 #include <JavaScriptCore/StackFrame.h>
 #include <JavaScriptCore/UnlinkedCodeBlock.h>
+#include <JavaScriptCore/VMEntryRecord.h>
 
 using namespace JSC;
+
+// dynamicDowncast(JSValue)'s isCell() check is true for the empty value on
+// JSVALUE64, so it would read through a null cell. asyncStackTraceContext()
+// and reaction getters return the empty value in several paths, so every
+// JSValue downcast in this file goes through this helper.
+template<typename T>
+static inline T* cellAs(JSValue v)
+{
+    return (v && v.isCell()) ? dynamicDowncast<T>(v.asCell()) : nullptr;
+}
+
+template<typename T>
+static inline bool dynamicCastValue(JSValue v, T** out)
+{
+    *out = cellAs<T>(v);
+    return *out != nullptr;
+}
+
+static BytecodeIndex computeGeneratorBytecodeIndex(CodeBlock* codeBlock, JSAsyncFunctionGenerator* generator)
+{
+    BytecodeIndex bytecodeIndex(0);
+    JSValue stateValue = generator->internalField(JSAsyncFunctionGenerator::Field::State).get();
+    if (stateValue.isInt32()) {
+        int32_t state = stateValue.asInt32();
+        size_t numberOfJumpTables = codeBlock->numberOfUnlinkedSwitchJumpTables();
+        if (state > 0 && numberOfJumpTables > 0) {
+            size_t lastTableIndex = numberOfJumpTables - 1;
+            const UnlinkedSimpleJumpTable& jumpTable = codeBlock->unlinkedSwitchJumpTable(lastTableIndex);
+            int32_t offset = jumpTable.offsetForValue(state);
+            if (offset)
+                bytecodeIndex = BytecodeIndex(offset);
+        }
+    }
+    return bytecodeIndex;
+}
+
+static bool appendGeneratorFrame(VM& vm, JSCell* owner, JSAsyncFunctionGenerator* generator, WTF::Vector<StackFrame>& results)
+{
+    auto* asyncFunction = cellAs<JSFunction>(generator->next());
+    if (!asyncFunction || asyncFunction->isHostOrPrivateBuiltinFunction())
+        return false;
+    FunctionExecutable* executable = asyncFunction->jsExecutable();
+    if (!executable)
+        return false;
+    if (CodeBlock* codeBlock = executable->codeBlockForCall()) {
+        BytecodeIndex bytecodeIndex = computeGeneratorBytecodeIndex(codeBlock, generator);
+        results.append(StackFrame(vm, owner, asyncFunction, codeBlock, bytecodeIndex, /* isAsyncFrame */ true));
+    } else {
+        results.append(StackFrame(vm, owner, asyncFunction, /* isAsyncFrame */ true));
+    }
+    return true;
+}
+
+// With AsyncLocalStorage active, JSPromise::resolveWithInternalMicrotaskForAsyncAwait
+// wraps the await context in InternalFieldTuple(context, asyncContext). Unwrap
+// to field 0 so the generator/combinator probes see the real cell.
+static inline JSValue unwrapAsyncContextTuple(JSValue v)
+{
+    if (auto* tuple = cellAs<InternalFieldTuple>(v))
+        return tuple->getInternalField(0);
+    return v;
+}
 
 // Walk a promise's reaction chain to find the async generators awaiting it,
 // and collect them as async StackFrames. Used when an error is created from
@@ -35,20 +98,8 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
 
     JSC::AssertNoGC assertNoGC;
 
-    auto dynamicCastValue = []<typename T>(JSC::JSValue v, T** out) -> bool {
-        if (!v || !v.isCell())
-            return false;
-        *out = dynamicDowncast<T>(v.asCell());
-        return *out != nullptr;
-    };
-
     auto unwrapGeneratorFromContext = [&](JSC::JSValue context) -> JSC::JSAsyncFunctionGenerator* {
-        JSC::InternalFieldTuple* tuple = nullptr;
-        if (dynamicCastValue(context, &tuple))
-            context = tuple->getInternalField(0);
-        JSC::JSAsyncFunctionGenerator* generator = nullptr;
-        dynamicCastValue(context, &generator);
-        return generator;
+        return cellAs<JSC::JSAsyncFunctionGenerator>(unwrapAsyncContextTuple(context));
     };
 
     // Walk reaction->context → generator. If context is not a generator (e.g.
@@ -104,43 +155,9 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
         return nullptr;
     };
 
-    auto computeBytecodeIndex = [&](JSC::CodeBlock* codeBlock, JSC::JSAsyncFunctionGenerator* generator) -> JSC::BytecodeIndex {
-        JSC::BytecodeIndex bytecodeIndex(0);
-        JSC::JSValue stateValue = generator->internalField(JSC::JSAsyncFunctionGenerator::Field::State).get();
-        if (stateValue.isInt32()) {
-            int32_t state = stateValue.asInt32();
-            size_t numberOfJumpTables = codeBlock->numberOfUnlinkedSwitchJumpTables();
-            if (state > 0 && numberOfJumpTables > 0) {
-                size_t lastTableIndex = numberOfJumpTables - 1;
-                const JSC::UnlinkedSimpleJumpTable& jumpTable = codeBlock->unlinkedSwitchJumpTable(lastTableIndex);
-                int32_t offset = jumpTable.offsetForValue(state);
-                if (offset)
-                    bytecodeIndex = JSC::BytecodeIndex(offset);
-            }
-        }
-        return bytecodeIndex;
-    };
-
-    auto appendFrame = [&](JSC::JSAsyncFunctionGenerator* generator) {
-        JSC::JSFunction* asyncFunction = nullptr;
-        if (!dynamicCastValue(generator->next(), &asyncFunction))
-            return;
-        if (asyncFunction->isHostOrPrivateBuiltinFunction())
-            return;
-        JSC::FunctionExecutable* executable = asyncFunction->jsExecutable();
-        if (!executable)
-            return;
-        if (JSC::CodeBlock* codeBlock = executable->codeBlockForCall()) {
-            JSC::BytecodeIndex bytecodeIndex = computeBytecodeIndex(codeBlock, generator);
-            results.append(JSC::StackFrame(vm, owner, asyncFunction, codeBlock, bytecodeIndex, /* isAsyncFrame */ true));
-        } else {
-            results.append(JSC::StackFrame(vm, owner, asyncFunction, /* isAsyncFrame */ true));
-        }
-    };
-
     JSC::JSAsyncFunctionGenerator* gen = getAwaitingGenerator(promise);
     while (gen && results.size() < maxStackSize) {
-        appendFrame(gen);
+        appendGeneratorFrame(vm, owner, gen, results);
         JSC::JSPromise* returnPromise = nullptr;
         if (!dynamicCastValue(gen->context(), &returnPromise))
             break;
@@ -175,4 +192,79 @@ extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObje
         return;
 
     instance->setStackFrames(vm, WTF::move(frames));
+}
+
+// Installed as VM::onAppendStackTrace. Interpreter::getAsyncStackTrace walks
+// the await chain via JSPromise::asyncStackTraceContext(), but under
+// AsyncLocalStorage that context is an InternalFieldTuple(generator, asyncContext)
+// (see JSPromise::resolveWithInternalMicrotaskForAsyncAwait) and the walk's
+// dynamicDowncast<JSAsyncFunctionGenerator> fails, dropping every `at async`
+// frame. getStackTrace calls this hook before inserting its own async frames,
+// so we replicate getParentGenerator here with tuple unwrapping and append the
+// frames JSC's walk misses. To avoid duplicating frames JSC does find (when
+// ALS was inactive at some hop), we run the unwrapped and non-unwrapped walks
+// in lockstep and only start appending once the non-unwrapped walk stops.
+void Bun::appendAsyncLocalStorageStackFrames(VM& vm, JSCell* owner, Vector<StackFrame>& results, size_t maxToAppend)
+{
+    if (!maxToAppend || !Options::useAsyncStackTrace())
+        return;
+
+    AssertNoGC assertNoGC;
+
+    JSAsyncFunctionGenerator* origin = nullptr;
+    for (EntryFrame* entryFrame = vm.topEntryFrame; entryFrame;) {
+        VMEntryRecord* record = vmEntryRecord(entryFrame);
+        if (auto* generator = dynamicDowncast<JSAsyncFunctionGenerator>(record->m_context)) {
+            origin = generator;
+            break;
+        }
+        entryFrame = record->prevTopEntryFrame();
+    }
+    if (!origin)
+        return;
+
+    auto promiseContext = [](JSPromise* p, bool unwrap) -> JSValue {
+        if (!p)
+            return { };
+        JSValue context = p->asyncStackTraceContext();
+        return unwrap ? unwrapAsyncContextTuple(context) : context;
+    };
+
+    // Mirrors Interpreter::getAsyncStackTrace's getParentGenerator for the
+    // direct-await and Promise.race shapes. Promise.all/allSettled/any store a
+    // JSPromiseCombinatorsGlobalContext (a private header the prebuilt WebKit
+    // doesn't forward), so under ALS the chain still ends at a combinator hop
+    // the same way JSC's own walk does; that narrower case wants the unwrap in
+    // getAsyncStackTrace itself.
+    auto getParentGenerator = [&](JSAsyncFunctionGenerator* gen, bool unwrap) -> JSAsyncFunctionGenerator* {
+        auto* returnPromise = cellAs<JSPromise>(gen->internalField(JSAsyncFunctionGenerator::Field::Context).get());
+        JSValue context = promiseContext(returnPromise, unwrap);
+        if (!context)
+            return nullptr;
+        if (auto* generator = cellAs<JSAsyncFunctionGenerator>(context))
+            return generator;
+        if (auto* promise = cellAs<JSPromise>(context))
+            return cellAs<JSAsyncFunctionGenerator>(promiseContext(promise, unwrap));
+        return nullptr;
+    };
+
+    size_t appended = 0;
+    bool jscStopped = false;
+    JSAsyncFunctionGenerator* current = origin;
+    for (unsigned hops = 0; hops < 256 && appended < maxToAppend; hops++) {
+        JSAsyncFunctionGenerator* next = getParentGenerator(current, /* unwrap */ true);
+        if (!next)
+            break;
+        if (!jscStopped) {
+            if (getParentGenerator(current, /* unwrap */ false))
+                current = next;
+            else
+                jscStopped = true;
+        }
+        if (jscStopped) {
+            if (appendGeneratorFrame(vm, owner, next, results))
+                appended++;
+            current = next;
+        }
+    }
 }

--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -20,10 +20,8 @@
 
 using namespace JSC;
 
-// dynamicDowncast(JSValue)'s isCell() check is true for the empty value on
-// JSVALUE64, so it would read through a null cell. asyncStackTraceContext()
-// and reaction getters return the empty value in several paths, so every
-// JSValue downcast in this file goes through this helper.
+// dynamicDowncast(JSValue)'s isCell() is true for the empty value on JSVALUE64
+// (null cell deref); asyncStackTraceContext() and reaction getters return empty.
 template<typename T>
 static inline T* cellAs(JSValue v)
 {
@@ -72,9 +70,8 @@ static bool appendGeneratorFrame(VM& vm, JSCell* owner, JSAsyncFunctionGenerator
     return true;
 }
 
-// With AsyncLocalStorage active, JSPromise::resolveWithInternalMicrotaskForAsyncAwait
-// wraps the await context in InternalFieldTuple(context, asyncContext). Unwrap
-// to field 0 so the generator/combinator probes see the real cell.
+// resolveWithInternalMicrotaskForAsyncAwait wraps await contexts as
+// InternalFieldTuple(context, asyncContext) when ALS is active; field 0 is the real cell.
 static inline JSValue unwrapAsyncContextTuple(JSValue v)
 {
     if (auto* tuple = cellAs<InternalFieldTuple>(v))
@@ -194,16 +191,13 @@ extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObje
     instance->setStackFrames(vm, WTF::move(frames));
 }
 
-// Installed as VM::onAppendStackTrace. Interpreter::getAsyncStackTrace walks
-// the await chain via JSPromise::asyncStackTraceContext(), but under
-// AsyncLocalStorage that context is an InternalFieldTuple(generator, asyncContext)
-// (see JSPromise::resolveWithInternalMicrotaskForAsyncAwait) and the walk's
-// dynamicDowncast<JSAsyncFunctionGenerator> fails, dropping every `at async`
-// frame. getStackTrace calls this hook before inserting its own async frames,
-// so we replicate getParentGenerator here with tuple unwrapping and append the
-// frames JSC's walk misses. To avoid duplicating frames JSC does find (when
-// ALS was inactive at some hop), we run the unwrapped and non-unwrapped walks
-// in lockstep and only start appending once the non-unwrapped walk stops.
+// VM::onAppendStackTrace hook, installed lazily by jsSetAsyncHooksEnabled so the
+// no-ALS path is untouched. Interpreter::getAsyncStackTrace's getParentGenerator
+// casts asyncStackTraceContext() to JSAsyncFunctionGenerator and fails on the
+// InternalFieldTuple ALS puts there, dropping every `at async` frame. Run the same
+// walk with and without the unwrap in lockstep and append only the frames the
+// un-unwrapped walk misses, so hops where ALS was inactive aren't doubled. See
+// oven-sh/WebKit#347 for the in-tree unwrap that will obsolete this hook.
 void Bun::appendAsyncLocalStorageStackFrames(VM& vm, JSCell* owner, Vector<StackFrame>& results, size_t maxToAppend)
 {
     if (!maxToAppend || !Options::useAsyncStackTrace())
@@ -230,12 +224,9 @@ void Bun::appendAsyncLocalStorageStackFrames(VM& vm, JSCell* owner, Vector<Stack
         return unwrap ? unwrapAsyncContextTuple(context) : context;
     };
 
-    // Mirrors Interpreter::getAsyncStackTrace's getParentGenerator for the
-    // direct-await and Promise.race shapes. Promise.all/allSettled/any store a
-    // JSPromiseCombinatorsGlobalContext (a private header the prebuilt WebKit
-    // doesn't forward), so under ALS the chain still ends at a combinator hop
-    // the same way JSC's own walk does; that narrower case wants the unwrap in
-    // getAsyncStackTrace itself.
+    // Mirrors Interpreter::getAsyncStackTrace's getParentGenerator for direct
+    // await and Promise.race. Promise.all/allSettled/any use JSPromiseCombinatorsGlobalContext
+    // (private header, not forwarded) so the chain still ends at those hops under ALS.
     auto getParentGenerator = [&](JSAsyncFunctionGenerator* gen, bool unwrap) -> JSAsyncFunctionGenerator* {
         auto* returnPromise = cellAs<JSPromise>(gen->internalField(JSAsyncFunctionGenerator::Field::Context).get());
         JSValue context = promiseContext(returnPromise, unwrap);

--- a/src/jsc/bindings/AsyncStackTrace.h
+++ b/src/jsc/bindings/AsyncStackTrace.h
@@ -11,6 +11,10 @@
 // ErrorInstance with no stack of its own; no-op otherwise. Never throws.
 extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject*, JSC::EncodedJSValue errorValue, JSC::JSPromise*);
 
+namespace JSC {
+class StackFrame;
+}
+
 namespace Bun {
 
 // C++ convenience wrapper over Bun__attachAsyncStackFromPromise.
@@ -18,5 +22,9 @@ inline void attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObject, JSC::
 {
     Bun__attachAsyncStackFromPromise(globalObject, JSC::JSValue::encode(error), promise);
 }
+
+// VM::onAppendStackTrace hook: appends the `at async` frames JSC's own walk drops when
+// AsyncLocalStorage wraps await contexts in InternalFieldTuple. See AsyncStackTrace.cpp.
+void appendAsyncLocalStorageStackFrames(JSC::VM&, JSC::JSCell* owner, WTF::Vector<JSC::StackFrame>&, size_t maxToAppend);
 
 } // namespace Bun

--- a/src/jsc/bindings/NodeAsyncHooks.cpp
+++ b/src/jsc/bindings/NodeAsyncHooks.cpp
@@ -4,6 +4,7 @@
 #include "JavaScriptCore/ObjectConstructor.h"
 #include "JavaScriptCore/ArrayConstructor.h"
 
+#include "AsyncStackTrace.h"
 #include "ZigGlobalObject.h"
 
 namespace Bun {
@@ -27,7 +28,11 @@ JSC_DEFINE_HOST_FUNCTION(jsCleanupLater, (JSC::JSGlobalObject * globalObject, JS
 JSC_DEFINE_HOST_FUNCTION(jsSetAsyncHooksEnabled, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ASSERT(callFrame->argumentCount() == 1);
-    globalObject->setAsyncContextTrackingEnabled(callFrame->uncheckedArgument(0).toBoolean(globalObject));
+    bool enabled = callFrame->uncheckedArgument(0).toBoolean(globalObject);
+    globalObject->setAsyncContextTrackingEnabled(enabled);
+    auto& vm = JSC::getVM(globalObject);
+    if (enabled && !vm.onAppendStackTrace())
+        vm.setOnAppendStackTrace(Bun::appendAsyncLocalStorageStackFrames);
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -61,7 +61,6 @@
 #include "JavaScriptCore/VM.h"
 #include "AddEventListenerOptions.h"
 #include "AsyncContextFrame.h"
-#include "AsyncStackTrace.h"
 #include "BunClientData.h"
 #include "BunIDLConvert.h"
 #include "BunObject.h"
@@ -555,7 +554,6 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     vm.setOnComputeErrorInfo(computeErrorInfoWrapperToString);
     vm.setOnComputeErrorInfoJSValue(computeErrorInfoWrapperToJSValue);
     vm.setComputeLineColumnWithSourcemap(computeLineColumnWithSourcemap);
-    vm.setOnAppendStackTrace(Bun::appendAsyncLocalStorageStackFrames);
     vm.setOnEachMicrotaskTick([](JSC::VM& vm) -> void {
         // if you process.nextTick on a microtask we need this
         auto* globalObject = defaultGlobalObject();

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -61,6 +61,7 @@
 #include "JavaScriptCore/VM.h"
 #include "AddEventListenerOptions.h"
 #include "AsyncContextFrame.h"
+#include "AsyncStackTrace.h"
 #include "BunClientData.h"
 #include "BunIDLConvert.h"
 #include "BunObject.h"
@@ -554,6 +555,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     vm.setOnComputeErrorInfo(computeErrorInfoWrapperToString);
     vm.setOnComputeErrorInfoJSValue(computeErrorInfoWrapperToJSValue);
     vm.setComputeLineColumnWithSourcemap(computeLineColumnWithSourcemap);
+    vm.setOnAppendStackTrace(Bun::appendAsyncLocalStorageStackFrames);
     vm.setOnEachMicrotaskTick([](JSC::VM& vm) -> void {
         // if you process.nextTick on a microtask we need this
         auto* globalObject = defaultGlobalObject();

--- a/test/regression/issue/24003.test.ts
+++ b/test/regression/issue/24003.test.ts
@@ -1,0 +1,129 @@
+// https://github.com/oven-sh/bun/issues/24003
+// Async stack traces were missing their `at async <fn>` frames when an
+// AsyncLocalStorage store was active at the point of `await`.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function run(source: string): Promise<string> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return stdout;
+}
+
+function asyncFrames(stack: string): string[] {
+  return stack
+    .split("\n")
+    .filter(l => l.includes("at async "))
+    .map(l => l.trim().replace(/ \(.*\)$/, ""));
+}
+
+describe.concurrent("issue #24003", () => {
+  test("async stack frames under AsyncLocalStorage.run()", async () => {
+    const stdout = await run(`
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+    async function fn3() { await 0; throw new Error("boom"); }
+    async function fn2() { await fn3(); }
+    async function fn1() { await fn2(); }
+    async function main() {
+      try { await als.run({}, () => fn1()); }
+      catch (e) { console.log(e.stack); }
+    }
+    main();
+  `);
+    expect(stdout).toContain("at fn3");
+    expect(asyncFrames(stdout)).toEqual(["at async fn2", "at async fn1", "at async main"]);
+  });
+
+  test("async stack frames under AsyncLocalStorage.enterWith()", async () => {
+    const stdout = await run(`
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+    als.enterWith({ x: 1 });
+    async function inner() { await 0; console.log(new Error("boom").stack); }
+    async function outer() { await inner(); }
+    async function main() { await outer(); }
+    main();
+  `);
+    expect(stdout).toContain("at inner");
+    expect(asyncFrames(stdout)).toEqual(["at async outer", "at async main"]);
+  });
+
+  test("async stack frames through Promise.race under AsyncLocalStorage", async () => {
+    const stdout = await run(`
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+    async function leaf() { await 0; throw new Error("boom"); }
+    async function viaRace() { await Promise.race([leaf()]); }
+    async function caller() { await viaRace(); }
+    async function main() {
+      try { await als.run({}, () => caller()); }
+      catch (e) { console.log(e.stack); }
+    }
+    main();
+  `);
+    expect(stdout).toContain("at leaf");
+    expect(asyncFrames(stdout)).toEqual(["at async viaRace", "at async caller", "at async main"]);
+  });
+
+  test("async stack frames without AsyncLocalStorage are not duplicated", async () => {
+    const stdout = await run(`
+    async function fn3() { await 0; throw new Error("boom"); }
+    async function fn2() { await fn3(); }
+    async function fn1() { await fn2(); }
+    async function main() {
+      try { await fn1(); }
+      catch (e) { console.log(e.stack); }
+    }
+    main();
+  `);
+    expect(stdout).toContain("at fn3");
+    expect(asyncFrames(stdout)).toEqual(["at async fn2", "at async fn1", "at async main"]);
+  });
+
+  test("async stack frames through Promise.race without AsyncLocalStorage are not duplicated", async () => {
+    const stdout = await run(`
+    async function leaf() { await 0; throw new Error("boom"); }
+    async function viaRace() { await Promise.race([leaf()]); }
+    async function caller() { await viaRace(); }
+    async function main() {
+      try { await caller(); }
+      catch (e) { console.log(e.stack); }
+    }
+    main();
+  `);
+    expect(stdout).toContain("at leaf");
+    expect(asyncFrames(stdout)).toEqual(["at async viaRace", "at async caller", "at async main"]);
+  });
+
+  test("async stack frames when AsyncLocalStorage is entered mid-chain", async () => {
+    // fn2 awaits fn3 before ALS is entered, so JSC's own walk finds fn2; fn1
+    // awaits fn2 after enterWith, so JSC stops there and the hook must supply
+    // fn1/main without duplicating fn2.
+    const stdout = await run(`
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+    async function fn3() { await 0; throw new Error("boom"); }
+    async function fn2() { await fn3(); }
+    async function fn1() {
+      const p = fn2();
+      als.enterWith({});
+      await p;
+    }
+    async function main() {
+      try { await fn1(); }
+      catch (e) { console.log(e.stack); }
+    }
+    main();
+  `);
+    expect(stdout).toContain("at fn3");
+    expect(asyncFrames(stdout)).toEqual(["at async fn2", "at async fn1", "at async main"]);
+  });
+});

--- a/test/regression/issue/24003.test.ts
+++ b/test/regression/issue/24003.test.ts
@@ -73,8 +73,11 @@ describe.concurrent("issue #24003", () => {
     expect(asyncFrames(stdout)).toEqual(["at async viaRace", "at async caller", "at async main"]);
   });
 
-  test("async stack frames without AsyncLocalStorage are not duplicated", async () => {
+  // The hook is installed lazily from the AsyncLocalStorage constructor; construct one
+  // without entering a store so the lockstep walk runs but JSC succeeds at every hop.
+  test("async stack frames are not duplicated when no AsyncLocalStorage store is active", async () => {
     const stdout = await run(`
+    new (require("node:async_hooks").AsyncLocalStorage)();
     async function fn3() { await 0; throw new Error("boom"); }
     async function fn2() { await fn3(); }
     async function fn1() { await fn2(); }
@@ -88,8 +91,9 @@ describe.concurrent("issue #24003", () => {
     expect(asyncFrames(stdout)).toEqual(["at async fn2", "at async fn1", "at async main"]);
   });
 
-  test("async stack frames through Promise.race without AsyncLocalStorage are not duplicated", async () => {
+  test("async stack frames through Promise.race are not duplicated when no AsyncLocalStorage store is active", async () => {
     const stdout = await run(`
+    new (require("node:async_hooks").AsyncLocalStorage)();
     async function leaf() { await 0; throw new Error("boom"); }
     async function viaRace() { await Promise.race([leaf()]); }
     async function caller() { await viaRace(); }


### PR DESCRIPTION
Fixes #24003.

## Problem

When an `AsyncLocalStorage` store is active, `error.stack` for errors created deep in an `await` chain drops every `at async <fn>` frame:

```js
import { AsyncLocalStorage } from "node:async_hooks";
const als = new AsyncLocalStorage();
async function fn3() { await 0; throw new Error("boom"); }
async function fn2() { await fn3(); }
async function fn1() { await fn2(); }
try { await als.run({}, () => fn1()); } catch (e) { console.log(e.stack); }
```

| | |
|-|-|
| Node | `at fn3` → `at async fn2` → `at async fn1` |
| Bun (before) | `at fn3` |
| Bun (after) | `at fn3` → `at async fn2` → `at async fn1` |

The same chain without ALS already shows the full trace.

## Cause

Under `USE(BUN_JSC_ADDITIONS)`, `JSPromise::resolveWithInternalMicrotaskForAsyncAwait` wraps the awaiting generator in an `InternalFieldTuple(generator, asyncContext)` whenever an async context is active, and stores that tuple as the reaction context so the context can be restored when the microtask resumes.

`Interpreter::getAsyncStackTrace` walks the await chain by reading the reaction context via `asyncStackTraceContext()` and casting it with `dynamicDowncast<JSAsyncFunctionGenerator>`. On a tuple that cast (and the combinator/promise fallbacks) fails, so the walk returns nothing and every async frame is dropped.

## Fix

oven-sh/WebKit#347 unwraps the tuple inside `getContextValueFromPromise`, which every branch of `getParentGenerator` flows through. That is the complete fix (direct `await`, `Promise.all`/`allSettled`/`any`, `Promise.race`) with no extra per-Error work.

Until `WEBKIT_VERSION` moves past that change, this PR installs a `VM::onAppendStackTrace` hook that replicates `getParentGenerator` with tuple unwrapping. The hook is registered lazily from `jsSetAsyncHooksEnabled` the first time AsyncLocalStorage turns tracking on, so code that never touches ALS pays nothing. To avoid duplicating frames JSC does find (when ALS was inactive at some hop), the hook runs the unwrapped and non-unwrapped walks in lockstep and only starts appending once the non-unwrapped walk stops.

### Known limitations of the interim hook

- `Promise.all`/`allSettled`/`any` under ALS still stop at the combinator hop; `JSPromiseCombinatorsGlobalContext` is a private JSC header. oven-sh/WebKit#347 covers this.
- Under a nested VM entry that has visible JS frames below the async origin (e.g. `node:vm` with `microtaskMode: "afterEvaluate"`), the recovered `at async` frames land after those outer frames instead of directly after JSC's async block. The frames are still present (they were absent before).

## Tests

`test/regression/issue/24003.test.ts` covers `als.run()`, `als.enterWith()`, `Promise.race` under ALS, the no-ALS baselines (no duplication, direct and via `Promise.race`), and a mid-chain ALS entry where JSC's walk finds one frame and the hook supplies the rest.

Existing `test/js/bun/test/stack.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, and `test/js/node/async_hooks/AsyncLocalStorage.test.ts` all pass unchanged.

## Related

Supersedes #29619.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/24003.test.ts"
bun test v1.4.0 (ca5c60b1a)

test/regression/issue/24003.test.ts:
(pass) issue #24003 > async stack frames are not duplicated when no AsyncLocalStorage store is active [558.13ms]
(pass) issue #24003 > async stack frames through Promise.race are not duplicated when no AsyncLocalStorage store is active [576.22ms]
37 |       catch (e) { console.log(e.stack); }
38 |     }
39 |     main();
40 |   `);
41 |     expect(stdout).toContain("at fn3");
42 |     expect(asyncFrames(stdout)).toEqual(["at async fn2", "at async fn1", "at async main"]);
                                     ^
error: expect(received).toEqual(expected)

- [
-   "at async fn2",
-   "at async fn1",
-   "at async main",
- ]
+ []

- Expected  - 5
+ Received  + 1

      at <anonymous> (/workspace/bun/test/regression/issue/24003.test.ts:42:33)
(fail) issue #24003 > async stack frames under AsyncLocalStorage.run() [986.14ms]
51 |     async function outer() { await inner(); }
52 |     async function main() { await outer(); }
53 |     main();
54
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9f710c780)

test/regression/issue/24003.test.ts:
(pass) issue #24003 > async stack frames under AsyncLocalStorage.run() [18.22ms]
(pass) issue #24003 > async stack frames under AsyncLocalStorage.enterWith() [11.21ms]
(pass) issue #24003 > async stack frames through Promise.race under AsyncLocalStorage [11.60ms]
(pass) issue #24003 > async stack frames are not duplicated when no AsyncLocalStorage store is active [11.23ms]
(pass) issue #24003 > async stack frames through Promise.race are not duplicated when no AsyncLocalStorage store is active [10.70ms]
(pass) issue #24003 > async stack frames when AsyncLocalStorage is entered mid-chain [10.26ms]

 6 pass
 0 fail
 24 expect() calls
Ran 6 tests across 1 file. [359.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/24003.test.ts"
bun test v1.4.0 (ca5c60b1a)

test/regression/issue/24003.test.ts:
(pass) issue #24003 > async stack frames are not duplicated when no AsyncLocalStorage store is active [745.39ms]
(pass) issue #24003 > async stack frames through Promise.race are not duplicated when no AsyncLocalStorage store is active [784.45ms]
(pass) issue #24003 > async stack frames under AsyncLocalStorage.run() [989.98ms]
(pass) issue #24003 > async stack frames under AsyncLocalStorage.enterWith() [959.38ms]
(pass) issue #24003 > async stack frames through Promise.race under AsyncLocalStorage [1358.88ms]
(pass) issue #24003 > async stack frames when AsyncLocalStorage is entered mid-chain [910.39ms]

 6 pass
 0 fail
 24 expect() calls
Ran 6 tests across 1 file. [5.91s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1138ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/10] gen cpp.rs (cppbind)
[1/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/AsyncStackTrace.cpp | 179 +++++++++++++++++++++++++----------
 src/jsc/bindings/AsyncStackTrace.h   |   8 ++
 src/jsc/bindings/NodeAsyncHooks.cpp  |   7 +-
 test/regression/issue/24003.test.ts  | 133 ++++++++++++++++++++++++++
 4 files changed, 278 insertions(+), 49 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/jsc/bindings/AsyncStackTrace.cpp      5      6      0
src/jsc/bindings/AsyncStackTrace.h        1      1      0
src/jsc/bindings/NodeAsyncHooks.cpp       1      1      0
test/regression/issue/24003.test.ts       3      8      0
```

</details>

<!-- robobun:evidence:end -->