### PR TITLE
EventTarget: make dispatching N {once:true} listeners O(N) instead of O(N^2)

### DIFF
--- a/src/jsc/bindings/webcore/EventListenerMap.cpp
+++ b/src/jsc/bindings/webcore/EventListenerMap.cpp
@@ -95,6 +95,8 @@ static inline size_t findListener(const EventListenerVector& listeners, EventLis
 {
     for (size_t i = 0; i < listeners.size(); ++i) {
         auto& registeredListener = listeners[i];
+        if (registeredListener->wasRemoved())
+            continue;
         if (registeredListener->callback() == listener && registeredListener->useCapture() == useCapture)
             return i;
     }
@@ -161,6 +163,23 @@ bool EventListenerMap::remove(const AtomString& eventType, EventListener& listen
     }
 
     return false;
+}
+
+void EventListenerMap::compactRemoved(const AtomString& eventType)
+{
+    releaseAssertOrSetThreadUID();
+    Locker locker { m_lock };
+
+    for (unsigned i = 0; i < m_entries.size(); ++i) {
+        if (m_entries[i].first == eventType) {
+            m_entries[i].second.removeAllMatching([](auto& listener) {
+                return listener->wasRemoved();
+            });
+            if (m_entries[i].second.isEmpty())
+                m_entries.removeAt(i);
+            return;
+        }
+    }
 }
 
 EventListenerVector* EventListenerMap::find(const AtomString& eventType)

--- a/src/jsc/bindings/webcore/EventListenerMap.h
+++ b/src/jsc/bindings/webcore/EventListenerMap.h
@@ -61,6 +61,7 @@ public:
     void replace(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, const RegisteredEventListener::Options&);
     RegisteredEventListener* add(const AtomString& eventType, Ref<EventListener>&&, const RegisteredEventListener::Options&);
     bool remove(const AtomString& eventType, EventListener&, bool useCapture);
+    void compactRemoved(const AtomString& eventType);
     WEBCORE_EXPORT EventListenerVector* find(const AtomString& eventType);
     const EventListenerVector* find(const AtomString& eventType) const { return const_cast<EventListenerMap*>(this)->find(eventType); }
     Vector<AtomString> eventTypes() const;

--- a/src/jsc/bindings/webcore/EventTarget.cpp
+++ b/src/jsc/bindings/webcore/EventTarget.cpp
@@ -300,6 +300,7 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
     ASSERT(scriptExecutionContext());
 
     auto& context = *scriptExecutionContext();
+    bool hasRemovedOnceListener = false;
     // bool contextIsDocument = is<Document>(context);
     // if (contextIsDocument)
     //     InspectorInstrumentation::willDispatchEvent(downcast<Document>(context), event);
@@ -329,8 +330,15 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
         JSC::EnsureStillAliveScope jsFunctionProtector(registeredListener->callback().jsFunction());
 
         // Do this before invocation to avoid reentrancy issues.
-        if (registeredListener->isOnce())
-            removeEventListener(event.type(), registeredListener->callback(), registeredListener->useCapture());
+        // Mark the listener as removed in place and compact the live vector once
+        // after the loop; calling removeEventListener here is O(N) per listener
+        // (linear find + linear erase) and makes dispatching N once-listeners O(N^2).
+        if (registeredListener->isOnce()) {
+            registeredListener->markAsRemoved();
+            hasRemovedOnceListener = true;
+            if (this->onDidChangeListener) [[unlikely]]
+                this->onDidChangeListener(*this, event.type(), OnDidChangeListenerKind::Remove);
+        }
 
         if (registeredListener->isPassive())
             event.setInPassiveListener(true);
@@ -345,6 +353,12 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
 
         if (registeredListener->isPassive())
             event.setInPassiveListener(false);
+    }
+
+    if (hasRemovedOnceListener) {
+        if (auto* data = eventTargetData())
+            data->eventListenerMap.compactRemoved(event.type());
+        eventListenersDidChange();
     }
 
     // if (contextIsDocument)

