### PR TITLE
fetch: enforce body framing for streamed request bodies

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2420,11 +2420,7 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(CHUNKED_ENCODED_HEADER.name()) => {
-                    // Transfer-Encoding is always engine-managed: a buffered body is
-                    // sent with Content-Length, and a streamed body is chunked (or
-                    // raw with a validated Content-Length). A caller-supplied value
-                    // would be written verbatim while the body is still chunk-framed,
-                    // producing an undecodable message per RFC 9112 section 6.1.
+                    // Engine-owned: a caller value never matches the body framing.
                     continue;
                 }
                 _ => {}
@@ -2469,10 +2465,7 @@ impl<'a> HTTPClient<'a> {
 
         if body_len > 0 || self.method.has_request_body() {
             if self.flags.is_streaming_request_body {
-                // A caller-supplied Content-Length is honoured only when it parses
-                // as a non-negative integer; the body writer (FetchTasklet) then
-                // enforces the byte count and rejects any mismatch, so the value
-                // on the wire is never a lie. Anything else falls back to chunked.
+                // Parseable caller CL is honoured (FetchTasklet enforces the count).
                 if let Some(content_length) = original_content_length
                     && bun_core::parse_unsigned::<u64>(content_length, 10).is_ok()
                 {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2465,8 +2465,9 @@ impl<'a> HTTPClient<'a> {
 
         if body_len > 0 || self.method.has_request_body() {
             if self.flags.is_streaming_request_body {
-                // Parseable caller CL is honoured (FetchTasklet enforces the count).
+                // RFC 9110 8.6 `1*DIGIT` caller CL is honoured (FetchTasklet enforces the count).
                 if let Some(content_length) = original_content_length
+                    && content_length.iter().all(u8::is_ascii_digit)
                     && bun_core::parse_unsigned::<u64>(content_length, 10).is_ok()
                 {
                     request_headers_buf[header_count] =

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -410,6 +410,9 @@ pub struct HTTPClientResult<'a> {
     /// Set once ALPN selected h2 so the JS side writes raw bytes into the
     /// streaming-body buffer instead of chunked-encoding them.
     pub is_http2: bool,
+    /// `upgrade_state != None`: an `Upgrade:` offer is on the wire, so the
+    /// streaming-body buffer carries raw bytes, not a chunked-encoded body.
+    pub is_upgrade: bool,
 
     pub fail: Option<crate::Error>,
     /// Raw `getaddrinfo(3)` return code when `fail` is `DNSResolveFailed`;
@@ -480,6 +483,7 @@ impl<'a> HTTPClientResult<'a> {
             redirected: self.redirected,
             can_stream: self.can_stream,
             is_http2: self.is_http2,
+            is_upgrade: self.is_upgrade,
             fail: self.fail,
             dns_error: self.dns_error,
             dns_hostname: self.dns_hostname,
@@ -2337,7 +2341,6 @@ impl<'a> HTTPClient<'a> {
         let mut override_connection_header = false;
         let mut override_user_agent = false;
         let mut original_content_length: Option<&[u8]> = None;
-        let mut saw_upgrade = false;
 
         // Reserve slots for default headers that may be appended after user headers
         // (Connection, User-Agent, Accept, Host, Accept-Encoding, Content-Length/Transfer-Encoding).
@@ -2410,13 +2413,12 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Upgrade") => {
-                    let value = self.header_str(header_values[i]);
-                    if !bun_core::strings::eql_any_case_insensitive_ascii(value, &[b"h2", b"h2c"]) {
-                        // `saw_upgrade` (position-independent) suppresses the
-                        // chunked fallback; `upgrade_state` (wire-dependent)
-                        // only goes Pending when the header is actually sent.
-                        saw_upgrade = true;
-                        if will_append {
+                    if will_append {
+                        let value = self.header_str(header_values[i]);
+                        if !bun_core::strings::eql_any_case_insensitive_ascii(
+                            value,
+                            &[b"h2", b"h2c"],
+                        ) {
                             self.flags.upgrade_state = HTTPUpgradeState::Pending;
                         }
                     }
@@ -2475,7 +2477,7 @@ impl<'a> HTTPClient<'a> {
                     request_headers_buf[header_count] =
                         picohttp::Header::new(CONTENT_LENGTH_HEADER_NAME, content_length);
                     header_count += 1;
-                } else if !saw_upgrade {
+                } else if self.flags.upgrade_state == HTTPUpgradeState::None {
                     request_headers_buf[header_count] = CHUNKED_ENCODED_HEADER;
                     header_count += 1;
                 }
@@ -4436,6 +4438,7 @@ impl<'a> HTTPClient<'a> {
                         || self.state.request_stage == RequestStage::ProxyBody)
                         && self.flags.is_streaming_request_body,
                     is_http2: self.flags.protocol != Protocol::Http1_1,
+                    is_upgrade: self.flags.upgrade_state != HTTPUpgradeState::None,
                 };
             }
         }
@@ -4456,6 +4459,7 @@ impl<'a> HTTPClient<'a> {
                 || self.state.request_stage == RequestStage::ProxyBody)
                 && self.flags.is_streaming_request_body,
             is_http2: self.flags.protocol != Protocol::Http1_1,
+            is_upgrade: self.flags.upgrade_state != HTTPUpgradeState::None,
         }
     }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2337,6 +2337,7 @@ impl<'a> HTTPClient<'a> {
         let mut override_connection_header = false;
         let mut override_user_agent = false;
         let mut original_content_length: Option<&[u8]> = None;
+        let mut saw_upgrade = false;
 
         // Reserve slots for default headers that may be appended after user headers
         // (Connection, User-Agent, Accept, Host, Accept-Encoding, Content-Length/Transfer-Encoding).
@@ -2409,10 +2410,15 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Upgrade") => {
-                    // Always consumed: `upgrade_state` drives body framing.
                     let value = self.header_str(header_values[i]);
                     if !bun_core::strings::eql_any_case_insensitive_ascii(value, &[b"h2", b"h2c"]) {
-                        self.flags.upgrade_state = HTTPUpgradeState::Pending;
+                        // `saw_upgrade` (position-independent) suppresses the
+                        // chunked fallback; `upgrade_state` (wire-dependent)
+                        // only goes Pending when the header is actually sent.
+                        saw_upgrade = true;
+                        if will_append {
+                            self.flags.upgrade_state = HTTPUpgradeState::Pending;
+                        }
                     }
                 }
                 h if h == hash_header_const(CHUNKED_ENCODED_HEADER.name()) => {
@@ -2469,7 +2475,7 @@ impl<'a> HTTPClient<'a> {
                     request_headers_buf[header_count] =
                         picohttp::Header::new(CONTENT_LENGTH_HEADER_NAME, content_length);
                     header_count += 1;
-                } else if self.flags.upgrade_state == HTTPUpgradeState::None {
+                } else if !saw_upgrade {
                     request_headers_buf[header_count] = CHUNKED_ENCODED_HEADER;
                     header_count += 1;
                 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2409,9 +2409,7 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Upgrade") => {
-                    // Set regardless of `will_append`: the body framer keys on
-                    // `upgrade_state`, so it must agree with fetch.rs
-                    // `upgraded_connection` even when the header is dropped.
+                    // Always consumed: `upgrade_state` drives body framing.
                     let value = self.header_str(header_values[i]);
                     if !bun_core::strings::eql_any_case_insensitive_ascii(value, &[b"h2", b"h2c"]) {
                         self.flags.upgrade_state = HTTPUpgradeState::Pending;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2409,14 +2409,12 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Upgrade") => {
-                    if will_append {
-                        let value = self.header_str(header_values[i]);
-                        if !bun_core::strings::eql_any_case_insensitive_ascii(
-                            value,
-                            &[b"h2", b"h2c"],
-                        ) {
-                            self.flags.upgrade_state = HTTPUpgradeState::Pending;
-                        }
+                    // Set regardless of `will_append`: the body framer keys on
+                    // `upgrade_state`, so it must agree with fetch.rs
+                    // `upgraded_connection` even when the header is dropped.
+                    let value = self.header_str(header_values[i]);
+                    if !bun_core::strings::eql_any_case_insensitive_ascii(value, &[b"h2", b"h2c"]) {
+                        self.flags.upgrade_state = HTTPUpgradeState::Pending;
                     }
                 }
                 h if h == hash_header_const(CHUNKED_ENCODED_HEADER.name()) => {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2336,7 +2336,6 @@ impl<'a> HTTPClient<'a> {
         let mut override_host_header = false;
         let mut override_connection_header = false;
         let mut override_user_agent = false;
-        let mut add_transfer_encoding = true;
         let mut original_content_length: Option<&[u8]> = None;
 
         // Reserve slots for default headers that may be appended after user headers
@@ -2421,13 +2420,12 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(CHUNKED_ENCODED_HEADER.name()) => {
-                    if !self.flags.is_streaming_request_body {
-                        continue;
-                    }
-                    // We don't want to override chunked encoding header if it was set by the user
-                    if will_append {
-                        add_transfer_encoding = false;
-                    }
+                    // Transfer-Encoding is always engine-managed: a buffered body is
+                    // sent with Content-Length, and a streamed body is chunked (or
+                    // raw with a validated Content-Length). A caller-supplied value
+                    // would be written verbatim while the body is still chunk-framed,
+                    // producing an undecodable message per RFC 9112 section 6.1.
+                    continue;
                 }
                 _ => {}
             }
@@ -2471,21 +2469,17 @@ impl<'a> HTTPClient<'a> {
 
         if body_len > 0 || self.method.has_request_body() {
             if self.flags.is_streaming_request_body {
-                if let Some(content_length) = original_content_length {
-                    if add_transfer_encoding {
-                        // User explicitly set Content-Length and did not set Transfer-Encoding;
-                        // preserve Content-Length instead of using chunked encoding.
-                        // This matches Node.js behavior where an explicit Content-Length is always honored.
-                        request_headers_buf[header_count] =
-                            picohttp::Header::new(CONTENT_LENGTH_HEADER_NAME, content_length);
-                        header_count += 1;
-                    }
-                    // If !add_transfer_encoding, the user explicitly set Transfer-Encoding,
-                    // which was already added to request_headers_buf. We respect that and
-                    // do not add Content-Length (they are mutually exclusive per HTTP/1.1).
-                } else if add_transfer_encoding
-                    && self.flags.upgrade_state == HTTPUpgradeState::None
+                // A caller-supplied Content-Length is honoured only when it parses
+                // as a non-negative integer; the body writer (FetchTasklet) then
+                // enforces the byte count and rejects any mismatch, so the value
+                // on the wire is never a lie. Anything else falls back to chunked.
+                if let Some(content_length) = original_content_length
+                    && bun_core::parse_unsigned::<u64>(content_length, 10).is_ok()
                 {
+                    request_headers_buf[header_count] =
+                        picohttp::Header::new(CONTENT_LENGTH_HEADER_NAME, content_length);
+                    header_count += 1;
+                } else if self.flags.upgrade_state == HTTPUpgradeState::None {
                     request_headers_buf[header_count] = CHUNKED_ENCODED_HEADER;
                     header_count += 1;
                 }

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -85,6 +85,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_HTTP_BODY_NOT_ALLOWED", Error],
   ["ERR_HTTP_HEADERS_SENT", Error],
   ["ERR_HTTP_CONTENT_LENGTH_MISMATCH", Error],
+  ["UND_ERR_REQ_CONTENT_LENGTH_MISMATCH", TypeError],
   ["ERR_HTTP_INVALID_HEADER_VALUE", TypeError],
   ["ERR_HTTP_INVALID_STATUS_CODE", RangeError],
   ["ERR_HTTP_REQUEST_TIMEOUT", Error],

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2087,7 +2087,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         global_this: Some(global_this.into()),
         ssl_config: ssl_config.take(),
         hostname: hostname.take(),
-        upgraded_connection,
         force_http2,
         force_http3,
         force_http1,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1385,7 +1385,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 let upgrade = upgrade_.to_slice();
                 // `defer upgrade.deinit()` → Drop.
                 let slice = upgrade.slice();
-                if slice != b"h2" && slice != b"h2c" {
+                // Case-insensitive to agree with build_request (RFC 9110 7.8).
+                if !bun_core::strings::eql_any_case_insensitive_ascii(slice, &[b"h2", b"h2c"]) {
                     upgraded_connection = true;
                 }
             }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2198,7 +2198,6 @@ impl FetchTasklet {
             return ResumableSinkBackpressure::WantMore;
         }
         if let Some(declared) = self.declared_request_content_length
-            && !self.upgraded_connection
             && !self.result.is_http2
         {
             self.request_body_bytes_written = self
@@ -2277,7 +2276,6 @@ impl FetchTasklet {
             }
             self.abort_task();
         } else if let Some(declared) = self.declared_request_content_length
-            && !self.upgraded_connection
             && !self.result.is_http2
             && self.request_body_bytes_written != declared
         {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -115,11 +115,8 @@ pub struct FetchTasklet {
     pub check_server_identity: StrongOptional,
     pub reject_unauthorized: bool,
     pub upgraded_connection: bool,
-    /// A caller-supplied `Content-Length` for a streamed request body, parsed
-    /// once at setup. `None` when not set (or unparseable), in which case the
-    /// body is chunk-framed. When `Some`, `write_request_data` /
-    /// `write_end_request` count bytes against it and reject on mismatch so the
-    /// header this client writes is never contradicted by the body it sends.
+    /// Caller-supplied `Content-Length` for a streamed body; `None` means
+    /// chunked framing, `Some` is enforced against the byte count.
     pub declared_request_content_length: Option<u64>,
     pub request_body_bytes_written: u64,
     // Custom Hostname
@@ -2179,9 +2176,6 @@ impl FetchTasklet {
     }
 
     /// Whether the request body should skip chunked transfer encoding framing.
-    /// True for upgraded connections, HTTP/2, or when the caller supplied a
-    /// valid Content-Length (which `build_request` then emits instead of
-    /// `Transfer-Encoding: chunked`).
     fn skip_chunked_framing(&self) -> bool {
         self.upgraded_connection
             || self.result.is_http2
@@ -2210,9 +2204,7 @@ impl FetchTasklet {
                 .request_body_bytes_written
                 .saturating_add(data.len() as u64);
             if self.request_body_bytes_written > declared {
-                // Rejecting before the surplus bytes are buffered is what makes
-                // this a request-smuggling guard: the wire never carries more
-                // body bytes than the Content-Length header promised.
+                // Reject before buffering so the surplus never reaches the wire.
                 self.abort_with_content_length_mismatch();
                 return ResumableSinkBackpressure::Done;
             }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -115,6 +115,13 @@ pub struct FetchTasklet {
     pub check_server_identity: StrongOptional,
     pub reject_unauthorized: bool,
     pub upgraded_connection: bool,
+    /// A caller-supplied `Content-Length` for a streamed request body, parsed
+    /// once at setup. `None` when not set (or unparseable), in which case the
+    /// body is chunk-framed. When `Some`, `write_request_data` /
+    /// `write_end_request` count bytes against it and reject on mismatch so the
+    /// header this client writes is never contradicted by the body it sends.
+    pub declared_request_content_length: Option<u64>,
+    pub request_body_bytes_written: u64,
     // Custom Hostname
     pub hostname: Option<Box<[u8]>>,
     pub is_waiting_body: bool,
@@ -1900,6 +1907,8 @@ impl FetchTasklet {
             check_server_identity: fetch_options.check_server_identity,
             reject_unauthorized: fetch_options.reject_unauthorized,
             upgraded_connection: fetch_options.upgraded_connection,
+            declared_request_content_length: None,
+            request_body_bytes_written: 0,
             hostname: fetch_options.hostname,
             is_waiting_body: false,
             is_waiting_abort: false,
@@ -2048,6 +2057,10 @@ impl FetchTasklet {
         http_client.client.flags.is_node_http_client = fetch_options.is_node_http_client;
         fetch_tasklet.is_waiting_request_stream_start = is_stream;
         if is_stream {
+            fetch_tasklet.declared_request_content_length = fetch_tasklet
+                .request_headers
+                .get(b"content-length")
+                .and_then(|v| bun_core::parse_unsigned::<u64>(v, 10).ok());
             // Intrusive `ref_count` starts at 2 (one for the main thread, one for the HTTP
             // thread), so the same raw pointer can be handed to both sides.
             let buffer = ThreadSafeStreamBuffer::new(ThreadSafeStreamBuffer::default());
@@ -2166,13 +2179,13 @@ impl FetchTasklet {
     }
 
     /// Whether the request body should skip chunked transfer encoding framing.
-    /// True for upgraded connections (e.g. WebSocket) or when the user explicitly
-    /// set Content-Length without setting Transfer-Encoding.
+    /// True for upgraded connections, HTTP/2, or when the caller supplied a
+    /// valid Content-Length (which `build_request` then emits instead of
+    /// `Transfer-Encoding: chunked`).
     fn skip_chunked_framing(&self) -> bool {
         self.upgraded_connection
             || self.result.is_http2
-            || (self.request_headers.get(b"content-length").is_some()
-                && self.request_headers.get(b"transfer-encoding").is_none())
+            || self.declared_request_content_length.is_some()
     }
 
     pub(crate) fn write_request_data(&mut self, data: &[u8]) -> ResumableSinkBackpressure {
@@ -2188,6 +2201,20 @@ impl FetchTasklet {
         // paused sink) can never fire, and the upload stalls forever.
         if data.is_empty() {
             return ResumableSinkBackpressure::WantMore;
+        }
+        if let Some(declared) = self.declared_request_content_length
+            && !self.upgraded_connection
+            && !self.result.is_http2
+        {
+            self.request_body_bytes_written =
+                self.request_body_bytes_written.saturating_add(data.len() as u64);
+            if self.request_body_bytes_written > declared {
+                // Rejecting before the surplus bytes are buffered is what makes
+                // this a request-smuggling guard: the wire never carries more
+                // body bytes than the Content-Length header promised.
+                self.abort_with_content_length_mismatch();
+                return ResumableSinkBackpressure::Done;
+            }
         }
         // reshaped for borrowck — read sink HWM (Copy) before
         // borrowing the stream buffer so `self` is unborrowed during the
@@ -2255,6 +2282,12 @@ impl FetchTasklet {
                 self.abort_reason.set(&self.global_this, js_error);
             }
             self.abort_task();
+        } else if let Some(declared) = self.declared_request_content_length
+            && !self.upgraded_connection
+            && !self.result.is_http2
+            && self.request_body_bytes_written != declared
+        {
+            self.abort_with_content_length_mismatch();
         } else {
             if !self.skip_chunked_framing() {
                 // Using chunked transfer encoding, send the terminating chunk
@@ -2276,6 +2309,17 @@ impl FetchTasklet {
         }
         // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
         FetchTasklet::deref(this_ptr);
+    }
+
+    #[cold]
+    fn abort_with_content_length_mismatch(&mut self) {
+        let global_this = self.global_this;
+        let err = jsc::ErrorCode::UND_ERR_REQ_CONTENT_LENGTH_MISMATCH.fmt(
+            &*global_this,
+            format_args!("Request body length does not match content-length header"),
+        );
+        self.abort_reason.set(&global_this, err);
+        self.abort_task();
     }
 
     pub(crate) fn abort_task(&mut self) {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2177,8 +2177,10 @@ impl FetchTasklet {
     }
 
     /// Whether the request body should skip chunked transfer encoding framing.
+    /// Derived from the HTTP thread's `to_result` snapshot so the body framer
+    /// and `build_request` agree by construction on what went onto the wire.
     fn skip_chunked_framing(&self) -> bool {
-        self.upgraded_connection
+        self.result.is_upgrade
             || self.result.is_http2
             || self.declared_request_content_length.is_some()
     }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2057,6 +2057,7 @@ impl FetchTasklet {
             fetch_tasklet.declared_request_content_length = fetch_tasklet
                 .request_headers
                 .get(b"content-length")
+                .filter(|v| v.iter().all(u8::is_ascii_digit))
                 .and_then(|v| bun_core::parse_unsigned::<u64>(v, 10).ok());
             // Intrusive `ref_count` starts at 2 (one for the main thread, one for the HTTP
             // thread), so the same raw pointer can be handed to both sides.

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2206,8 +2206,9 @@ impl FetchTasklet {
             && !self.upgraded_connection
             && !self.result.is_http2
         {
-            self.request_body_bytes_written =
-                self.request_body_bytes_written.saturating_add(data.len() as u64);
+            self.request_body_bytes_written = self
+                .request_body_bytes_written
+                .saturating_add(data.len() as u64);
             if self.request_body_bytes_written > declared {
                 // Rejecting before the surplus bytes are buffered is what makes
                 // this a request-smuggling guard: the wire never carries more

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -114,7 +114,6 @@ pub struct FetchTasklet {
     // custom checkServerIdentity
     pub check_server_identity: StrongOptional,
     pub reject_unauthorized: bool,
-    pub upgraded_connection: bool,
     /// Caller-supplied `Content-Length` for a streamed body; `None` means
     /// chunked framing, `Some` is enforced against the byte count.
     pub declared_request_content_length: Option<u64>,
@@ -1903,7 +1902,6 @@ impl FetchTasklet {
             abort_reason: StrongOptional::empty(),
             check_server_identity: fetch_options.check_server_identity,
             reject_unauthorized: fetch_options.reject_unauthorized,
-            upgraded_connection: fetch_options.upgraded_connection,
             declared_request_content_length: None,
             request_body_bytes_written: 0,
             hostname: fetch_options.hostname,
@@ -2604,7 +2602,6 @@ pub struct FetchOptions {
     pub check_server_identity: StrongOptional,
     pub unix_socket_path: ZigStringSlice,
     pub ssl_config: Option<http::ssl_config::SharedPtr>,
-    pub upgraded_connection: bool,
     pub force_http2: bool,
     pub force_http3: bool,
     pub force_http1: bool,
@@ -2640,7 +2637,6 @@ impl Default for FetchOptions {
             check_server_identity: StrongOptional::empty(),
             unix_socket_path: ZigStringSlice::EMPTY,
             ssl_config: None,
-            upgraded_connection: false,
             force_http2: false,
             force_http3: false,
             force_http1: false,

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -654,54 +654,60 @@ test("an empty request body chunk does not stall a stream body sent with an expl
 // byte count it declares must be enforced: a stream that produces more bytes is
 // a client-side request-smuggling primitive (the surplus lands at request-line
 // position on a keep-alive connection), and a stream that produces fewer leaves
-// the request unterminated. Node's fetch (undici) rejects both cases.
-test("a streamed body longer than its declared Content-Length is rejected before the surplus reaches the wire", async () => {
-  let recorded = Buffer.alloc(0);
-  const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
-  await using server = net
-    .createServer(sock => {
-      sock.on("error", () => {});
-      sock.on("close", onClose);
-      sock.on("data", d => {
-        recorded = Buffer.concat([recorded, d]);
-        const raw = recorded.toString("latin1");
-        const i = raw.indexOf("\r\n\r\n");
-        // Respond only once body bytes have arrived. A regression writes the
-        // full stream here; the fixed client aborts before buffering, so the
-        // server sees headers only and this branch is never taken.
-        if (i >= 0 && raw.length > i + 4) {
-          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
-        }
-      });
-    })
-    .listen(0, "127.0.0.1");
-  await once(server, "listening");
-  const { port } = server.address() as net.AddressInfo;
+// the request unterminated. Node's fetch (undici) rejects both cases. The second
+// case pairs the Content-Length with an Upgrade header a server may ignore
+// (RFC 9110 section 7.8): the initial message is still HTTP/1.1-framed, so the
+// count must be enforced regardless of a requested upgrade.
+test.each([{ "content-length": "4" }, { "content-length": "4", "upgrade": "H2c" }])(
+  "a streamed body longer than its declared Content-Length %j is rejected before the surplus reaches the wire",
+  async headers => {
+    let recorded = Buffer.alloc(0);
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    await using server = net
+      .createServer(sock => {
+        sock.on("error", () => {});
+        sock.on("close", onClose);
+        sock.on("data", d => {
+          recorded = Buffer.concat([recorded, d]);
+          const raw = recorded.toString("latin1");
+          const i = raw.indexOf("\r\n\r\n");
+          // Respond only once body bytes have arrived. A regression writes the
+          // full stream here; the fixed client aborts before buffering, so the
+          // server sees headers only and this branch is never taken.
+          if (i >= 0 && raw.length > i + 4) {
+            sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+          }
+        });
+      })
+      .listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
 
-  const smuggled = "abcdGET /admin HTTP/1.1\r\n\r\n";
-  const outcome = await fetch(`http://127.0.0.1:${port}/`, {
-    method: "POST",
-    duplex: "half",
-    headers: { "content-length": "4" },
-    body: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(smuggled));
-        c.close();
-      },
-    }),
-  }).then(
-    r => ({ rejected: false as const, status: r.status }),
-    e => ({ rejected: true as const, code: e?.code }),
-  );
-  await closed;
-  const raw = recorded.toString("latin1");
-  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
-  expect({ outcome, contentLength: /^content-length: (.*)$/im.exec(raw)?.[1], body }).toEqual({
-    outcome: { rejected: true, code: "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH" },
-    contentLength: "4",
-    body: "",
-  });
-});
+    const smuggled = "abcdGET /admin HTTP/1.1\r\n\r\n";
+    const outcome = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      duplex: "half",
+      headers,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(smuggled));
+          c.close();
+        },
+      }),
+    }).then(
+      r => ({ rejected: false as const, status: r.status }),
+      e => ({ rejected: true as const, code: e?.code }),
+    );
+    await closed;
+    const raw = recorded.toString("latin1");
+    const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+    expect({ outcome, contentLength: /^content-length: (.*)$/im.exec(raw)?.[1], body }).toEqual({
+      outcome: { rejected: true, code: "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH" },
+      contentLength: "4",
+      body: "",
+    });
+  },
+);
 
 test("a streamed body shorter than its declared Content-Length is rejected", async () => {
   await using server = net

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -654,60 +654,54 @@ test("an empty request body chunk does not stall a stream body sent with an expl
 // byte count it declares must be enforced: a stream that produces more bytes is
 // a client-side request-smuggling primitive (the surplus lands at request-line
 // position on a keep-alive connection), and a stream that produces fewer leaves
-// the request unterminated. Node's fetch (undici) rejects both cases. The second
-// case pairs the Content-Length with an Upgrade header a server may ignore
-// (RFC 9110 section 7.8): the initial message is still HTTP/1.1-framed, so the
-// count must be enforced regardless of a requested upgrade.
-test.each([{ "content-length": "4" }, { "content-length": "4", "upgrade": "H2c" }])(
-  "a streamed body longer than its declared Content-Length %j is rejected before the surplus reaches the wire",
-  async headers => {
-    let recorded = Buffer.alloc(0);
-    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
-    await using server = net
-      .createServer(sock => {
-        sock.on("error", () => {});
-        sock.on("close", onClose);
-        sock.on("data", d => {
-          recorded = Buffer.concat([recorded, d]);
-          const raw = recorded.toString("latin1");
-          const i = raw.indexOf("\r\n\r\n");
-          // Respond only once body bytes have arrived. A regression writes the
-          // full stream here; the fixed client aborts before buffering, so the
-          // server sees headers only and this branch is never taken.
-          if (i >= 0 && raw.length > i + 4) {
-            sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
-          }
-        });
-      })
-      .listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const { port } = server.address() as net.AddressInfo;
+// the request unterminated. Node's fetch (undici) rejects both cases.
+test("a streamed body longer than its declared Content-Length is rejected before the surplus reaches the wire", async () => {
+  let recorded = Buffer.alloc(0);
+  const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("close", onClose);
+      sock.on("data", d => {
+        recorded = Buffer.concat([recorded, d]);
+        const raw = recorded.toString("latin1");
+        const i = raw.indexOf("\r\n\r\n");
+        // Respond only once body bytes have arrived. A regression writes the
+        // full stream here; the fixed client aborts before buffering, so the
+        // server sees headers only and this branch is never taken.
+        if (i >= 0 && raw.length > i + 4) {
+          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
 
-    const smuggled = "abcdGET /admin HTTP/1.1\r\n\r\n";
-    const outcome = await fetch(`http://127.0.0.1:${port}/`, {
-      method: "POST",
-      duplex: "half",
-      headers,
-      body: new ReadableStream({
-        start(c) {
-          c.enqueue(new TextEncoder().encode(smuggled));
-          c.close();
-        },
-      }),
-    }).then(
-      r => ({ rejected: false as const, status: r.status }),
-      e => ({ rejected: true as const, code: e?.code }),
-    );
-    await closed;
-    const raw = recorded.toString("latin1");
-    const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
-    expect({ outcome, contentLength: /^content-length: (.*)$/im.exec(raw)?.[1], body }).toEqual({
-      outcome: { rejected: true, code: "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH" },
-      contentLength: "4",
-      body: "",
-    });
-  },
-);
+  const smuggled = "abcdGET /admin HTTP/1.1\r\n\r\n";
+  const outcome = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    duplex: "half",
+    headers: { "content-length": "4" },
+    body: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(smuggled));
+        c.close();
+      },
+    }),
+  }).then(
+    r => ({ rejected: false as const, status: r.status }),
+    e => ({ rejected: true as const, code: e?.code }),
+  );
+  await closed;
+  const raw = recorded.toString("latin1");
+  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  expect({ outcome, contentLength: /^content-length: (.*)$/im.exec(raw)?.[1], body }).toEqual({
+    outcome: { rejected: true, code: "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH" },
+    contentLength: "4",
+    body: "",
+  });
+});
 
 test("a streamed body shorter than its declared Content-Length is rejected", async () => {
   await using server = net
@@ -827,6 +821,58 @@ test.each([{ "transfer-encoding": "gzip" }, { "upgrade": "H2c" }])(
     });
   },
 );
+
+// build_request caps user headers at MAX_USER_HEADERS; an Upgrade entry past
+// the cap used to be read by the body framer (position-independent fast_get)
+// but not by the header writer (will_append gate), so the wire carried
+// Transfer-Encoding: chunked while the body was buffered raw.
+test("an Upgrade header past the user-header cap does not desynchronise body framing", async () => {
+  let recorded = Buffer.alloc(0);
+  const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("close", onClose);
+      sock.on("data", d => {
+        recorded = Buffer.concat([recorded, d]);
+        if (recorded.toString("latin1").includes("\r\n\r\n")) {
+          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const headers: Record<string, string> = { upgrade: "websocket" };
+  for (let i = 0; i < 250; i++) headers[`A-${String(i).padStart(3, "0")}`] = "x";
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    duplex: "half",
+    headers,
+    body: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("0\r\n\r\nGET /admin HTTP/1.1\r\n\r\n"));
+        c.close();
+      },
+    }),
+  });
+  expect(res.status).toBe(200);
+  await closed;
+
+  const raw = recorded.toString("latin1");
+  const head = raw.slice(0, raw.indexOf("\r\n\r\n"));
+  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  // Body framing must match the wire header: no Transfer-Encoding means no
+  // chunked body expected, so the raw stream bytes staying out of the wire is
+  // the correct outcome. A regression writes TE: chunked alongside the raw
+  // stream bytes, which a server parses as a zero-length body plus a second
+  // request.
+  expect({ transferEncoding: /^transfer-encoding: (.*)$/im.exec(head)?.[1], body }).toEqual({
+    transferEncoding: undefined,
+    body: "",
+  });
+});
 
 // RFC 9112 section 5.2: an obs-fold continuation line in a response must be
 // joined into the preceding field value with SP, or the message rejected.

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -778,51 +778,55 @@ test.each(["1_0", "+10", "0x10", "1e1"])(
   },
 );
 
-// Transfer-Encoding is a forbidden request header (WHATWG fetch): the engine
-// owns body framing. A caller-supplied value used to be written verbatim while
-// the body was still chunk-framed, so `Transfer-Encoding: gzip` produced a
-// message that is undecodable per RFC 9112 section 6.1 (chunk octets presented
-// as a gzip member). The caller's value is now dropped and `chunked` emitted.
-test("a caller-supplied Transfer-Encoding on a streamed body is ignored", async () => {
-  let recorded = Buffer.alloc(0);
-  await using server = net
-    .createServer(sock => {
-      sock.on("error", () => {});
-      sock.on("data", d => {
-        recorded = Buffer.concat([recorded, d]);
-        if (recorded.toString("latin1").endsWith("0\r\n\r\n")) {
-          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
-        }
-      });
-    })
-    .listen(0, "127.0.0.1");
-  await once(server, "listening");
-  const { port } = server.address() as net.AddressInfo;
+// The engine owns body framing for a streamed body without a valid
+// Content-Length. A caller-supplied Transfer-Encoding used to be written
+// verbatim while the body was still chunk-framed; a case-mismatched
+// `Upgrade: H2c` used to switch the body writer to raw while the header
+// writer still emitted `Transfer-Encoding: chunked`. Both must produce a
+// `chunked` header with a correctly chunk-framed body.
+test.each([{ "transfer-encoding": "gzip" }, { "upgrade": "H2c" }])(
+  "a streamed body with %j is sent with Transfer-Encoding: chunked and a chunk-framed body",
+  async headers => {
+    let recorded = Buffer.alloc(0);
+    await using server = net
+      .createServer(sock => {
+        sock.on("error", () => {});
+        sock.on("data", d => {
+          recorded = Buffer.concat([recorded, d]);
+          if (recorded.toString("latin1").endsWith("0\r\n\r\n")) {
+            sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+          }
+        });
+      })
+      .listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
 
-  const res = await fetch(`http://127.0.0.1:${port}/`, {
-    method: "POST",
-    duplex: "half",
-    headers: { "transfer-encoding": "gzip" },
-    body: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode("xy"));
-        c.close();
-      },
-    }),
-  });
-  expect(await res.text()).toBe("ok");
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      duplex: "half",
+      headers,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("xy"));
+          c.close();
+        },
+      }),
+    });
+    expect(await res.text()).toBe("ok");
 
-  const raw = recorded.toString("latin1");
-  const headers = raw.slice(0, raw.indexOf("\r\n\r\n"));
-  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
-  expect({
-    transferEncoding: headers.match(/^transfer-encoding: (.*)$/gim),
-    body,
-  }).toEqual({
-    transferEncoding: ["Transfer-Encoding: chunked"],
-    body: "2\r\nxy\r\n0\r\n\r\n",
-  });
-});
+    const raw = recorded.toString("latin1");
+    const head = raw.slice(0, raw.indexOf("\r\n\r\n"));
+    const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+    expect({
+      transferEncoding: head.match(/^transfer-encoding: (.*)$/gim),
+      body,
+    }).toEqual({
+      transferEncoding: ["Transfer-Encoding: chunked"],
+      body: "2\r\nxy\r\n0\r\n\r\n",
+    });
+  },
+);
 
 // RFC 9112 section 5.2: an obs-fold continuation line in a response must be
 // joined into the preceding field value with SP, or the message rejected.

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -840,52 +840,49 @@ test.each([{ "transfer-encoding": "gzip" }, { "upgrade": "H2c" }])(
 test.each([
   [{}, { transferEncoding: "chunked", contentLength: undefined, body: "4\r\nabcd\r\n0\r\n\r\n" }],
   [{ "content-length": "4" }, { transferEncoding: undefined, contentLength: "4", body: "abcd" }],
-])(
-  "an Upgrade header past the user-header cap with %j frames the body to match the wire",
-  async (extra, expected) => {
-    let recorded = Buffer.alloc(0);
-    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
-    await using server = net
-      .createServer(sock => {
-        sock.on("error", () => {});
-        sock.on("close", onClose);
-        sock.on("data", d => {
-          recorded = Buffer.concat([recorded, d]);
-          if (recorded.toString("latin1").endsWith(expected.body)) {
-            sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
-          }
-        });
-      })
-      .listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const { port } = server.address() as net.AddressInfo;
+])("an Upgrade header past the user-header cap with %j frames the body to match the wire", async (extra, expected) => {
+  let recorded = Buffer.alloc(0);
+  const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("close", onClose);
+      sock.on("data", d => {
+        recorded = Buffer.concat([recorded, d]);
+        if (recorded.toString("latin1").endsWith(expected.body)) {
+          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
 
-    const headers: Record<string, string> = { upgrade: "websocket", ...extra };
-    for (let i = 0; i < 250; i++) headers[`A-${String(i).padStart(3, "0")}`] = "x";
-    const res = await fetch(`http://127.0.0.1:${port}/`, {
-      method: "POST",
-      duplex: "half",
-      headers,
-      body: new ReadableStream({
-        start(c) {
-          c.enqueue(new TextEncoder().encode("abcd"));
-          c.close();
-        },
-      }),
-    });
-    expect(res.status).toBe(200);
-    await closed;
+  const headers: Record<string, string> = { upgrade: "websocket", ...extra };
+  for (let i = 0; i < 250; i++) headers[`A-${String(i).padStart(3, "0")}`] = "x";
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    duplex: "half",
+    headers,
+    body: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("abcd"));
+        c.close();
+      },
+    }),
+  });
+  expect(res.status).toBe(200);
+  await closed;
 
-    const raw = recorded.toString("latin1");
-    const head = raw.slice(0, raw.indexOf("\r\n\r\n"));
-    const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
-    expect({
-      transferEncoding: /^transfer-encoding: (.*)$/im.exec(head)?.[1],
-      contentLength: /^content-length: (.*)$/im.exec(head)?.[1],
-      body,
-    }).toEqual(expected);
-  },
-);
+  const raw = recorded.toString("latin1");
+  const head = raw.slice(0, raw.indexOf("\r\n\r\n"));
+  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  expect({
+    transferEncoding: /^transfer-encoding: (.*)$/im.exec(head)?.[1],
+    contentLength: /^content-length: (.*)$/im.exec(head)?.[1],
+    body,
+  }).toEqual(expected);
+});
 
 // RFC 9112 section 5.2: an obs-fold continuation line in a response must be
 // joined into the preceding field value with SP, or the message rejected.

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -650,6 +650,132 @@ test("an empty request body chunk does not stall a stream body sent with an expl
   expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("AAAABBBB");
 });
 
+// An explicit Content-Length on a streamed body is honoured on the wire, so the
+// byte count it declares must be enforced: a stream that produces more bytes is
+// a client-side request-smuggling primitive (the surplus lands at request-line
+// position on a keep-alive connection), and a stream that produces fewer leaves
+// the request unterminated. Node's fetch (undici) rejects both cases.
+test("a streamed body longer than its declared Content-Length is rejected before the surplus reaches the wire", async () => {
+  let recorded = Buffer.alloc(0);
+  const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("close", onClose);
+      sock.on("data", d => {
+        recorded = Buffer.concat([recorded, d]);
+        const raw = recorded.toString("latin1");
+        const i = raw.indexOf("\r\n\r\n");
+        // Respond only once body bytes have arrived. A regression writes the
+        // full stream here; the fixed client aborts before buffering, so the
+        // server sees headers only and this branch is never taken.
+        if (i >= 0 && raw.length > i + 4) {
+          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const smuggled = "abcdGET /admin HTTP/1.1\r\n\r\n";
+  const outcome = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    duplex: "half",
+    headers: { "content-length": "4" },
+    body: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(smuggled));
+        c.close();
+      },
+    }),
+  }).then(
+    r => ({ rejected: false as const, status: r.status }),
+    e => ({ rejected: true as const, code: e?.code }),
+  );
+  await closed;
+  const raw = recorded.toString("latin1");
+  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  expect({ outcome, contentLength: /^content-length: (.*)$/im.exec(raw)?.[1], body }).toEqual({
+    outcome: { rejected: true, code: "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH" },
+    contentLength: "4",
+    body: "",
+  });
+});
+
+test("a streamed body shorter than its declared Content-Length is rejected", async () => {
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("data", () => sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"));
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const outcome = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    duplex: "half",
+    headers: { "content-length": "100" },
+    body: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("abc"));
+        c.close();
+      },
+    }),
+  }).then(
+    r => ({ rejected: false as const, status: r.status }),
+    e => ({ rejected: true as const, code: e?.code }),
+  );
+  expect(outcome).toEqual({ rejected: true, code: "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH" });
+});
+
+// Transfer-Encoding is a forbidden request header (WHATWG fetch): the engine
+// owns body framing. A caller-supplied value used to be written verbatim while
+// the body was still chunk-framed, so `Transfer-Encoding: gzip` produced a
+// message that is undecodable per RFC 9112 section 6.1 (chunk octets presented
+// as a gzip member). The caller's value is now dropped and `chunked` emitted.
+test("a caller-supplied Transfer-Encoding on a streamed body is ignored", async () => {
+  let recorded = Buffer.alloc(0);
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("data", d => {
+        recorded = Buffer.concat([recorded, d]);
+        if (recorded.toString("latin1").endsWith("0\r\n\r\n")) {
+          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    duplex: "half",
+    headers: { "transfer-encoding": "gzip" },
+    body: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("xy"));
+        c.close();
+      },
+    }),
+  });
+  expect(await res.text()).toBe("ok");
+
+  const raw = recorded.toString("latin1");
+  const headers = raw.slice(0, raw.indexOf("\r\n\r\n"));
+  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  expect({
+    transferEncoding: headers.match(/^transfer-encoding: (.*)$/gim),
+    body,
+  }).toEqual({
+    transferEncoding: ["Transfer-Encoding: chunked"],
+    body: "2\r\nxy\r\n0\r\n\r\n",
+  });
+});
+
 // RFC 9112 section 5.2: an obs-fold continuation line in a response must be
 // joined into the preceding field value with SP, or the message rejected.
 // Accepting it while silently discarding the continuation is neither: it

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -730,6 +730,48 @@ test("a streamed body shorter than its declared Content-Length is rejected", asy
   expect(outcome).toEqual({ rejected: true, code: "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH" });
 });
 
