### PR TITLE
Bun.serve: reject Transfer-Encoding on an HTTP/1.0 request (RFC 9112 6.1)

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -961,9 +961,12 @@ struct HttpResponseData;
             }
             postPaddedBuffer = requestLineResult.position;
 
-            if(requestLineResult.isAncientHTTP) {
-                isAncientHTTP = true;
-            }
+            /* Written unconditionally (not just on true): ancientHttp is per-request and
+             * the caller re-enters this function for each pipelined request in the same
+             * recv buffer without clearing it, so a stale true from a prior HTTP/1.0
+             * request would mis-classify a following HTTP/1.1 request. isConnectRequest
+             * below is deliberately latched (tunnel mode persists across the loop). */
+            isAncientHTTP = requestLineResult.isAncientHTTP;
             if(requestLineResult.isConnect) {
                 isConnectRequest = true;
             }

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1201,6 +1201,17 @@ struct HttpResponseData;
             /* Check Transfer-Encoding header validity and conflicts */
             HttpRequest::TransferEncoding transferEncoding = req->getTransferEncoding();
 
+            /* RFC 9112 6.1: Transfer-Encoding was introduced in HTTP/1.1. A server that
+             * receives an HTTP/1.0 message containing a Transfer-Encoding header field
+             * MUST treat the message as if the framing is faulty and close the connection
+             * after processing the message. Bun.serve rejects such a request outright,
+             * consistent with the TE+CL and non-chunked TE rejections below. node:http
+             * follows llhttp, which dispatches the request (the HTTP/1.0 request already
+             * marks the connection for close via isAncient). */
+            if (!IsNodeHttp && req->ancientHttp && transferEncoding.has) [[unlikely]] {
+                return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_TRANSFER_ENCODING);
+            }
+
             /* node:http compat: a Transfer-Encoding that names no chunked coding (e.g.
              * "chunkedchunked") and no Content-Length is rejected by llhttp only after
              * the request head completes - Node dispatches the 'request' first and the

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -151,6 +151,105 @@ test("rejects Transfer-Encoding + Content-Length", async () => {
   });
 });
 
+test.each([
+  ["default close", ""],
+  ["Connection: keep-alive", "Connection: keep-alive\r\n"],
+])("rejects Transfer-Encoding on an HTTP/1.0 request (%s)", async (_label, connectionHeader) => {
+  // RFC 9112 6.1: a server that receives an HTTP/1.0 message containing a
+  // Transfer-Encoding header field MUST treat the message as if the framing is
+  // faulty and close the connection after processing the message. Bun.serve
+  // rejects such a request outright (400) so a proxy/backend split on whether
+  // HTTP/1.0 honours Transfer-Encoding cannot desync on the body boundary.
+  let handlerCalled = false;
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      handlerCalled = true;
+      return new Response("OK");
+    },
+  });
+
+  const client = net.connect(server.port, "127.0.0.1");
+
+  const maliciousRequest =
+    "POST / HTTP/1.0\r\n" +
+    "Host: localhost\r\n" +
+    connectionHeader +
+    "Transfer-Encoding: chunked\r\n" +
+    "\r\n" +
+    "5\r\nhello\r\n0\r\n\r\n";
+
+  const response = await new Promise<string>((resolve, reject) => {
+    let buf = "";
+    client.on("error", reject);
+    client.on("data", data => (buf += data.toString("latin1")));
+    client.on("close", () => resolve(buf));
+    client.write(maliciousRequest);
+  });
+
+  expect(response).toContain("HTTP/1.1 400");
+  expect(handlerCalled).toBe(false);
+});
+
+test("accepts Transfer-Encoding: chunked on an HTTP/1.1 request", async () => {
+  // Control for the HTTP/1.0 rejection above: the same chunked body is valid on HTTP/1.1.
+  let received = "";
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      received = await req.text();
+      return new Response("OK");
+    },
+  });
+
+  const client = net.connect(server.port, "127.0.0.1");
+  const request =
+    "POST / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+
+  const response = await new Promise<string>((resolve, reject) => {
+    let buf = "";
+    client.on("error", reject);
+    client.on("data", data => (buf += data.toString("latin1")));
+    client.on("close", () => resolve(buf));
+    client.write(request);
+  });
+
+  expect(response).toContain("HTTP/1.1 200");
+  expect(received).toBe("hello");
+});
+
+test("node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity)", async () => {
+  // node:http follows llhttp here: the HTTP/1.0 + Transfer-Encoding: chunked request
+  // is dispatched with the chunked body decoded, and the connection closes after (an
+  // HTTP/1.0 request already marks the connection for close).
+  const hits: { url: string; body: string; httpVersion: string }[] = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", d => (body += d));
+    req.on("end", () => {
+      hits.push({ url: req.url!, body, httpVersion: req.httpVersion });
+      res.end("ok");
+    });
+  });
+  await new Promise<void>(r => server.listen(0, r));
+  const port = (server.address() as net.AddressInfo).port;
+
+  const client = net.connect(port, "127.0.0.1");
+  const request = "POST /a HTTP/1.0\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+
+  const response = await new Promise<string>((resolve, reject) => {
+    let buf = "";
+    client.on("error", reject);
+    client.on("data", d => (buf += d.toString("latin1")));
+    client.on("close", () => resolve(buf));
+    client.write(request);
+  });
+  server.close();
+
+  expect(response).toContain("HTTP/1.1 200");
+  expect(hits).toEqual([{ url: "/a", body: "hello", httpVersion: "1.0" }]);
+});
+
 test("rejects conflicting duplicate Content-Length headers", async () => {
   // RFC 9112 6.3: multiple Content-Length headers with differing values must be rejected
   // to prevent request smuggling.

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -187,7 +187,7 @@ test.each([
     client.write(maliciousRequest);
   });
 
-  expect(response).toContain("HTTP/1.1 400");
+  expect(response).toStartWith("HTTP/1.1 400 Bad Request\r\n");
   expect(handlerCalled).toBe(false);
 });
 
@@ -214,7 +214,7 @@ test("accepts Transfer-Encoding: chunked on an HTTP/1.1 request", async () => {
     client.write(request);
   });
 
-  expect(response).toContain("HTTP/1.1 200");
+  expect(response).toStartWith("HTTP/1.1 200 OK\r\n");
   expect(received).toBe("hello");
 });
 
@@ -246,7 +246,7 @@ test("node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp pari
       client.write(request);
     });
 
-    expect(response).toContain("HTTP/1.1 200");
+    expect(response).toStartWith("HTTP/1.1 200 OK\r\n");
     expect(hits).toEqual([{ url: "/a", body: "hello", httpVersion: "1.0" }]);
   } finally {
     server.close();

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -232,22 +232,25 @@ test("node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp pari
     });
   });
   await new Promise<void>(r => server.listen(0, r));
-  const port = (server.address() as net.AddressInfo).port;
+  try {
+    const port = (server.address() as net.AddressInfo).port;
 
-  const client = net.connect(port, "127.0.0.1");
-  const request = "POST /a HTTP/1.0\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+    const client = net.connect(port, "127.0.0.1");
+    const request = "POST /a HTTP/1.0\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
 
-  const response = await new Promise<string>((resolve, reject) => {
-    let buf = "";
-    client.on("error", reject);
-    client.on("data", d => (buf += d.toString("latin1")));
-    client.on("close", () => resolve(buf));
-    client.write(request);
-  });
-  server.close();
+    const response = await new Promise<string>((resolve, reject) => {
+      let buf = "";
+      client.on("error", reject);
+      client.on("data", d => (buf += d.toString("latin1")));
+      client.on("close", () => resolve(buf));
+      client.write(request);
+    });
 
-  expect(response).toContain("HTTP/1.1 200");
-  expect(hits).toEqual([{ url: "/a", body: "hello", httpVersion: "1.0" }]);
+    expect(response).toContain("HTTP/1.1 200");
+    expect(hits).toEqual([{ url: "/a", body: "hello", httpVersion: "1.0" }]);
+  } finally {
+    server.close();
+  }
 });
 
 test("rejects conflicting duplicate Content-Length headers", async () => {


### PR DESCRIPTION
## Repro

```js
import net from "node:net";
const server = Bun.serve({ port: 0, async fetch(req) { return new Response(await req.text()); } });
const c = net.connect(server.port, "127.0.0.1");
c.on("data", d => console.log(JSON.stringify(d.toString("latin1"))));
c.write("POST /a HTTP/1.0\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n");
```

Before: `HTTP/1.1 200 OK`, handler invoked, body `"hello"` decoded from the chunked framing.

RFC 9112 6.1:

> A server or client that receives an HTTP/1.0 message containing a Transfer-Encoding header field MUST treat the message as if the framing is faulty, even if a Content-Length is present, and close the connection after processing the message.

An HTTP/1.0 sender by definition does not implement Transfer-Encoding, so a proxy and backend that disagree on whether to honour it on a 1.0 message disagree on where the body ends.

## Cause

`fenceAndConsumePostPadded` in `packages/bun-uws/src/HttpParser.h` validates `Transfer-Encoding` (TE+CL conflict, chunked-not-last, duplicate chunked) but never consults `req->ancientHttp`, so an HTTP/1.0 request with `Transfer-Encoding: chunked` passes every check and is parsed as chunked.

## Fix

For `Bun.serve` (non-`IsNodeHttp`), return `HTTP_PARSER_ERROR_INVALID_TRANSFER_ENCODING` (400) when `req->ancientHttp && transferEncoding.has`, checked alongside the existing TE validity checks. `node:http` keeps llhttp's behaviour (dispatch and close): Node v26.3.0 dispatches such a request with `httpVersion === "1.0"` and the decoded body, and the HTTP/1.0 request already marks the connection for close via `isAncient`.

## Verification

New tests in `test/js/bun/http/request-smuggling.test.ts`:

- `rejects Transfer-Encoding on an HTTP/1.0 request` (`default close` and `Connection: keep-alive` variants): 400, handler never called. Both return 200 on main.
- `accepts Transfer-Encoding: chunked on an HTTP/1.1 request`: control, still 200 with body `"hello"`.
- `node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity)`: unchanged, matches Node.

```
bun bd test test/js/bun/http/request-smuggling.test.ts   # 79 pass, 0 fail
```

Related: #33878 (non-persistent pipelined dispatch), #35295 (TE lists), #33633 (DEL in header values). None of those reject the HTTP/1.0 + TE case.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/request-smuggling.test.ts
bun test v1.4.0 (ba20a7ee9)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [399.17ms]
(pass) rejects Transfer-Encoding with chunked not last [124.45ms]
(pass) rejects duplicate chunked in Transfer-Encoding [69.87ms]
(pass) rejects Transfer-Encoding + Content-Length [73.48ms]
185 |     client.on("data", data => (buf += data.toString("latin1")));
186 |     client.on("close", () => resolve(buf));
187 |     client.write(maliciousRequest);
188 |   });
189 | 
190 |   expect(response).toStartWith("HTTP/1.1 400 Bad Request\r\n");
                         ^
error: expect(received).toStartWith(expected)

Expected to start with: "HTTP/1.1 400 Bad Request\r\n"
Received: "HTTP/1.1 200 OK\r\ncontent-type: text/plain;charset=utf-8\r\nDate: Wed, 29 Jul 2026 06:18:12 GMT\r\nContent-Length: 2\r\n\r\nOK"

      at <anonymous> (/workspace/bun/test/js/bun/http/request-smuggling.test.ts:190:20)
(fail) rejects Transfer-Encoding on an HTTP/1.0 request (defa
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [7.84ms]
(pass) rejects Transfer-Encoding with chunked not last [1.91ms]
(pass) rejects duplicate chunked in Transfer-Encoding [2.50ms]
(pass) rejects Transfer-Encoding + Content-Length [2.67ms]
185 |     client.on("data", data => (buf += data.toString("latin1")));
186 |     client.on("close", () => resolve(buf));
187 |     client.write(maliciousRequest);
188 |   });
189 | 
190 |   expect(response).toStartWith("HTTP/1.1 400 Bad Request\r\n");
                         ^
error: expect(received).toStartWith(expected)

Expected to start with: "HTTP/1.1 400 Bad Request\r\n"
Received: "HTTP/1.1 200 OK\r\ncontent-type: text/plain;charset=utf-8\r\nDate: Wed, 29 Jul 2026 06:18:23 GMT\r\nContent-Length: 2\r\n\r\nOK"

      at <anonymous> (/workspace/bun/test/js/bun/http/request-smuggling.test.ts:190:20)
(fail) rejects Transfer-Encoding on an HTTP/1.0 request (default close) [2.69ms]
185 |     client.on("data", data => (buf += data.toString("latin1")));
186 |     client.on("close", () => resolve(buf));
187 |     client.write(malicious
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/request-smuggling.test.ts
bun test v1.4.0 (ba20a7ee9)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [367.37ms]
(pass) rejects Transfer-Encoding with chunked not last [118.62ms]
(pass) rejects duplicate chunked in Transfer-Encoding [61.39ms]
(pass) rejects Transfer-Encoding + Content-Length [75.57ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (default close) [98.03ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (Connection: keep-alive) [54.87ms]
(pass) accepts Transfer-Encoding: chunked on an HTTP/1.1 request [94.44ms]
(pass) node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity) [408.27ms]
(pass) rejects conflicting duplicate Content-Length headers [53.39ms]
(pass) accepts duplicate Content-Length headers with identical values [77.41ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [59.97ms]
(pass) accepts valid Transfer-Encoding: chunked [62.79ms]
(pass) accepts valid Transfer-
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 752ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/105] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_md v0.0.0 (/workspace/bun/src/md)
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_io v0.0.0 (/workspace/bun/src/io)
[1m[92m   Compiling[0m bun_uws v0.0.0 (/workspace/bun/src/uws)
[1m[92m   Compiling[0m bun_zlib v0.0.0 (/workspace/bun/src/zlib)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_dotenv v0.0.0 (/workspace/bun/src/dotenv)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpParser.h          |  20 +++++-
 test/js/bun/http/request-smuggling.test.ts | 102 +++++++++++++++++++++++++++++
 2 files changed, 119 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-uws/src/HttpParser.h               5      3      0
test/js/bun/http/request-smuggling.test.ts      4      5      0
```

</details>

<!-- robobun:evidence:end -->