### PR TITLE
Bun.gunzipSync/zstdDecompress: throw ERR_BUFFER_TOO_LARGE instead of aborting when output exceeds 4 GiB

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2787,8 +2787,6 @@ pub mod JSZstd {
             .throw_invalid_arguments(format_args!("Expected buffer to be a string or buffer")))
     }
 
-    /// Move `output` into a Node `Buffer` without copying, or throw
-    /// `ERR_BUFFER_TOO_LARGE` when it exceeds the ArrayBuffer max.
     fn leak_vec_into_buffer(global_this: &JSGlobalObject, output: Vec<u8>) -> JsResult<JSValue> {
         let max_output = ArrayBuffer::MAX_SIZE as usize;
         if output.len() > max_output {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2366,6 +2366,15 @@ pub mod JSZlib {
         global_this: &JSGlobalObject,
         mut list: Vec<u8>,
     ) -> JsResult<JSValue> {
+        let max_output = ArrayBuffer::MAX_SIZE as usize;
+        if list.len() > max_output {
+            return Err(global_this
+                .err(
+                    jsc::ErrCode::BUFFER_TOO_LARGE,
+                    format_args!("Cannot create a Buffer larger than {max_output} bytes"),
+                )
+                .throw());
+        }
         list.shrink_to_fit();
         let is_empty = list.is_empty();
         let leaked: &'static mut [u8] = list.leak();
@@ -2852,6 +2861,16 @@ pub mod JSZstd {
             }
         };
 
+        let max_output = ArrayBuffer::MAX_SIZE as usize;
+        if output.len() > max_output {
+            return Err(global_this
+                .err(
+                    jsc::ErrCode::BUFFER_TOO_LARGE,
+                    format_args!("Cannot create a Buffer larger than {max_output} bytes"),
+                )
+                .throw());
+        }
+
         Ok(JSValue::create_buffer(global_this, output.leak()))
     }
 
@@ -2934,6 +2953,19 @@ pub mod JSZstd {
             }
 
             let output_slice = core::mem::take(&mut self.output);
+            let max_output = ArrayBuffer::MAX_SIZE as usize;
+            if output_slice.len() > max_output {
+                promise.reject_with_async_stack(
+                    global_this,
+                    Ok(global_this
+                        .err(
+                            jsc::ErrCode::BUFFER_TOO_LARGE,
+                            format_args!("Cannot create a Buffer larger than {max_output} bytes"),
+                        )
+                        .to_js()),
+                )?;
+                return Ok(());
+            }
             let buffer_value = JSValue::create_buffer(global_this, output_slice.leak());
             promise.resolve(global_this, buffer_value)?;
             Ok(())

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2837,6 +2837,16 @@ pub mod JSZstd {
             output.shrink_to_fit();
         }
 
+        let max_output = ArrayBuffer::MAX_SIZE as usize;
+        if output.len() > max_output {
+            return Err(global_this
+                .err(
+                    jsc::ErrCode::BUFFER_TOO_LARGE,
+                    format_args!("Cannot create a Buffer larger than {max_output} bytes"),
+                )
+                .throw());
+        }
+
         Ok(JSValue::create_buffer(global_this, output.leak()))
     }
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2730,21 +2730,7 @@ pub mod JSZlib {
                     )));
                 }
 
-                // Ownership of the allocation transfers to JSC; freed via
-                // `global_deallocator` once the ArrayBuffer is finalized.
-                let leaked: &'static mut [u8] = list.leak();
-                let ptr = leaked.as_mut_ptr();
-                let array_buffer = ArrayBuffer::from_bytes(leaked, jsc::JSType::Uint8Array);
-                // SAFETY: `ptr` is the just-leaked `Vec` allocation, live until
-                // `global_deallocator` (`mi_free_ctx`) frees it exactly once at
-                // GC via the ctx pointer (the data pointer itself).
-                unsafe {
-                    array_buffer.to_js_with_context(
-                        global_this,
-                        ptr.cast::<c_void>(),
-                        Some(global_deallocator),
-                    )
-                }
+                leak_list_into_uint8array(global_this, list)
             }
         }
     }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2787,6 +2787,21 @@ pub mod JSZstd {
             .throw_invalid_arguments(format_args!("Expected buffer to be a string or buffer")))
     }
 
