### PR TITLE
fetch: engine-compute framing for ReadableStream bodies; honour Connection: close on 3xx

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2421,10 +2421,14 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(CHUNKED_ENCODED_HEADER.name()) => {
-                    if !self.flags.is_streaming_request_body {
+                    // Transfer-Encoding is a forbidden request-header name
+                    // (Fetch spec); only node:http's raw ClientRequest API
+                    // lets the caller own framing. For fetch() the engine
+                    // always writes the framing header itself, so drop the
+                    // caller's value regardless of body shape.
+                    if !self.flags.is_streaming_request_body || !self.flags.is_node_http_client {
                         continue;
                     }
-                    // We don't want to override chunked encoding header if it was set by the user
                     if will_append {
                         add_transfer_encoding = false;
                     }
@@ -2471,11 +2475,18 @@ impl<'a> HTTPClient<'a> {
 
         if body_len > 0 || self.method.has_request_body() {
             if self.flags.is_streaming_request_body {
-                if let Some(content_length) = original_content_length {
+                // Content-Length is a forbidden request-header name (Fetch
+                // spec). For WebIDL fetch() the engine computes framing, so a
+                // caller-supplied Content-Length on a ReadableStream body is
+                // dropped and the body is always chunked. Honoring it would
+                // let the stream emit more bytes than the declared length,
+                // which is the CL-desync request-smuggling primitive. Only
+                // node:http's ClientRequest (which owns framing by contract)
+                // keeps the caller's value.
+                if let Some(content_length) = original_content_length
+                    && self.flags.is_node_http_client
+                {
                     if add_transfer_encoding {
-                        // User explicitly set Content-Length and did not set Transfer-Encoding;
-                        // preserve Content-Length instead of using chunked encoding.
-                        // This matches Node.js behavior where an explicit Content-Length is always honored.
                         request_headers_buf[header_count] =
                             picohttp::Header::new(CONTENT_LENGTH_HEADER_NAME, content_length);
                         header_count += 1;
@@ -4876,19 +4887,20 @@ impl<'a> HTTPClient<'a> {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Connection") => {
-                    if response.status_code >= 200 && response.status_code <= 299 {
-                        // HTTP headers are case-insensitive (RFC 7230)
-                        if bun_core::strings::eql_case_insensitive_ascii_check_length(
-                            header.value(),
-                            b"close",
-                        ) {
-                            self.state.flags.allow_keepalive = false;
-                        } else if bun_core::strings::eql_case_insensitive_ascii_check_length(
-                            header.value(),
-                            b"keep-alive",
-                        ) {
-                            self.state.flags.allow_keepalive = true;
-                        }
+                    // RFC 9112 §9.6: the `close` connection option is
+                    // connection-scoped, not tied to any status class. A 3xx
+                    // redirect that sends `Connection: close` must not have
+                    // its socket pooled for the follow-up request.
+                    if bun_core::strings::eql_case_insensitive_ascii_check_length(
+                        header.value(),
+                        b"close",
+                    ) {
+                        self.state.flags.allow_keepalive = false;
+                    } else if bun_core::strings::eql_case_insensitive_ascii_check_length(
+                        header.value(),
+                        b"keep-alive",
+                    ) {
+                        self.state.flags.allow_keepalive = true;
                     }
                 }
                 h if h == hash_header_const(b"Last-Modified") => {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -115,6 +115,7 @@ pub struct FetchTasklet {
     pub check_server_identity: StrongOptional,
     pub reject_unauthorized: bool,
     pub upgraded_connection: bool,
+    pub is_node_http_client: bool,
     // Custom Hostname
     pub hostname: Option<Box<[u8]>>,
     pub is_waiting_body: bool,
@@ -1900,6 +1901,7 @@ impl FetchTasklet {
             check_server_identity: fetch_options.check_server_identity,
             reject_unauthorized: fetch_options.reject_unauthorized,
             upgraded_connection: fetch_options.upgraded_connection,
+            is_node_http_client: fetch_options.is_node_http_client,
             hostname: fetch_options.hostname,
             is_waiting_body: false,
             is_waiting_abort: false,
@@ -2166,12 +2168,18 @@ impl FetchTasklet {
     }
 
     /// Whether the request body should skip chunked transfer encoding framing.
-    /// True for upgraded connections (e.g. WebSocket) or when the user explicitly
-    /// set Content-Length without setting Transfer-Encoding.
+    /// True for upgraded connections, for h2/h3 (which frame at the protocol
+    /// layer), and for node:http's ClientRequest when the caller set
+    /// Content-Length without Transfer-Encoding. WebIDL fetch() always chunks
+    /// a ReadableStream body: Content-Length and Transfer-Encoding are
+    /// forbidden request-header names, and honoring a caller-supplied
+    /// Content-Length there would decouple the declared length from the bytes
+    /// actually written (CL-desync request smuggling).
     fn skip_chunked_framing(&self) -> bool {
         self.upgraded_connection
             || self.result.is_http2
-            || (self.request_headers.get(b"content-length").is_some()
+            || (self.is_node_http_client
+                && self.request_headers.get(b"content-length").is_some()
                 && self.request_headers.get(b"transfer-encoding").is_none())
     }
 

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -613,43 +613,6 @@ test.each([
   });
 });
 
-// The same empty-chunk hazard on the other framing path: with an explicit
-// Content-Length the body is sent raw, so an empty enqueue buffers nothing,
-// but it still reported backpressure -- pausing the request body stream to
-// wait for a drain event that can never arrive. The upload hung forever.
-test("an empty request body chunk does not stall a stream body sent with an explicit Content-Length", async () => {
-  let recorded = Buffer.alloc(0);
-  await using server = net
-    .createServer(sock => {
-      sock.on("error", () => {});
-      sock.on("data", d => {
-        recorded = Buffer.concat([recorded, d]);
-        if (recorded.toString("latin1").endsWith("AAAABBBB")) {
-          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
-        }
-      });
-    })
-    .listen(0, "127.0.0.1");
-  await once(server, "listening");
-  const { port } = server.address() as net.AddressInfo;
-
-  const encoder = new TextEncoder();
-  const res = await fetch(`http://127.0.0.1:${port}/`, {
-    method: "POST",
-    duplex: "half",
-    headers: { "content-length": "8" },
-    body: new ReadableStream({
-      start(controller) {
-        for (const chunk of ["AAAA", "", "BBBB"]) controller.enqueue(encoder.encode(chunk));
-        controller.close();
-      },
-    }),
-  });
-  expect(await res.text()).toBe("ok");
-  const raw = recorded.toString("latin1");
-  expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("AAAABBBB");
-});
-
 // RFC 9112 section 5.2: an obs-fold continuation line in a response must be
 // joined into the preceding field value with SP, or the message rejected.
 // Accepting it while silently discarding the continuation is neither: it

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -328,3 +328,60 @@ describe("fetch() follows a redirect whose Location scheme is not lowercase", ()
     }
   });
 });
+
+// RFC 9112 §9.6: `Connection: close` applies to the connection regardless of
+// status code. A 3xx response that sets it must not have its socket pooled for
+// the follow-up request; the client has to open a fresh connection.
+//
+// The original request is a streamed POST so its chunked terminator is on the
+// wire before the 303 arrives; that is the one path where the redirect
+// socket-pool check would otherwise succeed.
+it("fetch() does not reuse a socket whose 303 response sent Connection: close (streamed POST)", async () => {
+  const requestsPerConn: string[][] = [];
+  const server = net.createServer(socket => {
+    const mine: string[] = [];
+    requestsPerConn.push(mine);
+    let buf = "";
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      buf += chunk.toString("latin1");
+      for (const m of buf.match(/(GET|POST) \S+ HTTP\/1\.1/g) ?? []) {
+        if (!mine.includes(m)) mine.push(m);
+      }
+      if (buf.includes("0\r\n\r\n") && mine[0]?.startsWith("POST /start ")) {
+        buf = "";
+        const port = (server.address() as net.AddressInfo).port;
+        socket.write(
+          `HTTP/1.1 303 See Other\r\nLocation: http://127.0.0.1:${port}/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`,
+        );
+      } else if (mine.some(l => l.startsWith("GET /final "))) {
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nFINAL");
+      }
+    });
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as net.AddressInfo;
+  try {
+    const body = new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("abcd"));
+        c.close();
+      },
+    });
+    const res = await fetch(`http://127.0.0.1:${port}/start`, {
+      method: "POST",
+      body,
+      // @ts-expect-error
+      duplex: "half",
+    });
+    expect({ status: res.status, redirected: res.redirected, body: await res.text() }).toEqual({
+      status: 200,
+      redirected: true,
+      body: "FINAL",
+    });
+    expect(requestsPerConn).toEqual([["POST /start HTTP/1.1"], ["GET /final HTTP/1.1"]]);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});

--- a/test/js/web/fetch/fetch-request-body-framing.test.ts
+++ b/test/js/web/fetch/fetch-request-body-framing.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
+
+// fetch() must compute request-body framing itself. A caller-supplied
+// Content-Length or Transfer-Encoding on a ReadableStream body would let the
+// body bytes diverge from the declared length, which is the primitive behind
+// HTTP request smuggling (CL.0 desync) through any front end that frames by
+// Content-Length. Both header names are forbidden request-header names in the
+// Fetch spec; undici rejects the same shapes with
+// RequestContentLengthMismatchError / InvalidArgumentError.
+describe("fetch() with a ReadableStream body ignores caller framing headers", () => {
+  async function roundTrip(opts: { headers?: Record<string, string>; streamPayload: string; terminator: string }) {
+    const sockets: net.Socket[] = [];
+    let raw = "";
+    const { promise: sawTerminator, resolve } = Promise.withResolvers<void>();
+    const server = net.createServer(socket => {
+      sockets.push(socket);
+      socket.on("error", () => {});
+      socket.on("data", chunk => {
+        raw += chunk.toString("latin1");
+        if (raw.includes(opts.terminator)) resolve();
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      const body = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(opts.streamPayload));
+          c.close();
+        },
+      });
+      const resP = fetch(`http://127.0.0.1:${port}/upload`, {
+        method: "POST",
+        body,
+        // @ts-expect-error duplex not yet in lib types
+        duplex: "half",
+        headers: opts.headers,
+      });
+      await sawTerminator;
+      for (const s of sockets) s.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+      const res = await resP;
+      await res.arrayBuffer();
+      return raw;
+    } finally {
+      for (const s of sockets) s.destroy();
+      server.close();
+      await once(server, "close");
+    }
+  }
+
+  function head(raw: string) {
+    return raw.slice(0, raw.indexOf("\r\n\r\n")).toLowerCase();
+  }
+
+  test("caller Content-Length is dropped; body is chunked", async () => {
+    const injected = "GET /admin HTTP/1.1\r\nHost: origin.internal\r\n\r\n";
+    const raw = await roundTrip({
+      headers: { "content-length": "4" },
+      streamPayload: "abcd" + injected,
+      terminator: "origin.internal",
+    });
+    const h = head(raw);
+    expect(h).toContain("transfer-encoding: chunked");
+    expect(h).not.toContain("content-length:");
+    expect(raw.startsWith("POST /upload HTTP/1.1\r\n")).toBe(true);
+  });
+
+  test("caller Transfer-Encoding is dropped; body is still engine-chunked", async () => {
+    const raw = await roundTrip({
+      headers: { "transfer-encoding": "chunked" },
+      streamPayload: "abcd",
+      terminator: "0\r\n\r\n",
+    });
+    const h = head(raw);
+    expect(h.match(/transfer-encoding:/g)?.length).toBe(1);
+    expect(h).not.toContain("content-length:");
+    expect(raw).toEndWith("0\r\n\r\n");
+  });
+
+  test("caller Content-Length + Transfer-Encoding both present: still chunked, no CL", async () => {
+    const raw = await roundTrip({
+      headers: { "content-length": "4", "transfer-encoding": "chunked" },
+      streamPayload: "abcdEXTRA",
+      terminator: "0\r\n\r\n",
+    });
+    const h = head(raw);
+    expect(h).toContain("transfer-encoding: chunked");
+    expect(h.match(/transfer-encoding:/g)?.length).toBe(1);
+    expect(h).not.toContain("content-length:");
+  });
+
+  // End-to-end: a keep-alive front end delimits each inbound message by its
+  // declared framing (Content-Length, or Transfer-Encoding: chunked) and
+  // records the request line of every message it parses. If fetch honored the
+  // caller's CL:4 for a longer stream body, the surplus bytes would be parsed
+  // here as a SECOND request (`GET /admin`).
+  test("a CL-trusting front end cannot be desynced", async () => {
+    function chunkedLen(s: string): number | null {
+      let i = 0;
+      for (;;) {
+        const nl = s.indexOf("\r\n", i);
+        if (nl < 0) return null;
+        const n = parseInt(s.slice(i, nl), 16);
+        if (!Number.isFinite(n)) return null;
+        i = nl + 2 + n + 2;
+        if (n === 0) return i <= s.length ? i : null;
+        if (i > s.length) return null;
+      }
+    }
+
+    const seen: string[] = [];
+    const frontend = net.createServer(s => {
+      let buf = "";
+      s.on("error", () => {});
+      s.on("data", b => {
+        buf += b.toString("latin1");
+        for (;;) {
+          const he = buf.indexOf("\r\n\r\n");
+          if (he < 0) break;
+          const headText = buf.slice(0, he);
+          let bodyLen: number;
+          if (/transfer-encoding:\s*chunked/i.test(headText)) {
+            const len = chunkedLen(buf.slice(he + 4));
+            if (len === null) break;
+            bodyLen = len;
+          } else {
+            const m = /content-length:\s*(\d+)/i.exec(headText);
+            bodyLen = m ? Number(m[1]) : 0;
+            if (buf.length - (he + 4) < bodyLen) break;
+          }
+          seen.push(headText.split("\r\n")[0]);
+          buf = buf.slice(he + 4 + bodyLen);
+          s.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+    });
+    await once(frontend.listen(0, "127.0.0.1"), "listening");
+    const port = (frontend.address() as net.AddressInfo).port;
+    const sockets = new Set<net.Socket>();
+    frontend.on("connection", s => {
+      sockets.add(s);
+      s.on("close", () => sockets.delete(s));
+    });
+
+    try {
+      const body = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("abcd" + "GET /admin HTTP/1.1\r\nHost: origin.internal\r\n\r\n"));
+          c.close();
+        },
+      });
+      const res = await fetch(`http://127.0.0.1:${port}/upload`, {
+        method: "POST",
+        body,
+        // @ts-expect-error
+        duplex: "half",
+        headers: { "content-length": "4" },
+      });
+      expect(res.status).toBe(200);
+      await res.arrayBuffer();
+      expect(seen).toEqual(["POST /upload HTTP/1.1"]);
+    } finally {
+      for (const s of sockets) s.destroy();
+      frontend.close();
+      await once(frontend, "close");
+    }
+  });
+});
+
+// node:http's ClientRequest is a raw HTTP/1.1 API where the caller owns
+// framing; an explicit Content-Length there MUST be honored (Node.js parity).
+test("node:http request() still honors an explicit Content-Length with a streamed body", async () => {
+  let raw = "";
+  const { promise: done, resolve } = Promise.withResolvers<void>();
+  const server = net.createServer(socket => {
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      raw += chunk.toString("latin1");
+      if (raw.endsWith("abcd")) {
+        socket.end("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        resolve();
+      }
+    });
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as net.AddressInfo;
+  try {
+    const req = http.request({
+      host: "127.0.0.1",
+      port,
+      method: "POST",
+      path: "/upload",
+      headers: { "content-length": "4" },
+    });
+    req.write("ab");
+    req.write("cd");
+    req.end();
+    await done;
+    const h = raw.slice(0, raw.indexOf("\r\n\r\n")).toLowerCase();
+    expect(h).toContain("content-length: 4");
+    expect(h).not.toContain("transfer-encoding");
+    expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("abcd");
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});


### PR DESCRIPTION
Two HTTP/1.1 client fixes.

## 1. Stream body framing (request smuggling primitive)

### Repro

```js
import net from "node:net";
let raw = "";
const srv = net.createServer(s => s.on("data", d => { raw += d; if (raw.includes("origin.internal"))
  s.end("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"); }));
await new Promise(r => srv.listen(0, "127.0.0.1", r));
await fetch(`http://127.0.0.1:${srv.address().port}/upload`, {
  method: "POST",
  body: new ReadableStream({ start(c) {
    c.enqueue(new TextEncoder().encode("abcd" + "GET /admin HTTP/1.1\r\nHost: origin.internal\r\n\r\n"));
    c.close();
  } }),
  duplex: "half",
  headers: { "content-length": "4" },
});
console.log(raw.slice(0, raw.indexOf("\r\n\r\n")).match(/content-length: .*|transfer-encoding: .*/gi));
```

Before: `["content-length: 4"]` and the 49 body bytes are written raw. Any keep-alive front end that frames by Content-Length reads 4 bytes as the body and parses the surplus as a second request (`GET /admin`). That is the CL.0 request-smuggling primitive (injection, same-connection response poisoning, and cross-client capture through a streaming front end all follow). Node/undici reject this with `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH` before any byte leaves.

### Cause

`HTTPClient::build_request` kept a caller `Content-Length` for a streaming body and wrote it verbatim; `FetchTasklet::skip_chunked_framing` then skipped chunked framing whenever `content-length` was present without `transfer-encoding`, so every stream byte was written raw behind the declared length. `Transfer-Encoding` was similarly passed through.

### Fix

Both header names are forbidden request-header names in the Fetch spec. For `fetch()` with a `ReadableStream` body the engine now drops any caller `Content-Length` / `Transfer-Encoding` and always emits `Transfer-Encoding: chunked` with a chunk-framed body. The guard is keyed on `is_node_http_client` so a future raw-HTTP entrypoint could opt back in; `node:http`'s `ClientRequest` writes over its own socket and is unaffected.

## 2. `Connection: close` on a 3xx is ignored

### Repro

Streamed POST to a server that replies `303 See Other` with `Content-Length: 0` and `Connection: close`, same-origin `Location`. Before: the follow-up `GET` is sent on the same connection (1 TCP connect). After: 2 connects.

### Cause

`handle_response_metadata` read the response `Connection` header only inside `status_code >= 200 && status_code <= 299`, so a 3xx `close` left `allow_keepalive` true and `do_redirect` pooled the closing socket.

### Fix

Drop the 2xx gate. RFC 9112 section 9.6: the `close` connection option is connection-scoped, not tied to a status class. (#35545 has a broader take on this half that also covers HTTP/1.0 defaults; whichever lands second is a trivial rebase.)

## Verification

```
bun bd test test/js/web/fetch/fetch-request-body-framing.test.ts    # 5 pass (2 fail-before)
bun bd test test/js/web/fetch/fetch-redirect.test.ts                # 16 pass (1 new, fail-before)
bun bd test test/js/web/fetch/client-fetch.test.ts                  # 32 pass
bun bd test test/js/web/fetch/fetch-keepalive.test.ts               # 5 pass
```

The removed `client-fetch.test.ts` case asserted the now-removed raw-CL framing path; its empty-chunk regression is still covered by the chunked-path test immediately above it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/client-fetch.test.ts test/js/web/fetch/fetch-redirect.test.ts test/js/web/fetch/fetch-request-body-framing.test.ts
bun test v1.4.0 (f25926e07)

test/js/web/fetch/fetch-redirect.test.ts:
(pass) fetch() follows a redirect on headers without waiting for the 3xx body > chunked body with no terminating chunk [837.97ms]
(pass) fetch() follows a redirect on headers without waiting for the 3xx body > Content-Length body that is never completed [127.87ms]
(pass) fetch() follows a redirect on headers without waiting for the 3xx body > close-delimited body on a connection that stays open [99.48ms]
(pass) fetch() with redirect: 'manual' still exposes the 3xx response body [91.32ms]
(pass) fetch() preserves body on redirect [119.09ms]
(pass) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:/etc/hosts) [40.18ms]
(pass) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:hosts) [37.39ms]
(pass) fetch() normalizes a redirect Location containing a raw tab character before re-r
... (truncated)

release without fix: 11 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/fetch-redirect.test.ts:
(fail) fetch() follows a redirect on headers without waiting for the 3xx body > chunked body with no terminating chunk [5000.99ms]
  ^ this test timed out after 5000ms.
(fail) fetch() follows a redirect on headers without waiting for the 3xx body > Content-Length body that is never completed [5001.42ms]
  ^ this test timed out after 5000ms.
(fail) fetch() follows a redirect on headers without waiting for the 3xx body > close-delimited body on a connection that stays open [5001.40ms]
  ^ this test timed out after 5000ms.
(pass) fetch() with redirect: 'manual' still exposes the 3xx response body [3.98ms]
(pass) fetch() preserves body on redirect [8.29ms]
134 | 
135 |     const outcome = await fetch(new URL("/start", server.url)).then(
136 |       () => ({ rejected: false as const }),
137 |       e => ({ rejected: true as const, code: e.code }),
138 |     );
139 |     expect(outcome).toEqual({ rejected: true, code: "UnsupportedRedirectProtocol" });
                          ^
error: expect(received).toEqual(expected)

  {
-   "code": "UnsupportedRedirectProtocol",
+   "code": "ENOTFOUND",
 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/client-fetch.test.ts test/js/web/fetch/fetch-redirect.test.ts test/js/web/fetch/fetch-request-body-framing.test.ts
bun test v1.4.0 (f25926e07)

test/js/web/fetch/fetch-redirect.test.ts:
(pass) fetch() follows a redirect on headers without waiting for the 3xx body > chunked body with no terminating chunk [787.06ms]
(pass) fetch() follows a redirect on headers without waiting for the 3xx body > Content-Length body that is never completed [112.06ms]
(pass) fetch() follows a redirect on headers without waiting for the 3xx body > close-delimited body on a connection that stays open [101.27ms]
(pass) fetch() with redirect: 'manual' still exposes the 3xx response body [94.14ms]
(pass) fetch() preserves body on redirect [82.30ms]
(pass) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:/etc/hosts) [58.86ms]
(pass) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:hosts) [24.95ms]
(pass) fetch() normalizes a redirect Location containing a raw tab character before re-r
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f25926e07c
  features     baseline

22 deps, 108 codegen, 1171 objects in 6990ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen .bind.ts → GeneratedBindings.cpp
[2/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[3/1234] fetch tinycc
[tinycc] up to date
[4/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1234] fetch zlib
[zlib] up to date
[6/1234] gen ErrorCode+*.h
[7/1234] gen bindgenv2
[8/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[9/1234] subst deps/zlib/zlib.h
[10/1234] fetch zstd
[zstd] up to date
[11/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[12/1234] subst deps/libjpeg-turbo/jconfig.h
[13/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/co
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/lib.rs                                    |  50 +++--
 src/runtime/webcore/fetch/FetchTasklet.rs          |  14 +-
 test/js/web/fetch/client-fetch.test.ts             |  37 ----
 test/js/web/fetch/fetch-redirect.test.ts           |  57 ++++++
 .../web/fetch/fetch-request-body-framing.test.ts   | 210 +++++++++++++++++++++
 5 files changed, 309 insertions(+), 59 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/http/lib.rs                                          10      3      0
src/runtime/webcore/fetch/FetchTasklet.rs                 4      3      0
test/js/web/fetch/client-fetch.test.ts                    2      1      0
test/js/web/fetch/fetch-redirect.test.ts                  2      2      0
test/js/web/fetch/fetch-request-body-framing.test.ts      0      7      0
```

</details>

<!-- robobun:evidence:end -->