### PR TITLE
fetch: honour the server's Keep-Alive: timeout= hint in the keep-alive pool

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -181,11 +181,8 @@ pub struct PooledSocket<const SSL: bool> {
     /// HTTP/2 connection state (HPACK tables, server SETTINGS) when
     /// this socket negotiated "h2". Owned by the pool while parked.
     pub h2_session: Option<NonNull<h2::ClientSession>>,
-    /// HTTP-thread monotonic timestamp (ns since `http_thread().timer`) after
-    /// which this parked socket must not be handed out. Derived from the
-    /// server's `Keep-Alive: timeout=N` hint minus
-    /// [`crate::KEEPALIVE_TIMEOUT_BUFFER_SECONDS`]. `0` means no server hint
-    /// was received and only the fixed 5-minute idle timer applies.
+    /// Reuse deadline from `Keep-Alive: timeout=N` (ns since
+    /// `http_thread().timer`); `0` = no server hint.
     pub idle_deadline_ns: u64,
 }
 
@@ -593,11 +590,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
         debug_assert!(!hostname.is_empty());
         debug_assert!(port > 0);
 
-        // Server's `Keep-Alive: timeout=N` → drop the connection before the
-        // server does. Subtract a 1 s safety margin (Node's
-        // `agentKeepAliveTimeoutBuffer` default); if that leaves 0, the
-        // server's idle window is too short to safely reuse at all, so close
-        // instead of pooling. Matches undici / Node's http.Agent.
+        // `Keep-Alive: timeout=N` minus a 1 s margin; 0 ⇒ too short to
+        // safely reuse, close instead of pooling (matches Node's http.Agent).
         let idle_seconds = keepalive_hint_seconds
             .map(|n| n.saturating_sub(crate::KEEPALIVE_TIMEOUT_BUFFER_SECONDS));
         let reusable = hostname.len() <= MAX_KEEPALIVE_HOSTNAME
@@ -624,10 +618,6 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     ActiveSocket::<SSL>::init(pending_addr.as_ptr().cast_const()),
                 );
                 socket.flush();
