### PR TITLE
node:events: mutate listener arrays in place; copy only when emit() has iterated them

### DIFF
--- a/src/js/internal/streams/legacy.ts
+++ b/src/js/internal/streams/legacy.ts
@@ -112,7 +112,8 @@ function prependListener(emitter, event, fn) {
   let events, existing;
   if (!(events = emitter._events) || !(existing = events[event])) emitter.on(event, fn);
   // A fresh array, not unshift(): node:events iterates stored arrays without
-  // cloning, so a stored `_events` array must never be mutated in place.
+  // cloning and marks them so its own mutators copy-on-write, but this path
+  // bypasses that mark check, so only a new array is guaranteed safe here.
   else if (ArrayIsArray(existing)) events[event] = [fn, ...existing];
   else events[event] = [fn, existing];
 }

--- a/src/js/internal/streams/legacy.ts
+++ b/src/js/internal/streams/legacy.ts
@@ -111,8 +111,7 @@ function prependListener(emitter, event, fn) {
   // the prependListener() method. The goal is to eventually remove this hack.
   let events, existing;
   if (!(events = emitter._events) || !(existing = events[event])) emitter.on(event, fn);
-  // A fresh array, not unshift(): emit() in node:events iterates without
-  // cloning, and this path can't see the kIterated mark that guards in-place edits.
+  // A fresh array, not unshift(): this path can't see node:events' kIterated mark, so in-place isn't safe here.
   else if (ArrayIsArray(existing)) events[event] = [fn, ...existing];
   else events[event] = [fn, existing];
 }

--- a/src/js/internal/streams/legacy.ts
+++ b/src/js/internal/streams/legacy.ts
@@ -111,9 +111,8 @@ function prependListener(emitter, event, fn) {
   // the prependListener() method. The goal is to eventually remove this hack.
   let events, existing;
   if (!(events = emitter._events) || !(existing = events[event])) emitter.on(event, fn);
-  // A fresh array, not unshift(): node:events iterates stored arrays without
-  // cloning and marks them so its own mutators copy-on-write, but this path
-  // bypasses that mark check, so only a new array is guaranteed safe here.
+  // A fresh array, not unshift(): emit() in node:events iterates without
+  // cloning, and this path can't see the kIterated mark that guards in-place edits.
   else if (ArrayIsArray(existing)) events[event] = [fn, ...existing];
   else events[event] = [fn, existing];
 }

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -43,6 +43,15 @@ const ArrayPrototypeUnshift = Array.prototype.unshift;
 const ReflectOwnKeys = Reflect.ownKeys;
 
 const kCapture = Symbol("kCapture");
+// Set on a listener array the first time emit() iterates it, and never
+// cleared. Mutators (on / prepend / removeListener) install a copy instead of
+// editing in place when they see it, so any emit() loop still running on that
+// array keeps a stable snapshot; the fresh copy has no mark, so subsequent
+// mutations are in-place again. Sticky (not a counter) keeps emit()'s hot
+// path to a single read-and-maybe-write instead of two writes, and sidesteps
+// the "nested emit clears the outer mark" problem a clear-after-loop boolean
+// would have.
+const kIterated = Symbol("kIterated");
 // Set when `_events` was preallocated (streams do this): removeListener then
 // writes `undefined` instead of `delete`, keeping one shared JSC Structure
 // so the (StructureID, name)-keyed megamorphic cache stays hot.
@@ -142,13 +151,14 @@ function emitError(emitter, args) {
 }
 
 // A listener list is a bare function for a single listener, else an array
-// (like node). Arrays are never mutated in place - mutators install a copy -
-// so a stored list can be iterated with no defensive clone.
+// (like node). Arrays are mutated in place by on/off; the kIterated mark makes
+// any concurrent mutation install a copy instead, so this snapshot stays stable.
 function applyHandlers(handlers, emitter, args) {
   if (typeof handlers === "function") {
     handlers.$apply(emitter, args);
     return;
   }
+  if (!handlers[kIterated]) handlers[kIterated] = true;
   for (let i = 0, { length } = handlers; i < length; i++) {
     handlers[i].$apply(emitter, args);
   }
@@ -208,9 +218,9 @@ const emitWithoutRejectionCapture = function emit(type, ...args) {
     }
     return true;
   }
