### PR TITLE
bun test: stop panicking on a path argument or tree entry longer than the path buffer

### DIFF
--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1366,7 +1366,7 @@ pub mod fs {
             existing_fd: Fd,
             store_fd: bool,
         ) -> crate::CrateResult<EntryCache> {
-            use bun_paths::resolve_path::{join_abs_string_buf, platform};
+            use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
             #[cfg(not(windows))]
             use bun_sys::{FileKind, kind_from_mode};
 
@@ -1378,8 +1378,15 @@ pub mod fs {
 
             let combo: [&[u8]; 2] = [dir_, base];
             let mut outpath = bun_paths::PathBuffer::uninit();
-            let entry_path_len =
-                join_abs_string_buf::<platform::Auto>(self.cwd, &mut outpath[..], &combo).len();
+            let join_capacity = outpath.len() - 2;
+            let Some(entry_path) = join_abs_string_buf_checked::<platform::Auto>(
+                self.cwd,
+                &mut outpath[..join_capacity],
+                &combo,
+            ) else {
+                return Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+            };
+            let entry_path_len = entry_path.len();
 
             outpath[entry_path_len + 1] = 0;
             outpath[entry_path_len] = 0;

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -350,13 +350,6 @@ pub mod fs {
             join_abs_string_buf_checked::<platform::Loose>(self.top_level_dir, buf, parts)
         }
 
-        /// Like `abs_buf` but writes a
-        /// NUL sentinel and returns a `ZStr` borrowing `buf`.
-        pub fn abs_buf_z<'b>(&self, parts: &[&[u8]], buf: &'b mut [u8]) -> &'b ZStr {
-            use bun_paths::resolve_path::{join_abs_string_buf_z, platform};
-            join_abs_string_buf_z::<platform::Loose>(self.top_level_dir, buf, parts)
-        }
-
         /// Normalizes `str` (separators, `.`/`..` segments) into `buf`.
         pub fn normalize_buf<'b>(&self, buf: &'b mut [u8], str: &[u8]) -> &'b [u8] {
             use bun_paths::resolve_path::{normalize_string_buf, platform};

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -7,7 +7,7 @@ use bun_bundler::options::BundleOptions;
 use bun_core::ZStr;
 use bun_core::{StringOrTinyString, strings};
 use bun_output::{declare_scope, scoped_log};
-use bun_paths::resolve_path::{join_abs_string_buf, platform};
+use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
 use bun_paths::{self, PathBuffer};
 use bun_ptr::Interned;
 use bun_resolver::fs::{self as fs, DirEntryIterator, EntriesOption, FileSystem};
@@ -47,8 +47,9 @@ pub struct ScanEntry {
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum ScanError {
-    /// Scan entrypoint file/directory does not exist. Not returned when
-    /// a subdirectory is scanned but does not exist.
+    /// Scan entrypoint file/directory does not exist, or its absolute path
+    /// does not fit in a `PathBuffer`. Not returned when a subdirectory is
+    /// scanned but does not exist.
     #[error("DoesNotExist")]
     DoesNotExist,
     #[error("OutOfMemory")]
@@ -117,8 +118,8 @@ impl<'a> Scanner<'a> {
         top_level_dir: &'static [u8],
         parts: &[&[u8]],
         buf: &'b mut [u8],
-    ) -> &'b [u8] {
-        join_abs_string_buf::<platform::Loose>(top_level_dir, buf, parts)
+    ) -> Option<&'b [u8]> {
+        join_abs_string_buf_checked::<platform::Loose>(top_level_dir, buf, parts)
     }
 
     /// Take the list of test files out of this scanner. Caller owns the returned
