### PR TITLE
fetch: stream FormData bodies that contain Bun.file() parts

### DIFF
--- a/src/http/HTTPRequestBody.rs
+++ b/src/http/HTTPRequestBody.rs
@@ -24,6 +24,16 @@ pub struct Stream {
 }
 
 impl Stream {
+    /// True when `gen_` predates a restart of this stream body (307/308
+    /// redirect replay). The write message was scheduled by a superseded
+    /// sink and must not touch the current request's state.
+    #[inline]
+    pub fn is_stale_generation(&mut self, gen_: u32) -> bool {
+        self.buffer_mut()
+            .map(|b| b.generation.load(core::sync::atomic::Ordering::Acquire) != gen_)
+            .unwrap_or(false)
+    }
+
     /// Mutable access to the JS-side `ThreadSafeStreamBuffer` while attached.
     ///
     /// INVARIANT: while `buffer` is `Some`, this `Stream` holds an intrusive

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -256,6 +256,10 @@ impl RequestBodyBuffer {
 pub struct WriteMessage {
     pub async_http_id: u32,
     pub kind: WriteMessageType,
+    /// Stream buffer generation this message was scheduled for. Discarded if
+    /// the buffer's current generation is newer (a restartable body was
+    /// replayed on redirect).
+    pub generation: u32,
 }
 
 #[repr(u8)]
@@ -722,6 +726,9 @@ impl HttpThread {
                                 if let crate::HTTPRequestBody::Stream(stream) =
                                     &mut client.state.original_request_body
                                 {
+                                    if stream.is_stale_generation(write.generation) {
+                                        continue;
+                                    }
                                     stream.ended = ended;
                                     client.flush_stream::<true>(socket);
                                 }
@@ -739,6 +746,9 @@ impl HttpThread {
                                 if let crate::HTTPRequestBody::Stream(stream) =
                                     &mut client.state.original_request_body
                                 {
+                                    if stream.is_stale_generation(write.generation) {
+                                        continue;
+                                    }
                                     stream.ended = ended;
                                     client.flush_stream::<false>(socket);
                                 }
@@ -990,12 +1000,18 @@ impl HttpThread {
         self.wakeup();
     }
 
-    pub fn schedule_request_write(&mut self, http: &AsyncHttp, kind: WriteMessageType) {
+    pub fn schedule_request_write(
+        &mut self,
+        http: &AsyncHttp,
+        kind: WriteMessageType,
+        generation: u32,
+    ) {
         {
             let _guard = self.queued_writes_lock.lock_guard();
             self.queued_writes.push(WriteMessage {
                 async_http_id: http.async_http_id,
                 kind,
+                generation,
             });
         }
         self.wakeup();

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -734,7 +734,11 @@ impl HttpThread {
                                 }
                             }
                             if let Some(session) = tagged.session_mut() {
-                                session.stream_body_by_http_id(write.async_http_id, ended);
+                                session.stream_body_by_http_id(
+                                    write.async_http_id,
+                                    ended,
+                                    write.generation,
+                                );
                             }
                         }
                         uws::AnySocket::SocketTcp(socket) => {
@@ -754,12 +758,20 @@ impl HttpThread {
                                 }
                             }
                             if let Some(session) = tagged.session_mut() {
-                                session.stream_body_by_http_id(write.async_http_id, ended);
+                                session.stream_body_by_http_id(
+                                    write.async_http_id,
+                                    ended,
+                                    write.generation,
+                                );
                             }
                         }
                     }
                 } else {
-                    h3::ClientContext::stream_body_by_http_id(write.async_http_id, ended);
+                    h3::ClientContext::stream_body_by_http_id(
+                        write.async_http_id,
+                        ended,
+                        write.generation,
+                    );
                 }
             }
             let len = queued_writes.len();

