### PR TITLE
install: show blocked-postinstall notice when registry omits hasInstallScript

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1923,13 +1923,9 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            // For npm packages `meta.has_install_script()` is the registry's
-                            // `hasInstallScript` packument field, which a minimal/private
-                            // registry may omit (false negative) or which may be a false positive
-                            // when the published tarball dropped its binding.gyp. For every other
-                            // resolution tag the flag was derived from the installed
-                            // package.json + binding.gyp, so it is authoritative and skips the
-                            // disk read when there is nothing to count.
+                            // `has_install_script()` is registry-supplied for npm (may be wrong
+                            // either way); non-npm tags derived it from package.json so it is
+                            // authoritative there.
                             if !is_trusted
                                 && (resolution.tag == resolution::Tag::Npm
                                     || self.metas[package_id as usize].has_install_script())

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1923,9 +1923,17 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            if !is_trusted && self.metas[package_id as usize].has_install_script() {
-                                // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
-                                // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
+                            // For npm packages `meta.has_install_script()` is the registry's
+                            // `hasInstallScript` packument field, which a minimal/private
+                            // registry may omit (false negative) or which may be a false positive
+                            // when the published tarball dropped its binding.gyp. For every other
+                            // resolution tag the flag was derived from the installed
+                            // package.json + binding.gyp, so it is authoritative and skips the
+                            // disk read when there is nothing to count.
+                            if !is_trusted
+                                && (resolution.tag == resolution::Tag::Npm
+                                    || self.metas[package_id as usize].has_install_script())
+                            {
                                 let mut folder_path =
                                     AutoAbsPath::from(self.node_modules.path.as_slice())
                                         .unwrap_or_oom();

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1103,6 +1103,9 @@ impl<'a> PackageInstaller<'a> {
             let mut string_builder = temp_lockfile.string_builder();
             let log = self.manager().log_mut();
             if let Err(err) = temp.fill_from_package_json(&mut string_builder, log, folder_path) {
+                if matches!(err, crate::Error::Sys(bun_errno::SystemErrno::ENOENT)) {
+                    return 0;
+                }
                 if log_level != Options::LogLevel::Silent {
                     Output::err_generic(
                         "failed to fill lifecycle scripts for <b>{}<r>: {}",
@@ -1923,11 +1926,7 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            // npm's flag is registry-supplied and may be wrong; non-npm derived it from disk.
-                            if !is_trusted
-                                && (resolution.tag == resolution::Tag::Npm
-                                    || self.metas[package_id as usize].has_install_script())
-                            {
+                            if !is_trusted {
                                 let mut folder_path =
                                     AutoAbsPath::from(self.node_modules.path.as_slice())
                                         .unwrap_or_oom();

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1923,9 +1923,7 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            // `has_install_script()` is registry-supplied for npm (may be wrong
-                            // either way); non-npm tags derived it from package.json so it is
-                            // authoritative there.
+                            // npm's flag is registry-supplied and may be wrong; non-npm derived it from disk.
                             if !is_trusted
                                 && (resolution.tag == resolution::Tag::Npm
                                     || self.metas[package_id as usize].has_install_script())

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -211,6 +211,98 @@ test.concurrent("trustedDependencies matches the resolved package name, not the 
   expect(await exited).toBe(0);
 });
 
+describe.concurrent.each([
+  ["omitted", undefined],
+  ["false", false],
+])("blocked-script notice when registry hasInstallScript is %s", (_, hasInstallScript) => {
+  // A private/minimal registry may omit the npm `hasInstallScript` packument
+  // field (or a hostile one may set it to false). The install-time
+  // "Blocked N postinstalls" notice must come from the installed
+  // package.json / binding.gyp, not from that registry-supplied flag, so it
+  // agrees with `bun pm untrusted`.
+  async function installFromMinimalRegistry(pkgName: string, tgz: string) {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+
+    await using registry = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith(".tgz")) {
+          return new Response(file(join(import.meta.dir, "registry", "packages", pkgName, tgz)));
+        }
+        return Response.json({
+          name: pkgName,
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: pkgName,
+              version: "1.0.0",
+              ...(hasInstallScript !== undefined ? { hasInstallScript } : {}),
+              dist: { tarball: `${registry.url}${pkgName}/-/${tgz}` },
+            },
+          },
+        });
+      },
+    });
+
+    await write(
+      join(packageDir, "bunfig.toml"),
+      `[install]\ncache = "${join(packageDir, ".bun-cache").replaceAll("\\", "\\\\")}"\nregistry = "${registry.url}"\nlinker = "hoisted"\n`,
+    );
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: { [pkgName]: "1.0.0" },
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    return { out, err, code, packageDir };
+  }
+
+  test("package.json scripts", async () => {
+    const { out, err, code, packageDir } = await installFromMinimalRegistry(
+      "lifecycle-postinstall",
+      "lifecycle-postinstall-1.0.0.tgz",
+    );
+    expect(err).not.toContain("error:");
+    expect(out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/)).toEqual([
+      expect.stringContaining("bun install v1."),
+      "",
+      "+ lifecycle-postinstall@1.0.0",
+      "",
+      "1 package installed",
+      "",
+      "Blocked 1 postinstall. Run `bun pm untrusted` for details.",
+      "",
+    ]);
+    expect(await exists(join(packageDir, "node_modules", "lifecycle-postinstall", "postinstall.txt"))).toBeFalse();
+    expect(code).toBe(0);
+  });
+
+  test("binding.gyp", async () => {
+    const { out, err, code, packageDir } = await installFromMinimalRegistry(
+      "binding-gyp-scripts",
+      "binding-gyp-scripts-1.5.0.tgz",
+    );
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Blocked 1 postinstall. Run `bun pm untrusted` for details.");
+    expect(await exists(join(packageDir, "node_modules", "binding-gyp-scripts", "build.node"))).toBeFalse();
+    expect(code).toBe(0);
+  });
+});
+
 test.concurrent("default trusted dependencies require the canonical registry tarball URL", async () => {
   using ctx = await setupTest();
   const { packageDir, packageJson, env } = ctx;


### PR DESCRIPTION
## What

The install-time `Blocked N postinstalls. Run `bun pm untrusted` for details.` notice for untrusted dependencies is now derived from the installed package.json and `binding.gyp`, matching what `bun pm untrusted` reports.

## Why

The notice was gated on `meta.has_install_script()`, which is unreliable on several paths:

- For npm packages it is the registry's `hasInstallScript` packument field. A minimal or private registry that does not compute that field (it is npm.js-specific packument metadata), or a hostile one that sets it to `false`, produced a clean-looking install with no notice even though the dependency has install scripts.
- For every resolution tag, the flag is not serialised in `bun.lock`, is forced to `False` on yarn-lockfile migration, and is blanket-reset on old-format binary lockfile upgrade. So a git/github/tarball dependency with scripts would also skip the notice on a warm-cache reinstall from a text lockfile.

Script execution was always gated correctly (the trust gate never consults the flag), so this is an audit-hint gap: the operator's only passive signal that a dependency wanted to run code was delegated to state the installer cannot trust.

### Repro

```sh
# serve a packument without "hasInstallScript":
#   {"name":"evil","versions":{"1.0.0":{"scripts":{"postinstall":"..."},"dist":{...}}}}
bun install                 # before: "1 package installed", no Blocked line
bun pm untrusted            # lists: ./node_modules/evil @1.0.0 » [postinstall]: ...
```

## How

In the hoisted installer's post-install script census (`PackageInstaller.rs`), drop the `has_install_script()` short-circuit and always count scripts from the installed package.json + `binding.gyp` via `get_installed_package_scripts_count` when the package is untrusted. The disk read happens only on a fresh install (inside the `needs_install` / `InstallResult::Success` branch) and the package.json was just written by the installer, so it is hot in the OS page cache. `get_installed_package_scripts_count` now treats a missing package.json as zero scripts (git dependency without one, or a transitive `file:` target that was not shipped) instead of logging an error, matching the `pm untrusted` behaviour.

## Verification

Added four test cases in `test/cli/install/bun-install-lifecycle-scripts.test.ts` that serve a packument with `hasInstallScript` omitted and explicitly `false`, for both a `scripts.postinstall` package and a `binding.gyp`-only package. All four fail on the released binary and pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->