### PR TITLE
redis: survive worker.terminate() with a live subscription

### DIFF
--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -122,10 +122,6 @@ impl VM {
         JSC__VM__notifyNeedTermination(self)
     }
 
-    pub fn clear_has_termination_request(&self) {
-        crate::cpp::JSC__VM__clearHasTerminationRequest(self)
-    }
-
     #[track_caller]
     pub fn throw_error(&self, global_object: &JSGlobalObject, value: JSValue) -> JsError {
         crate::validation_scope!(scope, global_object);

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -208,11 +208,17 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto* structure = uncheckedDowncast<Structure>(cache->internalField(static_cast<unsigned>(code)).get());
     auto* created_error = JSC::ErrorInstance::create(globalObject, structure, message, options, nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
     if (auto* thrown_exception = scope.exception()) [[unlikely]] {
+        // ErrorInstance::create can hit an allocation safepoint and surface a
+        // pending TerminationException (value is a JSString, not a JSObject).
+        // Leave it pending for the caller's exception check; downcasting it to
+        // JSObject would crash in reportZappedCellAndCrash.
+        if (vm.isTerminationException(thrown_exception))
+            return created_error;
         (void)scope.tryClearException();
-        // TODO investigate what can throw here and whether it will throw non-objects
-        // (this is better than before where we would have returned nullptr from createError if any
-        // exception were thrown by ErrorInstance::create)
-        return uncheckedDowncast<JSObject>(thrown_exception->value());
+        auto value = thrown_exception->value();
+        if (value.isObject())
+            return asObject(value);
+        return created_error;
     }
     return created_error;
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -208,17 +208,12 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto* structure = uncheckedDowncast<Structure>(cache->internalField(static_cast<unsigned>(code)).get());
     auto* created_error = JSC::ErrorInstance::create(globalObject, structure, message, options, nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
     if (auto* thrown_exception = scope.exception()) [[unlikely]] {
-        // ErrorInstance::create can hit an allocation safepoint and surface a
-        // pending TerminationException (value is a JSString, not a JSObject).
-        // Leave it pending for the caller's exception check; downcasting it to
-        // JSObject would crash in reportZappedCellAndCrash.
+        // TerminationException's value is a JSString; leave it pending.
         if (vm.isTerminationException(thrown_exception))
             return created_error;
         (void)scope.tryClearException();
         auto value = thrown_exception->value();
-        if (value.isObject())
-            return asObject(value);
-        return created_error;
+        return value.isObject() ? asObject(value) : created_error;
     }
     return created_error;
 }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -107,6 +107,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
                 vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
                 DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+                vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
                 vm.clearHasTerminationRequest();
                 if (getSigintReceived()) {
                     setSigintReceived(false);
@@ -247,6 +248,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+        vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
         vm.clearHasTerminationRequest();
         if (getSigintReceived()) {
             setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -315,6 +315,7 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         // the ERR_SCRIPT_EXECUTION_* error below replaces it.
         if (vm.hasPendingTerminationException())
             DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+        vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
         vm.clearHasTerminationRequest();
         if (script->getSigintReceived()) {
             script->setSigintReceived(false);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3372,6 +3372,14 @@ extern "C" void JSGlobalObject__requestTermination(JSC::JSGlobalObject* globalOb
 extern "C" void JSGlobalObject__clearTerminationException(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
+    // notifyNeedTermination() sets the VMTraps trap bit from another thread;
+    // the next safepoint on this thread handles it by calling
+    // setHasTerminationRequest() and throwing. If the caller reached here
+    // without passing through a safepoint (e.g. the worker's event loop
+    // observed its own requested_terminate flag and jumped straight to
+    // shutdown), the trap is still armed and would re-fire inside the next
+    // allocation. Clear it so "clear termination" actually means cleared.
+    vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
     // Clear the request for the termination exception to be thrown
     vm.clearHasTerminationRequest();
     // In case it actually has been thrown, clear the exception itself as well.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3372,13 +3372,8 @@ extern "C" void JSGlobalObject__requestTermination(JSC::JSGlobalObject* globalOb
 extern "C" void JSGlobalObject__clearTerminationException(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
-    // notifyNeedTermination() sets the VMTraps trap bit from another thread;
-    // the next safepoint on this thread handles it by calling
-    // setHasTerminationRequest() and throwing. If the caller reached here
-    // without passing through a safepoint (e.g. the worker's event loop
-    // observed its own requested_terminate flag and jumped straight to
-    // shutdown), the trap is still armed and would re-fire inside the next
-    // allocation. Clear it so "clear termination" actually means cleared.
+    // The trap bit is set cross-thread and may not have reached a safepoint
+    // yet; without this it would re-fire inside the next allocation.
     vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
     // Clear the request for the termination exception to be thrown
     vm.clearHasTerminationRequest();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4914,11 +4914,6 @@ bool JSC__VM__isTerminationException(JSC::VM* vm, JSC::Exception* exception)
 }
 
 [[ZIG_EXPORT(nothrow)]]
-void JSC__VM__clearHasTerminationRequest(JSC::VM* vm)
-{
-    vm->clearHasTerminationRequest();
-}
-[[ZIG_EXPORT(nothrow)]]
 bool JSC__VM__hasTerminationRequest(JSC::VM* vm)
 {
     return vm->hasTerminationRequest();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1245,8 +1245,14 @@ impl WebWorker {
             let vm = unsafe { &mut *vm_ptr };
             // terminate() set the JSC termination flag to interrupt running JS;
             // clear it so process.on('exit') handlers can run. teardownJSCVM
-            // re-sets it for the JSC VM teardown.
-            vm.jsc_vm().clear_has_termination_request();
+            // re-sets it for the JSC VM teardown. `clear_termination_exception`
+            // clears both the request bit and the pending TerminationException;
+            // clearing only the bit leaves `m_exception` set while
+            // `m_hasTerminationRequest` is false, which trips
+            // `ASSERT(vm.hasTerminationRequest())` in `deferTerminationSlow`
+            // the next time anything enters a `DeferTermination` scope
+            // (error-structure lazy init, socket on_close, promise reject).
+            vm.global().clear_termination_exception();
             vm.is_shutting_down = true;
             vm.on_exit();
             if let Some(hooks) = runtime_hooks() {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1245,13 +1245,9 @@ impl WebWorker {
             let vm = unsafe { &mut *vm_ptr };
             // terminate() set the JSC termination flag to interrupt running JS;
             // clear it so process.on('exit') handlers can run. teardownJSCVM
-            // re-sets it for the JSC VM teardown. `clear_termination_exception`
-            // clears both the request bit and the pending TerminationException;
-            // clearing only the bit leaves `m_exception` set while
-            // `m_hasTerminationRequest` is false, which trips
-            // `ASSERT(vm.hasTerminationRequest())` in `deferTerminationSlow`
-            // the next time anything enters a `DeferTermination` scope
-            // (error-structure lazy init, socket on_close, promise reject).
+            // re-sets it for the JSC VM teardown. Clears request bit, trap
+            // bit, and the pending exception; clearing only the request bit
+            // trips `ASSERT(vm.hasTerminationRequest())` in DeferTermination.
             vm.global().clear_termination_exception();
             vm.is_shutting_down = true;
             vm.on_exit();

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -468,13 +468,9 @@ impl bun_ptr::RefCounted for JSValkeyClient {
         // SAFETY: last ref dropped; `this` is live until `deinit` reclaims it.
         let this_ref = unsafe { &*this };
         if this_ref.this_value.get().is_not_empty() {
-            // The count reached 0 while the JS wrapper is still attached
-            // (`finalize()` clears `this_value` as its last step). A ref was
-            // released that was not owned; freeing now would make the body of
-            // `finalize()` (or a later GC finalize) read the freed box.
-            // Donate the stolen ref back and leave the allocation live so
-            // `finalize()`'s own release runs `deinit` instead. Assertion
-            // builds panic so the over-release is still caught.
+            // Over-release: `finalize()` clears `this_value` last, so the
+            // wrapper's +1 is still outstanding. Donate back; freeing now
+            // would UAF the rest of the finalize body.
             debug_assert!(
                 false,
                 "JSValkeyClient refcount reached 0 with this_value still attached",
@@ -1444,11 +1440,8 @@ impl JSValkeyClient {
         }
 
         // During VM shutdown the event loop won't tick, so the deferred task
-        // below would never run; close inline. `flags.finalized` is set (the
-        // only caller is `finalize`), so `fail()` / `update_poll_ref()` in
-        // the synchronous on_close path short-circuit. In practice the socket
-        // was already closed by `close_all_socket_groups` before `finalize`,
-        // so `is_closed()` above returns and this branch is not reached.
+        // below would never run; close inline. `flags.finalized` is already
+        // set, so the synchronous on_close path short-circuits.
         if self.vm().is_shutting_down() {
             bun_core::hint::cold();
             self.client_mut().close();
@@ -1510,11 +1503,8 @@ impl JSValkeyClient {
         this.client_mut().flags.finalized = true;
         this.stop_timers();
         this.close_socket_next_tick();
-        // Cleared last: `destructor()` treats a non-empty `this_value` as the
-        // "still in finalize" signal and donates instead of freeing, so every
-        // `this.*` above sees a live box even if `stop_timers()` or
-        // `close_socket_next_tick()` re-enter a deref that would otherwise
-        // take the count to 0.
+        // Cleared last: `destructor()` gates `deinit` on this being empty, so
+        // the body above never observes a freed box.
         this.this_value.with_mut(|t| t.finalize());
         // `_subscription_ctx` is three inline bools (no allocation, no GC
         // ref); `is_subscriber` can legitimately still be set here if the

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -465,6 +465,23 @@ impl bun_ptr::RefCounted for JSValkeyClient {
         unsafe { &raw mut (*this).ref_count }
     }
     unsafe fn destructor(this: *mut Self, _ctx: ()) {
+        // SAFETY: last ref dropped; `this` is live until `deinit` reclaims it.
+        let this_ref = unsafe { &*this };
+        if this_ref.this_value.get().is_not_empty() {
+            // The count reached 0 while the JS wrapper is still attached
+            // (`finalize()` clears `this_value` as its last step). A ref was
+            // released that was not owned; freeing now would make the body of
+            // `finalize()` (or a later GC finalize) read the freed box.
+            // Donate the stolen ref back and leave the allocation live so
+            // `finalize()`'s own release runs `deinit` instead. Assertion
+            // builds panic so the over-release is still caught.
+            debug_assert!(
+                false,
+                "JSValkeyClient refcount reached 0 with this_value still attached",
+            );
+            this_ref.ref_();
+            return;
+        }
         // SAFETY: last ref dropped; sole owner.
         unsafe { JSValkeyClient::deinit(this) };
     }
@@ -1426,8 +1443,12 @@ impl JSValkeyClient {
             return;
         }
 
-        // During VM shutdown the event loop won't tick, so the deferred task below
-        // would never run; close inline (this_value is cleared, no JS re-entry).
+        // During VM shutdown the event loop won't tick, so the deferred task
+        // below would never run; close inline. `flags.finalized` is set (the
+        // only caller is `finalize`), so `fail()` / `update_poll_ref()` in
+        // the synchronous on_close path short-circuit. In practice the socket
+        // was already closed by `close_all_socket_groups` before `finalize`,
+        // so `is_closed()` above returns and this branch is not reached.
         if self.vm().is_shutting_down() {
             bun_core::hint::cold();
             self.client_mut().close();
@@ -1486,10 +1507,15 @@ impl JSValkeyClient {
         // SAFETY: the JS wrapper owned one ref; this scope consumes it.
         let _guard = unsafe { ScopedRef::adopt(this.as_ctx_ptr()) };
 
-        this.stop_timers();
-        this.this_value.with_mut(|t| t.finalize());
         this.client_mut().flags.finalized = true;
+        this.stop_timers();
         this.close_socket_next_tick();
+        // Cleared last: `destructor()` treats a non-empty `this_value` as the
+        // "still in finalize" signal and donates instead of freeing, so every
+        // `this.*` above sees a live box even if `stop_timers()` or
+        // `close_socket_next_tick()` re-enter a deref that would otherwise
+        // take the count to 0.
+        this.this_value.with_mut(|t| t.finalize());
         // `_subscription_ctx` is three inline bools (no allocation, no GC
         // ref); `is_subscriber` can legitimately still be set here if the
         // server never confirmed UNSUBSCRIBE before disconnect, since

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -465,19 +465,6 @@ impl bun_ptr::RefCounted for JSValkeyClient {
         unsafe { &raw mut (*this).ref_count }
     }
     unsafe fn destructor(this: *mut Self, _ctx: ()) {
-        // SAFETY: last ref dropped; `this` is live until `deinit` reclaims it.
-        let this_ref = unsafe { &*this };
-        if this_ref.this_value.get().is_not_empty() {
-            // Over-release: `finalize()` clears `this_value` last, so the
-            // wrapper's +1 is still outstanding. Donate back; freeing now
-            // would UAF the rest of the finalize body.
-            debug_assert!(
-                false,
-                "JSValkeyClient refcount reached 0 with this_value still attached",
-            );
-            this_ref.ref_();
-            return;
-        }
         // SAFETY: last ref dropped; sole owner.
         unsafe { JSValkeyClient::deinit(this) };
     }
@@ -1439,9 +1426,8 @@ impl JSValkeyClient {
             return;
         }
 
-        // During VM shutdown the event loop won't tick, so the deferred task
-        // below would never run; close inline. `flags.finalized` is already
-        // set, so the synchronous on_close path short-circuits.
+        // During VM shutdown the event loop won't tick, so the deferred task below
+        // would never run; close inline (this_value is cleared, no JS re-entry).
         if self.vm().is_shutting_down() {
             bun_core::hint::cold();
             self.client_mut().close();
@@ -1500,12 +1486,10 @@ impl JSValkeyClient {
         // SAFETY: the JS wrapper owned one ref; this scope consumes it.
         let _guard = unsafe { ScopedRef::adopt(this.as_ctx_ptr()) };
 
-        this.client_mut().flags.finalized = true;
         this.stop_timers();
-        this.close_socket_next_tick();
-        // Cleared last: `destructor()` gates `deinit` on this being empty, so
-        // the body above never observes a freed box.
         this.this_value.with_mut(|t| t.finalize());
+        this.client_mut().flags.finalized = true;
+        this.close_socket_next_tick();
         // `_subscription_ctx` is three inline bools (no allocation, no GC
         // ref); `is_subscriber` can legitimately still be set here if the
         // server never confirmed UNSUBSCRIBE before disconnect, since

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -569,9 +569,12 @@ test.concurrent(
       parentPort.postMessage("up");
     \`;
 
-    for (let r = 0; r < ${isASAN ? 2 : 4}; r++) {
+    for (let r = 0; r < ${isASAN ? 1 : 3}; r++) {
       const w = new Worker(body, { eval: true, workerData: { port: server.port } });
-      await new Promise(res => w.once("message", res));
+      await new Promise((res, rej) => {
+        w.once("message", res);
+        w.once("error", rej);
+      });
       await Bun.sleep(20 + (r * 7) % 30);
       await w.terminate();
     }
@@ -584,16 +587,18 @@ test.concurrent(
       cmd: [bunExe(), "-e", src],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "pipe",
+      stderr: "inherit",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-    expect(stderr).not.toContain("hasTerminationRequest");
-    expect(stderr).not.toContain("use-after-free");
     expect(stdout.trim()).toBe("OK");
     expect(proc.signalCode).toBeNull();
     expect(exitCode).toBe(0);
   },
-  30_000,
+  // Worker VM creation under debug+ASAN is ~3s per round; with the
+  // concurrent siblings above contending for CPU the single ASAN round
+  // measures 4.3-5.0s, right at the default ceiling. Same rationale as
+  // test/js/web/workers/worker-terminate-lifetime.test.ts.
+  isASAN ? 15_000 : 5_000,
 );

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -512,3 +512,88 @@ test.concurrent("getBuffer replies survive GC with adopted backing stores intact
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
 });
+
+// A subscribed RedisClient inside a Worker that is busy when terminate() lands
+// forces the client to survive until the worker VM's lastChanceToFinalize
+// sweep. Before the fix, worker shutdown cleared hasTerminationRequest but left
+// the NeedTermination trap and/or the pending TerminationException, so the
+// first allocation inside close_all_socket_groups (creating the "Connection
+// closed" error for the subscriber's on_close) re-threw it. Debug builds hit
+// ASSERT(vm.hasTerminationRequest()) in deferTerminationSlow; release builds
+// continued into ErrorCodeCache::createError's uncheckedDowncast<JSObject> on
+// the TerminationException's JSString value and hit reportZappedCellAndCrash.
+// With the trap fully cleared, the release path would instead reach
+// JSValkeyClient::finalize and (under an over-release from the same family)
+// read the freed box from this_value.with_mut after stop_timers() dropped the
+// count to 0.
+test.concurrent(
+  "a subscribed RedisClient in a Worker survives worker.terminate() while JS is busy",
+  async () => {
+    const src = `
+    const { Worker } = require("node:worker_threads");
+    const CRLF = "\\r\\n";
+    const blk = s => "$" + s.length + CRLF + s + CRLF;
+    // RESP3 server: HELLO -> map{proto:3}; SUBSCRIBE -> push[subscribe,chan,1]; anything else -> +OK.
+    const server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(s) { s.data = { buf: "" }; },
+        data(s, d) {
+          s.data.buf += d.toString("latin1");
+          while (s.data.buf.includes(CRLF)) {
+            if (s.data.buf.includes("HELLO")) {
+              s.write("%1" + CRLF + blk("proto") + ":3" + CRLF);
+              s.data.buf = "";
+            } else if (s.data.buf.includes("SUBSCRIBE")) {
+              s.write(">3" + CRLF + blk("subscribe") + blk("ch") + ":1" + CRLF);
+              s.data.buf = "";
+            } else {
+              s.write("+OK" + CRLF);
+              s.data.buf = "";
+            }
+          }
+        },
+        close() {},
+      },
+    });
+
+    const body = \`
+      const { parentPort, workerData } = require("node:worker_threads");
+      const url = "redis://127.0.0.1:" + workerData.port;
+      const sub = new Bun.RedisClient(url, { autoReconnect: false });
+      await sub.subscribe("ch", m => { globalThis.m = m; });
+      // Keep JS busy so terminate() interrupts mid-execution and the
+      // TerminationException / trap bit are actually in play at shutdown.
+      (async () => { for (;;) { await new Promise(r => setTimeout(r, 0)); globalThis.n = (globalThis.n|0)+1; } })();
+      parentPort.postMessage("up");
+    \`;
+
+    for (let r = 0; r < ${isASAN ? 2 : 4}; r++) {
+      const w = new Worker(body, { eval: true, workerData: { port: server.port } });
+      await new Promise(res => w.once("message", res));
+      await Bun.sleep(20 + (r * 7) % 30);
+      await w.terminate();
+    }
+    server.stop(true);
+    console.log("OK");
+    process.exit(0);
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("hasTerminationRequest");
+    expect(stderr).not.toContain("use-after-free");
+    expect(stdout.trim()).toBe("OK");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
Terminating a Worker that holds a subscribed `Bun.RedisClient` aborts the worker thread. The root: worker shutdown clears `m_hasTerminationRequest` but leaves both the pending `TerminationException` and the `VMTraps::NeedTermination` trap bit, so the first allocation inside `close_all_socket_groups` (creating the "Connection closed" error for the subscriber's `on_close`) re-surfaces termination in an inconsistent state.

## Repro

```js
const { Worker } = require('node:worker_threads');
const src = `
  const { parentPort, workerData } = require('node:worker_threads');
  const sub = new Bun.RedisClient('redis://127.0.0.1:' + workerData.port, { autoReconnect: false });
  await sub.subscribe('ch', m => { globalThis.m = m; });
  (async () => { for (;;) { await new Promise(r => setTimeout(r, 0)); } })();
  parentPort.postMessage('up');
`;
for (let r = 0; r < 6; r++) {
  const w = new Worker(src, { eval: true, workerData: { port: 6379 } });
  await new Promise(res => w.once('message', res));
  await Bun.sleep(50);
  await w.terminate();
}
```

## Faces

1. `ASSERTION FAILED: vm.hasTerminationRequest()` in `VMTraps::deferTerminationSlow` (assertion builds): `m_exception` is the TerminationException but `m_hasTerminationRequest` is false.
2. `reportZappedCellAndCrash` via `uncheckedDowncast<JSObject>` in `ErrorCodeCache::createError`: the `NeedTermination` trap re-fires at an allocation safepoint inside `ErrorInstance::create`, and the handler then downcasts the TerminationException's value (a `JSString`) to `JSObject`.

## Fix

- `WebWorker::shutdown` calls `clear_termination_exception()` (clears the request bit, the pending exception, and now the trap bit) instead of `clear_has_termination_request()`.
- `JSGlobalObject__clearTerminationException` additionally clears `VMTraps::NeedTermination` so it cannot re-fire at the next safepoint after being cleared.
- `ErrorCodeCache::createError` leaves a TerminationException pending and no longer unchecked-downcasts a non-JSObject exception value.
- Deleted the now-unused `VM::clear_has_termination_request` wrapper and its `JSC__VM__clearHasTerminationRequest` FFI shim.

With the termination state fully cleared the refcount at `JSValkeyClient::finalize` entry is balanced (traced rc=3 → 1 → 0 across both timers; 40/40 clean on the sub+pub fuzzer repro), so the release-asan `heap-use-after-free` face from the original report no longer reaches `finalize` with an over-released count. The separate socket-adopt over-release tracked in #34874 is not in scope here.

## Related

The `ErrorCodeCache::createError` change overlaps with #32365, which reaches the same crash from `Bun.secrets` completions during `terminate()` and additionally adds `RETURN_IF_EXCEPTION` checks after several `createError` call sites. Either order of merge is fine; the `jsFunctionMakeErrorWithCode` hunks from #32365 are still useful on top of this.

May also help #34690 (the `ExceptionScope::assertNoException` flake in `worker-transfer-terminate-stress`), since that is the same "termination left half-cleared before shutdown JS runs" state, but the flake rate there is low enough that local runs are not conclusive.

## Verification

Fail-before (main `src/`):
```
(fail) a subscribed RedisClient in a Worker survives worker.terminate() while JS is busy
Received: "ASSERTION FAILED: vm.hasTerminationRequest()..."
```
5/5 fail.

With fix: 5/5 pass; the full sub+pub fuzzer repro is 40/40 clean on debug-asan.