@@ -130,7 +131,10 @@ impl<'a> Scanner<'a> {
     pub(crate) fn scan(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
         let mut scan_dir_buf = PathBuffer::uninit();
         let parts: [&[u8]; 2] = [self.top_level_dir(), path_literal];
-        let path: &[u8] = Self::abs_buf_projected(self.top_level_dir(), &parts, &mut scan_dir_buf);
+        let Some(path) = Self::abs_buf_projected(self.top_level_dir(), &parts, &mut scan_dir_buf)
+        else {
+            return Err(ScanError::DoesNotExist);
+        };
 
         let root = self
             .read_dir_with_name(path, None)
@@ -197,7 +201,13 @@ impl<'a> Scanner<'a> {
                 let dir = entry.relative_dir;
 
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
-                let path2 = self.fs().abs_buf(&parts2, &mut self.open_dir_buf);
+                let buf_len = self.open_dir_buf.len();
+                let Some(path2) = self
+                    .fs()
+                    .abs_buf_checked(&parts2, &mut self.open_dir_buf[..buf_len - 1])
+                else {
+                    continue;
+                };
                 let path2_len = path2.len();
                 self.open_dir_buf[path2_len] = 0;
                 let name_len = entry.name.slice().len();
@@ -227,17 +237,18 @@ impl<'a> Scanner<'a> {
             {
                 let fs = self.fs();
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
-                let path2 = fs.abs_buf_z(&parts2, &mut self.open_dir_buf);
-                let Ok(child_fd) = bun_sys::open_dir_no_renaming_or_deleting_windows(
-                    Fd::INVALID,
-                    path2.as_bytes(),
-                ) else {
+                let Some(path2) = fs.abs_buf_checked(&parts2, &mut self.open_dir_buf) else {
+                    continue;
+                };
+                let Ok(child_fd) =
+                    bun_sys::open_dir_no_renaming_or_deleting_windows(Fd::INVALID, path2)
+                else {
                     continue;
                 };
                 let child_dir = bun_sys::Dir::from_fd(child_fd);
                 let stored = fs
                     .dirname_store
-                    .append_slice(path2.as_bytes())
+                    .append_slice(path2)
                     .map_err(|_| ScanError::OutOfMemory)?;
                 let _ = self
                     .read_dir_with_name(stored, Some(child_dir))
@@ -380,12 +391,14 @@ impl<'a> Scanner<'a> {
                     // reshaped for borrowck — drop the &mut borrow from
                     // abs_buf and reborrow open_dir_buf immutably so &self methods
                     // can be called with the slice.
-                    let dir_path_len = Self::abs_buf_projected(
+                    let Some(dir_path_len) = Self::abs_buf_projected(
                         self.top_level_dir(),
                         &parts,
                         &mut self.open_dir_buf,
                     )
-                    .len();
+                    .map(<[u8]>::len) else {
+                        return;
+                    };
                     let dir_path = &self.open_dir_buf[..dir_path_len];
                     if self.matches_path_ignore_pattern(dir_path) {
                         return;
@@ -417,9 +430,12 @@ impl<'a> Scanner<'a> {
                 // reshaped for borrowck — drop the &mut borrow from
                 // abs_buf and reborrow open_dir_buf immutably so &self methods
                 // below can be called with the slice.
-                let path_len =
+                let Some(path_len) =
                     Self::abs_buf_projected(self.top_level_dir(), &parts, &mut self.open_dir_buf)
-                        .len();
+                        .map(<[u8]>::len)
+                else {
+                    return;
+                };
                 let path = &self.open_dir_buf[..path_len];
 
                 if !self.does_absolute_path_match_filter(path) {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -47,9 +47,7 @@ pub struct ScanEntry {
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum ScanError {
-    /// Scan entrypoint file/directory does not exist, or its absolute path
-    /// does not fit in a `PathBuffer`. Not returned when a subdirectory is
-    /// scanned but does not exist.
+    /// The entrypoint does not exist or does not fit a `PathBuffer`; never returned for subdirectories.
     #[error("DoesNotExist")]
     DoesNotExist,
     #[error("OutOfMemory")]

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1884,9 +1884,10 @@ describe.concurrent("test file discovery (scanner)", () => {
   });
 
   // The scanner builds every absolute path in a PathBuffer of MAX_PATH_BYTES:
-  // 4096 on Linux, 1024 on macOS. On Windows it is 32767*3+1 bytes, more than
-  // a command line or an NT path can hold, so the overflow is unreachable there.
-  const maxPathBytes = isMacOS ? 1024 : 4096;
+  // 4096 on Linux, 1024 on every other POSIX (src/bun_core/util.rs). On Windows
+  // it is 32767*3+1 bytes, more than a command line or an NT path can hold, so
+  // the overflow is unreachable there.
+  const maxPathBytes = isLinux ? 4096 : 1024;
   const existsTest = `import { test } from "bun:test"; test("exists", () => {});`;
 
   for (const [kind, prefix, len] of [

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1882,4 +1882,115 @@ describe.concurrent("test file discovery (scanner)", () => {
     expect(stderr).toContain(" 1 pass");
     expect(exitCode).toBe(0);
   });
+
+  // The scanner builds every absolute path in a PathBuffer of MAX_PATH_BYTES:
+  // 4096 on Linux, 1024 on macOS. On Windows it is 32767*3+1 bytes, more than
+  // a command line or an NT path can hold, so the overflow is unreachable there.
+  const maxPathBytes = isMacOS ? 1024 : 4096;
+  const existsTest = `import { test } from "bun:test"; test("exists", () => {});`;
+
+  for (const [kind, prefix, len] of [
+    ["absolute", "/", 5000],
+    ["absolute", "/", 100_000],
+    ["relative", "./", 5000],
+  ] as const) {
+    test.skipIf(isWindows)(
+      `${kind} path argument of ${len} bytes (longer than MAX_PATH_BYTES) reports no match instead of panicking`,
+      async () => {
+        using dir = tempDir("scanner-long-arg", { "exists.test.ts": existsTest });
+        const longArg = prefix + Buffer.alloc(len, "a").toString() + ".test.ts";
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test", longArg],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toContain("had no matches");
+        expect(exitCode).toBe(1);
+      },
+    );
+  }
+
+  test.skipIf(isWindows)(
+    "a path argument longer than MAX_PATH_BYTES is skipped like a missing path when other arguments match",
+    async () => {
+      using dir = tempDir("scanner-long-arg-mixed", { "exists.test.ts": existsTest });
+      const longArg = "/" + Buffer.alloc(5000, "a").toString() + ".test.ts";
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./exists.test.ts", longArg],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain("Ran 1 test across 1 file.");
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  // The directory walk joins parent + entry name for every directory it
+  // descends into and every candidate test file. With pathIgnorePatterns
+  // configured it additionally joins each directory before queueing it, so the
+  // same tree is scanned once per configuration to reach both code paths.
+  for (const [config, files] of [
+    ["no bunfig", {}],
+    ["pathIgnorePatterns configured", { "bunfig.toml": `[test]\npathIgnorePatterns = ["unrelated/**"]\n` }],
+  ] as const) {
+    test.skipIf(isWindows)(
+      `entries whose absolute path exceeds MAX_PATH_BYTES are skipped during the directory walk (${config})`,
+      async () => {
+        using dir = tempDir("scanner-deep-tree", {
+          ...files,
+          "shallow.test.ts": `import { test } from "bun:test"; test("shallow", () => {});`,
+        });
+        const root = String(dir);
+        // Each level adds "/" + segment = 255 bytes. The deepest directory the
+        // scanner can still open is the last one whose path is at most
+        // maxPathBytes - 1 (it reserves one byte for the NUL); the directory
+        // below it is skipped. A 255-byte file name in the deepest directory
+        // overflows too: that directory is at most 254 bytes short of the limit
+        // and the name adds 256.
+        const segment = Buffer.alloc(254, "d").toString();
+        const longTestFile = Buffer.alloc(247, "f").toString() + ".test.ts";
+        const fitDepth = Math.floor((maxPathBytes - 1 - root.length) / (segment.length + 1));
+        expect(longTestFile).toHaveLength(255);
+        expect(root.length + fitDepth * 255 + 256).toBeGreaterThan(maxPathBytes);
+
+        // The two over-long entries cannot be addressed by absolute path
+        // (ENAMETOOLONG), so walk down the chain and create them relative to
+        // the deepest directory.
+        const script = ["set -e"];
+        for (let level = 1; level <= fitDepth; level++) {
+          script.push(`mkdir ${segment} && cd ${segment}`);
+        }
+        script.push(`touch ${longTestFile}`, `mkdir ${segment}`);
+        await using setup = Bun.spawn({
+          cmd: ["bash", "-c", script.join("\n")],
+          env: bunEnv,
+          cwd: root,
+          stderr: "pipe",
+        });
+        const [setupStderr, setupExitCode] = await Promise.all([setup.stderr.text(), setup.exited]);
+        expect(setupStderr).toBe("");
+        expect(setupExitCode).toBe(0);
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test"],
+          env: bunEnv,
+          cwd: root,
+          stderr: "pipe",
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toContain("shallow.test.ts:");
+        expect(stderr).toContain("Ran 1 test across 1 file.");
+        expect(exitCode).toBe(0);
+      },
+    );
+  }
 });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1953,23 +1953,28 @@ describe.concurrent("test file discovery (scanner)", () => {
         // Each level adds "/" + segment = 255 bytes. The deepest directory the
         // scanner can still open is the last one whose path is at most
         // maxPathBytes - 1 (it reserves one byte for the NUL); the directory
-        // below it is skipped. A 255-byte file name in the deepest directory
+        // below it is skipped. A 255-byte name in the deepest directory
         // overflows too: that directory is at most 254 bytes short of the limit
-        // and the name adds 256.
+        // and the name adds 256. The deepest directory gets three such entries:
+        // a test file, a subdirectory, and a symlink. readdir does not report a
+        // symlink's kind, so the scanner stats it first, and that stat builds
+        // the path through the resolver (RealFS::kind) rather than through the
+        // scanner's own joins.
         const segment = Buffer.alloc(254, "d").toString();
         const longTestFile = Buffer.alloc(247, "f").toString() + ".test.ts";
+        const longTestLink = Buffer.alloc(247, "l").toString() + ".test.ts";
         const fitDepth = Math.floor((maxPathBytes - 1 - root.length) / (segment.length + 1));
-        expect(longTestFile).toHaveLength(255);
+        expect([longTestFile.length, longTestLink.length]).toEqual([255, 255]);
         expect(root.length + fitDepth * 255 + 256).toBeGreaterThan(maxPathBytes);
 
-        // The two over-long entries cannot be addressed by absolute path
+        // The over-long entries cannot be addressed by absolute path
         // (ENAMETOOLONG), so walk down the chain and create them relative to
         // the deepest directory.
         const script = ["set -e"];
         for (let level = 1; level <= fitDepth; level++) {
           script.push(`mkdir ${segment} && cd ${segment}`);
         }
-        script.push(`touch ${longTestFile}`, `mkdir ${segment}`);
+        script.push(`touch ${longTestFile}`, `ln -s ${longTestFile} ${longTestLink}`, `mkdir ${segment}`);
         await using setup = Bun.spawn({
           cmd: ["bash", "-c", script.join("\n")],
           env: bunEnv,


### PR DESCRIPTION
Fixes #35728

### Problem
- `bun test "/$(printf 'a%.0s' $(seq 1 5000)).test.ts"` aborts with `panic: range end index 5008 out of range for slice of length 4095` (exit 134) instead of reporting that the path matched nothing. The reporter hit it at 997 bytes on macOS, where the buffer is 1024 bytes.
- `bun test` with no arguments aborts the same way when the tree it walks contains an entry (directory, test file, or symlink) whose absolute path is longer than the buffer; this is the scenario of #32412.
- `Scanner` (`src/runtime/cli/test/Scanner.rs`) builds every absolute path it needs into a fixed `PathBuffer` with the unchecked `join_abs_string_buf` / `FileSystem::abs_buf`: the positional argument in `scan()`, each directory it descends into in the `dirs_to_scan` loop, and each directory and candidate file in `next()`.
- For an entry that `readdir` reports as a symlink (or as unknown, which some filesystems do for everything), `next()` first asks the resolver for the entry's kind, and `RealFS::kind` (`src/resolver/lib.rs`) joins dir + name into its own `PathBuffer` with the same unchecked join. `normalize_string_buf` writes into the caller's buffer without a bounds check, so any result longer than the buffer panics at either layer.

### Fix
- Every join in `Scanner.rs` goes through the existing `join_abs_string_buf_checked` / `FileSystem::abs_buf_checked`, which return `None` when the normalized result does not fit.
- `scan()` maps `None` to `ScanError::DoesNotExist`, so a single over-long argument prints `Test filter "..." had no matches` and exits 1, and an over-long argument next to valid ones is ignored, exactly like a path that does not exist. This is correct because such a path cannot be opened either: the OS rejects it with `ENAMETOOLONG`.
- The directory walk skips an entry whose path does not fit (not descended into, not matched, not added) and the rest of the run is unaffected. Directories are opened relative to the parent fd, so everything that does fit is still scanned when a tree continues past the limit.
- `RealFS::kind` uses the checked join too and returns `Error::Sys(ENAMETOOLONG)` when the path does not fit. Its only callers, `Entry::kind` / `Entry::symlink`, already treat a failed stat as "unknown, assume file" (the same thing that happens when an entry is deleted between `readdir` and `stat`), and the scanner's file path then skips the entry through its checked join. Without this part, a symlink in the deepest directory still aborted with the scanner change alone (`range end index 4100 out of range for slice of length 4095`, in the `platform::Posix` join that only the resolver uses).
- The POSIX `dirs_to_scan` join and `RealFS::kind` join into `buf[..len - 1]` / `buf[..len - 2]` because they write NULs after the path (same shape as `node_fs.rs`), so the set of paths that work is exactly the set that worked before; only the panicking inputs change behavior. The Windows `dirs_to_scan` branch passes the joined bytes to `open_dir_no_renaming_or_deleting_windows` directly (it transcodes to UTF-16 and never used the NUL), which leaves `FileSystem::abs_buf_z` without callers, so it is removed.
- Scope: this PR covers the scanner, which is what #35728, #32412 and #38896 are about. The other `bun test` inputs that reach this buffer family (`--coverage-dir`, `--reporter-outfile`, bunfig `[test] root`, in `test_command.rs`) still abort on over-long values and are intentionally left to a separate change, as are `bun -c <path>` (`bunfig/arguments.rs`) and `Module._nodeModulePaths()` (`resolver_jsc.rs`); each has its own reporting path and test location. Per-site conversion to the checked helpers is how the rest of this family has been fixed (#37526, #37531).
- Tests: six new cases in `test/cli/test/bun-test.test.ts` under "test file discovery (scanner)". Absolute (5000 and 100000 bytes) and relative over-long arguments report `had no matches` and exit 1; an over-long argument next to a valid one still runs the valid file; a tree whose deepest reachable directory contains an over-long test file, symlink and subdirectory runs only the shallow test file, scanned once without a bunfig and once with `pathIgnorePatterns` (which joins directories on a different path in `next()`). The three entries cover the file join, the resolver join and the directory joins. On the unfixed build all six abort (`range end index 5008 / 5036 / 100008 / 4108 / 4109 ...`); with the fix all six pass, and `bun-test.test.ts`, `path-ignore-patterns.test.ts`, `resolve.test.ts`, `require.test.ts` and `resolve-error.test.ts` pass (214 pass). `cargo check --target x86_64-pc-windows-msvc` for `bun_resolver` and `bun_runtime` and `cargo clippy` for both crates are clean.
- The tests are skipped on Windows, where the buffer is `32767 * 3 + 1` bytes: larger than a command line or an NT path can deliver, so the overflow is not reachable there.

### Background
- `PathBuffer` is `[u8; MAX_PATH_BYTES]`, the stack buffer bun uses for path syscalls: 4096 bytes on Linux, 1024 on macOS and the BSDs, 98302 on Windows.
- `join_abs_string_buf(cwd, buf, parts)` resolves `parts` against `cwd` and normalizes the result into `buf`; it assumes the caller knows the result fits. `join_abs_string_buf_checked` is the variant for input of arbitrary length: it normalizes into heap scratch when the input might not fit and returns `None` if the normalized result is longer than `buf` (a long input that normalizes down through `..` still succeeds). `FileSystem::abs_buf` / `abs_buf_checked` are the same two functions with the project root as `cwd`.
- The resolver's directory cache records each entry's kind from `readdir`'s `d_type`. Symlinks and `DT_UNKNOWN` entries have no kind yet, so `Entry::kind` stats them on first use through `RealFS::kind`, and on any error keeps the placeholder kind (file). The test scanner calls `Entry::kind` for every entry before deciding whether to queue or match it.
- The scanner queues each subdirectory and opens it with `openat` relative to the parent's fd, so each syscall only sees one component; that is why a tree can legitimately be deeper than the buffer while still being walkable up to the limit.

<details>
<summary>Relationship to the other PRs and to the first version of this PR</summary>

- #32412 (June) is the original of the Scanner change, for the deep-tree variant seen in Sentry; it was marked superseded by this PR but left open. Its scenario is covered by the directory-walk tests here (now including the resolver path, which neither version had), and it is closed.
- #38896 by @deepshekhardas switches the `abs_buf_projected` sites to the checked join but leaves the two `dirs_to_scan` joins unchecked, so a deep tree still panics, and its 997 / 1200 byte arguments do not overflow the 4096-byte buffer on Linux (the "no matches" assertion fails there with or without the fix). Closed in favor of this PR.
- The first version of this PR additionally made `join_abs_string_buf` itself return an empty slice on overflow. Main has since fixed the other callers of this family individually with the checked helpers, and an empty path silently handed to a caller that does not expect it is harder to reason about than `Option` at each site, so that part was dropped when the PR was rebased.

</details>