-                // With a server hint, arm the short-tick timer for
-                // `hint - 1 s` and also record an absolute deadline so
-                // `existing_socket` can refuse reuse even if the timer tick
-                // hasn't fired yet. Cap the hint at the fixed 5-minute ceiling.
                 let idle_deadline_ns = match idle_seconds {
                     Some(secs) => {
                         let secs = secs.min(5 * 60);
@@ -818,9 +808,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     continue;
                 }
 
-                // A socket parked with a server `Keep-Alive: timeout=N` hint
-                // that has since elapsed is about to be (or already is) closed
-                // by the peer; dispatching onto it races the server's FIN.
+                // Past the server's advertised `Keep-Alive: timeout=N` ⇒ the
+                // peer is about to (or already did) close it; don't dispatch.
                 if socket.idle_deadline_ns != 0 && now_ns >= socket.idle_deadline_ns {
                     Self::close_socket(http_socket);
                     continue;

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -308,6 +308,36 @@ impl<const SSL: bool> HTTPContext<SSL> {
         socket.close(uws::CloseKind::Normal);
     }
 
+    /// Non-blocking `MSG_PEEK` on the pooled socket's raw fd. A pooled
+    /// HTTP/1.1 socket is idle with an empty receive queue, so `recv` = 0
+    /// is a peer FIN already queued in the kernel that the event loop has
+    /// not yet dispatched; handing that socket to a new request races the
+    /// server's close and a non-idempotent request surfaces `ECONNRESET`.
+    /// The only healthy result is `EAGAIN`. Not applied to HTTP/2 (servers
+    /// legitimately send PING/SETTINGS while idle) and POSIX-only: on
+    /// Windows the pool relies on the `Keep-Alive` hint and the libuv
+    /// deferred-FIN sweep.
+    #[cfg_attr(windows, allow(unused_variables))]
+    fn probe_idle_socket_alive(socket: HTTPSocket<SSL>) -> bool {
+        #[cfg(unix)]
+        {
+            let fd = socket.fd();
+            if !fd.is_valid() {
+                return true;
+            }
+            let mut buf = [0u8; 1];
+            match bun_sys::recv(fd, &mut buf, libc::MSG_PEEK | libc::MSG_DONTWAIT) {
+                Ok(0) => false,
+                Ok(_) => true,
+                Err(e) => e.is_retry(),
+            }
+        }
+        #[cfg(windows)]
+        {
+            true
+        }
+    }
+
     /// `ptr` is the *value* stored in the socket ext (the packed
     /// `ActiveSocket` tagged pointer), already dereferenced by
     /// `NsHandler` before reaching `Handler.on*`. No second deref.
@@ -589,7 +619,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
         debug_assert!(!hostname.is_empty());
         debug_assert!(port > 0);
 
-        // `Keep-Alive: timeout=N` minus a 1 s margin; 0 ⇒ close instead of pooling (Node-compat).
+        // `Keep-Alive: timeout=N` minus the safety margin; 0 ⇒ close instead of pooling.
         let idle_seconds = keepalive_hint_seconds
             .map(|n| n.saturating_sub(crate::KEEPALIVE_TIMEOUT_BUFFER_SECONDS));
         let reusable = hostname.len() <= MAX_KEEPALIVE_HOSTNAME
@@ -808,6 +838,12 @@ impl<const SSL: bool> HTTPContext<SSL> {
 
                 // Past the server's `Keep-Alive: timeout=N`: the peer is about to close it.
                 if socket.idle_deadline_ns != 0 && now_ns >= socket.idle_deadline_ns {
+                    Self::close_socket(http_socket);
+                    continue;
+                }
+
+                // Peer FIN queued in the kernel but not yet dispatched.
+                if socket.h2_session.is_none() && !Self::probe_idle_socket_alive(http_socket) {
                     Self::close_socket(http_socket);
                     continue;
                 }

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -308,15 +308,9 @@ impl<const SSL: bool> HTTPContext<SSL> {
         socket.close(uws::CloseKind::Normal);
     }
 
-    /// Non-blocking `MSG_PEEK` on the pooled socket's raw fd. A pooled
-    /// HTTP/1.1 socket is idle with an empty receive queue, so `recv` = 0
-    /// is a peer FIN already queued in the kernel that the event loop has
-    /// not yet dispatched; handing that socket to a new request races the
-    /// server's close and a non-idempotent request surfaces `ECONNRESET`.
-    /// The only healthy result is `EAGAIN`. Not applied to HTTP/2 (servers
-    /// legitimately send PING/SETTINGS while idle) and POSIX-only: on
-    /// Windows the pool relies on the `Keep-Alive` hint and the libuv
-    /// deferred-FIN sweep.
+    /// `recv(MSG_PEEK|MSG_DONTWAIT)` on the pooled fd: 0 = peer FIN queued
+    /// in the kernel but not yet dispatched, so the socket must not be reused.
+    /// POSIX-only; caller skips HTTP/2 (servers send PING/SETTINGS while idle).
     #[cfg_attr(windows, allow(unused_variables))]
     fn probe_idle_socket_alive(socket: HTTPSocket<SSL>) -> bool {
         #[cfg(unix)]

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -308,9 +308,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
         socket.close(uws::CloseKind::Normal);
     }
 
-    /// `recv(MSG_PEEK|MSG_DONTWAIT)` on the pooled fd: 0 = peer FIN queued
-    /// in the kernel but not yet dispatched, so the socket must not be reused.
-    /// POSIX-only; caller skips HTTP/2 (servers send PING/SETTINGS while idle).
+    /// `MSG_PEEK|MSG_DONTWAIT` probe: only `EAGAIN` means an idle, reusable h1 socket. POSIX-only.
     #[cfg_attr(windows, allow(unused_variables))]
     fn probe_idle_socket_alive(socket: HTTPSocket<SSL>) -> bool {
         #[cfg(unix)]
@@ -321,8 +319,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
             }
             let mut buf = [0u8; 1];
             match bun_sys::recv(fd, &mut buf, libc::MSG_PEEK | libc::MSG_DONTWAIT) {
-                Ok(0) => false,
-                Ok(_) => true,
+                Ok(_) => false,
                 Err(e) => e.is_retry(),
             }
         }

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -181,8 +181,7 @@ pub struct PooledSocket<const SSL: bool> {
     /// HTTP/2 connection state (HPACK tables, server SETTINGS) when
     /// this socket negotiated "h2". Owned by the pool while parked.
     pub h2_session: Option<NonNull<h2::ClientSession>>,
-    /// Reuse deadline from `Keep-Alive: timeout=N` (ns since
-    /// `http_thread().timer`); `0` = no server hint.
+    /// `Keep-Alive: timeout=N` reuse deadline (ns since `http_thread().timer`); `0` = no hint.
     pub idle_deadline_ns: u64,
 }
 
@@ -590,8 +589,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
         debug_assert!(!hostname.is_empty());
         debug_assert!(port > 0);
 
-        // `Keep-Alive: timeout=N` minus a 1 s margin; 0 ⇒ too short to
-        // safely reuse, close instead of pooling (matches Node's http.Agent).
+        // `Keep-Alive: timeout=N` minus a 1 s margin; 0 ⇒ close instead of pooling (Node-compat).
         let idle_seconds = keepalive_hint_seconds
             .map(|n| n.saturating_sub(crate::KEEPALIVE_TIMEOUT_BUFFER_SECONDS));
         let reusable = hostname.len() <= MAX_KEEPALIVE_HOSTNAME
@@ -808,8 +806,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     continue;
                 }
 
-                // Past the server's advertised `Keep-Alive: timeout=N` ⇒ the
-                // peer is about to (or already did) close it; don't dispatch.
+                // Past the server's `Keep-Alive: timeout=N`: the peer is about to close it.
                 if socket.idle_deadline_ns != 0 && now_ns >= socket.idle_deadline_ns {
                     Self::close_socket(http_socket);
                     continue;

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -598,8 +598,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
         // `agentKeepAliveTimeoutBuffer` default); if that leaves 0, the
         // server's idle window is too short to safely reuse at all, so close
         // instead of pooling. Matches undici / Node's http.Agent.
-        let idle_seconds =
-            keepalive_hint_seconds.map(|n| n.saturating_sub(crate::KEEPALIVE_TIMEOUT_BUFFER_SECONDS));
+        let idle_seconds = keepalive_hint_seconds
+            .map(|n| n.saturating_sub(crate::KEEPALIVE_TIMEOUT_BUFFER_SECONDS));
         let reusable = hostname.len() <= MAX_KEEPALIVE_HOSTNAME
             && idle_seconds != Some(0)
             && !(socket.is_closed() || socket.is_shutdown() || socket.get_error() != 0)

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -181,6 +181,12 @@ pub struct PooledSocket<const SSL: bool> {
     /// HTTP/2 connection state (HPACK tables, server SETTINGS) when
     /// this socket negotiated "h2". Owned by the pool while parked.
     pub h2_session: Option<NonNull<h2::ClientSession>>,
+    /// HTTP-thread monotonic timestamp (ns since `http_thread().timer`) after
+    /// which this parked socket must not be handed out. Derived from the
+    /// server's `Keep-Alive: timeout=N` hint minus
+    /// [`crate::KEEPALIVE_TIMEOUT_BUFFER_SECONDS`]. `0` means no server hint
+    /// was received and only the fixed 5-minute idle timer applies.
+    pub idle_deadline_ns: u64,
 }
 
 /// Upgrade an `Option<NonNull<h2::ClientSession>>` held by a pool / found-slot
@@ -577,6 +583,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
         target_port: u16,
         proxy_auth_hash: u64,
         h2_session: Option<NonNull<h2::ClientSession>>,
+        keepalive_hint_seconds: Option<u32>,
     ) {
         // log("releaseSocket(0x{f})", .{bun.fmt.hexIntUpper(@intFromPtr(socket.socket))});
 
@@ -586,10 +593,19 @@ impl<const SSL: bool> HTTPContext<SSL> {
         debug_assert!(!hostname.is_empty());
         debug_assert!(port > 0);
 
-        if hostname.len() <= MAX_KEEPALIVE_HOSTNAME
+        // Server's `Keep-Alive: timeout=N` → drop the connection before the
+        // server does. Subtract a 1 s safety margin (Node's
+        // `agentKeepAliveTimeoutBuffer` default); if that leaves 0, the
+        // server's idle window is too short to safely reuse at all, so close
+        // instead of pooling. Matches undici / Node's http.Agent.
+        let idle_seconds =
+            keepalive_hint_seconds.map(|n| n.saturating_sub(crate::KEEPALIVE_TIMEOUT_BUFFER_SECONDS));
+        let reusable = hostname.len() <= MAX_KEEPALIVE_HOSTNAME
+            && idle_seconds != Some(0)
             && !(socket.is_closed() || socket.is_shutdown() || socket.get_error() != 0)
-            && socket.is_established()
-        {
+            && socket.is_established();
+
+        if reusable {
             // Captured before `claim()` so the `&mut self.pending_sockets`
             // borrow held by the `HiveSlot` doesn't conflict with a whole-`self`
             // borrow inside the initializer.
@@ -608,8 +624,27 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     ActiveSocket::<SSL>::init(pending_addr.as_ptr().cast_const()),
                 );
                 socket.flush();
-                socket.timeout(0);
-                socket.set_timeout_minutes(5);
+                // With a server hint, arm the short-tick timer for
+                // `hint - 1 s` and also record an absolute deadline so
+                // `existing_socket` can refuse reuse even if the timer tick
+                // hasn't fired yet. Cap the hint at the fixed 5-minute ceiling.
+                let idle_deadline_ns = match idle_seconds {
+                    Some(secs) => {
+                        let secs = secs.min(5 * 60);
+                        socket.set_timeout(secs);
+                        http::http_thread()
+                            .timer
+                            .elapsed()
+                            .as_nanos()
+                            .saturating_add(u128::from(secs) * 1_000_000_000)
+                            as u64
+                    }
+                    None => {
+                        socket.timeout(0);
+                        socket.set_timeout_minutes(5);
+                        0
+                    }
+                };
 
                 let had_tunnel = tunnel.is_some();
                 let mut hostname_buf = [0u8; MAX_KEEPALIVE_HOSTNAME];
@@ -636,6 +671,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     target_port,
                     proxy_auth_hash,
                     h2_session,
+                    idle_deadline_ns,
                 });
 
                 bun_core::scoped_log!(
@@ -686,6 +722,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
             return None;
         }
 
+        let now_ns = http::http_thread().timer.elapsed().as_nanos() as u64;
         let mut iter = self.pending_sockets.used.iterator::<true, true>();
 
         while let Some(pending_socket_index) = iter.next() {
@@ -778,6 +815,14 @@ impl<const SSL: bool> HTTPContext<SSL> {
 
                 if http_socket.is_shutdown() || http_socket.get_error() != 0 {
                     Self::terminate_socket(http_socket);
+                    continue;
+                }
+
+                // A socket parked with a server `Keep-Alive: timeout=N` hint
+                // that has since elapsed is about to be (or already is) closed
+                // by the peer; dispatching onto it races the server's FIN.
+                if socket.idle_deadline_ns != 0 && now_ns >= socket.idle_deadline_ns {
+                    Self::close_socket(http_socket);
                     continue;
                 }
 

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -31,10 +31,8 @@ pub struct InternalState<'a> {
     pub body_out_str: Option<NonNull<MutableString>>,
     pub compressed_body: MutableString,
     pub content_length: Option<usize>,
-    /// The `timeout=N` parameter from the response's `Keep-Alive` header, in
-    /// seconds. `None` when the header is absent or carries no `timeout`
-    /// parameter. Consumed by the keep-alive pool on release so the pooled
-    /// socket is dropped before the server closes its side.
+    /// `timeout=N` from the response's `Keep-Alive` header; bounds the pooled
+    /// socket's idle lifetime on release.
     pub keepalive_timeout_seconds: Option<u32>,
     pub total_body_received: usize,
     // Self-borrow into `original_request_body.bytes`; `RawSlice` carries the

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -31,8 +31,7 @@ pub struct InternalState<'a> {
     pub body_out_str: Option<NonNull<MutableString>>,
     pub compressed_body: MutableString,
     pub content_length: Option<usize>,
-    /// `timeout=N` from the response's `Keep-Alive` header; bounds the pooled
-    /// socket's idle lifetime on release.
+    /// `timeout=N` from the response's `Keep-Alive` header; bounds pooled-socket idle lifetime.
     pub keepalive_timeout_seconds: Option<u32>,
     pub total_body_received: usize,
     // Self-borrow into `original_request_body.bytes`; `RawSlice` carries the

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -31,6 +31,11 @@ pub struct InternalState<'a> {
     pub body_out_str: Option<NonNull<MutableString>>,
     pub compressed_body: MutableString,
     pub content_length: Option<usize>,
+    /// The `timeout=N` parameter from the response's `Keep-Alive` header, in
+    /// seconds. `None` when the header is absent or carries no `timeout`
+    /// parameter. Consumed by the keep-alive pool on release so the pooled
+    /// socket is dropped before the server closes its side.
+    pub keepalive_timeout_seconds: Option<u32>,
     pub total_body_received: usize,
     // Self-borrow into `original_request_body.bytes`; `RawSlice` carries the
     // outlives-holder invariant (the backing `original_request_body` is a
@@ -127,6 +132,7 @@ impl Default for InternalState<'_> {
             body_out_str: None,
             compressed_body: MutableString::init_empty(),
             content_length: None,
+            keepalive_timeout_seconds: None,
             total_body_received: 0,
             request_body: bun_ptr::RawSlice::EMPTY,
             original_request_body: HTTPRequestBody::Bytes(b""),

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -953,6 +953,7 @@ impl ClientSession {
                 0,
                 self.host_header_hash,
                 Some(self_ptr),
+                None,
             );
         } else {
             NewHTTPContext::<true>::close_socket(self.socket);

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4912,6 +4912,13 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Keep-Alive") => {
+                    // RFC 9110 §9.3.6: the proxy's CONNECT 200 hint does not govern the opaque tunnel.
+                    if self.flags.proxy_tunneling
+                        && self.proxy_tunnel.is_none()
+                        && response.status_code == 200
+                    {
+                        continue;
+                    }
                     if let Some(secs) = parse_keepalive_timeout(header.value()) {
                         self.state.keepalive_timeout_seconds = Some(secs);
                     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -991,9 +991,7 @@ fn hash_header_const(name: &[u8]) -> u64 {
     hash_header_name(name)
 }
 
-/// Margin subtracted from a `Keep-Alive: timeout=N` hint before pooling
-/// (undici's `keepAliveTimeoutThreshold` default, 2 s). A hint at or below
-/// the margin means the safe idle window is empty: close instead of pooling.
+/// Margin subtracted from a `Keep-Alive: timeout=N` hint (undici's `keepAliveTimeoutThreshold`, 2 s).
 pub(crate) const KEEPALIVE_TIMEOUT_BUFFER_SECONDS: u32 = 2;
 
 /// `timeout=` parameter from a `Keep-Alive` header value (`timeout=5, max=100`). Case-insensitive.

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -991,15 +991,12 @@ fn hash_header_const(name: &[u8]) -> u64 {
     hash_header_name(name)
 }
 
-/// Safety margin subtracted from the server's `Keep-Alive: timeout=N` hint so
-/// the pool drops an idle connection before the server does. Matches Node's
-/// `http.Agent` `agentKeepAliveTimeoutBuffer` default.
+/// Margin subtracted from the server's `Keep-Alive: timeout=N` hint; matches
+/// Node's `agentKeepAliveTimeoutBuffer` default.
 pub(crate) const KEEPALIVE_TIMEOUT_BUFFER_SECONDS: u32 = 1;
 
-/// Parse the `timeout` parameter from a `Keep-Alive` header value
-/// (`timeout=5, max=100`). Parameter name is case-insensitive; a leading
-/// `max=` (Apache's ordering) is accepted. Returns `None` when no `timeout=`
-/// parameter is present or its value is not a non-negative integer.
+/// `timeout=` parameter from a `Keep-Alive` header value such as
+/// `timeout=5, max=100`. Case-insensitive, any parameter order.
 pub(crate) fn parse_keepalive_timeout(value: &[u8]) -> Option<u32> {
     for param in value.split(|&b| b == b',') {
         let param = param.trim_ascii();
@@ -4917,11 +4914,6 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Keep-Alive") => {
-                    // RFC 9112 Appendix A.1.2: `timeout=N` advertises how long
-                    // the server will keep an idle connection open. Honoring it
-                    // lets the pool drop the socket before the server does,
-                    // avoiding the ECONNRESET race on a request dispatched at
-                    // the server's expiry. Matches undici / Node's http.Agent.
                     if let Some(secs) = parse_keepalive_timeout(header.value()) {
                         self.state.keepalive_timeout_seconds = Some(secs);
                     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -991,12 +991,10 @@ fn hash_header_const(name: &[u8]) -> u64 {
     hash_header_name(name)
 }
 
-/// Margin subtracted from the server's `Keep-Alive: timeout=N` hint; matches
-/// Node's `agentKeepAliveTimeoutBuffer` default.
+/// Margin subtracted from a `Keep-Alive: timeout=N` hint (Node's `agentKeepAliveTimeoutBuffer`).
 pub(crate) const KEEPALIVE_TIMEOUT_BUFFER_SECONDS: u32 = 1;
 
-/// `timeout=` parameter from a `Keep-Alive` header value such as
-/// `timeout=5, max=100`. Case-insensitive, any parameter order.
+/// `timeout=` parameter from a `Keep-Alive` header value (`timeout=5, max=100`). Case-insensitive.
 pub(crate) fn parse_keepalive_timeout(value: &[u8]) -> Option<u32> {
     for param in value.split(|&b| b == b',') {
         let param = param.trim_ascii();

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1003,9 +1003,7 @@ pub(crate) const KEEPALIVE_TIMEOUT_BUFFER_SECONDS: u32 = 1;
 pub(crate) fn parse_keepalive_timeout(value: &[u8]) -> Option<u32> {
     for param in value.split(|&b| b == b',') {
         let param = param.trim_ascii();
-        if param.len() > 8
-            && strings::eql_case_insensitive_ascii(&param[..8], b"timeout=", false)
-        {
+        if param.len() > 8 && strings::eql_case_insensitive_ascii(&param[..8], b"timeout=", false) {
             let digits = param[8..].trim_ascii();
             if let Ok(n) = bun_core::parse_unsigned::<u32>(digits, 10) {
                 return Some(n);

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -991,6 +991,30 @@ fn hash_header_const(name: &[u8]) -> u64 {
     hash_header_name(name)
 }
 
+/// Safety margin subtracted from the server's `Keep-Alive: timeout=N` hint so
+/// the pool drops an idle connection before the server does. Matches Node's
+/// `http.Agent` `agentKeepAliveTimeoutBuffer` default.
+pub(crate) const KEEPALIVE_TIMEOUT_BUFFER_SECONDS: u32 = 1;
+
+/// Parse the `timeout` parameter from a `Keep-Alive` header value
+/// (`timeout=5, max=100`). Parameter name is case-insensitive; a leading
+/// `max=` (Apache's ordering) is accepted. Returns `None` when no `timeout=`
+/// parameter is present or its value is not a non-negative integer.
+pub(crate) fn parse_keepalive_timeout(value: &[u8]) -> Option<u32> {
+    for param in value.split(|&b| b == b',') {
+        let param = param.trim_ascii();
+        if param.len() > 8
+            && strings::eql_case_insensitive_ascii(&param[..8], b"timeout=", false)
+        {
+            let digits = param[8..].trim_ascii();
+            if let Ok(n) = bun_core::parse_unsigned::<u32>(digits, 10) {
+                return Some(n);
+            }
+        }
+    }
+    None
+}
+
 bun_core::comptime_string_map! {
     /// Request-body-header names
     /// (https://fetch.spec.whatwg.org/#request-body-header-name).
@@ -2618,6 +2642,7 @@ impl<'a> HTTPClient<'a> {
                 0,
                 0,
                 None,
+                self.state.keepalive_timeout_seconds,
             );
         } else {
             GenHttpContext::<IS_SSL>::close_socket(socket);
@@ -4200,6 +4225,7 @@ impl<'a> HTTPClient<'a> {
                         0
                     },
                     None,
+                    self.state.keepalive_timeout_seconds,
                 );
             } else {
                 if self.proxy_tunnel.is_some() {
@@ -4376,6 +4402,7 @@ impl<'a> HTTPClient<'a> {
             b"",
             0,
             0,
+            None,
             None,
         );
 
@@ -4889,6 +4916,16 @@ impl<'a> HTTPClient<'a> {
                         ) {
                             self.state.flags.allow_keepalive = true;
                         }
+                    }
+                }
+                h if h == hash_header_const(b"Keep-Alive") => {
+                    // RFC 9112 Appendix A.1.2: `timeout=N` advertises how long
+                    // the server will keep an idle connection open. Honoring it
+                    // lets the pool drop the socket before the server does,
+                    // avoiding the ECONNRESET race on a request dispatched at
+                    // the server's expiry. Matches undici / Node's http.Agent.
+                    if let Some(secs) = parse_keepalive_timeout(header.value()) {
+                        self.state.keepalive_timeout_seconds = Some(secs);
                     }
                 }
                 h if h == hash_header_const(b"Last-Modified") => {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -991,8 +991,10 @@ fn hash_header_const(name: &[u8]) -> u64 {
     hash_header_name(name)
 }
 
-/// Margin subtracted from a `Keep-Alive: timeout=N` hint (Node's `agentKeepAliveTimeoutBuffer`).
-pub(crate) const KEEPALIVE_TIMEOUT_BUFFER_SECONDS: u32 = 1;
+/// Margin subtracted from a `Keep-Alive: timeout=N` hint before pooling
+/// (undici's `keepAliveTimeoutThreshold` default, 2 s). A hint at or below
+/// the margin means the safe idle window is empty: close instead of pooling.
+pub(crate) const KEEPALIVE_TIMEOUT_BUFFER_SECONDS: u32 = 2;
 
 /// `timeout=` parameter from a `Keep-Alive` header value (`timeout=5, max=100`). Case-insensitive.
 pub(crate) fn parse_keepalive_timeout(value: &[u8]) -> Option<u32> {

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -39,7 +39,7 @@ test("fetch honours the server's Keep-Alive: timeout= hint", async () => {
         const { server, conns } = mkServer(hint);
         await new Promise(r => server.listen(0, "127.0.0.1", r));
         const url = "http://127.0.0.1:" + server.address().port + "/";
-        for (let i = 0; i < 4; i++) await (await fetch(url)).text();
+        for (let i = 0; i < 2; i++) await (await fetch(url)).text();
         server.close();
         return conns();
       };
@@ -48,15 +48,13 @@ test("fetch honours the server's Keep-Alive: timeout= hint", async () => {
       // idle window, so each request must open a fresh connection (matches
       // Node: canKeepSocketAlive = false when serverHintTimeout <= 0).
       const short = await run("timeout=1");
-      // timeout=0 → never safe to reuse.
-      const zero = await run("timeout=0");
       // Apache's "max=100, timeout=1" ordering must parse the same.
       const reordered = await run("max=100, timeout=1");
       // timeout=60 → well above the margin; sequential requests reuse one
       // connection (regression guard: the hint must not disable keep-alive).
       const long = await run("timeout=60");
 
-      console.log(JSON.stringify({ short, zero, reordered, long }));
+      console.log(JSON.stringify({ short, reordered, long }));
       process.exit(0);
       `,
     ],
@@ -69,8 +67,8 @@ test("fetch honours the server's Keep-Alive: timeout= hint", async () => {
   const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
   expect({ result, exitCode }).toEqual({
     // Without the fix the hint is ignored and every case reuses one connection
-    // (short/zero/reordered would be 1).
-    result: { short: 4, zero: 4, reordered: 4, long: 1 },
+    // (short/reordered would be 1).
+    result: { short: 2, reordered: 2, long: 1 },
     exitCode: 0,
   });
 });

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -1,6 +1,80 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tls } from "harness";
 
+// The server's `Keep-Alive: timeout=N` hint advertises when it will close an
+// idle connection. The pool must stop reusing the socket before that window
+// (undici / Node's http.Agent subtract a 1 s safety margin), otherwise a
+// request dispatched at the server's expiry lands on a socket the server is
+// closing and the caller sees a spurious ECONNRESET. Subprocess so the pool
+// state is isolated from the rest of the suite.
+test("fetch honours the server's Keep-Alive: timeout= hint", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      const mkServer = hint => {
+        let conns = 0;
+        const server = net.createServer(sock => {
+          conns++;
+          sock.on("error", () => {});
+          let buf = "";
+          sock.on("data", d => {
+            buf += d.toString("latin1");
+            let i;
+            while ((i = buf.indexOf("\\r\\n\\r\\n")) !== -1) {
+              buf = buf.slice(i + 4);
+              sock.write(
+                "HTTP/1.1 200 OK\\r\\nConnection: keep-alive\\r\\nKeep-Alive: " + hint +
+                "\\r\\nContent-Length: 2\\r\\n\\r\\nok",
+              );
+            }
+          });
+        });
+        return { server, conns: () => conns };
+      };
+
+      const run = async hint => {
+        const { server, conns } = mkServer(hint);
+        await new Promise(r => server.listen(0, "127.0.0.1", r));
+        const url = "http://127.0.0.1:" + server.address().port + "/";
+        for (let i = 0; i < 4; i++) await (await fetch(url)).text();
+        server.close();
+        return conns();
+      };
+
+      // timeout=1: after the 1 s safety margin is subtracted there is no safe
+      // idle window, so each request must open a fresh connection (matches
+      // Node: canKeepSocketAlive = false when serverHintTimeout <= 0).
+      const short = await run("timeout=1");
+      // timeout=0 → never safe to reuse.
+      const zero = await run("timeout=0");
+      // Apache's "max=100, timeout=1" ordering must parse the same.
+      const reordered = await run("max=100, timeout=1");
+      // timeout=60 → well above the margin; sequential requests reuse one
+      // connection (regression guard: the hint must not disable keep-alive).
+      const long = await run("timeout=60");
+
+      console.log(JSON.stringify({ short, zero, reordered, long }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    // Without the fix the hint is ignored and every case reuses one connection
+    // (short/zero/reordered would be 1).
+    result: { short: 4, zero: 4, reordered: 4, long: 1 },
+    exitCode: 0,
+  });
+});
+
 test("keepalive", async () => {
   using server = Bun.serve({
     port: 0,

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -3,10 +3,10 @@ import { bunEnv, bunExe, tls } from "harness";
 
 // The server's `Keep-Alive: timeout=N` hint advertises when it will close an
 // idle connection. The pool must stop reusing the socket before that window
-// (undici / Node's http.Agent subtract a 1 s safety margin), otherwise a
-// request dispatched at the server's expiry lands on a socket the server is
-// closing and the caller sees a spurious ECONNRESET. Subprocess so the pool
-// state is isolated from the rest of the suite.
+// (undici subtracts a 2 s safety margin, `keepAliveTimeoutThreshold`),
+// otherwise a request dispatched at the server's expiry lands on a socket the
+// server is closing and the caller sees a spurious ECONNRESET. Subprocess so
+// the pool state is isolated from the rest of the suite.
 test("fetch honours the server's Keep-Alive: timeout= hint", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -44,17 +44,18 @@ test("fetch honours the server's Keep-Alive: timeout= hint", async () => {
         return conns();
       };
 
-      // timeout=1: after the 1 s safety margin is subtracted there is no safe
-      // idle window, so each request must open a fresh connection (matches
-      // Node: canKeepSocketAlive = false when serverHintTimeout <= 0).
+      // timeout<=2: after the 2 s safety margin is subtracted there is no
+      // safe idle window, so each request must open a fresh connection
+      // (matches undici: don't pool when hint - threshold <= 0).
       const short = await run("timeout=1");
+      const atMargin = await run("timeout=2");
       // Apache's "max=100, timeout=1" ordering must parse the same.
       const reordered = await run("max=100, timeout=1");
       // timeout=60 → well above the margin; sequential requests reuse one
       // connection (regression guard: the hint must not disable keep-alive).
       const long = await run("timeout=60");
 
-      console.log(JSON.stringify({ short, reordered, long }));
+      console.log(JSON.stringify({ short, atMargin, reordered, long }));
       process.exit(0);
       `,
     ],
@@ -67,8 +68,8 @@ test("fetch honours the server's Keep-Alive: timeout= hint", async () => {
   const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
   expect({ result, exitCode }).toEqual({
     // Without the fix the hint is ignored and every case reuses one connection
-    // (short/reordered would be 1).
-    result: { short: 2, reordered: 2, long: 1 },
+    // (short/atMargin/reordered would be 1).
+    result: { short: 2, atMargin: 2, reordered: 2, long: 1 },
     exitCode: 0,
   });
 });


### PR DESCRIPTION
## What

The HTTP/1.1 keep-alive pool held every pooled connection on a fixed 5-minute idle timer and never read the response's `Keep-Alive` header. Against a server that advertises `Keep-Alive: timeout=1` and closes the idle connection 1 s after its last response (the nginx/apache `keepalive_timeout` shape), bun would hand the pooled socket to the next request right at the server's expiry. A non-idempotent request dispatched at that moment lands on a socket the server is closing and surfaces a spurious `ECONNRESET` to the caller; GETs are transparently retried so the race is invisible there.

undici avoids this by subtracting a 2 s safety margin (`keepAliveTimeoutThreshold`) from the advertised timeout and either not pooling the socket at all (when the remaining window is 0) or bounding its idle lifetime by the hint.

Fixes #3801.

## Repro

```js
import net from "node:net";
let conns = 0;
const server = net.createServer(sock => {
  conns++;
  let buf = "";
  sock.on("error", () => {});
  sock.on("data", d => {
    buf += d.toString("latin1");
    let i;
    while ((i = buf.indexOf("\r\n\r\n")) !== -1) {
      buf = buf.slice(i + 4);
      sock.write("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nKeep-Alive: timeout=1\r\nContent-Length: 2\r\n\r\nok");
    }
  });
});
await new Promise(r => server.listen(0, "127.0.0.1", r));
const url = `http://127.0.0.1:${server.address().port}/`;
for (let i = 0; i < 4; i++) await (await fetch(url)).text();
console.log({ conns });
process.exit(0);
```

before: `{ conns: 1 }` (hint ignored, connection reused across the advertised expiry)
node: `{ conns: 4 }`
after: `{ conns: 4 }`

## Fix

- `handle_response_metadata` now parses the `timeout=` parameter from the `Keep-Alive` response header (case-insensitive, accepts Apache's `max=100, timeout=5` ordering) into `InternalState.keepalive_timeout_seconds`. A `Keep-Alive` header on the proxy's CONNECT 200 response is ignored (it governs the hop to the proxy, not the opaque tunnel).
- `release_socket` takes the hint: subtract a 2 s safety margin (undici's `keepAliveTimeoutThreshold` default); if the result is 0 the socket is closed instead of pooled. Otherwise the pooled socket is armed with a short idle timer of `hint - 2` seconds (capped at the existing 5-minute ceiling) and stamped with an absolute `idle_deadline_ns`.
- `existing_socket` refuses to hand out a parked socket past its `idle_deadline_ns`, closing it instead. This makes the reuse decision independent of uSockets timer-tick granularity.
- `existing_socket` also does a non-blocking `recv(MSG_PEEK|MSG_DONTWAIT)` on the pooled fd before handing it back (POSIX only, HTTP/1.1 only). A 0-byte read is a peer FIN already queued in the kernel that the event loop has not yet dispatched; the probe discards the socket so the request opens a fresh connection instead of racing the server's close. HTTP/2 sockets are skipped (servers legitimately send PING/SETTINGS while idle); on Windows the pool relies on the hint and the existing libuv deferred-FIN sweep.

No hint (the common case) keeps the existing 5-minute idle timer and `idle_deadline_ns = 0`.

## Verification

New test in `test/js/web/fetch/fetch-keepalive.test.ts` asserts `timeout=1` / `timeout=2` / `max=100, timeout=1` each open 2 connections for 2 sequential requests, while `timeout=60` still reuses a single connection (so the hint does not accidentally disable keep-alive).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-keepalive.test.ts
bun test v1.4.0 (1adf1f209)

test/js/web/fetch/fetch-keepalive.test.ts:
64 |     stderr: "pipe",
65 |   });
66 | 
67 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
68 |   const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
69 |   expect({ result, exitCode }).toEqual({
                                    ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "result": {
-     "atMargin": 2,
+     "atMargin": 1,
      "long": 1,
-     "reordered": 2,
-     "short": 2,
+     "reordered": 1,
+     "short": 1,
    },
  }

- Expected  - 3
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-keepalive.test.ts:69:32)
(fail) fetch honours the server's Keep-Alive: timeout= hint [2244.94ms]
(pass) keepalive [84.37ms]
(pass) fetch does not reuse a pooled TLS connection for a request with a different Host header [260.62ms]
(pass) PUT with a ReadableStream body is no
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/fetch-keepalive.test.ts:
64 |     stderr: "pipe",
65 |   });
66 | 
67 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
68 |   const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
69 |   expect({ result, exitCode }).toEqual({
                                    ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "result": {
-     "atMargin": 2,
+     "atMargin": 1,
      "long": 1,
-     "reordered": 2,
-     "short": 2,
+     "reordered": 1,
+     "short": 1,
    },
  }

- Expected  - 3
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-keepalive.test.ts:69:32)
(fail) fetch honours the server's Keep-Alive: timeout= hint [60.88ms]
(pass) keepalive [4.40ms]
(pass) fetch does not reuse a pooled TLS connection for a request with a different Host header [19.96ms]
(pass) PUT with a ReadableStream body is not retried on keep-alive disconnect [32.09ms]
(pass) an early response to a streaming POST closes the socket instead of pooling it mid-chunked-body [53.78ms]
(pass) a comp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-keepalive.test.ts
bun test v1.4.0 (1adf1f209)

test/js/web/fetch/fetch-keepalive.test.ts:
(pass) fetch honours the server's Keep-Alive: timeout= hint [2513.34ms]
(pass) keepalive [94.45ms]
(pass) fetch does not reuse a pooled TLS connection for a request with a different Host header [291.44ms]
(pass) PUT with a ReadableStream body is not retried on keep-alive disconnect [670.66ms]
(pass) an early response to a streaming POST closes the socket instead of pooling it mid-chunked-body [2090.36ms]
(pass) a completed streaming POST keeps its connection in the keep-alive pool [2193.21ms]

 6 pass
 0 fail
 9 expect() calls
Ran 6 tests across 1 file. [11.61s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1adf1f2091
  features     baseline

22 deps, 108 codegen, 1171 objects in 1722ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] gen bindgenv2
[3/1234] gen .bind.ts → GeneratedBindings.cpp
[4/1234] fetch zlib
[zlib] up to date
[5/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1234] fetch tinycc
[tinycc] up to date
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1234] subst deps/zlib/zlib.h
[11/1234] subst deps/zlib/zconf.h
[12/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/HTTPContext.rs                   | 68 +++++++++++++++++++++++++---
 src/http/InternalState.rs                 |  3 ++
 src/http/h2_client/ClientSession.rs       |  1 +
 src/http/lib.rs                           | 32 ++++++++++++++
 test/js/web/fetch/fetch-keepalive.test.ts | 73 +++++++++++++++++++++++++++++++
 5 files changed, 172 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/HTTPContext.rs                       14     19      0
src/http/InternalState.rs                      3      5      0
src/http/h2_client/ClientSession.rs            1      1      0
src/http/lib.rs                               13     10      0
test/js/web/fetch/fetch-keepalive.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->