### PR TITLE
node: fix broken error messages for ERR_HTTP2_UNSUPPORTED_PROTOCOL and 4 others

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -398,7 +398,7 @@ function hasServerResponseFinished(self, chunk, callback) {
       if (finished) {
         err = $ERR_STREAM_WRITE_AFTER_END();
       } else if (destroyed) {
-        err = $ERR_STREAM_DESTROYED("Stream is destroyed");
+        err = $ERR_STREAM_DESTROYED("write");
       }
 
       if (!destroyed) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2114,7 +2114,7 @@ function _writeHead(statusCode, reason, obj, response) {
         // header fields, regardless of the header fields present in the
         // message, and thus cannot contain a message body or 'trailers'.
         if (hasInvalidTrailer(response)) {
-          throw $ERR_HTTP_TRAILER_INVALID("Trailers are invalid with this transfer encoding");
+          throw $ERR_HTTP_TRAILER_INVALID();
         }
         // Headers in obj should override previous headers but still
         // allow explicit duplicates. To do so, we first remove any
@@ -2144,7 +2144,7 @@ function _writeHead(statusCode, reason, obj, response) {
       // The message is not chunk-framed, so `Trailer` is the offending header; drop it
       // so a caller that swallows the throw cannot put it on the wire.
       response.removeHeader("trailer");
-      throw $ERR_HTTP_TRAILER_INVALID("Trailers are invalid with this transfer encoding");
+      throw $ERR_HTTP_TRAILER_INVALID();
     }
   }
 }

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1148,7 +1148,7 @@ function asyncWrap(fn: any, name: string) {
 
             if (bytesWritten === 0) {
               if (++retries > 5) {
-                throw $ERR_OPERATION_FAILED("Operation failed: write failed after retries");
+                throw $ERR_OPERATION_FAILED("write failed after retries");
               }
             } else {
               retries = 0;
@@ -1192,7 +1192,7 @@ function asyncWrap(fn: any, name: string) {
               // Retry the writev as-is on a zero-byte write (up to 5 times)
               // instead of degrading to the concat fallback below.
               if (++retries > 5) {
-                throw $ERR_OPERATION_FAILED("Operation failed: writev failed after retries");
+                throw $ERR_OPERATION_FAILED("writev failed after retries");
               }
               continue;
             }
@@ -1229,7 +1229,7 @@ function asyncWrap(fn: any, name: string) {
           const bytesWritten = fsSync.writeSync(fd, buf, offset, length, position >= 0 ? position : null) || 0;
           if (bytesWritten === 0) {
             if (++retries > 5) {
-              throw $ERR_OPERATION_FAILED("Operation failed: write failed after retries");
+              throw $ERR_OPERATION_FAILED("write failed after retries");
             }
           } else {
             retries = 0;

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -2691,6 +2691,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_BODY_NOT_ALLOWED, "Adding content for this request method or response status is not allowed."_s));
     case ErrorCode::ERR_HTTP_TRAILER_INVALID:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_TRAILER_INVALID, "Trailers are invalid with this transfer encoding"_s));
+    case ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED:
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s));
     case ErrorCode::ERR_HTTP_SOCKET_ASSIGNED:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_SOCKET_ASSIGNED, "Socket already assigned"_s));
     case ErrorCode::ERR_STREAM_RELEASE_LOCK:

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -2391,6 +2391,25 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_HEADERS_SENT, message));
     }
 
+    case Bun::ErrorCode::ERR_HTTP_CONTENT_LENGTH_MISMATCH: {
+        auto arg0 = callFrame->argument(1);
+        auto str0 = arg0.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto arg1 = callFrame->argument(2);
+        auto str1 = arg1.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto message = makeString("Response body's content-length of "_s, str0, " byte(s) does not match the content-length of "_s, str1, " byte(s) set in header"_s);
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_CONTENT_LENGTH_MISMATCH, message));
+    }
+
+    case Bun::ErrorCode::ERR_HTTP2_UNSUPPORTED_PROTOCOL: {
+        auto arg0 = callFrame->argument(1);
+        auto str0 = arg0.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto message = makeString("protocol \""_s, str0, "\" is unsupported."_s);
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_UNSUPPORTED_PROTOCOL, message));
+    }
+
     case Bun::ErrorCode::ERR_UNESCAPED_CHARACTERS: {
         auto arg0 = callFrame->argument(1);
         auto str0 = arg0.toWTFString(globalObject);
@@ -2670,6 +2689,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_GOAWAY_SESSION, "New streams cannot be created after receiving a GOAWAY"_s));
     case ErrorCode::ERR_HTTP_BODY_NOT_ALLOWED:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_BODY_NOT_ALLOWED, "Adding content for this request method or response status is not allowed."_s));
