### PR TITLE
resolver: bound load_as_file path before writing into its PathBuffer

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5777,10 +5777,8 @@ impl<'a> Resolver<'a> {
         path: &[u8],
         extension_order: options::ExtOrder,
     ) -> Option<LoadResult> {
-        // A path this long cannot name a real file, and the extension probing
-        // below writes `path` into a fixed `PathBuffer`. Absolute import
-        // specifiers reach here with a short (existing) dirname and an
-        // arbitrarily long basename; bail before that write can overflow.
+        // Extension probing below writes `path` into a fixed `PathBuffer`; an
+        // absolute specifier can carry an arbitrarily long basename here.
         if path.len() >= MAX_PATH_BYTES {
             return None;
         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5443,6 +5443,9 @@ impl<'a> Resolver<'a> {
         // this fn (only `remap_path` is, via a separate `bufs!` raw-ptr projection).
         let path_buf = bufs!(remap_path_trailing_slash);
         if !strings::ends_with_char(path_, SEP) {
+            if path.len() + 2 > MAX_PATH_BYTES {
+                return MatchStatus::NotFound;
+            }
             path_buf[..path.len()].copy_from_slice(path);
             path_buf[path.len()] = SEP;
             path_buf[path.len() + 1] = 0;
@@ -5455,13 +5458,15 @@ impl<'a> Resolver<'a> {
 
                 if let Some(browser_json) = browser_scope.package_json() {
                     let index_paths = [path, FIELD_REL_PATH];
-                    let index_abs_path = self.fs_ref().abs_buf(&index_paths, bufs!(remap_path));
-                    if let Some(remap) = self
-                        .check_browser_map::<{ BrowserMapPathKind::AbsolutePath }>(
+                    let index_abs_path = self
+                        .fs_ref()
+                        .abs_buf_checked(&index_paths, bufs!(remap_path));
+                    if let Some(remap) = index_abs_path.and_then(|index_abs_path| {
+                        self.check_browser_map::<{ BrowserMapPathKind::AbsolutePath }>(
                             &browser_scope,
                             index_abs_path,
                         )
-                    {
+                    }) {
                         // Is the path disabled?
                         if remap.is_empty() {
                             let new_path =

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5777,6 +5777,14 @@ impl<'a> Resolver<'a> {
         path: &[u8],
         extension_order: options::ExtOrder,
     ) -> Option<LoadResult> {
+        // A path this long cannot name a real file, and the extension probing
+        // below writes `path` into a fixed `PathBuffer`. Absolute import
+        // specifiers reach here with a short (existing) dirname and an
+        // arbitrarily long basename; bail before that write can overflow.
+        if path.len() >= MAX_PATH_BYTES {
+            return None;
+        }
+
         // SAFETY: RealFS is the global singleton. Derive provenance from the raw
         // `*mut FileSystem` field so intervening `unsafe { &mut *self.fs() }` calls in
         // `load_extension` / `dirname_store.append_slice` don't invalidate `rfs`
@@ -6044,6 +6052,9 @@ impl<'a> Resolver<'a> {
         // field so `unsafe { &mut *self.fs() }` calls below (`filename_store.append_parts`) don't pop
         // its provenance under Stacked Borrows.
         let rfs: *mut Fs::file_system::RealFS = self.rfs_ptr();
+        if path.len() + ext.len() > MAX_PATH_BYTES {
+            return None;
+        }
         let buffer = &mut bufs!(load_as_file)[0..path.len() + ext.len()];
         buffer[path.len()..].copy_from_slice(ext);
         let file_name = &buffer[path.len() - base.len()..buffer.len()];

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -295,10 +295,9 @@ describe.concurrent("absolute specifier with long basename (load_as_file buffer)
     );
   });
 
-  // Exactly MAX_PATH_BYTES: load_as_file returns not-found, then the
-  // fall-through directory probe in dir_info_cached_miss slices
-  // `[..len + 1]` for its NUL-splice.
-  it("require.resolve: path == MAX_PATH_BYTES (dir_info_cached_miss +1 slice)", async () => {
+  // Exactly MAX_PATH_BYTES: the bare copy fits, so only the `>=` in
+  // load_as_file keeps the extension probe from overflowing.
+  it("require.resolve: path == MAX_PATH_BYTES", async () => {
     await expectNotFound(
       `${JSON.stringify(root)} + Buffer.alloc(${max - root.length - 3}, "a").toString() + ".ts"`,
       "require.resolve",

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -242,6 +242,75 @@ describe.concurrent("long import path overflow", () => {
   });
 });
 
+// load_as_file copies the full path into a fixed PathBuffer and then probes
+// extensions by appending to that buffer. When the specifier's dirname names
+// a real directory (so read_directory succeeds), a basename long enough to
+// push the total path to MAX_PATH_BYTES used to abort the process instead of
+// returning MODULE_NOT_FOUND.
+describe.concurrent("absolute specifier with long basename (load_as_file buffer)", () => {
+  // MAX_PATH_BYTES: 1024 darwin, 4096 linux, 32767*3+1 windows.
+  const max = process.platform === "darwin" ? 1024 : process.platform === "win32" ? 32767 * 3 + 1 : 4096;
+  const root = process.platform === "win32" ? "C:/" : "/";
+
+  async function expectNotFound(specExpr: string, how: "require.resolve" | "import" | "Bun.resolveSync") {
+    const body =
+      how === "require.resolve"
+        ? `require.resolve(p)`
+        : how === "import"
+          ? `await import(p)`
+          : `Bun.resolveSync(p, process.cwd())`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const p = ${specExpr}; try { ${body} } catch (e) { console.log("ERR", e.code ?? e.name) }`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: expect.stringMatching(/^ERR (MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND|ResolveMessage)$/),
+      stderr: "",
+      exitCode: 0,
+    });
+  }
+
+  // Well past MAX_PATH_BYTES: the raw copy into bufs!(load_as_file) panicked.
+  for (const how of ["require.resolve", "import", "Bun.resolveSync"] as const) {
+    it(`${how}: path > MAX_PATH_BYTES`, async () => {
+      await expectNotFound(`${JSON.stringify(root)} + Buffer.alloc(${max + 1000}, "a").toString() + ".ts"`, how);
+    });
+  }
+
+  // Just under MAX_PATH_BYTES so the copy fits, but appending the longest
+  // probed extension (".json", 5 bytes) pushes past it: load_extension
+  // panicked slicing `[0..path.len() + ext.len()]`.
+  it("require.resolve: path + probed extension > MAX_PATH_BYTES", async () => {
+    const pathLen = max - 4;
+    await expectNotFound(
+      `${JSON.stringify(root)} + Buffer.alloc(${pathLen - root.length - 3}, "a").toString() + ".ts"`,
+      "require.resolve",
+    );
+  });
+
+  // Exactly MAX_PATH_BYTES: load_as_file returns not-found, then the
+  // fall-through directory probe in dir_info_cached_miss slices
+  // `[..len + 1]` for its NUL-splice.
+  it("require.resolve: path == MAX_PATH_BYTES (dir_info_cached_miss +1 slice)", async () => {
+    await expectNotFound(
+      `${JSON.stringify(root)} + Buffer.alloc(${max - root.length - 3}, "a").toString() + ".ts"`,
+      "require.resolve",
+    );
+  });
+
+  // Byte length governs, not char length.
+  it("require.resolve: multibyte basename past MAX_PATH_BYTES", async () => {
+    const chars = Math.ceil((max + 100) / 3);
+    await expectNotFound(
+      `${JSON.stringify(root)} + Buffer.alloc(${chars * 3}, "\\u20ac", "utf8").toString() + ".ts"`,
+      "require.resolve",
+    );
+  });
+});
+
 // matchTSConfigPaths sliced `path[prefix.len()..path.len() - suffix.len()]`
 // after only checking starts_with/ends_with. When the prefix and suffix bytes
 // overlap inside the import path (e.g. key "ab*ba" vs import "aba"), the slice

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { mkdirSync } from "node:fs";
 import path from "node:path";
 
 describe("ResolveMessage", () => {
@@ -246,10 +247,17 @@ describe.concurrent("long import path overflow", () => {
 // extensions by appending to that buffer. When the specifier's dirname names
 // a real directory (so read_directory succeeds), a basename long enough to
 // push the total path to MAX_PATH_BYTES used to abort the process instead of
-// returning MODULE_NOT_FOUND.
-describe.concurrent("absolute specifier with long basename (load_as_file buffer)", () => {
-  // MAX_PATH_BYTES: 1024 darwin, 4096 linux, 32767*3+1 windows.
-  const max = process.platform === "darwin" ? 1024 : process.platform === "win32" ? 32767 * 3 + 1 : 4096;
+// returning MODULE_NOT_FOUND. The directory cases at the end cover the index
+// probe that runs after load_as_file gives up.
+describe.concurrent("absolute specifier at the PathBuffer boundary", () => {
+  // Mirrors MAX_PATH_BYTES in src/bun_core/util.rs: 4096 on linux/android,
+  // PATH_MAX_WIDE * 3 + 1 on windows, 1024 everywhere else (darwin, the BSDs).
+  const max =
+    process.platform === "linux" || process.platform === "android"
+      ? 4096
+      : process.platform === "win32"
+        ? 32767 * 3 + 1
+        : 1024;
   const root = process.platform === "win32" ? "C:/" : "/";
 
   async function expectNotFound(specExpr: string, how: "require.resolve" | "import" | "Bun.resolveSync") {
@@ -295,11 +303,12 @@ describe.concurrent("absolute specifier with long basename (load_as_file buffer)
     );
   });
 
-  // Exactly MAX_PATH_BYTES: the bare copy fits, so only the `>=` in
-  // load_as_file keeps the extension probe from overflowing.
-  it("require.resolve: path == MAX_PATH_BYTES", async () => {
+  // Exactly MAX_PATH_BYTES with a .js specifier: the bare copy fits and every
+  // load_extension probe is rejected, but the .js -> .tsx rewrite grows the
+  // path by one byte. Only the `>=` (not `>`) in load_as_file stops it.
+  it("require.resolve: .js path == MAX_PATH_BYTES", async () => {
     await expectNotFound(
-      `${JSON.stringify(root)} + Buffer.alloc(${max - root.length - 3}, "a").toString() + ".ts"`,
+      `${JSON.stringify(root)} + Buffer.alloc(${max - root.length - 3}, "a").toString() + ".js"`,
       "require.resolve",
     );
   });
@@ -311,6 +320,69 @@ describe.concurrent("absolute specifier with long basename (load_as_file buffer)
       `${JSON.stringify(root)} + Buffer.alloc(${chars * 3}, "\\u20ac", "utf8").toString() + ".ts"`,
       "require.resolve",
     );
+  });
+
+  // Creates a real directory under `root` whose absolute path is exactly
+  // `byteLength` bytes and returns its path.
+  function mkLongDir(root: string, byteLength: number): string {
+    let p = root;
+    for (;;) {
+      const remaining = byteLength - Buffer.byteLength(p);
+      if (remaining === 0) break;
+      // Each step appends "/" + segment. NAME_MAX is 255 on linux and darwin.
+      // Never leave exactly one byte, which would force an empty final
+      // segment and a trailing slash.
+      let segLen = Math.min(200, remaining - 1);
+      if (remaining - 1 - segLen === 1) segLen -= 1;
+      p += "/" + Buffer.alloc(segLen, "x").toString();
+    }
+    expect(Buffer.byteLength(p)).toBe(byteLength);
+    expect(p.endsWith("/")).toBe(false);
+    mkdirSync(p, { recursive: true });
+    return p;
+  }
+
+  // The directory cases below need a directory that really exists at the
+  // boundary. On Windows MAX_PATH_BYTES is far past what the filesystem
+  // allows, so such a directory cannot be created there.
+
+  // A directory at MAX_PATH_BYTES - 1 (the longest path the OS allows) gets
+  // past load_as_file and dir_info_cached, then
+  // load_as_index_with_browser_remapping appended SEP and a NUL to it in a
+  // PathBuffer, writing one byte past the end.
+  it.skipIf(isWindows)("import: real directory at MAX_PATH_BYTES - 1", async () => {
+    using dir = tempDir("resolve-long-dir", {});
+    const p = mkLongDir(String(dir), max - 1);
+    await expectNotFound(JSON.stringify(p), "import");
+  });
+
+  // With target browser and an enclosing package.json "browser" map, the same
+  // function joins the directory with "index" into another PathBuffer. A
+  // directory a few bytes under MAX_PATH_BYTES overflowed that join.
+  it.skipIf(isWindows)("Bun.build target browser: real directory at MAX_PATH_BYTES - 2", async () => {
+    using dir = tempDir("resolve-long-dir-browser", {
+      "package.json": JSON.stringify({ name: "p", browser: { "./unrelated.js": "./other.js" } }),
+    });
+    const p = mkLongDir(String(dir), max - 2);
+    await Bun.write(path.join(String(dir), "entry.js"), `import ${JSON.stringify(p)};`);
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const r = await Bun.build({ entrypoints: ["./entry.js"], target: "browser", throw: false });
+         console.log(r.success, r.logs.map(l => l.name).join(","));`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "false ResolveMessage",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });
 

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -260,7 +260,11 @@ describe.concurrent("absolute specifier with long basename (load_as_file buffer)
           ? `await import(p)`
           : `Bun.resolveSync(p, process.cwd())`;
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", `const p = ${specExpr}; try { ${body} } catch (e) { console.log("ERR", e.code ?? e.name) }`],
+      cmd: [
+        bunExe(),
+        "-e",
+        `const p = ${specExpr}; try { ${body} } catch (e) { console.log("ERR", e.code ?? e.name) }`,
+      ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
### Problem

Any absolute import specifier at or past ~4092 bytes aborts the process instead of throwing `MODULE_NOT_FOUND`.

```js
const p = "/" + "a".repeat(5000) + ".ts";
try { require.resolve(p) } catch (e) { console.log("ERR", e.code) }
console.log("SURVIVED");
```

```
panic: range end index 5004 out of range for slice of length 4096
```

Every public entry that reaches the module resolver hits it: `require(p)`, `require.resolve(p)`, `await import(p)`, `Bun.resolveSync(p, cwd)`, `new Worker(p)`, `Bun.build({entrypoints:[p]})`, and `bun /aaa...ts` on the CLI. A 4091-byte path throws cleanly; 4092 aborts. Byte length governs (a 1404-char / 4204-byte `€`-filled path also aborts).

### Cause

`load_as_file` copies the incoming path into a fixed `MAX_PATH_BYTES` `PathBuffer` before probing extensions:

```rust
bufs!(load_as_file)[..path.len()].copy_from_slice(path);
```

When the specifier's dirname names a real directory (e.g. `/`), `read_directory` succeeds and the copy runs with an arbitrarily long `path`. `load_extension` then slices `[0..path.len() + ext.len()]` from the same buffer, so a path that fits on its own still overflows once an extension is appended.

The directory probe that runs after `load_as_file` gives up has the same shape. `load_as_index_with_browser_remapping` appends `SEP` and a NUL to the directory path in a `PathBuffer`, which writes one byte past the end for a directory at `MAX_PATH_BYTES - 1` (the longest path the OS allows). Under `target: "browser"` it also joins the directory with `"index"` through the unchecked `abs_buf`, which panics for directories at `MAX_PATH_BYTES - 2` through `- 5`.

### Fix

`src/resolver/resolver.rs`:
- `load_as_file`: return `None` when `path.len() >= MAX_PATH_BYTES`. `>=` rather than `>` because the `.js` to `.tsx` rewrite grows the path by one byte.
- `load_extension`: return `None` when `path.len() + ext.len() > MAX_PATH_BYTES`.
- `load_as_index_with_browser_remapping`: return `NotFound` when the path plus `SEP` plus NUL does not fit, and use the existing `abs_buf_checked` for the `"index"` join.

### Tests

`test/js/bun/resolve/resolve-error.test.ts` gains a `describe` with eight cases:
- a path well past `MAX_PATH_BYTES` through `require.resolve`, `import()`, and `Bun.resolveSync` (the `load_as_file` copy),
- a path at `MAX_PATH_BYTES - 4` so only the appended extension overflows (the `load_extension` slice),
- a `.js` path at exactly `MAX_PATH_BYTES` (pins the `>=`: weakening it to `>` fails this test and nothing else),
- a multibyte basename past `MAX_PATH_BYTES`,
- a real directory created at `MAX_PATH_BYTES - 1` (the `SEP` + NUL append),
- a real directory at `MAX_PATH_BYTES - 2` under `Bun.build({ target: "browser" })` with a `browser` map (the `"index"` join).

Each spawned child aborts with a `range end index` or `index out of bounds` panic on current main and exits 0 with `MODULE_NOT_FOUND` / a `ResolveMessage` with the fix. The two directory cases skip on Windows, where `MAX_PATH_BYTES` is far past what the filesystem allows.

<details><summary>Notes</summary>

The first revision also tightened an off-by-one in `dir_info_cached_maybe_log` (`>` guarding a `[..len + 1]` slice). #36165 landed the same change on main independently, so that hunk dropped out in the rebase.

The two index-probe sites were found in review after the rebase. The `SEP` + NUL one needs a directory whose absolute path is exactly one byte under the OS limit, so it is much harder to reach than the `load_as_file` copy, but it goes through the same public entry points. Boundary sweep on linux after the fix: every length from 4076 to 6145 through `require.resolve`, and directories at `MAX - 1` through `MAX - 20` through both `import()` and browser-target `Bun.build`, return a normal error.

Also ran `test/js/bun/resolve/resolve.test.ts` and `test/bundler/bundler_browser.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve-error.test.ts

<!-- robobun:evidence:end -->