### PR TITLE
node:fs: snapshot resizable-ArrayBuffer-backed path buffers so an option getter cannot resize(0) through the borrow

### DIFF
--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -114,12 +114,19 @@ impl Clone for PathLike {
             } else {
                 s.borrow()
             }),
-            Self::Buffer(b) => Self::Buffer(MarkedArrayBuffer {
-                buffer: b.buffer,
-                // The clone borrows the JS-owned backing store; only the
-                // original (if any) owns the allocation.
-                owns_buffer: false,
-                pinned: false,
+            Self::Buffer(b) => Self::Buffer(if b.owns_buffer {
+                // An owned snapshot (resizable-backed path) is freed by the
+                // original's `Drop`; dupe so the clone is independently
+                // droppable, mirroring the owned-`String` arm above.
+                bun_core::handle_oom(MarkedArrayBuffer::from_string(b.slice()))
+            } else {
+                MarkedArrayBuffer {
+                    buffer: b.buffer,
+                    // The clone borrows the JS-owned backing store; only the
+                    // original (if any) owns the allocation.
+                    owns_buffer: false,
+                    pinned: false,
+                }
             }),
             Self::SliceWithUnderlyingString(s) => {
                 // `dupe_ref()` alone leaves `utf8` empty (lib.rs:1603) — a
@@ -155,6 +162,9 @@ impl Drop for PathLike {
                     b.pinned = false;
                     b.buffer.unpin();
                 }
+                // Frees the snapshot copy taken for resizable-backed paths
+                // (`owns_buffer`); no-op for JS-owned backings.
+                b.destroy();
             }
             Self::SliceWithUnderlyingString(s) | Self::ThreadsafeString(s) => {
                 core::mem::take(s).deinit();

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -115,15 +115,11 @@ impl Clone for PathLike {
                 s.borrow()
             }),
             Self::Buffer(b) => Self::Buffer(if b.owns_buffer {
-                // An owned snapshot (resizable-backed path) is freed by the
-                // original's `Drop`; dupe so the clone is independently
-                // droppable, mirroring the owned-`String` arm above.
+                // Owned snapshot: dupe so the clone's `Drop` is independent.
                 bun_core::handle_oom(MarkedArrayBuffer::from_string(b.slice()))
             } else {
                 MarkedArrayBuffer {
                     buffer: b.buffer,
-                    // The clone borrows the JS-owned backing store; only the
-                    // original (if any) owns the allocation.
                     owns_buffer: false,
                     pinned: false,
                 }
@@ -162,8 +158,6 @@ impl Drop for PathLike {
                     b.pinned = false;
                     b.buffer.unpin();
                 }
-                // Frees the snapshot copy taken for resizable-backed paths
-                // (`owns_buffer`); no-op for JS-owned backings.
                 b.destroy();
             }
             Self::SliceWithUnderlyingString(s) | Self::ThreadsafeString(s) => {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -915,15 +915,10 @@ pub(crate) trait PathOrFdExt {
         Self: Sized;
 }
 
-/// The pin taken by [`Buffer::from_js_pinned`] blocks `transfer()`/detach but
-/// not `ArrayBuffer.prototype.resize`: shrinking a resizable ArrayBuffer
-/// decommits its tail pages (`JSC::ArrayBuffer::resize` → `OSAllocator::protect`),
-/// so any later read of the captured `(ptr, len)` faults. That later read can be
-/// a work-pool thread (async ops) or a sync op's own `slice_z` after an options
-/// getter (`flag`/`mode`/`encoding`/...) re-entered JS. Copy the path bytes
-/// instead; they are already bounded by `MAX_PATH_BYTES`. Growable
-/// SharedArrayBuffers never shrink and keep a stable data pointer, so they stay
-/// on the borrowed path.
+/// `pin()` blocks `transfer()` but not `ArrayBuffer.prototype.resize`, which
+/// decommits tail pages: a later `slice_z` (after an option getter) or a
+/// work-pool read faults. Copy resizable non-shared paths; growable SABs only
+/// grow in place so stay borrowed.
 fn snapshot_resizable_path_buffer(buffer: &mut Buffer) {
     if !(buffer.buffer.resizable && !buffer.buffer.shared) {
         return;

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -915,6 +915,27 @@ pub(crate) trait PathOrFdExt {
         Self: Sized;
 }
 
+/// The pin taken by [`Buffer::from_js_pinned`] blocks `transfer()`/detach but
+/// not `ArrayBuffer.prototype.resize`: shrinking a resizable ArrayBuffer
+/// decommits its tail pages (`JSC::ArrayBuffer::resize` → `OSAllocator::protect`),
+/// so any later read of the captured `(ptr, len)` faults. That later read can be
+/// a work-pool thread (async ops) or a sync op's own `slice_z` after an options
+/// getter (`flag`/`mode`/`encoding`/...) re-entered JS. Copy the path bytes
+/// instead; they are already bounded by `MAX_PATH_BYTES`. Growable
+/// SharedArrayBuffers never shrink and keep a stable data pointer, so they stay
+/// on the borrowed path.
+fn snapshot_resizable_path_buffer(buffer: &mut Buffer) {
+    if !(buffer.buffer.resizable && !buffer.buffer.shared) {
+        return;
+    }
+    let copy = bun_core::handle_oom(Buffer::from_string(buffer.slice()));
+    if buffer.pinned {
+        buffer.pinned = false;
+        buffer.buffer.unpin();
+    }
+    *buffer = copy;
+}
+
 impl PathLikeExt for PathLike {
     // Const-generics can't change return mutability, so this always returns
     // `&ZStr`. A future force=true caller that needs `&mut ZStr` will need a
@@ -1151,8 +1172,13 @@ impl PathLikeExt for PathLike {
                     }
                     return Err(err);
                 }
+                snapshot_resizable_path_buffer(&mut buffer);
 
-                arguments.protect_eat();
+                if buffer.owns_buffer {
+                    arguments.eat();
+                } else {
+                    arguments.protect_eat();
+                }
                 Ok(Some(Self::Buffer(buffer)))
             }
 
@@ -1168,8 +1194,13 @@ impl PathLikeExt for PathLike {
                     }
                     return Err(err);
                 }
+                snapshot_resizable_path_buffer(&mut buffer);
 
-                arguments.protect_eat();
+                if buffer.owns_buffer {
+                    arguments.eat();
+                } else {
+                    arguments.protect_eat();
+                }
                 Ok(Some(Self::Buffer(buffer)))
             }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5742,6 +5742,104 @@ it("fs.promises.writeFile keeps a buffer path argument attached while options ar
   expect(readFileSync(file, "utf8")).toBe("hello world");
 });
 
+it("fs path buffers backed by a resizable ArrayBuffer are snapshotted before option getters run", async () => {
+  // Pinning the backing ArrayBuffer blocks transfer()/detach but not
+  // ArrayBuffer.prototype.resize: shrinking decommits the tail pages, so a
+  // later read of the captured (ptr, len) faults. That later read can be a
+  // sync op's own option getter (writeFileSync reading `flag`) or a work-pool
+  // thread for an async op. The path bytes must instead be copied at capture
+  // time. Growable SharedArrayBuffers never shrink so they stay zero-copy.
+  using dir = tempDir("fs-rab-path", {
+    "rab-path-fixture.js": String.raw`
+      import fs from "node:fs";
+      import path from "node:path";
+
+      const dir = process.cwd();
+
+      function resizablePath(p) {
+        const bytes = Buffer.from(p);
+        const rab = new ArrayBuffer(bytes.length, { maxByteLength: 64 * 1024 });
+        new Uint8Array(rab).set(bytes);
+        return { rab, view: new Uint8Array(rab, 0, bytes.length) };
+      }
+
+      // sync: writeFileSync — Uint8Array path, getter on the options object
+      // resizes the backing store to 0 between capture and use.
+      {
+        const file = path.join(dir, "w.txt");
+        const { rab, view } = resizablePath(file);
+        fs.writeFileSync(view, "sync-write", {
+          get flag() { rab.resize(0); return "w"; },
+        });
+        if (fs.readFileSync(file, "utf8") !== "sync-write") throw new Error("writeFileSync lost path");
+      }
+
+      // sync: readFileSync — DataView path over a resizable ArrayBuffer.
+      {
+        const file = path.join(dir, "r.txt");
+        fs.writeFileSync(file, "sync-read");
+        const bytes = Buffer.from(file);
+        const rab = new ArrayBuffer(bytes.length, { maxByteLength: 64 * 1024 });
+        new Uint8Array(rab).set(bytes);
+        const dv = new DataView(rab, 0, bytes.length);
+        const got = fs.readFileSync(dv, {
+          get encoding() { rab.resize(0); return "utf8"; },
+        });
+        if (got !== "sync-read") throw new Error("readFileSync lost path: " + JSON.stringify(got));
+      }
+
+      // sync: mkdirSync — resizable ArrayBuffer passed directly as the path.
+      {
+        const target = path.join(dir, "made");
+        const bytes = Buffer.from(target);
+        const rab = new ArrayBuffer(bytes.length, { maxByteLength: bytes.length });
+        new Uint8Array(rab).set(bytes);
+        fs.mkdirSync(rab, {
+          get recursive() { rab.resize(0); return true; },
+        });
+        if (!fs.existsSync(target)) throw new Error("mkdirSync lost path");
+      }
+
+      // async: rename — shrinking right after the call must not affect the
+      // work-pool thread's read of the path bytes.
+      {
+        const src = path.join(dir, "src.txt");
+        fs.writeFileSync(src, "hi");
+        const { rab, view } = resizablePath(src);
+        const renamed = fs.promises.rename(view, path.join(dir, "dst.txt"));
+        rab.resize(0);
+        await renamed;
+        if (!fs.existsSync(path.join(dir, "dst.txt"))) throw new Error("rename lost path");
+      }
+
+      // Growable SharedArrayBuffer: stays zero-copy (only grows in place), so
+      // the path is read from the live backing and the write still lands.
+      {
+        const file = path.join(dir, "sab.txt");
+        const bytes = Buffer.from(file);
+        const sab = new SharedArrayBuffer(bytes.length, { maxByteLength: 64 * 1024 });
+        new Uint8Array(sab).set(bytes);
+        fs.writeFileSync(new Uint8Array(sab, 0, bytes.length), "sab-write", {
+          get flag() { sab.grow(bytes.length + 16); return "w"; },
+        });
+        if (fs.readFileSync(file, "utf8") !== "sab-write") throw new Error("SAB path failed");
+      }
+
+      console.log("done");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "rab-path-fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "done\n", stderr: "", exitCode: 0 });
+});
+
 describe("fs.close on stdio descriptors", () => {
   it.skipIf(isWindows)("closeSync(2) actually closes fd 2 and allows redirect", async () => {
     using dir = tempDir("fs-close-stdio", {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5825,6 +5825,23 @@ it("fs path buffers backed by a resizable ArrayBuffer are snapshotted before opt
         if (fs.readFileSync(file, "utf8") !== "sab-write") throw new Error("SAB path failed");
       }
 
+      // Bun.file(): captures the path via the same PathLike funnel (owned
+      // snapshot for resizable). .text() clones the stored PathLike on the JS
+      // thread and again on the worker; the owned-buffer Clone arm must dupe
+      // so both clones are independently droppable.
+      {
+        const file = path.join(dir, "bunfile.txt");
+        fs.writeFileSync(file, "bun-file");
+        const { rab, view } = resizablePath(file);
+        const f = Bun.file(view);
+        rab.resize(0);
+        const got = await f.text();
+        if (got !== "bun-file") throw new Error("Bun.file().text() lost path: " + JSON.stringify(got));
+        // Second read reuses the stored owned PathLike via a fresh clone; the
+        // original must not have been freed by the first.
+        if ((await f.text()) !== "bun-file") throw new Error("Bun.file().text() second read failed");
+      }
+
       console.log("done");
     `,
   });


### PR DESCRIPTION
## Repro

```js
const fs = require("node:fs");
const pb = Buffer.from("/tmp/pathlike-resize-test.txt");
const p = new Uint8Array(new ArrayBuffer(pb.length, { maxByteLength: 1 << 16 }));
p.set(pb);
fs.writeFileSync(p, "data", { get flag() { p.buffer.resize(0); return "w"; } });
```

```
panic(main thread): Segmentation fault at address 0x728022000000
```

Every `node:fs` op that takes a buffer-typed path through `PathLike::from_js_with_allocator` and then evaluates a later argument is affected, on both paths:

- sync: `writeFileSync`/`appendFileSync` (`flag`/`mode`/`signal`/`flush`), `readFileSync` (`encoding`/`flag`), `mkdirSync` (`recursive`/`mode`), `readdirSync`, `rmSync`, `openSync`, `statSync` (`throwIfNoEntry`), ...
- async: any `fs.promises.*`/callback op, where JS can shrink the buffer between the call returning and the work-pool thread reading the path bytes.
- `Bun.file(Uint8Array)` + `.text()`/`.arrayBuffer()`, which store the PathLike and read it later on a worker.

## Cause

`PathLike::from_js_with_allocator` pins the backing `JSC::ArrayBuffer` via `Buffer::from_js_pinned` so `transfer()`/`structuredClone`/`postMessage` cannot detach it (#31221). The pin does not guard `ArrayBuffer.prototype.resize`: `JSC::ArrayBuffer::resize` answers a shrink by `OSAllocator::protect`ing the trimmed pages `PROT_NONE`. The captured `(ptr, len)` still spans those pages, so the next `slice_z` → `copy_from_slice` (sync) or the work-pool thread's read (async) faults.

Node does not crash: it copies buffer paths into an internal string before the syscall.

## Fix

When the path buffer is backed by a resizable non-shared `ArrayBuffer`, snapshot the bytes into an owned `MarkedArrayBuffer` at capture time (`snapshot_resizable_path_buffer` in `src/runtime/node/types.rs`, applied to both the `Uint8Array`/`DataView` and `ArrayBuffer` arms). Paths are already validated to fit in `MAX_PATH_BYTES`, so the copy is cheap. Fixed-length buffers stay on the zero-copy pinned path. Growable `SharedArrayBuffer`s can only grow in place within the reserved max and keep a stable data pointer, so they stay borrowed.

Because a `PathLike::Buffer` can now own its allocation, `src/jsc/node_path.rs` gains:

- `Drop for PathLike` frees an owned snapshot via `MarkedArrayBuffer::destroy` (idempotent; no-op for JS-owned backings).
- `Clone for PathLike` dupes an owned payload instead of borrowing it, so the clone is independently droppable (mirroring the owned-`String` arm).

The owned snapshot carries `value = JSValue::ZERO`, so `to_thread_safe`/`unprotect`'s `protect()`/`unprotect()` calls are no-ops for it, and the `protect_eat()` on the original JS value is skipped (nothing to root once the bytes are copied).

### Semantics

Snapshotting at capture time means a resizable-backed path is read as it was when passed, so an option getter that overwrites the bytes in place (without resizing) no longer changes which path is used. That differs from both Node and Bun's non-resizable path (which borrow and see the overwrite). Matching Node's read-after-options order would require reordering path parsing in every `args::*::from_js` and re-reading the live `byteLength` from JSC after arbitrary JS ran; that is a much larger refactor than this crash fix and would need to cover every `PathLike` caller at once. The practical impact is limited to programs that deliberately rewrite the path buffer from inside an option getter. The existing pin-against-`transfer()` tests continue to pass unchanged (they use fixed-length buffers).

## Verification

`test/js/node/fs/fs.test.ts` spawns a subprocess that exercises `writeFileSync` (Uint8Array path, `flag` getter), `readFileSync` (DataView path, `encoding` getter), `mkdirSync` (ArrayBuffer path, `recursive` getter), `fs.promises.rename` (async, post-call shrink), a growable `SharedArrayBuffer` path, and `Bun.file(view).text()` called twice (stores the owned PathLike, then clones it on the JS thread and again on the worker, covering the new `Clone`/`Drop` arms under ASAN). The subprocess segfaults on stock `bun` and exits 0 with this change. The existing pin tests ("keeps a ... attached") and the `readFileSync`/`mkdirSync`/`statSync` suites pass.

Related: #32189 covered the async side only; this change covers sync and async in one place. #35821 is the sibling fix for `StringOrBuffer`. #31221 added the pin that guards `transfer()` but not `resize()`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->