### PR TITLE
StringOrBuffer: dupe FastTypedArray bytes instead of forcing slowDownAndWasteMemory()

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -142,18 +142,13 @@ unsafe extern "C" {
     ) -> i32;
 }
 
-/// Result of [`JSValue::borrow_array_buffer_bytes`] — mirrors
-/// `JSC__JSValue__borrowBytesForOffThread` (bindings.cpp).
+/// Result of [`JSValue::borrow_array_buffer_bytes`]. See `JSC__JSValue__borrowBytesForOffThread`.
 pub enum BorrowedBufferBytes {
-    /// Not a buffer, or detached / zero-length.
+    /// Not a buffer, or detached.
     None,
-    /// `FastTypedArray` (≤ `fastSizeLimit` elements, inline in the GC heap).
-    /// The storage is GC-movable so the slice is only valid until the next
-    /// allocation / safe-point; callers must copy immediately. No unpin.
+    /// `FastTypedArray`: GC-movable inline storage. Copy immediately; no unpin.
     Fast { ptr: *const u8, len: usize },
-    /// Every other mode: the backing `JSC::ArrayBuffer` has been `pin()`ed.
-    /// For `OversizeTypedArray` the helper adopted the existing storage in
-    /// place (zero byte copy). Caller MUST [`ArrayBuffer::unpin`] when done.
+    /// Backing `JSC::ArrayBuffer` is now `pin()`ed. Caller MUST [`ArrayBuffer::unpin`].
     Pinned(ArrayBuffer),
 }
 
@@ -164,9 +159,7 @@ impl JSValue {
         JSC__JSValue__unpinArrayBuffer(self);
     }
 
