### PR TITLE
Bun.serve: percent-encode unix socket paths in server.url

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1136,16 +1136,29 @@ pub enum URLProto {
 
 impl Display for URLFormatter<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}://",
-            match self.proto {
-                URLProto::Http => "http",
-                URLProto::Https => "https",
-                URLProto::Unix => "unix",
-                URLProto::Abstract => "abstract",
+        match self.proto {
+            URLProto::Unix => {
+                let path = self.hostname.unwrap_or(b"");
+                // Without a leading `/`, the first segment lands in the URL host slot.
+                let host_len = if path.first() == Some(&b'/') {
+                    0
+                } else {
+                    strings::index_of_char_usize(path, b'/').unwrap_or(path.len())
+                };
+                return write!(
+                    f,
+                    "unix://{}{}",
+                    PercentEncoded::host(&path[..host_len]),
+                    PercentEncoded::path(&path[host_len..])
+                );
             }
-        )?;
+            URLProto::Abstract => {
+                let name = self.hostname.unwrap_or(b"");
+                return write!(f, "abstract://{}/", PercentEncoded::host(name));
+            }
+            URLProto::Http => f.write_str("http://")?,
+            URLProto::Https => f.write_str("https://")?,
+        }
 
         if let Some(hostname) = self.hostname {
             let needs_brackets =
@@ -1159,10 +1172,6 @@ impl Display for URLFormatter<'_> {
             f.write_str("localhost")?;
         }
 
-        if self.proto == URLProto::Unix {
-            return Ok(());
-        }
-
         let is_port_optional = self.port.is_none()
             || (self.proto == URLProto::Https && self.port == Some(443))
             || (self.proto == URLProto::Http && self.port == Some(80));
@@ -1171,6 +1180,68 @@ impl Display for URLFormatter<'_> {
         } else {
             write!(f, ":{}/", self.port.unwrap())
         }
+    }
+}
+
+/// The URL component that raw bytes land in once they follow `scheme://`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum URLSlot {
+    Host,
+    Path,
+}
+
+/// Socket path bytes percent-encoded for one URL slot, so the WHATWG parser takes them losslessly.
+struct PercentEncoded<'a> {
+    bytes: &'a [u8],
+    slot: URLSlot,
+}
+
+impl<'a> PercentEncoded<'a> {
+    fn host(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            slot: URLSlot::Host,
+        }
+    }
+
+    fn path(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            slot: URLSlot::Path,
+        }
+    }
+}
+
+/// Only bytes the parser rejects, strips, reads as a delimiter or encodes itself, plus `%`.
+fn needs_percent_encoding(b: u8, slot: URLSlot) -> bool {
+    // C0 controls, DEL and non-ASCII: the parser strips tab, LF, CR and encodes the rest.
+    if b < 0x20 || b >= 0x7F {
+        return true;
+    }
+    match b {
+        // Delimiters, bytes both slots reject, and `%` so the output decodes back.
+        b' ' | b'#' | b'%' | b'<' | b'>' | b'?' | b'^' => true,
+        // Forbidden host code points. A path keeps them as-is.
+        b'/' | b':' | b'@' | b'[' | b'\\' | b']' | b'|' => slot == URLSlot::Host,
+        // The path percent-encode set. An opaque host keeps them as-is.
+        b'"' | b'`' | b'{' | b'}' => slot == URLSlot::Path,
+        _ => false,
+    }
+}
+
+impl Display for PercentEncoded<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for &b in self.bytes {
+            if needs_percent_encoding(b, self.slot) {
+                let h = hex_byte_upper(b);
+                f.write_char('%')?;
+                f.write_char(h[0] as char)?;
+                f.write_char(h[1] as char)?;
+            } else {
+                f.write_char(b as char)?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -1,6 +1,7 @@
 import { serve } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows, tmpdirSync } from "../../../harness";
+import { join } from "node:path";
+import { isLinux, isWindows, tempDir, tmpdirSync } from "../../../harness";
 
 const defaultHostname = "localhost";
 
@@ -303,6 +304,68 @@ describe("Bun.serve unix socket", () => {
       },
     });
     server.stop();
