### PR TITLE
fetch: mark body disturbed when a reader fails; reject network errors as TypeError

### DIFF
--- a/src/jsc/SystemError.rs
+++ b/src/jsc/SystemError.rs
@@ -95,9 +95,7 @@ impl SystemError {
         SystemError__toErrorInstance(&self, global)
     }
 
-    /// Same as `to_error_instance` but constructs a JS `TypeError` (still
-    /// carrying `.code`/`.path`/`.syscall`/...). The fetch spec maps every
-    /// network error to `TypeError`.
+    /// `to_error_instance` but as a JS `TypeError` (keeps `.code`/`.path`/...).
     pub fn to_type_error_instance(self, global: &JSGlobalObject) -> JSValue {
         SystemError__toTypeErrorInstance(&self, global)
     }

--- a/src/jsc/SystemError.rs
+++ b/src/jsc/SystemError.rs
@@ -72,6 +72,10 @@ pub type Maybe<R> = core::result::Result<R, SystemError>;
 // is ABI-identical to a non-null `JSGlobalObject*` with write provenance.
 unsafe extern "C" {
     safe fn SystemError__toErrorInstance(this: &SystemError, global: &JSGlobalObject) -> JSValue;
+    safe fn SystemError__toTypeErrorInstance(
+        this: &SystemError,
+        global: &JSGlobalObject,
+    ) -> JSValue;
     safe fn SystemError__toErrorInstanceWithInfoObject(
         this: &SystemError,
         global: &JSGlobalObject,
@@ -89,6 +93,13 @@ impl SystemError {
     /// first when two `Error`s are genuinely wanted.
     pub fn to_error_instance(self, global: &JSGlobalObject) -> JSValue {
         SystemError__toErrorInstance(&self, global)
+    }
+
+    /// Same as `to_error_instance` but constructs a JS `TypeError` (still
+    /// carrying `.code`/`.path`/`.syscall`/...). The fetch spec maps every
+    /// network error to `TypeError`.
+    pub fn to_type_error_instance(self, global: &JSGlobalObject) -> JSValue {
+        SystemError__toTypeErrorInstance(&self, global)
     }
 
     /// Like `to_error_instance` but populates the error's stack trace with async

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2353,7 +2353,7 @@ JSC::EncodedJSValue JSGlobalObject__createOutOfMemoryError(JSC::JSGlobalObject* 
     return JSValue::encode(exception);
 }
 
-JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject)
+static JSC::EncodedJSValue systemErrorToErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject, JSC::ErrorType errorType)
 {
     SystemError err = *arg0;
 
@@ -2367,7 +2367,7 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
 
     auto& names = WebCore::builtinNames(vm);
 
-    JSC::JSObject* result = createError(globalObject, ErrorType::Error, message);
+    JSC::JSObject* result = createError(globalObject, errorType, message);
 
     auto clientData = WebCore::clientData(vm);
 
@@ -2424,6 +2424,16 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
     result->putDirect(vm, names.errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
 
     return JSC::JSValue::encode(result);
+}
+
+JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject)
+{
+    return systemErrorToErrorInstance(arg0, globalObject, ErrorType::Error);
+}
+
+JSC::EncodedJSValue SystemError__toTypeErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject)
+{
+    return systemErrorToErrorInstance(arg0, globalObject, ErrorType::TypeError);
 }
 
 JSC::EncodedJSValue SystemError__toErrorInstanceWithInfoObject(const SystemError* arg0, JSC::JSGlobalObject* globalObject)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -99,6 +99,7 @@ CPP_DECL void WebCore__FetchHeaders__remove(WebCore::FetchHeaders* arg0, const Z
 CPP_DECL JSC::EncodedJSValue WebCore__FetchHeaders__toJS(WebCore::FetchHeaders* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0, UWSResponseKind kind, void* arg2);
 CPP_DECL JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* arg1);
+CPP_DECL JSC::EncodedJSValue SystemError__toTypeErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* arg1);
 
 #pragma mark - JSC::JSCell
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2158,8 +2158,7 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
 
 /// If the body already failed, reject the read with that error. Every body
 /// reader must call this before its `Locked` handling: `Value::Error` would