--- a/test/js/web/events/event-target.test.ts
+++ b/test/js/web/events/event-target.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+describe("EventTarget {once:true}", () => {
+  test("fires each once-listener exactly once and removes them", () => {
+    const et = new EventTarget();
+    let calls = 0;
+    const order: number[] = [];
+    for (let i = 0; i < 50; i++) {
+      const n = i;
+      et.addEventListener(
+        "z",
+        () => {
+          calls++;
+          order.push(n);
+        },
+        { once: true },
+      );
+    }
+    et.dispatchEvent(new Event("z"));
+    expect(calls).toBe(50);
+    expect(order).toEqual(Array.from({ length: 50 }, (_, i) => i));
+
+    et.dispatchEvent(new Event("z"));
+    expect(calls).toBe(50);
+  });
+
+  test("non-once listeners survive alongside once listeners", () => {
+    const et = new EventTarget();
+    let plain = 0;
+    let once = 0;
+    et.addEventListener("z", () => plain++);
+    for (let i = 0; i < 20; i++) et.addEventListener("z", () => once++, { once: true });
+    et.addEventListener("z", () => plain++);
+
+    et.dispatchEvent(new Event("z"));
+    expect({ plain, once }).toEqual({ plain: 2, once: 20 });
+
+    et.dispatchEvent(new Event("z"));
+    expect({ plain, once }).toEqual({ plain: 4, once: 20 });
+  });
+
+  test("re-adding inside a once-callback registers a fresh listener", () => {
+    const et = new EventTarget();
+    let calls = 0;
+    const fn = () => {
+      calls++;
+      if (calls === 1) et.addEventListener("z", fn, { once: true });
+    };
+    et.addEventListener("z", fn, { once: true });
+
+    et.dispatchEvent(new Event("z"));
+    expect(calls).toBe(1);
+
+    et.dispatchEvent(new Event("z"));
+    expect(calls).toBe(2);
+
+    et.dispatchEvent(new Event("z"));
+    expect(calls).toBe(2);
+  });
+
+  test("stopImmediatePropagation leaves unfired once-listeners in place", () => {
+    const et = new EventTarget();
+    let a = 0;
+    let b = 0;
+    et.addEventListener(
+      "z",
+      e => {
+        a++;
+        e.stopImmediatePropagation();
+      },
+      { once: true },
+    );
+    et.addEventListener("z", () => b++, { once: true });
+
+    et.dispatchEvent(new Event("z"));
+    expect({ a, b }).toEqual({ a: 1, b: 0 });
+
+    et.dispatchEvent(new Event("z"));
+    expect({ a, b }).toEqual({ a: 1, b: 1 });
+  });
+
+  test("removeEventListener from inside a once-callback skips a later listener", () => {
+    const et = new EventTarget();
+    let a = 0;
+    let b = 0;
+    const later = () => b++;
+    et.addEventListener(
+      "z",
+      () => {
+        a++;
+        et.removeEventListener("z", later);
+      },
+      { once: true },
+    );
+    et.addEventListener("z", later, { once: true });
+
+    et.dispatchEvent(new Event("z"));
+    expect({ a, b }).toEqual({ a: 1, b: 0 });
+
+    et.dispatchEvent(new Event("z"));
+    expect({ a, b }).toEqual({ a: 1, b: 0 });
+  });
+
+  test("nested dispatch inside a once-callback fires remaining once-listeners once", () => {
+    const et = new EventTarget();
+    const order: string[] = [];
+    et.addEventListener(
+      "z",
+      () => {
+        order.push("a");
+        et.dispatchEvent(new Event("z"));
+      },
+      { once: true },
+    );
+    et.addEventListener("z", () => order.push("b"), { once: true });
+    et.addEventListener("z", () => order.push("c"), { once: true });
+
+    et.dispatchEvent(new Event("z"));
+    expect(order).toEqual(["a", "b", "c"]);
+
+    et.dispatchEvent(new Event("z"));
+    expect(order).toEqual(["a", "b", "c"]);
+  });
+
+  test("AbortSignal fires many once-listeners on abort", () => {
+    const ac = new AbortController();
+    let calls = 0;
+    for (let i = 0; i < 200; i++) {
+      ac.signal.addEventListener("abort", () => calls++, { once: true });
+    }
+    ac.abort();
+    expect(calls).toBe(200);
+    expect(ac.signal.aborted).toBe(true);
+  });
+
+  // Dispatching N once-listeners used to call removeEventListener per listener,
+  // which linearly scans and shifts the live listener vector: O(N^2) total.
+  // With non-once listeners ahead of the once-listeners the linear scan is also
+  // O(N), so a quadratic dispatch is clearly visible relative to a baseline
+  // dispatch of the same number of plain listeners.
+  test("dispatching many once-listeners is O(N), not O(N^2)", () => {
+    const M = 1500;
+    function dispatch(once: boolean): number {
+      const et = new EventTarget();
+      for (let i = 0; i < M; i++) et.addEventListener("z", () => {});
+      for (let i = 0; i < M; i++) et.addEventListener("z", () => {}, once ? { once: true } : undefined);
+      Bun.gc(true);
+      const t0 = performance.now();
+      et.dispatchEvent(new Event("z"));
+      return performance.now() - t0;
+    }
+    dispatch(false);
+    const baseline = Math.min(dispatch(false), dispatch(false), dispatch(false));
+    const onceTime = Math.min(dispatch(true), dispatch(true), dispatch(true));
+    expect(onceTime).toBeLessThan(Math.max(baseline, 1) * 5);
+  }, 60_000);
+});