-  // No defensive clone: stored arrays are never mutated in place (mutators
-  // install a copy), so this list stays stable for the whole loop even if a
-  // listener adds/removes listeners.
+  // No defensive clone: the kIterated mark makes any listener that adds or
+  // removes on this event install a fresh array, so `handler` stays stable.
+  if (!handler[kIterated]) handler[kIterated] = true;
   for (let i = 0, { length } = handler; i < length; i++) {
     const listener = handler[i];
     switch (args.length) {
@@ -268,9 +278,9 @@ const emitWithRejectionCapture = function emit(type, ...args) {
     }
     return true;
   }
-  // No defensive clone: stored arrays are never mutated in place (mutators
-  // install a copy), so this list stays stable for the whole loop even if a
-  // listener adds/removes listeners.
+  // No defensive clone: the kIterated mark makes any listener that adds or
+  // removes on this event install a fresh array, so `handler` stays stable.
+  if (!handler[kIterated]) handler[kIterated] = true;
   for (let i = 0, { length } = handler; i < length; i++) {
     const listener = handler[i];
     let result;
@@ -322,8 +332,15 @@ function _addListener(target, type, fn, prepend) {
   var handlers;
   if (typeof existing === "function") {
     handlers = events[type] = prepend ? [fn, existing] : [existing, fn];
-  } else {
+  } else if (existing[kIterated]) {
+    // emit() has iterated (and may still be iterating) this exact array;
+    // install a copy so its loop stays stable. The copy has no mark, so the
+    // next mutation is in-place again.
     handlers = events[type] = copyWithInserted(existing, fn, prepend);
+  } else {
+    if (prepend) ArrayPrototypeUnshift.$call(existing, fn);
+    else $arrayPush(existing, fn);
+    handlers = existing;
   }
   var m = _getMaxListeners(target);
   if (m > 0 && handlers.length > m && !handlers.warned) {
@@ -343,9 +360,9 @@ EventEmitterPrototype.prependListener = function prependListener(type, fn) {
   return this;
 };
 
-// Copy-on-write: emit iterates stored arrays with no clone, so new listeners
-// land in a fresh array; `warned` carries over so the leak warning fires once.
-// An inline loop beats concat/slice here ~10x (host-call boundary).
+// Copy path for when `list` carries kIterated (emit() has walked it): a fresh
+// array leaves the iterated one untouched. `warned` carries over so the leak
+// warning fires once. An inline loop beats concat/slice ~10x (host-call cost).
 function copyWithInserted(list, fn, prepend) {
   const n = list.length;
   const copy = $newArrayWithSize(n + 1);
@@ -447,20 +464,34 @@ EventEmitterPrototype.removeListener = function removeListener(type, listener) {
   }
   if (position < 0) return this;
 
-  // Copy-remove (arrays are never mutated in place), and store a lone
-  // survivor bare like node does, so `_events[type]` shape matches theirs.
-  const n = list.length;
-  const copy = $newArrayWithSize(n - 1);
-  for (let i = 0, j = 0; i < n; i++) {
-    if (i !== position) copy[j++] = list[i];
+  if (list[kIterated]) {
+    // emit() has iterated (and may still be iterating) this exact array;
+    // install a copy so its loop stays stable. A lone survivor is stored bare
+    // so `_events[type]` matches node.
+    const n = list.length;
+    const copy = $newArrayWithSize(n - 1);
+    for (let i = 0, j = 0; i < n; i++) {
+      if (i !== position) copy[j++] = list[i];
+    }
+    if (list.warned) copy.warned = true;
+    events[type] = copy.length === 1 ? copy[0] : copy;
+  } else if (list.length === 2) {
+    events[type] = list[1 - position];
+  } else {
+    spliceOne(list, position);
   }
-  if (list.warned) copy.warned = true;
-  events[type] = copy.length === 1 ? copy[0] : copy;
 
   if (events.removeListener !== undefined) this.emit("removeListener", type, listener.listener ?? listener);
 
   return this;
 };
+
+// In-place single-element remove; node's internal/util spliceOne. Removing the
+// last element is O(1), which makes a tail-first drain of N listeners linear.
+function spliceOne(list, index) {
+  for (; index + 1 < list.length; index++) list[index] = list[index + 1];
+  list.pop();
+}
 
 EventEmitterPrototype.off = EventEmitterPrototype.removeListener;
 
@@ -498,8 +529,10 @@ EventEmitterPrototype.removeAllListeners = function removeAllListeners(type) {
   if (typeof listeners === "function") {
     this.removeListener(type, listeners);
   } else if (listeners !== undefined) {
-    // LIFO order. `listeners` is our own snapshot; each removeListener call
-    // installs a fresh array (or bare fn / nothing), so it stays intact here.
+    // LIFO order, same as node's loop. Unmarked arrays shrink from the tail as
+    // we walk indices high-to-low; a marked array is left intact (the first
+    // removeListener COWs it away), so either way `listeners[i]` is the right
+    // function at every step.
     for (let i = listeners.length - 1; i >= 0; i--) this.removeListener(type, listeners[i]);
   }
   return this;

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -39,13 +39,12 @@ const types = require("node:util/types");
 let inspect: typeof import("node:util").inspect | undefined;
 
 const SymbolFor = Symbol.for;
+const ArrayPrototypePop = Array.prototype.pop;
 const ArrayPrototypeUnshift = Array.prototype.unshift;
 const ReflectOwnKeys = Reflect.ownKeys;
 
 const kCapture = Symbol("kCapture");
-// Sticky mark emit() puts on a listener array before iterating it. on/prepend/
-// removeListener mutate in place unless they see this mark, in which case they
-// install a fresh (unmarked) copy so the in-flight emit() keeps a stable view.
+// Sticky mark emit() sets before iterating a listener array; on/off mutate in place unless they see it, then they install a fresh copy so the running emit() stays stable.
 const kIterated = Symbol("kIterated");
 // Set when `_events` was preallocated (streams do this): removeListener then
 // writes `undefined` instead of `delete`, keeping one shared JSC Structure
@@ -145,8 +144,7 @@ function emitError(emitter, args) {
   throw err; // Unhandled 'error' event
 }
 
-// A listener list is a bare function for a single listener, else an array (as
-// in node). kIterated on the array keeps it stable through the loop; see above.
+// A listener list is a bare function for a single listener, else an array (as in node).
 function applyHandlers(handlers, emitter, args) {
   if (typeof handlers === "function") {
     handlers.$apply(emitter, args);
@@ -349,8 +347,7 @@ EventEmitterPrototype.prependListener = function prependListener(type, fn) {
   return this;
 };
 
-// Fresh-array insert for a kIterated `list`. Propagates `warned` so the leak
-// warning fires once. An inline loop beats concat/slice ~10x (host-call cost).
+// Fresh-array insert for a kIterated `list`; propagates `warned`, inline loop beats concat/slice ~10x.
 function copyWithInserted(list, fn, prepend) {
   const n = list.length;
   const copy = $newArrayWithSize(n + 1);
@@ -474,7 +471,7 @@ EventEmitterPrototype.removeListener = function removeListener(type, listener) {
 // Node's internal/util spliceOne: O(1) at the tail, so a tail-first drain is linear.
 function spliceOne(list, index) {
   for (; index + 1 < list.length; index++) list[index] = list[index + 1];
-  list.pop();
+  ArrayPrototypePop.$call(list);
 }
 
 EventEmitterPrototype.off = EventEmitterPrototype.removeListener;
@@ -513,8 +510,7 @@ EventEmitterPrototype.removeAllListeners = function removeAllListeners(type) {
   if (typeof listeners === "function") {
     this.removeListener(type, listeners);
   } else if (listeners !== undefined) {
-    // LIFO, as in node. Unmarked `listeners` shrinks from the tail under us;
-    // a kIterated one is COW'd away on the first call and stays intact.
+    // LIFO, as in node; `listeners` either shrinks from the tail in step with i, or (if kIterated) is COW'd away and stays intact.
     for (let i = listeners.length - 1; i >= 0; i--) this.removeListener(type, listeners[i]);
   }
   return this;

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -43,14 +43,9 @@ const ArrayPrototypeUnshift = Array.prototype.unshift;
 const ReflectOwnKeys = Reflect.ownKeys;
 
 const kCapture = Symbol("kCapture");
-// Set on a listener array the first time emit() iterates it, and never
-// cleared. Mutators (on / prepend / removeListener) install a copy instead of
-// editing in place when they see it, so any emit() loop still running on that
-// array keeps a stable snapshot; the fresh copy has no mark, so subsequent
-// mutations are in-place again. Sticky (not a counter) keeps emit()'s hot
-// path to a single read-and-maybe-write instead of two writes, and sidesteps
-// the "nested emit clears the outer mark" problem a clear-after-loop boolean
-// would have.
+// Sticky mark emit() puts on a listener array before iterating it. on/prepend/
+// removeListener mutate in place unless they see this mark, in which case they
+// install a fresh (unmarked) copy so the in-flight emit() keeps a stable view.
 const kIterated = Symbol("kIterated");
 // Set when `_events` was preallocated (streams do this): removeListener then
 // writes `undefined` instead of `delete`, keeping one shared JSC Structure
@@ -150,9 +145,8 @@ function emitError(emitter, args) {
   throw err; // Unhandled 'error' event
 }
 
-// A listener list is a bare function for a single listener, else an array
-// (like node). Arrays are mutated in place by on/off; the kIterated mark makes
-// any concurrent mutation install a copy instead, so this snapshot stays stable.
+// A listener list is a bare function for a single listener, else an array (as
+// in node). kIterated on the array keeps it stable through the loop; see above.
 function applyHandlers(handlers, emitter, args) {
   if (typeof handlers === "function") {
     handlers.$apply(emitter, args);
@@ -218,8 +212,7 @@ const emitWithoutRejectionCapture = function emit(type, ...args) {
     }
     return true;
   }
-  // No defensive clone: the kIterated mark makes any listener that adds or
-  // removes on this event install a fresh array, so `handler` stays stable.
+  // kIterated diverts reentrant on/off to a copy, so `handler` stays stable.
   if (!handler[kIterated]) handler[kIterated] = true;
   for (let i = 0, { length } = handler; i < length; i++) {
     const listener = handler[i];
@@ -278,8 +271,7 @@ const emitWithRejectionCapture = function emit(type, ...args) {
     }
     return true;
   }
-  // No defensive clone: the kIterated mark makes any listener that adds or
-  // removes on this event install a fresh array, so `handler` stays stable.
+  // kIterated diverts reentrant on/off to a copy, so `handler` stays stable.
   if (!handler[kIterated]) handler[kIterated] = true;
   for (let i = 0, { length } = handler; i < length; i++) {
     const listener = handler[i];
@@ -333,9 +325,6 @@ function _addListener(target, type, fn, prepend) {
   if (typeof existing === "function") {
     handlers = events[type] = prepend ? [fn, existing] : [existing, fn];
   } else if (existing[kIterated]) {
-    // emit() has iterated (and may still be iterating) this exact array;
-    // install a copy so its loop stays stable. The copy has no mark, so the
-    // next mutation is in-place again.
     handlers = events[type] = copyWithInserted(existing, fn, prepend);
   } else {
     if (prepend) ArrayPrototypeUnshift.$call(existing, fn);
@@ -360,8 +349,7 @@ EventEmitterPrototype.prependListener = function prependListener(type, fn) {
   return this;
 };
 
-// Copy path for when `list` carries kIterated (emit() has walked it): a fresh
-// array leaves the iterated one untouched. `warned` carries over so the leak
+// Fresh-array insert for a kIterated `list`. Propagates `warned` so the leak
 // warning fires once. An inline loop beats concat/slice ~10x (host-call cost).
 function copyWithInserted(list, fn, prepend) {
   const n = list.length;
@@ -465,9 +453,6 @@ EventEmitterPrototype.removeListener = function removeListener(type, listener) {
   if (position < 0) return this;
 
   if (list[kIterated]) {
-    // emit() has iterated (and may still be iterating) this exact array;
-    // install a copy so its loop stays stable. A lone survivor is stored bare
-    // so `_events[type]` matches node.
     const n = list.length;
     const copy = $newArrayWithSize(n - 1);
     for (let i = 0, j = 0; i < n; i++) {
@@ -486,8 +471,7 @@ EventEmitterPrototype.removeListener = function removeListener(type, listener) {
   return this;
 };
 
-// In-place single-element remove; node's internal/util spliceOne. Removing the
-// last element is O(1), which makes a tail-first drain of N listeners linear.
+// Node's internal/util spliceOne: O(1) at the tail, so a tail-first drain is linear.
 function spliceOne(list, index) {
   for (; index + 1 < list.length; index++) list[index] = list[index + 1];
   list.pop();
@@ -529,10 +513,8 @@ EventEmitterPrototype.removeAllListeners = function removeAllListeners(type) {
   if (typeof listeners === "function") {
     this.removeListener(type, listeners);
   } else if (listeners !== undefined) {
-    // LIFO order, same as node's loop. Unmarked arrays shrink from the tail as
-    // we walk indices high-to-low; a marked array is left intact (the first
-    // removeListener COWs it away), so either way `listeners[i]` is the right
-    // function at every step.
+    // LIFO, as in node. Unmarked `listeners` shrinks from the tail under us;
+    // a kIterated one is COW'd away on the first call and stays intact.
     for (let i = listeners.length - 1; i >= 0; i--) this.removeListener(type, listeners[i]);
   }
   return this;

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -264,6 +264,69 @@ describe("EventEmitter", () => {
     expect(EventEmitter.prototype.removeListener).toBe(EventEmitter.prototype.off);
   });
 
+  // Node mutates the stored listener array in place (push / spliceOne), so
+  // capturing `_events[type]` and then adding or removing keeps the same array
+  // reference. A copy-on-write scheme allocates a fresh array per call instead,
+  // turning N adds (or a tail-first drain of N listeners) into O(N^2) work.
+  // https://github.com/oven-sh/bun/issues/3770
+  // https://github.com/oven-sh/bun/issues/3734
+  test("on/removeListener mutate the stored listener array in place", () => {
+    const ee = new EventEmitter() as any;
+    ee.setMaxListeners(0);
+    const f1 = () => {};
+    const f2 = () => {};
+    const f3 = () => {};
+    const f4 = () => {};
+    ee.on("x", f1);
+    ee.on("x", f2);
+    const list = ee._events.x;
+    expect(Array.isArray(list)).toBe(true);
+
+    ee.on("x", f3);
+    expect(ee._events.x).toBe(list);
+    expect(list).toEqual([f1, f2, f3]);
+
+    ee.prependListener("x", f4);
+    expect(ee._events.x).toBe(list);
+    expect(list).toEqual([f4, f1, f2, f3]);
+
+    ee.removeListener("x", f3);
+    expect(ee._events.x).toBe(list);
+    expect(list).toEqual([f4, f1, f2]);
+
+    ee.removeListener("x", f4);
+    expect(ee._events.x).toBe(list);
+    expect(list).toEqual([f1, f2]);
+  });
+
+  // The in-place mutation above is only safe because emit() marks the array it
+  // is iterating: a listener that adds or removes on the same event gets a
+  // fresh copy, so the running loop still sees its original snapshot. This
+  // also has to hold across a nested emit() of the same event, which must not
+  // clear the outer emit()'s mark when it finishes.
+  test("nested emit + removeListener inside a listener preserves the outer emit snapshot", () => {
+    const ee = new EventEmitter();
+    const calls: string[] = [];
+    let depth = 0;
+    const a = () => calls.push("a" + depth);
+    const b = () => {
+      calls.push("b" + depth);
+      if (depth === 0) {
+        depth = 1;
+        ee.emit("x");
+        depth = 0;
+        ee.removeListener("x", c);
+      }
+    };
+    const c = () => calls.push("c" + depth);
+    ee.on("x", a);
+    ee.on("x", b);
+    ee.on("x", c);
+    ee.emit("x");
+    expect(calls).toEqual(["a0", "b0", "a1", "b1", "c1", "c0"]);
+    expect(ee.listeners("x")).toEqual([a, b]);
+  });
+
   test("prependListener", () => {
     const myEmitter = new EventEmitter();
     const order: number[] = [];


### PR DESCRIPTION
Since #34519 the listener array is copy-on-write: every `on()` / `prependListener()` / `removeListener()` allocates a fresh N±1 array so `emit()` can iterate the stored one with no defensive clone. That makes each call O(N), so N adds or a tail-first drain of N listeners is O(N²). Node's `push`/`spliceOne` is O(1) from the tail, so the same drain is linear there.

```
import { EventEmitter } from "node:events";
for (const n of [4000, 8000, 16000, 32000, 64000]) {
  const ee = new EventEmitter(); ee.setMaxListeners(0);
  const fns = Array.from({ length: n }, () => () => {});
  for (const f of fns) ee.on("x", f);
  const t0 = performance.now();
  for (let i = n - 1; i >= 0; i--) ee.removeListener("x", fns[i]);
  console.log(n, (performance.now() - t0).toFixed(1), "ms");
}
```

Release build, this machine:

| N | main (drain) | PR (drain) | main (add) | PR (add) |
| --- | --- | --- | --- | --- |
| 4000 | 23.5 ms | 0.10 ms | 26.5 ms | 0.18 ms |
| 8000 | 84.7 ms | 0.18 ms | 64.3 ms | 0.32 ms |
| 16000 | 335 ms | 2.55 ms | 243 ms | 0.49 ms |
| 32000 | 1512 ms | 1.57 ms | 1000 ms | 3.57 ms |
| 64000 | 5744 ms | 0.71 ms | 3794 ms | 2.65 ms |

### Fix

Mutate in place (`$arrayPush` / `ArrayPrototypeUnshift` / `spliceOne`) by default. `emit()` sets a sticky `kIterated` symbol on the array before its loop; a mutator that sees the mark installs a fresh copy instead, so any running emit loop keeps a stable snapshot. The copy carries no mark, so the next mutation is in-place again. The mark is never cleared: that is one property read per emit (plus a single write the first time a given array is emitted), so the hot `emit()` path stays within noise of main (6.4 → 6.6 ns for 3 listeners over 5e6 iters), and it also sidesteps the nested-emit hazard a clear-after-loop boolean would have.

This restores Node's observable shape: `_events[type]` is the same array object across `on`/`off` (until `emit()` has walked it), which is what the new test asserts deterministically. Semantics for listeners that add/remove during their own emit are unchanged and covered by `test-event-emitter-modify-in-emit.js` / `test-event-emitter-remove-listeners.js`, plus a new nested-emit case.

Fixes #3770.
Fixes #3734.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts
bun test v1.4.0 (019e53d3f)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [4.95ms]
(pass) node:events > once [60.93ms]
(pass) node:events > once (abort) [20.34ms]
(pass) node:events > once (two events in same tick) [33.62ms]
(pass) node:events > once removes the listener afterwards [42.16ms]
(pass) node:events > once is an async function [2.40ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [13.75ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [22.28ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [8.94ms]
(pass) EventEmitter > getEventListeners [9.52ms]
(pass) EventEmitter > constructor [5.64ms]
(pass) EventEmitter > removeAllListeners() [11.56ms]
(pass) EventEmitter > removeAllListeners(type) [5.83ms]
(pass) EventEmitter > emit > different tick [7.30ms]
(pass) EventEmitter > emit > async microtask before [11.39ms]
(pass) EventE
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [0.06ms]
(pass) node:events > once [1.04ms]
(pass) node:events > once (abort) [0.37ms]
(pass) node:events > once (two events in same tick) [11.48ms]
(pass) node:events > once removes the listener afterwards [1.21ms]
(pass) node:events > once is an async function [0.03ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [0.29ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [0.33ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [0.14ms]
(pass) EventEmitter > getEventListeners [0.24ms]
(pass) EventEmitter > constructor [0.09ms]
(pass) EventEmitter > removeAllListeners() [0.49ms]
(pass) EventEmitter > removeAllListeners(type) [0.10ms]
(pass) EventEmitter > emit > different tick [0.09ms]
(pass) EventEmitter > emit > async microtask before [0.12ms]
(pass) EventEmitter > emit > async microtask after [0.11ms]
(pass) EventEmitter > emit > same tick [0.04ms]
(pass) EventEmitter > emit > setTimeout task [1.23ms]
(pass) EventEmitter > em
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts
bun test v1.4.0 (019e53d3f)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [4.14ms]
(pass) node:events > once [68.41ms]
(pass) node:events > once (abort) [13.71ms]
(pass) node:events > once (two events in same tick) [27.63ms]
(pass) node:events > once removes the listener afterwards [55.28ms]
(pass) node:events > once is an async function [3.20ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [9.44ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [12.21ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [7.57ms]
(pass) EventEmitter > getEventListeners [9.84ms]
(pass) EventEmitter > constructor [8.12ms]
(pass) EventEmitter > removeAllListeners() [17.34ms]
(pass) EventEmitter > removeAllListeners(type) [8.88ms]
(pass) EventEmitter > emit > different tick [6.54ms]
(pass) EventEmitter > emit > async microtask before [10.40ms]
(pass) EventEm
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     019e53d3f4
  features     baseline

22 deps, 108 codegen, 1171 objects in 1222ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [31.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1234] fetch zlib
[zlib] up to date
[4/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1234] fetch tinycc
[tinycc] up to date
[6/1234] fetch picohttpparser
[picohttpparser] up to date
[7/1234] gen ErrorCode+*.h
[8/1234] gen bindgenv2
[9/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[10/1234] subst deps/zlib/zconf.h
[11/1234] subst deps/zlib/zlib.h
[12/1234] subst deps/libjpeg-turbo/jconfig.h
[13/1234] gen .bind.ts → GeneratedBindings.cpp
[14/1234] subst
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/streams/legacy.ts         |  3 +-
 src/js/node/events.ts                     | 57 +++++++++++++++++-----------
 test/js/node/events/event-emitter.test.ts | 63 +++++++++++++++++++++++++++++++
 3 files changed, 98 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/internal/streams/legacy.ts              2      3      0
src/js/node/events.ts                          7     32      0
test/js/node/events/event-emitter.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->