### PR TITLE
Guard AggregateError .errors printing against self-reference

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4853,6 +4853,9 @@ impl VirtualMachine {
                 // SAFETY: `ctx.formatter` borrows the caller's stack local,
                 // live across the synchronous `for_each` call.
                 let formatter = unsafe { &mut *ctx.formatter };
+                if formatter.failed {
+                    return;
+                }
                 // SAFETY: `ctx.writer` borrows the caller's stack local,
                 // live across the synchronous `for_each` call.
                 let writer = unsafe { &mut *ctx.writer };

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4469,6 +4469,7 @@ impl VirtualMachine {
         allow_side_effects: bool,
     ) {
         let mut formatter = crate::console_object::Formatter::new(self.global());
+        formatter.stack_check = bun_core::StackCheck::init();
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         self.print_errorlike_object(
             exception.value(),
@@ -4785,6 +4786,45 @@ impl VirtualMachine {
         let global_ref = self.global();
 
         if value.is_aggregate_error(global_ref) {
+            // Stack-safety + cycle guard for the `.errors` recursion below
+            // (`agg_iter` → `print_errorlike_object`). An AggregateError may
+            // appear in its own `.errors` array, and `.errors` may nest
+            // arbitrarily deep; neither case should overflow the native stack.
+            // Mirrors the `cause`-chain guard in `print_error_instance_body`.
+            if !formatter.stack_check.is_safe_to_recurse() {
+                formatter.failed = true;
+                if formatter.can_throw_stack_overflow {
+                    let _ = global_ref.throw_stack_overflow();
+                }
+                return;
+            }
+            if formatter.map_node.is_none() {
+                let mut node =
+                    NonNull::new(crate::console_object::formatter::visited::Pool::get_node())
+                        .expect("ObjectPool::get_node always returns a valid heap node");
+                let data = crate::console_object::formatter::visited::node_data_mut(&mut node);
+                data.clear();
+                formatter.map = core::mem::take(data);
+                formatter.map_node = Some(node);
+            }
+            if formatter
+                .map
+                .get_or_put(value)
+                .expect("unreachable")
+                .found_existing
+            {
+                let _ = if allow_ansi_color {
+                    writer.write_all(
+                        bun_core::pretty_fmt!("<r><cyan>[Circular]<r>\n", true).as_bytes(),
+                    )
+                } else {
+                    writer.write_all(
+                        bun_core::pretty_fmt!("<r><cyan>[Circular]<r>\n", false).as_bytes(),
+                    )
+                };
+                return;
+            }
+
             // Note: `JSValue::for_each` takes a C-ABI fn
             // pointer + erased ctx, so thread the captures through a struct.
             // The C trampoline erases lifetimes via `*mut c_void`; round-trip
@@ -4844,6 +4884,7 @@ impl VirtualMachine {
             // which case the error is swallowed.
             let errors = value.get_errors_property(global_ref);
             let _ = errors.for_each(global_ref, (&raw mut ctx).cast(), agg_iter);
+            let _ = formatter.map.remove(&value);
             return;
         }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4786,11 +4786,7 @@ impl VirtualMachine {
         let global_ref = self.global();
 
         if value.is_aggregate_error(global_ref) {
-            // Stack-safety + cycle guard for the `.errors` recursion below
-            // (`agg_iter` → `print_errorlike_object`). An AggregateError may
-            // appear in its own `.errors` array, and `.errors` may nest
-            // arbitrarily deep; neither case should overflow the native stack.
-            // Mirrors the `cause`-chain guard in `print_error_instance_body`.
+            // Same stack + cycle guard the `cause` chain gets in `print_error_instance_body`.
             if !formatter.stack_check.is_safe_to_recurse() {
                 formatter.failed = true;
                 if formatter.can_throw_stack_overflow {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1194,6 +1194,7 @@ fn print_exception(
         vm_ref.print_exception(exception, exception_list, writer, true);
     } else {
         let mut formatter = bun_jsc::console_object::Formatter::new(global);
+        formatter.stack_check = bun_core::StackCheck::init();
         // `Formatter::new` already
         // defaults `error_display_level` to `Full` (ConsoleObject.rs:1176).
         let colors = bun_core::Output::enable_ansi_colors_stderr();

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -123,6 +123,23 @@ describe("Bun.inspect", () => {
     expect(exitCode).toBe(expectedExit);
   });
 
+  it.concurrent.each([
+    ["throw", `throw e;`],
+    ["Promise.reject", `Promise.reject(e); await 0;`],
+  ])("deeply nested AggregateError via %s does not crash", async (name, emit) => {
+    const src = `let e = new Error("leaf"); for (let i = 0; i < 16 * 1024; i++) e = new AggregateError([e], "agg"); process.stderr.write("built\\n"); ${emit}`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr.slice(0, 6)).toBe("built\n");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(1);
+  });
+
   it("depth = 0", () => {
     expect(Bun.inspect({ a: { b: { c: { d: 1 } } } }, { depth: 0 })).toEqual("{\n  a: [Object ...],\n}");
   });

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import stripAnsi from "strip-ansi";
 
 describe("Bun.inspect", () => {
@@ -85,6 +86,41 @@ describe("Bun.inspect", () => {
     expect(() => Bun.inspect(object, { depth: Infinity })).toThrowErrorMatchingInlineSnapshot(
       `"Maximum call stack size exceeded."`,
     );
+  });
+
+  it("self-referential AggregateError prints [Circular]", () => {
+    const ae: any = new AggregateError([], "circ");
+    ae.errors.push(ae);
+    const out = Bun.inspect(ae);
+    expect(out).toContain("[Circular]");
+  });
+
+  it("deeply nested AggregateError throws a stack overflow instead of crashing", () => {
+    let e: unknown = new Error("leaf");
+    for (let i = 0; i < 16 * 1024; i++) {
+      e = new AggregateError([e], "agg");
+    }
+    expect(() => Bun.inspect(e)).toThrowErrorMatchingInlineSnapshot(`"Maximum call stack size exceeded."`);
+  });
+
+  it.concurrent.each([
+    ["console.log", `console.log(ae);`, 0],
+    ["Bun.inspect", `process.stdout.write(Bun.inspect(ae));`, 0],
+    ["throw", `throw ae;`, 1],
+    ["Promise.reject", `Promise.reject(ae); await 0;`, 1],
+  ])("self-referential AggregateError via %s does not crash", async (name, emit, expectedExit) => {
+    const src = `const ae = new AggregateError([], "circ"); ae.errors.push(ae); ${emit}`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdout + stderr;
+    expect(output).toContain("[Circular]");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(expectedExit);
   });
 
   it("depth = 0", () => {

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -127,7 +127,9 @@ describe("Bun.inspect", () => {
     ["throw", `throw e;`],
     ["Promise.reject", `Promise.reject(e); await 0;`],
   ])("deeply nested AggregateError via %s does not crash", async (name, emit) => {
-    const src = `let e = new Error("leaf"); for (let i = 0; i < 16 * 1024; i++) e = new AggregateError([e], "agg"); process.stderr.write("built\\n"); ${emit}`;
+    // Fan-out of 2 so the test also covers the `formatter.failed` short-circuit
+    // in `agg_iter`; without it the throw path re-descends per sibling and hangs.
+    const src = `let e = new Error("leaf"); for (let i = 0; i < 16 * 1024; i++) e = new AggregateError([e, e], "agg"); process.stderr.write("built\\n"); ${emit}`;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", src],
       env: bunEnv,


### PR DESCRIPTION
A self-referential `AggregateError` (its own `.errors` array contains itself) SIGSEGVs every error-printing path: `console.log`, `Bun.inspect`, uncaught `throw`, and unhandled `Promise.reject`. Node prints `[errors]: [ [Circular *1] ]`.

### Repro

```js
const ae = new AggregateError([], "circ");
ae.errors.push(ae);
console.log(ae); // Segmentation fault (exit 139), same for Bun.inspect / throw / reject
```

3/3 on 1.4.0-canary and ASAN main; all four entries crash. No depth needed, a single self-reference is enough.

### Cause

The `is_aggregate_error` branch of `VirtualMachine::print_errorlike_object` iterates `.errors` via `for_each` -> `agg_iter` -> `print_errorlike_object` with neither a cycle guard nor a stack check. A cycle (or a sufficiently deep non-cyclic chain) recurses until the native stack overflows. The `cause` chain already has both protections, in `print_error_instance_body` / `print_error_instance_js`.

### Fix

`src/jsc/VirtualMachine.rs`: inside the `is_aggregate_error` branch, add the formatter's visited-map cycle guard (prints `[Circular]` on re-entry, removed after iteration so sibling duplicates still print in full) and a `stack_check.is_safe_to_recurse()` guard. Same pattern as the existing `cause`-chain guard.

`src/jsc/VirtualMachine.rs` and `src/runtime/jsc_hooks.rs`: seat `formatter.stack_check = StackCheck::init()` at the two `print_exception` entry points so the stack guard actually fires on uncaught throw / unhandled rejection (the default `StackCheck` has `cached_stack_end == 0` and never trips).

### Verification

New tests in `test/js/node/util/bun-inspect.test.ts` alongside the existing deep-Error/object stack-overflow tests:
- `Bun.inspect` of a self-referential AggregateError returns a string containing `[Circular]`
- `Bun.inspect` of a 16K-deep AggregateError chain throws `RangeError: Maximum call stack size exceeded.`
- spawned subprocesses for `console.log` / `Bun.inspect` / `throw` / `Promise.reject` of a self-referential AggregateError all print `[Circular]` with `signalCode === null`

On the unfixed build the first two segfault the test runner (exit 139) and all four subprocess variants exit 139.

### Related

- #34892 adds only the stack-check half for the deep-nesting face (#2692); this PR is a superset (cycle guard + stack check + StackCheck seating). Whichever lands second is a trivial rebase.
- #35174 moves the `.errors` iteration to run after the aggregate header; orthogonal to this change, trivial rebase whichever lands second.
- #31988 (tampered `.errors` property) is a different failure mode.

The bare `[Circular]` output (no aggregate header) matches current Bun behaviour for AggregateError printing; #35174 addresses the header separately.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/bun-inspect.test.ts
bun test v1.4.0 (d489dc3fd)

test/js/node/util/bun-inspect.test.ts:
(pass) Bun.inspect > reports error instead of [native code] [294.17ms]
(pass) Bun.inspect > supports colors: false [5.99ms]
(pass) Bun.inspect > supports colors: true [3.42ms]
(pass) Bun.inspect > supports colors: false, via 2nd arg [2.02ms]
(pass) Bun.inspect > supports colors: true, via 2nd arg [2.06ms]
(pass) Bun.inspect > supports compact [5.03ms]
(pass) Bun.inspect > depth < 0 throws [5.07ms]
(pass) Bun.inspect > depth = Infinity works for Error [112.53ms]
(pass) Bun.inspect > depth = Infinity works for Object [98.09ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for objects [66.50ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for Error [814.43ms]
============================================================
Bun Canary v1.4.0-canary.1 (1498d7b77) Linux x64
Linux Kernel v6.17.0 | glibc v2.41
CPU: sse42 popcnt avx avx2 avx512
Args: "bun" "scripts/build.ts" "--profile=debug" "--quiet" "test
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/util/bun-inspect.test.ts:
(pass) Bun.inspect > reports error instead of [native code] [4.75ms]
(pass) Bun.inspect > supports colors: false [0.24ms]
(pass) Bun.inspect > supports colors: true [0.07ms]
(pass) Bun.inspect > supports colors: false, via 2nd arg [0.02ms]
(pass) Bun.inspect > supports colors: true, via 2nd arg [0.03ms]
(pass) Bun.inspect > supports compact [0.07ms]
(pass) Bun.inspect > depth < 0 throws [0.07ms]
(pass) Bun.inspect > depth = Infinity works for Error [3.00ms]
(pass) Bun.inspect > depth = Infinity works for Object [1.37ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for objects [60.97ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for Error [230.18ms]
/bin/bash: line 1: 64810 Segmentation fault      (core dumped) USE_SYSTEM_BUN=1 bun test --reporter=junit --reporter-outfile=/tmp/mechgate.xml 'test/js/node/util/bun-inspect.test.ts' 2>&1
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/bun-inspect.test.ts
bun test v1.4.0 (d489dc3fd)

test/js/node/util/bun-inspect.test.ts:
(pass) Bun.inspect > reports error instead of [native code] [237.73ms]
(pass) Bun.inspect > supports colors: false [5.71ms]
(pass) Bun.inspect > supports colors: true [3.63ms]
(pass) Bun.inspect > supports colors: false, via 2nd arg [2.93ms]
(pass) Bun.inspect > supports colors: true, via 2nd arg [2.15ms]
(pass) Bun.inspect > supports compact [5.21ms]
(pass) Bun.inspect > depth < 0 throws [5.73ms]
(pass) Bun.inspect > depth = Infinity works for Error [108.17ms]
(pass) Bun.inspect > depth = Infinity works for Object [96.97ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for objects [67.24ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for Error [813.04ms]
(pass) Bun.inspect > self-referential AggregateError prints [Circular] [3.88ms]
(pass) Bun.inspect > deeply nested AggregateError throws a stack overflow instead of crashing [1050.06ms]
(pass) Bun.inspect > self-referential AggregateError via 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d489dc3fd4
  features     baseline

22 deps, 108 codegen, 1171 objects in 1572ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] gen bindgenv2
[3/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[4/1234] fetch tinycc
[tinycc] up to date
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] fetch zlib
[zlib] up to date
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] gen .bind.ts → GeneratedBindings.cpp
[9/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1234] subst deps/zlib/zlib.h
[11/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[12/1234] subst deps
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs             | 37 ++++++++++++++++++++++++
 src/runtime/jsc_hooks.rs              |  1 +
 test/js/node/util/bun-inspect.test.ts | 53 +++++++++++++++++++++++++++++++++++
 3 files changed, 91 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/VirtualMachine.rs                  6      4      0
src/runtime/jsc_hooks.rs                   1      1      0
test/js/node/util/bun-inspect.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->