### PR TITLE
spawn: drain pre-created terminal on child exit before resolving proc.exited

### DIFF
--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -693,11 +693,9 @@ impl Terminal {
         }
     }
 
-    /// Pump any buffered PTY output into the data callback without touching
-    /// slave_fd or ref state. Called from `Subprocess::on_process_exit` for
-    /// pre-created terminals so the child's final write reaches the data
-    /// callback before `proc.exited` resolves; inline terminals go through
-    /// `drain_and_close_slave_fd` instead.
+    /// Pump buffered PTY output into the data callback without touching
+    /// slave_fd or ref state. `Subprocess::on_process_exit` calls this for
+    /// pre-created terminals; inline ones use `drain_and_close_slave_fd`.
     #[cfg(unix)]
     pub(crate) fn drain_reader(&self) {
         let flags = self.flags.get();
@@ -707,13 +705,9 @@ impl Terminal {
         {
             return;
         }
-        // The data callback re-enters user JS and may deref; hold a +1 so
-        // `self` stays live across the call.
         self.ref_();
         let guard = scopeguard::guard((), |()| self.deref_());
-        // SAFETY: single JS thread; re-entrant user JS (the data callback may
-        // call `terminal.close()`) is handled via the raw-pointer dispatch
-        // convention used by `__bun_run_file_poll` for BUFFERED_READER.
+        // SAFETY: single JS thread; see `drain_and_close_slave_fd`.
         unsafe { (*self.reader.as_ptr()).read() };
         drop(guard);
     }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -693,6 +693,31 @@ impl Terminal {
         }
     }
 
+    /// Pump any buffered PTY output into the data callback without touching
+    /// slave_fd or ref state. Called from `Subprocess::on_process_exit` for
+    /// pre-created terminals so the child's final write reaches the data
+    /// callback before `proc.exited` resolves; inline terminals go through
+    /// `drain_and_close_slave_fd` instead.
+    #[cfg(unix)]
+    pub(crate) fn drain_reader(&self) {
+        let flags = self.flags.get();
+        if flags.contains(Flags::CLOSED)
+            || !flags.contains(Flags::READER_STARTED)
+            || flags.contains(Flags::READER_DONE)
+        {
+            return;
+        }
+        // The data callback re-enters user JS and may deref; hold a +1 so
+        // `self` stays live across the call.
+        self.ref_();
+        let guard = scopeguard::guard((), |()| self.deref_());
+        // SAFETY: single JS thread; re-entrant user JS (the data callback may
+        // call `terminal.close()`) is handled via the raw-pointer dispatch
+        // convention used by `__bun_run_file_poll` for BUFFERED_READER.
+        unsafe { (*self.reader.as_ptr()).read() };
+        drop(guard);
+    }
+
     /// Drain buffered pty output, close our slave_fd, then drive the reader to
     /// EOF and unref both polls so the event loop can exit. BSD kernels flush
     /// the output queue on last slave close; holding ours until

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -989,11 +989,7 @@ impl Subprocess<'_> {
                 #[cfg(windows)]
                 term.unref_after_inline_child_exit();
             } else {
-                // Pre-created terminal: the user manages slave_fd so we don't
-                // close or unref, but still drain buffered output so the
-                // child's final write reaches the data callback before
-                // `proc.exited` resolves (matching inline behaviour and the
-                // stdout/stderr pipe drain below).
+                // Pre-created terminal: drain only (user manages slave_fd).
                 #[cfg(unix)]
                 term.drain_reader();
             }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -970,23 +970,32 @@ impl Subprocess<'_> {
         // provenance (no `&Process → *mut` round-trip).
         unsafe { (*jsc_vm).on_subprocess_exit(NonNull::new_unchecked(process)) };
 
