### PR TITLE
node:http: fix ERR_HTTP_CONTENT_LENGTH_MISMATCH and ERR_HTTP_TRAILER_INVALID message text

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2114,7 +2114,7 @@ function _writeHead(statusCode, reason, obj, response) {
         // header fields, regardless of the header fields present in the
         // message, and thus cannot contain a message body or 'trailers'.
         if (hasInvalidTrailer(response)) {
-          throw $ERR_HTTP_TRAILER_INVALID("Trailers are invalid with this transfer encoding");
+          throw $ERR_HTTP_TRAILER_INVALID();
         }
         // Headers in obj should override previous headers but still
         // allow explicit duplicates. To do so, we first remove any
@@ -2144,7 +2144,7 @@ function _writeHead(statusCode, reason, obj, response) {
       // The message is not chunk-framed, so `Trailer` is the offending header; drop it
       // so a caller that swallows the throw cannot put it on the wire.
       response.removeHeader("trailer");
-      throw $ERR_HTTP_TRAILER_INVALID("Trailers are invalid with this transfer encoding");
+      throw $ERR_HTTP_TRAILER_INVALID();
     }
   }
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -2391,6 +2391,17 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_HEADERS_SENT, message));
     }
 
+    case Bun::ErrorCode::ERR_HTTP_CONTENT_LENGTH_MISMATCH: {
+        auto arg0 = callFrame->argument(1);
+        auto str0 = arg0.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto arg1 = callFrame->argument(2);
+        auto str1 = arg1.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto message = makeString("Response body's content-length of "_s, str0, " byte(s) does not match the content-length of "_s, str1, " byte(s) set in header"_s);
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_CONTENT_LENGTH_MISMATCH, message));
+    }
+
     case Bun::ErrorCode::ERR_UNESCAPED_CHARACTERS: {
         auto arg0 = callFrame->argument(1);
         auto str0 = arg0.toWTFString(globalObject);
@@ -2672,6 +2683,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_BODY_NOT_ALLOWED, "Adding content for this request method or response status is not allowed."_s));
     case ErrorCode::ERR_HTTP_SOCKET_ASSIGNED:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_SOCKET_ASSIGNED, "Socket already assigned"_s));
+    case ErrorCode::ERR_HTTP_TRAILER_INVALID:
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_TRAILER_INVALID, "Trailers are invalid with this transfer encoding"_s));
     case ErrorCode::ERR_STREAM_RELEASE_LOCK:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_STREAM_RELEASE_LOCK, "Stream reader cancelled via releaseLock()"_s));
     case ErrorCode::ERR_SOCKET_CONNECTION_TIMEOUT:

--- a/test/js/node/http/node-http-outgoing-errors.test.ts
+++ b/test/js/node/http/node-http-outgoing-errors.test.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+import { once } from "node:events";
+
+async function withRawServer(fn: (port: number) => void | Promise<void>) {
+  const srv = net.createServer(s => {
+    s.on("data", () => s.end("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"));
+    s.on("error", () => {});
+  });
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  const port = (srv.address() as net.AddressInfo).port;
+  try {
+    await fn(port);
+  } finally {
+    await new Promise<void>(r => srv.close(() => r()));
+  }
+}
+
+test("ERR_HTTP_CONTENT_LENGTH_MISMATCH message matches Node.js", async () => {
+  await withRawServer(port => {
+    const req = http.request({
+      host: "127.0.0.1",
+      port,
+      method: "POST",
+      agent: false,
+      headers: { "Content-Length": 5 },
+    });
+    req.on("error", () => {});
+    req.strictContentLength = true;
+    let err: any;
+    try {
+      req.end("abc");
+    } catch (e) {
+      err = e;
+    }
+    req.destroy();
+    expect(err).toBeDefined();
+    expect(err.code).toBe("ERR_HTTP_CONTENT_LENGTH_MISMATCH");
+    expect(err.message).toBe(
+      "Response body's content-length of 3 byte(s) does not match the content-length of 5 byte(s) set in header",
+    );
+  });
+});
+
+test("ERR_HTTP_TRAILER_INVALID message matches Node.js", async () => {
+  await withRawServer(port => {
+    const req = http.request({
+      host: "127.0.0.1",
+      port,
+      method: "GET",
+      agent: false,
+      headers: { Trailer: "X-T" },
+    });
+    req.on("error", () => {});
+    let err: any;
+    try {
+      req.end();
+    } catch (e) {
+      err = e;
+    }
+    req.destroy();
+    expect(err).toBeDefined();
+    expect(err.code).toBe("ERR_HTTP_TRAILER_INVALID");
+    expect(err.message).toBe("Trailers are invalid with this transfer encoding");
+  });
+});

--- a/test/js/node/http/node-http-outgoing-errors.test.ts
+++ b/test/js/node/http/node-http-outgoing-errors.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { once } from "node:events";
 import http from "node:http";
 import net from "node:net";
-import { once } from "node:events";
 
 async function withRawServer(fn: (port: number) => void | Promise<void>) {
   const srv = net.createServer(s => {


### PR DESCRIPTION
## What

Two `node:http` client error codes had broken message templates. The codes and throw timing were already node-identical; only the `.message` text was wrong.

| Code | Bun before | Node.js |
|---|---|---|
| `ERR_HTTP_CONTENT_LENGTH_MISMATCH` | `"3"` | `"Response body's content-length of 3 byte(s) does not match the content-length of 5 byte(s) set in header"` |
| `ERR_HTTP_TRAILER_INVALID` | `"undefined"` | `"Trailers are invalid with this transfer encoding"` |

## Repro

```js
import http from 'node:http';
import net from 'node:net';
const srv = net.createServer(s => s.on('data', () => s.end('HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n')));
await new Promise(r => srv.listen(0, '127.0.0.1', r));
const port = srv.address().port;
{
  const req = http.request({ host: '127.0.0.1', port, method: 'POST', agent: false, headers: { 'Content-Length': 5 } });
  req.on('error', () => {}); req.strictContentLength = true;
  try { req.end('abc'); } catch (e) { console.log(e.code, JSON.stringify(e.message)); }
  req.destroy();
}
{
  const req = http.request({ host: '127.0.0.1', port, method: 'GET', agent: false, headers: { Trailer: 'X-T' } });
  req.on('error', () => {});
  try { req.end(); } catch (e) { console.log(e.code, JSON.stringify(e.message)); }
  req.destroy();
}
srv.close();
```

## Cause

`jsFunctionMakeErrorWithCode` in `src/jsc/bindings/ErrorCode.cpp` had no case for either code, so they fell through to the default which stringifies `callFrame->argument(1)`. `$ERR_HTTP_CONTENT_LENGTH_MISMATCH(3, 5)` became `"3"`; `$ERR_HTTP_TRAILER_INVALID()` became `String(undefined)`.

## Fix

Added a two-arg template case for `ERR_HTTP_CONTENT_LENGTH_MISMATCH` and a constant-message case for `ERR_HTTP_TRAILER_INVALID`, matching Node's `lib/internal/errors.js`. Also dropped the now-redundant inline string from the two server-side `$ERR_HTTP_TRAILER_INVALID(...)` calls in `_http_server.ts`.

## Verification

```
$ bun bd test test/js/node/http/node-http-outgoing-errors.test.ts
 2 pass, 0 fail
```

Also passes `node-http-transfer-encoding.test.ts` (23 tests) and the Node parallel tests `test-http-content-length-mismatch.js` / `test-http-server-de-chunked-trailer.js`.