### PR TITLE
node:http: defer server 'close' until every tracked connection has ended

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -70,6 +70,7 @@ const { kIncomingMessage } = require("node:_http_common");
 let http1Fallback;
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
+const kPendingDrainClose = Symbol("http.server.pendingDrainClose");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
@@ -102,7 +103,14 @@ const DateNow = Date.now;
 let cluster;
 
 function emitCloseServer(self: Server) {
-  callCloseCallback(self);
+  // The native all-closed promise tracks pending requests, not open connections.
+  if (self[serverSymbol]) return;
+  const connections = self[kTrackedConnections];
+  if (connections && connections.size > 0) {
+    self[kPendingDrainClose] = true;
+    return;
+  }
+  self[kPendingDrainClose] = false;
   self.emit("close");
 }
 function emitCloseNTServer(this: Server) {
@@ -278,6 +286,7 @@ function Server(options, callback): void {
   defineHttpAllowHalfOpen(this);
   this[kInternalSocketData] = undefined;
   this[kTrackedConnections] = new Set();
+  this[kPendingDrainClose] = false;
   this[tlsSymbol] = null;
   this.noDelay = true;
   if (typeof options === "function") {
@@ -445,14 +454,18 @@ Server.prototype.unref = function () {
 Server.prototype.closeAllConnections = function () {
   http1Fallback?.closeAllHttp1Connections(this);
   const server = this[serverSymbol];
-  if (!server) {
+  if (server) {
+    this[serverSymbol] = undefined;
+    clearInterval(this[kConnectionsCheckingInterval]);
+    this.listening = false;
+    server.stop(true);
     return;
   }
-  this[serverSymbol] = undefined;
-  clearInterval(this[kConnectionsCheckingInterval]);
-  this.listening = false;
-
-  server.stop(true);
+  // close() already dropped the native handle; destroy what is still tracked.
+  const tracked = this[kTrackedConnections];
+  if (tracked && tracked.size > 0) {
+    for (const socket of Array.from(tracked)) socket.destroy();
+  }
 };
 
 Server.prototype.getConnections = function (callback) {
@@ -468,7 +481,16 @@ Server.prototype.getConnections = function (callback) {
 Server.prototype.closeIdleConnections = function () {
   http1Fallback?.closeIdleHttp1Connections(this);
   const server = this[serverSymbol];
-  server?.closeIdleConnections();
+  if (server) {
+    server.closeIdleConnections();
+    return;
+  }
+  const tracked = this[kTrackedConnections];
+  if (tracked && tracked.size > 0) {
+    for (const socket of Array.from(tracked)) {
+      if (!socket._httpMessage) socket.destroy();
+    }
+  }
 };
 
 Server.prototype.close = function (optionalCallback?) {
@@ -483,7 +505,7 @@ Server.prototype.close = function (optionalCallback?) {
     return this;
   }
   this[serverSymbol] = undefined;
-  if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
+  if (typeof optionalCallback === "function") this.once("close", optionalCallback);
   this.listening = false;
   server.closeIdleConnections();
   // stop() queues the task that emits 'close', which holds the loop one more turn, as node's uv_close() does.
@@ -1059,6 +1081,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
 
     // Bun.serve() has bound and listened by now, so the flag is true at once, as node's getter is.
     this.listening = true;
+    this[kPendingDrainClose] = false;
     getBunServerAllClosedPromise(this[serverSymbol]).$then(emitCloseNTServer.bind(this));
     applyServerCustomOptions(this);
 
@@ -1612,7 +1635,14 @@ function getNodeHTTPServerSocket() {
       // released parser (free() invoked, kOnTimeout nulled).
       releaseServerParserShim(this);
       this[kHandle] = null;
-      this.server?.[kTrackedConnections]?.delete(this);
+      const server = this.server;
+      const tracked = server?.[kTrackedConnections];
+      if (tracked) {
+        tracked.delete(this);
+        if (tracked.size === 0 && server[kPendingDrainClose]) {
+          process.nextTick(emitCloseServer, server);
+        }
+      }
       const timer = this[kSocketTimeoutTimer];
       if (timer) {
         clearTimeout(timer);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -464,7 +464,7 @@ Server.prototype.closeAllConnections = function () {
   // close() already dropped the native handle; destroy what is still tracked.
   const tracked = this[kTrackedConnections];
   if (tracked && tracked.size > 0) {
-    for (const socket of Array.from(tracked)) socket.destroy();
+    for (const socket of $Array.from(tracked)) socket.destroy();
   }
 };
 
@@ -487,7 +487,7 @@ Server.prototype.closeIdleConnections = function () {
   }
   const tracked = this[kTrackedConnections];
   if (tracked && tracked.size > 0) {
-    for (const socket of Array.from(tracked)) {
+    for (const socket of $Array.from(tracked)) {
       if (!socket._httpMessage) socket.destroy();
     }
   }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -71,9 +71,7 @@ let http1Fallback;
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
 const kPendingDrainClose = Symbol("http.server.pendingDrainClose");
-// Set once a socket is handed to 'connect'/'upgrade'. Node frees the parser
-// there, which takes the socket off the list that closeAllConnections() and
-// closeIdleConnections() iterate; it still counts as a connection for 'close'.
+// Set on the 'connect'/'upgrade' handoff; closeAll/closeIdleConnections() skip these, as in Node.
 const kHandedOff = Symbol("http.server.socketHandedOff");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -71,6 +71,10 @@ let http1Fallback;
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
 const kPendingDrainClose = Symbol("http.server.pendingDrainClose");
+// Set once a socket is handed to 'connect'/'upgrade'. Node frees the parser
+// there, which takes the socket off the list that closeAllConnections() and
+// closeIdleConnections() iterate; it still counts as a connection for 'close'.
+const kHandedOff = Symbol("http.server.socketHandedOff");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
@@ -464,7 +468,9 @@ Server.prototype.closeAllConnections = function () {
   // close() already dropped the native handle; destroy what is still tracked.
   const tracked = this[kTrackedConnections];
   if (tracked && tracked.size > 0) {
-    for (const socket of $Array.from(tracked)) socket.destroy();
+    for (const socket of $Array.from(tracked)) {
+      if (!socket[kHandedOff]) socket.destroy();
+    }
   }
 };
 
@@ -488,7 +494,7 @@ Server.prototype.closeIdleConnections = function () {
   const tracked = this[kTrackedConnections];
   if (tracked && tracked.size > 0) {
     for (const socket of $Array.from(tracked)) {
-      if (!socket._httpMessage) socket.destroy();
+      if (!socket[kHandedOff] && !socket._httpMessage) socket.destroy();
     }
   }
 };
@@ -1347,6 +1353,7 @@ function clearUpgradeIncoming(socket) {
 // close/drain/error/timeout listeners) and only net.Socket's own 'end' listener
 // left in place.
 function detachSocketListenersForHandoff(socket) {
+  socket[kHandedOff] = true;
   socket.removeListener("error", socketOnError);
   socket.removeListener("timeout", onNodeHTTPServerSocketTimeout);
   socket.on("end", onReadableStreamEnd);
@@ -1508,6 +1515,7 @@ function getNodeHTTPServerSocket() {
     [kBytesWritten] = 0;
     [kHandle];
     [kUpgradeIncoming] = undefined;
+    [kHandedOff] = false;
     server: Server;
     _httpMessage;
     _secureEstablished = false;

--- a/test/js/node/http/node-http-server-close-drain.test.ts
+++ b/test/js/node/http/node-http-server-close-drain.test.ts
@@ -208,6 +208,89 @@ test("closeAllConnections() after close() force-drains the withheld callback", a
   }
 });
 
+// Node frees the parser when it hands a socket to 'upgrade'/'connect', which
+// takes it off the list closeIdleConnections()/closeAllConnections() walk. After
+// close() those two must reap a plain keep-alive socket but leave an upgraded
+// one alone, while 'close' itself still waits for the upgraded socket to end.
+test("closeIdleConnections()/closeAllConnections() after close() leave an upgraded socket open", async () => {
+  const inHandler = Promise.withResolvers<void>();
+  let releaseResponse!: () => void;
+  let upgradedServerSocket!: import("node:net").Socket;
+  const server = createServer((req, res) => {
+    inHandler.resolve();
+    releaseResponse = () => res.end("ok");
+  });
+  server.on("upgrade", (req, socket) => {
+    upgradedServerSocket = socket;
+    socket.on("error", () => {});
+    socket.on("data", chunk => socket.write(chunk));
+    socket.write("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: echo\r\n\r\n");
+  });
+  server.keepAliveTimeout = 60000;
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const upgraded = connect(port, "127.0.0.1");
+  const plain = connect(port, "127.0.0.1");
+  try {
+    await Promise.all([once(upgraded, "connect"), once(plain, "connect")]);
+    upgraded.on("error", () => {});
+    plain.on("error", () => {});
+    let upgradedData = "";
+    upgraded.on("data", chunk => (upgradedData += chunk));
+    const upgradedClosed = Promise.withResolvers<void>();
+    upgraded.on("close", () => upgradedClosed.resolve());
+    let plainData = "";
+    plain.on("data", chunk => (plainData += chunk));
+    const plainClosed = Promise.withResolvers<void>();
+    plain.on("close", () => plainClosed.resolve());
+    // Round-trips a token through the upgraded connection; false if it closed instead.
+    const echo = async (token: string) => {
+      upgraded.write(token);
+      while (!upgradedData.includes(token) && !upgraded.destroyed) {
+        await Promise.race([once(upgraded, "data"), upgradedClosed.promise]);
+      }
+      return upgradedData.includes(token);
+    };
+
+    upgraded.write("GET /up HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: echo\r\n\r\n");
+    while (!upgradedData.includes("101 Switching Protocols")) await once(upgraded, "data");
+    plain.write("GET /slow HTTP/1.1\r\nHost: x\r\n\r\n");
+    await inHandler.promise;
+
+    let closeCbFired = false;
+    const closed = Promise.withResolvers<void>();
+    server.close(() => {
+      closeCbFired = true;
+      closed.resolve();
+    });
+    releaseResponse();
+    while (!plainData.includes("ok")) await once(plain, "data");
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+    expect(closeCbFired).toBe(false);
+
+    server.closeIdleConnections();
+    expect(upgradedServerSocket.destroyed).toBe(false);
+    await plainClosed.promise;
+    expect(await echo("ping1")).toBe(true);
+    expect(closeCbFired).toBe(false);
+
+    server.closeAllConnections();
+    expect(upgradedServerSocket.destroyed).toBe(false);
+    expect(await echo("ping2")).toBe(true);
+    expect(closeCbFired).toBe(false);
+
+    upgradedServerSocket.destroy();
+    await closed.promise;
+    expect(closeCbFired).toBe(true);
+  } finally {
+    upgraded.destroy();
+    plain.destroy();
+    server.closeAllConnections();
+  }
+});
+
 // Re-listening after close() while a keep-alive connection from the previous
 // cycle is still open must not fire 'close' on the new (listening) server
 // when that old connection finally ends.

--- a/test/js/node/http/node-http-server-close-drain.test.ts
+++ b/test/js/node/http/node-http-server-close-drain.test.ts
@@ -1,0 +1,280 @@
+import { expect, test } from "bun:test";
+import { tls as tlsCert } from "harness";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { Agent as HttpsAgent, createServer as createHttpsServer, get as httpsGet } from "node:https";
+import type { AddressInfo } from "node:net";
+import { connect } from "node:net";
+
+// Node's net.Server#close callback (and the 'close' event) only fires once
+// every accepted connection has ended. A connection that was mid-request
+// when close() ran stays open after the response is delivered, so the
+// callback must be withheld until that connection closes.
+test("server.close(cb) does not fire while a keep-alive connection is still open", async () => {
+  const inHandler = Promise.withResolvers<void>();
+  let releaseResponse!: () => void;
+  const paths: string[] = [];
+  const server = createServer((req, res) => {
+    paths.push(req.url as string);
+    if (paths.length === 1) {
+      inHandler.resolve();
+      releaseResponse = () => res.end("resp:" + req.url);
+    } else {
+      res.end("resp:" + req.url);
+    }
+  });
+  server.keepAliveTimeout = 60000;
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const socket = connect(port, "127.0.0.1");
+  try {
+    await once(socket, "connect");
+    let body = "";
+    socket.on("data", chunk => (body += chunk));
+    socket.on("error", () => {});
+
+    // First request: handler is entered but response held until after close().
+    socket.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n");
+    await inHandler.promise;
+
+    let closeEventFired = false;
+    server.once("close", () => (closeEventFired = true));
+    const closed = Promise.withResolvers<void>();
+    let closeCbFired = false;
+    server.close(() => {
+      closeCbFired = true;
+      closed.resolve();
+    });
+
+    // Handler finishes: response is delivered, connection stays open.
+    // Yield a few event-loop turns after the bytes arrive so the server's
+    // "all requests done" task chain has run before the callback is checked.
+    releaseResponse();
+    while (!body.includes("resp:/first")) await once(socket, "data");
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+    expect(closeCbFired).toBe(false);
+    expect(closeEventFired).toBe(false);
+
+    // A second request on the same connection is still served (matching Node),
+    // and the close callback must still be withheld afterwards.
+    socket.write("GET /second HTTP/1.1\r\nHost: x\r\n\r\n");
+    while (!body.includes("resp:/second")) await once(socket, "data");
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+    expect(closeCbFired).toBe(false);
+    expect(closeEventFired).toBe(false);
+    expect(paths).toEqual(["/first", "/second"]);
+
+    // Closing the connection drains the server and releases the callback.
+    socket.destroy();
+    await closed.promise;
+    expect(closeCbFired).toBe(true);
+    expect(closeEventFired).toBe(true);
+  } finally {
+    socket.destroy();
+    server.closeAllConnections();
+  }
+});
+
+// https.createServer goes through the same Server class, so the same gate must
+// hold for a TLS keep-alive connection driven by a real client agent (the shape
+// a browser produces: one connection, a slow response, then another request).
+test("https server.close(cb) does not fire while a keep-alive TLS connection is still open", async () => {
+  const inHandler = Promise.withResolvers<void>();
+  let releaseResponse!: () => void;
+  const paths: string[] = [];
+  const clientPorts: (number | undefined)[] = [];
+  const server = createHttpsServer({ key: tlsCert.key, cert: tlsCert.cert }, (req, res) => {
+    paths.push(req.url as string);
+    clientPorts.push(req.socket.remotePort);
+    if (paths.length === 1) {
+      inHandler.resolve();
+      releaseResponse = () => res.end("first");
+    } else {
+      res.end("second");
+    }
+  });
+  server.keepAliveTimeout = 60000;
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const agent = new HttpsAgent({ keepAlive: true, maxSockets: 1, rejectUnauthorized: false });
+  const get = (path: string) =>
+    new Promise<number>((resolve, reject) => {
+      const req = httpsGet({ port, host: "127.0.0.1", path, agent, rejectUnauthorized: false }, res => {
+        res.resume();
+        res.on("end", () => resolve(res.statusCode as number));
+      });
+      req.on("error", reject);
+    });
+
+  try {
+    const first = get("/first");
+    await inHandler.promise;
+
+    let closeCbFired = false;
+    const closed = Promise.withResolvers<void>();
+    server.close(() => {
+      closeCbFired = true;
+      closed.resolve();
+    });
+
+    // The in-flight response is delivered, and the TLS connection stays open.
+    releaseResponse();
+    expect(await first).toBe(200);
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+    expect(closeCbFired).toBe(false);
+
+    // The agent reuses that same connection for a second request.
+    expect(await get("/second")).toBe(200);
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+    expect(paths).toEqual(["/first", "/second"]);
+    expect(clientPorts[1]).toBe(clientPorts[0]);
+    expect(closeCbFired).toBe(false);
+
+    // Closing the client side drains the server and releases the callback.
+    agent.destroy();
+    await closed.promise;
+    expect(closeCbFired).toBe(true);
+  } finally {
+    agent.destroy();
+    server.closeAllConnections();
+  }
+});
+
+// Sanity: an idle keep-alive connection at close() time is reaped by
+// closeIdleConnections(), so the callback fires promptly like before.
+test("server.close(cb) fires once an idle keep-alive connection is reaped", async () => {
+  const server = createServer((req, res) => res.end("ok"));
+  server.keepAliveTimeout = 60000;
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const socket = connect(port, "127.0.0.1");
+  try {
+    await once(socket, "connect");
+    let body = "";
+    socket.on("data", chunk => (body += chunk));
+    socket.on("error", () => {});
+    socket.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    while (!body.includes("ok")) await once(socket, "data");
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+
+    const closed = Promise.withResolvers<void>();
+    server.close(() => closed.resolve());
+    await closed.promise;
+  } finally {
+    socket.destroy();
+    server.closeAllConnections();
+  }
+});
+
+// The graceful-drain-with-deadline pattern: close(), then force via
+// closeAllConnections() once the caller has waited long enough. The force
+// step must work even though close() already dropped the native handle.
+test("closeAllConnections() after close() force-drains the withheld callback", async () => {
+  const inHandler = Promise.withResolvers<void>();
+  let releaseResponse!: () => void;
+  const server = createServer((req, res) => {
+    inHandler.resolve();
+    releaseResponse = () => res.end("ok");
+  });
+  server.keepAliveTimeout = 60000;
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const socket = connect(port, "127.0.0.1");
+  try {
+    await once(socket, "connect");
+    let body = "";
+    socket.on("data", chunk => (body += chunk));
+    socket.on("error", () => {});
+    socket.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    await inHandler.promise;
+
+    const closed = Promise.withResolvers<void>();
+    let closeCbFired = false;
+    server.close(() => {
+      closeCbFired = true;
+      closed.resolve();
+    });
+    releaseResponse();
+    while (!body.includes("ok")) await once(socket, "data");
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+    expect(closeCbFired).toBe(false);
+
+    server.closeAllConnections();
+    await closed.promise;
+    expect(closeCbFired).toBe(true);
+  } finally {
+    socket.destroy();
+    server.closeAllConnections();
+  }
+});
+
+// Re-listening after close() while a keep-alive connection from the previous
+// cycle is still open must not fire 'close' on the new (listening) server
+// when that old connection finally ends.
+test("no 'close' is emitted on a re-listened server when an earlier connection ends", async () => {
+  const inHandler = Promise.withResolvers<void>();
+  let releaseResponse!: () => void;
+  let requests = 0;
+  const server = createServer((req, res) => {
+    if (++requests === 1) {
+      inHandler.resolve();
+      releaseResponse = () => res.end("ok");
+    } else {
+      res.end("ok");
+    }
+  });
+  server.keepAliveTimeout = 60000;
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port1 = (server.address() as AddressInfo).port;
+
+  const socket = connect(port1, "127.0.0.1");
+  try {
+    await once(socket, "connect");
+    let body = "";
+    socket.on("data", chunk => (body += chunk));
+    socket.on("error", () => {});
+    socket.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    await inHandler.promise;
+
+    let cb1Fired = false;
+    server.close(() => (cb1Fired = true));
+    releaseResponse();
+    while (!body.includes("ok")) await once(socket, "data");
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+
+    // Re-listen while the old connection is still open.
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    let closeEmitted = 0;
+    server.on("close", () => closeEmitted++);
+
+    // Old connection ends. No 'close' must fire on the listening server.
+    socket.destroy();
+    for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
+    expect(closeEmitted).toBe(0);
+    expect(cb1Fired).toBe(false);
+    expect(server.listening).toBe(true);
+
+    // Closing the new server then emits 'close' exactly once. The first
+    // cycle's callback was registered via once('close') and fires now too,
+    // like Node (and passing a second callback does not throw).
+    const closed = Promise.withResolvers<void>();
+    server.close(() => closed.resolve());
+    await closed.promise;
+    expect(closeEmitted).toBe(1);
+    expect(cb1Fired).toBe(true);
+  } finally {
+    socket.destroy();
+    server.closeAllConnections();
+  }
+});

--- a/test/js/node/http/node-http-server-close-drain.test.ts
+++ b/test/js/node/http/node-http-server-close-drain.test.ts
@@ -35,7 +35,6 @@ test("server.close(cb) does not fire while a keep-alive connection is still open
     socket.on("data", chunk => (body += chunk));
     socket.on("error", () => {});
 
-    // First request: handler is entered but response held until after close().
     socket.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n");
     await inHandler.promise;
 
@@ -48,7 +47,6 @@ test("server.close(cb) does not fire while a keep-alive connection is still open
       closed.resolve();
     });
 
-    // Handler finishes: response is delivered, connection stays open.
     // Yield a few event-loop turns after the bytes arrive so the server's
     // "all requests done" task chain has run before the callback is checked.
     releaseResponse();
@@ -57,8 +55,6 @@ test("server.close(cb) does not fire while a keep-alive connection is still open
     expect(closeCbFired).toBe(false);
     expect(closeEventFired).toBe(false);
 
-    // A second request on the same connection is still served (matching Node),
-    // and the close callback must still be withheld afterwards.
     socket.write("GET /second HTTP/1.1\r\nHost: x\r\n\r\n");
     while (!body.includes("resp:/second")) await once(socket, "data");
     for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
@@ -66,7 +62,6 @@ test("server.close(cb) does not fire while a keep-alive connection is still open
     expect(closeEventFired).toBe(false);
     expect(paths).toEqual(["/first", "/second"]);
 
-    // Closing the connection drains the server and releases the callback.
     socket.destroy();
     await closed.promise;
     expect(closeCbFired).toBe(true);
@@ -121,20 +116,17 @@ test("https server.close(cb) does not fire while a keep-alive TLS connection is 
       closed.resolve();
     });
 
-    // The in-flight response is delivered, and the TLS connection stays open.
     releaseResponse();
     expect(await first).toBe(200);
     for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
     expect(closeCbFired).toBe(false);
 
-    // The agent reuses that same connection for a second request.
     expect(await get("/second")).toBe(200);
     for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
     expect(paths).toEqual(["/first", "/second"]);
     expect(clientPorts[1]).toBe(clientPorts[0]);
     expect(closeCbFired).toBe(false);
 
-    // Closing the client side drains the server and releases the callback.
     agent.destroy();
     await closed.promise;
     expect(closeCbFired).toBe(true);
@@ -251,23 +243,20 @@ test("no 'close' is emitted on a re-listened server when an earlier connection e
     while (!body.includes("ok")) await once(socket, "data");
     for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
 
-    // Re-listen while the old connection is still open.
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
 
     let closeEmitted = 0;
     server.on("close", () => closeEmitted++);
 
-    // Old connection ends. No 'close' must fire on the listening server.
     socket.destroy();
     for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
     expect(closeEmitted).toBe(0);
     expect(cb1Fired).toBe(false);
     expect(server.listening).toBe(true);
 
-    // Closing the new server then emits 'close' exactly once. The first
-    // cycle's callback was registered via once('close') and fires now too,
-    // like Node (and passing a second callback does not throw).
+    // Like Node, the first cycle's callback is a once('close') listener: it
+    // fires here too, and passing a second callback does not throw.
     const closed = Promise.withResolvers<void>();
     server.close(() => closed.resolve());
     await closed.promise;


### PR DESCRIPTION
### Problem
- `server.close(cb)` on a `node:http` (or `node:https`) server fires `cb` and `'close'` as soon as the in-flight response finishes, while the keep-alive connection that carried it is still open and keeps serving new requests. Node v26.3.0 withholds both until every connection has ended. A `server.close(() => process.exit())` drain is told the server is drained while a live client still issues requests into it.
- Cause: `emitCloseServer` is driven by the native all-closed promise (`getBunServerAllClosedPromise`, `src/js/node/_http_server.ts`), whose condition is `pending_requests == 0 && !listener`. That counts requests, not connections.

### Fix
- Gate `emitCloseServer` on `kTrackedConnections.size === 0` and on the native handle being gone, like Node's `net.Server#_emitCloseIfDrained`. If connections remain, it sets `kPendingDrainClose`; the last socket's `#onClose` re-runs it. `kRealListen` resets the flag, and `close(cb)` registers `cb` with `once('close')` as Node does, so a re-listen cycle cannot fire or block a stale callback.
- `closeAllConnections()` / `closeIdleConnections()` keep working after `close()` dropped the native handle: they walk `kTrackedConnections` and destroy the plain HTTP sockets (idle ones only, for the latter). Sockets handed to `'upgrade'`/`'connect'` are marked `kHandedOff` and skipped, which matches Node, where the freed parser takes them off that list.
- Correct because the `'close'` signal now tracks the same thing Node tracks (open connections), and the two drain helpers select the same sockets Node's `ConnectionsList` would.
- Verified: `test/js/node/http/node-http-server-close-drain.test.ts` (6 tests, 5 fail on main). Also `node-http.test.ts`, the upstream `test-http{,s}-server-close-*`, upgrade and CONNECT tests, and the ws, CONNECT and https suites. Self-reviewed plus four bot review rounds: 6 concerns raised, 6 addressed.

### Background
- A `node:http` server in Bun wraps a `Bun.serve` instance. `close()` calls `stop()` on it and drops the handle (`this[serverSymbol] = undefined`). The native side resolves an "all closed" promise once no request is pending.
- `kTrackedConnections` is the JS-side set of accepted `NodeHTTPServerSocket`s. A socket joins on accept and leaves in `#onClose`. `getConnections()` already reads it. It plays the role of Node's `net.Server._connections`.
- Node keeps a second, narrower list (`ConnectionsList`, one entry per live HTTP parser) for `closeAllConnections()` / `closeIdleConnections()`. Handing a socket to `'upgrade'` or `'connect'` frees its parser, so those two methods never touch upgraded or tunnel sockets, while `'close'` still waits for them.

<details><summary>Notes</summary>

Repro (from the report; `node:https` behaves the same because `https.createServer` is `http.createServer` with TLS options):

```js
import http from "node:http"; import net from "node:net";
const server = http.createServer((req, res) => setTimeout(() => res.end("resp:" + req.url), 200));
server.keepAliveTimeout = 60000;
server.listen(0, "127.0.0.1", () => {
  const c = net.connect(server.address().port, "127.0.0.1");
  let closeCbAt = null, data = "";
  c.on("data", d => data += d);
  c.on("connect", () => {
    c.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n");
    setTimeout(() => {
      server.close(() => { closeCbAt = Date.now(); });
      setTimeout(() => {
        c.write("GET /second HTTP/1.1\r\nHost: x\r\n\r\n");
        setTimeout(() => { console.log({ closeCbFired: closeCbAt !== null, resps: data.match(/resp:\/\w+/g) }); process.exit(0); }, 900);
      }, 900);
    }, 50);
  });
});
```

bun 1.4.x: `{ closeCbFired: true, resps: ["resp:/first","resp:/second"] }`. node: `closeCbFired: false`, same responses.

Tests in `node-http-server-close-drain.test.ts` (main vs this PR, with main's `_http_server.ts` swapped in for the first column):

```
server.close(cb) … keep-alive connection still open              FAIL  pass
https server.close(cb) … keep-alive TLS connection (https.Agent) FAIL  pass
server.close(cb) fires once an idle keep-alive conn is reaped     pass  pass  (control)
closeAllConnections() after close() force-drains the callback    FAIL  pass
closeIdle/closeAllConnections() after close() leave an upgraded
  socket open                                                     FAIL  pass  (fails on the earlier revision of this PR too)
no 'close' on a re-listened server when an earlier conn ends     FAIL  pass
```

Each test body was also run under node v26.3.0 with `assert` in place of `expect` and passes there.

Review history: the post-`close()` no-op of the drain helpers, the stale pending flag across re-listen, the single-slot close callback colliding after re-listen, `Array.from` vs `$Array.from`, and the drain helpers destroying upgraded/CONNECT sockets were raised in review and are each fixed with a covering test.

Relationship to #35839: that PR reworks `closeAllConnections()` / `closeIdleConnections()` more broadly (listener stays up). If it lands first, the two fallback branches here become redundant and this PR reduces to the `'close'` gate.

A note for anyone re-running the report's standalone script on a debug/ASAN build: its fixed 200 ms `close()` timer fires before the first request is dispatched there (first dispatch takes about 1 s), which produces an ECONNRESET instead of the bug, on main as well. The tests tie `close()` to the handler entering instead.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http-server-close-drain.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/164] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/164] gen cpp.rs (cppbind)
[3/164] gen JS modules (bundle-modules)
Preprocess modules (13068ms)
Bundle modules (66ms)
Postprocesss modules (97ms)
Bundle Functions (642ms)
Generate Code (31ms)

[13.91s] Bundled "src/js" for development
  2786 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/164] cargo bun_runtime → libbun_runtime.a
[4/164] cc obj/codegen/InternalModuleRegistryConstants.S.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (d65da482a)

test/js/node/http/node-http-server-close-drain.test.ts:
(pass) server.close(cb) does not fire while a keep-alive connection is still open [26.77ms]
(pass) https server.close(cb) does not fire while a keep-alive TLS connection is still open [43.19ms]
(pass) server.close(cb) fires once an idle keep-alive connection is reaped [5.11ms]
(pass) closeAllConnections() after close() force-drains the withheld callback [4.12ms]
269 |     while (!plainData.includes("ok")) await once(plain, "data");
270 |     for (let i = 0; i < 4; i++) await new Promise<void>(r => setImmediate(r));
271 |     expect(closeCbFired).toBe(false);
272 | 
273 |     server.closeIdleConnections();
274 |     expect(upgradedServerSocket.destroyed).toBe(false);
                                                 ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-server-close-drain.test.ts:274:44)
(fail) closeIdleConnections()/closeAllConnections() after close() leave an upgraded socket open [6.50ms]
(pass) no 'close' is emitted on a re-listened server when an earlier connection ends [5
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http-server-close-drain.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/http/node-http-server-close-drain.test.ts:
(pass) server.close(cb) does not fire while a keep-alive connection is still open [1097.32ms]
(pass) https server.close(cb) does not fire while a keep-alive TLS connection is still open [989.99ms]
(pass) server.close(cb) fires once an idle keep-alive connection is reaped [187.85ms]
(pass) closeAllConnections() after close() force-drains the withheld callback [112.19ms]
(pass) closeIdleConnections()/closeAllConnections() after close() leave an upgraded socket open [195.05ms]
(pass) no 'close' is emitted on a re-listened server when an earlier connection ends [228.35ms]

 6 pass
 0 fail
 29 expect() calls
Ran 6 tests across 1 file. [5.93s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 756ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (10494ms)
Bundle modules (68ms)
Postprocesss modules (161ms)
Bundle Functions (585ms)
Generate Code (33ms)

[11.35s] Bundled "src/js" for production
  2596 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        |  56 +++-
 .../node/http/node-http-server-close-drain.test.ts | 352 +++++++++++++++++++++
 2 files changed, 398 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 7 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js/node/_http_server.ts                                33     33     37
test/js/node/http/node-http-server-close-drain.test.ts      8     10     36
```

</details>

<!-- robobun:evidence:end -->
