### PR TITLE
Bun.gzipSync/deflateSync: feed >=4 GiB inputs to zlib in u32 windows instead of wrapping to 0

### DIFF
--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -144,6 +144,24 @@ unsafe extern "C" {
     pub fn crc32(crc: uLong, buf: *const Bytef, len: uInt) -> uLong;
 }
 
+/// zlib's `avail_in` / `avail_out` are `uInt` (u32), so a `usize` length
+/// >= 4 GiB must be clamped and the remainder presented on a later call;
+/// a bare `as uInt` would wrap 2^32 to 0.
+#[inline]
+fn clamp_to_uint(n: usize) -> uInt {
+    n.min(uInt::MAX as usize) as uInt
+}
+
+/// Bytes of `input` that zlib has not yet consumed, derived from how far
+/// `strm.next_in` has advanced from `input.as_ptr()`.
+#[inline]
+fn remaining_input(strm: &zStream_struct, input: &[u8]) -> usize {
+    // SAFETY: init sets next_in = input.as_ptr(); zlib only advances it
+    // within the window it was given.
+    let consumed = unsafe { strm.next_in.offset_from(input.as_ptr()) } as usize;
+    input.len() - consumed
+}
+
 /// Safe CRC-32 over an arbitrary-length slice. zlib's `crc32` takes a 32-bit
 /// length, so inputs larger than `u32::MAX` are fed in chunks.
 pub fn crc32_bytes(crc: u32, data: &[u8]) -> u32 {
@@ -328,9 +346,7 @@ impl<'a> ZlibReaderArrayList<'a> {
         let list_len = zlib_reader.list_ptr.len();
         zlib_reader.zlib = zStream_struct {
             next_in: input.as_ptr(),
-            // avail_in is a u32; inputs >= 4 GiB are fed in u32::MAX windows by
-            // read_all().
-            avail_in: input.len().min(uInt::MAX as usize) as uInt,
+            avail_in: clamp_to_uint(input.len()),
             total_in: input.len() as _,
 
             next_out: zlib_reader.list_ptr.as_mut_ptr(),
@@ -419,17 +435,8 @@ impl<'a> ZlibReaderArrayList<'a> {
                 //   or no more space in the output buffer (see below about the
                 //   flush parameter).
 
-                // Refill the input window when zlib has drained it: avail_in
-                // is a u32, so inputs >= 4 GiB must be presented in slices.
                 if self.zlib.avail_in == 0 {
-                    // SAFETY: next_in is initialized to input.as_ptr() and zlib
-                    // only advances it within the provided window.
-                    let consumed =
-                        unsafe { self.zlib.next_in.offset_from(self.input.as_ptr()) } as usize;
-                    let remaining = self.input.len() - consumed;
-                    if remaining > 0 {
-                        self.zlib.avail_in = remaining.min(uInt::MAX as usize) as uInt;
-                    }
+                    self.zlib.avail_in = clamp_to_uint(remaining_input(&self.zlib, self.input));
                 }
 
                 if self.zlib.avail_out == 0 {
@@ -446,8 +453,7 @@ impl<'a> ZlibReaderArrayList<'a> {
                     };
                     self.zlib.next_out = next_out;
                     // Clamp so a single inflate call cannot write past `max_output_size`.
-                    self.zlib.avail_out =
-                        avail_out.min(remaining_budget).min(uInt::MAX as usize) as uInt;
+                    self.zlib.avail_out = clamp_to_uint(avail_out.min(remaining_budget));
                 }
 
                 // Try to inflate even if avail_in is 0, as this could be a valid empty gzip stream
@@ -843,10 +849,7 @@ impl<'a> ZlibCompressorArrayList<'a> {
         let list_len = zlib_reader.list_ptr.len();
         zlib_reader.zlib = zStream_struct {
             next_in: input.as_ptr(),
-            // avail_in is a u32; inputs >= 4 GiB are fed in u32::MAX windows by
-            // read_all(). A bare `as uInt` here wraps 2^32 to 0 and compresses
-            // an empty stream.
-            avail_in: input.len().min(uInt::MAX as usize) as uInt,
+            avail_in: clamp_to_uint(input.len()),
             total_in: input.len() as _,
 
             next_out: zlib_reader.list_ptr.as_mut_ptr(),
@@ -893,8 +896,7 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 // ensureTotalCapacityPrecise → reserve_exact
                 let need = (bound as usize).saturating_sub(zlib_reader.list_ptr.len());
                 zlib_reader.list_ptr.reserve_exact(need);
-                zlib_reader.zlib.avail_out =
-                    zlib_reader.list_ptr.capacity().min(uInt::MAX as usize) as uInt;
+                zlib_reader.zlib.avail_out = clamp_to_uint(zlib_reader.list_ptr.capacity());
                 zlib_reader.zlib.next_out = zlib_reader.list_ptr.as_mut_ptr();
 
                 Ok(zlib_reader)
@@ -956,18 +958,11 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 //   or no more space in the output buffer (see below about the
                 //   flush parameter).
 
-                // Refill the input window when zlib has drained it: avail_in
-                // is a u32, so inputs >= 4 GiB must be presented in slices.
-                // SAFETY: next_in is initialized to input.as_ptr() and zlib
-                // only advances it within the provided window.
-                let consumed =
-                    unsafe { self.zlib.next_in.offset_from(self.input.as_ptr()) } as usize;
                 if self.zlib.avail_in == 0 {
-                    let remaining = self.input.len() - consumed;
-                    if remaining > 0 {
-                        self.zlib.avail_in = remaining.min(uInt::MAX as usize) as uInt;
-                    }
+                    self.zlib.avail_in = clamp_to_uint(remaining_input(&self.zlib, self.input));
                 }
+                let last_window =
+                    remaining_input(&self.zlib, self.input) == self.zlib.avail_in as usize;
 
                 if self.zlib.avail_out == 0 {
                     // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
@@ -975,17 +970,14 @@ impl<'a> ZlibCompressorArrayList<'a> {
                     // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
                     let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(4096) };
                     self.zlib.next_out = next_out;
-                    self.zlib.avail_out = avail_out.min(uInt::MAX as usize) as uInt;
+                    self.zlib.avail_out = clamp_to_uint(avail_out);
                 }
 
                 if self.zlib.avail_out == 0 {
                     return Err(ZlibError::ShortRead);
                 }
 
-                // Finish only once the final input window is loaded; otherwise
-                // zlib would emit the trailer before the tail of the input is
-                // presented.
-                let flush = if consumed + self.zlib.avail_in as usize >= self.input.len() {
+                let flush = if last_window {
                     FlushValue::Finish
                 } else {
                     FlushValue::NoFlush

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -144,16 +144,12 @@ unsafe extern "C" {
     pub fn crc32(crc: uLong, buf: *const Bytef, len: uInt) -> uLong;
 }
 
-/// zlib's `avail_in` / `avail_out` are `uInt` (u32), so a `usize` length
-/// >= 4 GiB must be clamped and the remainder presented on a later call;
-/// a bare `as uInt` would wrap 2^32 to 0.
+/// `avail_in`/`avail_out` are u32; clamp so a >= 4 GiB length doesn't wrap to 0 via `as uInt`.
 #[inline]
 fn clamp_to_uint(n: usize) -> uInt {
     n.min(uInt::MAX as usize) as uInt
 }
 
-/// Bytes of `input` that zlib has not yet consumed, derived from how far
-/// `strm.next_in` has advanced from `input.as_ptr()`.
 #[inline]
 fn remaining_input(strm: &zStream_struct, input: &[u8]) -> usize {
     // SAFETY: init sets next_in = input.as_ptr(); zlib only advances it

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -158,6 +158,14 @@ fn remaining_input(strm: &zStream_struct, input: &[u8]) -> usize {
     input.len() - consumed
 }
 
+#[inline]
+fn produced_output(strm: &zStream_struct, out_base: *const u8) -> usize {
+    // SAFETY: next_out was set into `out_base`'s allocation and zlib only
+    // advances it within the window it was given. Preferred over
+    // `strm.total_out`, which is a 32-bit `c_ulong` on Windows.
+    unsafe { strm.next_out.offset_from(out_base) as usize }
+}
+
 /// Safe CRC-32 over an arbitrary-length slice. zlib's `crc32` takes a 32-bit
 /// length, so inputs larger than `u32::MAX` are fed in chunks.
 pub fn crc32_bytes(crc: u32, data: &[u8]) -> u32 {
@@ -436,13 +444,15 @@ impl<'a> ZlibReaderArrayList<'a> {
                 }
 
                 if self.zlib.avail_out == 0 {
-                    let produced = self.zlib.total_out as usize;
+                    let produced = produced_output(&self.zlib, self.list_ptr.as_ptr());
                     let remaining_budget = self.max_output_size.saturating_sub(produced);
                     if remaining_budget == 0 {
                         self.state = ZlibReaderArrayListState::Error;
                         return Err(ZlibError::ZlibError);
                     }
-                    // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
+                    // SAFETY: zlib has written `produced` bytes into list_ptr's buffer.
+                    unsafe { self.list_ptr.set_len(produced) };
+                    // SAFETY: zlib writes the tail; len is synced to `produced` before any read.
                     let (next_out, avail_out) = unsafe {
                         self.list_ptr
                             .reserve_expand_tail(remaining_budget.min(4096))
@@ -495,12 +505,12 @@ impl<'a> ZlibReaderArrayList<'a> {
         })();
 
         // defer epilogue (runs unconditionally):
-        let total_out = self.zlib.total_out as usize;
-        if self.list_ptr.len() > total_out {
-            self.list_ptr.truncate(total_out);
-        } else if total_out < self.list_ptr.capacity() {
-            // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
-            unsafe { self.list_ptr.set_len(total_out) };
+        let produced = produced_output(&self.zlib, self.list_ptr.as_ptr());
+        if self.list_ptr.len() > produced {
+            self.list_ptr.truncate(produced);
+        } else if produced < self.list_ptr.capacity() {
+            // SAFETY: zlib has written `produced` bytes into list_ptr's buffer.
+            unsafe { self.list_ptr.set_len(produced) };
         }
 
         result
@@ -886,7 +896,7 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 let bound = unsafe {
                     deflateBound(
                         &raw mut zlib_reader.zlib,
-                        uLong::try_from(input.len()).expect("int cast"),
+                        input.len().min(uLong::MAX as usize) as uLong,
                     )
                 };
                 // ensureTotalCapacityPrecise → reserve_exact
@@ -961,9 +971,10 @@ impl<'a> ZlibCompressorArrayList<'a> {
                     remaining_input(&self.zlib, self.input) == self.zlib.avail_in as usize;
 
                 if self.zlib.avail_out == 0 {
-                    // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
-                    unsafe { self.list_ptr.set_len(self.zlib.total_out as usize) };
-                    // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
+                    let produced = produced_output(&self.zlib, self.list_ptr.as_ptr());
+                    // SAFETY: zlib has written `produced` bytes into list_ptr's buffer.
+                    unsafe { self.list_ptr.set_len(produced) };
+                    // SAFETY: zlib writes the tail; len is synced to `produced` before any read.
                     let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(4096) };
                     self.zlib.next_out = next_out;
                     self.zlib.avail_out = clamp_to_uint(avail_out);
@@ -985,8 +996,9 @@ impl<'a> ZlibCompressorArrayList<'a> {
 
                 match rc {
                     ReturnCode::StreamEnd => {
-                        // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
-                        unsafe { self.list_ptr.set_len(self.zlib.total_out as usize) };
+                        let produced = produced_output(&self.zlib, self.list_ptr.as_ptr());
+                        // SAFETY: zlib has written `produced` bytes into list_ptr's buffer.
+                        unsafe { self.list_ptr.set_len(produced) };
                         self.end();
 
                         return Ok(());
@@ -1013,7 +1025,8 @@ impl<'a> ZlibCompressorArrayList<'a> {
         })();
 
         // epilogue (runs unconditionally): sync the output length back.
-        self.list_ptr.truncate(self.zlib.total_out as usize);
+        self.list_ptr
+            .truncate(produced_output(&self.zlib, self.list_ptr.as_ptr()));
 
         result
     }

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -328,7 +328,9 @@ impl<'a> ZlibReaderArrayList<'a> {
         let list_len = zlib_reader.list_ptr.len();
         zlib_reader.zlib = zStream_struct {
             next_in: input.as_ptr(),
-            avail_in: input.len() as uInt,
+            // avail_in is a u32; inputs >= 4 GiB are fed in u32::MAX windows by
+            // read_all().
+            avail_in: input.len().min(uInt::MAX as usize) as uInt,
             total_in: input.len() as _,
 
             next_out: zlib_reader.list_ptr.as_mut_ptr(),
@@ -417,6 +419,19 @@ impl<'a> ZlibReaderArrayList<'a> {
                 //   or no more space in the output buffer (see below about the
                 //   flush parameter).
 
+                // Refill the input window when zlib has drained it: avail_in
+                // is a u32, so inputs >= 4 GiB must be presented in slices.
+                if self.zlib.avail_in == 0 {
+                    // SAFETY: next_in is initialized to input.as_ptr() and zlib
+                    // only advances it within the provided window.
+                    let consumed =
+                        unsafe { self.zlib.next_in.offset_from(self.input.as_ptr()) } as usize;
+                    let remaining = self.input.len() - consumed;
+                    if remaining > 0 {
+                        self.zlib.avail_in = remaining.min(uInt::MAX as usize) as uInt;
+                    }
+                }
+
                 if self.zlib.avail_out == 0 {
                     let produced = self.zlib.total_out as usize;
                     let remaining_budget = self.max_output_size.saturating_sub(produced);
@@ -431,7 +446,8 @@ impl<'a> ZlibReaderArrayList<'a> {
                     };
                     self.zlib.next_out = next_out;
                     // Clamp so a single inflate call cannot write past `max_output_size`.
-                    self.zlib.avail_out = avail_out.min(remaining_budget) as uInt;
+                    self.zlib.avail_out =
+                        avail_out.min(remaining_budget).min(uInt::MAX as usize) as uInt;
                 }
 
                 // Try to inflate even if avail_in is 0, as this could be a valid empty gzip stream
@@ -827,7 +843,10 @@ impl<'a> ZlibCompressorArrayList<'a> {
         let list_len = zlib_reader.list_ptr.len();
         zlib_reader.zlib = zStream_struct {
             next_in: input.as_ptr(),
-            avail_in: input.len() as uInt,
+            // avail_in is a u32; inputs >= 4 GiB are fed in u32::MAX windows by
+            // read_all(). A bare `as uInt` here wraps 2^32 to 0 and compresses
+            // an empty stream.
+            avail_in: input.len().min(uInt::MAX as usize) as uInt,
             total_in: input.len() as _,
 
             next_out: zlib_reader.list_ptr.as_mut_ptr(),
@@ -874,7 +893,8 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 // ensureTotalCapacityPrecise → reserve_exact
                 let need = (bound as usize).saturating_sub(zlib_reader.list_ptr.len());
                 zlib_reader.list_ptr.reserve_exact(need);
-                zlib_reader.zlib.avail_out = zlib_reader.list_ptr.capacity() as uInt;
+                zlib_reader.zlib.avail_out =
+                    zlib_reader.list_ptr.capacity().min(uInt::MAX as usize) as uInt;
                 zlib_reader.zlib.next_out = zlib_reader.list_ptr.as_mut_ptr();
 
                 Ok(zlib_reader)
@@ -936,19 +956,43 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 //   or no more space in the output buffer (see below about the
                 //   flush parameter).
 
+                // Refill the input window when zlib has drained it: avail_in
+                // is a u32, so inputs >= 4 GiB must be presented in slices.
+                // SAFETY: next_in is initialized to input.as_ptr() and zlib
+                // only advances it within the provided window.
+                let consumed =
+                    unsafe { self.zlib.next_in.offset_from(self.input.as_ptr()) } as usize;
+                if self.zlib.avail_in == 0 {
+                    let remaining = self.input.len() - consumed;
+                    if remaining > 0 {
+                        self.zlib.avail_in = remaining.min(uInt::MAX as usize) as uInt;
+                    }
+                }
+
                 if self.zlib.avail_out == 0 {
+                    // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
+                    unsafe { self.list_ptr.set_len(self.zlib.total_out as usize) };
                     // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
                     let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(4096) };
                     self.zlib.next_out = next_out;
-                    self.zlib.avail_out = avail_out as uInt;
+                    self.zlib.avail_out = avail_out.min(uInt::MAX as usize) as uInt;
                 }
 
                 if self.zlib.avail_out == 0 {
                     return Err(ZlibError::ShortRead);
                 }
 
+                // Finish only once the final input window is loaded; otherwise
+                // zlib would emit the trailer before the tail of the input is
+                // presented.
+                let flush = if consumed + self.zlib.avail_in as usize >= self.input.len() {
+                    FlushValue::Finish
+                } else {
+                    FlushValue::NoFlush
+                };
+
                 // SAFETY: self.zlib was initialized via deflateInit2_.
-                let rc = unsafe { deflate(&raw mut self.zlib, FlushValue::Finish) };
+                let rc = unsafe { deflate(&raw mut self.zlib, flush) };
                 self.state = ZlibCompressorArrayListState::Inflating;
 
                 match rc {

--- a/test/js/bun/util/gzip-deflate.test.ts
+++ b/test/js/bun/util/gzip-deflate.test.ts
@@ -7,9 +7,10 @@ import { bunEnv, bunExe } from "harness";
 // and returned a 20-byte (gzip) / 2-byte (deflate) output that round-trips to
 // 0 bytes: silent total data loss on a success return.
 //
-// The child needs ~9 GiB resident (the 4 GiB input plus the ~4 GiB
-// deflateBound() scratch Vec); if the allocation fails it prints "SKIP" and
-// the test passes trivially.
+// Peak resident is ~9 GiB (the 4 GiB input plus the ~4 GiB deflateBound()
+// scratch Vec). A runner that cannot satisfy that sees the child OOM-killed
+// (SIGKILL) or abort in the allocator, which the parent treats as a skip so
+// low-memory lanes don't flake; any other non-zero exit is a real failure.
 test("Bun.gzipSync / Bun.deflateSync compress a 4 GiB input instead of wrapping avail_in to 0", async () => {
   const script = `
       const zlib = require("node:zlib");
@@ -51,8 +52,15 @@ test("Bun.gzipSync / Bun.deflateSync compress a 4 GiB input instead of wrapping 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
-  if (out === "SKIP") return;
+  const out = JSON.parse(stdout.trim() || "null");
+  const oom =
+    out === "SKIP" ||
+    proc.signalCode === "SIGKILL" ||
+    (out === null && /memory allocation of \d+ bytes failed|out of memory|OutOfMemory/i.test(stderr));
+  if (oom) {
+    console.log(`skipping: child could not allocate ~9 GiB (signal=${proc.signalCode}, exit=${exitCode})`);
+    return;
+  }
 
   expect(stderr).toBe("");
   // With the bug: gzip = 20, deflate = 2, rgLen = 0.

--- a/test/js/bun/util/gzip-deflate.test.ts
+++ b/test/js/bun/util/gzip-deflate.test.ts
@@ -10,10 +10,8 @@ import { bunEnv, bunExe } from "harness";
 // The child needs ~9 GiB resident (the 4 GiB input plus the ~4 GiB
 // deflateBound() scratch Vec); if the allocation fails it prints "SKIP" and
 // the test passes trivially.
-test(
-  "Bun.gzipSync / Bun.deflateSync compress a 4 GiB input instead of wrapping avail_in to 0",
-  async () => {
-    const script = `
+test("Bun.gzipSync / Bun.deflateSync compress a 4 GiB input instead of wrapping avail_in to 0", async () => {
+  const script = `
       const zlib = require("node:zlib");
       let b;
       try {
@@ -42,32 +40,30 @@ test(
       );
     `;
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: {
-        ...bunEnv,
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
-    if (out === "SKIP") return;
+  const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
+  if (out === "SKIP") return;
 
-    expect(stderr).toBe("");
-    // With the bug: gzip = 20, deflate = 2, rgLen = 0.
-    expect(out).toEqual({
-      gzip: expect.any(Number),
-      deflate: expect.any(Number),
-      rgLen: 2 ** 32,
-      rgFirst: 0x41,
-      rgSentinel: 0x5a,
-    });
-    expect(out.gzip).toBeGreaterThan(1_000_000);
-    expect(out.deflate).toBeGreaterThan(1_000_000);
-    expect(exitCode).toBe(0);
-  },
-  300_000,
-);
+  expect(stderr).toBe("");
+  // With the bug: gzip = 20, deflate = 2, rgLen = 0.
+  expect(out).toEqual({
+    gzip: expect.any(Number),
+    deflate: expect.any(Number),
+    rgLen: 2 ** 32,
+    rgFirst: 0x41,
+    rgSentinel: 0x5a,
+  });
+  expect(out.gzip).toBeGreaterThan(1_000_000);
+  expect(out.deflate).toBeGreaterThan(1_000_000);
+  expect(exitCode).toBe(0);
+}, 300_000);

--- a/test/js/bun/util/gzip-deflate.test.ts
+++ b/test/js/bun/util/gzip-deflate.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// zlib's z_stream.avail_in is a u32. Passing a buffer of exactly 2^32 bytes
+// (Bun's own buffer.constants.MAX_LENGTH) to Bun.gzipSync / Bun.deflateSync
+// used to wrap `input.len() as u32` to 0, so zlib compressed an empty stream
+// and returned a 20-byte (gzip) / 2-byte (deflate) output that round-trips to
+// 0 bytes: silent total data loss on a success return.
+//
+// The child needs ~9 GiB resident (the 4 GiB input plus the ~4 GiB
+// deflateBound() scratch Vec); if the allocation fails it prints "SKIP" and
+// the test passes trivially.
+test(
+  "Bun.gzipSync / Bun.deflateSync compress a 4 GiB input instead of wrapping avail_in to 0",
+  async () => {
+    const script = `
+      const zlib = require("node:zlib");
+      let b;
+      try {
+        b = Buffer.alloc(2 ** 32);
+      } catch {
+        console.log(JSON.stringify("SKIP"));
+        process.exit(0);
+      }
+      b[0] = 0x41;
+      b[4_294_967_294] = 0x5a;
+
+      const g = Bun.gzipSync(b);
+      const dLen = Bun.deflateSync(b).length;
+      b = null;
+      Bun.gc(true);
+
+      const rg = zlib.gunzipSync(g);
+      console.log(
+        JSON.stringify({
+          gzip: g.length,
+          deflate: dLen,
+          rgLen: rg.length,
+          rgFirst: rg[0],
+          rgSentinel: rg[4_294_967_294],
+        }),
+      );
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
+    if (out === "SKIP") return;
+
+    expect(stderr).toBe("");
+    // With the bug: gzip = 20, deflate = 2, rgLen = 0.
+    expect(out).toEqual({
+      gzip: expect.any(Number),
+      deflate: expect.any(Number),
+      rgLen: 2 ** 32,
+      rgFirst: 0x41,
+      rgSentinel: 0x5a,
+    });
+    expect(out.gzip).toBeGreaterThan(1_000_000);
+    expect(out.deflate).toBeGreaterThan(1_000_000);
+    expect(exitCode).toBe(0);
+  },
+  300_000,
+);


### PR DESCRIPTION
## What

`Bun.gzipSync` / `Bun.deflateSync` (default `{library: "zlib"}`) on a buffer of exactly 2^32 bytes silently returned an empty compressed stream: a 20-byte gzip / 2-byte deflate output that decompresses to 0 bytes. 2^32 is Bun's own `buffer.constants.MAX_LENGTH`, so this is the advertised max size.

```js
const b = Buffer.alloc(2 ** 32);
Bun.gzipSync(b).length        // 20 (an empty gzip stream: 1f8b08...0300...)
Bun.gunzipSync(Bun.gzipSync(b)).length  // 0
Bun.deflateSync(b).length     // 2
// controls that already worked:
Bun.gzipSync(b, { library: "libdeflate" }).length    // 4340739
require("node:zlib").gzipSync(b).length              // 4174811
Bun.gzipSync(b.subarray(0, 2 ** 32 - 1)).length      // 4174527
```

## Why

`ZlibCompressorArrayList::init` set `avail_in: input.len() as uInt`. `uInt` is `c_uint` (u32), so `2^32 as u32` wraps to `0` and zlib is handed an empty input. `deflate(Z_FINISH)` then returns a valid empty stream and `StreamEnd` on the first call.

The owned streaming helper at `step()` already did `input.len().min(u32::MAX as usize)`; the one-shot compressor did not.

## Fix

Clamp `avail_in` / `avail_out` to `u32::MAX` at init, and have `read_all()` refill the input window from the remaining tail whenever zlib drains it, using `Z_NO_FLUSH` until the last window is loaded and `Z_FINISH` only then. Same clamp and refill applied to `ZlibReaderArrayList` so a >= 4 GiB compressed input no longer truncates on the inflate side either.

## Verification

`test/js/bun/util/gzip-deflate.test.ts` allocates a 4 GiB buffer with sentinel bytes, compresses with both `Bun.gzipSync` and `Bun.deflateSync`, and round-trips the gzip output through `node:zlib.gunzipSync` back to 4294967296 bytes with the sentinels intact. Without the fix the assertions see `{gzip: 20, deflate: 2, rgLen: 0}`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/gzip-deflate.test.ts
bun test v1.4.0 (3bec39c46)

test/js/bun/util/gzip-deflate.test.ts:
62 |     return;
63 |   }
64 | 
65 |   expect(stderr).toBe("");
66 |   // With the bug: gzip = 20, deflate = 2, rgLen = 0.
67 |   expect(out).toEqual({
                   ^
error: expect(received).toEqual(expected)

  {
-   "deflate": Any<Number>,
-   "gzip": Any<Number>,
-   "rgFirst": 65,
-   "rgLen": 4294967296,
-   "rgSentinel": 90,
+   "deflate": 2,
+   "gzip": 20,
+   "rgLen": 0,
  }

- Expected  - 5
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/util/gzip-deflate.test.ts:67:15)
(fail) Bun.gzipSync / Bun.deflateSync compress a 4 GiB input instead of wrapping avail_in to 0 [8949.94ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [11.70s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (82102ce48)

test/js/bun/util/gzip-deflate.test.ts:
(pass) Bun.gzipSync / Bun.deflateSync compress a 4 GiB input instead of wrapping avail_in to 0 [14708.77ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [15.77s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/gzip-deflate.test.ts
bun test v1.4.0 (3bec39c46)

test/js/bun/util/gzip-deflate.test.ts:
(pass) Bun.gzipSync / Bun.deflateSync compress a 4 GiB input instead of wrapping avail_in to 0 [78294.05ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [80.42s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 751ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_paths v0.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/zlib/lib.rs                       | 83 +++++++++++++++++++++++++++--------
 test/js/bun/util/gzip-deflate.test.ts | 77 ++++++++++++++++++++++++++++++++
 2 files changed, 141 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/zlib/lib.rs                            9     20      0
test/js/bun/util/gzip-deflate.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->