### PR TITLE
worker_threads: deliver the emit() payload to MessagePort listeners

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -130,9 +130,7 @@ function injectFakeEmitter(Class) {
     };
   }
 
-  // message/messageerror arrive as MessageEvent (.data), from native dispatch
-  // and from emit() below; everything else rides CustomEvent.detail (node's
-  // NodeEventTarget default). MessagePort has no native "error" event.
+  // native messageerror is a MessageEvent (.data), not an ErrorEvent
   function functionForEventType(event, listener) {
     switch (event) {
       case "message":
@@ -190,9 +188,7 @@ function injectFakeEmitter(Class) {
     return this;
   }
 
-  // node's NodeEventTarget.emit(type, arg): single arg, boolean return. The
-  // init dicts here must round-trip through functionForEventType's extractors.
-  // listenerCount() misses addEventListener-only listeners (pre-existing gap).
+  // init dicts here must round-trip through functionForEventType's extractors
   function emit(event, arg) {
     const hadListeners = listenerCount.$call(this, event) > 0;
     switch (event) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -130,12 +130,9 @@ function injectFakeEmitter(Class) {
     };
   }
 
-  // These extractors recover the raw value for .on() listeners from whatever
-  // event shape dispatchEvent delivered. They must match both the native
-  // MessagePort events (message/messageerror are MessageEvent carrying .data)
-  // and the events emit() constructs below. Everything else (including "error",
-  // which MessagePort never fires natively) rides CustomEvent.detail, which is
-  // what node's NodeEventTarget[kCreateEvent] produces for non-message types.
+  // message/messageerror arrive as MessageEvent (.data), from native dispatch
+  // and from emit() below; everything else rides CustomEvent.detail (node's
+  // NodeEventTarget default). MessagePort has no native "error" event.
   function functionForEventType(event, listener) {
     switch (event) {
       case "message":
@@ -193,14 +190,9 @@ function injectFakeEmitter(Class) {
     return this;
   }
 
-  // node's NodeEventTarget.prototype.emit(type, arg): carry a single raw arg,
-  // hand it as-is to node-style listeners, lazily wrap it as a typed event for
-  // addEventListener listeners, and return whether any listeners were
-  // registered. The extractors in functionForEventType undo the wrapping for
-  // .on() listeners, so the init dict here must round-trip through them.
-  // Known gap: listenerCount() only sees the .on()/.once() registry, so an
-  // addEventListener-only listener yields false here where node returns true
-  // (same pre-existing gap as listenerCount() itself).
+  // node's NodeEventTarget.emit(type, arg): single arg, boolean return. The
+  // init dicts here must round-trip through functionForEventType's extractors.
+  // listenerCount() misses addEventListener-only listeners (pre-existing gap).
   function emit(event, arg) {
     const hadListeners = listenerCount.$call(this, event) > 0;
     switch (event) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -220,10 +220,10 @@ function injectFakeEmitter(Class) {
   function getMaxListeners() {
     return this[kMaxListeners] ?? 10;
   }
-  const getEventListeners = EventEmitter.getEventListeners;
+  const getEventListenersForEventTarget = $newCppFunction("JSEventTargetNode.cpp", "jsFunctionNodeEventsGetEventListeners", 1);
   function listenerCount(type) {
     try {
-      return getEventListeners(this, type).length;
+      return getEventListenersForEventTarget(this, type).length;
     } catch {
       // fakeParentPort has no EventTarget internal slot; fall back to the .on() registry.
       return registryFor(this, false)?.get(type)?.size ?? 0;

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -121,8 +121,9 @@ function injectFakeEmitter(Class) {
   }
 
   // fakeParentPort routes self's native ErrorEvent (.error) here; emit() sends CustomEvent (.detail)
+  const _ErrorEvent = ErrorEvent;
   function errorEventHandler(event) {
-    return event instanceof ErrorEvent ? event.error : event.detail;
+    return event instanceof _ErrorEvent ? event.error : event.detail;
   }
 
   function customEventHandler(event) {
@@ -203,10 +204,10 @@ function injectFakeEmitter(Class) {
     switch (event) {
       case "message":
       case "messageerror":
-        this.dispatchEvent(new MessageEvent(event, { data: arg }));
+        this.dispatchEvent(new MessageEvent(event, { __proto__: null, data: arg }));
         break;
       default:
-        this.dispatchEvent(new CustomEvent(event, { detail: arg }));
+        this.dispatchEvent(new CustomEvent(event, { __proto__: null, detail: arg }));
         break;
     }
     return hadListeners;

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -120,10 +120,6 @@ function injectFakeEmitter(Class) {
     return event.data;
   }
 
-  function errorEventHandler(event: ErrorEvent) {
-    return event.error;
-  }
-
   function customEventHandler(event) {
     return event.detail;
   }
@@ -134,14 +130,16 @@ function injectFakeEmitter(Class) {
     };
   }
 
+  // These extractors recover the raw value for .on() listeners from whatever
+  // event shape dispatchEvent delivered. They must match both the native
+  // MessagePort events (message/messageerror are MessageEvent carrying .data)
+  // and the events emit() constructs below. Everything else (including "error",
+  // which MessagePort never fires natively) rides CustomEvent.detail, which is
+  // what node's NodeEventTarget[kCreateEvent] produces for non-message types.
   function functionForEventType(event, listener) {
     switch (event) {
-      case "error":
+      case "message":
       case "messageerror": {
-        return wrapped(errorEventHandler, listener);
-      }
-
-      case "message": {
         return wrapped(messageEventHandler, listener);
       }
 
@@ -149,14 +147,6 @@ function injectFakeEmitter(Class) {
         return wrapped(customEventHandler, listener);
       }
     }
-  }
-
-  function EventClass(eventName) {
-    if (eventName === "error" || eventName === "messageerror") {
-      return ErrorEvent;
-    }
-
-    return MessageEvent;
   }
 
   // EventTarget dedupes on (type, callback), so in node the FIRST registration of
@@ -203,20 +193,23 @@ function injectFakeEmitter(Class) {
     return this;
   }
 
-  function emit(event, ...args) {
+  // node's NodeEventTarget.prototype.emit(type, arg): carry a single raw arg,
+  // hand it as-is to node-style listeners, lazily wrap it as a typed event for
+  // addEventListener listeners, and return whether any listeners were
+  // registered. The extractors in functionForEventType undo the wrapping for
+  // .on() listeners, so the init dict here must round-trip through them.
+  function emit(event, arg) {
+    const hadListeners = listenerCount.$call(this, event) > 0;
     switch (event) {
-      case "error":
-      case "messageerror":
       case "message":
-        this.dispatchEvent(new (EventClass(event))(event, ...args));
+      case "messageerror":
+        this.dispatchEvent(new MessageEvent(event, { data: arg }));
         break;
       default:
-        // Non-standard events surface as CustomEvent (detail = first arg) to
-        // addEventListener and as the raw argument to .on(), matching node.
-        this.dispatchEvent(new CustomEvent(event, { detail: args[0] }));
+        this.dispatchEvent(new CustomEvent(event, { detail: arg }));
         break;
     }
-    return this;
+    return hadListeners;
   }
 
   const kMaxListeners = Symbol("kMaxListeners");

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -220,8 +220,14 @@ function injectFakeEmitter(Class) {
   function getMaxListeners() {
     return this[kMaxListeners] ?? 10;
   }
+  const getEventListeners = EventEmitter.getEventListeners;
   function listenerCount(type) {
-    return registryFor(this, false)?.get(type)?.size ?? 0;
+    try {
+      return getEventListeners(this, type).length;
+    } catch {
+      // fakeParentPort has no EventTarget internal slot; fall back to the .on() registry.
+      return registryFor(this, false)?.get(type)?.size ?? 0;
+    }
   }
   function eventNames() {
     const map = registryFor(this, false);

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -220,7 +220,11 @@ function injectFakeEmitter(Class) {
   function getMaxListeners() {
     return this[kMaxListeners] ?? 10;
   }
-  const getEventListenersForEventTarget = $newCppFunction("JSEventTargetNode.cpp", "jsFunctionNodeEventsGetEventListeners", 1);
+  const getEventListenersForEventTarget = $newCppFunction(
+    "JSEventTargetNode.cpp",
+    "jsFunctionNodeEventsGetEventListeners",
+    1,
+  );
   function listenerCount(type) {
     try {
       return getEventListenersForEventTarget(this, type).length;

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -198,6 +198,9 @@ function injectFakeEmitter(Class) {
   // addEventListener listeners, and return whether any listeners were
   // registered. The extractors in functionForEventType undo the wrapping for
   // .on() listeners, so the init dict here must round-trip through them.
+  // Known gap: listenerCount() only sees the .on()/.once() registry, so an
+  // addEventListener-only listener yields false here where node returns true
+  // (same pre-existing gap as listenerCount() itself).
   function emit(event, arg) {
     const hadListeners = listenerCount.$call(this, event) > 0;
     switch (event) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -120,6 +120,11 @@ function injectFakeEmitter(Class) {
     return event.data;
   }
 
+  // fakeParentPort routes self's native ErrorEvent (.error) here; emit() sends CustomEvent (.detail)
+  function errorEventHandler(event) {
+    return event.error ?? event.detail;
+  }
+
   function customEventHandler(event) {
     return event.detail;
   }
@@ -136,6 +141,10 @@ function injectFakeEmitter(Class) {
       case "message":
       case "messageerror": {
         return wrapped(messageEventHandler, listener);
+      }
+
+      case "error": {
+        return wrapped(errorEventHandler, listener);
       }
 
       default: {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -122,7 +122,7 @@ function injectFakeEmitter(Class) {
 
   // fakeParentPort routes self's native ErrorEvent (.error) here; emit() sends CustomEvent (.detail)
   function errorEventHandler(event) {
-    return event.error ?? event.detail;
+    return event instanceof ErrorEvent ? event.error : event.detail;
   }
 
   function customEventHandler(event) {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1393,6 +1393,21 @@ test("MessagePort emit() delivers the raw payload and returns a boolean", () => 
     p.close();
   }
 
+  // listenerCount reads the native EventTarget map directly, not via a
+  // user-overridable `.listeners` duck-type (tamper-resistance).
+  {
+    const { port1: p } = new MessageChannel();
+    p.on("message", () => {});
+    (p as any).listeners = () => [];
+    try {
+      (MessagePort.prototype as any).listeners = () => [];
+      expect({ count: p.listenerCount("message"), emit: p.emit("message", 1) }).toEqual({ count: 1, emit: true });
+    } finally {
+      delete (MessagePort.prototype as any).listeners;
+    }
+    p.close();
+  }
+
   // Custom events (unchanged behaviour, guards against regression): .on() gets
   // the arg, addEventListener gets CustomEvent with .detail = arg.
   {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1384,6 +1384,15 @@ test("MessagePort emit() delivers the raw payload and returns a boolean", () => 
     p.close();
   }
 
+  // addEventListener-only: emit() -> true and listenerCount() sees it (node's
+  // NodeEventTarget counts both styles from one store).
+  {
+    const { port1: p } = new MessageChannel();
+    p.addEventListener("message", () => {});
+    expect({ emit: p.emit("message", 1), count: p.listenerCount("message") }).toEqual({ emit: true, count: 1 });
+    p.close();
+  }
+
   // Custom events (unchanged behaviour, guards against regression): .on() gets
   // the arg, addEventListener gets CustomEvent with .detail = arg.
   {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1312,6 +1312,92 @@ test("MessagePort NodeEventTarget methods", () => {
   port1.close();
 });
 
+// emit() previously did `new MessageEvent("message", payload)` / `new
+// ErrorEvent("error", err)`, so the payload was (mis)read as an init dict and
+// .on() listeners received null/undefined. It also returned `this`. Verified
+// against node: .on() sees the raw arg by identity; addEventListener sees a
+// MessageEvent (data = arg) for message/messageerror and a CustomEvent
+// (detail = arg) otherwise; emit() returns a boolean.
+test("MessagePort emit() delivers the raw payload and returns a boolean", () => {
+  // message: .on() gets the payload by identity, addEventListener gets a
+  // MessageEvent whose .data is the payload; emit() -> true.
+  {
+    const { port1: p } = new MessageChannel();
+    const payload = { id: 42 };
+    let onArg: unknown = "unset";
+    let aelData: unknown = "unset";
+    let aelCtor = "";
+    p.on("message", x => (onArg = x));
+    p.addEventListener("message", e => ((aelData = e.data), (aelCtor = e.constructor.name)));
+    const ret = p.emit("message", payload);
+    expect({ onArg, aelData, aelCtor, ret }).toEqual({
+      onArg: payload,
+      aelData: payload,
+      aelCtor: "MessageEvent",
+      ret: true,
+    });
+    expect(onArg).toBe(payload);
+    expect(aelData).toBe(payload);
+    p.close();
+  }
+
+  // error: .on() gets the Error by identity; addEventListener gets a
+  // CustomEvent whose .detail is the Error (node's NodeEventTarget default).
+  {
+    const { port1: p } = new MessageChannel();
+    const err = new Error("boom");
+    let onArg: unknown = "unset";
+    let aelDetail: unknown = "unset";
+    let aelCtor = "";
+    p.on("error", x => (onArg = x));
+    p.addEventListener("error", (e: any) => ((aelDetail = e.detail), (aelCtor = e.constructor.name)));
+    const ret = p.emit("error", err);
+    expect({ onArg, aelDetail, aelCtor, ret }).toEqual({
+      onArg: err,
+      aelDetail: err,
+      aelCtor: "CustomEvent",
+      ret: true,
+    });
+    expect(onArg).toBe(err);
+    p.close();
+  }
+
+  // messageerror: same shape as message (MessageEvent, .data = arg).
+  {
+    const { port1: p } = new MessageChannel();
+    const err = new Error("boom");
+    let onArg: unknown = "unset";
+    let aelData: unknown = "unset";
+    p.on("messageerror", x => (onArg = x));
+    p.addEventListener("messageerror", (e: any) => (aelData = e.data));
+    p.emit("messageerror", err);
+    expect(onArg).toBe(err);
+    expect(aelData).toBe(err);
+    p.close();
+  }
+
+  // No listeners: emit() -> false (not `this`).
+  {
+    const { port1: p } = new MessageChannel();
+    expect(p.emit("message", 1)).toBe(false);
+    expect(p.emit("custom", 1)).toBe(false);
+    p.close();
+  }
+
+  // Custom events (unchanged behaviour, guards against regression): .on() gets
+  // the arg, addEventListener gets CustomEvent with .detail = arg.
+  {
+    const { port1: p } = new MessageChannel();
+    let onArg: unknown = "unset";
+    let aelDetail: unknown = "unset";
+    p.on("foo", (x: unknown) => (onArg = x));
+    p.addEventListener("foo", (e: any) => (aelDetail = e.detail));
+    p.emit("foo", 123);
+    expect({ onArg, aelDetail }).toEqual({ onArg: 123, aelDetail: 123 });
+    p.close();
+  }
+});
+
 // jsRef() only gated on m_isDetached, so .ref()/onmessage= after the peer closed
 // re-took an event-loop ref that nothing releases and the process hung. Node no-ops
 // both. Spawned, because the symptom is "the process never exits".


### PR DESCRIPTION
## Repro

```js
const { MessageChannel } = require("node:worker_threads");
const { port1: p } = new MessageChannel();
const payload = { id: 42 };
let onArg, aelData;
p.on("message", x => (onArg = x));
p.addEventListener("message", e => (aelData = e.data));
const ret = p.emit("message", payload);
console.log(onArg === payload, aelData === payload, ret);
// bun:  false false MessagePort {...}
// node: true  true  true
```

`.on("error", cb)` and `.on("messageerror", cb)` similarly receive `null`/`undefined` instead of the emitted value, and `emit()` returns `this` instead of a boolean.

## Cause

`injectFakeEmitter`'s `emit()` in `src/js/node/worker_threads.ts` built the event as `new MessageEvent("message", payload)` / `new ErrorEvent("error", err)`, passing the user's value as the init dictionary instead of wrapping it (`{data: payload}` / `{error: err}`). The `.on()` wrapper then read `event.data` / `event.error`, which were their defaults (`null`). The function also ended with `return this`.

The `messageerror` extractor read `event.error`, but both native MessagePort `messageerror` dispatch and node's `MessagePort[kCreateEvent]` produce a `MessageEvent` whose payload is `.data`, so `.on("messageerror", cb)` would miss the value even for real deserialization failures.

## Fix

Construct events whose shape matches node's `NodeEventTarget`/`MessagePort[kCreateEvent]` and round-trips through the `.on()` extractors:

- `"message"` / `"messageerror"` → `new MessageEvent(type, { data: arg })`
- everything else (including `"error"`, which MessagePort never fires natively) → `new CustomEvent(type, { detail: arg })`

Update the `messageerror` extractor to read `.data`, drop the now-unused `errorEventHandler`/`EventClass`, and return `listenerCount(type) > 0` before dispatch (node's `NodeEventTarget.prototype.emit` semantics).

## Verification

New test in `test/js/node/worker_threads/worker_threads.test.ts` covers `message`/`error`/`messageerror`/custom events for both `.on()` (identity) and `addEventListener` (event class + `.data`/`.detail`), plus the boolean return for the listener / no-listener cases. Fails on `main` with `onArg: null, aelData: null, ret: MessagePort`, passes with the fix.

The full `worker_threads.test.ts` (92 tests), `test/js/web/workers/message-channel.test.ts`, and the node-compat `test-worker-message-port.js` / `test-event-target.js` / `test-messagechannel.js` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (6f947afc2)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [2147.69ms]
(pass) all worker_threads module properties are present [29.58ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [29.05ms]
(pass) all worker_threads worker instance properties are present [213.08ms]
(pass) threadId module and worker property is consistent [227.21ms]
(pass) receiveMessageOnPort works across threads [2338.94ms]
(pass) receiveMessageOnPort works as FIFO [18.47ms]
(pass) you can override globalThis.postMessage [1976.62ms]
(pass) support require in eval [3044.09ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1852.43ms]
(pass) support require in eval for a file that doesnt exist [1728.69ms]
(pass) support worker eval that throws [1852.74ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [8809.62ms]
(
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6f947afc2)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [35.25ms]
(pass) all worker_threads module properties are present [0.45ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.55ms]
(pass) all worker_threads worker instance properties are present [3.29ms]
(pass) threadId module and worker property is consistent [4.52ms]
(pass) receiveMessageOnPort works across threads [32.51ms]
(pass) receiveMessageOnPort works as FIFO [0.34ms]
(pass) you can override globalThis.postMessage [45.79ms]
(pass) support require in eval [31.90ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [34.24ms]
(pass) support require in eval for a file that doesnt exist [45.51ms]
(pass) support worker eval that throws [30.51ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [129.77ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [80.19ms]
(pass) execArgv option > can specify an array of strings [61.57ms]
(pass) eval does not leak source code [2003.4
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (6f947afc2)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1949.40ms]
(pass) all worker_threads module properties are present [30.60ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [27.61ms]
(pass) all worker_threads worker instance properties are present [189.46ms]
(pass) threadId module and worker property is consistent [211.63ms]
(pass) receiveMessageOnPort works across threads [1811.27ms]
(pass) receiveMessageOnPort works as FIFO [13.50ms]
(pass) you can override globalThis.postMessage [1769.77ms]
(pass) support require in eval [2593.65ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1961.57ms]
(pass) support require in eval for a file that doesnt exist [2954.41ms]
(pass) support worker eval that throws [1741.76ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [7878.89ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 868ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen cpp.rs (cppbind)
[2/31] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (31 fields)
Found 8 classes from /workspace/bun/src/runtime/api/html_rewriter.classes.ts
  - HTMLRewriter (3 fields)
  - TextChunk (7 fi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      |  50 +++++-----
 test/js/node/worker_threads/worker_threads.test.ts | 110 +++++++++++++++++++++
 2 files changed, 137 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/worker_threads.ts                           9     14      0
test/js/node/worker_threads/worker_threads.test.ts      4      3      0
```

</details>

<!-- robobun:evidence:end -->