### PR TITLE
cli: hard-error on Node permission-model flags instead of running unsandboxed

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -307,6 +307,23 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--trace-exit"),
     parse_param!("--expose-internals"),
     parse_param!("--stack-trace-limit <STR>"),
+    // Node's permission model. Bun does not implement any of it, so these are
+    // recognized only to refuse to start (see `reject_permission_flags`):
+    // silently running unsandboxed when the caller asked for a sandbox is a
+    // fail-open security hole, and the unknown-flag skip path would do exactly
+    // that while also reporting the flags in `process.execArgv` as if applied.
+    parse_param!("--permission"),
+    parse_param!("--permission-audit"),
+    parse_param!("--experimental-permission"),
+    parse_param!("--allow-fs-read <STR>..."),
+    parse_param!("--allow-fs-write <STR>..."),
+    parse_param!("--allow-child-process"),
+    parse_param!("--allow-worker"),
+    parse_param!("--allow-addons"),
+    parse_param!("--allow-net <STR>?"),
+    parse_param!("--allow-wasi"),
+    parse_param!("--allow-inspector"),
+    parse_param!("--allow-ffi"),
 ];
 
 pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
@@ -707,6 +724,39 @@ pub(crate) static Bun__Node__UseSystemCA: core::sync::atomic::AtomicBool =
 // `crate::cli::arguments::load_config*` callers are unaffected.
 pub use bun_bunfig::arguments::{load_config, load_config_path, load_config_with_cmd_args};
 
+/// Bun does not implement Node's permission model. Accepting any of its flags
+/// and running anyway would be a silent fail-open, so refuse to start instead.
+#[cold]
+fn reject_permission_flags(args: &clap::Args<clap::Help>) {
+    const FLAGS: &[&[u8]] = &[
+        b"--permission",
+        b"--permission-audit",
+        b"--experimental-permission",
+        b"--allow-child-process",
+        b"--allow-worker",
+        b"--allow-addons",
+        b"--allow-wasi",
+        b"--allow-inspector",
+        b"--allow-ffi",
+    ];
+    const MULTI: &[&[u8]] = &[b"--allow-fs-read", b"--allow-fs-write"];
+    let mut seen: Option<&[u8]> = FLAGS.iter().copied().find(|n| args.flag(n));
+    seen = seen.or_else(|| MULTI.iter().copied().find(|n| !args.options(n).is_empty()));
+    if seen.is_none() && args.option(b"--allow-net").is_some() {
+        seen = Some(b"--allow-net");
+    }
+    if let Some(name) = seen {
+        Output::err_generic(
+            "{} is not supported: Bun does not implement the Node.js permission model\n",
+            format_args!("{}", BStr::new(name)),
+        );
+        bun_core::note!(
+            "Running without enforcement would silently bypass the requested sandbox. Remove the flag to run without permission restrictions."
+        );
+        Global::exit(1);
+    }
+}
+
 /// Parse `argv` into `api::TransformOptions` for the given subcommand.
 ///
 /// `command::tag_params(cmd)` does a runtime lookup of the per-subcommand
@@ -994,6 +1044,8 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             // for disabling export condition "node-addons"
             opts.allow_addons = Some(false);
         }