-/// otherwise fall through to `use_as_any_blob_*` and resolve empty. Leaves the
-/// body `Used` since calling a reader disturbs it.
+/// otherwise fall through to `use_as_any_blob_*` and resolve empty.
 fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Option<JSValue> {
     let Value::Error(err) = value else {
         return None;

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -564,10 +564,7 @@ pub enum Tag {
 pub enum ValueError {
     AbortReason(CommonAbortReason),
     SystemError(SystemError),
-    /// A `SystemError` that surfaces as a JS `TypeError` but keeps
-    /// `.code`/`.path`/`.syscall`/`.hostname`. Fetch network errors use this:
-    /// the fetch spec requires `TypeError`, while callers still feature-detect
-    /// on `err.code === "ECONNRESET"` etc.
+    /// `SystemError` surfaced as a JS `TypeError` (fetch network errors).
     SystemTypeError(SystemError),
     Message(BunString),
     /// Surfaces as a JS `TypeError`. The fetch spec maps every "network
@@ -1301,9 +1298,6 @@ impl Value {
                 Value::Locked(l) => core::mem::take(l),
                 _ => unreachable!(),
             };
-            // A body reader (`.text()` etc.) had already started consuming this
-            // body; per fetch spec the body's stream is now disturbed regardless
-            // of how the read ends.
             let was_disturbed = !locked.action.is_none() || locked.promise.is_some();
             *self = Value::Error(err);
             let Value::Error(err_ref) = self else {
@@ -2164,11 +2158,8 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
 
 /// If the body already failed, reject the read with that error. Every body
 /// reader must call this before its `Locked` handling: `Value::Error` would
-/// otherwise fall through to `use_as_any_blob_*` and resolve empty.
-///
-/// Calling a body reader disturbs the body, so on return `value` is `Used`:
-/// `bodyUsed` reports `true` and a second read rejects with
-/// `ERR_BODY_ALREADY_USED` rather than the stored network error again.
+/// otherwise fall through to `use_as_any_blob_*` and resolve empty. Leaves the
+/// body `Used` since calling a reader disturbs it.
 fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Option<JSValue> {
     let Value::Error(err) = value else {
         return None;

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -564,6 +564,11 @@ pub enum Tag {
 pub enum ValueError {
     AbortReason(CommonAbortReason),
     SystemError(SystemError),
+    /// A `SystemError` that surfaces as a JS `TypeError` but keeps
+    /// `.code`/`.path`/`.syscall`/`.hostname`. Fetch network errors use this:
+    /// the fetch spec requires `TypeError`, while callers still feature-detect
+    /// on `err.code === "ECONNRESET"` etc.
+    SystemTypeError(SystemError),
     Message(BunString),
     /// Surfaces as a JS `TypeError`. The fetch spec maps every "network
     /// error" to TypeError, so use this for fetch-layer rejections that
@@ -578,7 +583,7 @@ impl ValueError {
     pub fn reset(&mut self) {
         match self {
             // The bun.String fields are dropped by the assignment below.
-            ValueError::SystemError(_system_error) => {}
+            ValueError::SystemError(_) | ValueError::SystemTypeError(_) => {}
             ValueError::Message(message) => message.deref(),
             ValueError::TypeError(message) => message.deref(),
             ValueError::JSValue(v) => v.deinit(),
@@ -612,6 +617,9 @@ impl ValueError {
             ValueError::SystemError(system_error) => {
                 core::mem::take(system_error).to_error_instance(global_object)
             }
+            ValueError::SystemTypeError(system_error) => {
+                core::mem::take(system_error).to_type_error_instance(global_object)
+            }
             ValueError::Message(message) => message.to_error_instance(global_object),
             ValueError::TypeError(message) => message.to_type_error_instance(global_object),
             // do an early return in this case we don't need to create a new Strong
@@ -628,6 +636,7 @@ impl ValueError {
             // `.clone()` on BunString/SystemError already bumps the refcount (paired
             // with their Drop deref); an extra `.ref_()` here would leak +1 per dupe.
             ValueError::SystemError(e) => ValueError::SystemError(e.clone()),
+            ValueError::SystemTypeError(e) => ValueError::SystemTypeError(e.clone()),
             ValueError::Message(m) => ValueError::Message(m.clone()),
             ValueError::TypeError(m) => ValueError::TypeError(m.clone()),
             ValueError::JSValue(js_ref) => {
@@ -1292,6 +1301,10 @@ impl Value {
                 Value::Locked(l) => core::mem::take(l),
                 _ => unreachable!(),
             };
+            // A body reader (`.text()` etc.) had already started consuming this
+            // body; per fetch spec the body's stream is now disturbed regardless
+            // of how the read ends.
+            let was_disturbed = !locked.action.is_none() || locked.promise.is_some();
             *self = Value::Error(err);
             let Value::Error(err_ref) = self else {
                 unreachable!()
@@ -1332,6 +1345,13 @@ impl Value {
                 // `task` is the live request-ctx pointer registered alongside
                 // this callback.
                 on_receive_value(locked.task.unwrap(), self);
+            }
+
+            if was_disturbed {
+                if let Value::Error(e) = self {
+                    e.reset();
+                }
+                *self = Value::Used;
             }
 
             return Ok(());
@@ -2145,11 +2165,18 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
 /// If the body already failed, reject the read with that error. Every body
 /// reader must call this before its `Locked` handling: `Value::Error` would
 /// otherwise fall through to `use_as_any_blob_*` and resolve empty.
+///
+/// Calling a body reader disturbs the body, so on return `value` is `Used`:
+/// `bodyUsed` reports `true` and a second read rejects with
+/// `ERR_BODY_ALREADY_USED` rather than the stored network error again.
 fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Option<JSValue> {
     let Value::Error(err) = value else {
         return None;
     };
-    Some(JSPromise::rejected_promise(global_object, err.to_js(global_object)).to_js())
+    let js = err.to_js(global_object);
+    err.reset();
+    *value = Value::Used;
+    Some(JSPromise::rejected_promise(global_object, js).to_js())
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1298,7 +1298,9 @@ impl Value {
                 Value::Locked(l) => core::mem::take(l),
                 _ => unreachable!(),
             };
-            let was_disturbed = !locked.action.is_none() || locked.promise.is_some();
+            let was_disturbed = !locked.action.is_none()
+                || locked.promise.is_some()
+                || locked.readable.is_disturbed(global);
             *self = Value::Error(err);
             let Value::Error(err_ref) = self else {
                 unreachable!()

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1342,9 +1342,6 @@ impl Value {
             }
 
             if was_disturbed {
-                if let Value::Error(e) = self {
-                    e.reset();
-                }
                 *self = Value::Used;
             }
 
@@ -2164,7 +2161,6 @@ fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Optio
         return None;
     };
     let js = err.to_js(global_object);
-    err.reset();
     *value = Value::Used;
     Some(JSPromise::rejected_promise(global_object, js).to_js())
 }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1322,7 +1322,7 @@ impl FetchTasklet {
                     hostname,
                 );
                 err.path = path.into();
-                return BodyValueError::SystemError(err);
+                return BodyValueError::SystemTypeError(err);
             }
         }
 
@@ -1562,7 +1562,7 @@ impl FetchTasklet {
             ..Default::default()
         };
 
-        BodyValueError::SystemError(fetch_error)
+        BodyValueError::SystemTypeError(fetch_error)
     }
 
     pub(crate) fn on_readable_stream_available(

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1286,9 +1286,6 @@ impl FetchTasklet {
 
         let fail = self.result.fail.unwrap();
 
-        // Fetch-spec "network error" cases that callers feature-detect via
-        // `instanceof TypeError`. Keep this list narrow; the catch-all
-        // SystemError below is still a plain Error for backwards compat.
         if fail == http::Error::RequestBodyNotReusable {
             return BodyValueError::TypeError(BunString::static_(
                 "Request body is a ReadableStream and cannot be replayed for this redirect",

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import net from "node:net";
 import { once } from "node:events";
+import net from "node:net";
 
 describe("body-mixin-errors", () => {
   it.concurrent.each([
@@ -67,32 +67,29 @@ describe("body-mixin-errors", () => {
     });
   });
 
-  it.concurrent(
-    "fetch: body that failed before any reader call is still consumed by the first read",
-    async () => {
-      await withTruncatedBodyServer(async url => {
-        const res = await fetch(url);
-        // Force the download to run to its (truncated) end before we ever call
-        // a reader: arrayBuffer() on a clone drains the underlying connection.
-        await res
-          .clone()
-          .arrayBuffer()
-          .catch(() => {});
+  it.concurrent("fetch: body that failed before any reader call is still consumed by the first read", async () => {
+    await withTruncatedBodyServer(async url => {
+      const res = await fetch(url);
+      // Force the download to run to its (truncated) end before we ever call
+      // a reader: arrayBuffer() on a clone drains the underlying connection.
+      await res
+        .clone()
+        .arrayBuffer()
+        .catch(() => {});
 
-        expect(res.bodyUsed).toBe(false);
+      expect(res.bodyUsed).toBe(false);
 
-        let firstErr: unknown;
-        await res.text().catch(e => (firstErr = e));
-        expect(firstErr).toBeInstanceOf(TypeError);
+      let firstErr: unknown;
+      await res.text().catch(e => (firstErr = e));
+      expect(firstErr).toBeInstanceOf(TypeError);
 
-        expect(res.bodyUsed).toBe(true);
+      expect(res.bodyUsed).toBe(true);
 
-        let secondErr: unknown;
-        await res.text().catch(e => (secondErr = e));
-        expectBodyAlreadyUsed(secondErr);
-      });
-    },
-  );
+      let secondErr: unknown;
+      await res.text().catch(e => (secondErr = e));
+      expectBodyAlreadyUsed(secondErr);
+    });
+  });
 
   it.concurrent.each(["arrayBuffer", "bytes", "blob", "json"] as const)(
     "fetch: truncated body %s() marks body used",

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import net from "node:net";
+import { once } from "node:events";
 
 describe("body-mixin-errors", () => {
   it.concurrent.each([
@@ -21,4 +23,93 @@ describe("body-mixin-errors", () => {
       expect(err instanceof TypeError).toBe(true);
     }
   });
+
+  // fetch spec: every network error is a TypeError, and once a body read has
+  // started the body's stream is disturbed regardless of how the read ends.
+  // Server announces Content-Length: 100000 but only ever sends 1000 bytes
+  // then closes, so the body read is guaranteed to fail.
+  async function withTruncatedBodyServer<T>(fn: (url: string) => Promise<T>): Promise<T> {
+    const body = Buffer.alloc(1000, "x").toString();
+    const server = net.createServer(socket => {
+      socket.end(`HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 100000\r\n\r\n${body}`);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      return await fn(`http://127.0.0.1:${port}/`);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  }
+
+  function expectBodyAlreadyUsed(err: unknown) {
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as any).code).toBe("ERR_BODY_ALREADY_USED");
+    expect((err as Error).message).toBe("Body already used");
+  }
+
+  it.concurrent("fetch: truncated body read rejects with TypeError and marks body used", async () => {
+    await withTruncatedBodyServer(async url => {
+      const res = await fetch(url);
+      expect(res.bodyUsed).toBe(false);
+
+      let firstErr: unknown;
+      await res.text().catch(e => (firstErr = e));
+      expect(firstErr).toBeInstanceOf(TypeError);
+      expect((firstErr as any).code).toBe("ECONNRESET");
+
+      expect(res.bodyUsed).toBe(true);
+
+      let secondErr: unknown;
+      await res.text().catch(e => (secondErr = e));
+      expectBodyAlreadyUsed(secondErr);
+    });
+  });
+
+  it.concurrent(
+    "fetch: body that failed before any reader call is still consumed by the first read",
+    async () => {
+      await withTruncatedBodyServer(async url => {
+        const res = await fetch(url);
+        // Force the download to run to its (truncated) end before we ever call
+        // a reader: arrayBuffer() on a clone drains the underlying connection.
+        await res
+          .clone()
+          .arrayBuffer()
+          .catch(() => {});
+
+        expect(res.bodyUsed).toBe(false);
+
+        let firstErr: unknown;
+        await res.text().catch(e => (firstErr = e));
+        expect(firstErr).toBeInstanceOf(TypeError);
+
+        expect(res.bodyUsed).toBe(true);
+
+        let secondErr: unknown;
+        await res.text().catch(e => (secondErr = e));
+        expectBodyAlreadyUsed(secondErr);
+      });
+    },
+  );
+
+  it.concurrent.each(["arrayBuffer", "bytes", "blob", "json"] as const)(
+    "fetch: truncated body %s() marks body used",
+    async method => {
+      await withTruncatedBodyServer(async url => {
+        const res = await fetch(url);
+
+        let firstErr: unknown;
+        await (res as any)[method]().catch((e: unknown) => (firstErr = e));
+        expect(firstErr).toBeInstanceOf(TypeError);
+
+        expect(res.bodyUsed).toBe(true);
+
+        let secondErr: unknown;
+        await res.text().catch(e => (secondErr = e));
+        expectBodyAlreadyUsed(secondErr);
+      });
+    },
+  );
 });

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -72,10 +72,7 @@ describe("body-mixin-errors", () => {
       const res = await fetch(url);
       // Force the download to run to its (truncated) end before we ever call
       // a reader: arrayBuffer() on a clone drains the underlying connection.
-      await res
-        .clone()
-        .arrayBuffer()
-        .catch(() => {});
+      await expect(res.clone().arrayBuffer()).rejects.toThrow(TypeError);
 
       expect(res.bodyUsed).toBe(false);
 

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -88,6 +88,26 @@ describe("body-mixin-errors", () => {
     });
   });
 
+  it.concurrent("fetch: reading .body directly marks body used when the stream errors", async () => {
+    await withTruncatedBodyServer(async url => {
+      const res = await fetch(url);
+      const reader = res.body!.getReader();
+      let firstErr: unknown;
+      try {
+        while (!(await reader.read()).done) {}
+      } catch (e) {
+        firstErr = e;
+      }
+      expect(firstErr).toBeInstanceOf(TypeError);
+
+      expect(res.bodyUsed).toBe(true);
+
+      let secondErr: unknown;
+      await res.text().catch(e => (secondErr = e));
+      expectBodyAlreadyUsed(secondErr);
+    });
+  });
+
   it.concurrent.each(["arrayBuffer", "bytes", "blob", "json"] as const)(
     "fetch: truncated body %s() marks body used",
     async method => {

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -448,7 +448,7 @@ test("unresolvable hostname rejects with the resolver error", async () => {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const notFound = (hostname: string) => ({
-    name: "Error",
+    name: "TypeError",
     code: "ENOTFOUND",
     syscall: "getaddrinfo",
     hostname,

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -1263,17 +1263,14 @@ describe.concurrent("fetch() with streaming", () => {
             gcTick(false);
             expect(buffer.toString("utf8")).toBe("unreachable");
           } catch (err) {
+            expect(err).toBeInstanceOf(TypeError);
             if (compression === "br") {
-              expect((err as Error).name).toBe("Error");
               expect((err as Error).code).toBe("BrotliDecompressionError");
             } else if (compression === "deflate-libdeflate") {
-              expect((err as Error).name).toBe("Error");
               expect((err as Error).code).toBe("ZlibError");
             } else if (compression === "zstd") {
-              expect((err as Error).name).toBe("Error");
               expect((err as Error).code).toBe("ZstdDecompressionError");
             } else {
-              expect((err as Error).name).toBe("Error");
               expect((err as Error).code).toBe("ZlibError");
             }
           }
@@ -1365,7 +1362,7 @@ describe.concurrent("fetch() with streaming", () => {
         gcTick(false);
         expect(buffer.toString("utf8")).toBe("unreachable");
       } catch (err) {
-        expect((err as Error).name).toBe("Error");
+        expect(err).toBeInstanceOf(TypeError);
         expect((err as Error).code).toBe("ECONNRESET");
       }
     });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -154,15 +154,17 @@ describe("HTMLRewriter", () => {
     function settle(promise) {
       return promise.then(
         value => ({ rejected: false, value }),
-        error => ({ rejected: true, message: String(error?.message) }),
+        error => ({ rejected: true, name: error?.name, message: String(error?.message) }),
       );
     }
     const rejectedWithConnectionError = {
       rejected: true,
+      name: "TypeError",
       message: expect.stringMatching(connectionError),
     };
     const rejectedWithBodyAlreadyUsed = {
       rejected: true,
+      name: "TypeError",
       message: "Body already used",
     };
 
@@ -210,7 +212,9 @@ describe("HTMLRewriter", () => {
         // `.body` must surface the consumed state, not close cleanly as an
         // empty "successful" document. The pending-reader-before-failure case
         // is covered by the test below.
-        expect(() => transformed.body.getReader()).toThrow();
+        expect(() => transformed.body.getReader()).toThrow(
+          expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_STATE" }),
+        );
       });
     });
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -161,6 +161,10 @@ describe("HTMLRewriter", () => {
       rejected: true,
       message: expect.stringMatching(connectionError),
     };
+    const rejectedWithBodyAlreadyUsed = {
+      rejected: true,
+      message: "Body already used",
+    };
 
     it("control: .text() on the untransformed response rejects", async () => {
       await withPartialBodyServer(async (url, release) => {
@@ -180,9 +184,9 @@ describe("HTMLRewriter", () => {
         // Must reject with the upstream connection error, and must never
         // resolve with the truncated document.
         expect(await text).toEqual(rejectedWithConnectionError);
-        // The body is now in its error state. A second read must report the
-        // same failure, not resolve as an empty "successful" document.
-        expect(await settle(transformed.text())).toEqual(rejectedWithConnectionError);
+        // The failed read consumed the body; a second read must reject as
+        // already-used, not resolve as an empty "successful" document.
+        expect(await settle(transformed.text())).toEqual(rejectedWithBodyAlreadyUsed);
       });
     });
 
@@ -195,17 +199,18 @@ describe("HTMLRewriter", () => {
       });
     });
 
-    it(".body on the transformed response is an errored stream", async () => {
+    it(".body on the transformed response is unusable after a failed read", async () => {
       await withPartialBodyServer(async (url, release) => {
         const res = await fetch(url);
         const transformed = rewriter().transform(res);
         const text = settle(transformed.text());
         release();
-        // Barrier: once this has rejected, the body is in its error state.
+        // Barrier: once this has rejected, the body has been consumed.
         expect(await text).toEqual(rejectedWithConnectionError);
-        // Reading `.body` must reject with the same upstream error instead of
-        // closing cleanly as an empty "successful" document.
-        expect(await settle(transformed.body.getReader().read())).toEqual(rejectedWithConnectionError);
+        // `.body` must surface the consumed state, not close cleanly as an
+        // empty "successful" document. The pending-reader-before-failure case
+        // is covered by the test below.
+        expect(() => transformed.body.getReader()).toThrow();
       });
     });
 
@@ -222,17 +227,17 @@ describe("HTMLRewriter", () => {
       });
     });
 
-    it(".clone() of a failed transformed body is also failed", async () => {
+    it(".clone() after a failed read throws", async () => {
       await withPartialBodyServer(async (url, release) => {
         const res = await fetch(url);
         const transformed = rewriter().transform(res);
         const text = settle(transformed.text());
         release();
-        // Barrier: the body is now in its error state.
+        // Barrier: the body has now been consumed by the failed read.
         expect(await text).toEqual(rejectedWithConnectionError);
-        // Cloning a failed body must produce a failed body, not an empty one
-        // that reads back as a complete (and empty) document.
-        expect(await settle(transformed.clone().text())).toEqual(rejectedWithConnectionError);
+        // A disturbed body is not clonable; it must not read back as a
+        // complete (and empty) document.
+        expect(() => transformed.clone()).toThrow("Body is disturbed or locked");
       });
     });
 
@@ -271,10 +276,11 @@ describe("HTMLRewriter", () => {
       // not an unrelated (and usually empty) HTMLRewriter internal error.
       await withPartialBodyServer(async (url, release) => {
         const res = await fetch(url);
-        const text = res.text();
+        // Drain via a clone so `res` itself stays undisturbed while we wait
+        // for the upstream failure to land.
+        const barrier = res.clone().arrayBuffer();
         release();
-        // Awaiting the rejection is the barrier: the body is now Value::Error.
-        await expect(text).rejects.toThrow(connectionError);
+        await expect(barrier).rejects.toThrow(connectionError);
         expect(() => rewriter().transform(res)).toThrow(connectionError);
       });
     });
@@ -286,9 +292,9 @@ describe("HTMLRewriter", () => {
         const controller = new AbortController();
         const res = await fetch(url, { signal: controller.signal });
         // The body is mid-stream (the server is stalled until release()).
-        const text = res.text();
+        const barrier = res.clone().arrayBuffer();
         controller.abort();
-        await expect(text).rejects.toThrow(/abort/i);
+        await expect(barrier).rejects.toThrow(/abort/i);
         let thrown;
         try {
           rewriter().transform(res);


### PR DESCRIPTION
When a `fetch()` response body is being consumed and the underlying download fails mid-body (socket closed before `Content-Length` is satisfied, decompression error, ...):

```js
import net from "node:net";
const srv = net.createServer(s =>
  s.end("HTTP/1.1 200 OK\r\nContent-Length: 100000\r\n\r\n" + "x".repeat(1000))
).listen(0, "127.0.0.1");
await once(srv, "listening");
const r = await fetch(`http://127.0.0.1:${srv.address().port}/`);
try { await r.text(); } catch (e) { console.log(e.constructor.name, e instanceof TypeError); }
console.log(r.bodyUsed);
try { await r.text(); } catch (e) { console.log(e.message); }
```

| | before | node | after |
| --- | --- | --- | --- |
| first `text()` | `Error` (`instanceof TypeError === false`) | `TypeError: terminated` | `TypeError` (with `.code === "ECONNRESET"`) |
| `bodyUsed` after failed read | `false` | `true` | `true` |
| second `text()` | re-rejects with the socket error | `TypeError: Body is unusable` | `TypeError: Body already used` |

### Cause

`Value::to_error_instance` moved a `Locked` body straight to `Value::Error`, dropping the "a read was started" bit (`action`/`promise`). `body_stream_check` has no `Value::Error` arm, so `bodyUsed` fell through to `false`, and every reader re-entered `handle_body_error` and rejected with the stored error again.

Separately, `FetchTasklet::on_reject` produced the network error as `ValueError::SystemError`, which `SystemError__toErrorInstance` materialises as a plain `Error`. The fetch spec maps every network error to `TypeError`; node/undici match that.

### Fix

* `Value::to_error_instance` records whether a reader had already begun before swapping in `Value::Error`; after rejecting the pending promise, erroring any readable, and notifying `on_receive_value`, it leaves the body in `Value::Used` so subsequent reads hit `ERR_BODY_ALREADY_USED`.
* `handle_body_error` (body already failed before any reader was called) now transitions `Error` to `Used` after producing the rejection, since calling a reader is itself the disturbing read.
* New `ValueError::SystemTypeError(SystemError)` variant surfaces as a JS `TypeError` while keeping `.code`/`.path`/`.syscall`/`.hostname`; `FetchTasklet::on_reject` returns it for every fetch network error. `.code === "ECONNRESET"` / `"ENOTFOUND"` / `"ZlibError"` etc. are preserved.
* `bindings.cpp` gains `SystemError__toTypeErrorInstance` (shared body with the existing `Error` path, parameterised on `ErrorType`).

Updated the handful of tests that asserted `name === "Error"` for fetch network errors to assert `TypeError` instead.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.stream.test.ts

<!-- robobun:evidence:end -->

---

Related: #20486, #34397 (this change makes fetch network errors `instanceof TypeError`; it does not add the `.cause` wrapping those issues also request, so they are not fully closed here).
