### PR TITLE
verify-baseline-static: blanket-pass the CRT strspn family; drop stale provenance claims

### DIFF
--- a/scripts/verify-baseline-static/CLAUDE.md
+++ b/scripts/verify-baseline-static/CLAUDE.md
@@ -186,7 +186,11 @@ Signs of a false positive:
 - `objdump -d` around the reported address shows `ret` then byte soup — no
   stack frame setup, no control flow leading to it.
 
-If confirmed: allowlist the symbol. Note the reason in the group comment.
+If confirmed: allowlist the symbol as a **blanket pass** (bare name, no
+`[...]` bracket). The reported features are misdecoded data bytes whose
+values move with link layout, not gated code, so a ceiling has nothing to
+bound and just re-flakes on the next layout that decodes differently. Note
+the reason in the group comment.
 
 ## Adding an allowlist entry
 
@@ -201,10 +205,12 @@ existing `# Gate: ...` header; if no existing group matches, add one:
 symbol_name_exactly_as_the_tool_printed_it  [FEAT1, FEAT2]
 ```
 
-**Always use a feature ceiling** (`[...]`). A blanket pass (no brackets)
-defeats the "did the gate get updated when the dep grew AVX-512?" check
-(`src/main.rs:616-621`). List exactly the features the tool reported; that's
-what the gate currently checks.
+**Use a feature ceiling** (`[...]`) for gated code. A blanket pass (no
+brackets) defeats the "did the gate get updated when the dep grew AVX-512?"
+check (`src/main.rs:616-621`). List exactly the features the tool reported;
+that's what the gate currently checks. The exceptions are confirmed
+data-in-.text misdecodes (previous section) and `<no-symbol@...>` padding
+(below): there is no gate to drift past, so blanket-pass those.
 
 **x64 feature names** (iced-x86 Debug strings — must match exactly):
 `AVX`, `AVX2`, `FMA`, `FMA4`, `BMI1`, `BMI2`, `MOVBE`, `ADX`, `RDRAND`,

--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -889,15 +889,16 @@ wcsnlen                     [AVX, AVX2]
 # to an indirect `jmp *table[rbp + rax*4]` where MSVC stores the table as
 # three arrays of 4-byte image-relative RVAs in .text right after the
 # function's `ret`. Those RVAs change with link layout, and linear sweep
-# desyncs into them: entry bytes `C7 F8 xx xx` / `C6 F8 xx` decode as
-# XBEGIN/XABORT (handled in is_impossible_feature), and `C4/C5 xx ..` can
-# decode as stray VEX. The SDE -nhm step in this job calls strcspn
-# (libarchive mtree, sqlite3) and passes, confirming no post-SSE2 code runs.
+# desyncs into them: entry bytes `C7 F8 ..`/`C6 F8 ..` decode as
+# XBEGIN/XABORT (handled in is_impossible_feature); `C4/C5/62/8F ..` can
+# decode as stray VEX/EVEX/XOP. Blanket-pass: the source has no post-SSE2
+# path to grow past, so a ceiling here just means the next layout that
+# decodes as FMA/BMI2/AVX512* re-flakes.
 # (3 symbols)
 # ----------------------------------------------------------------------------
-strcspn                     [AVX, AVX2]
-strpbrk                     [AVX, AVX2]
-strspn                      [AVX, AVX2]
+strcspn
+strpbrk
+strspn
 
 
 # ----------------------------------------------------------------------------

--- a/scripts/verify-baseline-static/src/main.rs
+++ b/scripts/verify-baseline-static/src/main.rs
@@ -153,9 +153,10 @@ fn is_harmless_on_nehalem(insn: &Instruction) -> bool {
     }
 
     // CLDEMOTE encodes in hint/NOP space (0f 1c /0) and is architecturally
-    // treated as a NOP on CPUs that don't enumerate it (SDM vol. 2A). Newer
-    // UCRT string routines (e.g. strpbrk) emit it unconditionally as a cache
-    // hint; on Nehalem it NOPs and the routine behaves identically.
+    // treated as a NOP on CPUs that don't enumerate it (SDM vol. 2A). Only
+    // ever observed as a data-in-.text misdecode (the CRT strspn family's
+    // switch-table RVAs, same as RTM below), but the hint-space encoding
+    // makes it harmless regardless of provenance.
     if insn.mnemonic() == Mnemonic::Cldemote {
         return true;
     }


### PR DESCRIPTION
Follow-up to #35770.

## Why

Self-review of #35770 surfaced three residual issues:

1. **The `[AVX, AVX2]` ceiling is layout-lottery.** It was inherited verbatim from the old miscategorized `strpbrk` entry, not derived from what the switch-table RVAs can actually decode as. An iced-x86 probe simulating the `ret; nop; 3×16×u32-RVA` table over link base addresses in `[0x01000000, 0x04000000)` with the scanner's exact filter set shows ~0.27% of layouts decode at least one feature outside `[AVX, AVX2]` (most often `AVX512VL/F/BW` via `62` EVEX, `FMA`/`BMI2` via `C4` 3-byte VEX, `FMA4`/`XOP` via `8F`). With three routines per binary that is ~0.8% per build; it will recur.

   `ucrt/string/amd64/strspn.c` has no post-SSE2 path and no CPUID dispatch, so the ceiling's purpose ("flag when the gate didn't keep up with the code") does not apply. Switched to a blanket pass, and updated the triage doc to carve out confirmed data-in-.text from the always-use-a-ceiling rule so the next person doesn't re-add a flaky bracket.

2. **CLDEMOTE comment contradicted the new section.** `is_harmless_on_nehalem` said "newer UCRT string routines (e.g. strpbrk) emit it unconditionally as a cache hint". Per the corrected analysis in #35770 that sighting was the same RVA-table misdecode (`0F 1C /0` lines up just like `C7 F8` does). Reworded to say so; the hint-NOP-space justification stays since it holds regardless of provenance.

3. **SDE claim was unsupported.** The allowlist comment said the SDE `-nhm` step "calls strcspn (libarchive mtree, sqlite3)". The `-nhm` phase only runs `simd-baseline.test.ts`, which exercises neither. Dropped that sentence; the UCRT source analysis is the evidence that stands on its own.

## Verification

Rebuilt the scanner and re-ran against the build 80917 `bun-windows-x64-profile` artifact: 0 violations, PASS (unchanged from #35770).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->