### PR TITLE
Bun.write: reject a sliced Bun.file() destination instead of truncating the whole file

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5015,6 +5015,16 @@ pub fn write_file_internal(
         // TODO only reset last_modified on success paths instead of resetting
         // last_modified at the beginning for better performance.
         if let store::Data::File(ref mut file) = *blob_store.data_mut() {
+            // A sliced Bun.file() (non-zero offset) would have its window
+            // ignored: the destination is opened with O_TRUNC and written from
+            // position 0, silently replacing the whole file. Reject up front
+            // rather than destroy data. `offset` is only ever non-zero via
+            // `.slice()`, so this has no false positives.
+            if blob.offset.get() != 0 {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "Cannot write to a sliced Bun.file(). Writing at an offset is not supported; write to the un-sliced file instead."
+                )));
+            }
             file.last_modified = jsc::INIT_TIMESTAMP;
         }
     }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -471,22 +471,11 @@ impl WriteFile {
             false
         };
 
-        // We have never supported offset in Bun.write().
-        // and properly adding support means we need to also support it
-        // with splice, sendfile, and the other cases.
-        //
-        // if (this.file_blob.offset > 0) {
-        //     // if we start at an offset in the file
-        //     // example code:
-        //     //
-        //     //    Bun.write(Bun.file("/tmp/lol.txt").slice(10), "hello world");
-        //     //
-        //     // it should write "hello world" to /tmp/lol.txt starting at offset 10
-        //     switch (bun.sys.setFileOffset(fd, this.file_blob.offset)) {
-        //         // we ignore errors because it should continue to work even if its a pipe
-        //         .err, .result => {},
-        //     }
-        // }
+        // We have never supported offset in Bun.write(); a sliced Bun.file()
+        // destination is rejected up front in `write_file_internal`. Properly
+        // adding support means handling it with splice, sendfile, and the other
+        // copy paths too.
+        debug_assert_eq!(self.file_blob.offset.get(), 0);
 
         if self.could_block && bun_core::is_writable(fd) == bun_core::Pollable::NotReady {
             self.wait_for_writable();

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -727,4 +727,87 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
 
     expect(f.name).toBe(filePath);
   });
+
+  describe("sliced Bun.file() as a destination", () => {
+    async function tryWrite(fn) {
+      try {
+        return { err: null, result: await fn() };
+      } catch (err) {
+        return { err, result: null };
+      }
+    }
+
+    it.each([
+      ["slice(5)", f => f.slice(5), "XY"],
+      ["slice(5, 7)", f => f.slice(5, 7), "XY"],
+      ["slice(5, 6) with oversized data", f => f.slice(5, 6), "ABCDEFGHIJKLMNOP"],
+    ])("Bun.write rejects %s and leaves the file intact", async (_label, slicer, payload) => {
+      using dir = tempDir("bun-write-sliced-dest", { "f.txt": "0123456789" });
+      const p = join(String(dir), "f.txt");
+      const dest = slicer(Bun.file(p));
+
+      const { err } = await tryWrite(() => Bun.write(dest, payload));
+      expect({ err, after: fs.readFileSync(p, "utf8") }).toEqual({
+        err: expect.any(TypeError),
+        after: "0123456789",
+      });
+      expect(err.message).toContain("sliced");
+    });
+
+    it("file.slice().write() rejects and leaves the file intact", async () => {
+      using dir = tempDir("bun-write-sliced-dest-instance", { "f.txt": "0123456789" });
+      const p = join(String(dir), "f.txt");
+
+      const { err } = await tryWrite(() => Bun.file(p).slice(5, 7).write("XY"));
+      expect({ err, after: fs.readFileSync(p, "utf8") }).toEqual({
+        err: expect.any(TypeError),
+        after: "0123456789",
+      });
+      expect(err.message).toContain("sliced");
+    });
+
+    it("large (non-fast-path) payload to a sliced destination is rejected", async () => {
+      using dir = tempDir("bun-write-sliced-dest-large", { "f.txt": "0123456789" });
+      const p = join(String(dir), "f.txt");
+      const big = Buffer.alloc(512 * 1024, "Z");
+
+      const { err } = await tryWrite(() => Bun.write(Bun.file(p).slice(5), big));
+      expect({ err, after: fs.readFileSync(p, "utf8") }).toEqual({
+        err: expect.any(TypeError),
+        after: "0123456789",
+      });
+    });
+
+    it("Bun.file as a source is rejected too", async () => {
+      using dir = tempDir("bun-write-sliced-dest-file-src", {
+        "dst.txt": "0123456789",
+        "src.txt": "abcdefghij",
+      });
+      const dst = join(String(dir), "dst.txt");
+      const src = join(String(dir), "src.txt");
+
+      const { err } = await tryWrite(() => Bun.write(Bun.file(dst).slice(5), Bun.file(src)));
+      expect({ err, after: fs.readFileSync(dst, "utf8") }).toEqual({
+        err: expect.any(TypeError),
+        after: "0123456789",
+      });
+    });
+
+    it("un-sliced Bun.file() still works after reading .size", async () => {
+      using dir = tempDir("bun-write-unsliced-after-size", { "f.txt": "0123456789" });
+      const p = join(String(dir), "f.txt");
+      const f = Bun.file(p);
+      expect(f.size).toBe(10);
+
+      const written = await Bun.write(f, "hello world, this is longer than before");
+      expect(fs.readFileSync(p, "utf8")).toBe("hello world, this is longer than before");
+      expect(written).toBe(39);
+    });
+
+    it("in-memory Blob slice destination is still rejected with the bytes message", async () => {
+      const { err } = await tryWrite(() => Bun.write(new Blob(["0123456789"]).slice(5, 7), "XY"));
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.message).toContain("backed by bytes");
+    });
+  });
 });


