### PR TITLE
StringOrBuffer: snapshot resizable ArrayBuffer inputs so a later arg cannot resize(0) through the borrow

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -386,8 +386,8 @@ impl ArrayBuffer {
 
     pub fn from_bytes(bytes: &mut [u8], typed_array_type: JSType) -> ArrayBuffer {
         ArrayBuffer {
-            len: u32::try_from(bytes.len()).expect("int cast") as usize,
-            byte_len: u32::try_from(bytes.len()).expect("int cast") as usize,
+            len: bytes.len(),
+            byte_len: bytes.len(),
             typed_array_type,
             ptr: bytes.as_mut_ptr(),
             ..Default::default()
@@ -408,8 +408,8 @@ impl ArrayBuffer {
         // this is an FFI hand-off, not a leak.
         let ptr = bun_core::heap::into_raw(bytes).cast::<u8>();
         ArrayBuffer {
-            len: u32::try_from(len).expect("int cast") as usize,
-            byte_len: u32::try_from(len).expect("int cast") as usize,
+            len,
+            byte_len: len,
             typed_array_type,
             ptr,
             ..Default::default()

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -876,9 +876,8 @@ impl MarkedArrayBuffer {
         })
     }
 
-    /// The caller's live `ArrayBuffer` for in-place writes. When this is an
-    /// owned snapshot of a resizable input (see `StringOrBuffer::array_buffer_into`),
-    /// `self.buffer.ptr` points at a private copy, so re-read from `value`.
+    /// For in-place writes: re-read from `value` when `self.buffer.ptr` is an
+    /// owned snapshot (see `StringOrBuffer::array_buffer_into`).
     #[inline]
     pub fn live_array_buffer(&self, global: &JSGlobalObject) -> ArrayBuffer {
         if self.owns_buffer && self.buffer.value != JSValue::ZERO {

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -876,6 +876,21 @@ impl MarkedArrayBuffer {
         })
     }
 
+    /// The caller's live `ArrayBuffer` for in-place writes. When this is an
+    /// owned snapshot of a resizable input (see `StringOrBuffer::array_buffer_into`),
+    /// `self.buffer.ptr` points at a private copy, so re-read from `value`.
+    #[inline]
+    pub fn live_array_buffer(&self, global: &JSGlobalObject) -> ArrayBuffer {
+        if self.owns_buffer && self.buffer.value != JSValue::ZERO {
+            return self
+                .buffer
+                .value
+                .as_array_buffer(global)
+                .unwrap_or_default();
+        }
+        self.buffer
+    }
+
     pub fn from_bytes(bytes: &mut [u8], typed_array_type: JSType) -> MarkedArrayBuffer {
         MarkedArrayBuffer {
             buffer: ArrayBuffer::from_bytes(bytes, typed_array_type),

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -79,6 +79,9 @@ impl PinnedView {
         let Some(b) = buffer.buffer() else {
             return Ok(None);
         };
+        if b.owns_buffer {
+            return Ok(None);
+        }
         match b.buffer.value.as_pinned_arraybuffer(global) {
             Some(pinned) => Ok(Some(Self(pinned))),
             None => Err(global.throw_out_of_memory()),

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -438,7 +438,7 @@ impl CryptoHasher {
 
         if let Some(string_or_buffer) = output {
             if let StringOrBuffer::Buffer(buffer) = &string_or_buffer {
-                let ab = buffer.buffer;
+                let ab = buffer.live_array_buffer(global);
                 return Self::hash_to_bytes(global, &mut evp, input, Some(ab));
             }
             // `inline else => |*str|` — every non-buffer arm yields a string-like
@@ -687,7 +687,7 @@ impl CryptoHasher {
     ) -> JsResult<JSValue> {
         if let Some(string_or_buffer) = output {
             if let StringOrBuffer::Buffer(buffer) = &string_or_buffer {
-                let ab = buffer.buffer;
+                let ab = buffer.live_array_buffer(global);
                 return this.digest_to_bytes(global, Some(ab));
             }
             // `defer str.deinit()` — handled by Drop.
@@ -927,7 +927,7 @@ impl CryptoHasherZig {
     ) -> JsResult<JSValue> {
         if let Some(string_or_buffer) = output {
             if let StringOrBuffer::Buffer(buffer) = &string_or_buffer {
-                let ab = buffer.buffer;
+                let ab = buffer.live_array_buffer(global);
                 return Self::hash_by_name_inner_to_bytes::<A>(global, input, Some(ab));
             }
             let Some(encoding) = Encoding::from(string_or_buffer.slice()) else {
@@ -1374,7 +1374,7 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
 
         if let Some(string_or_buffer) = output {
             if let StringOrBuffer::Buffer(buffer) = &string_or_buffer {
-                let ab = buffer.buffer;
+                let ab = buffer.live_array_buffer(global);
                 return Self::hash_to_bytes(global, input, Some(ab));
             }
             let Some(encoding) = Encoding::from(string_or_buffer.slice()) else {
@@ -1464,7 +1464,7 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
         }
         if let Some(string_or_buffer) = output {
             if let StringOrBuffer::Buffer(buffer) = &string_or_buffer {
-                let ab = buffer.buffer;
+                let ab = buffer.live_array_buffer(global);
                 return this.digest_to_bytes(global, Some(ab));
             }
             let Some(encoding) = Encoding::from(string_or_buffer.slice()) else {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3891,7 +3891,9 @@ pub mod args {
                     }
                 }
             }
-            if arguments.will_be_async && matches!(args.buffer, StringOrBuffer::Buffer(_)) {
+            if arguments.will_be_async
+                && matches!(&args.buffer, StringOrBuffer::Buffer(b) if !b.owns_buffer)
+            {
                 if let Some(pinned) = bv.as_pinned_arraybuffer(ctx) {
                     args.buffer = StringOrBuffer::Buffer(Buffer {
                         buffer: pinned,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -274,7 +274,9 @@ impl Drop for StringOrBuffer {
             Self::EncodedSlice(_encoded) => {
                 // ZigStringSlice has Drop; cleanup is implicit.
             }
-            Self::Buffer(_) => {}
+            Self::Buffer(buffer) => {
+                buffer.destroy();
+            }
         }
     }
 }
@@ -356,7 +358,9 @@ impl StringOrBuffer {
                 if buffer.buffer.value != JSValue::ZERO {
                     return Ok(buffer.buffer.value);
                 }
-                Ok(buffer.to_node_buffer(ctx))
+                let js = buffer.to_node_buffer(ctx);
+                buffer.owns_buffer = false;
+                Ok(js)
             }
         }
     }
@@ -369,6 +373,47 @@ impl StringOrBuffer {
         } else {
             None
         }
+    }
+
+    /// Core of the `ArrayBuffer`/view arm of `from_js_*`. `pin()` guards
+    /// `transfer()` but not `ArrayBuffer.prototype.resize()`: a shrink
+    /// mprotects trimmed pages `PROT_NONE` while a borrowed slice still spans
+    /// them, so a later argument's getter/`toString` (sync) or the JS thread
+    /// (async) can SIGSEGV the reader. Snapshot resizable non-shared inputs
+    /// into an owned `Buffer` so variant dispatch (CryptoHasher output,
+    /// `fs.write`) stays intact; growable `SharedArrayBuffer` only grows
+    /// in-place so the captured extent remains readable.
+    #[inline]
+    fn array_buffer_into(out: &mut Self, global: &JSGlobalObject, value: JSValue, is_async: bool) {
+        let ab = value.as_array_buffer(global).unwrap_or_default();
+        let buffer = if ab.resizable && !ab.shared {
+            let bytes = ab.byte_slice();
+            let mut owned = if bytes.is_empty() {
+                Buffer::EMPTY
+            } else {
+                global.vm().report_extra_memory(bytes.len());
+                bun_core::handle_oom(Buffer::from_string(bytes))
+            };
+            owned.buffer.value = value;
+            owned.buffer.typed_array_type = ab.typed_array_type;
+            owned
+        } else if is_async {
+            Buffer::from_js_pinned(global, value).unwrap_or(Buffer {
+                buffer: ab,
+                owns_buffer: false,
+                pinned: false,
+            })
+        } else {
+            Buffer {
+                buffer: ab,
+                owns_buffer: false,
+                pinned: false,
+            }
+        };
+        if is_async {
+            buffer.buffer.value.protect();
+        }
+        *out = Self::Buffer(buffer);
     }
 
     /// Out-param core of [`from_js_maybe_async`]. Writes the decoded payload
@@ -437,18 +482,7 @@ impl StringOrBuffer {
             | JSType::BigInt64Array
             | JSType::BigUint64Array
             | JSType::DataView => {
-                let buffer = if is_async {
-                    Buffer::from_js_pinned(global, value)
-                        .unwrap_or_else(|| Buffer::from_array_buffer(global, value))
-                } else {
-                    Buffer::from_array_buffer(global, value)
-                };
-
-                if is_async {
-                    buffer.buffer.value.protect();
-                }
-
-                *out = Self::Buffer(buffer);
+                Self::array_buffer_into(out, global, value, is_async);
                 Ok(true)
             }
             _ => Ok(false),
@@ -508,16 +542,7 @@ impl StringOrBuffer {
         allow_string_object: bool,
     ) -> JsResult<bool> {
         if value.is_cell() && value.js_type().is_array_buffer_like() {
-            let buffer = if is_async {
-                Buffer::from_js_pinned(global, value)
-                    .unwrap_or_else(|| Buffer::from_array_buffer(global, value))
-            } else {
-                Buffer::from_array_buffer(global, value)
-            };
-            if is_async {
-                buffer.buffer.value.protect();
-            }
-            *out = Self::Buffer(buffer);
+            Self::array_buffer_into(out, global, value, is_async);
             return Ok(true);
         }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -390,19 +390,10 @@ impl StringOrBuffer {
         }
     }
 
-    /// Core of the `ArrayBuffer`/view arm of `from_js_*`. `pin()` guards
-    /// `transfer()` but not `ArrayBuffer.prototype.resize()`: a shrink
-    /// mprotects trimmed pages `PROT_NONE` while a borrowed slice still spans
-    /// them, so a later argument's getter/`toString` (sync) or the JS thread
-    /// (async) can SIGSEGV the reader. Snapshot resizable non-shared inputs
-    /// into an owned `Buffer` so variant dispatch (CryptoHasher output,
-    /// `fs.write`) stays intact; growable `SharedArrayBuffer` only grows
-    /// in-place so the captured extent remains readable.
-    ///
-    /// `snapshot_volatile = false` skips the resizable copy for callers that
-    /// have already evaluated every later argument (e.g. `NodeHTTPResponse`,
-    /// which resolves `encoding`/`callback` before capturing and carries its
-    /// own tail-only resizable spill).
+    /// `pin()` guards `transfer()` but not `ArrayBuffer.prototype.resize()`,
+    /// so resizable non-shared inputs are snapshotted (growable SAB only grows
+    /// in-place; captured extent stays readable). `snapshot_volatile = false`
+    /// opts out for callers that run no more user JS before reading.
     #[inline]
     fn array_buffer_into(
         out: &mut Self,
@@ -535,9 +526,8 @@ impl StringOrBuffer {
         Self::from_js_with_encoding_maybe_async(global, value, encoding, false, true)
     }
 
-    /// Out-param convenience wrapper for `NodeHTTPResponse::write_or_end`:
-    /// encoding/callback are resolved before the buffer is captured and the
-    /// write path spills resizable tails itself, so skip the upfront copy.
+    /// Out-param wrapper for `NodeHTTPResponse`; it evaluates encoding/callback
+    /// before capture and spills resizable tails itself (`snapshot_volatile=false`).
     #[inline]
     pub fn from_js_with_encoding_into(
         out: &mut StringOrBuffer,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -281,6 +281,21 @@ impl Drop for StringOrBuffer {
     }
 }
 
+#[cold]
+#[inline(never)]
+fn snapshot_resizable(global: &JSGlobalObject, ab: &jsc::ArrayBuffer) -> Buffer {
+    let bytes = ab.byte_slice();
+    let mut owned = if bytes.is_empty() {
+        Buffer::EMPTY
+    } else {
+        global.vm().report_extra_memory(bytes.len());
+        bun_core::handle_oom(Buffer::from_string(bytes))
+    };
+    owned.buffer.value = ab.value;
+    owned.buffer.typed_array_type = ab.typed_array_type;
+    owned
+}
+
 impl bun_jsc::Unprotect for BlobOrStringOrBuffer {
     /// JS-side half of cleanup — owned
     /// payloads are released by `Drop` (which runs next when held in a
@@ -383,20 +398,22 @@ impl StringOrBuffer {
     /// into an owned `Buffer` so variant dispatch (CryptoHasher output,
     /// `fs.write`) stays intact; growable `SharedArrayBuffer` only grows
     /// in-place so the captured extent remains readable.
+    ///
+    /// `snapshot_volatile = false` skips the resizable copy for callers that
+    /// have already evaluated every later argument (e.g. `NodeHTTPResponse`,
+    /// which resolves `encoding`/`callback` before capturing and carries its
+    /// own tail-only resizable spill).
     #[inline]
-    fn array_buffer_into(out: &mut Self, global: &JSGlobalObject, value: JSValue, is_async: bool) {
+    fn array_buffer_into(
+        out: &mut Self,
+        global: &JSGlobalObject,
+        value: JSValue,
+        is_async: bool,
+        snapshot_volatile: bool,
+    ) {
         let ab = value.as_array_buffer(global).unwrap_or_default();
-        let buffer = if ab.resizable && !ab.shared {
-            let bytes = ab.byte_slice();
-            let mut owned = if bytes.is_empty() {
-                Buffer::EMPTY
-            } else {
-                global.vm().report_extra_memory(bytes.len());
-                bun_core::handle_oom(Buffer::from_string(bytes))
-            };
-            owned.buffer.value = value;
-            owned.buffer.typed_array_type = ab.typed_array_type;
-            owned
+        let buffer = if snapshot_volatile && ab.resizable && !ab.shared {
+            snapshot_resizable(global, &ab)
         } else if is_async {
             Buffer::from_js_pinned(global, value).unwrap_or(Buffer {
                 buffer: ab,
@@ -482,7 +499,7 @@ impl StringOrBuffer {
             | JSType::BigInt64Array
             | JSType::BigUint64Array
             | JSType::DataView => {
-                Self::array_buffer_into(out, global, value, is_async);
+                Self::array_buffer_into(out, global, value, is_async, true);
                 Ok(true)
             }
             _ => Ok(false),
@@ -518,7 +535,9 @@ impl StringOrBuffer {
         Self::from_js_with_encoding_maybe_async(global, value, encoding, false, true)
     }
 
-    /// Out-param convenience wrapper — see [`from_js_with_encoding_maybe_async_into`].
+    /// Out-param convenience wrapper for `NodeHTTPResponse::write_or_end`:
+    /// encoding/callback are resolved before the buffer is captured and the
+    /// write path spills resizable tails itself, so skip the upfront copy.
     #[inline]
     pub fn from_js_with_encoding_into(
         out: &mut StringOrBuffer,
@@ -526,7 +545,9 @@ impl StringOrBuffer {
         value: JSValue,
         encoding: Encoding,
     ) -> JsResult<bool> {
-        Self::from_js_with_encoding_maybe_async_into(out, global, value, encoding, false, true)
+        Self::from_js_with_encoding_maybe_async_into(
+            out, global, value, encoding, false, true, false,
+        )
     }
 
     /// Out-param core of [`from_js_with_encoding_maybe_async`]. Writes into
@@ -540,9 +561,10 @@ impl StringOrBuffer {
         encoding: Encoding,
         is_async: bool,
         allow_string_object: bool,
+        snapshot_volatile: bool,
     ) -> JsResult<bool> {
         if value.is_cell() && value.js_type().is_array_buffer_like() {
-            Self::array_buffer_into(out, global, value, is_async);
+            Self::array_buffer_into(out, global, value, is_async, snapshot_volatile);
             return Ok(true);
         }
 
@@ -595,6 +617,7 @@ impl StringOrBuffer {
             encoding,
             is_async,
             allow_string_object,
+            true,
         )? {
             Ok(Some(out))
         } else {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4032,15 +4032,8 @@ impl FormDataContext<'_> {
                                     let js_err = err.to_js(global_this);
                                     let _ = global_this.throw_value(js_err);
                                 }
-                                Ok(mut result) => {
+                                Ok(result) => {
                                     joiner.push_cloned(result.slice());
-                                    // StringOrBuffer::Drop is a no-op for Buffer; release
-                                    // the readFile allocation explicitly.
-                                    if let crate::node::types::StringOrBuffer::Buffer(buf) =
-                                        &mut result
-                                    {
-                                        buf.destroy();
-                                    }
                                 }
                             }
                         }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1814,16 +1814,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     body.detach();
                     return Ok(rejected_value);
                 }
-                Ok(mut result) => {
+                Ok(result) => {
                     body.detach();
                     body = HTTPRequestBody::AnyBlob(blob::Any::from_owned_slice(
                         result.slice().to_vec(),
                     ));
-                    // StringOrBuffer::Drop is a no-op for Buffer; release the
-                    // readFile allocation now that the bytes are copied out.
-                    if let crate::node::types::StringOrBuffer::Buffer(buf) = &mut result {
-                        buf.destroy();
-                    }
                 }
             }
         }

--- a/test/js/bun/md/md-render-callback.test.ts
+++ b/test/js/bun/md/md-render-callback.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 const Markdown = Bun.markdown;
 
@@ -425,5 +426,25 @@ describe("Bun.markdown buffer input", () => {
 
     input.buffer.transfer();
     expect((input.buffer as ArrayBuffer).detached).toBe(true);
+  });
+
+  test("a resizable input is read at call time even if an option getter resizes it to 0", async () => {
+    // `StringOrBuffer::from_js` used to borrow the view; the `autolinks` getter
+    // runs before the parser touches the bytes and can `resize(0)` the backing
+    // store out from under the borrow, mprotecting the trimmed pages. The
+    // funnel now snapshots resizable non-shared inputs.
+    const script = `
+      const bytes = new TextEncoder().encode("# Hello\\n\\nworld\\n" + Buffer.alloc(1 << 16, 0x20).toString());
+      const input = new Uint8Array(new ArrayBuffer(bytes.length, { maxByteLength: bytes.length }));
+      input.set(bytes);
+      const fixed = Bun.markdown.html(Buffer.from(bytes), { autolinks: false });
+      const out = Bun.markdown.html(input, { get autolinks() { input.buffer.resize(0); return false; } });
+      console.log(out === fixed ? "OK" : "MISMATCH " + JSON.stringify(out.slice(0, 200)));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/md/md-render-callback.test.ts
+++ b/test/js/bun/md/md-render-callback.test.ts
@@ -429,10 +429,6 @@ describe("Bun.markdown buffer input", () => {
   });
 
   test("a resizable input is read at call time even if an option getter resizes it to 0", async () => {
-    // `StringOrBuffer::from_js` used to borrow the view; the `autolinks` getter
-    // runs before the parser touches the bytes and can `resize(0)` the backing
-    // store out from under the borrow, mprotecting the trimmed pages. The
-    // funnel now snapshots resizable non-shared inputs.
     const script = `
       const bytes = new TextEncoder().encode("# Hello\\n\\nworld\\n" + Buffer.alloc(1 << 16, 0x20).toString());
       const input = new Uint8Array(new ArrayBuffer(bytes.length, { maxByteLength: bytes.length }));

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -77,11 +77,7 @@ test("scrypt async does not leak callback/buffers when output allocation fails",
   expect(exitCode).toBe(0);
 });
 
-// `StringOrBuffer::from_js` borrowed the password/salt view, then a later
-// argument's getter ran `ArrayBuffer.prototype.resize(0)`, which mprotects
-// the trimmed pages PROT_NONE while the borrowed slice still spans them;
-// reading it SIGSEGVs. `pin()` only guards `transfer()`, so resizable
-// non-shared inputs are now snapshotted at capture time.
+// pin() guards transfer(), not ArrayBuffer.prototype.resize(); a later-arg getter calling resize(0) SIGSEGV'd the borrowed slice.
 test("scrypt reads resizable ArrayBuffer inputs at capture time even if a later arg resizes them", async () => {
   const script = `
     const crypto = require("node:crypto");

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -76,3 +76,88 @@ test("scrypt async does not leak callback/buffers when output allocation fails",
 
   expect(exitCode).toBe(0);
 });
+
+// `StringOrBuffer::from_js` borrowed the password/salt view, then a later
+// argument's getter ran `ArrayBuffer.prototype.resize(0)`, which mprotects
+// the trimmed pages PROT_NONE while the borrowed slice still spans them;
+// reading it SIGSEGVs. `pin()` only guards `transfer()`, so resizable
+// non-shared inputs are now snapshotted at capture time.
+test("scrypt reads resizable ArrayBuffer inputs at capture time even if a later arg resizes them", async () => {
+  const script = `
+    const crypto = require("node:crypto");
+    const SIZE = 1 << 16;
+    const fixed = b => Buffer.alloc(SIZE, b);
+    const resizable = b => new Uint8Array(new ArrayBuffer(SIZE, { maxByteLength: SIZE })).fill(b);
+
+    const fullPw   = crypto.scryptSync(fixed(0x41), fixed(0x42).subarray(0, 16), 16, { N: 1024 }).toString("hex");
+    const fullSalt = crypto.scryptSync(fixed(0x41).subarray(0, 16), fixed(0x42), 16, { N: 1024 }).toString("hex");
+
+    const out = {};
+
+    // sync: options.N getter resizes the captured password to 0.
+    {
+      const pw = resizable(0x41);
+      out.syncPw = crypto.scryptSync(pw, fixed(0x42).subarray(0, 16), 16, {
+        get N() { pw.buffer.resize(0); return 1024; },
+      }).toString("hex") === fullPw;
+    }
+    // sync: options.N getter resizes the captured salt to 0.
+    {
+      const salt = resizable(0x42);
+      out.syncSalt = crypto.scryptSync(fixed(0x41).subarray(0, 16), salt, 16, {
+        get N() { salt.buffer.resize(0); return 1024; },
+      }).toString("hex") === fullSalt;
+    }
+    // async: JS thread resizes the password after the job is queued.
+    {
+      const pw = resizable(0x41);
+      const p = new Promise((res, rej) =>
+        crypto.scrypt(pw, fixed(0x42).subarray(0, 16), 16, { N: 1024 }, (e, k) => e ? rej(e) : res(k)));
+      pw.buffer.resize(0);
+      out.asyncPw = (await p).toString("hex") === fullPw;
+    }
+    // zero-length resizable input stays zero-length.
+    {
+      const pw = new Uint8Array(new ArrayBuffer(0, { maxByteLength: SIZE }));
+      out.syncEmpty = crypto.scryptSync(pw, fixed(0x42).subarray(0, 16), 16, { N: 1024 }).toString("hex")
+        === crypto.scryptSync(Buffer.alloc(0), fixed(0x42).subarray(0, 16), 16, { N: 1024 }).toString("hex");
+    }
+    // growable SharedArrayBuffer is not snapshotted (grow-only, reading the
+    // captured extent stays valid) but still derives the same key.
+    {
+      const pw = new Uint8Array(new SharedArrayBuffer(SIZE, { maxByteLength: 2 * SIZE })).fill(0x41);
+      out.sab = crypto.scryptSync(pw, fixed(0x42).subarray(0, 16), 16, { N: 1024 }).toString("hex") === fullPw;
+    }
+
+    // regression guard: passing a resizable output buffer to Bun.SHA256.hash
+    // still writes into the caller's buffer, not a private copy.
+    {
+      const dst = new Uint8Array(new ArrayBuffer(32, { maxByteLength: 64 }));
+      const ret = Bun.SHA256.hash(fixed(0x41).subarray(0, 5), dst);
+      const want = Bun.SHA256.hash(fixed(0x41).subarray(0, 5));
+      out.hashOutput = ret === dst && Buffer.from(dst).equals(Buffer.from(want));
+    }
+
+    console.log(JSON.stringify(out));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    syncPw: true,
+    syncSalt: true,
+    asyncPw: true,
+    syncEmpty: true,
+    sab: true,
+    hashOutput: true,
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5640,6 +5640,39 @@ it("fs.write keeps the source buffer attached while the write is in flight", asy
   expect(readFileSync(file, "latin1")).toBe("DDDDDDDD");
 });
 
+it("fs.write writes the bytes captured at call time when a resizable source is resized to 0 while in flight", async () => {
+  // `args::Write::from_js` captures the buffer via the sync `StringOrBuffer::from_js`
+  // and re-pins on the async path. Pinning guards `transfer()` but not
+  // `ArrayBuffer.prototype.resize()`, so the worker thread would read
+  // mprotected pages. Resizable inputs are now snapshotted and the re-pin
+  // guard skips owned snapshots so it does not swap the borrow back in.
+  using dir = tempDir("fs-write-resizable", {
+    "run.js": `
+      const fs = require("node:fs");
+      const fd = fs.openSync("out.bin", "w");
+      const buf = new Uint8Array(new ArrayBuffer(1 << 16, { maxByteLength: 1 << 16 })).fill(0x44);
+      fs.write(fd, buf, 0, buf.byteLength, 0, (err, written) => {
+        fs.closeSync(fd);
+        if (err) throw err;
+        const got = fs.readFileSync("out.bin");
+        console.log(JSON.stringify({ written, len: got.length, allD: got.every(b => b === 0x44) }));
+      });
+      buf.buffer.resize(0);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ written: 1 << 16, len: 1 << 16, allD: true });
+  expect(exitCode).toBe(0);
+});
+
 it("fs.promises.writeFile keeps the source buffer attached while the write is in flight", async () => {
   using dir = tempDir("fs-writefile-pin", {});
   const file = join(String(dir), "out.bin");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5641,11 +5641,6 @@ it("fs.write keeps the source buffer attached while the write is in flight", asy
 });
 
 it("fs.write writes the bytes captured at call time when a resizable source is resized to 0 while in flight", async () => {
-  // `args::Write::from_js` captures the buffer via the sync `StringOrBuffer::from_js`
-  // and re-pins on the async path. Pinning guards `transfer()` but not
-  // `ArrayBuffer.prototype.resize()`, so the worker thread would read
-  // mprotected pages. Resizable inputs are now snapshotted and the re-pin
-  // guard skips owned snapshots so it does not swap the borrow back in.
   using dir = tempDir("fs-write-resizable", {
     "run.js": `
       const fs = require("node:fs");


### PR DESCRIPTION
## Repro

```js
const crypto = require("node:crypto");
const pw = new Uint8Array(new ArrayBuffer(1 << 16, { maxByteLength: 1 << 16 })).fill(0x41);
crypto.scryptSync(pw, Buffer.alloc(16), 16, { get N() { pw.buffer.resize(0); return 1024; } });
```

```
panic(main thread): Segmentation fault at address 0x760078000000
```

Any `StringOrBuffer::from_js*` caller that captures a buffer and then evaluates a later argument (options getter, `toString()` on a boxed string, `valueOf()` on a numeric) is affected, on both the sync and async paths: `crypto.scryptSync`/`scrypt`, `crypto.pbkdf2Sync`/`pbkdf2`, `Bun.password.*`, `Bun.zstdCompress`/`Decompress`, `Bun.Transpiler.transform`, `Bun.Markdown.*`, `fs.writeFile`, and the `Bun.*` CryptoHasher input paths.

## Cause

`StringOrBuffer::from_js_maybe_async_into` stores `(ptr, len)` into the caller's backing store. On the async path it pins; on the sync path it does not. Either way, `pin()` only clears `isDetachable()` (so `transfer()`/`structuredClone`/`postMessage` copy instead of detaching). It does not guard `ArrayBuffer.prototype.resize()`: JSC answers a shrink on a resizable buffer by mprotecting the trimmed pages `PROT_NONE`. The captured slice still spans those pages, so the next `slice()` read faults. The codebase already documents this interaction at the `NodeHTTPResponse` large-write path.

Node.js copies the password/salt bytes before handing them to the threadpool and does not crash.

## Fix

When the input is backed by a resizable non-shared `ArrayBuffer`, snapshot the bytes into an owned `MarkedArrayBuffer` at capture time (sync and async). The result stays a `StringOrBuffer::Buffer` so callers that dispatch on the variant (`fs.write(fd, buffer, offset, length)`, `CryptoHasher` digest-into-buffer) keep working; `buffer.value` keeps pointing at the caller's JS value so `protect()`/`unprotect()` and return-the-input paths are unchanged. Growable `SharedArrayBuffer` is left borrowed: it can only grow in-place within the reserved max, so reading the captured extent stays valid.

Supporting changes:

- `Drop for StringOrBuffer` now releases an owned buffer. `destroy()` is idempotent and `StringOrBuffer::to_js` clears `owns_buffer` after transferring the allocation to JSC, so the existing explicit `.destroy()` callers (`fetch.rs`, `Blob.rs`) and the readFile/mkdtemp result paths are unaffected.
- `MarkedArrayBuffer::live_array_buffer` re-reads the caller's live view from `value` when `self` is an owned snapshot; the five `CryptoHasher` digest-into-buffer sites use it so a resizable output buffer still gets written into (not the private copy).
- `args::Write::from_js` skips the async re-pin when the input is already an owned snapshot, and `MarkdownObject::PinnedView` skips re-borrowing the original when the `StringOrBuffer` already owns its bytes.

Fixed-length buffers (the common case) stay on the existing zero-copy / pin path.

## Verification

`test/js/node/crypto/scrypt.test.ts` spawns a subprocess that exercises sync password, sync salt, async password, zero-length resizable, and growable `SharedArrayBuffer` inputs, plus a regression guard that `Bun.SHA256.hash(input, resizableOut)` still writes into the caller's buffer. The subprocess segfaults on stock `bun` and passes with this change. `test/js/node/crypto/`, `test/js/bun/util/bun-cryptohasher.test.ts`, `test/js/bun/util/password.test.ts`, and the `fs.write` dispatch tests pass.

`PathLike::from_js_with_allocator` has the same hole for buffer-typed paths and is intentionally left out here: its `Drop` lives in `bun_jsc::node_path` and does not currently `destroy()`, so the snapshot needs that crate updated too; #32189 covers the async side. `VectorArrayBuffer::from_js` (`fs.writev`/`fs.readv`) has it too and is likewise left out: its iovec capture lives in `Bun__JSArray__collectBufferSpans` (C++) and the type has no owned-buffer tracking; #34758 covers it. Related: #35757 and #34966 pin on the sync path for `transfer()`; #34751 and #31645 snapshot on the async path only. This change covers the `resize()` hole on both paths without changing the variant the funnel returns.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->