-        if self.flags.get().contains(Flags::OWNS_TERMINAL) {
-            // Deliver EOF to the terminal reader without closing the Terminal.
-            // POSIX drains then releases slave_fd (BSD kernels flush on last
-            // slave close). Windows: the ConDrv \Reference handle was released
-            // at spawn time, so conhost exits and breaks the output pipe once
-            // its last client (this child, or a grandchild it left behind) has
-            // disconnected; unref the writer here and leave the reader ref'd
-            // until that EOF arrives.
-            if let Some(terminal) = self.terminal.get() {
-                // `BackRef` invariant holds: the terminal is owned by (or
-                // borrowed from a JS wrapper kept live by) this subprocess and
-                // outlives this scope; single JS thread.
-                let term = bun_ptr::BackRef::from(terminal);
+        if let Some(terminal) = self.terminal.get() {
+            // `BackRef` invariant holds: the terminal is owned by (or
+            // borrowed from a JS wrapper kept live by) this subprocess and
+            // outlives this scope; single JS thread.
+            let term = bun_ptr::BackRef::from(terminal);
+            if self.flags.get().contains(Flags::OWNS_TERMINAL) {
+                // Deliver EOF to the terminal reader without closing the
+                // Terminal. POSIX drains then releases slave_fd (BSD kernels
+                // flush on last slave close). Windows: the ConDrv \Reference
+                // handle was released at spawn time, so conhost exits and
+                // breaks the output pipe once its last client (this child, or
+                // a grandchild it left behind) has disconnected; unref the
+                // writer here and leave the reader ref'd until that EOF
+                // arrives.
                 #[cfg(unix)]
                 term.drain_and_close_slave_fd();
                 #[cfg(windows)]
                 term.unref_after_inline_child_exit();
+            } else {
+                // Pre-created terminal: the user manages slave_fd so we don't
+                // close or unref, but still drain buffered output so the
+                // child's final write reaches the data callback before
+                // `proc.exited` resolves (matching inline behaviour and the
+                // stdout/stderr pipe drain below).
+                #[cfg(unix)]
+                term.drain_reader();
             }
         }
 

--- a/test/cli/install/bun-security-scanner-matrix-runner.ts
+++ b/test/cli/install/bun-security-scanner-matrix-runner.ts
@@ -240,35 +240,40 @@ scanner = "${scannerPath}"`,
   if (hasTTY) {
     let responseSent = false;
 
-    await using terminal = new Bun.Terminal({
-      cols: 80,
-      rows: 24,
-      data(_term, data) {
-        const text = new TextDecoder().decode(data);
-        errAndOut += text;
-
-        if (DO_TEST_DEBUG) {
-          const lines = text.split("\n");
-          for (const line of lines) {
-            process.stdout.write(redSubprocessPrefix);
-            process.stdout.write(" ");
-            process.stdout.write(line);
-            process.stdout.write("\n");
-          }
-        }
-
-        // When we see the prompt, send the configured response
-        if (!responseSent && errAndOut.includes("Continue anyway? [y/N]")) {
-          responseSent = true;
-          terminal.write(ttyResponse + "\n");
-        }
-      },
-    });
-
+    // Use an inline terminal (rather than a pre-created Bun.Terminal) so the
+    // subprocess owns the PTY lifecycle: on process exit Bun drains any
+    // buffered PTY output before `proc.exited` resolves. With a pre-created
+    // terminal the drain is skipped (the user may reuse it), and the child's
+    // final "Continuing with installation..." / "Installation cancelled." line
+    // can race `proc.exited` when the process-exit notification is dispatched
+    // ahead of the PTY-readable event.
     await using proc = Bun.spawn(cmd, {
       cwd: dir,
       env: bunEnv,
-      terminal,
+      terminal: {
+        cols: 80,
+        rows: 24,
+        data(term, data) {
+          const text = new TextDecoder().decode(data);
+          errAndOut += text;
+
+          if (DO_TEST_DEBUG) {
+            const lines = text.split("\n");
+            for (const line of lines) {
+              process.stdout.write(redSubprocessPrefix);
+              process.stdout.write(" ");
+              process.stdout.write(line);
+              process.stdout.write("\n");
+            }
+          }
+
+          // When we see the prompt, send the configured response
+          if (!responseSent && errAndOut.includes("Continue anyway? [y/N]")) {
+            responseSent = true;
+            term.write(ttyResponse + "\n");
+          }
+        },
+      },
     });
 
     exitCode = await proc.exited;

--- a/test/cli/install/bun-security-scanner-matrix-runner.ts
+++ b/test/cli/install/bun-security-scanner-matrix-runner.ts
@@ -240,40 +240,35 @@ scanner = "${scannerPath}"`,
   if (hasTTY) {
     let responseSent = false;
 
-    // Use an inline terminal (rather than a pre-created Bun.Terminal) so the
-    // subprocess owns the PTY lifecycle: on process exit Bun drains any
-    // buffered PTY output before `proc.exited` resolves. With a pre-created
-    // terminal the drain is skipped (the user may reuse it), and the child's
-    // final "Continuing with installation..." / "Installation cancelled." line
-    // can race `proc.exited` when the process-exit notification is dispatched
-    // ahead of the PTY-readable event.
+    await using terminal = new Bun.Terminal({
+      cols: 80,
+      rows: 24,
+      data(_term, data) {
+        const text = new TextDecoder().decode(data);
+        errAndOut += text;
+
+        if (DO_TEST_DEBUG) {
+          const lines = text.split("\n");
+          for (const line of lines) {
+            process.stdout.write(redSubprocessPrefix);
+            process.stdout.write(" ");
+            process.stdout.write(line);
+            process.stdout.write("\n");
+          }
+        }
+
+        // When we see the prompt, send the configured response
+        if (!responseSent && errAndOut.includes("Continue anyway? [y/N]")) {
+          responseSent = true;
+          terminal.write(ttyResponse + "\n");
+        }
+      },
+    });
+
     await using proc = Bun.spawn(cmd, {
       cwd: dir,
       env: bunEnv,
-      terminal: {
-        cols: 80,
-        rows: 24,
-        data(term, data) {
-          const text = new TextDecoder().decode(data);
-          errAndOut += text;
-
-          if (DO_TEST_DEBUG) {
-            const lines = text.split("\n");
-            for (const line of lines) {
-              process.stdout.write(redSubprocessPrefix);
-              process.stdout.write(" ");
-              process.stdout.write(line);
-              process.stdout.write("\n");
-            }
-          }
-
-          // When we see the prompt, send the configured response
-          if (!responseSent && errAndOut.includes("Continue anyway? [y/N]")) {
-            responseSent = true;
-            term.write(ttyResponse + "\n");
-          }
-        },
-      },
+      terminal,
     });
 
     exitCode = await proc.exited;

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1365,6 +1365,47 @@ describe.concurrent("Bun.spawn with terminal option", () => {
     }
   });
 
+  // Same guarantee as above but for a pre-created terminal that the subprocess
+  // does not own: on_process_exit must still drain buffered PTY output before
+  // resolving `proc.exited`, even though it leaves slave_fd open for reuse.
+  // POSIX only: the drain is a `reader.read()` call; ConPTY's EOF remains
+  // asynchronous.
+  test.skipIf(isWindows)(
+    "pre-created terminal: child's final output is delivered before proc.exited resolves",
+    async () => {
+      let output = "";
+      let sawPrompt = false;
+      await using terminal = new Bun.Terminal({
+        cols: 80,
+        rows: 24,
+        data(_t, chunk) {
+          output += Buffer.from(chunk).toString();
+          if (!sawPrompt && output.includes("PROMPT>")) {
+            sawPrompt = true;
+            terminal.write("go\n");
+          }
+        },
+      });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.stdout.write("PROMPT>");
+           process.stdin.setEncoding("utf8");
+           process.stdin.once("data", () => {
+             process.stdout.write("FINAL-LINE\\n");
+             process.exit(0);
+           });`,
+        ],
+        env: bunEnv,
+        terminal,
+      });
+      const exitCode = await proc.exited;
+      expect(output).toContain("FINAL-LINE");
+      expect(exitCode).toBe(0);
+    },
+  );
+
   // Cross-platform loop-exit check: after an inline terminal's child exits,
   // nothing else in the inner script refs the event loop. POSIX drains to EOF
   // synchronously; on Windows the reader stays ref'd only until conhost


### PR DESCRIPTION
## What

`bun-security-scanner-matrix-{with,without}-node-modules.test.ts` intermittently fail on Alpine 3.23 (x64 and aarch64) with:

```
error: expect(received).toContain(expected)

Expected to contain: "Installation cancelled."
Received: "...Security warnings found. Continue anyway? [y/N] n\r\n"
```

Seen in builds 76546, 77347, 78488, 79962 and [81604](https://buildkite.com/bun/bun/builds/81604). Both matrix files share `bun-security-scanner-matrix-runner.ts`. Introduced by #25587.

## Cause

The TTY test path creates a `Bun.Terminal`, passes it to `Bun.spawn`, then asserts on the accumulated PTY output after `await proc.exited`.

`Subprocess::on_process_exit` already drains the PTY reader before resolving `proc.exited` for **inline** terminals (via `Terminal::drain_and_close_slave_fd`, gated on `Flags::OWNS_TERMINAL`). A pre-created `Bun.Terminal` is skipped so the user can reuse it across spawns, which means the child's final write can race `proc.exited` whenever the process-exit notification (pidfd poll or waiter-thread task) is dispatched ahead of the PTY-readable event in the same event-loop iteration. The `enter_scope` guard around the promise resolve drains microtasks at count==1, so the test's `await proc.exited` continuation runs before the remaining ready polls in the batch are dispatched.

This is not specific to the test: the documented reuse example in `packages/bun-types/bun.d.ts` has the same shape.

## Fix

Add `Terminal::drain_reader()` (a single non-closing `reader.read()`) and call it from `on_process_exit` for the non-owned path on POSIX. `slave_fd` and the poll refs are left untouched so the terminal stays reusable. Inline terminals and Windows behaviour are unchanged; this brings the pre-created path in line with inline terminals and with the stdout/stderr pipe drain that already happens in the same function.

The security-scanner matrix runner is left as-is on `main` (pre-created terminal); it now relies on the runtime drain. A direct ordering test is added in `test/js/bun/terminal/terminal.test.ts` next to the existing inline-terminal one.

## Verification

- All 133 tests under `test/js/bun/terminal/` pass with this change.
- `test/regression/issue/26286.test.ts` (the other pre-created `Bun.Terminal` consumer) passes.
- The specific failing matrix case `0109 (with modules)` passes across repeated runs.
- `cargo check -p bun_runtime` clean on linux-x64, aarch64-apple-darwin, and x86_64-pc-windows-msvc.

## Fail-before note

The race depends on epoll ready-list ordering (pidfd vs PTY master) which Linux does not specify; on this dev box the PTY-readable event wins consistently, so the failure does not reproduce locally even under load or with `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD`. The Alpine CI sightings (6 across as many months, always `[y/N] <resp>\r\n` with the next line missing) match the mechanism above, and `drain_reader()` makes the read unconditional.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts

<!-- robobun:evidence:end -->