+    case ErrorCode::ERR_HTTP_TRAILER_INVALID:
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_TRAILER_INVALID, "Trailers are invalid with this transfer encoding"_s));
     case ErrorCode::ERR_HTTP_SOCKET_ASSIGNED:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP_SOCKET_ASSIGNED, "Socket already assigned"_s));
     case ErrorCode::ERR_STREAM_RELEASE_LOCK:
@@ -2708,7 +2729,14 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
     }
     }
 
-    auto&& message = callFrame->argument(1).toWTFString(globalObject);
+    auto messageValue = callFrame->argument(1);
+#if ASSERT_ENABLED
+    if (!messageValue.isString()) {
+        JSC::throwTypeError(globalObject, scope, makeString("$ERR_ code "_s, static_cast<int>(error), " has no message template; first argument must be the full message string"_s));
+        RELEASE_AND_RETURN(scope, {});
+    }
+#endif
+    auto&& message = messageValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSC::JSValue::encode(createError(globalObject, error, message));

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -289,6 +289,24 @@ fn err_throw<T>(global: &JSGlobalObject, code: ErrorCode, msg: &'static str) -> 
     Err(err_throw_cold(global, code, msg))
 }
 
+#[cold]
+#[inline(never)]
+fn err_throw_content_length_mismatch<T>(
+    global: &JSGlobalObject,
+    actual: u64,
+    expected: u64,
+) -> JsResult<T> {
+    Err(global
+        .err(
+            ErrorCode::ERR_HTTP_CONTENT_LENGTH_MISMATCH,
+            format_args!(
+                "Response body's content-length of {} byte(s) does not match the content-length of {} byte(s) set in header",
+                actual, expected
+            ),
+        )
+        .throw())
+}
+
 /// AnyResponse `is_ssl()` shim (upstream lacks this accessor).
 #[inline]
 fn any_response_is_ssl(r: &uws::AnyResponse) -> bool {
@@ -1989,17 +2007,17 @@ impl NodeHTTPResponse {
 
             if IS_END {
                 if bytes_written as u64 != content_length {
-                    return err_throw(
+                    return err_throw_content_length_mismatch(
                         global_object,
-                        ErrorCode::ERR_HTTP_CONTENT_LENGTH_MISMATCH,
-                        "Content-Length mismatch",
+                        bytes_written as u64,
+                        content_length,
                     );
                 }
             } else if bytes_written as u64 > content_length {
-                return err_throw(
+                return err_throw_content_length_mismatch(
                     global_object,
-                    ErrorCode::ERR_HTTP_CONTENT_LENGTH_MISMATCH,
-                    "Content-Length mismatch",
+                    bytes_written as u64,
+                    content_length,
                 );
             }
             self.bytes_written.set(bytes_written);

--- a/test/js/node/node-error-messages.test.ts
+++ b/test/js/node/node-error-messages.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { once } from "node:events";
+import http from "node:http";
 import http2 from "node:http2";
+import net from "node:net";
 
 // Node.js error codes are produced in C++ (ErrorCode.cpp jsFunctionMakeErrorWithCode).
 // Codes with no message template fall through to "use the first JS argument verbatim
@@ -20,79 +22,60 @@ test("ERR_HTTP2_UNSUPPORTED_PROTOCOL message matches Node.js", () => {
   expect(err?.message).toBe('protocol "gopher:" is unsupported.');
 });
 
-test.concurrent("ERR_HTTP_TRAILER_INVALID message matches Node.js", async () => {
-  const fixture = `
-    const http = require("node:http");
-    const req = http.request({ port: 1, method: "POST", createConnection: () => new (require("node:net").Socket)() });
-    req.on("error", () => {});
-    req.setHeader("Content-Length", "5");
-    req.setHeader("Trailer", "X-Foo");
-    try {
-      req.flushHeaders();
-      console.log("NO THROW");
-    } catch (e) {
-      console.log(e.code + "|" + e.message);
-    }
-    process.exit(0);
-  `;
-  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-    stdout: "ERR_HTTP_TRAILER_INVALID|Trailers are invalid with this transfer encoding",
-    stderr: "",
-    exitCode: 0,
-  });
-});
-
-test.concurrent("ERR_HTTP_CONTENT_LENGTH_MISMATCH message matches Node.js", async () => {
-  const fixture = `
-    const http = require("node:http");
-    const req = http.request({ port: 1, method: "POST", createConnection: () => new (require("node:net").Socket)() });
-    req.on("error", () => {});
-    req.strictContentLength = true;
-    req.setHeader("Content-Length", "5");
+test("ERR_HTTP_TRAILER_INVALID message matches Node.js", () => {
+  const req = http.request({ port: 1, method: "POST", createConnection: () => new net.Socket() });
+  req.on("error", () => {});
+  req.setHeader("Content-Length", "5");
+  req.setHeader("Trailer", "X-Foo");
+  let err: any;
+  try {
     req.flushHeaders();
-    try {
-      req.write("hello world");
-      console.log("NO THROW");
-    } catch (e) {
-      console.log(e.code + "|" + e.message);
-    }
-    process.exit(0);
-  `;
-  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-    stdout:
-      "ERR_HTTP_CONTENT_LENGTH_MISMATCH|Response body's content-length of 11 byte(s) does not match the content-length of 5 byte(s) set in header",
-    stderr: "",
-    exitCode: 0,
+  } catch (e) {
+    err = e;
+  }
+  req.destroy();
+  expect({ code: err?.code, message: err?.message }).toEqual({
+    code: "ERR_HTTP_TRAILER_INVALID",
+    message: "Trailers are invalid with this transfer encoding",
   });
 });
 
-test.concurrent("ERR_STREAM_DESTROYED message from http ServerResponse matches Node.js", async () => {
-  const fixture = `
-    const http = require("node:http");
-    const net = require("node:net");
-    const server = http.createServer((req, res) => {
-      res.destroy();
-      res.write("x", err => {
-        console.log(err.code + "|" + err.message);
-        server.close();
-        process.exit(0);
-      });
-    });
-    server.listen(0, function () {
-      const sock = net.connect(this.address().port);
-      sock.on("error", () => {});
-      sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
-    });
-  `;
-  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-    stdout: "ERR_STREAM_DESTROYED|Cannot call write after a stream was destroyed",
-    stderr: "",
-    exitCode: 0,
+test("ERR_HTTP_CONTENT_LENGTH_MISMATCH message matches Node.js", () => {
+  const req = http.request({ port: 1, method: "POST", createConnection: () => new net.Socket() });
+  req.on("error", () => {});
+  req.strictContentLength = true;
+  req.setHeader("Content-Length", "5");
+  req.flushHeaders();
+  let err: any;
+  try {
+    req.write("hello world");
+  } catch (e) {
+    err = e;
+  }
+  req.destroy();
+  expect({ code: err?.code, message: err?.message }).toEqual({
+    code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+    message:
+      "Response body's content-length of 11 byte(s) does not match the content-length of 5 byte(s) set in header",
+  });
+});
+
+test("ERR_STREAM_DESTROYED message from http ServerResponse matches Node.js", async () => {
+  const { promise, resolve } = Promise.withResolvers<any>();
+  const server = http.createServer((req, res) => {
+    res.destroy();
+    res.write("x", resolve);
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const sock = net.connect((server.address() as net.AddressInfo).port);
+  sock.on("error", () => {});
+  sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+  const err = await promise;
+  sock.destroy();
+  await new Promise<void>(r => server.close(() => r()));
+  expect({ code: err?.code, message: err?.message }).toEqual({
+    code: "ERR_STREAM_DESTROYED",
+    message: "Cannot call write after a stream was destroyed",
   });
 });

--- a/test/js/node/node-error-messages.test.ts
+++ b/test/js/node/node-error-messages.test.ts
@@ -60,6 +60,36 @@ test("ERR_HTTP_CONTENT_LENGTH_MISMATCH message matches Node.js", () => {
   });
 });
 
+test("ERR_HTTP_CONTENT_LENGTH_MISMATCH message from http ServerResponse matches Node.js", async () => {
+  const { promise, resolve } = Promise.withResolvers<any>();
+  const server = http.createServer((req, res) => {
+    res.strictContentLength = true;
+    res.setHeader("Content-Length", "5");
+    try {
+      res.end("hello world");
+      resolve(undefined);
+    } catch (e) {
+      resolve(e);
+    }
+    try {
+      res.destroy();
+    } catch {}
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const sock = net.connect((server.address() as net.AddressInfo).port);
+  sock.on("error", () => {});
+  sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+  const err = await promise;
+  sock.destroy();
+  await new Promise<void>(r => server.close(() => r()));
+  expect({ code: err?.code, message: err?.message }).toEqual({
+    code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+    message:
+      "Response body's content-length of 11 byte(s) does not match the content-length of 5 byte(s) set in header",
+  });
+});
+
 test("ERR_STREAM_DESTROYED message from http ServerResponse matches Node.js", async () => {
   const { promise, resolve } = Promise.withResolvers<any>();
   const server = http.createServer((req, res) => {

--- a/test/js/node/node-error-messages.test.ts
+++ b/test/js/node/node-error-messages.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import http2 from "node:http2";
+
+// Node.js error codes are produced in C++ (ErrorCode.cpp jsFunctionMakeErrorWithCode).
+// Codes with no message template fall through to "use the first JS argument verbatim
+// as .message", so a call site that passes template args instead of the full sentence
+// yields a broken message, and a call site that passes the full sentence into a code
+// that *is* templated gets the template wrapper applied twice. These tests pin the
+// messages to Node.js's format for the codes that were observably wrong.
+
+test("ERR_HTTP2_UNSUPPORTED_PROTOCOL message matches Node.js", () => {
+  let err: any;
+  try {
+    http2.connect("gopher://127.0.0.1:1");
+  } catch (e) {
+    err = e;
+  }
+  expect(err?.code).toBe("ERR_HTTP2_UNSUPPORTED_PROTOCOL");
+  expect(err?.message).toBe('protocol "gopher:" is unsupported.');
+});
+
+test.concurrent("ERR_HTTP_TRAILER_INVALID message matches Node.js", async () => {
+  const fixture = `
+    const http = require("node:http");
+    const req = http.request({ port: 1, method: "POST", createConnection: () => new (require("node:net").Socket)() });
+    req.on("error", () => {});
+    req.setHeader("Content-Length", "5");
+    req.setHeader("Trailer", "X-Foo");
+    try {
+      req.flushHeaders();
+      console.log("NO THROW");
+    } catch (e) {
+      console.log(e.code + "|" + e.message);
+    }
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "ERR_HTTP_TRAILER_INVALID|Trailers are invalid with this transfer encoding",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("ERR_HTTP_CONTENT_LENGTH_MISMATCH message matches Node.js", async () => {
+  const fixture = `
+    const http = require("node:http");
+    const req = http.request({ port: 1, method: "POST", createConnection: () => new (require("node:net").Socket)() });
+    req.on("error", () => {});
+    req.strictContentLength = true;
+    req.setHeader("Content-Length", "5");
+    req.flushHeaders();
+    try {
+      req.write("hello world");
+      console.log("NO THROW");
+    } catch (e) {
+      console.log(e.code + "|" + e.message);
+    }
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout:
+      "ERR_HTTP_CONTENT_LENGTH_MISMATCH|Response body's content-length of 11 byte(s) does not match the content-length of 5 byte(s) set in header",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("ERR_STREAM_DESTROYED message from http ServerResponse matches Node.js", async () => {
+  const fixture = `
+    const http = require("node:http");
+    const net = require("node:net");
+    const server = http.createServer((req, res) => {
+      res.destroy();
+      res.write("x", err => {
+        console.log(err.code + "|" + err.message);
+        server.close();
+        process.exit(0);
+      });
+    });
+    server.listen(0, function () {
+      const sock = net.connect(this.address().port);
+      sock.on("error", () => {});
+      sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+    });
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "ERR_STREAM_DESTROYED|Cannot call write after a stream was destroyed",
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
## What

`jsFunctionMakeErrorWithCode` (ErrorCode.cpp) has message templates for ~134 of the 346 registered `ERR_*` codes. Every other code falls through to the tail which uses `callFrame->argument(1).toWTFString()` verbatim as `.message`. A JS call site that passes template args instead of a full sentence yields a garbage message, and a call site that passes a full sentence into a code that *is* templated gets double-wrapped.

## Repro

```js
import http2 from "node:http2";
try { http2.connect("gopher://127.0.0.1:1"); } catch (e) { console.log(e.code, JSON.stringify(e.message)); }
// bun:  ERR_HTTP2_UNSUPPORTED_PROTOCOL "gopher:"
// node: ERR_HTTP2_UNSUPPORTED_PROTOCOL "protocol \"gopher:\" is unsupported."

const http = require("node:http");
http.createServer((q, res) => { res.destroy(); res.write("x", err => { console.log(err.code, JSON.stringify(err.message)); process.exit(0); }); })
  .listen(0, function () { require("node:net").connect(this.address().port).write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"); });
// bun:  ERR_STREAM_DESTROYED "Cannot call Stream is destroyed after a stream was destroyed"
// node: ERR_STREAM_DESTROYED "Cannot call write after a stream was destroyed"
```

## Fix

| code | before | after |
| --- | --- | --- |
| `ERR_HTTP2_UNSUPPORTED_PROTOCOL` | `"gopher:"` | `protocol "gopher:" is unsupported.` |
| `ERR_HTTP_TRAILER_INVALID` | `"undefined"` | `Trailers are invalid with this transfer encoding` |
| `ERR_HTTP_CONTENT_LENGTH_MISMATCH` (client `OutgoingMessage`) | `"11"` | `Response body's content-length of 11 byte(s) does not match the content-length of 5 byte(s) set in header` |
| `ERR_HTTP_CONTENT_LENGTH_MISMATCH` (server `ServerResponse`, native) | `"Content-Length mismatch"` | same as above |
| `ERR_STREAM_DESTROYED` (http ServerResponse) | `Cannot call Stream is destroyed after a stream was destroyed` | `Cannot call write after a stream was destroyed` |
| `ERR_OPERATION_FAILED` (fs.promises writeFile) | `Operation failed: Operation failed: write failed after retries` | `Operation failed: write failed after retries` |
| `ERR_SCRIPT_EXECUTION_INTERRUPTED` (REPL) | `"undefined"` | ``Script execution was interrupted by `SIGINT` `` |

- Added C++ message templates for `ERR_HTTP2_UNSUPPORTED_PROTOCOL`, `ERR_HTTP_TRAILER_INVALID`, `ERR_HTTP_CONTENT_LENGTH_MISMATCH`, `ERR_SCRIPT_EXECUTION_INTERRUPTED`.
- `NodeHTTPResponse.rs`: format the actual/expected byte counts into the same Node template (the server-side check throws via the native `err_throw` path and doesn't reach `jsFunctionMakeErrorWithCode`).
- `internal/http.ts`: `$ERR_STREAM_DESTROYED("Stream is destroyed")` → `$ERR_STREAM_DESTROYED("write")` (the code already has a `"Cannot call <arg> after a stream was destroyed"` template).
- `fs.promises.ts` (3 sites): drop the redundant `"Operation failed: "` prefix (the template already prepends it).
- `_http_server.ts` (2 sites): drop now-redundant message arg from `$ERR_HTTP_TRAILER_INVALID(...)`.
- Debug-only guard on the fallthrough tail: throw if the first argument is not a string, so future mismatches surface at test time. Swept all `$ERR_*(...)` call sites in `src/js/` (including the `...args` spread wrappers in `internal/repl/node-errors.js`); none pass a non-string through the fallthrough with these templates in place.

Supersedes #35777 (two of the six codes) and #17927 (old `src/bun.js/` path).

## Verification

```
bun bd test test/js/node/node-error-messages.test.ts
 5 pass, 0 fail
```

With `src/` reverted to `origin/main`:
```
 0 pass, 5 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/node-error-messages.test.ts
bun test v1.4.0 (b832defec)

test/js/node/node-error-messages.test.ts:
17 |     http2.connect("gopher://127.0.0.1:1");
18 |   } catch (e) {
19 |     err = e;
20 |   }
21 |   expect(err?.code).toBe("ERR_HTTP2_UNSUPPORTED_PROTOCOL");
22 |   expect(err?.message).toBe('protocol "gopher:" is unsupported.');
                            ^
error: expect(received).toBe(expected)

Expected: "protocol "gopher:" is unsupported."
Received: "gopher:"

      at <anonymous> (/workspace/bun/test/js/node/node-error-messages.test.ts:22:24)
(fail) ERR_HTTP2_UNSUPPORTED_PROTOCOL message matches Node.js [99.43ms]
32 |     req.flushHeaders();
33 |   } catch (e) {
34 |     err = e;
35 |   }
36 |   req.destroy();
37 |   expect({ code: err?.code, message: err?.message }).toEqual({
                                                          ^
error: expect(received).toEqual(expected)

  {
    "code": "ERR_HTTP_TRAILER_INVALID",
-   "message": "Trailers are invalid with this transfer encoding",
+   "message": "undefined",
  
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (5c12a3501)

test/js/node/node-error-messages.test.ts:
(pass) ERR_HTTP2_UNSUPPORTED_PROTOCOL message matches Node.js [2.89ms]
(pass) ERR_HTTP_TRAILER_INVALID message matches Node.js [7.13ms]
(pass) ERR_HTTP_CONTENT_LENGTH_MISMATCH message matches Node.js [1.00ms]
81 |   sock.on("error", () => {});
82 |   sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
83 |   const err = await promise;
84 |   sock.destroy();
85 |   await new Promise<void>(r => server.close(() => r()));
86 |   expect({ code: err?.code, message: err?.message }).toEqual({
                                                          ^
error: expect(received).toEqual(expected)

  {
    "code": "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
-   "message": "Response body's content-length of 11 byte(s) does not match the content-length of 5 byte(s) set in header",
+   "message": "Content-Length mismatch",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/node-error-messages.test.ts:86:54)
(fail) ERR_HTTP_CONTENT_LENGTH_MISMATCH message from http ServerResponse matches Node.js [21.44ms]
(pass) ERR_STREAM_DESTROYED message from http ServerResponse matches Node.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/node-error-messages.test.ts
bun test v1.4.0 (b832defec)

test/js/node/node-error-messages.test.ts:
(pass) ERR_HTTP2_UNSUPPORTED_PROTOCOL message matches Node.js [66.54ms]
(pass) ERR_HTTP_TRAILER_INVALID message matches Node.js [284.55ms]
(pass) ERR_HTTP_CONTENT_LENGTH_MISMATCH message matches Node.js [34.54ms]
(pass) ERR_HTTP_CONTENT_LENGTH_MISMATCH message from http ServerResponse matches Node.js [919.17ms]
(pass) ERR_STREAM_DESTROYED message from http ServerResponse matches Node.js [127.23ms]

 5 pass
 0 fail
 6 expect() calls
Ran 5 tests across 1 file. [6.66s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1621ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/80] gen ErrorCode+*.h
[2/33] gen cpp.rs (cppbind)
[3/33] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (31 fields)
Found 8 classes from /workspace/bun/src/runtime/api/html_rewriter.classes.ts
  - HTMLRewriter (3 f
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/http.ts                  |   2 +-
 src/js/node/_http_server.ts              |   4 +-
 src/js/node/fs.promises.ts               |   6 +-
 src/jsc/bindings/ErrorCode.cpp           |  32 ++++++++-
 src/runtime/server/NodeHTTPResponse.rs   |  30 +++++++--
 test/js/node/node-error-messages.test.ts | 111 +++++++++++++++++++++++++++++++
 6 files changed, 172 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/http.ts                       1      1      0
src/js/node/_http_server.ts                   1      1      0
src/js/node/fs.promises.ts                    1      1      0
src/jsc/bindings/ErrorCode.cpp                4      5      0
src/runtime/server/NodeHTTPResponse.rs        4      4      0
test/js/node/node-error-messages.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->