### PR TITLE
module-loader: deref keyZ/referrerZ on the virtual-module resolve early return

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3595,6 +3595,8 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
 
     if (globalObject->onLoadPlugins.hasVirtualModules()) {
         if (auto resolvedString = globalObject->onLoadPlugins.resolveVirtualModule(keyZ.toWTFString(), referrerZ.toWTFString())) {
+            keyZ.deref();
+            referrerZ.deref();
             return Identifier::fromString(globalObject->vm(), resolvedString.value());
         }
     } else {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -722,3 +722,62 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+it.concurrent(
+  "moduleLoaderResolve releases the specifier StringImpl on a virtual-module hit",
+  async () => {
+    // GlobalObject::moduleLoaderResolve acquires keyZ/referrerZ via
+    // Bun::toStringRef (+1 ref each) and must deref them on every exit. The
+    // virtual-module early return used to skip the deref. With a file:// key the
+    // resolver allocates a fresh fileSystemPath() StringImpl on every call, so
+    // each import that resolves to a registered virtual module leaked one copy
+    // of the path string.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const pad = Buffer.alloc(128 * 1024, "x").toString();
+          const urlKey = (process.platform === "win32" ? "file:///C:/v" : "file:///v") + pad;
+          // The virtual-module map is consulted with the raw specifier in
+          // moduleLoaderImportModule and with fileSystemPath() in
+          // moduleLoaderResolve, so both forms must be registered for the
+          // resolve-time lookup to hit the early return this test exercises.
+          const pathKey = Bun.fileURLToPath(urlKey);
+          Bun.plugin({
+            name: "virtual-resolve-leak",
+            setup(build) {
+              build.module(urlKey, () => ({ exports: { ok: true }, loader: "object" }));
+              build.module(pathKey, () => ({ exports: { ok: true }, loader: "object" }));
+            },
+          });
+          const first = await import(urlKey);
+          if (!first.ok) throw new Error("virtual module did not load");
+          Bun.gc(true);
+          const before = process.memoryUsage.rss();
+          for (let i = 0; i < 200; i++) await import(urlKey);
+          Bun.gc(true);
+          const after = process.memoryUsage.rss();
+          console.log(JSON.stringify({ deltaMB: (after - before) / 1024 / 1024 }));
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        // ASAN's allocator quarantine retains freed allocations (default 256 MB),
+        // which would make the fixed build's RSS look the same as the leaking
+        // one. Disable it for this measurement subprocess only.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { deltaMB } = JSON.parse(stdout.trim()) as { deltaMB: number };
+    // Unfixed: ~27 MB on release / ~32 MB under ASAN (one 128 KB StringImpl
+    // leaked per import). Fixed: ~3 MB of ambient growth.
+    expect(deltaMB).toBeLessThan(12);
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -197,7 +197,7 @@ plugin({
 });
 
 // This is to test that it works when imported from a separate file
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
 import "../../third_party/svelte";
 import "./module-plugins";
@@ -774,10 +774,14 @@ it.concurrent(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const { deltaMB } = JSON.parse(stdout.trim()) as { deltaMB: number };
-    // Unfixed: ~27 MB on release / ~32 MB under ASAN (one 128 KB StringImpl
-    // leaked per import). Fixed: ~3 MB of ambient growth.
-    expect(deltaMB).toBeLessThan(12);
+    // Unfixed: ~27 MB on release / ~32 MB on debug+ASAN (one 128 KB StringImpl
+    // leaked per import). Fixed: low-single-digit MB on release; ~4-10 MB of
+    // ambient growth on debug+ASAN even with quarantine disabled.
+    expect(deltaMB).toBeLessThan(isASAN || isDebug ? 20 : 12);
     expect(exitCode).toBe(0);
   },
+  // WTF::URL parsing + fileSystemPath() over ~25 MB of URL bytes is ~25 s under
+  // debug+ASAN; the workload cannot be shrunk without losing separation from
+  // the ambient RSS noise. Same allowance as test/js/bun/glob/leak.test.ts.
   60_000,
 );


### PR DESCRIPTION
## What

`GlobalObject::moduleLoaderResolve` acquires `keyZ` and `referrerZ` via `Bun::toStringRef`, which adds a StringImpl ref each. The function has three exits:

- the virtual-module hit: `return Identifier::fromString(...)` with **no** `deref()`
- the plugin-namespace hit: `keyZ.deref(); referrerZ.deref();` then return
- the fall-through to `Zig__GlobalObject__resolve`: `keyZ.deref(); referrerZ.deref();` after the call

So every resolve that matched a registered virtual module (`mock.module` / `Bun.plugin`'s `build.module`) leaked two StringImpl refs. For a `file://` specifier `keyZ` is the freshly-allocated result of `url.fileSystemPath()`, so each hit leaked a brand-new copy of the path string rather than just a refcount on an atom.

Found during review of #35601 (pre-existing on main; that PR touches the `keyZ` acquisition line but not this exit).

## Fix

Add the matching `keyZ.deref(); referrerZ.deref();` before the virtual-module return, same as the other two exits. `resolvedString` already holds its own ref to the impl at that point, so the subsequent `Identifier::fromString(vm, resolvedString.value())` is unaffected.

## Verification

New test in `test/js/bun/plugin/plugins.test.ts` registers a virtual module whose key is a 128 KB `file://` URL and imports it 200 times. `JSModuleLoader::requestImportModule` re-runs resolve on every call, so each iteration leaks one 128 KB `fileSystemPath()` copy without the fix.

```console
$ USE_SYSTEM_BUN=1 bun test test/js/bun/plugin/plugins.test.ts -t "releases the specifier"
error: expect(received).toBeLessThan(expected)
Expected: < 12
Received: 27
(fail) moduleLoaderResolve releases the specifier StringImpl on a virtual-module hit

$ bun bd test test/js/bun/plugin/plugins.test.ts
 36 pass  0 fail
```

`test/js/bun/test/mock/mock-module.test.ts` (the other virtual-module consumer) still passes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/plugin/plugins.test.ts

<!-- robobun:evidence:end -->