### PR TITLE
node:tls: handle destroy() on a TLSSocket wrapping an unconnected stream

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4127,12 +4127,10 @@ function closeSocketHandle(self, isException, isCleanupPending = false) {
   const handle = self._handle;
   $debug("closeSocketHandle", isException, isCleanupPending, !!handle);
   if (handle) {
-    // A client TLSSocket wrapping a not-yet-connected Duplex stores that stream
-    // as _handle directly (tls.ts sets `this._handle = socket`); Node wraps it
-    // in a JSStreamSocket whose close() destroys the stream. Do the same here.
     if (typeof handle.close === "function") {
       handle.close(onSocketHandleClosed);
     } else if (!handle.destroyed) {
+      // tls.ts stores the wrapped Duplex directly as _handle; it has destroy(), not close().
       handle.destroy?.();
     }
     setImmediate(() => {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4127,7 +4127,14 @@ function closeSocketHandle(self, isException, isCleanupPending = false) {
   const handle = self._handle;
   $debug("closeSocketHandle", isException, isCleanupPending, !!handle);
   if (handle) {
-    handle.close(onSocketHandleClosed);
+    // A client TLSSocket wrapping a not-yet-connected Duplex stores that stream
+    // as _handle directly (tls.ts sets `this._handle = socket`); Node wraps it
+    // in a JSStreamSocket whose close() destroys the stream. Do the same here.
+    if (typeof handle.close === "function") {
+      handle.close(onSocketHandleClosed);
+    } else if (!handle.destroyed) {
+      handle.destroy?.();
+    }
     setImmediate(() => {
       $debug("emit close", isCleanupPending);
       self.emit("close", isException);

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -208,6 +208,25 @@ it("should be able to grab the JSStreamSocket constructor", () => {
   expect(socket._handle._parentWrap).not.toBeNull();
   //@ts-ignore
   expect(socket._handle._parentWrap.constructor).toBeFunction();
+  socket.destroy();
+});
+
+// new tls.TLSSocket(rawSocket).destroy() before any connect: _handle is the
+// wrapped Duplex itself (no native handle yet). Node's JSStreamSocket close()
+// destroys that stream; the wrapper must too, and must not throw.
+describe.each([
+  ["net.Socket", () => new net.Socket()],
+  ["Duplex", () => new Duplex({ read() {}, write(_c, _e, cb) { cb(); } })],
+])("new TLSSocket(%s).destroy() before connect", (_, makeRaw) => {
+  it("destroys both sockets and emits 'close'", async () => {
+    const raw = makeRaw();
+    const socket = new tls.TLSSocket(raw);
+    const tlsClose = once(socket, "close");
+    const rawClose = once(raw, "close");
+    socket.destroy();
+    await Promise.all([tlsClose, rawClose]);
+    expect({ tls: socket.destroyed, raw: raw.destroyed }).toEqual({ tls: true, raw: true });
+  });
 });
 for (const { name, connect } of tests) {
   describe(name, () => {
@@ -938,14 +957,13 @@ it("TLSSocket._requestCert follows Node's _init rule", () => {
   // Clients always request the peer certificate; servers only when asked.
   // Must be decided in the constructor, before a server wrap starts its
   // upgrade: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L845-L848
-  // Like the JSStreamSocket test above, the detached wrappers are not
-  // destroyed: tearing down a never-connected duplex wrap is its own quirk.
   const cases = [
     new TLSSocket(new stream.PassThrough()), // client
     new TLSSocket(new stream.PassThrough(), { isServer: true }),
     new TLSSocket(new stream.PassThrough(), { isServer: true, requestCert: true }),
   ];
   expect(cases.map(s => (s as any)._requestCert)).toEqual([true, false, true]);
+  for (const s of cases) s.destroy();
 });
 
 it("socket.ssl is assignable like Node's plain own property", async () => {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -216,7 +216,16 @@ it("should be able to grab the JSStreamSocket constructor", () => {
 // destroys that stream; the wrapper must too, and must not throw.
 describe.each([
   ["net.Socket", () => new net.Socket()],
-  ["Duplex", () => new Duplex({ read() {}, write(_c, _e, cb) { cb(); } })],
+  [
+    "Duplex",
+    () =>
+      new Duplex({
+        read() {},
+        write(_c, _e, cb) {
+          cb();
+        },
+      }),
+  ],
 ])("new TLSSocket(%s).destroy() before connect", (_, makeRaw) => {
   it("destroys both sockets and emits 'close'", async () => {
     const raw = makeRaw();


### PR DESCRIPTION
### Reproduction

```js
import tls from 'node:tls'; import net from 'node:net';
const s = new tls.TLSSocket(new net.Socket());
s.destroy();
setTimeout(() => { console.log('SURVIVED destroyed=' + s.destroyed); process.exit(0); }, 200);
```

Node v26.3.0: `SURVIVED destroyed=true`, exit 0.

Bun on main (44f6469e):
```
TypeError: handle.close is not a function. (In 'handle.close()', 'handle.close' is undefined)
      at closeSocketHandle (node:net:1999:17)
      at _destroy (node:net:1024:24)
```
The error is uncaught and kills the process. Same for `new tls.TLSSocket(new Duplex())`.

### Cause

A client-side `new tls.TLSSocket(duplex)` stores the wrapped stream directly as `this._handle` (tls.ts `this._handle = socket`); until a connect/upgrade runs there is no native handle. `Socket.prototype._destroy` sees `_handle` is truthy and routes it to `closeSocketHandle`, which calls `handle.close(cb)` unconditionally. A `net.Socket`/`Duplex` has no `close` method.

Node wraps such a stream in a `JSStreamSocket`, whose `close()` destroys the underlying stream, so `handle.close()` always exists there.

### Fix

`closeSocketHandle` falls back to `handle.destroy()` when `handle.close` is not a function (i.e. `_handle` is a wrapped stream, not a native handle). This both stops the uncaught TypeError and destroys the wrapped stream like Node does: with the fix, the wrapped socket's `'close'` fires and `raw.destroyed === true`, matching Node.

### Verification

```
$ bun bd test test/js/node/tls/node-tls-connect.test.ts -t "before connect"
(pass) new TLSSocket(net.Socket).destroy() before connect > destroys both sockets and emits 'close'
(pass) new TLSSocket(Duplex).destroy() before connect > destroys both sockets and emits 'close'
```

Both tests throw `handle.close is not a function` without the fix. Vendored `test-tls-on-empty-socket`, `test-tls-destroy-whilst-write`, `test-tls-js-stream`, `test-tls-connect-given-socket` still pass.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.0 (bd462795d)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.33ms]
(pass) should thow ECONNRESET if FIN is received before handshake [407.14ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [17.86ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [144.74ms]
(pass) should be able to grab the JSStreamSocket constructor [33.04ms]
TypeError: handle.close is not a function. (In 'handle.close(onSocketHandleClosed)', 'handle.close' is undefined)
      at closeSocketHandle (node:net:3116:17)
      at _destroy (node:net:1685:24)
      at _destroy (internal:streams/destroy:85:18)
      at destroy (internal:streams/destroy:55:13)
      at internal:streams/writable:800:16
      at /workspace/bun/test/js/node/tls/node-tls-connect.test.ts:323:9
      at /workspace/bun/test/js/node/tls/node-tls-connect.test.ts:318:14
(fail) new TLSSocket(net.Socket).destroy() before connect > destroys both s
... (truncated)

release without fix: 18 skipped
bun test v1.4.0-canary.1 (bd462795d)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.05ms]
(pass) should thow ECONNRESET if FIN is received before handshake [7.81ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.13ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [4.42ms]
(pass) should be able to grab the JSStreamSocket constructor [0.30ms]
(pass) new TLSSocket(net.Socket).destroy() before connect > destroys both sockets and emits 'close' [1.69ms]
(pass) new TLSSocket(Duplex).destroy() before connect > destroys both sockets and emits 'close' [0.38ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [3.46ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [3.55ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.0 (bd462795d)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.55ms]
(pass) should thow ECONNRESET if FIN is received before handshake [448.49ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [17.16ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [153.33ms]
(pass) should be able to grab the JSStreamSocket constructor [29.75ms]
(pass) new TLSSocket(net.Socket).destroy() before connect > destroys both sockets and emits 'close' [56.65ms]
(pass) new TLSSocket(Duplex).destroy() before connect > destroys both sockets and emits 'close' [35.34ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [90.95ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [96.45ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, get
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 823ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (10045ms)
Bundle modules (60ms)
Postprocesss modules (682ms)
Bundle Functions (1084ms)
Generate Code (32ms)

[11.92s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (bd462795d)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.06ms]
(pass) should thow ECONNRESET if FIN is received before handshake [8.77ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.17ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [4.81ms]
(pass) should be able to grab the JSStreamSocket constructor [0.40ms]
(pass) new TLSSocket(net.Socket).destroy() before connect > destroys both sockets and emits 'close' [1.48ms]
(pass) new TLSSocket(Duplex).destroy() before connect > destroys both sockets and emits 'close' [1.70ms]
(skip) tls.connect > should work with alp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                        |  7 ++++++-
 test/js/node/tls/node-tls-connect.test.ts | 31 +++++++++++++++++++++++++++++--
 2 files changed, 35 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/net.ts                             5      2      0
test/js/node/tls/node-tls-connect.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->