### PR TITLE
Bun.serve: require key+cert when a tls object is passed

### DIFF
--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -135,11 +135,8 @@ impl SSLConfig {
         Self::default()
     }
 
-    /// Whether this config carries a server identity (a key+cert pair, inline
-    /// or by file path). `ca`/`crl` are trust material, not identity, and the
-    /// remaining fields are tuning knobs: none of them can make a TLS server
-    /// handshake succeed on their own. Used by `Bun.serve` to reject a `tls`
-    /// option that would listen as `https:` but fail every handshake.
+    /// Whether this config carries a server identity (key+cert pair); `ca`,
+    /// `crl` and the tuning fields alone cannot complete a TLS handshake.
     #[inline]
     pub fn has_identity_material(&self) -> bool {
         (self.cert.is_some() && self.key.is_some())

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -135,8 +135,7 @@ impl SSLConfig {
         Self::default()
     }
 
-    /// Whether this config carries a server identity (key+cert pair); `ca`,
-    /// `crl` and the tuning fields alone cannot complete a TLS handshake.
+    /// Whether this config carries a key+cert pair a TLS server can present.
     #[inline]
     pub fn has_identity_material(&self) -> bool {
         (self.cert.is_some() && self.key.is_some())

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -138,8 +138,8 @@ impl SSLConfig {
     /// Whether this config carries a key+cert pair a TLS server can present.
     #[inline]
     pub fn has_identity_material(&self) -> bool {
-        (self.cert.is_some() && self.key.is_some())
-            || (!self.cert_file_name.is_null() && !self.key_file_name.is_null())
+        (self.cert.is_some() || !self.cert_file_name.is_null())
+            && (self.key.is_some() || !self.key_file_name.is_null())
     }
 
     /// Borrow `server_name` as a `&CStr` (None if null). Convenience accessor

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -138,8 +138,17 @@ impl SSLConfig {
     /// Whether this config carries a key+cert pair a TLS server can present.
     #[inline]
     pub fn has_identity_material(&self) -> bool {
-        (self.cert.is_some() || !self.cert_file_name.is_null())
-            && (self.key.is_some() || !self.key_file_name.is_null())
+        self.has_any_cert() && self.has_any_key()
+    }
+
+    #[inline]
+    pub fn has_any_cert(&self) -> bool {
+        self.cert.is_some() || !self.cert_file_name.is_null()
+    }
+
+    #[inline]
+    pub fn has_any_key(&self) -> bool {
+        self.key.is_some() || !self.key_file_name.is_null()
     }
 
     /// Borrow `server_name` as a `&CStr` (None if null). Convenience accessor

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -135,6 +135,17 @@ impl SSLConfig {
         Self::default()
     }
 
+    /// Whether this config carries a server identity (a key+cert pair, inline
+    /// or by file path). `ca`/`crl` are trust material, not identity, and the
+    /// remaining fields are tuning knobs: none of them can make a TLS server
+    /// handshake succeed on their own. Used by `Bun.serve` to reject a `tls`
+    /// option that would listen as `https:` but fail every handshake.
+    #[inline]
+    pub fn has_identity_material(&self) -> bool {
+        (self.cert.is_some() && self.key.is_some())
+            || (!self.cert_file_name.is_null() && !self.key_file_name.is_null())
+    }
+
     /// Borrow `server_name` as a `&CStr` (None if null). Convenience accessor
     /// for callers that previously pattern-matched `Option<CString>`.
     #[inline]

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -319,9 +319,8 @@ function Server(options, callback): void {
   } else {
     validateObject(options, "options");
     options = { ...options };
-    // `node:https` stamps this on the options object it hands over so an https
-    // server is TLS even without key/cert (handshakes fail closed, like Node).
     if (options[isTlsSymbol]) {
+      // Set by `node:https`; an https server is TLS even without key/cert.
       this[isTlsSymbol] = true;
       delete options[isTlsSymbol];
     }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -319,6 +319,12 @@ function Server(options, callback): void {
   } else {
     validateObject(options, "options");
     options = { ...options };
+    // `node:https` stamps this on the options object it hands over so an https
+    // server is TLS even without key/cert (handshakes fail closed, like Node).
+    if (options[isTlsSymbol]) {
+      this[isTlsSymbol] = true;
+      delete options[isTlsSymbol];
+    }
 
     // Node's https.Server accepts PKCS#12 bundles (pfx [+ passphrase]); fold
     // them into plain key/cert/ca so the native TLS config sees PEM material.

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -501,7 +501,8 @@ const { shouldUseEnvProxy } = require("node:_http_agent");
 // normalized protocol list / callback on the server instance the way
 // tls.Server does (test-https-argument-of-creating.js).
 // https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L82-L97
-function createServer(options, requestListener) {
+function Server(options, requestListener) {
+  if (!(this instanceof Server)) return new Server(options, requestListener);
   if (typeof options === "function") {
     requestListener = options;
     options = {};
@@ -518,13 +519,17 @@ function createServer(options, requestListener) {
   }
   // https is always TLS even without key/cert (handshakes fail closed, like Node).
   options[isTlsSymbol] = true;
-  const server = http.createServer(options, requestListener);
+  http.Server.$call(this, options, requestListener);
   const optionsALPNProtocols = options.ALPNProtocols;
   if (optionsALPNProtocols) {
-    tls.convertALPNProtocols(optionsALPNProtocols, server);
+    tls.convertALPNProtocols(optionsALPNProtocols, this);
   }
-  server.ALPNCallback = options.ALPNCallback;
-  return server;
+  this.ALPNCallback = options.ALPNCallback;
+}
+$toClass(Server, "Server", http.Server);
+
+function createServer(options, requestListener) {
+  return new Server(options, requestListener);
 }
 
 var https = {
@@ -535,7 +540,7 @@ var https = {
     timeout: 5000,
     proxyEnv: shouldUseEnvProxy() ? process.env : undefined,
   }),
-  Server: http.Server,
+  Server,
   createServer,
   get,
   request,

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -8,7 +8,7 @@ const net = require("node:net");
 const { urlToHttpOptions } = require("internal/url");
 const { kEmptyObject, once } = require("internal/shared");
 const { validateObject } = require("internal/validators");
-const { kProxyConfig, checkShouldUseProxy, kWaitForProxyTunnel } = require("internal/http");
+const { kProxyConfig, checkShouldUseProxy, kWaitForProxyTunnel, isTlsSymbol } = require("internal/http");
 const { validateHeaderValue } = require("node:_http_common");
 
 const ArrayPrototypeShift = Array.prototype.shift;
@@ -516,6 +516,10 @@ function createServer(options, requestListener) {
     // ALPN requests are always answered with http/1.1.
     options.ALPNProtocols = ["http/1.1"];
   }
+  // Node's https.Server is always a TLS listener, even without key/cert: the
+  // handshake fails closed (sslv3 alert handshake failure) rather than
+  // downgrading to plaintext. The Server constructor keys TLS off this symbol.
+  options[isTlsSymbol] = true;
   const server = http.createServer(options, requestListener);
   const optionsALPNProtocols = options.ALPNProtocols;
   if (optionsALPNProtocols) {

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -516,9 +516,7 @@ function createServer(options, requestListener) {
     // ALPN requests are always answered with http/1.1.
     options.ALPNProtocols = ["http/1.1"];
   }
-  // Node's https.Server is always a TLS listener, even without key/cert: the
-  // handshake fails closed (sslv3 alert handshake failure) rather than
-  // downgrading to plaintext. The Server constructor keys TLS off this symbol.
+  // https is always TLS even without key/cert (handshakes fail closed, like Node).
   options[isTlsSymbol] = true;
   const server = http.createServer(options, requestListener);
   const optionsALPNProtocols = options.ALPNProtocols;

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1369,7 +1369,25 @@ impl ServerConfig {
             }
         }
 
+        // `node:http`'s Server wrapper always passes `onNodeHTTPRequest`, and its
+        // https flavour must match Node's fail-closed behaviour (a TLS listener
+        // whose every handshake alerts) when the user supplied no key/cert.
+        // Direct `Bun.serve` callers get a synchronous TypeError instead so an
+        // empty/tuning-only `tls` object can never quietly downgrade to
+        // plaintext or stand up a cert-less `https:` listener.
+        let is_node_http = !args.on_node_http_request.is_empty();
+        let require_identity = |global: &JSGlobalObject, cfg: Option<&SSLConfig>| -> JsResult<()> {
+            if is_node_http || cfg.is_some_and(SSLConfig::has_identity_material) {
+                return Ok(());
+            }
+            Err(global.throw_invalid_arguments(format_args!(
+                "tls option requires both \"key\" and \"cert\" (or \"keyFile\" and \"certFile\")",
+            )))
+        };
+
+        let mut saw_tls_key = false;
         if let Some(tls) = arg.get_truthy(global, "tls")? {
+            saw_tls_key = true;
             if tls.is_falsey() {
                 args.ssl_config = None;
             } else if tls.js_type().is_array() {
@@ -1388,6 +1406,7 @@ impl ServerConfig {
                                 continue;
                             }
                         };
+                        require_identity(global, Some(&ssl_config))?;
 
                         if args.ssl_config.is_none() {
                             args.ssl_config = Some(ssl_config);
@@ -1407,12 +1426,15 @@ impl ServerConfig {
                     }
                 }
             } else {
-                if let Some(ssl_config) = SSLConfig::from_js(vm, global, tls)? {
-                    args.ssl_config = Some(ssl_config);
-                }
+                let parsed = SSLConfig::from_js(vm, global, tls)?;
                 if global.has_exception() {
                     return Err(JsError::Thrown);
                 }
+                require_identity(global, parsed.as_ref())?;
+                // `require_identity` only lets `None`/no-identity through on the
+                // node:https path; arm a cert-less context there so handshakes
+                // fail-closed instead of downgrading to plaintext.
+                args.ssl_config = Some(parsed.unwrap_or_else(SSLConfig::zero));
             }
         }
         if global.has_exception() {
@@ -1421,9 +1443,11 @@ impl ServerConfig {
 
         // @compatibility Bun v0.x - v0.2.1
         // this used to be top-level, now it's "tls" object
-        if args.ssl_config.is_none() {
+        if args.ssl_config.is_none() && !saw_tls_key {
             if let Some(ssl_config) = SSLConfig::from_js(vm, global, arg)? {
-                args.ssl_config = Some(ssl_config);
+                if ssl_config.has_identity_material() {
+                    args.ssl_config = Some(ssl_config);
+                }
             }
             if global.has_exception() {
                 return Err(JsError::Thrown);

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1388,7 +1388,7 @@ impl ServerConfig {
             } else if tls.js_type().is_array() {
                 let mut value_iter = tls.array_iterator(global)?;
                 if value_iter.len == 0 {
-                    // Empty TLS array means no TLS - this is valid
+                    // `[]` = zero SNI configs (plain HTTP, #21792), unlike `{}` which throws.
                 } else {
                     while let Some(item) = value_iter.next()? {
                         let ssl_config = match SSLConfig::from_js(vm, global, item)? {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1397,7 +1397,6 @@ impl ServerConfig {
                                 if global.has_exception() {
                                     return Err(JsError::Thrown);
                                 }
-                                // Backwards-compatibility; we ignored empty tls objects.
                                 continue;
                             }
                         };
@@ -1418,6 +1417,9 @@ impl ServerConfig {
 
                             args.sni.as_mut().unwrap().push(ssl_config);
                         }
+                    }
+                    if args.ssl_config.is_none() {
+                        require_identity(global, None)?;
                     }
                 }
             } else {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1369,8 +1369,7 @@ impl ServerConfig {
             }
         }
 
-        // node:https (via `onNodeHTTPRequest`) keeps Node's cert-less
-        // fail-closed listener; direct `Bun.serve` callers get a TypeError.
+        // node:https keeps Node's cert-less fail-closed listener; direct Bun.serve throws.
         let is_node_http = !args.on_node_http_request.is_empty();
         let require_identity = |global: &JSGlobalObject, cfg: Option<&SSLConfig>| -> JsResult<()> {
             if is_node_http || cfg.is_some_and(SSLConfig::has_identity_material) {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1382,14 +1382,12 @@ impl ServerConfig {
 
         let mut saw_tls_key = false;
         if let Some(tls) = arg.get_truthy(global, "tls")? {
-            saw_tls_key = true;
-            if tls.is_falsey() {
-                args.ssl_config = None;
-            } else if tls.js_type().is_array() {
+            if tls.js_type().is_array() {
                 let mut value_iter = tls.array_iterator(global)?;
                 if value_iter.len == 0 {
                     // `[]` = zero SNI configs (plain HTTP, #21792), unlike `{}` which throws.
                 } else {
+                    saw_tls_key = true;
                     while let Some(item) = value_iter.next()? {
                         let ssl_config = match SSLConfig::from_js(vm, global, item)? {
                             Some(c) => c,
@@ -1423,6 +1421,7 @@ impl ServerConfig {
                     }
                 }
             } else {
+                saw_tls_key = true;
                 let parsed = SSLConfig::from_js(vm, global, tls)?;
                 if global.has_exception() {
                     return Err(JsError::Thrown);

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1369,12 +1369,8 @@ impl ServerConfig {
             }
         }
 
-        // `node:http`'s Server wrapper always passes `onNodeHTTPRequest`, and its
-        // https flavour must match Node's fail-closed behaviour (a TLS listener
-        // whose every handshake alerts) when the user supplied no key/cert.
-        // Direct `Bun.serve` callers get a synchronous TypeError instead so an
-        // empty/tuning-only `tls` object can never quietly downgrade to
-        // plaintext or stand up a cert-less `https:` listener.
+        // node:https (via `onNodeHTTPRequest`) keeps Node's cert-less
+        // fail-closed listener; direct `Bun.serve` callers get a TypeError.
         let is_node_http = !args.on_node_http_request.is_empty();
         let require_identity = |global: &JSGlobalObject, cfg: Option<&SSLConfig>| -> JsResult<()> {
             if is_node_http || cfg.is_some_and(SSLConfig::has_identity_material) {
@@ -1431,9 +1427,7 @@ impl ServerConfig {
                     return Err(JsError::Thrown);
                 }
                 require_identity(global, parsed.as_ref())?;
-                // `require_identity` only lets `None`/no-identity through on the
-                // node:https path; arm a cert-less context there so handshakes
-                // fail-closed instead of downgrading to plaintext.
+                // Only node:https reaches here without identity; arm cert-less.
                 args.ssl_config = Some(parsed.unwrap_or_else(SSLConfig::zero));
             }
         }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1382,7 +1382,9 @@ impl ServerConfig {
 
         let mut saw_tls_key = false;
         if let Some(tls) = arg.get_truthy(global, "tls")? {
-            if tls.js_type().is_array() {
+            if tls.is_falsey() {
+                // `get_truthy` passes `false`/`0`/`NaN` through; treat as no TLS (like `[]`).
+            } else if tls.js_type().is_array() {
                 let mut value_iter = tls.array_iterator(global)?;
                 if value_iter.len == 0 {
                     // `[]` = zero SNI configs (plain HTTP, #21792), unlike `{}` which throws.

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1442,6 +1442,8 @@ impl ServerConfig {
             if let Some(ssl_config) = SSLConfig::from_js(vm, global, arg)? {
                 if ssl_config.has_identity_material() {
                     args.ssl_config = Some(ssl_config);
+                } else if ssl_config.has_any_key() || ssl_config.has_any_cert() {
+                    require_identity(global, Some(&ssl_config))?;
                 }
             }
             if global.has_exception() {

--- a/test/integration/bun-types/fixture/serve-types.test.ts
+++ b/test/integration/bun-types/fixture/serve-types.test.ts
@@ -293,10 +293,8 @@ test(
     tls: {},
   },
   {
-    overrideExpectBehavior: server => {
-      expect(server.hostname).toBeUndefined();
-      expect(server.port).toBeUndefined();
-      expect(server.url.toString()).toStartWith("unix://");
+    onConstructorFailure: error => {
+      expect(error.message).toContain('tls option requires both "key" and "cert"');
     },
   },
 );

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { tls as tlsCert } from "harness";
+import { once } from "node:events";
 import { createServer as createHttpsServer } from "node:https";
 import { connect as tlsConnect } from "node:tls";
-import { once } from "node:events";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
 import publicKey from "../../third_party/jsonwebtoken/pub.pem" with { type: "text" };
 

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { tls as tlsCert } from "harness";
 import { once } from "node:events";
-import { createServer as createHttpsServer, Server as HttpsServer } from "node:https";
 import { Server as HttpServer } from "node:http";
+import { createServer as createHttpsServer, Server as HttpsServer } from "node:https";
 import { connect as tlsConnect } from "node:tls";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
 import publicKey from "../../third_party/jsonwebtoken/pub.pem" with { type: "text" };

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -210,9 +210,9 @@ describe("Bun.serve tls must carry key+cert", () => {
     ["cert without key", { cert: tlsCert.cert }],
   ] as const) {
     test(`top-level ${label} throws (legacy path)`, () => {
-      expect(() =>
-        Bun.serve({ port: 0, ...opts, fetch: () => new Response("ok") } as any),
-      ).toThrow('tls option requires both "key" and "cert"');
+      expect(() => Bun.serve({ port: 0, ...opts, fetch: () => new Response("ok") } as any)).toThrow(
+        'tls option requires both "key" and "cert"',
+      );
     });
   }
 

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -205,6 +205,17 @@ describe("Bun.serve tls must carry key+cert", () => {
     expect(await res.text()).toBe("ok");
   });
 
+  for (const [label, opts] of [
+    ["key without cert", { key: tlsCert.key }],
+    ["cert without key", { cert: tlsCert.cert }],
+  ] as const) {
+    test(`top-level ${label} throws (legacy path)`, () => {
+      expect(() =>
+        Bun.serve({ port: 0, ...opts, fetch: () => new Response("ok") } as any),
+      ).toThrow('tls option requires both "key" and "cert"');
+    });
+  }
+
   test("top-level key+cert still arms TLS (legacy path)", async () => {
     await using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { tls as tlsCert } from "harness";
+import { createServer as createHttpsServer } from "node:https";
+import { connect as tlsConnect } from "node:tls";
+import { once } from "node:events";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
 import publicKey from "../../third_party/jsonwebtoken/pub.pem" with { type: "text" };
 
@@ -148,4 +152,119 @@ describe("Bun.serve SSL validations", () => {
       });
     }
   }
+});
+
+// A `tls` object must carry server identity (key+cert / keyFile+certFile).
+// Before this was enforced, `tls: {}` silently fell back to plaintext HTTP and
+// `tls: { <tuning field> }` stood up a cert-less `https:` listener whose every
+// handshake aborted with an internal alert.
+describe("Bun.serve tls must carry key+cert", () => {
+  const withoutIdentity = [
+    ["empty object", {}],
+    ["rejectUnauthorized only", { rejectUnauthorized: false }],
+    ["requestCert only", { requestCert: true }],
+    ["lowMemoryMode only", { lowMemoryMode: true }],
+    ["ciphers only", { ciphers: "DEFAULT" }],
+    ["key without cert", { key: tlsCert.key }],
+    ["cert without key", { cert: tlsCert.cert }],
+    ["array entry without cert", [{ key: tlsCert.key, rejectUnauthorized: false }]],
+  ] as const;
+  for (const [label, tls] of withoutIdentity) {
+    test(label, () => {
+      expect(() =>
+        Bun.serve({
+          port: 0,
+          tls: tls as Bun.TLSOptions,
+          fetch: () => new Response("ok"),
+        }),
+      ).toThrow('tls option requires both "key" and "cert"');
+    });
+  }
+
+  test("key+cert is accepted and serves over TLS", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      tls: { key: tlsCert.key, cert: tlsCert.cert },
+      fetch: () => new Response("ok"),
+    });
+    expect(server.url.protocol).toBe("https:");
+    const res = await fetch(server.url, { tls: { rejectUnauthorized: false } });
+    expect(await res.text()).toBe("ok");
+  });
+
+  // The v0.2.1 legacy reader parsed TLS options off the top-level serve object
+  // too; a stray tuning field there must not accidentally arm TLS.
+  test("top-level tuning field does not arm TLS", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      lowMemoryMode: true,
+      requestCert: true,
+      fetch: () => new Response("ok"),
+    } as any);
+    expect(server.url.protocol).toBe("http:");
+    const res = await fetch(server.url);
+    expect(await res.text()).toBe("ok");
+  });
+
+  test("top-level key+cert still arms TLS (legacy path)", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      key: tlsCert.key,
+      cert: tlsCert.cert,
+      fetch: () => new Response("ok"),
+    } as any);
+    expect(server.url.protocol).toBe("https:");
+  });
+});
+
+// Node.js's https.createServer never throws for a missing key/cert and never
+// downgrades to plaintext: it listens as TLS and every handshake fails with a
+// fatal alert.
+describe("node:https createServer without key/cert is TLS fail-closed", () => {
+  for (const [label, options] of [
+    ["no options", undefined],
+    ["empty options", {}],
+    ["requestCert only", { requestCert: true }],
+    ["rejectUnauthorized only", { rejectUnauthorized: false }],
+  ] as const) {
+    test(label, async () => {
+      const server = createHttpsServer(options as any, (_req, res) => res.end("plaintext"));
+      await once(server.listen(0), "listening");
+      const { port } = server.address() as import("node:net").AddressInfo;
+      try {
+        // A plaintext HTTP client must not get a response body.
+        await expect(
+          fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) }).then(r => r.text()),
+        ).rejects.toThrow();
+
+        // A TLS client must see the handshake fail (not succeed).
+        const handshake = new Promise<void>((resolve, reject) => {
+          const sock = tlsConnect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+          sock.once("secureConnect", () => {
+            sock.destroy();
+            reject(new Error("handshake unexpectedly succeeded"));
+          });
+          sock.once("error", () => {
+            sock.destroy();
+            resolve();
+          });
+        });
+        await expect(handshake).resolves.toBeUndefined();
+      } finally {
+        await new Promise<void>(r => server.close(() => r()));
+      }
+    });
+  }
+
+  test("with key+cert serves over TLS", async () => {
+    const server = createHttpsServer({ key: tlsCert.key, cert: tlsCert.cert }, (_req, res) => res.end("ok"));
+    await once(server.listen(0), "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      const res = await fetch(`https://127.0.0.1:${port}/`, { tls: { rejectUnauthorized: false } });
+      expect(await res.text()).toBe("ok");
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
 });

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -225,6 +225,17 @@ describe("Bun.serve tls must carry key+cert", () => {
     } as any);
     expect(server.url.protocol).toBe("https:");
   });
+
+  test("tls: [] with top-level key+cert still arms TLS (legacy path)", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      tls: [],
+      key: tlsCert.key,
+      cert: tlsCert.cert,
+      fetch: () => new Response("ok"),
+    } as any);
+    expect(server.url.protocol).toBe("https:");
+  });
 });
 
 describe("node:https without key/cert is TLS fail-closed", () => {

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -154,10 +154,8 @@ describe("Bun.serve SSL validations", () => {
   }
 });
 
-// A `tls` object must carry server identity (key+cert / keyFile+certFile).
-// Before this was enforced, `tls: {}` silently fell back to plaintext HTTP and
-// `tls: { <tuning field> }` stood up a cert-less `https:` listener whose every
-// handshake aborted with an internal alert.
+// `tls: {}` used to fall back to plaintext and tuning-only `tls` stood up a
+// cert-less https:// listener; both must now throw synchronously.
 describe("Bun.serve tls must carry key+cert", () => {
   const withoutIdentity = [
     ["empty object", {}],
@@ -192,8 +190,6 @@ describe("Bun.serve tls must carry key+cert", () => {
     expect(await res.text()).toBe("ok");
   });
 
-  // The v0.2.1 legacy reader parsed TLS options off the top-level serve object
-  // too; a stray tuning field there must not accidentally arm TLS.
   test("top-level tuning field does not arm TLS", async () => {
     await using server = Bun.serve({
       port: 0,
@@ -217,9 +213,6 @@ describe("Bun.serve tls must carry key+cert", () => {
   });
 });
 
-// Node.js's https.createServer never throws for a missing key/cert and never
-// downgrades to plaintext: it listens as TLS and every handshake fails with a
-// fatal alert.
 describe("node:https createServer without key/cert is TLS fail-closed", () => {
   for (const [label, options] of [
     ["no options", undefined],

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { tls as tlsCert } from "harness";
 import { once } from "node:events";
-import { createServer as createHttpsServer } from "node:https";
+import { createServer as createHttpsServer, Server as HttpsServer } from "node:https";
+import { Server as HttpServer } from "node:http";
 import { connect as tlsConnect } from "node:tls";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
 import publicKey from "../../third_party/jsonwebtoken/pub.pem" with { type: "text" };
@@ -166,6 +167,8 @@ describe("Bun.serve tls must carry key+cert", () => {
     ["key without cert", { key: tlsCert.key }],
     ["cert without key", { cert: tlsCert.cert }],
     ["array entry without cert", [{ key: tlsCert.key, rejectUnauthorized: false }]],
+    ["array with only an empty entry", [{}]],
+    ["array with only empty entries", [{}, {}]],
   ] as const;
   for (const [label, tls] of withoutIdentity) {
     test(label, () => {
@@ -213,41 +216,54 @@ describe("Bun.serve tls must carry key+cert", () => {
   });
 });
 
-describe("node:https createServer without key/cert is TLS fail-closed", () => {
-  for (const [label, options] of [
+describe("node:https without key/cert is TLS fail-closed", () => {
+  const matrix = [
     ["no options", undefined],
     ["empty options", {}],
     ["requestCert only", { requestCert: true }],
     ["rejectUnauthorized only", { rejectUnauthorized: false }],
-  ] as const) {
-    test(label, async () => {
-      const server = createHttpsServer(options as any, (_req, res) => res.end("plaintext"));
-      await once(server.listen(0), "listening");
-      const { port } = server.address() as import("node:net").AddressInfo;
-      try {
-        // A plaintext HTTP client must not get a response body.
-        await expect(
-          fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) }).then(r => r.text()),
-        ).rejects.toThrow();
+  ] as const;
+  const makers = [
+    ["createServer", (o: any, h: any) => createHttpsServer(o, h)],
+    ["new Server", (o: any, h: any) => new HttpsServer(o, h)],
+  ] as const;
+  for (const [makeLabel, make] of makers) {
+    for (const [label, options] of matrix) {
+      test(`${makeLabel}: ${label}`, async () => {
+        const server = make(options, (_req, res) => res.end("plaintext"));
+        await once(server.listen(0), "listening");
+        const { port } = server.address() as import("node:net").AddressInfo;
+        try {
+          // A plaintext HTTP client must not get a response body.
+          await expect(
+            fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) }).then(r => r.text()),
+          ).rejects.toThrow();
 
-        // A TLS client must see the handshake fail (not succeed).
-        const handshake = new Promise<void>((resolve, reject) => {
-          const sock = tlsConnect({ port, host: "127.0.0.1", rejectUnauthorized: false });
-          sock.once("secureConnect", () => {
-            sock.destroy();
-            reject(new Error("handshake unexpectedly succeeded"));
+          // A TLS client must see the handshake fail (not succeed).
+          const handshake = new Promise<void>((resolve, reject) => {
+            const sock = tlsConnect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+            sock.once("secureConnect", () => {
+              sock.destroy();
+              reject(new Error("handshake unexpectedly succeeded"));
+            });
+            sock.once("error", () => {
+              sock.destroy();
+              resolve();
+            });
           });
-          sock.once("error", () => {
-            sock.destroy();
-            resolve();
-          });
-        });
-        await expect(handshake).resolves.toBeUndefined();
-      } finally {
-        await new Promise<void>(r => server.close(() => r()));
-      }
-    });
+          await expect(handshake).resolves.toBeUndefined();
+        } finally {
+          await new Promise<void>(r => server.close(() => r()));
+        }
+      });
+    }
   }
+
+  test("https.Server instanceof http.Server", () => {
+    const server = new HttpsServer({});
+    expect(server instanceof HttpsServer).toBe(true);
+    expect(server instanceof HttpServer).toBe(true);
+  });
 
   test("with key+cert serves over TLS", async () => {
     const server = createHttpsServer({ key: tlsCert.key, cert: tlsCert.cert }, (_req, res) => res.end("ok"));

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -205,6 +205,14 @@ describe("Bun.serve tls must carry key+cert", () => {
     expect(await res.text()).toBe("ok");
   });
 
+  for (const tls of [false, 0, null, undefined] as const) {
+    test(`tls: ${tls} serves plain HTTP`, async () => {
+      await using server = Bun.serve({ port: 0, tls: tls as any, fetch: () => new Response("ok") });
+      expect(server.url.protocol).toBe("http:");
+      expect(await (await fetch(server.url)).text()).toBe("ok");
+    });
+  }
+
   for (const [label, opts] of [
     ["key without cert", { key: tlsCert.key }],
     ["cert without key", { cert: tlsCert.cert }],

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2353,9 +2353,11 @@ describe.concurrent("should error with invalid options", async () => {
         tls: [
           {
             key: "lkwejflkwjeflkj",
+            cert: "lkwejflkwjeflkj",
           },
           {
             key: "lkwjefhwlkejfklwj",
+            cert: "lkwjefhwlkejfklwj",
           },
         ],
       });


### PR DESCRIPTION
### What

`Bun.serve`'s TLS-presence detection treats tuning fields (`requestCert`, `rejectUnauthorized`, `lowMemoryMode`, `ciphers`, `minVersion`/`maxVersion`, `sessionTimeout`, ...) as peers of `key`/`cert` when deciding whether to stand up a TLS listener, and never requires `key`/`cert` at all. Both directions of that are wrong:

```js
// fail-OPEN: quietly serves plaintext http even though `tls` was given
Bun.serve({ tls: {}, fetch: () => new Response("ok") });
// url.protocol === "http:", plaintext fetch works

// cert-less https: listens as https:// but every handshake aborts
// with TLSV1_ALERT_INTERNAL_ERROR
Bun.serve({ tls: { requestCert: true }, fetch: () => new Response("ok") });

// the v0.2.1 legacy reader re-parses the *top-level* object, so a
// stray tuning field there also arms a cert-less https:// listener
Bun.serve({ lowMemoryMode: true, fetch: () => new Response("ok") });

// node parity: Node listens as TLS and every handshake fails closed;
// we listened as plaintext http
require("node:https").createServer({}, handler).listen(0);
```

### Root cause

`SSLConfig::from_generated` computes `any = passphrase || dhParams || ... || rejectUnauthorized.is_some() || requestCert || secureOptions || ...` and returns `Some` whenever any tuning field is set. `ServerConfig` then arms TLS on `Some` (cert-less `https:`) and silently drops to plaintext on `None` (`tls:{}`). The legacy top-level reader applies the same check to the whole serve-options object.

### Fix

Identity material is the only thing that arms TLS.

- `SSLConfig::has_identity_material()` reports `(key || keyFile) && (cert || certFile)`. `ca`/`crl` are trust, not identity.
- `Bun.serve({ tls: <object> })` now throws a synchronous `TypeError: tls option requires both "key" and "cert" (or "keyFile" and "certFile")` when the object (or any `tls: [...]` entry) lacks identity material. The `node:http` wrapper path (`onNodeHTTPRequest`) is exempt so `node:https` keeps Node's fail-closed behaviour.
- `tls: false`/`0`/`null`/`undefined` and `tls: []` stay plain HTTP and leave the legacy top-level reader active (unchanged; covered by the #21792 regression test).
- The legacy top-level reader only keeps a parsed config that carries identity material; a lone tuning field is inert and never arms or throws. A top-level `key` without `cert` (or vice versa) now throws the same TypeError.
- `https.Server` is now its own constructor that stamps the internal is-TLS marker and delegates to `http.Server`, and `https.createServer` just returns `new Server(...)` (matching Node's structure). An `https` server is always a TLS listener: with no `key`/`cert` every handshake now fails (like Node v26) instead of serving plaintext. **Observable change:** `require("node:https").Server !== require("node:http").Server` (it was previously the same constructor); `https.Server` still extends `http.Server` so `instanceof` holds.

### Verification

`test/js/bun/http/bun-serve-ssl.test.ts` gains a `tls must carry key+cert` matrix (10 throw cases + legacy/falsey controls) and a `node:https without key/cert is TLS fail-closed` matrix (plaintext fetch rejected, TLS handshake errors, `createServer` and `new Server` both covered, key+cert control, `instanceof` check). Roughly 20 of the new tests fail on `main` and all pass with this change.

Fixture adjustments: `serve-types.test.ts`'s `tls: {}` case now asserts the constructor error, and `serve.test.ts`'s "SNI missing serverName" case carries `cert` alongside `key` so it still reaches the serverName check.