--- a/src/http/ThreadSafeStreamBuffer.rs
+++ b/src/http/ThreadSafeStreamBuffer.rs
@@ -115,6 +115,7 @@ impl ThreadSafeStreamBuffer {
 
     pub fn clear_drain_callback(&mut self) {
         self.callback = None;
+        self.restart_callback = None;
     }
 
     pub fn set_restart_callback<T>(&mut self, callback: fn(*mut T), context: *mut T) {

--- a/src/http/ThreadSafeStreamBuffer.rs
+++ b/src/http/ThreadSafeStreamBuffer.rs
@@ -12,6 +12,15 @@ pub struct ThreadSafeStreamBuffer {
     /// callback will be called passing the context for the http callback
     /// this is used to report when the buffer is drained and only if end chunk was not sent/reported
     pub callback: Option<Callback>,
+    /// Fired from `do_redirect` when a restartable streaming body must be
+    /// re-sent, so the JS side can quiesce the previous sink before the HTTP
+    /// thread reaches the redirected request's body stage.
+    pub restart_callback: Option<Callback>,
+    /// Incremented on each restart. End/Data messages are stamped with the
+    /// generation they were scheduled for and discarded if a newer one is
+    /// current, so a previous sink's end-of-stream cannot mark a replayed
+    /// request done.
+    pub generation: core::sync::atomic::AtomicU32,
 }
 
 pub struct Callback {
@@ -43,6 +52,8 @@ impl Default for ThreadSafeStreamBuffer {
             // .initExactRefs(2) — 1 for main thread and 1 for http thread
             ref_count: bun_ptr::ThreadSafeRefCount::init_exact_refs(2),
             callback: None,
+            restart_callback: None,
+            generation: core::sync::atomic::AtomicU32::new(0),
         }
     }
 }
@@ -104,6 +115,18 @@ impl ThreadSafeStreamBuffer {
 
     pub fn clear_drain_callback(&mut self) {
         self.callback = None;
+    }
+
+    pub fn set_restart_callback<T>(&mut self, callback: fn(*mut T), context: *mut T) {
+        self.restart_callback = Some(Callback::init(callback, context));
+    }
+
+    /// Called from the HTTP thread in `do_redirect` for a restartable
+    /// streaming body. The callback runs on the HTTP thread.
+    pub fn report_restart(&self) {
+        if let Some(cb) = &self.restart_callback {
+            cb.call();
+        }
     }
 
     /// This is exclusively called from the http thread.

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -605,7 +605,7 @@ impl ClientSession {
 
     /// HTTP-thread wake-up from `scheduleRequestWrite`: new body bytes (or
     /// end-of-body) are available in the ThreadSafeStreamBuffer.
-    pub fn stream_body_by_http_id(&mut self, async_http_id: u32, ended: bool) {
+    pub fn stream_body_by_http_id(&mut self, async_http_id: u32, ended: bool, generation: u32) {
         let _guard = self.ref_scope();
         let Some(stream) = self.stream_for_http_id(async_http_id) else {
             return;
@@ -617,6 +617,9 @@ impl ClientSession {
             let HTTPRequestBody::Stream(ref mut st) = client.state.original_request_body else {
                 return;
             };
+            if st.is_stale_generation(generation) {
+                return;
+            }
             st.ended = ended;
         }
         self.rearm_timeout();

--- a/src/http/h2_client/encode.rs
+++ b/src/http/h2_client/encode.rs
@@ -355,7 +355,7 @@ pub(crate) fn drain_send_body(session: &mut ClientSession, stream: &mut Stream, 
                 sb.report_drain();
             }
             sb.release();
-            if stream.local_closed() {
+            if stream.local_closed() && !client.flags.streaming_body_can_restart {
                 body.detach();
             }
         }

--- a/src/http/h3_client/ClientContext.rs
+++ b/src/http/h3_client/ClientContext.rs
@@ -213,7 +213,7 @@ impl ClientContext {
         false
     }
 
-    pub fn stream_body_by_http_id(async_http_id: u32, ended: bool) {
+    pub fn stream_body_by_http_id(async_http_id: u32, ended: bool, generation: u32) {
         let Some(this) = Self::get() else {
             return;
         };
@@ -221,7 +221,7 @@ impl ClientContext {
         let ctx = bun_ptr::BackRef::from(this);
         for &s in ctx.sessions.iter() {
             // Registry only holds live sessions — `session_mut` upgrade.
-            if session_mut(s).stream_body_by_http_id(async_http_id, ended) {
+            if session_mut(s).stream_body_by_http_id(async_http_id, ended, generation) {
                 return;
             }
         }

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -119,7 +119,12 @@ impl ClientSession {
         }
     }
 
-    pub fn stream_body_by_http_id(&mut self, async_http_id: u32, ended: bool) -> bool {
+    pub fn stream_body_by_http_id(
+        &mut self,
+        async_http_id: u32,
+        ended: bool,
+        generation: u32,
+    ) -> bool {
         for &stream_ptr in self.pending.iter() {
             let stream = stream_mut(stream_ptr);
             let Some(client) = stream.client else {
@@ -130,6 +135,9 @@ impl ClientSession {
                 continue;
             }
             if let crate::HTTPRequestBody::Stream(s) = &mut client.state.original_request_body {
+                if s.is_stale_generation(generation) {
+                    return true;
+                }
                 s.ended = ended;
                 if let Some(qs) = stream.qstream_mut() {
                     encode::drain_send_body(stream, qs);

--- a/src/http/h3_client/encode.rs
+++ b/src/http/h3_client/encode.rs
@@ -191,7 +191,7 @@ pub(crate) fn drain_send_body(stream: &mut Stream, qs: &mut quic::Stream) {
             sb.report_drain();
         }
         sb.release();
-        if stream.request_body_done {
+        if stream.request_body_done && !client.flags.streaming_body_can_restart {
             body.detach();
         }
         return;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4434,13 +4434,6 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
-    /// Build the result payload for the progress/completion callback.
-    ///
-    /// `body` is left `None`: every caller attaches it from `state.body_out_str`
-    /// *after* the `state.reset()` that follows this call (reset writes through
-    /// the same allocation). With `body` absent the result is fully owned, so
-    /// it can be held across the caller's `&mut self` mutations without a
-    /// lifetime widen.
     /// For a restartable streaming body, decide what `do_redirect` does with
     /// it and return the `Stream` to pass to `start()` when the follow-up
     /// request must re-send it. The 303/301/302 GET-downgrade path drops the
@@ -4482,6 +4475,13 @@ impl<'a> HTTPClient<'a> {
         None
     }
 
+    /// Build the result payload for the progress/completion callback.
+    ///
+    /// `body` is left `None`: every caller attaches it from `state.body_out_str`
+    /// *after* the `state.reset()` that follows this call (reset writes through
+    /// the same allocation). With `body` absent the result is fully owned, so
+    /// it can be held across the caller's `&mut self` mutations without a
+    /// lifetime widen.
     pub fn to_result(&mut self) -> HTTPClientResult<'static> {
         let body_size: BodySize = if self.state.is_chunked_encoding() {
             BodySize::TotalReceived(self.state.total_body_received)

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -182,6 +182,15 @@ pub struct Flags {
     pub reject_unauthorized: bool,
     pub is_preconnect_only: bool,
     pub is_streaming_request_body: bool,
+    /// The streaming request body has a non-null Fetch "source" (e.g. a
+    /// FormData) and can be restarted from the beginning on a 307/308
+    /// redirect. When false, the body is a bare ReadableStream and a non-303
+    /// redirect is a network error.
+    pub streaming_body_can_restart: bool,
+    /// One-shot: set by `do_redirect` when the follow-up request must re-send
+    /// a restartable streaming body; consumed by `to_result()` once the
+    /// redirected request reaches the body stage.
+    pub pending_request_stream_restart: bool,
     pub defer_fail_until_connecting_is_complete: bool,
     pub upgrade_state: HTTPUpgradeState,
     pub protocol: Protocol,
@@ -213,6 +222,8 @@ impl Default for Flags {
             reject_unauthorized: true,
             is_preconnect_only: false,
             is_streaming_request_body: false,
+            streaming_body_can_restart: false,
+            pending_request_stream_restart: false,
             defer_fail_until_connecting_is_complete: false,
             upgrade_state: HTTPUpgradeState::None,
             protocol: Protocol::Http1_1,
@@ -407,6 +418,9 @@ pub struct HTTPClientResult<'a> {
     pub has_more: bool,
     pub redirected: bool,
     pub can_stream: bool,
+    /// A 307/308 redirect needs the restartable streaming body re-sent from
+    /// the beginning; the JS thread rewinds its source and re-pipes it.
+    pub restart_request_stream: bool,
     /// Set once ALPN selected h2 so the JS side writes raw bytes into the
     /// streaming-body buffer instead of chunked-encoding them.
     pub is_http2: bool,
@@ -479,6 +493,7 @@ impl<'a> HTTPClientResult<'a> {
             has_more: self.has_more,
             redirected: self.redirected,
             can_stream: self.can_stream,
+            restart_request_stream: self.restart_request_stream,
             is_http2: self.is_http2,
             fail: self.fail,
             dns_error: self.dns_error,
@@ -2539,14 +2554,8 @@ impl<'a> HTTPClient<'a> {
             return self.do_redirect_multiplexed();
         }
         bun_core::scoped_log!(fetch, "doRedirect");
-        if matches!(self.state.original_request_body, HTTPRequestBody::Stream(_)) {
-            // handleResponseMetadata already rejected every non-303 status with a
-            // stream body (RequestBodyNotReusable). Reaching here means the
-            // redirect downgraded to GET with a null body; drop the streaming
-            // flag so the follow-up request goes out without Transfer-Encoding,
-            // and let state.reset() release the ThreadSafeStreamBuffer ref.
-            self.flags.is_streaming_request_body = false;
-        }
+        let restart_stream =
+            Self::prepare_stream_body_for_redirect(&mut self.state, &mut self.flags);
 
         // There is no struct copy-back
         // (`sync_progress_from` skips owned fields) and the original retains
@@ -2555,7 +2564,6 @@ impl<'a> HTTPClient<'a> {
         // double-free when the original later runs `clear_data()`. Forget the
         // clone's view; the original is the sole owner.
         let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
-        // TODO: what we do with stream body?
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
         {
@@ -2574,6 +2582,9 @@ impl<'a> HTTPClient<'a> {
         // the request is already terminal; there is nowhere to deliver a
         // redirected response.
         let Some(body_out_str) = self.state.body_out_str else {
+            if let Some(mut s) = restart_stream {
+                s.detach();
+            }
             GenHttpContext::<IS_SSL>::close_socket(socket);
             return;
         };
@@ -2637,6 +2648,9 @@ impl<'a> HTTPClient<'a> {
         // TODO: should this check be before decrementing the redirect count?
         // the current logic will allow one less redirect than requested
         if self.remaining_redirect_count == 0 {
+            if let Some(mut s) = restart_stream {
+                s.detach();
+            }
             self.fail(crate::Error::TooManyRedirects);
             return;
         }
@@ -2648,10 +2662,11 @@ impl<'a> HTTPClient<'a> {
         self.flags.protocol = Protocol::Http1_1;
         self.reevaluate_proxy_for_redirect();
 
-        self.start(
-            HTTPRequestBody::Bytes(request_body),
-            body_out::as_mut(body_out_str),
-        );
+        let body = match restart_stream {
+            Some(s) => HTTPRequestBody::Stream(s),
+            None => HTTPRequestBody::Bytes(request_body),
+        };
+        self.start(body, body_out::as_mut(body_out_str));
     }
 
     /// Re-resolve `http_proxy` against the post-redirect `self.url`. The
@@ -3232,6 +3247,13 @@ impl<'a> HTTPClient<'a> {
     /// calling `&mut self` methods, then re-acquire only for the detach.
     #[inline]
     fn request_stream_detach(&mut self) {
+        // A restartable body may still be replayed on a 307/308 redirect;
+        // releasing the buffer ref here would leave `do_redirect` nothing to
+        // pass to the follow-up request. The eventual `state.reset()` releases
+        // it when the request is actually done.
+        if self.flags.streaming_body_can_restart {
+            return;
+        }
         if let HTTPRequestBody::Stream(stream) = &mut self.state.original_request_body {
             stream.detach();
         }
@@ -4279,9 +4301,8 @@ impl<'a> HTTPClient<'a> {
             self.state.flags.clear_hostname_on_redirect = false;
             self.hostname = None;
         }
-        if matches!(self.state.original_request_body, HTTPRequestBody::Stream(_)) {
-            self.flags.is_streaming_request_body = false;
-        }
+        let restart_stream =
+            Self::prepare_stream_body_for_redirect(&mut self.state, &mut self.flags);
         // See `do_redirect`: the HTTP-thread clone shares this allocation
         // with the JS-thread original (created via `ptr::read`); dropping it
         // here double-frees once the original runs `clear_data()`.
@@ -4302,6 +4323,9 @@ impl<'a> HTTPClient<'a> {
         // the request is already terminal; there is nowhere to deliver a
         // redirected response.
         let Some(body_out_str) = self.state.body_out_str else {
+            if let Some(mut s) = restart_stream {
+                s.detach();
+            }
             return;
         };
         self.remaining_redirect_count = self.remaining_redirect_count.saturating_sub(1);
@@ -4311,6 +4335,9 @@ impl<'a> HTTPClient<'a> {
         self.connected_url = URL::default();
         self.prev_redirect = Vec::new();
         if self.remaining_redirect_count == 0 {
+            if let Some(mut s) = restart_stream {
+                s.detach();
+            }
             self.fail(crate::Error::TooManyRedirects);
             return;
         }
@@ -4319,10 +4346,11 @@ impl<'a> HTTPClient<'a> {
         self.flags.protocol = Protocol::Http1_1;
         self.reevaluate_proxy_for_redirect();
         // SAFETY: body_out_str points at the caller-owned MutableString.
-        self.start(
-            HTTPRequestBody::Bytes(request_body),
-            body_out::as_mut(body_out_str),
-        );
+        let body = match restart_stream {
+            Some(s) => HTTPRequestBody::Stream(s),
+            None => HTTPRequestBody::Bytes(request_body),
+        };
+        self.start(body, body_out::as_mut(body_out_str));
     }
 
     pub fn progress_update_h3(&mut self) {
@@ -4413,6 +4441,47 @@ impl<'a> HTTPClient<'a> {
     /// the same allocation). With `body` absent the result is fully owned, so
     /// it can be held across the caller's `&mut self` mutations without a
     /// lifetime widen.
+    /// For a restartable streaming body, decide what `do_redirect` does with
+    /// it and return the `Stream` to pass to `start()` when the follow-up
+    /// request must re-send it. The 303/301/302 GET-downgrade path drops the
+    /// body and the streaming flag; 307/308 extracts the stream (so
+    /// `state.reset()` does not release its buffer ref), clears any bytes the
+    /// previous attempt left in the buffer, and arms the JS-side restart
+    /// signal.
+    fn prepare_stream_body_for_redirect(
+        state: &mut InternalState<'a>,
+        flags: &mut Flags,
+    ) -> Option<http_request_body::Stream> {
+        if !matches!(state.original_request_body, HTTPRequestBody::Stream(_)) {
+            return None;
+        }
+        if flags.streaming_body_can_restart && state.flags.resend_request_body_on_redirect {
+            let HTTPRequestBody::Stream(mut stream) = core::mem::replace(
+                &mut state.original_request_body,
+                HTTPRequestBody::Bytes(b""),
+            ) else {
+                unreachable!()
+            };
+            if let Some(buf) = stream.buffer_mut() {
+                // `report_restart` publishes the restart to the JS side (sets
+                // the tasklet's atomic) before the generation bump, so any
+                // JS-side write that observes the new generation has already
+                // observed the restart and will discard itself.
+                buf.report_restart();
+                buf.generation
+                    .fetch_add(1, core::sync::atomic::Ordering::AcqRel);
+                buf.lock().reset();
+            }
+            stream.ended = false;
+            flags.pending_request_stream_restart = true;
+            return Some(stream);
+        }
+        // GET downgrade (or a bare ReadableStream that reached here via 303):
+        // the follow-up request has no body.
+        flags.is_streaming_request_body = false;
+        None
+    }
+
     pub fn to_result(&mut self) -> HTTPClientResult<'static> {
         let body_size: BodySize = if self.state.is_chunked_encoding() {
             BodySize::TotalReceived(self.state.total_body_received)
@@ -4445,10 +4514,16 @@ impl<'a> HTTPClient<'a> {
                     can_stream: (self.state.request_stage == RequestStage::Body
                         || self.state.request_stage == RequestStage::ProxyBody)
                         && self.flags.is_streaming_request_body,
+                    restart_request_stream: false,
                     is_http2: self.flags.protocol != Protocol::Http1_1,
                 };
             }
         }
+        let can_stream = (self.state.request_stage == RequestStage::Body
+            || self.state.request_stage == RequestStage::ProxyBody)
+            && self.flags.is_streaming_request_body;
+        let restart_request_stream =
+            can_stream && core::mem::take(&mut self.flags.pending_request_stream_restart);
         HTTPClientResult {
             body: None,
             metadata: None,
@@ -4462,9 +4537,8 @@ impl<'a> HTTPClient<'a> {
             body_size,
             certificate_info,
             // we can stream the request_body at this stage
-            can_stream: (self.state.request_stage == RequestStage::Body
-                || self.state.request_stage == RequestStage::ProxyBody)
-                && self.flags.is_streaming_request_body,
+            can_stream,
+            restart_request_stream,
             is_http2: self.flags.protocol != Protocol::Http1_1,
         }
     }
@@ -5004,6 +5078,7 @@ impl<'a> HTTPClient<'a> {
                                 self.state.original_request_body,
                                 HTTPRequestBody::Stream(_)
                             )
+                            && !self.flags.streaming_body_can_restart
                         {
                             return Err(crate::Error::RequestBodyNotReusable);
                         }

--- a/src/runtime/api/streams.classes.ts
+++ b/src/runtime/api/streams.classes.ts
@@ -7,8 +7,7 @@ const rustPaths = {
   MultipartForm: "crate::webcore::multipart_form_loader::Source",
 };
 
-// Sources without a one-shot buffered representation: their prototypes
-// omit .text()/.json()/.arrayBuffer()/.blob()/.bytes().
+// Sources whose prototypes omit the buffered .text()/.json()/etc. shortcuts.
 const noBufferedShortcut = new Set(["File", "MultipartForm"]);
 
 function source(name) {

--- a/src/runtime/api/streams.classes.ts
+++ b/src/runtime/api/streams.classes.ts
@@ -4,7 +4,12 @@ const rustPaths = {
   Blob: "crate::webcore::byte_blob_loader::Source",
   File: "crate::webcore::file_reader::Source",
   Bytes: "crate::webcore::byte_stream::Source",
+  MultipartForm: "crate::webcore::multipart_form_loader::Source",
 };
+
+// Sources without a one-shot buffered representation: their prototypes
+// omit .text()/.json()/.arrayBuffer()/.blob()/.bytes().
+const noBufferedShortcut = new Set(["File", "MultipartForm"]);
 
 function source(name) {
   return define({
@@ -52,7 +57,7 @@ function source(name) {
       isClosed: {
         getter: "getIsClosedFromJS",
       },
-      ...(name !== "File"
+      ...(!noBufferedShortcut.has(name)
         ? // Buffered versions
           // not implemented in File, yet.
           {
@@ -96,6 +101,6 @@ function source(name) {
   });
 }
 
-const sources = ["Blob", "File", "Bytes"];
+const sources = ["Blob", "File", "Bytes", "MultipartForm"];
 
 export default sources.map(source);

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -11,6 +11,8 @@ pub mod array_buffer_sink;
 pub mod bake_response;
 #[path = "webcore/ByteBlobLoader.rs"]
 pub mod byte_blob_loader;
+#[path = "webcore/MultipartFormLoader.rs"]
+pub mod multipart_form_loader;
 #[path = "webcore/ByteStream.rs"]
 pub mod byte_stream;
 #[path = "webcore/CookieMap.rs"]

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -11,14 +11,14 @@ pub mod array_buffer_sink;
 pub mod bake_response;
 #[path = "webcore/ByteBlobLoader.rs"]
 pub mod byte_blob_loader;
-#[path = "webcore/MultipartFormLoader.rs"]
-pub mod multipart_form_loader;
 #[path = "webcore/ByteStream.rs"]
 pub mod byte_stream;
 #[path = "webcore/CookieMap.rs"]
 pub mod cookie_map;
 #[path = "webcore/Crypto.rs"]
 pub mod crypto;
+#[path = "webcore/MultipartFormLoader.rs"]
+pub mod multipart_form_loader;
 #[path = "webcore/ResumableSink.rs"]
 pub mod resumable_sink;
 #[path = "webcore/S3Client.rs"]

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3925,137 +3925,139 @@ fn encode_form_data_component(bytes: &[u8], component: FormDataComponent) -> Opt
     Some(out.into_boxed_slice())
 }
 
-impl FormDataContext<'_> {
-    /// Append the UTF-8 view of a form-data string without copying it: the
-    /// borrowed case points into a WTF string owned by the `DOMFormData` being
-    /// serialized, which outlives `joiner.done()` in `from_dom_form_data`; an owned slice
-    /// (UTF-16 / non-ASCII Latin-1 conversion) transfers its allocation to the
-    /// joiner. `component` selects the spec's newline-normalization and
-    /// percent-encoding transforms, which copy when they apply.
-    fn push_string_slice(
-        joiner: &mut StringJoiner<'_>,
-        slice: ZigStringSlice,
-        component: FormDataComponent,
-    ) {
-        if let Some(encoded) = encode_form_data_component(slice.slice(), component) {
-            joiner.push_owned(encoded);
-            return;
+/// Byte sink for `write_multipart_entry`. `push_borrowed` receives slices that
+/// outlive the sink (borrowed from the `DOMFormData` being serialised); an
+/// implementation may either copy them or keep the borrow.
+trait MultipartSink {
+    fn push_static(&mut self, bytes: &'static [u8]);
+    fn push_borrowed(&mut self, bytes: &[u8]);
+    fn push_string(&mut self, slice: ZigStringSlice, component: FormDataComponent);
+}
+
+/// Serialise one `FormData` entry's multipart framing: boundary line,
+/// `Content-Disposition` (and for file entries `filename` + `Content-Type`),
+/// then delegate to `blob_body` for the file arm's payload and write the
+/// trailing CRLF. Both the buffered and streaming serializers call this so
+/// the wire layout lives in one place.
+fn write_multipart_entry<S: MultipartSink>(
+    sink: &mut S,
+    boundary: &[u8],
+    name: ZigString,
+    entry: FormDataEntry<'_>,
+    blob_body: impl FnOnce(&mut S, &mut Blob),
+) {
+    sink.push_static(b"--");
+    sink.push_borrowed(boundary);
+    sink.push_static(b"\r\n");
+
+    sink.push_static(b"Content-Disposition: form-data; name=\"");
+    sink.push_string(name.to_slice(), FormDataComponent::Name);
+
+    match entry {
+        FormDataEntry::String(value) => {
+            sink.push_static(b"\"\r\n\r\n");
+            sink.push_string(value.to_slice(), FormDataComponent::StringValue);
         }
-        if matches!(slice, ZigStringSlice::Owned(_)) {
-            // `into_vec` moves the buffer out of an `Owned` slice without copying.
-            joiner.push_owned(slice.into_vec().into_boxed_slice());
-        } else if matches!(slice, ZigStringSlice::Static(..)) {
-            // SAFETY: `Static` bytes are owned by the `DOMFormData` being serialized
-            // (never freed), which outlives `joiner.done()` in `from_dom_form_data`.
-            joiner.push(unsafe { bun_ptr::detach_lifetime(slice.slice()) });
-        } else {
-            // WTF-backed slices release their pin on drop — copy rather than
-            // borrow past it. (`ZigString::to_slice` never produces these.)
-            joiner.push_cloned(slice.slice());
-        }
-    }
+        FormDataEntry::File { blob, filename } => {
+            sink.push_static(b"\"; filename=\"");
+            sink.push_string(filename.to_slice(), FormDataComponent::Filename);
+            sink.push_static(b"\"\r\n");
 
-    pub(crate) fn on_entry(&mut self, name: ZigString, entry: FormDataEntry<'_>) {
-        if self.failed {
-            return;
-        }
-        // Copy the borrowed refs out first (disjoint-field reads) so the
-        // long-lived `&mut self.joiner` below doesn't conflict.
-        let global_this = self.global_this;
-        let boundary = self.boundary;
-        let joiner = &mut self.joiner;
-
-        joiner.push_static(b"--");
-        joiner.push_static(boundary); // note: "static" here means "outlives the joiner"
-        joiner.push_static(b"\r\n");
-
-        joiner.push_static(b"Content-Disposition: form-data; name=\"");
-        Self::push_string_slice(joiner, name.to_slice(), FormDataComponent::Name);
-
-        match entry {
-            FormDataEntry::String(value) => {
-                joiner.push_static(b"\"\r\n\r\n");
-                Self::push_string_slice(joiner, value.to_slice(), FormDataComponent::StringValue);
-            }
-            FormDataEntry::File { blob, filename } => {
-                joiner.push_static(b"\"; filename=\"");
-                Self::push_string_slice(joiner, filename.to_slice(), FormDataComponent::Filename);
-                joiner.push_static(b"\"\r\n");
-
-                // Borrowed from the blob, which the `DOMFormData` keeps alive
-                // past `joiner.done()`.
-                let blob_ct = blob.content_type_slice();
-                let content_type: &[u8] = if !blob_ct.is_empty()
-                    && !blob_ct.iter().any(|&b| matches!(b, b'\r' | b'\n'))
-                {
+            let blob_ct = blob.content_type_slice();
+            let content_type: &[u8] =
+                if !blob_ct.is_empty() && !blob_ct.iter().any(|&b| matches!(b, b'\r' | b'\n')) {
                     blob_ct
                 } else {
                     b"application/octet-stream"
                 };
-                joiner.push_static(b"Content-Type: ");
-                // SAFETY: either a `'static` literal or borrowed from the entry's Blob,
-                // which the `DOMFormData` keeps alive past `joiner.done()` in
-                // `from_dom_form_data`.
-                joiner.push(unsafe { bun_ptr::detach_lifetime(content_type) });
-                joiner.push_static(b"\r\n\r\n");
+            sink.push_static(b"Content-Type: ");
+            sink.push_borrowed(content_type);
+            sink.push_static(b"\r\n\r\n");
 
-                if blob.store.get().is_some() {
-                    if blob.size.get() == MAX_SIZE {
-                        blob.resolve_size();
-                    }
-                    let store = blob
-                        .store
-                        .get()
-                        .as_deref()
-                        .expect("infallible: store present");
-                    match &store.data {
-                        store::Data::S3(_) => {
-                            // TODO: s3
-                            // we need to make this async and use download/downloadSlice
+            if blob.store.get().is_some() {
+                if blob.size.get() == MAX_SIZE {
+                    blob.resolve_size();
+                }
+                blob_body(sink, blob);
+            }
+        }
+    }
+
+    sink.push_static(b"\r\n");
+}
+
+impl MultipartSink for StringJoiner<'_> {
+    fn push_static(&mut self, bytes: &'static [u8]) {
+        StringJoiner::push_static(self, bytes);
+    }
+    fn push_borrowed(&mut self, bytes: &[u8]) {
+        // SAFETY: `push_borrowed` callers (boundary, blob content-type) borrow
+        // from storage that outlives `joiner.done()` in `from_dom_form_data`.
+        self.push(unsafe { bun_ptr::detach_lifetime(bytes) });
+    }
+    fn push_string(&mut self, slice: ZigStringSlice, component: FormDataComponent) {
+        if let Some(encoded) = encode_form_data_component(slice.slice(), component) {
+            self.push_owned(encoded);
+        } else if matches!(slice, ZigStringSlice::Owned(_)) {
+            self.push_owned(slice.into_vec().into_boxed_slice());
+        } else if matches!(slice, ZigStringSlice::Static(..)) {
+            // SAFETY: `Static` bytes are owned by the `DOMFormData` being
+            // serialized, which outlives `joiner.done()`.
+            self.push(unsafe { bun_ptr::detach_lifetime(slice.slice()) });
+        } else {
+            self.push_cloned(slice.slice());
+        }
+    }
+}
+
+impl FormDataContext<'_> {
+    pub(crate) fn on_entry(&mut self, name: ZigString, entry: FormDataEntry<'_>) {
+        if self.failed {
+            return;
+        }
+        let global_this = self.global_this;
+        let boundary = self.boundary;
+        let failed = &mut self.failed;
+        write_multipart_entry(&mut self.joiner, boundary, name, entry, |joiner, blob| {
+            let store = blob
+                .store
+                .get()
+                .as_deref()
+                .expect("infallible: store present");
+            match &store.data {
+                store::Data::S3(_) => {
+                    // TODO: s3
+                    // we need to make this async and use download/downloadSlice
+                }
+                store::Data::File(file) => {
+                    // TODO: make this async + lazy
+                    let mut node_fs = crate::node::fs::NodeFS::default();
+                    let mut rf_args = crate::node::fs::args::ReadFile::default();
+                    rf_args.encoding = crate::node::types::Encoding::Buffer;
+                    rf_args.path = file.pathlike.clone();
+                    rf_args.offset = blob.offset.get();
+                    rf_args.max_size = Some(blob.size.get());
+                    match node_fs.read_file(&rf_args, crate::node::fs::Flavor::Sync) {
+                        Err(err) => {
+                            *failed = true;
+                            let js_err = err.to_js(global_this);
+                            let _ = global_this.throw_value(js_err);
                         }
-                        store::Data::File(file) => {
-                            // TODO: make this async + lazy
-                            // Use a fresh stack
-                            // `NodeFS` (it is stateless aside from a path scratch
-                            // buffer; a per-VM cache would be purely a perf reuse).
-                            let mut node_fs = crate::node::fs::NodeFS::default();
-                            // `ReadFile` has `Drop`; can't use FRU `..Default::default()`.
-                            let mut rf_args = crate::node::fs::args::ReadFile::default();
-                            rf_args.encoding = crate::node::types::Encoding::Buffer;
-                            rf_args.path = file.pathlike.clone();
-                            rf_args.offset = blob.offset.get();
-                            rf_args.max_size = Some(blob.size.get());
-                            let res = node_fs.read_file(&rf_args, crate::node::fs::Flavor::Sync);
-                            match res {
-                                Err(err) => {
-                                    self.failed = true;
-                                    let js_err = err.to_js(global_this);
-                                    let _ = global_this.throw_value(js_err);
-                                }
-                                Ok(mut result) => {
-                                    joiner.push_cloned(result.slice());
-                                    // StringOrBuffer::Drop is a no-op for Buffer; release
-                                    // the readFile allocation explicitly.
-                                    if let crate::node::types::StringOrBuffer::Buffer(buf) =
-                                        &mut result
-                                    {
-                                        buf.destroy();
-                                    }
-                                }
+                        Ok(mut result) => {
+                            joiner.push_cloned(result.slice());
+                            if let crate::node::types::StringOrBuffer::Buffer(buf) = &mut result {
+                                buf.destroy();
                             }
-                        }
-                        store::Data::Bytes(_) => {
-                            // SAFETY: borrowed from the blob's store, which the
-                            // `DOMFormData` entry keeps alive until after
-                            // `joiner.done()`.
-                            joiner.push(unsafe { bun_ptr::detach_lifetime(blob.shared_view()) });
                         }
                     }
                 }
+                store::Data::Bytes(_) => {
+                    // SAFETY: borrowed from the blob's store, which the
+                    // `DOMFormData` entry keeps alive until after `joiner.done()`.
+                    joiner.push(unsafe { bun_ptr::detach_lifetime(blob.shared_view()) });
+                }
             }
-        }
-
-        joiner.push_static(b"\r\n");
+        });
     }
 }
 
@@ -4074,18 +4076,26 @@ struct MultipartSegmentBuilder<'a> {
     failed: bool,
 }
 
-impl MultipartSegmentBuilder<'_> {
-    fn push(&mut self, bytes: &[u8]) {
-        self.current.extend_from_slice(bytes);
-        self.total_size += bytes.len() as u64;
+impl MultipartSink for MultipartSegmentBuilder<'_> {
+    fn push_static(&mut self, bytes: &'static [u8]) {
+        self.push(bytes);
     }
-
+    fn push_borrowed(&mut self, bytes: &[u8]) {
+        self.push(bytes);
+    }
     fn push_string(&mut self, slice: ZigStringSlice, component: FormDataComponent) {
         if let Some(encoded) = encode_form_data_component(slice.slice(), component) {
             self.push(&encoded);
         } else {
             self.push(slice.slice());
         }
+    }
+}
+
+impl MultipartSegmentBuilder<'_> {
+    fn push(&mut self, bytes: &[u8]) {
+        self.current.extend_from_slice(bytes);
+        self.total_size += bytes.len() as u64;
     }
 
     fn flush_bytes(&mut self) {
@@ -4102,71 +4112,36 @@ impl MultipartSegmentBuilder<'_> {
         if self.failed {
             return;
         }
-        self.push(b"--");
-        self.push(self.boundary);
-        self.push(b"\r\n");
-        self.push(b"Content-Disposition: form-data; name=\"");
-        self.push_string(name.to_slice(), FormDataComponent::Name);
-
-        match entry {
-            FormDataEntry::String(value) => {
-                self.push(b"\"\r\n\r\n");
-                self.push_string(value.to_slice(), FormDataComponent::StringValue);
-            }
-            FormDataEntry::File { blob, filename } => {
-                self.push(b"\"; filename=\"");
-                self.push_string(filename.to_slice(), FormDataComponent::Filename);
-                self.push(b"\"\r\n");
-
-                let blob_ct = blob.content_type_slice();
-                let content_type: &[u8] = if !blob_ct.is_empty()
-                    && !blob_ct.iter().any(|&b| matches!(b, b'\r' | b'\n'))
-                {
-                    blob_ct
-                } else {
-                    b"application/octet-stream"
-                };
-                self.push(b"Content-Type: ");
-                self.push(content_type);
-                self.push(b"\r\n\r\n");
-
-                if blob.store.get().is_some() {
-                    if blob.size.get() == MAX_SIZE {
-                        blob.resolve_size();
+        let boundary = self.boundary;
+        write_multipart_entry(self, boundary, name, entry, |this, blob| {
+            let store = blob.store.get().as_ref().unwrap().clone();
+            match store.data_mut().tag() {
+                // `needs_streaming_multipart` rejects S3; unreachable here.
+                store::DataTag::S3 => {}
+                store::DataTag::File => {
+                    let size = blob.size.get();
+                    // `seekable == None` ⇒ stat failed; `size == MAX_SIZE`
+                    // ⇒ pipe/FIFO. Both lack a Content-Length: fall back
+                    // to the buffered path so the sync read handles it.
+                    if size == MAX_SIZE || store.data_mut().as_file().seekable.is_none() {
+                        this.failed = true;
+                        return;
                     }
-                    let store = blob.store.get().as_ref().unwrap().clone();
-                    match store.data_mut().tag() {
-                        // `needs_streaming_multipart` rejects S3; unreachable here.
-                        store::DataTag::S3 => {}
-                        store::DataTag::File => {
-                            let size = blob.size.get();
-                            // `seekable == None` ⇒ stat failed; `size == MAX_SIZE`
-                            // ⇒ pipe/FIFO. Both lack a Content-Length: fall back
-                            // to the buffered path so the sync read handles it.
-                            if size == MAX_SIZE || store.data_mut().as_file().seekable.is_none() {
-                                self.failed = true;
-                                return;
-                            }
-                            self.flush_bytes();
-                            self.segments.push(
-                                crate::webcore::multipart_form_loader::Segment::File {
-                                    store,
-                                    pos: blob.offset.get(),
-                                    remain: size,
-                                    fd: Fd::INVALID,
-                                },
-                            );
-                            self.total_size += size;
-                        }
-                        store::DataTag::Bytes => {
-                            self.push(blob.shared_view());
-                        }
-                    }
+                    this.flush_bytes();
+                    this.segments
+                        .push(crate::webcore::multipart_form_loader::Segment::File {
+                            store,
+                            pos: blob.offset.get(),
+                            remain: size,
+                            fd: Fd::INVALID,
+                        });
+                    this.total_size += size;
+                }
+                store::DataTag::Bytes => {
+                    this.push(blob.shared_view());
                 }
             }
-        }
-
-        self.push(b"\r\n");
+        });
     }
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4059,12 +4059,7 @@ impl FormDataContext<'_> {
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Streaming multipart serialization
-// ──────────────────────────────────────────────────────────────────────────
-
-/// Serialized `multipart/form-data` body whose file-backed parts are kept as
-/// references to be read in chunks at send time.
+/// Multipart body split so file-backed parts can be read in chunks at send time.
 pub struct MultipartSegments {
     pub segments: Vec<crate::webcore::multipart_form_loader::Segment>,
     pub content_type: Box<[u8]>,
@@ -4141,19 +4136,13 @@ impl MultipartSegmentBuilder<'_> {
                     }
                     let store = blob.store.get().as_ref().unwrap().clone();
                     match store.data_mut().tag() {
-                        store::DataTag::S3 => {
-                            // Not reachable: `needs_streaming_multipart` only selects
-                            // this path for file-backed stores. S3 parts fall through
-                            // to the buffered serializer.
-                        }
+                        // `needs_streaming_multipart` rejects S3; unreachable here.
+                        store::DataTag::S3 => {}
                         store::DataTag::File => {
                             let size = blob.size.get();
-                            // `resolve_size` leaves `seekable == None` when stat
-                            // failed (missing file) and `size == MAX_SIZE` for a
-                            // non-seekable fd (pipe/FIFO). Both mean we cannot
-                            // emit a valid Content-Length; fall back to the
-                            // buffered path so the synchronous read surfaces the
-                            // error (or drains the pipe) there.
+                            // `seekable == None` ⇒ stat failed; `size == MAX_SIZE`
+                            // ⇒ pipe/FIFO. Both lack a Content-Length: fall back
+                            // to the buffered path so the sync read handles it.
                             if size == MAX_SIZE || store.data_mut().as_file().seekable.is_none() {
                                 self.failed = true;
                                 return;
@@ -4182,10 +4171,8 @@ impl MultipartSegmentBuilder<'_> {
 }
 
 impl MultipartSegments {
-    /// Build the segment representation of a `FormData` multipart body.
-    /// Boundary generation, header formatting and escaping match
-    /// [`Blob::from_dom_form_data`]; the difference is that file-backed parts
-    /// are recorded as `Segment::File` instead of being read into memory.
+    /// Same wire encoding as [`Blob::from_dom_form_data`], but file-backed
+    /// parts are kept as `Segment::File` instead of read into memory.
     pub fn from_dom_form_data(
         global_this: &JSGlobalObject,
         form_data: &mut jsc::DOMFormData,
@@ -4265,8 +4252,7 @@ impl MultipartSegments {
         })
     }
 
-    /// True when streaming the body instead of buffering it is worthwhile:
-    /// at least one file-backed entry and no S3 or unsized (pipe/FIFO) entry.
+    /// At least one file-backed entry and no S3 entry.
     pub fn needs_streaming_multipart(form_data: &mut jsc::DOMFormData) -> bool {
         struct Probe {
             has_file: bool,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4060,6 +4060,257 @@ impl FormDataContext<'_> {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// Streaming multipart serialization
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Serialized `multipart/form-data` body whose file-backed parts are kept as
+/// references to be read in chunks at send time.
+pub struct MultipartSegments {
+    pub segments: Vec<crate::webcore::multipart_form_loader::Segment>,
+    pub content_type: Box<[u8]>,
+    pub total_size: u64,
+}
+
+struct MultipartSegmentBuilder<'a> {
+    segments: Vec<crate::webcore::multipart_form_loader::Segment>,
+    current: Vec<u8>,
+    total_size: u64,
+    boundary: &'a [u8],
+    failed: bool,
+}
+
+impl MultipartSegmentBuilder<'_> {
+    fn push(&mut self, bytes: &[u8]) {
+        self.current.extend_from_slice(bytes);
+        self.total_size += bytes.len() as u64;
+    }
+
+    fn push_string(&mut self, slice: ZigStringSlice, component: FormDataComponent) {
+        if let Some(encoded) = encode_form_data_component(slice.slice(), component) {
+            self.push(&encoded);
+        } else {
+            self.push(slice.slice());
+        }
+    }
+
+    fn flush_bytes(&mut self) {
+        if !self.current.is_empty() {
+            self.segments
+                .push(crate::webcore::multipart_form_loader::Segment::Bytes {
+                    bytes: core::mem::take(&mut self.current),
+                    offset: 0,
+                });
+        }
+    }
+
+    fn on_entry(&mut self, name: ZigString, entry: FormDataEntry<'_>) {
+        if self.failed {
+            return;
+        }
+        self.push(b"--");
+        self.push(self.boundary);
+        self.push(b"\r\n");
+        self.push(b"Content-Disposition: form-data; name=\"");
+        self.push_string(name.to_slice(), FormDataComponent::Name);
+
+        match entry {
+            FormDataEntry::String(value) => {
+                self.push(b"\"\r\n\r\n");
+                self.push_string(value.to_slice(), FormDataComponent::StringValue);
+            }
+            FormDataEntry::File { blob, filename } => {
+                self.push(b"\"; filename=\"");
+                self.push_string(filename.to_slice(), FormDataComponent::Filename);
+                self.push(b"\"\r\n");
+
+                let blob_ct = blob.content_type_slice();
+                let content_type: &[u8] = if !blob_ct.is_empty()
+                    && !blob_ct.iter().any(|&b| matches!(b, b'\r' | b'\n'))
+                {
+                    blob_ct
+                } else {
+                    b"application/octet-stream"
+                };
+                self.push(b"Content-Type: ");
+                self.push(content_type);
+                self.push(b"\r\n\r\n");
+
+                if blob.store.get().is_some() {
+                    if blob.size.get() == MAX_SIZE {
+                        blob.resolve_size();
+                    }
+                    let store = blob.store.get().as_ref().unwrap().clone();
+                    match store.data_mut().tag() {
+                        store::DataTag::S3 => {
+                            // Not reachable: `needs_streaming_multipart` only selects
+                            // this path for file-backed stores. S3 parts fall through
+                            // to the buffered serializer.
+                        }
+                        store::DataTag::File => {
+                            let size = blob.size.get();
+                            // `resolve_size` leaves `seekable == None` when stat
+                            // failed (missing file) and `size == MAX_SIZE` for a
+                            // non-seekable fd (pipe/FIFO). Both mean we cannot
+                            // emit a valid Content-Length; fall back to the
+                            // buffered path so the synchronous read surfaces the
+                            // error (or drains the pipe) there.
+                            if size == MAX_SIZE || store.data_mut().as_file().seekable.is_none() {
+                                self.failed = true;
+                                return;
+                            }
+                            self.flush_bytes();
+                            self.segments.push(
+                                crate::webcore::multipart_form_loader::Segment::File {
+                                    store,
+                                    pos: blob.offset.get(),
+                                    remain: size,
+                                    fd: Fd::INVALID,
+                                },
+                            );
+                            self.total_size += size;
+                        }
+                        store::DataTag::Bytes => {
+                            self.push(blob.shared_view());
+                        }
+                    }
+                }
+            }
+        }
+
+        self.push(b"\r\n");
+    }
+}
+
+impl MultipartSegments {
+    /// Build the segment representation of a `FormData` multipart body.
+    /// Boundary generation, header formatting and escaping match
+    /// [`Blob::from_dom_form_data`]; the difference is that file-backed parts
+    /// are recorded as `Segment::File` instead of being read into memory.
+    pub fn from_dom_form_data(
+        global_this: &JSGlobalObject,
+        form_data: &mut jsc::DOMFormData,
+    ) -> Option<Self> {
+        const BOUNDARY_PREFIX: &[u8; 22] = b"----WebKitFormBoundary";
+        let mut boundary_buf = [0u8; BOUNDARY_PREFIX.len() + 32];
+        let boundary: &[u8] = {
+            let random = global_this.bun_vm().as_mut().rare_data().next_uuid().bytes;
+            boundary_buf[..BOUNDARY_PREFIX.len()].copy_from_slice(BOUNDARY_PREFIX);
+            bun_core::fmt::bytes_to_hex_lower(&random, &mut boundary_buf[BOUNDARY_PREFIX.len()..]);
+            &boundary_buf
+        };
+
+        let mut ctx = MultipartSegmentBuilder {
+            segments: Vec::with_capacity(form_data.count() * 2 + 1),
+            current: Vec::new(),
+            total_size: 0,
+            boundary,
+            failed: false,
+        };
+
+        extern "C" fn for_each_thunk(
+            ctx_ptr: *mut c_void,
+            name_: *mut ZigString,
+            value_ptr: *mut c_void,
+            filename: *mut ZigString,
+            is_blob: u8,
+        ) {
+            // SAFETY: `ctx_ptr` is the `&mut MultipartSegmentBuilder` passed below.
+            let ctx = unsafe { bun_ptr::callback_ctx::<MultipartSegmentBuilder<'_>>(ctx_ptr) };
+            let entry = if is_blob == 0 {
+                // SAFETY: when `is_blob == 0`, `value_ptr` points to a `ZigString`.
+                FormDataEntry::String(unsafe { *value_ptr.cast::<ZigString>() })
+            } else {
+                FormDataEntry::File {
+                    // SAFETY: `value_ptr` is the C++ `JSBlob::m_ctx` (`*mut Blob`);
+                    // valid for the synchronous callback scope.
+                    blob: unsafe { &mut *value_ptr.cast::<Blob>() },
+                    filename: if filename.is_null() {
+                        ZigString::EMPTY
+                    } else {
+                        // SAFETY: non-null `filename` is a valid `*ZigString`.
+                        unsafe { *filename }
+                    },
+                }
+            };
+            // SAFETY: `name_` is always a valid non-null `*ZigString`.
+            ctx.on_entry(unsafe { *name_ }, entry);
+        }
+        unsafe extern "C" {
+            safe fn DOMFormData__forEach(
+                this: *mut jsc::DOMFormData,
+                ctx: *mut c_void,
+                cb: extern "C" fn(*mut c_void, *mut ZigString, *mut c_void, *mut ZigString, u8),
+            );
+        }
+        DOMFormData__forEach(form_data, (&raw mut ctx).cast::<c_void>(), for_each_thunk);
+
+        if ctx.failed {
+            return None;
+        }
+
+        ctx.push(b"--");
+        ctx.push(boundary);
+        ctx.push(b"--\r\n");
+        ctx.flush_bytes();
+
+        const CONTENT_TYPE_PREFIX: &[u8] = b"multipart/form-data; boundary=";
+        let mut ct = Vec::with_capacity(CONTENT_TYPE_PREFIX.len() + boundary.len());
+        ct.extend_from_slice(CONTENT_TYPE_PREFIX);
+        ct.extend_from_slice(boundary);
+
+        Some(Self {
+            segments: ctx.segments,
+            content_type: ct.into_boxed_slice(),
+            total_size: ctx.total_size,
+        })
+    }
+
+    /// True when streaming the body instead of buffering it is worthwhile:
+    /// at least one file-backed entry and no S3 or unsized (pipe/FIFO) entry.
+    pub fn needs_streaming_multipart(form_data: &mut jsc::DOMFormData) -> bool {
+        struct Probe {
+            has_file: bool,
+            unsupported: bool,
+        }
+        let mut probe = Probe {
+            has_file: false,
+            unsupported: false,
+        };
+        extern "C" fn thunk(
+            ctx_ptr: *mut c_void,
+            _name: *mut ZigString,
+            value_ptr: *mut c_void,
+            _filename: *mut ZigString,
+            is_blob: u8,
+        ) {
+            // SAFETY: `ctx_ptr` is the `&mut Probe` passed below.
+            let probe = unsafe { bun_ptr::callback_ctx::<Probe>(ctx_ptr) };
+            if probe.unsupported || is_blob == 0 {
+                return;
+            }
+            // SAFETY: `value_ptr` is the C++ `JSBlob::m_ctx` (`*mut Blob`).
+            let blob = unsafe { &*value_ptr.cast::<Blob>() };
+            if let Some(store) = blob.store.get().as_ref() {
+                match store.data_mut().tag() {
+                    store::DataTag::File => probe.has_file = true,
+                    store::DataTag::S3 => probe.unsupported = true,
+                    store::DataTag::Bytes => {}
+                }
+            }
+        }
+        unsafe extern "C" {
+            safe fn DOMFormData__forEach(
+                this: *mut jsc::DOMFormData,
+                ctx: *mut c_void,
+                cb: extern "C" fn(*mut c_void, *mut ZigString, *mut c_void, *mut ZigString, u8),
+            );
+        }
+        DOMFormData__forEach(form_data, (&raw mut probe).cast::<c_void>(), thunk);
+        probe.has_file && !probe.unsupported
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // getContentType
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -866,16 +866,8 @@ impl BlobExt for Blob {
     }
 
     fn from_dom_form_data(global_this: &JSGlobalObject, form_data: &mut jsc::DOMFormData) -> Blob {
-        // "----WebKitFormBoundary" (22 bytes) + 32 lowercase-hex chars of a fresh UUID.
-        const BOUNDARY_PREFIX: &[u8; 22] = b"----WebKitFormBoundary";
-        let mut boundary_buf = [0u8; BOUNDARY_PREFIX.len() + 32];
-        let boundary: &[u8] = {
-            // SAFETY: bun_vm() never returns null for a Bun-owned global.
-            let random = global_this.bun_vm().as_mut().rare_data().next_uuid().bytes;
-            boundary_buf[..BOUNDARY_PREFIX.len()].copy_from_slice(BOUNDARY_PREFIX);
-            bun_core::fmt::bytes_to_hex_lower(&random, &mut boundary_buf[BOUNDARY_PREFIX.len()..]);
-            &boundary_buf
-        };
+        let boundary_buf = make_multipart_boundary(global_this);
+        let boundary: &[u8] = &boundary_buf;
 
         let mut context = FormDataContext {
             joiner: bun_core::string_joiner::StringJoiner::default(),
@@ -887,66 +879,7 @@ impl BlobExt for Blob {
         // string entry 8, plus 3 for the closing boundary.
         context.joiner.reserve(form_data.count() * 13 + 3);
 
-        // `bun_jsc::DOMFormData::for_each` yields the
-        // lower-tier `bun_jsc::dom_form_data::FormDataEntry`, whose `blob`
-        // field is `&bun_jsc::WebCore::Blob` (the forward-decl). The native
-        // pointer the C++ hands us is the `m_ctx` `*mut Blob`; reinterpret it
-        // as the runtime `&mut Blob` here. Driving the FFI directly (rather
-        // than going through `for_each`'s immutable wrapper) avoids a
-        // `&T → &mut T` cast. Every raw deref is wrapped locally; the safe fn
-        // item coerces to the callback-pointer type at `DOMFormData__forEach`.
-        extern "C" fn for_each_thunk(
-            ctx_ptr: *mut c_void,
-            name_: *mut ZigString,
-            value_ptr: *mut c_void,
-            filename: *mut ZigString,
-            is_blob: u8,
-        ) {
-            // SAFETY: `ctx_ptr` is the `&mut FormDataContext` passed below; the
-            // erased lifetime is the caller's stack frame in `from_dom_form_data`.
-            let ctx = unsafe { bun_ptr::callback_ctx::<FormDataContext<'_>>(ctx_ptr) };
-            let entry = if is_blob == 0 {
-                // SAFETY: when `is_blob == 0`, `value_ptr` points to a `ZigString`.
-                FormDataEntry::String(unsafe { *value_ptr.cast::<ZigString>() })
-            } else {
-                FormDataEntry::File {
-                    // SAFETY: `value_ptr` is the C++ `JSBlob::m_ctx` (`*mut Blob`);
-                    // valid for the synchronous callback scope.
-                    blob: unsafe { &mut *value_ptr.cast::<Blob>() },
-                    filename: if filename.is_null() {
-                        ZigString::EMPTY
-                    } else {
-                        // SAFETY: non-null `filename` is a valid `*ZigString` for this call.
-                        unsafe { *filename }
-                    },
-                }
-            };
-            // SAFETY: `name_` is always a valid non-null `*ZigString` for this callback.
-            ctx.on_entry(unsafe { *name_ }, entry);
-        }
-        unsafe extern "C" {
-            // `this` is the `&mut DOMFormData` param (coerced); `ctx`/`cb` are
-            // stored opaquely and only used synchronously. Module-private with
-            // one call site below — no caller-side precondition remains. Kept
-            // `*mut` (not `&mut`) to match the `bun_jsc` decl and avoid
-            // `clashing_extern_declarations`.
-            safe fn DOMFormData__forEach(
-                this: *mut jsc::DOMFormData,
-                ctx: *mut c_void,
-                // Safe fn-ptr: `for_each_thunk` is a safe `extern "C" fn` (its
-                // body localises every raw deref individually), so the callback
-                // type carries no caller-side precondition. ABI-identical to
-                // `bun_jsc`'s `ForEachFunction` alias.
-                cb: extern "C" fn(*mut c_void, *mut ZigString, *mut c_void, *mut ZigString, u8),
-            );
-        }
-        // C++ invokes the callback synchronously and does not retain `ctx`/`cb`
-        // past this call.
-        DOMFormData__forEach(
-            form_data,
-            (&raw mut context).cast::<c_void>(),
-            for_each_thunk,
-        );
+        for_each_form_data_entry(form_data, |name, entry| context.on_entry(name, entry));
         if context.failed {
             // Drop the joiner (Drop runs StringJoiner::deinit) so every
             // heap-owned slice already pushed — escaped names, non-ASCII
@@ -3829,6 +3762,67 @@ pub enum FormDataEntry<'a> {
     },
 }
 
+unsafe extern "C" {
+    // `this` is the `&mut DOMFormData` param (coerced); `ctx`/`cb` are stored
+    // opaquely and only used synchronously. Kept `*mut` (not `&mut`) to match
+    // the `bun_jsc` decl and avoid `clashing_extern_declarations`.
+    safe fn DOMFormData__forEach(
+        this: *mut jsc::DOMFormData,
+        ctx: *mut c_void,
+        cb: extern "C" fn(*mut c_void, *mut ZigString, *mut c_void, *mut ZigString, u8),
+    );
+}
+
+/// Drive the C++ `DOMFormData__forEach` and hand each entry to `f` as the
+/// runtime's mutable [`FormDataEntry`]. The C++ side invokes the callback
+/// synchronously and does not retain `ctx`/`cb`.
+fn for_each_form_data_entry<F: FnMut(ZigString, FormDataEntry<'_>)>(
+    form_data: &mut jsc::DOMFormData,
+    mut f: F,
+) {
+    extern "C" fn thunk<F: FnMut(ZigString, FormDataEntry<'_>)>(
+        ctx_ptr: *mut c_void,
+        name_: *mut ZigString,
+        value_ptr: *mut c_void,
+        filename: *mut ZigString,
+        is_blob: u8,
+    ) {
+        // SAFETY: `ctx_ptr` is `&mut F` for the caller's synchronous stack frame.
+        let f = unsafe { bun_ptr::callback_ctx::<F>(ctx_ptr) };
+        let entry = if is_blob == 0 {
+            // SAFETY: when `is_blob == 0`, `value_ptr` points to a `ZigString`.
+            FormDataEntry::String(unsafe { *value_ptr.cast::<ZigString>() })
+        } else {
+            FormDataEntry::File {
+                // SAFETY: `value_ptr` is the C++ `JSBlob::m_ctx` (`*mut Blob`);
+                // valid for the synchronous callback scope.
+                blob: unsafe { &mut *value_ptr.cast::<Blob>() },
+                filename: if filename.is_null() {
+                    ZigString::EMPTY
+                } else {
+                    // SAFETY: non-null `filename` is a valid `*ZigString`.
+                    unsafe { *filename }
+                },
+            }
+        };
+        // SAFETY: `name_` is always a valid non-null `*ZigString`.
+        f(unsafe { *name_ }, entry);
+    }
+    DOMFormData__forEach(form_data, (&raw mut f).cast::<c_void>(), thunk::<F>);
+}
+
+/// `----WebKitFormBoundary` + 32 lowercase-hex chars of a fresh UUID.
+pub(crate) const MULTIPART_BOUNDARY_LEN: usize = 22 + 32;
+
+fn make_multipart_boundary(global_this: &JSGlobalObject) -> [u8; MULTIPART_BOUNDARY_LEN] {
+    const PREFIX: &[u8; 22] = b"----WebKitFormBoundary";
+    let mut buf = [0u8; MULTIPART_BOUNDARY_LEN];
+    let random = global_this.bun_vm().as_mut().rare_data().next_uuid().bytes;
+    buf[..PREFIX.len()].copy_from_slice(PREFIX);
+    bun_core::fmt::bytes_to_hex_lower(&random, &mut buf[PREFIX.len()..]);
+    buf
+}
+
 /// Carries `Function(ctx, bytes)` at the type level —
 /// a trait impl so `run` can be taken as a
 /// plain `fn(*mut c_void, ReadFileResultType)` thunk, monomorphized per `(C, F)`.
@@ -4025,12 +4019,10 @@ impl FormDataContext<'_> {
                 .as_deref()
                 .expect("infallible: store present");
             match &store.data {
-                store::Data::S3(_) => {
-                    // TODO: s3
-                    // we need to make this async and use download/downloadSlice
-                }
+                // S3 parts are not read here; the body serialiser is
+                // synchronous and download/downloadSlice are async.
+                store::Data::S3(_) => {}
                 store::Data::File(file) => {
-                    // TODO: make this async + lazy
                     let mut node_fs = crate::node::fs::NodeFS::default();
                     let mut rf_args = crate::node::fs::args::ReadFile::default();
                     rf_args.encoding = crate::node::types::Encoding::Buffer;
@@ -4119,10 +4111,14 @@ impl MultipartSegmentBuilder<'_> {
                 // `needs_streaming_multipart` rejects S3; unreachable here.
                 store::DataTag::S3 => {}
                 store::DataTag::File => {
+                    if store.data_mut().as_file().seekable.is_none() {
+                        resolve_file_stat(&store);
+                    }
                     let size = blob.size.get();
-                    // `seekable == None` ⇒ stat failed; `size == MAX_SIZE`
-                    // ⇒ pipe/FIFO. Both lack a Content-Length: fall back
-                    // to the buffered path so the sync read handles it.
+                    // `seekable` is `None` only when stat failed (missing
+                    // file), `size == MAX_SIZE` only for a non-seekable fd
+                    // (pipe/FIFO). Both lack a Content-Length: fall back so
+                    // the buffered path surfaces the error or drains the pipe.
                     if size == MAX_SIZE || store.data_mut().as_file().seekable.is_none() {
                         this.failed = true;
                         return;
@@ -4152,14 +4148,8 @@ impl MultipartSegments {
         global_this: &JSGlobalObject,
         form_data: &mut jsc::DOMFormData,
     ) -> Option<Self> {
-        const BOUNDARY_PREFIX: &[u8; 22] = b"----WebKitFormBoundary";
-        let mut boundary_buf = [0u8; BOUNDARY_PREFIX.len() + 32];
-        let boundary: &[u8] = {
-            let random = global_this.bun_vm().as_mut().rare_data().next_uuid().bytes;
-            boundary_buf[..BOUNDARY_PREFIX.len()].copy_from_slice(BOUNDARY_PREFIX);
-            bun_core::fmt::bytes_to_hex_lower(&random, &mut boundary_buf[BOUNDARY_PREFIX.len()..]);
-            &boundary_buf
-        };
+        let boundary_buf = make_multipart_boundary(global_this);
+        let boundary: &[u8] = &boundary_buf;
 
         let mut ctx = MultipartSegmentBuilder {
             segments: Vec::with_capacity(form_data.count() * 2 + 1),
@@ -4169,42 +4159,7 @@ impl MultipartSegments {
             failed: false,
         };
 
-        extern "C" fn for_each_thunk(
-            ctx_ptr: *mut c_void,
-            name_: *mut ZigString,
-            value_ptr: *mut c_void,
-            filename: *mut ZigString,
-            is_blob: u8,
-        ) {
-            // SAFETY: `ctx_ptr` is the `&mut MultipartSegmentBuilder` passed below.
-            let ctx = unsafe { bun_ptr::callback_ctx::<MultipartSegmentBuilder<'_>>(ctx_ptr) };
-            let entry = if is_blob == 0 {
-                // SAFETY: when `is_blob == 0`, `value_ptr` points to a `ZigString`.
-                FormDataEntry::String(unsafe { *value_ptr.cast::<ZigString>() })
-            } else {
-                FormDataEntry::File {
-                    // SAFETY: `value_ptr` is the C++ `JSBlob::m_ctx` (`*mut Blob`);
-                    // valid for the synchronous callback scope.
-                    blob: unsafe { &mut *value_ptr.cast::<Blob>() },
-                    filename: if filename.is_null() {
-                        ZigString::EMPTY
-                    } else {
-                        // SAFETY: non-null `filename` is a valid `*ZigString`.
-                        unsafe { *filename }
-                    },
-                }
-            };
-            // SAFETY: `name_` is always a valid non-null `*ZigString`.
-            ctx.on_entry(unsafe { *name_ }, entry);
-        }
-        unsafe extern "C" {
-            safe fn DOMFormData__forEach(
-                this: *mut jsc::DOMFormData,
-                ctx: *mut c_void,
-                cb: extern "C" fn(*mut c_void, *mut ZigString, *mut c_void, *mut ZigString, u8),
-            );
-        }
-        DOMFormData__forEach(form_data, (&raw mut ctx).cast::<c_void>(), for_each_thunk);
+        for_each_form_data_entry(form_data, |name, entry| ctx.on_entry(name, entry));
 
         if ctx.failed {
             return None;
@@ -4229,45 +4184,23 @@ impl MultipartSegments {
 
     /// At least one file-backed entry and no S3 entry.
     pub fn needs_streaming_multipart(form_data: &mut jsc::DOMFormData) -> bool {
-        struct Probe {
-            has_file: bool,
-            unsupported: bool,
-        }
-        let mut probe = Probe {
-            has_file: false,
-            unsupported: false,
-        };
-        extern "C" fn thunk(
-            ctx_ptr: *mut c_void,
-            _name: *mut ZigString,
-            value_ptr: *mut c_void,
-            _filename: *mut ZigString,
-            is_blob: u8,
-        ) {
-            // SAFETY: `ctx_ptr` is the `&mut Probe` passed below.
-            let probe = unsafe { bun_ptr::callback_ctx::<Probe>(ctx_ptr) };
-            if probe.unsupported || is_blob == 0 {
+        let mut has_file = false;
+        let mut unsupported = false;
+        for_each_form_data_entry(form_data, |_name, entry| {
+            if unsupported {
                 return;
             }
-            // SAFETY: `value_ptr` is the C++ `JSBlob::m_ctx` (`*mut Blob`).
-            let blob = unsafe { &*value_ptr.cast::<Blob>() };
-            if let Some(store) = blob.store.get().as_ref() {
+            if let FormDataEntry::File { blob, .. } = entry
+                && let Some(store) = blob.store.get().as_ref()
+            {
                 match store.data_mut().tag() {
-                    store::DataTag::File => probe.has_file = true,
-                    store::DataTag::S3 => probe.unsupported = true,
+                    store::DataTag::File => has_file = true,
+                    store::DataTag::S3 => unsupported = true,
                     store::DataTag::Bytes => {}
                 }
             }
-        }
-        unsafe extern "C" {
-            safe fn DOMFormData__forEach(
-                this: *mut jsc::DOMFormData,
-                ctx: *mut c_void,
-                cb: extern "C" fn(*mut c_void, *mut ZigString, *mut c_void, *mut ZigString, u8),
-            );
-        }
-        DOMFormData__forEach(form_data, (&raw mut probe).cast::<c_void>(), thunk);
-        probe.has_file && !probe.unsupported
+        });
+        has_file && !unsupported
     }
 }
 

--- a/src/runtime/webcore/MultipartFormLoader.rs
+++ b/src/runtime/webcore/MultipartFormLoader.rs
@@ -1,8 +1,5 @@
-//! ReadableStream source that serialises a `multipart/form-data` body as a
-//! sequence of in-memory byte runs and file-backed parts, reading each file
-//! in fixed-size chunks. Used as the `fetch()` request body when a
-//! `FormData` contains `Bun.file()` entries so the whole file is not loaded
-//! into memory at once.
+//! Streams a `multipart/form-data` body for `fetch()` so `Bun.file()` parts
+//! are read in chunks instead of buffered whole.
 
 use bun_jsc::JSValue;
 use bun_sys::{self as sys, Fd, FdExt as _};
@@ -15,9 +12,6 @@ use crate::webcore::streams;
 
 pub type Source = readable_stream::NewSource<MultipartFormLoader>;
 
-/// Chunk size requested from the JS pull loop. Sized so a single file part
-/// drains in a small number of pulls while the in-flight buffer stays well
-/// below the sizes that motivated streaming in the first place.
 const CHUNK_SIZE: blob::SizeType = 256 * 1024;
 
 pub enum Segment {
@@ -27,13 +21,10 @@ pub enum Segment {
     },
     File {
         store: StoreRef,
-        /// Absolute byte offset into the file for the next read (starts at the
-        /// Blob's `offset`, advanced on each `pread`).
+        /// Absolute `pread` offset; starts at the Blob's `offset`.
         pos: u64,
-        /// Bytes still to read from this segment.
         remain: u64,
-        /// Opened lazily on the first pull of this segment; closed when
-        /// `remain` reaches 0 or on cancel/deinit.
+        /// Opened lazily on first pull; closed when drained or on cancel.
         fd: Fd,
     },
 }
@@ -118,9 +109,7 @@ impl readable_stream::SourceContext for MultipartFormLoader {
                             return streams::Result::Err(streams::result::StreamError::Error(err));
                         }
                         Ok(0) => {
-                            // EOF before `remain` was satisfied (file shrank or stat
-                            // over-reported). Finish this segment short rather than
-                            // spinning on a 0-byte read.
+                            // EOF before `remain`: file shrank since stat. Stop short.
                             *remain = 0;
                         }
                         Ok(n) => {

--- a/src/runtime/webcore/MultipartFormLoader.rs
+++ b/src/runtime/webcore/MultipartFormLoader.rs
@@ -44,7 +44,6 @@ pub struct MultipartFormLoader {
     pub segments: Vec<Segment>,
     pub idx: usize,
     pub done: bool,
-    pub total_size: u64,
 }
 
 impl readable_stream::SourceContext for MultipartFormLoader {
@@ -109,8 +108,12 @@ impl readable_stream::SourceContext for MultipartFormLoader {
                             return streams::Result::Err(streams::result::StreamError::Error(err));
                         }
                         Ok(0) => {
-                            // EOF before `remain`: file shrank since stat. Stop short.
-                            *remain = 0;
+                            // File shrank after Content-Length went on the wire:
+                            // abort rather than underrun the promised length.
+                            let err = sys::Error::new(bun_errno::SystemErrno::EIO, sys::Tag::pread)
+                                .with_fd(*fd);
+                            self.clear_data();
+                            return streams::Result::Err(streams::result::StreamError::Error(err));
                         }
                         Ok(n) => {
                             written += n;

--- a/src/runtime/webcore/MultipartFormLoader.rs
+++ b/src/runtime/webcore/MultipartFormLoader.rs
@@ -1,0 +1,205 @@
+//! ReadableStream source that serialises a `multipart/form-data` body as a
+//! sequence of in-memory byte runs and file-backed parts, reading each file
+//! in fixed-size chunks. Used as the `fetch()` request body when a
+//! `FormData` contains `Bun.file()` entries so the whole file is not loaded
+//! into memory at once.
+
+use bun_jsc::JSValue;
+use bun_sys::{self as sys, Fd, FdExt as _};
+
+use crate::node::types::PathLikeExt as _;
+use crate::webcore::blob::{self, StoreRef};
+use crate::webcore::node_types::PathOrFileDescriptor;
+use crate::webcore::readable_stream;
+use crate::webcore::streams;
+
+pub type Source = readable_stream::NewSource<MultipartFormLoader>;
+
+/// Chunk size requested from the JS pull loop. Sized so a single file part
+/// drains in a small number of pulls while the in-flight buffer stays well
+/// below the sizes that motivated streaming in the first place.
+const CHUNK_SIZE: blob::SizeType = 256 * 1024;
+
+pub enum Segment {
+    Bytes {
+        bytes: Vec<u8>,
+        offset: usize,
+    },
+    File {
+        store: StoreRef,
+        /// Absolute byte offset into the file for the next read (starts at the
+        /// Blob's `offset`, advanced on each `pread`).
+        pos: u64,
+        /// Bytes still to read from this segment.
+        remain: u64,
+        /// Opened lazily on the first pull of this segment; closed when
+        /// `remain` reaches 0 or on cancel/deinit.
+        fd: Fd,
+    },
+}
+
+impl Segment {
+    fn close(&mut self) {
+        if let Segment::File { fd, .. } = self
+            && *fd != Fd::INVALID
+        {
+            core::mem::replace(fd, Fd::INVALID).close();
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct MultipartFormLoader {
+    pub segments: Vec<Segment>,
+    pub idx: usize,
+    pub done: bool,
+    pub total_size: u64,
+}
+
+impl readable_stream::SourceContext for MultipartFormLoader {
+    const NAME: &'static str = "MultipartForm";
+    const SUPPORTS_REF: bool = false;
+    crate::source_context_codegen!(js_MultipartFormInternalReadableStreamSource);
+
+    fn on_start(&mut self) -> streams::Start {
+        streams::Start::ChunkSize(CHUNK_SIZE)
+    }
+
+    fn on_pull(&mut self, buffer: &mut [u8], array: JSValue) -> streams::Result {
+        array.ensure_still_alive();
+        let _keep = bun_jsc::EnsureStillAlive(array);
+        if self.done {
+            return streams::Result::Done;
+        }
+
+        let mut written = 0usize;
+        while written < buffer.len() {
+            let Some(seg) = self.segments.get_mut(self.idx) else {
+                break;
+            };
+            match seg {
+                Segment::Bytes { bytes, offset } => {
+                    let src = &bytes[*offset..];
+                    let take = src.len().min(buffer.len() - written);
+                    buffer[written..written + take].copy_from_slice(&src[..take]);
+                    *offset += take;
+                    written += take;
+                    if *offset >= bytes.len() {
+                        *bytes = Vec::new();
+                        self.idx += 1;
+                    }
+                }
+                Segment::File {
+                    store,
+                    pos,
+                    remain,
+                    fd,
+                } => {
+                    if *remain == 0 {
+                        seg.close();
+                        self.idx += 1;
+                        continue;
+                    }
+                    if *fd == Fd::INVALID {
+                        match Self::open(store) {
+                            Ok(opened) => *fd = opened,
+                            Err(err) => {
+                                self.clear_data();
+                                return streams::Result::Err(streams::result::StreamError::Error(
+                                    err,
+                                ));
+                            }
+                        }
+                    }
+                    let want = ((buffer.len() - written) as u64).min(*remain) as usize;
+                    match sys::pread(*fd, &mut buffer[written..written + want], *pos as i64) {
+                        Err(err) => {
+                            self.clear_data();
+                            return streams::Result::Err(streams::result::StreamError::Error(err));
+                        }
+                        Ok(0) => {
+                            // EOF before `remain` was satisfied (file shrank or stat
+                            // over-reported). Finish this segment short rather than
+                            // spinning on a 0-byte read.
+                            *remain = 0;
+                        }
+                        Ok(n) => {
+                            written += n;
+                            *pos += n as u64;
+                            *remain = remain.saturating_sub(n as u64);
+                        }
+                    }
+                    if *remain == 0 {
+                        seg.close();
+                        self.idx += 1;
+                    }
+                }
+            }
+        }
+
+        if self.idx >= self.segments.len() {
+            self.done = true;
+            self.segments = Vec::new();
+            if written == 0 {
+                return streams::Result::Done;
+            }
+            return streams::Result::IntoArrayAndDone(streams::IntoArray {
+                value: array,
+                len: written as blob::SizeType,
+            });
+        }
+
+        streams::Result::IntoArray(streams::IntoArray {
+            value: array,
+            len: written as blob::SizeType,
+        })
+    }
+
+    fn on_cancel(&mut self) {
+        self.clear_data();
+    }
+
+    fn deinit_fn(&mut self) {
+        self.clear_data();
+    }
+
+    fn memory_cost_fn(&self) -> usize {
+        self.segments
+            .iter()
+            .map(|s| match s {
+                Segment::Bytes { bytes, .. } => bytes.len(),
+                Segment::File { .. } => 0,
+            })
+            .sum::<usize>()
+            + self.segments.len() * core::mem::size_of::<Segment>()
+    }
+}
+
+bun_core::impl_field_parent! { MultipartFormLoader => Source.context; pub fn parent_const; pub fn parent; }
+
+impl MultipartFormLoader {
+    fn open(store: &StoreRef) -> sys::Result<Fd> {
+        let file = store.data_mut().as_file();
+        match &file.pathlike {
+            PathOrFileDescriptor::Fd(fd) => sys::dup(*fd),
+            PathOrFileDescriptor::Path(path) => {
+                let mut buf = bun_paths::PathBuffer::uninit();
+                let zpath = path.slice_z(&mut buf);
+                let flags = if cfg!(windows) {
+                    sys::O::RDONLY
+                } else {
+                    sys::O::RDONLY | sys::O::NOCTTY
+                };
+                sys::open(zpath, flags, 0)
+            }
+        }
+    }
+
+    fn clear_data(&mut self) {
+        self.done = true;
+        for seg in self.segments.iter_mut() {
+            seg.close();
+        }
+        self.segments = Vec::new();
+    }
+}

--- a/src/runtime/webcore/MultipartFormLoader.rs
+++ b/src/runtime/webcore/MultipartFormLoader.rs
@@ -14,6 +14,7 @@ pub type Source = readable_stream::NewSource<MultipartFormLoader>;
 
 const CHUNK_SIZE: blob::SizeType = 256 * 1024;
 
+#[derive(Clone)]
 pub enum Segment {
     Bytes {
         bytes: Vec<u8>,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -63,7 +63,6 @@ use crate::node::types::{Encoding, PathOrFileDescriptor};
 use crate::socket::ssl_config::{SSLConfig, SSLConfigFromJs};
 use crate::webcore::blob::BlobExt as _;
 use crate::webcore::body::{Action as BodyValueLockedAction, InternalBlob, Value as BodyValue};
-use crate::webcore::headers_ref::any_blob_content_type_opt;
 use crate::webcore::s3::client as s3;
 use crate::webcore::{
     AbortSignal, Blob, Body, FetchHeaders, ObjectURLRegistry, ReadableStream, Request, Response,
@@ -1392,7 +1391,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
             Some(from_fetch_headers(
                 Some(headers_ref),
-                any_blob_content_type_opt(body.get_any_blob().map(|b| &*b)),
+                body.implied_content_type(),
             ))
         } else {
             headers
@@ -1624,7 +1623,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // `abort_reason()` is the stored `m_reason` (same object as
             // `signal.reason`), not a reconstructed DOMException.
             let reason = sig.abort_reason();
-            if let HTTPRequestBody::ReadableStream(stream_ref) = &body {
+            if let Some(stream_ref) = body.readable_stream() {
                 if let Some(stream) = stream_ref.get(global_this) {
                     stream.cancel_with_reason(global_this, reason);
                 }
@@ -1639,11 +1638,18 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
     }
 
-    if headers.is_none() && body.has_body() && body.has_content_type_from_user() {
-        headers = Some(from_fetch_headers(
-            None,
-            any_blob_content_type_opt(body.get_any_blob().map(|b| &*b)),
-        ));
+    if headers.is_none() && body.has_body() && body.implied_content_type().is_some() {
+        headers = Some(from_fetch_headers(None, body.implied_content_type()));
+    }
+
+    if let HTTPRequestBody::MultipartFormStream { content_length, .. } = &body {
+        let h = headers.get_or_insert_default();
+        if h.get(b"content-length").is_none() {
+            let mut len_buf = [0u8; 20];
+            let len = bun_core::fmt::buf_print(&mut len_buf, format_args!("{content_length}"))
+                .expect("u64 fits in 20 bytes");
+            h.append(b"Content-Length", len);
+        }
     }
 
     // `body` is mutated in place for the sendfile/readfile paths and then

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1206,11 +1206,18 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     //
     // body: BodyInit | null | undefined;
     //
+    // Features that need a fully buffered body keep FormData on the buffered
+    // serializer: S3 signs over the body length, `compress` acts on the bytes.
+    let prefer_buffered_body = url.is_s3() || compress.is_some();
     let mut body = 'extract_body: {
         if let Some(options) = options_object {
             if let Some(body__) = options.fast_get(global_this, jsc::BuiltinName::Body)? {
                 if !body__.is_undefined() {
-                    break 'extract_body Some(HTTPRequestBody::from_js(ctx, body__)?);
+                    break 'extract_body Some(HTTPRequestBody::from_js(
+                        ctx,
+                        body__,
+                        prefer_buffered_body,
+                    )?);
                 }
             }
 
@@ -1278,7 +1285,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         if let Some(req) = request_init_object {
             if let Some(body__) = req.fast_get(global_this, jsc::BuiltinName::Body)? {
                 if !body__.is_undefined() {
-                    break 'extract_body Some(HTTPRequestBody::from_js(ctx, body__)?);
+                    break 'extract_body Some(HTTPRequestBody::from_js(
+                        ctx,
+                        body__,
+                        prefer_buffered_body,
+                    )?);
                 }
             }
         }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -992,6 +992,7 @@ impl FetchTasklet {
                     self.request_stream_restart_pending
                         .store(false, Ordering::Release);
                     self.abort_task();
+                    self.mutex.unlock();
                     return Ok(());
                 }
             }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -961,6 +961,11 @@ impl FetchTasklet {
                 else {
                     unreachable!()
                 };
+                if let Some(s) = stream.get(&global_this) {
+                    // Cancel so the old loader's `on_cancel` → `clear_data()`
+                    // closes its fd now instead of waiting for GC.
+                    s.cancel(&global_this);
+                }
                 stream.deinit();
                 multipart_form_stream(&global_this, segments)
             };

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -135,6 +135,16 @@ pub enum HTTPRequestBody {
     AnyBlob(AnyBlob),
     Sendfile(http::SendFile),
     ReadableStream(ReadableStreamStrong),
+    /// `FormData` body whose file-backed parts are streamed in chunks from
+    /// disk. The stream produces the full multipart encoding; `content_type`
+    /// carries the `multipart/form-data; boundary=...` value and
+    /// `content_length` the precomputed total so the request is sent with an
+    /// explicit `Content-Length` instead of chunked transfer-encoding.
+    MultipartFormStream {
+        stream: ReadableStreamStrong,
+        content_type: Box<[u8]>,
+        content_length: u64,
+    },
 }
 
 impl Default for HTTPRequestBody {
@@ -163,7 +173,8 @@ impl HTTPRequestBody {
     pub fn detach(&mut self) {
         match self {
             HTTPRequestBody::AnyBlob(blob) => blob.detach(),
-            HTTPRequestBody::ReadableStream(stream) => {
+            HTTPRequestBody::ReadableStream(stream)
+            | HTTPRequestBody::MultipartFormStream { stream, .. } => {
                 stream.deinit();
             }
             HTTPRequestBody::Sendfile(sendfile) => {
@@ -176,7 +187,48 @@ impl HTTPRequestBody {
         }
     }
 
+    /// Borrow the streaming `ReadableStream` if this body is one of the
+    /// streaming variants.
+    pub fn readable_stream(&self) -> Option<&ReadableStreamStrong> {
+        match self {
+            HTTPRequestBody::ReadableStream(s)
+            | HTTPRequestBody::MultipartFormStream { stream: s, .. } => Some(s),
+            _ => None,
+        }
+    }
+
     pub fn from_js(global_this: &JSGlobalObject, value: JSValue) -> JsResult<HTTPRequestBody> {
+        if let Some(form_data) = bun_jsc::DOMFormData::from_js(value)
+            && crate::webcore::blob::MultipartSegments::needs_streaming_multipart(form_data)
+            && let Some(segs) =
+                crate::webcore::blob::MultipartSegments::from_dom_form_data(global_this, form_data)
+        {
+            let total_size = segs.total_size;
+            let content_type = segs.content_type;
+            let reader = crate::webcore::readable_stream::NewSource::<
+                crate::webcore::multipart_form_loader::MultipartFormLoader,
+            >::new_mut(crate::webcore::readable_stream::NewSource {
+                global_this: Some(bun_ptr::BackRef::new(global_this)),
+                context: crate::webcore::multipart_form_loader::MultipartFormLoader {
+                    segments: segs.segments,
+                    idx: 0,
+                    done: false,
+                    total_size,
+                },
+                ..Default::default()
+            });
+            let stream_value = reader.to_readable_stream(global_this)?;
+            if let Some(stream) =
+                crate::webcore::ReadableStream::from_js(stream_value, global_this)?
+            {
+                return Ok(HTTPRequestBody::MultipartFormStream {
+                    stream: ReadableStreamStrong::init(stream, global_this),
+                    content_type,
+                    content_length: total_size,
+                });
+            }
+        }
+
         let mut body_value = BodyValue::from_js(global_this, value)?;
         if matches!(body_value, BodyValue::Used)
             || (matches!(&body_value, BodyValue::Locked(l) if !l.action.is_none() || l.is_disturbed2(global_this)))
@@ -229,25 +281,23 @@ impl HTTPRequestBody {
         }
     }
 
-    pub fn has_content_type_from_user(&self) -> bool {
-        match self {
-            HTTPRequestBody::AnyBlob(blob) => blob.has_content_type_from_user(),
-            _ => false,
-        }
-    }
-
-    pub fn get_any_blob(&mut self) -> Option<&mut AnyBlob> {
-        match self {
-            HTTPRequestBody::AnyBlob(blob) => Some(blob),
-            _ => None,
-        }
-    }
-
     pub fn has_body(&mut self) -> bool {
         match self {
             HTTPRequestBody::AnyBlob(blob) => blob.size() > 0,
-            HTTPRequestBody::ReadableStream(stream) => stream.has(),
+            HTTPRequestBody::ReadableStream(stream)
+            | HTTPRequestBody::MultipartFormStream { stream, .. } => stream.has(),
             HTTPRequestBody::Sendfile(_) => true,
+        }
+    }
+
+    /// Content-Type to use when the user did not set one.
+    pub fn implied_content_type(&self) -> Option<&[u8]> {
+        match self {
+            HTTPRequestBody::AnyBlob(blob) if blob.has_content_type_from_user() => {
+                Some(blob.content_type())
+            }
+            HTTPRequestBody::MultipartFormStream { content_type, .. } => Some(content_type),
+            _ => None,
         }
     }
 }
@@ -610,11 +660,8 @@ impl FetchTasklet {
 
     pub(crate) fn start_request_stream(&mut self) {
         self.is_waiting_request_stream_start = false;
-        debug_assert!(matches!(
-            self.request_body,
-            HTTPRequestBody::ReadableStream(_)
-        ));
-        let HTTPRequestBody::ReadableStream(ref stream_ref) = self.request_body else {
+        let Some(stream_ref) = self.request_body.readable_stream() else {
+            debug_assert!(false, "start_request_stream without a streaming body");
             return;
         };
         if let Some(stream) = stream_ref.get(&self.global_this) {
@@ -2036,10 +2083,7 @@ impl FetchTasklet {
             },
         )));
         // enable streaming the write side
-        let is_stream = matches!(
-            fetch_tasklet.request_body,
-            HTTPRequestBody::ReadableStream(_)
-        );
+        let is_stream = fetch_tasklet.request_body.readable_stream().is_some();
         let http_client = fetch_tasklet.http.as_mut().unwrap();
         http_client.client.flags.is_streaming_request_body = is_stream;
         http_client.client.flags.force_http2 = fetch_options.force_http2;
@@ -2119,7 +2163,7 @@ impl FetchTasklet {
         // the underlying source's cancel(reason) callback still observes the
         // signal's reason (https://fetch.spec.whatwg.org/#abort-fetch step 5).
         if this.is_waiting_request_stream_start {
-            if let HTTPRequestBody::ReadableStream(stream_ref) = &this.request_body {
+            if let Some(stream_ref) = this.request_body.readable_stream() {
                 this.is_waiting_request_stream_start = false;
                 if let Some(stream) = stream_ref.get(&this.global_this) {
                     stream.cancel_with_reason(&this.global_this, reason);

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -120,6 +120,14 @@ pub struct FetchTasklet {
     pub is_waiting_body: bool,
     pub is_waiting_abort: bool,
     pub is_waiting_request_stream_start: bool,
+    /// Set by the HTTP-thread `callback` when a 307/308 redirect asks for the
+    /// streaming body to be replayed. While set, writes from the previous
+    /// sink are discarded so its end-of-stream cannot reach the new request.
+    pub request_stream_restart_pending: core::sync::atomic::AtomicBool,
+    /// Stream-buffer generation the current sink writes for. Captured at sink
+    /// creation; stale Data/End messages stamped with an earlier generation
+    /// are discarded on the HTTP thread.
+    pub request_stream_generation: u32,
     pub mutex: Mutex,
 
     pub tracker: AsyncTaskTracker,
@@ -138,10 +146,35 @@ pub enum HTTPRequestBody {
     /// `FormData` with file-backed parts streamed from disk. Carries the
     /// precomputed length so the request uses `Content-Length`, not chunked.
     MultipartFormStream {
+        /// Template: cloned into a fresh loader on each (re)start so 307/308
+        /// redirects can replay the body from the beginning.
+        segments: Vec<crate::webcore::multipart_form_loader::Segment>,
         stream: ReadableStreamStrong,
         content_type: Box<[u8]>,
         content_length: u64,
     },
+}
+
+fn multipart_form_stream(
+    global_this: &JSGlobalObject,
+    segments: &[crate::webcore::multipart_form_loader::Segment],
+) -> JsResult<Option<ReadableStreamStrong>> {
+    let reader = crate::webcore::readable_stream::NewSource::<
+        crate::webcore::multipart_form_loader::MultipartFormLoader,
+    >::new_mut(crate::webcore::readable_stream::NewSource {
+        global_this: Some(bun_ptr::BackRef::new(global_this)),
+        context: crate::webcore::multipart_form_loader::MultipartFormLoader {
+            segments: segments.to_vec(),
+            idx: 0,
+            done: false,
+        },
+        ..Default::default()
+    });
+    let stream_value = reader.to_readable_stream(global_this)?;
+    Ok(
+        crate::webcore::ReadableStream::from_js(stream_value, global_this)?
+            .map(|s| ReadableStreamStrong::init(s, global_this)),
+    )
 }
 
 impl Default for HTTPRequestBody {
@@ -192,33 +225,25 @@ impl HTTPRequestBody {
         }
     }
 
-    pub fn from_js(global_this: &JSGlobalObject, value: JSValue) -> JsResult<HTTPRequestBody> {
-        if let Some(form_data) = bun_jsc::DOMFormData::from_js(value)
+    /// `prefer_buffered`: skip the streaming FormData path because the caller
+    /// needs a buffered body (S3 destination, explicit `compress`).
+    pub fn from_js(
+        global_this: &JSGlobalObject,
+        value: JSValue,
+        prefer_buffered: bool,
+    ) -> JsResult<HTTPRequestBody> {
+        if !prefer_buffered
+            && let Some(form_data) = bun_jsc::DOMFormData::from_js(value)
             && crate::webcore::blob::MultipartSegments::needs_streaming_multipart(form_data)
             && let Some(segs) =
                 crate::webcore::blob::MultipartSegments::from_dom_form_data(global_this, form_data)
         {
-            let total_size = segs.total_size;
-            let content_type = segs.content_type;
-            let reader = crate::webcore::readable_stream::NewSource::<
-                crate::webcore::multipart_form_loader::MultipartFormLoader,
-            >::new_mut(crate::webcore::readable_stream::NewSource {
-                global_this: Some(bun_ptr::BackRef::new(global_this)),
-                context: crate::webcore::multipart_form_loader::MultipartFormLoader {
-                    segments: segs.segments,
-                    idx: 0,
-                    done: false,
-                },
-                ..Default::default()
-            });
-            let stream_value = reader.to_readable_stream(global_this)?;
-            if let Some(stream) =
-                crate::webcore::ReadableStream::from_js(stream_value, global_this)?
-            {
+            if let Some(stream) = multipart_form_stream(global_this, &segs.segments)? {
                 return Ok(HTTPRequestBody::MultipartFormStream {
-                    stream: ReadableStreamStrong::init(stream, global_this),
-                    content_type,
-                    content_length: total_size,
+                    segments: segs.segments,
+                    stream,
+                    content_type: segs.content_type,
+                    content_length: segs.total_size,
                 });
             }
         }
@@ -898,6 +923,29 @@ impl FetchTasklet {
                 FetchTasklet::deref(std::ptr::from_mut(this));
             }
         };
+
+        if self.result.restart_request_stream
+            && let HTTPRequestBody::MultipartFormStream {
+                segments, stream, ..
+            } = &mut self.request_body
+        {
+            let global_this = self.global_this;
+            if let Some(sink) = self.sink.take() {
+                // SAFETY: `sink` is the live ResumableSink this tasklet owns.
+                unsafe { (*sink).detach_js() };
+            }
+            stream.deinit();
+            if let Ok(Some(fresh)) = multipart_form_stream(&global_this, segments) {
+                *stream = fresh;
+                self.is_waiting_request_stream_start = true;
+            }
+            self.result.restart_request_stream = false;
+            if let Some(buf) = self.stream_buffer_mut() {
+                self.request_stream_generation = buf.generation.load(Ordering::Acquire);
+            }
+            self.request_stream_restart_pending
+                .store(false, Ordering::Release);
+        }
 
         if self.is_waiting_request_stream_start && self.result.can_stream {
             // start streaming
@@ -1945,6 +1993,8 @@ impl FetchTasklet {
             is_waiting_body: false,
             is_waiting_abort: false,
             is_waiting_request_stream_start: false,
+            request_stream_restart_pending: core::sync::atomic::AtomicBool::new(false),
+            request_stream_generation: 0,
             mutex: Mutex::new(),
             // SAFETY: jsc_vm derived from FFI ptr above; AsyncTaskTracker::init only
             // bumps a counter on the VM.
@@ -2080,6 +2130,10 @@ impl FetchTasklet {
         let is_stream = fetch_tasklet.request_body.readable_stream().is_some();
         let http_client = fetch_tasklet.http.as_mut().unwrap();
         http_client.client.flags.is_streaming_request_body = is_stream;
+        http_client.client.flags.streaming_body_can_restart = matches!(
+            fetch_tasklet.request_body,
+            HTTPRequestBody::MultipartFormStream { .. }
+        );
         http_client.client.flags.force_http2 = fetch_options.force_http2;
         http_client.client.flags.force_http3 = fetch_options.force_http3;
         http_client.client.flags.force_http1 = fetch_options.force_http1;
@@ -2096,6 +2150,12 @@ impl FetchTasklet {
                     FetchTasklet::on_write_request_data_drain,
                     fetch_tasklet_ptr,
                 );
+                if http_client.client.flags.streaming_body_can_restart {
+                    (*buffer).set_restart_callback::<FetchTasklet>(
+                        FetchTasklet::on_request_stream_restart,
+                        fetch_tasklet_ptr,
+                    );
+                }
             }
             let buffer_nn = core::ptr::NonNull::new(buffer);
             fetch_tasklet.request_body_streaming_buffer = buffer_nn;
@@ -2166,6 +2226,39 @@ impl FetchTasklet {
         }
     }
 
+    /// Called from the HTTP thread when a 307/308 redirect will replay a
+    /// restartable streaming body. Sets the atomic immediately so any stale
+    /// sink write arriving first is discarded, then enqueues the JS-thread
+    /// detach so later stale writes hit a detached sink.
+    pub(crate) fn on_request_stream_restart(this: *mut FetchTasklet) {
+        let this_ref = Self::from_raw_ref(this);
+        this_ref
+            .request_stream_restart_pending
+            .store(true, Ordering::Release);
+        if this_ref.javascript_vm.is_shutting_down() {
+            return;
+        }
+        this_ref.ref_();
+        Self::enqueue_concurrent(
+            this_ref.javascript_vm,
+            ConcurrentTask::from_callback(this, FetchTasklet::detach_stale_request_sink),
+        );
+    }
+
+    /// JS-thread half of `on_request_stream_restart`: detach the current sink
+    /// so any in-flight pump read that resolves later no-ops at `js_write` /
+    /// `js_end` instead of reaching `write_end_request`.
+    pub(crate) fn detach_stale_request_sink(this: *mut FetchTasklet) -> ElJsResult<()> {
+        let this_ref = Self::from_raw_mut(this);
+        if let Some(sink) = this_ref.sink.take() {
+            // SAFETY: `sink` is the live ResumableSink this tasklet owns.
+            unsafe { (*sink).detach_js() };
+        }
+        // SAFETY: `this` is the live heap tasklet; we hold the ref taken above.
+        FetchTasklet::deref(this);
+        Ok(())
+    }
+
     /// This is ALWAYS called from the http thread and we cannot touch the buffer here because is locked
     pub(crate) fn on_write_request_data_drain(this: *mut FetchTasklet) {
         let this_ref = Self::from_raw_ref(this);
@@ -2192,6 +2285,12 @@ impl FetchTasklet {
                 // already aborted; nothing to drain
                 return;
             }
+            if this_ref
+                .request_stream_restart_pending
+                .load(Ordering::Acquire)
+            {
+                return;
+            }
             if let Some(sink) = this_ref.sink_mut() {
                 sink.drain();
             }
@@ -2216,6 +2315,9 @@ impl FetchTasklet {
     pub(crate) fn write_request_data(&mut self, data: &[u8]) -> ResumableSinkBackpressure {
         bun_output::scoped_log!(FetchTasklet, "writeRequestData {}", data.len());
         if self.signal_aborted() {
+            return ResumableSinkBackpressure::Done;
+        }
+        if self.request_stream_restart_pending.load(Ordering::Acquire) {
             return ResumableSinkBackpressure::Done;
         }
         // An empty chunk is a no-op on every framing path. It must not reach
@@ -2273,6 +2375,7 @@ impl FetchTasklet {
             http::http_thread().schedule_request_write(
                 self.http.as_mut().unwrap(),
                 http::http_thread::WriteMessageType::Data,
+                self.request_stream_generation,
             );
         }
 
@@ -2283,6 +2386,13 @@ impl FetchTasklet {
     pub(crate) fn write_end_request(&mut self, err: Option<JSValue>) {
         bun_output::scoped_log!(FetchTasklet, "writeEndRequest hasError? {}", err.is_some());
         let this_ptr = std::ptr::from_mut(self);
+        if err.is_none() && self.request_stream_restart_pending.load(Ordering::Acquire) {
+            // A 307/308 redirect is replaying this body; discard the previous
+            // sink's end-of-stream so it cannot mark the new request done.
+            // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
+            FetchTasklet::deref(this_ptr);
+            return;
+        }
         if let Some(js_error) = err {
             if self.signal_store.aborted.load(Ordering::Relaxed) || self.abort_reason.has() {
                 // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
@@ -2308,8 +2418,11 @@ impl FetchTasklet {
                     .write(http::END_OF_CHUNKED_HTTP1_1_ENCODING_RESPONSE_BODY); // OOM/capacity: fire-and-forget
             }
             if let Some(http_) = self.http.as_mut() {
-                http::http_thread()
-                    .schedule_request_write(http_, http::http_thread::WriteMessageType::End);
+                http::http_thread().schedule_request_write(
+                    http_,
+                    http::http_thread::WriteMessageType::End,
+                    self.request_stream_generation,
+                );
             }
         }
         // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
@@ -2405,6 +2518,7 @@ impl FetchTasklet {
         let prev_metadata = task_ref.result.metadata.take();
         let prev_cert_info = task_ref.result.certificate_info.take();
         let prev_can_stream = task_ref.result.can_stream;
+        let prev_restart = task_ref.result.restart_request_stream;
         // SAFETY: lifetime erasure — `HTTPClientResult<'a>` borrows the
         // `*mut MutableString` we passed into `AsyncHTTP::init` (which lives
         // in `self.response_buffer` for the FetchTasklet's lifetime); widen
@@ -2413,6 +2527,13 @@ impl FetchTasklet {
         // can_stream is a one-shot signal to start the request body stream; don't let a
         // later coalesced result clobber it before the JS thread sees it.
         task_ref.result.can_stream = task_ref.result.can_stream || prev_can_stream;
+        task_ref.result.restart_request_stream =
+            task_ref.result.restart_request_stream || prev_restart;
+        if task_ref.result.restart_request_stream {
+            task_ref
+                .request_stream_restart_pending
+                .store(true, Ordering::Release);
+        }
 
         // Preserve pending certificate info if it was preovided in the previous update.
         if task_ref.result.certificate_info.is_none() {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -489,6 +489,28 @@ impl FetchTasklet {
         Ok(())
     }
 
+    /// Release the tasklet-held sink ref without touching the stream buffer
+    /// (which is reused across redirect-replay generations). If the sink had
+    /// not yet reached `write_end_request`, also release the tasklet ref that
+    /// `start_request_stream` took for it, since after `detach_js` the pump's
+    /// `js_end` will no-op and never balance it.
+    fn take_and_detach_sink(&mut self) {
+        if let Some(sink) = self.sink.take() {
+            // SAFETY: sink came from init_exact_refs; FetchTasklet holds one
+            // ref. `detach_js` runs no JS callbacks. JS-thread-only.
+            let was_done = unsafe { (*sink).is_detached() };
+            unsafe {
+                (*sink).detach_js();
+                ResumableFetchSink::deref_(sink);
+            }
+            if !was_done {
+                // SAFETY: the tasklet has additional refs while the fetch is
+                // active; this balances the one `start_request_stream` took.
+                FetchTasklet::deref(std::ptr::from_mut(self));
+            }
+        }
+    }
+
     fn clear_sink(&mut self) {
         if let Some(sink) = self.sink.take() {
             // SAFETY: sink came from init_exact_refs; FetchTasklet holds one ref.
@@ -925,18 +947,30 @@ impl FetchTasklet {
         };
 
         if self.result.restart_request_stream
-            && let HTTPRequestBody::MultipartFormStream {
-                segments, stream, ..
-            } = &mut self.request_body
+            && matches!(
+                self.request_body,
+                HTTPRequestBody::MultipartFormStream { .. }
+            )
         {
             let global_this = self.global_this;
-            if let Some(sink) = self.sink.take() {
-                // SAFETY: `sink` is the live ResumableSink this tasklet owns.
-                unsafe { (*sink).detach_js() };
-            }
-            stream.deinit();
-            match multipart_form_stream(&global_this, segments) {
+            self.take_and_detach_sink();
+            let fresh = {
+                let HTTPRequestBody::MultipartFormStream {
+                    segments, stream, ..
+                } = &mut self.request_body
+                else {
+                    unreachable!()
+                };
+                stream.deinit();
+                multipart_form_stream(&global_this, segments)
+            };
+            match fresh {
                 Ok(Some(fresh)) => {
+                    let HTTPRequestBody::MultipartFormStream { stream, .. } =
+                        &mut self.request_body
+                    else {
+                        unreachable!()
+                    };
                     *stream = fresh;
                     self.is_waiting_request_stream_start = true;
                 }
@@ -964,6 +998,12 @@ impl FetchTasklet {
             self.result.restart_request_stream = false;
             if let Some(buf) = self.stream_buffer_mut() {
                 self.request_stream_generation = buf.generation.load(Ordering::Acquire);
+                // A `write_request_data` that passed its `restart_pending`
+                // check before the HTTP thread reset the buffer can still
+                // deposit a stale chunk afterwards; reset again here (JS
+                // thread, after any such write has returned) so the new sink
+                // starts from an empty buffer.
+                buf.lock().reset();
             }
             self.request_stream_restart_pending
                 .store(false, Ordering::Release);
@@ -2272,9 +2312,13 @@ impl FetchTasklet {
     /// `js_end` instead of reaching `write_end_request`.
     pub(crate) fn detach_stale_request_sink(this: *mut FetchTasklet) -> ElJsResult<()> {
         let this_ref = Self::from_raw_mut(this);
-        if let Some(sink) = this_ref.sink.take() {
-            // SAFETY: `sink` is the live ResumableSink this tasklet owns.
-            unsafe { (*sink).detach_js() };
+        // If the restart block in `on_progress_update` already ran (callbacks
+        // coalesced), `self.sink` is the fresh sink and must not be detached.
+        if this_ref
+            .request_stream_restart_pending
+            .load(Ordering::Acquire)
+        {
+            this_ref.take_and_detach_sink();
         }
         // SAFETY: `this` is the live heap tasklet; we hold the ref taken above.
         FetchTasklet::deref(this);

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -135,11 +135,8 @@ pub enum HTTPRequestBody {
     AnyBlob(AnyBlob),
     Sendfile(http::SendFile),
     ReadableStream(ReadableStreamStrong),
-    /// `FormData` body whose file-backed parts are streamed in chunks from
-    /// disk. The stream produces the full multipart encoding; `content_type`
-    /// carries the `multipart/form-data; boundary=...` value and
-    /// `content_length` the precomputed total so the request is sent with an
-    /// explicit `Content-Length` instead of chunked transfer-encoding.
+    /// `FormData` with file-backed parts streamed from disk. Carries the
+    /// precomputed length so the request uses `Content-Length`, not chunked.
     MultipartFormStream {
         stream: ReadableStreamStrong,
         content_type: Box<[u8]>,
@@ -187,8 +184,6 @@ impl HTTPRequestBody {
         }
     }
 
-    /// Borrow the streaming `ReadableStream` if this body is one of the
-    /// streaming variants.
     pub fn readable_stream(&self) -> Option<&ReadableStreamStrong> {
         match self {
             HTTPRequestBody::ReadableStream(s)

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -208,7 +208,6 @@ impl HTTPRequestBody {
                     segments: segs.segments,
                     idx: 0,
                     done: false,
-                    total_size,
                 },
                 ..Default::default()
             });

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -935,9 +935,31 @@ impl FetchTasklet {
                 unsafe { (*sink).detach_js() };
             }
             stream.deinit();
-            if let Ok(Some(fresh)) = multipart_form_stream(&global_this, segments) {
-                *stream = fresh;
-                self.is_waiting_request_stream_start = true;
+            match multipart_form_stream(&global_this, segments) {
+                Ok(Some(fresh)) => {
+                    *stream = fresh;
+                    self.is_waiting_request_stream_start = true;
+                }
+                err => {
+                    // `to_readable_stream` failing here means OOM or a tampered
+                    // global; abort so the fetch promise rejects instead of
+                    // stalling at the body stage with no sink.
+                    let reason = match err {
+                        Err(_) => global_this.try_take_exception(),
+                        _ => None,
+                    }
+                    .unwrap_or_else(|| {
+                        global_this.create_error_instance(format_args!(
+                            "Failed to restart request body stream"
+                        ))
+                    });
+                    self.abort_reason.set(&global_this, reason);
+                    self.result.restart_request_stream = false;
+                    self.request_stream_restart_pending
+                        .store(false, Ordering::Release);
+                    self.abort_task();
+                    return Ok(());
+                }
             }
             self.result.restart_request_stream = false;
             if let Some(buf) = self.stream_buffer_mut() {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -998,6 +998,10 @@ impl FetchTasklet {
                         .store(false, Ordering::Release);
                     self.abort_task();
                     self.mutex.unlock();
+                    if is_done {
+                        // SAFETY: `self` is the live heap tasklet; we hold a ref.
+                        FetchTasklet::deref(std::ptr::from_mut(self));
+                    }
                     return Ok(());
                 }
             }

--- a/src/runtime/webcore/headers_ref.rs
+++ b/src/runtime/webcore/headers_ref.rs
@@ -25,9 +25,3 @@ pub(crate) fn blob_content_type(b: &Blob) -> Option<&[u8]> {
         None
     }
 }
-
-/// `Some(ct)` only when the body has a *user-set* content-type.
-#[inline]
-pub(crate) fn any_blob_content_type_opt(b: Option<&AnyBlob>) -> Option<&[u8]> {
-    b.and_then(any_blob_content_type)
-}

--- a/test/js/web/html/FormData-file-stream-fixture.ts
+++ b/test/js/web/html/FormData-file-stream-fixture.ts
@@ -1,0 +1,96 @@
+// Fixture for the FormData + Bun.file() streaming upload test.
+//
+// Pre-fix, serialising a FormData whose entry is a file-backed Bun.file()
+// read the whole file into memory before sending (peak RSS roughly 2x the
+// file size). Post-fix, the file is read in fixed-size chunks, so peak RSS
+// stays bounded regardless of the file size.
+//
+// The server runs in a separate subprocess so its request-body buffering is
+// not attributed to this process's RSS.
+
+import { createServer } from "node:http";
+
+const MB = 1024 * 1024;
+const path = process.env.FILE_PATH!;
+const fileSize = Number(process.env.FILE_SIZE!);
+
+const rss = () => process.memoryUsage().rss;
+
+// node:http so the body is streamed to us chunk by chunk without any large
+// server-side buffer that would mask the client's peak.
+const server = createServer((req, res) => {
+  let n = 0;
+  let hash = 0;
+  req.on("data", c => {
+    n += c.length;
+    for (let i = 0; i < c.length; i++) hash = ((hash << 1) | (hash >>> 31)) ^ c[i];
+    hash >>>= 0;
+  });
+  req.on("end", () => {
+    res.setHeader("content-type", "application/json");
+    res.end(
+      JSON.stringify({
+        n,
+        hash,
+        ct: req.headers["content-type"],
+        cl: req.headers["content-length"],
+        te: req.headers["transfer-encoding"],
+      }),
+    );
+  });
+});
+await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+const port = (server.address() as { port: number }).port;
+
+async function upload(label: string, body: () => BodyInit) {
+  Bun.gc(true);
+  const before = rss();
+  let peak = before;
+  const iv = setInterval(() => (peak = Math.max(peak, rss())), 10);
+  const res = await fetch(`http://127.0.0.1:${port}/`, { method: "POST", body: body() });
+  clearInterval(iv);
+  const j = (await res.json()) as { n: number; hash: number; ct: string; cl: string; te?: string };
+  return { label, peakDeltaMB: Math.round((peak - before) / MB), ...j };
+}
+
+// Baseline: a plain ReadableStream body already streams today. The FormData
+// path should end up in the same ballpark.
+const stream = await upload("stream", () => Bun.file(path).stream());
+
+const form = await upload("formdata", () => {
+  const fd = new FormData();
+  fd.append("before", "hello");
+  fd.append("file", Bun.file(path), "big.bin");
+  fd.append("after", "world");
+  return fd;
+});
+
+server.close();
+
+// Independently rebuild the exact multipart body from the received
+// Content-Type boundary so the parent test can verify wire bytes, not just
+// byte counts.
+const boundaryMatch = /boundary=([^;]+)/.exec(form.ct);
+const boundary = boundaryMatch ? boundaryMatch[1] : "";
+function hashMultipart(boundary: string) {
+  let hash = 0;
+  const push = (buf: Uint8Array) => {
+    for (let i = 0; i < buf.length; i++) hash = ((hash << 1) | (hash >>> 31)) ^ buf[i];
+    hash >>>= 0;
+  };
+  const T = (s: string) => push(new TextEncoder().encode(s));
+  T(`--${boundary}\r\nContent-Disposition: form-data; name="before"\r\n\r\nhello\r\n`);
+  T(
+    `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="big.bin"\r\n` +
+      `Content-Type: application/octet-stream\r\n\r\n`,
+  );
+  const chunk = new Uint8Array(1024);
+  for (let i = 0; i < 1024; i++) chunk[i] = i & 0xff;
+  for (let i = 0; i < fileSize / 1024; i++) push(chunk);
+  T(`\r\n--${boundary}\r\nContent-Disposition: form-data; name="after"\r\n\r\nworld\r\n`);
+  T(`--${boundary}--\r\n`);
+  return hash;
+}
+const expectedHash = hashMultipart(boundary);
+
+console.log(JSON.stringify({ stream, form, expectedHash, boundary }));

--- a/test/js/web/html/FormData-file-stream-fixture.ts
+++ b/test/js/web/html/FormData-file-stream-fixture.ts
@@ -5,8 +5,9 @@
 // file size). Post-fix, the file is read in fixed-size chunks, so peak RSS
 // stays bounded regardless of the file size.
 //
-// The server runs in a separate subprocess so its request-body buffering is
-// not attributed to this process's RSS.
+// Client and server share this process; node:http hands the body up chunk
+// by chunk without buffering, so server allocations stay bounded and do not
+// mask the client's peak.
 
 import { createServer } from "node:http";
 

--- a/test/js/web/html/FormData-file-stream.test.ts
+++ b/test/js/web/html/FormData-file-stream.test.ts
@@ -63,3 +63,63 @@ test("fetch streams FormData with a Bun.file() part instead of buffering it", as
 
   expect(exitCode).toBe(0);
 }, 60_000);
+
+// The streaming FormData body has a non-null Fetch "source" (the FormData),
+// so 307/308 redirects must re-send it instead of failing with
+// RequestBodyNotReusable. Exercises the stream-buffer generation/restart
+// path that lets the HTTP client replay the body from its saved segments.
+test("fetch replays a streaming FormData+Bun.file() body across a redirect", async () => {
+  using dir = tempDir("formdata-file-stream-redirect", {
+    "payload.bin": Buffer.alloc(1024, "x"),
+  });
+
+  const fixture = `
+    const srv = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const code = Number(url.searchParams.get("code"));
+        if (url.pathname === "/a") {
+          for await (const _ of req.body ?? []) {}
+          return new Response(null, { status: code, headers: { Location: "/b?code=" + code } });
+        }
+        let n = 0;
+        for await (const c of req.body ?? []) n += c.length;
+        return new Response(JSON.stringify({ method: req.method, n }));
+      },
+    });
+    const filePath = ${JSON.stringify(join(String(dir), "payload.bin"))};
+    const out = {};
+    for (const code of [301, 302, 303, 307, 308]) {
+      const fd = new FormData();
+      fd.append("f", Bun.file(filePath), "p.bin");
+      const r = await fetch(\`http://127.0.0.1:\${srv.port}/a?code=\${code}\`, { method: "POST", body: fd });
+      out[code] = await r.json();
+    }
+    console.log(JSON.stringify(out));
+    srv.stop(true);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error(stderr);
+
+  const out = JSON.parse(stdout.trim());
+  // 307/308 preserve the method and re-send the body; the byte count must
+  // match each other and exceed the file size (body + multipart framing).
+  expect(out[307]).toEqual(out[308]);
+  expect(out[307].method).toBe("POST");
+  expect(out[307].n).toBeGreaterThan(1024);
+  // 301/302/303 downgrade to GET with no body.
+  expect([out[301], out[302], out[303]]).toEqual([
+    { method: "GET", n: 0 },
+    { method: "GET", n: 0 },
+    { method: "GET", n: 0 },
+  ]);
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/web/html/FormData-file-stream.test.ts
+++ b/test/js/web/html/FormData-file-stream.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { openSync, writeSync, closeSync } from "node:fs";
+import { join } from "node:path";
+
+// fetch(url, { body: formData }) where the FormData holds a Bun.file() entry
+// used to read the whole file into memory while building the multipart body.
+// The fix streams file-backed parts in fixed-size chunks, so peak RSS stays
+// bounded regardless of file size.
+test("fetch streams FormData with a Bun.file() part instead of buffering it", async () => {
+  const MB = 1024 * 1024;
+  const fileSizeMB = 48;
+  const fileSize = fileSizeMB * MB;
+
+  using dir = tempDir("formdata-file-stream", {});
+  const filePath = join(String(dir), "big.bin");
+  {
+    const fd = openSync(filePath, "w");
+    const chunk = Buffer.alloc(1024);
+    for (let i = 0; i < 1024; i++) chunk[i] = i & 0xff;
+    for (let i = 0; i < fileSize / 1024; i++) writeSync(fd, chunk);
+    closeSync(fd);
+  }
+
+  // ASAN's free quarantine retains every freed stream chunk, so RSS growth
+  // under ASAN tracks the quarantine rather than live allocations and masks
+  // the buffered-vs-streamed difference. Disable it for the fixture process.
+  const asanOpts = [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", join(import.meta.dir, "FormData-file-stream-fixture.ts")],
+    env: { ...bunEnv, FILE_PATH: filePath, FILE_SIZE: String(fileSize), ASAN_OPTIONS: asanOpts },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) console.error(stderr);
+  const result = JSON.parse(stdout.trim());
+
+  console.log(
+    `FormData Bun.file() upload: file=${fileSizeMB} MB, ` +
+      `stream peak=${result.stream.peakDeltaMB} MB, form peak=${result.form.peakDeltaMB} MB`,
+  );
+
+  // Content-Type carries the boundary and the body is sent with an explicit
+  // Content-Length, not chunked transfer-encoding.
+  expect(result.form.ct).toMatch(/^multipart\/form-data; boundary=----WebKitFormBoundary[0-9a-f]{32}$/);
+  expect(result.form.te).toBeUndefined();
+  expect(result.form.n).toBe(Number(result.form.cl));
+  expect(result.form.n).toBeGreaterThan(fileSize);
+
+  // Wire bytes match an independently rebuilt multipart body.
+  expect(result.form.hash).toBe(result.expectedHash);
+
+  // Pre-fix, `from_dom_form_data` read the whole file and copied it into the
+  // joiner (peak roughly 2x file size). The streamed path keeps the peak far
+  // below one file's worth; it should be in the same ballpark as a bare
+  // `Bun.file().stream()` body.
+  expect(result.form.peakDeltaMB).toBeLessThan(fileSizeMB);
+  expect(result.form.peakDeltaMB).toBeLessThan(result.stream.peakDeltaMB + fileSizeMB);
+
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/web/html/FormData-file-stream.test.ts
+++ b/test/js/web/html/FormData-file-stream.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { openSync, writeSync, closeSync } from "node:fs";
+import { closeSync, openSync, writeSync } from "node:fs";
 import { join } from "node:path";
 
 // fetch(url, { body: formData }) where the FormData holds a Bun.file() entry

--- a/test/js/web/html/FormData-file-stream.test.ts
+++ b/test/js/web/html/FormData-file-stream.test.ts
@@ -83,18 +83,39 @@ test("fetch replays a streaming FormData+Bun.file() body across a redirect", asy
           for await (const _ of req.body ?? []) {}
           return new Response(null, { status: code, headers: { Location: "/b?code=" + code } });
         }
-        let n = 0;
-        for await (const c of req.body ?? []) n += c.length;
-        return new Response(JSON.stringify({ method: req.method, n }));
+        const cl = req.headers.get("content-length");
+        const ct = req.headers.get("content-type");
+        let n = 0, hash = 0;
+        for await (const c of req.body ?? []) {
+          n += c.length;
+          for (let i = 0; i < c.length; i++) hash = (((hash << 1) | (hash >>> 31)) ^ c[i]) >>> 0;
+        }
+        return new Response(JSON.stringify({ method: req.method, n, cl, ct, hash }));
       },
     });
+    function hashParts(parts) {
+      let hash = 0;
+      for (const p of parts) for (let i = 0; i < p.length; i++) hash = (((hash << 1) | (hash >>> 31)) ^ p[i]) >>> 0;
+      return hash;
+    }
     const filePath = ${JSON.stringify(join(String(dir), "payload.bin"))};
     const out = {};
     for (const code of [301, 302, 303, 307, 308]) {
       const fd = new FormData();
       fd.append("f", Bun.file(filePath), "p.bin");
       const r = await fetch(\`http://127.0.0.1:\${srv.port}/a?code=\${code}\`, { method: "POST", body: fd });
-      out[code] = await r.json();
+      const j = await r.json();
+      if (j.ct) {
+        const b = /boundary=(.*)$/.exec(j.ct)[1];
+        const enc = new TextEncoder();
+        j.expectedHash = hashParts([
+          enc.encode(\`--\${b}\\r\\nContent-Disposition: form-data; name="f"; filename="p.bin"\\r\\nContent-Type: application/octet-stream\\r\\n\\r\\n\`),
+          new Uint8Array(1024).fill(0x78),
+          enc.encode(\`\\r\\n--\${b}--\\r\\n\`),
+        ]);
+      }
+      delete j.ct;
+      out[code] = j;
     }
     console.log(JSON.stringify(out));
     srv.stop(true);
@@ -110,16 +131,20 @@ test("fetch replays a streaming FormData+Bun.file() body across a redirect", asy
   if (exitCode !== 0) console.error(stderr);
 
   const out = JSON.parse(stdout.trim());
-  // 307/308 preserve the method and re-send the body; the byte count must
-  // match each other and exceed the file size (body + multipart framing).
-  expect(out[307]).toEqual(out[308]);
-  expect(out[307].method).toBe("POST");
-  expect(out[307].n).toBeGreaterThan(1024);
+  // 307/308 preserve the method and re-send the body byte-for-byte: the
+  // received hash must match an independently rebuilt multipart body, and
+  // Content-Length must match what arrived.
+  for (const code of [307, 308]) {
+    expect(out[code].method).toBe("POST");
+    expect(out[code].hash).toBe(out[code].expectedHash);
+    expect(Number(out[code].cl)).toBe(out[code].n);
+    expect(out[code].n).toBeGreaterThan(1024);
+  }
   // 301/302/303 downgrade to GET with no body.
   expect([out[301], out[302], out[303]]).toEqual([
-    { method: "GET", n: 0 },
-    { method: "GET", n: 0 },
-    { method: "GET", n: 0 },
+    { method: "GET", n: 0, cl: null, hash: 0 },
+    { method: "GET", n: 0, cl: null, hash: 0 },
+    { method: "GET", n: 0, cl: null, hash: 0 },
   ]);
   expect(exitCode).toBe(0);
 }, 30_000);


### PR DESCRIPTION
## What

`fetch(url, { body: formData })` where the FormData holds a `Bun.file(path)` entry read the entire file into memory while building the multipart body. `Blob::from_dom_form_data` did a synchronous `read_file` + `push_cloned` per file-backed part, then flattened the joiner into one contiguous buffer. Peak RSS was roughly 2x the combined file size, so a 500 MB upload peaked at 570-1040 MB, while the same file as `body: Bun.file(path)` streams flat via sendfile.

## Repro

```js
const fd = new FormData();
fd.append("f", Bun.file("/tmp/500mb.bin"));
await fetch(url, { method: "POST", body: fd });
// peak RSS ~570-1040 MB on stock 1.4.0-canary
```

## Fix

Adds a streaming path used by fetch's body extraction:

- `MultipartSegments::from_dom_form_data` walks the FormData and emits the same boundary/header bytes as the buffered serializer (both now call the shared `write_multipart_entry<S: MultipartSink>` / `for_each_form_data_entry` / `make_multipart_boundary` helpers), but records file-backed parts as `Segment::File { store, offset, size }` instead of reading them. Total body size is computed from stat so the request is sent with an explicit `Content-Length`.
- `MultipartFormLoader` is a new `ReadableStream` source that iterates the segments, serving `Bytes` segments from memory and reading `File` segments with `pread` in 256 KB chunks.
- `HTTPRequestBody` gains a `MultipartFormStream` variant carrying the segment template, the stream, the content-type and the precomputed length. `fetch` injects `Content-Length` for it so the HTTP client avoids chunked transfer-encoding.

### Gating

`needs_streaming_multipart` takes the new path only when the FormData contains at least one file-backed entry and no S3 entry. `HTTPRequestBody::from_js` additionally keeps the buffered path when `prefer_buffered` is set, which `fetch` does for S3 destinations and an explicit `compress` option. Missing files, pipes/FIFOs, and plain in-memory FormData still flow through the buffered serializer, so `new Response(formData)`, `new Request({body: formData})`, the S3 PUT path, request-body compression, and the `ENOENT` error behaviour are unchanged.

### Redirect replay

A FormData body has a non-null Fetch "source", so 307/308 redirects must re-send it rather than failing with `RequestBodyNotReusable`. The HTTP client now supports replaying a restartable streaming body:

- `Flags.streaming_body_can_restart` lets `handle_response_metadata` follow non-303 redirects for this body and makes `request_stream_detach` keep the buffer ref so the redirect path still has it.
- `do_redirect` / `do_redirect_multiplexed` call `prepare_stream_body_for_redirect`, which for 307/308 extracts the `Stream`, fires the buffer's `restart_callback`, bumps its atomic `generation`, resets it, and passes the stream to `start()` for the follow-up request. For 301/302/303 it just drops the streaming flag as before.
- `WriteMessage` is stamped with the generation it was scheduled for and `drain_queued_writes` discards stale ones, so an in-flight `End` from the previous sink cannot mark the replayed request done.
- `FetchTasklet` registers `on_request_stream_restart` as the restart callback; it sets `request_stream_restart_pending` (which makes stale `write_request_data`/`write_end_request`/`resume_request_data_stream` calls no-op) and enqueues a JS-side `detach_stale_request_sink`. When the redirected request reaches its body stage, `HTTPClientResult.restart_request_stream` drives `on_progress_update` to rebuild a fresh loader/stream from the saved segment template and start a new sink writing at the new generation.

## Verification

48 MB file, client-side peak RSS delta (ASAN quarantine disabled for the fixture process):

| body | before | after |
| --- | --- | --- |
| `Bun.file()` (sendfile) | 2 MB | 2 MB |
| `Bun.file().stream()` | 20 MB | 20 MB |
| `FormData{Bun.file()}` | **106 MB** | **18 MB** |

The new tests rebuild the expected multipart bytes independently and compare a rolling hash of the received body, and exercise 301/302/303/307/308 redirects with a FormData+`Bun.file()` body. Existing `FormData & Bun.file (roundtrip)`, `FormData-multipart-serialization`, `FormData-file-error-leak`, and `fetch-redirect` tests pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 18 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData-file-stream.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/39] gen cpp.rs (cppbind)
[2/39] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (31 fields)
Found 8 classes from /workspace/bun/src/runtime/api/h
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (95c909bbb)

test/js/web/html/FormData-file-stream.test.ts:
FormData Bun.file() upload: file=48 MB, stream peak=20 MB, form peak=8 MB
(pass) fetch streams FormData with a Bun.file() part instead of buffering it [458.76ms]
(pass) fetch replays a streaming FormData+Bun.file() body across a redirect [16.53ms]

 2 pass
 0 fail
 18 expect() calls
Ran 2 tests across 1 file. [662.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData-file-stream.test.ts
bun test v1.4.0 (6fe893da7)

test/js/web/html/FormData-file-stream.test.ts:
FormData Bun.file() upload: file=48 MB, stream peak=38 MB, form peak=19 MB
(pass) fetch streams FormData with a Bun.file() part instead of buffering it [6062.12ms]
(pass) fetch replays a streaming FormData+Bun.file() body across a redirect [484.96ms]

 2 pass
 0 fail
 18 expect() calls
Ran 2 tests across 1 file. [8.54s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 776ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/32] gen cpp.rs (cppbind)
[2/32] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/32] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameP
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/HTTPRequestBody.rs                      |  10 +
 src/http/HTTPThread.rs                           |  36 +-
 src/http/ThreadSafeStreamBuffer.rs               |  24 ++
 src/http/h2_client/ClientSession.rs              |   5 +-
 src/http/h2_client/encode.rs                     |   2 +-
 src/http/h3_client/ClientContext.rs              |   4 +-
 src/http/h3_client/ClientSession.rs              |  10 +-
 src/http/h3_client/encode.rs                     |   2 +-
 src/http/lib.rs                                  | 121 +++++-
 src/runtime/api/streams.classes.ts               |   8 +-
 src/runtime/webcore.rs                           |   2 +
 src/runtime/webcore/Blob.rs                      | 507 +++++++++++++++--------
 src/runtime/webcore/MultipartFormLoader.rs       | 198 +++++++++
 src/runtime/webcore/fetch.rs                     |  37 +-
 src/runtime/webcore/fetch/FetchTasklet.rs        | 289 +++++++++++--
 src/runtime/webcore/headers_ref.rs               |   6 -
 test/js/web/html/FormData-file-stream-fixture.ts |  97 +++++
 test/js/web/html/FormData-file-stream.test.ts    | 150 +++++++
 18 files changed, 1249 insertions(+), 259 deletions(-)
```

</details>

**gate history** · 7 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/http/HTTPRequestBody.rs                     1      1      0
src/http/HTTPThread.rs                          3      5      0
src/http/ThreadSafeStreamBuffer.rs              2      8      0
src/http/h2_client/ClientSession.rs             1      2      0
src/http/h2_client/encode.rs                    1      1      0
src/http/h3_client/ClientContext.rs             1      1      0
src/http/h3_client/ClientSession.rs             1      1      0
src/http/h3_client/encode.rs                    1      1      0
src/http/lib.rs                                 3     20      0
src/runtime/api/streams.classes.ts              2      4      0
src/runtime/webcore.rs                          1      1      0
src/runtime/webcore/Blob.rs                    12     21      0
src/runtime/webcore/MultipartFormLoader.rs      2      9      0
src/runtime/webcore/fetch.rs                    6      8      0
src/runtime/webcore/fetch/FetchTasklet.rs      22     46      0
src/runtime/webcore/headers_ref.rs              3      3      0
(+ 2 more files)
```

</details>

<!-- robobun:evidence:end -->