### PR TITLE
worker: report uncaught Web Worker errors to the parent when there is no error listener

### DIFF
--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -38,6 +38,7 @@
 #include "SerializedScriptValue.h"
 #include "Worker.h"
 #include "ZigGlobalObject.h"
+#include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -445,15 +446,40 @@ void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& m
     }
 }
 
-void WorkerMessagingProxy::postMessageErrorToWorkerObject(String&& message)
+void WorkerMessagingProxy::postMessageErrorToWorkerObject(String&& message, RefPtr<SerializedScriptValue>&& errorForDefaultReport)
 {
-    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, m_loaderLoopKind, [protectedThis = Ref { *this }, message = WTF::move(message).isolatedCopy()](ScriptExecutionContext&) {
+    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, m_loaderLoopKind, [protectedThis = Ref { *this }, message = WTF::move(message).isolatedCopy(), errorForDefaultReport = WTF::move(errorForDefaultReport)](ScriptExecutionContext& context) {
         RefPtr workerObject = protectedThis->m_workerObject;
         if (!workerObject)
             return;
+        bool hadListener = workerObject->hasEventListeners(eventNames().errorEvent);
         ErrorEvent::Init init;
         init.message = message;
+        init.cancelable = true;
         workerObject->dispatchEvent(ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes));
+
+        // Default action for a Web Worker error nobody listened for: report it as an uncaught error
+        // in this (the parent) context, so it prints and sets the exit code, and a parent that is
+        // itself a worker repeats this one level up (https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2).
+        // node:worker_threads always has a listener (its JS wrapper re-emits on the EventEmitter).
+        if (protectedThis->m_options.kind != WorkerOptions::Kind::Web || hadListener || workerObject->wasTerminated())
+            return;
+        auto* globalObject = context.globalObject();
+        auto& vm = JSC::getVM(globalObject);
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        JSC::JSValue reported;
+        if (errorForDefaultReport) {
+            reported = errorForDefaultReport->deserialize(*globalObject, globalObject, SerializationErrorMode::NonThrowing);
+            if (scope.exception()) [[unlikely]] {
+                if (!scope.clearExceptionExceptTermination())
+                    return;
+                reported = {};
+            }
+        }
+        if (!reported)
+            reported = JSC::createError(globalObject, message);
+        Bun__reportUnhandledError(globalObject, JSC::JSValue::encode(reported));
+        CLEAR_IF_EXCEPTION(scope);
     });
 }
 
