### PR TITLE
cli: refuse to run under Node.js permission-model flags

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -80,10 +80,8 @@ new!(pub BUN_ENABLE_CRASH_REPORTING: boolean, "BUN_ENABLE_CRASH_REPORTING", {});
 // a signal), and on its own clean exit recursively SIGKILLs every descendant
 // so nothing it spawned outlives it. See `src/io/ParentDeathWatchdog.rs`.
 new!(pub BUN_FEATURE_FLAG_NO_ORPHANS: boolean, "BUN_FEATURE_FLAG_NO_ORPHANS", { default: false });
-// Bun does not implement Node's permission model. When `--permission` /
-// `--allow-*` are passed, Bun refuses to run rather than silently executing
-// unsandboxed. Setting this skips that refusal (for node/bun CI matrices that
-// pass the flag unconditionally and do not depend on the sandbox).
+// Skip the refusal to run under Node's `--permission` / `--allow-*` flags
+// (which Bun does not implement). See `runtime/cli/Arguments.rs`.
 new!(pub BUN_IGNORE_NODE_PERMISSION_FLAGS: boolean, "BUN_IGNORE_NODE_PERMISSION_FLAGS", { default: false });
 new!(pub BUN_FEATURE_FLAG_DUMP_CODE: string, "BUN_FEATURE_FLAG_DUMP_CODE", {});
 // TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -80,8 +80,7 @@ new!(pub BUN_ENABLE_CRASH_REPORTING: boolean, "BUN_ENABLE_CRASH_REPORTING", {});
 // a signal), and on its own clean exit recursively SIGKILLs every descendant
 // so nothing it spawned outlives it. See `src/io/ParentDeathWatchdog.rs`.
 new!(pub BUN_FEATURE_FLAG_NO_ORPHANS: boolean, "BUN_FEATURE_FLAG_NO_ORPHANS", { default: false });
-// Skip the refusal to run under Node's `--permission` / `--allow-*` flags
-// (which Bun does not implement). See `runtime/cli/Arguments.rs`.
+// Skip the refusal to run under Node's `--permission`/`--allow-*` flags (see runtime/cli/Arguments.rs).
 new!(pub BUN_IGNORE_NODE_PERMISSION_FLAGS: boolean, "BUN_IGNORE_NODE_PERMISSION_FLAGS", { default: false });
 new!(pub BUN_FEATURE_FLAG_DUMP_CODE: string, "BUN_FEATURE_FLAG_DUMP_CODE", {});
 // TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -80,6 +80,11 @@ new!(pub BUN_ENABLE_CRASH_REPORTING: boolean, "BUN_ENABLE_CRASH_REPORTING", {});
 // a signal), and on its own clean exit recursively SIGKILLs every descendant
 // so nothing it spawned outlives it. See `src/io/ParentDeathWatchdog.rs`.
 new!(pub BUN_FEATURE_FLAG_NO_ORPHANS: boolean, "BUN_FEATURE_FLAG_NO_ORPHANS", { default: false });
