### PR TITLE
console: guard throwing Event/AggregateError property reads in the native formatters

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4881,8 +4881,13 @@ pub mod formatter {
             }
 
             let event_type_value: JSValue = 'brk: {
-                let Some(value_) = value.get(self.global_this, "type")? else {
-                    break 'brk JSValue::UNDEFINED;
+                let value_ = match value.get(self.global_this, "type") {
+                    Ok(Some(v)) => v,
+                    Ok(None) => break 'brk JSValue::UNDEFINED,
+                    Err(_) => {
+                        self.global_this.clear_exception();
+                        break 'brk JSValue::UNDEFINED;
+                    }
                 };
                 if value_.is_string() {
                     break 'brk value_;
@@ -4956,9 +4961,15 @@ pub mod formatter {
                     );
                 }
 
-                if let Some(message_value) =
-                    value.fast_get(self.global_this, jsc::BuiltinName::Message)?
-                {
+                let message_value =
+                    match value.fast_get(self.global_this, jsc::BuiltinName::Message) {
+                        Ok(v) => v,
+                        Err(_) => {
+                            self.global_this.clear_exception();
+                            None
+                        }
+                    };
+                if let Some(message_value) = message_value {
                     if message_value.is_string() {
                         if !self.single_line {
                             self.write_indent(writer_).expect("unreachable");
@@ -4995,9 +5006,14 @@ pub mod formatter {
                             pf!("<d>"),
                             pf!("<r>")
                         );
-                        let data: JSValue = value
-                            .fast_get(self.global_this, jsc::BuiltinName::Data)?
-                            .unwrap_or(JSValue::UNDEFINED);
+                        let data: JSValue =
+                            match value.fast_get(self.global_this, jsc::BuiltinName::Data) {
+                                Ok(v) => v.unwrap_or(JSValue::UNDEFINED),
+                                Err(_) => {
+                                    self.global_this.clear_exception();
+                                    JSValue::UNDEFINED
+                                }
+                            };
                         let tag = Tag::get_advanced(data, self.global_this, self.tag_opts())?;
                         self.format::<C>(tag, writer_, data, self.global_this)?;
                         if self.failed {
@@ -5009,9 +5025,15 @@ pub mod formatter {
                         }
                     }
                     EventType::ErrorEvent => {
-                        if let Some(error_value) =
-                            value.fast_get(self.global_this, jsc::BuiltinName::Error)?
-                        {
+                        let error_value =
+                            match value.fast_get(self.global_this, jsc::BuiltinName::Error) {
+                                Ok(v) => v,
+                                Err(_) => {
+                                    self.global_this.clear_exception();
+                                    None
+                                }
+                            };
+                        if let Some(error_value) = error_value {
                             if !self.single_line {
                                 self.write_indent(writer_).expect("unreachable");
                             }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5218,11 +5218,15 @@ impl VirtualMachine {
                 allow_ansi_color,
                 allow_side_effects,
             };
-            // `getErrorsProperty` is
-            // `getDirect` (own data prop, nothrow); `for_each` may throw, in
-            // which case the error is swallowed.
+            // `getDirect` may hand back empty or a GetterSetter; `is_object()` rejects both.
             let errors = value.get_errors_property(global_ref);
-            let _ = errors.for_each(global_ref, (&raw mut ctx).cast(), agg_iter);
+            if errors.is_object()
+                && errors
+                    .for_each(global_ref, (&raw mut ctx).cast(), agg_iter)
+                    .is_err()
+            {
+                global_ref.clear_exception();
+            }
             return;
         }
 

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1829,9 +1829,13 @@ impl<'a> Formatter<'a> {
                 }
                 Tag::Event => {
                     let event_type_value: JSValue = 'brk: {
-                        let value_: JSValue = match value.get(self.global_this, "type")? {
-                            Some(v) => v,
-                            None => break 'brk JSValue::UNDEFINED,
+                        let value_: JSValue = match value.get(self.global_this, "type") {
+                            Ok(Some(v)) => v,
+                            Ok(None) => break 'brk JSValue::UNDEFINED,
+                            Err(_) => {
+                                self.global_this.clear_exception();
+                                break 'brk JSValue::UNDEFINED;
+                            }
                         };
                         if value_.is_string() {
                             break 'brk value_;
@@ -1878,9 +1882,16 @@ impl<'a> Formatter<'a> {
                             pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r>"),
                         ));
 
-                        if let Some(message_value) =
-                            value.fast_get(self.global_this, jsc::BuiltinName::Message)?
+                        let message_value = match value
+                            .fast_get(self.global_this, jsc::BuiltinName::Message)
                         {
+                            Ok(v) => v,
+                            Err(_) => {
+                                self.global_this.clear_exception();
+                                None
+                            }
+                        };
+                        if let Some(message_value) = message_value {
                             if message_value.is_string() {
                                 self.write_indent(writer.ctx).expect("unreachable");
                                 writer.print(format_args!(
@@ -1907,9 +1918,15 @@ impl<'a> Formatter<'a> {
                                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<d>"),
                                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r>"),
                                 ));
-                                let data: JSValue = value
-                                    .fast_get(self.global_this, jsc::BuiltinName::Data)?
-                                    .unwrap_or(JSValue::UNDEFINED);
+                                let data: JSValue = match value
+                                    .fast_get(self.global_this, jsc::BuiltinName::Data)
+                                {
+                                    Ok(v) => v.unwrap_or(JSValue::UNDEFINED),
+                                    Err(_) => {
+                                        self.global_this.clear_exception();
+                                        JSValue::UNDEFINED
+                                    }
+                                };
                                 let tag = Tag::get(data, self.global_this)?;
 
                                 self.format::<W, ENABLE_ANSI_COLORS>(
@@ -1918,9 +1935,16 @@ impl<'a> Formatter<'a> {
                                 writer.write_all(b", \n");
                             }
                             EventType::ErrorEvent => {
-                                if let Some(data) =
-                                    value.fast_get(self.global_this, jsc::BuiltinName::Error)?
+                                let error_value = match value
+                                    .fast_get(self.global_this, jsc::BuiltinName::Error)
                                 {
+                                    Ok(v) => v,
+                                    Err(_) => {
+                                        self.global_this.clear_exception();
+                                        None
+                                    }
+                                };
+                                if let Some(data) = error_value {
                                     self.write_indent(writer.ctx).expect("unreachable");
                                     writer.print(format_args!(
                                         "{}error{}:{} ",

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -203,6 +203,107 @@ it("MessageEvent with deleted data", () => {
   data: null,
 }`,
   );
+});
+
+it("Event subclass with a throwing getter does not make Bun.inspect throw", () => {
+  class ThrowType extends Event {
+    get type() {
+      throw new Error("type-getter-boom");
+    }
+  }
+  const typeOut = Bun.inspect(new ThrowType("t"));
+  expect(typeOut).toContain("type: [Getter]");
+  expect(typeOut).not.toContain("type-getter-boom");
+  expect(() => Bun.inspect({ payload: [new ThrowType("t")] })).not.toThrow();
+
+  class ThrowData extends MessageEvent {
+    get data() {
+      throw new Error("data-getter-boom");
+    }
+  }
+  expect(Bun.inspect(new ThrowData("message", { data: "p" }))).toBe(
+    `MessageEvent {\n  type: "message",\n  data: undefined,\n}`,
+  );
+
+  class ThrowError extends ErrorEvent {
+    get error() {
+      throw new Error("error-getter-boom");
+    }
+    get message() {
+      throw new Error("message-getter-boom");
+    }
+  }
+  expect(Bun.inspect(new ThrowError("error", { message: "m", error: new Error("i") }))).toBe(
+    `ErrorEvent {\n  type: "error",\n}`,
+  );
+
+  // Own-instance accessors (not subclass) on the Event branch reads.
+  const me = new MessageEvent("message", { data: "p" });
+  Object.defineProperty(me, "data", {
+    get() {
+      throw new Error("own-data-boom");
+    },
+    configurable: true,
+  });
+  expect(Bun.inspect(me)).toBe(`MessageEvent {\n  type: "message",\n  data: undefined,\n}`);
+  expect(Bun.inspect({ nested: me })).toContain("data: undefined");
+});
+
+it("AggregateError with a hostile 'errors' property does not make Bun.inspect throw", () => {
+  // Accessor own prop: getDirect returns the GetterSetter cell, for_each throws.
+  const a = new AggregateError([new Error("x")], "agg");
+  Object.defineProperty(a, "errors", {
+    get() {
+      throw new Error("errors-getter-boom");
+    },
+    configurable: true,
+  });
+  expect(() => Bun.inspect(a)).not.toThrow();
+  expect(() => Bun.inspect({ nested: a })).not.toThrow();
+
+  // Non-iterable data prop: for_each throws TypeError.
+  const b = new AggregateError([new Error("x")], "agg");
+  b.errors = { not: "iterable" };
+  expect(() => Bun.inspect(b)).not.toThrow();
+
+  // Deleted own prop: getDirect returns empty; used to segfault in for_each.
+  const c = new AggregateError([new Error("x")], "agg");
+  delete c.errors;
+  expect(() => Bun.inspect(c)).not.toThrow();
+});
+
+it("Event subclass with a throwing getter does not make toMatchSnapshot fail", async () => {
+  using dir = tempDir("inspect-event-snapshot", {
+    "snap.test.js": `
+      import { test, expect } from "bun:test";
+      test("type", () => {
+        class E extends Event { get type() { throw new Error("type-getter-boom"); } }
+        expect(new E("t")).toMatchSnapshot();
+      });
+      test("data", () => {
+        class M extends Event { get data() { throw new Error("data-getter-boom"); } }
+        expect(new M("message")).toMatchSnapshot();
+      });
+      test("error", () => {
+        class R extends Event {
+          get error() { throw new Error("error-getter-boom"); }
+          get message() { throw new Error("message-getter-boom"); }
+        }
+        expect(new R("error")).toMatchSnapshot();
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--update-snapshots", "snap.test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const all = stdout + stderr;
+  expect(all).not.toContain("Failed to pretty format");
+  expect(all).toContain("3 pass");
+  expect(exitCode).toBe(0);
 });
 
 // https://github.com/oven-sh/bun/issues/561


### PR DESCRIPTION
## Repro

```js
// throws out of console.log / Bun.inspect on current main; Node prints all of these
class E extends Event { get type() { throw new Error("boom") } }
console.log(new E("t"));

class M extends MessageEvent { get data() { throw new Error("boom") } }
console.log(new M("message", { data: "p" }));

class R extends ErrorEvent { get error() { throw 0 } get message() { throw 0 } }
console.log(new R("error", { message: "m", error: new Error("i") }));

const a = new AggregateError([new Error("x")], "m");
Object.defineProperty(a, "errors", { get() { throw new Error("boom") } });
console.log(a);          // TypeError escapes

const b = new AggregateError([new Error("x")], "m");
delete b.errors;
console.log(b);          // segfault at 0x5
```

## Cause

- `print_event` in `src/jsc/ConsoleObject.rs` reads `.type` / `.message` / `.data` / `.error` via `value.get(...)?` / `value.fast_get(...)?` before deciding how to render. The `?` propagates a thrown getter straight out of `console.log` / `Bun.inspect`. The near-identical `Tag::Event` arm in `src/runtime/test_runner/pretty_format.rs` (used by `toMatchSnapshot` / `DiffFormatter`) has the same four unguarded reads.
- `print_errorlike_object` in `src/jsc/VirtualMachine.rs` reads `AggregateError.errors` via `getDirect` and unconditionally hands the result to `for_each`. `getDirect` on a deleted prop returns empty (crash in `forEachInIterable`), on a `defineProperty` accessor returns the `GetterSetter` cell (debug assert in `synthesizePrototype`, TypeError in release), and on a non-iterable object `for_each` throws; the `let _ =` discarded the `JsResult` but left the exception pending on the VM.

## Fix

- Match the `Err(_)` arm on the four Event reads in both formatters, call `global_this.clear_exception()`, and fall back to `undefined` / `None`. This mirrors the existing `print_to_json` pattern in `ConsoleObject.rs`. When `.type` throws, the formatter falls through to the generic object printer which renders `type: [Getter]`.
- Gate the `AggregateError.errors` iteration on `is_object()` (excludes empty / `GetterSetter` / primitives) and clear the exception if `for_each` still throws.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/inspect.test.js -t "throwing getter|hostile"` fails (2 tests)
- `bun bd test test/js/bun/util/inspect.test.js` passes (76 tests)
- `BUN_JSC_validateExceptionChecks=1` clean

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->