### PR TITLE
bun test: nest results under describe scopes instead of repeating the scope path

### DIFF
--- a/docs/guides/test/coverage-threshold.mdx
+++ b/docs/guides/test/coverage-threshold.mdx
@@ -12,8 +12,9 @@ bun test --coverage
 
 ```txt
 test.test.ts:
-✓ math > add [0.71ms]
-✓ math > multiply [0.03ms]
+math
+  ✓ add [0.71ms]
+  ✓ multiply [0.03ms]
 ✓ random [0.13ms]
 -------------|---------|---------|-------------------
 File         | % Funcs | % Lines | Uncovered Line #s

--- a/docs/guides/test/coverage.mdx
+++ b/docs/guides/test/coverage.mdx
@@ -19,8 +19,9 @@ bun test --coverage
 ```txt
 
 test.test.ts:
-✓ math > add [0.71ms]
-✓ math > multiply [0.03ms]
+math
+  ✓ add [0.71ms]
+  ✓ multiply [0.03ms]
 ✓ random [0.13ms]
 -------------|---------|---------|-------------------
 File         | % Funcs | % Lines | Uncovered Line #s

--- a/docs/test/reporters.mdx
+++ b/docs/test/reporters.mdx
@@ -41,6 +41,22 @@ test/package-json-lint.test.ts:
 Ran 4 tests across 1 files. [0.66ms]
 ```
 
+Tests inside a `describe` block are nested beneath their scope, which is printed once:
+
+```sh terminal icon="terminal"
+test/math.test.ts:
+math
+  arithmetic
+    ✓ add [0.12ms]
+    ✓ subtract [0.04ms]
+  ✓ is a module [0.03ms]
+✓ top-level test [0.02ms]
+
+ 4 pass
+ 0 fail
+Ran 4 tests across 1 files. [0.31ms]
+```
+
 ### Dots Reporter
 
 The dots reporter shows `.` for passing tests and prints full error details for failures, useful for large test suites.

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -50,6 +50,9 @@ pub struct Coordinator<'a> {
     /// from concurrent workers interleave; whenever the source file changes the
     /// header is re-emitted so every line has visible context. None at start.
     pub last_header_idx: Option<u32>,
+    /// Describe-scope path whose headers have already been printed under the
+    /// current `last_header_idx`. Cleared whenever the file header is re-emitted.
+    pub printed_scope_path: Vec<u8>,
     pub frame: Frame,
     pub parallel_limit: u32,
     pub scale_up_after_ms: i64,
@@ -307,6 +310,7 @@ impl<'a> Coordinator<'a> {
             return;
         }
         self.last_header_idx = Some(file_idx);
+        self.printed_scope_path.clear();
         let _ = write!(
             Output::error_writer(),
             "\n{}:\n",
@@ -344,6 +348,7 @@ impl<'a> Coordinator<'a> {
             }
             frame::Kind::TestDone => {
                 let idx = rd.u32_();
+                let scope_path = rd.str();
                 let formatted = rd.str();
                 if w.inflight != Some(idx) {
                     return;
@@ -358,6 +363,11 @@ impl<'a> Coordinator<'a> {
                 if !is_dot {
                     self.break_dots();
                     self.ensure_header(idx);
+                    CommandLineReporter::emit_scope_headers(
+                        &mut self.printed_scope_path,
+                        scope_path,
+                        Output::error_writer(),
+                    );
                 }
                 let _ = Output::error_writer().write_all(formatted);
                 self.last_printed_dot = is_dot;

--- a/src/runtime/cli/test/parallel/Frame.rs
+++ b/src/runtime/cli/test/parallel/Frame.rs
@@ -10,7 +10,8 @@ pub enum Kind {
     Ready,
     /// u32 file_idx
     FileStart,
-    /// u32 file_idx, str formatted_line (ANSI included; printed verbatim)
+    /// u32 file_idx, str scope_path (`\x1f`-separated describe names, outermost
+    /// first), str formatted_line (ANSI included; printed verbatim)
     TestDone,
     /// 9 × u32: file_idx, pass, fail, skip, todo, expectations, skipped_label, files, unhandled
     FileDone,

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -225,6 +225,7 @@ pub fn run_as_coordinator(
         junit_fragments: Vec::new(),
         coverage_fragments: Vec::new(),
         last_header_idx: None,
+        printed_scope_path: Vec::new(),
         frame: Frame::default(),
         files_done: 0,
         spawned_count: 0,
@@ -803,9 +804,10 @@ static WORKER_CMDS: bun_core::RacyCell<Option<*mut WorkerCommands>> = bun_core::
 // pointee outlives all callers (process exits before it's dropped).
 
 /// Called from `CommandLineReporter.handleTestCompleted` in the worker with the
-/// fully-formatted status line (✓/✗ + scopes + name + duration, including ANSI
-/// codes). The coordinator prints these bytes verbatim so output matches serial.
-pub fn worker_emit_test_done(file_idx: u32, formatted_line: &[u8]) {
+/// describe-scope path plus the fully-formatted status line (✓/✗ + indent + name
+/// + duration, including ANSI codes). The coordinator prints the scope headers it
+/// hasn't printed yet, then these bytes verbatim, so output matches serial.
+pub fn worker_emit_test_done(file_idx: u32, scope_path: &[u8], formatted_line: &[u8]) {
     // SAFETY: single-threaded worker; WORKER_CMDS only written/read on this thread.
     let Some(cmds_ptr) = (unsafe { WORKER_CMDS.read() }) else {
         return;
@@ -817,6 +819,7 @@ pub fn worker_emit_test_done(file_idx: u32, formatted_line: &[u8]) {
     let wf = unsafe { &mut *WORKER_FRAME.get() };
     wf.begin(frame::Kind::TestDone);
     wf.u32_(file_idx);
+    wf.str(scope_path);
     wf.str(formatted_line);
     cmds.send(wf.finish());
 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -210,6 +210,31 @@ fn fmt_status_text_line(
 // `&mut io::Writer`; the previous local `err_w`/`out_w` wrappers were no-op
 // reborrows. Call sites use the `Output` accessors directly.
 
+/// Separator between describe-scope names in a serialized scope path. A describe
+/// name containing `\x1f` only causes cosmetic misgrouping.
+const SCOPE_PATH_SEP: u8 = 0x1f;
+
+const INDENT_SPACES: [u8; 64] = [b' '; 64];
+
+/// Segments of a `\x1f`-separated scope path, outermost first.
+fn scope_segments(path: &[u8]) -> impl Iterator<Item = &[u8]> {
+    let inner = if path.is_empty() {
+        None
+    } else {
+        Some(path.split(|&b| b == SCOPE_PATH_SEP))
+    };
+    inner.into_iter().flatten()
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum Layout {
+    /// `<describe> > <describe> > <name>` on one line. Used for the end-of-run
+    /// skip/todo/failure recap and for `--dots`, where no headers precede it.
+    Flat,
+    /// `<name>` only, indented beneath headers written by `emit_scope_headers`.
+    Nested,
+}
+
 #[derive(Default)]
 pub struct JunitFailure {
     pub name: Vec<u8>,
@@ -929,6 +954,10 @@ pub struct CommandLineReporter {
     pub skips_to_repeat_buf: Vec<u8>,
     pub todos_to_repeat_buf: Vec<u8>,
 
+    /// Describe-scope path (`\x1f`-separated, outermost first) whose headers
+    /// have already been printed. Reset on file entry; see `emit_scope_headers`.
+    pub printed_scope_path: Vec<u8>,
+
     pub reporters: ReportersConfig,
 }
 
@@ -940,100 +969,170 @@ pub struct ReportersConfig {
 }
 
 impl CommandLineReporter {
-    fn print_test_line<const DIM: bool>(
-        status: bun_test::Execution::Result,
-        sequence: &mut bun_test::Execution::ExecutionSequence,
-        test_entry: &mut bun_test::ExecutionEntry,
-        elapsed_ns: u64,
-        writer: &mut impl bun_io::Write,
-    ) {
-        let initial_retry_count = test_entry.retry_count;
-        let attempts = (initial_retry_count - sequence.remaining_retry_count) + 1;
-        let initial_repeat_count = test_entry.repeat_count;
-        let repeats = (initial_repeat_count - sequence.remaining_repeat_count) + 1;
-        let mut scopes_stack: BoundedArray<*const bun_test::DescribeScope, 64> =
-            BoundedArray::default();
+    /// Describe scopes enclosing `test_entry`, innermost first. Unnamed scopes
+    /// are omitted so they don't consume an indent level.
+    fn collect_scopes(
+        test_entry: &bun_test::ExecutionEntry,
+    ) -> BoundedArray<*const bun_test::DescribeScope, 64> {
+        let mut scopes: BoundedArray<*const bun_test::DescribeScope, 64> = BoundedArray::default();
         let mut parent_: Option<*const bun_test::DescribeScope> =
             test_entry.base.parent.map(|p| p.cast_const());
 
         while let Some(scope) = parent_ {
-            if scopes_stack.push(scope).is_err() {
+            if !Self::scope_name(scope).is_empty() && scopes.push(scope).is_err() {
                 break;
             }
             // SAFETY: scope is a live DescribeScope pointer kept alive for the test run
             parent_ = unsafe { (*scope).base.parent.map(|p| p.cast_const()) };
         }
 
-        let scopes: &[*const bun_test::DescribeScope] = scopes_stack.as_slice();
-        let display_label: &[u8] = test_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
+        scopes
+    }
 
-        // Quieter output when claude code is in use.
-        if !Output::is_ai_agent() || !status.is_pass(bun_test::PendingMode::PendingIsFail) {
-            // `color_code`/`line_color_code` literals are inlined at use sites
-            // below via `if DIM { ... } else { ... }` to avoid runtime `format!`.
+    fn scope_name(scope: *const bun_test::DescribeScope) -> &'static [u8] {
+        // SAFETY: scope is alive for the duration of the test run
+        unsafe { (*scope).base.name.as_deref() }.unwrap_or(b"")
+    }
 
-            // `switch (Output.enable_ansi_colors_stderr) { inline else => |_| ... }` — the
-            // captured bool was unused except for monomorphization; collapsed to runtime.
-            match status {
-                bun_test::Execution::Result::FailBecauseExpectedAssertionCount => {
-                    // not sent to writer so it doesn't get printed twice
-                    let expected_count =
-                        if let bun_test::ExpectAssertions::Exact(n) = sequence.expect_assertions {
-                            n
-                        } else {
-                            12345
-                        };
-                    Output::err(
-                        crate::Error::AssertionError,
-                        "expected <green>{} assertion{}<r>, but test ended with <red>{} assertion{}<r>\n",
-                        (
-                            expected_count,
-                            if expected_count == 1 { "" } else { "s" },
-                            sequence.expect_call_count,
-                            if sequence.expect_call_count == 1 {
-                                ""
-                            } else {
-                                "s"
-                            },
-                        ),
-                    );
-                    Output::flush();
-                }
-                bun_test::Execution::Result::FailBecauseExpectedHasAssertions => {
-                    Output::err(
-                        crate::Error::AssertionError,
-                        "received <red>0 assertions<r>, but expected <green>at least one assertion<r> to be called\n",
-                        (),
-                    );
-                    Output::flush();
-                }
-                bun_test::Execution::Result::FailBecauseTimeout
-                | bun_test::Execution::Result::FailBecauseHookTimeout
-                | bun_test::Execution::Result::FailBecauseTimeoutWithDoneCallback
-                | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
-                    if Output::is_github_action() {
-                        Output::print_error(format_args!(
-                            "::error title=error: Test \"{}\" timed out after {}ms::\n",
-                            bun_fmt::github_action_property(display_label),
-                            test_entry.timeout
-                        ));
-                        Output::flush();
-                    }
-                }
-                _ => {}
+    /// Serialize `scopes` (innermost first) outermost-first into `out`.
+    fn write_scope_path(scopes: &[*const bun_test::DescribeScope], out: &mut Vec<u8>) {
+        for (i, scope) in scopes.iter().rev().enumerate() {
+            if i > 0 {
+                out.push(SCOPE_PATH_SEP);
             }
+            out.extend_from_slice(Self::scope_name(*scope));
+        }
+    }
 
-            if Output::enable_ansi_colors_stderr() {
-                for i in 0..scopes.len() {
-                    let index = (scopes.len() - 1) - i;
-                    let scope = scopes[index];
-                    // SAFETY: scope is alive for duration of test run
-                    let name: &[u8] = unsafe { (*scope).base.name.as_deref() }.unwrap_or(b"");
-                    if name.is_empty() {
-                        continue;
-                    }
-                    let _ = writer.write_all(b" ");
+    fn write_indent(writer: &mut impl bun_io::Write, depth: usize) {
+        let n = core::cmp::min(depth * 2, INDENT_SPACES.len());
+        let _ = writer.write_all(&INDENT_SPACES[..n]);
+    }
 
+    /// Print the describe headers in `scope_path` that `printed` doesn't already
+    /// cover, then record `scope_path` as printed.
+    ///
+    /// Header state belongs to the printing site, not the formatter: under
+    /// `--parallel` the coordinator interleaves files from several workers, and
+    /// concurrent tests complete out of scope order, so a scope legitimately
+    /// needs re-announcing when the path changes.
+    pub(crate) fn emit_scope_headers(
+        printed: &mut Vec<u8>,
+        scope_path: &[u8],
+        writer: &mut impl bun_io::Write,
+    ) {
+        let common = scope_segments(printed)
+            .zip(scope_segments(scope_path))
+            .take_while(|(a, b)| a == b)
+            .count();
+
+        let colors = Output::enable_ansi_colors_stderr();
+        for (depth, name) in scope_segments(scope_path).enumerate().skip(common) {
+            Self::write_indent(writer, depth);
+            if colors {
+                let _ = writer.write_all(&Output::pretty_fmt::<true>("<r><d>"));
+                let _ = writer.write_all(name);
+                let _ = writer.write_all(&Output::pretty_fmt::<true>("<r>"));
+            } else {
+                let _ = writer.write_all(name);
+            }
+            let _ = writer.write_all(b"\n");
+        }
+
+        printed.clear();
+        printed.extend_from_slice(scope_path);
+    }
+
+    /// Diagnostics that accompany a result but are not part of the status line:
+    /// assertion-count errors and GitHub Actions annotations. Must run exactly
+    /// once per result — the status line itself may be formatted twice (nested
+    /// for streaming, flat for the end-of-run recap).
+    fn print_status_side_effects(
+        status: bun_test::Execution::Result,
+        sequence: &bun_test::Execution::ExecutionSequence,
+        test_entry: &bun_test::ExecutionEntry,
+    ) {
+        match status {
+            bun_test::Execution::Result::FailBecauseExpectedAssertionCount => {
+                // not sent to writer so it doesn't get printed twice
+                let expected_count =
+                    if let bun_test::ExpectAssertions::Exact(n) = sequence.expect_assertions {
+                        n
+                    } else {
+                        12345
+                    };
+                Output::err(
+                    crate::Error::AssertionError,
+                    "expected <green>{} assertion{}<r>, but test ended with <red>{} assertion{}<r>\n",
+                    (
+                        expected_count,
+                        if expected_count == 1 { "" } else { "s" },
+                        sequence.expect_call_count,
+                        if sequence.expect_call_count == 1 {
+                            ""
+                        } else {
+                            "s"
+                        },
+                    ),
+                );
+                Output::flush();
+            }
+            bun_test::Execution::Result::FailBecauseExpectedHasAssertions => {
+                Output::err(
+                    crate::Error::AssertionError,
+                    "received <red>0 assertions<r>, but expected <green>at least one assertion<r> to be called\n",
+                    (),
+                );
+                Output::flush();
+            }
+            bun_test::Execution::Result::FailBecauseTimeout
+            | bun_test::Execution::Result::FailBecauseHookTimeout
+            | bun_test::Execution::Result::FailBecauseTimeoutWithDoneCallback
+            | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
+                if Output::is_github_action() {
+                    let display_label: &[u8] =
+                        test_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
+                    Output::print_error(format_args!(
+                        "::error title=error: Test \"{}\" timed out after {}ms::\n",
+                        bun_fmt::github_action_property(display_label),
+                        test_entry.timeout
+                    ));
+                    Output::flush();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Writes one status line (without the leading glyph, which the caller
+    /// emits) plus any trailing explanation lines.
+    fn print_test_line<const DIM: bool>(
+        status: bun_test::Execution::Result,
+        sequence: &mut bun_test::Execution::ExecutionSequence,
+        test_entry: &mut bun_test::ExecutionEntry,
+        elapsed_ns: u64,
+        scopes: &[*const bun_test::DescribeScope],
+        layout: Layout,
+        writer: &mut impl bun_io::Write,
+    ) {
+        let initial_retry_count = test_entry.retry_count;
+        let attempts = (initial_retry_count - sequence.remaining_retry_count) + 1;
+        let initial_repeat_count = test_entry.repeat_count;
+        let repeats = (initial_repeat_count - sequence.remaining_repeat_count) + 1;
+
+        let display_label: &[u8] = test_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
+        let colors = Output::enable_ansi_colors_stderr();
+        let indent = if layout == Layout::Nested {
+            scopes.len()
+        } else {
+            0
+        };
+
+        if layout == Layout::Flat {
+            for scope in scopes.iter().rev() {
+                let name = Self::scope_name(*scope);
+                let _ = writer.write_all(b" ");
+                if colors {
                     let prefix = if DIM {
                         Output::pretty_fmt::<true>("<r><d>")
                     } else {
@@ -1042,120 +1141,104 @@ impl CommandLineReporter {
                     let _ = writer.write_all(&prefix);
                     let _ = writer.write_all(name);
                     let _ = writer.write_all(&Output::pretty_fmt::<true>("<d>"));
-                    let _ = writer.write_all(b" >");
-                }
-            } else {
-                for i in 0..scopes.len() {
-                    let index = (scopes.len() - 1) - i;
-                    let scope = scopes[index];
-                    // SAFETY: scope is alive for duration of test run
-                    let name: &[u8] = unsafe { (*scope).base.name.as_deref() }.unwrap_or(b"");
-                    if name.is_empty() {
-                        continue;
-                    }
-                    let _ = writer.write_all(b" ");
-                    let _ = writer.write_all(name);
-                    let _ = writer.write_all(b" >");
-                }
-            }
-
-            if Output::enable_ansi_colors_stderr() {
-                let label_prefix = if DIM {
-                    Output::pretty_fmt::<true>("<r><d> ")
                 } else {
-                    Output::pretty_fmt::<true>("<r><b> ")
-                };
-                let _ = writer.write_all(&label_prefix);
-                let _ = writer.write_all(display_label);
-                let _ = writer.write_all(&Output::pretty_fmt::<true>("<r>"));
+                    let _ = writer.write_all(name);
+                }
+                let _ = writer.write_all(b" >");
+            }
+        }
+
+        if colors {
+            let label_prefix = if DIM {
+                Output::pretty_fmt::<true>("<r><d> ")
             } else {
-                let _ = writer.write_all(b" ");
-                let _ = writer.write_all(display_label);
-            }
+                Output::pretty_fmt::<true>("<r><b> ")
+            };
+            let _ = writer.write_all(&label_prefix);
+            let _ = writer.write_all(display_label);
+            let _ = writer.write_all(&Output::pretty_fmt::<true>("<r>"));
+        } else {
+            let _ = writer.write_all(b" ");
+            let _ = writer.write_all(display_label);
+        }
 
-            // Print attempt count if test was retried (attempts > 1)
-            if attempts > 1 {
+        // Print attempt count if test was retried (attempts > 1)
+        if attempts > 1 {
+            let _ = bun_core::write_pretty!(writer, colors, " <d>(attempt {d})<r>", attempts,);
+        }
+
+        // Print repeat count if test failed on a repeat (repeats > 1)
+        if repeats > 1 {
+            let _ = bun_core::write_pretty!(writer, colors, " <d>(run {d})<r>", repeats,);
+        }
+
+        if elapsed_ns > (bun::time::NS_PER_US * 10) {
+            let _ = write!(
+                writer,
+                " {}",
+                Output::ElapsedFormatter {
+                    colors,
+                    duration_ns: elapsed_ns,
+                }
+            );
+        }
+
+        let _ = writer.write_all(b"\n");
+
+        use bun_test::Execution::Result as R;
+        match status {
+            R::Pending | R::Pass | R::Skip | R::SkippedBecauseLabel | R::Todo | R::Fail => {}
+
+            R::FailBecauseFailingTestPassed => {
+                Self::write_indent(writer, indent);
                 let _ = bun_core::write_pretty!(
                     writer,
-                    Output::enable_ansi_colors_stderr(),
-                    " <d>(attempt {d})<r>",
-                    attempts,
+                    colors,
+                    "  <d>^<r> <red>this test is marked as failing but it passed.<r> <d>Remove `.failing` if tested behavior now works<r>\n"
                 );
             }
-
-            // Print repeat count if test failed on a repeat (repeats > 1)
-            if repeats > 1 {
+            R::FailBecauseTodoPassed => {
+                Self::write_indent(writer, indent);
                 let _ = bun_core::write_pretty!(
                     writer,
-                    Output::enable_ansi_colors_stderr(),
-                    " <d>(run {d})<r>",
-                    repeats,
+                    colors,
+                    "  <d>^<r> <red>this test is marked as todo but passes.<r> <d>Remove `.todo` if tested behavior now works<r>\n"
                 );
             }
-
-            if elapsed_ns > (bun::time::NS_PER_US * 10) {
-                let _ = write!(
+            R::FailBecauseExpectedAssertionCount | R::FailBecauseExpectedHasAssertions => {} // printed by print_status_side_effects
+            R::FailBecauseTimeout => {
+                Self::write_indent(writer, indent);
+                let _ = bun_core::write_pretty!(
                     writer,
-                    " {}",
-                    Output::ElapsedFormatter {
-                        colors: Output::enable_ansi_colors_stderr(),
-                        duration_ns: elapsed_ns,
-                    }
+                    colors,
+                    "  <d>^<r> <red>this test timed out after {d}ms.<r>\n",
+                    test_entry.timeout
                 );
             }
-
-            let _ = writer.write_all(b"\n");
-
-            let colors = Output::enable_ansi_colors_stderr();
-            use bun_test::Execution::Result as R;
-            match status {
-                R::Pending | R::Pass | R::Skip | R::SkippedBecauseLabel | R::Todo | R::Fail => {}
-
-                R::FailBecauseFailingTestPassed => {
-                    let _ = bun_core::write_pretty!(
-                        writer,
-                        colors,
-                        "  <d>^<r> <red>this test is marked as failing but it passed.<r> <d>Remove `.failing` if tested behavior now works<r>\n"
-                    );
-                }
-                R::FailBecauseTodoPassed => {
-                    let _ = bun_core::write_pretty!(
-                        writer,
-                        colors,
-                        "  <d>^<r> <red>this test is marked as todo but passes.<r> <d>Remove `.todo` if tested behavior now works<r>\n"
-                    );
-                }
-                R::FailBecauseExpectedAssertionCount | R::FailBecauseExpectedHasAssertions => {} // printed above
-                R::FailBecauseTimeout => {
-                    let _ = bun_core::write_pretty!(
-                        writer,
-                        colors,
-                        "  <d>^<r> <red>this test timed out after {d}ms.<r>\n",
-                        test_entry.timeout
-                    );
-                }
-                R::FailBecauseHookTimeout => {
-                    let _ = bun_core::write_pretty!(
-                        writer,
-                        colors,
-                        "  <d>^<r> <red>a beforeEach/afterEach hook timed out for this test.<r>\n"
-                    );
-                }
-                R::FailBecauseTimeoutWithDoneCallback => {
-                    let _ = bun_core::write_pretty!(
-                        writer,
-                        colors,
-                        "  <d>^<r> <red>this test timed out after {d}ms, before its done callback was called.<r> <d>If a done callback was not intended, remove the last parameter from the test callback function<r>\n",
-                        test_entry.timeout
-                    );
-                }
-                R::FailBecauseHookTimeoutWithDoneCallback => {
-                    let _ = bun_core::write_pretty!(
-                        writer,
-                        colors,
-                        "  <d>^<r> <red>a beforeEach/afterEach hook timed out before its done callback was called.<r> <d>If a done callback was not intended, remove the last parameter from the hook callback function<r>\n"
-                    );
-                }
+            R::FailBecauseHookTimeout => {
+                Self::write_indent(writer, indent);
+                let _ = bun_core::write_pretty!(
+                    writer,
+                    colors,
+                    "  <d>^<r> <red>a beforeEach/afterEach hook timed out for this test.<r>\n"
+                );
+            }
+            R::FailBecauseTimeoutWithDoneCallback => {
+                Self::write_indent(writer, indent);
+                let _ = bun_core::write_pretty!(
+                    writer,
+                    colors,
+                    "  <d>^<r> <red>this test timed out after {d}ms, before its done callback was called.<r> <d>If a done callback was not intended, remove the last parameter from the test callback function<r>\n",
+                    test_entry.timeout
+                );
+            }
+            R::FailBecauseHookTimeoutWithDoneCallback => {
+                Self::write_indent(writer, indent);
+                let _ = bun_core::write_pretty!(
+                    writer,
+                    colors,
+                    "  <d>^<r> <red>a beforeEach/afterEach hook timed out before its done callback was called.<r> <d>If a done callback was not intended, remove the last parameter from the hook callback function<r>\n"
+                );
             }
         }
     }
@@ -1364,6 +1447,10 @@ impl CommandLineReporter {
         elapsed_ns: u64,
     ) {
         let mut output_buf: Vec<u8> = Vec::new();
+        // Flat-formatted copy of the status line for the end-of-run recap, where
+        // the describe headers printed during streaming are absent.
+        let mut recap_buf: Vec<u8> = Vec::new();
+        let mut scope_path: Vec<u8> = Vec::new();
 
         let initial_length = output_buf.len();
         let writer = &mut output_buf;
@@ -1413,28 +1500,66 @@ impl CommandLineReporter {
             } else {
                 buntest.bun_test_root.on_before_print();
 
-                if Output::enable_ansi_colors_stderr() {
-                    let _ = writer.write_all(&fmt_status_text_line(result, true));
-                } else {
-                    let _ = writer.write_all(&fmt_status_text_line(result, false));
-                }
-                let dim = match basic {
-                    bun_test::BasicResult::Todo => {
-                        if let Some(runner) = jest::Jest::runner() {
-                            !runner.run_todo
+                // Quieter output when an AI agent is driving.
+                if !Output::is_ai_agent() || !result.is_pass(bun_test::PendingMode::PendingIsFail) {
+                    Self::print_status_side_effects(result, sequence, test_entry);
+
+                    let scopes_stack = Self::collect_scopes(test_entry);
+                    let scopes = scopes_stack.as_slice();
+
+                    // In dots mode the coordinator/reporter suppresses headers, so
+                    // the rare full line printed there stays self-describing.
+                    let layout = if reporter_ref.is_some_and(|r| r.reporters.dots) {
+                        Layout::Flat
+                    } else {
+                        Self::write_scope_path(scopes, &mut scope_path);
+                        Layout::Nested
+                    };
+
+                    let dim = match basic {
+                        bun_test::BasicResult::Todo => {
+                            if let Some(runner) = jest::Jest::runner() {
+                                !runner.run_todo
+                            } else {
+                                true
+                            }
+                        }
+                        bun_test::BasicResult::Skip | bun_test::BasicResult::Pending => true,
+                        bun_test::BasicResult::Pass | bun_test::BasicResult::Fail => false,
+                    };
+
+                    let colors = Output::enable_ansi_colors_stderr();
+                    let glyph = fmt_status_text_line(result, colors);
+
+                    let mut write_line = |layout: Layout, writer: &mut Vec<u8>| {
+                        if layout == Layout::Nested {
+                            Self::write_indent(writer, scopes.len());
+                        }
+                        let _ = writer.write_all(&glyph);
+                        if dim {
+                            Self::print_test_line::<true>(
+                                result, sequence, test_entry, elapsed_ns, scopes, layout, writer,
+                            );
                         } else {
-                            true
+                            Self::print_test_line::<false>(
+                                result, sequence, test_entry, elapsed_ns, scopes, layout, writer,
+                            );
+                        }
+                    };
+
+                    write_line(layout, writer);
+                    if matches!(
+                        basic,
+                        bun_test::BasicResult::Skip
+                            | bun_test::BasicResult::Todo
+                            | bun_test::BasicResult::Fail
+                    ) {
+                        if layout == Layout::Flat {
+                            recap_buf.extend_from_slice(writer);
+                        } else {
+                            write_line(Layout::Flat, &mut recap_buf);
                         }
                     }
-                    bun_test::BasicResult::Skip | bun_test::BasicResult::Pending => true,
-                    bun_test::BasicResult::Pass | bun_test::BasicResult::Fail => false,
-                };
-                if dim {
-                    Self::print_test_line::<true>(result, sequence, test_entry, elapsed_ns, writer);
-                } else {
-                    Self::print_test_line::<false>(
-                        result, sequence, test_entry, elapsed_ns, writer,
-                    );
                 }
             }
         }
@@ -1443,37 +1568,42 @@ impl CommandLineReporter {
         Self::maybe_print_junit_line(result, buntest, sequence, test_entry, elapsed_ns);
 
         let formatted_line = &output_buf[initial_length..];
-        // SAFETY: `BunTest.reporter` is `NonNull<CommandLineReporter>`; re-derived
-        // here (not held across `maybe_print_junit_line`'s `&mut`) per stacked
-        // borrows.
-        let worker_idx = buntest
-            .reporter
-            .and_then(|p| unsafe { (*p.as_ptr()).worker_ipc_file_idx });
-        if let Some(idx) = worker_idx {
-            ParallelRunner::worker_emit_test_done(idx, formatted_line);
-        } else {
-            let _ = Output::error_writer().write_all(formatted_line);
-        }
 
         let Some(this) = buntest.reporter else {
+            // command line reporter is missing! uh oh!
+            let _ = Output::error_writer().write_all(formatted_line);
             return;
-        }; // command line reporter is missing! uh oh!
+        };
         // SAFETY: `BunTest.reporter` is `NonNull<CommandLineReporter>` with write
         // provenance from `enter_file`'s `&mut`; single-threaded test runner,
-        // sole writer for the duration of this completion callback.
+        // sole writer for the duration of this completion callback. Re-derived
+        // here (not held across `maybe_print_junit_line`'s `&mut`) per stacked
+        // borrows.
         let this: &mut CommandLineReporter = unsafe { &mut *this.as_ptr() };
+
+        if let Some(idx) = this.worker_ipc_file_idx {
+            // The coordinator owns the terminal and therefore the header state;
+            // ship the scope path alongside the line so it can decide.
+            ParallelRunner::worker_emit_test_done(idx, &scope_path, formatted_line);
+        } else {
+            let writer = Output::error_writer();
+            if !formatted_line.is_empty() {
+                Self::emit_scope_headers(&mut this.printed_scope_path, &scope_path, writer);
+            }
+            let _ = writer.write_all(formatted_line);
+        }
 
         if !this.reporters.dots && !this.reporters.only_failures {
             match sequence.result.basic_result() {
-                bun_test::BasicResult::Skip => this
-                    .skips_to_repeat_buf
-                    .extend_from_slice(&output_buf[initial_length..]),
-                bun_test::BasicResult::Todo => this
-                    .todos_to_repeat_buf
-                    .extend_from_slice(&output_buf[initial_length..]),
-                bun_test::BasicResult::Fail => this
-                    .failures_to_repeat_buf
-                    .extend_from_slice(&output_buf[initial_length..]),
+                bun_test::BasicResult::Skip => {
+                    this.skips_to_repeat_buf.extend_from_slice(&recap_buf)
+                }
+                bun_test::BasicResult::Todo => {
+                    this.todos_to_repeat_buf.extend_from_slice(&recap_buf)
+                }
+                bun_test::BasicResult::Fail => {
+                    this.failures_to_repeat_buf.extend_from_slice(&recap_buf)
+                }
                 bun_test::BasicResult::Pass | bun_test::BasicResult::Pending => {}
             }
         }
@@ -2258,6 +2388,7 @@ impl TestCommand {
             failures_to_repeat_buf: Vec::new(),
             skips_to_repeat_buf: Vec::new(),
             todos_to_repeat_buf: Vec::new(),
+            printed_scope_path: Vec::new(),
             reporters: ReportersConfig::default(),
         });
         // `defer { if (reporter.reporters.junit) |fr| fr.deinit() }` — handled by Drop.

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -510,6 +510,10 @@ impl BunTestRoot {
         debug_assert!(self.active_file.is_none());
         self.file_generation = self.file_generation.wrapping_add(1);
 
+        // Each file re-prints its `path:` header, so describe headers must be
+        // re-announced too.
+        reporter.printed_scope_path.clear();
+
         // Derive the stored backref from the TestRunner's *stable* storage
         // (the global `Jest::RUNNER` NonNull) rather than `self as *mut _`.
         // A pointer coerced from `&mut self` carries provenance bounded by this

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1532,7 +1532,7 @@ describe("nested describe output", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, , exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
     return { stderr: normalizeBunSnapshot(stderr, dir), exitCode };
   }
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -985,8 +985,8 @@ describe("bun test", () => {
           `,
         });
 
