### PR TITLE
webcore: consume body when formData() rejects on MIME type

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1526,6 +1526,12 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToFormDataFulfilled
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue blob = callFrame->argument(0);
     JSValue contentType = callFrame->argument(1);
+    if (contentType.isFalse()) {
+        // Body.formData() with an invalid MIME type: the stream has been fully
+        // read (per spec "consume body"), now reject from packageData.
+        Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_FORMDATA_PARSE_ERROR, "Can't decode form data from body because of incorrect MIME type/boundary"_s);
+        return {};
+    }
     JSValue constructor = JSDOMFormData::getConstructor(vm, globalObject);
     JSValue fromFunction = constructor.get(globalObject, vm.propertyNames->from);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1527,8 +1527,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToFormDataFulfilled
     JSValue blob = callFrame->argument(0);
     JSValue contentType = callFrame->argument(1);
     if (contentType.isFalse()) {
-        // Body.formData() with an invalid MIME type: the stream has been fully
-        // read (per spec "consume body"), now reject from packageData.
+        // Sentinel from Body.formData() when the MIME check failed: stream is drained, now reject.
         Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_FORMDATA_PARSE_ERROR, "Can't decode form data from body because of incorrect MIME type/boundary"_s);
         return {};
     }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -387,12 +387,9 @@ impl PendingValue {
                         Action::GetText => global_this.readable_stream_to_text(readable.value),
                         Action::GetBlob => global_this.readable_stream_to_blob(readable.value),
                         Action::GetFormData(form_data) => 'brk: {
-                            // `None` means the MIME check already failed; per spec the
-                            // body is still fully read before `packageData` throws, so
-                            // drain the stream and have the C++ fulfillment handler
-                            // reject. The sentinel is `false` (null/undefined are
-                            // dropped by the promise-reaction context plumbing).
                             let encoding_js = match form_data.take() {
+                                // MIME check failed: drain then reject. `false` survives
+                                // the reaction-context plumbing (null/undefined do not).
                                 None => JSValue::FALSE,
                                 Some(fd) => match &fd.encoding {
                                     bun_core::form_data::Encoding::Multipart(multipart) => {
@@ -1991,9 +1988,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             }
         }
 
-        // Spec "consume body": fully read the body, then run packageData (which
-        // performs the MIME check). A failed MIME check must therefore still
-        // consume the body (bodyUsed becomes true; subsequent reads reject).
+        // Spec "consume body" fully reads before the MIME check, so consume even when encoder is None.
         let encoder = self.get_form_data_encoding()?;
 
         let value = self.get_body_value();

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -388,8 +388,7 @@ impl PendingValue {
                         Action::GetBlob => global_this.readable_stream_to_blob(readable.value),
                         Action::GetFormData(form_data) => 'brk: {
                             let encoding_js = match form_data.take() {
-                                // MIME check failed: drain then reject. `false` survives
-                                // the reaction-context plumbing (null/undefined do not).
+                                // `false` survives the reaction-context plumbing; null/undefined do not.
                                 None => JSValue::FALSE,
                                 Some(fd) => match &fd.encoding {
                                     bun_core::form_data::Encoding::Multipart(multipart) => {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2004,11 +2004,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             let Value::Locked(locked) = value else {
                 unreachable!()
             };
-            return locked.set_promise(
-                global_object,
-                Action::GetFormData(encoder),
-                owned_readable,
-            );
+            return locked.set_promise(global_object, Action::GetFormData(encoder), owned_readable);
         }
 
         let mut blob: AnyBlob = value.use_as_any_blob();

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -19,9 +19,8 @@ use crate::jsc::HTTPHeaderName;
 pub use crate::webcore::InternalBlob;
 use crate::webcore::form_data::AsyncFormDataExt as _;
 use crate::webcore::sink::{self, ArrayBufferSink};
-use bun_core::{MutableString, String as BunString, ZigString};
+use bun_core::{MutableString, String as BunString};
 use bun_core::{WTFStringImpl, WTFStringImplExt as _, WTFStringImplStruct};
-use bun_jsc::ZigStringJsc as _;
 use bun_jsc::{JsCell, StringJsc as _};
 
 /// Deref the `Value::WTFStringImpl` / `AnyBlob::WTFStringImpl` payload.
@@ -388,15 +387,20 @@ impl PendingValue {
                         Action::GetText => global_this.readable_stream_to_text(readable.value),
                         Action::GetBlob => global_this.readable_stream_to_blob(readable.value),
                         Action::GetFormData(form_data) => 'brk: {
-                            let fd = form_data.take().unwrap();
-                            // defer: form_data already taken; action.getFormData = None handled by take()
-                            let encoding_js = match &fd.encoding {
-                                bun_core::form_data::Encoding::Multipart(multipart) => {
-                                    BunString::init(&multipart[..]).to_js(global_this)?
-                                }
-                                bun_core::form_data::Encoding::URLEncoded => JSValue::UNDEFINED,
+                            // `None` means the MIME check already failed; per spec the
+                            // body is still fully read before `packageData` throws, so
+                            // drain the stream and have the C++ fulfillment handler
+                            // reject. The sentinel is `false` (null/undefined are
+                            // dropped by the promise-reaction context plumbing).
+                            let encoding_js = match form_data.take() {
+                                None => JSValue::FALSE,
+                                Some(fd) => match &fd.encoding {
+                                    bun_core::form_data::Encoding::Multipart(multipart) => {
+                                        BunString::init(&multipart[..]).to_js(global_this)?
+                                    }
+                                    bun_core::form_data::Encoding::URLEncoded => JSValue::UNDEFINED,
+                                },
                             };
-                            // fd dropped at end of scope (Box<AsyncFormData> -> Drop)
                             break 'brk global_this
                                 .readable_stream_to_form_data(readable.value, encoding_js);
                         }
@@ -1065,14 +1069,8 @@ impl Value {
                     Action::GetFormData(form_data_slot) => 'inner: {
                         let mut blob = new.use_as_any_blob();
                         let Some(async_form_data) = form_data_slot.take() else {
-                            // `blob.detach()` below covers the reject error path too.
-                            let r = promise.reject(
-                                global,
-                                ZigString::init(
-                                    b"Internal error: task for FormData must not be null",
-                                )
-                                .to_error_instance(global),
-                            );
+                            // MIME check failed up front; body is consumed above, now reject.
+                            let r = promise.reject(global, form_data_mime_error(global));
                             blob.detach();
                             r?;
                             break 'inner;
@@ -1993,17 +1991,10 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             }
         }
 
-        let Some(encoder) = self.get_form_data_encoding()? else {
-            // TODO: catch specific errors from getFormDataEncoding
-            return Ok(global_object
-                .err(
-                    jsc::ErrorCode::FORMDATA_PARSE_ERROR,
-                    format_args!(
-                        "Can't decode form data from body because of incorrect MIME type/boundary"
-                    ),
-                )
-                .reject());
-        };
+        // Spec "consume body": fully read the body, then run packageData (which
+        // performs the MIME check). A failed MIME check must therefore still
+        // consume the body (bodyUsed becomes true; subsequent reads reject).
+        let encoder = self.get_form_data_encoding()?;
 
         let value = self.get_body_value();
         if let Value::Locked(_locked) = value {
@@ -2015,12 +2006,20 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             };
             return locked.set_promise(
                 global_object,
-                Action::GetFormData(Some(encoder)),
+                Action::GetFormData(encoder),
                 owned_readable,
             );
         }
 
         let mut blob: AnyBlob = value.use_as_any_blob();
+        let Some(encoder) = encoder else {
+            blob.detach();
+            return Ok(JSPromise::rejected_promise(
+                global_object,
+                form_data_mime_error(global_object),
+            )
+            .to_js());
+        };
         // `encoder.encoding` is `bun_core::form_data::Encoding`; convert
         // to the `webcore::form_data::Encoding` shape FormData::to_js expects.
         let encoding = match encoder.encoding {
@@ -2140,6 +2139,17 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
             format_args!("Body already used"),
         )
         .reject()
+}
+
+fn form_data_mime_error(global_object: &JSGlobalObject) -> JSValue {
+    global_object
+        .err(
+            jsc::ErrorCode::FORMDATA_PARSE_ERROR,
+            format_args!(
+                "Can't decode form data from body because of incorrect MIME type/boundary"
+            ),
+        )
+        .to_js()
 }
 
 /// If the body already failed, reject the read with that error. Every body

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -749,6 +749,82 @@ describe.concurrent("string body consumption does not leak", () => {
   }
 });
 
+// https://fetch.spec.whatwg.org/#concept-body-consume-body
+// The spec fully reads the body before packageData runs (and may throw),
+// so a rejected formData() must still consume the body. Node/undici agree:
+// bodyUsed becomes true and further reads reject with TypeError.
+describe("formData() rejecting on MIME type still consumes the body", () => {
+  const stringStream = () =>
+    new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("hello world"));
+        c.close();
+      },
+    });
+
+  for (const { body, fn } of bodyTypes) {
+    describe(body.name, () => {
+      test.each([
+        ["string", () => fn("hello world")],
+        ["Uint8Array", () => fn(new TextEncoder().encode("hello world"))],
+        ["Blob", () => fn(new Blob(["hello world"]))],
+        ["ReadableStream", () => fn(stringStream(), { "content-type": "text/plain" })],
+        ["application/json", () => fn(JSON.stringify({ a: 1 }), { "content-type": "application/json" })],
+      ])("%s", async (_, make) => {
+        const r = make();
+        await expect(r.formData()).rejects.toThrow(TypeError);
+        expect(r.bodyUsed).toBe(true);
+        await expect(r.text()).rejects.toThrow(TypeError);
+        await expect(r.json()).rejects.toThrow(TypeError);
+        await expect(r.arrayBuffer()).rejects.toThrow(TypeError);
+        await expect(r.formData()).rejects.toThrow(TypeError);
+      });
+
+      // Null body: spec says body is null so fully-read is vacuous; Node leaves
+      // bodyUsed false and subsequent text() resolves "".
+      test("null body stays unconsumed", async () => {
+        const r = fn();
+        await expect(r.formData()).rejects.toThrow(TypeError);
+        expect(r.bodyUsed).toBe(false);
+        expect(await r.text()).toBe("");
+      });
+    });
+  }
+
+  test("Bun.serve request body", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        let fd: string;
+        try {
+          await req.formData();
+          fd = "RESOLVED";
+        } catch (e) {
+          fd = "REJECTED " + (e as Error).constructor.name;
+        }
+        const bodyUsed = req.bodyUsed;
+        let text: string;
+        try {
+          text = "RESOLVED " + (await req.text());
+        } catch (e) {
+          text = "REJECTED " + (e as Error).constructor.name;
+        }
+        return Response.json({ fd, bodyUsed, text });
+      },
+    });
+    const res = await fetch(`http://localhost:${server.port}/`, {
+      method: "POST",
+      body: "hello server",
+      headers: { "content-type": "text/plain" },
+    });
+    expect(await res.json()).toEqual({
+      fd: "REJECTED TypeError",
+      bodyUsed: true,
+      text: "REJECTED TypeError",
+    });
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/6860
 describe("constructing a body from an unusable ReadableStream", () => {
   const bytes = () =>


### PR DESCRIPTION
### What does this PR do?

`Body.formData()` rejected early on an unrecognized Content-Type without touching the body. After the TypeError, `bodyUsed` stayed `false` and a subsequent `text()`/`json()`/`blob()` re-read the full payload. Code like `try { await req.formData() } catch { await req.json() }` silently worked in Bun and threw everywhere else.

The spec's [consume body](https://fetch.spec.whatwg.org/#concept-body-consume-body) fully reads the body before `packageData` runs (which performs the MIME check and may throw), so a failed MIME check must still consume the body. Node/undici match the spec: `bodyUsed` is `true` after the rejection and further reads throw TypeError.

```js
// before: {formData:"REJECTED TypeError", bodyUsedAfterReject:false, thenText:'RESOLVED "hello world"'}
// after:  {formData:"REJECTED TypeError", bodyUsedAfterReject:true,  thenText:'REJECTED TypeError'}
// node:   {formData:"REJECTED TypeError", bodyUsedAfterReject:true,  thenText:'REJECTED TypeError'}
const r = new Response("hello world");
let fd; try { await r.formData(); fd = "RESOLVED"; } catch (e) { fd = "REJECTED " + e.constructor.name; }
const usedAfterReject = r.bodyUsed;
let t; try { t = "RESOLVED " + JSON.stringify(await r.text()); } catch (e) { t = "REJECTED " + e.constructor.name; }
console.log({ formData: fd, bodyUsedAfterReject: usedAfterReject, thenText: t });
```

### How did you verify your code works?

New tests in `test/js/web/fetch/body.test.ts` cover string / Uint8Array / Blob / ReadableStream / JSON bodies on both Request and Response, a null body (stays unconsumed, matching Node), and an incoming `Bun.serve` request body. All fail on the previous build and pass with the fix.

### Fix

- Synchronous body: call `use_as_any_blob()` before the encoding check so the body is marked `Used` first.
- Locked body: pass the `Option<encoder>` through `Action::GetFormData`. With `None`, the ReadableStream is still drained (via a `false` contentType sentinel that the fulfillment handler turns into the `ERR_FORMDATA_PARSE_ERROR` rejection), and a pending HTTP body is still buffered before `resolve()` rejects.
- Null body: unchanged (`use_as_any_blob()` leaves `Null` as `Null`), matching Node.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body.test.ts
bun test v1.4.0 (02ea67da4)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [5.42ms]
(pass) Request > constructor > null [3.80ms]
(pass) Request > constructor > string > "" [6.92ms]
(pass) Request > constructor > string > "Hello world" [1.70ms]
(pass) Request > constructor > string > "🫠" [1.54ms]
(pass) Request > constructor > string > "⁉️" [1.16ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [10.60ms]
(pass) Request > constructor > ArrayBuffer > small buffer [5.63ms]
(pass) Request > constructor > ArrayBuffer > large buffer [5.09ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [2.21ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [2.09ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [4.18ms]
(pass) Request > constructor > Buffer > empty buffer [1.89ms]
(pass) Request > constructor > Buffer > small buffer [1.78ms]
(pass) Request > constructor > Buffer > large buffer [4.19ms]
(pass) Request > constructor
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (1f5cfdc95)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [5.17ms]
(pass) Request > constructor > null [0.12ms]
(pass) Request > constructor > string > "" [0.13ms]
(pass) Request > constructor > string > "Hello world" [0.02ms]
(pass) Request > constructor > string > "🫠" [0.02ms]
(pass) Request > constructor > string > "⁉️"
(pass) Request > constructor > ArrayBuffer > empty buffer [0.14ms]
(pass) Request > constructor > ArrayBuffer > small buffer [3.39ms]
(pass) Request > constructor > ArrayBuffer > large buffer [1.64ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [0.04ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [0.03ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [2.11ms]
(pass) Request > constructor > Buffer > empty buffer [0.02ms]
(pass) Request > constructor > Buffer > small buffer [0.02ms]
(pass) Request > constructor > Buffer > large buffer [1.70ms]
(pass) Request > constructor > Uint8Array > empty buffer [0.01ms]
(pass) Request > constructor > Uint8Array > small buffer [0.04ms]
(pass) Request > constructor > Uint8Array > large buffer [1.5
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body.test.ts
bun test v1.4.0 (02ea67da4)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [4.98ms]
(pass) Request > constructor > null [3.08ms]
(pass) Request > constructor > string > "" [6.27ms]
(pass) Request > constructor > string > "Hello world" [1.56ms]
(pass) Request > constructor > string > "🫠" [1.44ms]
(pass) Request > constructor > string > "⁉️" [1.10ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [9.92ms]
(pass) Request > constructor > ArrayBuffer > small buffer [5.21ms]
(pass) Request > constructor > ArrayBuffer > large buffer [5.39ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [2.36ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [2.01ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [4.04ms]
(pass) Request > constructor > Buffer > empty buffer [1.61ms]
(pass) Request > constructor > Buffer > small buffer [1.53ms]
(pass) Request > constructor > Buffer > large buffer [3.60ms]
(pass) Request > constructor 
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 909ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen cpp.rs (cppbind)
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/BunStreamConsumers.cpp         |  5 ++
 src/runtime/webcore/Body.rs                        | 68 +++++++++----------
 test/js/web/fetch/body.test.ts                     | 76 ++++++++++++++++++++++
 3 files changed, 115 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp      4      4      0
src/runtime/webcore/Body.rs                                  8     10      0
test/js/web/fetch/body.test.ts                               2      1      0
```

</details>

<!-- robobun:evidence:end -->