### PR TITLE
node:module: route require() through an overridden Module.prototype._compile

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1420,13 +1420,13 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
     JSValue keyJSString,
     ResolvedSource& source)
 {
-    if (JSValue compileFunction = this->m_overriddenCompile.get()) {
+    JSValue compileFunction = this->m_overriddenCompile.get();
+    if (!compileFunction && globalObject->hasOverriddenModulePrototypeCompile) [[unlikely]] {
+        compileFunction = globalObject->modulePrototypeUnderscoreCompileFunction();
+    }
+    if (compileFunction) {
         auto& vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        if (!compileFunction) {
-            throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);
-            return;
-        }
         JSC::CallData callData = JSC::getCallData(compileFunction.asCell());
         if (callData.type == JSC::CallData::Type::None) {
             throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1463,6 +1463,7 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
         arguments.append(keyJSString);
         JSC::profiledCall(globalObject, ProfilingReason::API, compileFunction, callData, this, arguments);
         RETURN_IF_EXCEPTION(scope, );
+        this->hasEvaluated = true;
         return;
     }
     this->evaluate(globalObject, key, source, false);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -731,6 +731,13 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
             zigGlobalObject->m_moduleWrapperStart,
             sourceString,
             zigGlobalObject->m_moduleWrapperEnd);
+    } else if (sourceString.contains("$Bun_import_meta"_s)) [[unlikely]] {
+        // The transpiler rewrote import.meta to a sixth wrapper parameter;
+        // evaluateCommonJSModuleOnce supplies it when parameterCount() > 5.
+        wrappedString = makeString(
+            "(function(exports,require,module,__filename,__dirname,$Bun_import_meta){"_s,
+            sourceString,
+            "\n})"_s);
     } else {
         wrappedString = makeString(
             "(function(exports,require,module,__filename,__dirname){"_s,

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1429,7 +1429,7 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
         auto scope = DECLARE_THROW_SCOPE(vm);
         JSC::CallData callData = JSC::getCallData(compileFunction.asCell());
         if (callData.type == JSC::CallData::Type::None) {
-            throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);
+            throwTypeError(globalObject, scope, "overridden module._compile is not a function"_s);
             return;
         }
         WTF::String sourceString = source.source_code.toWTFString(BunString::ZeroCopy);

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -772,9 +772,9 @@ JSValue fetchCommonJSModule(
     if (Bun::IsolatedModuleCache::canUse(vm, bunVM, typeAttribute)) {
         if (auto* cached = Bun::IsolatedModuleCache::lookup(vm, specifierWtfString)) {
             if (cached->sourceType() == JSC::SourceProviderSourceType::Program) {
-                // The wrapper override only affects CJS evaluation; if it's
-                // active, fall through and re-transpile so the override can run.
-                if (!globalObject->hasOverriddenModuleWrapper) {
+                // The wrapper/_compile overrides only affect CJS evaluation; if
+                // either is active, fall through and re-transpile so the override runs.
+                if (!globalObject->hasOverriddenModuleWrapper && !globalObject->hasOverriddenModulePrototypeCompile) {
                     target->evaluate(globalObject, Ref(*cached), cached->m_resolvedSource.tag == ResolvedSourceTagPackageJSONTypeModule);
                     RETURN_IF_EXCEPTION(scope, {});
                     RELEASE_AND_RETURN(scope, target);

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -814,6 +814,8 @@ JSValue fetchCommonJSModuleNonBuiltin(
     if (res->success && res->result.value.isCommonJSModule) {
         if constexpr (isExtension) {
             target->evaluateWithPotentiallyOverriddenCompile(globalObject, specifierWtfString, specifierValue, res->result.value);
+        } else if (globalObject->hasOverriddenModulePrototypeCompile) [[unlikely]] {
+            target->evaluateWithPotentiallyOverriddenCompile(globalObject, specifierWtfString, specifierValue, res->result.value);
         } else {
             target->evaluate(globalObject, specifierWtfString, res->result.value);
         }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -303,7 +303,7 @@ public:
 
     JSObject* lazyRequireCacheObject() const { return m_lazyRequireCacheObject.getInitializedOnMainThread(this); }
     Bun::JSCommonJSExtensions* lazyRequireExtensionsObject() const { return m_lazyRequireExtensionsObject.getInitializedOnMainThread(this); }
-    JSC::JSFunction* modulePrototypeUnderscoreCompileFunction() const { return m_modulePrototypeUnderscoreCompileFunction.getInitializedOnMainThread(this); }
+    JSC::JSCell* modulePrototypeUnderscoreCompileFunction() const { return m_modulePrototypeUnderscoreCompileFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* requireESMFromHijackedExtension() const { return m_commonJSRequireESMFromHijackedExtensionFunction.getInitializedOnMainThread(this); }
 
     Structure* NodeVMGlobalObjectStructure() const { return m_cachedNodeVMGlobalObjectStructure.getInitializedOnMainThread(this); }
@@ -486,7 +486,7 @@ public:
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleResolveFilenameFunction)                           \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleRunMainFunction)                                   \
-    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \
+    V(public, LazyPropertyOfGlobalObject<JSCell>, m_modulePrototypeUnderscoreCompileFunction)                \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMFromHijackedExtensionFunction)     \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_nodeModuleConstructor)                                 \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapEntryStructure)                    \
@@ -775,6 +775,8 @@ public:
     bool hasOverriddenModuleWrapper = false;
     // De-optimization once `require("module").runMain` is written to
     bool hasOverriddenModuleRunMain = false;
+    // De-optimization once `require("module").prototype._compile` is written to
+    bool hasOverriddenModulePrototypeCompile = false;
 
     // node:crypto deprecation warnings are emitted at most once per realm, like Node, whose
     // flags live in per-realm module state (lib/internal/crypto/keys.js). They must not be

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -767,6 +767,39 @@ JSC_DEFINE_CUSTOM_SETTER(setNodeModuleWrapper,
     return true;
 }
 
+JSC_DEFINE_CUSTOM_GETTER(getModulePrototypeCompile,
+    (JSGlobalObject * lexicalGlobalObject,
+        EncodedJSValue thisValue,
+        PropertyName propertyName))
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    return JSValue::encode(globalObject->modulePrototypeUnderscoreCompileFunction());
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setModulePrototypeCompile,
+    (JSGlobalObject * lexicalGlobalObject,
+        EncodedJSValue thisValue, EncodedJSValue encodedValue,
+        PropertyName propertyName))
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto value = JSValue::decode(encodedValue);
+    if (value.isCell()) {
+        bool isOriginal = false;
+        if (value.isCallable()) {
+            JSC::CallData callData = JSC::getCallData(value);
+            if (callData.type == JSC::CallData::Type::Native) {
+                if (callData.native.function.untaggedPtr() == &functionJSCommonJSModule_compile) {
+                    isOriginal = true;
+                }
+            }
+        }
+        globalObject->hasOverriddenModulePrototypeCompile = !isOriginal;
+        globalObject->m_modulePrototypeUnderscoreCompileFunction.set(
+            lexicalGlobalObject->vm(), globalObject, value.asCell());
+    }
+    return true;
+}
+
 static JSValue getModulePrototypeObject(VM& vm, JSObject* moduleObject)
 {
     auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
@@ -778,7 +811,11 @@ static JSValue getModulePrototypeObject(VM& vm, JSObject* moduleObject)
             setterRequireFunction),
         0);
 
-    prototype->putDirect(vm, Identifier::fromString(vm, "_compile"_s), globalObject->modulePrototypeUnderscoreCompileFunction());
+    prototype->putDirectCustomAccessor(
+        vm, Identifier::fromString(vm, "_compile"_s),
+        JSC::CustomGetterSetter::create(vm, getModulePrototypeCompile,
+            setModulePrototypeCompile),
+        0);
 
     return prototype;
 }
@@ -1121,12 +1158,12 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
         });
 
     globalObject->m_modulePrototypeUnderscoreCompileFunction.initLater(
-        [](const Zig::GlobalObject::Initializer<JSFunction>& init) {
-            JSFunction* resolveFilenameFunction = JSFunction::create(
+        [](const Zig::GlobalObject::Initializer<JSCell>& init) {
+            JSFunction* compileFunction = JSFunction::create(
                 init.vm, init.owner, 2, "_compile"_s,
                 functionJSCommonJSModule_compile, JSC::ImplementationVisibility::Public,
                 JSC::NoIntrinsic);
-            init.set(resolveFilenameFunction);
+            init.set(compileFunction);
         });
 
     globalObject->m_commonJSRequireESMFromHijackedExtensionFunction.initLater(

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -227,23 +227,24 @@ describe.concurrent("node-module-module", () => {
         const Module = require("module");
         const orig = Module.prototype._compile;
         let hits = 0;
-        Module.prototype._compile = function (code, filename) {
+        const override = function (code, filename) {
           hits++;
           return orig.call(this, code.replace("ORIGINAL", "PATCHED"), filename);
         };
+        Module.prototype._compile = override;
+        // A module instance must reflect the prototype override while it's active.
+        const reflects = new Module("x")._compile === override;
         const v1 = require("./t.js");
         // Restoring the original re-enables the fast path.
         Module.prototype._compile = orig;
         delete require.cache[require.resolve("./t.js")];
         const v2 = require("./t.js");
-        // A module instance reflects the prototype override.
-        const m = new Module("x");
         console.log(JSON.stringify({
           present: typeof orig === "function",
           hits,
           v1,
           v2,
-          reflects: m._compile === orig,
+          reflects,
         }));
       `,
       "t.js": `module.exports = "ORIGINAL";`,

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -273,6 +273,37 @@ describe.concurrent("node-module-module", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("non-chaining Module.prototype._compile override still marks the module loaded", async () => {
+    using dir = tempDir("module-prototype-compile-vm", {
+      "package.json": JSON.stringify({ type: "commonjs" }),
+      "main.cjs": `
+        const Module = require("module"), vm = require("vm"), path = require("path");
+        Module.prototype._compile = function (code, filename) {
+          const wrapped = vm.runInThisContext(Module.wrap(code));
+          return wrapped.call(this.exports, this.exports, require, this, filename, path.dirname(filename));
+        };
+        const v = require("./t.cjs");
+        const loaded = require.cache[require.resolve("./t.cjs")].loaded;
+        import("./t.cjs").then(
+          m => console.log(JSON.stringify({ v, loaded, importOk: true, default: m.default })),
+          e => console.log(JSON.stringify({ v, loaded, importOk: false, err: String(e) })),
+        );
+      `,
+      "t.cjs": `module.exports = 42;`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ v: 42, loaded: true, importOk: true, default: 42 });
+    expect(exitCode).toBe(0);
+  });
+
   test.each([
     "/file/name/goes/here.js",
     "file/here.js",

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -218,6 +218,53 @@ describe.concurrent("node-module-module", () => {
     const stdout = await proc.stdout.text();
     expect(stdout.trim().endsWith("--pass--")).toBe(true);
     expect(await proc.exited).toBe(0);
+  });
+
+  test("Overwriting Module.prototype._compile intercepts require()", async () => {
+    using dir = tempDir("module-prototype-compile", {
+      "package.json": JSON.stringify({ type: "commonjs" }),
+      "main.cjs": `
+        const Module = require("module");
+        const orig = Module.prototype._compile;
+        let hits = 0;
+        Module.prototype._compile = function (code, filename) {
+          hits++;
+          return orig.call(this, code.replace("ORIGINAL", "PATCHED"), filename);
+        };
+        const v1 = require("./t.js");
+        // Restoring the original re-enables the fast path.
+        Module.prototype._compile = orig;
+        delete require.cache[require.resolve("./t.js")];
+        const v2 = require("./t.js");
+        // A module instance reflects the prototype override.
+        const m = new Module("x");
+        console.log(JSON.stringify({
+          present: typeof orig === "function",
+          hits,
+          v1,
+          v2,
+          reflects: m._compile === orig,
+        }));
+      `,
+      "t.js": `module.exports = "ORIGINAL";`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      present: true,
+      hits: 1,
+      v1: "PATCHED",
+      v2: "ORIGINAL",
+      reflects: true,
+    });
+    expect(exitCode).toBe(0);
   });
 
   test.each([

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -235,6 +235,8 @@ describe.concurrent("node-module-module", () => {
         // A module instance must reflect the prototype override while it's active.
         const reflects = new Module("x")._compile === override;
         const v1 = require("./t.js");
+        // import.meta in CJS (Bun extension) must still work when routed through _compile.
+        const metaUrl = require("./meta.cjs");
         // Restoring the original re-enables the fast path.
         Module.prototype._compile = orig;
         delete require.cache[require.resolve("./t.js")];
@@ -245,9 +247,11 @@ describe.concurrent("node-module-module", () => {
           v1,
           v2,
           reflects,
+          metaIsFileUrl: typeof metaUrl === "string" && metaUrl.startsWith("file://") && metaUrl.endsWith("meta.cjs"),
         }));
       `,
       "t.js": `module.exports = "ORIGINAL";`,
+      "meta.cjs": `module.exports = import.meta.url;`,
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "main.cjs"],
@@ -260,10 +264,11 @@ describe.concurrent("node-module-module", () => {
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({
       present: true,
-      hits: 1,
+      hits: 2,
       v1: "PATCHED",
       v2: "ORIGINAL",
       reflects: true,
+      metaIsFileUrl: true,
     });
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
Packages like `v8-compile-cache`, `bytenode`, `webpack-cli`, and `source-map-support` monkeypatch `Module.prototype._compile` to transform source before evaluation. Node routes every CJS compile through that prototype method via `Module._extensions['.js'] → module._compile(content, filename)`. In Bun the function existed on `require('module').prototype` (so feature detection passed) but the built-in loader went straight from `Bun__transpileFile` to `evaluateCommonJSModuleOnce` without ever dispatching it.

## Repro

```js
const Module = require("module"), fs = require("fs"), path = require("path"), os = require("os");
const d = fs.mkdtempSync(path.join(os.tmpdir(), "mpc-"));
fs.writeFileSync(path.join(d, "package.json"), '{"type":"commonjs"}');
const p = path.join(d, "t.js"); fs.writeFileSync(p, 'module.exports = "ORIGINAL";');
const orig = Module.prototype._compile; let hits = 0;
Module.prototype._compile = function (code, filename) {
  hits++; return orig.call(this, code.replace("ORIGINAL", "PATCHED"), filename);
};
const v = require(p);
console.log(JSON.stringify({ present: typeof orig === "function", hits, value: v }));
```

| | before | after / node |
|-|-|-|
| output | `{"present":true,"hits":0,"value":"ORIGINAL"}` | `{"present":true,"hits":1,"value":"PATCHED"}` |

## Cause

Two separate pieces:

- `require('module').prototype._compile` was a plain data property on a JS object that is *not* the actual `[[Prototype]]` of module instances, so assigning to it touched nothing the loader reads.
- The default `require()` path (`overridableRequire` → `jsFunctionRequireCommonJS` → `fetchCommonJSModuleNonBuiltin<false>` → `target->evaluate(...)`) never consults `_compile`. Only the `<true>` variant (reached when a user calls the original `Module._extensions['.js']` from inside their own hook) calls `evaluateWithPotentiallyOverriddenCompile`, and even that only looked at the per-instance `m_overriddenCompile`.

## Fix

Follows the existing `_resolveFilename` / `runMain` de-optimization pattern:

- `Module.prototype._compile` on the user-visible prototype is now a `CustomAccessor`. The setter stores the value in the existing `m_modulePrototypeUnderscoreCompileFunction` slot (retyped `JSFunction` → `JSCell`) and flips a new `hasOverriddenModulePrototypeCompile` flag on `Zig::GlobalObject`. Assigning the original native function back clears the flag.
- `fetchCommonJSModuleNonBuiltin<false>` takes the `evaluateWithPotentiallyOverriddenCompile` branch when the flag is set.
- `evaluateWithPotentiallyOverriddenCompile` falls back to the global prototype override when no instance-level `m_overriddenCompile` is present.
- `getterUnderscoreCompile` on `JSCommonJSModulePrototype` already returns `modulePrototypeUnderscoreCompileFunction()`, so `someModule._compile` reflects the prototype override with no extra code.

No behavior change when `_compile` is untouched (flag stays `false`, fast path unchanged).

## Verification

```
$ bun bd test test/js/node/module/node-module-module.test.js
33 pass, 0 fail
$ bun bd test test/js/node/module/require-extensions.test.ts
10 pass, 0 fail
```

New test fails on the released binary with `hits: 0, v1: "ORIGINAL"` and passes on this build.

Related: #33804 unifies the two prototype objects but does not route `require()` through the override; the two changes are complementary and will conflict on one `putDirect` line.

## Scope

This change covers `require()` only. The ESM-imports-CJS entry point (`fetchESMSourceCode` -> `createCommonJSModule` -> the synthetic-source lambda) still calls `evaluateCommonJSModuleOnce` directly; routing that path through `_compile` needs the pre-transpiled source threaded into the deferred evaluator and is left for a follow-up. Node does route ESM-imported CJS through `module._compile`, so this is a known gap.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/node-module-module.test.js
bun test v1.4.0 (632a5b2b0)

test/js/node/module/node-module-module.test.js:
(pass) node-module-module > builtinModules exists [3.69ms]
(pass) node-module-module > isBuiltin() works [9.09ms]
(pass) node-module-module > module.globalPaths exists [4.37ms]
(pass) node-module-module > module.enableCompileCache validates its argument [50.49ms]
(pass) node-module-module > native module functions are not constructors [24.25ms]
(pass) node-module-module > Module._resolveFilename accepts an options object without paths [7.08ms]
(pass) node-module-module > createRequire trailing slash [10.66ms]
(pass) node-module-module > createRequire trailing slash file url [7.34ms]
(pass) node-module-module > Module exists [2.70ms]
(pass) node-module-module > module.Module works [3.32ms]
(pass) node-module-module > _nodeModulePaths() works [16.30ms]
(pass) node-module-module > Module.wrap [10.15ms]
260 |       stderr: "pipe",
261 |       stdout: "pipe",
262 |     });
263 |     const [stdout, stderr, exitCode] = a
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/module/node-module-module.test.js:
4 | import path from "path";
5 | 
6 | describe.concurrent("node-module-module", () => {
7 |   test("builtinModules exists", () => {
8 |     expect(Array.isArray(builtinModules)).toBe(true);
9 |     expect(builtinModules).toHaveLength(77);
                               ^
error: expect(received).toHaveLength(expected)

Expected length: 77
Received length: 76

      at <anonymous> (/workspace/bun/test/js/node/module/node-module-module.test.js:9:28)
(fail) node-module-module > builtinModules exists [0.28ms]
(pass) node-module-module > isBuiltin() works [0.10ms]
(pass) node-module-module > module.globalPaths exists [0.05ms]
25 |   test("module.globalPaths exists", () => {
26 |     expect(Array.isArray(require("module").globalPaths)).toBe(true);
27 |   });
28 | 
29 |   test("module.enableCompileCache validates its argument", () => {
30 |     expect(Module.enableCompileCache.length).toBe(1);
                                                  ^
error: expect(received).toBe(expected)

Expected: 1
Received: 0

      at <anonymous> (/workspace/bun/test/js/node/module/node-module-module.test.j
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/node-module-module.test.js
bun test v1.4.0 (632a5b2b0)

test/js/node/module/node-module-module.test.js:
(pass) node-module-module > builtinModules exists [2.69ms]
(pass) node-module-module > isBuiltin() works [5.09ms]
(pass) node-module-module > module.globalPaths exists [2.44ms]
(pass) node-module-module > module.enableCompileCache validates its argument [27.45ms]
(pass) node-module-module > native module functions are not constructors [13.38ms]
(pass) node-module-module > Module._resolveFilename accepts an options object without paths [3.65ms]
(pass) node-module-module > createRequire trailing slash [5.79ms]
(pass) node-module-module > createRequire trailing slash file url [4.06ms]
(pass) node-module-module > Module exists [1.55ms]
(pass) node-module-module > module.Module works [1.85ms]
(pass) node-module-module > _nodeModulePaths() works [9.67ms]
(pass) node-module-module > Module.wrap [8.75ms]
(pass) node-module-module > Overwriting Module.prototype._compile intercepts require() [404.11ms]
(pass) node-module-mo
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     632a5b2b00
  features     baseline

22 deps, 108 codegen, 1171 objects in 1310ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] gen ErrorCode+*.h
[3/1234] fetch tinycc
[tinycc] up to date
[4/1234] fetch picohttpparser
[picohttpparser] up to date
[5/1234] gen .bind.ts → GeneratedBindings.cpp
[6/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1234] fetch zlib
[zlib] up to date
[8/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1234] subst deps/zlib/zconf.h
[11/1234] fetch zstd
[zstd] up to date
[12/1234] subst deps/zlib/zlib.h
[13/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[14/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/releas
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSCommonJSModule.cpp          | 20 ++++--
 src/jsc/bindings/ModuleLoader.cpp              |  8 ++-
 src/jsc/bindings/ZigGlobalObject.h             |  6 +-
 src/jsc/modules/NodeModuleModule.cpp           | 45 ++++++++++++--
 test/js/node/module/node-module-module.test.js | 86 +++++++++++++++++++++++++-
 5 files changed, 149 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/jsc/bindings/JSCommonJSModule.cpp               7      5      0
src/jsc/bindings/ModuleLoader.cpp                   3      2      0
src/jsc/bindings/ZigGlobalObject.h                  3      3      0
src/jsc/modules/NodeModuleModule.cpp                3      3      0
test/js/node/module/node-module-module.test.js      6      6      0
```

</details>

<!-- robobun:evidence:end -->