### PR TITLE
Bun.file().slice(): reject delete()/writer()/write(), fix exists(); cap chardev slice reads

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -129,10 +129,8 @@ pub struct Blob {
     pub charset: Cell<AsciiStatus>,
     /// Was it created via the `File` constructor?
     pub is_jsdom_file: Cell<bool>,
-    /// Set by `.slice()`: a range view onto a file/S3-backed store. Destructive
-    /// operations (`delete`, `writer`, `write`) on such a view would act on the
-    /// whole underlying object, so they are rejected. This is distinct from
-    /// `offset != 0` because `slice(0, n)` is also a partial view.
+    /// Set by `.slice()`. A byte-range view is read-only for file/S3 stores
+    /// (`delete`/`writer`/`write` would act on the whole path).
     pub is_sliced_view: Cell<bool>,
     /// `bun.ptr.RawRefCount(u32, .single_threaded)` — counts in-flight `*Blob`
     /// borrows handed to async readers; not the JS GC retain count. Zero while

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -129,8 +129,7 @@ pub struct Blob {
     pub charset: Cell<AsciiStatus>,
     /// Was it created via the `File` constructor?
     pub is_jsdom_file: Cell<bool>,
-    /// Set by `.slice()`. A byte-range view is read-only for file/S3 stores
-    /// (`delete`/`writer`/`write` would act on the whole path).
+    /// Set by `.slice()`; file/S3 `delete`/`writer`/`write` reject it.
     pub is_sliced_view: Cell<bool>,
     /// `bun.ptr.RawRefCount(u32, .single_threaded)` — counts in-flight `*Blob`
     /// borrows handed to async readers; not the JS GC retain count. Zero while

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -129,6 +129,11 @@ pub struct Blob {
     pub charset: Cell<AsciiStatus>,
     /// Was it created via the `File` constructor?
     pub is_jsdom_file: Cell<bool>,
+    /// Set by `.slice()`: a range view onto a file/S3-backed store. Destructive
+    /// operations (`delete`, `writer`, `write`) on such a view would act on the
+    /// whole underlying object, so they are rejected. This is distinct from
+    /// `offset != 0` because `slice(0, n)` is also a partial view.
+    pub is_sliced_view: Cell<bool>,
     /// `bun.ptr.RawRefCount(u32, .single_threaded)` — counts in-flight `*Blob`
     /// borrows handed to async readers; not the JS GC retain count. Zero while
     /// the JS cell is the sole owner.
@@ -162,6 +167,7 @@ impl Default for Blob {
             content_type_was_set: Cell::new(false),
             charset: Cell::new(AsciiStatus::Unknown),
             is_jsdom_file: Cell::new(false),
+            is_sliced_view: Cell::new(false),
             ref_count: bun_ptr::RawRefCount::init(0),
             global_this: Cell::new(core::ptr::null()),
             last_modified: Cell::new(0.0),
@@ -374,6 +380,7 @@ impl Blob {
             content_type_was_set: Cell::new(self.content_type_was_set.get()),
             charset: Cell::new(self.charset.get()),
             is_jsdom_file: Cell::new(self.is_jsdom_file.get()),
+            is_sliced_view: Cell::new(self.is_sliced_view.get()),
             ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
             global_this: Cell::new(self.global_this.get()),
             last_modified: Cell::new(self.last_modified.get()),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1284,8 +1284,7 @@ impl BlobExt for Blob {
         if !matches!(store.data, store::Data::File(_)) {
             return JSValue::FALSE;
         }
-        // A slice has concrete `size`, so the `MAX_SIZE` gate above skipped the
-        // stat and `file.mode` is still 0. `seekable == None` means never stat'd.
+        // Slices have concrete `size` so the stat above was skipped; `seekable == None` means never stat'd.
         if store.data_mut().as_file().seekable.is_none() {
             resolve_file_stat(store);
         }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1281,9 +1281,17 @@ impl BlobExt for Blob {
         }
 
         // We say regular files and pipes exist.
-        let store::Data::File(file) = &store.data else {
+        if !matches!(store.data, store::Data::File(_)) {
             return JSValue::FALSE;
-        };
+        }
+        // A `.slice()` sets `size` to a concrete length, so the `MAX_SIZE`
+        // gate above skips `resolve_size()` and `file.mode` stays 0. Stat the
+        // file when it has never been stat'd (`seekable` is the resolved
+        // sentinel) so `ISREG`/`ISFIFO` below sees the real mode.
+        if store.data_mut().as_file().seekable.is_none() {
+            resolve_file_stat(store);
+        }
+        let file = store.data_mut().as_file();
         JSValue::from(bun_sys::S::ISREG(file.mode) || bun_sys::S::ISFIFO(file.mode))
     }
     fn do_write(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
@@ -1970,6 +1978,7 @@ impl BlobExt for Blob {
         let blob = self.dupe();
         blob.offset.set(offset);
         blob.size.set(len);
+        blob.is_sliced_view.set(true);
 
         let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
         // infer the content type if it was not specified
@@ -3339,6 +3348,7 @@ impl BlobExt for Blob {
                                     ),
                                     charset: Cell::new(blob.charset.get()),
                                     is_jsdom_file: Cell::new(blob.is_jsdom_file.get()),
+                                    is_sliced_view: Cell::new(blob.is_sliced_view.get()),
                                     ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
                                     global_this: Cell::new(blob.global_this.get()),
                                     last_modified: Cell::new(blob.last_modified.get()),
@@ -5012,6 +5022,14 @@ pub fn write_file_internal(
             return Err(global_this.throw_invalid_arguments(format_args!("Blob is detached")));
         };
         debug_assert!(!matches!(blob_store.data, store::Data::Bytes(_)));
+        // Callers that reach here via `PathOrBlob::from_js_no_copy` (Image,
+        // `Bun.s3.file().write`) do not go through `validate_writable_blob`,
+        // so reject a sliced destination here too.
+        if blob.is_sliced_view.get() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "A sliced Bun.file() is a read-only byte-range view; delete() and write() would affect the whole file. Use the un-sliced Bun.file() instead."
+            )));
+        }
         // TODO only reset last_modified on success paths instead of resetting
         // last_modified at the beginning for better performance.
         if let store::Data::File(ref mut file) = *blob_store.data_mut() {
@@ -5305,6 +5323,14 @@ fn validate_writable_blob(global_this: &JSGlobalObject, blob: &Blob) -> JsResult
     if matches!(store.data, store::Data::Bytes(_)) {
         return Err(global_this.throw_invalid_arguments(format_args!(
             "Cannot write to a Blob backed by bytes, which are always read-only"
+        )));
+    }
+    // A `.slice()` of a file/S3-backed blob keeps the parent's pathlike store
+    // but represents a byte-range view. `delete()`/`writer()`/`write()` ignore
+    // the window and would unlink or truncate the whole underlying object.
+    if blob.is_sliced_view.get() {
+        return Err(global_this.throw_invalid_arguments(format_args!(
+            "A sliced Bun.file() is a read-only byte-range view; delete() and write() would affect the whole file. Use the un-sliced Bun.file() instead."
         )));
     }
     Ok(())

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -114,7 +114,8 @@ pub use bun_jsc::webcore_types::{
 /// 3: Added File name serialization for File objects (when is_jsdom_file is true)
 /// 4: Added the blob's `size` to file-backed stores so a sliced Bun.file()
 ///    keeps its window's end across structuredClone/postMessage
-const SERIALIZATION_VERSION: u8 = 4;
+/// 5: Added `is_sliced_view` so a cloned slice stays read-only for writes
+const SERIALIZATION_VERSION: u8 = 5;
 
 pub use bun_jsc::generated::JSBlob as js;
 
@@ -778,6 +779,8 @@ impl BlobExt for Blob {
                 writer.write_int_le::<u32>(0)?;
             }
         }
+
+        writer.write_int_le::<u8>(self.is_sliced_view.get() as u8)?;
         Ok(())
     }
 
@@ -1266,7 +1269,8 @@ impl BlobExt for Blob {
     }
 
     fn get_exists_sync(&self) -> JSValue {
-        if self.size.get() == MAX_SIZE {
+        let size_was_unresolved = self.size.get() == MAX_SIZE;
+        if size_was_unresolved {
             self.resolve_size();
         }
 
@@ -1284,8 +1288,8 @@ impl BlobExt for Blob {
         if !matches!(store.data, store::Data::File(_)) {
             return JSValue::FALSE;
         }
-        // Slices have concrete `size` so the stat above was skipped; `seekable == None` means never stat'd.
-        if store.data_mut().as_file().seekable.is_none() {
+        // Slices have concrete `size`, so `resolve_size()` above was skipped and `file.mode` is still 0.
+        if !size_was_unresolved && store.data_mut().as_file().seekable.is_none() {
             resolve_file_stat(store);
         }
         let file = store.data_mut().as_file();
@@ -4261,9 +4265,11 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
             blob.name.set(BunString::clone_utf8(&name_bytes));
         }
 
-        if version == 3 {
+        if version <= 4 {
             break 'versions;
         }
+
+        blob.is_sliced_view.set(reader.read_int_le::<u8>()? != 0);
     }
 
     debug_assert!(
@@ -5021,9 +5027,9 @@ pub fn write_file_internal(
         debug_assert!(!matches!(blob_store.data, store::Data::Bytes(_)));
         // Some callers bypass `validate_writable_blob`; reject sliced here too.
         if blob.is_sliced_view.get() {
-            return Err(global_this.throw_invalid_arguments(format_args!(
-                "A sliced Bun.file() is a read-only byte-range view; delete() and write() would affect the whole file. Use the un-sliced Bun.file() instead."
-            )));
+            return Err(
+                global_this.throw_invalid_arguments(format_args!("{}", SLICED_VIEW_READONLY_MSG))
+            );
         }
         // TODO only reset last_modified on success paths instead of resetting
         // last_modified at the beginning for better performance.
@@ -5311,6 +5317,8 @@ pub fn write_file_internal(
     )
 }
 
+const SLICED_VIEW_READONLY_MSG: &str = "A sliced Bun.file() is a read-only byte-range view; delete() and write() would affect the whole file. Use the un-sliced Bun.file() instead.";
+
 fn validate_writable_blob(global_this: &JSGlobalObject, blob: &Blob) -> JsResult<()> {
     let Some(store) = blob.store.get() else {
         return Err(global_this.throw(format_args!("Cannot write to a detached Blob")));
@@ -5321,9 +5329,9 @@ fn validate_writable_blob(global_this: &JSGlobalObject, blob: &Blob) -> JsResult
         )));
     }
     if blob.is_sliced_view.get() {
-        return Err(global_this.throw_invalid_arguments(format_args!(
-            "A sliced Bun.file() is a read-only byte-range view; delete() and write() would affect the whole file. Use the un-sliced Bun.file() instead."
-        )));
+        return Err(
+            global_this.throw_invalid_arguments(format_args!("{}", SLICED_VIEW_READONLY_MSG))
+        );
     }
     Ok(())
 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1284,10 +1284,8 @@ impl BlobExt for Blob {
         if !matches!(store.data, store::Data::File(_)) {
             return JSValue::FALSE;
         }
-        // A `.slice()` sets `size` to a concrete length, so the `MAX_SIZE`
-        // gate above skips `resolve_size()` and `file.mode` stays 0. Stat the
-        // file when it has never been stat'd (`seekable` is the resolved
-        // sentinel) so `ISREG`/`ISFIFO` below sees the real mode.
+        // A slice has concrete `size`, so the `MAX_SIZE` gate above skipped the
+        // stat and `file.mode` is still 0. `seekable == None` means never stat'd.
         if store.data_mut().as_file().seekable.is_none() {
             resolve_file_stat(store);
         }
@@ -5022,9 +5020,7 @@ pub fn write_file_internal(
             return Err(global_this.throw_invalid_arguments(format_args!("Blob is detached")));
         };
         debug_assert!(!matches!(blob_store.data, store::Data::Bytes(_)));
-        // Callers that reach here via `PathOrBlob::from_js_no_copy` (Image,
-        // `Bun.s3.file().write`) do not go through `validate_writable_blob`,
-        // so reject a sliced destination here too.
+        // Some callers bypass `validate_writable_blob`; reject sliced here too.
         if blob.is_sliced_view.get() {
             return Err(global_this.throw_invalid_arguments(format_args!(
                 "A sliced Bun.file() is a read-only byte-range view; delete() and write() would affect the whole file. Use the un-sliced Bun.file() instead."
@@ -5325,9 +5321,6 @@ fn validate_writable_blob(global_this: &JSGlobalObject, blob: &Blob) -> JsResult
             "Cannot write to a Blob backed by bytes, which are always read-only"
         )));
     }
-    // A `.slice()` of a file/S3-backed blob keeps the parent's pathlike store
-    // but represents a byte-range view. `delete()`/`writer()`/`write()` ignore
-    // the window and would unlink or truncate the whole underlying object.
     if blob.is_sliced_view.get() {
         return Err(global_this.throw_invalid_arguments(format_args!(
             "A sliced Bun.file() is a read-only byte-range view; delete() and write() would affect the whole file. Use the un-sliced Bun.file() instead."

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -815,6 +815,7 @@ impl ReadFile {
                     let mut read_amount: usize = 0;
                     let mut retry = false;
                     let continue_reading = self.do_read(buf, &mut read_amount, &mut retry);
+                    self.read_off += read_amount as SizeType;
 
                     // We might read into the stack buffer, so we need to copy it into the heap.
                     if use_stack {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -248,13 +248,16 @@ const IS_UV_FS_COPYFILE_DISABLED =
     }
 
     {
-      await Bun.write(
-        Bun.file(tmpbase + "fetch.js.in").slice(0, (exampleHtml.length / 2) | 0),
-        Bun.file(tmpbase + "fetch.js.out"),
-      );
-      expect(await Bun.file(tmpbase + "fetch.js.in").text()).toBe(
-        exampleHtml.substring(0, (exampleHtml.length / 2) | 0),
-      );
+      // A sliced Bun.file() destination is a read-only byte-range view; the
+      // previous behavior truncated the whole destination and copied the
+      // first N bytes, which silently destroyed the rest of the file.
+      expect(() =>
+        Bun.write(
+          Bun.file(tmpbase + "fetch.js.in").slice(0, (exampleHtml.length / 2) | 0),
+          Bun.file(tmpbase + "fetch.js.out"),
+        ),
+      ).toThrow(TypeError);
+      expect(await Bun.file(tmpbase + "fetch.js.in").text()).toBe(exampleHtml);
     }
 
     {

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
 import fsPromises from "fs/promises";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isPosix, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 test("delete() and stat() should work with unicode paths", async () => {
@@ -274,5 +274,18 @@ describe("Bun.file().slice() is a read-only view", () => {
       statSize: 10,
       text: "234",
     });
+  });
+});
+
+// The threadpool ReadFile loop caps each read by `max_length - read_off`, but
+// `read_off` was never advanced on POSIX, so a character-device slice kept
+// reading whole 64 KiB stack-buffer chunks and returned the next multiple of
+// 64 KiB above the requested length (1_000_000 -> 1_048_576).
+describe.skipIf(!isPosix)("Bun.file(chardev).slice().bytes() returns exactly the requested length", () => {
+  test.concurrent.each([1, 4095, 4096, 4097, 65535, 65536, 65537, 1_000_000])("%d bytes", async n => {
+    const bytes = await Bun.file("/dev/zero").slice(0, n).bytes();
+    expect(bytes.length).toBe(n);
+    expect(bytes[0]).toBe(0);
+    expect(bytes[n - 1]).toBe(0);
   });
 });

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import fs from "fs";
 import fsPromises from "fs/promises";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 test("delete() and stat() should work with unicode paths", async () => {
@@ -154,4 +155,124 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
     emptyErr: "Unexpected end of JSON input",
   });
   expect(exitCode).toBe(0);
+});
+
+// A `Bun.file(p).slice(a, b)` keeps the parent's pathlike store, so
+// `.delete()` unlinked the whole file and `.writer()`/`.write()` truncated
+// it and wrote at offset 0, ignoring the [a, b) window. A byte-range view
+// has no sensible whole-file mutation semantics, so these now throw.
+describe("Bun.file().slice() is a read-only view", () => {
+  async function tryOp(fn: () => unknown) {
+    try {
+      return { err: null, result: await fn() };
+    } catch (err) {
+      return { err, result: null };
+    }
+  }
+
+  test.concurrent.each([
+    ["slice(2, 5)", (f: ReturnType<typeof Bun.file>) => f.slice(2, 5)],
+    ["slice(5)", (f: ReturnType<typeof Bun.file>) => f.slice(5)],
+    ["slice(0, 3)", (f: ReturnType<typeof Bun.file>) => f.slice(0, 3)],
+    ["slice(-3)", (f: ReturnType<typeof Bun.file>) => f.slice(-3)],
+    ["slice().slice(2, 5)", (f: ReturnType<typeof Bun.file>) => f.slice().slice(2, 5)],
+  ] as const)("%s: delete()/writer()/write()/Bun.write() throw and leave the file intact", async (_label, slicer) => {
+    using dir = tempDir("bun-file-slice-mutate", { "f.txt": "0123456789" });
+    const p = join(String(dir), "f.txt");
+
+    // .delete() / .unlink()
+    {
+      const { err } = await tryOp(() => slicer(Bun.file(p)).delete());
+      expect({ err, after: fs.readFileSync(p, "utf8") }).toEqual({
+        err: expect.any(TypeError),
+        after: "0123456789",
+      });
+      expect((err as Error).message).toContain("sliced Bun.file()");
+    }
+
+    // .writer()
+    {
+      const { err } = await tryOp(() => slicer(Bun.file(p)).writer());
+      expect({ err, after: fs.readFileSync(p, "utf8") }).toEqual({
+        err: expect.any(TypeError),
+        after: "0123456789",
+      });
+      expect((err as Error).message).toContain("sliced Bun.file()");
+    }
+
+    // .write()
+    {
+      const { err } = await tryOp(() => slicer(Bun.file(p)).write("XY"));
+      expect({ err, after: fs.readFileSync(p, "utf8") }).toEqual({
+        err: expect.any(TypeError),
+        after: "0123456789",
+      });
+      expect((err as Error).message).toContain("sliced Bun.file()");
+    }
+
+    // Bun.write(dest=slice, ...)
+    {
+      const { err } = await tryOp(() => Bun.write(slicer(Bun.file(p)), "XY"));
+      expect({ err, after: fs.readFileSync(p, "utf8") }).toEqual({
+        err: expect.any(TypeError),
+        after: "0123456789",
+      });
+      expect((err as Error).message).toContain("sliced Bun.file()");
+    }
+  });
+
+  test.concurrent("un-sliced Bun.file() can still delete()/writer()/write() after reading .size", async () => {
+    using dir = tempDir("bun-file-unsliced-ops", { "f.txt": "0123456789" });
+    const p = join(String(dir), "f.txt");
+
+    // Reading .size resolves the stat size into blob.size (so it is no
+    // longer MAX_SIZE); this must not be mistaken for a slice.
+    {
+      const f = Bun.file(p);
+      expect(f.size).toBe(10);
+      await f.write("abc");
+      expect(fs.readFileSync(p, "utf8")).toBe("abc");
+    }
+    {
+      fs.writeFileSync(p, "0123456789");
+      const f = Bun.file(p);
+      expect(f.size).toBe(10);
+      await Bun.write(f, "xyz");
+      expect(fs.readFileSync(p, "utf8")).toBe("xyz");
+    }
+    {
+      fs.writeFileSync(p, "0123456789");
+      const f = Bun.file(p);
+      expect(f.size).toBe(10);
+      const w = f.writer();
+      w.write("hello world");
+      await w.end();
+      expect(fs.readFileSync(p, "utf8")).toBe("hello world");
+    }
+    {
+      fs.writeFileSync(p, "0123456789");
+      const f = Bun.file(p);
+      expect(f.size).toBe(10);
+      await f.delete();
+      expect(fs.existsSync(p)).toBe(false);
+    }
+  });
+
+  // `exists()` reads `file.mode` from the store, which is only populated by
+  // `resolve_size()`. A slice's `size` is concrete so `resolve_size()` was
+  // skipped and `exists()` returned false while `stat()` succeeded.
+  test.concurrent("slice().exists() agrees with slice().stat()", async () => {
+    using dir = tempDir("bun-file-slice-exists", { "f.txt": "0123456789" });
+    const p = join(String(dir), "f.txt");
+    const sl = Bun.file(p).slice(2, 5);
+    expect({
+      exists: await sl.exists(),
+      statSize: (await sl.stat()).size,
+      text: await sl.text(),
+    }).toEqual({
+      exists: true,
+      statSize: 10,
+      text: "234",
+    });
+  });
 });

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -258,6 +258,32 @@ describe("Bun.file().slice() is a read-only view", () => {
     }
   });
 
+  test.concurrent("structuredClone of a slice is also a read-only view", async () => {
+    using dir = tempDir("bun-file-slice-clone", { "f.txt": "0123456789" });
+    const p = join(String(dir), "f.txt");
+
+    const clone = structuredClone(Bun.file(p).slice(2, 5));
+    expect(await clone.text()).toBe("234");
+
+    const { err } = await tryOp(() => clone.delete());
+    expect({ err, after: fs.readFileSync(p, "utf8") }).toEqual({
+      err: expect.any(TypeError),
+      after: "0123456789",
+    });
+    expect(() => Bun.write(clone, "XY")).toThrow(TypeError);
+    expect(fs.readFileSync(p, "utf8")).toBe("0123456789");
+  });
+
+  test.concurrent("structuredClone of an un-sliced Bun.file() can still write after .size was read", async () => {
+    using dir = tempDir("bun-file-unsliced-clone", { "f.txt": "0123456789" });
+    const p = join(String(dir), "f.txt");
+    const f = Bun.file(p);
+    expect(f.size).toBe(10);
+    const clone = structuredClone(f);
+    await Bun.write(clone, "abc");
+    expect(fs.readFileSync(p, "utf8")).toBe("abc");
+  });
+
   // `exists()` reads `file.mode` from the store, which is only populated by
   // `resolve_size()`. A slice's `size` is concrete so `resolve_size()` was
   // skipped and `exists()` returned false while `stat()` succeeded.


### PR DESCRIPTION
### What

Three file-backed `Blob.slice()` defects:

```js
// 1. buffered read of a character-device slice over-reads to the next 64 KiB multiple
(await Bun.file('/dev/urandom').slice(0, 1_000_000).bytes()).length
// => 1048576, expected 1000000

// 2. delete()/write()/writer() on a sliced Bun.file() act on the whole file
await Bun.write('/tmp/a', '0123456789');
await Bun.file('/tmp/a').slice(2, 5).delete();
// => /tmp/a is gone; same for .write('x') (file becomes 'x') and Bun.write(slice, ...)

// 3. exists() on a slice returns false for a file that exists
await Bun.file('/tmp/a').slice(2, 5).exists()
// => false (stat() on the same slice succeeds)
```

### Why

**Over-read**: `ReadFile::do_read_loop` caps each read by `max_length.saturating_sub(read_off)`, but `read_off` is initialised to 0 and never advanced on the POSIX path (the only `read_off +=` is on the Windows `ReadFileUV` branch). A chardev slice sizes its initial buffer at `min(max_length, 4096)`, so the loop lands on the 64 KiB stack buffer and appends whole 65536-byte reads until `buffer.len() >= max_length` without the cap ever shrinking.

**Whole-file mutation on a slice**: `.slice()` `dupe()`s the parent's pathlike store and records only `offset`/`size`. `WriteFile` opens `O_WRONLY|O_CREAT|O_TRUNC` and never threads the offset; `do_unlink` calls `unlink(path)`; `writer()` opens the same path at position 0. `validate_writable_blob` only rejected `Bytes`-backed destinations, so a file-backed slice reached every destructive path.

**exists() false on a slice**: `get_exists_sync` tests `ISREG(file.mode) || ISFIFO(file.mode)`, where `file.mode` is filled in by `resolve_size()`. A slice has a concrete `size`, so the `size == MAX_SIZE` gate skipped `resolve_size()` and `mode` stayed 0.

### How

- Advance `self.read_off += read_amount` per iteration in `do_read_loop`, matching the Windows path. `remaining_buffer`'s cap now shrinks correctly and the final buffer is exactly `max_length` bytes.
- Add `Blob.is_sliced_view: Cell<bool>`, set by `get_slice_from` and preserved by `dupe()`, the manual clone literal, and structured-clone serialization (`SERIALIZATION_VERSION` bumped to 5). `validate_writable_blob` and `write_file_internal` both reject when it is set, with the message hoisted to a single `const`. This covers `Bun.write()`, `.write()`, `.writer()`, `.delete()`/`.unlink()`, and `Bun.Image#write()`. An explicit flag avoids the false positive that keying on `size != MAX_SIZE` would have after `.size` is read on an un-sliced `Bun.file()`.
- Stat the file in `get_exists_sync` when `seekable` is still `None`, gated on `!size_was_unresolved` so a nonexistent un-sliced path still issues exactly one `stat`.

### Verification

```
$ bun bd test test/js/bun/util/bun-file.test.ts
23 pass (the slice-is-read-only, structuredClone, exists(), and chardev-length groups all fail on main)
$ bun bd test test/js/bun/io/bun-write.test.js -t 'file-file'
the existing sliced-destination case now asserts the TypeError instead of the truncated output
```

`blob.test.ts` (46 tests), `blob-write.test.ts`, `bun-file-read.test.ts`, `structured-clone-blob-file.test.ts` and `blob-file-name-ownership.test.ts` pass with the debug build. The four timeouts in `bun-write.test.js` reproduce identically on an unpatched debug/ASAN build.

The streaming face of the chardev slice bug (sliced `.stream()` never closes after delivering `max_size`) is covered by #31680. #35815 overlaps on the sliced-destination rejection (different shape, `offset != 0` only).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->