### PR TITLE
worker_threads: make MessagePort's on()/addEventListener() share one listener registry

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -116,6 +116,18 @@ function injectFakeEmitter(Class) {
     return map;
   }
 
+  // The native EventTarget methods are on the prototype chain above the
+  // intermediate prototype we insert below; capture them so the overrides can
+  // call through without re-entering themselves.
+  const eventTargetProto = Object.getPrototypeOf(Class.prototype);
+  const nativeAddEventListener = eventTargetProto.addEventListener;
+  const nativeRemoveEventListener = eventTargetProto.removeEventListener;
+
+  // on()/once() store a wrapper in the native map; mark it so the
+  // addEventListener override recognises the call as internal and does not
+  // record the wrapper itself in the registry (the user's listener is).
+  const kWrapped = Symbol("wrappedListener");
+
   function messageEventHandler(event: MessageEvent) {
     return event.data;
   }
@@ -129,9 +141,11 @@ function injectFakeEmitter(Class) {
   }
 
   function wrapped(run, listener) {
-    return function (event) {
+    const w = function (event) {
       return listener(run(event));
     };
+    w[kWrapped] = true;
+    return w;
   }
 
   function functionForEventType(event, listener) {
@@ -199,8 +213,44 @@ function injectFakeEmitter(Class) {
       registryFor(target, false)?.get(event)?.delete(listener);
       return wrapper(ev);
     }
+    onceWrapper[kWrapped] = true;
     register(this, event, listener, onceWrapper, { once: true });
     return this;
+  }
+
+  // Overridden so EventTarget-style registration shares the registry with
+  // on()/once(): node's NodeEventTarget has one listener map, so the same
+  // function added via both APIs registers once, listenerCount()/eventNames()
+  // see addEventListener()-added listeners, and removeEventListener() removes
+  // an on()-added listener (and vice versa).
+  function addEventListener(type, listener, options) {
+    // on()/once() call through here with their wrapper; it is already recorded
+    // under the user's listener, so pass it straight to the native method.
+    if (typeof listener === "function" && listener[kWrapped])
+      return nativeAddEventListener.$call(this, type, listener, options);
+    if (listener == null || (typeof listener !== "function" && typeof listener !== "object"))
+      return nativeAddEventListener.$call(this, type, listener, options);
+    let actual = listener;
+    if (typeof options === "object" && options !== null && options.once) {
+      const target = this;
+      actual = function (ev) {
+        registryFor(target, false)?.get(type)?.delete(listener);
+        return typeof listener === "function" ? listener.$call(this, ev) : listener.handleEvent?.(ev);
+      };
+    }
+    const map = registryFor(this, true)!;
+    let byListener = map.get(type);
+    if (!byListener) map.set(type, (byListener = new SafeMap()));
+    if (byListener.has(listener)) return;
+    nativeAddEventListener.$call(this, type, actual, options);
+    byListener.set(listener, actual);
+  }
+
+  function removeEventListener(type, listener) {
+    const byListener = registryFor(this, false)?.get(type);
+    const actual = byListener?.get(listener) ?? listener;
+    nativeRemoveEventListener.$call(this, type, actual);
+    byListener?.delete(listener);
   }
 
   function emit(event, ...args) {
@@ -261,7 +311,7 @@ function injectFakeEmitter(Class) {
   // EventEmitter, not EventEmitter itself); use an intermediate prototype so
   // Object.getOwnPropertyNames(MessagePort.prototype) matches node.
   const proto = Class.prototype;
-  const inherited = Object.create(Object.getPrototypeOf(proto));
+  const inherited = Object.create(eventTargetProto);
   const emitterMethods: [string, Function][] = [
     ["on", on],
     ["off", off],
@@ -269,6 +319,8 @@ function injectFakeEmitter(Class) {
     ["emit", emit],
     ["addListener", on],
     ["removeListener", off],
+    ["addEventListener", addEventListener],
+    ["removeEventListener", removeEventListener],
     ["listenerCount", listenerCount],
     ["eventNames", eventNames],
     ["removeAllListeners", removeAllListeners],

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -116,16 +116,14 @@ function injectFakeEmitter(Class) {
     return map;
   }
 
-  // The native EventTarget methods are on the prototype chain above the
-  // intermediate prototype we insert below; capture them so the overrides can
-  // call through without re-entering themselves.
+  // Captured so the addEventListener/removeEventListener overrides below can
+  // call through to EventTarget without re-entering themselves.
   const eventTargetProto = Object.getPrototypeOf(Class.prototype);
   const nativeAddEventListener = eventTargetProto.addEventListener;
   const nativeRemoveEventListener = eventTargetProto.removeEventListener;
 
-  // on()/once() store a wrapper in the native map; mark it so the
-  // addEventListener override recognises the call as internal and does not
-  // record the wrapper itself in the registry (the user's listener is).
+  // Marks the wrapper on()/once() pass to addEventListener so the override
+  // forwards it to native instead of recording it a second time.
   const kWrapped = Symbol("wrappedListener");
 
   function messageEventHandler(event: MessageEvent) {
@@ -173,13 +171,9 @@ function injectFakeEmitter(Class) {
     return MessageEvent;
   }
 
-  // EventTarget dedupes on (type, callback, capture), so in node the FIRST
-  // registration wins outright — including its once-ness — and later adds of
-  // the same function with the same capture flag are no-ops. The registry entry
-  // per listener is a two-slot pair [bubble, capture] holding what was handed
-  // to the native map (the listener itself for addEventListener(), a wrapper
-  // for on()/once() and {once:true}); a slot is vacated by setting it back to
-  // undefined and the listener key is dropped once both are.
+  // EventTarget identity is (type, callback, capture): the registry entry per
+  // listener is a two-slot [bubble, capture] pair holding what was handed to
+  // the native map (the listener itself, or a wrapper for on()/once()/{once}).
   function captureSlot(options) {
     return options === true || (typeof options === "object" && options !== null && options.capture) ? 1 : 0;
   }
@@ -213,8 +207,7 @@ function injectFakeEmitter(Class) {
   }
 
   function off(event, listener) {
-    // Node's removeListener is bubble-only; a capture-phase addEventListener()
-    // listener is only removed via removeEventListener() with a matching flag.
+    // node's removeListener is bubble-only (capture-phase stays for removeEventListener).
     const actual = forgetListener(this, event, listener, 0) ?? listener;
     this.removeEventListener(event, actual);
     return this;
@@ -236,22 +229,16 @@ function injectFakeEmitter(Class) {
     return this;
   }
 
-  // Overridden so EventTarget-style registration shares the registry with
-  // on()/once(): node's NodeEventTarget has one listener map, so the same
-  // function added via both APIs registers once, listenerCount()/eventNames()
-  // see addEventListener()-added listeners, and removeEventListener() removes
-  // an on()-added listener (and vice versa).
+  // Overridden so EventTarget-style registration shares the on()/once()
+  // registry, like node's single-map NodeEventTarget.
   function addEventListener(type, listener, options) {
-    // on()/once() call through here with their wrapper; it is already recorded
-    // under the user's listener, so pass it straight to the native method.
     if (typeof listener === "function" && listener[kWrapped])
       return nativeAddEventListener.$call(this, type, listener, options);
     if (listener == null || (typeof listener !== "function" && typeof listener !== "object"))
       return nativeAddEventListener.$call(this, type, listener, options);
     const opts = typeof options === "object" && options !== null ? options : undefined;
     const signal = opts?.signal;
-    // Native addEventListener no-ops on an already-aborted signal; don't record
-    // a listener that will never be in the native map.
+    // native is a no-op on an already-aborted signal; don't record a phantom entry.
     if (signal?.aborted) return;
     const slot = captureSlot(options);
     const target = this;
@@ -263,10 +250,27 @@ function injectFakeEmitter(Class) {
       };
     }
     if (!recordListener(this, type, listener, actual, slot)) return;
-    nativeAddEventListener.$call(this, type, actual, options);
-    // Native removes via a C++ abort algorithm that never re-enters this
-    // override, so purge the registry entry from here when the signal fires.
-    if (signal) signal.addEventListener("abort", () => forgetListener(target, type, listener, slot), { once: true });
+    try {
+      nativeAddEventListener.$call(this, type, actual, options);
+    } catch (e) {
+      forgetListener(this, type, listener, slot);
+      throw e;
+    }
+    if (signal) {
+      // The native abort algorithm is C++ and never re-enters this override, so
+      // mirror node: remove via the override on abort so registry and native stay
+      // in step. WeakRef the port because the native algorithm holds it weakly.
+      const weak = new WeakRef(this);
+      const capture = slot === 1;
+      signal.addEventListener(
+        "abort",
+        () => {
+          const t = weak.deref();
+          if (t) removeEventListener.$call(t, type, listener, capture);
+        },
+        { once: true },
+      );
+    }
   }
 
   function removeEventListener(type, listener, options) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -173,33 +173,50 @@ function injectFakeEmitter(Class) {
     return MessageEvent;
   }
 
-  // EventTarget dedupes on (type, callback), so in node the FIRST registration of
-  // a listener wins outright -- including its once-ness -- and later adds of the
-  // same function are no-ops. Keying wrappers per listener reproduces that.
-  function register(target, event, listener, wrapper, options) {
+  // EventTarget dedupes on (type, callback, capture), so in node the FIRST
+  // registration wins outright — including its once-ness — and later adds of
+  // the same function with the same capture flag are no-ops. The registry entry
+  // per listener is a two-slot pair [bubble, capture] holding what was handed
+  // to the native map (the listener itself for addEventListener(), a wrapper
+  // for on()/once() and {once:true}); a slot is vacated by setting it back to
+  // undefined and the listener key is dropped once both are.
+  function captureSlot(options) {
+    return options === true || (typeof options === "object" && options !== null && options.capture) ? 1 : 0;
+  }
+  function recordListener(target, type, listener, actual, slot) {
     const map = registryFor(target, true)!;
-    let byListener = map.get(event);
-    if (!byListener) map.set(event, (byListener = new SafeMap()));
-    if (byListener.has(listener)) return false;
-    target.addEventListener(event, wrapper, options);
-    byListener.set(listener, wrapper);
+    let byListener = map.get(type);
+    if (!byListener) map.set(type, (byListener = new SafeMap()));
+    let rec = byListener.get(listener);
+    if (rec) {
+      if (rec[slot] !== undefined) return false;
+    } else {
+      byListener.set(listener, (rec = [undefined, undefined]));
+    }
+    rec[slot] = actual;
     return true;
+  }
+  function forgetListener(target, type, listener, slot) {
+    const byListener = registryFor(target, false)?.get(type);
+    const rec = byListener?.get(listener);
+    if (!rec || rec[slot] === undefined) return undefined;
+    const actual = rec[slot];
+    rec[slot] = undefined;
+    if (rec[0] === undefined && rec[1] === undefined) byListener!.delete(listener);
+    return actual;
   }
 
   function on(event, listener) {
-    register(this, event, listener, functionForEventType(event, listener), undefined);
+    const wrapper = functionForEventType(event, listener);
+    if (recordListener(this, event, listener, wrapper, 0)) this.addEventListener(event, wrapper);
     return this;
   }
 
   function off(event, listener) {
-    if (listener) {
-      const byListener = registryFor(this, false)?.get(event);
-      const wrapper = byListener?.get(listener) ?? listener;
-      this.removeEventListener(event, wrapper);
-      byListener?.delete(listener);
-    } else {
-      this.removeEventListener(event);
-    }
+    // Node's removeListener is bubble-only; a capture-phase addEventListener()
+    // listener is only removed via removeEventListener() with a matching flag.
+    const actual = forgetListener(this, event, listener, 0) ?? listener;
+    this.removeEventListener(event, actual);
     return this;
   }
 
@@ -210,11 +227,11 @@ function injectFakeEmitter(Class) {
     // registry — so purge it here or listenerCount()/eventNames() keep counting
     // a listener that already fired.
     function onceWrapper(ev) {
-      registryFor(target, false)?.get(event)?.delete(listener);
+      forgetListener(target, event, listener, 0);
       return wrapper(ev);
     }
     onceWrapper[kWrapped] = true;
-    register(this, event, listener, onceWrapper, { once: true });
+    if (recordListener(this, event, listener, onceWrapper, 0)) this.addEventListener(event, onceWrapper, { once: true });
     return this;
   }
 
@@ -230,27 +247,30 @@ function injectFakeEmitter(Class) {
       return nativeAddEventListener.$call(this, type, listener, options);
     if (listener == null || (typeof listener !== "function" && typeof listener !== "object"))
       return nativeAddEventListener.$call(this, type, listener, options);
+    const opts = typeof options === "object" && options !== null ? options : undefined;
+    const signal = opts?.signal;
+    // Native addEventListener no-ops on an already-aborted signal; don't record
+    // a listener that will never be in the native map.
+    if (signal?.aborted) return;
+    const slot = captureSlot(options);
+    const target = this;
     let actual = listener;
-    if (typeof options === "object" && options !== null && options.once) {
-      const target = this;
+    if (opts?.once) {
       actual = function (ev) {
-        registryFor(target, false)?.get(type)?.delete(listener);
+        forgetListener(target, type, listener, slot);
         return typeof listener === "function" ? listener.$call(this, ev) : listener.handleEvent?.(ev);
       };
     }
-    const map = registryFor(this, true)!;
-    let byListener = map.get(type);
-    if (!byListener) map.set(type, (byListener = new SafeMap()));
-    if (byListener.has(listener)) return;
+    if (!recordListener(this, type, listener, actual, slot)) return;
     nativeAddEventListener.$call(this, type, actual, options);
-    byListener.set(listener, actual);
+    // Native removes via a C++ abort algorithm that never re-enters this
+    // override, so purge the registry entry from here when the signal fires.
+    if (signal) signal.addEventListener("abort", () => forgetListener(target, type, listener, slot), { once: true });
   }
 
-  function removeEventListener(type, listener) {
-    const byListener = registryFor(this, false)?.get(type);
-    const actual = byListener?.get(listener) ?? listener;
-    nativeRemoveEventListener.$call(this, type, actual);
-    byListener?.delete(listener);
+  function removeEventListener(type, listener, options) {
+    const actual = forgetListener(this, type, listener, captureSlot(options)) ?? listener;
+    nativeRemoveEventListener.$call(this, type, actual, options);
   }
 
   function emit(event, ...args) {
@@ -278,7 +298,14 @@ function injectFakeEmitter(Class) {
     return this[kMaxListeners] ?? 10;
   }
   function listenerCount(type) {
-    return registryFor(this, false)?.get(type)?.size ?? 0;
+    const byListener = registryFor(this, false)?.get(type);
+    if (!byListener) return 0;
+    let n = 0;
+    for (const rec of byListener.values()) {
+      if (rec[0] !== undefined) n++;
+      if (rec[1] !== undefined) n++;
+    }
+    return n;
   }
   function eventNames() {
     const map = registryFor(this, false);
@@ -293,7 +320,10 @@ function injectFakeEmitter(Class) {
     const removeType = t => {
       const byListener = map.get(t);
       if (byListener) {
-        for (const w of byListener.values()) this.removeEventListener(t, w);
+        for (const rec of byListener.values()) {
+          if (rec[0] !== undefined) this.removeEventListener(t, rec[0]);
+          if (rec[1] !== undefined) this.removeEventListener(t, rec[1], true);
+        }
         map.delete(t);
       }
     };

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -174,9 +174,6 @@ function injectFakeEmitter(Class) {
   // EventTarget identity is (type, callback, capture): the registry entry per
   // listener is a two-slot [bubble, capture] pair holding what was handed to
   // the native map (the listener itself, or a wrapper for on()/once()/{once}).
-  function captureSlot(options) {
-    return options === true || (typeof options === "object" && options !== null && options.capture) ? 1 : 0;
-  }
   function recordListener(target, type, listener, actual, slot) {
     const map = registryFor(target, true)!;
     let byListener = map.get(type);
@@ -231,19 +228,31 @@ function injectFakeEmitter(Class) {
 
   // Overridden so EventTarget-style registration shares the on()/once()
   // registry, like node's single-map NodeEventTarget.
-  function addEventListener(type, listener, options) {
+  function addEventListener(type, listener) {
+    if (arguments.length < 2) throw $ERR_MISSING_ARGS("type", "listener");
+    const options = arguments[2];
     if (typeof listener === "function" && listener[kWrapped])
       return nativeAddEventListener.$call(this, type, listener, options);
     if (listener == null || (typeof listener !== "function" && typeof listener !== "object"))
       return nativeAddEventListener.$call(this, type, listener, options);
-    const opts = typeof options === "object" && options !== null ? options : undefined;
-    const signal = opts?.signal;
+    // Read each option once and hand a normalized dictionary to native so a
+    // stateful getter can't make the registry and the native map disagree.
+    let capture = options === true;
+    let once = false;
+    let passive = false;
+    let signal;
+    if (typeof options === "object" && options !== null) {
+      capture = !!options.capture;
+      once = !!options.once;
+      passive = !!options.passive;
+      signal = options.signal;
+    }
     // native is a no-op on an already-aborted signal; don't record a phantom entry.
     if (signal?.aborted) return;
-    const slot = captureSlot(options);
+    const slot = capture ? 1 : 0;
     const target = this;
     let actual = listener;
-    if (opts?.once) {
+    if (once) {
       actual = function (ev) {
         forgetListener(target, type, listener, slot);
         return typeof listener === "function" ? listener.$call(this, ev) : listener.handleEvent?.(ev);
@@ -251,31 +260,34 @@ function injectFakeEmitter(Class) {
     }
     if (!recordListener(this, type, listener, actual, slot)) return;
     try {
-      nativeAddEventListener.$call(this, type, actual, options);
+      nativeAddEventListener.$call(this, type, actual, { __proto__: null, capture, once, passive, signal });
     } catch (e) {
       forgetListener(this, type, listener, slot);
       throw e;
     }
-    if (signal) {
+    if (signal !== undefined) {
       // The native abort algorithm is C++ and never re-enters this override, so
       // mirror node: remove via the override on abort so registry and native stay
       // in step. WeakRef the port because the native algorithm holds it weakly.
       const weak = new WeakRef(this);
-      const capture = slot === 1;
-      signal.addEventListener(
+      nativeAddEventListener.$call(
+        signal,
         "abort",
         () => {
           const t = weak.deref();
           if (t) removeEventListener.$call(t, type, listener, capture);
         },
-        { once: true },
+        { __proto__: null, once: true },
       );
     }
   }
 
-  function removeEventListener(type, listener, options) {
-    const actual = forgetListener(this, type, listener, captureSlot(options)) ?? listener;
-    nativeRemoveEventListener.$call(this, type, actual, options);
+  function removeEventListener(type, listener) {
+    if (arguments.length < 2) throw $ERR_MISSING_ARGS("type", "listener");
+    const options = arguments[2];
+    const capture = options === true || (typeof options === "object" && options !== null && !!options.capture);
+    const actual = forgetListener(this, type, listener, capture ? 1 : 0) ?? listener;
+    nativeRemoveEventListener.$call(this, type, actual, capture);
   }
 
   function emit(event, ...args) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -231,7 +231,8 @@ function injectFakeEmitter(Class) {
       return wrapper(ev);
     }
     onceWrapper[kWrapped] = true;
-    if (recordListener(this, event, listener, onceWrapper, 0)) this.addEventListener(event, onceWrapper, { once: true });
+    if (recordListener(this, event, listener, onceWrapper, 0))
+      this.addEventListener(event, onceWrapper, { once: true });
     return this;
   }
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
-import { once } from "node:events";
+import { getEventListeners, once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { Readable } from "node:stream";
@@ -1310,6 +1310,91 @@ test("MessagePort NodeEventTarget methods", () => {
   port1.removeAllListeners("message");
   expect(port1.listenerCount("message")).toBe(0);
   port1.close();
+});
+
+// Node's NodeEventTarget has one listener map serving both the EventEmitter-
+// style methods and addEventListener/removeEventListener. The emitter methods
+// here are backed by a JS-side registry (the native EventTarget map is
+// opaque), so the EventTarget methods must be routed through it too.
+test("MessagePort emitter and EventTarget registrations share one registry", () => {
+  // (a) the same function registered via on() then addEventListener() is one
+  // listener: fires once per dispatch, counted once.
+  {
+    const { port1: p } = new MessageChannel();
+    let n = 0;
+    const f = () => n++;
+    p.on("x", f);
+    p.addEventListener("x", f);
+    p.dispatchEvent(new Event("x"));
+    expect({ calls: n, count: p.listenerCount("x"), gel: getEventListeners(p, "x").length }).toEqual({
+      calls: 1,
+      count: 1,
+      gel: 1,
+    });
+    p.close();
+  }
+
+  // (b) an addEventListener()-registered listener is visible to
+  // listenerCount()/eventNames(), and off() can remove it.
+  {
+    const { port1: p } = new MessageChannel();
+    let n = 0;
+    const f = () => n++;
+    p.addEventListener("y", f);
+    expect({ count: p.listenerCount("y"), named: p.eventNames().includes("y") }).toEqual({ count: 1, named: true });
+    p.off("y", f);
+    p.dispatchEvent(new Event("y"));
+    expect({ calls: n, count: p.listenerCount("y") }).toEqual({ calls: 0, count: 0 });
+    p.close();
+  }
+
+  // (c) removeEventListener() removes an on()-registered listener.
+  {
+    const { port1: p } = new MessageChannel();
+    let n = 0;
+    const f = () => n++;
+    p.on("z", f);
+    p.removeEventListener("z", f);
+    p.dispatchEvent(new Event("z"));
+    expect({ calls: n, count: p.listenerCount("z") }).toEqual({ calls: 0, count: 0 });
+    p.close();
+  }
+
+  // (d) removeAllListeners() removes addEventListener()-registered listeners.
+  {
+    const { port1: p } = new MessageChannel();
+    let n = 0;
+    p.addEventListener("w", () => n++);
+    p.removeAllListeners("w");
+    p.dispatchEvent(new Event("w"));
+    expect({ calls: n, count: p.listenerCount("w") }).toEqual({ calls: 0, count: 0 });
+    p.close();
+  }
+
+  // addEventListener({once:true}) drops from the registry after firing.
+  {
+    const { port1: p } = new MessageChannel();
+    let n = 0;
+    p.addEventListener("o", () => n++, { once: true });
+    const before = p.listenerCount("o");
+    p.dispatchEvent(new Event("o"));
+    expect({ before, calls: n, after: p.listenerCount("o") }).toEqual({ before: 1, calls: 1, after: 0 });
+    p.close();
+  }
+
+  // first registration wins regardless of which API added it.
+  {
+    const { port1: p } = new MessageChannel();
+    let got: unknown;
+    const f = (arg: unknown) => (got = arg);
+    p.addEventListener("m", f);
+    p.on("m", f);
+    p.dispatchEvent(new Event("m"));
+    // addEventListener was first: listener receives the Event, not event.detail.
+    expect(got).toBeInstanceOf(Event);
+    expect(p.listenerCount("m")).toBe(1);
+    p.close();
+  }
 });
 
 // jsRef() only gated on m_isDetached, so .ref()/onmessage= after the peer closed

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1452,6 +1452,32 @@ test("MessagePort emitter and EventTarget registrations share one registry", () 
     p.close();
   }
 
+  // Fewer than two arguments still throws (the override must not pad the call).
+  {
+    const { port1: p } = new MessageChannel();
+    expect(() => (p.addEventListener as any)("x")).toThrow(TypeError);
+    expect(() => (p.removeEventListener as any)("x")).toThrow(TypeError);
+    expect({ ael: p.addEventListener.length, rel: p.removeEventListener.length }).toEqual({ ael: 2, rel: 2 });
+    p.close();
+  }
+
+  // Each option getter is observed once: the override normalizes the dictionary
+  // before handing it to native so the registry slot agrees with the native map.
+  {
+    const { port1: p } = new MessageChannel();
+    let reads = 0;
+    const f = () => {};
+    p.addEventListener("g", f, {
+      get capture() {
+        reads++;
+        return false;
+      },
+    });
+    expect(reads).toBe(1);
+    p.removeEventListener("g", f);
+    p.close();
+  }
+
   // EventTarget identity is (type, listener, capture): the same function can be
   // registered once per capture flag, and removeEventListener only removes the
   // entry whose capture flag matches.

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1395,6 +1395,56 @@ test("MessagePort emitter and EventTarget registrations share one registry", () 
     expect(p.listenerCount("m")).toBe(1);
     p.close();
   }
+
+  // An AbortSignal removes the listener natively; the registry must drop it too
+  // so a later add of the same function is not blocked by a stale entry.
+  {
+    const { port1: p } = new MessageChannel();
+    const ac = new AbortController();
+    let n = 0;
+    const f = () => n++;
+    p.addEventListener("s", f, { signal: ac.signal });
+    ac.abort();
+    const afterAbort = p.listenerCount("s");
+    p.addEventListener("s", f);
+    p.dispatchEvent(new Event("s"));
+    expect({ afterAbort, calls: n, count: p.listenerCount("s") }).toEqual({ afterAbort: 0, calls: 1, count: 1 });
+    p.close();
+  }
+
+  // An already-aborted signal makes addEventListener a no-op, registry included.
+  {
+    const { port1: p } = new MessageChannel();
+    const ac = new AbortController();
+    ac.abort();
+    p.addEventListener("s", () => {}, { signal: ac.signal });
+    expect(p.listenerCount("s")).toBe(0);
+    p.close();
+  }
+
+  // EventTarget identity is (type, listener, capture): the same function can be
+  // registered once per capture flag, and removeEventListener only removes the
+  // entry whose capture flag matches.
+  {
+    const { port1: p } = new MessageChannel();
+    let n = 0;
+    const f = () => n++;
+    p.addEventListener("c", f, { capture: true });
+    p.addEventListener("c", f);
+    p.dispatchEvent(new Event("c"));
+    const both = { calls: n, count: p.listenerCount("c") };
+    p.removeEventListener("c", f);
+    p.dispatchEvent(new Event("c"));
+    const afterWrongCapture = { calls: n, count: p.listenerCount("c") };
+    p.removeEventListener("c", f, true);
+    p.dispatchEvent(new Event("c"));
+    expect({ both, afterWrongCapture, final: { calls: n, count: p.listenerCount("c") } }).toEqual({
+      both: { calls: 2, count: 2 },
+      afterWrongCapture: { calls: 3, count: 1 },
+      final: { calls: 3, count: 0 },
+    });
+    p.close();
+  }
 });
 
 // jsRef() only gated on m_isDetached, so .ref()/onmessage= after the peer closed

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1422,6 +1422,36 @@ test("MessagePort emitter and EventTarget registrations share one registry", () 
     p.close();
   }
 
+  // Aborting after remove-then-re-add of the same function removes the re-added
+  // listener too (node's abort handler is removeEventListener by identity), and
+  // the registry stays consistent with the native map.
+  {
+    const { port1: p } = new MessageChannel();
+    const ac = new AbortController();
+    let n = 0;
+    const f = () => n++;
+    p.addEventListener("s", f, { signal: ac.signal });
+    p.removeEventListener("s", f);
+    p.addEventListener("s", f);
+    ac.abort();
+    p.dispatchEvent(new Event("s"));
+    expect({ calls: n, count: p.listenerCount("s") }).toEqual({ calls: 0, count: 0 });
+    p.close();
+  }
+
+  // A failed native add (bad signal) must not leave a phantom registry entry.
+  {
+    const { port1: p } = new MessageChannel();
+    let n = 0;
+    const f = () => n++;
+    expect(() => p.addEventListener("t", f, { signal: {} as any })).toThrow(TypeError);
+    const afterThrow = p.listenerCount("t");
+    p.addEventListener("t", f);
+    p.dispatchEvent(new Event("t"));
+    expect({ afterThrow, calls: n, count: p.listenerCount("t") }).toEqual({ afterThrow: 0, calls: 1, count: 1 });
+    p.close();
+  }
+
   // EventTarget identity is (type, listener, capture): the same function can be
   // registered once per capture flag, and removeEventListener only removes the
   // entry whose capture flag matches.


### PR DESCRIPTION
## Repro

```js
const { MessageChannel } = await import("node:worker_threads");
const { getEventListeners } = await import("node:events");

{ const { port1: p } = new MessageChannel(); let n = 0; const f = () => n++;
  p.on("x", f); p.addEventListener("x", f); p.dispatchEvent(new Event("x"));
  console.log("calls", n, "gel", getEventListeners(p, "x").length); p.close(); }
{ const { port1: p } = new MessageChannel(); p.addEventListener("y", () => {});
  console.log("lc", p.listenerCount("y"), "names", p.eventNames()); p.close(); }
{ const { port1: p } = new MessageChannel(); const f = () => {}; p.on("z", f); p.removeEventListener("z", f);
  console.log("afterCrossRemove", p.listenerCount("z")); p.close(); }
{ const { port1: p } = new MessageChannel(); let n = 0; p.addEventListener("w", () => n++);
  p.removeAllListeners("w"); p.dispatchEvent(new Event("w")); console.log("afterRemoveAll", n); p.close(); }
```

| | bun (before) | node |
|---|---|---|
| calls / getEventListeners length | `2` / `2` | `1` / `1` |
| listenerCount / eventNames | `0` / `[]` | `1` / `[..., 'y']` |
| afterCrossRemove | `1` | `0` |
| afterRemoveAll | `1` | `0` |

## Cause

`injectFakeEmitter` gives `MessagePort` its NodeEventTarget-style methods (`on`/`off`/`once`/`listenerCount`/`eventNames`/`removeAllListeners`) backed by a JS-side per-instance `SafeMap` registry, because the native `EventTarget` listener map is opaque. The native `addEventListener`/`removeEventListener` were not touched, so they bypassed that registry entirely. The two halves therefore kept disjoint state: a listener added via `on()` and again via `addEventListener()` registered as two distinct listeners in the native map (the `on()` path stores a wrapper, so EventTarget's own dedup doesn't fire), `listenerCount()`/`eventNames()` only counted the `on()` side, `removeEventListener(fn)` looked for the user's function while only the wrapper was registered, and `removeAllListeners()` only iterated the registry so it missed `addEventListener()`-added listeners.

Node's `MessagePort` inherits from `NodeEventTarget`, which has one listener map serving both APIs.

## Fix

Override `addEventListener`/`removeEventListener` on the same intermediate prototype that already carries the emitter methods, so both APIs go through one registry. EventTarget identity is `(type, callback, capture)`, so the registry entry per listener is a two-slot `[bubble, capture]` pair holding whatever was handed to the native map (the listener itself, or a wrapper for `on()`/`once()`/`{once:true}`).

- `addEventListener(type, listener, options)` records `listener` in the slot for the requested capture flag and forwards to native. If that slot is already occupied the call is a no-op (first registration wins, like node). For `{once:true}` the listener is wrapped so the registry entry is purged when the native map drops it. If native throws (e.g. a non-AbortSignal `options.signal`), the registry entry is rolled back before rethrowing. If `options.signal` is set, an abort handler calls the `removeEventListener` override so registry and native stay in step; the port is held via `WeakRef` so the signal does not pin it.
- `removeEventListener(type, listener, options)` looks `listener` up in the slot for the requested capture flag, removes the stored value from the native map with the same options, and vacates that slot.

`on()`/`once()` still call `this.addEventListener(...)` with their unwrapping wrapper; those wrappers are tagged with a module-private symbol so the override passes them straight to native instead of recording them a second time. This keeps `parentPort` (which shadows `addEventListener` with `self.addEventListener`) working unchanged.

## Verification

New test `MessagePort emitter and EventTarget registrations share one registry` in `test/js/node/worker_threads/worker_threads.test.ts` covers the four cases above plus `{once:true}` via `addEventListener`, first-wins ordering across the two APIs, `(type, listener, capture)` identity, `AbortSignal` (abort purges the entry; already-aborted is a no-op; abort after remove-then-re-add matches node), and rollback on a throwing native add.

```
# without src/ change
(fail) MessagePort emitter and EventTarget registrations share one registry
  { calls: 2, count: 1, gel: 2 }  vs expected  { calls: 1, count: 1, gel: 1 }

# with fix
(pass) MessagePort emitter and EventTarget registrations share one registry
```

Full `worker_threads.test.ts` (92 tests), `test/js/web/workers/message-channel.test.ts`, `test/js/node/events/`, and the node-compat `test-event-target` / `test-messagechannel` / `test-worker-message-port*` tests stay green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (a84eb5a38)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1860.31ms]
(pass) all worker_threads module properties are present [25.08ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [26.94ms]
(pass) all worker_threads worker instance properties are present [167.32ms]
(pass) threadId module and worker property is consistent [231.70ms]
(pass) receiveMessageOnPort works across threads [1796.18ms]
(pass) receiveMessageOnPort works as FIFO [24.10ms]
(pass) you can override globalThis.postMessage [2363.11ms]
(pass) support require in eval [2356.75ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [2608.63ms]
(pass) support require in eval for a file that doesnt exist [1727.40ms]
(pass) support worker eval that throws [1686.52ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [9932.35ms]
(
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (3ae89c3cc)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [51.24ms]
(pass) all worker_threads module properties are present [1.10ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [2.41ms]
(pass) all worker_threads worker instance properties are present [1.76ms]
(pass) threadId module and worker property is consistent [5.47ms]
(pass) receiveMessageOnPort works across threads [32.50ms]
(pass) receiveMessageOnPort works as FIFO [0.31ms]
(pass) you can override globalThis.postMessage [30.70ms]
(pass) support require in eval [27.78ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [31.38ms]
(pass) support require in eval for a file that doesnt exist [30.16ms]
(pass) support worker eval that throws [28.50ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [151.91ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [81.18ms]
(pass) execArgv option > can specify an array of strings [80.67ms]
(pass) eval does not leak source code [2231.0
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (a84eb5a38)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [2291.37ms]
(pass) all worker_threads module properties are present [25.59ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [28.69ms]
(pass) all worker_threads worker instance properties are present [164.88ms]
(pass) threadId module and worker property is consistent [223.33ms]
(pass) receiveMessageOnPort works across threads [1878.22ms]
(pass) receiveMessageOnPort works as FIFO [22.08ms]
(pass) you can override globalThis.postMessage [2150.59ms]
(pass) support require in eval [2002.38ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1998.06ms]
(pass) support require in eval for a file that doesnt exist [2775.65ms]
(pass) support worker eval that throws [1968.85ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [7514.87ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 896ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (15784ms)
Bundle modules (81ms)
Postprocesss modules (256ms)
Bundle Functions (815ms)
Generate Code (38ms)

[17.00s] Bundled "src/js" for production
  2574 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      | 147 +++++++++++++---
 test/js/node/worker_threads/worker_threads.test.ts | 193 ++++++++++++++++++++-
 2 files changed, 315 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/worker_threads.ts                           6     17      0
test/js/node/worker_threads/worker_threads.test.ts      3      6      0
```

</details>

<!-- robobun:evidence:end -->