### PR TITLE
webcore: revoke a Worker's blob URLs when the worker exits

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1820,6 +1820,12 @@ pub struct RuntimeHooks {
     /// never lazily created. Called from `WebWorker::shutdown` / `global_exit`
     /// right after `close_all_socket_groups`.
     pub close_dns_for_terminate: fn(),
+    /// `ObjectURLRegistry::singleton().revoke_all_for_context(context_id)` —
+    /// removes every blob URL registered by the given script execution context.
+    /// The File API spec ties a blob URL store entry to its creating
+    /// environment; called from `WebWorker::shutdown` so a worker's blob URLs
+    /// do not outlive the worker. Registry lives in `bun_runtime::webcore`.
+    pub revoke_object_urls_for_context: fn(context_id: i32),
 }
 
 /// Canonical `EventLoopCtx` vtable for a `*mut VirtualMachine` owner — the JS

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1820,11 +1820,9 @@ pub struct RuntimeHooks {
     /// never lazily created. Called from `WebWorker::shutdown` / `global_exit`
     /// right after `close_all_socket_groups`.
     pub close_dns_for_terminate: fn(),
-    /// `ObjectURLRegistry::singleton().revoke_all_for_context(context_id)` —
-    /// removes every blob URL registered by the given script execution context.
-    /// The File API spec ties a blob URL store entry to its creating
-    /// environment; called from `WebWorker::shutdown` so a worker's blob URLs
-    /// do not outlive the worker. Registry lives in `bun_runtime::webcore`.
+    /// `ObjectURLRegistry::revoke_all_for_context` — drops every blob URL a
+    /// worker registered, called from `WebWorker::shutdown`. Registry lives in
+    /// `bun_runtime::webcore`.
     pub revoke_object_urls_for_context: fn(context_id: i32),
 }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1251,6 +1251,10 @@ impl WebWorker {
             vm.on_exit();
             if let Some(hooks) = runtime_hooks() {
                 (hooks.cron_clear_all_teardown)(vm);
+                // This worker's realm is gone; per the File API spec its blob
+                // URL store entries go with it. Runs before `dispatchExit` so
+                // by the time the parent observes `exit`, the URLs are revoked.
+                (hooks.revoke_object_urls_for_context)(self.execution_context_id as i32);
                 // Drain `TimeoutObject`s from this worker's timer heap before
                 // `close_all_socket_groups` / `WebWorker__teardownJSCVM` so
                 // their heap nodes are unlinked while `runtime_state` and the

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1251,9 +1251,8 @@ impl WebWorker {
             vm.on_exit();
             if let Some(hooks) = runtime_hooks() {
                 (hooks.cron_clear_all_teardown)(vm);
-                // This worker's realm is gone; per the File API spec its blob
-                // URL store entries go with it. Runs before `dispatchExit` so
-                // by the time the parent observes `exit`, the URLs are revoked.
+                // Before `dispatchExit` so the parent never observes `exit`
+                // with this worker's blob URLs still live.
                 (hooks.revoke_object_urls_for_context)(self.execution_context_id as i32);
                 // Drain `TimeoutObject`s from this worker's timer heap before
                 // `close_all_socket_groups` / `WebWorker__teardownJSCVM` so

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1274,6 +1274,12 @@ fn has_blob_url(blob_id: &[u8]) -> bool {
     crate::webcore::object_url_registry::ObjectURLRegistry::singleton().has(blob_id)
 }
 
+/// `WebCore.ObjectURLRegistry.singleton().revoke_all_for_context(context_id)`.
+fn revoke_object_urls_for_context(context_id: i32) {
+    crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
+        .revoke_all_for_context(context_id)
+}
+
 /// `Response::get_blob_without_call_frame` /
 /// `Request::get_blob_without_call_frame`. Downcasts
 /// `value` to a `Response`/`Request` (whose data shapes + `BodyMixin` impl live
@@ -1487,6 +1493,7 @@ pub(crate) static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     retroactively_report_discovered_tests,
     cancel_all_timers,
     close_dns_for_terminate,
+    revoke_object_urls_for_context,
 };
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -28,6 +28,12 @@ impl Default for ObjectURLRegistry {
 
 pub struct Entry {
     blob: Blob,
+    /// The `ScriptExecutionContext` id of the realm that called
+    /// `URL.createObjectURL`. Used by [`ObjectURLRegistry::revoke_all_for_context`]
+    /// so worker teardown removes that worker's entries per the File API spec
+    /// (a blob URL store entry is removed when its creating environment is
+    /// discarded).
+    context_id: i32,
 }
 
 // `Entry` is auto-`Send`: its sole field is `Blob`, which already asserts
@@ -38,9 +44,10 @@ const _: fn() = || {
 };
 
 impl Entry {
-    pub fn init(blob: &Blob) -> Box<Entry> {
+    pub fn init(blob: &Blob, context_id: i32) -> Box<Entry> {
         Box::new(Entry {
             blob: blob.dupe_with_content_type(true),
+            context_id,
         })
     }
 }
@@ -55,7 +62,7 @@ impl Drop for Entry {
 impl ObjectURLRegistry {
     pub fn register(&self, vm: &mut VirtualMachine, blob: &Blob) -> UUID {
         let uuid = vm.rare_data().next_uuid();
-        let entry = Entry::init(blob);
+        let entry = Entry::init(blob, vm.initial_script_execution_context_identifier);
 
         self.map.lock().insert(uuid.bytes, entry);
         uuid
@@ -89,6 +96,21 @@ impl ObjectURLRegistry {
         };
         // Box<Entry> dropped here
         let _ = self.map.lock().remove(&uuid.bytes);
+    }
+
+    /// Remove every entry registered by `context_id`. Called from worker
+    /// teardown (via `RuntimeHooks::revoke_object_urls_for_context`) so a
+    /// worker's blob URLs do not outlive that worker.
+    pub fn revoke_all_for_context(&self, context_id: i32) {
+        let mut map = self.map.lock();
+        let keys: Vec<[u8; 16]> = map
+            .iter()
+            .filter(|(_, e)| e.context_id == context_id)
+            .map(|(k, _)| *k)
+            .collect();
+        for k in keys {
+            let _ = map.remove(&k);
+        }
     }
 
     pub fn has(&self, pathname: &[u8]) -> bool {

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -28,11 +28,7 @@ impl Default for ObjectURLRegistry {
 
 pub struct Entry {
     blob: Blob,
-    /// The `ScriptExecutionContext` id of the realm that called
-    /// `URL.createObjectURL`. Used by [`ObjectURLRegistry::revoke_all_for_context`]
-    /// so worker teardown removes that worker's entries per the File API spec
-    /// (a blob URL store entry is removed when its creating environment is
-    /// discarded).
+    /// Registering realm; see [`ObjectURLRegistry::revoke_all_for_context`].
     context_id: i32,
 }
 
@@ -98,9 +94,7 @@ impl ObjectURLRegistry {
         let _ = self.map.lock().remove(&uuid.bytes);
     }
 
-    /// Remove every entry registered by `context_id`. Called from worker
-    /// teardown (via `RuntimeHooks::revoke_object_urls_for_context`) so a
-    /// worker's blob URLs do not outlive that worker.
+    /// Remove every entry registered by `context_id` (worker teardown).
     pub fn revoke_all_for_context(&self, context_id: i32) {
         let mut map = self.map.lock();
         let keys: Vec<[u8; 16]> = map

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { Worker as NodeWorker } from "node:worker_threads";
 import { resolveObjectURL } from "node:buffer";
+import { Worker as NodeWorker } from "node:worker_threads";
 
 test("Worker from a Blob", async () => {
   const worker = new Worker(

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { Worker as NodeWorker } from "node:worker_threads";
+import { resolveObjectURL } from "node:buffer";
 
 test("Worker from a Blob", async () => {
   const worker = new Worker(
@@ -123,4 +125,38 @@ test("Worker on a revoked blob still works", async () => {
   });
 
   expect(revoked).toBe("revoked.");
+});
+
+test("Blob URLs created inside a Worker are revoked when the worker exits", async () => {
+  const worker = new NodeWorker(
+    `const { parentPort } = require("node:worker_threads");
+     const u8 = new Uint8Array(1024).fill(7);
+     parentPort.postMessage(URL.createObjectURL(new Blob([u8])));`,
+    { eval: true },
+  );
+  const url = await new Promise<string>(resolve => worker.once("message", resolve));
+  await new Promise(resolve => worker.once("exit", resolve));
+
+  expect(resolveObjectURL(url)).toBeUndefined();
+  await expect(fetch(url)).rejects.toThrow();
+});
+
+test("Worker exit does not revoke Blob URLs created by other threads", async () => {
+  const parentUrl = URL.createObjectURL(new Blob([new Uint8Array(64).fill(1)]));
+  try {
+    const worker = new NodeWorker(
+      `const { parentPort } = require("node:worker_threads");
+       parentPort.postMessage(URL.createObjectURL(new Blob([new Uint8Array(64)])));`,
+      { eval: true },
+    );
+    const workerUrl = await new Promise<string>(resolve => worker.once("message", resolve));
+    await new Promise(resolve => worker.once("exit", resolve));
+
+    expect(resolveObjectURL(workerUrl)).toBeUndefined();
+    const blob = resolveObjectURL(parentUrl);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(new Uint8Array(await blob!.arrayBuffer())).toEqual(new Uint8Array(64).fill(1));
+  } finally {
+    URL.revokeObjectURL(parentUrl);
+  }
 });


### PR DESCRIPTION
## Problem

`URL.createObjectURL` inside a Worker registers the blob in the process-global `ObjectURLRegistry` with no record of which realm created it. When the worker exits, the entry (and its payload) stays resolvable from any thread for the life of the process.

```js
import { Worker } from "node:worker_threads";
const urls = [];
for (let i = 0; i < 5; i++) {
  const w = new Worker(`
    const { parentPort } = require("node:worker_threads");
    const u8 = new Uint8Array(16 << 20); u8.fill(0x30 + ${i});
    parentPort.postMessage(URL.createObjectURL(new Blob([u8])));
    setTimeout(() => process.exit(0), 10);`, { eval: true });
  urls.push(await new Promise(r => w.once("message", r)));
  await new Promise(r => w.once("exit", r));
}
let servedMB = 0;
for (const u of urls) { try { servedMB += (await (await fetch(u)).arrayBuffer()).byteLength >> 20; } catch {} }
console.log({ servedMBAfterAllWorkersExited: servedMB });
// node: 0   bun (before): 80
```

The File API spec scopes a blob URL store entry to the environment that created it and removes the entry when that environment is discarded. Node follows this (the parent's `fetch` rejects after the worker exits).

## Fix

- `ObjectURLRegistry::Entry` now carries the creating `ScriptExecutionContext` id, recorded in `register()` from `vm.initial_script_execution_context_identifier`.
- New `ObjectURLRegistry::revoke_all_for_context(context_id)` removes every entry whose context matches.
- New `RuntimeHooks::revoke_object_urls_for_context` slot (the registry lives in `bun_runtime`, worker teardown in `bun_jsc`).
- `WebWorker::shutdown` calls it right after `vm.on_exit()` and before `dispatchExit`, so by the time the parent observes the `exit` event the worker's URLs are gone. Entries from other contexts are untouched.

## Verification

With the fix the repro above prints `{ servedMBAfterAllWorkersExited: 0 }`. New tests in `test/js/web/workers/worker_blob.test.ts` check that a worker's blob URL stops resolving (via `resolveObjectURL` and `fetch`) once the worker has exited, and that worker exit leaves the parent's own blob URLs alone.