### PR TITLE
node:quic H3: reset rejected 0-RTT streams synchronously so lsquic doesn't retransmit or decode-assert on them

### DIFF
--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -2522,11 +2522,8 @@ lsquic_callback! {
     }
 
     pub(super) fn on_early_data_failed(session: &QuicSession) {
-        // Inside the engine tick: runs before `stash_0rtt_packets`, and
-        // the stash is drained to the lost queue and retransmitted in this
-        // same tick once the handshake completes. Resetting the early
-        // streams here (not deferred to `process_events`) is what makes
-        // `send_ctl_next_lost` elide their frames.
+        // Synchronous so the resets precede lsquic's 0-RTT stash-to-lost
+        // retransmit in this same tick; `process_events` would be too late.
         let code = session.with_state(|s| {
             if s.internal_error_code != 0 {
                 s.internal_error_code

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -325,7 +325,6 @@ pub(super) enum SessionEvent {
         count: u32,
         acked: bool,
     },
-    EarlyDataFailed,
     /// HTTP/3 ORIGIN frame payload (RFC 9412).
     Origin(Vec<u8>),
     /// Version Negotiation packet (RFC 8999 sec 6).
@@ -1218,23 +1217,6 @@ impl QuicSession {
                             self.handle(),
                             &[id_js, status_js],
                         );
-                    }
-                }
-                SessionEvent::EarlyDataFailed => {
-                    // Node parity: their `closed` promises reject with an
-                    // application error.
-                    let code = self.with_state(|s| {
-                        if s.internal_error_code != 0 {
-                            s.internal_error_code
-                        } else {
-                            1
-                        }
-                    });
-                    let streams: Vec<*mut super::stream::QuicStream> = self.streams.get().clone();
-                    for sp in streams {
-                        if let Some(stream) = self.live_stream(sp) {
-                            stream.cancel_early_rejected(code);
-                        }
                     }
                 }
                 SessionEvent::DatagramAckStatus { count, acked } => {
@@ -2540,10 +2522,24 @@ lsquic_callback! {
     }
 
     pub(super) fn on_early_data_failed(session: &QuicSession) {
-        // Front of the queue: lsquic resets the early streams before this
-        // callback, so their clean closes are already queued and would settle
-        // `closed` before the rejection node delivers could land.
-        session.events.with_mut(|e| e.insert(0, SessionEvent::EarlyDataFailed));
+        // Inside the engine tick: runs before `stash_0rtt_packets`, and
+        // the stash is drained to the lost queue and retransmitted in this
+        // same tick once the handshake completes. Resetting the early
+        // streams here (not deferred to `process_events`) is what makes
+        // `send_ctl_next_lost` elide their frames.
+        let code = session.with_state(|s| {
+            if s.internal_error_code != 0 {
+                s.internal_error_code
+            } else {
+                1
+            }
+        });
+        let streams: Vec<*mut super::stream::QuicStream> = session.streams.get().clone();
+        for sp in streams {
+            if let Some(stream) = session.live_stream(sp) {
+                stream.cancel_early_rejected(code);
+            }
+        }
         session.schedule_process();
     }
 

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -207,9 +207,8 @@ impl QuicStream {
             st.pending = 0;
         });
         self.write_stat(IDX_STATS_OPENED_AT, super::now_ns());
-        // A delayed 0-RTT stream the session cancelled while this wrapper
-        // was still raw==null: propagate the cancel to the lsquic stream
-        // it was just given instead of sending the request it queued.
+        // Cancelled while still pending (rejected delayed 0-RTT): reset the
+        // lsquic stream we were just given instead of sending what we queued.
         if let Some(code) = self.with_state(|st| (st.reset != 0).then_some(st.reset_code)) {
             s.stop_sending(code);
             s.reset(code);
@@ -392,10 +391,8 @@ impl QuicStream {
         self.wakeup.replace(None)
     }
 
-    /// 0-RTT was rejected: Node destroys every stream opened during the
-    /// early-data phase. Called synchronously from `on_early_data_failed`,
-    /// i.e. inside the engine tick, before lsquic re-queues the stashed
-    /// 0-RTT packets as 1-RTT lost.
+    /// 0-RTT was rejected: Node destroys every early-data stream. Runs
+    /// inside the engine tick from `on_early_data_failed`.
     pub(super) fn cancel_early_rejected(&self, code: u64) {
         self.mark_reset(code);
         self.outbound.with_mut(|o| {
@@ -406,14 +403,9 @@ impl QuicStream {
         self.pending_headers.with_mut(Vec::clear);
         self.with_state(|st| st.write_ended = 1);
         if let Some(s) = self.ls() {
-            // stop_sending swaps `sm_readable` to `stream_readable_discard`
-            // via `stream_shutdown_read`, so a response HEADERS that raced
-            // the reset cannot reach `lsquic_qdh_header_in_begin` (which
-            // asserts `!STREAM_U_READ_DONE`). reset sets `SMQF_SEND_RST`,
-            // making `send_ctl_next_lost` elide this stream's frames from
-            // the 0-RTT stash instead of retransmitting them at 1-RTT; the
-            // H3 control and QPACK streams are lsquic-internal and never
-            // reach here, so their frames survive the retransmit.
+            // Not `shutdown_internal`: that leaves `sm_readable` at the H3
+            // QPACK filter, which asserts on a read-done stream. `reset`
+            // makes `send_ctl_next_lost` elide this stream's 0-RTT frames.
             s.stop_sending(code);
             s.reset(code);
         }

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -207,6 +207,14 @@ impl QuicStream {
             st.pending = 0;
         });
         self.write_stat(IDX_STATS_OPENED_AT, super::now_ns());
+        // A delayed 0-RTT stream the session cancelled while this wrapper
+        // was still raw==null: propagate the cancel to the lsquic stream
+        // it was just given instead of sending the request it queued.
+        if let Some(code) = self.with_state(|st| (st.reset != 0).then_some(st.reset_code)) {
+            s.stop_sending(code);
+            s.reset(code);
+            return;
+        }
         let pre_reset_code = s.error_code();
         if s.is_rejected() && self.peer_stop_sending_code.get().is_none() {
             self.peer_stop_sending_code.set(Some(pre_reset_code));
@@ -395,6 +403,7 @@ impl QuicStream {
             o.fin_pending = false;
             o.trailers_pending = false;
         });
+        self.pending_headers.with_mut(Vec::clear);
         self.with_state(|st| st.write_ended = 1);
         if let Some(s) = self.ls() {
             // stop_sending swaps `sm_readable` to `stream_readable_discard`

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -207,12 +207,21 @@ impl QuicStream {
             st.pending = 0;
         });
         self.write_stat(IDX_STATS_OPENED_AT, super::now_ns());
-        // Cancelled while still pending (rejected delayed 0-RTT): reset the
-        // lsquic stream we were just given instead of sending what we queued.
-        if let Some(code) = self.with_state(|st| (st.reset != 0).then_some(st.reset_code)) {
-            s.stop_sending(code);
+        // Wrapper already reset while still pending: propagate to the lsquic
+        // stream it was just given. `read_ended` distinguishes a full cancel
+        // (`mark_reset`, both sides) from user `resetStream()` (write side
+        // only, read must still come up).
+        if let Some((code, read_done)) =
+            self.with_state(|st| (st.reset != 0).then_some((st.reset_code, st.read_ended != 0)))
+        {
+            self.pending_headers.with_mut(Vec::clear);
+            if read_done {
+                s.stop_sending(code);
+                s.reset(code);
+                s.shutdown_internal();
+                return;
+            }
             s.reset(code);
-            return;
         }
         let pre_reset_code = s.error_code();
         if s.is_rejected() && self.peer_stop_sending_code.get().is_none() {
@@ -403,11 +412,14 @@ impl QuicStream {
         self.pending_headers.with_mut(Vec::clear);
         self.with_state(|st| st.write_ended = 1);
         if let Some(s) = self.ls() {
-            // Not `shutdown_internal`: that leaves `sm_readable` at the H3
-            // QPACK filter, which asserts on a read-done stream. `reset`
-            // makes `send_ctl_next_lost` elide this stream's 0-RTT frames.
+            // `shutdown_internal` alone leaves `sm_readable` at the H3 QPACK
+            // filter, which asserts on a read-done stream. `reset` makes
+            // `send_ctl_next_lost` elide this stream's 0-RTT frames.
             s.stop_sending(code);
             s.reset(code);
+            // Sets U_WRITE_DONE so on_close schedules without waiting on the
+            // RST ack; the queued RST/STOP_SENDING still go out.
+            s.shutdown_internal();
         }
     }
 

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -385,7 +385,9 @@ impl QuicStream {
     }
 
     /// 0-RTT was rejected: Node destroys every stream opened during the
-    /// early-data phase.
+    /// early-data phase. Called synchronously from `on_early_data_failed`,
+    /// i.e. inside the engine tick, before lsquic re-queues the stashed
+    /// 0-RTT packets as 1-RTT lost.
     pub(super) fn cancel_early_rejected(&self, code: u64) {
         self.mark_reset(code);
         self.outbound.with_mut(|o| {
@@ -395,8 +397,16 @@ impl QuicStream {
         });
         self.with_state(|st| st.write_ended = 1);
         if let Some(s) = self.ls() {
-            // Node destroys it silently.
-            s.shutdown_internal();
+            // stop_sending swaps `sm_readable` to `stream_readable_discard`
+            // via `stream_shutdown_read`, so a response HEADERS that raced
+            // the reset cannot reach `lsquic_qdh_header_in_begin` (which
+            // asserts `!STREAM_U_READ_DONE`). reset sets `SMQF_SEND_RST`,
+            // making `send_ctl_next_lost` elide this stream's frames from
+            // the 0-RTT stash instead of retransmitting them at 1-RTT; the
+            // H3 control and QPACK streams are lsquic-internal and never
+            // reach here, so their frames survive the retransmit.
+            s.stop_sending(code);
+            s.reset(code);
         }
     }
 

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -186,7 +186,9 @@ describe("HTTP/3 header encoding", () => {
 // node:quic already tore the stream down; the server's HEADERS then hit
 // lsquic_qdh_header_in_begin's `!STREAM_U_READ_DONE` assert.
 describe("0-RTT rejected on HTTP/3", () => {
-  const makeServer = async (paths: string[]) => {
+  const H = (path: string) => ({ ":method": "GET", ":path": path, ":scheme": "https", ":authority": "localhost" });
+
+  const makeServer = async (paths: string[], tp: Record<string, number> = {}) => {
     const ready = Promise.withResolvers<void>();
     const ep = await listen(
       async s => {
@@ -195,7 +197,7 @@ describe("0-RTT rejected on HTTP/3", () => {
       },
       {
         sni: { "*": { keys: [key], certs: [cert] } },
-        transportParams: { maxIdleTimeout: 1 },
+        transportParams: { maxIdleTimeout: 1, ...tp },
         onheaders(this: any, headers: Record<string, string>) {
           paths.push(headers[":path"]);
           this.sendHeaders({ ":status": "200" });
@@ -207,28 +209,28 @@ describe("0-RTT rejected on HTTP/3", () => {
     return { ep, ready, [Symbol.asyncDispose]: () => ep.close() };
   };
 
-  test("a rejected early request is elided, not retransmitted at 1-RTT", async () => {
+  async function getTicket(tp: Record<string, number> = {}) {
     const gotTicket = Promise.withResolvers<Buffer>();
     let token: Buffer | undefined;
-    {
-      await using a = await makeServer([]);
-      const ca = await connect(a.ep.address, {
-        servername: "localhost",
-        verifyPeer: "manual",
-        transportParams: { maxIdleTimeout: 1 },
-        onsessionticket: (t: Buffer) => gotTicket.resolve(t),
-        onnewtoken: (t: Buffer) => (token = t),
-      });
-      await ca.opened;
-      const answered = Promise.withResolvers<void>();
-      await ca.createBidirectionalStream({
-        headers: { ":method": "GET", ":path": "/warm", ":scheme": "https", ":authority": "localhost" },
-        onheaders: () => answered.resolve(),
-      });
-      await answered.promise;
-      var ticket = await gotTicket.promise;
-      ca.close();
-    }
+    await using a = await makeServer([], tp);
+    const ca = await connect(a.ep.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 1 },
+      onsessionticket: (t: Buffer) => gotTicket.resolve(t),
+      onnewtoken: (t: Buffer) => (token = t),
+    });
+    await ca.opened;
+    const answered = Promise.withResolvers<void>();
+    await ca.createBidirectionalStream({ headers: H("/warm"), onheaders: () => answered.resolve() });
+    await answered.promise;
+    const ticket = await gotTicket.promise;
+    ca.close();
+    return { ticket, token };
+  }
+
+  test("a rejected early request is elided, not retransmitted at 1-RTT", async () => {
+    const { ticket, token } = await getTicket();
 
     // Fresh server B: A's ticket keys are gone, so 0-RTT is rejected.
     const paths: string[] = [];
@@ -243,10 +245,7 @@ describe("0-RTT rejected on HTTP/3", () => {
     c.closed.catch(() => {});
 
     // The 0-RTT request: opened before the handshake is known rejected.
-    const early = await c.createBidirectionalStream({
-      headers: { ":method": "GET", ":path": "/early", ":scheme": "https", ":authority": "localhost" },
-      onheaders() {},
-    });
+    const early = await c.createBidirectionalStream({ headers: H("/early"), onheaders() {} });
     const earlyClose = early.closed.catch((e: any) => e);
 
     const info = await c.opened;
@@ -259,13 +258,52 @@ describe("0-RTT rejected on HTTP/3", () => {
     // The documented re-open: this is the one request the server must see.
     const retried = Promise.withResolvers<string>();
     await c.createBidirectionalStream({
-      headers: { ":method": "GET", ":path": "/retry", ":scheme": "https", ":authority": "localhost" },
+      headers: H("/retry"),
       onheaders: (h: Record<string, string>) => retried.resolve(h[":status"]),
     });
     expect(await retried.promise).toBe("200");
 
     // /retry reached the server; any retransmitted /early headers that were
     // going to arrive have arrived by now (same path, lower stream id).
+    await b.ready.promise;
+    expect(paths).toEqual(["/retry"]);
+    c.close();
+  });
+
+  // The second 0-RTT request exceeds the cached initial_max_streams_bidi
+  // budget, so lsquic defers creating it; the wrapper has raw==null and
+  // its headers sit in pending_headers when the rejection fires. bind_raw
+  // must propagate the cancel instead of sending the queued request when
+  // handshake_ok creates the delayed stream.
+  test("a delayed early request past the cached stream limit is also cancelled", async () => {
+    const { ticket, token } = await getTicket({ initialMaxStreamsBidi: 1 });
+
+    const paths: string[] = [];
+    await using b = await makeServer(paths, { initialMaxStreamsBidi: 4 });
+    const c = await connect(b.ep.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 1 },
+      sessionTicket: ticket,
+      token,
+    });
+    c.closed.catch(() => {});
+
+    const a = await c.createBidirectionalStream({ headers: H("/a"), onheaders() {} });
+    const d = await c.createBidirectionalStream({ headers: H("/delayed"), onheaders() {} });
+    const [aErr, dErr] = await Promise.all([a.closed.catch((e: any) => e), d.closed.catch((e: any) => e)]);
+
+    const info = await c.opened;
+    expect(info.earlyDataAccepted).toBe(false);
+    expect(aErr?.code).toBe("ERR_QUIC_APPLICATION_ERROR");
+    expect(dErr?.code).toBe("ERR_QUIC_APPLICATION_ERROR");
+
+    const retried = Promise.withResolvers<string>();
+    await c.createBidirectionalStream({
+      headers: H("/retry"),
+      onheaders: (h: Record<string, string>) => retried.resolve(h[":status"]),
+    });
+    expect(await retried.promise).toBe("200");
     await b.ready.promise;
     expect(paths).toEqual(["/retry"]);
     c.close();

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -179,3 +179,95 @@ describe("HTTP/3 header encoding", () => {
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
 });
+
+// A 0-RTT H3 request the server rejects must not reach it at 1-RTT, and
+// must not crash the client decoding a response on the destroyed stream.
+// lsquic's transparent stash-and-retransmit would deliver the request after
+// node:quic already tore the stream down; the server's HEADERS then hit
+// lsquic_qdh_header_in_begin's `!STREAM_U_READ_DONE` assert.
+describe("0-RTT rejected on HTTP/3", () => {
+  const makeServer = async (paths: string[]) => {
+    const ready = Promise.withResolvers<void>();
+    const ep = await listen(
+      async s => {
+        s.onstream = (st: any) => st.closed.catch(() => {});
+        await s.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 1 },
+        onheaders(this: any, headers: Record<string, string>) {
+          paths.push(headers[":path"]);
+          this.sendHeaders({ ":status": "200" });
+          this.writer.endSync();
+          ready.resolve();
+        },
+      },
+    );
+    return { ep, ready, [Symbol.asyncDispose]: () => ep.close() };
+  };
+
+  test("a rejected early request is elided, not retransmitted at 1-RTT", async () => {
+    const gotTicket = Promise.withResolvers<Buffer>();
+    let token: Buffer | undefined;
+    {
+      await using a = await makeServer([]);
+      const ca = await connect(a.ep.address, {
+        servername: "localhost",
+        verifyPeer: "manual",
+        transportParams: { maxIdleTimeout: 1 },
+        onsessionticket: (t: Buffer) => gotTicket.resolve(t),
+        onnewtoken: (t: Buffer) => (token = t),
+      });
+      await ca.opened;
+      const answered = Promise.withResolvers<void>();
+      await ca.createBidirectionalStream({
+        headers: { ":method": "GET", ":path": "/warm", ":scheme": "https", ":authority": "localhost" },
+        onheaders: () => answered.resolve(),
+      });
+      await answered.promise;
+      var ticket = await gotTicket.promise;
+      ca.close();
+    }
+
+    // Fresh server B: A's ticket keys are gone, so 0-RTT is rejected.
+    const paths: string[] = [];
+    await using b = await makeServer(paths);
+    const c = await connect(b.ep.address, {
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 1 },
+      sessionTicket: ticket,
+      token,
+    });
+    c.closed.catch(() => {});
+
+    // The 0-RTT request: opened before the handshake is known rejected.
+    const early = await c.createBidirectionalStream({
+      headers: { ":method": "GET", ":path": "/early", ":scheme": "https", ":authority": "localhost" },
+      onheaders() {},
+    });
+    const earlyClose = early.closed.catch((e: any) => e);
+
+    const info = await c.opened;
+    expect(info.earlyDataAttempted).toBe(true);
+    expect(info.earlyDataAccepted).toBe(false);
+
+    const err = await earlyClose;
+    expect(err?.code).toBe("ERR_QUIC_APPLICATION_ERROR");
+
+    // The documented re-open: this is the one request the server must see.
+    const retried = Promise.withResolvers<string>();
+    await c.createBidirectionalStream({
+      headers: { ":method": "GET", ":path": "/retry", ":scheme": "https", ":authority": "localhost" },
+      onheaders: (h: Record<string, string>) => retried.resolve(h[":status"]),
+    });
+    expect(await retried.promise).toBe("200");
+
+    // /retry reached the server; any retransmitted /early headers that were
+    // going to arrive have arrived by now (same path, lower stream id).
+    await b.ready.promise;
+    expect(paths).toEqual(["/retry"]);
+    c.close();
+  });
+});


### PR DESCRIPTION
## Problem

Opening an HTTP/3 request stream on a resumed `node:quic` client before `await c.opened`, when the server rejects 0-RTT, crashes with:

```
lsquic_qdec_hdl.c:721: lsquic_qdh_header_in_begin: Assertion `!(stream->stream_flags & STREAM_U_READ_DONE)' failed.
```

Repro: two server instances A then B (fresh ticket keys), `connect(B, { sessionTicket: ticketFromA })`, then before `await c.opened` open `createBidirectionalStream({ headers: { ":method":"GET", ... } })`, then `await c.opened` (`earlyDataAccepted === false`).

## Cause

`on_early_data_failed` queued `SessionEvent::EarlyDataFailed` and deferred the teardown to `process_events`, which runs after `lsquic_engine_process_conns` returns. By then lsquic has already called `lsquic_send_ctl_stash_0rtt_packets`, `handshake_ok` has drained the stash to `sc_lost_packets` via `lsquic_send_ctl_0rtt_to_1rtt`, and the same tick has retransmitted them. The server processes the retransmitted request and sends HEADERS back.

The deferred teardown called `lsquic_stream_shutdown_internal`, which sets `STREAM_U_READ_DONE` but does not swap `sm_readable` to `stream_readable_discard` (only `stream_shutdown_read` does that). When the response arrives, `lsquic_stream_frame_in` -> `maybe_conn_to_tickable_if_readable` -> `lsquic_stream_readable` -> `stream_readable_http_ietf` -> `hq_filter_readable` -> `hq_read` -> `lsquic_qdh_header_in_begin` asserts.

This is the HTTP/3 variant of #35734's raw-QUIC double-delivery; that PR's `lsquic_conn_drop_0rtt_packets` is deliberately a no-op for HTTP/3 because dropping whole packets would discard the H3 control and QPACK streams too.

## Fix

Tear the early streams down synchronously inside `on_early_data_failed` (while still in the engine tick, before the stash step), and use `stop_sending` + `reset` + `shutdown_internal` in sequence:

- `reset` sets `SMQF_SEND_RST`, so `send_ctl_next_lost`'s `lsquic_packet_out_elide_reset_stream_frames(packet, UINT64_MAX)` elides this stream's frames from the stashed 0-RTT packets instead of retransmitting them. The H3 control and QPACK streams are lsquic-internal, never in `session.streams`, and not write-reset, so their frames survive the retransmit.
- `stop_sending` swaps `sm_readable` to `stream_readable_discard` via `stream_shutdown_read`, so a response that raced the reset cannot reach the QPACK decoder.
- `shutdown_internal` sets `STREAM_U_WRITE_DONE` so `on_close` schedules in the same tick instead of after the RST ack one RTT later; `SMQF_SEND_RST` keeps `stream_is_finished` false so the queued RST/STOP_SENDING still go out.

This matches Node's behavior (`ngtcp2_conn_shutdown_stream` on each early stream sends both frames) and also fixes the raw-QUIC double-delivery by the same elision.

A second early request that exceeds the cached `initial_max_streams_bidi` limit is still pending (`raw==null`) when the rejection fires, so `cancel_early_rejected` cannot touch its lsquic stream yet. `cancel_early_rejected` now also clears `pending_headers`, and `bind_raw` checks whether the wrapper was already reset and propagates the cancel to the lsquic stream it was just given instead of sending the queued request. That guard keys on `st.read_ended` so a user `resetStream()` on a pending stream (write side only) still brings the read side up.

## Verification

Two new tests in `test/js/node/quic/quic-stream.test.ts`:
- `a rejected early request is elided, not retransmitted at 1-RTT`: one 0-RTT H3 request, asserts `closed` rejects with `ERR_QUIC_APPLICATION_ERROR`, the session survives a follow-up, and the server's `onheaders` only saw `/retry`. Fails on main with the assert above.
- `a delayed early request past the cached stream limit is also cancelled`: cached `initialMaxStreamsBidi: 1`, two 0-RTT requests so the second is delayed; asserts both reject and the server only saw `/retry`.

All `test-quic-*zero-rtt*` / `test-quic-enable-early-data` / `test-quic-stream-reset*` / `test-quic-h3-pending-stream` node-parallel tests and the three `test/js/node/quic/*.test.ts` files pass.