+    /// Move `output` into a Node `Buffer` without copying, or throw
+    /// `ERR_BUFFER_TOO_LARGE` when it exceeds the ArrayBuffer max.
+    fn leak_vec_into_buffer(global_this: &JSGlobalObject, output: Vec<u8>) -> JsResult<JSValue> {
+        let max_output = ArrayBuffer::MAX_SIZE as usize;
+        if output.len() > max_output {
+            return Err(global_this
+                .err(
+                    jsc::ErrCode::BUFFER_TOO_LARGE,
+                    format_args!("Cannot create a Buffer larger than {max_output} bytes"),
+                )
+                .throw());
+        }
+        Ok(JSValue::create_buffer(global_this, output.leak()))
+    }
+
     #[bun_jsc::host_fn]
     pub(crate) fn compress_sync(
         global_this: &JSGlobalObject,
@@ -2823,17 +2838,7 @@ pub mod JSZstd {
             output.shrink_to_fit();
         }
 
-        let max_output = ArrayBuffer::MAX_SIZE as usize;
-        if output.len() > max_output {
-            return Err(global_this
-                .err(
-                    jsc::ErrCode::BUFFER_TOO_LARGE,
-                    format_args!("Cannot create a Buffer larger than {max_output} bytes"),
-                )
-                .throw());
-        }
-
-        Ok(JSValue::create_buffer(global_this, output.leak()))
+        leak_vec_into_buffer(global_this, output)
     }
 
     #[bun_jsc::host_fn]
@@ -2857,17 +2862,7 @@ pub mod JSZstd {
             }
         };
 
-        let max_output = ArrayBuffer::MAX_SIZE as usize;
-        if output.len() > max_output {
-            return Err(global_this
-                .err(
-                    jsc::ErrCode::BUFFER_TOO_LARGE,
-                    format_args!("Cannot create a Buffer larger than {max_output} bytes"),
-                )
-                .throw());
-        }
-
-        Ok(JSValue::create_buffer(global_this, output.leak()))
+        leak_vec_into_buffer(global_this, output)
     }
 
     // --- Async versions ---

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -9,7 +9,7 @@ import {
   zstdDecompressSync,
 } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import os from "os";
 import path from "path";
 
