### PR TITLE
node:http: dispatch a CONNECT whose head arrives across two reads

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1133,7 +1133,12 @@ struct HttpResponseData;
                     }
                 }
             }
-            auto result = getHeaders(data, data + length, req->headers, reserved, req->ancientHttp, isConnectRequest, useStrictMethodValidation, useInsecureHTTPParser, maxHeaderSize);
+            /* getHeaders writes isConnect as soon as the request-line is parsed, before it
+             * knows the header block is complete; committing that through the persistent
+             * isConnectRequest& on a short read would make the next onData treat the
+             * buffered head as tunnel data instead of re-parsing it. */
+            bool parsedConnect = false;
+            auto result = getHeaders(data, data + length, req->headers, reserved, req->ancientHttp, parsedConnect, useStrictMethodValidation, useInsecureHTTPParser, maxHeaderSize);
             if(result.isError()) {
                 return result;
             }
@@ -1141,6 +1146,9 @@ struct HttpResponseData;
             /* Short read */
             if(!consumed) {
                 return HttpParserResult::success(consumedTotal, user);
+            }
+            if (parsedConnect) {
+                isConnectRequest = true;
             }
             data += consumed;
             length -= consumed;

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -964,9 +964,6 @@ struct HttpResponseData;
             if(requestLineResult.isAncientHTTP) {
                 isAncientHTTP = true;
             }
-            if(requestLineResult.isConnect) {
-                isConnectRequest = true;
-            }
             /* No request headers found */
             const char * headerStart = (headers[0].key.length() > 0) ? headers[0].key.data() : end;
 
@@ -980,6 +977,9 @@ struct HttpResponseData;
             if (postPaddedBuffer[0] == '\r' && postPaddedBuffer[1] == '\n') {
                 /* Valid request with no headers - write null terminator like the normal path */
                 headers[1].key = std::string_view(nullptr, 0);
+                if (requestLineResult.isConnect) {
+                    isConnectRequest = true;
+                }
                 return HttpParserResult::success((unsigned int) ((postPaddedBuffer + 2) - start));
             }
 
@@ -1065,6 +1065,9 @@ struct HttpResponseData;
                         if (postPaddedBuffer[1] == '\n') {
                             /* This cann take the very last header space */
                             headers->key = std::string_view(nullptr, 0);
+                            if (requestLineResult.isConnect) {
+                                isConnectRequest = true;
+                            }
                             return HttpParserResult::success((unsigned int) ((postPaddedBuffer + 2) - start));
                         } else {
                             /* \r\n\r plus non-\n letter is malformed request, or simply out of search space */
@@ -1133,12 +1136,7 @@ struct HttpResponseData;
                     }
                 }
             }
-            /* getHeaders writes isConnect as soon as the request-line is parsed, before it
-             * knows the header block is complete; committing that through the persistent
-             * isConnectRequest& on a short read would make the next onData treat the
-             * buffered head as tunnel data instead of re-parsing it. */
-            bool parsedConnect = false;
-            auto result = getHeaders(data, data + length, req->headers, reserved, req->ancientHttp, parsedConnect, useStrictMethodValidation, useInsecureHTTPParser, maxHeaderSize);
+            auto result = getHeaders(data, data + length, req->headers, reserved, req->ancientHttp, isConnectRequest, useStrictMethodValidation, useInsecureHTTPParser, maxHeaderSize);
             if(result.isError()) {
                 return result;
             }
