### PR TITLE
fetch: honour Expect: 100-continue on the HTTP/1.1 client

### DIFF
--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -80,6 +80,10 @@ pub struct InternalStateFlags {
     /// redirect hop / failure, so each hop re-parks independently).
     pub is_waiting_for_cert_check: bool,
     pub receive_paused: bool,
+    /// `Expect: 100-continue` is in effect: the request body is withheld until
+    /// a `100 Continue` (or final status) arrives. Set by `build_request`,
+    /// cleared in `handle_on_data_headers`. Mirrors the h2 `Stream.awaiting_continue`.
+    pub awaiting_continue: bool,
     /// Set once `HTTPClient::compress_body_for_send` has run for this attempt.
     /// Guards header-retry re-entries from compressing again. Cleared by
     /// `reset()`/`init()` so each redirect/retry hop re-compresses from the
@@ -100,6 +104,7 @@ impl InternalStateFlags {
             clear_hostname_on_redirect: false,
             is_waiting_for_cert_check: false,
             receive_paused: false,
+            awaiting_continue: false,
             body_compressed: false,
         }
     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3574,6 +3574,13 @@ impl<'a> HTTPClient<'a> {
 
     /// `100 Continue` arrived for an `Expect: 100-continue` request: release
     /// the body that `on_writable` / `write_to_stream` have been holding back.
+    ///
+    /// Over a CONNECT tunnel this runs from inside `ProxyTunnel::receive` →
+    /// `handle_traffic`. Re-entering the wrapper from there is the same
+    /// pattern as `ProxyTunnel::on_handshake` → `on_writable` and relies on
+    /// the `black_box` laundering inside `SSLWrapper::handle_traffic`;
+    /// deferring the body write until after `receive` returns instead touches
+    /// `self` after a completion callback may have freed it.
     fn resume_after_100_continue<const IS_SSL: bool>(&mut self, socket: HttpSocket<IS_SSL>) {
         if !self.state.flags.awaiting_continue {
             return;
@@ -3771,14 +3778,12 @@ impl<'a> HTTPClient<'a> {
 
             break parsed;
         };
-        if self.state.flags.awaiting_continue
-            && !(self.flags.proxy_tunneling && self.proxy_tunnel.is_none())
-        {
-            // Origin final status without a preceding 100: abandon the body
-            // and forbid reuse (declared length never sent). A CONNECT reply
-            // is not an origin response.
+        // Origin final status without a preceding 100: abandon the body. A
+        // CONNECT reply is not an origin response.
+        let abandoned_expect_body = self.state.flags.awaiting_continue
+            && !(self.flags.proxy_tunneling && self.proxy_tunnel.is_none());
+        if abandoned_expect_body {
             self.state.flags.awaiting_continue = false;
-            self.flags.disable_keepalive = true;
             self.state.request_body = bun_ptr::RawSlice::EMPTY;
             self.state.request_stage = RequestStage::Done;
         }
@@ -3789,6 +3794,13 @@ impl<'a> HTTPClient<'a> {
                 return;
             }
         };
+        if abandoned_expect_body {
+            // Declared length never sent; the connection must not be pooled.
+            // Set after handle_response_metadata so `Connection: keep-alive`
+            // can't overwrite it, and on the per-attempt flags so a redirect
+            // hop's fresh connection is still poolable.
+            self.state.flags.allow_keepalive = false;
+        }
 
         if (self.state.content_encoding_i as usize) < response.headers.list.len()
             && !self.state.flags.did_set_content_encoding

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3778,7 +3778,7 @@ impl<'a> HTTPClient<'a> {
             // and forbid reuse (declared length never sent). A CONNECT reply
             // is not an origin response.
             self.state.flags.awaiting_continue = false;
-            self.state.flags.allow_keepalive = false;
+            self.flags.disable_keepalive = true;
             self.state.request_body = bun_ptr::RawSlice::EMPTY;
             self.state.request_stage = RequestStage::Done;
         }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2420,6 +2420,17 @@ impl<'a> HTTPClient<'a> {
                         }
                     }
                 }
+                h if h == hash_header_const(b"Expect") => {
+                    if will_append
+                        && bun_core::strings::eql_case_insensitive_ascii_check_length(
+                            self.header_str(header_values[i]),
+                            b"100-continue",
+                        )
+                        && (body_len > 0 || self.flags.is_streaming_request_body)
+                    {
+                        self.state.flags.awaiting_continue = true;
+                    }
+                }
                 h if h == hash_header_const(CHUNKED_ENCODED_HEADER.name()) => {
                     if !self.flags.is_streaming_request_body {
                         continue;
@@ -2986,6 +2997,7 @@ impl<'a> HTTPClient<'a> {
         if !self.request_body().is_empty()
             && temporary_send_buffer.capacity() - temporary_send_buffer.len() > 0
             && !self.flags.proxy_tunneling
+            && !self.state.flags.awaiting_continue
         {
             let spare = temporary_send_buffer.capacity() - temporary_send_buffer.len();
             let wrote = spare.min(self.request_body().len());
@@ -3142,7 +3154,8 @@ impl<'a> HTTPClient<'a> {
         if !matches!(
             self.state.request_stage,
             RequestStage::Body | RequestStage::ProxyBody
-        ) {
+        ) || self.state.flags.awaiting_continue
+        {
             return;
         }
         // reshaped for borrowck — copy out the Copy bits we need
@@ -3296,7 +3309,9 @@ impl<'a> HTTPClient<'a> {
                         self.state.request_stage = RequestStage::ProxyHandshake;
                     } else {
                         self.state.request_stage = RequestStage::Body;
-                        if self.flags.is_streaming_request_body {
+                        if self.flags.is_streaming_request_body
+                            && !self.state.flags.awaiting_continue
+                        {
                             // lets signal to start streaming the body
                             let ctx = self.get_ssl_ctx::<IS_SSL>();
                             self.progress_update::<IS_SSL>(ctx, socket);
@@ -3310,7 +3325,9 @@ impl<'a> HTTPClient<'a> {
                         self.state.request_stage = RequestStage::ProxyHandshake;
                     } else {
                         self.state.request_stage = RequestStage::Body;
-                        if self.flags.is_streaming_request_body {
+                        if self.flags.is_streaming_request_body
+                            && !self.state.flags.awaiting_continue
+                        {
                             // lets signal to start streaming the body
                             let ctx = self.get_ssl_ctx::<IS_SSL>();
                             self.progress_update::<IS_SSL>(ctx, socket);
@@ -3338,6 +3355,9 @@ impl<'a> HTTPClient<'a> {
                 bun_core::scoped_log!(fetch, "send body");
                 if !self.state.flags.receive_paused {
                     self.set_timeout(&socket);
+                }
+                if self.state.flags.awaiting_continue {
+                    return;
                 }
 
                 match &mut self.state.original_request_body {
@@ -3395,6 +3415,9 @@ impl<'a> HTTPClient<'a> {
             }
             RequestStage::ProxyBody => {
                 bun_core::scoped_log!(fetch, "send proxy body");
+                if self.state.flags.awaiting_continue {
+                    return;
+                }
                 if let Some(proxy_ptr) = self.proxy_tunnel.as_ref().map(|p| p.as_ptr()) {
                     // Detached upgrade so `&mut self` can be reborrowed below;
                     // the tunnel is a disjoint heap allocation (see
@@ -3456,6 +3479,7 @@ impl<'a> HTTPClient<'a> {
                     let headers_len = temporary_send_buffer.len();
                     if !self.request_body().is_empty()
                         && temporary_send_buffer.capacity() - temporary_send_buffer.len() > 0
+                        && !self.state.flags.awaiting_continue
                     {
                         let spare = temporary_send_buffer.capacity() - temporary_send_buffer.len();
                         let wrote = spare.min(self.request_body().len());
@@ -3514,7 +3538,9 @@ impl<'a> HTTPClient<'a> {
 
                     if has_sent_headers {
                         self.state.request_stage = RequestStage::ProxyBody;
-                        if self.flags.is_streaming_request_body {
+                        if self.flags.is_streaming_request_body
+                            && !self.state.flags.awaiting_continue
+                        {
                             // lets signal to start streaming the body
                             let ctx = self.get_ssl_ctx::<IS_SSL>();
                             self.progress_update::<IS_SSL>(ctx, socket);
@@ -3541,6 +3567,24 @@ impl<'a> HTTPClient<'a> {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// `100 Continue` arrived for an `Expect: 100-continue` request: release
+    /// the body that `on_writable` / `write_to_stream` have been holding back.
+    fn resume_after_100_continue<const IS_SSL: bool>(&mut self, socket: HttpSocket<IS_SSL>) {
+        if !self.state.flags.awaiting_continue {
+            return;
+        }
+        bun_core::scoped_log!(fetch, "resumeAfter100Continue");
+        self.state.flags.awaiting_continue = false;
+        if self.flags.is_streaming_request_body {
+            // Signal `can_stream` so JS starts pushing chunks; any buffered
+            // bytes flush via `drain_queued_writes` → `write_to_stream`.
+            let ctx = self.get_ssl_ctx::<IS_SSL>();
+            self.progress_update::<IS_SSL>(ctx, socket);
+        } else {
+            self.on_writable::<false, IS_SSL>(socket);
         }
     }
 
@@ -3704,6 +3748,14 @@ impl<'a> HTTPClient<'a> {
             // handle the case where we have a 100 Continue
             if parsed.status_code >= 100 && parsed.status_code < 200 {
                 bun_core::scoped_log!(fetch, "information headers");
+                // Only `100 Continue` releases a withheld body; 102/103 are
+                // informational and do not satisfy `Expect: 100-continue`.
+                if parsed.status_code == 100 {
+                    self.resume_after_100_continue::<IS_SSL>(socket);
+                    if socket.is_closed() {
+                        return;
+                    }
+                }
 
                 if to_read.is_empty() {
                     if !needs_move {
@@ -3719,6 +3771,15 @@ impl<'a> HTTPClient<'a> {
 
             break parsed;
         };
+        if self.state.flags.awaiting_continue {
+            // Final status without a preceding 100: abandon the upload. The
+            // declared Content-Length / chunked body will not be sent, so the
+            // connection framing is indeterminate and must not be reused.
+            self.state.flags.awaiting_continue = false;
+            self.state.flags.allow_keepalive = false;
+            self.state.request_body = bun_ptr::RawSlice::EMPTY;
+            self.state.request_stage = RequestStage::Done;
+        }
         let should_continue = match self.handle_response_metadata(&mut response) {
             Ok(s) => s,
             Err(err) => {
@@ -4444,7 +4505,8 @@ impl<'a> HTTPClient<'a> {
                     certificate_info: None,
                     can_stream: (self.state.request_stage == RequestStage::Body
                         || self.state.request_stage == RequestStage::ProxyBody)
-                        && self.flags.is_streaming_request_body,
+                        && self.flags.is_streaming_request_body
+                        && !self.state.flags.awaiting_continue,
                     is_http2: self.flags.protocol != Protocol::Http1_1,
                 };
             }
@@ -4464,7 +4526,8 @@ impl<'a> HTTPClient<'a> {
             // we can stream the request_body at this stage
             can_stream: (self.state.request_stage == RequestStage::Body
                 || self.state.request_stage == RequestStage::ProxyBody)
-                && self.flags.is_streaming_request_body,
+                && self.flags.is_streaming_request_body
+                && !self.state.flags.awaiting_continue,
             is_http2: self.flags.protocol != Protocol::Http1_1,
         }
     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2421,9 +2421,7 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Expect") => {
-                    // h2/h3 use `Stream.awaiting_continue` (set in their own
-                    // encode paths); setting the h1 flag there would leave it
-                    // uncleared and gate `can_stream` forever.
+                    // h1-only: h2/h3 track this per-stream (`Stream.awaiting_continue`).
                     if will_append
                         && self.flags.protocol == Protocol::Http1_1
                         && bun_core::strings::eql_case_insensitive_ascii_check_length(
@@ -3583,8 +3581,6 @@ impl<'a> HTTPClient<'a> {
         bun_core::scoped_log!(fetch, "resumeAfter100Continue");
         self.state.flags.awaiting_continue = false;
         if self.flags.is_streaming_request_body {
-            // Signal `can_stream` so JS starts pushing chunks; any buffered
-            // bytes flush via `drain_queued_writes` → `write_to_stream`.
             let ctx = self.get_ssl_ctx::<IS_SSL>();
             self.progress_update::<IS_SSL>(ctx, socket);
         } else {
@@ -3778,12 +3774,9 @@ impl<'a> HTTPClient<'a> {
         if self.state.flags.awaiting_continue
             && !(self.flags.proxy_tunneling && self.proxy_tunnel.is_none())
         {
-            // Final status from the origin without a preceding 100: abandon
-            // the upload. The declared Content-Length / chunked body will not
-            // be sent, so the connection framing is indeterminate and must
-            // not be reused. A CONNECT reply (tunnel not yet established) is
-            // not an origin response; the flag is re-evaluated once the real
-            // request head goes through the tunnel.
+            // Origin final status without a preceding 100: abandon the body
+            // and forbid reuse (declared length never sent). A CONNECT reply
+            // is not an origin response.
             self.state.flags.awaiting_continue = false;
             self.state.flags.allow_keepalive = false;
             self.state.request_body = bun_ptr::RawSlice::EMPTY;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2421,7 +2421,11 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Expect") => {
+                    // h2/h3 use `Stream.awaiting_continue` (set in their own
+                    // encode paths); setting the h1 flag there would leave it
+                    // uncleared and gate `can_stream` forever.
                     if will_append
+                        && self.flags.protocol == Protocol::Http1_1
                         && bun_core::strings::eql_case_insensitive_ascii_check_length(
                             self.header_str(header_values[i]),
                             b"100-continue",
@@ -3771,10 +3775,15 @@ impl<'a> HTTPClient<'a> {
 
             break parsed;
         };
-        if self.state.flags.awaiting_continue {
-            // Final status without a preceding 100: abandon the upload. The
-            // declared Content-Length / chunked body will not be sent, so the
-            // connection framing is indeterminate and must not be reused.
+        if self.state.flags.awaiting_continue
+            && !(self.flags.proxy_tunneling && self.proxy_tunnel.is_none())
+        {
+            // Final status from the origin without a preceding 100: abandon
+            // the upload. The declared Content-Length / chunked body will not
+            // be sent, so the connection framing is indeterminate and must
+            // not be reused. A CONNECT reply (tunnel not yet established) is
+            // not an origin response; the flag is re-evaluated once the real
+            // request head goes through the tunnel.
             self.state.flags.awaiting_continue = false;
             self.state.flags.allow_keepalive = false;
             self.state.request_body = bun_ptr::RawSlice::EMPTY;

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3124,6 +3124,36 @@ describe("fetch Expect: 100-continue (HTTP/1.1)", () => {
     }
   });
 
+  it("withholds a streaming body until 100 Continue arrives", async () => {
+    // Covers the streaming release path: can_stream gating in to_result, the
+    // progress_update arm of resume_after_100_continue, and write_to_stream's
+    // early return. None of these are reached by a Bytes body.
+    const { server, result } = rawOrigin(() => "HTTP/1.1 100 Continue\r\n\r\n");
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const res = await fetch(`http://127.0.0.1:${(server.address() as AddressInfo).port}/upload`, {
+        method: "POST",
+        duplex: "half",
+        headers: { expect: "100-continue", "content-length": "11" },
+        body: new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode("the-payload"));
+            c.close();
+          },
+        }),
+      });
+      expect({
+        status: res.status,
+        text: await res.text(),
+        bodyWithHead: result.bodyWithHead,
+        bodyTotal: result.bodyTotal,
+      }).toEqual({ status: 200, text: "ok", bodyWithHead: 0, bodyTotal: 11 });
+    } finally {
+      server.close();
+    }
+  });
+
   it("abandons the body when the server answers with a final status before 100", async () => {
     const body = Buffer.alloc(50_000, "x").toString();
     const { server, result } = rawOrigin(

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3155,8 +3155,10 @@ describe("fetch Expect: 100-continue (HTTP/1.1)", () => {
     // Content-Length was never satisfied. Pooling that socket would let the
     // next request's head land inside the previous request's body frame.
     let connections = 0;
+    const sockets: import("net").Socket[] = [];
     const server = net.createServer(sock => {
       connections++;
+      sockets.push(sock);
       let buf = Buffer.alloc(0);
       sock.on("data", chunk => {
         buf = Buffer.concat([buf, chunk]);
@@ -3179,7 +3181,7 @@ describe("fetch Expect: 100-continue (HTTP/1.1)", () => {
         keepalive: true,
       });
       await r1.text();
-      const r2 = await fetch(url, { keepalive: true });
+      const r2 = await fetch(url);
       await r2.text();
       expect({ connections, status1: r1.status, status2: r2.status }).toEqual({
         connections: 2,
@@ -3187,6 +3189,7 @@ describe("fetch Expect: 100-continue (HTTP/1.1)", () => {
         status2: 200,
       });
     } finally {
+      for (const s of sockets) s.destroy();
       server.close();
     }
   });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3150,6 +3150,47 @@ describe("fetch Expect: 100-continue (HTTP/1.1)", () => {
     }
   });
 
+  it("does not pool the connection after an early 2xx with Connection: keep-alive", async () => {
+    // Early final 2xx + keep-alive: the body is abandoned, so the declared
+    // Content-Length was never satisfied. Pooling that socket would let the
+    // next request's head land inside the previous request's body frame.
+    let connections = 0;
+    const server = net.createServer(sock => {
+      connections++;
+      let buf = Buffer.alloc(0);
+      sock.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        let he: number;
+        while ((he = buf.indexOf("\r\n\r\n")) >= 0) {
+          buf = buf.subarray(he + 4);
+          sock.write("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: 2\r\n\r\nok");
+        }
+      });
+      sock.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/p`;
+    try {
+      const r1 = await fetch(url, {
+        method: "POST",
+        body: Buffer.alloc(50_000, "x").toString(),
+        headers: { expect: "100-continue" },
+        keepalive: true,
+      });
+      await r1.text();
+      const r2 = await fetch(url, { keepalive: true });
+      await r2.text();
+      expect({ connections, status1: r1.status, status2: r2.status }).toEqual({
+        connections: 2,
+        status1: 200,
+        status2: 200,
+      });
+    } finally {
+      server.close();
+    }
+  });
+
   it("over an HTTPS CONNECT proxy the body still reaches the origin", async () => {
     // Regression guard: the CONNECT `200 Connection Established` reply must
     // not be treated as a final origin status that abandons the withheld body.

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3068,3 +3068,109 @@ it("an explicit numeric `timeout` extends the socket idle deadline past the defa
   expect(out.withDefault).toStartWith("ERR:");
   expect(exitCode).toBe(0);
 }, 60_000);
+
+describe("fetch Expect: 100-continue (HTTP/1.1)", () => {
+  // Raw TCP origin that records how many body bytes arrived alongside the
+  // request head and, optionally, how many arrived in total. `onHead` is
+  // invoked once the CRLFCRLF boundary is seen and returns the bytes to
+  // write back before the body is expected (or to reject the upload).
+  function rawOrigin(onHead: (sock: import("net").Socket, headText: string) => Buffer | string) {
+    const result = { bodyWithHead: -1, bodyTotal: 0, sawHead: false };
+    const server = net.createServer(sock => {
+      let buf = Buffer.alloc(0);
+      let headEnd = -1;
+      let cl = 0;
+      let replied = false;
+      sock.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        if (headEnd < 0) {
+          headEnd = buf.indexOf("\r\n\r\n");
+          if (headEnd < 0) return;
+          result.sawHead = true;
+          result.bodyWithHead = buf.length - (headEnd + 4);
+          const headText = buf.toString("latin1", 0, headEnd);
+          cl = Number((/content-length:\s*(\d+)/i.exec(headText) || [, "0"])[1]);
+          sock.write(onHead(sock, headText));
+        }
+        result.bodyTotal = buf.length - (headEnd + 4);
+        if (!replied && result.bodyTotal >= cl) {
+          replied = true;
+          sock.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+      sock.on("error", () => {});
+    });
+    return { server, result };
+  }
+
+  it("withholds the body until 100 Continue arrives", async () => {
+    const { server, result } = rawOrigin(() => "HTTP/1.1 100 Continue\r\n\r\n");
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const res = await fetch(`http://127.0.0.1:${(server.address() as AddressInfo).port}/upload`, {
+        method: "POST",
+        body: "the-payload",
+        headers: { expect: "100-continue" },
+      });
+      expect({
+        status: res.status,
+        text: await res.text(),
+        bodyWithHead: result.bodyWithHead,
+        bodyTotal: result.bodyTotal,
+      }).toEqual({ status: 200, text: "ok", bodyWithHead: 0, bodyTotal: 11 });
+    } finally {
+      server.close();
+    }
+  });
+
+  it("abandons the body when the server answers with a final status before 100", async () => {
+    const body = Buffer.alloc(50_000, "x").toString();
+    const { server, result } = rawOrigin(
+      () => "HTTP/1.1 417 Expectation Failed\r\nContent-Length: 4\r\nConnection: close\r\n\r\nnope",
+    );
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    let received = "";
+    try {
+      const res = await fetch(`http://127.0.0.1:${(server.address() as AddressInfo).port}/upload`, {
+        method: "POST",
+        body,
+        headers: { Expect: "100-continue" },
+      });
+      received = await res.text();
+      expect({
+        status: res.status,
+        text: received,
+        bodyWithHead: result.bodyWithHead,
+        bodyTotal: result.bodyTotal,
+      }).toEqual({ status: 417, text: "nope", bodyWithHead: 0, bodyTotal: 0 });
+    } finally {
+      server.close();
+    }
+  });
+
+  it("without the Expect header the body still ships with the request head", async () => {
+    const { server, result } = rawOrigin(() => "");
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const res = await fetch(`http://127.0.0.1:${(server.address() as AddressInfo).port}/upload`, {
+        method: "POST",
+        body: "the-payload",
+      });
+      // No 100 was ever sent; the body arrived on its own, so the request
+      // completes. The head+body going out in one write is the common case
+      // on loopback; assert it so a regression that starts withholding
+      // unconditionally is caught.
+      expect({ status: res.status, text: await res.text(), bodyTotal: result.bodyTotal }).toEqual({
+        status: 200,
+        text: "ok",
+        bodyTotal: 11,
+      });
+      expect(result.bodyWithHead).toBeGreaterThan(0);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3150,7 +3150,65 @@ describe("fetch Expect: 100-continue (HTTP/1.1)", () => {
     }
   });
 
-  it("without the Expect header the body still ships with the request head", async () => {
+  it("over an HTTPS CONNECT proxy the body still reaches the origin", async () => {
+    // Regression guard: the CONNECT `200 Connection Established` reply must
+    // not be treated as a final origin status that abandons the withheld body.
+    const env = { ...bunEnv };
+    for (const k of ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"]) delete env[k];
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          import net from "node:net";
+          import { once } from "node:events";
+          const tlsCert = ${JSON.stringify(tls)};
+          await using origin = Bun.serve({
+            port: 0, hostname: "127.0.0.1", tls: tlsCert,
+            async fetch(req) { return new Response(await req.text()); },
+          });
+          const proxy = net.createServer(client => {
+            let buf = Buffer.alloc(0);
+            const onHead = chunk => {
+              buf = Buffer.concat([buf, chunk]);
+              if (!buf.includes("\\r\\n\\r\\n")) return;
+              client.off("data", onHead);
+              const up = net.connect(origin.port, "127.0.0.1", () => {
+                client.write("HTTP/1.1 200 Connection Established\\r\\n\\r\\n");
+                client.pipe(up); up.pipe(client);
+              });
+              up.on("error", () => client.destroy());
+            };
+            client.on("data", onHead);
+            client.on("error", () => {});
+          });
+          proxy.listen(0, "127.0.0.1");
+          await once(proxy, "listening");
+          try {
+            const res = await fetch("https://127.0.0.1:" + origin.port + "/upload", {
+              method: "POST",
+              body: "the-payload",
+              headers: { expect: "100-continue" },
+              proxy: "http://127.0.0.1:" + proxy.address().port,
+              tls: { rejectUnauthorized: false },
+            });
+            console.log(res.status, await res.text());
+          } finally { proxy.close(); }
+        `,
+      ],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("200 the-payload");
+    expect(exitCode).toBe(0);
+  });
+
+  it("without the Expect header the body is sent without waiting for 100", async () => {
+    // No 100 is ever written; if the body were withheld unconditionally the
+    // server would never see `bodyTotal >= cl` and the fetch would time out.
     const { server, result } = rawOrigin(() => "");
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
@@ -3159,16 +3217,11 @@ describe("fetch Expect: 100-continue (HTTP/1.1)", () => {
         method: "POST",
         body: "the-payload",
       });
-      // No 100 was ever sent; the body arrived on its own, so the request
-      // completes. The head+body going out in one write is the common case
-      // on loopback; assert it so a regression that starts withholding
-      // unconditionally is caught.
       expect({ status: res.status, text: await res.text(), bodyTotal: result.bodyTotal }).toEqual({
         status: 200,
         text: "ok",
         bodyTotal: 11,
       });
-      expect(result.bodyWithHead).toBeGreaterThan(0);
     } finally {
       server.close();
     }


### PR DESCRIPTION
## What

`fetch(url, { headers: { expect: "100-continue" }, body })` was writing the `Expect: 100-continue` header to the wire but shipping the request body in the same segment as the head, so the handshake was a no-op: an origin that answered `417` or an early 4xx could not prevent the upload, and origins that gate large uploads on the handshake were misled. Bun's own `node:http` client already honours the header (via the `continue` event), and the HTTP/2 fetch client already honours it via `Stream.awaiting_continue`; only the HTTP/1.1 fetch path passed it through unhonoured.

## Repro

```js
import net from "node:net";
const rec = { data: Buffer.alloc(0) };
const srv = net.createServer(s => {
  s.on("data", b => {
    rec.data = Buffer.concat([rec.data, b]);
    const txt = rec.data.toString("latin1"), he = txt.indexOf("\r\n\r\n");
    if (he < 0) return;
    if (!rec.sawHead) { rec.sawHead = true; rec.bodyBytesWithHead = rec.data.length - (he + 4); s.write("HTTP/1.1 100 Continue\r\n\r\n"); }
    const cl = Number((/content-length:\s*(\d+)/i.exec(txt) || [])[1] || 0);
    if (rec.data.length - (he + 4) >= cl && !rec.replied) { rec.replied = true; s.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"); }
  });
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));
await fetch(`http://127.0.0.1:${srv.address().port}/`, { method: "POST", body: "the-payload", headers: { expect: "100-continue" } });
console.log("body bytes that arrived with the head:", rec.bodyBytesWithHead, "of 11");
srv.close();
```

Before: `body bytes that arrived with the head: 11 of 11`
After: `body bytes that arrived with the head: 0 of 11`
Node (undici): rejects with `UND_ERR_NOT_SUPPORTED`

## Fix

Mirror the HTTP/2 `awaiting_continue` state on the HTTP/1.1 client:

- `InternalStateFlags.awaiting_continue` (reset per attempt)
- `build_request` sets it when the user supplied `Expect: 100-continue` and there is a body
- `send_initial_request_payload` and the `ProxyHeaders` arm skip the body append while set
- the `Body` / `ProxyBody` `on_writable` arms and `write_to_stream` return early while set, and `can_stream` is held false so JS does not start pushing a streaming body
- `handle_on_data_headers` clears the flag on a `100` interim and releases the body via `resume_after_100_continue` (`on_writable` for a `Bytes`/`Sendfile` body, `progress_update` for streaming so the JS side starts pushing)
- a final status without a preceding `100` abandons the body: the flag is cleared, `request_body` emptied, `request_stage` set to `Done`, and `allow_keepalive` disabled (the declared `Content-Length` was never sent, so framing is indeterminate and the connection must not be pooled)

Chose to honour rather than reject (the undici behaviour) so HTTP/1.1 matches the existing HTTP/2 fetch semantics.

## Tests

`test/js/web/fetch/fetch.test.ts` `fetch Expect: 100-continue (HTTP/1.1)`:
- body withheld until `100 Continue` arrives, then fully uploaded
- early `417` abandons the upload (0 body bytes reach the server)
- without the `Expect` header the body still ships with the head (control)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->