### PR TITLE
bundler: surface ENAMETOOLONG for oversized onResolve paths instead of panicking

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7490,10 +7490,34 @@ pub mod bv2_impl {
 
         if path.is_file() || is_node {
             let mut buf2 = bun_paths::path_buffer_pool::get();
-            let rel = bun_paths::resolve_path::relative_platform_buf::<
-                bun_paths::resolve_path::platform::Loose,
-                false,
-            >(&mut **buf2, top_level_dir, path.text);
+            let mut spill: Vec<u8>;
+            // `relative_platform_buf` normalizes `path.text` into a fixed
+            // `MAX_PATH_BYTES - 1` thread-local, and the relative result can
+            // grow past `path.text.len()` by the `../` prefix derived from
+            // `top_level_dir`. An `onResolve` plugin can return a path of any
+            // length, so both the normalize scratch and the output buffer can
+            // overflow. Fall back to `path.text` when it cannot be normalized,
+            // and spill the output buffer to the heap when the pooled one is
+            // too small; the file open will surface `ENAMETOOLONG`.
+            let rel: &[u8] = if path.text.len() >= bun_paths::MAX_PATH_BYTES {
+                path.text
+            } else {
+                let need = path
+                    .text
+                    .len()
+                    .saturating_add(top_level_dir.len().saturating_mul(2))
+                    .saturating_add(8);
+                let out: &mut [u8] = if need <= buf2.0.len() {
+                    &mut buf2.0[..]
+                } else {
+                    spill = vec![0u8; need];
+                    &mut spill[..]
+                };
+                bun_paths::resolve_path::relative_platform_buf::<
+                    bun_paths::resolve_path::platform::Loose,
+                    false,
+                >(out, top_level_dir, path.text)
+            };
             let mut path_clone: crate::bun_fs::Path<'_> = *path;
             if target == options::Target::ServerComponentsSsr {
                 let mut fbs = bun_io::FixedBufferStream::new_mut(&mut buf.0[..]);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7491,14 +7491,13 @@ pub mod bv2_impl {
         if path.is_file() || is_node {
             let mut buf2 = bun_paths::path_buffer_pool::get();
             let mut spill: Vec<u8>;
-            let rel: &[u8] = if path.text.len() >= bun_paths::MAX_PATH_BYTES {
-                path.text
-            } else {
-                let need = path
-                    .text
-                    .len()
-                    .saturating_add(top_level_dir.len().saturating_mul(2))
-                    .saturating_add(8);
+            let mut to_spill: Vec<u8>;
+            let need = path
+                .text
+                .len()
+                .saturating_add(top_level_dir.len().saturating_mul(2))
+                .saturating_add(8);
+            let rel: &[u8] = if path.text.len() < bun_paths::MAX_PATH_BYTES {
                 let out: &mut [u8] = if need <= buf2.0.len() {
                     &mut buf2.0[..]
                 } else {
@@ -7509,6 +7508,19 @@ pub mod bv2_impl {
                     bun_paths::resolve_path::platform::Loose,
                     false,
                 >(out, top_level_dir, path.text)
+            } else {
+                spill = vec![0u8; need];
+                to_spill = vec![0u8; path.text.len().saturating_add(2)];
+                bun_paths::resolve_path::relative_platform_buf_with_scratch::<
+                    bun_paths::resolve_path::platform::Loose,
+                    false,
+                >(
+                    &mut spill[..],
+                    top_level_dir,
+                    path.text,
+                    &mut buf2.0[..],
+                    &mut to_spill[..],
+                )
             };
             let mut path_clone: crate::bun_fs::Path<'_> = *path;
             if target == options::Target::ServerComponentsSsr {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7491,8 +7491,6 @@ pub mod bv2_impl {
         if path.is_file() || is_node {
             let mut buf2 = bun_paths::path_buffer_pool::get();
             let mut spill: Vec<u8>;
-            // `relative_platform_buf` writes into fixed `MAX_PATH_BYTES` scratch
-            // buffers; an `onResolve` plugin can return a path of any length.
             let rel: &[u8] = if path.text.len() >= bun_paths::MAX_PATH_BYTES {
                 path.text
             } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7491,14 +7491,8 @@ pub mod bv2_impl {
         if path.is_file() || is_node {
             let mut buf2 = bun_paths::path_buffer_pool::get();
             let mut spill: Vec<u8>;
-            // `relative_platform_buf` normalizes `path.text` into a fixed
-            // `MAX_PATH_BYTES - 1` thread-local, and the relative result can
-            // grow past `path.text.len()` by the `../` prefix derived from
-            // `top_level_dir`. An `onResolve` plugin can return a path of any
-            // length, so both the normalize scratch and the output buffer can
-            // overflow. Fall back to `path.text` when it cannot be normalized,
-            // and spill the output buffer to the heap when the pooled one is
-            // too small; the file open will surface `ENAMETOOLONG`.
+            // `relative_platform_buf` writes into fixed `MAX_PATH_BYTES` scratch
+            // buffers; an `onResolve` plugin can return a path of any length.
             let rel: &[u8] = if path.text.len() >= bun_paths::MAX_PATH_BYTES {
                 path.text
             } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7510,7 +7510,7 @@ pub mod bv2_impl {
                 >(out, top_level_dir, path.text)
             } else {
                 spill = vec![0u8; need];
-                to_spill = vec![0u8; path.text.len().saturating_add(2)];
+                to_spill = vec![0u8; need];
                 bun_paths::resolve_path::relative_platform_buf_with_scratch::<
                     bun_paths::resolve_path::platform::Loose,
                     false,

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -662,11 +662,8 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     )
 }
 
-/// [`relative_platform_buf`] with caller-supplied normalize scratch instead of
-/// the fixed `MAX_PATH_BYTES` thread-locals. Use this when `from` or `to` may
-/// exceed `MAX_PATH_BYTES` (a bundler `onResolve` plugin can return a path of
-/// any length). Each scratch buffer must be at least one byte longer than the
-/// corresponding input.
+/// [`relative_platform_buf`] with caller-supplied normalize scratch. Each
+/// scratch buffer must hold at least `input.len() + 1` bytes.
 pub fn relative_platform_buf_with_scratch<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
     from: &[u8],

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -653,7 +653,27 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     // two `&mut` borrows below are disjoint.
     let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
     let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
+    relative_platform_buf_with_scratch::<P, ALWAYS_COPY>(
+        buf,
+        from,
+        to,
+        &mut relative_from_buf[..],
+        &mut relative_to_buf[..],
+    )
+}
 
+/// [`relative_platform_buf`] with caller-supplied normalize scratch instead of
+/// the fixed `MAX_PATH_BYTES` thread-locals. Use this when `from` or `to` may
+/// exceed `MAX_PATH_BYTES` (a bundler `onResolve` plugin can return a path of
+/// any length). Each scratch buffer must be at least one byte longer than the
+/// corresponding input.
+pub fn relative_platform_buf_with_scratch<'a, P: PlatformT, const ALWAYS_COPY: bool>(
+    buf: &'a mut [u8],
+    from: &[u8],
+    to: &[u8],
+    relative_from_buf: &'a mut [u8],
+    relative_to_buf: &'a mut [u8],
+) -> &'a [u8] {
     let normalized_from: &[u8] = if P::P.is_absolute(from) {
         'brk: {
             if P::P == Platform::Loose && cfg!(windows) {

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -662,8 +662,7 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     )
 }
 
-/// [`relative_platform_buf`] with caller-supplied normalize scratch. Each
-/// scratch buffer must hold at least `input.len() + 1` bytes.
+/// [`relative_platform_buf`] with caller-supplied normalize scratch (each `>= input.len() + 1`).
 pub fn relative_platform_buf_with_scratch<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
     from: &[u8],

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1513,3 +1513,56 @@ test("Bun.build can be called thousands of times in one process without crashing
   expect(stdout.trim()).toBe("OK 400");
   expect(exitCode).toBe(0);
 }, 180_000);
+
+test("onResolve returning a path longer than PATH_MAX surfaces a build error instead of aborting", async () => {
+  // The bundler's path prettifier relativizes the onResolve-returned path into
+  // a fixed PATH_MAX-sized buffer. An oversized plugin path should surface as a
+  // BuildMessage (ENAMETOOLONG / ENOENT), not abort the process with
+  // "panic: range end index N out of range for slice of length 4095".
+  using dir = tempDir("onresolve-long-path", {
+    "entry.ts": `import { two } from "./two.ts"; console.log(two);`,
+    "run.ts": `
+      const entry = process.argv[2];
+      // 4094 exercises the output-buffer overflow on Linux (PATH_MAX 4096);
+      // 5000 and 100000 exercise the normalize-buffer overflow on POSIX and
+      // Windows respectively. On platforms where a given length is under the
+      // limit the build still fails (the file does not exist).
+      for (const len of [4094, 5000, 100000]) {
+        const p = "/" + Buffer.alloc(len - 4, "a").toString() + ".ts";
+        const r = await Bun.build({
+          entrypoints: [entry],
+          throw: false,
+          target: "bun",
+          plugins: [{
+            name: "long",
+            setup(b) {
+              b.onResolve({ filter: /^\\.\\/two\\.ts$/ }, () => ({ path: p }));
+            },
+          }],
+        });
+        console.log(JSON.stringify({ len, success: r.success, hasError: r.logs.length > 0 }));
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(String(dir), "run.ts"), path.join(String(dir), "entry.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(
+    stdout
+      .trim()
+      .split("\n")
+      .map(l => JSON.parse(l)),
+  ).toEqual([
+    { len: 4094, success: false, hasError: true },
+    { len: 5000, success: false, hasError: true },
+    { len: 100000, success: false, hasError: true },
+  ]);
+  expect(exitCode).toBe(0);
+});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1518,7 +1518,8 @@ test("onResolve returning a path longer than PATH_MAX surfaces a build error ins
   // The bundler's path prettifier relativizes the onResolve-returned path into
   // a fixed PATH_MAX-sized buffer. An oversized plugin path should surface as a
   // BuildMessage (ENAMETOOLONG / ENOENT), not abort the process with
-  // "panic: range end index N out of range for slice of length 4095".
+  // "panic: range end index N out of range for slice of length 4095". When an
+  // onLoad hook services the path the build should succeed outright.
   using dir = tempDir("onresolve-long-path", {
     "entry.ts": `import { two } from "./two.ts"; console.log(two);`,
     "run.ts": `
@@ -1526,7 +1527,7 @@ test("onResolve returning a path longer than PATH_MAX surfaces a build error ins
       // 4094 exercises the output-buffer overflow on Linux (PATH_MAX 4096);
       // 5000 and 100000 exercise the normalize-buffer overflow on POSIX and
       // Windows respectively. On platforms where a given length is under the
-      // limit the build still fails (the file does not exist).
+      // limit the onResolve-only build still fails (the file does not exist).
       for (const len of [4094, 5000, 100000]) {
         const p = "/" + Buffer.alloc(len - 4, "a").toString() + ".ts";
         const r = await Bun.build({
@@ -1542,6 +1543,30 @@ test("onResolve returning a path longer than PATH_MAX surfaces a build error ins
         });
         console.log(JSON.stringify({ len, success: r.success, hasError: r.logs.length > 0 }));
       }
+      // With an onLoad supplying contents the file is never opened, so the
+      // build proceeds through the linker with the oversized pretty path.
+      const p = "/" + Buffer.alloc(100000 - 4, "a").toString() + ".ts";
+      const r = await Bun.build({
+        entrypoints: [entry],
+        throw: false,
+        target: "bun",
+        plugins: [{
+          name: "long-loaded",
+          setup(b) {
+            b.onResolve({ filter: /^\\.\\/two\\.ts$/ }, () => ({ path: p }));
+            b.onLoad({ filter: /\\.ts$/ }, args => {
+              if (args.path === p) return { contents: "export const two = 2;", loader: "ts" };
+            });
+          },
+        }],
+      });
+      const out = r.success ? await r.outputs[0].text() : "";
+      console.log(JSON.stringify({
+        onLoad: true,
+        success: r.success,
+        hasError: r.logs.length > 0,
+        bundled: out.includes("two = 2"),
+      }));
     `,
   });
 
@@ -1563,6 +1588,7 @@ test("onResolve returning a path longer than PATH_MAX surfaces a build error ins
     { len: 4094, success: false, hasError: true },
     { len: 5000, success: false, hasError: true },
     { len: 100000, success: false, hasError: true },
+    { onLoad: true, success: true, hasError: false, bundled: true },
   ]);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem

A `Bun.build` plugin whose `onResolve` returns an absolute `path` close to or longer than `MAX_PATH_BYTES` aborts the process:

```js
const p = "/" + Buffer.alloc(4200, "a").toString() + ".ts";
await Bun.build({
  entrypoints: ["entry.ts"], throw: false, target: "bun",
  plugins: [{ name: "long", setup(b) {
    b.onResolve({ filter: /^\.\/two\.ts$/ }, () => ({ path: p }));
  } }],
});
```

```
panic: range end index 4203 out of range for slice of length 4095
```

A path a few bytes shorter surfaces a clean `ENAMETOOLONG` BuildMessage; a few bytes longer aborts. Same fixed-`PathBuffer`-join class as #33219 (which guarded the worker-specifier joins).

### Cause

`generic_path_with_pretty_initialized` (`src/bundler/bundle_v2.rs`) relativizes the plugin path against `top_level_dir` via `relative_platform_buf`, which has two fixed-size writes with no bounds check on the caller-supplied `to`:

- the `to` normalize into the `MAX_PATH_BYTES - 1` thread-local scratch (overflows when `path.text.len()` exceeds it), and
- the final relative result into the caller's pooled `PathBuffer` (overflows earlier, when the `../` prefix derived from `top_level_dir` pushes a near-limit path past `MAX_PATH_BYTES`).

An `onResolve` plugin can return a path of any length, so both are reachable from the public API.

### Fix

- `src/paths/resolve_path.rs`: extract the body of `relative_platform_buf` into `relative_platform_buf_with_scratch`, which takes the two normalize scratch buffers as parameters instead of hard-coding the fixed `MAX_PATH_BYTES` thread-locals. `relative_platform_buf` now forwards to it with those thread-locals, so existing callers are unchanged.
- `src/bundler/bundle_v2.rs`: in `generic_path_with_pretty_initialized`, size the output buffer for the worst-case relative result (`path.text.len() + 2 * top_level_dir.len() + 8`), spilling to a heap `Vec` when the pooled `PathBuffer` is too small. When `path.text.len() >= MAX_PATH_BYTES`, call `relative_platform_buf_with_scratch` with a heap-sized `to`-scratch so the relativization still runs instead of overflowing the fixed thread-local.

Computing the real relative path for the oversized case (rather than falling back to `path.text` as the pretty) keeps `generic_path_with_pretty_initialized`'s postcondition `text.as_ptr() != pretty.as_ptr()` that `generate_isolated_hash` asserts, and the `../`-prefixed result routes `dupe_alloc` to the per-build arena rather than the process-lifetime `FilenameStore`.

### Test

`test/bundler/bun-build-api.test.ts` spawns a child that runs `Bun.build` with `onResolve` returning paths of length 4094, 5000 and 100000 (covering the output-buffer overflow on Linux, the normalize-scratch overflow on POSIX, and the Windows `MAX_PATH_BYTES`), and a fourth build where an `onLoad` hook services the 100000-byte path so the bundle proceeds through the linker. Before the fix the child aborts with the slice-index panic; after, the first three return `success: false` with a build error, the `onLoad` case returns `success: true` with the module bundled, and the child exits 0.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->