+// Bun does not implement Node's permission model. When `--permission` /
+// `--allow-*` are passed, Bun refuses to run rather than silently executing
+// unsandboxed. Setting this skips that refusal (for node/bun CI matrices that
+// pass the flag unconditionally and do not depend on the sandbox).
+new!(pub BUN_IGNORE_NODE_PERMISSION_FLAGS: boolean, "BUN_IGNORE_NODE_PERMISSION_FLAGS", { default: false });
 new!(pub BUN_FEATURE_FLAG_DUMP_CODE: string, "BUN_FEATURE_FLAG_DUMP_CODE", {});
 // TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior
 // so we'll keep it for now.

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -980,7 +980,10 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 None
             };
             if let Some(flag) = permission_flag {
-                if !env_var::BUN_IGNORE_NODE_PERMISSION_FLAGS.get().unwrap_or(false) {
+                if !env_var::BUN_IGNORE_NODE_PERMISSION_FLAGS
+                    .get()
+                    .unwrap_or(false)
+                {
                     Output::err_generic(
                         "Bun does not implement the Node.js permission model, so {} would run without the requested restrictions. Refusing to run.\n       Set BUN_IGNORE_NODE_PERMISSION_FLAGS=1 to ignore this flag and run without a sandbox.",
                         format_args!("{}", BStr::new(flag)),

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -307,9 +307,7 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--trace-exit"),
     parse_param!("--expose-internals"),
     parse_param!("--stack-trace-limit <STR>"),
-    // Node.js permission-model flags. Declared so `parse()` can refuse to run
-    // instead of silently executing unsandboxed; `<STR>?` lets the boolean
-    // grants accept `--allow-x=val` without a DoesntTakeValue error.
+    // Node.js permission-model flags; see `refuse_node_permission_flags`.
     parse_param!("--permission"),
     parse_param!("--experimental-permission"),
     parse_param!("--permission-audit"),
@@ -323,6 +321,48 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--allow-inspector <STR>?"),
     parse_param!("--allow-ffi <STR>?"),
 ];
+
+/// Bun does not implement Node's permission model: refuse to run rather than silently executing with none of the restrictions the caller asked for. `BUN_IGNORE_NODE_PERMISSION_FLAGS=1` opts out.
+fn refuse_node_permission_flags(args: &clap::Args<clap::Help>) {
+    let flag: Option<&[u8]> = if args.flag(b"--permission") {
+        Some(b"--permission")
+    } else if args.flag(b"--experimental-permission") {
+        Some(b"--experimental-permission")
+    } else if args.flag(b"--permission-audit") {
+        Some(b"--permission-audit")
+    } else if !args.options(b"--allow-fs-read").is_empty() {
+        Some(b"--allow-fs-read")
+    } else if !args.options(b"--allow-fs-write").is_empty() {
+        Some(b"--allow-fs-write")
+    } else if args.option(b"--allow-child-process").is_some() {
+        Some(b"--allow-child-process")
+    } else if args.option(b"--allow-worker").is_some() {
+        Some(b"--allow-worker")
+    } else if args.option(b"--allow-addons").is_some() {
+        Some(b"--allow-addons")
+    } else if args.option(b"--allow-wasi").is_some() {
+        Some(b"--allow-wasi")
+    } else if args.option(b"--allow-net").is_some() {
+        Some(b"--allow-net")
+    } else if args.option(b"--allow-inspector").is_some() {
+        Some(b"--allow-inspector")
+    } else if args.option(b"--allow-ffi").is_some() {
+        Some(b"--allow-ffi")
+    } else {
+        None
+    };
+    if let Some(flag) = flag
+        && !env_var::BUN_IGNORE_NODE_PERMISSION_FLAGS
+            .get()
+            .unwrap_or(false)
+    {
+        Output::err_generic(
+            "Bun does not implement the Node.js permission model, so {} would run without the requested restrictions. Refusing to run.\n       Set BUN_IGNORE_NODE_PERMISSION_FLAGS=1 to ignore this flag and run without a sandbox.",
+            format_args!("{}", BStr::new(flag)),
+        );
+        Global::exit(1);
+    }
+}
 
 pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
     parse_param!(
@@ -940,50 +980,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             | CommandTag::TestCommand
             | CommandTag::RunAsNodeCommand
     ) {
-        // Bun does not implement Node's permission model. Refuse to run rather
-        // than silently executing with none of the restrictions the caller
-        // asked for.
-        {
-            let permission_flag: Option<&[u8]> = if args.flag(b"--permission") {
-                Some(b"--permission")
-            } else if args.flag(b"--experimental-permission") {
-                Some(b"--experimental-permission")
-            } else if args.flag(b"--permission-audit") {
-                Some(b"--permission-audit")
-            } else if !args.options(b"--allow-fs-read").is_empty() {
-                Some(b"--allow-fs-read")
-            } else if !args.options(b"--allow-fs-write").is_empty() {
-                Some(b"--allow-fs-write")
-            } else if args.option(b"--allow-child-process").is_some() {
-                Some(b"--allow-child-process")
-            } else if args.option(b"--allow-worker").is_some() {
-                Some(b"--allow-worker")
-            } else if args.option(b"--allow-addons").is_some() {
-                Some(b"--allow-addons")
-            } else if args.option(b"--allow-wasi").is_some() {
-                Some(b"--allow-wasi")
-            } else if args.option(b"--allow-net").is_some() {
-                Some(b"--allow-net")
-            } else if args.option(b"--allow-inspector").is_some() {
-                Some(b"--allow-inspector")
-            } else if args.option(b"--allow-ffi").is_some() {
-                Some(b"--allow-ffi")
-            } else {
-                None
-            };
-            if let Some(flag) = permission_flag {
-                if !env_var::BUN_IGNORE_NODE_PERMISSION_FLAGS
-                    .get()
-                    .unwrap_or(false)
-                {
-                    Output::err_generic(
-                        "Bun does not implement the Node.js permission model, so {} would run without the requested restrictions. Refusing to run.\n       Set BUN_IGNORE_NODE_PERMISSION_FLAGS=1 to ignore this flag and run without a sandbox.",
-                        format_args!("{}", BStr::new(flag)),
-                    );
-                    Global::exit(1);
-                }
-            }
-        }
+        refuse_node_permission_flags(&args);
 
         {
             let preloads = args.options(b"--preload");

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -307,11 +307,9 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--trace-exit"),
     parse_param!("--expose-internals"),
     parse_param!("--stack-trace-limit <STR>"),
-    // Node.js permission-model flags. Bun does not implement the permission
-    // model; these are declared so `parse()` can refuse to run rather than
-    // silently executing with no sandbox. `<STR>?` on the boolean grants
-    // accepts both `--allow-x` and `--allow-x=val` without a DoesntTakeValue
-    // parse error.
+    // Node.js permission-model flags. Declared so `parse()` can refuse to run
+    // instead of silently executing unsandboxed; `<STR>?` lets the boolean
+    // grants accept `--allow-x=val` without a DoesntTakeValue error.
     parse_param!("--permission"),
     parse_param!("--experimental-permission"),
     parse_param!("--permission-audit"),
@@ -942,15 +940,9 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             | CommandTag::TestCommand
             | CommandTag::RunAsNodeCommand
     ) {
-        // Node's permission model (`--permission`) runs user code inside a
-        // sandbox that denies filesystem / child-process / worker / net access
-        // unless granted via `--allow-*`. Bun does not implement that model,
-        // so accepting the flag and running anyway would execute the program
-        // with none of the restrictions the caller asked for, and
-        // `process.permission` being undefined makes that indistinguishable
-        // from Node launched without `--permission`. Refuse to run instead.
-        // The escape hatch exists for node/bun CI matrices that pass the flag
-        // unconditionally and do not actually rely on the sandbox.
+        // Bun does not implement Node's permission model. Refuse to run rather
+        // than silently executing with none of the restrictions the caller
+        // asked for.
         {
             let permission_flag: Option<&[u8]> = if args.flag(b"--permission") {
                 Some(b"--permission")

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -307,6 +307,23 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--trace-exit"),
     parse_param!("--expose-internals"),
     parse_param!("--stack-trace-limit <STR>"),
+    // Node.js permission-model flags. Bun does not implement the permission
+    // model; these are declared so `parse()` can refuse to run rather than
+    // silently executing with no sandbox. `<STR>?` on the boolean grants
+    // accepts both `--allow-x` and `--allow-x=val` without a DoesntTakeValue
+    // parse error.
+    parse_param!("--permission"),
+    parse_param!("--experimental-permission"),
+    parse_param!("--permission-audit"),
+    parse_param!("--allow-fs-read <STR>..."),
+    parse_param!("--allow-fs-write <STR>..."),
+    parse_param!("--allow-child-process <STR>?"),
+    parse_param!("--allow-worker <STR>?"),
+    parse_param!("--allow-addons <STR>?"),
+    parse_param!("--allow-wasi <STR>?"),
+    parse_param!("--allow-net <STR>?"),
+    parse_param!("--allow-inspector <STR>?"),
+    parse_param!("--allow-ffi <STR>?"),
 ];
 
 pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
@@ -925,6 +942,54 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             | CommandTag::TestCommand
             | CommandTag::RunAsNodeCommand
     ) {
+        // Node's permission model (`--permission`) runs user code inside a
+        // sandbox that denies filesystem / child-process / worker / net access
+        // unless granted via `--allow-*`. Bun does not implement that model,
+        // so accepting the flag and running anyway would execute the program
+        // with none of the restrictions the caller asked for, and
+        // `process.permission` being undefined makes that indistinguishable
+        // from Node launched without `--permission`. Refuse to run instead.
+        // The escape hatch exists for node/bun CI matrices that pass the flag
+        // unconditionally and do not actually rely on the sandbox.
+        {
+            let permission_flag: Option<&[u8]> = if args.flag(b"--permission") {
+                Some(b"--permission")
+            } else if args.flag(b"--experimental-permission") {
+                Some(b"--experimental-permission")
+            } else if args.flag(b"--permission-audit") {
+                Some(b"--permission-audit")
+            } else if !args.options(b"--allow-fs-read").is_empty() {
+                Some(b"--allow-fs-read")
+            } else if !args.options(b"--allow-fs-write").is_empty() {
+                Some(b"--allow-fs-write")
+            } else if args.option(b"--allow-child-process").is_some() {
+                Some(b"--allow-child-process")
+            } else if args.option(b"--allow-worker").is_some() {
+                Some(b"--allow-worker")
+            } else if args.option(b"--allow-addons").is_some() {
+                Some(b"--allow-addons")
+            } else if args.option(b"--allow-wasi").is_some() {
+                Some(b"--allow-wasi")
+            } else if args.option(b"--allow-net").is_some() {
+                Some(b"--allow-net")
+            } else if args.option(b"--allow-inspector").is_some() {
+                Some(b"--allow-inspector")
+            } else if args.option(b"--allow-ffi").is_some() {
+                Some(b"--allow-ffi")
+            } else {
+                None
+            };
+            if let Some(flag) = permission_flag {
+                if !env_var::BUN_IGNORE_NODE_PERMISSION_FLAGS.get().unwrap_or(false) {
+                    Output::err_generic(
+                        "Bun does not implement the Node.js permission model, so {} would run without the requested restrictions. Refusing to run.\n       Set BUN_IGNORE_NODE_PERMISSION_FLAGS=1 to ignore this flag and run without a sandbox.",
+                        format_args!("{}", BStr::new(flag)),
+                    );
+                    Global::exit(1);
+                }
+            }
+        }
+
         {
             let preloads = args.options(b"--preload");
             let preloads2 = args.options(b"--require");

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -357,8 +357,11 @@ fn refuse_node_permission_flags(args: &clap::Args<clap::Help>) {
             .unwrap_or(false)
     {
         Output::err_generic(
-            "Bun does not implement the Node.js permission model, so {} would run without the requested restrictions. Refusing to run.\n       Set BUN_IGNORE_NODE_PERMISSION_FLAGS=1 to ignore this flag and run without a sandbox.",
+            "Bun does not implement the Node.js permission model, so {} would run without the requested restrictions. Refusing to run.",
             format_args!("{}", BStr::new(flag)),
+        );
+        bun_core::note!(
+            "Set BUN_IGNORE_NODE_PERMISSION_FLAGS=1 to ignore this flag and run without a sandbox."
         );
         Global::exit(1);
     }

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -287,7 +287,11 @@ mod _impl {
                 std::sync::LazyLock::new(|| {
                     let mut set = bun_collections::StringSet::new();
                     for param in crate::cli::arguments::AUTO_PARAMS.iter() {
-                        if param.takes_value != bun_clap::Values::None {
+                        // OneOptional only takes a value via `--flag=val`; the streaming parser does not consume the next token for a bare `--flag`, so neither should this re-parser.
+                        if matches!(
+                            param.takes_value,
+                            bun_clap::Values::One | bun_clap::Values::Many
+                        ) {
                             if let Some(name) = param.names.long {
                                 let mut k = Vec::with_capacity(2 + name.len());
                                 k.extend_from_slice(b"--");

--- a/test/cli/run/node-permission-flags.test.ts
+++ b/test/cli/run/node-permission-flags.test.ts
@@ -75,9 +75,7 @@ describe("Node.js permission-model flags", () => {
       expect(stderr).toBe("");
       // The read of __filename succeeds (no sandbox), process.permission stays undefined,
       // and the flags remain visible in execArgv.
-      expect(stdout).toBe(
-        'read OK permission=undefined execArgv=["--permission","--allow-fs-read=/nope"]\n',
-      );
+      expect(stdout).toBe('read OK permission=undefined execArgv=["--permission","--allow-fs-read=/nope"]\n');
       expect(exitCode).toBe(0);
     },
   );

--- a/test/cli/run/node-permission-flags.test.ts
+++ b/test/cli/run/node-permission-flags.test.ts
@@ -80,12 +80,24 @@ describe("Node.js permission-model flags", () => {
     },
   );
 
+  test.concurrent(
+    "BUN_IGNORE_NODE_PERMISSION_FLAGS=1 execArgv does not swallow the script name after a bare grant",
+    async () => {
+      const { stdout, stderr, exitCode } = await run(["--permission", "--allow-child-process"], {
+        ...bunEnv,
+        BUN_IGNORE_NODE_PERMISSION_FLAGS: "1",
+      });
+      expect(stderr).toBe("");
+      expect(stdout).toBe('read OK permission=undefined execArgv=["--permission","--allow-child-process"]\n');
+      expect(exitCode).toBe(0);
+    },
+  );
+
   test.concurrent("--permission is hidden from --help", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--help"],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "pipe",
     });
     const [stdout] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect(stdout).not.toContain("--permission");

--- a/test/cli/run/node-permission-flags.test.ts
+++ b/test/cli/run/node-permission-flags.test.ts
@@ -12,7 +12,12 @@ const probe =
   "  console.log('read OK permission=' + typeof process.permission + ' execArgv=' + JSON.stringify(process.execArgv)) }" +
   "catch (e) { console.log('read ' + e.code + ' ' + e.permission) }";
 
-async function run(argv: string[], env: Record<string, string | undefined> = bunEnv) {
+// bunEnv spreads process.env; pin the escape hatch off so an ambient
+// BUN_IGNORE_NODE_PERMISSION_FLAGS from the outer shell cannot flip the
+// refusal cases.
+const baseEnv = { ...bunEnv, BUN_IGNORE_NODE_PERMISSION_FLAGS: undefined };
+
+async function run(argv: string[], env: Record<string, string | undefined> = baseEnv) {
   using dir = tempDir("node-permission", { "probe.cjs": probe });
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...argv, "probe.cjs"],
@@ -54,7 +59,7 @@ describe("Node.js permission-model flags", () => {
     using dir = tempDir("node-permission", { "probe.cjs": probe });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", "--permission", "./probe.cjs"],
-      env: bunEnv,
+      env: baseEnv,
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
@@ -69,7 +74,7 @@ describe("Node.js permission-model flags", () => {
     "BUN_IGNORE_NODE_PERMISSION_FLAGS=1 runs (unsandboxed) and keeps process.permission undefined",
     async () => {
       const { stdout, stderr, exitCode } = await run(["--permission", "--allow-fs-read=/nope"], {
-        ...bunEnv,
+        ...baseEnv,
         BUN_IGNORE_NODE_PERMISSION_FLAGS: "1",
       });
       expect(stderr).toBe("");
@@ -84,7 +89,7 @@ describe("Node.js permission-model flags", () => {
     "BUN_IGNORE_NODE_PERMISSION_FLAGS=1 execArgv does not swallow the script name after a bare grant",
     async () => {
       const { stdout, stderr, exitCode } = await run(["--permission", "--allow-child-process"], {
-        ...bunEnv,
+        ...baseEnv,
         BUN_IGNORE_NODE_PERMISSION_FLAGS: "1",
       });
       expect(stderr).toBe("");
@@ -96,12 +101,14 @@ describe("Node.js permission-model flags", () => {
   test.concurrent("--permission is hidden from --help", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--help"],
-      env: bunEnv,
+      env: baseEnv,
       stdout: "pipe",
     });
-    const [stdout] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toContain("--watch");
     expect(stdout).not.toContain("--permission");
     expect(stdout).not.toContain("--allow-fs-read");
+    expect(exitCode).toBe(0);
   });
 
   test.concurrent("does not trip on an unrelated flag", async () => {

--- a/test/cli/run/node-permission-flags.test.ts
+++ b/test/cli/run/node-permission-flags.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Bun does not implement Node's permission model. Before this change,
+// `bun --permission --allow-fs-read=/nope script.js` ran the script with no
+// sandbox, `process.permission` stayed undefined, and the flags were echoed
+// back in `process.execArgv` so callers that checked the receipt believed the
+// sandbox was active. Bun now refuses to run instead.
+
+const probe =
+  "try { require('fs').readFileSync(__filename);" +
+  "  console.log('read OK permission=' + typeof process.permission + ' execArgv=' + JSON.stringify(process.execArgv)) }" +
+  "catch (e) { console.log('read ' + e.code + ' ' + e.permission) }";
+
+async function run(argv: string[], env: Record<string, string | undefined> = bunEnv) {
+  using dir = tempDir("node-permission", { "probe.cjs": probe });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...argv, "probe.cjs"],
+    env,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("Node.js permission-model flags", () => {
+  test.concurrent.each([
+    [["--permission"], "--permission"],
+    [["--permission", "--allow-fs-read=/nope"], "--permission"],
+    [["--experimental-permission"], "--experimental-permission"],
+    [["--permission-audit"], "--permission-audit"],
+    [["--allow-fs-read=/nope"], "--allow-fs-read"],
+    [["--allow-fs-write=/nope"], "--allow-fs-write"],
+    [["--allow-child-process"], "--allow-child-process"],
+    [["--allow-worker"], "--allow-worker"],
+    [["--allow-addons"], "--allow-addons"],
+    [["--allow-wasi"], "--allow-wasi"],
+    [["--allow-net"], "--allow-net"],
+    [["--allow-net=example.com"], "--allow-net"],
+    [["--allow-inspector"], "--allow-inspector"],
+    [["--allow-ffi"], "--allow-ffi"],
+  ])("%j refuses to run", async (argv, named) => {
+    const { stdout, stderr, exitCode } = await run(argv);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("does not implement the Node.js permission model");
+    expect(stderr).toContain(named);
+    expect(stderr).toContain("BUN_IGNORE_NODE_PERMISSION_FLAGS");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("bun run --permission refuses to run", async () => {
+    using dir = tempDir("node-permission", { "probe.cjs": probe });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--permission", "./probe.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("does not implement the Node.js permission model");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent(
+    "BUN_IGNORE_NODE_PERMISSION_FLAGS=1 runs (unsandboxed) and keeps process.permission undefined",
+    async () => {
+      const { stdout, stderr, exitCode } = await run(["--permission", "--allow-fs-read=/nope"], {
+        ...bunEnv,
+        BUN_IGNORE_NODE_PERMISSION_FLAGS: "1",
+      });
+      expect(stderr).toBe("");
+      // The read of __filename succeeds (no sandbox), process.permission stays undefined,
+      // and the flags remain visible in execArgv.
+      expect(stdout).toBe(
+        'read OK permission=undefined execArgv=["--permission","--allow-fs-read=/nope"]\n',
+      );
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test.concurrent("--permission is hidden from --help", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--help"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).not.toContain("--permission");
+    expect(stdout).not.toContain("--allow-fs-read");
+  });
+
+  test.concurrent("does not trip on an unrelated flag", async () => {
+    const { stdout, stderr, exitCode } = await run(["--no-warnings"]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("read OK");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -177,6 +177,14 @@ if (process.argv.length === 2 &&
         // does not exist, so don't re-spawn just to pass the flag through.
         continue;
       }
+      if (process.versions.bun &&
+          (flag === "--permission" || flag === "--experimental-permission" ||
+           flag === "--permission-audit" || flag.startsWith("--allow-"))) {
+        // Bun refuses to start under Node's permission-model flags. Vendored
+        // tests that carry them are granting a capability the test needs; under
+        // Bun that capability is never restricted, so drop the flag.
+        continue;
+      }
       if (flag === "test") {
         process.env.SKIP_FLAG_CHECK = "1";
         break;

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -178,8 +178,7 @@ if (process.argv.length === 2 &&
         continue;
       }
       if (process.versions.bun &&
-          (flag === "--permission" || flag === "--experimental-permission" ||
-           flag === "--permission-audit" || flag.startsWith("--allow-"))) {
+          /^--(permission(-audit)?|experimental-permission|allow-(fs-read|fs-write|child-process|worker|addons|wasi|net|inspector|ffi))(=|$)/.test(flag)) {
         // Bun refuses to start under Node's permission-model flags. Vendored
         // tests that carry them are granting a capability the test needs; under
         // Bun that capability is never restricted, so drop the flag.
@@ -196,6 +195,7 @@ if (process.argv.length === 2 &&
       );
       const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];
       const options = { encoding: 'utf8', stdio: 'inherit' };
+      if (process.versions.bun) options.env = { ...process.env, BUN_IGNORE_NODE_PERMISSION_FLAGS: '1' };
       const result = spawnSync(process.execPath, args, options);
       if (result.signal) {
         process.kill(process.pid, result.signal);


### PR DESCRIPTION
Bun does not implement Node's permission model. Today `--permission` and every `--allow-*` flag fall through the unknown-flag skip path in `bun_clap::streaming`: the program runs with no sandbox, `process.permission` stays `undefined`, and the flags are still echoed back in `process.execArgv`. The dominant real-world guard (`process.permission && !process.permission.has(...)`) evaluates the same as "model off", and callers that key on the `execArgv` receipt (e.g. Platformatic/Fastify building the `--permission` argv for app workers) are told the sandbox is active.

## Repro

```js
// probe.cjs
try { require('fs').readFileSync('/tmp/secret.txt');
      console.log('read: OK, permission =', typeof process.permission, 'execArgv =', JSON.stringify(process.execArgv)) }
catch (e) { console.log('read:', e.code, e.permission) }
```
```
$ node --permission --allow-fs-read=/nope probe.cjs
read: ERR_ACCESS_DENIED FileSystemRead
$ bun --permission --allow-fs-read=/nope probe.cjs
read: OK, permission = undefined execArgv = ["--permission","--allow-fs-read=/nope"]
```

## Fix

Declare the permission-model flag surface in `RUNTIME_PARAMS_` (hidden from `--help`) and refuse to run when any of them is present:

```
$ bun --permission --allow-fs-read=/nope probe.cjs
error: Bun does not implement the Node.js permission model, so --permission would run without the requested restrictions. Refusing to run.
       Set BUN_IGNORE_NODE_PERMISSION_FLAGS=1 to ignore this flag and run without a sandbox.
$ echo $?
1
```

Covers `--permission`, `--experimental-permission`, `--permission-audit`, `--allow-fs-read`, `--allow-fs-write`, `--allow-child-process`, `--allow-worker`, `--allow-addons`, `--allow-wasi`, `--allow-net`, `--allow-inspector`, `--allow-ffi`. Applies to `bun <file>`, `bun run`, `bun test`, and run-as-node.

`BUN_IGNORE_NODE_PERMISSION_FLAGS=1` restores the previous behaviour (run unsandboxed, flags visible in `execArgv`) for node/bun CI matrices that pass the flag unconditionally and do not actually depend on the sandbox. The vendored-node-test `// Flags:` re-spawn in `test/js/node/test/common/index.js` drops these flags under Bun for the same reason.

This is the safe interim state. A partial `node:fs`-only enforcement would still be bypassed by `Bun.file`/`Bun.write`/S3/static routes/the module loader, so it would be another false receipt; a sound model means gating at the syscall layer across every capability, which #35403 / #35492 are working toward.

## Verification

New: `test/cli/run/node-permission-flags.test.ts` (18 cases, 15 fail on released bun).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/node-permission-flags.test.ts
bun test v1.4.0 (bd7ded710)

test/cli/run/node-permission-flags.test.ts:
46 |     [["--allow-net=example.com"], "--allow-net"],
47 |     [["--allow-inspector"], "--allow-inspector"],
48 |     [["--allow-ffi"], "--allow-ffi"],
49 |   ])("%j refuses to run", async (argv, named) => {
50 |     const { stdout, stderr, exitCode } = await run(argv);
51 |     expect(stdout).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "read OK permission=undefined execArgv=["--experimental-permission"]
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/cli/run/node-permission-flags.test.ts:51:20)
(fail) Node.js permission-model flags > ["--experimental-permission"] refuses to run [1339.18ms]
46 |     [["--allow-net=example.com"], "--allow-net"],
47 |     [["--allow-inspector"], "--allow-inspector"],
48 |     [["--allow-ffi"], "--allow-ffi"],
49 |   ])("%j refuses to run", async (argv, named) => {
50 |     const { stdout, stderr, exitCode } = await run(
... (truncated)

release without fix: 15 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/run/node-permission-flags.test.ts:
46 |     [["--allow-net=example.com"], "--allow-net"],
47 |     [["--allow-inspector"], "--allow-inspector"],
48 |     [["--allow-ffi"], "--allow-ffi"],
49 |   ])("%j refuses to run", async (argv, named) => {
50 |     const { stdout, stderr, exitCode } = await run(argv);
51 |     expect(stdout).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "read OK permission=undefined execArgv=["--allow-fs-read=/nope"]
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/cli/run/node-permission-flags.test.ts:51:20)
46 |     [["--allow-net=example.com"], "--allow-net"],
47 |     [["--allow-inspector"], "--allow-inspector"],
48 |     [["--allow-ffi"], "--allow-ffi"],
49 |   ])("%j refuses to run", async (argv, named) => {
50 |     const { stdout, stderr, exitCode } = await run(argv);
51 |     expect(stdout).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "read OK permission=undefined execArgv=["--experimental-permission"]
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/cli/r
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/node-permission-flags.test.ts
bun test v1.4.0 (bd7ded710)

test/cli/run/node-permission-flags.test.ts:
(pass) Node.js permission-model flags > ["--permission"] refuses to run [236.96ms]
(pass) Node.js permission-model flags > ["--permission","--allow-fs-read=/nope"] refuses to run [506.46ms]
(pass) Node.js permission-model flags > ["--experimental-permission"] refuses to run [596.17ms]
(pass) Node.js permission-model flags > ["--allow-fs-read=/nope"] refuses to run [578.21ms]
(pass) Node.js permission-model flags > ["--permission-audit"] refuses to run [603.96ms]
(pass) Node.js permission-model flags > ["--allow-fs-write=/nope"] refuses to run [457.88ms]
(pass) Node.js permission-model flags > ["--allow-child-process"] refuses to run [216.02ms]
(pass) Node.js permission-model flags > ["--allow-worker"] refuses to run [545.36ms]
(pass) Node.js permission-model flags > ["--allow-addons"] refuses to run [550.16ms]
(pass) Node.js permission-model flags > ["--allow-wasi"] refuses to run [552.63ms]
(pass) Node.js permission-mode
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     bd7ded710e
  features     baseline

22 deps, 108 codegen, 1171 objects in 3782ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch tinycc
[tinycc] up to date
[2/1234] fetch picohttpparser
[picohttpparser] up to date
[3/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/1234] gen .bind.ts → GeneratedBindings.cpp
[5/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1234] gen bindgenv2
[7/1234] gen ErrorCode+*.h
[8/1234] fetch zlib
[zlib] up to date
[9/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[11/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[12/1234] f
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                    |   2 +
 src/runtime/cli/Arguments.rs               |  60 +++++++++++++++
 src/runtime/node/node_process.rs           |   6 +-
 test/cli/run/node-permission-flags.test.ts | 120 +++++++++++++++++++++++++++++
 test/js/node/test/common/index.js          |   8 ++
 5 files changed, 195 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/bun_core/env_var.rs                         3      3      0
src/runtime/cli/Arguments.rs                    8      9      0
src/runtime/node/node_process.rs                1      1      0
test/cli/run/node-permission-flags.test.ts      3      8      0
test/js/node/test/common/index.js               2      2      0
```

</details>

<!-- robobun:evidence:end -->