### PR TITLE
node:http: gate server.close() on connection drain, not request count

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -86,6 +86,8 @@ const OutgoingMessagePrototype = OutgoingMessage.prototype;
 const { kIncomingMessage } = require("node:_http_common");
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
+const kClosing = Symbol("http.server.closing");
+const kPendingDrainClose = Symbol("http.server.pendingDrainClose");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
@@ -120,6 +122,20 @@ const DateNow = Date.now;
 let cluster;
 
 function emitCloseServer(self: Server) {
+  // Like Node.js's net.Server#_emitCloseIfDrained: 'close' (and the close
+  // callback) only fire once every accepted connection has ended. The native
+  // all-closed promise that schedules this resolves on pending_requests == 0,
+  // so a keep-alive connection that was serving a request when close() ran is
+  // still open when that promise resolves; the last connection's #onClose
+  // re-checks and reschedules once kTrackedConnections empties.
+  const connections = self[kTrackedConnections];
+  if (connections && connections.size > 0) {
+    self[kPendingDrainClose] = true;
+    return;
+  }
+  self[kPendingDrainClose] = false;
+  self[kClosing] = false;
+  self[serverSymbol] = undefined;
   callCloseCallback(self);
   self.emit("close");
 }
@@ -309,6 +325,8 @@ function Server(options, callback): void {
   defineHttpAllowHalfOpen(this);
   this[kInternalSocketData] = undefined;
   this[kTrackedConnections] = new Set();
+  this[kClosing] = false;
+  this[kPendingDrainClose] = false;
   this[tlsSymbol] = null;
   this.noDelay = true;
   if (typeof options === "function") {
@@ -472,15 +490,14 @@ Server.prototype.unref = function () {
 };
 
 Server.prototype.closeAllConnections = function () {
-  const server = this[serverSymbol];
-  if (!server) {
-    return;
+  // Node destroys every tracked connection and leaves the listen socket alone.
+  // Driven off kTrackedConnections so it also works as the forced half of a
+  // close() + closeAllConnections() drain, once the native handle is gone.
+  const connections = this[kTrackedConnections];
+  if (!connections) return;
+  for (const socket of connections) {
+    socket.destroy();
   }
-  this[serverSymbol] = undefined;
-  clearInterval(this[kConnectionsCheckingInterval]);
-  this.listening = false;
-
-  server.stop(true);
 };
 
 Server.prototype.getConnections = function (callback) {
@@ -494,8 +511,22 @@ Server.prototype.getConnections = function (callback) {
 };
 
 Server.prototype.closeIdleConnections = function () {
-  const server = this[serverSymbol];
-  server?.closeIdleConnections();
+  // Like Node.js: destroy connections that are neither writing a response nor
+  // receiving a request, and leave the listen socket alone. The native sweep
+  // skips connections with a partially-parsed request (its isIdle flag); the
+  // kTrackedConnections pass is what keeps this working after close(), once
+  // the native app has deinit'd.
+  this[serverSymbol]?.closeIdleConnections();
+  const connections = this[kTrackedConnections];
+  if (!connections) return;
+  for (const socket of connections) {
+    if (socket.destroyed) continue;
+    const message = socket._httpMessage;
+    if (message && !message.finished) continue;
+    if (socket[kPipelinedResponses]?.length) continue;
+    if (socket[kHandle]?.response) continue;
+    socket.destroy();
+  }
 };
 
 Server.prototype.close = function (optionalCallback?) {
@@ -503,12 +534,15 @@ Server.prototype.close = function (optionalCallback?) {
   // Node.js's httpServerPreClose clears the connections-checking interval
   // even when the server was never listening.
   clearInterval(this[kConnectionsCheckingInterval]);
-  if (!server) {
+  if (!server || this[kClosing]) {
     if (typeof optionalCallback === "function") process.nextTick(optionalCallback, $ERR_SERVER_NOT_RUNNING());
     // Like Node.js's net.Server#close, close() returns the server.
     return this;
   }
-  this[serverSymbol] = undefined;
+  // The native handle stays reachable until every connection has drained
+  // (emitCloseServer clears it) so closeIdleConnections/closeAllConnections
+  // keep working after close(); kClosing is Node's "_handle == null" stand-in.
+  this[kClosing] = true;
   if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
   this.listening = false;
   server.closeIdleConnections();
@@ -553,7 +587,7 @@ Server.prototype[Symbol.asyncDispose] = function () {
 };
 
 Server.prototype.address = function () {
-  if (!this[serverSymbol]) return null;
+  if (!this[serverSymbol] || this[kClosing]) return null;
   return this[serverSymbol].address;
 };
 
@@ -1667,7 +1701,14 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
     // released parser (free() invoked, kOnTimeout nulled).
     releaseServerParserShim(this);
     this[kHandle] = null;
-    this.server?.[kTrackedConnections]?.delete(this);
+    const server = this.server;
+    const tracked = server?.[kTrackedConnections];
+    if (tracked) {
+      tracked.delete(this);
+      if (tracked.size === 0 && server[kPendingDrainClose]) {
+        process.nextTick(emitCloseServer, server);
+      }
+    }
     const timer = this[kSocketTimeoutTimer];
     if (timer) {
       clearTimeout(timer);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -123,11 +123,14 @@ let cluster;
 
 function emitCloseServer(self: Server) {
   // Like Node.js's net.Server#_emitCloseIfDrained: 'close' (and the close
-  // callback) only fire once every accepted connection has ended. The native
-  // all-closed promise that schedules this resolves on pending_requests == 0,
-  // so a keep-alive connection that was serving a request when close() ran is
-  // still open when that promise resolves; the last connection's #onClose
-  // re-checks and reschedules once kTrackedConnections empties.
+  // callback) only fire once every accepted connection has ended, and a
+  // re-listen before the drain completes cancels it (Node bails when
+  // `_handle` is set again). The native all-closed promise that schedules
+  // this resolves on pending_requests == 0, so a keep-alive connection that
+  // was serving a request when close() ran is still open when that promise
+  // resolves; the last connection's #onClose re-checks and reschedules once
+  // kTrackedConnections empties.
+  if (!self[kClosing]) return;
   const connections = self[kTrackedConnections];
   if (connections && connections.size > 0) {
     self[kPendingDrainClose] = true;
@@ -292,7 +295,7 @@ function emitRequestCloseNT(self) {
 }
 
 function emitListeningNextTick(self, hostname, port) {
-  if ((self.listening = !!self[serverSymbol])) {
+  if ((self.listening = !!self[serverSymbol] && !self[kClosing])) {
     // TODO: remove the arguments
     // Note does not pass any arguments.
     self.emit("listening", null, hostname, port);
@@ -512,11 +515,13 @@ Server.prototype.getConnections = function (callback) {
 
 Server.prototype.closeIdleConnections = function () {
   // Like Node.js: destroy connections that are neither writing a response nor
-  // receiving a request, and leave the listen socket alone. The native sweep
-  // skips connections with a partially-parsed request (its isIdle flag); the
-  // kTrackedConnections pass is what keeps this working after close(), once
-  // the native app has deinit'd.
+  // receiving a request, and leave the listen socket alone. On a live server
+  // the native sweep is authoritative (its isIdle flag spares connections
+  // whose request head is still arriving); the kTrackedConnections pass runs
+  // only during a close() drain, so it keeps working once the native app has
+  // deinit'd without undoing that decision on a live server.
   this[serverSymbol]?.closeIdleConnections();
+  if (!this[kClosing]) return;
   const connections = this[kTrackedConnections];
   if (!connections) return;
   for (const socket of connections) {
@@ -705,6 +710,10 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
     if (tls) {
       this.serverName = tls.serverName || host || "localhost";
     }
+    // A listen() during a prior close()'s drain installs a fresh handle; the
+    // pending drain must not clear it (emitCloseServer bails on !kClosing).
+    this[kClosing] = false;
+    this[kPendingDrainClose] = false;
     this[serverSymbol] = Bun.serve<any>({
       idleTimeout: 0, // nodejs dont have a idleTimeout by default
       tls,

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -121,15 +121,10 @@ const DateNow = Date.now;
 
 let cluster;
 
+// Like Node.js's net.Server#_emitCloseIfDrained: the native all-closed promise
+// resolves on pending_requests == 0 (not connections == 0), so gate the actual
+// 'close' on kTrackedConnections draining; #onClose reschedules once it does.
 function emitCloseServer(self: Server) {
-  // Like Node.js's net.Server#_emitCloseIfDrained: 'close' (and the close
-  // callback) only fire once every accepted connection has ended, and a
-  // re-listen before the drain completes cancels it (Node bails when
-  // `_handle` is set again). The native all-closed promise that schedules
-  // this resolves on pending_requests == 0, so a keep-alive connection that
-  // was serving a request when close() ran is still open when that promise
-  // resolves; the last connection's #onClose re-checks and reschedules once
-  // kTrackedConnections empties.
   if (!self[kClosing]) return;
   const connections = self[kTrackedConnections];
   if (connections && connections.size > 0) {
@@ -492,10 +487,8 @@ Server.prototype.unref = function () {
   return this;
 };
 
+// Node destroys every tracked connection and leaves the listen socket alone.
 Server.prototype.closeAllConnections = function () {
-  // Node destroys every tracked connection and leaves the listen socket alone.
-  // Driven off kTrackedConnections so it also works as the forced half of a
-  // close() + closeAllConnections() drain, once the native handle is gone.
   const connections = this[kTrackedConnections];
   if (!connections) return;
   for (const socket of connections) {
@@ -514,12 +507,9 @@ Server.prototype.getConnections = function (callback) {
 };
 
 Server.prototype.closeIdleConnections = function () {
-  // Like Node.js: destroy connections that are neither writing a response nor
-  // receiving a request, and leave the listen socket alone. On a live server
-  // the native sweep is authoritative (its isIdle flag spares connections
-  // whose request head is still arriving); the kTrackedConnections pass runs
-  // only during a close() drain, so it keeps working once the native app has
-  // deinit'd without undoing that decision on a live server.
+  // Native sweep is authoritative on a live server (its isIdle flag spares
+  // mid-parse connections); the kTrackedConnections pass covers the
+  // post-close() window once the native app has deinit'd.
   this[serverSymbol]?.closeIdleConnections();
   if (!this[kClosing]) return;
   const connections = this[kTrackedConnections];
@@ -544,9 +534,8 @@ Server.prototype.close = function (optionalCallback?) {
     // Like Node.js's net.Server#close, close() returns the server.
     return this;
   }
-  // The native handle stays reachable until every connection has drained
-  // (emitCloseServer clears it) so closeIdleConnections/closeAllConnections
-  // keep working after close(); kClosing is Node's "_handle == null" stand-in.
+  // kClosing is Node's "_handle == null" stand-in; serverSymbol stays set
+  // until emitCloseServer so the drain helpers keep working after close().
   this[kClosing] = true;
   if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
   this.listening = false;
@@ -710,8 +699,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
     if (tls) {
       this.serverName = tls.serverName || host || "localhost";
     }
-    // A listen() during a prior close()'s drain installs a fresh handle; the
-    // pending drain must not clear it (emitCloseServer bails on !kClosing).
+    // Cancel any prior close()'s pending drain before installing a new handle.
     this[kClosing] = false;
     this[kPendingDrainClose] = false;
     this[serverSymbol] = Bun.serve<any>({

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -699,11 +699,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
     if (tls) {
       this.serverName = tls.serverName || host || "localhost";
     }
-    // Cancel any prior close()'s pending drain before installing a new handle.
-    this[kClosing] = false;
-    this[kPendingDrainClose] = false;
-    this[kCloseCallback] = undefined;
-    this[serverSymbol] = undefined;
     this[serverSymbol] = Bun.serve<any>({
       idleTimeout: 0, // nodejs dont have a idleTimeout by default
       tls,
@@ -1181,6 +1176,11 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       // },
     });
 
+    // Cancel any prior close()'s pending drain now that the new handle is
+    // installed (after the fallible Bun.serve() so a throw leaves state intact).
+    this[kClosing] = false;
+    this[kPendingDrainClose] = false;
+    this[kCloseCallback] = undefined;
     getBunServerAllClosedPromise(this[serverSymbol]).$then(emitCloseNTServer.bind(this));
     isHTTPS = this[serverSymbol].protocol === "https";
     applyServerCustomOptions(this);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -703,6 +703,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
     this[kClosing] = false;
     this[kPendingDrainClose] = false;
     this[kCloseCallback] = undefined;
+    this[serverSymbol] = undefined;
     this[serverSymbol] = Bun.serve<any>({
       idleTimeout: 0, // nodejs dont have a idleTimeout by default
       tls,

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -702,6 +702,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
     // Cancel any prior close()'s pending drain before installing a new handle.
     this[kClosing] = false;
     this[kPendingDrainClose] = false;
+    this[kCloseCallback] = undefined;
     this[serverSymbol] = Bun.serve<any>({
       idleTimeout: 0, // nodejs dont have a idleTimeout by default
       tls,

--- a/test/js/bun/test/parallel/test-http-server.listening-should-work.ts
+++ b/test/js/bun/test/parallel/test-http-server.listening-should-work.ts
@@ -6,5 +6,9 @@ const { expect } = createTest(import.meta.path);
 const server = http.createServer();
 await once(server.listen(0), "listening");
 expect(server.listening).toBe(true);
+// closeAllConnections() destroys the connections, it does not stop listening.
 server.closeAllConnections();
+expect(server.listening).toBe(true);
+server.close();
 expect(server.listening).toBe(false);
+await once(server, "close");

--- a/test/js/bun/test/parallel/test-http-timeout-destruction-should-be-visible-using-kConnectionsCheckingInterval.ts
+++ b/test/js/bun/test/parallel/test-http-timeout-destruction-should-be-visible-using-kConnectionsCheckingInterval.ts
@@ -6,5 +6,10 @@ const { expect } = createTest(import.meta.path);
 const { kConnectionsCheckingInterval } = require("_http_server");
 const server = http.createServer();
 await once(server.listen(0), "listening");
+expect(server[kConnectionsCheckingInterval]._destroyed).toBe(false);
+// Only close() tears the interval down; closeAllConnections() keeps listening.
 server.closeAllConnections();
+expect(server[kConnectionsCheckingInterval]._destroyed).toBe(false);
+server.close();
 expect(server[kConnectionsCheckingInterval]._destroyed).toBe(true);
+await once(server, "close");

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -771,6 +771,7 @@ it("Server should be able to send empty pings", async () => {
       return await promise;
     } finally {
       httpServer.closeAllConnections();
+      httpServer.close();
     }
   }
   {

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -94,6 +94,7 @@ test.concurrent("should not crash when closing sockets after upgrade", async () 
             http_socket?.destroy();
           });
           server.closeAllConnections();
+          server.close();
           resolve();
         }, 10);
       }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3710,6 +3710,44 @@ describe("server.close() drains connections, not requests", () => {
       server.close();
     }
   });
+
+  it("closeIdleConnections() on a live server spares a connection mid-header-parse", async () => {
+    // Node's ConnectionsList.idle() excludes parsers with last_message_start != 0
+    // (test-http-server-close-idle.js client1). The JS kTrackedConnections sweep
+    // would treat such a connection as idle, so it must not run on a live server.
+    const server = createServer((req, res) => res.end("ok:" + req.url));
+    server.keepAliveTimeout = 60_000;
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    const connected = once(server, "connection");
+    const sock = connect(port, "127.0.0.1");
+    sock.on("error", () => {});
+    await once(sock, "connect");
+    try {
+      let ended = false;
+      sock.on("end", () => (ended = true));
+      sock.write("GET /p HTTP/1.1");
+      await connected;
+      await drainTicks();
+
+      server.closeIdleConnections();
+      await drainTicks();
+      expect({ socketDestroyed: sock.destroyed, socketEnded: ended }).toEqual({
+        socketDestroyed: false,
+        socketEnded: false,
+      });
+
+      let body = "";
+      sock.on("data", c => (body += c));
+      sock.write("\r\nHost: x\r\n\r\n");
+      while (!body.includes("ok:/p")) await once(sock, "data");
+    } finally {
+      sock.destroy();
+      server.closeAllConnections();
+      server.close();
+    }
+  });
 });
 
 it("req.upgrade is true inside the 'connect' listener", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1543,6 +1543,7 @@ describe("HTTP Server Security Tests - Advanced", () => {
     // Close the server if it's still running
     if (server.listening) {
       server.closeAllConnections();
+      server.close();
     }
   });
 
@@ -3465,6 +3466,250 @@ it("server.close(cb) completes after a raw upgrade once both sockets are destroy
   const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
   server.close(() => onClosed());
   await closed;
+});
+
+// Node's server.close(cb) waits for every accepted connection to end
+// (net.Server#_emitCloseIfDrained), not for the in-flight request count to
+// reach zero. These four scenarios cover graceful-shutdown shapes that
+// otherwise look identical to the "pending requests == 0" condition.
+describe("server.close() drains connections, not requests", () => {
+  async function startServer(handler: http.RequestListener) {
+    const server = createServer(handler);
+    server.keepAliveTimeout = 60_000;
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    const sock = connect(port, "127.0.0.1");
+    sock.on("error", () => {});
+    await once(sock, "connect");
+    return { server, sock, port };
+  }
+
+  async function drainTicks() {
+    for (let i = 0; i < 6; i++) await new Promise<void>(r => setImmediate(r));
+  }
+
+  it("A: close() FINs an idle keep-alive connection and fires", async () => {
+    const { server, sock } = await startServer((req, res) => res.end("ok:" + req.url));
+    try {
+      let body = "";
+      sock.on("data", c => (body += c));
+      sock.write("GET /a HTTP/1.1\r\nHost: x\r\n\r\n");
+      while (!body.includes("ok:/a")) await once(sock, "data");
+      await drainTicks();
+
+      const ended = once(sock, "end");
+      const closed = Promise.withResolvers<void>();
+      server.close(() => closed.resolve());
+      await closed.promise;
+      await ended;
+    } finally {
+      sock.destroy();
+      server.closeAllConnections();
+    }
+  });
+
+  it("C: close(cb) waits while a keep-alive connection is still open", async () => {
+    const inHandler = Promise.withResolvers<void>();
+    let finishFirst!: () => void;
+    const paths: string[] = [];
+    const { server, sock } = await startServer((req, res) => {
+      paths.push(req.url as string);
+      if (paths.length === 1) {
+        inHandler.resolve();
+        finishFirst = () => res.end("ok:" + req.url);
+      } else {
+        res.end("ok:" + req.url);
+      }
+    });
+    try {
+      let body = "";
+      sock.on("data", c => (body += c));
+      sock.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n");
+      await inHandler.promise;
+
+      let closeCbFired = false;
+      let closeEventFired = false;
+      server.once("close", () => (closeEventFired = true));
+      const closed = Promise.withResolvers<void>();
+      server.close(() => {
+        closeCbFired = true;
+        closed.resolve();
+      });
+
+      finishFirst();
+      while (!body.includes("ok:/first")) await once(sock, "data");
+      await drainTicks();
+      expect({ closeCbFired, closeEventFired }).toEqual({ closeCbFired: false, closeEventFired: false });
+
+      sock.write("GET /second HTTP/1.1\r\nHost: x\r\n\r\n");
+      while (!body.includes("ok:/second")) await once(sock, "data");
+      await drainTicks();
+      expect({ closeCbFired, closeEventFired }).toEqual({ closeCbFired: false, closeEventFired: false });
+      expect(paths).toEqual(["/first", "/second"]);
+
+      sock.destroy();
+      await closed.promise;
+      expect({ closeCbFired, closeEventFired }).toEqual({ closeCbFired: true, closeEventFired: true });
+    } finally {
+      sock.destroy();
+      server.closeAllConnections();
+    }
+  });
+
+  it("B: closeIdleConnections() after close() drains a now-idle connection", async () => {
+    const inHandler = Promise.withResolvers<void>();
+    let finishFirst!: () => void;
+    const { server, sock } = await startServer((req, res) => {
+      inHandler.resolve();
+      finishFirst = () => res.end("ok:" + req.url);
+    });
+    try {
+      let body = "";
+      sock.on("data", c => (body += c));
+      const ended = once(sock, "end");
+      sock.write("GET /b HTTP/1.1\r\nHost: x\r\n\r\n");
+      await inHandler.promise;
+
+      let closeCbFired = false;
+      const closed = Promise.withResolvers<void>();
+      server.close(() => {
+        closeCbFired = true;
+        closed.resolve();
+      });
+
+      finishFirst();
+      while (!body.includes("ok:/b")) await once(sock, "data");
+      await drainTicks();
+      expect(closeCbFired).toBe(false);
+
+      // The response has been delivered and the connection is idle; a
+      // post-close closeIdleConnections() must reach it and let the
+      // callback fire.
+      server.closeIdleConnections();
+      await closed.promise;
+      await ended;
+    } finally {
+      sock.destroy();
+      server.closeAllConnections();
+    }
+  });
+
+  it("B': closeAllConnections() after close() drains the in-flight connection", async () => {
+    const inHandler = Promise.withResolvers<void>();
+    const { server, sock } = await startServer((req, res) => {
+      inHandler.resolve();
+      void res;
+    });
+    try {
+      sock.write("GET /b2 HTTP/1.1\r\nHost: x\r\n\r\n");
+      await inHandler.promise;
+
+      const closed = Promise.withResolvers<void>();
+      server.close(() => closed.resolve());
+      await drainTicks();
+
+      // The request handler never responded; closeAllConnections() must
+      // destroy the connection regardless and let the callback fire.
+      server.closeAllConnections();
+      await closed.promise;
+      expect(sock.destroyed || sock.readableEnded).toBe(true);
+    } finally {
+      sock.destroy();
+      server.closeAllConnections();
+    }
+  });
+
+  it("D: close(cb) never fires while a keep-alive client keeps the connection busy", async () => {
+    // SIGTERM shape: close() arrives while a request is in flight, the client
+    // then keeps issuing keep-alive requests on that same connection. The
+    // close callback must not fire (and no request is served "after cb")
+    // until the client releases the connection.
+    const inHandler = Promise.withResolvers<void>();
+    let finishFirst!: () => void;
+    const paths: string[] = [];
+    const { server, sock } = await startServer((req, res) => {
+      paths.push(req.url as string);
+      if (paths.length === 1) {
+        inHandler.resolve();
+        finishFirst = () => res.end("ok:" + req.url);
+      } else {
+        res.end("ok:" + req.url);
+      }
+    });
+    try {
+      let body = "";
+      sock.on("data", c => (body += c));
+      let servedAfterCb = 0;
+      let closeCbFired = false;
+
+      sock.write("GET /d0 HTTP/1.1\r\nHost: x\r\n\r\n");
+      await inHandler.promise;
+
+      const closed = Promise.withResolvers<void>();
+      server.close(() => {
+        closeCbFired = true;
+        closed.resolve();
+      });
+      finishFirst();
+      while (!body.includes("ok:/d0")) await once(sock, "data");
+      await drainTicks();
+      if (closeCbFired) servedAfterCb = -1;
+
+      for (let i = 1; i <= 5; i++) {
+        const marker = "ok:/d" + i;
+        sock.write(`GET /d${i} HTTP/1.1\r\nHost: x\r\n\r\n`);
+        while (!body.includes(marker)) await once(sock, "data");
+        if (closeCbFired) servedAfterCb++;
+        await drainTicks();
+      }
+      expect({ closeCbFired, servedAfterCb }).toEqual({ closeCbFired: false, servedAfterCb: 0 });
+
+      sock.destroy();
+      await closed.promise;
+      expect(paths).toEqual(["/d0", "/d1", "/d2", "/d3", "/d4", "/d5"]);
+    } finally {
+      sock.destroy();
+      server.closeAllConnections();
+    }
+  });
+
+  it("closeAllConnections() leaves the listener running", async () => {
+    const { server, sock, port } = await startServer((req, res) => res.end("ok:" + req.url));
+    try {
+      let body = "";
+      sock.on("data", c => (body += c));
+      sock.write("GET /l HTTP/1.1\r\nHost: x\r\n\r\n");
+      while (!body.includes("ok:/l")) await once(sock, "data");
+
+      let closeEventFired = false;
+      server.once("close", () => (closeEventFired = true));
+      const clientClosed = once(sock, "close");
+      server.closeAllConnections();
+      await clientClosed;
+      await drainTicks();
+      expect(server.listening).toBe(true);
+      expect(closeEventFired).toBe(false);
+
+      // A fresh connection is still accepted.
+      const sock2 = connect(port, "127.0.0.1");
+      sock2.on("error", () => {});
+      await once(sock2, "connect");
+      let body2 = "";
+      sock2.on("data", c => (body2 += c));
+      sock2.write("GET /l2 HTTP/1.1\r\nHost: x\r\n\r\n");
+      while (!body2.includes("ok:/l2")) await once(sock2, "data");
+      sock2.destroy();
+
+      const closed = Promise.withResolvers<void>();
+      server.close(() => closed.resolve());
+      await closed.promise;
+    } finally {
+      sock.destroy();
+      server.closeAllConnections();
+      server.close();
+    }
+  });
 });
 
 it("req.upgrade is true inside the 'connect' listener", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3506,6 +3506,7 @@ describe("server.close() drains connections, not requests", () => {
     } finally {
       sock.destroy();
       server.closeAllConnections();
+      server.close();
     }
   });
 
@@ -3554,6 +3555,7 @@ describe("server.close() drains connections, not requests", () => {
     } finally {
       sock.destroy();
       server.closeAllConnections();
+      server.close();
     }
   });
 
@@ -3592,6 +3594,7 @@ describe("server.close() drains connections, not requests", () => {
     } finally {
       sock.destroy();
       server.closeAllConnections();
+      server.close();
     }
   });
 
@@ -3617,6 +3620,7 @@ describe("server.close() drains connections, not requests", () => {
     } finally {
       sock.destroy();
       server.closeAllConnections();
+      server.close();
     }
   });
 
@@ -3671,6 +3675,7 @@ describe("server.close() drains connections, not requests", () => {
     } finally {
       sock.destroy();
       server.closeAllConnections();
+      server.close();
     }
   });
 

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -85,6 +85,7 @@ test("pre aborted with readable request body", async () => {
     ).rejects.toThrow();
   } finally {
     server.closeAllConnections();
+    server.close();
   }
 });
 
@@ -559,6 +560,7 @@ test("fetching with Request object - issue #1527", async () => {
     expect(await fetch(request)).resolves.pass();
   } finally {
     server.closeAllConnections();
+    server.close();
   }
 });
 

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -243,6 +243,7 @@ describe.concurrent("fetch() with streaming", () => {
         expect(true).toBe(true);
       } finally {
         server?.closeAllConnections();
+        server?.close();
       }
     });
   }


### PR DESCRIPTION
## Repro

```js
import http from "node:http"; import net from "node:net";
const server = http.createServer((req, res) => setTimeout(() => res.end("resp:" + req.url), 50));
server.keepAliveTimeout = 60000;
server.listen(0, "127.0.0.1", () => {
  const c = net.connect(server.address().port, "127.0.0.1");
  let cbAt = null, n = 0, body = "";
  c.on("data", d => body += d);
  c.on("connect", () => {
    c.write("GET /0 HTTP/1.1\r\nHost: x\r\n\r\n");
    setTimeout(() => server.close(() => { cbAt = n }), 10);
    const id = setInterval(() => {
      n++;
      c.write("GET /" + n + " HTTP/1.1\r\nHost: x\r\n\r\n");
      if (n === 5) {
        clearInterval(id);
        setTimeout(() => {
          console.log({ cbFiredAt: cbAt, responses: (body.match(/resp:/g) || []).length });
          process.exit(0);
        }, 200);
      }
    }, 100);
  });
});
```

|         | `cbFiredAt` | `responses` |
| ------- | ----------- | ----------- |
| node    | `null`      | 6           |
| bun     | **`0`**     | 6           |

`server.close()`'s callback fires as soon as the first response is written, then five more requests are served on that same connection. Any `server.close(() => process.exit())` style graceful drain is told the server is drained while a live keep-alive client is still issuing requests into it.

## Cause

`emitCloseNTServer` is driven by `getBunServerAllClosedPromise`, whose condition (`deinit_if_we_can`) is `pending_requests == 0 && !listener && !websockets`. That is a pending-*request* counter, where Node's `net.Server` waits for `_connections` to reach zero. A keep-alive connection that was mid-request when `close()` ran drops `pending_requests` to zero once that response is written, so the promise resolves while the TCP connection is still open and serving.

Two consequences of `close()` also nulling `this[serverSymbol]` immediately:

- `closeIdleConnections()` / `closeAllConnections()` became no-ops after `close()`, so the standard `close(); closeAllConnections()` drain could not force the orphaned connection down.
- `closeAllConnections()` itself called `server.stop(true)`, which tears down the listener and fires `'close'`; Node's contract is to destroy the connections and keep accepting.

## Fix

All in `_http_server.ts` (no native change):

- `emitCloseServer` is gated on `kTrackedConnections.size === 0`, mirroring Node's `net.Server#_emitCloseIfDrained`. When the native promise resolves with connections still tracked it records `kPendingDrainClose` and returns; the last connection's `#onClose` re-checks and schedules the actual `'close'` emit.
- `close()` keeps the native handle reachable under a `kClosing` flag instead of nulling `serverSymbol` (so `address()` reports `null` and a second `close()` reports `ERR_SERVER_NOT_RUNNING`, while the drain helpers still work).
- `closeAllConnections()` iterates `kTrackedConnections` and `destroy()`s each socket, leaving the listener alone.
- `closeIdleConnections()` does the native idle sweep (knows about partially-parsed requests) and additionally iterates `kTrackedConnections`, skipping sockets with an in-flight response, so it keeps working after `close()` once the native app has deinit'd.

## Verification

New `describe("server.close() drains connections, not requests")` in `test/js/node/http/node-http.test.ts` covers the four graceful-shutdown shapes plus the listener invariant:

```
# without the fix                                       # with the fix
A: close() FINs an idle keep-alive connection     pass  pass  (control)
C: close(cb) waits while a keep-alive conn open   FAIL  pass
B: closeIdleConnections() after close() drains    FAIL  pass
B': closeAllConnections() after close() drains    FAIL  pass
D: cb never fires while client keeps conn busy    FAIL  pass  (servedAfterCb 4 -> 0)
closeAllConnections() leaves the listener running FAIL  pass
```

Also green: `test-http-server-close-{all,idle,idle-wait-response,destroy-timeout}.js`, `test-https-server-close-{all,idle}.js`, `test-http-server-connection-list-when-close.js`, `test-http-req-res-close.js`, `bun-server.test.ts` "late keep-alive request", `node-http-server-timeouts.test.ts`.

Two bun-parallel tests and five test cleanups that used `closeAllConnections()` as a stand-in for `close()` now call `close()` explicitly, matching Node.

## Relationship to open PRs

#35837 adds the `kTrackedConnections.size` gate alone (scenario C); #35839 rewrites `closeIdleConnections()`/`closeAllConnections()` off the set (scenarios B/B' and the listener invariant, like #33394). #31302 and #30505 are earlier partial approaches to the `closeAllConnections()` half. This PR is the unified fix for the full drain contract and subsumes #35837, #35839, and #33394.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.stream.test.ts

<!-- robobun:evidence:end -->

Fixes #31301
Fixes #30501