### PR TITLE
child_process: keep spawn/execFile timeout kill timers ref'd like Node

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -151,7 +151,7 @@ function spawn(file, args, options) {
           child.emit("error", err);
         }
       }
-    }, timeout).unref();
+    }, timeout);
 
     const clear = () => {
       if (timeoutId) {
@@ -339,7 +339,7 @@ function execFile(file, args, options, callback) {
     timeoutId = setTimeout(function delayedKill() {
       timeoutId = null;
       kill();
-    }, optionsTimeout).unref();
+    }, optionsTimeout);
   }
 
   function addOnDataListener(child_buffer, _buffer, kind) {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -290,6 +290,67 @@ describe("spawn()", () => {
     expect(end! - start < 2000).toBe(true);
   });
 
+  it("timeout kill timer keeps the event loop alive when the child is unref'd (Node.js parity)", async () => {
+    // Node's spawn/execFile timeout timers are ref'd: if the user unref()s the child, the
+    // parent must still stay alive until the deadline, deliver the kill, then exit.
+    const parent = `
+      const { spawn } = require("node:child_process");
+      const c = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+        stdio: "ignore",
+        timeout: 500,
+        killSignal: "SIGKILL",
+      });
+      process.stdout.write(String(c.pid) + "\\n");
+      c.unref();
+    `;
+    const start = performance.now();
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", parent], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const parentLivedMs = performance.now() - start;
+    expect(stderr).toBe("");
+    const grandchildPid = parseInt(stdout.trim(), 10);
+    expect(Number.isFinite(grandchildPid) && grandchildPid > 0).toBe(true);
+
+    const isAlive = (pid: number) => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    let alive = isAlive(grandchildPid);
+    for (let i = 0; alive && i < 40; i++) {
+      await Bun.sleep(25);
+      alive = isAlive(grandchildPid);
+    }
+    try {
+      if (alive) process.kill(grandchildPid, "SIGKILL");
+    } catch {}
+
+    expect({ grandchildAlive: alive, parentWaitedForTimeout: parentLivedMs >= 400 }).toEqual({
+      grandchildAlive: false,
+      parentWaitedForTimeout: true,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("timeout kill timer is cleared when the child exits early, releasing the loop", async () => {
+    const parent = `
+      const { spawn } = require("node:child_process");
+      const c = spawn(process.execPath, ["-e", ""], { stdio: "ignore", timeout: 30000 });
+      c.unref();
+    `;
+    const start = performance.now();
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", parent], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const parentLivedMs = performance.now() - start;
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(parentLivedMs).toBeLessThan(15000);
+    expect(exitCode).toBe(0);
+  });
+
   it("should allow us to set env", async () => {
     async function getChildEnv(env: any): Promise<object> {
       const result: string = await new Promise(resolve => {


### PR DESCRIPTION
## Repro

```js
const { spawn } = require("node:child_process");
const c = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
  stdio: "ignore",
  timeout: 500,
  killSignal: "SIGKILL",
});
console.log(c.pid);
c.unref();
```

Node v26.3.0: parent lives ~505 ms, delivers the kill, grandchild dies, parent exits.
Bun before: parent exits in ~40 ms with nothing ref'd, grandchild orphaned for 30 s.

Adding an unrelated ref'd interval to the parent makes Bun deliver the SIGKILL at 500 ms, which isolates the cause: the kill timer exists and works, it just is not holding the loop.

## Cause

`src/js/node/child_process.ts` creates the `spawn()` and `execFile()` timeout kill timers with `.unref()` (L154, L342). Node's `lib/child_process.js` creates both ref'd (no `.unref()` on either `setTimeout`, both in `spawnWithSignal` and `execFile`), so the timer itself keeps the loop alive until the deadline when the user has unref'd the child handle.

## Fix

Drop the `.unref()` from both timers. The existing `exit`/`close` handlers already `clearTimeout()` when the child finishes before the deadline, so a ref'd timer does not extend the parent's life past the child's natural exit; the second test below pins that.

## Verification

New tests in `test/js/node/child_process/child_process.test.ts`:

- `timeout kill timer keeps the event loop alive when the child is unref'd`: spawns the repro above, asserts the grandchild is dead after the parent exits and that the parent lived past the deadline.
- `timeout kill timer is cleared when the child exits early, releasing the loop`: a child that exits immediately under `timeout: 30000` must not hold the parent for 30 s.

```
# fail-before (released bun):
$ USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t "timeout kill timer"
  { grandchildAlive: true, parentWaitedForTimeout: false }   vs expected { false, true }
 1 pass  1 fail

# pass-after (debug build):
$ bun bd test test/js/node/child_process/child_process.test.ts -t "timeout kill timer"
 2 pass  0 fail
```

Node's ported timeout tests still pass (`test-child-process-exec-timeout-{expire,kill,not-expired}.js`, `test-child-process-{spawn,fork}-timeout-kill-signal.js`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->