@@ -1146,9 +1144,6 @@ struct HttpResponseData;
             /* Short read */
             if(!consumed) {
                 return HttpParserResult::success(consumedTotal, user);
-            }
-            if (parsedConnect) {
-                isConnectRequest = true;
             }
             data += consumed;
             length -= consumed;

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -563,64 +563,70 @@ describe("HTTP server CONNECT", () => {
   // 'connect' listener rather than being swallowed as tunnel data. Every split
   // below lands after consumeRequestLine has recognised CONNECT and before the
   // header block is complete.
+  const connectLine = "CONNECT example.com:443 HTTP/1.1\r\n";
   test.each([
-    ["one byte into the header block", "CONNECT example.com:443 HTTP/1.1\r\nH", "ost: example.com:443\r\n\r\n", ""],
-    ["mid header name", "CONNECT example.com:443 HTTP/1.1\r\nHost", ": example.com:443\r\n\r\n", ""],
-    ["mid header value", "CONNECT example.com:443 HTTP/1.1\r\nHost: exam", "ple.com:443\r\n\r\n", ""],
-    ["before the terminating CRLF", "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n", "\r\n", ""],
+    ["one byte into the header block", connectLine + "H", "ost: example.com:443\r\n\r\n", "example.com:443", ""],
+    ["mid header name", connectLine + "Host", ": example.com:443\r\n\r\n", "example.com:443", ""],
+    ["mid header value", connectLine + "Host: exam", "ple.com:443\r\n\r\n", "example.com:443", ""],
+    ["before the terminating CRLF", connectLine + "Host: example.com:443\r\n", "\r\n", "example.com:443", ""],
     [
       "with tunnel bytes trailing the second half",
-      "CONNECT example.com:443 HTTP/1.1\r\nHost",
+      connectLine + "Host",
       ": example.com:443\r\n\r\nHELLO",
+      "example.com:443",
       "HELLO",
     ],
-  ])("dispatches a CONNECT whose head arrives in two reads (%s)", async (_name, first, second, expectedHead) => {
-    await using proxyServer = http.createServer();
-    const {
-      promise: gotConnect,
-      resolve: onConnect,
-      reject: onConnectFail,
-    } = Promise.withResolvers<{
-      url: string;
-      host: string | undefined;
-      head: string;
-    }>();
-    proxyServer.on("connect", (req, socket, head) => {
-      onConnect({ url: String(req.url), host: req.headers.host, head: head.toString() });
-      socket.end("HTTP/1.1 200 Connection established\r\n\r\n");
-    });
-    proxyServer.on("clientError", (err: NodeJS.ErrnoException, socket) => {
-      socket.destroy();
-      onConnectFail(new Error("unexpected clientError " + err.code));
-    });
-    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
-    const proxyAddress = proxyServer.address() as AddressInfo;
-
-    const client = net.connect(proxyAddress.port, proxyAddress.address);
-    try {
-      client.setNoDelay(true);
-      client.on("error", onConnectFail);
-      await once(client, "connect");
-      client.write(first);
-      // Two turns of the event loop: the listening side's readable wakes and
-      // consumes the first write before the second one is queued.
-      await new Promise(resolve => setImmediate(resolve));
-      await new Promise(resolve => setImmediate(resolve));
-      client.write(second);
-
-      const { promise: clientClosed, resolve: onClientClosed } = Promise.withResolvers<string>();
-      let reply = "";
-      client.on("data", chunk => {
-        reply += chunk.toString();
+    ["inside the no-header terminator", connectLine + "\r", "\nHELLO", undefined, "HELLO"],
+  ] as const)(
+    "dispatches a CONNECT whose head arrives in two reads (%s)",
+    async (_name, first, second, expectedHost, expectedHead) => {
+      await using proxyServer = http.createServer();
+      const {
+        promise: gotConnect,
+        resolve: onConnect,
+        reject: onConnectFail,
+      } = Promise.withResolvers<{
+        url: string;
+        host: string | undefined;
+        head: string;
+      }>();
+      proxyServer.on("connect", (req, socket, head) => {
+        onConnect({ url: String(req.url), host: req.headers.host, head: head.toString() });
+        socket.end("HTTP/1.1 200 Connection established\r\n\r\n");
       });
-      client.on("close", () => onClientClosed(reply));
+      proxyServer.on("clientError", (err: NodeJS.ErrnoException, socket) => {
+        socket.destroy();
+        onConnectFail(new Error("unexpected clientError " + err.code));
+      });
+      await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+      const proxyAddress = proxyServer.address() as AddressInfo;
 
-      expect(await gotConnect).toEqual({ url: "example.com:443", host: "example.com:443", head: expectedHead });
-      expect(await clientClosed).toBe("HTTP/1.1 200 Connection established\r\n\r\n");
-    } finally {
-      client.destroy();
-    }
-  });
+      const client = net.connect(proxyAddress.port, proxyAddress.address);
+      try {
+        client.setNoDelay(true);
+        client.on("error", onConnectFail);
+        await once(client, "connect");
+        client.write(first);
+        // Two turns of the event loop: the listening side's readable wakes and
+        // consumes the first write before the second one is queued.
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+        client.write(second);
+
+        const { promise: clientClosed, resolve: onClientClosed } = Promise.withResolvers<string>();
+        let reply = "";
+        client.on("data", chunk => {
+          reply += chunk.toString();
+        });
+        client.on("close", () => onClientClosed(reply));
+
+        expect(await gotConnect).toEqual({ url: "example.com:443", host: expectedHost, head: expectedHead });
+        expect(await clientClosed).toBe("HTTP/1.1 200 Connection established\r\n\r\n");
+      } finally {
+        client.destroy();
+      }
+    },
+  );
 
   // https CONNECT: server socket.end() after peer FIN must also FIN the TCP
   // write side. Linux-only: the close is observed via EPOLLHUP once both halves

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -558,6 +558,66 @@ describe("HTTP server CONNECT", () => {
     }
   });
 
+  // The parser buffers an incomplete head and re-parses it when more bytes
+  // arrive; a CONNECT split after its request-line must still dispatch to the
+  // 'connect' listener rather than being swallowed as tunnel data. Every split
+  // below lands after consumeRequestLine has recognised CONNECT and before the
+  // header block is complete.
+  test.each([
+    ["one byte into the header block", "CONNECT example.com:443 HTTP/1.1\r\nH", "ost: example.com:443\r\n\r\n", ""],
+    ["mid header name", "CONNECT example.com:443 HTTP/1.1\r\nHost", ": example.com:443\r\n\r\n", ""],
+    ["mid header value", "CONNECT example.com:443 HTTP/1.1\r\nHost: exam", "ple.com:443\r\n\r\n", ""],
+    ["before the terminating CRLF", "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n", "\r\n", ""],
+    [
+      "with tunnel bytes trailing the second half",
+      "CONNECT example.com:443 HTTP/1.1\r\nHost",
+      ": example.com:443\r\n\r\nHELLO",
+      "HELLO",
+    ],
+  ])("dispatches a CONNECT whose head arrives in two reads (%s)", async (_name, first, second, expectedHead) => {
+    await using proxyServer = http.createServer();
+    const { promise: gotConnect, resolve: onConnect, reject: onConnectFail } = Promise.withResolvers<{
+      url: string;
+      host: string | undefined;
+      head: string;
+    }>();
+    proxyServer.on("connect", (req, socket, head) => {
+      onConnect({ url: String(req.url), host: req.headers.host, head: head.toString() });
+      socket.end("HTTP/1.1 200 Connection established\r\n\r\n");
+    });
+    proxyServer.on("clientError", (err: NodeJS.ErrnoException, socket) => {
+      socket.destroy();
+      onConnectFail(new Error("unexpected clientError " + err.code));
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const proxyAddress = proxyServer.address() as AddressInfo;
+
+    const client = net.connect(proxyAddress.port, proxyAddress.address);
+    try {
+      client.setNoDelay(true);
+      client.on("error", onConnectFail);
+      await once(client, "connect");
+      client.write(first);
+      // Two turns of the event loop: the listening side's readable wakes and
+      // consumes the first write before the second one is queued.
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+      client.write(second);
+
+      const { promise: clientClosed, resolve: onClientClosed } = Promise.withResolvers<string>();
+      let reply = "";
+      client.on("data", chunk => {
+        reply += chunk.toString();
+      });
+      client.on("close", () => onClientClosed(reply));
+
+      expect(await gotConnect).toEqual({ url: "example.com:443", host: "example.com:443", head: expectedHead });
+      expect(await clientClosed).toBe("HTTP/1.1 200 Connection established\r\n\r\n");
+    } finally {
+      client.destroy();
+    }
+  });
+
   // https CONNECT: server socket.end() after peer FIN must also FIN the TCP
   // write side. Linux-only: the close is observed via EPOLLHUP once both halves
   // have FIN'd; kqueue/libuv need the readable_ended re-arm to re-derive it.

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -576,7 +576,11 @@ describe("HTTP server CONNECT", () => {
     ],
   ])("dispatches a CONNECT whose head arrives in two reads (%s)", async (_name, first, second, expectedHead) => {
     await using proxyServer = http.createServer();
-    const { promise: gotConnect, resolve: onConnect, reject: onConnectFail } = Promise.withResolvers<{
+    const {
+      promise: gotConnect,
+      resolve: onConnect,
+      reject: onConnectFail,
+    } = Promise.withResolvers<{
       url: string;
       host: string | undefined;
       head: string;


### PR DESCRIPTION
## Repro

```js
const http = require("http"), net = require("net");
const server = http.createServer();
server.on("connect", (req, sock) => { sock.end("HTTP/1.1 200 OK\r\n\r\n"); });
server.listen(0, () => {
  const c = net.connect(server.address().port);
  c.setNoDelay(true);
  c.write("CONNECT x:1 HTTP/1.1\r\nHost");     // packet 1
  setTimeout(() => c.write(": x\r\n\r\n"), 200); // packet 2
});
```

Node emits `'connect'` and replies; Bun on `main` never dispatches and the connection hangs.

## Cause

`getHeaders()` wrote `isConnectRequest = true` through a `bool&` that aliases `HttpResponseData::isConnectRequest` as soon as `consumeRequestLine` recognised the `CONNECT` method, before it knew the header block was complete. Five later `return shortRead()` paths left that persistent flag set. On the next `onData` the `if (IsNodeHttp && isConnectRequest)` guard at the top of `fenceAndConsumePostPadded` (HttpParser.h:1110, added in 4bbe0751a2e) routed the fallback buffer plus the new bytes to the tunnel `dataHandler`, so `requestHandler` never ran and the `'connect'` event was never emitted.

`Bun.serve` is not affected: that guard is `IsNodeHttp`-gated and the other reads of the flag happen after a successful parse.

## Fix

`getHeaders` has exactly two success returns (empty header block and end of header block). Write `isConnectRequest` immediately before each, so the out-param is only committed once a complete request head has been parsed; short-read and error returns no longer mutate it.

## Verification

New `test.each` in `test/js/node/http/node-http-connect.test.ts` covers six split points (one byte into the header block, mid header name, mid header value, before the terminating CRLF, a second half that also carries tunnel bytes, and inside a no-header terminator) so both success returns are exercised. All hang on `main` and pass with this change; Node passes them all.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/http/node-http-connect.test.ts

<!-- robobun:evidence:end -->