### PR TITLE
node:dns: use ares_query_dnsrec so malformed replies report EFORMERR not ENOTFOUND

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -863,13 +863,6 @@ impl Channel {
         let mut name_buf = [0u8; 1024];
         let name_ptr = copy_nul_terminated(&mut name_buf, name);
 
-        // Node.js calls `ares_query_dnsrec` (which the legacy `ares_query` is
-        // deprecated in favor of) and re-serializes the `ares_dns_record_t` to a
-        // buffer for the `ares_parse_*_reply` helpers, so follow the same path.
-        // The legacy `ares_query` wrapper would overwrite a post-response status
-        // with `ares_dns_write`'s own failure, which is observable when a
-        // resolver returns a malformed answer.
-        //
         // SAFETY: c-ares FFI; name_ptr is a NUL-terminated stack buffer; ctx outlives the channel.
         unsafe {
             ares_query_dnsrec(
@@ -1271,14 +1264,10 @@ pub trait ReplyHandler<R: AresReply>: Sized {
     fn on_reply(&mut self, status: Option<Error>, timeouts: i32, results: *mut R);
 }
 
-/// `ares_callback_dnsrec` thunk used by [`Channel::resolve`]: re-serializes the
-/// parsed `ares_dns_record_t` to a wire buffer and forwards to the existing
-/// legacy-shaped `T::raw_callback`. Matches the conversion Node.js performs in
-/// `QueryWrap::Callback` (src/cares_wrap.h), including not overriding `status`
-/// when `ares_dns_write` itself fails: a malformed answer that c-ares parsed
-/// but cannot re-encode reaches the `ares_parse_*_reply` step as an empty
-/// buffer, which reports it as a response parse failure instead of as a bad
-/// query name.
+/// `ares_callback_dnsrec` thunk for [`Channel::resolve`]: re-serializes the
+/// reply and forwards to `T::raw_callback`, matching Node's `QueryWrap::Callback`.
+/// An `ares_dns_write` failure does not override `status`; the parse thunk
+/// classifies the resulting empty buffer.
 unsafe extern "C" fn dnsrec_to_buf_callback<T: ResolveHandler>(
     ctx: *mut c_void,
     status: c_int,

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -473,9 +473,13 @@ impl hostent_with_ttls {
             this.on_hostent_with_ttls(Error::get(status), timeouts, None);
             return;
         }
-        // SAFETY: c-ares passes the reply buffer it owns; valid for `buffer_length` bytes.
-        let buffer = unsafe {
-            core::slice::from_raw_parts(buffer, usize::try_from(buffer_length).unwrap_or(0))
+        let buffer = if buffer.is_null() {
+            &[][..]
+        } else {
+            // SAFETY: c-ares passes the reply buffer it owns; valid for `buffer_length` bytes.
+            unsafe {
+                core::slice::from_raw_parts(buffer, usize::try_from(buffer_length).unwrap_or(0))
+            }
         };
         match (T::PARSE)(buffer) {
             Ok(result) => this.on_hostent_with_ttls(None, timeouts, Some(result)),
@@ -688,6 +692,11 @@ bun_opaque::opaque_ffi! {
     /// mutates the channel on every dispatch/process call).
     pub struct Channel;
 }
+
+bun_opaque::opaque_ffi! {
+    /// Opaque parsed DNS record handed to `ares_callback_dnsrec`.
+    pub struct ares_dns_record_t;
+}
 // Load-bearing: `ares_cancel`/`ares_process_fd` are declared `safe fn(&mut Channel)`
 // on the basis that re-entrant callbacks re-deriving `&mut Channel` from a raw
 // pointer cannot conflict because `Channel` claims zero bytes. If this type ever
@@ -854,15 +863,23 @@ impl Channel {
         let mut name_buf = [0u8; 1024];
         let name_ptr = copy_nul_terminated(&mut name_buf, name);
 
+        // Node.js calls `ares_query_dnsrec` (which the legacy `ares_query` is
+        // deprecated in favor of) and re-serializes the `ares_dns_record_t` to a
+        // buffer for the `ares_parse_*_reply` helpers, so follow the same path.
+        // The legacy `ares_query` wrapper would overwrite a post-response status
+        // with `ares_dns_write`'s own failure, which is observable when a
+        // resolver returns a malformed answer.
+        //
         // SAFETY: c-ares FFI; name_ptr is a NUL-terminated stack buffer; ctx outlives the channel.
         unsafe {
-            ares_query(
+            ares_query_dnsrec(
                 self,
                 name_ptr,
                 NSClass::ns_c_in,
                 T::NS_TYPE,
-                Some(T::raw_callback),
+                Some(dnsrec_to_buf_callback::<T>),
                 std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
+                ptr::null_mut(),
             );
         }
     }
@@ -979,6 +996,8 @@ fn library_init() {
 }
 
 pub type ares_callback = Option<unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int)>;
+pub type ares_callback_dnsrec =
+    Option<unsafe extern "C" fn(*mut c_void, c_int, usize, *const ares_dns_record_t)>;
 pub type ares_host_callback =
     Option<unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut struct_hostent)>;
 pub type ares_nameinfo_callback =
@@ -1094,6 +1113,20 @@ unsafe extern "C" {
         callback: ares_callback,
         arg: *mut c_void,
     );
+    pub fn ares_query_dnsrec(
+        channel: *mut Channel,
+        name: *const c_char,
+        dnsclass: NSClass,
+        type_: NSType,
+        callback: ares_callback_dnsrec,
+        arg: *mut c_void,
+        qid: *mut c_ushort,
+    ) -> c_int;
+    pub fn ares_dns_write(
+        dnsrec: *const ares_dns_record_t,
+        buf: *mut *mut u8,
+        buf_len: *mut usize,
+    ) -> c_int;
     pub fn ares_search(
         channel: *mut Channel,
         name: *const c_char,
@@ -1236,6 +1269,44 @@ pub trait AresReply: Sized {
 /// Receiver for a parsed `R` reply (replaces the per-type `*Handler` traits).
 pub trait ReplyHandler<R: AresReply>: Sized {
     fn on_reply(&mut self, status: Option<Error>, timeouts: i32, results: *mut R);
+}
+
+/// `ares_callback_dnsrec` thunk used by [`Channel::resolve`]: re-serializes the
+/// parsed `ares_dns_record_t` to a wire buffer and forwards to the existing
+/// legacy-shaped `T::raw_callback`. Matches the conversion Node.js performs in
+/// `QueryWrap::Callback` (src/cares_wrap.h), including not overriding `status`
+/// when `ares_dns_write` itself fails: a malformed answer that c-ares parsed
+/// but cannot re-encode reaches the `ares_parse_*_reply` step as an empty
+/// buffer, which reports it as a response parse failure instead of as a bad
+/// query name.
+unsafe extern "C" fn dnsrec_to_buf_callback<T: ResolveHandler>(
+    ctx: *mut c_void,
+    status: c_int,
+    timeouts: usize,
+    dnsrec: *const ares_dns_record_t,
+) {
+    let mut abuf: *mut u8 = ptr::null_mut();
+    let mut alen: usize = 0;
+    if !dnsrec.is_null() {
+        // SAFETY: c-ares FFI; `dnsrec` is the live record owned by the caller for
+        // the duration of this callback; out-params are valid stack pointers.
+        let _ = unsafe { ares_dns_write(dnsrec, &raw mut abuf, &raw mut alen) };
+    }
+    // SAFETY: `ctx` is the `*mut T` registered with `ares_query_dnsrec`;
+    // `abuf` is null or a c-ares-allocated buffer of `alen` bytes.
+    unsafe {
+        T::raw_callback(
+            ctx,
+            status,
+            c_int::try_from(timeouts).unwrap_or(c_int::MAX),
+            abuf,
+            c_int::try_from(alen).unwrap_or(c_int::MAX),
+        );
+    }
+    if !abuf.is_null() {
+        // SAFETY: `abuf` was allocated by `ares_dns_write`.
+        unsafe { ares_free_string(abuf.cast::<c_void>()) };
+    }
 }
 
 /// Generic `ares_callback` thunk. Monomorphized per `(R, T)` to a concrete
@@ -1474,10 +1545,14 @@ impl struct_any_reply {
             this.on_any(Error::get(status), timeouts, None);
             return;
         }
-        // SAFETY: c-ares guarantees `buffer` is non-null and readable for
-        // `buffer_length` bytes on a successful callback.
-        let buffer = unsafe {
-            core::slice::from_raw_parts(buffer, usize::try_from(buffer_length).unwrap_or(0))
+        let buffer = if buffer.is_null() {
+            &[][..]
+        } else {
+            // SAFETY: c-ares guarantees `buffer` is readable for `buffer_length`
+            // bytes on a successful callback.
+            unsafe {
+                core::slice::from_raw_parts(buffer, usize::try_from(buffer_length).unwrap_or(0))
+            }
         };
         match Self::parse(buffer) {
             Ok(reply) => this.on_any(None, timeouts, Some(reply)),
@@ -1924,7 +1999,7 @@ impl Error {
             Error::ENOTIMP => "DNS_ENOTIMP",
             Error::EREFUSED => "DNS_EREFUSED",
             Error::EBADQUERY => "DNS_EBADQUERY",
-            Error::EBADNAME => "DNS_ENOTFOUND",
+            Error::EBADNAME => "DNS_EBADNAME",
             Error::EBADFAMILY => "DNS_EBADFAMILY",
             Error::EBADRESP => "DNS_EBADRESP",
             Error::ECONNREFUSED => "DNS_ECONNREFUSED",

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1264,10 +1264,8 @@ pub trait ReplyHandler<R: AresReply>: Sized {
     fn on_reply(&mut self, status: Option<Error>, timeouts: i32, results: *mut R);
 }
 
-/// `ares_callback_dnsrec` thunk for [`Channel::resolve`]: re-serializes the
-/// reply and forwards to `T::raw_callback`, matching Node's `QueryWrap::Callback`.
-/// An `ares_dns_write` failure does not override `status`; the parse thunk
-/// classifies the resulting empty buffer.
+/// `ares_callback_dnsrec` thunk for [`Channel::resolve`] that re-serializes
+/// the reply and forwards to `T::raw_callback`.
 unsafe extern "C" fn dnsrec_to_buf_callback<T: ResolveHandler>(
     ctx: *mut c_void,
     status: c_int,
@@ -1277,6 +1275,8 @@ unsafe extern "C" fn dnsrec_to_buf_callback<T: ResolveHandler>(
     let mut abuf: *mut u8 = ptr::null_mut();
     let mut alen: usize = 0;
     if !dnsrec.is_null() {
+        // Matches Node's QueryWrap::Callback: a write failure is left to the
+        // parse thunk to classify instead of overriding `status`.
         // SAFETY: c-ares FFI; `dnsrec` is the live record owned by the caller for
         // the duration of this callback; out-params are valid stack pointers.
         let _ = unsafe { ares_dns_write(dnsrec, &raw mut abuf, &raw mut alen) };

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1630,8 +1630,7 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
         timeouts: i32,
         results: *mut c_ares::AddrInfo,
     ) {
-        // Node's dns.lookup is libc getaddrinfo and never yields EBADNAME; the
-        // resolve* path doesn't reach this handler and keeps EBADNAME intact.
+        // Node's dns.lookup (libc getaddrinfo) never yields EBADNAME.
         let status = match status {
             Some(c_ares::Error::EBADNAME) => Some(c_ares::Error::ENOTFOUND),
             other => other,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1630,6 +1630,12 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
         timeouts: i32,
         results: *mut c_ares::AddrInfo,
     ) {
+        // Node's dns.lookup is libc getaddrinfo and never yields EBADNAME; the
+        // resolve* path doesn't reach this handler and keeps EBADNAME intact.
+        let status = match status {
+            Some(c_ares::Error::EBADNAME) => Some(c_ares::Error::ENOTFOUND),
+            other => other,
+        };
         let result = if results.is_null() {
             None
         } else {

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { isWindows } from "harness";
 import * as dgram from "node:dgram";
 import * as dns from "node:dns";
@@ -687,81 +687,69 @@ describe("resolve4 against a loopback responder", () => {
     return b;
   };
 
-  async function withResponder(build, fn) {
-    const udp = dgram.createSocket("udp4");
-    try {
-      udp.on("message", (msg, rinfo) => {
-        let off = 12;
-        while (off < msg.length && msg[off] !== 0) off += msg[off] + 1;
-        const question = msg.slice(12, off + 5);
-        udp.send(build(msg, question), rinfo.port, rinfo.address);
-      });
-      udp.bind(0, "127.0.0.1");
-      await once(udp, "listening");
-      const resolver = new dns_promises.Resolver({ timeout: 3000, tries: 1 });
-      resolver.setServers([`127.0.0.1:${udp.address().port}`]);
-      await fn(resolver);
-    } finally {
-      udp.close();
-    }
-  }
+  let udp;
+  let resolver;
+  let build;
+
+  beforeAll(async () => {
+    udp = dgram.createSocket("udp4");
+    udp.on("message", (msg, rinfo) => {
+      let off = 12;
+      while (off < msg.length && msg[off] !== 0) off += msg[off] + 1;
+      const question = msg.slice(12, off + 5);
+      udp.send(build(msg, question), rinfo.port, rinfo.address);
+    });
+    udp.bind(0, "127.0.0.1");
+    await once(udp, "listening");
+    resolver = new dns_promises.Resolver({ timeout: 3000, tries: 1 });
+    resolver.setServers([`127.0.0.1:${udp.address().port}`]);
+  });
+
+  afterAll(() => {
+    udp?.close();
+    // Drop the describe-scope reference so the native Resolver channel can be
+    // finalized before LeakSanitizer runs its end-of-process check.
+    resolver = undefined;
+    Bun.gc(true);
+  });
 
   it("reports EFORMERR for an answer RR owner name over 255 octets", async () => {
     // 6 x 63-byte labels = 383 wire octets, above the RFC 1035 255-octet limit.
     const label = Buffer.concat([Buffer.from([63]), Buffer.alloc(63, 0x61)]);
     const owner = Buffer.concat([label, label, label, label, label, label, Buffer.from([0])]);
-    await withResponder(
-      (msg, question) => {
-        const rr = Buffer.concat([owner, u16(1), u16(1), u32(60), u16(4), Buffer.from([127, 0, 0, 7])]);
-        const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8180), u16(1), u16(1), u16(0), u16(0)]);
-        return Buffer.concat([hdr, question, rr]);
-      },
-      async resolver => {
-        const err = await resolver.resolve4("longname.test").then(
-          ok => ({ ok }),
-          e => e,
-        );
-        expect(err.code).toBe("EFORMERR");
-        expect(err.syscall).toBe("queryA");
-        expect(err.hostname).toBe("longname.test");
-      },
+    build = (msg, question) => {
+      const rr = Buffer.concat([owner, u16(1), u16(1), u32(60), u16(4), Buffer.from([127, 0, 0, 7])]);
+      const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8180), u16(1), u16(1), u16(0), u16(0)]);
+      return Buffer.concat([hdr, question, rr]);
+    };
+    const err = await resolver.resolve4("longname.test").then(
+      ok => ({ ok }),
+      e => e,
     );
+    expect(err.code).toBe("EFORMERR");
+    expect(err.syscall).toBe("queryA");
+    expect(err.hostname).toBe("longname.test");
   });
 
   it("still resolves a well-formed A record from the same path", async () => {
-    await withResponder(
-      (msg, question) => {
-        const rr = Buffer.concat([
-          Buffer.from([0xc0, 0x0c]),
-          u16(1),
-          u16(1),
-          u32(60),
-          u16(4),
-          Buffer.from([127, 0, 0, 7]),
-        ]);
-        const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8180), u16(1), u16(1), u16(0), u16(0)]);
-        return Buffer.concat([hdr, question, rr]);
-      },
-      async resolver => {
-        expect(await resolver.resolve4("good.test")).toEqual(["127.0.0.7"]);
-      },
-    );
+    build = (msg, question) => {
+      const rr = Buffer.concat([Buffer.from([0xc0, 0x0c]), u16(1), u16(1), u32(60), u16(4), Buffer.from([127, 0, 0, 7])]);
+      const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8180), u16(1), u16(1), u16(0), u16(0)]);
+      return Buffer.concat([hdr, question, rr]);
+    };
+    expect(await resolver.resolve4("good.test")).toEqual(["127.0.0.7"]);
   });
 
   it("reports EBADNAME for a query name c-ares rejects before sending", async () => {
-    await withResponder(
-      (msg, question) => {
-        const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8183), u16(1), u16(0), u16(0), u16(0)]);
-        return Buffer.concat([hdr, question]);
-      },
-      async resolver => {
-        const longLabel = Buffer.alloc(64, 0x61).toString() + ".test";
-        const err = await resolver.resolve4(longLabel).then(
-          ok => ({ ok }),
-          e => e,
-        );
-        expect(err.code).toBe("EBADNAME");
-      },
+    build = (msg, question) => {
+      const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8183), u16(1), u16(0), u16(0), u16(0)]);
+      return Buffer.concat([hdr, question]);
+    };
+    const longLabel = Buffer.alloc(64, 0x61).toString() + ".test";
+    const err = await resolver.resolve4(longLabel).then(
+      ok => ({ ok }),
+      e => e,
     );
+    expect(err.code).toBe("EBADNAME");
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,7 +1,9 @@
 import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { isWindows } from "harness";
+import * as dgram from "node:dgram";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
+import { once } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as util from "node:util";
@@ -658,6 +660,101 @@ describe("dns.lookupService with a numeric-string port", () => {
   it("promises API still throws ERR_SOCKET_BAD_PORT synchronously for a truly bad port", () => {
     expect(() => dns_promises.lookupService("127.0.0.1", "nope")).toThrow(
       expect.objectContaining({ code: "ERR_SOCKET_BAD_PORT" }),
+    );
+  });
+});
+
+describe("resolve4 against a loopback responder", () => {
+  // A DNS response whose answer RR owner name exceeds 255 octets is a malformed
+  // reply from the resolver. Node.js reports EFORMERR; Bun previously reported
+  // ENOTFOUND, which is indistinguishable from "domain does not exist" for
+  // callers that branch on err.code.
+  //
+  // Node.js calls ares_query_dnsrec() and re-serializes the parsed record for
+  // ares_parse_a_reply(). The re-serialize fails for an over-length name and
+  // ares_parse_a_reply then sees an empty buffer, which it reports as EFORMERR.
+  // The legacy ares_query() path differs: its internal converter overwrites the
+  // post-response status with the re-serialize failure (ARES_EBADNAME), which
+  // Bun then relabeled to ENOTFOUND.
+  const u16 = n => {
+    const b = Buffer.alloc(2);
+    b.writeUInt16BE(n & 0xffff);
+    return b;
+  };
+  const u32 = n => {
+    const b = Buffer.alloc(4);
+    b.writeUInt32BE(n >>> 0);
+    return b;
+  };
+
+  async function withResponder(build, fn) {
+    const udp = dgram.createSocket("udp4");
+    try {
+      udp.on("message", (msg, rinfo) => {
+        let off = 12;
+        while (off < msg.length && msg[off] !== 0) off += msg[off] + 1;
+        const question = msg.slice(12, off + 5);
+        udp.send(build(msg, question), rinfo.port, rinfo.address);
+      });
+      udp.bind(0, "127.0.0.1");
+      await once(udp, "listening");
+      const resolver = new dns_promises.Resolver({ timeout: 3000, tries: 1 });
+      resolver.setServers([`127.0.0.1:${udp.address().port}`]);
+      await fn(resolver);
+    } finally {
+      udp.close();
+    }
+  }
+
+  it("reports EFORMERR for an answer RR owner name over 255 octets", async () => {
+    // 6 x 63-byte labels = 383 wire octets, above the RFC 1035 255-octet limit.
+    const label = Buffer.concat([Buffer.from([63]), Buffer.alloc(63, 0x61)]);
+    const owner = Buffer.concat([label, label, label, label, label, label, Buffer.from([0])]);
+    await withResponder(
+      (msg, question) => {
+        const rr = Buffer.concat([owner, u16(1), u16(1), u32(60), u16(4), Buffer.from([127, 0, 0, 7])]);
+        const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8180), u16(1), u16(1), u16(0), u16(0)]);
+        return Buffer.concat([hdr, question, rr]);
+      },
+      async resolver => {
+        const err = await resolver.resolve4("longname.test").then(
+          ok => ({ ok }),
+          e => e,
+        );
+        expect(err.code).toBe("EFORMERR");
+        expect(err.syscall).toBe("queryA");
+        expect(err.hostname).toBe("longname.test");
+      },
+    );
+  });
+
+  it("still resolves a well-formed A record from the same path", async () => {
+    await withResponder(
+      (msg, question) => {
+        const rr = Buffer.concat([Buffer.from([0xc0, 0x0c]), u16(1), u16(1), u32(60), u16(4), Buffer.from([127, 0, 0, 7])]);
+        const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8180), u16(1), u16(1), u16(0), u16(0)]);
+        return Buffer.concat([hdr, question, rr]);
+      },
+      async resolver => {
+        expect(await resolver.resolve4("good.test")).toEqual(["127.0.0.7"]);
+      },
+    );
+  });
+
+  it("reports EBADNAME for a query name c-ares rejects before sending", async () => {
+    await withResponder(
+      (msg, question) => {
+        const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8183), u16(1), u16(0), u16(0), u16(0)]);
+        return Buffer.concat([hdr, question]);
+      },
+      async resolver => {
+        const longLabel = Buffer.alloc(64, 0x61).toString() + ".test";
+        const err = await resolver.resolve4(longLabel).then(
+          ok => ({ ok }),
+          e => e,
+        );
+        expect(err.code).toBe("EBADNAME");
+      },
     );
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -731,7 +731,14 @@ describe("resolve4 against a loopback responder", () => {
   it("still resolves a well-formed A record from the same path", async () => {
     await withResponder(
       (msg, question) => {
-        const rr = Buffer.concat([Buffer.from([0xc0, 0x0c]), u16(1), u16(1), u32(60), u16(4), Buffer.from([127, 0, 0, 7])]);
+        const rr = Buffer.concat([
+          Buffer.from([0xc0, 0x0c]),
+          u16(1),
+          u16(1),
+          u32(60),
+          u16(4),
+          Buffer.from([127, 0, 0, 7]),
+        ]);
         const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8180), u16(1), u16(1), u16(0), u16(0)]);
         return Buffer.concat([hdr, question, rr]);
       },

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -733,7 +733,14 @@ describe("resolve4 against a loopback responder", () => {
 
   it("still resolves a well-formed A record from the same path", async () => {
     build = (msg, question) => {
-      const rr = Buffer.concat([Buffer.from([0xc0, 0x0c]), u16(1), u16(1), u32(60), u16(4), Buffer.from([127, 0, 0, 7])]);
+      const rr = Buffer.concat([
+        Buffer.from([0xc0, 0x0c]),
+        u16(1),
+        u16(1),
+        u32(60),
+        u16(4),
+        Buffer.from([127, 0, 0, 7]),
+      ]);
       const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8180), u16(1), u16(1), u16(0), u16(0)]);
       return Buffer.concat([hdr, question, rr]);
     };

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -746,17 +746,4 @@ describe("resolve4 against a loopback responder", () => {
     };
     expect(await resolver.resolve4("good.test")).toEqual(["127.0.0.7"]);
   });
-
-  it("reports EBADNAME for a query name c-ares rejects before sending", async () => {
-    build = (msg, question) => {
-      const hdr = Buffer.concat([msg.slice(0, 2), u16(0x8183), u16(1), u16(0), u16(0), u16(0)]);
-      return Buffer.concat([hdr, question]);
-    };
-    const longLabel = Buffer.alloc(64, 0x61).toString() + ".test";
-    const err = await resolver.resolve4(longLabel).then(
-      ok => ({ ok }),
-      e => e,
-    );
-    expect(err.code).toBe("EBADNAME");
-  });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -427,8 +427,7 @@ describe("test invalid arguments", () => {
       try {
         expect(err).not.toBeNull();
         expect(results).toBeUndefined();
-        // Assert we convert our error codes to Node.js error codes
-        expect(err.code).not.toStartWith("DNS_");
+        expect(err.code).toBe("EBADNAME");
         done();
       } catch (e) {
         done(e);

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -714,7 +714,7 @@ describe("resolve4 against a loopback responder", () => {
   });
 
   it("reports EFORMERR for an answer RR owner name over 255 octets", async () => {
-    // 6 x 63-byte labels = 383 wire octets, above the RFC 1035 255-octet limit.
+    // 6 x 63-byte labels + terminator = 385 wire octets, above the RFC 1035 255-octet limit.
     const label = Buffer.concat([Buffer.from([63]), Buffer.alloc(63, 0x61)]);
     const owner = Buffer.concat([label, label, label, label, label, label, Buffer.from([0])]);
     build = (msg, question) => {


### PR DESCRIPTION
## What

`dns.resolve4` (and the rest of the `resolve*` family) reports `ENOTFOUND` when the configured resolver returns a malformed answer whose RR owner name exceeds 255 octets. Node.js reports `EFORMERR`. Callers that branch on `err.code === 'ENOTFOUND'` to distinguish "domain does not exist" from a resolver fault cannot tell them apart.

```js
import dgram from 'node:dgram';
import dns from 'node:dns';
const server = dgram.createSocket('udp4');
server.on('message', (msg, rinfo) => {
  // Reply NOERROR with one A record whose owner name is 6 x 63-byte labels (385 wire octets)
  let off = 12; while (msg[off] !== 0) off += msg[off] + 1;
  const question = msg.slice(12, off + 5);
  const lab = Buffer.concat([Buffer.from([63]), Buffer.alloc(63, 0x61)]);
  const owner = Buffer.concat([lab, lab, lab, lab, lab, lab, Buffer.from([0])]);
  const rr = Buffer.concat([owner, Buffer.from([0,1,0,1,0,0,0,60,0,4,127,0,0,7])]);
  const hdr = Buffer.concat([msg.slice(0, 2), Buffer.from([0x81,0x80,0,1,0,1,0,0,0,0])]);
  server.send(Buffer.concat([hdr, question, rr]), rinfo.port, rinfo.address);
});
server.bind(0, '127.0.0.1', async () => {
  const r = new dns.promises.Resolver({ timeout: 3000, tries: 1 });
  r.setServers([`127.0.0.1:${server.address().port}`]);
  try { await r.resolve4('longname.test'); } catch (e) { console.log(e.code); }
  server.close();
});
```

Before: `ENOTFOUND`. After (and Node.js v26.3.0): `EFORMERR`.

## Cause

`Channel::resolve` called the legacy `ares_query`, which routes through c-ares's own `ares_dnsrec_convert_cb`. c-ares 1.34 parses the over-length name fine (`ares_dns_name_parse` has no 255-octet total check) but `ares_dns_write` enforces it and fails with `ARES_EBADNAME`. `ares_dnsrec_convert_cb` overwrites the post-response `ARES_SUCCESS` with that write status, so Bun's callback received `ARES_EBADNAME`. `Error::code()` then mapped `EBADNAME` to `"DNS_ENOTFOUND"`.

Node.js calls `ares_query_dnsrec` directly. Its `QueryWrap::Callback` also calls `ares_dns_write` but does not let a write failure override `status`; `ares_parse_a_reply` then sees an empty buffer and reports `ARES_EFORMERR`.

## Fix

`Channel::resolve` now calls `ares_query_dnsrec` with a converter thunk (`dnsrec_to_buf_callback`) that re-serializes the record the same way Node does: `ares_dns_write` is called but its status is not promoted to the callback, so the `ares_parse_*_reply` step classifies the malformed reply.

`Error::code()` now maps `EBADNAME` to `"DNS_EBADNAME"`. That also fixes the query-side case where a name c-ares rejects before sending (label > 63, name > 255) surfaces as `EBADNAME` instead of `ENOTFOUND`, matching Node. `GetAddrInfoRequest::on_addr_info` remaps `EBADNAME` back to `ENOTFOUND` for `dns.lookup` only, since Node's `dns.lookup` is libc `getaddrinfo` and never yields `EBADNAME`.

The two callback wrappers that build a `&[u8]` from the reply buffer now handle a null pointer (empty slice) so the converter can forward one.

## Verification

New tests in `test/js/node/dns/node-dns.test.js` bind a loopback UDP responder and assert:

- an answer RR owner name over 255 octets yields `code: 'EFORMERR'`, `syscall: 'queryA'`, `hostname: 'longname.test'`
- a well-formed A record from the same dispatch path still resolves (`['127.0.0.7']`)

The pre-existing "test invalid arguments" `it.each` (module-level `dns.resolve*` with a 2000-byte name) is tightened from `not.toStartWith("DNS_")` to `toBe("EBADNAME")`, locking in the `Error::code()` change for all nine record types without allocating a per-test Resolver.

All of the above fail on the released Bun (`ENOTFOUND`) and pass with this change. Other malformed-response shapes (compression-pointer loops, count/rdlength lies) already reported `EBADRESP` identically on Bun and Node and still do.

## Related

- #35591 is the query-side sibling; the `Error::code()` table change and the `dns.lookup` remap are shared with it. This PR additionally switches the dispatch path so the response-side case matches Node's `EFORMERR`.
- A per-Resolver query-side EBADNAME test is intentionally not included: a name c-ares rejects before sending trips the pre-existing retransmit-timer ordering bug fixed by #35776, which LSan reports as a Resolver leak on the debian 13 x64-asan lane independent of this change. The tightened "test invalid arguments" assertion covers the same code path on the permanently-pinned global resolver instead.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->