@@ -386,8 +386,10 @@ describe.skipIf(os.totalmem() < 16 * 1024 ** 3)("decompressed output > ArrayBuff
 
   // Bun.gunzipSync stops at the first gzip member, so the bomb has to be a
   // single stream that decompresses to exactly 2^32 bytes (one past
-  // ArrayBuffer::MAX_SIZE).
-  it("Bun.gunzipSync throws ERR_BUFFER_TOO_LARGE instead of panicking", async () => {
+  // ArrayBuffer::MAX_SIZE). Skipped on Windows: zlib's total_out is a 32-bit
+  // c_ulong there and wraps to 0 at 2^32, so the zlib reader's epilogue
+  // truncates the output list before the ArrayBuffer guard ever sees it.
+  it.skipIf(isWindows)("Bun.gunzipSync throws ERR_BUFFER_TOO_LARGE instead of panicking", async () => {
     const script = `
       import * as zlib from "node:zlib";
       const chunks = [];

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -385,7 +385,8 @@ describe.skipIf(os.totalmem() < 16 * 1024 ** 3)("decompressed output > ArrayBuff
   }
 
   // Bun.gunzipSync stops at the first gzip member, so the bomb has to be a
-  // single stream: compress (4 GiB + 1 KiB) of zeros and decompress that.
+  // single stream that decompresses to exactly 2^32 bytes (one past
+  // ArrayBuffer::MAX_SIZE).
   it("Bun.gunzipSync throws ERR_BUFFER_TOO_LARGE instead of panicking", async () => {
     const script = `
       import * as zlib from "node:zlib";

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -10,6 +10,7 @@ import {
 } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import os from "os";
 import path from "path";
 
 describe("Zstandard compression", async () => {
@@ -364,6 +365,104 @@ describe("sync compression argument handling", () => {
     });
     expect(exitCode).toBe(0);
   }, 60_000);
+});
+
+// When the decompressed output exceeds the ArrayBuffer max, the Bun-native
+// decompress APIs must throw ERR_BUFFER_TOO_LARGE (a RangeError) instead of
+// aborting the process. Spawned so the multi-GB allocation is released with
+// the child and so a regression (process abort) fails the test instead of
+// killing the runner.
+describe.skipIf(os.totalmem() < 16 * 1024 ** 3)("decompressed output > ArrayBuffer max", () => {
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  // Bun.gunzipSync stops at the first gzip member, so the bomb has to be a
+  // single stream: compress (4 GiB + 1 KiB) of zeros and decompress that.
+  it("Bun.gunzipSync throws ERR_BUFFER_TOO_LARGE instead of panicking", async () => {
+    const script = `
+      import * as zlib from "node:zlib";
+      const chunks = [];
+      const gz = zlib.createGzip({ level: 1 });
+      gz.on("data", c => chunks.push(c));
+      const done = new Promise(r => gz.on("end", r));
+      const zero = Buffer.alloc(64 << 20);
+      let left = 4 * 1024 ** 3;
+      const feed = () => {
+        while (left > 0) {
+          const n = Math.min(zero.length, left);
+          left -= n;
+          if (!gz.write(zero.subarray(0, n))) return gz.once("drain", feed);
+        }
+        gz.end();
+      };
+      feed();
+      await done;
+      const bomb = Buffer.concat(chunks);
+      try {
+        Bun.gunzipSync(bomb);
+        console.log(JSON.stringify({ threw: false }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, isRangeError: e instanceof RangeError }));
+      }
+    `;
+    const { stdout, stderr, exitCode } = await run(script);
+    expect({ stdout, stderr }).toEqual({
+      stdout: JSON.stringify({ threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true }),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  }, 120_000);
+
+  // zstd decoders accept concatenated frames, so a single 64 MiB frame
+  // repeated 65x yields 4160 MiB of output from a ~130 KB bomb.
+  const zstdBomb = `
+    const frame = Bun.zstdCompressSync(Buffer.alloc(64 << 20));
+    const bomb = Buffer.concat(Array(65).fill(frame));
+  `;
+
+  it("Bun.zstdDecompressSync throws ERR_BUFFER_TOO_LARGE instead of aborting", async () => {
+    const script = `
+      ${zstdBomb}
+      try {
+        Bun.zstdDecompressSync(bomb);
+        console.log(JSON.stringify({ threw: false }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, isRangeError: e instanceof RangeError }));
+      }
+    `;
+    const { stdout, stderr, exitCode } = await run(script);
+    expect({ stdout, stderr }).toEqual({
+      stdout: JSON.stringify({ threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true }),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  }, 120_000);
+
+  it("Bun.zstdDecompress rejects with ERR_BUFFER_TOO_LARGE instead of aborting", async () => {
+    const script = `
+      ${zstdBomb}
+      try {
+        await Bun.zstdDecompress(bomb);
+        console.log(JSON.stringify({ threw: false }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, isRangeError: e instanceof RangeError }));
+      }
+    `;
+    const { stdout, stderr, exitCode } = await run(script);
+    expect({ stdout, stderr }).toEqual({
+      stdout: JSON.stringify({ threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true }),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  }, 120_000);
 });
 
 describe.concurrent("Zstandard HTTP compression", () => {

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -393,7 +393,10 @@ describe.skipIf(os.totalmem() < 16 * 1024 ** 3)("decompressed output > ArrayBuff
       const chunks = [];
       const gz = zlib.createGzip({ level: 1 });
       gz.on("data", c => chunks.push(c));
-      const done = new Promise(r => gz.on("end", r));
+      const done = new Promise((resolve, reject) => {
+        gz.on("end", resolve);
+        gz.on("error", reject);
+      });
       const zero = Buffer.alloc(64 << 20);
       let left = 4 * 1024 ** 3;
       const feed = () => {

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -389,8 +389,10 @@ describe.skipIf(os.totalmem() < 16 * 1024 ** 3)("decompressed output > ArrayBuff
   // ArrayBuffer::MAX_SIZE). Skipped on Windows: zlib's total_out is a 32-bit
   // c_ulong there and wraps to 0 at 2^32, so the zlib reader's epilogue
   // truncates the output list before the ArrayBuffer guard ever sees it.
-  it.skipIf(isWindows)("Bun.gunzipSync throws ERR_BUFFER_TOO_LARGE instead of panicking", async () => {
-    const script = `
+  it.skipIf(isWindows)(
+    "Bun.gunzipSync throws ERR_BUFFER_TOO_LARGE instead of panicking",
+    async () => {
+      const script = `
       import * as zlib from "node:zlib";
       const chunks = [];
       const gz = zlib.createGzip({ level: 1 });
@@ -419,13 +421,15 @@ describe.skipIf(os.totalmem() < 16 * 1024 ** 3)("decompressed output > ArrayBuff
         console.log(JSON.stringify({ threw: true, code: e.code, isRangeError: e instanceof RangeError }));
       }
     `;
-    const { stdout, stderr, exitCode } = await run(script);
-    expect({ stdout, stderr }).toEqual({
-      stdout: JSON.stringify({ threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true }),
-      stderr: "",
-    });
-    expect(exitCode).toBe(0);
-  }, 120_000);
+      const { stdout, stderr, exitCode } = await run(script);
+      expect({ stdout, stderr }).toEqual({
+        stdout: JSON.stringify({ threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true }),
+        stderr: "",
+      });
+      expect(exitCode).toBe(0);
+    },
+    120_000,
+  );
 
   // zstd decoders accept concatenated frames, so a single 64 MiB frame
   // repeated 65x yields 4160 MiB of output from a ~130 KB bomb.


### PR DESCRIPTION
A small hostile compressed payload can abort the whole process through the Bun-native decompress APIs when the decompressed output reaches the ArrayBuffer limit. The sibling `node:zlib` and `{library: "libdeflate"}` paths already guard this and throw a catchable `ERR_BUFFER_TOO_LARGE`; the Bun-native zlib and zstd paths do not.

## Repro

```js
// ~165 KB of attacker input kills the process
const frame = Bun.zstdCompressSync(Buffer.alloc(64 << 20));
const bomb = Buffer.concat(Array(65).fill(frame)); // 65 * 64 MiB = 4160 MiB out
Bun.zstdDecompressSync(bomb); // SIGABRT, uncatchable
```

```
panic: int cast: TryFromIntError(PosOverflow)   // Bun.gunzipSync / Bun.inflateSync, output == 2^32
// or silent SIGABRT (JSC RELEASE_ASSERT m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE) for Bun.zstdDecompressSync / Bun.zstdDecompress, output > 2^32
```

## Cause

The Bun-native decompress paths hand the output buffer straight to the JS wrapper without a length check:

- `JSZlib::leak_list_into_uint8array` calls `ArrayBuffer::from_bytes`, which does `u32::try_from(len).expect("int cast")` and panics at `len == 2^32`.
- `JSZstd::decompress_sync` / `ZstdCtx::then` call `JSValue::create_buffer`, which forwards to `JSC::ArrayBufferContents` and trips `RELEASE_ASSERT(m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE)` for `len > 2^32`.

The `{library: "libdeflate"}` branch in the same function already caps at `ArrayBuffer::MAX_SIZE` and throws `ERR_BUFFER_TOO_LARGE`; the default zlib branch and the zstd paths were missing the equivalent.

## Fix

Check the output length against `ArrayBuffer::MAX_SIZE` before wrapping it in a JS buffer, and throw/reject `RangeError [ERR_BUFFER_TOO_LARGE]` when it exceeds the cap. Applied at the four wrap sites in `src/runtime/api/BunObject.rs`:

- `JSZlib::leak_list_into_uint8array` (covers `Bun.gunzipSync` / `Bun.inflateSync` / `Bun.gzipSync` / `Bun.deflateSync`)
- `JSZstd::compress_sync`
- `JSZstd::decompress_sync`
- `JSZstd::ZstdCtx::then` (async `Bun.zstdCompress` / `Bun.zstdDecompress`)

The oversized `Vec` drops on the early return, so the allocation is released before control returns to JS.

## Verification

Added three spawned-subprocess tests to `test/js/bun/util/zstd.test.ts` (gated on `os.totalmem() >= 16 GiB`). Each generates a bomb that decompresses past 4 GiB and asserts the subprocess prints `{"threw":true,"code":"ERR_BUFFER_TOO_LARGE","isRangeError":true}` and exits 0.

<details>
<summary>Fail-before on stock bun</summary>

```
(fail) Bun.gunzipSync ...   stderr: "panic: int cast: TryFromIntError(PosOverflow)"
(fail) Bun.zstdDecompressSync ...   stdout: "" (silent abort, exit 134)
(fail) Bun.zstdDecompress ...       stdout: "" (silent abort, exit 134)
```

</details>

All 86 tests in `test/js/bun/util/zstd.test.ts` and the `test/regression/issue/23314/` suite pass on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/zstd.test.ts

<!-- robobun:evidence:end -->