### PR DESCRIPTION
## What

`Bun.write(Bun.file(p).slice(a, b), data)` accepted a sliced `BunFile` as a destination but dropped the `[a, b)` window: the underlying file was opened with `O_TRUNC` and `data` was written from position 0, silently replacing the whole file. The call resolved with the written byte count, so there was no error signal. `file.slice(a, b).write(data)` went through the same path.

```js
import fs from "node:fs";
fs.writeFileSync(p, "0123456789");
await Bun.write(Bun.file(p).slice(5, 7), "XY");
fs.readFileSync(p, "utf8"); // "XY" (whole file replaced), not "01234XY789"
```

An in-memory `new Blob([...]).slice()` destination was already rejected with `"Cannot write to a Blob backed by bytes, which are always read-only"`; only the file-backed slice slipped through and clobbered.

## Cause

`write_file_internal` carries the destination `Blob` (with its `offset`/`size`) all the way into `WriteFile`, but the file is opened with `O_WRONLY | O_CREAT | O_TRUNC` and the offset is never applied. The positioned-write block in `write_file.rs` was already commented out with a note that supporting it properly requires handling splice/sendfile/copy as well.

## Fix

Reject the sliced destination up front in `write_file_internal` with a `TypeError` when the destination is a file-backed `Blob` with a non-zero `offset`. `offset` is only ever non-zero via `.slice()` (`resolve_size` clamps but never raises it from 0), so there are no false positives: an un-sliced `Bun.file()` still writes normally, including after `.size` has been read.

This covers `Bun.write(dest, ...)` and `dest.write(...)`, and both the bytes-source and file-source paths. `file.writer()` and `file.delete()` are not touched. The dead commented-out seek in `write_file.rs` is replaced with a `debug_assert_eq!(offset, 0)`.

### Not covered

`Bun.file(p).slice(0, n)` (offset 0, bounded size) still reaches `O_TRUNC`. Detecting it cleanly would need an explicit "was sliced" flag on `Blob`; `size != MAX_SIZE` has false positives because `get_size()` resolves the stat size into the same field. Happy to follow up with the flag if we want that shape covered too.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/io/bun-write.test.js -t "sliced Bun.file"  # 6 fail (clobber observed)
bun bd test test/js/bun/io/bun-write.test.js -t "sliced Bun.file"                # 8 pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->