+  });
+});
+
+describe("Bun.serve unix socket url", () => {
+  // https://github.com/oven-sh/bun/issues/40182
+  test("server.url parses for a path with a drive letter and backslashes", () => {
+    using dir = tempDir("unix-url-drive", {});
+    // On Windows the temp dir already starts with `C:\`. Elsewhere a relative
+    // socket file named `C:\test` puts the same bytes into the URL.
+    const cwd = process.cwd();
+    process.chdir(String(dir));
+    try {
+      const p = isWindows ? join(String(dir), "test.sock") : "C:\\test";
+      using server = serve({ unix: p, fetch: () => new Response("ok") });
+      const url = server.url;
+      expect(url).toBeInstanceOf(URL);
+      expect(url.protocol).toBe("unix:");
+      expect(decodeURIComponent(url.hostname)).toBe(p);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  test.skipIf(isWindows)("server.url percent-encodes only what the URL parser cannot take", () => {
+    using dir = tempDir("unix-url-encode", { "sub dir": {} });
+    const cwd = process.cwd();
+    process.chdir(String(dir));
+    try {
+      // A relative path puts its first segment in the URL host slot, which
+      // forbids more bytes (`:`, `@`, `[`, `]`) than the path does.
+      const cases: [path: string, href: string][] = [
+        ["my app.sock", "unix://my%20app.sock"],
+        ["a#b?c.sock", "unix://a%23b%3Fc.sock"],
+        ["a:b@c.sock", "unix://a%3Ab%40c.sock"],
+        ["[weird name].sock", "unix://%5Bweird%20name%5D.sock"],
+        ["a%b.sock", "unix://a%25b.sock"],
+        ["a+b=c,d.sock", "unix://a+b=c,d.sock"],
+        ["sub dir/a:b@c.sock", "unix://sub%20dir/a:b@c.sock"],
+        [`${dir}/a b#c%d.sock`, `unix://${dir}/a%20b%23c%25d.sock`],
+        [`${dir}/a+b=c@d:e.sock`, `unix://${dir}/a+b=c@d:e.sock`],
+      ];
+      for (const [path, href] of cases) {
+        using server = serve({ unix: path, fetch: () => new Response("ok") });
+        const url = server.url;
+        expect({ path, href: url.href, decoded: decodeURIComponent(url.hostname + url.pathname) }).toEqual({
+          path,
+          href,
+          decoded: path,
+        });
+      }
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  test.skipIf(!isLinux)("server.url percent-encodes an abstract socket name", () => {
+    const suffix = Math.random().toString(36).slice(2);
+    const name = "bun url test/" + suffix;
+    using server = serve({ unix: "\0" + name, fetch: () => new Response("ok") });
+    const url = server.url;
+    expect(url.href).toBe("abstract://bun%20url%20test%2F" + suffix + "/");
+    expect(decodeURIComponent(url.hostname)).toBe(name);
   });
 });
 

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -116,7 +116,9 @@ describe.each([
       ? {
           protocol: "unix:",
           pathname: unix.substring(unix.indexOf(":") + 1),
-          hostname: unix.substring(0, unix.indexOf(":")),
+          // "C:" has no leading "/" so it lands in the host slot, where ":" is
+          // percent-encoded so that it does not read as a port separator.
+          hostname: unix.substring(0, unix.indexOf(":")) + "%3A",
           port: "",
         }
       : {

--- a/test/js/bun/http/server-url-invalid.test.ts
+++ b/test/js/bun/http/server-url-invalid.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 import { tempDir } from "harness";
 
-test("server.url does not crash when unix socket path produces invalid URL", () => {
-  // Passing an object as the unix socket path causes the URL formatter to produce
-  // a string like "unix://[object Bun]" which is not a valid URL. Accessing
-  // server.url should throw a proper JS error instead of crashing.
+test("server.url percent-encodes a unix socket path the URL parser would reject", () => {
+  // An object passed as the unix socket path is coerced to "[object Bun]". The
+  // URL formatter used to write it as-is after "unix://", which is not a valid
+  // URL, so server.url threw.
   //
   // The socket path is relative, so run inside a fresh temp dir to avoid
   // EADDRINUSE from a stale socket file left in cwd by an earlier run.
@@ -19,7 +19,9 @@ test("server.url does not crash when unix socket path produces invalid URL", () 
         return new Response("ok");
       },
     });
-    expect(() => server.url).toThrow();
+    expect(server.url).toBeInstanceOf(URL);
+    expect(server.url.href).toBe("unix://%5Bobject%20Bun%5D");
+    expect(decodeURIComponent(server.url.hostname)).toBe("[object Bun]");
   } finally {
     process.chdir(prev);
   }


### PR DESCRIPTION
### Problem
- `Bun.serve({ unix: "C:\\test" }).url` throws `TypeError: Invalid URL` on Windows (#40182). `URLFormatter` (`src/bun_core/fmt.rs:1137`) writes the raw socket path after `unix://`. A path with no leading `/` (relative, or a Windows drive path) lands in the URL host slot, so `C:\test` reads as host `C` with port `\test`. `#` or `?` in any path truncates it.

### Fix
- `URLFormatter` percent-encodes the socket path per URL slot: the first segment of a path with no leading `/` is the host, the rest is the path. An abstract socket name is a host. A new `PercentEncoded` Display helper holds the rule.
- It encodes only the bytes the WHATWG parser rejects, strips (tab, LF, CR), reads as a delimiter, or would percent-encode itself, plus `%`. Everything else is written as-is.
- Correct because every output now parses, `decodeURIComponent(url.hostname + url.pathname)` returns the original path, and apart from `%` a URL that parsed before serializes the same.
- Verified: `test/js/bun/http/bun-serve-args.test.ts` (new `Bun.serve unix socket url` block), `server-url-invalid.test.ts`, `serve-listen.test.ts`. The 4 changed tests fail on 1.4.0 with `TypeError: Invalid URL`. Also the other unix socket suites under `test/js/bun/` and `node-http.test.ts`.

### Background
- `server.url` hands the `URLFormatter` string to the WHATWG URL parser. `unix:` is a non-special scheme: the text after `//` up to the first `/` is an opaque host, the rest is the path. An opaque host rejects the forbidden host code points (`:`, `@`, `[`, `\` and others), and `:` starts a port.
- The parser percent-encodes controls, non-ASCII and a few path bytes itself, so encoding them up front does not change the href. It silently drops tab, LF and CR.
- #28342 takes the same approach but applies the host rule only to abstract sockets, so `unix://C:%5Ctest` still fails on the port. #40307 replaced `\` with `/` on Windows only. This PR supersedes both.

Fixes #40182

<details><summary>Notes</summary>

An earlier revision of this PR also validated the `unix` option (`""` and non-string values threw). That half is dropped. `unix: ""` meaning absent matches `hostname: ""`, the loose string option of `Bun.listen`, the permutations pinned in #15368, and node:http `listen({ port, path: "" })`, which passes `path` through as `unix`. Non-string values still ToString-coerce as before. The coerced `[object Bun]` now yields `unix://%5Bobject%20Bun%5D` (`server-url-invalid.test.ts`).

Per-byte parser behaviour, measured with `new URL("unix://a<c>b.sock")` and `new URL("unix:///tmp/a<c>b.sock")` for every printable ASCII byte plus tab, LF, CR, 0x01, DEL and `é`:

- host slot: fails on space `:` `<` `>` `[` `\` `]` `^` `|`, misreads `#` `/` `?` `@`, strips tab LF CR, percent-encodes other controls and non-ASCII, keeps the rest raw.
- path slot: misreads `#` `?`, strips tab LF CR, percent-encodes space `"` `<` `>` `^` `` ` `` `{` `}`, controls and non-ASCII, keeps the rest raw.
- `%` is kept raw in both slots, so it has to be encoded for `decodeURIComponent` to be lossless.

Windows: `C:/Users/x/unix.sock` (forward slashes, as `serve-listen.test.ts` uses) used to parse as host `C`, which lost the colon. It is now `unix://C%3A/Users/x/unix.sock` with hostname `C%3A`.

`server.address` still returns the raw path for a unix server.

```
USE_SYSTEM_BUN=1 bun test bun-serve-args server-url-invalid serve-listen   # 4 fail, 87 pass
bun bd test bun-serve-args server-url-invalid serve-listen                 # 91 pass
```

</details>