-    /// Classifies and borrows `self`'s byte storage without forcing a
-    /// `FastTypedArray` through `slowDownAndWasteMemory()` the way
-    /// [`JSValue::as_pinned_arraybuffer`] does. See [`BorrowedBufferBytes`].
+    /// [`JSValue::as_pinned_arraybuffer`] without forcing a `FastTypedArray` through `slowDownAndWasteMemory()`.
     pub fn borrow_array_buffer_bytes(self, global: &JSGlobalObject) -> BorrowedBufferBytes {
         let mut ptr: *const u8 = core::ptr::null();
         let mut len: usize = 0;

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -135,6 +135,26 @@ unsafe extern "C" {
     safe fn JSC__ArrayBuffer__deref(self_: &JSCArrayBuffer);
     // safe: by-value `JSValue`; no-op for non-buffer values.
     safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
+    fn JSC__JSValue__borrowBytesForOffThread(
+        v: JSValue,
+        out_ptr: *mut *const u8,
+        out_len: *mut usize,
+    ) -> i32;
+}
+
+/// Result of [`JSValue::borrow_array_buffer_bytes`] — mirrors
+/// `JSC__JSValue__borrowBytesForOffThread` (bindings.cpp).
+pub enum BorrowedBufferBytes {
+    /// Not a buffer, or detached / zero-length.
+    None,
+    /// `FastTypedArray` (≤ `fastSizeLimit` elements, inline in the GC heap).
+    /// The storage is GC-movable so the slice is only valid until the next
+    /// allocation / safe-point; callers must copy immediately. No unpin.
+    Fast { ptr: *const u8, len: usize },
+    /// Every other mode: the backing `JSC::ArrayBuffer` has been `pin()`ed.
+    /// For `OversizeTypedArray` the helper adopted the existing storage in
+    /// place (zero byte copy). Caller MUST [`ArrayBuffer::unpin`] when done.
+    Pinned(ArrayBuffer),
 }
 
 impl JSValue {
@@ -142,6 +162,27 @@ impl JSValue {
     /// [`JSValue::as_pinned_arraybuffer`] or a pinning collector.
     pub fn unpin_array_buffer(self) {
         JSC__JSValue__unpinArrayBuffer(self);
+    }
+
+    /// Classifies and borrows `self`'s byte storage without forcing a
+    /// `FastTypedArray` through `slowDownAndWasteMemory()` the way
+    /// [`JSValue::as_pinned_arraybuffer`] does. See [`BorrowedBufferBytes`].
+    pub fn borrow_array_buffer_bytes(self, global: &JSGlobalObject) -> BorrowedBufferBytes {
+        let mut ptr: *const u8 = core::ptr::null();
+        let mut len: usize = 0;
+        // SAFETY: out-params are valid pointers to locals.
+        match unsafe { JSC__JSValue__borrowBytesForOffThread(self, &raw mut ptr, &raw mut len) } {
+            1 => BorrowedBufferBytes::Fast { ptr, len },
+            2 => match self.as_array_buffer(global) {
+                Some(buf) => BorrowedBufferBytes::Pinned(buf),
+                None => {
+                    // Pin was taken but the descriptor read failed; release it.
+                    JSC__JSValue__unpinArrayBuffer(self);
+                    BorrowedBufferBytes::None
+                }
+            },
+            _ => BorrowedBufferBytes::None,
+        }
     }
 }
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -228,8 +228,7 @@ pub use self::js_value::{
 // and is wired into `event_loop::tick` directly at link time. No fn-pointer
 // hook is re-exported from the crate root.
 pub use self::array_buffer::{
-    ArrayBuffer, BinaryType, BorrowedBufferBytes, JSCArrayBuffer, MarkedArrayBuffer,
-    TypedArrayType,
+    ArrayBuffer, BinaryType, BorrowedBufferBytes, JSCArrayBuffer, MarkedArrayBuffer, TypedArrayType,
 };
 pub use self::console_object as ConsoleObject;
 pub use self::console_object::Formatter;

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -228,7 +228,8 @@ pub use self::js_value::{
 // and is wired into `event_loop::tick` directly at link time. No fn-pointer
 // hook is re-exported from the crate root.
 pub use self::array_buffer::{
-    ArrayBuffer, BinaryType, JSCArrayBuffer, MarkedArrayBuffer, TypedArrayType,
+    ArrayBuffer, BinaryType, BorrowedBufferBytes, JSCArrayBuffer, MarkedArrayBuffer,
+    TypedArrayType,
 };
 pub use self::console_object as ConsoleObject;
 pub use self::console_object::Formatter;

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -124,22 +124,6 @@ pub enum Source {
 // `Vec<u8>`, `ZString`, and
 // `Strong` all implement `Drop`, so no explicit `Drop` body is needed.
 
-// These C++ helpers are
-// Image-specific (they pin/adopt typed-array storage for the off-thread
-// pipeline) and have no `bun_jsc` wrapper.
-unsafe extern "C" {
-    fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
-    /// 0 = detached/null, 1 = FastTypedArray (≤~1 KB, GC-movable — dupe),
-    /// 2 = pinned ArrayBuffer (caller must unpin). For OversizeTypedArray the
-    /// helper adopts the storage in-place (createAdopted — no byte copy) and
-    /// pins; once adopted it's detachable, so it MUST be pinned, not borrowed.
-    fn JSC__JSValue__borrowBytesForOffThread(
-        v: JSValue,
-        out_ptr: *mut *const u8,
-        out_len: *mut usize,
-    ) -> i32;
-}
-
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, strum::IntoStaticStr, strum::EnumString)]
 pub enum Fit {
@@ -706,7 +690,7 @@ impl Image {
     fn pin_for_task(
         &self,
         this_value: JSValue,
-        _global: &JSGlobalObject,
+        global: &JSGlobalObject,
     ) -> Result<Input, PinError> {
         match self.source.get() {
             Source::JsBuffer => {
@@ -721,51 +705,27 @@ impl Image {
                 // `slowDownAndWasteMemory()` → copy + allocate a wrapper for
                 // every input. The classifier returns the slice directly and
                 // tells us whether anything actually needs pinning.
-                let mut ptr: *const u8 = core::ptr::null();
-                let mut len: usize = 0;
-                // SAFETY: FFI call; out-params are valid pointers to locals.
-                match unsafe {
-                    JSC__JSValue__borrowBytesForOffThread(v, &raw mut ptr, &raw mut len)
-                } {
-                    0 => Err(PinError::Detached),
-                    // FastTypedArray (≤ fastSizeLimit elements, GC-movable): tiny
-                    // by definition — dupe instead of forcing JSC to copy via
-                    // tryCreate(span()) + allocate a butterfly.
-                    1 => {
-                        if len == 0 {
-                            Err(PinError::Detached)
-                        } else {
-                            // SAFETY: classifier guarantees `ptr[0..len]` is
-                            // valid for the duration of this call (JS thread).
-                            let copied = unsafe { bun_core::ffi::slice(ptr, len) }.to_vec();
-                            Ok(Input {
-                                copied: Some(copied),
-                                ..Default::default()
-                            })
-                        }
+                match v.borrow_array_buffer_bytes(global) {
+                    jsc::BorrowedBufferBytes::None => Err(PinError::Detached),
+                    jsc::BorrowedBufferBytes::Fast { len: 0, .. } => Err(PinError::Detached),
+                    jsc::BorrowedBufferBytes::Fast { ptr, len } => {
+                        // SAFETY: classifier guarantees `ptr[0..len]` is valid
+                        // for the duration of this call (JS thread).
+                        let copied = unsafe { bun_core::ffi::slice(ptr, len) }.to_vec();
+                        Ok(Input {
+                            copied: Some(copied),
+                            ..Default::default()
+                        })
                     }
-                    // Oversize/Wasteful/DataView/JSArrayBuffer: pinned by the
-                    // helper. For Oversize, possiblySharedBuffer() adopts the
-                    // existing fastMalloc storage in-place (zero byte copy);
-                    // pinning then keeps it alive even if JS does `.buffer` →
-                    // `transfer()` while the worker reads.
-                    2 => {
-                        if len == 0 {
-                            // SAFETY: helper pinned `v`; unpin before erroring.
-                            unsafe { JSC__JSValue__unpinArrayBuffer(v) };
-                            Err(PinError::Detached)
-                        } else {
-                            // SAFETY: pinned for the lifetime of the task;
-                            // unpinned in `then()` via `Input::release()`.
-                            let bytes = unsafe { bun_core::ffi::slice(ptr, len) };
-                            Ok(Input {
-                                bytes: bun_ptr::RawSlice::new(bytes),
-                                pinned: v,
-                                ..Default::default()
-                            })
-                        }
+                    jsc::BorrowedBufferBytes::Pinned(buf) if buf.byte_len == 0 => {
+                        buf.unpin();
+                        Err(PinError::Detached)
                     }
-                    _ => unreachable!(),
+                    jsc::BorrowedBufferBytes::Pinned(buf) => Ok(Input {
+                        bytes: bun_ptr::RawSlice::new(buf.byte_slice()),
+                        pinned: v,
+                        ..Default::default()
+                    }),
                 }
             }
             // SAFETY: `Owned` bytes outlive the task because `this_ref` is held
@@ -1435,9 +1395,7 @@ impl Input {
     }
     fn release(mut self) {
         if !self.pinned.is_empty() {
-            // SAFETY: JS thread; `pinned` was returned by
-            // `JSC__JSValue__borrowBytesForOffThread` with mode 2.
-            unsafe { JSC__JSValue__unpinArrayBuffer(self.pinned) };
+            self.pinned.unpin_array_buffer();
         }
         self.copied = None;
     }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -309,9 +309,7 @@ impl bun_jsc::Unprotect for StringOrBuffer {
 }
 
 impl StringOrBuffer {
-    /// Pin-or-dupe `value`'s bytes for a call that may outlive later JS coercions.
-    /// `FastTypedArray` inputs are duped (pinning would `slowDownAndWasteMemory()`); every
-    /// other mode is pinned in place. `protect` GC-roots the JS value for the `Buffer` arms.
+    /// Pin `value`'s bytes (`FastTypedArray` is duped instead; pinning would `slowDownAndWasteMemory()`).
     fn pinned_buffer_from_js(global: &JSGlobalObject, value: JSValue, protect: bool) -> Self {
         use jsc::BorrowedBufferBytes;
         match value.borrow_array_buffer_bytes(global) {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -309,6 +309,45 @@ impl bun_jsc::Unprotect for StringOrBuffer {
 }
 
 impl StringOrBuffer {
+    /// Borrow `value`'s byte storage for a call that may outlive later JS
+    /// coercions (async work, or a sync call whose later arguments can run
+    /// user code). `FastTypedArray` storage is duped into an owned
+    /// [`EncodedSlice`](Self::EncodedSlice) — pinning it would run
+    /// `slowDownAndWasteMemory()` (malloc + copy + butterfly) for a view that
+    /// cannot be detached anyway. Every other mode is pinned in place.
+    ///
+    /// `protect=true` GC-roots the JS value for the pinned case; the duped
+    /// case owns its bytes and never needs a root.
+    fn pinned_buffer_from_js(global: &JSGlobalObject, value: JSValue, protect: bool) -> Self {
+        use jsc::BorrowedBufferBytes;
+        match value.borrow_array_buffer_bytes(global) {
+            BorrowedBufferBytes::Fast { ptr, len } => {
+                // SAFETY: classifier guarantees `ptr[0..len]` is valid until
+                // the next GC safe-point; we copy immediately.
+                let owned = unsafe { bun_core::ffi::slice(ptr, len) }.to_vec();
+                global.vm().report_extra_memory(owned.len());
+                Self::EncodedSlice(ZigStringSlice::init_owned(owned))
+            }
+            BorrowedBufferBytes::Pinned(buf) => {
+                if protect {
+                    buf.value.protect();
+                }
+                Self::Buffer(Buffer {
+                    buffer: buf,
+                    owns_buffer: false,
+                    pinned: true,
+                })
+            }
+            BorrowedBufferBytes::None => {
+                let buffer = Buffer::from_array_buffer(global, value);
+                if protect {
+                    buffer.buffer.value.protect();
+                }
+                Self::Buffer(buffer)
+            }
+        }
+    }
+
     pub fn to_thread_safe(&mut self) {
         match self {
             Self::String(s) => {
@@ -437,18 +476,11 @@ impl StringOrBuffer {
             | JSType::BigInt64Array
             | JSType::BigUint64Array
             | JSType::DataView => {
-                let buffer = if is_async {
-                    Buffer::from_js_pinned(global, value)
-                        .unwrap_or_else(|| Buffer::from_array_buffer(global, value))
+                *out = if is_async {
+                    Self::pinned_buffer_from_js(global, value, true)
                 } else {
-                    Buffer::from_array_buffer(global, value)
+                    Self::Buffer(Buffer::from_array_buffer(global, value))
                 };
-
-                if is_async {
-                    buffer.buffer.value.protect();
-                }
-
-                *out = Self::Buffer(buffer);
                 Ok(true)
             }
             _ => Ok(false),
@@ -508,16 +540,11 @@ impl StringOrBuffer {
         allow_string_object: bool,
     ) -> JsResult<bool> {
         if value.is_cell() && value.js_type().is_array_buffer_like() {
-            let buffer = if is_async {
-                Buffer::from_js_pinned(global, value)
-                    .unwrap_or_else(|| Buffer::from_array_buffer(global, value))
+            *out = if is_async {
+                Self::pinned_buffer_from_js(global, value, true)
             } else {
-                Buffer::from_array_buffer(global, value)
+                Self::Buffer(Buffer::from_array_buffer(global, value))
             };
-            if is_async {
-                buffer.buffer.value.protect();
-            }
-            *out = Self::Buffer(buffer);
             return Ok(true);
         }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -309,21 +309,14 @@ impl bun_jsc::Unprotect for StringOrBuffer {
 }
 
 impl StringOrBuffer {
-    /// Borrow `value`'s byte storage for a call that may outlive later JS
-    /// coercions (async work, or a sync call whose later arguments can run
-    /// user code). `FastTypedArray` storage is duped into an owned
-    /// [`EncodedSlice`](Self::EncodedSlice) — pinning it would run
-    /// `slowDownAndWasteMemory()` (malloc + copy + butterfly) for a view that
-    /// cannot be detached anyway. Every other mode is pinned in place.
-    ///
-    /// `protect=true` GC-roots the JS value for the pinned case; the duped
-    /// case owns its bytes and never needs a root.
+    /// Pin-or-dupe `value`'s bytes for a call that may outlive later JS coercions.
+    /// `FastTypedArray` inputs are duped (pinning would `slowDownAndWasteMemory()`); every
+    /// other mode is pinned in place. `protect` GC-roots the JS value for the `Buffer` arms.
     fn pinned_buffer_from_js(global: &JSGlobalObject, value: JSValue, protect: bool) -> Self {
         use jsc::BorrowedBufferBytes;
         match value.borrow_array_buffer_bytes(global) {
             BorrowedBufferBytes::Fast { ptr, len } => {
-                // SAFETY: classifier guarantees `ptr[0..len]` is valid until
-                // the next GC safe-point; we copy immediately.
+                // SAFETY: `ptr[0..len]` valid until next GC safe-point; copy immediately.
                 let owned = unsafe { bun_core::ffi::slice(ptr, len) }.to_vec();
                 global.vm().report_extra_memory(owned.len());
                 Self::EncodedSlice(ZigStringSlice::init_owned(owned))

--- a/test/js/bun/util/string-or-buffer-fast-typed-array.test.ts
+++ b/test/js/bun/util/string-or-buffer-fast-typed-array.test.ts
@@ -1,0 +1,110 @@
+// A fresh `new Uint8Array(n)` with n ≤ JSC::fastSizeLimit lives inline in the
+// GC heap (FastTypedArray mode) until someone touches `.buffer`. Borrowing its
+// bytes for an async call should copy them, not force the view through
+// `slowDownAndWasteMemory()` (malloc + byte copy + butterfly allocation) just
+// to take a pin on storage that cannot be detached anyway.
+//
+// `jscDescribe` prints `butterfly (nil)` (or `0x0` on some platforms) for a
+// FastTypedArray and a real pointer once the view has been wastefully
+// materialized, so comparing the descriptor before/after tells us whether the
+// call allocated a backing ArrayBuffer.
+
+import { describe, test, expect } from "bun:test";
+import { jscDescribe } from "bun:jsc";
+import { tempDir } from "harness";
+import fs from "fs";
+import crypto from "crypto";
+import { promisify } from "util";
+
+const pbkdf2 = promisify(crypto.pbkdf2);
+
+// Control: accessing `.buffer` DOES allocate a butterfly. If jscDescribe ever
+// stops exposing that, every assertion below would pass vacuously; guard once.
+{
+  const u8 = new Uint8Array(64);
+  const before = jscDescribe(u8);
+  void u8.buffer;
+  const after = jscDescribe(u8);
+  if (before === after) {
+    throw new Error(
+      "control: jscDescribe no longer distinguishes FastTypedArray from a " +
+        "materialized view; this test needs a new observable",
+    );
+  }
+}
+
+async function expectNoMaterialize(label: string, run: (u8: Uint8Array) => unknown | Promise<unknown>) {
+  const u8 = new Uint8Array(64);
+  u8.fill(0x61);
+  const before = jscDescribe(u8);
+  await run(u8);
+  const after = jscDescribe(u8);
+  expect(after, `${label}: FastTypedArray was materialized (slowDownAndWasteMemory)`).toBe(before);
+}
+
+describe("StringOrBuffer does not materialize a FastTypedArray input", () => {
+  test("fs.promises.writeFile", async () => {
+    using dir = tempDir("sob-fast", { out: "" });
+    await expectNoMaterialize("writeFile", u8 => fs.promises.writeFile(`${dir}/out`, u8));
+  });
+
+  test("fs.promises.appendFile", async () => {
+    using dir = tempDir("sob-fast", { out: "" });
+    await expectNoMaterialize("appendFile", u8 => fs.promises.appendFile(`${dir}/out`, u8));
+  });
+
+  test("crypto.pbkdf2 password", async () => {
+    await expectNoMaterialize("pbkdf2 password", u8 => pbkdf2(u8, "salt", 1, 16, "sha256"));
+  });
+
+  test("crypto.pbkdf2 salt", async () => {
+    await expectNoMaterialize("pbkdf2 salt", u8 => pbkdf2("pass", u8, 1, 16, "sha256"));
+  });
+
+  test("crypto.scrypt password", async () => {
+    const scrypt = promisify(crypto.scrypt);
+    await expectNoMaterialize("scrypt password", u8 => scrypt(u8, "salt", 16));
+  });
+
+  test("Bun.Transpiler#transform", async () => {
+    const t = new Bun.Transpiler({ loader: "js" });
+    const src = new Uint8Array([49, 59, 10]); // "1;\n"
+    const before = jscDescribe(src);
+    await t.transform(src);
+    const after = jscDescribe(src);
+    expect(after, "transform: FastTypedArray was materialized").toBe(before);
+  });
+
+  test("the borrowed bytes are read correctly", async () => {
+    // Duping must preserve the contents: hash a FastTypedArray and the same
+    // bytes wrapped in a Buffer (already WastefulTypedArray) and compare.
+    const u8 = new Uint8Array(64);
+    for (let i = 0; i < u8.length; i++) u8[i] = i;
+    const viaFast = await pbkdf2(u8, "salt", 1, 32, "sha256");
+    const viaBuffer = await pbkdf2(Buffer.from(u8), "salt", 1, 32, "sha256");
+    expect(viaFast.equals(viaBuffer)).toBe(true);
+  });
+
+  test("zero-length FastTypedArray", async () => {
+    const u8 = new Uint8Array(0);
+    const [out, ref] = await Promise.all([
+      pbkdf2(u8, "salt", 1, 32, "sha256"),
+      pbkdf2("", "salt", 1, 32, "sha256"),
+    ]);
+    expect(out.equals(ref)).toBe(true);
+  });
+
+  test("an OversizeTypedArray is still pinned, not copied", async () => {
+    // > fastSizeLimit (1000) elements: storage lives in fastMalloc and is
+    // adopted in place by possiblySharedBuffer(). That path should still run;
+    // transfer() during the async work must leave the source attached.
+    const u8 = new Uint8Array(4096);
+    for (let i = 0; i < u8.length; i++) u8[i] = i & 0xff;
+    const ref = await pbkdf2(Buffer.from(u8), "salt", 1, 32, "sha256");
+
+    const p = pbkdf2(u8, "salt", 1, 32, "sha256");
+    u8.buffer.transfer();
+    expect(u8.byteLength).toBe(4096);
+    expect((await p).equals(ref)).toBe(true);
+  });
+});

--- a/test/js/bun/util/string-or-buffer-fast-typed-array.test.ts
+++ b/test/js/bun/util/string-or-buffer-fast-typed-array.test.ts
@@ -9,11 +9,11 @@
 // materialized, so comparing the descriptor before/after tells us whether the
 // call allocated a backing ArrayBuffer.
 
-import { describe, test, expect } from "bun:test";
 import { jscDescribe } from "bun:jsc";
-import { tempDir } from "harness";
-import fs from "fs";
+import { describe, expect, test } from "bun:test";
 import crypto from "crypto";
+import fs from "fs";
+import { tempDir } from "harness";
 import { promisify } from "util";
 
 const pbkdf2 = promisify(crypto.pbkdf2);
@@ -87,10 +87,7 @@ describe("StringOrBuffer does not materialize a FastTypedArray input", () => {
 
   test("zero-length FastTypedArray", async () => {
     const u8 = new Uint8Array(0);
-    const [out, ref] = await Promise.all([
-      pbkdf2(u8, "salt", 1, 32, "sha256"),
-      pbkdf2("", "salt", 1, 32, "sha256"),
-    ]);
+    const [out, ref] = await Promise.all([pbkdf2(u8, "salt", 1, 32, "sha256"), pbkdf2("", "salt", 1, 32, "sha256")]);
     expect(out.equals(ref)).toBe(true);
   });
 


### PR DESCRIPTION
## What

On the async path, `StringOrBuffer::from_js_maybe_async_into` / `from_js_with_encoding_maybe_async_into` route every buffer-like input through `Buffer::from_js_pinned` → `as_pinned_arraybuffer` → `JSC__JSValue__pinArrayBuffer` → `arrayBufferImpl` → `view->possiblySharedBuffer()`.

For a `FastTypedArray` (a fresh `new Uint8Array(n)` with `n ≤ fastSizeLimit` whose `.buffer` was never touched) `possiblySharedBuffer()` runs `slowDownAndWasteMemory()`: malloc a fresh `ArrayBuffer`, copy the bytes, allocate a butterfly, then pin the result. The old unpinned path read `view->vector()` with zero allocation.

This hits `fs.promises.writeFile(new Uint8Array(64))`, async `crypto.pbkdf2` / `crypto.scrypt`, `Bun.Transpiler#transform`, and any other `StringOrBuffer` consumer that passes `is_async=true`. Node `Buffer`s and already-materialized views only pay a pin-counter bump and are unaffected.

Flagged in review on #35757 (https://github.com/oven-sh/bun/pull/35757#discussion_r3650640866); deferred there to keep the security fix focused.

## Fix

A `FastTypedArray`'s inline storage cannot be detached (there is no `ArrayBuffer` to detach), so pinning buys nothing, and `JSC__JSValue__borrowBytesForOffThread` already knows to hand back the `vector()` span for exactly this case. Route the `StringOrBuffer` pinning arm through that classifier instead of `pinArrayBuffer`:

* `FastTypedArray` → dupe the (≤ 1000-byte) span into an owned `StringOrBuffer::EncodedSlice`. No pin, no GC root needed; the copy is freed on `Drop`.
* every other mode → unchanged: `possiblySharedBuffer()` + `pin()` (for `OversizeTypedArray` this adopts the existing storage in place, zero byte copy), GC-rooted for the async path as before.
* detached / not-a-buffer → unchanged: zero-length `Buffer`, GC-rooted.

The classifier and the dupe are the same approach `Bun.Image` already uses for its off-thread input (`Image.rs:706-746`). The `bun_jsc` wrapper added here (`JSValue::borrow_array_buffer_bytes` → `BorrowedBufferBytes`) centralizes the FFI so other callers can share it.

`pinned_buffer_from_js` is also what #35757 can call on the sync path once it drops the `is_async` branch, so that change stays zero-alloc for `FastTypedArray` inputs there too.

## Why this is correct

Pinning exists so a later argument's coercion (or off-thread work) cannot free the borrowed slice mid-call. `FastTypedArray` storage lives inline in the GC heap and cannot be detached: `transfer()` / `structuredClone(..., {transfer})` / `postMessage(..., [..])` all require an `ArrayBuffer`, and reaching `.buffer` materializes a *copy* into a fresh one, leaving the view we already read untouched. Duping the span up front makes the borrowed bytes independent of any later coercion, so the safety property the pin provides is preserved without the materialization cost. The remaining modes (`Oversize`/`Wasteful`/`DataView`/`JSArrayBuffer`) keep pinning exactly as before.

## Verification

`jscDescribe` prints `butterfly (nil)` for a `FastTypedArray` and a real pointer once the view has been wastefully materialized:

```console
$ bun -e 'const {jscDescribe}=require("bun:jsc");const u=new Uint8Array(64);console.log(jscDescribe(u));u.buffer;console.log(jscDescribe(u));'
Object: 0x... with butterfly (nil) (...)
Object: 0x... with butterfly 0x7603... (...)
```

The new test asserts the descriptor is unchanged across the async consumers above (6 tests fail on main, pass with this change), that the duped bytes hash to the same result as a `Buffer` wrapping the same contents, that an `OversizeTypedArray` input is still pinned (a concurrent `transfer()` leaves the source attached), and includes a module-load control so the suite fails loudly if `jscDescribe` ever stops exposing the distinction.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/string-or-buffer-fast-typed-array.test.ts
bun test v1.4.0 (441d3b555)

test/js/bun/util/string-or-buffer-fast-typed-array.test.ts:
37 |   const u8 = new Uint8Array(64);
38 |   u8.fill(0x61);
39 |   const before = jscDescribe(u8);
40 |   await run(u8);
41 |   const after = jscDescribe(u8);
42 |   expect(after, `${label}: FastTypedArray was materialized (slowDownAndWasteMemory)`).toBe(before);
                                                                                           ^
error: writeFile: FastTypedArray was materialized (slowDownAndWasteMemory)

Expected: "Object: 0x799bb606ea88 with butterfly (nil) (Structure 0x799a01009ad0:[0x1009ad0/16816848, Uint8Array, (0/0, 0/0){}, NonArray, Unknown, Proto:0x799bb7144320, Leaf]), StructureID: 16816848"
Received: "Object: 0x799bb606ea88 with butterfly 0x799bb7364208(base=0x799bb7364200) (Structure 0x799a01009ad0:[0x1009ad0/16816848, Uint8Array, (0/0, 0/0){}, NonArray, Unknown, Proto:0x799bb7144320, Leaf]), StructureID: 16816848"

      at expectNoMaterialize (/workspac
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (441d3b555)

test/js/bun/util/string-or-buffer-fast-typed-array.test.ts:
(pass) StringOrBuffer does not materialize a FastTypedArray input > fs.promises.writeFile [1.91ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > fs.promises.appendFile [0.68ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > crypto.pbkdf2 password [0.49ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > crypto.pbkdf2 salt [0.18ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > crypto.scrypt password [61.48ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > Bun.Transpiler#transform [0.75ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > the borrowed bytes are read correctly [0.37ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > zero-length FastTypedArray [0.27ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > an OversizeTypedArray is still pinned, not copied [0.66ms]

 9 pass
 0 fail
 10 expect() calls
Ran 9 tests across 1 file. [269.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/string-or-buffer-fast-typed-array.test.ts
bun test v1.4.0 (441d3b555)

test/js/bun/util/string-or-buffer-fast-typed-array.test.ts:
(pass) StringOrBuffer does not materialize a FastTypedArray input > fs.promises.writeFile [113.06ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > fs.promises.appendFile [25.20ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > crypto.pbkdf2 password [23.89ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > crypto.pbkdf2 salt [10.01ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > crypto.scrypt password [477.13ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > Bun.Transpiler#transform [19.09ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > the borrowed bytes are read correctly [14.86ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > zero-length FastTypedArray [12.23ms]
(pass) StringOrBuffer does not materialize a FastTypedArray input > an Oversi
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1058ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/32] gen cpp.rs (cppbind)
[2/32] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[3/32] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2Frame
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/array_buffer.rs                            |  34 +++++++
 src/jsc/lib.rs                                     |   2 +-
 src/runtime/image/Image.rs                         |  84 ++++------------
 src/runtime/node/types.rs                          |  54 +++++++----
 .../util/string-or-buffer-fast-typed-array.test.ts | 107 +++++++++++++++++++++
 5 files changed, 199 insertions(+), 82 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/array_buffer.rs                                       4      4      0
src/jsc/lib.rs                                                1      1      0
src/runtime/image/Image.rs                                    6      5      0
src/runtime/node/types.rs                                     5      7      0
…t/js/bun/util/string-or-buffer-fast-typed-array.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->