### PR TITLE
js_parser: reject duplicate function declarations at ESM module scope

### DIFF
--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -29,6 +29,11 @@ pub struct Scope {
     /// so iteration yields safe `Deref` instead of `unsafe { child.as_ref() }`.
     pub children: AstVec<StoreRef<Scope>>,
     pub members: MemberHashMap,
+    /// Members replaced by a later declaration in this scope (`declare_symbol`
+    /// → `SymbolMergeResult::ReplaceWithNew`). Needed so `hoist_symbols` can
+    /// retroactively reject duplicate function declarations once the file's
+    /// strict-mode / ESM status is known.
+    pub replaced: AstVec<Member>,
     /// `AstVec`: arena-backed.
     pub generated: AstVec<Ref>,
 
@@ -69,6 +74,7 @@ impl Scope {
         parent: None,
         children: AstAlloc::vec(),
         members: MemberHashMap::new_in(AstAlloc),
+        replaced: AstAlloc::vec(),
         generated: AstAlloc::vec(),
         label_ref: Ref::NONE,
         label_stmt_is_loop: false,

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -29,10 +29,7 @@ pub struct Scope {
     /// so iteration yields safe `Deref` instead of `unsafe { child.as_ref() }`.
     pub children: AstVec<StoreRef<Scope>>,
     pub members: MemberHashMap,
-    /// Members replaced by a later declaration in this scope (`declare_symbol`
-    /// → `SymbolMergeResult::ReplaceWithNew`). Needed so `hoist_symbols` can
-    /// retroactively reject duplicate function declarations once the file's
-    /// strict-mode / ESM status is known.
+    /// Members `declare_symbol` replaced in this scope; read by `hoist_symbols`.
     pub replaced: AstVec<Member>,
     /// `AstVec`: arena-backed.
     pub generated: AstVec<Ref>,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2944,34 +2944,35 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Duplicate function declarations are forbidden in strict-mode blocks and
         // at a module's top level. Checked here (not at declaration time) because
         // strict / ESM status may be decided by a later `"use strict"` / `export`.
-        if !scope_ref.replaced.is_empty()
-            && ((scope_ref.strict_mode != js_ast::StrictModeKind::SloppyMode
-                && scope_ref.kind == js_ast::scope::Kind::Block)
-                || (scope_ref.parent.is_none()
-                    && (self.has_es_module_syntax
-                        || self.options.module_type == options::ModuleType::Esm)))
-        {
-            for replaced in scope_ref.replaced.slice() {
-                let symbol = &self.symbols[replaced.ref_.inner_index() as usize];
-                if !symbol.kind.is_function() {
-                    continue;
+        if !scope_ref.replaced.is_empty() {
+            let is_file_esm = self.has_es_module_syntax
+                || self.options.module_type == options::ModuleType::Esm;
+            let scope_rejects_duplicate_fns = (scope_ref.kind == js_ast::scope::Kind::Block
+                && (scope_ref.strict_mode != js_ast::StrictModeKind::SloppyMode || is_file_esm))
+                || (scope_ref.parent.is_none() && is_file_esm);
+            if scope_rejects_duplicate_fns {
+                for replaced in scope_ref.replaced.slice() {
+                    let symbol = &self.symbols[replaced.ref_.inner_index() as usize];
+                    if !symbol.kind.is_function() {
+                        continue;
+                    }
+                    let name: &'a [u8] = symbol.original_name.slice();
+                    let Some(member) = scope_ref.members.get(name) else {
+                        continue;
+                    };
+                    if !self.symbols[member.ref_.inner_index() as usize]
+                        .kind
+                        .is_function()
+                    {
+                        continue;
+                    }
+                    self.log().add_symbol_already_declared_error(
+                        self.source,
+                        name,
+                        member.loc,
+                        replaced.loc,
+                    );
                 }
-                let name: &'a [u8] = symbol.original_name.slice();
-                let Some(member) = scope_ref.members.get(name) else {
-                    continue;
-                };
-                if !self.symbols[member.ref_.inner_index() as usize]
-                    .kind
-                    .is_function()
-                {
-                    continue;
-                }
-                self.log().add_symbol_already_declared_error(
-                    self.source,
-                    name,
-                    member.loc,
-                    replaced.loc,
-                );
             }
         }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2945,8 +2945,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // at a module's top level. Checked here (not at declaration time) because
         // strict / ESM status may be decided by a later `"use strict"` / `export`.
         if !scope_ref.replaced.is_empty() {
-            let is_file_esm = self.has_es_module_syntax
-                || self.options.module_type == options::ModuleType::Esm;
+            let is_file_esm =
+                self.has_es_module_syntax || self.options.module_type == options::ModuleType::Esm;
             let scope_rejects_duplicate_fns = (scope_ref.kind == js_ast::scope::Kind::Block
                 && (scope_ref.strict_mode != js_ast::StrictModeKind::SloppyMode || is_file_esm))
                 || (scope_ref.parent.is_none() && is_file_esm);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2940,6 +2940,43 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // only later access is the `scope.generated` push (DerefMut, after the
         // shared borrow is dropped) and the post-loop `children` walk.
         let scope_ref = &*scope;
+
+        // Duplicate function declarations are forbidden in nested blocks in strict
+        // mode. Separately, they are also forbidden at the top-level of modules.
+        // This check needs to be delayed until now instead of being done when the
+        // functions are declared because we potentially need to scan the whole file
+        // to know if the file is considered to be in strict mode (or is considered
+        // to be a module). We might only encounter an "export {}" clause at the end
+        // of the file.
+        if !scope_ref.replaced.is_empty()
+            && ((scope_ref.strict_mode != js_ast::StrictModeKind::SloppyMode
+                && scope_ref.kind == js_ast::scope::Kind::Block)
+                || (scope_ref.parent.is_none() && self.has_es_module_syntax))
+        {
+            for replaced in scope_ref.replaced.slice() {
+                let symbol = &self.symbols[replaced.ref_.inner_index() as usize];
+                if !symbol.kind.is_function() {
+                    continue;
+                }
+                let name: &'a [u8] = symbol.original_name.slice();
+                let Some(member) = scope_ref.members.get(name) else {
+                    continue;
+                };
+                if !self.symbols[member.ref_.inner_index() as usize]
+                    .kind
+                    .is_function()
+                {
+                    continue;
+                }
+                self.log().add_symbol_already_declared_error(
+                    self.source,
+                    name,
+                    member.loc,
+                    replaced.loc,
+                );
+            }
+        }
+
         if !scope_ref.kind_stops_hoisting() {
             let arena = self.arena;
             // Re-borrow `self.symbols` after each `new_symbol` call.
@@ -4563,6 +4600,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // SAFETY: see key-lifetime note above — `name: &'a [u8]` outlives the
         // arena-owned `Scope` map.
         let entry = unsafe { scope.members.get_or_put_borrowed(name) };
+        let mut replaced_member: Option<js_ast::scope::Member> = None;
         if entry.found_existing {
             let existing: js_ast::scope::Member = *entry.value_ptr;
             let symbol_idx = existing.ref_.inner_index() as usize;
@@ -4591,6 +4629,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 MR::ReplaceWithNew => {
                     self.symbols[symbol_idx].link.set(ref_);
+                    replaced_member = Some(existing);
 
                     // If these are both functions, remove the overwritten declaration
                     if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
@@ -4609,6 +4648,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
         *entry.value_ptr = js_ast::scope::Member { ref_, loc };
+        if let Some(replaced) = replaced_member {
+            VecExt::append(&mut scope.replaced, replaced);
+        }
         Ok(ref_)
     }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2941,17 +2941,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // shared borrow is dropped) and the post-loop `children` walk.
         let scope_ref = &*scope;
 
-        // Duplicate function declarations are forbidden in nested blocks in strict
-        // mode. Separately, they are also forbidden at the top-level of modules.
-        // This check needs to be delayed until now instead of being done when the
-        // functions are declared because we potentially need to scan the whole file
-        // to know if the file is considered to be in strict mode (or is considered
-        // to be a module). We might only encounter an "export {}" clause at the end
-        // of the file.
+        // Duplicate function declarations are forbidden in strict-mode blocks and
+        // at a module's top level. Checked here (not at declaration time) because
+        // strict / ESM status may be decided by a later `"use strict"` / `export`.
         if !scope_ref.replaced.is_empty()
             && ((scope_ref.strict_mode != js_ast::StrictModeKind::SloppyMode
                 && scope_ref.kind == js_ast::scope::Kind::Block)
-                || (scope_ref.parent.is_none() && self.has_es_module_syntax))
+                || (scope_ref.parent.is_none()
+                    && (self.has_es_module_syntax
+                        || self.options.module_type == options::ModuleType::Esm)))
         {
             for replaced in scope_ref.replaced.slice() {
                 let symbol = &self.symbols[replaced.ref_.inner_index() as usize];

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -939,7 +939,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 Expr::init_identifier(func_name.ref_, func_name.loc),
             ));
         } else if !mark_as_dead {
-            if remove_overwritten {
+            if remove_overwritten && !data.func.flags.contains(flags::Function::IsExport) {
                 // restore on early return.
                 p.react_refresh.hook_ctx_storage = prev_hook_storage;
                 if mark_as_dead {

--- a/test/bundler/transpiler/duplicate-function-declaration.test.ts
+++ b/test/bundler/transpiler/duplicate-function-declaration.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// ECMA-262 §16.2.1.1: duplicate entries in the ExportedNames and
+// LexicallyDeclaredNames of a Module are Syntax Errors. Top-level function
+// declarations are lexically declared in a Module (unlike in a function body),
+// so two `function foo` at module scope must be rejected.
+
+const js = new Bun.Transpiler({ loader: "js" });
+const ts = new Bun.Transpiler({ loader: "ts" });
+
+function transpileError(code: string, t = js): string {
+  try {
+    t.transformSync(code);
+  } catch (e: any) {
+    const err = e instanceof AggregateError ? e.errors[0] : e;
+    return String(err.message);
+  }
+  throw new Error("expected a parse error for:\n" + code);
+}
+
+function transpiles(code: string, t = js): string {
+  return t.transformSync(code);
+}
+
+describe("duplicate function declarations", () => {
+  describe("rejected at module scope in ESM", () => {
+    test("export function + export function", () => {
+      expect(
+        transpileError(
+          "export function foo() { return 1 }\n" + "export function foo() { return 2 }",
+        ),
+      ).toMatch(/"foo" has already been declared|Multiple exports with the same name "foo"/);
+    });
+
+    test("export async function + export async function", () => {
+      expect(
+        transpileError(
+          "export async function foo() { return 1 }\n" + "export async function foo() { return 2 }",
+        ),
+      ).toMatch(/"foo" has already been declared|Multiple exports with the same name "foo"/);
+    });
+
+    test("function + export function", () => {
+      expect(
+        transpileError("function foo() { return 1 }\n" + "export function foo() { return 2 }"),
+      ).toContain('"foo" has already been declared');
+    });
+
+    test("export function + function", () => {
+      expect(
+        transpileError("export function foo() { return 1 }\n" + "function foo() { return 2 }"),
+      ).toContain('"foo" has already been declared');
+    });
+
+    test("two non-exported functions in a module (via export {})", () => {
+      expect(
+        transpileError(
+          "function foo() { return 1 }\n" + "function foo() { return 2 }\n" + "export {}",
+        ),
+      ).toContain('"foo" has already been declared');
+    });
+
+    test("two non-exported functions in a module (via import)", () => {
+      expect(
+        transpileError(
+          "import 'x'\n" + "function foo() { return 1 }\n" + "function foo() { return 2 }",
+        ),
+      ).toContain('"foo" has already been declared');
+    });
+  });
+
+  describe("rejected inside a block in strict mode", () => {
+    test('explicit "use strict"', () => {
+      expect(
+        transpileError(
+          "'use strict'\n" + "{ function foo() { return 1 }\n" + "function foo() { return 2 } }",
+        ),
+      ).toContain('"foo" has already been declared');
+    });
+
+    test("implicit via ESM", () => {
+      expect(
+        transpileError(
+          "{ function foo() { return 1 }\n" + "function foo() { return 2 } }\n" + "export {}",
+        ),
+      ).toContain('"foo" has already been declared');
+    });
+  });
+
+  describe("allowed", () => {
+    test("in a script with no ESM syntax", () => {
+      // Top-level of a script is like a function body; last declaration wins.
+      expect(() =>
+        transpiles("function foo() { return 1 }\n" + "function foo() { return 2 }"),
+      ).not.toThrow();
+    });
+
+    test("inside a function body (even in ESM)", () => {
+      expect(() =>
+        transpiles(
+          "function outer() { function foo() {}\n" + "function foo() {} }\n" + "export {}",
+        ),
+      ).not.toThrow();
+    });
+
+    test("inside a block in sloppy mode", () => {
+      expect(() =>
+        transpiles("{ function foo() { return 1 }\n" + "function foo() { return 2 } }"),
+      ).not.toThrow();
+    });
+
+    test("TypeScript overload signatures", () => {
+      // Forward declarations have no body and are discarded before symbol
+      // declaration, so they must not trip the duplicate check.
+      expect(() =>
+        transpiles(
+          "export function foo(x: number): number\n" +
+            "export function foo(x: string): string\n" +
+            "export function foo(x: any): any { return x }",
+          ts,
+        ),
+      ).not.toThrow();
+    });
+
+    test("var + var at module scope", () => {
+      expect(() => transpiles("var foo = 1\n" + "var foo = 2\n" + "export {}")).not.toThrow();
+    });
+  });
+});
+
+describe("duplicate function declarations at runtime", () => {
+  // The runtime module loader must surface the parse error instead of silently
+  // executing the last declaration.
+  test.concurrent("duplicate export function in .mjs is a SyntaxError", async () => {
+    using dir = tempDir("dup-export-fn", {
+      "dup.mjs":
+        "export function foo() { return 1 }\n" +
+        "export function foo() { return 2 }\n" +
+        "console.log(foo())",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "dup.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toMatch(/"foo" has already been declared|Multiple exports with the same name "foo"/);
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test.concurrent("duplicate top-level function in .mjs is a SyntaxError", async () => {
+    using dir = tempDir("dup-fn", {
+      "dup.mjs":
+        "function foo() { return 1 }\n" +
+        "function foo() { return 2 }\n" +
+        "console.log(foo())\n" +
+        "export {}",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "dup.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toContain('"foo" has already been declared');
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/test/bundler/transpiler/duplicate-function-declaration.test.ts
+++ b/test/bundler/transpiler/duplicate-function-declaration.test.ts
@@ -148,7 +148,7 @@ describe("duplicate function declarations at runtime", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toMatch(/"foo" has already been declared|Multiple exports with the same name "foo"/);
     expect(stdout).toBe("");
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 
   test.concurrent("duplicate top-level function in .mjs is a SyntaxError", async () => {
@@ -167,7 +167,7 @@ describe("duplicate function declarations at runtime", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain('"foo" has already been declared');
     expect(stdout).toBe("");
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 
   test.concurrent("duplicate block-scoped function in .mjs is a SyntaxError", async () => {
@@ -185,6 +185,6 @@ describe("duplicate function declarations at runtime", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain('"foo" has already been declared');
     expect(stdout).toBe("");
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/bundler/transpiler/duplicate-function-declaration.test.ts
+++ b/test/bundler/transpiler/duplicate-function-declaration.test.ts
@@ -26,46 +26,38 @@ function transpiles(code: string, t = js): string {
 describe("duplicate function declarations", () => {
   describe("rejected at module scope in ESM", () => {
     test("export function + export function", () => {
-      expect(
-        transpileError(
-          "export function foo() { return 1 }\n" + "export function foo() { return 2 }",
-        ),
-      ).toMatch(/"foo" has already been declared|Multiple exports with the same name "foo"/);
+      expect(transpileError("export function foo() { return 1 }\n" + "export function foo() { return 2 }")).toMatch(
+        /"foo" has already been declared|Multiple exports with the same name "foo"/,
+      );
     });
 
     test("export async function + export async function", () => {
       expect(
-        transpileError(
-          "export async function foo() { return 1 }\n" + "export async function foo() { return 2 }",
-        ),
+        transpileError("export async function foo() { return 1 }\n" + "export async function foo() { return 2 }"),
       ).toMatch(/"foo" has already been declared|Multiple exports with the same name "foo"/);
     });
 
     test("function + export function", () => {
-      expect(
-        transpileError("function foo() { return 1 }\n" + "export function foo() { return 2 }"),
-      ).toContain('"foo" has already been declared');
+      expect(transpileError("function foo() { return 1 }\n" + "export function foo() { return 2 }")).toContain(
+        '"foo" has already been declared',
+      );
     });
 
     test("export function + function", () => {
-      expect(
-        transpileError("export function foo() { return 1 }\n" + "function foo() { return 2 }"),
-      ).toContain('"foo" has already been declared');
+      expect(transpileError("export function foo() { return 1 }\n" + "function foo() { return 2 }")).toContain(
+        '"foo" has already been declared',
+      );
     });
 
     test("two non-exported functions in a module (via export {})", () => {
-      expect(
-        transpileError(
-          "function foo() { return 1 }\n" + "function foo() { return 2 }\n" + "export {}",
-        ),
-      ).toContain('"foo" has already been declared');
+      expect(transpileError("function foo() { return 1 }\n" + "function foo() { return 2 }\n" + "export {}")).toContain(
+        '"foo" has already been declared',
+      );
     });
 
     test("two non-exported functions in a module (via import)", () => {
       expect(
-        transpileError(
-          "import 'x'\n" + "function foo() { return 1 }\n" + "function foo() { return 2 }",
-        ),
+        transpileError("import 'x'\n" + "function foo() { return 1 }\n" + "function foo() { return 2 }"),
       ).toContain('"foo" has already been declared');
     });
   });
@@ -73,17 +65,13 @@ describe("duplicate function declarations", () => {
   describe("rejected inside a block in strict mode", () => {
     test('explicit "use strict"', () => {
       expect(
-        transpileError(
-          "'use strict'\n" + "{ function foo() { return 1 }\n" + "function foo() { return 2 } }",
-        ),
+        transpileError("'use strict'\n" + "{ function foo() { return 1 }\n" + "function foo() { return 2 } }"),
       ).toContain('"foo" has already been declared');
     });
 
     test("implicit via ESM", () => {
       expect(
-        transpileError(
-          "{ function foo() { return 1 }\n" + "function foo() { return 2 } }\n" + "export {}",
-        ),
+        transpileError("{ function foo() { return 1 }\n" + "function foo() { return 2 } }\n" + "export {}"),
       ).toContain('"foo" has already been declared');
     });
   });
@@ -91,23 +79,17 @@ describe("duplicate function declarations", () => {
   describe("allowed", () => {
     test("in a script with no ESM syntax", () => {
       // Top-level of a script is like a function body; last declaration wins.
-      expect(() =>
-        transpiles("function foo() { return 1 }\n" + "function foo() { return 2 }"),
-      ).not.toThrow();
+      expect(() => transpiles("function foo() { return 1 }\n" + "function foo() { return 2 }")).not.toThrow();
     });
 
     test("inside a function body (even in ESM)", () => {
       expect(() =>
-        transpiles(
-          "function outer() { function foo() {}\n" + "function foo() {} }\n" + "export {}",
-        ),
+        transpiles("function outer() { function foo() {}\n" + "function foo() {} }\n" + "export {}"),
       ).not.toThrow();
     });
 
     test("inside a block in sloppy mode", () => {
-      expect(() =>
-        transpiles("{ function foo() { return 1 }\n" + "function foo() { return 2 } }"),
-      ).not.toThrow();
+      expect(() => transpiles("{ function foo() { return 1 }\n" + "function foo() { return 2 } }")).not.toThrow();
     });
 
     test("TypeScript overload signatures", () => {
@@ -134,10 +116,7 @@ describe("duplicate function declarations at runtime", () => {
   // executing the last declaration.
   test.concurrent("duplicate export function in .mjs is a SyntaxError", async () => {
     using dir = tempDir("dup-export-fn", {
-      "dup.mjs":
-        "export function foo() { return 1 }\n" +
-        "export function foo() { return 2 }\n" +
-        "console.log(foo())",
+      "dup.mjs": "export function foo() { return 1 }\n" + "export function foo() { return 2 }\n" + "console.log(foo())",
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "dup.mjs"],
@@ -146,11 +125,7 @@ describe("duplicate function declarations at runtime", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toMatch(/"foo" has already been declared|Multiple exports with the same name "foo"/);
     expect(stdout).toBe("");
     expect(exitCode).not.toBe(0);
@@ -159,10 +134,7 @@ describe("duplicate function declarations at runtime", () => {
   test.concurrent("duplicate top-level function in .mjs is a SyntaxError", async () => {
     using dir = tempDir("dup-fn", {
       "dup.mjs":
-        "function foo() { return 1 }\n" +
-        "function foo() { return 2 }\n" +
-        "console.log(foo())\n" +
-        "export {}",
+        "function foo() { return 1 }\n" + "function foo() { return 2 }\n" + "console.log(foo())\n" + "export {}",
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "dup.mjs"],
@@ -171,11 +143,7 @@ describe("duplicate function declarations at runtime", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain('"foo" has already been declared');
     expect(stdout).toBe("");
     expect(exitCode).not.toBe(0);

--- a/test/bundler/transpiler/duplicate-function-declaration.test.ts
+++ b/test/bundler/transpiler/duplicate-function-declaration.test.ts
@@ -132,9 +132,10 @@ describe("duplicate function declarations at runtime", () => {
   });
 
   test.concurrent("duplicate top-level function in .mjs is a SyntaxError", async () => {
+    // No import/export/TLA: the .mjs extension alone must be enough for the
+    // parser to treat the top level as a Module.
     using dir = tempDir("dup-fn", {
-      "dup.mjs":
-        "function foo() { return 1 }\n" + "function foo() { return 2 }\n" + "console.log(foo())\n" + "export {}",
+      "dup.mjs": "function foo() { return 1 }\n" + "function foo() { return 2 }\n" + "console.log(foo())",
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "dup.mjs"],

--- a/test/bundler/transpiler/duplicate-function-declaration.test.ts
+++ b/test/bundler/transpiler/duplicate-function-declaration.test.ts
@@ -60,6 +60,18 @@ describe("duplicate function declarations", () => {
         transpileError("import 'x'\n" + "function foo() { return 1 }\n" + "function foo() { return 2 }"),
       ).toContain('"foo" has already been declared');
     });
+
+    test("function + async function", () => {
+      expect(transpileError("function foo() {}\n" + "async function foo() {}\n" + "export {}")).toContain(
+        '"foo" has already been declared',
+      );
+    });
+
+    test("function + function*", () => {
+      expect(transpileError("function foo() {}\n" + "function* foo() {}\n" + "export {}")).toContain(
+        '"foo" has already been declared',
+      );
+    });
   });
 
   describe("rejected inside a block in strict mode", () => {
@@ -80,6 +92,14 @@ describe("duplicate function declarations", () => {
     test("in a script with no ESM syntax", () => {
       // Top-level of a script is like a function body; last declaration wins.
       expect(() => transpiles("function foo() { return 1 }\n" + "function foo() { return 2 }")).not.toThrow();
+    });
+
+    test("at script top level with 'use strict' (no ESM)", () => {
+      // Entry scope in a strict script is still a function-body-like scope,
+      // not a Module; only blocks pick up the strict-mode restriction.
+      expect(() =>
+        transpiles("'use strict'\n" + "function foo() { return 1 }\n" + "function foo() { return 2 }"),
+      ).not.toThrow();
     });
 
     test("inside a function body (even in ESM)", () => {
@@ -136,6 +156,24 @@ describe("duplicate function declarations at runtime", () => {
     // parser to treat the top level as a Module.
     using dir = tempDir("dup-fn", {
       "dup.mjs": "function foo() { return 1 }\n" + "function foo() { return 2 }\n" + "console.log(foo())",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "dup.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain('"foo" has already been declared');
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test.concurrent("duplicate block-scoped function in .mjs is a SyntaxError", async () => {
+    // Block scope in an .mjs file with no import/export/TLA is still strict.
+    using dir = tempDir("dup-block-fn", {
+      "dup.mjs": "{ function foo() { return 1 }\n" + "function foo() { return 2 } }\n" + "console.log(typeof foo)",
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "dup.mjs"],

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -122,11 +122,6 @@ export function pgErrorResponse(fields: { S: string; C: string; M: string; [k: s
   return buf;
 }
 
-// PostgreSQL FE/BE protocol §55.7 ParameterStatus: Byte1('S') Int32(len) String(name) String(value)
-export function pgParameterStatus(name: string, value: string): Buffer {
-  return pgRaw("S", Buffer.concat([pgCString(name), pgCString(value)]));
-}
-
 // PostgreSQL FE/BE protocol §55.7 NotificationResponse: Byte1('A') Int32(len) Int32(pid) String(channel) String(payload)
 export function pgNotificationResponse(pid: number, channel: string, payload: string): Buffer {
   return pgRaw("A", Buffer.concat([pgInt32(pid), pgCString(channel), pgCString(payload)]));


### PR DESCRIPTION
## What

Two `export function foo` declarations in the same ES module must be a SyntaxError (ECMA-262 §16.2.1.1: duplicate entries in ExportedNames / LexicallyDeclaredNames of a Module are early errors). Node and esbuild both reject them; Bun silently kept the last declaration.

```js
// a.mjs
export function foo() { return 1; }
export function foo() { return 2; }
```
```
$ node a.mjs
SyntaxError: Identifier 'foo' has already been declared
$ bun a.mjs   # before this change
(exits 0)
```

This let `test/js/sql/wire-frames.ts` ship with two identical `export function pgParameterStatus` declarations without any tooling noticing.

## Why it was silent

`declare_symbol` merges the second `function foo` into the first with `SymbolMergeResult::ReplaceWithNew` and marks the first symbol `remove_overwritten_function_declaration`. The visit pass then dropped the first `SFunction` statement unconditionally, so by the time `scan_imports`/`record_export` ran there was only one `export function foo` and nothing to flag.

## Fix

Ports esbuild's handling:

- `Scope` gains a `replaced: AstVec<Member>` list; `declare_symbol` records the member it replaced on `ReplaceWithNew`.
- At the start of `hoist_symbols`, if the scope is either a strict-mode block or the ESM module scope, any `replaced` entry where both the old and the current member are functions is reported as `"foo" has already been declared`. The check has to live here (not at declaration time) because the file's ESM / strict-mode status may only be determined by a trailing `export {}` or `"use strict"`.
- The visit-pass strip of overwritten function declarations now skips exported ones (matching esbuild's `!s.IsExport` guard), so `record_export` also reports `Multiple exports with the same name "foo"` for the export+export case.

This additionally matches Node on the adjacent cases Bun used to miss:

- `function foo(){}` + `export function foo(){}` (either order) at module scope
- two non-exported `function foo(){}` at module scope in an ES module
- two `function foo(){}` inside a `{}` block in strict mode

TypeScript overload signatures are unaffected: forward declarations with no body are discarded before `declare_symbol` runs, so only the implementation is ever declared.

## Verification

New `test/bundler/transpiler/duplicate-function-declaration.test.ts` covers the rejected cases above plus the still-allowed ones (script top level, function-body scope, sloppy-mode block, TS overloads, `var`+`var`). Also drops the duplicate `pgParameterStatus` from `test/js/sql/wire-frames.ts` now that the parser catches it.

Supersedes #35753 (the wire-frames dedup is included here).


Fixes #14273.
