### PR TITLE
redis: give SubscriptionCtx an explicit BackRef to fix the subscribe() refcount over-release

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -746,13 +746,9 @@ macro_rules! from_field_ptr {
 /// standalone, the generated accessors are unsound; keep a hand-rolled
 /// `pub unsafe fn` instead.
 ///
-/// The ref-only form derives `&$Parent` from `core::ptr::from_ref(self)`, so
-/// its provenance is that of `&$Child`. Use it for **reads only**: if `$Child`
-/// is `Freeze` the argument is `noalias readonly` and a write to any parent
-/// field through the result is UB the optimizer will exploit. When the parent
-/// must be written through, store an explicit `BackRef<$Parent>` on the child
-/// (constructed from the allocation's raw pointer) instead of using this
-/// macro.
+/// The `&self` forms carry `&$Child`'s provenance (`noalias readonly` when
+/// `$Child: Freeze`), so treat the returned `&$Parent` as read-only; store a
+/// `BackRef<$Parent>` on the child if it must write.
 #[macro_export]
 macro_rules! impl_field_parent {
     // ref + raw-mut pair

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -723,7 +723,7 @@ macro_rules! from_field_ptr {
 /// bun_core::impl_field_parent! { Assets => DevServer.assets; pub fn owner; fn owner_mut; }
 ///
 /// // (2) ref-only                   (&self -> &P)
-/// bun_core::impl_field_parent! { SubscriptionCtx => JSValkeyClient._subscription_ctx; fn parent; }
+/// bun_core::impl_field_parent! { ValkeyClient => JSValkeyClient.client; fn parent; }
 ///
 /// // (3) mut-only                   (&mut self -> *mut P)
 /// bun_core::impl_field_parent! { DirectoryWatchStore => DevServer.directory_watchers; fn mut owner; }
@@ -745,6 +745,14 @@ macro_rules! from_field_ptr {
 /// `$Parent.$field` for its entire lifetime. If `$Child` can exist
 /// standalone, the generated accessors are unsound; keep a hand-rolled
 /// `pub unsafe fn` instead.
+///
+/// The ref-only form derives `&$Parent` from `core::ptr::from_ref(self)`, so
+/// its provenance is that of `&$Child`. Use it for **reads only**: if `$Child`
+/// is `Freeze` the argument is `noalias readonly` and a write to any parent
+/// field through the result is UB the optimizer will exploit. When the parent
+/// must be written through, store an explicit `BackRef<$Parent>` on the child
+/// (constructed from the allocation's raw pointer) instead of using this
+/// macro.
 #[macro_export]
 macro_rules! impl_field_parent {
     // ref + raw-mut pair

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -278,7 +278,23 @@ impl<T: RefCounted> RefCount<T> {
             dump_stack_hook(None, return_address());
         }
         count.assert_single_threaded();
-        count.raw_count.set(count.raw_count.get() + 1);
+        let next = count.raw_count.get() + 1;
+        count.raw_count.set(next);
+        // Tripwire for readonly-provenance stores: if `self_` was derived from
+        // a `&T` whose provenance does not cover `ref_count` (e.g. container_of
+        // from a Freeze child field), LLVM may elide this store at O2+ while
+        // the paired `deref` on the opaque side survives, silently dropping a
+        // ref. Re-reading via a volatile load defeats forwarding so the assert
+        // observes the actual cell contents.
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            // SAFETY: `count` is live per the caller contract; `Cell<u32>` is
+            // `repr(transparent)` over `UnsafeCell<u32>`, so reading the
+            // underlying `u32` at this address is valid.
+            unsafe { core::ptr::read_volatile(count.raw_count.as_ptr()) },
+            next,
+            "RefCount::ref_ store elided (pointer derived from readonly provenance?)",
+        );
     }
 
     /// # Safety

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -280,17 +280,11 @@ impl<T: RefCounted> RefCount<T> {
         count.assert_single_threaded();
         let next = count.raw_count.get() + 1;
         count.raw_count.set(next);
-        // Tripwire for readonly-provenance stores: if `self_` was derived from
-        // a `&T` whose provenance does not cover `ref_count` (e.g. container_of
-        // from a Freeze child field), LLVM may elide this store at O2+ while
-        // the paired `deref` on the opaque side survives, silently dropping a
-        // ref. Re-reading via a volatile load defeats forwarding so the assert
-        // observes the actual cell contents.
+        // Volatile re-read catches an O2+ dead-store when `self_` was derived
+        // from a readonly-provenance `&T` (container_of on a Freeze child).
         #[cfg(debug_assertions)]
         debug_assert_eq!(
-            // SAFETY: `count` is live per the caller contract; `Cell<u32>` is
-            // `repr(transparent)` over `UnsafeCell<u32>`, so reading the
-            // underlying `u32` at this address is valid.
+            // SAFETY: `count` is live per the caller contract.
             unsafe { core::ptr::read_volatile(count.raw_count.as_ptr()) },
             next,
             "RefCount::ref_ store elided (pointer derived from readonly provenance?)",

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1958,7 +1958,7 @@ pub(crate) fn get_valkey_default_client(global_this: &JSGlobalObject, _: &JSObje
     // hold the only reference for field init below.
     let valkey_ref = unsafe { &*valkey };
     valkey_ref.this_value.set(jsc::JsRef::init_weak(as_js));
-    match SubscriptionCtx::init(valkey_ref) {
+    match SubscriptionCtx::init(valkey) {
         Ok(ctx) => valkey_ref._subscription_ctx.set(ctx),
         Err(jsc::JsError::Thrown) | Err(jsc::JsError::Terminated) => return JSValue::ZERO,
         Err(err) => {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1958,7 +1958,9 @@ pub(crate) fn get_valkey_default_client(global_this: &JSGlobalObject, _: &JSObje
     // hold the only reference for field init below.
     let valkey_ref = unsafe { &*valkey };
     valkey_ref.this_value.set(jsc::JsRef::init_weak(as_js));
-    match SubscriptionCtx::init(valkey) {
+    // SAFETY: `valkey` is the fresh `heap::into_raw` pointer from
+    // `create_no_js_no_pubsub` above.
+    match unsafe { SubscriptionCtx::init(valkey) } {
         Ok(ctx) => valkey_ref._subscription_ctx.set(ctx),
         Err(jsc::JsError::Thrown) | Err(jsc::JsError::Terminated) => return JSValue::ZERO,
         Err(err) => {

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -86,13 +86,12 @@ pub struct SubscriptionCtx {
 pub use crate::generated_classes::js_RedisClient as Js;
 
 impl SubscriptionCtx {
-    /// `valkey_parent` must be the `heap::into_raw` pointer for the owning
-    /// `JSValkeyClient` (full-allocation provenance), not a pointer derived
-    /// from a narrower borrow.
-    pub fn init(valkey_parent: *mut JSValkeyClient) -> JsResult<Self> {
-        // SAFETY: freshly heap-allocated by `JSValkeyClient::new`; caller
-        // owns the +1 and has not yet handed it to any path that could free
-        // it.
+    /// # Safety
+    /// `valkey_parent` must be the live `heap::into_raw` pointer for the
+    /// owning `JSValkeyClient` (full-allocation provenance), not a pointer
+    /// derived from a narrower borrow, and must outlive the returned context.
+    pub unsafe fn init(valkey_parent: *mut JSValkeyClient) -> JsResult<Self> {
+        // SAFETY: caller contract.
         let parent = unsafe { BackRef::from_raw(valkey_parent) };
         let callback_map = JSMap::create(&parent.global_object);
         let parent_this = parent.this_value.get().try_get().expect("unreachable");
@@ -841,9 +840,11 @@ impl JSValkeyClient {
         new_client.this_value.set(JsRef::init_weak(js_this));
 
         // Need to associate the subscription context, after the JS ref has been populated.
+        // SAFETY: `new_client_ptr` is the fresh `heap::into_raw` pointer from
+        // `create_no_js_no_pubsub` above.
         new_client
             ._subscription_ctx
-            .set(SubscriptionCtx::init(new_client_ptr)?);
+            .set(unsafe { SubscriptionCtx::init(new_client_ptr) }?);
 
         Ok(new_client_ptr)
     }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -66,6 +66,15 @@ type Socket = uws::AnySocket;
 
 #[derive(Default)]
 pub struct SubscriptionCtx {
+    /// Back-reference to the owning client. Constructed from the Box's raw
+    /// `*mut JSValkeyClient` so reads through it carry the allocation's full
+    /// provenance; the previous `container_of` recovery from `&self` (three
+    /// `bool`s, a Freeze type) produced a pointer LLVM may mark
+    /// `noalias readonly`, making the refcount write in
+    /// `on_new_subscription_callback_insert` a dead store at O2+ while the
+    /// paired `ScopedRef` drop survived as an opaque call. `None` only between
+    /// `JSValkeyClient::new` and `SubscriptionCtx::init`.
+    parent: Option<BackRef<JSValkeyClient>>,
     pub is_subscriber: bool,
     pub original_enable_offline_queue: bool,
     pub original_enable_auto_pipelining: bool,
@@ -76,34 +85,39 @@ pub struct SubscriptionCtx {
 /// free-fns plus `to_js`/`from_js`. Re-exported here as `Js`.
 pub use crate::generated_classes::js_RedisClient as Js;
 
-// SAFETY: `SubscriptionCtx` lives at `JSValkeyClient._subscription_ctx`
-// (intrusive backref). `JsCell<SubscriptionCtx>` is `#[repr(transparent)]`.
-bun_core::impl_field_parent! { SubscriptionCtx => JSValkeyClient._subscription_ctx; fn parent; }
-
 impl SubscriptionCtx {
-    pub fn init(valkey_parent: &JSValkeyClient) -> JsResult<Self> {
-        let callback_map = JSMap::create(&valkey_parent.global_object);
-        let parent_this = valkey_parent
-            .this_value
-            .get()
-            .try_get()
-            .expect("unreachable");
+    /// `valkey_parent` must be the `heap::into_raw` pointer for the owning
+    /// `JSValkeyClient` (full-allocation provenance), not a pointer derived
+    /// from a narrower borrow.
+    pub fn init(valkey_parent: *mut JSValkeyClient) -> JsResult<Self> {
+        // SAFETY: freshly heap-allocated by `JSValkeyClient::new`; caller
+        // owns the +1 and has not yet handed it to any path that could free
+        // it.
+        let parent = unsafe { BackRef::from_raw(valkey_parent) };
+        let callback_map = JSMap::create(&parent.global_object);
+        let parent_this = parent.this_value.get().try_get().expect("unreachable");
 
-        Js::subscription_callback_map_set_cached(
-            parent_this,
-            &valkey_parent.global_object,
-            callback_map,
-        );
+        Js::subscription_callback_map_set_cached(parent_this, &parent.global_object, callback_map);
 
         Ok(SubscriptionCtx {
-            original_enable_offline_queue: valkey_parent.client.get().flags.enable_offline_queue,
-            original_enable_auto_pipelining: valkey_parent
-                .client
-                .get()
-                .flags
-                .enable_auto_pipelining,
+            parent: Some(parent),
+            original_enable_offline_queue: parent.client.get().flags.enable_offline_queue,
+            original_enable_auto_pipelining: parent.client.get().flags.enable_auto_pipelining,
             is_subscriber: false,
         })
+    }
+
+    #[inline]
+    fn parent(&self) -> &JSValkeyClient {
+        self.parent
+            .as_ref()
+            .expect("SubscriptionCtx used before init()")
+            .get()
+    }
+
+    #[inline]
+    fn parent_backref(&self) -> BackRef<JSValkeyClient> {
+        self.parent.expect("SubscriptionCtx used before init()")
     }
 
     fn subscription_callback_map(&self) -> &mut JSMap {
@@ -202,10 +216,7 @@ impl SubscriptionCtx {
         channel_name: JSValue,
         callback: JSValue,
     ) -> JsResult<()> {
-        // `BackRef` (Copy + Deref) detaches the borrow so the guard closure is
-        // safe even though intervening JS may re-enter `&self`.
-        let parent_br = BackRef::new(self.parent());
-        let _guard = scopeguard::guard(parent_br, |p| {
+        let _guard = scopeguard::guard(self.parent_backref(), |p| {
             p.on_new_subscription_callback_insert();
         });
         let map = self.subscription_callback_map();
@@ -283,10 +294,7 @@ impl SubscriptionCtx {
 
         // After we go through every single callback, we will have to update the poll ref.
         // The user may, for example, unsubscribe in the callbacks, or even stop the client.
-        // `BackRef` (Copy + Deref) detaches the borrow so the guard closure is
-        // safe even though intervening JS may re-enter `&self`.
-        let parent_br = BackRef::new(self.parent());
-        let _update = scopeguard::guard(parent_br, |p| p.update_poll_ref());
+        let _update = scopeguard::guard(self.parent_backref(), |p| p.update_poll_ref());
 
         // If callbacks is an array, iterate and call each one
         let mut iter = callbacks.array_iterator(global_object)?;
@@ -835,7 +843,7 @@ impl JSValkeyClient {
         // Need to associate the subscription context, after the JS ref has been populated.
         new_client
             ._subscription_ctx
-            .set(SubscriptionCtx::init(new_client)?);
+            .set(SubscriptionCtx::init(new_client_ptr)?);
 
         Ok(new_client_ptr)
     }
@@ -1437,9 +1445,8 @@ impl JSValkeyClient {
         self.ref_();
         // socket close can potentially call JS so we need to enqueue the deinit
         struct Holder {
-            // BACKREF — JSValkeyClient is intrusively ref-counted (RefCount + @fieldParentPtr
-            // recovery in SubscriptionCtx::parent). The `self.ref_()` above / `(*ctx).deref()`
-            // in run() keep it alive across the task hop.
+            // The `self.ref_()` above / `(*ctx).deref()` in run() keep the
+            // intrusively ref-counted client alive across the task hop.
             ctx: *const JSValkeyClient,
             task: jsc::AnyTask::AnyTask,
         }
@@ -1490,11 +1497,11 @@ impl JSValkeyClient {
         this.this_value.with_mut(|t| t.finalize());
         this.client_mut().flags.finalized = true;
         this.close_socket_next_tick();
-        // `_subscription_ctx` is three inline bools (no allocation, no GC
-        // ref); `is_subscriber` can legitimately still be set here if the
-        // server never confirmed UNSUBSCRIBE before disconnect, since
-        // `update_poll_ref()` gates on the JS handler map, not this flag.
-        // Nothing to release.
+        // `_subscription_ctx` owns no allocation and no GC ref (the backref is
+        // non-owning, the rest are inline bools); `is_subscriber` can
+        // legitimately still be set here if the server never confirmed
+        // UNSUBSCRIBE before disconnect, since `update_poll_ref()` gates on
+        // the JS handler map, not this flag. Nothing to release.
     }
 
     pub fn stop_timers(&self) {

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -66,14 +66,9 @@ type Socket = uws::AnySocket;
 
 #[derive(Default)]
 pub struct SubscriptionCtx {
-    /// Back-reference to the owning client. Constructed from the Box's raw
-    /// `*mut JSValkeyClient` so reads through it carry the allocation's full
-    /// provenance; the previous `container_of` recovery from `&self` (three
-    /// `bool`s, a Freeze type) produced a pointer LLVM may mark
-    /// `noalias readonly`, making the refcount write in
-    /// `on_new_subscription_callback_insert` a dead store at O2+ while the
-    /// paired `ScopedRef` drop survived as an opaque call. `None` only between
-    /// `JSValkeyClient::new` and `SubscriptionCtx::init`.
+    /// Stored (not `container_of`-recovered) so writes to the parent carry the
+    /// Box's provenance rather than `&self`'s `noalias readonly`. `None` only
+    /// until [`SubscriptionCtx::init`].
     parent: Option<BackRef<JSValkeyClient>>,
     pub is_subscriber: bool,
     pub original_enable_offline_queue: bool,

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -1912,7 +1912,7 @@ impl JSValkeyClient {
         new_client.this_value.set(JsRef::init_weak(new_client_js));
         new_client
             ._subscription_ctx
-            .set(SubscriptionCtx::init(new_client)?);
+            .set(SubscriptionCtx::init(new_client_ptr)?);
         // If the original client is already connected and not manually closed, start connecting the new client.
         if this.client.get().status == valkey::Status::Connected
             && !this.client.get().flags.is_manually_closed

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -1910,9 +1910,11 @@ impl JSValkeyClient {
 
         let new_client_js = JSValkeyClient::ptr_to_js(new_client_ptr, global);
         new_client.this_value.set(JsRef::init_weak(new_client_js));
+        // SAFETY: `new_client_ptr` is the fresh `heap::into_raw` pointer from
+        // `clone_without_connecting` above.
         new_client
             ._subscription_ctx
-            .set(SubscriptionCtx::init(new_client_ptr)?);
+            .set(unsafe { SubscriptionCtx::init(new_client_ptr) }?);
         // If the original client is already connected and not manually closed, start connecting the new client.
         if this.client.get().status == valkey::Status::Connected
             && !this.client.get().flags.is_manually_closed

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -166,7 +166,10 @@ impl ByteBlobLoader {
             blob.content_type.set(ct);
         }
 
-        self.parent_const().is_closed.set(true);
+        // SAFETY: `impl_field_parent!` contract; `is_closed` is disjoint from
+        // `context`. Reached via the `&mut self` accessor (not `parent_const`)
+        // so the store is not routed through a Freeze-`&self` readonly pointer.
+        unsafe { (*self.parent()).is_closed.set(true) };
         Some(blob::Any::Blob(blob))
     }
 

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -665,8 +665,9 @@ pub struct NewSource<C: SourceContext> {
     /// `Finalized` so [`Self::on_js_close`] reads `None` instead of a
     /// dead-but-unswept cell.
     pub this_jsvalue: jsc::JsRef,
-    /// R-2: written by `&self` context methods (`ByteStream::to_any_blob`,
-    /// `ByteBlobLoader::to_any_blob`) via `parent_const()`, so interior-mutable.
+    /// R-2: written by context methods (`ByteStream::to_any_blob`,
+    /// `ByteBlobLoader::to_any_blob`) via `impl_field_parent!` recovery, so
+    /// interior-mutable.
     pub is_closed: Cell<bool>,
 }
 

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -127,6 +127,93 @@ test.concurrent(
 // on_writable/update_poll_ref before send() takes its own ref, so a
 // connect/close fault path inside could free the client under the live
 // `&self`. This variant races a server-side RST against subscribe()+close().
+// subscribe() used to release one more intrusive ref than it took:
+// SubscriptionCtx.parent() recovered &JSValkeyClient via container_of on
+// &SubscriptionCtx (three plain bools, a Freeze type). The shared-ref argument
+// is lowered as noalias readonly, so at O2+ LLVM may drop the refcount .set()
+// reached through it while the paired ScopedRef drop (an opaque call)
+// survives. After close() releases the socket ref, only the connection-timeout
+// timer holds the allocation; when it fires the count reaches zero and deinit
+// frees the Box under the still-live JS wrapper. The next GC finalize (or any
+// property read) is a heap-use-after-free.
+//
+// Debug cargo builds are opt-level=0 and do not perform this elision, so this
+// test exercises the fault only on optimized ASAN builds. It still asserts the
+// healthy-server subscribe/close/GC path stays balanced everywhere.
+test.concurrent(
+  "RedisClient survives subscribe() + close() against a healthy server across connection-timeout + GC",
+  async () => {
+    const src = `
+    const CRLF = "\\r\\n";
+    const blk = s => "$" + s.length + CRLF + s + CRLF;
+    const server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(s) { s.data = { buf: "" }; },
+        data(s, d) {
+          s.data.buf += d.toString("latin1");
+          if (s.data.buf.includes("HELLO")) {
+            s.write("%1" + CRLF + blk("proto") + ":3" + CRLF);
+            s.data.buf = "";
+          }
+        },
+        close() {},
+      },
+    });
+    const url = "redis://127.0.0.1:" + server.port;
+    const timeoutMs = 1000;
+    const clients = [];
+    for (let i = 0; i < 40; i++) {
+      const c = new Bun.RedisClient(url, {
+        connectionTimeout: timeoutMs,
+        idleTimeout: 0,
+        autoReconnect: false,
+      });
+      c.onconnect = () => {}; c.onclose = () => {};
+      await c.connect();
+      // upsert_receive_handler runs synchronously here; the server never
+      // replies to SUBSCRIBE so the returned promise is discarded.
+      try { c.subscribe("ch" + i, () => {}).catch(() => {}); } catch {}
+      c.close();
+      clients.push(c);
+    }
+    // Let every client's connection-timeout timer (armed at connect()) fire.
+    // This is the condition under test, not an arbitrary wait.
+    const { promise, resolve } = Promise.withResolvers();
+    setTimeout(resolve, timeoutMs + 200);
+    await promise;
+    Bun.gc(true);
+    for (const c of clients) {
+      // Any native read on the wrapper is a heap-UAF once the backing Box is
+      // freed under it.
+      if (typeof c.bufferedAmount !== "number") throw new Error("bufferedAmount");
+      if (c.connected !== false) throw new Error("connected");
+    }
+    clients.length = 0;
+    server.stop(true);
+    Bun.gc(true);
+    await 1;
+    Bun.gc(true);
+    console.log("OK");
+    process.exit(0);
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("OK");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+);
+
 test.concurrent("RedisClient survives subscribe() + close() against a server that resets the connection", async () => {
   const src = `
     const CRLF = "\\r\\n";

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -122,11 +122,6 @@ test.concurrent(
   },
 );
 
-// Fuzzer found the same over-release reachable from subscribe() when the
-// socket dies mid-call: upsert_receive_handler's exit guard re-enters
-// on_writable/update_poll_ref before send() takes its own ref, so a
-// connect/close fault path inside could free the client under the live
-// `&self`. This variant races a server-side RST against subscribe()+close().
 // subscribe() used to release one more intrusive ref than it took:
 // SubscriptionCtx.parent() recovered &JSValkeyClient via container_of on
 // &SubscriptionCtx (three plain bools, a Freeze type). The shared-ref argument
@@ -214,6 +209,11 @@ test.concurrent(
   },
 );
 
+// Fuzzer found the same over-release reachable from subscribe() when the
+// socket dies mid-call: upsert_receive_handler's exit guard re-enters
+// on_writable/update_poll_ref before send() takes its own ref, so a
+// connect/close fault path inside could free the client under the live
+// `&self`. This variant races a server-side RST against subscribe()+close().
 test.concurrent("RedisClient survives subscribe() + close() against a server that resets the connection", async () => {
   const src = `
     const CRLF = "\\r\\n";


### PR DESCRIPTION
## Root cause

`RedisClient.subscribe()` releases exactly one more intrusive ref than it takes, which frees the `Box<JSValkeyClient>` under its still-live JS wrapper once the connection-timeout timer (or any other last legitimate holder) lets go. The crash surfaces as whichever path next touches the allocation: `RefCountedTimer::state`/`disarm` from `stop_timers` in GC finalize, `bufferedAmount`, the `!ref_held` asserts, etc., which is why the face kept moving across #34714 and #34760.

The missing increment is a codegen artifact of writing through a `Freeze`-typed shared reference:

```rust
bun_core::impl_field_parent! { SubscriptionCtx => JSValkeyClient._subscription_ctx; fn parent; }
```

`SubscriptionCtx` was three plain `bool`s, so `&SubscriptionCtx` is a `Freeze` shared ref that rustc lowers as `noalias readonly`. `parent()` derives `&JSValkeyClient` from `core::ptr::from_ref(self)`, and `upsert_receive_handler`'s exit guard reaches `on_new_subscription_callback_insert` → `ref_scope()` → `RefCount::ref_` through it. At O2+ LLVM is entitled to treat the `raw_count.set()` store as dead (it's a write through a pointer derived from a `readonly` argument) while the paired `ScopedRef` drop survives as an opaque call to `deref_with_context`. Disassembly of the optimized build shows both predecessor blocks of `upsert_receive_handler` executing `assert_single_threaded` → compute `&raw_count` → overflow-probe `get()+1` → **no store** → `call on_writable`.

Numbered trace on a healthy server (no faults):

1. create → count=1 (the ref `finalize` later adopts)
2. connect → +socket keep-alive + connection-timeout timer → 3
3. subscribe → elided +1, kept −1 → 2 (wrapper's own ref is spent while `this_value` is still attached)
4. close → `on_valkey_close` releases the socket ref → 1 (only the armed timer)
5. timer fires → 0 → `deinit` frees the Box under the live wrapper
6. GC finalize (or any earlier native read) → heap-use-after-free

The free stack is always the *last legitimate release*; the defect is a *missing increment*, which appears in no stack trace.

## Fix

`SubscriptionCtx` now stores an explicit `Option<BackRef<JSValkeyClient>>` constructed from the `heap::into_raw` pointer in `SubscriptionCtx::init`, and the `impl_field_parent!` invocation is removed. All five `parent()` consumers (subscription-map lookup, the `upsert_receive_handler` exit guard, the `invoke_callbacks` poll-ref guard, `is_deletable`, `close`) read through the stored back-reference, so writes to `ref_count`/`poll_ref`/`client` carry the allocation's full provenance instead of a readonly-derived one. `init` is called from all three construction paths (`create`, `Bun.redis`'s default-client accessor, `duplicate()`).

### Tripwire

`RefCount::ref_` re-reads the count via `ptr::read_volatile` under `debug_assertions` and asserts it advanced. On optimized builds with assertions enabled this converts the class of bug from "heap-UAF at a distance" into an assertion at the dropped store itself.

### `impl_field_parent!` audit

| child | arm | Freeze? | writes through ref accessor? | status |
|---|---|---|---|---|
| `SubscriptionCtx` | ref-only | **yes** | yes (`ref_scope`, `update_poll_ref`) | **fixed here** |
| `ByteBlobLoader` | ref+mut | **yes** | yes (`is_closed.set`) | **fixed here** (switched to the `&mut self` accessor) |
| `ValkeyClient` | ref-only | no (`AutoFlusher.registered: Cell<bool>`) | yes (`ref_`, `add_subscription`, …) | OK today; load-bearing on one `Cell` |
| `MySQLConnection` | ref+mut | no (`MySQLRequestQueue` `Cell`/`JsCell`) | yes (`ref_guard`, `stop_timers`, …) | OK today; load-bearing on `queue` |
| `Assets` | ref+mut | yes | no (reads only) | OK |
| `CapturedWriter` | ref+mut | yes | no (reads only) | OK |
| `ByteStream` | ref+mut | no | yes | OK |
| `Execution` | nonnull | n/a | n/a | OK by construction |
| `SourceMapStore` | mut-only | n/a | n/a | OK by construction |
| `FileReader` | raw | n/a | n/a | OK by construction |

Added a safety note to the macro's docs so the next refactor of `ValkeyClient`/`MySQLConnection` doesn't silently reintroduce this.

## Verification

Healthy-server subscribe isolation (shape A): connect → `subscribe()` → `close()` → wait for the connection-timeout timer → `Bun.gc(true)` → touch `bufferedAmount`/`connected`, 40 clients per process. Added to `test/js/valkey/valkey-gc.test.ts`.

The defect is an LLVM dead-store at O2+ on a `Cell::set` reached through a `noalias readonly` argument, so it is only observable on a build that both (a) compiles the Rust side at O2 or higher and (b) instruments the heap so the post-free read faults. Neither of the mechanical fail-before configurations has both:

| build | Rust opt | heap check | result without fix |
|---|---|---|---|
| `--profile=debug` (ASAN) | 0 | yes | store is emitted, refcount stays balanced |
| `--profile=release` | 3 + fat LTO | no | Box is freed early, but mimalloc does not poison and the property reads return the stale values |
| `--profile=release-asan` | 3 | yes | **heap-use-after-free** |

Disassembly of the optimized build shows both predecessor blocks of `upsert_receive_handler` reaching `assert_single_threaded` → compute `&raw_count` → overflow-probe `get()+1` → no store → `call on_writable`; the same site in the `dev` build is an out-of-line `call ref_` that executes the store. The added `RefCount::ref_` volatile tripwire turns the elision into an assertion on any O2+debug-assertions build.

Locally against the debug build: 9/9 in `valkey-gc.test.ts`, `body.test.ts` 348/348, `serve.test.ts` unchanged from main.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-gc.test.ts
bun test v1.4.0 (393298281)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [398.38ms]
(pass) RedisClient survives GC after a command throws during argument validation [482.46ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [383.40ms]
(pass) RedisClient survives GC across many short-lived instances [717.57ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [576.52ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [1349.30ms]
(pass) RedisClient survives subscribe() + close() against a healthy server across connection-timeout + GC [1782.91ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [3039.70ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [2310.95ms]

 9 pass
 0 fail
 26 expect() calls
Ran 9 tests across 1 file. [8.54s]
__F:0:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/valkey/valkey-gc.test.ts:
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [44.69ms]
(pass) RedisClient survives GC across many short-lived instances [43.65ms]
(pass) RedisClient survives GC after a command throws during argument validation [45.35ms]
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [50.67ms]
439 |       });
440 |       try {
441 |         await client.send("PING", []);
442 |         expect.unreachable();
443 |       } catch (error: any) {
444 |         expect(error.code).toBe("ERR_REDIS_CONNECTION_CLOSED");
                                 ^
error: expect(received).toBe(expected)

Expected: "ERR_REDIS_CONNECTION_CLOSED"
Received: "ERR_REDIS_INVALID_RESPONSE"

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-gc.test.ts:444:28)
(fail) rejects a RESP simple-string reply whose line terminator never arrives [55.06ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [61.48ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [466.50ms]
(pass) RedisClient survives 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-gc.test.ts
bun test v1.4.0 (393298281)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [428.74ms]
(pass) RedisClient survives GC after a command throws during argument validation [500.53ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [406.66ms]
(pass) RedisClient survives GC across many short-lived instances [687.95ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [710.41ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [1705.80ms]
(pass) RedisClient survives subscribe() + close() against a healthy server across connection-timeout + GC [1808.50ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [2676.81ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [2445.49ms]

 9 pass
 0 fail
 26 expect() calls
Ran 9 tests across 1 file. [6.45s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3932982819
  features     baseline

22 deps, 108 codegen, 1171 objects in 4608ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/1234] gen ErrorCode+*.h
[3/1234] gen bindgenv2
[4/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[5/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1234] fetch zlib
[zlib] up to date
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch tinycc
[tinycc] up to date
[9/1234] fetch picohttpparser
[picohttpparser] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/lib.rs                           |  6 +-
 src/ptr/ref_count.rs                          | 12 +++-
 src/runtime/api/BunObject.rs                  |  4 +-
 src/runtime/valkey_jsc/js_valkey.rs           | 81 +++++++++++++------------
 src/runtime/valkey_jsc/js_valkey_functions.rs |  4 +-
 src/runtime/webcore/ByteBlobLoader.rs         |  5 +-
 src/runtime/webcore/ReadableStream.rs         |  5 +-
 test/js/valkey/valkey-gc.test.ts              | 87 +++++++++++++++++++++++++++
 8 files changed, 158 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/bun_core/lib.rs                                2      2      0
src/ptr/ref_count.rs                               2      2      0
src/runtime/api/BunObject.rs                       2      2      0
src/runtime/valkey_jsc/js_valkey.rs                9     11      0
src/runtime/valkey_jsc/js_valkey_functions.rs      2      2      0
src/runtime/webcore/ByteBlobLoader.rs              2      1      0
src/runtime/webcore/ReadableStream.rs              1      1      0
test/js/valkey/valkey-gc.test.ts                   3      5      0
```

</details>

<!-- robobun:evidence:end -->