### PR DESCRIPTION
### What does this PR do?

Dispatching an event to N listeners registered with `{once: true}` was O(N^2): `innerInvokeEventListeners` calls `removeEventListener` for each fired once-listener, and `EventListenerMap::remove` does a linear scan (`findListener`) plus a linear `Vector::removeAt` to erase it.

For the abort-fan-out pattern (many `signal.addEventListener('abort', fn, {once: true})` on one `AbortSignal`, then `controller.abort()`) this blocked the event loop for seconds once N reached the tens of thousands.

Instead of calling `removeEventListener` per listener, mark each fired once-listener as removed in place (we already hold the `RegisteredEventListener*`) and compact the live vector in a single `removeAllMatching` pass after the dispatch loop. `findListener` now skips entries already marked removed, so a listener that re-adds itself from inside its own once-callback still registers a fresh entry.

`onDidChangeListener(Remove)` is still called once per removed listener to keep `MessagePort` / worker `m_messageEventCount` accounting correct; `eventListenersDidChange()` is called once after the compact so `AbortSignal` / `BroadcastChannel` see the final listener state.

### How did you verify your code works?

Release build, Linux x64:

```js
for (const n of [5000, 10000, 20000, 40000]) {
  const et = new EventTarget();
  for (let i = 0; i < n; i++) et.addEventListener("z", () => {}, { once: true });
  const t0 = performance.now(); et.dispatchEvent(new Event("z"));
  console.log(n, (performance.now() - t0).toFixed(1), "ms");
}
const ac = new AbortController();
for (let i = 0; i < 40000; i++) ac.signal.addEventListener("abort", () => {}, { once: true });
const t0 = performance.now(); ac.abort();
console.log("abort 40k once:", (performance.now()-t0).toFixed(1), "ms");
```

| N | before | after | node v26 |
|---|---|---|---|
| 5000 | 45 ms | 1.0 ms | ~5 ms |
| 10000 | 185 ms | 1.9 ms | ~6 ms |
| 20000 | 684 ms | 2.5 ms | ~8 ms |
| 40000 | 2118 ms | 9.4 ms | ~12 ms |
| `abort()` 40k | 2322 ms | 9.7 ms | ~15 ms |

New test file `test/js/web/events/event-target.test.ts` covers:
- ordering, single-fire and removal of many once-listeners
- non-once listeners surviving alongside once-listeners
- re-adding a listener from inside its own once-callback
- `stopImmediatePropagation` leaving unfired once-listeners in place
- `removeEventListener` from inside a once-callback
- nested dispatch from inside a once-callback
- `AbortSignal` firing many once-listeners on abort
- dispatch of N once-listeners is O(N) relative to a plain-listener baseline

Also verified `test/js/deno/event/event-target.test.ts`, `test/js/node/test/parallel/test-eventtarget*.js`, `test/js/web/abort/` and `test/js/web/broadcastchannel/` pass.

Upstream WebKit has the same per-listener `removeEventListener` call in `innerInvokeEventListeners`; this deviates from it intentionally.

Note: `addEventListener` itself is still O(N) per call due to the spec-required duplicate check in `EventListenerMap::add`, so registering N distinct listeners is still O(N^2). That is a separate change.