### PR TITLE
Bun.stdin: reject concurrent text/bytes/arrayBuffer/json reads instead of racing on fd 0

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -119,12 +119,7 @@ const SERIALIZATION_VERSION: u8 = 4;
 pub use bun_jsc::generated::JSBlob as js;
 
 thread_local! {
-    /// Set while a `ReadFile` spawned by one of the `Bun.stdin` Blob read
-    /// helpers (`text()/json()/arrayBuffer()/bytes()`) is in flight. A second
-    /// concurrent call checks this and rejects with `ERR_INVALID_STATE`
-    /// instead of registering a second poll on fd 0 (which the kernel answers
-    /// with `EEXIST` from `epoll_ctl` after the loser has already consumed
-    /// bytes). Claimed in `do_read_file`; released in `NewReadFileHandler::run`.
+    /// Claimed in `do_read_file`, released in `NewReadFileHandler::run`.
     static STDIN_BLOB_READ_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -145,8 +140,6 @@ pub(crate) fn release_stdin_blob_read_claim() {
     STDIN_BLOB_READ_IN_FLIGHT.set(false);
 }
 
-/// For an fd-backed Blob, return the `ReadableStream` cached on the JS wrapper
-/// by `get_stream_with_cache`, if one has been materialised.
 fn fd_cached_stream(blob: &Blob, this_value: JSValue) -> Option<JSValue> {
     let store = blob.store.get().as_deref()?;
     let store::Data::File(f) = &store.data else {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -118,10 +118,9 @@ const SERIALIZATION_VERSION: u8 = 4;
 
 pub use bun_jsc::generated::JSBlob as js;
 
-thread_local! {
-    /// Claimed in `do_read_file`, released in `NewReadFileHandler::run`.
-    static STDIN_BLOB_READ_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
-}
+/// Claimed in `do_read_file`, released in `NewReadFileHandler::run`.
+static STDIN_BLOB_READ_IN_FLIGHT: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
 
 pub(crate) fn is_stdin_fd_store(blob: &Blob) -> bool {
     matches!(
@@ -137,18 +136,19 @@ pub(crate) fn is_stdin_fd_store(blob: &Blob) -> bool {
 }
 
 pub(crate) fn release_stdin_blob_read_claim() {
-    STDIN_BLOB_READ_IN_FLIGHT.set(false);
+    STDIN_BLOB_READ_IN_FLIGHT.store(false, core::sync::atomic::Ordering::SeqCst);
 }
 
-fn fd_cached_stream(blob: &Blob, this_value: JSValue) -> Option<JSValue> {
-    let store = blob.store.get().as_deref()?;
-    let store::Data::File(f) = &store.data else {
-        return None;
-    };
-    if !matches!(f.pathlike, PathOrFileDescriptor::Fd(_)) {
+fn locked_stdin_stream(
+    blob: &Blob,
+    this_value: JSValue,
+    global: &JSGlobalObject,
+) -> Option<JSValue> {
+    if !is_stdin_fd_store(blob) {
         return None;
     }
-    js::stream_get_cached(this_value)
+    let stream = js::stream_get_cached(this_value)?;
+    ReadableStream::is_locked_value(stream, global).then_some(stream)
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -474,7 +474,9 @@ impl BlobExt for Blob {
     fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue {
         debug!("doReadFile");
 
-        if is_stdin_fd_store(self) && STDIN_BLOB_READ_IN_FLIGHT.replace(true) {
+        if is_stdin_fd_store(self)
+            && STDIN_BLOB_READ_IN_FLIGHT.swap(true, core::sync::atomic::Ordering::SeqCst)
+        {
             return global
                 .err(
                     jsc::ErrorCode::INVALID_STATE,
@@ -1261,7 +1263,7 @@ impl BlobExt for Blob {
         Ok(stream)
     }
     fn get_text(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        if let Some(stream) = fd_cached_stream(self, callframe.this()) {
+        if let Some(stream) = locked_stdin_stream(self, callframe.this(), global_this) {
             return bun_jsc::from_js_host_call(global_this, || {
                 global_this.readable_stream_to_text(stream)
             });
@@ -1275,7 +1277,7 @@ impl BlobExt for Blob {
     }
 
     fn get_json(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        if let Some(stream) = fd_cached_stream(self, callframe.this()) {
+        if let Some(stream) = locked_stdin_stream(self, callframe.this(), global_this) {
             return bun_jsc::from_js_host_call(global_this, || {
                 global_this.readable_stream_to_json(stream)
             });
@@ -1301,7 +1303,7 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        if let Some(stream) = fd_cached_stream(self, callframe.this()) {
+        if let Some(stream) = locked_stdin_stream(self, callframe.this(), global_this) {
             return bun_jsc::from_js_host_call(global_this, || {
                 global_this.readable_stream_to_array_buffer(stream)
             });
@@ -1315,7 +1317,7 @@ impl BlobExt for Blob {
     }
 
     fn get_bytes(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        if let Some(stream) = fd_cached_stream(self, callframe.this()) {
+        if let Some(stream) = locked_stdin_stream(self, callframe.this(), global_this) {
             return bun_jsc::from_js_host_call(global_this, || {
                 global_this.readable_stream_to_bytes(stream)
             });

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -118,6 +118,46 @@ const SERIALIZATION_VERSION: u8 = 4;
 
 pub use bun_jsc::generated::JSBlob as js;
 
+thread_local! {
+    /// Set while a `ReadFile` spawned by one of the `Bun.stdin` Blob read
+    /// helpers (`text()/json()/arrayBuffer()/bytes()`) is in flight. A second
+    /// concurrent call checks this and rejects with `ERR_INVALID_STATE`
+    /// instead of registering a second poll on fd 0 (which the kernel answers
+    /// with `EEXIST` from `epoll_ctl` after the loser has already consumed
+    /// bytes). Claimed in `do_read_file`; released in `NewReadFileHandler::run`.
+    static STDIN_BLOB_READ_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(crate) fn is_stdin_fd_store(blob: &Blob) -> bool {
+    matches!(
+        blob.store.get().as_deref(),
+        Some(s) if matches!(
+            &s.data,
+            store::Data::File(f) if matches!(
+                f.pathlike,
+                PathOrFileDescriptor::Fd(fd) if matches!(fd.stdio_tag(), Some(bun_sys::Stdio::StdIn))
+            )
+        )
+    )
+}
+
+pub(crate) fn release_stdin_blob_read_claim() {
+    STDIN_BLOB_READ_IN_FLIGHT.set(false);
+}
+
+/// For an fd-backed Blob, return the `ReadableStream` cached on the JS wrapper
+/// by `get_stream_with_cache`, if one has been materialised.
+fn fd_cached_stream(blob: &Blob, this_value: JSValue) -> Option<JSValue> {
+    let store = blob.store.get().as_deref()?;
+    let store::Data::File(f) = &store.data else {
+        return None;
+    };
+    if !matches!(f.pathlike, PathOrFileDescriptor::Fd(_)) {
+        return None;
+    }
+    js::stream_get_cached(this_value)
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 
 // is_s3: defined once above (near is_bun_file); duplicate removed to fix E0034.
@@ -440,6 +480,15 @@ impl BlobExt for Blob {
 
     fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue {
         debug!("doReadFile");
+
+        if is_stdin_fd_store(self) && STDIN_BLOB_READ_IN_FLIGHT.replace(true) {
+            return global
+                .err(
+                    jsc::ErrorCode::INVALID_STATE,
+                    format_args!("stdin is already being read by another Bun.stdin consumer"),
+                )
+                .reject();
+        }
 
         type Handler<'a, F> = read_file::NewReadFileHandler<'a, F>;
 
@@ -1218,7 +1267,12 @@ impl BlobExt for Blob {
 
         Ok(stream)
     }
-    fn get_text(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+    fn get_text(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        if let Some(stream) = fd_cached_stream(self, callframe.this()) {
+            return bun_jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_text(stream)
+            });
+        }
         Ok(self.get_text_clone(global_this)?)
     }
 
@@ -1227,7 +1281,12 @@ impl BlobExt for Blob {
         JSPromise::wrap(global_object, |g| self.to_string(g, Lifetime::Clone))
     }
 
-    fn get_json(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+    fn get_json(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        if let Some(stream) = fd_cached_stream(self, callframe.this()) {
+            return bun_jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_json(stream)
+            });
+        }
         Ok(self.get_json_share(global_this)?)
     }
 
@@ -1244,7 +1303,16 @@ impl BlobExt for Blob {
         JSPromise::wrap(global_this, |g| self.to_array_buffer(g, Lifetime::Clone))
     }
 
-    fn get_array_buffer(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+    fn get_array_buffer(
+        &self,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        if let Some(stream) = fd_cached_stream(self, callframe.this()) {
+            return bun_jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_array_buffer(stream)
+            });
+        }
         Ok(self.get_array_buffer_clone(global_this)?)
     }
 
@@ -1253,7 +1321,12 @@ impl BlobExt for Blob {
         JSPromise::wrap(global_this, |g| self.to_uint8_array(g, Lifetime::Clone))
     }
 
-    fn get_bytes(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+    fn get_bytes(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        if let Some(stream) = fd_cached_stream(self, callframe.this()) {
+            return bun_jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_bytes(stream)
+            });
+        }
         Ok(self.get_bytes_clone(global_this)?)
     }
 

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -266,6 +266,10 @@ impl ReadableStream {
         ReadableStream__isLocked(self.value, global_object)
     }
 
+    pub fn is_locked_value(value: JSValue, global_object: &JSGlobalObject) -> bool {
+        ReadableStream__isLocked(value, global_object)
+    }
+
     /// A pure `dynamicDowncast<JSReadableStream>` type test: no tagging, no conversion.
     pub fn is_readable_stream(value: JSValue) -> bool {
         ReadableStream__is(value)

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -101,6 +101,9 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
         let blob = core::mem::take(&mut handler.context);
         let global_this = handler.global_this;
         drop(handler);
+        if crate::webcore::blob::is_stdin_fd_store(&blob) {
+            crate::webcore::blob::release_stdin_blob_read_claim();
+        }
         match maybe_bytes {
             ReadFileResultType::Result(result) => {
                 let bytes = result.buf;

--- a/test/js/bun/util/bun-stdin-concurrent-read.test.ts
+++ b/test/js/bun/util/bun-stdin-concurrent-read.test.ts
@@ -70,8 +70,11 @@ describe.each(["text", "arrayBuffer", "bytes"] as const)("Bun.stdin.%s()", metho
   });
 });
 
-test.concurrent("sequential Bun.stdin.text() after the first read completes does not reject", async () => {
-  const { stdout, stderr, exitCode } = await run(`
+test.concurrent(
+  "sequential Bun.stdin.text() still works after process.stdin was referenced without reading",
+  async () => {
+    const { stdout, stderr, exitCode } = await run(`
+    void process.stdin.isTTY;
     const a = await Bun.stdin.text();
     const b = await Bun.stdin.text().then(
       v => ({ state: "resolved", len: v.length }),
@@ -79,13 +82,14 @@ test.concurrent("sequential Bun.stdin.text() after the first read completes does
     );
     process.stdout.write(JSON.stringify({ aLen: a.length, b }));
   `);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
-    aLen: SIZE,
-    b: { state: "resolved", len: 0 },
-  });
-  expect(exitCode).toBe(0);
-});
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      aLen: SIZE,
+      b: { state: "resolved", len: 0 },
+    });
+    expect(exitCode).toBe(0);
+  },
+);
 
 test.concurrent("Bun.stdin.text() with no other consumer reads every byte", async () => {
   const { stdout, stderr, exitCode } = await run(`process.stdout.write(String((await Bun.stdin.text()).length));`);

--- a/test/js/bun/util/bun-stdin-concurrent-read.test.ts
+++ b/test/js/bun/util/bun-stdin-concurrent-read.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// `Bun.stdin.text()/bytes()/arrayBuffer()/json()` read fd 0 via a `ReadFile`
+// task that owns its own io poll. A second concurrent `ReadFile` on the same
+// fd used to issue a second `EPOLL_CTL_ADD`, so one call rejected with the raw
+// `EEXIST: file already exists, epoll_ctl` after already having consumed bytes
+// (those bytes were dropped, so the other call resolved short). The helpers now
+// reject `ERR_INVALID_STATE` up front for a second concurrent consumer instead,
+// and route through the cached `ReadableStream` when `process.stdin` (or a
+// manual `Bun.stdin.stream().getReader()`) already holds it.
+
+const SIZE = 1024 * 1024;
+const payload = Buffer.alloc(SIZE, "abcdefghij");
+
+async function run(src: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  proc.stdin.write(payload);
+  await proc.stdin.end();
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("two concurrent Bun.stdin.text() calls: second rejects ERR_INVALID_STATE, first reads every byte", async () => {
+  const { stdout, stderr, exitCode } = await run(`
+    const wrap = p => p.then(
+      v => ({ state: "resolved", len: v.length }),
+      e => ({ state: "rejected", code: e?.code, name: e?.name }),
+    );
+    const [a, b] = await Promise.all([wrap(Bun.stdin.text()), wrap(Bun.stdin.text())]);
+    process.stdout.write(JSON.stringify({ a, b }));
+  `);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    a: { state: "resolved", len: SIZE },
+    b: { state: "rejected", code: "ERR_INVALID_STATE", name: "Error" },
+  });
+  expect(exitCode).toBe(0);
+});
+
+describe.each(["text", "arrayBuffer", "bytes"] as const)("Bun.stdin.%s()", method => {
+  test.concurrent(`rejects when process.stdin holds the reader; process.stdin receives every byte`, async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      let n = 0;
+      process.stdin.on("data", c => (n += c.length));
+      let blob = { state: "pending" };
+      Bun.stdin.${method}().then(
+        v => { blob = { state: "resolved" }; },
+        e => { blob = { state: "rejected", code: e?.code }; },
+      );
+      await new Promise(r => process.stdin.once("end", r));
+      await Promise.resolve();
+      process.stdout.write(JSON.stringify({ n, blob }));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      n: SIZE,
+      blob: { state: "rejected", code: "ERR_INVALID_STATE" },
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
+test.concurrent("sequential Bun.stdin.text() after the first read completes does not reject", async () => {
+  const { stdout, stderr, exitCode } = await run(`
+    const a = await Bun.stdin.text();
+    const b = await Bun.stdin.text().then(
+      v => ({ state: "resolved", len: v.length }),
+      e => ({ state: "rejected", code: e?.code }),
+    );
+    process.stdout.write(JSON.stringify({ aLen: a.length, b }));
+  `);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    aLen: SIZE,
+    b: { state: "resolved", len: 0 },
+  });
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("Bun.stdin.text() with no other consumer reads every byte", async () => {
+  const { stdout, stderr, exitCode } = await run(
+    `process.stdout.write(String((await Bun.stdin.text()).length));`,
+  );
+  expect(stderr).toBe("");
+  expect(stdout).toBe(String(SIZE));
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/bun-stdin-concurrent-read.test.ts
+++ b/test/js/bun/util/bun-stdin-concurrent-read.test.ts
@@ -27,8 +27,10 @@ async function run(src: string) {
   return { stdout, stderr, exitCode };
 }
 
-test.concurrent("two concurrent Bun.stdin.text() calls: second rejects ERR_INVALID_STATE, first reads every byte", async () => {
-  const { stdout, stderr, exitCode } = await run(`
+test.concurrent(
+  "two concurrent Bun.stdin.text() calls: second rejects ERR_INVALID_STATE, first reads every byte",
+  async () => {
+    const { stdout, stderr, exitCode } = await run(`
     const wrap = p => p.then(
       v => ({ state: "resolved", len: v.length }),
       e => ({ state: "rejected", code: e?.code, name: e?.name }),
@@ -36,13 +38,14 @@ test.concurrent("two concurrent Bun.stdin.text() calls: second rejects ERR_INVAL
     const [a, b] = await Promise.all([wrap(Bun.stdin.text()), wrap(Bun.stdin.text())]);
     process.stdout.write(JSON.stringify({ a, b }));
   `);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
-    a: { state: "resolved", len: SIZE },
-    b: { state: "rejected", code: "ERR_INVALID_STATE", name: "Error" },
-  });
-  expect(exitCode).toBe(0);
-});
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      a: { state: "resolved", len: SIZE },
+      b: { state: "rejected", code: "ERR_INVALID_STATE", name: "Error" },
+    });
+    expect(exitCode).toBe(0);
+  },
+);
 
 describe.each(["text", "arrayBuffer", "bytes"] as const)("Bun.stdin.%s()", method => {
   test.concurrent(`rejects when process.stdin holds the reader; process.stdin receives every byte`, async () => {
@@ -85,9 +88,7 @@ test.concurrent("sequential Bun.stdin.text() after the first read completes does
 });
 
 test.concurrent("Bun.stdin.text() with no other consumer reads every byte", async () => {
-  const { stdout, stderr, exitCode } = await run(
-    `process.stdout.write(String((await Bun.stdin.text()).length));`,
-  );
+  const { stdout, stderr, exitCode } = await run(`process.stdout.write(String((await Bun.stdin.text()).length));`);
   expect(stderr).toBe("");
   expect(stdout).toBe(String(SIZE));
   expect(exitCode).toBe(0);

--- a/test/js/bun/util/bun-stdin-concurrent-read.test.ts
+++ b/test/js/bun/util/bun-stdin-concurrent-read.test.ts
@@ -47,7 +47,7 @@ test.concurrent(
   },
 );
 
-describe.each(["text", "arrayBuffer", "bytes"] as const)("Bun.stdin.%s()", method => {
+describe.each(["text", "arrayBuffer", "bytes", "json"] as const)("Bun.stdin.%s()", method => {
   test.concurrent(`rejects when process.stdin holds the reader; process.stdin receives every byte`, async () => {
     const { stdout, stderr, exitCode } = await run(`
       let n = 0;


### PR DESCRIPTION
## Problem

Three stdin consumers share fd 0: `Bun.stdin.stream()` (cached on the JS wrapper), `process.stdin` (built on that cached stream's reader), and `Bun.stdin.text()/bytes()/arrayBuffer()/json()` (each spawns a fresh `ReadFile` task with its own `io::Poll`). Only the first two honour the WHATWG reader lock; the blob helpers ignored it and read fd 0 directly.

Two visible failures:

```js
// cat 1MB.bin | bun child.mjs
const [a, b] = await Promise.all([Bun.stdin.text(), Bun.stdin.text()]);
// a rejects  EEXIST: file already exists, epoll_ctl
// b resolves with 524288..894848 bytes (truncated; loser's partial read is dropped)
```

```js
process.stdin.on("data", c => ...);       // holds the cached stream's reader
await Bun.stdin.arrayBuffer();            // ignores the reader, reads fd 0 anyway; bytes split silently
```

The second `ReadFile` issues `EPOLL_CTL_ADD` on a fd already in the `IoRequestLoop` epoll set (each `io::Poll` tracks `WasEverRegistered` independently), so the kernel returns `EEXIST`. The loser has already consumed bytes before it needs to wait; its error path drops that buffer.

## Fix

- `do_read_file` claims a process-wide `STDIN_BLOB_READ_IN_FLIGHT` atomic before scheduling a stdin `ReadFile`; a second concurrent caller rejects `ERR_INVALID_STATE` immediately. `NewReadFileHandler::run` releases the claim on completion so sequential reads keep working.
- When the `ReadableStream` cached on the `Bun.stdin` wrapper is **locked** (held by `process.stdin` or a manual `.getReader()`), `get_text`/`get_json`/`get_array_buffer`/`get_bytes` route through `readableStreamTo{Text,JSON,ArrayBuffer,Bytes}` so the held reader produces the same `ERR_INVALID_STATE: ReadableStream is locked` as a second `getReader()` would. A cached-but-unlocked stream (e.g. after a bare `process.stdin.isTTY`) falls through to `do_read_file` so sequential reads keep resolving at EOF.

Node v26 has no single-owner stdin lock either (`process.stdin` + `fs.promises.readFile('/dev/stdin')` splits silently), so the locked-stream rejection is a quality improvement rather than a compat requirement; not surfacing a raw `epoll_ctl` errno is a bug fix.

Supersedes #35831 (that PR routed through the cached stream but left two concurrent blob reads racing).

## Verification

`test/js/bun/util/bun-stdin-concurrent-read.test.ts` pipes 1 MiB into a child and asserts:

| scenario | before | after |
| --- | --- | --- |
| two concurrent `Bun.stdin.text()` | one rejects `EEXIST`, other truncated | first resolves full 1 MiB, second rejects `ERR_INVALID_STATE` |
| `process.stdin.on('data')` + `Bun.stdin.{text,bytes,arrayBuffer}()` | bytes split, no error | `process.stdin` receives full 1 MiB, blob rejects `ERR_INVALID_STATE` |
| `process.stdin.isTTY` then sequential `text()`, `text()` | second resolves `""` | second resolves `""` (no regression) |
| single `text()` | pass | pass (fast path unchanged) |

Existing `Bun.stdin` regressions (`07500`, `27849`, `29787`), `bun-stdin-slice`, `process-stdin` and `blob.test.ts` all pass.

## Intentionally not covered

- **`Bun.stdin.text()` started *before* `process.stdin` is first touched**: `get_stream_with_cache` does not consult the in-flight flag, so a `FileReader` created after the `ReadFile` is already running still reads fd 0 independently (silent split, no `EEXIST`; the two readers sit on different epoll instances). Throwing from `.stream()` here would make `process.stdin` initialisation itself throw, which is worse UX than the split. Pre-existing behaviour; the common ordering (listener first) is the one that now rejects.
- **`Bun.stdin.formData()` while `process.stdin` holds the reader**: `get_form_data` is not routed through the cached stream (it would need the boundary plumbed into `readable_stream_to_form_data`). Two concurrent `formData()`/`text()` calls are still caught by the `do_read_file` claim; only the `process.stdin` + `formData()` combination still reads fd 0 before rejecting on the missing content-type.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-stdin-concurrent-read.test.ts
bun test v1.4.0 (1c7e2b843)

test/js/bun/util/bun-stdin-concurrent-read.test.ts:
37 |     );
38 |     const [a, b] = await Promise.all([wrap(Bun.stdin.text()), wrap(Bun.stdin.text())]);
39 |     process.stdout.write(JSON.stringify({ a, b }));
40 |   `);
41 |     expect(stderr).toBe("");
42 |     expect(JSON.parse(stdout)).toEqual({
                                    ^
error: expect(received).toEqual(expected)

  {
    "a": {
      "len": 1048576,
      "state": "resolved",
    },
    "b": {
-     "code": "ERR_INVALID_STATE",
+     "code": "EEXIST",
      "name": "Error",
      "state": "rejected",
    },
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/util/bun-stdin-concurrent-read.test.ts:42:32)
(fail) two concurrent Bun.stdin.text() calls: second rejects ERR_INVALID_STATE, first reads every byte [1124.24ms]
60 |       await new Promise(r => process.stdin.once("end", r));
61 |       await Promise.resolve();
62 |       process.stdout.write(JSON.s
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1a28f3223)

test/js/bun/util/bun-stdin-concurrent-read.test.ts:
(pass) Bun.stdin.text() with no other consumer reads every byte [23.66ms]
(pass) sequential Bun.stdin.text() still works after process.stdin was referenced without reading [27.48ms]
(pass) Bun.stdin.json() > rejects when process.stdin holds the reader; process.stdin receives every byte [29.53ms]
(pass) Bun.stdin.bytes() > rejects when process.stdin holds the reader; process.stdin receives every byte [30.54ms]
(pass) Bun.stdin.arrayBuffer() > rejects when process.stdin holds the reader; process.stdin receives every byte [31.18ms]
(pass) Bun.stdin.text() > rejects when process.stdin holds the reader; process.stdin receives every byte [32.18ms]
(pass) two concurrent Bun.stdin.text() calls: second rejects ERR_INVALID_STATE, first reads every byte [40.36ms]

 7 pass
 0 fail
 21 expect() calls
Ran 7 tests across 1 file. [392.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-stdin-concurrent-read.test.ts
bun test v1.4.0 (1c7e2b843)

test/js/bun/util/bun-stdin-concurrent-read.test.ts:
(pass) two concurrent Bun.stdin.text() calls: second rejects ERR_INVALID_STATE, first reads every byte [1126.27ms]
(pass) Bun.stdin.text() > rejects when process.stdin holds the reader; process.stdin receives every byte [1319.50ms]
(pass) Bun.stdin.bytes() > rejects when process.stdin holds the reader; process.stdin receives every byte [1318.24ms]
(pass) Bun.stdin.arrayBuffer() > rejects when process.stdin holds the reader; process.stdin receives every byte [1331.07ms]
(pass) Bun.stdin.json() > rejects when process.stdin holds the reader; process.stdin receives every byte [1325.91ms]
(pass) sequential Bun.stdin.text() still works after process.stdin was referenced without reading [1180.62ms]
(pass) Bun.stdin.text() with no other consumer reads every byte [1082.35ms]

 7 pass
 0 fail
 21 expect() calls
Ran 7 tests across 1 file. [4.42s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 699ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/32] gen cpp.rs (cppbind)
[2/32] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/32] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameP
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs                        | 76 ++++++++++++++++-
 src/runtime/webcore/ReadableStream.rs              |  4 +
 src/runtime/webcore/blob/read_file.rs              |  3 +
 test/js/bun/util/bun-stdin-concurrent-read.test.ts | 99 ++++++++++++++++++++++
 4 files changed, 178 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/runtime/webcore/Blob.rs                             8     15      0
src/runtime/webcore/ReadableStream.rs                   3      1      0
src/runtime/webcore/blob/read_file.rs                   2      1      0
test/js/bun/util/bun-stdin-concurrent-read.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->
- **Worker terminated mid-`Bun.stdin.text()`**: the in-flight claim is released in `NewReadFileHandler::run`, which runs on the claiming thread's event loop. A Worker terminated while its `ReadFile` is parked in the io loop never reaches that callback, so the claim stays set and later `Bun.stdin` blob reads reject `ERR_INVALID_STATE`. On main the same scenario already rejects `EEXIST` (the dead worker's `io::Poll` on fd 0 stays registered), so this is a lateral change in error text, not a regression; clearing the claim in `Drop` would not help because the handler box is leaked on that teardown path.