-        expect(stderr).toContain("fs module > has $method");
-        expect(stderr).toContain("path module > has $method");
+        expect(stderr).toContain("fs module\n  (pass) has $method");
+        expect(stderr).toContain("path module\n  (pass) has $method");
         expect(stderr).toContain("2 pass");
       });
 
@@ -1314,8 +1314,10 @@ describe("bun test", () => {
         .trim(),
     ).toMatchInlineSnapshot(`
       "bun-test-*.test.ts:
-      (pass) group 1 > should match filter
-      (pass) group 2 > another test that should match filter
+      group 1
+        (pass) should match filter
+      group 2
+        (pass) another test that should match filter
 
        2 pass
        5 filtered out
@@ -1500,6 +1502,149 @@ describe("bun test", () => {
     expect(stdout).not.toContain("pass");
     expect(stderr).toContain("1 pass");
     expect(exitCode).toBe(1);
+  });
+});
+
+describe("nested describe output", () => {
+  const fixture = `
+    import { describe, expect, it } from "bun:test";
+    describe("group one", () => {
+      describe("sub A", () => {
+        it("zero", () => { expect(0).toBe(0); });
+        it("one", () => { expect(1).toBe(1); });
+      });
+      it("four", () => { expect(4).toBe(4); });
+    });
+    describe("group two", () => {
+      it("five", () => { expect(5).toBe(5); });
+      it.skip("six", () => {});
+      it.todo("seven");
+    });
+    it("top level", () => {});
+  `;
+
+  async function run(files: Record<string, string>, args: string[], dirName: string) {
+    using dir = tempDir(dirName, files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr: normalizeBunSnapshot(stderr, dir), exitCode };
+  }
+
+  test("describe scopes are printed once with tests indented beneath", async () => {
+    const { stderr, exitCode } = await run({ "a.test.ts": fixture }, ["a.test.ts"], "nested-output");
+
+    expect(stderr).toMatchInlineSnapshot(`
+      "a.test.ts:
+      group one
+        sub A
+          (pass) zero
+          (pass) one
+        (pass) four
+      group two
+        (pass) five
+        (skip) six
+        (todo) seven
+      (pass) top level
+
+       5 pass
+       1 skip
+       1 todo
+       0 fail
+       4 expect() calls
+      Ran 7 tests across 1 file."
+    `);
+    expect(exitCode).toBe(0);
+  });
+
+  test("unnamed describe scopes do not consume an indent level", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "a.test.ts": `
+          import { describe, it } from "bun:test";
+          describe("", () => { it("no scope", () => {}); });
+          describe("outer", () => {
+            describe("", () => { it("skips a level", () => {}); });
+          });
+        `,
+      },
+      ["a.test.ts"],
+      "nested-output-unnamed",
+    );
+
+    expect(stderr).toMatchInlineSnapshot(`
+      "a.test.ts:
+      (pass) no scope
+      outer
+        (pass) skips a level
+
+       2 pass
+       0 fail
+      Ran 2 tests across 1 file."
+    `);
+    expect(exitCode).toBe(0);
+  });
+
+  test("--only-failures prints headers only for the failures", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "a.test.ts": `
+          import { describe, expect, it } from "bun:test";
+          describe("passing group", () => { it("fine", () => {}); });
+          describe("failing group", () => {
+            describe("inner", () => { it("boom", () => { expect(1).toBe(2); }); });
+          });
+        `,
+      },
+      ["a.test.ts", "--only-failures"],
+      "nested-output-only-failures",
+    );
+
+    expect(stderr).toContain("failing group\n  inner\n    (fail) boom");
+    expect(stderr).not.toContain("\npassing group\n");
+    expect(exitCode).toBe(1);
+  });
+
+  test("each file re-announces its describe scopes under --parallel", async () => {
+    const { stderr, exitCode } = await run(
+      { "a.test.ts": fixture, "b.test.ts": fixture },
+      ["--parallel=2", "a.test.ts", "b.test.ts"],
+      "nested-output-parallel",
+    );
+
+    for (const file of ["a.test.ts", "b.test.ts"]) {
+      expect(stderr).toContain(`${file}:\ngroup one\n  sub A\n    (pass) zero`);
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test("the end-of-run recap keeps the flat scope path", async () => {
+    const passing = Array.from({ length: 21 }, (_, i) => `it("t${i}", () => {});`).join("\n");
+    const { stderr, exitCode } = await run(
+      {
+        "a.test.ts": `
+          import { describe, it } from "bun:test";
+          describe("outer", () => {
+            describe("inner", () => {
+              ${passing}
+              it.skip("skipped", () => {});
+              it.todo("pending");
+            });
+          });
+        `,
+      },
+      ["a.test.ts"],
+      "nested-output-recap",
+    );
+
+    expect(stderr).toContain("(skip) outer > inner > skipped");
+    expect(stderr).toContain("(todo) outer > inner > pending");
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/cli/test/test-filter-lifecycle-snapshot.test.ts
+++ b/test/cli/test/test-filter-lifecycle-snapshot.test.ts
@@ -29,8 +29,10 @@ test("snapshot", () => {
     <parent afterAll>
 
     test/cli/test/test-filter-lifecycle.js:
-    (pass) parent > should run > test
-    (pass) parent > should run > test 2
+    parent
+      should run
+        (pass) test
+        (pass) test 2
 
      2 pass
      4 filtered out

--- a/test/js/bun/test/bun_test.test.ts
+++ b/test/js/bun/test/bun_test.test.ts
@@ -36,11 +36,13 @@ test("describe/test", async () => {
 
     error: uh oh
     uh oh
-    (fail) actual tests > more functions called after delayed done
-    (pass) actual tests > another test
-    (pass) concurrent describe 1 > item 1
-    (pass) concurrent describe 1 > item 2
-    (pass) concurrent describe 1 > snapshot in concurrent group
+    actual tests
+      (fail) more functions called after delayed done
+      (pass) another test
+    concurrent describe 1
+      (pass) item 1
+      (pass) item 2
+      (pass) snapshot in concurrent group
     (pass) LINE 66
     (skip) LINE 67
     (fail) LINE 68
@@ -72,12 +74,15 @@ test("describe/test", async () => {
     (pass) another test
     (pass) misattributed error
     (pass) passes because it catches the misattributed error
-    (pass) hooks > test1
-    (pass) hooks > test2
-    (pass) done parameter > instant done
-    (pass) done parameter > delayed done
-    (pass) done parameter > done combined with promise > done combined with promise, promise resolves first
-    (pass) done parameter > done combined with promise > done combined with promise, done resolves first
+    hooks
+      (pass) test1
+      (pass) test2
+    done parameter
+      (pass) instant done
+      (pass) delayed done
+      done combined with promise
+        (pass) done combined with promise, promise resolves first
+        (pass) done combined with promise, done resolves first
     224 |   });
     225 |   describe("done combined with promise", () => {
     226 |     let completion = 0;
@@ -87,22 +92,24 @@ test("describe/test", async () => {
                                            ^
     error: completion is not 2
         at <anonymous> (file:NN:NN)
-    (fail) done parameter > done combined with promise > fails when completion is not incremented
+        (fail) fails when completion is not incremented
     error: test error
     test error
     error: promise error
     promise error
-    (fail) done parameter > done combined with promise error conditions > both error and done resolves first
+      done combined with promise error conditions
+        (fail) both error and done resolves first
     error: done error
     done error
-    (fail) done parameter > done combined with promise error conditions > done errors only
+        (fail) done errors only
     error: promise error
     promise error
-    (fail) done parameter > done combined with promise error conditions > promise errors only
-    (pass) done parameter > second call of done callback ignores triggers error
+        (fail) promise errors only
+      (pass) second call of done callback ignores triggers error
     (pass) microtasks and rejections are drained after the test callback is executed
-    (pass) after inside test > the test 1
-    (pass) after inside test > the test 2
+    after inside test
+      (pass) the test 1
+      (pass) the test 2
     (pass) beforeEach inside test fails
 
     2 tests skipped:

--- a/test/js/bun/test/concurrent.test.ts
+++ b/test/js/bun/test/concurrent.test.ts
@@ -26,8 +26,10 @@ test.concurrent("concurrent order", async () => {
     (pass) test 4
     (pass) test 5
     (pass) test 6
-    (pass) describe group 7 > test 7
-    (pass) describe group 8 > test 8
+    describe group 7
+      (pass) test 7
+    describe group 8
+      (pass) test 8
 
      8 pass
      0 fail

--- a/test/js/bun/test/describe.test.ts
+++ b/test/js/bun/test/describe.test.ts
@@ -104,8 +104,8 @@ describe("shows first arg name correctly in test output", () => {
 
     const fullOutput = stdout.toString() + stderr.toString();
 
-    expect(fullOutput).toInclude("add > should pass");
-    expect(fullOutput).not.toInclude("[object Object] > should pass");
+    expect(fullOutput).toInclude("add\n  (pass) should pass");
+    expect(fullOutput).not.toInclude("[object Object]");
   });
   test("describe block shows named class correctly in test output", async () => {
     const test_dir = tempDirWithFiles(".", {
@@ -131,9 +131,9 @@ describe("shows first arg name correctly in test output", () => {
 
     const fullOutput = stdout.toString() + stderr.toString();
 
-    expect(fullOutput).toInclude("Rectangle > should pass");
-    expect(fullOutput).not.toInclude("[object Object] > should pass");
-    expect(fullOutput).not.toInclude("MyClass > should pass");
+    expect(fullOutput).toInclude("Rectangle\n  (pass) should pass");
+    expect(fullOutput).not.toInclude("[object Object]");
+    expect(fullOutput).not.toInclude("MyClass");
   });
 
   test("describe block shows anonymous class correctly in test output", async () => {
@@ -160,8 +160,8 @@ describe("shows first arg name correctly in test output", () => {
 
     const fullOutput = stdout.toString() + stderr.toString();
 
-    expect(fullOutput).toInclude("MyClass > should pass");
-    expect(fullOutput).not.toInclude("[object Object] > should pass");
+    expect(fullOutput).toInclude("MyClass\n  (pass) should pass");
+    expect(fullOutput).not.toInclude("[object Object]");
   });
 });
 

--- a/test/js/bun/test/nested-describes.test.ts
+++ b/test/js/bun/test/nested-describes.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, test } from "bun:test";
 
 /*
 In this test we want the tests to print out the following on a success.
-Each success / fail should show the path of describe and test scopes
+Each success / fail is nested under its describe scopes.
 
-✓ outer most describe > mid describe 1 > inner most describe 1 > first
-✓ outer most describe > mid describe 1 > inner most describe 2 > second
-✓ outer most describe > mid describe 2 > inner most describe 3 > first
+outer most describe
+  mid describe 1
+    inner most describe 1
+      ✓ first
+    inner most describe 2
+      ✓ second
+  mid describe 2
+    inner most describe 3
+      ✓ third
 
 @TODO add testing for this, would require to read the test console output
 */

--- a/test/regression/issue/12782.test.ts
+++ b/test/regression/issue/12782.test.ts
@@ -34,8 +34,10 @@ test("12782", async () => {
     (fail) (unnamed)
 
     test/regression/issue/12782.bar.fixture.ts:
-    (pass) bar > should not run
-    (pass) bar > inner describe > should not run
+    bar
+      (pass) should not run
+      inner describe
+        (pass) should not run
 
      2 pass
      1 fail

--- a/test/regression/issue/19875.test.ts
+++ b/test/regression/issue/19875.test.ts
@@ -15,7 +15,9 @@ test("19875", async () => {
   expect(exitCode).toBe(0);
   expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
     "test/regression/issue/19875.fixture.ts:
-    (todo) only > todo > fail
+    only
+      todo
+        (todo) fail
 
      0 pass
      1 todo

--- a/test/regression/issue/20092.test.ts
+++ b/test/regression/issue/20092.test.ts
@@ -15,8 +15,10 @@ test("20092", async () => {
   expect(exitCode).toBe(0);
   expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
     "test/regression/issue/20092.fixture.ts:
-    (pass) foo > works
-    (pass) bar > works
+    foo
+      (pass) works
+    bar
+      (pass) works
 
      2 pass
      0 fail


### PR DESCRIPTION
> Branch: `nest-describe-blocks-streaming` · Commit: `70323bea`
> Closes #3342
>
> **This is one of two alternative implementations of #3342.** The sibling PR, #35794,
> solves the same problem by buffering each file's results. Pick one.
> See [Streaming vs. buffered](#streaming-vs-buffered) below.

### What does this PR do?

`bun test` repeats the full describe path on every single result line. In a suite with
any real nesting that means the same 40 characters of scope are re-printed hundreds of
times, and the actual test names are pushed off to the right.

This PR prints each `describe` scope **once**, as its own dim header line, and indents
its tests beneath it — two spaces per level.

**Before**

```
demo.test.ts:
(pass) math > arithmetic > add
(fail) math > arithmetic > subtract [1.84ms]
(pass) math > is a module
(skip) all skipped > x
(todo) all todo > y
(pass) top-level test
```

**After**

```
demo.test.ts:
math
  arithmetic
    (pass) add
    (fail) subtract [0.09ms]
  (pass) is a module
all skipped
  (skip) x
all todo
  (todo) y
(pass) top-level test
```

Headers are emitted lazily: a scope line is written the first time a result inside it is
about to print, and re-announced if results from a different scope interleave in between.
Nothing is buffered — every line still goes out the instant the test finishes.

<details>
<summary>Design notes &amp; edge cases</summary>

- **Scope path is tracked, not the tree.** The reporter keeps a single
  `printed_scope_path: Vec<u8>` (`\x1f`-separated). Before printing a result it diffs the
  test's scope path against the last-printed one, emits headers for the segments that
  differ, and stores the new path. This is O(depth) per test with one allocation reused
  for the whole run.
- **Unnamed describes are transparent.** `describe(() => {...})` contributes no header
  and no indent level, so the anonymous scope doesn't shift its children right.
- **Depth is capped at 64** scopes (`BoundedArray`), matching the existing limit in
  `collect_scopes`. Beyond that, indentation stops growing rather than running away.
- **Recap buffers keep the flat format.** The skip/todo/fail lists printed after the run
  still read `math > arithmetic > subtract` — they're a flat index, and nesting them out of
  context would be worse. This means each line is formatted twice, so the side effects of
  formatting (assertion-count errors, GitHub Actions timeout annotations) were extracted
  into `print_status_side_effects` so they fire exactly once.
- **`--reporter=dots` is untouched.** It uses `Layout::Flat` and never nests.
- **`--only-failures`** nests the same way; scopes with no failures never print a header.
- **JUnit / LCOV output is unchanged** — this is purely the terminal reporter.

</details>

### How did you verify your code works?

<details>
<summary>Test runs</summary>

- `bun bd test test/cli/test/` — 220 pass, 6 todo, 0 fail
- `bun bd test test/js/bun/test/` — no regressions vs. the parent commit
  (`df6c7eed6b` has 6 pre-existing failures, 4 of them missing-`node_modules` load
  errors; this branch has the same set)
- All `test/regression/issue/*.test.ts` files that spawn `bun test` — green
  (5 inline snapshots regenerated for the new shape)

New tests in `test/cli/test/bun-test.test.ts` cover indentation depth, unnamed-describe
transparency, re-announcing a scope after interleaving, and `--only-failures`. They fail
under `USE_SYSTEM_BUN=1` and pass under `bun bd test`.

Manually verified: default reporter, `FORCE_COLOR=1`, `NO_COLOR=1`, `--parallel=2`,
`--reporter=dots`, `--only-failures`, `--rerun-each=2`, `test.concurrent`,
`--bail`, `process.exit()` mid-file, GitHub Actions `::group::` output, and JUnit output.

</details>

### Performance

Release builds, macOS arm64, best-of-5, stdout discarded, stderr piped.
Workloads: **wide** = 200 files x 200 tests x 3 levels (40k tests); **deep** = 20 files x
5,000 tests x 8 levels (100k tests).

| workload | mode | build | wall (ms) | peak RSS (MB) | first output (ms) |
| --- | --- | --- | ---: | ---: | ---: |
| wide | default | baseline | 89 | 26.2 | 6 |
| wide | default | **streaming** | **92** | **26.5** | **6** |
| deep | default | baseline | 143 | 59.4 | 6 |
| deep | default | **streaming** | **159** | **60.4** | **7** |
| wide | parallel | baseline | 152 | 53.5 | 11 |
| wide | parallel | **streaming** | **154** | **53.3** | **11** |
| deep | dots | baseline | 136 | 57.7 | 13 |
| deep | dots | **streaming** | **131** | **59.1** | **13** |

<details>
<summary>Full benchmark matrix (all 3 builds x 2 workloads x 4 modes)</summary>

| workload | mode | build | wall (ms) | peak RSS (MB) | first output (ms) |
| --- | --- | --- | ---: | ---: | ---: |
| wide | default | baseline | 89 | 26.2 | 6 |
| wide | default | streaming | 92 | 26.5 | 6 |
| wide | default | buffered | 98 | 26.4 | 7 |
| wide | parallel | baseline | 152 | 53.5 | 11 |
| wide | parallel | streaming | 154 | 53.3 | 11 |
| wide | parallel | buffered | 181 | 53.2 | 12 |
| wide | dots | baseline | 86 | 25.8 | 7 |
| wide | dots | streaming | 87 | 26.3 | 8 |
| wide | dots | buffered | 86 | 26.0 | 8 |
| wide | only-failures | baseline | 71 | 26.0 | 70 |
| wide | only-failures | streaming | 70 | 25.9 | 69 |
| wide | only-failures | buffered | 70 | 26.1 | 69 |
| deep | default | baseline | 143 | 59.4 | 6 |
| deep | default | streaming | 159 | 60.4 | 7 |
| deep | default | buffered | 163 | 58.2 | 18 |
| deep | parallel | baseline | 95 | 35.3 | 20 |
| deep | parallel | streaming | 129 | 35.8 | 20 |
| deep | parallel | buffered | 113 | 35.4 | 30 |
| deep | dots | baseline | 136 | 57.7 | 13 |
| deep | dots | streaming | 131 | 59.1 | 13 |
| deep | dots | buffered | 134 | 59.5 | 14 |
| deep | only-failures | baseline | 92 | 52.4 | 91 |
| deep | only-failures | streaming | 92 | 51.8 | 91 |
| deep | only-failures | buffered | 91 | 51.8 | 90 |

`baseline` = `df6c7eed6b` (main), `streaming` = this branch, `buffered` = the sibling PR.

</details>

**Summary:** memory is unchanged (single reused `Vec<u8>` for the scope path, ~1 KB).
Wall time is +3% on `wide` and +11% on `deep` for the default reporter; `--dots` and
`--only-failures` are within noise. Time-to-first-output is identical to today.

### Streaming vs. buffered

|  | **this PR (streaming)** | sibling PR (buffered) |
| --- | --- | --- |
| Groups split when results interleave | yes, scope is re-announced | never |
| `test.concurrent` / `--parallel` grouping | best-effort | guaranteed contiguous |
| Aggregate status on file/`describe` lines (#12378) | no | yes |
| Time to first output | unchanged | +12 ms on a 5,000-test file |
| Peak RSS | unchanged | unchanged (bounded ~190 KB/file) |
| Wall time vs. main (default reporter) | +3% / +11% | +10% / +14% |
| Failure diagnostics position | inline, under their test | above the file's block |
| Lines changed in `src/` | ~370 | ~770 |

Streaming is the conservative option: it changes only how the scope prefix is rendered and
keeps every other timing property of the reporter identical. The cost is that under
`test.concurrent` or `--parallel` a `describe` can appear more than once, because the
reporter can't know what's still coming.

### Known limitations

- A scope header is re-printed whenever results from another scope interleave. With
  `test.concurrent` this is common; with sequential tests it never happens.
- The end-of-run recap lists keep the flat `a > b > name` form (intentional, see design
  notes).
