### PR TITLE
dns: arm the c-ares retransmit timer before dispatch so sync rejections balance

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2143,10 +2143,8 @@ impl Resolver {
             // SAFETY: `channel` is the live handle from `ares_init_options`, owned by this resolver.
             unsafe { c_ares::Channel::destroy(channel) };
         }
-        // Native-backend lookups (libinfo/libc/libuv) occupy
-        // `pending_host_cache_native` and are not cancelled by `ares_destroy`,
-        // so every EDESTRUCTION callback's `request_completed()` takes the
-        // `add_timer` branch while one is in flight; drop the timer (and its
+        // Native-backend lookups (`pending_host_cache_native`) are not cancelled
+        // by `ares_destroy`, so the timer may still be linked; drop it (and its
         // +1 ref / uws active-handle) explicitly.
         self.remove_timer();
     }
@@ -4162,16 +4160,10 @@ impl Resolver {
         false
     }
 
-    /// Arm the retransmit timer for a just-dispatched query.
-    ///
-    /// c-ares callers must invoke this *before* handing the request to the
-    /// channel (`Channel::resolve` / `get_host_by_addr` / `get_addr_info` /
-    /// `get_name_info`): those entry points may invoke the completion callback
-    /// synchronously (e.g. `ARES_EBADNAME` for a malformed name, `ARES_ENOTIMP`
-    /// for an unparseable IP), and that callback's `request_completed()` →
-    /// `remove_timer()` must see the timer as ACTIVE so the `ref_()`/`deref()`
-    /// pair on this resolver stays balanced. Native backends (libinfo/libc/
-    /// libuv) are truly async so ordering does not matter there.
+    /// Arm the retransmit timer. Call *before* handing the request to c-ares:
+    /// dispatch can fire the completion callback synchronously (EBADNAME/
+    /// ENOTIMP/…), and its `request_completed()` must see the timer ACTIVE so
+    /// the `ref_()`/`deref()` pair balances.
     fn request_sent(&self, _vm: &VirtualMachine) {
         let _ = self.add_timer(None);
     }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -819,6 +819,7 @@ impl GetHostByAddrInfoRequest {
         // SAFETY: this is the heap-allocated request c-ares calls back with
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching {
+                scopeguard::defer! { (*resolver).request_completed() };
                 if (*this).cache.pending_cache() {
                     (*resolver).drain_pending_addr_cares(
                         (*this).cache.pos_in_pending(),
@@ -1542,6 +1543,7 @@ impl GetAddrInfoRequest {
         // `resolver` (if set) is the live intrusive-RC ctx stored at init time.
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching {
+                scopeguard::defer! { (*resolver).request_completed() };
                 if (*this).cache.pending_cache() {
                     (*resolver).drain_pending_host_cares(
                         (*this).cache.pos_in_pending(),
@@ -4158,6 +4160,15 @@ impl Resolver {
         false
     }
 
+    /// Arm the retransmit timer for a just-dispatched c-ares query.
+    ///
+    /// Callers must invoke this *before* handing the request to c-ares
+    /// (`Channel::resolve` / `get_host_by_addr` / `get_addr_info` /
+    /// `get_name_info`): those entry points may invoke the completion callback
+    /// synchronously (e.g. `ARES_EBADNAME` for a malformed name, `ARES_ENOTIMP`
+    /// for an unparseable IP), and that callback's `request_completed()` →
+    /// `remove_timer()` must see the timer as ACTIVE so the `ref_()`/`deref()`
+    /// pair on this resolver stays balanced.
     fn request_sent(&self, _vm: &VirtualMachine) {
         let _ = self.add_timer(None);
     }
@@ -5133,14 +5144,16 @@ impl Resolver {
 
         // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
         let promise = unsafe { (*(*request).tail).promise.value() };
+
+        // Before dispatch — see `request_sent` doc for the ordering constraint.
+        // SAFETY: `bun_vm()` returns the live VM back-ptr.
+        self.request_sent(global_this.bun_vm());
+
         // SAFETY: `request` is the heap-allocated GetHostByAddrInfoRequest; channel
         // stores it as the c-ares ctx and calls back via HostentHandler::on_hostent.
         unsafe {
             (*channel).get_host_by_addr(ip, &mut *request);
         }
-
-        // SAFETY: `bun_vm()` returns the live VM back-ptr.
-        self.request_sent(global_this.bun_vm());
         Ok(promise)
     }
 
@@ -5433,14 +5446,15 @@ impl Resolver {
         // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
         let promise = unsafe { (*(*request).tail).promise.value() };
 
+        // Before dispatch — see `request_sent` doc for the ordering constraint.
+        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
+        self.request_sent(global_this.bun_vm());
+
         // SAFETY: `channel` is the live c-ares channel owned by `self`; `request`
         // is the freshly heap-allocated ResolveInfoRequest. c-ares stores the ctx
         // pointer and calls `T::RAW_CALLBACK` (→ `on_cares_complete`) which
         // consumes the request, so the `&mut` borrow is not held past this call.
         unsafe { (*channel).resolve(name, &mut *request) };
-
-        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
-        self.request_sent(global_this.bun_vm());
         Ok(promise)
     }
 
@@ -5488,15 +5502,16 @@ impl Resolver {
         // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
         let promise = unsafe { (*(*request).tail).promise.value() };
 
+        // Before dispatch — see `request_sent` doc for the ordering constraint.
+        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
+        self.request_sent(global_this.bun_vm());
+
         // SAFETY: `channel` is the live c-ares channel owned by `self`; `request`
         // is the freshly heap-allocated GetAddrInfoRequest. c-ares stores the ctx
         // pointer and calls `AddrInfo::callback_wrapper::<GetAddrInfoRequest>`
         // (→ `on_cares_complete`) which consumes the request, so the `&mut`
         // borrow is not held past this call.
         unsafe { (*channel).get_addr_info(&query.name, query.port, &hints_buf, &mut *request) };
-
-        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
-        self.request_sent(global_this.bun_vm());
         Ok(promise)
     }
 
@@ -6010,6 +6025,11 @@ impl Resolver {
 
         // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
         let promise = unsafe { (*(*request).tail).promise.value() };
+
+        // Before dispatch — see `request_sent` doc for the ordering constraint.
+        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
+        resolver.request_sent(global_this.bun_vm());
+
         // SAFETY: `channel` is the live c-ares channel; `sa` is a valid
         // sockaddr_storage reborrowed as sockaddr; `request` was just
         // `heap::alloc`'d and is owned by c-ares until the callback fires.
@@ -6021,9 +6041,6 @@ impl Resolver {
                 &mut *request,
             );
         }
-
-        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
-        resolver.request_sent(global_this.bun_vm());
         Ok(promise)
     }
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2143,9 +2143,7 @@ impl Resolver {
             // SAFETY: `channel` is the live handle from `ares_init_options`, owned by this resolver.
             unsafe { c_ares::Channel::destroy(channel) };
         }
-        // Native-backend lookups (`pending_host_cache_native`) are not cancelled
-        // by `ares_destroy`, so the timer may still be linked; drop it (and its
-        // +1 ref / uws active-handle) explicitly.
+        // Native-backend lookups aren't cancelled by `ares_destroy`; drop the timer ref explicitly.
         self.remove_timer();
     }
 }
@@ -4160,10 +4158,7 @@ impl Resolver {
         false
     }
 
-    /// Arm the retransmit timer. Call *before* handing the request to c-ares:
-    /// dispatch can fire the completion callback synchronously (EBADNAME/
-    /// ENOTIMP/…), and its `request_completed()` must see the timer ACTIVE so
-    /// the `ref_()`/`deref()` pair balances.
+    /// Arm the retransmit timer. Call *before* c-ares dispatch: it may fire the completion callback synchronously.
     fn request_sent(&self, _vm: &VirtualMachine) {
         let _ = self.add_timer(None);
     }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2143,9 +2143,11 @@ impl Resolver {
             // SAFETY: `channel` is the live handle from `ares_init_options`, owned by this resolver.
             unsafe { c_ares::Channel::destroy(channel) };
         }
-        // `GetAddrInfoRequest`'s EDESTRUCTION path does not call
-        // `request_completed()`, so the c-ares timeout timer (and its +1 ref on
-        // this resolver plus the uws active-handle bump) can still be linked.
+        // Native-backend lookups (libinfo/libc/libuv) occupy
+        // `pending_host_cache_native` and are not cancelled by `ares_destroy`,
+        // so every EDESTRUCTION callback's `request_completed()` takes the
+        // `add_timer` branch while one is in flight; drop the timer (and its
+        // +1 ref / uws active-handle) explicitly.
         self.remove_timer();
     }
 }
@@ -4160,15 +4162,16 @@ impl Resolver {
         false
     }
 
-    /// Arm the retransmit timer for a just-dispatched c-ares query.
+    /// Arm the retransmit timer for a just-dispatched query.
     ///
-    /// Callers must invoke this *before* handing the request to c-ares
-    /// (`Channel::resolve` / `get_host_by_addr` / `get_addr_info` /
+    /// c-ares callers must invoke this *before* handing the request to the
+    /// channel (`Channel::resolve` / `get_host_by_addr` / `get_addr_info` /
     /// `get_name_info`): those entry points may invoke the completion callback
     /// synchronously (e.g. `ARES_EBADNAME` for a malformed name, `ARES_ENOTIMP`
     /// for an unparseable IP), and that callback's `request_completed()` →
     /// `remove_timer()` must see the timer as ACTIVE so the `ref_()`/`deref()`
-    /// pair on this resolver stays balanced.
+    /// pair on this resolver stays balanced. Native backends (libinfo/libc/
+    /// libuv) are truly async so ordering does not matter there.
     fn request_sent(&self, _vm: &VirtualMachine) {
         let _ = self.add_timer(None);
     }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1438,6 +1438,7 @@ impl GetAddrInfoRequest {
             }
 
             if let Some(resolver) = (*this).resolver_for_caching {
+                scopeguard::defer! { (*resolver).request_completed() };
                 if (*this).cache.pending_cache() {
                     (*resolver).drain_pending_host_native(
                         (*this).cache.pos_in_pending(),
@@ -1494,6 +1495,7 @@ impl GetAddrInfoRequest {
                     // at the end of whichever callee receives `any`.
                     let any = GetAddrInfoResultAny::List(result);
                     if let Some(resolver) = (*this).resolver_for_caching {
+                        scopeguard::defer! { (*resolver).request_completed() };
                         if (*this).cache.pending_cache() {
                             (*resolver).drain_pending_host_native(
                                 (*this).cache.pos_in_pending(),

--- a/test/js/node/dns/dns-lookup-keepalive.test.ts
+++ b/test/js/node/dns/dns-lookup-keepalive.test.ts
@@ -1,7 +1,53 @@
-import { expect, test } from "bun:test";
-import "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
 test("expect dns.lookup to keep the process alive", () => {
   expect([join(import.meta.dir, "dns-fixture.js")]).toRun();
+});
+
+// c-ares rejects some inputs client-side (no wire query) and invokes the
+// completion callback synchronously inside the dispatch call. Before the fix,
+// `Resolver::request_sent()` ran *after* dispatch, so the synchronous
+// `request_completed()` was a no-op and the retransmit timer (1 s, +1 ref on
+// the native Resolver) was left armed with nothing pending. Observable as a
+// ~1 s exit delay; under LSAN with an early exit, as a ~25 KB leak of the
+// Resolver allocation.
+describe("dns.Resolver does not keep the event loop alive after a synchronously-rejected query", () => {
+  async function run(stmt: string) {
+    const src = `
+      const dns = require("node:dns");
+      const r = new dns.Resolver();
+      r.setServers(["127.0.0.1:1"]);
+      let cb_t, code;
+      const cb = err => { cb_t = Date.now(); code = err && err.code; };
+      ${stmt}
+      process.on("exit", () => {
+        console.log(JSON.stringify({ delay: Date.now() - cb_t, code }));
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    return JSON.parse(stdout.trim()) as { delay: number; code: string };
+  }
+
+  test.concurrent("resolve4 with a malformed hostname (ARES_EBADNAME)", async () => {
+    // "a..b" has an empty interior label; c-ares rejects it before sending.
+    const { delay, code } = await run(`r.resolve4("a..b", cb);`);
+    expect(typeof code).toBe("string");
+    // Before the fix: delay ≈ 1000 ms (the retransmit timer interval).
+    expect(delay).toBeLessThan(500);
+  });
+
+  test.concurrent("reverse with an unparseable address (ARES_ENOTIMP)", async () => {
+    const { delay, code } = await run(`r.reverse("not-an-ip", cb);`);
+    expect(code).toBe("ENOTIMP");
+    expect(delay).toBeLessThan(500);
+  });
 });

--- a/test/js/node/dns/dns-lookup-keepalive.test.ts
+++ b/test/js/node/dns/dns-lookup-keepalive.test.ts
@@ -47,7 +47,15 @@ describe("dns.Resolver does not keep the event loop alive after a synchronously-
 
   test.concurrent("reverse with an unparseable address (ARES_ENOTIMP)", async () => {
     const { delay, code } = await run(`r.reverse("not-an-ip", cb);`);
-    expect(code).toBe("ENOTIMP");
+    expect(typeof code).toBe("string");
+    expect(delay).toBeLessThan(500);
+  });
+
+  test.concurrent("Bun.dns.lookup backend=c-ares with a .onion name (ARES_ENOTFOUND)", async () => {
+    // ares_getaddrinfo refuses .onion (RFC 7686) before sending; this covers
+    // the global resolver's `c_ares_lookup_with_normalized_name` entry point.
+    const { delay, code } = await run(`Bun.dns.lookup("example.onion", { backend: "c-ares" }).catch(cb);`);
+    expect(typeof code).toBe("string");
     expect(delay).toBeLessThan(500);
   });
 });


### PR DESCRIPTION
## What

A `dns.Resolver` whose last call is a query that c-ares rejects client-side keeps the event loop alive for ~1 s after the callback fires. Node.js exits immediately.

```js
import dns from "node:dns";
const r = new dns.Resolver();
r.setServers(["127.0.0.1:1"]);
r.resolve4("a..b", err => {});       // empty interior label: ARES_EBADNAME, no wire query
// process should drain here; before this change it waits ~1000 ms
```

The same applies to `r.reverse("not-an-ip", cb)` (ARES_ENOTIMP), `Bun.dns.lookup("example.onion", {backend:"c-ares"})` (RFC 7686 client-side refusal), and failed native-backend lookups via `Bun.dns.lookup(..., {backend:"libc"/"system"})`. Under LeakSanitizer with an early exit the extra ref on the native `Resolver` is reported as a ~25 KB leak (`Resolver::new_resolver`); this was surfaced by `test/js/node/dns/node-dns.test.js` on the debian 13 x64-asan lane.

## Cause

`Resolver::do_resolve_cares` (and the sibling entry points for `reverse` / c-ares `getaddrinfo` / `getnameinfo`) called `request_sent()` *after* handing the request to c-ares. `ares_query` and friends invoke the completion callback synchronously for inputs they refuse to encode, so the callback chain ran `request_completed()` (timer not yet ACTIVE, so a no-op) and *then* `request_sent()` armed the 1 s retransmit timer with a +1 ref on the Resolver and a +1 event-loop active-handle, with no pending request to ever balance it. The timer's own fire path eventually drops the ref, hence the fixed ~1 s delay.

Separately, `GetHostByAddrInfoRequest::on_cares_complete`, `GetAddrInfoRequest::on_cares_complete`, and the native-backend `get_addr_info_async_callback`/`then` never called `request_completed()` on their error paths at all (`ResolveInfoRequest` and `GetNameInfoRequest` already did via a `scopeguard::defer!`). For those request types the reordering alone is not enough.

## Fix

Move `request_sent()` before the c-ares dispatch in all four call sites, and add the missing `request_completed()` defer to every completion entry point that lacked it, matching `ResolveInfoRequest` / `GetNameInfoRequest`. `remove_timer()` and `add_timer()` are both guarded on the timer's ACTIVE state, so the extra call on success paths (where `on_complete_with_array` already calls `request_completed()`) is a no-op. The Windows libuv lookup path never calls `request_sent()` and is unchanged.

## Verification

`test/js/node/dns/dns-lookup-keepalive.test.ts` gains three subprocess tests that measure the time between the rejected-query callback and `process.on("exit")`:

- `resolve4("a..b")` (ARES_EBADNAME): before ~1000 ms, after ~2 ms
- `reverse("not-an-ip")` (ARES_ENOTIMP): before ~1000 ms, after ~3 ms
- `Bun.dns.lookup("example.onion", {backend:"c-ares"})` (ARES_ENOTFOUND): before ~1000 ms, after ~15 ms

All three fail on `USE_SYSTEM_BUN=1` with `Received: 1000/1001` and pass on the debug build. The native-backend error path is intentionally not given its own test (a deterministic `getaddrinfo` failure depends on network/nsswitch configuration) but is covered by the same one-line defer; verified locally that a failed libc lookup's exit delay drops from ~915 ms to ~3 ms.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-lookup-keepalive.test.ts
bun test v1.4.0 (d8aa0d666)

test/js/node/dns/dns-lookup-keepalive.test.ts:
(pass) expect dns.lookup to keep the process alive [554.71ms]
54 |   test.concurrent("Bun.dns.lookup backend=c-ares with a .onion name (ARES_ENOTFOUND)", async () => {
55 |     // ares_getaddrinfo refuses .onion (RFC 7686) before sending; this covers
56 |     // the global resolver's `c_ares_lookup_with_normalized_name` entry point.
57 |     const { delay, code } = await run(`Bun.dns.lookup("example.onion", { backend: "c-ares" }).catch(cb);`);
58 |     expect(typeof code).toBe("string");
59 |     expect(delay).toBeLessThan(500);
                       ^
error: expect(received).toBeLessThan(expected)

Expected: < 500
Received: 997

      at <anonymous> (/workspace/bun/test/js/node/dns/dns-lookup-keepalive.test.ts:59:19)
(fail) dns.Resolver does not keep the event loop alive after a synchronously-rejected query > Bun.dns.lookup backend=c-ares with a .onion name (ARES_ENOTFOUND) [1516.75ms]
46 |   });
47 | 
48 |   test
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (25579ad2a)

test/js/node/dns/dns-lookup-keepalive.test.ts:
(pass) expect dns.lookup to keep the process alive [47.87ms]
(pass) dns.Resolver does not keep the event loop alive after a synchronously-rejected query > resolve4 with a malformed hostname (ARES_EBADNAME) [69.78ms]
(pass) dns.Resolver does not keep the event loop alive after a synchronously-rejected query > Bun.dns.lookup backend=c-ares with a .onion name (ARES_ENOTFOUND) [19.00ms]
(pass) dns.Resolver does not keep the event loop alive after a synchronously-rejected query > reverse with an unparseable address (ARES_ENOTIMP) [19.96ms]

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [675.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-lookup-keepalive.test.ts
bun test v1.4.0 (d8aa0d666)

test/js/node/dns/dns-lookup-keepalive.test.ts:
(pass) expect dns.lookup to keep the process alive [575.24ms]
(pass) dns.Resolver does not keep the event loop alive after a synchronously-rejected query > resolve4 with a malformed hostname (ARES_EBADNAME) [587.83ms]
(pass) dns.Resolver does not keep the event loop alive after a synchronously-rejected query > reverse with an unparseable address (ARES_ENOTIMP) [563.29ms]
(pass) dns.Resolver does not keep the event loop alive after a synchronously-rejected query > Bun.dns.lookup backend=c-ares with a .onion name (ARES_ENOTFOUND) [669.52ms]

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [6.44s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1052ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/dns_jsc/dns.rs                    | 39 +++++++++++-------
 test/js/node/dns/dns-lookup-keepalive.test.ts | 58 ++++++++++++++++++++++++++-
 2 files changed, 80 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/dns_jsc/dns.rs                        19     12      0
test/js/node/dns/dns-lookup-keepalive.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->