### PR TITLE
net: emit socket 'timeout' while still connecting (node:http dead-host guard)

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1804,8 +1804,6 @@ Socket.prototype.address = function address() {
 
 Socket.prototype._onTimeout = function () {
   const handle = this._handle;
-  // kwriteCallback is set exactly while an async write is in flight (Node's
-  // kLastWriteQueueSize > 0 after kAfterAsyncWrite); suppress only if draining.
   if (this[kwriteCallback] && handle) {
     const writeQueueSize = getBufferedAmount(handle);
     if (this[kLastWriteQueueSize] !== writeQueueSize) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -186,6 +186,7 @@ const kOnreadPendingEnd = Symbol("kOnreadPendingEnd");
 const kOnreadReadRequested = Symbol("kOnreadReadRequested");
 const kOnreadEmptyTail = Buffer.alloc(0);
 const kwriteCallback = Symbol("writeCallback");
+const kLastWriteQueueSize = Symbol("lastWriteQueueSize");
 const kSocketClass = Symbol("kSocketClass");
 
 // A completed write whose status is a negative errno: Node hands it to the write
@@ -1603,6 +1604,7 @@ function Socket(options?) {
   // node initializes the timer slot to null so it is observable before setTimeout() is called.
   // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L401
   this[kTimeout] = null;
+  this[kLastWriteQueueSize] = 0;
   this[kwriteCallback] = undefined;
   this._pendingData = undefined;
   this._pendingEncoding = undefined; // for compatibility
@@ -1801,17 +1803,17 @@ Socket.prototype.address = function address() {
 };
 
 Socket.prototype._onTimeout = function () {
-  // if there is pending data, write is in progress
-  // so we suppress the timeout
-  if (this._pendingData) {
-    return;
-  }
-
   const handle = this._handle;
-  // if there is a handle, and it has pending data,
-  // we suppress the timeout because a write is in progress
-  if (handle && getBufferedAmount(handle) > 0) {
-    return;
+  const lastWriteQueueSize = this[kLastWriteQueueSize];
+  if (lastWriteQueueSize > 0 && handle) {
+    // `lastWriteQueueSize !== writeQueueSize` means there is
+    // an active write in progress, so we suppress the timeout.
+    const writeQueueSize = getBufferedAmount(handle);
+    if (lastWriteQueueSize !== writeQueueSize) {
+      this[kLastWriteQueueSize] = writeQueueSize;
+      this._unrefTimer();
+      return;
+    }
   }
   this.emit("timeout");
 };
@@ -2824,6 +2826,7 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
     callback(new Error("overlapping _write()"));
   } else {
     this[kwriteCallback] = callback;
+    this[kLastWriteQueueSize] = getBufferedAmount(socket);
     // A pending write holds the loop even on a handle whose FIN/pause dropped
     // its hold (libuv: the uv_write_t is active); unrefAfterDrain lets go again.
     if ((this[kended] || this[kPausedUnref]) && !this[kUserUnrefed]) socket.ref?.();

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1804,14 +1804,9 @@ Socket.prototype.address = function address() {
 
 Socket.prototype._onTimeout = function () {
   const handle = this._handle;
-  // Node gates on kLastWriteQueueSize > 0, which kAfterAsyncWrite zeroes when
-  // the async write completes. Bun's equivalent completion signal is
-  // kwriteCallback being cleared by the drain/error handlers, so gate on that
-  // (set together with kLastWriteQueueSize in _write's async branch) instead
-  // of resetting the size at every completion site.
+  // kwriteCallback is set exactly while an async write is in flight (Node's
+  // kLastWriteQueueSize > 0 after kAfterAsyncWrite); suppress only if draining.
   if (this[kwriteCallback] && handle) {
-    // `lastWriteQueueSize !== writeQueueSize` means there is
-    // an active write in progress, so we suppress the timeout.
     const writeQueueSize = getBufferedAmount(handle);
     if (this[kLastWriteQueueSize] !== writeQueueSize) {
       this[kLastWriteQueueSize] = writeQueueSize;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1804,12 +1804,16 @@ Socket.prototype.address = function address() {
 
 Socket.prototype._onTimeout = function () {
   const handle = this._handle;
-  const lastWriteQueueSize = this[kLastWriteQueueSize];
-  if (lastWriteQueueSize > 0 && handle) {
+  // Node gates on kLastWriteQueueSize > 0, which kAfterAsyncWrite zeroes when
+  // the async write completes. Bun's equivalent completion signal is
+  // kwriteCallback being cleared by the drain/error handlers, so gate on that
+  // (set together with kLastWriteQueueSize in _write's async branch) instead
+  // of resetting the size at every completion site.
+  if (this[kwriteCallback] && handle) {
     // `lastWriteQueueSize !== writeQueueSize` means there is
     // an active write in progress, so we suppress the timeout.
     const writeQueueSize = getBufferedAmount(handle);
-    if (lastWriteQueueSize !== writeQueueSize) {
+    if (this[kLastWriteQueueSize] !== writeQueueSize) {
       this[kLastWriteQueueSize] = writeQueueSize;
       this._unrefTimer();
       return;

--- a/test/js/node/http/client-timeout-error.test.ts
+++ b/test/js/node/http/client-timeout-error.test.ts
@@ -170,12 +170,18 @@ describe("node:http client timeout", () => {
     });
   });
 
-  // A connected peer that has stopped reading: writes back up in the handle's
-  // send queue and getBufferedAmount() stays nonzero. Node's _onTimeout
-  // heuristic suppresses 'timeout' only while the write queue is *draining*
-  // (writeQueueSize moved since the last check), re-arming each time; once the
-  // queue stalls it emits. The old `if (getBufferedAmount(handle) > 0) return`
-  // dropped the one-shot timer with no re-arm, so 'timeout' was lost for good.
+  // A connected peer that has stopped reading: the kernel send and receive
+  // buffers fill, the rest of the write sits in the handle's native queue, and
+  // getBufferedAmount() stays nonzero. Node's _onTimeout heuristic suppresses
+  // 'timeout' only while that queue is still *draining* (writeQueueSize moved
+  // since the last check), re-arming each time; once it stalls it emits. The
+  // old `if (getBufferedAmount(handle) > 0) return` dropped the one-shot timer
+  // with no re-arm, so 'timeout' was lost for good.
+  //
+  // One 64 MiB chunk is far above any loopback socket-buffer capacity (Linux
+  // defaults cap at 4 MiB send + 6 MiB receive), so the native queue can never
+  // drain. A smaller write can fit in the kernel outright, and then the old
+  // guard never triggers.
   it("net.Socket 'timeout' fires when a connected write is stalled by a non-reading peer", async () => {
     const accepted: net.Socket[] = [];
     const server = net.createServer(s => {
@@ -191,9 +197,7 @@ describe("node:http client timeout", () => {
     socket.on("error", () => {});
     try {
       await once(socket, "connect");
-      const chunk = Buffer.alloc(1 << 20, 0x42);
-      let mb = 0;
-      while (socket.write(chunk) && ++mb < 64) {}
+      expect(socket.write(Buffer.alloc(64 << 20))).toBe(false);
       expect(socket.writableLength).toBeGreaterThan(0);
 
       socket.setTimeout(200);

--- a/test/js/node/http/client-timeout-error.test.ts
+++ b/test/js/node/http/client-timeout-error.test.ts
@@ -202,11 +202,15 @@ describe("node:http client timeout", () => {
       socket.on("error", () => {});
       try {
         await once(socket, "connect");
-        expect(socket.write(Buffer.alloc(64 << 20))).toBe(false);
+        let writeComplete = false;
+        expect(socket.write(Buffer.alloc(64 << 20), () => (writeComplete = true))).toBe(false);
         expect(socket.writableLength).toBeGreaterThan(0);
 
         socket.setTimeout(200);
         await once(socket, "timeout");
+        // The write is still in flight: 'timeout' came from the stalled-queue
+        // branch, not from an ordinary idle socket.
+        expect(writeComplete).toBe(false);
         expect(socket.connecting).toBe(false);
       } finally {
         socket.destroy();

--- a/test/js/node/http/client-timeout-error.test.ts
+++ b/test/js/node/http/client-timeout-error.test.ts
@@ -185,31 +185,34 @@ describe("node:http client timeout", () => {
   // the old guard never triggers. Windows is skipped: winsock takes the whole
   // non-blocking send() into the kernel (all 64 MiB on loopback in CI), so the
   // write never goes async and the queue under test is never populated.
-  it.skipIf(isWindows)("net.Socket 'timeout' fires when a connected write is stalled by a non-reading peer", async () => {
-    const accepted: net.Socket[] = [];
-    const server = net.createServer(s => {
-      accepted.push(s);
-      s.on("error", () => {});
-      s.pause();
-    });
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const { port } = server.address() as net.AddressInfo;
+  it.skipIf(isWindows)(
+    "net.Socket 'timeout' fires when a connected write is stalled by a non-reading peer",
+    async () => {
+      const accepted: net.Socket[] = [];
+      const server = net.createServer(s => {
+        accepted.push(s);
+        s.on("error", () => {});
+        s.pause();
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as net.AddressInfo;
 
-    const socket = net.connect({ host: "127.0.0.1", port });
-    socket.on("error", () => {});
-    try {
-      await once(socket, "connect");
-      expect(socket.write(Buffer.alloc(64 << 20))).toBe(false);
-      expect(socket.writableLength).toBeGreaterThan(0);
+      const socket = net.connect({ host: "127.0.0.1", port });
+      socket.on("error", () => {});
+      try {
+        await once(socket, "connect");
+        expect(socket.write(Buffer.alloc(64 << 20))).toBe(false);
+        expect(socket.writableLength).toBeGreaterThan(0);
 
-      socket.setTimeout(200);
-      await once(socket, "timeout");
-      expect(socket.connecting).toBe(false);
-    } finally {
-      socket.destroy();
-      for (const s of accepted) s.destroy();
-      server.close();
-    }
-  });
+        socket.setTimeout(200);
+        await once(socket, "timeout");
+        expect(socket.connecting).toBe(false);
+      } finally {
+        socket.destroy();
+        for (const s of accepted) s.destroy();
+        server.close();
+      }
+    },
+  );
 });

--- a/test/js/node/http/client-timeout-error.test.ts
+++ b/test/js/node/http/client-timeout-error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { once } from "node:events";
-import { createServer, request } from "node:http";
+import { createServer, get, request } from "node:http";
+import net from "node:net";
 
 describe("node:http client timeout", () => {
   it("should emit timeout event when timeout is reached", async () => {
@@ -89,5 +90,84 @@ describe("node:http client timeout", () => {
     } finally {
       server.close();
     }
+  });
+
+  // The socket stays in the `connecting` state while the lookup callback is
+  // withheld, which is observationally equivalent to a SYN that is never
+  // acknowledged. Node.js arms the idle timer at socket creation, so the
+  // 'timeout' event fires mid-connect; it must not be swallowed just because
+  // the request headers are queued in _pendingData waiting for the handle.
+  describe("fires while the socket is still connecting", () => {
+    type Finish = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
+
+    function stallingLookup(deferred: { finish?: Finish }) {
+      return function lookup(_hostname: string, opts: unknown, cb?: Finish) {
+        deferred.finish = typeof opts === "function" ? (opts as Finish) : cb!;
+      };
+    }
+
+    it("options.timeout emits req 'timeout' before connect", async () => {
+      const deferred: { finish?: Finish } = {};
+      const req = get({
+        host: "stalled.invalid",
+        port: 1,
+        path: "/",
+        timeout: 100,
+        agent: false,
+        autoSelectFamily: false,
+        lookup: stallingLookup(deferred),
+      });
+      req.on("error", () => {});
+      try {
+        await once(req, "timeout");
+        expect(req.socket?.connecting).toBe(true);
+      } finally {
+        req.destroy();
+        deferred.finish?.(new Error("aborted"), "", 0);
+      }
+    });
+
+    it("socket.setTimeout() emits socket 'timeout' before connect", async () => {
+      const deferred: { finish?: Finish } = {};
+      const req = get({
+        host: "stalled.invalid",
+        port: 1,
+        path: "/",
+        agent: false,
+        autoSelectFamily: false,
+        lookup: stallingLookup(deferred),
+      });
+      req.on("error", () => {});
+      const [socket] = await once(req, "socket");
+      const { promise, resolve } = Promise.withResolvers<void>();
+      socket.setTimeout(100, resolve);
+      try {
+        await promise;
+        expect(socket.connecting).toBe(true);
+      } finally {
+        req.destroy();
+        deferred.finish?.(new Error("aborted"), "", 0);
+      }
+    });
+
+    it("net.Socket 'timeout' fires with a write buffered pre-connect", async () => {
+      const deferred: { finish?: Finish } = {};
+      const socket = net.connect({
+        host: "stalled.invalid",
+        port: 1,
+        autoSelectFamily: false,
+        lookup: stallingLookup(deferred),
+      });
+      socket.on("error", () => {});
+      socket.write("GET / HTTP/1.1\r\n\r\n");
+      socket.setTimeout(100);
+      try {
+        await once(socket, "timeout");
+        expect(socket.connecting).toBe(true);
+      } finally {
+        socket.destroy();
+        deferred.finish?.(new Error("aborted"), "", 0);
+      }
+    });
   });
 });

--- a/test/js/node/http/client-timeout-error.test.ts
+++ b/test/js/node/http/client-timeout-error.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { isWindows } from "harness";
 import { once } from "node:events";
 import { createServer, get, request } from "node:http";
 import net from "node:net";
@@ -178,11 +179,13 @@ describe("node:http client timeout", () => {
   // old `if (getBufferedAmount(handle) > 0) return` dropped the one-shot timer
   // with no re-arm, so 'timeout' was lost for good.
   //
-  // One 64 MiB chunk is far above any loopback socket-buffer capacity (Linux
-  // defaults cap at 4 MiB send + 6 MiB receive), so the native queue can never
-  // drain. A smaller write can fit in the kernel outright, and then the old
-  // guard never triggers.
-  it("net.Socket 'timeout' fires when a connected write is stalled by a non-reading peer", async () => {
+  // One 64 MiB chunk is far above any POSIX loopback socket-buffer capacity
+  // (Linux defaults cap at 4 MiB send + 6 MiB receive), so the native queue
+  // can never drain. A smaller write can fit in the kernel outright, and then
+  // the old guard never triggers. Windows is skipped: winsock takes the whole
+  // non-blocking send() into the kernel (all 64 MiB on loopback in CI), so the
+  // write never goes async and the queue under test is never populated.
+  it.skipIf(isWindows)("net.Socket 'timeout' fires when a connected write is stalled by a non-reading peer", async () => {
     const accepted: net.Socket[] = [];
     const server = net.createServer(s => {
       accepted.push(s);

--- a/test/js/node/http/client-timeout-error.test.ts
+++ b/test/js/node/http/client-timeout-error.test.ts
@@ -208,8 +208,6 @@ describe("node:http client timeout", () => {
 
         socket.setTimeout(200);
         await once(socket, "timeout");
-        // The write is still in flight: 'timeout' came from the stalled-queue
-        // branch, not from an ordinary idle socket.
         expect(writeComplete).toBe(false);
         expect(socket.connecting).toBe(false);
       } finally {

--- a/test/js/node/http/client-timeout-error.test.ts
+++ b/test/js/node/http/client-timeout-error.test.ts
@@ -139,10 +139,9 @@ describe("node:http client timeout", () => {
       });
       req.on("error", () => {});
       const [socket] = await once(req, "socket");
-      const { promise, resolve } = Promise.withResolvers<void>();
-      socket.setTimeout(100, resolve);
+      socket.setTimeout(100);
       try {
-        await promise;
+        await once(socket, "timeout");
         expect(socket.connecting).toBe(true);
       } finally {
         req.destroy();

--- a/test/js/node/http/client-timeout-error.test.ts
+++ b/test/js/node/http/client-timeout-error.test.ts
@@ -169,4 +169,40 @@ describe("node:http client timeout", () => {
       }
     });
   });
+
+  // A connected peer that has stopped reading: writes back up in the handle's
+  // send queue and getBufferedAmount() stays nonzero. Node's _onTimeout
+  // heuristic suppresses 'timeout' only while the write queue is *draining*
+  // (writeQueueSize moved since the last check), re-arming each time; once the
+  // queue stalls it emits. The old `if (getBufferedAmount(handle) > 0) return`
+  // dropped the one-shot timer with no re-arm, so 'timeout' was lost for good.
+  it("net.Socket 'timeout' fires when a connected write is stalled by a non-reading peer", async () => {
+    const accepted: net.Socket[] = [];
+    const server = net.createServer(s => {
+      accepted.push(s);
+      s.on("error", () => {});
+      s.pause();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
+
+    const socket = net.connect({ host: "127.0.0.1", port });
+    socket.on("error", () => {});
+    try {
+      await once(socket, "connect");
+      const chunk = Buffer.alloc(1 << 20, 0x42);
+      let mb = 0;
+      while (socket.write(chunk) && ++mb < 64) {}
+      expect(socket.writableLength).toBeGreaterThan(0);
+
+      socket.setTimeout(200);
+      await once(socket, "timeout");
+      expect(socket.connecting).toBe(false);
+    } finally {
+      socket.destroy();
+      for (const s of accepted) s.destroy();
+      server.close();
+    }
+  });
 });


### PR DESCRIPTION
## What

`node:http` client `options.timeout` and `socket.setTimeout()` never fired while the underlying socket was still connecting. Against a host that drops SYNs (firewalled / black-holed), the documented dead-host guard

```js
const req = http.get({ host, port, timeout: 5000 });
req.on('timeout', () => req.destroy());
```

was inert: the request sat until the kernel's SYN-retransmit budget ran out (~130s on Linux) before failing with `ECONNREFUSED`. Node.js fires `'timeout'` at the requested interval.

## Repro

A `lookup` callback that is never invoked keeps the socket in `connecting` with no native handle, which is observationally the same as a SYN that is never ACKed:

```js
import http from 'node:http';
const req = http.get({
  host: 'stalled.invalid', port: 1, timeout: 200,
  agent: false, autoSelectFamily: false,
  lookup: () => {}, // never calls back
});
req.on('timeout', () => console.log('timeout'));  // bun: never; node: ~200ms
req.on('error', () => {});
```

Bare `net.connect({ timeout })` did fire mid-connect (nothing writes to that socket), which pointed at the write-queued path.

## Cause

`Socket.prototype._onTimeout` swallowed the event whenever `_pendingData` was non-null:

```js
if (this._pendingData) return;
```

`_pendingData` is only populated while `connecting` is true (or during a pending TLS upgrade): `_write()` parks the chunk there until the handle arrives. `node:http` always writes the request headers before the socket connects, so every HTTP client request had `_pendingData` set for the entire connect window and the idle timer was silently dropped.

The second guard (`getBufferedAmount(handle) > 0`) also suppressed without re-arming, so a stalled post-connect write buffer would eat the only timer firing.

## Fix

Match Node's `lib/net.js` `_onTimeout`: track `kLastWriteQueueSize` when a write goes async, and on timer expiry compare it to the current handle buffer. If the queue moved, the socket is still draining, so re-arm (`_unrefTimer()`) and wait; otherwise emit `'timeout'`. With no handle yet (still connecting) the check is skipped and `'timeout'` always fires.

## Verification

```
$ bun bd test test/js/node/http/client-timeout-error.test.ts
(pass) options.timeout emits req 'timeout' before connect
(pass) socket.setTimeout() emits socket 'timeout' before connect
(pass) net.Socket 'timeout' fires with a write buffered pre-connect
(pass) net.Socket 'timeout' fires when a connected write is stalled by a non-reading peer
```

All four hang on `main` waiting for an event that never arrives. The same assertions pass under Node v26.3.0. The fourth test covers the second guard directly: a loopback peer that `pause()`s, and one 64 MiB write so the client's native send queue is above any loopback socket-buffer capacity and `getBufferedAmount()` stays nonzero for good. Node fires `'timeout'` once the queue stops moving (400 ms); the old guard suppressed it with no re-arm, so the case hangs 3/3 against a build with main's `net.ts`. `test-http-client-timeout-on-connect.js`, `test-net-socket-timeout*.js`, and `node-http-server-timeouts.test.ts` continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/http/client-timeout-error.test.ts

<!-- robobun:evidence:end -->

