### PR TITLE
fs.Utf8Stream: suppress post-reopen 'drain' while a write is in flight

### DIFF
--- a/src/js/internal/streams/fast-utf8-stream.ts
+++ b/src/js/internal/streams/fast-utf8-stream.ts
@@ -454,7 +454,11 @@ class Utf8Stream extends EventEmitter {
       // start
       if ((!this.#writing && this.#len > this.#minLength) || this.#flushPending) {
         this.#actualWrite();
-      } else if (reopening) {
+      } else if (reopening && !this.#writing) {
+        // A write() inside the synchronous 'ready' emit above may have already
+        // started an async fs.write (#writing = true). Emitting 'drain' here
+        // would signal completion before that write lands; #release emits the
+        // real 'drain' once it does.
         process.nextTick(() => this.emit("drain"));
       }
     };

--- a/src/js/internal/streams/fast-utf8-stream.ts
+++ b/src/js/internal/streams/fast-utf8-stream.ts
@@ -452,10 +452,12 @@ class Utf8Stream extends EventEmitter {
       }
 
       // start
-      if ((!this.#writing && this.#len > this.#minLength) || this.#flushPending) {
-        this.#actualWrite();
-      } else if (reopening && !this.#writing) {
-        process.nextTick(() => this.emit("drain"));
+      if (!this.#writing) {
+        if (this.#len > this.#minLength || this.#flushPending) {
+          this.#actualWrite();
+        } else if (reopening) {
+          process.nextTick(() => this.emit("drain"));
+        }
       }
     };
 

--- a/src/js/internal/streams/fast-utf8-stream.ts
+++ b/src/js/internal/streams/fast-utf8-stream.ts
@@ -455,10 +455,6 @@ class Utf8Stream extends EventEmitter {
       if ((!this.#writing && this.#len > this.#minLength) || this.#flushPending) {
         this.#actualWrite();
       } else if (reopening && !this.#writing) {
-        // A write() inside the synchronous 'ready' emit above may have already
-        // started an async fs.write (#writing = true). Emitting 'drain' here
-        // would signal completion before that write lands; #release emits the
-        // real 'drain' once it does.
         process.nextTick(() => this.emit("drain"));
       }
     };

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -38,7 +38,7 @@ describe.concurrent("fs.Utf8Stream reopen", () => {
       },
     };
 
-    const stream = new Utf8Stream({ dest, sync: false, fs: fsOverride });
+    using stream = new Utf8Stream({ dest, sync: false, fs: fsOverride });
     const events: string[] = [];
 
     stream.write("hello world\n");
@@ -107,7 +107,7 @@ describe.concurrent("fs.Utf8Stream reopen", () => {
     using dir = tempDir("utf8stream-reopen-nowrite", {});
     const dest = join(String(dir), "out.log");
 
-    const stream = new Utf8Stream({ dest, sync: false });
+    using stream = new Utf8Stream({ dest, sync: false });
     stream.write("first\n");
     await once(stream, "drain");
 
@@ -141,7 +141,7 @@ describe.concurrent("fs.Utf8Stream reopen", () => {
       },
     };
 
-    const stream = new Utf8Stream({ dest, sync: false, minLength: 4, fs: fsOverride });
+    using stream = new Utf8Stream({ dest, sync: false, minLength: 4, fs: fsOverride });
     stream.write("first\n");
     await once(stream, "drain");
     writes.length = 0;

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { once } from "node:events";
+import * as realFs from "node:fs";
+import { Utf8Stream } from "node:fs";
+import { join } from "node:path";
+
+describe("fs.Utf8Stream reopen", () => {
+  // Deterministic reproduction of the test-fastutf8stream-reopen.js flake.
+  //
+  // After reopen(), fileOpened() emits 'ready' synchronously. If a listener on
+  // 'ready' calls write(), that write starts an async fs.write and then
+  // registers once('drain', ...) expecting it to fire when the write lands.
+  // The post-reopen code path previously scheduled an unconditional
+  // process.nextTick(() => emit('drain')) whenever `reopening` was true,
+  // regardless of whether a write was already in flight. On a loaded machine
+  // that nextTick would win the race against the threadpool worker performing
+  // the write() syscall, and the 'drain' listener would observe an empty file.
+  //
+  // We make the race deterministic by holding the post-reopen fs.write until
+  // after the microtask queue has drained, then asserting 'drain' only fires
+  // once the write callback has been delivered.
+  test("does not emit 'drain' while a write started in the 'ready' handler is still in flight", async () => {
+    using dir = tempDir("utf8stream-reopen", {});
+    const dest = join(String(dir), "out.log");
+    const after = dest + "-moved";
+
+    type HeldWrite = { fd: number; buf: string; enc: string; cb: (err: any, n?: number) => void };
+    let holding = false;
+    let held: HeldWrite | null = null;
+    const fsOverride = {
+      write(fd: number, buf: string, enc: string, cb: (err: any, n?: number) => void) {
+        if (holding) {
+          held = { fd, buf, enc, cb };
+          return;
+        }
+        return (realFs.write as any)(fd, buf, enc, cb);
+      },
+    };
+
+    const stream = new Utf8Stream({ dest, sync: false, fs: fsOverride });
+    const events: string[] = [];
+
+    stream.write("hello world\n");
+    stream.write("something else\n");
+    await once(stream, "drain");
+
+    realFs.renameSync(dest, after);
+
+    const readyHandled = Promise.withResolvers<void>();
+    const drained = Promise.withResolvers<void>();
+    let writeCallbackDelivered = false;
+
+    stream.once("ready", () => {
+      events.push("ready");
+      holding = true;
+      stream.write("after reopen\n");
+      expect(stream.writing).toBe(true);
+      stream.once("drain", () => {
+        events.push("drain");
+        drained.resolve();
+      });
+      readyHandled.resolve();
+    });
+    stream.reopen();
+
+    await readyHandled.promise;
+    // After 'ready' returns, fileOpened may schedule process.nextTick(emit('drain')).
+    // Give any such nextTick a chance to run before we assert.
+    await new Promise<void>(r => process.nextTick(r));
+
+    // The bug: 'drain' has already fired here even though fs.write's callback
+    // has not. With the fix, 'drain' is held back until #release runs.
+    expect({ events, writeCallbackDelivered }).toEqual({ events: ["ready"], writeCallbackDelivered: false });
+    expect(held).not.toBeNull();
+
+    // Now perform the held write and deliver its callback.
+    const h = held!;
+    holding = false;
+    held = null;
+    await new Promise<void>((resolve, reject) => {
+      (realFs.write as any)(h.fd, h.buf, h.enc, (err: any, n: number) => {
+        if (err) return reject(err);
+        writeCallbackDelivered = true;
+        h.cb(null, n);
+        resolve();
+      });
+    });
+
+    await drained.promise;
+    expect({ events, writeCallbackDelivered }).toEqual({ events: ["ready", "drain"], writeCallbackDelivered: true });
+    expect(realFs.readFileSync(dest, "utf8")).toBe("after reopen\n");
+    expect(realFs.readFileSync(after, "utf8")).toBe("hello world\nsomething else\n");
+
+    const closed = once(stream, "close");
+    stream.end();
+    await closed;
+  });
+
+  // Regression guard for the other direction: when nothing is written inside
+  // the 'ready' handler, reopen() must still emit a 'drain' so callers that
+  // queue work on once('drain') (test-fastutf8stream-reopen.js, block 5) make
+  // progress.
+  test("still emits 'drain' after reopen when no write happens in 'ready'", async () => {
+    using dir = tempDir("utf8stream-reopen-nowrite", {});
+    const dest = join(String(dir), "out.log");
+
+    const stream = new Utf8Stream({ dest, sync: false });
+    stream.write("first\n");
+    await once(stream, "drain");
+
+    stream.reopen();
+    await once(stream, "drain");
+    expect(stream.writing).toBe(false);
+
+    stream.write("second\n");
+    await once(stream, "drain");
+    expect(realFs.readFileSync(dest, "utf8")).toBe("first\nsecond\n");
+
+    const closed = once(stream, "close");
+    stream.end();
+    await closed;
+  });
+});

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -50,12 +50,13 @@ describe("fs.Utf8Stream reopen", () => {
     const readyHandled = Promise.withResolvers<void>();
     const drained = Promise.withResolvers<void>();
     let writeCallbackDelivered = false;
+    let writingAfterReadyWrite: boolean | undefined;
 
     stream.once("ready", () => {
       events.push("ready");
       holding = true;
       stream.write("after reopen\n");
-      expect(stream.writing).toBe(true);
+      writingAfterReadyWrite = stream.writing;
       stream.once("drain", () => {
         events.push("drain");
         drained.resolve();
@@ -65,6 +66,7 @@ describe("fs.Utf8Stream reopen", () => {
     stream.reopen();
 
     await readyHandled.promise;
+    expect(writingAfterReadyWrite).toBe(true);
     // After 'ready' returns, fileOpened may schedule process.nextTick(emit('drain')).
     // Give any such nextTick a chance to run before we assert.
     await new Promise<void>(r => process.nextTick(r));

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -123,4 +123,45 @@ describe.concurrent("fs.Utf8Stream reopen", () => {
     stream.end();
     await closed;
   });
+
+  // Same hazard on the other arm of the post-'ready' dispatch: with
+  // minLength > 0, calling flush(cb) while a reopen's fs.open is in flight
+  // sets #flushPending. If a write() inside the 'ready' handler then starts an
+  // fs.write, fileOpened must not dispatch a second #actualWrite() for the
+  // same buffer just because #flushPending is true.
+  test("does not double-dispatch fs.write when flush() is pending across reopen", async () => {
+    using dir = tempDir("utf8stream-reopen-flush", {});
+    const dest = join(String(dir), "out.log");
+
+    const writes: string[] = [];
+    const fsOverride = {
+      write(fd: number, buf: string, enc: string, cb: (err: any, n?: number) => void) {
+        writes.push(String(buf));
+        return (realFs.write as any)(fd, buf, enc, cb);
+      },
+    };
+
+    const stream = new Utf8Stream({ dest, sync: false, minLength: 4, fs: fsOverride });
+    stream.write("first\n");
+    await once(stream, "drain");
+    writes.length = 0;
+
+    const readyHandled = Promise.withResolvers<void>();
+    stream.once("ready", () => {
+      stream.write("hello\n");
+      readyHandled.resolve();
+    });
+    stream.reopen();
+    stream.flush(() => {});
+
+    await readyHandled.promise;
+    await once(stream, "drain");
+
+    expect(writes).toEqual(["hello\n"]);
+    expect(realFs.readFileSync(dest, "utf8")).toBe("first\nhello\n");
+
+    const closed = once(stream, "close");
+    stream.end();
+    await closed;
+  });
 });

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -5,7 +5,7 @@ import * as realFs from "node:fs";
 import { Utf8Stream } from "node:fs";
 import { join } from "node:path";
 
-describe("fs.Utf8Stream reopen", () => {
+describe.concurrent("fs.Utf8Stream reopen", () => {
   // Deterministic reproduction of the test-fastutf8stream-reopen.js flake.
   //
   // After reopen(), fileOpened() emits 'ready' synchronously. If a listener on


### PR DESCRIPTION
`test/js/node/test/parallel/test-fastutf8stream-reopen.js` has been flaking across CI (32 of the last 400 builds, 190 per-lane occurrences, heaviest on linux 25.04 x64/aarch64 and alpine 3.23):

```
AssertionError: Expected values to be strictly equal:
+ ''
- 'after reopen\n'
      at test/js/node/test/parallel/test-fastutf8stream-reopen.js:52:22
```

### Cause

After `reopen()`, `#openFile`'s `fileOpened` callback emits `'ready'` synchronously. A `'ready'` listener that calls `write()` starts an async `fs.write` (setting `#writing = true`) and then typically registers `once('drain', ...)` to read the file once the write lands. `fileOpened` then continues:

```js
if ((!this.#writing && this.#len > this.#minLength) || this.#flushPending) {
  this.#actualWrite();
} else if (reopening) {
  process.nextTick(() => this.emit("drain"));
}
```

Neither arm accounts for `#writing` having just been set inside the synchronous `emit('ready')`:

- The `else if (reopening)` arm schedules `process.nextTick(() => emit('drain'))` unconditionally. That nextTick races the threadpool worker executing the `write()` syscall; when the worker is delayed (loaded CI box), the nextTick wins, the `'drain'` listener fires early, and `readFile(dest)` observes an empty file. This is the CI flake.
- The `|| this.#flushPending` disjunct calls `#actualWrite()` even though one is already in flight. With `minLength > 0` and a `flush(cb)` issued while the reopen's `fs.open` is pending, `fileOpened` dispatches a second `fs.write` of the same `#writingBuf`, so the data is appended twice and `#release` fires twice.

Node's upstream `lib/internal/streams/fast-utf8-stream.js` has the identical code; it happens not to flake in Node's CI because libuv's threadpool worker almost always completes the small `write()` before the main thread drains the nextTick queue.

### Fix

Hoist a single `!this.#writing` guard above both arms. When a write is in flight, `#release` drives the state machine (emitting `'drain'`, continuing buffered writes, and servicing `#flushPending`) once that write completes. The no-write-in-`'ready'` path (block 5 of the upstream test) is unchanged: `#writing` stays false and the post-reopen `'drain'` still fires.

### Verification

`test/js/node/fs/fast-utf8-stream.test.ts` adds three deterministic tests via the `fs` override hook:

- holds the post-reopen `fs.write` until after nextTick and asserts `'drain'` only fires once the write callback is delivered (fails on main with `events: ["ready", "drain"]` before the callback);
- asserts reopen still emits `'drain'` when nothing is written in `'ready'`;
- counts `fs.write` dispatches across a reopen with `minLength: 4` and a pending `flush()` (fails on main with `["hello\n", "hello\n"]`).

```
bun bd test test/js/node/fs/fast-utf8-stream.test.ts         # 3 pass, 5/5 runs
bun bd test/js/node/test/parallel/test-fastutf8stream-reopen.js   # 30/30 runs
# all 14 test-fastutf8stream-*.js pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/fs/fast-utf8-stream.test.ts"
bun test v1.4.0 (f36438206)

test/js/node/fs/fast-utf8-stream.test.ts:
71 |     // Give any such nextTick a chance to run before we assert.
72 |     await new Promise<void>(r => process.nextTick(r));
73 | 
74 |     // The bug: 'drain' has already fired here even though fs.write's callback
75 |     // has not. With the fix, 'drain' is held back until #release runs.
76 |     expect({ events, writeCallbackDelivered }).toEqual({ events: ["ready"], writeCallbackDelivered: false });
                                                    ^
error: expect(received).toEqual(expected)

  {
    "events": [
      "ready",
+     "drain",
    ],
    "writeCallbackDelivered": false,
  }

- Expected  - 0
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/fs/fast-utf8-stream.test.ts:76:48)
(fail) fs.Utf8Stream reopen > does not emit 'drain' while a write started in the 'ready' handler is still in flight [545.41ms]
155 |     stream.flush(() => {});
156 | 
157 |     await readyHandled.promise;
158 | 
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/fs/fast-utf8-stream.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'Utf8Stream' not found in module 'node:fs'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [230.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/fs/fast-utf8-stream.test.ts"
bun test v1.4.0 (f36438206)

test/js/node/fs/fast-utf8-stream.test.ts:
(pass) fs.Utf8Stream reopen > does not emit 'drain' while a write started in the 'ready' handler is still in flight [474.52ms]
(pass) fs.Utf8Stream reopen > still emits 'drain' after reopen when no write happens in 'ready' [301.77ms]
(pass) fs.Utf8Stream reopen > does not double-dispatch fs.write when flush() is pending across reopen [275.37ms]

 3 pass
 0 fail
 10 expect() calls
Ran 3 tests across 1 file. [4.11s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1206ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/1188] codegen tinycc
[2/1188] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/1188] cc obj/vendor/zlib/deflate_huff.c.o
[4/1188] cc obj/vendor/zlib/adler32.c.o
[5/1188] fetch hdrhistogram
[hdrhistogram] up to date
[6/1188] cc obj/vendor/zlib/deflate_medium.c.o
[7/1188] cc obj/vendor/zlib/deflate_quick.c.o
[8/1188] cc obj/vendor/zlib/deflate_rle.c.o
[9/1188] cc obj/vendor/zlib/deflate_slow.c.o
[10/1188] fetch lsqpack
[lsqpack] up to date
[11/1188] fetch mimalloc
[mimalloc] up to date
[12/1188] fetch lshpack
[lshpack] up to date
[13/1188] cc obj/vendor/zlib/deflate_fast.c.o
[14/1188] cc obj/vendor/zlib/crc32_braid_comb.c.o
[15/1188] cc obj/vendor/zlib/insert_string.c.o
[16/1188] cc obj/vendor/zlib/insert_string_roll.c.o
[17/1188] fetch boringssl
[boringssl] up to date
[18/1188] cc obj/vendor/zlib/functable.c.o
[19/1188] cc obj/vendor/zlib/inftrees.c.o
[20/1188] fetch lolhtml
[lolhtml] up to date
[21/1188] cc obj/vendor/zlib/uncompr.c.o
[22/1188] cc obj/vendor/zlib/de
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/streams/fast-utf8-stream.ts |  10 +-
 test/js/node/fs/fast-utf8-stream.test.ts    | 167 ++++++++++++++++++++++++++++
 2 files changed, 173 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/internal/streams/fast-utf8-stream.ts      4      6      0
test/js/node/fs/fast-utf8-stream.test.ts         4      6      0
```

</details>

<!-- robobun:evidence:end -->