### PR TITLE
process: propagate listener throws out of process.emit()

### DIFF
--- a/src/js/internal/worker/messaging.ts
+++ b/src/js/internal/worker/messaging.ts
@@ -5,9 +5,7 @@
 //
 // Differences from node: thread info comes from initThreadInfo (Bun assigns threadId
 // differently); createMainThreadPort is split into createMessagingChannel (before
-// `new Worker`) + registerMainThreadPort (after the threadId exists); and the
-// `workerMessage` listeners are invoked directly because Bun's process.emit cannot
-// report no-listeners or a throwing listener (see receiveMessageFromWorker).
+// `new Worker`) + registerMainThreadPort (after the threadId exists).
 
 const { validateNumber } = require("internal/validators");
 const { SafeMap } = require("internal/primordials");

--- a/src/js/internal/worker/messaging.ts
+++ b/src/js/internal/worker/messaging.ts
@@ -128,25 +128,12 @@ function sendMessageToWorker(source, destination, value, transferList, memory) {
 function receiveMessageFromWorker(source, value, memory) {
   let response = WORKER_MESSAGING_RESULT_NO_LISTENERS;
 
-  // Don't use process.emit("workerMessage", ...): Bun's native emit routes a
-  // throwing listener to reportUnhandledError instead of rethrowing, so
-  // LISTENER_ERROR can't be detected. Invoke listeners directly.
-  //
-  // Known limitation: process.once('workerMessage', fn) listeners are not
-  // removed here — the native process EventEmitter tracks isOnce internally
-  // (fireEventListeners handles removal) with no JS-side onceWrapper to detect.
-  // Fixing this needs the native emit to rethrow (a broader change).
-  const listeners = process.listeners("workerMessage");
-  const listenerCount = listeners.length;
-  if (listenerCount > 0) {
-    try {
-      for (let i = 0; i < listenerCount; i++) {
-        listeners[i].$call(process, value, source);
-      }
+  try {
+    if (process.emit("workerMessage", value, source)) {
       response = WORKER_MESSAGING_RESULT_DELIVERED;
-    } catch {
-      response = WORKER_MESSAGING_RESULT_LISTENER_ERROR;
     }
+  } catch {
+    response = WORKER_MESSAGING_RESULT_LISTENER_ERROR;
   }
 
   // Populate the result.

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1174,7 +1174,7 @@ extern "C" void Bun__onSignalForJS(int signalNumber, Zig::GlobalObject* globalOb
     args.append(jsString(JSC::getVM(globalObject), signalNameIdentifier.string()));
     args.append(jsNumber(signalNumber));
 
-    process->wrapped().emitForBindings(signalNameIdentifier, args);
+    process->wrapped().emit(signalNameIdentifier, args);
 }
 
 #if OS(WINDOWS)

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -6,6 +6,7 @@
 #include "EventNames.h"
 #include "JSErrorHandler.h"
 #include "JSEventListener.h"
+#include <JavaScriptCore/ThrowScope.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
@@ -116,12 +117,12 @@ bool EventEmitter::emitForBindings(const Identifier& eventType, const MarkedArgu
     if (!scriptExecutionContext())
         return false;
 
-    return emit(eventType, arguments);
+    return fireEventListeners(eventType, arguments, /* propagateExceptions */ true);
 }
 
 bool EventEmitter::emit(const Identifier& eventType, const MarkedArgumentBuffer& arguments)
 {
-    return fireEventListeners(eventType, arguments);
+    return fireEventListeners(eventType, arguments, /* propagateExceptions */ false);
 }
 
 void EventEmitter::uncaughtExceptionInEventHandler()
@@ -175,7 +176,7 @@ Vector<JSObject*> EventEmitter::getListeners(const Identifier& eventType)
 }
 
 // https://dom.spec.whatwg.org/#concept-event-listener-invoke
-bool EventEmitter::fireEventListeners(const Identifier& eventType, const MarkedArgumentBuffer& arguments)
+bool EventEmitter::fireEventListeners(const Identifier& eventType, const MarkedArgumentBuffer& arguments, bool propagateExceptions)
 {
 
     auto* data = eventTargetData();
@@ -190,7 +191,13 @@ bool EventEmitter::fireEventListeners(const Identifier& eventType, const MarkedA
             if (!thisObject)
                 return false;
 
-            Bun__reportUnhandledError(thisObject->globalObject(), JSValue::encode(arguments.at(0)));
+            auto* globalObject = thisObject->globalObject();
+            if (propagateExceptions) {
+                auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+                scope.throwException(globalObject, arguments.at(0));
+                return false;
+            }
+            Bun__reportUnhandledError(globalObject, JSValue::encode(arguments.at(0)));
             return false;
         }
         return false;
@@ -198,7 +205,7 @@ bool EventEmitter::fireEventListeners(const Identifier& eventType, const MarkedA
 
     bool prevFiringEventListeners = data->isFiringEventListeners;
     data->isFiringEventListeners = true;
-    auto fired = innerInvokeEventListeners(eventType, *listenersVector, arguments);
+    auto fired = innerInvokeEventListeners(eventType, *listenersVector, arguments, propagateExceptions);
     data->isFiringEventListeners = prevFiringEventListeners;
     return fired;
 }
@@ -206,7 +213,7 @@ bool EventEmitter::fireEventListeners(const Identifier& eventType, const MarkedA
 // Intentionally creates a copy of the listeners vector to avoid event listeners added after this point from being run.
 // Note that removal still has an effect due to the removed field in RegisteredEventListener.
 // https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke
-bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, SimpleEventListenerVector listeners, const MarkedArgumentBuffer& arguments)
+bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, SimpleEventListenerVector listeners, const MarkedArgumentBuffer& arguments, bool propagateExceptions)
 {
     Ref<EventEmitter> protectedThis(*this);
     ASSERT(!listeners.isEmpty());
@@ -252,6 +259,13 @@ bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, Simple
         auto* exception = exceptionPtr.get();
 
         if (exception) [[unlikely]] {
+            if (propagateExceptions) {
+                // Node.js EventEmitter semantics: a listener's synchronous throw propagates
+                // out of emit() to the caller, and subsequent listeners do not run.
+                auto scope = DECLARE_THROW_SCOPE(vm);
+                scope.throwException(lexicalGlobalObject, exception);
+                return fired;
+            }
             auto errorIdentifier = vm.propertyNames->error;
             auto hasErrorListener = this->hasActiveEventListeners(errorIdentifier);
             if (!hasErrorListener || eventType == errorIdentifier) {
@@ -264,7 +278,7 @@ bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, Simple
                     errorValue = JSC::jsUndefined();
                 }
                 expcep.append(errorValue);
-                fireEventListeners(errorIdentifier, WTF::move(expcep));
+                fireEventListeners(errorIdentifier, WTF::move(expcep), false);
             }
         }
     }

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -259,8 +259,6 @@ bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, Simple
 
         if (exception) [[unlikely]] {
             if (propagateExceptions) {
-                // Node.js EventEmitter semantics: a listener's synchronous throw propagates
-                // out of emit() to the caller, and subsequent listeners do not run.
                 auto scope = DECLARE_THROW_SCOPE(vm);
                 scope.throwException(lexicalGlobalObject, exception);
                 return fired;

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -187,17 +187,16 @@ bool EventEmitter::fireEventListeners(const Identifier& eventType, const MarkedA
     if (!listenersVector) [[unlikely]] {
         if (eventType == scriptExecutionContext()->vm().propertyNames->error && arguments.size() > 0) {
             Ref<EventEmitter> protectedThis(*this);
-            auto* thisObject = protectedThis->m_thisObject.get();
-            if (!thisObject)
-                return false;
-
-            auto* globalObject = thisObject->globalObject();
             if (propagateExceptions) {
+                auto* globalObject = scriptExecutionContext()->jsGlobalObject();
                 auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
                 scope.throwException(globalObject, arguments.at(0));
                 return false;
             }
-            Bun__reportUnhandledError(globalObject, JSValue::encode(arguments.at(0)));
+            auto* thisObject = protectedThis->m_thisObject.get();
+            if (!thisObject)
+                return false;
+            Bun__reportUnhandledError(thisObject->globalObject(), JSValue::encode(arguments.at(0)));
             return false;
         }
         return false;

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -4,8 +4,11 @@
 
 #include "DOMWrapperWorld.h"
 #include "EventNames.h"
+#include "ErrorCode.h"
 #include "JSErrorHandler.h"
 #include "JSEventListener.h"
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/ThrowScope.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
@@ -185,18 +188,42 @@ bool EventEmitter::fireEventListeners(const Identifier& eventType, const MarkedA
 
     auto* listenersVector = data->eventListenerMap.find(eventType);
     if (!listenersVector) [[unlikely]] {
-        if (eventType == scriptExecutionContext()->vm().propertyNames->error && arguments.size() > 0) {
+        if (eventType == scriptExecutionContext()->vm().propertyNames->error) {
             Ref<EventEmitter> protectedThis(*this);
+            JSValue er = arguments.size() > 0 ? arguments.at(0) : JSC::jsUndefined();
             if (propagateExceptions) {
-                auto* globalObject = scriptExecutionContext()->jsGlobalObject();
-                auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-                scope.throwException(globalObject, arguments.at(0));
+                auto* globalObject = defaultGlobalObject(scriptExecutionContext()->jsGlobalObject());
+                auto& vm = globalObject->vm();
+                auto scope = DECLARE_THROW_SCOPE(vm);
+                if (er.isCell() && er.asCell()->inherits<JSC::ErrorInstance>()) {
+                    scope.throwException(globalObject, er);
+                    return false;
+                }
+                WTF::String inspected;
+                auto* inspectFn = globalObject->utilInspectFunction();
+                RETURN_IF_EXCEPTION(scope, false);
+                auto callData = JSC::getCallData(inspectFn);
+                MarkedArgumentBuffer inspectArgs;
+                inspectArgs.append(er);
+                WTF::NakedPtr<JSC::Exception> inspectException;
+                auto inspectResult = JSC::call(globalObject, inspectFn, callData, JSC::jsUndefined(), inspectArgs, inspectException);
+                if (!inspectException) {
+                    inspected = inspectResult.toWTFString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, false);
+                }
+                auto message = makeString("Unhandled error. ("_s, inspected, ")"_s);
+                auto* err = Bun::createError(globalObject, Bun::ErrorCode::ERR_UNHANDLED_ERROR, message);
+                RETURN_IF_EXCEPTION(scope, false);
+                err->putDirect(vm, JSC::Identifier::fromString(vm, "context"_s), er, 0);
+                scope.throwException(globalObject, err);
                 return false;
             }
-            auto* thisObject = protectedThis->m_thisObject.get();
-            if (!thisObject)
-                return false;
-            Bun__reportUnhandledError(thisObject->globalObject(), JSValue::encode(arguments.at(0)));
+            if (arguments.size() > 0) {
+                auto* thisObject = protectedThis->m_thisObject.get();
+                if (!thisObject)
+                    return false;
+                Bun__reportUnhandledError(thisObject->globalObject(), JSValue::encode(er));
+            }
             return false;
         }
         return false;

--- a/src/jsc/bindings/webcore/EventEmitter.h
+++ b/src/jsc/bindings/webcore/EventEmitter.h
@@ -49,12 +49,15 @@ public:
     WEBCORE_EXPORT void addListenerForBindings(const Identifier& eventType, RefPtr<EventListener>&&, bool, bool);
     WEBCORE_EXPORT void removeListenerForBindings(const Identifier& eventType, RefPtr<EventListener>&&);
     WEBCORE_EXPORT void removeAllListenersForBindings(const Identifier& eventType);
+    // emitForBindings propagates listener exceptions to the caller (Node.js EventEmitter semantics).
     WEBCORE_EXPORT bool emitForBindings(const Identifier&, const MarkedArgumentBuffer&);
 
     WEBCORE_EXPORT bool addListener(const Identifier& eventType, Ref<EventListener>&&, bool, bool);
     WEBCORE_EXPORT bool removeListener(const Identifier& eventType, EventListener&);
     WEBCORE_EXPORT bool removeAllListeners(const Identifier& eventType);
 
+    // emit() reports listener exceptions as uncaught (for runtime-initiated dispatch where
+    // there is no JS caller on the stack to catch them).
     WEBCORE_EXPORT bool emit(const Identifier&, const MarkedArgumentBuffer&);
     WEBCORE_EXPORT void uncaughtExceptionInEventHandler();
 
@@ -76,7 +79,7 @@ public:
     Vector<Identifier> eventTypes();
     const SimpleEventListenerVector& eventListeners(const Identifier& eventType);
 
-    bool fireEventListeners(const Identifier& eventName, const MarkedArgumentBuffer& arguments);
+    bool fireEventListeners(const Identifier& eventName, const MarkedArgumentBuffer& arguments, bool propagateExceptions = false);
     bool isFiringEventListeners() const;
 
     void invalidateJSEventListeners(JSC::JSObject*);
@@ -107,7 +110,7 @@ private:
     {
     }
 
-    bool innerInvokeEventListeners(const Identifier&, SimpleEventListenerVector, const MarkedArgumentBuffer& arguments);
+    bool innerInvokeEventListeners(const Identifier&, SimpleEventListenerVector, const MarkedArgumentBuffer& arguments, bool propagateExceptions);
     void invalidateEventListenerRegions();
 
     EventEmitterData m_eventTargetData;

--- a/src/jsc/bindings/webcore/EventEmitter.h
+++ b/src/jsc/bindings/webcore/EventEmitter.h
@@ -49,15 +49,14 @@ public:
     WEBCORE_EXPORT void addListenerForBindings(const Identifier& eventType, RefPtr<EventListener>&&, bool, bool);
     WEBCORE_EXPORT void removeListenerForBindings(const Identifier& eventType, RefPtr<EventListener>&&);
     WEBCORE_EXPORT void removeAllListenersForBindings(const Identifier& eventType);
-    // emitForBindings propagates listener exceptions to the caller (Node.js EventEmitter semantics).
+    // Propagates listener exceptions to the JS caller.
     WEBCORE_EXPORT bool emitForBindings(const Identifier&, const MarkedArgumentBuffer&);
 
     WEBCORE_EXPORT bool addListener(const Identifier& eventType, Ref<EventListener>&&, bool, bool);
     WEBCORE_EXPORT bool removeListener(const Identifier& eventType, EventListener&);
     WEBCORE_EXPORT bool removeAllListeners(const Identifier& eventType);
 
-    // emit() reports listener exceptions as uncaught (for runtime-initiated dispatch where
-    // there is no JS caller on the stack to catch them).
+    // Reports listener exceptions as uncaught; for runtime-initiated dispatch.
     WEBCORE_EXPORT bool emit(const Identifier&, const MarkedArgumentBuffer&);
     WEBCORE_EXPORT void uncaughtExceptionInEventHandler();
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1773,7 +1773,6 @@ describe("process.emit propagates listener exceptions to the caller", () => {
 
   it.concurrent("emit('error', err) with no error listener throws synchronously", async () => {
     const { stdout, exitCode } = await run(`
-      process.on("unused", () => {});
       let caught;
       try {
         process.emit("error", new Error("no-listener"));

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1786,7 +1786,13 @@ describe("process.emit propagates listener exceptions to the caller", () => {
     expect(JSON.parse(stdout.trim())).toEqual({
       "error-instance": { caught: true, isError: true, msg: "no-listener" },
       "no-arg": { caught: true, isError: true, code: "ERR_UNHANDLED_ERROR", msg: "Unhandled error. (undefined)" },
-      "string": { caught: true, isError: true, code: "ERR_UNHANDLED_ERROR", msg: "Unhandled error. ('boom')", ctx: "boom" },
+      "string": {
+        caught: true,
+        isError: true,
+        code: "ERR_UNHANDLED_ERROR",
+        msg: "Unhandled error. ('boom')",
+        ctx: "boom",
+      },
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1711,3 +1711,106 @@ describe("NODE_NO_WARNINGS", () => {
     expect(await warn("1")).not.toMatch(/Warning: foo/);
   });
 });
+
+describe("process.emit propagates listener exceptions to the caller", () => {
+  // A listener's synchronous throw must propagate out of process.emit() like any
+  // EventEmitter. Previously Bun's native EventEmitter routed the throw through
+  // Bun__reportUnhandledError, so `try { process.emit(...) } catch {}` never caught
+  // and the process exited 1.
+
+  async function run(script) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.concurrent("propagates for custom and built-in event names", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const res = {};
+      for (const name of ["custom-event", "message", "SIGUSR2", "warning", "exit", "beforeExit"]) {
+        const l = () => { throw new Error("T:" + name); };
+        process.on(name, l);
+        try {
+          process.emit(name, name === "warning" ? new Error("w") : undefined);
+          res[name] = "swallowed";
+        } catch (e) {
+          res[name] = e.message === "T:" + name ? "propagated" : "wrong:" + e.message;
+        }
+        process.removeListener(name, l);
+      }
+      console.log(JSON.stringify(res));
+    `);
+    expect(stderr).not.toContain("error:");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      "custom-event": "propagated",
+      "message": "propagated",
+      "SIGUSR2": "propagated",
+      "warning": "propagated",
+      "exit": "propagated",
+      "beforeExit": "propagated",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("stops at the first throwing listener", async () => {
+    const { stdout, exitCode } = await run(`
+      const ran = [];
+      process.on("foo", () => { ran.push(1); throw new Error("first"); });
+      process.on("foo", () => { ran.push(2); });
+      let caught;
+      try { process.emit("foo"); } catch (e) { caught = e.message; }
+      process.removeAllListeners("foo");
+      console.log(JSON.stringify({ ran, caught }));
+    `);
+    expect(JSON.parse(stdout.trim())).toEqual({ ran: [1], caught: "first" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("emit('error', err) with no error listener throws synchronously", async () => {
+    const { stdout, exitCode } = await run(`
+      process.on("unused", () => {});
+      let caught;
+      try {
+        process.emit("error", new Error("no-listener"));
+      } catch (e) {
+        caught = e.message;
+      }
+      console.log(JSON.stringify({ caught }));
+    `);
+    expect(JSON.parse(stdout.trim())).toEqual({ caught: "no-listener" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("newListener throw propagates out of process.on()", async () => {
+    const { stdout, exitCode } = await run(`
+      const nl = () => { throw new Error("nl"); };
+      process.on("newListener", nl);
+      let caught;
+      try {
+        process.on("foo", () => {});
+      } catch (e) {
+        caught = e.message;
+      }
+      process.removeListener("newListener", nl);
+      console.log(JSON.stringify({ caught }));
+    `);
+    expect(JSON.parse(stdout.trim())).toEqual({ caught: "nl" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("uncaught throw still reaches uncaughtException when emit() is not wrapped", async () => {
+    const { stdout, exitCode } = await run(`
+      process.on("uncaughtException", e => { console.log("uncaught:" + e.message); });
+      process.on("foo", () => { throw new Error("boom"); });
+      process.emit("foo");
+      console.log("after");
+    `);
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["uncaught:boom"]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1730,7 +1730,7 @@ describe("process.emit propagates listener exceptions to the caller", () => {
   }
 
   it.concurrent("propagates for custom and built-in event names", async () => {
-    const { stdout, stderr, exitCode } = await run(`
+    const { stdout, exitCode } = await run(`
       const res = {};
       for (const name of ["custom-event", "message", "SIGUSR2", "warning", "exit", "beforeExit"]) {
         const l = () => { throw new Error("T:" + name); };
@@ -1745,7 +1745,6 @@ describe("process.emit propagates listener exceptions to the caller", () => {
       }
       console.log(JSON.stringify(res));
     `);
-    expect(stderr).not.toContain("error:");
     expect(JSON.parse(stdout.trim())).toEqual({
       "custom-event": "propagated",
       "message": "propagated",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1771,17 +1771,23 @@ describe("process.emit propagates listener exceptions to the caller", () => {
     expect(exitCode).toBe(0);
   });
 
-  it.concurrent("emit('error', err) with no error listener throws synchronously", async () => {
+  it.concurrent("emit('error', ...) with no error listener throws synchronously", async () => {
     const { stdout, exitCode } = await run(`
-      let caught;
-      try {
-        process.emit("error", new Error("no-listener"));
-      } catch (e) {
-        caught = e.message;
+      const out = {};
+      function probe(name, fn) {
+        try { fn(); out[name] = { caught: false }; }
+        catch (e) { out[name] = { caught: true, isError: e instanceof Error, code: e?.code, msg: e?.message ?? e, ctx: e?.context }; }
       }
-      console.log(JSON.stringify({ caught }));
+      probe("error-instance", () => process.emit("error", new Error("no-listener")));
+      probe("no-arg",          () => process.emit("error"));
+      probe("string",          () => process.emit("error", "boom"));
+      console.log(JSON.stringify(out));
     `);
-    expect(JSON.parse(stdout.trim())).toEqual({ caught: "no-listener" });
+    expect(JSON.parse(stdout.trim())).toEqual({
+      "error-instance": { caught: true, isError: true, msg: "no-listener" },
+      "no-arg": { caught: true, isError: true, code: "ERR_UNHANDLED_ERROR", msg: "Unhandled error. (undefined)" },
+      "string": { caught: true, isError: true, code: "ERR_UNHANDLED_ERROR", msg: "Unhandled error. ('boom')", ctx: "boom" },
+    });
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
## Problem

`process.emit(<any event>)` did not propagate a listener's synchronous throw to the `emit()` caller. The exception was re-routed as an uncaught exception: printed to stderr, `uncaughtException` fired, exit code became 1, but `emit()` returned `true` and execution continued past the surrounding `try/catch`. Node.js (and Bun's own JS `EventEmitter`) propagate the throw synchronously.

```js
const res = {};
for (const name of ["custom-event", "message", "SIGUSR2", "warning"]) {
  const l = () => { throw new Error("T:" + name); };
  process.on(name, l);
  try { process.emit(name, name === "warning" ? new Error("w") : undefined); res[name] = "swallowed"; }
  catch { res[name] = "propagated"; }
  process.removeListener(name, l);
}
console.log(JSON.stringify(res));
```

```
node v26.3.0: {"custom-event":"propagated","message":"propagated","SIGUSR2":"propagated","warning":"propagated"}   exit 0
bun (before): {"custom-event":"swallowed","message":"swallowed","SIGUSR2":"swallowed","warning":"swallowed"}
              + each throw printed as an uncaught error, exit 1
```

This breaks the synthetic-event pattern (`try { process.emit('SIGINT') } catch {}`) used by exit-hook and IPC-shim libraries.

## Cause

`process` is backed by the native `WebCore::EventEmitter` rather than the JS `node:events` implementation. Its `innerInvokeEventListeners` (`src/jsc/bindings/webcore/EventEmitter.cpp`) invoked listeners with the catching form of `JSC::call(..., exceptionPtr)` and, on exception, either called `Bun__reportUnhandledError` or re-routed it to an `'error'` listener. The exception never reached the `emit()` caller.

The same code also handled `emit('error', err)` with no `error` listener by reporting it as unhandled, whereas Node throws synchronously from `emit()`.

## Fix

`fireEventListeners` / `innerInvokeEventListeners` gain a `propagateExceptions` flag.

- `emitForBindings` (the JS-visible `process.emit` path) sets it, so a listener throw is rethrown to the caller and subsequent listeners do not run (Node's `EventEmitter.prototype.emit` semantics).
- `emit('error', ...)` with no listener now throws synchronously: an `Error` argument is rethrown as-is; no-arg and non-`Error` arguments throw `ERR_UNHANDLED_ERROR` with `.context` set, matching Node and Bun's JS `EventEmitter`. The message text uses `util.inspect()` so the formatting matches.
- `emit()` (runtime-initiated dispatch with no JS caller on the stack: `exit`, `beforeExit`, IPC `message`/`disconnect`, memory-pressure) keeps the existing report-as-uncaught behavior.
- `Bun__onSignalForJS` now calls `emit()` rather than `emitForBindings()`, since a real OS signal arrives on a fresh tick and a listener throw there is an uncaught exception, same as in Node.
- `receiveMessageFromWorker` in `src/js/internal/worker/messaging.ts` drops its manual listener loop (which existed only to work around the old catch-and-report behavior) and calls `process.emit("workerMessage", ...)` directly. This also closes its documented `process.once('workerMessage', ...)` limitation.

> [!NOTE]
> The `propagateExceptions` plumbing overlaps mechanically with a hunk in #35388, which adds the same parameter but wires it only to the `newListener` emit. If #35388 lands first the conflict is a small rebase.

## Verification

New describe block in `test/js/node/process/process.test.js` (5 subprocess tests, all fail on the unfixed build and pass with the fix):
- listener throws propagate for custom and built-in event names (custom, `message`, `SIGUSR2`, `warning`, `exit`, `beforeExit`)
- emit stops at the first throwing listener; subsequent listeners do not run
- `emit('error', ...)` with no error listener throws synchronously for Error-instance, string, and no-arg
- `newListener` throw propagates out of `process.on()`
- an uncatchable `process.emit()` at top level still reaches `uncaughtException`

Also passing with no regressions: `test/js/node/events/`, `process-signal-listener-count.test.ts`, the four `test-worker-messaging*.js` Node parallel tests, `test-process-emitwarning.js`, `test-process-warning.js`, `test-emit-after-uncaught-exception.js`, `test-event-emitter-errors.js`, and the repro above under `BUN_JSC_validateExceptionChecks=1`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->