+// RFC 9110 section 8.6 defines Content-Length as 1*DIGIT. A value outside that
+// grammar must not reach the wire verbatim: downstream parsers disagree on how
+// to read it (e.g. strtol stops at the first non-digit), which is the same
+// desync as a mismatched count.
+test.each(["1_0", "+10", "0x10", "1e1"])(
+  "a streamed body with non-1*DIGIT Content-Length %j falls back to chunked",
+  async bad => {
+    let recorded = Buffer.alloc(0);
+    await using server = net
+      .createServer(sock => {
+        sock.on("error", () => {});
+        sock.on("data", d => {
+          recorded = Buffer.concat([recorded, d]);
+          if (recorded.toString("latin1").includes("abcdefghij")) {
+            sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+          }
+        });
+      })
+      .listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
+
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      duplex: "half",
+      headers: { "content-length": bad },
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("abcdefghij"));
+          c.close();
+        },
+      }),
+    });
+    expect(await res.text()).toBe("ok");
+    const headers = recorded.toString("latin1").split("\r\n\r\n")[0];
+    expect({
+      contentLength: /^content-length: (.*)$/im.exec(headers)?.[1],
+      transferEncoding: /^transfer-encoding: (.*)$/im.exec(headers)?.[1],
+    }).toEqual({ contentLength: undefined, transferEncoding: "chunked" });
+  },
+);
+
 // Transfer-Encoding is a forbidden request header (WHATWG fetch): the engine
 // owns body framing. A caller-supplied value used to be written verbatim while
 // the body was still chunk-framed, so `Transfer-Encoding: gzip` produced a

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -704,10 +704,20 @@ test("a streamed body longer than its declared Content-Length is rejected before
 });
 
 test("a streamed body shorter than its declared Content-Length is rejected", async () => {
+  let recorded = Buffer.alloc(0);
   await using server = net
     .createServer(sock => {
       sock.on("error", () => {});
-      sock.on("data", () => sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"));
+      sock.on("data", d => {
+        recorded = Buffer.concat([recorded, d]);
+        const raw = recorded.toString("latin1");
+        const i = raw.indexOf("\r\n\r\n");
+        // Respond only once body bytes have arrived, so the mismatch check at
+        // stream end has run on the JS thread before the 200 can be observed.
+        if (i >= 0 && raw.length > i + 4) {
+          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
     })
     .listen(0, "127.0.0.1");
   await once(server, "listening");

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -833,13 +833,16 @@ test.each([{ "transfer-encoding": "gzip" }, { "upgrade": "H2c" }])(
 );
 
 // build_request caps user headers at MAX_USER_HEADERS; an Upgrade entry past
-// the cap is read by the body framer (position-independent fast_get) but not
-// written to the wire. The header writer must then not emit Transfer-Encoding:
-// chunked (the body is raw), and must not set upgrade_state Pending (the
-// server never sees the offer, so the body must not be held for a 101).
-test.each([{}, { "content-length": "4" }])(
-  "an Upgrade header past the user-header cap with %j neither desynchronises framing nor hangs",
-  async extra => {
+// the cap is dropped from the wire. The body framer reads the same
+// build_request decision via result.is_upgrade, so the header that goes on the
+// wire and the body framing agree: no CL means TE:chunked with a chunk-framed
+// body, and a declared CL means exactly that many raw bytes.
+test.each([
+  [{}, { transferEncoding: "chunked", contentLength: undefined, body: "4\r\nabcd\r\n0\r\n\r\n" }],
+  [{ "content-length": "4" }, { transferEncoding: undefined, contentLength: "4", body: "abcd" }],
+])(
+  "an Upgrade header past the user-header cap with %j frames the body to match the wire",
+  async (extra, expected) => {
     let recorded = Buffer.alloc(0);
     const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
     await using server = net
@@ -848,8 +851,7 @@ test.each([{}, { "content-length": "4" }])(
         sock.on("close", onClose);
         sock.on("data", d => {
           recorded = Buffer.concat([recorded, d]);
-          // Respond only once body bytes have arrived so a held body hangs.
-          if (recorded.toString("latin1").includes("abcd")) {
+          if (recorded.toString("latin1").endsWith(expected.body)) {
             sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
           }
         });
@@ -874,8 +876,14 @@ test.each([{}, { "content-length": "4" }])(
     expect(res.status).toBe(200);
     await closed;
 
-    const head = recorded.toString("latin1").split("\r\n\r\n")[0];
-    expect(/^transfer-encoding: (.*)$/im.exec(head)?.[1]).toBeUndefined();
+    const raw = recorded.toString("latin1");
+    const head = raw.slice(0, raw.indexOf("\r\n\r\n"));
+    const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+    expect({
+      transferEncoding: /^transfer-encoding: (.*)$/im.exec(head)?.[1],
+      contentLength: /^content-length: (.*)$/im.exec(head)?.[1],
+      body,
+    }).toEqual(expected);
   },
 );
 

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -833,56 +833,51 @@ test.each([{ "transfer-encoding": "gzip" }, { "upgrade": "H2c" }])(
 );
 
 // build_request caps user headers at MAX_USER_HEADERS; an Upgrade entry past
-// the cap used to be read by the body framer (position-independent fast_get)
-// but not by the header writer (will_append gate), so the wire carried
-// Transfer-Encoding: chunked while the body was buffered raw.
-test("an Upgrade header past the user-header cap does not desynchronise body framing", async () => {
-  let recorded = Buffer.alloc(0);
-  const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
-  await using server = net
-    .createServer(sock => {
-      sock.on("error", () => {});
-      sock.on("close", onClose);
-      sock.on("data", d => {
-        recorded = Buffer.concat([recorded, d]);
-        if (recorded.toString("latin1").includes("\r\n\r\n")) {
-          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
-        }
-      });
-    })
-    .listen(0, "127.0.0.1");
-  await once(server, "listening");
-  const { port } = server.address() as net.AddressInfo;
+// the cap is read by the body framer (position-independent fast_get) but not
+// written to the wire. The header writer must then not emit Transfer-Encoding:
+// chunked (the body is raw), and must not set upgrade_state Pending (the
+// server never sees the offer, so the body must not be held for a 101).
+test.each([{}, { "content-length": "4" }])(
+  "an Upgrade header past the user-header cap with %j neither desynchronises framing nor hangs",
+  async extra => {
+    let recorded = Buffer.alloc(0);
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    await using server = net
+      .createServer(sock => {
+        sock.on("error", () => {});
+        sock.on("close", onClose);
+        sock.on("data", d => {
+          recorded = Buffer.concat([recorded, d]);
+          // Respond only once body bytes have arrived so a held body hangs.
+          if (recorded.toString("latin1").includes("abcd")) {
+            sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+          }
+        });
+      })
+      .listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
 
-  const headers: Record<string, string> = { upgrade: "websocket" };
-  for (let i = 0; i < 250; i++) headers[`A-${String(i).padStart(3, "0")}`] = "x";
-  const res = await fetch(`http://127.0.0.1:${port}/`, {
-    method: "POST",
-    duplex: "half",
-    headers,
-    body: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode("0\r\n\r\nGET /admin HTTP/1.1\r\n\r\n"));
-        c.close();
-      },
-    }),
-  });
-  expect(res.status).toBe(200);
-  await closed;
+    const headers: Record<string, string> = { upgrade: "websocket", ...extra };
+    for (let i = 0; i < 250; i++) headers[`A-${String(i).padStart(3, "0")}`] = "x";
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      duplex: "half",
+      headers,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("abcd"));
+          c.close();
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    await closed;
 
-  const raw = recorded.toString("latin1");
-  const head = raw.slice(0, raw.indexOf("\r\n\r\n"));
-  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
-  // Body framing must match the wire header: no Transfer-Encoding means no
-  // chunked body expected, so the raw stream bytes staying out of the wire is
-  // the correct outcome. A regression writes TE: chunked alongside the raw
-  // stream bytes, which a server parses as a zero-length body plus a second
-  // request.
-  expect({ transferEncoding: /^transfer-encoding: (.*)$/im.exec(head)?.[1], body }).toEqual({
-    transferEncoding: undefined,
-    body: "",
-  });
-});
+    const head = recorded.toString("latin1").split("\r\n\r\n")[0];
+    expect(/^transfer-encoding: (.*)$/im.exec(head)?.[1]).toBeUndefined();
+  },
+);
 
 // RFC 9112 section 5.2: an obs-fold continuation line in a response must be
 // joined into the preceding field value with SP, or the message rejected.


### PR DESCRIPTION
A `fetch()` with a `ReadableStream` / async-iterable request body honoured a caller-supplied `Content-Length` or `Transfer-Encoding` header verbatim without enforcing it, so the wire carried whatever CL/TE the caller wrote. Buffered bodies (string/Blob/FormData) already drop both headers and compute their own `Content-Length`; only the stream path deferred to the caller.

### Reproduction

```js
import net from "node:net";
const srv = net.createServer(s => { s.on("data", d => process.stdout.write(d)); });
await new Promise(r => srv.listen(0, "127.0.0.1", r));
await fetch(`http://127.0.0.1:${srv.address().port}/`, {
  method: "POST", duplex: "half",
  headers: { "content-length": "4" },
  body: new ReadableStream({ start(c) {
    c.enqueue(new TextEncoder().encode("abcdGET /admin HTTP/1.1\r\nHost: x\r\n\r\n")); c.close();
  } }),
});
```

Bun before this change wrote `Content-Length: 4` followed by all 36 body bytes; the surplus is a syntactically valid second request a keep-alive origin/proxy parses on its own (client-side request smuggling). Node's fetch rejects with `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH` and nothing reaches the wire.

The same path also produced:
- `Content-Length` larger than the stream: the body ends short and `fetch()` waits forever for a response to a request the server is still waiting to finish reading.
- `Transfer-Encoding: gzip` (or any value): the header is written as given while the body is still chunk-framed, which is undecodable per RFC 9112 section 6.1.

### Fix

- `build_request` now drops a caller-supplied `Transfer-Encoding` for every body shape. `Transfer-Encoding` is a forbidden request header in the Fetch spec, and the engine owns body framing.
- A caller-supplied `Content-Length` on a streamed body is still honoured on the wire (some servers require it, and the existing `client-fetch.test.ts` coverage for that path is kept), but `write_request_data` / `write_end_request` now count bytes against it and reject with `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH` on any mismatch. An over-long chunk is rejected before it is buffered to the socket, so surplus bytes never reach the wire; a short body surfaces as the same error instead of an indefinite wait. An unparseable `Content-Length` falls back to chunked.

### Verification

`test/js/web/fetch/client-fetch.test.ts` gains three tests capturing the exact wire bytes:
- `Content-Length: 4` with a 27-byte stream: rejects, and the server records zero body bytes (the smuggled `GET /admin` never reaches it).
- `Content-Length: 100` with a 3-byte stream: rejects.
- `Transfer-Encoding: gzip` with a stream: the wire carries `Transfer-Encoding: chunked` with a correctly framed body.

All three fail on main (the first two record the smuggled payload / a `200` resolution; the third records `Transfer-Encoding: gzip`) and pass with this change (0 flakes in 5 consecutive debug+ASAN runs). The pre-existing explicit-`Content-Length` test at the same location continues to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/client-fetch.test.ts
bun test v1.4.0 (af6f2a9f0)

test/js/web/fetch/client-fetch.test.ts:
(pass) function signature [10.08ms]
(pass) args validation [24.28ms]
(pass) request json [438.51ms]
(pass) request text [77.40ms]
(pass) request arrayBuffer [72.55ms]
(pass) should set type of blob object to the value of the `Content-Type` header from response [89.11ms]
(pass) pre aborted with readable request body [43.58ms]
(pass) pre aborted with closed readable request body [43.27ms]
(pass) unsupported formData 1 [80.03ms]
(pass) multipart formdata not base64 [122.83ms]
(todo) multipart formdata base64
(pass) multipart fromdata non-ascii filed names [6.36ms]
(pass) busboy emit error [81.68ms]
(pass) parsing formData preserve full path on files [6.33ms]
(pass) urlencoded formData [68.40ms]
(pass) text with BOM [72.84ms]
(todo) formData with BOM
(pass) locked blob body [64.12ms]
(pass) disturbed blob body [64.35ms]
(pass) redirect with body [126.24ms]
(pass) redirect with stream [393.74ms]
(pass) fail to extract locked body [4.7
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (54416322e)

test/js/web/fetch/client-fetch.test.ts:
(pass) function signature [1.89ms]
(pass) args validation [0.99ms]
(pass) request json [27.16ms]
(pass) request text [3.94ms]
(pass) request arrayBuffer [3.46ms]
(pass) should set type of blob object to the value of the `Content-Type` header from response [3.00ms]
(pass) pre aborted with readable request body [5.34ms]
(pass) pre aborted with closed readable request body [2.45ms]
(pass) unsupported formData 1 [2.53ms]
(pass) multipart formdata not base64 [6.71ms]
(todo) multipart formdata base64
(pass) multipart fromdata non-ascii filed names [0.78ms]
(pass) busboy emit error [2.87ms]
(pass) parsing formData preserve full path on files [0.13ms]
(pass) urlencoded formData [2.17ms]
(pass) text with BOM [3.11ms]
(todo) formData with BOM
(pass) locked blob body [3.22ms]
(pass) disturbed blob body [1.94ms]
(pass) redirect with body [4.85ms]
(pass) redirect with stream [304.91ms]
(pass) fail to extract locked body [0.16ms]
(pass) fail to extract locked body [0.07ms]
(pass) post FormData with Blob [4.47ms]
(pass) post FormData with File [2.87ms]
(pass) unresolvable hostname rejects with the resolv
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/client-fetch.test.ts
bun test v1.4.0 (af6f2a9f0)

test/js/web/fetch/client-fetch.test.ts:
(pass) function signature [11.39ms]
(pass) args validation [20.15ms]
(pass) request json [413.68ms]
(pass) request text [79.03ms]
(pass) request arrayBuffer [69.29ms]
(pass) should set type of blob object to the value of the `Content-Type` header from response [86.72ms]
(pass) pre aborted with readable request body [39.59ms]
(pass) pre aborted with closed readable request body [39.80ms]
(pass) unsupported formData 1 [69.21ms]
(pass) multipart formdata not base64 [109.59ms]
(todo) multipart formdata base64
(pass) multipart fromdata non-ascii filed names [5.75ms]
(pass) busboy emit error [69.83ms]
(pass) parsing formData preserve full path on files [5.97ms]
(pass) urlencoded formData [69.16ms]
(pass) text with BOM [68.55ms]
(todo) formData with BOM
(pass) locked blob body [62.07ms]
(pass) disturbed blob body [62.90ms]
(pass) redirect with body [121.16ms]
(pass) redirect with stream [396.62ms]
(pass) fail to extract locked body [4.3
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 833ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/80] gen ErrorCode+*.h
[2/33] gen cpp.rs (cppbind)
[3/33] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[4/33] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/lib.rs                           |  38 ++---
 src/jsc/bindings/ErrorCode.ts             |   1 +
 src/runtime/webcore/fetch.rs              |   4 +-
 src/runtime/webcore/fetch/FetchTasklet.rs |  52 +++++--
 test/js/web/fetch/client-fetch.test.ts    | 234 ++++++++++++++++++++++++++++++
 5 files changed, 296 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 7 passed · 1 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/lib.rs                               13     18      0
src/jsc/bindings/ErrorCode.ts                  1      1      0
src/runtime/webcore/fetch.rs                   3      2      0
src/runtime/webcore/fetch/FetchTasklet.rs     16     17      0
test/js/web/fetch/client-fetch.test.ts        11     17      0
```

</details>

<!-- robobun:evidence:end -->