@@ -501,12 +527,17 @@ bool WorkerMessagingProxy::postSerializedErrorToWorkerObject(Zig::GlobalObject& 
 void WorkerMessagingProxy::postErrorToWorkerObject(Zig::GlobalObject& workerGlobalObject, const String& message, JSC::JSValue error)
 {
     switch (m_options.kind) {
-    case WorkerOptions::Kind::Web:
-        postMessageErrorToWorkerObject(String { message });
+    case WorkerOptions::Kind::Web: {
+        auto& vm = JSC::getVM(&workerGlobalObject);
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        auto serialized = SerializedScriptValue::create(workerGlobalObject, error, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
+        CLEAR_IF_EXCEPTION(scope);
+        postMessageErrorToWorkerObject(String { message }, WTF::move(serialized));
         return;
+    }
     case WorkerOptions::Kind::Node:
         if (!postSerializedErrorToWorkerObject(workerGlobalObject, error))
-            postMessageErrorToWorkerObject(String { message });
+            postMessageErrorToWorkerObject(String { message }, nullptr);
         return;
     }
 }

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -126,7 +126,7 @@ private:
     void releaseWorkerThread();
     void drainMessagesToWorkerObject(ScriptExecutionContext&, DrainBudget);
     void rejectAllCrossVMRequests();
-    void postMessageErrorToWorkerObject(String&& message);
+    void postMessageErrorToWorkerObject(String&& message, RefPtr<SerializedScriptValue>&& errorForDefaultReport);
     bool postSerializedErrorToWorkerObject(Zig::GlobalObject&, JSC::JSValue error);
 
     // Parent thread only.

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -451,24 +451,41 @@ describe("web worker", () => {
 
     // A worker whose own nested worker dies with no listener sees that as its own uncaught error, so
     // the report repeats one level up until something listens or the main thread prints it.
-    test.concurrent("with no listener anywhere propagates from a nested worker to the main thread", async () => {
+    test.concurrent("with no listener on a nested worker propagates to that worker's parent", async () => {
       using dir = tempDir("worker-nested-error", {
         "inner.js": `setTimeout(() => { throw new Error("WEB-WORKER-NESTED-UNCAUGHT") }, 1);`,
-        "middle.js": `new Worker(new URL("inner.js", import.meta.url).href); setInterval(() => {}, 1000);`,
-        "main.js": `const w = new Worker(new URL("middle.js", import.meta.url).href);
-                    w.addEventListener("close", e => console.log("middle closed", e.code));`,
+        "middle.js": `new Worker(new URL("inner.js", import.meta.url).href);`,
+        "main-no-listener.js": `new Worker(new URL("middle.js", import.meta.url).href);`,
+        "main-listener.js": `const w = new Worker(new URL("middle.js", import.meta.url).href);
+          w.addEventListener("error", e => console.log("main saw", e.message.includes("WEB-WORKER-NESTED-UNCAUGHT")));
+          w.addEventListener("close", e => console.log("middle closed", e.code));`,
       });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "main.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toContain("error: WEB-WORKER-NESTED-UNCAUGHT");
-      expect(stdout).toContain("middle closed 1");
-      expect(exitCode).toBe(1);
+      const run = async (entry: string) => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), entry],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { stdout, stderr, exitCode };
+      };
+      // Nobody listens anywhere: the main thread prints it and exits 1.
+      {
+        const { stderr, exitCode } = await run("main-no-listener.js");
+        expect(stderr).toContain("error: WEB-WORKER-NESTED-UNCAUGHT");
+        expect(exitCode).toBe(1);
+      }
+      // The main thread listens on the middle worker: it receives inner's error as middle's, and
+      // middle itself exits 1 because the error was uncaught there.
+      {
+        const { stdout, stderr, exitCode } = await run("main-listener.js");
+        expect(stderr).not.toContain("WEB-WORKER-NESTED-UNCAUGHT");
+        expect(stdout).toContain("main saw true");
+        expect(stdout).toContain("middle closed 1");
+        expect(exitCode).toBe(0);
+      }
     });
 
     test.concurrent("with a listener present is not reported as unhandled", async () => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -401,6 +401,138 @@ describe("web worker", () => {
       const [err] = await once(worker, "error");
       expect(err.message).toBe(`BuildMessage: ModuleNotFound resolving "${specifier}" (entry point)`);
     });
+
+    // With no 'error' listener on the Worker object the error is reported as uncaught in the parent
+    // (printed, exit code 1) instead of vanishing. Each body is a different producer inside the worker.
+    for (const [name, body] of [
+      ["throw at evaluation", `throw new Error("WEB-WORKER-UNCAUGHT")`],
+      ["rejection at evaluation", `Promise.reject(new Error("WEB-WORKER-UNCAUGHT"))`],
+      ["throw in a timer", `setInterval(() => {}, 1000); setTimeout(() => { throw new Error("WEB-WORKER-UNCAUGHT") }, 1)`],
+      ["rejection in a timer", `setInterval(() => {}, 1000); setTimeout(() => { Promise.reject(new Error("WEB-WORKER-UNCAUGHT")) }, 1)`],
+    ]) {
+      test.concurrent(`with no listener is reported to the parent (${name})`, async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", `new Worker("data:text/javascript," + encodeURIComponent(${JSON.stringify(body)}));`],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toContain("error: WEB-WORKER-UNCAUGHT");
+        expect(exitCode).toBe(1);
+      });
+    }
+
+    test.concurrent("with no listener is caught by the parent's process.on('uncaughtException')", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("uncaughtException", err => console.log("caught", err.constructor.name, err.message));
+           const w = new Worker("data:text/javascript," + encodeURIComponent('throw new TypeError("WEB-WORKER-UNCAUGHT")'));
+           w.addEventListener("close", e => console.log("worker closed", e.code));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("WEB-WORKER-UNCAUGHT");
+      expect(stdout).toContain("caught TypeError WEB-WORKER-UNCAUGHT");
+      expect(stdout).toContain("worker closed 1");
+      expect(exitCode).toBe(0);
+    });
+
+    // A worker whose own nested worker dies with no listener sees that as its own uncaught error, so
+    // the report repeats one level up until something listens or the main thread prints it.
+    test.concurrent("with no listener anywhere propagates from a nested worker to the main thread", async () => {
+      using dir = tempDir("worker-nested-error", {
+        "inner.js": `setTimeout(() => { throw new Error("WEB-WORKER-NESTED-UNCAUGHT") }, 1);`,
+        "middle.js": `new Worker(new URL("inner.js", import.meta.url).href); setInterval(() => {}, 1000);`,
+        "main.js": `const w = new Worker(new URL("middle.js", import.meta.url).href);
+                    w.addEventListener("close", e => console.log("middle closed", e.code));`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("error: WEB-WORKER-NESTED-UNCAUGHT");
+      expect(stdout).toContain("middle closed 1");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("with a listener present is not reported as unhandled", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("uncaughtException", err => { console.log("caught"); process.exitCode = 2; });
+           const w = new Worker("data:text/javascript," + encodeURIComponent('throw new Error("WEB-WORKER-UNCAUGHT")'));
+           w.addEventListener("error", e => console.log("listener saw", e.message.includes("WEB-WORKER-UNCAUGHT"), "cancelable", e.cancelable));
+           w.addEventListener("close", e => console.log("worker closed", e.code));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("WEB-WORKER-UNCAUGHT");
+      expect(stdout).toContain("listener saw true cancelable true");
+      expect(stdout).not.toContain("caught");
+      expect(stdout).toContain("worker closed 1");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("with no listener is not reported after terminate()", async () => {
+      // Whether each in-flight error task lands before or after terminate(), it must never surface
+      // as an unhandled exception on the parent.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("uncaughtException", err => { console.error("UNHANDLED", err.message); process.exitCode = 2; });
+           const src = "data:text/javascript," + encodeURIComponent('throw new Error("POST-TERMINATE")');
+           const N = 32;
+           let closed = 0;
+           const { promise, resolve } = Promise.withResolvers();
+           for (let i = 0; i < N; i++) {
+             const w = new Worker(src);
+             w.addEventListener("close", () => { if (++closed === N) resolve(); });
+             w.terminate();
+           }
+           await promise;
+           console.log("done");`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("POST-TERMINATE");
+      expect(stdout).toContain("done");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("node:worker_threads with no listener prints and exits 1 (control)", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const { Worker } = require("node:worker_threads");
+           new Worker('throw new Error("NODE-WORKER-UNCAUGHT")', { eval: true });`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("NODE-WORKER-UNCAUGHT");
+      expect(exitCode).toBe(1);
+    });
   });
 
   // As in browsers (and Node's Web Worker), the worker's implicit port opens once the entry's

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -446,6 +446,7 @@ describe("web worker", () => {
       expect(stderr).not.toContain("WEB-WORKER-UNCAUGHT");
       expect(stdout).toContain("caught TypeError WEB-WORKER-UNCAUGHT");
       expect(stdout).toContain("worker closed 1");
+      if (exitCode !== 0) expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
 
@@ -484,6 +485,7 @@ describe("web worker", () => {
         expect(stderr).not.toContain("WEB-WORKER-NESTED-UNCAUGHT");
         expect(stdout).toContain("main saw true");
         expect(stdout).toContain("middle closed 1");
+        if (exitCode !== 0) expect(stderr).toBe("");
         expect(exitCode).toBe(0);
       }
     });
@@ -507,6 +509,7 @@ describe("web worker", () => {
       expect(stdout).toContain("listener saw true cancelable true");
       expect(stdout).not.toContain("caught");
       expect(stdout).toContain("worker closed 1");
+      if (exitCode !== 0) expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
 
@@ -537,6 +540,7 @@ describe("web worker", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).not.toContain("POST-TERMINATE");
       expect(stdout).toContain("done");
+      if (exitCode !== 0) expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -407,8 +407,14 @@ describe("web worker", () => {
     for (const [name, body] of [
       ["throw at evaluation", `throw new Error("WEB-WORKER-UNCAUGHT")`],
       ["rejection at evaluation", `Promise.reject(new Error("WEB-WORKER-UNCAUGHT"))`],
-      ["throw in a timer", `setInterval(() => {}, 1000); setTimeout(() => { throw new Error("WEB-WORKER-UNCAUGHT") }, 1)`],
-      ["rejection in a timer", `setInterval(() => {}, 1000); setTimeout(() => { Promise.reject(new Error("WEB-WORKER-UNCAUGHT")) }, 1)`],
+      [
+        "throw in a timer",
+        `setInterval(() => {}, 1000); setTimeout(() => { throw new Error("WEB-WORKER-UNCAUGHT") }, 1)`,
+      ],
+      [
+        "rejection in a timer",
+        `setInterval(() => {}, 1000); setTimeout(() => { Promise.reject(new Error("WEB-WORKER-UNCAUGHT")) }, 1)`,
+      ],
     ]) {
       test.concurrent(`with no listener is reported to the parent (${name})`, async () => {
         await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem
- An uncaught error or unhandled rejection inside a Web `Worker` (the global constructor) whose parent has no `error` listener is silent: nothing on stderr, `close` fires, and the process exits 0. The same throw through `node:worker_threads` prints `error: ...` and exits 1.
- Cause: `WorkerMessagingProxy::postMessageErrorToWorkerObject` (`src/jsc/bindings/webcore/WorkerMessagingProxy.cpp`) posts a task that dispatches an `ErrorEvent` on the parent `Worker` and stops. With no listener the event is dropped. The `node:worker_threads` wrapper never hits this because it always registers an `error` listener that re-emits on its `EventEmitter`, whose no-listener path calls `Bun__reportUnhandledError`.

### Fix
- For `Kind::Web`, structured-clone the thrown value on the worker thread and carry it with the message. On the parent, after dispatching the (now `cancelable`) `ErrorEvent`, if the `Worker` had no `error` listener and was not terminated, deserialize it (or build an `Error` from the message) and pass it to `Bun__reportUnhandledError`.
- That is the same entry point an uncaught main-thread error uses: `process.on("uncaughtException")` can observe it, otherwise it is printed and the exit code becomes 1. When the parent is itself a worker, this is an uncaught error in that worker, so the report repeats one level up.
- Listener presence suppresses the default report (the `node:worker_threads` contract, and what the existing docs example and tests rely on). The HTML spec instead suppresses only on `preventDefault()`. That stricter rule is a one-line change if wanted, see Notes.
- Verified: `test/js/web/workers/worker.test.ts` "error event" (9 new tests: four producers with no listener, `uncaughtException` capture, nested worker to main, listener present, `terminate()` race, `worker_threads` control).

### Background
- `WorkerMessagingProxy` is the one object shared between the parent-side `Worker` and the thread running its global scope. Worker-thread events reach the parent as tasks posted to the parent's `ScriptExecutionContext`.
- `web_worker.rs` `on_unhandled_rejection` is the worker VM's last-resort handler for both uncaught exceptions and unhandled rejections. It formats the error, calls `WebWorker__dispatchError` (which lands in `postErrorToWorkerObject`), runs the worker's `exit` handlers, and arms termination.
- `Bun__reportUnhandledError` routes a value into `VirtualMachine::uncaught_exception` on the calling thread: `uncaughtException` listeners first, then print and exit code 1.

<details><summary>Notes</summary>

- Spec reference: https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2. Under the spec (and Deno), a parent listener that does not call `preventDefault()` does not stop the report. This PR keys on listener presence instead, because `worker.addEventListener("error", ...)` without `preventDefault()` is the documented way to handle a worker error in `docs/runtime/workers.mdx` and in existing tests, and flipping that would turn those into process-fatal errors. Switching to the spec rule is `hadListener` -> `event->defaultPrevented()` in the posted task plus doc and test updates.
- The worker's own `close` code for a mid-life unhandled rejection is still 0 (the rejection path does not set the worker's exit code). That is independent of this change; the parent now prints the rejection and exits 1 either way.
- The `terminate()` gate mirrors `Worker::dispatchEvent`: an error task that lands after `terminate()` or after the proxy is closing is neither dispatched nor reported.
- History: the first version of this PR patched `Worker::dispatchErrorWithMessage`; #37075 moved that code into `WorkerMessagingProxy`, so the branch was rebased and the change re-applied there.

</details>