+
+        reject_permission_flags(&args);
 
         if let Some(unhandled_rejections) = args.option(b"--unhandled-rejections") {
             opts.unhandled_rejections = match api::UnhandledRejections::MAP

--- a/test/cli/run/permission-flags.test.ts
+++ b/test/cli/run/permission-flags.test.ts
@@ -36,11 +36,7 @@ describe.each([undefined, "run"] as const)("bun %s", runArg => {
       cmd.push(...flags, "-e", `console.log(${JSON.stringify(SCRIPT_RAN)})`);
 
       await using proc = Bun.spawn({ cmd, env: bunEnv, stderr: "pipe", stdout: "pipe" });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       // The script must never have been evaluated.
       expect(stdout).not.toContain(SCRIPT_RAN);
@@ -71,11 +67,7 @@ test("refuses to start when --permission is passed to a script file", async () =
     stderr: "pipe",
     stdout: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).not.toContain(SCRIPT_RAN);
   expect(stdout).toBe("");
   expect(stderr).toContain("--permission");
@@ -90,11 +82,7 @@ test("process.permission is still absent without the flag", async () => {
     stderr: "pipe",
     stdout: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(stdout).toBe("undefined\n");
   expect(exitCode).toBe(0);

--- a/test/cli/run/permission-flags.test.ts
+++ b/test/cli/run/permission-flags.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Bun does not implement Node's permission model. Before this change the whole
+// flag family fell through the unknown-flag skip path: the process ran with no
+// enforcement, exited 0, and process.execArgv reported the flags as applied.
+// For an enforcement flag that is a silent fail-open, so Bun must refuse to
+// start instead of running unsandboxed.
+
+const SCRIPT_RAN = "__script_ran__";
+
+const PERMISSION_FLAGS: readonly string[][] = [
+  ["--permission"],
+  ["--permission", "--allow-fs-read=/tmp"],
+  ["--permission-audit"],
+  ["--experimental-permission"],
+  ["--allow-fs-read=/tmp"],
+  ["--allow-fs-read", "/tmp"],
+  ["--allow-fs-write=/tmp"],
+  ["--allow-child-process"],
+  ["--allow-worker"],
+  ["--allow-addons"],
+  ["--allow-net"],
+  ["--allow-net=localhost"],
+  ["--allow-wasi"],
+  ["--allow-inspector"],
+  ["--allow-ffi"],
+];
+
+describe.each([undefined, "run"] as const)("bun %s", runArg => {
+  test.concurrent.each(PERMISSION_FLAGS)(
+    "refuses to start with %s (Node permission model is not implemented)",
+    async (...flags) => {
+      const cmd = [bunExe()];
+      if (runArg) cmd.push(runArg);
+      cmd.push(...flags, "-e", `console.log(${JSON.stringify(SCRIPT_RAN)})`);
+
+      await using proc = Bun.spawn({ cmd, env: bunEnv, stderr: "pipe", stdout: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+
+      // The script must never have been evaluated.
+      expect(stdout).not.toContain(SCRIPT_RAN);
+      expect(stdout).toBe("");
+      // Error names the first permission-family flag and the reason.
+      const bare = flags[0].split("=")[0];
+      expect(stderr).toContain(bare);
+      expect(stderr).toContain("does not implement the Node.js permission model");
+      expect(exitCode).toBe(1);
+    },
+  );
+});
+
+test("refuses to start when --permission is passed to a script file", async () => {
+  using dir = tempDir("permission-flags", {
+    "probe.js": `
+      // Under Node --permission this readFileSync throws ERR_ACCESS_DENIED.
+      // Under Bun the model is not implemented, so reaching this line at all is
+      // the bug: it means the sandbox the caller asked for was silently skipped.
+      require("fs").readFileSync(process.execPath);
+      console.log(${JSON.stringify(SCRIPT_RAN)});
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--permission", "--allow-fs-read=/tmp", "probe.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stdout).not.toContain(SCRIPT_RAN);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("--permission");
+  expect(stderr).toContain("does not implement the Node.js permission model");
+  expect(exitCode).toBe(1);
+});
+
+test("process.permission is still absent without the flag", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "console.log(typeof process.permission)"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("undefined\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -177,6 +177,16 @@ if (process.argv.length === 2 &&
         // does not exist, so don't re-spawn just to pass the flag through.
         continue;
       }
+      if (process.versions.bun &&
+          (flag === "--permission" || flag === "--permission-audit" ||
+           flag === "--experimental-permission" || flag.startsWith("--allow-"))) {
+        // Bun does not implement the Node.js permission model and hard-errors
+        // on these flags at startup. Re-spawning would turn every vendored
+        // test whose `// Flags:` header names them into a CLI-error assertion.
+        // Run the test body without the sandbox instead; tests that actually
+        // exercise permission semantics fail on their own assertions.
+        continue;
+      }
       if (flag === "test") {
         process.env.SKIP_FLAG_CHECK = "1";
         break;


### PR DESCRIPTION
## Problem

Bun silently accepts Node's permission-model flags and runs the program with no enforcement:

```js
// probe.js
try { require("fs").readFileSync("/etc/hostname", "utf8"); console.log("fs read outside allowlist: ok") }
catch (e) { console.log("fs read outside allowlist:", e.code) }
try { const r = require("child_process").spawnSync("true"); console.log("child_process:", r.error ? r.error.code : "ok") }
catch (e) { console.log("child_process:", e.code) }
console.log("process.permission API:", typeof process.permission === "object" ? "present" : "ABSENT")
console.log("execArgv receipt:", JSON.stringify(process.execArgv))
```

```
$ node --permission --allow-fs-read=/tmp probe.js
fs read outside allowlist: ERR_ACCESS_DENIED
child_process: ERR_ACCESS_DENIED
process.permission API: present
execArgv receipt: ["--permission","--allow-fs-read=/tmp"]

$ bun --permission --allow-fs-read=/tmp probe.js
fs read outside allowlist: ok
child_process: ok
process.permission API: ABSENT
execArgv receipt: ["--permission","--allow-fs-read=/tmp"]    # exit 0
```

The caller asked for a sandbox, got none, and `process.execArgv` reports the flags as applied. `--permission-audit` and the removed legacy alias `--experimental-permission` (Node: `bad option`, exit 9) behave the same way.

## Cause

Unknown long flags are silently skipped at `StreamingClap::normal()` (the unrecognized-flag warning is gated by `WARN_ON_UNRECOGNIZED_FLAG`, a static that is never enabled), and `process.execArgv` is a raw re-scan of argv that reports every leading-dash token as applied.

## Fix

Since Bun does not implement the permission model, any of its flags now refuses to start before the VM boots:

```
$ bun --permission --allow-fs-read=/tmp probe.js
error: --permission is not supported: Bun does not implement the Node.js permission model
note: Running without enforcement would silently bypass the requested sandbox. Remove the flag to run without permission restrictions.
$ echo $?
1
```

Covers `bun`, `bun run`, `bun test`, and bun-as-node, for the whole family: `--permission`, `--permission-audit`, `--experimental-permission`, `--allow-fs-read`, `--allow-fs-write`, `--allow-child-process`, `--allow-worker`, `--allow-net`, `--allow-wasi`, `--allow-addons`, `--allow-inspector`, `--allow-ffi`. The flags are declared (hidden from `--help`, same convention as the Node trace flags) so the parser can see them, and `reject_permission_flags()` exits 1 naming the first one found.

`test/js/node/test/common/index.js` gains the matching skip so the two vendored Node tests that carry these flags in their `// Flags:` header (`test-process-execve-permission-granted.js`, `test-repl-permission-model.js`) run their bodies without the sandbox instead of asserting on the new CLI error. They already ran without one: the re-spawned child's flags were being dropped by the same unknown-flag skip.

## Not in this PR

- `NODE_OPTIONS`: Bun does not parse runtime flags from `NODE_OPTIONS` at all (pre-existing), so `NODE_OPTIONS=--permission` is unchanged. Node itself honours it there, so this remains a gap until #35403 / #35492 land.
- `process.execArgv` reporting every unknown dash-token as applied is the generic root and is not addressed here; with this change the permission family never reaches the re-scan because the process exits first.

This is a stopgap for the fail-open; #35403 and #35492 implement the model proper and would supersede it.

## Verification

New `test/cli/run/permission-flags.test.ts` (32 cases). On the released binary 31/32 fail (the script runs and exits 0); with this change 32/32 pass. `test-process-execve-permission-granted.js`, `test-repl-permission-model.js`, `run_command.test.ts`, `as-node.test.ts`, `run-eval.test.ts`, `no-addons.test.ts`, and the `process.execArgv` tests in `process.test.js` all pass.