### PR TITLE
Bun.stdin: reject text/arrayBuffer/bytes/json when process.stdin already holds the reader

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1224,12 +1224,9 @@ impl BlobExt for Blob {
         Ok(stream)
     }
 
-    /// For an fd-backed Blob (the same condition under which `.stream()`
-    /// de-duplicates via the wrapper's cached slot), return that cached
-    /// ReadableStream so `.text()/.json()/.arrayBuffer()/.bytes()` can route
-    /// through it instead of reading the fd directly. This makes a second
-    /// consumer reject with `ERR_INVALID_STATE` when e.g. `process.stdin`
-    /// already holds the reader, rather than silently splitting the bytes.
+    /// The de-duplicated `.stream()` result, if this wrapper has one (only
+    /// fd-backed stores do). `text()`/`arrayBuffer()`/... route through it so
+    /// they reject `ERR_INVALID_STATE` instead of reading the fd concurrently.
     fn fd_cached_stream(&self, this_value: JSValue) -> Option<JSValue> {
         let store = self.store.get().as_deref()?;
         let store::Data::File(f) = &store.data else {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1224,9 +1224,6 @@ impl BlobExt for Blob {
         Ok(stream)
     }
 
-    /// The de-duplicated `.stream()` result, if this wrapper has one (only
-    /// fd-backed stores do). `text()`/`arrayBuffer()`/... route through it so
-    /// they reject `ERR_INVALID_STATE` instead of reading the fd concurrently.
     fn fd_cached_stream(&self, this_value: JSValue) -> Option<JSValue> {
         let store = self.store.get().as_deref()?;
         let store::Data::File(f) = &store.data else {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -210,17 +210,22 @@ pub trait BlobExt {
         get_cached: fn(JSValue) -> Option<JSValue>,
         set_cached: fn(JSValue, &JSGlobalObject, JSValue),
     ) -> JsResult<JSValue>;
-    fn get_text(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue>;
+    fn fd_cached_stream(&self, this_value: JSValue) -> Option<JSValue>;
+    fn get_text(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
     fn get_text_clone(&self, global_object: &JSGlobalObject) -> Result<JSValue, jsc::JsTerminated>;
-    fn get_json(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue>;
+    fn get_json(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
     fn get_json_share(&self, global_object: &JSGlobalObject) -> Result<JSValue, jsc::JsTerminated>;
     fn get_array_buffer_clone(
         &self,
         global_this: &JSGlobalObject,
     ) -> Result<JSValue, jsc::JsTerminated>;
-    fn get_array_buffer(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue>;
+    fn get_array_buffer(
+        &self,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue>;
     fn get_bytes_clone(&self, global_this: &JSGlobalObject) -> Result<JSValue, jsc::JsTerminated>;
-    fn get_bytes(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue>;
+    fn get_bytes(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
     fn get_form_data(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue>;
     fn get_exists_sync(&self) -> JSValue;
     fn do_write(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
@@ -1218,7 +1223,30 @@ impl BlobExt for Blob {
 
         Ok(stream)
     }
-    fn get_text(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+
+    /// For an fd-backed Blob (the same condition under which `.stream()`
+    /// de-duplicates via the wrapper's cached slot), return that cached
+    /// ReadableStream so `.text()/.json()/.arrayBuffer()/.bytes()` can route
+    /// through it instead of reading the fd directly. This makes a second
+    /// consumer reject with `ERR_INVALID_STATE` when e.g. `process.stdin`
+    /// already holds the reader, rather than silently splitting the bytes.
+    fn fd_cached_stream(&self, this_value: JSValue) -> Option<JSValue> {
+        let store = self.store.get().as_deref()?;
+        let store::Data::File(f) = &store.data else {
+            return None;
+        };
+        if !matches!(f.pathlike, PathOrFileDescriptor::Fd(_)) {
+            return None;
+        }
+        js::stream_get_cached(this_value)
+    }
+
+    fn get_text(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        if let Some(stream) = self.fd_cached_stream(callframe.this()) {
+            return bun_jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_text(stream)
+            });
+        }
         Ok(self.get_text_clone(global_this)?)
     }
 
@@ -1227,7 +1255,12 @@ impl BlobExt for Blob {
         JSPromise::wrap(global_object, |g| self.to_string(g, Lifetime::Clone))
     }
 
-    fn get_json(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+    fn get_json(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        if let Some(stream) = self.fd_cached_stream(callframe.this()) {
+            return bun_jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_json(stream)
+            });
+        }
         Ok(self.get_json_share(global_this)?)
     }
 
@@ -1244,7 +1277,16 @@ impl BlobExt for Blob {
         JSPromise::wrap(global_this, |g| self.to_array_buffer(g, Lifetime::Clone))
     }
 
-    fn get_array_buffer(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+    fn get_array_buffer(
+        &self,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        if let Some(stream) = self.fd_cached_stream(callframe.this()) {
+            return bun_jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_array_buffer(stream)
+            });
+        }
         Ok(self.get_array_buffer_clone(global_this)?)
     }
 
@@ -1253,7 +1295,12 @@ impl BlobExt for Blob {
         JSPromise::wrap(global_this, |g| self.to_uint8_array(g, Lifetime::Clone))
     }
 
-    fn get_bytes(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+    fn get_bytes(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        if let Some(stream) = self.fd_cached_stream(callframe.this()) {
+            return bun_jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_bytes(stream)
+            });
+        }
         Ok(self.get_bytes_clone(global_this)?)
     }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1225,6 +1225,8 @@ impl BlobExt for Blob {
     }
 
     fn fd_cached_stream(&self, this_value: JSValue) -> Option<JSValue> {
+        // `stream_get_cached` is `uncheckedDowncast<JSBlob>`.
+        js::from_js(this_value)?;
         let store = self.store.get().as_deref()?;
         let store::Data::File(f) = &store.data else {
             return None;

--- a/test/js/bun/util/bun-stdin-locked.test.ts
+++ b/test/js/bun/util/bun-stdin-locked.test.ts
@@ -1,0 +1,75 @@
+import { expect, test, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// process.stdin is built on Bun.stdin.stream()'s reader. The Blob read helpers
+// on Bun.stdin (text/json/arrayBuffer/bytes) used to bypass that stream and
+// read fd 0 directly, so a program that armed process.stdin *and* awaited
+// Bun.stdin.arrayBuffer() would see the piped bytes split between the two
+// consumers with no error. They now route through the same cached stream and
+// reject with ERR_INVALID_STATE, matching Bun.stdin.stream().getReader().
+
+const payload = Buffer.alloc(256 * 1024, "x").toString();
+
+describe.each(["arrayBuffer", "bytes", "text", "json"] as const)(
+  "Bun.stdin.%s() rejects when process.stdin holds the reader",
+  method => {
+    test.concurrent(method, async () => {
+      const child = `
+        let n = 0;
+        process.stdin.on("data", c => (n += c.length));
+        let result = { state: "pending" };
+        Bun.stdin.${method}().then(
+          () => { result = { state: "resolved" }; },
+          e => { result = { state: "rejected", code: e && (e.code || e.name) }; },
+        );
+        await new Promise(r => process.stdin.once("end", r));
+        await Promise.resolve();
+        process.stdout.write(JSON.stringify({ n, result }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", child],
+        env: bunEnv,
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      proc.stdin.write(payload);
+      await proc.stdin.end();
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        n: payload.length,
+        result: { state: "rejected", code: "ERR_INVALID_STATE" },
+      });
+      expect(exitCode).toBe(0);
+    });
+  },
+);
+
+test.concurrent("Bun.stdin.arrayBuffer() with no other consumer reads every byte", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.stdout.write(String((await Bun.stdin.arrayBuffer()).byteLength));`,
+    ],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  proc.stdin.write(payload);
+  await proc.stdin.end();
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe(String(payload.length));
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/bun-stdin-locked.test.ts
+++ b/test/js/bun/util/bun-stdin-locked.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // process.stdin is built on Bun.stdin.stream()'s reader. The Blob read helpers
@@ -35,11 +35,7 @@ describe.each(["arrayBuffer", "bytes", "text", "json"] as const)(
       });
       proc.stdin.write(payload);
       await proc.stdin.end();
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(JSON.parse(stdout)).toEqual({
         n: payload.length,
@@ -52,11 +48,7 @@ describe.each(["arrayBuffer", "bytes", "text", "json"] as const)(
 
 test.concurrent("Bun.stdin.arrayBuffer() with no other consumer reads every byte", async () => {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `process.stdout.write(String((await Bun.stdin.arrayBuffer()).byteLength));`,
-    ],
+    cmd: [bunExe(), "-e", `process.stdout.write(String((await Bun.stdin.arrayBuffer()).byteLength));`],
     env: bunEnv,
     stdin: "pipe",
     stdout: "pipe",
@@ -64,11 +56,7 @@ test.concurrent("Bun.stdin.arrayBuffer() with no other consumer reads every byte
   });
   proc.stdin.write(payload);
   await proc.stdin.end();
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(stdout).toBe(String(payload.length));
   expect(exitCode).toBe(0);


### PR DESCRIPTION
## Problem

`process.stdin` is built on `Bun.stdin.stream()`'s reader. The Blob read helpers on `Bun.stdin` (`text()`, `json()`, `arrayBuffer()`, `bytes()`) bypassed that stream and issued raw `read(2)` on fd 0 via `do_read_file`, so a program that had `process.stdin.on('data')` armed and also awaited `Bun.stdin.arrayBuffer()` would see the piped input **silently split** between the two consumers with no error:

```js
// cat 10MB.bin | bun repro.mjs
let dataBytes = 0;
process.stdin.on("data", c => dataBytes += c.length);
const ab = await Bun.stdin.arrayBuffer();
// { dataBytes: 327680, blobBytes: 10158080, sum: 10485760 }  (different split every run)
```

`Bun.stdin.stream().getReader()` in the same position already rejected with `ERR_INVALID_STATE: ReadableStream is locked`; the Blob read helpers did not.

## Cause

`.stream()` on an fd-backed Blob caches the `ReadableStream` on the JS wrapper so repeated calls return the same stream (and a second `getReader()` throws). `get_text` / `get_json` / `get_array_buffer` / `get_bytes` never consulted that cached slot; they checked `needs_to_read_file()` and went straight to `do_read_file`, which schedules a `ReadFile` task that calls `bun_sys::read(fd 0, ...)` on the work pool, racing with `process.stdin`'s `FileReader`.

## Fix

For fd-backed Blobs (the same condition under which `.stream()` caches), the four read helpers now check the cached stream slot first. When a cached stream exists they route through `readableStreamTo{Text,JSON,ArrayBuffer,Bytes}` instead of `do_read_file`, so a concurrent consumer rejects with `ERR_INVALID_STATE` rather than stealing bytes.

When no stream has been materialised yet (the common `await Bun.stdin.text()` on its own), the existing `do_read_file` fast path is unchanged.

The check is gated on `JSBlob::from_js(this)` so other classes that delegate to an inner Blob (e.g. `BuildArtifact`, whose fd-backed `OutputFileValue::Copy` blobs reach the same methods with a `JSBuildArtifact` receiver) fall through to the existing path instead of hitting JSBlob's `uncheckedDowncast` slot accessor.

## Not covered

- `Bun.file(0)` returns a fresh Blob wrapper with its own stream slot, so `Bun.file(0).arrayBuffer()` alongside `process.stdin` still reads fd 0 independently. `Bun.file(0).stream()` has the same issue (two `FileReader`s on fd 0 can hang). Fixing that needs the stream cache to be shared across wrappers, which is a larger change.
- `Bun.stdin.formData()` is left on the `do_read_file` path. It would still drain fd 0 before rejecting on the missing content-type, but piping multipart to stdin while also consuming `process.stdin` is implausible and the `readable_stream_to_form_data` content-type plumbing is not worth the extra surface here.

## Verification

```
TypeError: Invalid state: ReadableStream is locked
 code: "ERR_INVALID_STATE"
```

New `test/js/bun/util/bun-stdin-locked.test.ts` covers all four methods plus the standalone path; `bun-stdin-slice.test.ts`, `bun-build-api.test.ts` and the `Bun.stdin` regression tests (`07500`, `27849`, `29787`) still pass.