### PR TITLE
fs.promises, child_process: reject FileHandle and ChildProcess in structuredClone/v8.serialize

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1111,9 +1111,7 @@ class ChildProcess extends EventEmitter {
 
   constructor() {
     super();
-    // Node's ChildProcess carries a native Process at `_handle`, which structured
-    // clone rejects as a host object. Bun keeps the handle in a private field the
-    // serializer never walks, so brand the instance to surface the same DataCloneError.
+    // Node's ChildProcess has a native `_handle` the serializer rejects; Bun's #handle is private.
     markAsUncloneable(this);
   }
 

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -12,6 +12,8 @@ const {
   validateOneOf,
 } = require("internal/validators");
 
+const markAsUncloneable = $newCppFunction("Worker.cpp", "jsFunctionMarkAsUncloneable", 1);
+
 var NetModule;
 
 var ObjectCreate = Object.create;
@@ -1106,6 +1108,14 @@ class ChildProcess extends EventEmitter {
   pid;
   channel;
   killed = false;
+
+  constructor() {
+    super();
+    // Node's ChildProcess carries a native Process at `_handle`, which structured
+    // clone rejects as a host object. Bun keeps the handle in a private field the
+    // serializer never walks, so brand the instance to surface the same DataCloneError.
+    markAsUncloneable(this);
+  }
 
   [Symbol.dispose]() {
     if (!this.killed) {

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -428,9 +428,7 @@ function asyncWrap(fn: any, name: string) {
   class FileHandle extends EventEmitter {
     constructor(fd, flag, path?: string) {
       super();
-      // Node's FileHandle is a native JSTransferable; structuredClone/v8.serialize
-      // reject it instead of walking it as a plain object. Bun's is a JS class, so
-      // brand the instance for the serializer to produce the same DataCloneError.
+      // Node's FileHandle is a native host object the serializer rejects; Bun's is a JS class.
       markAsUncloneable(this);
       this[kFd] = fd ? fd : -1;
       this[kRefs] = 1;

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -17,6 +17,8 @@ var PromisePrototypeFinally = $Promise.prototype.finally; //TODO
 var SymbolAsyncDispose = Symbol.asyncDispose;
 var ObjectFreeze = Object.freeze;
 
+const markAsUncloneable = $newCppFunction("Worker.cpp", "jsFunctionMarkAsUncloneable", 1);
+
 const kFd = Symbol("kFd");
 const kRefs = Symbol("kRefs");
 const kClosePromise = Symbol("kClosePromise");
@@ -426,6 +428,10 @@ function asyncWrap(fn: any, name: string) {
   class FileHandle extends EventEmitter {
     constructor(fd, flag, path?: string) {
       super();
+      // Node's FileHandle is a native JSTransferable; structuredClone/v8.serialize
+      // reject it instead of walking it as a plain object. Bun's is a JS class, so
+      // brand the instance for the serializer to produce the same DataCloneError.
+      markAsUncloneable(this);
       this[kFd] = fd ? fd : -1;
       this[kRefs] = 1;
       this[kClosePromise] = null;

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -211,5 +211,6 @@ private:
 JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionPostMessage);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionMarkAsUncloneable);
 
 } // namespace WebCore

--- a/test/js/web/workers/structured-clone-node-handles.test.ts
+++ b/test/js/web/workers/structured-clone-node-handles.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { ChildProcess, spawn } from "node:child_process";
+import fsp from "node:fs/promises";
+import v8 from "node:v8";
+import { join } from "path";
+
+// Node's FileHandle is a native JSTransferable and ChildProcess carries a native
+// Process at `_handle`, so V8's serializer rejects both as host objects. Bun's
+// implementations are plain JS classes whose own string properties the serializer
+// happily walked, producing an inert `{ _events, _eventsCount, ... }` stub with no
+// fd/kill/etc. These tests assert the serializer now refuses them the way Node does.
+describe("FileHandle and ChildProcess are not structured-cloneable", () => {
+  const dataCloneError = expect.objectContaining({ name: "DataCloneError" });
+
+  async function withFileHandle(fn: (fh: fsp.FileHandle) => void | Promise<void>) {
+    using dir = tempDir("sc-fh", { "a.txt": "x" });
+    const fh = await fsp.open(join(String(dir), "a.txt"), "r");
+    try {
+      await fn(fh);
+    } finally {
+      await fh.close();
+    }
+  }
+
+  test("structuredClone(FileHandle) throws DataCloneError", async () => {
+    await withFileHandle(fh => {
+      expect(() => structuredClone(fh)).toThrow(dataCloneError);
+      expect(() => structuredClone({ nested: fh })).toThrow(dataCloneError);
+      expect(() => structuredClone([1, fh, 2])).toThrow(dataCloneError);
+    });
+  });
+
+  test("v8.serialize(FileHandle) throws DataCloneError", async () => {
+    await withFileHandle(fh => {
+      expect(() => v8.serialize(fh)).toThrow(dataCloneError);
+      expect(() => v8.serialize({ nested: fh })).toThrow(dataCloneError);
+    });
+  });
+
+  test("FileHandle is still usable after a rejected clone", async () => {
+    await withFileHandle(async fh => {
+      expect(() => structuredClone(fh)).toThrow(dataCloneError);
+      expect({
+        fd: typeof fh.fd,
+        read: typeof fh.read,
+        keys: Object.keys(fh),
+      }).toEqual({
+        fd: "number",
+        read: "function",
+        keys: ["_events", "_eventsCount", "_maxListeners"],
+      });
+      const { bytesRead } = await fh.read(Buffer.alloc(1), 0, 1, 0);
+      expect(bytesRead).toBe(1);
+    });
+  });
+
+  test("structuredClone(ChildProcess) throws DataCloneError", () => {
+    const cp = spawn(bunExe(), ["-e", "0"], { stdio: "ignore", env: bunEnv });
+    try {
+      expect(() => structuredClone(cp)).toThrow(dataCloneError);
+      expect(() => structuredClone({ nested: cp })).toThrow(dataCloneError);
+    } finally {
+      cp.kill();
+    }
+  });
+
+  test("v8.serialize(ChildProcess) throws DataCloneError", () => {
+    const cp = spawn(bunExe(), ["-e", "0"], { stdio: "ignore", env: bunEnv });
+    try {
+      expect(() => v8.serialize(cp)).toThrow(dataCloneError);
+      expect(() => v8.serialize({ nested: cp })).toThrow(dataCloneError);
+    } finally {
+      cp.kill();
+    }
+  });
+
+  test("bare new ChildProcess() is also rejected", () => {
+    const cp = new ChildProcess();
+    expect(() => structuredClone(cp)).toThrow(dataCloneError);
+    expect(() => v8.serialize(cp)).toThrow(dataCloneError);
+  });
+
+  test("MessagePort.postMessage(FileHandle) without transferList throws", async () => {
+    await withFileHandle(fh => {
+      const { port1, port2 } = new MessageChannel();
+      try {
+        expect(() => port2.postMessage(fh)).toThrow(dataCloneError);
+        expect(() => port2.postMessage({ nested: fh })).toThrow(dataCloneError);
+      } finally {
+        port1.close();
+        port2.close();
+      }
+    });
+  });
+});

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,11 +1,8 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { bunEnv, bunExe, tempDir, tls } from "harness";
-import { ChildProcess, spawn } from "node:child_process";
+import { bunEnv, bunExe, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
-import fsp from "node:fs/promises";
 import { BlockList } from "node:net";
-import v8 from "node:v8";
 import { deflate } from "node:zlib";
 import { join } from "path";
 
@@ -1019,95 +1016,5 @@ describe("truncated Set/Map payloads are rejected without hanging", () => {
   test("valid Set and Map payloads still round-trip", () => {
     expect(deserialize(serialize(new Set([1, 0])))).toEqual(new Set([1, 0]));
     expect(deserialize(serialize(new Map([[1, 1]])))).toEqual(new Map([[1, 1]]));
-  });
-});
-
-// Node's FileHandle is a native JSTransferable and ChildProcess carries a native
-// Process at `_handle`, so V8's serializer rejects both as host objects. Bun's
-// implementations are plain JS classes whose own string properties the serializer
-// happily walked, producing an inert `{ _events, _eventsCount, ... }` stub with no
-// fd/kill/etc. These tests assert the serializer now refuses them the way Node does.
-describe("FileHandle and ChildProcess are not structured-cloneable", () => {
-  const dataCloneError = expect.objectContaining({ name: "DataCloneError" });
-
-  async function withFileHandle(fn: (fh: fsp.FileHandle) => void | Promise<void>) {
-    using dir = tempDir("sc-fh", { "a.txt": "x" });
-    const fh = await fsp.open(join(String(dir), "a.txt"), "r");
-    try {
-      await fn(fh);
-    } finally {
-      await fh.close();
-    }
-  }
-
-  test("structuredClone(FileHandle) throws DataCloneError", async () => {
-    await withFileHandle(fh => {
-      expect(() => structuredClone(fh)).toThrow(dataCloneError);
-      expect(() => structuredClone({ nested: fh })).toThrow(dataCloneError);
-      expect(() => structuredClone([1, fh, 2])).toThrow(dataCloneError);
-    });
-  });
-
-  test("v8.serialize(FileHandle) throws DataCloneError", async () => {
-    await withFileHandle(fh => {
-      expect(() => v8.serialize(fh)).toThrow(dataCloneError);
-      expect(() => v8.serialize({ nested: fh })).toThrow(dataCloneError);
-    });
-  });
-
-  test("FileHandle is still usable after a rejected clone", async () => {
-    await withFileHandle(async fh => {
-      expect(() => structuredClone(fh)).toThrow(dataCloneError);
-      expect({
-        fd: typeof fh.fd,
-        read: typeof fh.read,
-        keys: Object.keys(fh),
-      }).toEqual({
-        fd: "number",
-        read: "function",
-        keys: ["_events", "_eventsCount", "_maxListeners"],
-      });
-      const { bytesRead } = await fh.read(Buffer.alloc(1), 0, 1, 0);
-      expect(bytesRead).toBe(1);
-    });
-  });
-
-  test("structuredClone(ChildProcess) throws DataCloneError", () => {
-    const cp = spawn(bunExe(), ["-e", "0"], { stdio: "ignore", env: bunEnv });
-    try {
-      expect(() => structuredClone(cp)).toThrow(dataCloneError);
-      expect(() => structuredClone({ nested: cp })).toThrow(dataCloneError);
-    } finally {
-      cp.kill();
-    }
-  });
-
-  test("v8.serialize(ChildProcess) throws DataCloneError", () => {
-    const cp = spawn(bunExe(), ["-e", "0"], { stdio: "ignore", env: bunEnv });
-    try {
-      expect(() => v8.serialize(cp)).toThrow(dataCloneError);
-      expect(() => v8.serialize({ nested: cp })).toThrow(dataCloneError);
-    } finally {
-      cp.kill();
-    }
-  });
-
-  test("bare new ChildProcess() is also rejected", () => {
-    const cp = new ChildProcess();
-    expect(() => structuredClone(cp)).toThrow(dataCloneError);
-    expect(() => v8.serialize(cp)).toThrow(dataCloneError);
-  });
-
-  test("MessagePort.postMessage(FileHandle) without transferList throws", async () => {
-    await withFileHandle(fh => {
-      const { port1, port2 } = new MessageChannel();
-      try {
-        expect(() => port2.postMessage(fh)).toThrow(dataCloneError);
-        expect(() => port2.postMessage({ nested: fh })).toThrow(dataCloneError);
-      } finally {
-        port1.close();
-        port2.close();
-      }
-    });
   });
 });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1048,10 +1048,10 @@ describe("FileHandle and ChildProcess are not structured-cloneable", () => {
     });
   });
 
-  test("v8.serialize(FileHandle) throws", async () => {
+  test("v8.serialize(FileHandle) throws DataCloneError", async () => {
     await withFileHandle(fh => {
-      expect(() => v8.serialize(fh)).toThrow();
-      expect(() => v8.serialize({ nested: fh })).toThrow();
+      expect(() => v8.serialize(fh)).toThrow(dataCloneError);
+      expect(() => v8.serialize({ nested: fh })).toThrow(dataCloneError);
     });
   });
 
@@ -1082,11 +1082,11 @@ describe("FileHandle and ChildProcess are not structured-cloneable", () => {
     }
   });
 
-  test("v8.serialize(ChildProcess) throws", () => {
+  test("v8.serialize(ChildProcess) throws DataCloneError", () => {
     const cp = spawn(bunExe(), ["-e", "0"], { stdio: "ignore", env: bunEnv });
     try {
-      expect(() => v8.serialize(cp)).toThrow();
-      expect(() => v8.serialize({ nested: cp })).toThrow();
+      expect(() => v8.serialize(cp)).toThrow(dataCloneError);
+      expect(() => v8.serialize({ nested: cp })).toThrow(dataCloneError);
     } finally {
       cp.kill();
     }
@@ -1095,7 +1095,7 @@ describe("FileHandle and ChildProcess are not structured-cloneable", () => {
   test("bare new ChildProcess() is also rejected", () => {
     const cp = new ChildProcess();
     expect(() => structuredClone(cp)).toThrow(dataCloneError);
-    expect(() => v8.serialize(cp)).toThrow();
+    expect(() => v8.serialize(cp)).toThrow(dataCloneError);
   });
 
   test("MessagePort.postMessage(FileHandle) without transferList throws", async () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,8 +1,11 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { bunEnv, bunExe, tls } from "harness";
+import { bunEnv, bunExe, tempDir, tls } from "harness";
+import { ChildProcess, spawn } from "node:child_process";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
+import fsp from "node:fs/promises";
 import { BlockList } from "node:net";
+import v8 from "node:v8";
 import { deflate } from "node:zlib";
 import { join } from "path";
 
@@ -1016,5 +1019,95 @@ describe("truncated Set/Map payloads are rejected without hanging", () => {
   test("valid Set and Map payloads still round-trip", () => {
     expect(deserialize(serialize(new Set([1, 0])))).toEqual(new Set([1, 0]));
     expect(deserialize(serialize(new Map([[1, 1]])))).toEqual(new Map([[1, 1]]));
+  });
+});
+
+// Node's FileHandle is a native JSTransferable and ChildProcess carries a native
+// Process at `_handle`, so V8's serializer rejects both as host objects. Bun's
+// implementations are plain JS classes whose own string properties the serializer
+// happily walked, producing an inert `{ _events, _eventsCount, ... }` stub with no
+// fd/kill/etc. These tests assert the serializer now refuses them the way Node does.
+describe("FileHandle and ChildProcess are not structured-cloneable", () => {
+  const dataCloneError = expect.objectContaining({ name: "DataCloneError" });
+
+  async function withFileHandle(fn: (fh: fsp.FileHandle) => void | Promise<void>) {
+    using dir = tempDir("sc-fh", { "a.txt": "x" });
+    const fh = await fsp.open(join(String(dir), "a.txt"), "r");
+    try {
+      await fn(fh);
+    } finally {
+      await fh.close();
+    }
+  }
+
+  test("structuredClone(FileHandle) throws DataCloneError", async () => {
+    await withFileHandle(fh => {
+      expect(() => structuredClone(fh)).toThrow(dataCloneError);
+      expect(() => structuredClone({ nested: fh })).toThrow(dataCloneError);
+      expect(() => structuredClone([1, fh, 2])).toThrow(dataCloneError);
+    });
+  });
+
+  test("v8.serialize(FileHandle) throws", async () => {
+    await withFileHandle(fh => {
+      expect(() => v8.serialize(fh)).toThrow();
+      expect(() => v8.serialize({ nested: fh })).toThrow();
+    });
+  });
+
+  test("FileHandle is still usable after a rejected clone", async () => {
+    await withFileHandle(async fh => {
+      expect(() => structuredClone(fh)).toThrow(dataCloneError);
+      expect({
+        fd: typeof fh.fd,
+        read: typeof fh.read,
+        keys: Object.keys(fh),
+      }).toEqual({
+        fd: "number",
+        read: "function",
+        keys: ["_events", "_eventsCount", "_maxListeners"],
+      });
+      const { bytesRead } = await fh.read(Buffer.alloc(1), 0, 1, 0);
+      expect(bytesRead).toBe(1);
+    });
+  });
+
+  test("structuredClone(ChildProcess) throws DataCloneError", () => {
+    const cp = spawn(bunExe(), ["-e", "0"], { stdio: "ignore", env: bunEnv });
+    try {
+      expect(() => structuredClone(cp)).toThrow(dataCloneError);
+      expect(() => structuredClone({ nested: cp })).toThrow(dataCloneError);
+    } finally {
+      cp.kill();
+    }
+  });
+
+  test("v8.serialize(ChildProcess) throws", () => {
+    const cp = spawn(bunExe(), ["-e", "0"], { stdio: "ignore", env: bunEnv });
+    try {
+      expect(() => v8.serialize(cp)).toThrow();
+      expect(() => v8.serialize({ nested: cp })).toThrow();
+    } finally {
+      cp.kill();
+    }
+  });
+
+  test("bare new ChildProcess() is also rejected", () => {
+    const cp = new ChildProcess();
+    expect(() => structuredClone(cp)).toThrow(dataCloneError);
+    expect(() => v8.serialize(cp)).toThrow();
+  });
+
+  test("MessagePort.postMessage(FileHandle) without transferList throws", async () => {
+    await withFileHandle(fh => {
+      const { port1, port2 } = new MessageChannel();
+      try {
+        expect(() => port2.postMessage(fh)).toThrow(dataCloneError);
+        expect(() => port2.postMessage({ nested: fh })).toThrow(dataCloneError);
+      } finally {
+        port1.close();
+        port2.close();
+      }
+    });
   });
 });


### PR DESCRIPTION
## What

`structuredClone`, `v8.serialize`, `MessagePort.postMessage` and advanced IPC now throw `DataCloneError` for `fs.promises.FileHandle` and `child_process.ChildProcess` instances, matching Node.js. Previously Bun silently walked them as plain objects and produced an inert `{ _events, _eventsCount, _maxListeners, ... }` stub with `read`/`kill`/`fd` all `undefined`.

## Repro

```js
import fsp from "node:fs/promises";
import v8 from "node:v8";
import { spawn } from "node:child_process";

const fh = await fsp.open(import.meta.filename, "r");
const cp = spawn(process.execPath, ["-e", "0"], { stdio: "ignore" });

structuredClone(fh);        // before: inert {} stub   now: DataCloneError
v8.serialize(fh);           // before: serialized stub now: DataCloneError
structuredClone(cp);        // before: inert {} stub   now: DataCloneError
v8.serialize(cp);           // before: serialized stub now: DataCloneError
```

Node v26.3.0 throws on all four: FileHandle with `Object that needs transfer was found in message but not listed in transferList`, ChildProcess with `Cannot clone object of unsupported type` (because `_handle` is a native `Process`).

## Cause

In Node, `FileHandle` is a native `JSTransferable` and `ChildProcess` stores a native `Process` object at `this._handle`, so V8's serializer rejects both as host objects. Bun's `FileHandle` and `ChildProcess` are pure-JS `EventEmitter` subclasses whose native state lives behind symbol keys / private fields that the structured-clone property walker never sees, so `CloneSerializer` treated them as plain objects.

## Fix

Stamp each instance with the existing `isUncloneable` private-name brand (the same one `worker_threads.markAsUncloneable` uses) in the `FileHandle` and `ChildProcess` constructors. `SerializedScriptValue` already rejects branded objects across every serialization entry point. `jsFunctionMarkAsUncloneable` is exposed to the two builtin modules via `$newCppFunction`; a header declaration is added so the generated wrapper can reference it.

This does not implement `FileHandle` transfer (tracked separately); it only closes the silent-degradation hole when a handle is cloned without being transferred.

## Verification

New tests in `test/js/web/workers/structured-clone.test.ts` cover `structuredClone`, `v8.serialize`, nested graphs, `MessagePort.postMessage`, and bare `new ChildProcess()`. All fail on the released binary and pass on this branch.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone-node-handles.test.ts
bun test v1.4.0 (4264ea352)

test/js/web/workers/structured-clone-node-handles.test.ts:
23 |     }
24 |   }
25 | 
26 |   test("structuredClone(FileHandle) throws DataCloneError", async () => {
27 |     await withFileHandle(fh => {
28 |       expect(() => structuredClone(fh)).toThrow(dataCloneError);
                                             ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: {
  _events: {},
  _eventsCount: 0,
  _maxListeners: undefined,
}

      at <anonymous> (/workspace/bun/test/js/web/workers/structured-clone-node-handles.test.ts:28:41)
      at withFileHandle (/workspace/bun/test/js/web/workers/structured-clone-node-handles.test.ts:20:13)
      at async <anonymous> (/workspace/bun/test/js/web/workers/structured-clone-node-handles.test.ts:27:11)
(fail) FileHandle and ChildProcess are not structured-cloneable > structuredClone(FileHandle) throws DataCloneError [67.64ms]

... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/workers/structured-clone-node-handles.test.ts:
23 |     }
24 |   }
25 | 
26 |   test("structuredClone(FileHandle) throws DataCloneError", async () => {
27 |     await withFileHandle(fh => {
28 |       expect(() => structuredClone(fh)).toThrow(dataCloneError);
                                             ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: {
  _events: {},
  _eventsCount: 0,
  _maxListeners: undefined,
}

      at <anonymous> (/workspace/bun/test/js/web/workers/structured-clone-node-handles.test.ts:28:41)
      at withFileHandle (/workspace/bun/test/js/web/workers/structured-clone-node-handles.test.ts:20:13)
      at async <anonymous> (/workspace/bun/test/js/web/workers/structured-clone-node-handles.test.ts:27:11)
(fail) FileHandle and ChildProcess are not structured-cloneable > structuredClone(FileHandle) throws DataCloneError [3.65ms]
31 |     });
32 |   });
33 | 
34 |   test("v8.serialize(FileHandle) throws DataCloneError", async () => {
35 |     await withFileHandle(fh => {
36 |       expect(() => v8.serialize(fh
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone-node-handles.test.ts
bun test v1.4.0 (4264ea352)

test/js/web/workers/structured-clone-node-handles.test.ts:
(pass) FileHandle and ChildProcess are not structured-cloneable > structuredClone(FileHandle) throws DataCloneError [69.89ms]
(pass) FileHandle and ChildProcess are not structured-cloneable > v8.serialize(FileHandle) throws DataCloneError [16.48ms]
(pass) FileHandle and ChildProcess are not structured-cloneable > FileHandle is still usable after a rejected clone [49.61ms]
(pass) FileHandle and ChildProcess are not structured-cloneable > structuredClone(ChildProcess) throws DataCloneError [100.76ms]
(pass) FileHandle and ChildProcess are not structured-cloneable > v8.serialize(ChildProcess) throws DataCloneError [19.56ms]
(pass) FileHandle and ChildProcess are not structured-cloneable > bare new ChildProcess() is also rejected [6.00ms]
(pass) FileHandle and ChildProcess are not structured-cloneable > MessagePort.postMessage(FileHandle) without transferList throws [16.01ms]

 7 pass
 0 fail
 16
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4264ea352c
  features     baseline

22 deps, 108 codegen, 1171 objects in 828ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[4/1234] gen ErrorCode+*.h
[5/1234] gen bindgenv2
[6/1234] fetch zlib
[zlib] up to date
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch picohttpparser
[picohttpparser] up to date
[9/1234] fetch tinycc
[tinycc] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/child_process.ts                       |  8 ++
 src/js/node/fs.promises.ts                         |  4 +
 src/jsc/bindings/webcore/Worker.h                  |  1 +
 .../workers/structured-clone-node-handles.test.ts  | 96 ++++++++++++++++++++++
 4 files changed, 109 insertions(+)
```

</details>

**gate history** · 2 passed · 2 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/child_process.ts                                  3      3      0
src/js/node/fs.promises.ts                                    3      4      0
src/jsc/bindings/webcore/Worker.h                             1      1      0
…st/js/web/workers/structured-clone-node-handles.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->