### PR TITLE
Bun.serve: reject tls objects that have no certificate

### DIFF
--- a/docs/runtime/http/tls.mdx
+++ b/docs/runtime/http/tls.mdx
@@ -62,6 +62,8 @@ To override Diffie-Hellman parameters:
 ```ts
 Bun.serve({
   tls: {
+    key: Bun.file("./key.pem"),
+    cert: Bun.file("./cert.pem"),
     dhParamsFile: "/path/to/dhparams.pem", // path to Diffie Hellman parameters // [!code ++]
   },
 });
@@ -76,6 +78,8 @@ To configure the server name indication (SNI) for the server, set the `serverNam
 ```ts
 Bun.serve({
   tls: {
+    key: Bun.file("./key.pem"),
+    cert: Bun.file("./cert.pem"),
     serverName: "my-server.com", // SNI // [!code ++]
   },
 });

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -167,17 +167,15 @@ impl SSLConfig {
         }
     }
 
-    /// Whether this config carries a certificate or private key (inline PEM or
-    /// file path). A TLS server needs both to complete a handshake; a config
-    /// with only tuning knobs (lowMemoryMode, requestCert, ...) has no server
-    /// identity and would otherwise produce an HTTPS listener that can never
-    /// respond.
+    /// Whether this config carries both a certificate and a private key (inline
+    /// PEM or file path). A TLS server needs both to complete a handshake; a
+    /// config with only tuning knobs (lowMemoryMode, requestCert, ...) or with
+    /// only one half of the pair has no usable server identity and would
+    /// otherwise produce an HTTPS listener that can never respond.
     #[inline]
     pub fn has_server_identity(&self) -> bool {
-        self.cert.is_some()
-            || self.key.is_some()
-            || !self.cert_file_name.is_null()
-            || !self.key_file_name.is_null()
+        (self.cert.is_some() || !self.cert_file_name.is_null())
+            && (self.key.is_some() || !self.key_file_name.is_null())
     }
 
     /// Extract the raw `*const SSLConfig` from an optional shared handle for

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -167,6 +167,19 @@ impl SSLConfig {
         }
     }
 
+    /// Whether this config carries a certificate or private key (inline PEM or
+    /// file path). A TLS server needs both to complete a handshake; a config
+    /// with only tuning knobs (lowMemoryMode, requestCert, ...) has no server
+    /// identity and would otherwise produce an HTTPS listener that can never
+    /// respond.
+    #[inline]
+    pub fn has_server_identity(&self) -> bool {
+        self.cert.is_some()
+            || self.key.is_some()
+            || !self.cert_file_name.is_null()
+            || !self.key_file_name.is_null()
+    }
+
     /// Extract the raw `*const SSLConfig` from an optional shared handle for
     /// pointer-equality comparison (interned configs have stable addresses).
     #[inline]

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -168,10 +168,7 @@ impl SSLConfig {
     }
 
     /// Whether this config carries both a certificate and a private key (inline
-    /// PEM or file path). A TLS server needs both to complete a handshake; a
-    /// config with only tuning knobs (lowMemoryMode, requestCert, ...) or with
-    /// only one half of the pair has no usable server identity and would
-    /// otherwise produce an HTTPS listener that can never respond.
+    /// PEM or file path). A TLS server needs both to complete a handshake.
     #[inline]
     pub fn has_server_identity(&self) -> bool {
         (self.cert.is_some() || !self.cert_file_name.is_null())

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1392,7 +1392,7 @@ impl ServerConfig {
                         if !ssl_config.has_server_identity() {
                             drop(ssl_config);
                             return Err(global.throw_invalid_arguments(format_args!(
-                                "tls object is missing \"cert\" and \"key\". A TLS server cannot be started without a certificate.",
+                                "tls object must specify both \"cert\" and \"key\" to start a TLS server",
                             )));
                         }
 
@@ -1418,7 +1418,7 @@ impl ServerConfig {
                     if !ssl_config.has_server_identity() {
                         drop(ssl_config);
                         return Err(global.throw_invalid_arguments(format_args!(
-                            "tls object is missing \"cert\" and \"key\". A TLS server cannot be started without a certificate.",
+                            "tls object must specify both \"cert\" and \"key\" to start a TLS server",
                         )));
                     }
                     args.ssl_config = Some(ssl_config);
@@ -1437,7 +1437,7 @@ impl ServerConfig {
         if args.ssl_config.is_none() {
             if let Some(ssl_config) = SSLConfig::from_js(vm, global, arg)? {
                 // The legacy top-level shape was `{ cert, key, fetch }`. Only
-                // accept it when a certificate or key is actually present so
+                // accept it when both a certificate and a key are present so
                 // that unrelated top-level keys that happen to collide with
                 // TLSOptions names (lowMemoryMode, requestCert, ...) don't
                 // accidentally arm a certificate-less HTTPS listener.

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1436,11 +1436,9 @@ impl ServerConfig {
         // this used to be top-level, now it's "tls" object
         if args.ssl_config.is_none() {
             if let Some(ssl_config) = SSLConfig::from_js(vm, global, arg)? {
-                // The legacy top-level shape was `{ cert, key, fetch }`. Only
-                // accept it when both a certificate and a key are present so
-                // that unrelated top-level keys that happen to collide with
-                // TLSOptions names (lowMemoryMode, requestCert, ...) don't
-                // accidentally arm a certificate-less HTTPS listener.
+                // Top-level keys that collide with TLSOptions names must not
+                // arm a certificate-less HTTPS listener; unlike an explicit
+                // `tls:` object above, ignore rather than throw.
                 if ssl_config.has_server_identity() {
                     args.ssl_config = Some(ssl_config);
                 }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1389,6 +1389,13 @@ impl ServerConfig {
                             }
                         };
 
+                        if !ssl_config.has_server_identity() {
+                            drop(ssl_config);
+                            return Err(global.throw_invalid_arguments(format_args!(
+                                "tls object is missing \"cert\" and \"key\". A TLS server cannot be started without a certificate.",
+                            )));
+                        }
+
                         if args.ssl_config.is_none() {
                             args.ssl_config = Some(ssl_config);
                         } else {
@@ -1408,6 +1415,12 @@ impl ServerConfig {
                 }
             } else {
                 if let Some(ssl_config) = SSLConfig::from_js(vm, global, tls)? {
+                    if !ssl_config.has_server_identity() {
+                        drop(ssl_config);
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "tls object is missing \"cert\" and \"key\". A TLS server cannot be started without a certificate.",
+                        )));
+                    }
                     args.ssl_config = Some(ssl_config);
                 }
                 if global.has_exception() {
@@ -1423,7 +1436,14 @@ impl ServerConfig {
         // this used to be top-level, now it's "tls" object
         if args.ssl_config.is_none() {
             if let Some(ssl_config) = SSLConfig::from_js(vm, global, arg)? {
-                args.ssl_config = Some(ssl_config);
+                // The legacy top-level shape was `{ cert, key, fetch }`. Only
+                // accept it when a certificate or key is actually present so
+                // that unrelated top-level keys that happen to collide with
+                // TLSOptions names (lowMemoryMode, requestCert, ...) don't
+                // accidentally arm a certificate-less HTTPS listener.
+                if ssl_config.has_server_identity() {
+                    args.ssl_config = Some(ssl_config);
+                }
             }
             if global.has_exception() {
                 return Err(JsError::Thrown);

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -3,8 +3,8 @@ import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "t
 import publicKey from "../../third_party/jsonwebtoken/pub.pem" with { type: "text" };
 
 describe("Bun.serve SSL validations", () => {
-  describe("tls option without a certificate", () => {
-    const tuningOnly: Record<string, Bun.TLSOptions> = {
+  describe("tls option without a server identity", () => {
+    const noIdentity: Record<string, Bun.TLSOptions> = {
       "lowMemoryMode": { lowMemoryMode: true },
       "requestCert": { requestCert: true },
       "rejectUnauthorized": { rejectUnauthorized: false },
@@ -12,28 +12,29 @@ describe("Bun.serve SSL validations", () => {
       "passphrase": { passphrase: "x" },
       "serverName": { serverName: "example.com" },
       "ca": { ca: publicKey },
+      "cert only": { cert: publicKey },
+      "key only": { key: privateKey },
     };
 
-    // An explicit `tls: { ... }` that only carries tuning knobs (no cert/key)
-    // must throw rather than start an HTTPS listener that can never complete a
-    // handshake.
-    for (const [label, tls] of Object.entries(tuningOnly)) {
+    // An explicit `tls: { ... }` that has no complete cert+key pair must throw
+    // rather than start an HTTPS listener that can never complete a handshake.
+    for (const [label, tls] of Object.entries(noIdentity)) {
       test(`tls: { ${label} } throws`, () => {
         expect(() => {
-          Bun.serve({ port: 0, tls, fetch: () => new Response("ok") });
-        }).toThrow('tls object is missing "cert" and "key"');
+          using _ = Bun.serve({ port: 0, tls, fetch: () => new Response("ok") });
+        }).toThrow('tls object must specify both "cert" and "key"');
       });
       test(`tls: [{ ${label} }] throws`, () => {
         expect(() => {
-          Bun.serve({ port: 0, tls: [tls], fetch: () => new Response("ok") });
-        }).toThrow('tls object is missing "cert" and "key"');
+          using _ = Bun.serve({ port: 0, tls: [tls], fetch: () => new Response("ok") });
+        }).toThrow('tls object must specify both "cert" and "key"');
       });
     }
 
     // The same keys at the top level (the legacy v0.2 flattened shape) must
     // NOT flip the server into TLS mode. They are silently ignored and the
     // server stays plain HTTP.
-    for (const [label, opts] of Object.entries(tuningOnly)) {
+    for (const [label, opts] of Object.entries(noIdentity)) {
       test(`top-level { ${label} } stays HTTP`, async () => {
         using server = Bun.serve({
           port: 0,

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -3,6 +3,74 @@ import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "t
 import publicKey from "../../third_party/jsonwebtoken/pub.pem" with { type: "text" };
 
 describe("Bun.serve SSL validations", () => {
+  describe("tls option without a certificate", () => {
+    const tuningOnly: Record<string, Bun.TLSOptions> = {
+      "lowMemoryMode": { lowMemoryMode: true },
+      "requestCert": { requestCert: true },
+      "rejectUnauthorized": { rejectUnauthorized: false },
+      "secureOptions": { secureOptions: 1 },
+      "passphrase": { passphrase: "x" },
+      "serverName": { serverName: "example.com" },
+      "ca": { ca: publicKey },
+    };
+
+    // An explicit `tls: { ... }` that only carries tuning knobs (no cert/key)
+    // must throw rather than start an HTTPS listener that can never complete a
+    // handshake.
+    for (const [label, tls] of Object.entries(tuningOnly)) {
+      test(`tls: { ${label} } throws`, () => {
+        expect(() => {
+          Bun.serve({ port: 0, tls, fetch: () => new Response("ok") });
+        }).toThrow('tls object is missing "cert" and "key"');
+      });
+      test(`tls: [{ ${label} }] throws`, () => {
+        expect(() => {
+          Bun.serve({ port: 0, tls: [tls], fetch: () => new Response("ok") });
+        }).toThrow('tls object is missing "cert" and "key"');
+      });
+    }
+
+    // The same keys at the top level (the legacy v0.2 flattened shape) must
+    // NOT flip the server into TLS mode. They are silently ignored and the
+    // server stays plain HTTP.
+    for (const [label, opts] of Object.entries(tuningOnly)) {
+      test(`top-level { ${label} } stays HTTP`, async () => {
+        using server = Bun.serve({
+          port: 0,
+          ...(opts as object),
+          fetch: () => new Response("ok"),
+        });
+        expect(server.url.protocol).toBe("http:");
+        const res = await fetch(server.url);
+        expect(await res.text()).toBe("ok");
+        expect(res.status).toBe(200);
+      });
+    }
+
+    // Back-compat: cert/key at the top level (no `tls:` wrapper) still works.
+    test("top-level { cert, key } still enables TLS", async () => {
+      using server = Bun.serve({
+        port: 0,
+        // @ts-expect-error legacy flattened shape
+        cert: publicKey,
+        key: privateKey,
+        fetch: () => new Response("ok"),
+      });
+      expect(server.url.protocol).toBe("https:");
+      const res = await fetch(server.url, { tls: { rejectUnauthorized: false } });
+      expect(await res.text()).toBe("ok");
+      expect(res.status).toBe(200);
+    });
+
+    // tls: {} with nothing in it was already treated as "no TLS"; keep that.
+    test("tls: {} stays HTTP", async () => {
+      using server = Bun.serve({ port: 0, tls: {}, fetch: () => new Response("ok") });
+      expect(server.url.protocol).toBe("http:");
+      const res = await fetch(server.url);
+      expect(res.status).toBe(200);
+    });
+  });
+
   const fixtures = [
     {
       label: "invalid key",

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import path from "node:path";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
 import publicKey from "../../third_party/jsonwebtoken/pub.pem" with { type: "text" };
+
+const privateKeyPath = path.join(import.meta.dir, "../../third_party/jsonwebtoken/priv.pem");
+const publicKeyPath = path.join(import.meta.dir, "../../third_party/jsonwebtoken/pub.pem");
 
 describe("Bun.serve SSL validations", () => {
   describe("tls option without a server identity", () => {
@@ -14,6 +18,8 @@ describe("Bun.serve SSL validations", () => {
       "ca": { ca: publicKey },
       "cert only": { cert: publicKey },
       "key only": { key: privateKey },
+      "certFile only": { certFile: publicKeyPath },
+      "keyFile only": { keyFile: privateKeyPath },
     };
 
     // An explicit `tls: { ... }` that has no complete cert+key pair must throw

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2351,12 +2351,8 @@ describe.concurrent("should error with invalid options", async () => {
           return new Response("hi");
         },
         tls: [
-          {
-            key: "lkwejflkwjeflkj",
-          },
-          {
-            key: "lkwjefhwlkejfklwj",
-          },
+          { key: tls.key, cert: tls.cert },
+          { key: tls.key, cert: tls.cert },
         ],
       });
     }).toThrow("SNI tls object must have a serverName");


### PR DESCRIPTION
An explicit `tls` object that only carries tuning knobs (`lowMemoryMode`, `requestCert`, `rejectUnauthorized`, `secureOptions`, `passphrase`, `serverName`, `ca`) or only one half of the cert/key pair previously started an HTTPS listener with no usable server identity: `server.url` reported `https:`, plain HTTP clients got `ECONNRESET`, and TLS clients hung after ClientHello because no ServerHello could be sent. The same keys at the top level (the legacy v0.2 flattened shape) triggered the same dead listener via the back-compat read of the serve options object.

## Repro

```js
const s = Bun.serve({ port: 0, lowMemoryMode: true, fetch: () => new Response("hi") });
console.log(s.url.protocol);                              // https:
await fetch(`http://127.0.0.1:${s.port}/`);               // ECONNRESET
```

## Cause

`SSLConfig::from_generated` sets its "any TLS option present" flag for each of these knobs, so the parser returned `Some(SSLConfig)` with `cert`/`key` still empty and `ServerConfig` created the listener in TLS mode. The v0.2.1 back-compat block in `ServerConfig::from_js` runs the same parser over the top-level serve options object when `tls` is absent, so a top-level `lowMemoryMode: true` took the same path.

## Fix

`SSLConfig::has_server_identity()` reports whether the config carries both a certificate and a private key (inline PEM or file path). `ServerConfig::from_js` checks it after parsing:

* `tls: {...}` / `tls: [{...}]` without both a cert and a key throws at construction time with `tls object must specify both "cert" and "key" to start a TLS server`.
* top-level keys without both are ignored so the server stays plain HTTP, preserving the v0.2 back-compat only for the `{ cert, key }` shape it existed for.

`Bun.listen` shares the underlying parser but is intentionally left out of this change: its `SocketConfig` path is shared with `Bun.connect` (where cert-less TLS is valid) and already accepts `tls: true` for both modes, so wiring the guard there needs a mode-aware placement plus a decision on what `tls: true` should mean for a listener. That belongs in a follow-up rather than bundled here.

## Verification

`test/js/bun/http/bun-serve-ssl.test.ts` gains a `tls option without a server identity` block covering 9 no-identity shapes (7 tuning-only plus `{cert}`-only and `{key}`-only) across `tls: {...}`, `tls: [{...}]`, and top-level placement, plus two back-compat guards (`tls: {}` stays HTTP, top-level `{cert, key}` still enables TLS). On the released binary 27 of the 29 new tests fail; with the fix all 45 tests in the file pass on both debug+ASAN and release builds.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->