### PR TITLE
crypto: reject KeyObject and CryptoKey in v8.serialize and child_process advanced IPC

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1912,8 +1912,15 @@ private:
             }
 #if ENABLE(WEB_CRYPTO)
             if (auto* key = JSCryptoKey::toWrapped(vm, obj)) {
-                if (m_forStorage == SerializationForStorage::Yes && !key->extractable()) {
+                if (m_forStorage == SerializationForStorage::Yes) {
                     code = SerializationReturnCode::DataCloneError;
+                    return true;
+                }
+                if (m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
+                    if (!startObjectInternal(obj))
+                        return true;
+                    write(ObjectTag);
+                    write(TerminatorTag);
                     return true;
                 }
                 if (!startObjectInternal(obj)) // handle duplicates

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2123,10 +2123,8 @@ private:
             }
 
             if (auto* keyObject = dynamicDowncast<Bun::JSKeyObject>(obj)) {
-                // Node.js allows KeyObject through structuredClone() and worker postMessage(),
-                // but v8.serialize() throws and child_process "advanced" IPC delivers {}.
-                // Without this gate the plaintext PEM (including private-key material) lands
-                // in any byte sink that stores v8.serialize() output.
+                // Node.js: v8.serialize() throws, child_process advanced IPC delivers {};
+                // only structuredClone / worker postMessage clone a KeyObject.
                 if (m_forStorage == SerializationForStorage::Yes) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2123,8 +2123,6 @@ private:
             }
 
             if (auto* keyObject = dynamicDowncast<Bun::JSKeyObject>(obj)) {
-                // Node.js: v8.serialize() throws, child_process advanced IPC delivers {};
-                // only structuredClone / worker postMessage clone a KeyObject.
                 if (m_forStorage == SerializationForStorage::Yes) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2123,6 +2123,22 @@ private:
             }
 
             if (auto* keyObject = dynamicDowncast<Bun::JSKeyObject>(obj)) {
+                // Node.js allows KeyObject through structuredClone() and worker postMessage(),
+                // but v8.serialize() throws and child_process "advanced" IPC delivers {}.
+                // Without this gate the plaintext PEM (including private-key material) lands
+                // in any byte sink that stores v8.serialize() output.
+                if (m_forStorage == SerializationForStorage::Yes) {
+                    code = SerializationReturnCode::DataCloneError;
+                    return true;
+                }
+                if (m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
+                    if (!startObjectInternal(keyObject))
+                        return true;
+                    write(ObjectTag);
+                    write(TerminatorTag);
+                    return true;
+                }
+
                 if (!startObjectInternal(keyObject)) // handle duplicates
                     return true;
                 write(Bun__KeyObjectTag);

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -423,14 +423,9 @@ it("serialize rejects CryptoKey regardless of extractability", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(stdout).toBe(
-    [
-      "nonExtractable rejected DataCloneError",
-      "extractable rejected DataCloneError",
-      "32",
-      "32",
-      "true HMAC",
-      "",
-    ].join("\n"),
+    ["nonExtractable rejected DataCloneError", "extractable rejected DataCloneError", "32", "32", "true HMAC", ""].join(
+      "\n",
+    ),
   );
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -430,6 +430,57 @@ it("serialize rejects CryptoKey regardless of extractability", async () => {
   expect(exitCode).toBe(0);
 });
 
+// serialize() no longer emits CryptoKey bytes, so the deserializer corruption
+// tests run against records captured from a build that predates that gate.
+const frozenEd25519PublicKey = Buffer.from(
+  "DgAAACE4AAAADgAAAAEAAAABAAAAAQAAAAMFFgEgAAAA2D0jBddySeu2kPeQNwjXqXxleqjLRdoeheXsYdbKZO8=",
+  "base64",
+);
+const frozenRsaOaepPublicKey = Buffer.from(
+  "DgAAACEkAQAADgAAAAEAAAABAAAAAQAAAAACAwEAAAAQAAABAADDin23FvsGxGcc2pDpAIBKOU172cD2PwMwFRHXXtU8J/TDv32L+4mkJnpFG5kx5c+L98j0a4XrlqkziylK8ER7tXvt/D+kvUiC0ZevGEWUML2EwSIwr8nAPHM7/Uvbn9sj14QpM0iop8gGhyp/ggZLvNbChp2624EIBiCQUnWEbhx53Y27teJ4zqUKw87X3fQ7nLpbRLcVRVoQk3SreIu0cPcXGDBQf6o5z0+n4iYQgCrtvcCcq8nadxIn5Ffvyas1UZjuvwiaNL34lIYdk37J1owIroxZfXnvWnghAjj55HnJOeGlHJbh0suWOsYnXU2x1mllRhWYNtIOdyizuLX3AwAAAAEAAQ==",
+  "base64",
+);
+
+function indexOfPattern(bytes: Uint8Array, pattern: number[]): number {
+  outer: for (let i = 0; i + pattern.length <= bytes.length; i++) {
+    for (let j = 0; j < pattern.length; j++) if (bytes[i + j] !== pattern[j]) continue outer;
+    return i;
+  }
+  return -1;
+}
+
+it("deserialize rejects a CryptoKey whose named curve does not match its algorithm", () => {
+  const bytes = new Uint8Array(frozenEd25519PublicKey);
+  const offset = indexOfPattern(bytes, [5, 22, 1, 32, 0, 0, 0]);
+  expect(offset).toBeGreaterThanOrEqual(0);
+
+  const roundTripped = deserialize(bytes);
+  expect({ isCryptoKey: roundTripped instanceof CryptoKey, algorithm: roundTripped.algorithm.name }).toEqual({
+    isCryptoKey: true,
+    algorithm: "Ed25519",
+  });
+
+  const mutated = bytes.slice();
+  mutated[offset + 2] = 0;
+  expect(() => deserialize(mutated)).toThrow(expect.objectContaining({ name: "TypeError" }));
+});
+
+it("deserialize rejects a CryptoKey whose algorithm does not belong to its key class", () => {
+  const bytes = new Uint8Array(frozenRsaOaepPublicKey);
+  const offset = indexOfPattern(bytes, [2, 3, 1, 0, 0, 0, 16]);
+  expect(offset).toBeGreaterThanOrEqual(0);
+
+  const roundTripped = deserialize(bytes);
+  expect({ isCryptoKey: roundTripped instanceof CryptoKey, algorithm: roundTripped.algorithm.name }).toEqual({
+    isCryptoKey: true,
+    algorithm: "RSA-OAEP",
+  });
+
+  const mutated = bytes.slice();
+  mutated[offset + 1] = 20;
+  expect(() => deserialize(mutated)).toThrow(expect.objectContaining({ name: "TypeError" }));
+});
+
 it("deserialize rejects a CryptoKey record with no key bytes", async () => {
   const script = `
     import { serialize, deserialize } from "bun:jsc";

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -372,11 +372,12 @@ it("deserialize rejects a RegExp record whose pattern does not parse", async () 
   expect(exitCode).toBe(0);
 });
 
-it("serialize rejects a CryptoKey created with extractable set to false", async () => {
+it("serialize rejects CryptoKey regardless of extractability", async () => {
   // bun:jsc serialize() (and node:v8 serialize(), which wraps it) hands the raw
-  // structured-clone buffer to the caller, so a key imported with
-  // extractable: false must not be serializable through it. Keys marked
-  // extractable still serialize, and the non-extractable key remains usable.
+  // structured-clone buffer to the caller. Node.js refuses every CryptoKey there;
+  // Bun does the same so raw key material cannot reach a byte sink the caller
+  // stores verbatim. The rejected keys stay usable, and structuredClone (the
+  // in-process clone path) still carries them.
   const script = `
     import { serialize } from "bun:jsc";
     const secret = "THIS-IS-SECRET-KEY-MATERIAL-32B!";
@@ -388,16 +389,6 @@ it("serialize rejects a CryptoKey created with extractable set to false", async 
       false,
       ["sign"],
     );
-    let outcome;
-    try {
-      const bytes = new Uint8Array(serialize(nonExtractable));
-      const text = Array.from(bytes, b => String.fromCharCode(b)).join("");
-      outcome = text.includes(secret) ? "serialized with key material" : "serialized without key material";
-    } catch {
-      outcome = "rejected";
-    }
-    console.log(outcome);
-    // A key the caller marked extractable still serializes.
     const extractable = await crypto.subtle.importKey(
       "raw",
       secretBytes,
@@ -405,10 +396,23 @@ it("serialize rejects a CryptoKey created with extractable set to false", async 
       true,
       ["sign"],
     );
-    console.log(serialize(extractable).byteLength > 0);
-    // The non-extractable key is still usable for its intended purpose.
-    const signature = await crypto.subtle.sign("HMAC", nonExtractable, secretBytes);
-    console.log(signature.byteLength);
+    for (const [label, key] of [["nonExtractable", nonExtractable], ["extractable", extractable]]) {
+      let outcome;
+      try {
+        const bytes = new Uint8Array(serialize(key));
+        const text = Array.from(bytes, b => String.fromCharCode(b)).join("");
+        outcome = text.includes(secret) ? "serialized with key material" : "serialized without key material";
+      } catch (err) {
+        outcome = "rejected " + err.name;
+      }
+      console.log(label, outcome);
+    }
+    // Both keys are still usable for their intended purpose.
+    console.log((await crypto.subtle.sign("HMAC", nonExtractable, secretBytes)).byteLength);
+    console.log((await crypto.subtle.sign("HMAC", extractable, secretBytes)).byteLength);
+    // structuredClone (SerializationForStorage::No) still carries the key.
+    const cloned = structuredClone(extractable);
+    console.log(cloned instanceof CryptoKey, cloned.algorithm.name);
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
@@ -418,78 +422,17 @@ it("serialize rejects a CryptoKey created with extractable set to false", async 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout).toBe("rejected\ntrue\n32\n");
+  expect(stdout).toBe(
+    [
+      "nonExtractable rejected DataCloneError",
+      "extractable rejected DataCloneError",
+      "32",
+      "32",
+      "true HMAC",
+      "",
+    ].join("\n"),
+  );
   expect(exitCode).toBe(0);
-});
-
-it("deserialize rejects a CryptoKey whose named curve does not match its algorithm", async () => {
-  const script = `
-    import { serialize, deserialize } from "bun:jsc";
-    const { publicKey } = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
-    const bytes = new Uint8Array(serialize(publicKey));
-    const pattern = [5, 22, 1, 32, 0, 0, 0];
-    const offsets = [];
-    for (let i = 0; i + pattern.length <= bytes.length; i++) {
-      if (pattern.every((byte, j) => bytes[i + j] === byte)) offsets.push(i);
-    }
-    console.log(offsets.length);
-    const mutated = bytes.slice();
-    mutated[offsets[0] + 2] = 0;
-    let outcome;
-    try {
-      outcome = deserialize(mutated) instanceof CryptoKey ? "accepted" : "rejected";
-    } catch {
-      outcome = "rejected";
-    }
-    console.log(outcome);
-    const roundTripped = deserialize(bytes);
-    console.log(roundTripped instanceof CryptoKey, roundTripped.algorithm.name);
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "1\nrejected\ntrue Ed25519\n", exitCode: 0 });
-});
-
-it("deserialize rejects a CryptoKey whose algorithm does not belong to its key class", async () => {
-  const script = `
-    import { serialize, deserialize } from "bun:jsc";
-    const { publicKey } = await crypto.subtle.generateKey(
-      { name: "RSA-OAEP", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
-      true,
-      ["encrypt", "decrypt"],
-    );
-    const bytes = new Uint8Array(serialize(publicKey));
-    const pattern = [2, 3, 1, 0, 0, 0, 16];
-    const offsets = [];
-    for (let i = 0; i + pattern.length <= bytes.length; i++) {
-      if (pattern.every((byte, j) => bytes[i + j] === byte)) offsets.push(i);
-    }
-    console.log(offsets.length);
-    const mutated = bytes.slice();
-    mutated[offsets[0] + 1] = 20;
-    let outcome;
-    try {
-      outcome = deserialize(mutated) instanceof CryptoKey ? "accepted" : "rejected";
-    } catch {
-      outcome = "rejected";
-    }
-    console.log(outcome);
-    const roundTripped = deserialize(bytes);
-    console.log(roundTripped instanceof CryptoKey, roundTripped.algorithm.name);
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "1\nrejected\ntrue RSA-OAEP\n", exitCode: 0 });
 });
 
 it("deserialize rejects a CryptoKey record with no key bytes", async () => {
@@ -505,8 +448,10 @@ it("deserialize rejects a CryptoKey record with no key bytes", async () => {
       outcome = "rejected";
     }
     console.log(outcome);
+    // structuredClone is the remaining path that emits a CryptoKey record; it
+    // round-trips so the non-empty decode path is still covered.
     const { publicKey } = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
-    const roundTripped = deserialize(serialize(publicKey));
+    const roundTripped = structuredClone(publicKey);
     console.log(roundTripped instanceof CryptoKey, roundTripped.algorithm.name);
   `;
   await using proc = Bun.spawn({

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1816,15 +1816,16 @@ describe("KeyObject serialization", () => {
     ["public", publicKey],
     ["secret", secretKey],
   ])("%s", (label, key) => {
-    test("v8.serialize() throws", () => {
+    test("v8.serialize() throws DataCloneError", () => {
+      const dataCloneError = expect.objectContaining({ name: "DataCloneError" });
       let bytes: Buffer | undefined;
       expect(() => {
         bytes = v8.serialize(key);
-      }).toThrow();
+      }).toThrow(dataCloneError);
       expect(bytes).toBeUndefined();
 
-      expect(() => v8.serialize({ nested: key })).toThrow();
-      expect(() => v8.serialize([1, key, 2])).toThrow();
+      expect(() => v8.serialize({ nested: key })).toThrow(dataCloneError);
+      expect(() => v8.serialize([1, key, 2])).toThrow(dataCloneError);
     });
 
     test("structuredClone() still produces a working KeyObject", () => {

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -23,7 +23,8 @@ import {
   verify,
 } from "crypto";
 import fs from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import v8 from "node:v8";
 import { createContext, runInContext, runInThisContext, Script } from "node:vm";
 import path from "path";
 
@@ -1800,3 +1801,141 @@ test("ECDSA should work", async () => {
 function randomProp() {
   return "prop" + crypto.randomUUID().replace(/-/g, "");
 }
+
+describe("KeyObject serialization", () => {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const secretKey = createSecretKey(Buffer.from("0123456789abcdef"));
+
+  // Node.js refuses to emit a KeyObject into a byte sink the caller stores verbatim:
+  // v8.serialize() throws, and child_process "advanced" IPC turns it into a plain {}.
+  // structuredClone() and worker postMessage() keep cloning it. Previously Bun wrote
+  // the plaintext PKCS#8 PEM into the v8.serialize() output and delivered a live,
+  // exportable private key to the IPC child.
+  describe.each([
+    ["private", privateKey],
+    ["public", publicKey],
+    ["secret", secretKey],
+  ])("%s", (label, key) => {
+    test("v8.serialize() throws", () => {
+      let bytes: Buffer | undefined;
+      expect(() => {
+        bytes = v8.serialize(key);
+      }).toThrow();
+      expect(bytes).toBeUndefined();
+
+      expect(() => v8.serialize({ nested: key })).toThrow();
+      expect(() => v8.serialize([1, key, 2])).toThrow();
+    });
+
+    test("structuredClone() still produces a working KeyObject", () => {
+      const cloned = structuredClone(key);
+      expect(cloned).toBeInstanceOf(KeyObject);
+      expect(cloned.type).toBe(label);
+      if (label === "secret") {
+        expect(cloned.export()).toEqual(key.export());
+      } else {
+        expect(cloned.asymmetricKeyType).toBe(key.asymmetricKeyType);
+      }
+    });
+  });
+
+  test("v8.serialize() of a private key does not emit plaintext key material", () => {
+    const pem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+    const marker = "BEGIN PRIVATE KEY";
+    expect(pem).toContain(marker);
+    let out: Buffer | undefined;
+    try {
+      out = v8.serialize(privateKey);
+    } catch {}
+    expect({
+      containsPlaintextPEM: out ? out.toString("latin1").includes(marker) : false,
+      threw: out === undefined,
+    }).toEqual({ containsPlaintextPEM: false, threw: true });
+  });
+
+  test.concurrent("child_process advanced IPC delivers {} in place of a KeyObject", async () => {
+    using dir = tempDir("keyobject-ipc", {
+      "parent.mjs": `
+        import crypto from "node:crypto";
+        import { fork } from "node:child_process";
+        const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+        const secret = crypto.createSecretKey(Buffer.from("0123456789abcdef"));
+        const c = fork("./child.mjs", [], { serialization: "advanced" });
+        c.on("message", m => { console.log(JSON.stringify(m)); c.kill(); });
+        c.send({ priv: privateKey, pub: publicKey, secret, other: 42, nested: { deep: privateKey } });
+      `,
+      "child.mjs": `
+        process.on("message", m => {
+          const describe = v => ({
+            ctor: v?.constructor?.name,
+            keys: Object.keys(v ?? {}),
+            isKeyObject: typeof v?.export === "function",
+          });
+          process.send({
+            priv: describe(m.priv),
+            pub: describe(m.pub),
+            secret: describe(m.secret),
+            other: m.other,
+            deep: describe(m.nested.deep),
+          });
+          process.exit(0);
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const empty = { ctor: "Object", keys: [], isKeyObject: false };
+    expect(JSON.parse(stdout)).toEqual({
+      priv: empty,
+      pub: empty,
+      secret: empty,
+      other: 42,
+      deep: empty,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("worker_threads postMessage still carries a private KeyObject", async () => {
+    using dir = tempDir("keyobject-worker", {
+      "main.mjs": `
+        import crypto from "node:crypto";
+        import { Worker } from "node:worker_threads";
+        const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+        const w = new Worker("./worker.mjs");
+        w.on("message", m => { console.log(JSON.stringify(m)); w.terminate(); });
+        w.on("error", e => { console.error(String(e)); process.exit(1); });
+        w.postMessage(privateKey);
+      `,
+      "worker.mjs": `
+        import { parentPort } from "node:worker_threads";
+        parentPort.on("message", k => {
+          parentPort.postMessage({
+            ctor: k.constructor.name,
+            type: k.type,
+            exportable: k.export({ type: "pkcs8", format: "der" }).length > 0,
+          });
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ ctor: "KeyObject", type: "private", exportable: true });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -26,6 +26,7 @@ import fs from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import v8 from "node:v8";
 import { createContext, runInContext, runInThisContext, Script } from "node:vm";
+import { Worker } from "node:worker_threads";
 import path from "path";
 
 function readFile(...args) {
@@ -1802,20 +1803,22 @@ function randomProp() {
   return "prop" + crypto.randomUUID().replace(/-/g, "");
 }
 
-describe("KeyObject serialization", () => {
+describe("KeyObject and CryptoKey serialization", () => {
   const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
-  const secretKey = createSecretKey(Buffer.from("0123456789abcdef"));
+  const secretMaterial = Buffer.from("0123456789abcdef");
+  const secretKey = createSecretKey(secretMaterial);
 
-  // Node.js refuses to emit a KeyObject into a byte sink the caller stores verbatim:
-  // v8.serialize() throws, and child_process "advanced" IPC turns it into a plain {}.
-  // structuredClone() and worker postMessage() keep cloning it. Previously Bun wrote
-  // the plaintext PKCS#8 PEM into the v8.serialize() output and delivered a live,
-  // exportable private key to the IPC child.
+  // Node.js refuses to emit a KeyObject or CryptoKey into a byte sink the caller
+  // stores verbatim: v8.serialize() throws, and child_process "advanced" IPC turns
+  // the value into a plain {}. structuredClone() and worker postMessage() keep
+  // cloning it. Previously Bun wrote the plaintext key material (PKCS#8 PEM, raw
+  // symmetric secret, raw AES bytes) into the v8.serialize() output and delivered
+  // a live, exportable key to the IPC child.
   describe.each([
     ["private", privateKey],
     ["public", publicKey],
     ["secret", secretKey],
-  ])("%s", (label, key) => {
+  ])("%s KeyObject", (label, key) => {
     test("v8.serialize() throws DataCloneError", () => {
       const dataCloneError = expect.objectContaining({ name: "DataCloneError" });
       let bytes: Buffer | undefined;
@@ -1840,30 +1843,69 @@ describe("KeyObject serialization", () => {
     });
   });
 
-  test("v8.serialize() of a private key does not emit plaintext key material", () => {
-    const pem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
-    const marker = "BEGIN PRIVATE KEY";
-    expect(pem).toContain(marker);
-    let out: Buffer | undefined;
-    try {
-      out = v8.serialize(privateKey);
-    } catch {}
-    expect({
-      containsPlaintextPEM: out ? out.toString("latin1").includes(marker) : false,
-      threw: out === undefined,
-    }).toEqual({ containsPlaintextPEM: false, threw: true });
+  describe.each([
+    ["extractable", true],
+    ["non-extractable", false],
+  ])("%s CryptoKey", (_label, extractable) => {
+    const keyPromise = crypto.subtle.importKey("raw", secretMaterial, { name: "AES-GCM" }, extractable, ["encrypt"]);
+
+    test("v8.serialize() throws DataCloneError", async () => {
+      const key = await keyPromise;
+      const dataCloneError = expect.objectContaining({ name: "DataCloneError" });
+      let bytes: Buffer | undefined;
+      expect(() => {
+        bytes = v8.serialize(key);
+      }).toThrow(dataCloneError);
+      expect(bytes).toBeUndefined();
+
+      expect(() => v8.serialize({ nested: key })).toThrow(dataCloneError);
+      expect(() => v8.serialize([1, key, 2])).toThrow(dataCloneError);
+    });
+
+    test("structuredClone() still produces a working CryptoKey", async () => {
+      const key = await keyPromise;
+      const cloned = structuredClone(key);
+      expect({
+        ctor: cloned.constructor.name,
+        algorithm: cloned.algorithm.name,
+        extractable: cloned.extractable,
+      }).toEqual({ ctor: "CryptoKey", algorithm: "AES-GCM", extractable });
+    });
   });
 
-  test.concurrent("child_process advanced IPC delivers {} in place of a KeyObject", async () => {
+  test.each([
+    ["private KeyObject", () => privateKey, "BEGIN PRIVATE KEY"],
+    ["secret KeyObject", () => secretKey, secretMaterial.toString("latin1")],
+    [
+      "extractable CryptoKey",
+      () => crypto.subtle.importKey("raw", secretMaterial, { name: "AES-GCM" }, true, ["encrypt"]),
+      secretMaterial.toString("latin1"),
+    ],
+  ])("v8.serialize() of a %s does not emit plaintext key material", async (_label, make, marker) => {
+    const key = await make();
+    let out: Buffer | undefined;
+    try {
+      out = v8.serialize(key);
+    } catch {}
+    expect({
+      containsPlaintextMaterial: out ? out.toString("latin1").includes(marker) : false,
+      threw: out === undefined,
+    }).toEqual({ containsPlaintextMaterial: false, threw: true });
+  });
+
+  test.concurrent("child_process advanced IPC delivers {} in place of a KeyObject or CryptoKey", async () => {
     using dir = tempDir("keyobject-ipc", {
       "parent.mjs": `
         import crypto from "node:crypto";
         import { fork } from "node:child_process";
         const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
         const secret = crypto.createSecretKey(Buffer.from("0123456789abcdef"));
+        const aes = await crypto.subtle.importKey(
+          "raw", Buffer.from("0123456789abcdef"), { name: "AES-GCM" }, true, ["encrypt"],
+        );
         const c = fork("./child.mjs", [], { serialization: "advanced" });
         c.on("message", m => { console.log(JSON.stringify(m)); c.kill(); });
-        c.send({ priv: privateKey, pub: publicKey, secret, other: 42, nested: { deep: privateKey } });
+        c.send({ priv: privateKey, pub: publicKey, secret, aes, other: 42, nested: { deep: privateKey } });
       `,
       "child.mjs": `
         process.on("message", m => {
@@ -1876,6 +1918,7 @@ describe("KeyObject serialization", () => {
             priv: describe(m.priv),
             pub: describe(m.pub),
             secret: describe(m.secret),
+            aes: describe(m.aes),
             other: m.other,
             deep: describe(m.nested.deep),
           });
@@ -1898,45 +1941,42 @@ describe("KeyObject serialization", () => {
       priv: empty,
       pub: empty,
       secret: empty,
+      aes: empty,
       other: 42,
       deep: empty,
     });
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("worker_threads postMessage still carries a private KeyObject", async () => {
-    using dir = tempDir("keyobject-worker", {
-      "main.mjs": `
-        import crypto from "node:crypto";
-        import { Worker } from "node:worker_threads";
-        const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
-        const w = new Worker("./worker.mjs");
-        w.on("message", m => { console.log(JSON.stringify(m)); w.terminate(); });
-        w.on("error", e => { console.error(String(e)); process.exit(1); });
-        w.postMessage(privateKey);
-      `,
-      "worker.mjs": `
-        import { parentPort } from "node:worker_threads";
-        parentPort.on("message", k => {
+  test("worker_threads postMessage still carries a KeyObject and CryptoKey", async () => {
+    const aes = await crypto.subtle.importKey("raw", secretMaterial, { name: "AES-GCM" }, true, ["encrypt"]);
+    const w = new Worker(
+      `
+        const { parentPort } = require("node:worker_threads");
+        parentPort.on("message", m => {
           parentPort.postMessage({
-            ctor: k.constructor.name,
-            type: k.type,
-            exportable: k.export({ type: "pkcs8", format: "der" }).length > 0,
+            priv: {
+              ctor: m.priv.constructor.name,
+              type: m.priv.type,
+              exportable: m.priv.export({ type: "pkcs8", format: "der" }).length > 0,
+            },
+            aes: { ctor: m.aes.constructor.name, algorithm: m.aes.algorithm.name, extractable: m.aes.extractable },
           });
         });
       `,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.mjs"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual({ ctor: "KeyObject", type: "private", exportable: true });
-    expect(exitCode).toBe(0);
+      { eval: true },
+    );
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+      w.on("message", resolve);
+      w.on("error", reject);
+      w.postMessage({ priv: privateKey, aes });
+      expect(await promise).toEqual({
+        priv: { ctor: "KeyObject", type: "private", exportable: true },
+        aes: { ctor: "CryptoKey", algorithm: "AES-GCM", extractable: true },
+      });
+    } finally {
+      await w.terminate();
+    }
   });
 });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -23,6 +23,12 @@ const identityCases: [string, () => object, Function][] = [
   ["Blob", () => new Blob(["hi"], { type: "text/plain" }), Blob],
   ["File", () => new File(["hi"], "a.txt", { type: "text/plain" }), File],
   ["X509Certificate", () => new X509Certificate(tls.cert), X509Certificate],
+];
+
+// node:crypto KeyObject clones through structuredClone / worker postMessage but is
+// rejected by bun:jsc serialize / v8.serialize (matching Node.js), so these run
+// for structuredClone only.
+const keyObjectIdentityCases: [string, () => object, Function][] = [
   ["secret KeyObject", () => createSecretKey(Buffer.from("0123456789abcdef")), KeyObject],
   ["public KeyObject", () => createPublicKey(tls.key), KeyObject],
   ["private KeyObject", () => createPrivateKey(tls.key), KeyObject],
@@ -289,7 +295,9 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       // Two references to the same object must deserialize to the same object:
       // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
       describe("duplicated references preserve identity", () => {
-        test.each(identityCases)("%s", (_label, make, ctor) => {
+        const cases =
+          structuredCloneFn === structuredClone ? [...identityCases, ...keyObjectIdentityCases] : identityCases;
+        test.each(cases)("%s", (_label, make, ctor) => {
           const value = make();
           const cloned = structuredCloneFn([value, value]);
           expect(cloned[0]).toBeInstanceOf(ctor);
@@ -772,7 +780,7 @@ for (const structuredCloneFn of [
 
 describe("reference pool survives a process boundary", () => {
   // One cold subprocess hop covering the whole identity matrix, so every platform object
-  // type (X509Certificate, KeyObjects, Blob, File, ...) is deserialized in a fresh VM.
+  // type (X509Certificate, Blob, File, ...) is deserialized in a fresh VM.
   test("duplicated references preserve identity for every type", () => {
     const values = identityCases.map(([, make]) => make());
     const cloned = jscSerializeRoundtripCrossProcessCold(values.map(value => [value, value]));

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -305,13 +305,17 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
           expect(cloned[0]).toBe(cloned[1]);
         });
 
-        test("CryptoKey", async () => {
-          const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt"]);
-          const cloned = structuredCloneFn([key, key]);
-          expect(cloned[0]).toBeInstanceOf(CryptoKey);
-          expect(cloned[0]).not.toBe(key);
-          expect(cloned[0]).toBe(cloned[1]);
-        });
+        if (structuredCloneFn === structuredClone) {
+          // CryptoKey clones through structuredClone / worker postMessage but is rejected
+          // by bun:jsc serialize / v8.serialize (matching Node.js).
+          test("CryptoKey", async () => {
+            const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt"]);
+            const cloned = structuredCloneFn([key, key]);
+            expect(cloned[0]).toBeInstanceOf(CryptoKey);
+            expect(cloned[0]).not.toBe(key);
+            expect(cloned[0]).toBe(cloned[1]);
+          });
+        }
 
         test("same object reachable through object, array, Map, and Set paths", () => {
           const d = new Date(7);
@@ -757,14 +761,18 @@ for (const structuredCloneFn of [
   jscSerializeRoundtripCrossProcessCold,
 ]) {
   describe(`${structuredCloneFn.name}: object pool back-references after platform objects`, () => {
-    test("a duplicated object after a CryptoKey keeps its identity", async () => {
-      const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 128 }, true, ["encrypt", "decrypt"]);
-      const o = { x: 1 };
-      const c = await structuredCloneFn([key, o, o]);
-      expect(c[0]).toBeInstanceOf(CryptoKey);
-      expect(c[1]).toEqual({ x: 1 });
-      expect(c[2]).toBe(c[1]);
-    });
+    if (structuredCloneFn === structuredClone) {
+      // bun:jsc serialize / v8.serialize rejects CryptoKey (matching Node.js); the
+      // back-reference path it covers is still reachable through structuredClone.
+      test("a duplicated object after a CryptoKey keeps its identity", async () => {
+        const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 128 }, true, ["encrypt", "decrypt"]);
+        const o = { x: 1 };
+        const c = await structuredCloneFn([key, o, o]);
+        expect(c[0]).toBeInstanceOf(CryptoKey);
+        expect(c[1]).toEqual({ x: 1 });
+        expect(c[2]).toBe(c[1]);
+      });
+    }
 
     test("a duplicated object after an X509Certificate keeps its identity", async () => {
       const cert = new X509Certificate(tls.cert);


### PR DESCRIPTION
## Problem

`KeyObject` (secret/public/private) and `CryptoKey` are first-class serializable through `v8.serialize()` and `child_process` `serialization: "advanced"` IPC on Bun, where Node.js rejects them. Raw key material (plaintext PKCS#8 PEM, raw symmetric secret, raw AES bytes) lands in any byte sink that stores `v8.serialize` output (caches, session stores, IPC frames), and a live key crosses the process boundary.

```js
import crypto from "node:crypto";
import v8 from "node:v8";
const secret = crypto.createSecretKey(Buffer.from("SECRETKEY_MARKER_0123456789ab"));
const aes = await crypto.subtle.importKey(
  "raw", Buffer.from("AESRAWKEYBYTES16"), { name: "AES-GCM" }, true, ["encrypt"],
);
v8.serialize(secret).includes("SECRETKEY_MARKER"); // bun (before): true; node: throws
v8.serialize(aes).includes("AESRAWKEYBYTES16");    // bun (before): true; node: throws
```

Over `child_process` advanced IPC, `child.send({ k: secret })` delivered a live, exportable `SecretKeyObject` / `CryptoKey` to the child on Bun; Node delivers `{ k: {} }`.

`structuredClone` and worker `postMessage` carry `KeyObject` and `CryptoKey` on both runtimes (documented), so those paths are unchanged.

## Cause

`CloneSerializer` wrote `Bun__KeyObjectTag` + plaintext PEM / raw secret for any `JSKeyObject` without checking `m_forStorage` or `m_forTransfer`, and wrote `CryptoKeyTag` + wrapped key bytes for any extractable `JSCryptoKey` under `m_forStorage`. Every entry point (structuredClone, worker postMessage, `bun:jsc`/`v8` serialize, IPC) therefore emitted the same bytes.

## Fix

Gate the `JSKeyObject` and `JSCryptoKey` branches in `SerializedScriptValue.cpp` on the existing context flags, matching the pattern already used for other Bun host types:

- `SerializationForStorage::Yes` (`bun:jsc` `serialize`, `v8.serialize`): `DataCloneError`.
- `SerializationForCrossProcessTransfer::Yes` (child_process advanced IPC): write `ObjectTag` + `TerminatorTag`, i.e. an empty `{}`.
- Neither (`structuredClone`, worker/MessagePort `postMessage`): unchanged, clones a working key.

## Verification

`bun bd test test/js/node/crypto/crypto.key-objects.test.ts -t "KeyObject and CryptoKey serialization"`: 15 pass (8 fail on the unpatched build: 4x `v8.serialize() throws`, 3x plaintext-material check, IPC empty-object check).

`bun-jsc.test.ts` and `structured-clone.test.ts` updated to reflect that `bun:jsc` `serialize` now rejects `CryptoKey` (matching Node). The two `deserialize`-corruption tests that relied on `serialize(publicKey)` for starting bytes are folded away; the hand-crafted empty-record rejection test remains.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts test/js/node/crypto/crypto.key-objects.test.ts

<!-- robobun:evidence:end -->