### PR TITLE
node:zlib: feed a 2^32-byte chunk to the native writer in u32 windows

### DIFF
--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -21,6 +21,8 @@ const ArrayBufferIsView = ArrayBuffer.isView;
 const isArrayBufferView = ArrayBufferIsView;
 const isAnyArrayBuffer = b => b instanceof ArrayBuffer || b instanceof SharedArrayBuffer;
 const kMaxLength = $requireMap.$get("buffer")?.exports.kMaxLength ?? BufferModule.kMaxLength;
+// Native write/writeSync read in_len as a u32; anything larger must be windowed.
+const U32_MAX = 0xffff_ffff;
 
 const { Transform, finished } = require("node:stream");
 const owner_symbol = Symbol("owner_symbol");
@@ -332,10 +334,10 @@ function processChunkSync(self, chunk, flushFlag) {
   });
 
   while (true) {
-    // Native in_len is u32; feed a MAX_LENGTH (2^32) chunk in u32 windows.
-    const inLen = availInBefore > 0xffff_ffff ? 0xffff_ffff : availInBefore;
+    const inLen = availInBefore > U32_MAX ? U32_MAX : availInBefore;
+    const lastInputWindow = inLen === availInBefore;
     handle.writeSync(
-      flushFlag,
+      lastInputWindow ? flushFlag : self._defaultFlushFlag,
       chunk, // in
       inOff, // in_off
       inLen, // in_len
@@ -359,6 +361,7 @@ function processChunkSync(self, chunk, flushFlag) {
     inputRead += inDelta;
 
     const have = availOutBefore - availOutAfter;
+    availOutBefore = availOutAfter;
     if (have > 0) {
       const out = buffer.slice(offset, offset + have);
       offset += have;
@@ -381,7 +384,7 @@ function processChunkSync(self, chunk, flushFlag) {
       buffer = Buffer.allocUnsafe(chunkSize);
     }
 
-    if (availOutAfter === 0 || inLen < availInBefore) {
+    if (availOutAfter === 0 || !lastInputWindow) {
       // Not actually done. Need to reprocess.
       // Also, update the availInBefore to the availInAfter value,
       // so that if we have to hit it a third (fourth, etc.) time,
@@ -412,11 +415,12 @@ function processChunk(self, chunk, flushFlag, cb) {
   handle.inOff = 0;
   handle.flushFlag = flushFlag;
 
+  const inLen = handle.availInBefore > U32_MAX ? U32_MAX : handle.availInBefore;
   handle.write(
-    flushFlag, // flush
+    inLen < handle.availInBefore ? self._defaultFlushFlag : flushFlag, // flush
     chunk, // in
     0, // in_off
-    handle.availInBefore > 0xffff_ffff ? 0xffff_ffff : handle.availInBefore, // in_len
+    inLen, // in_len
     self._outBuffer, // out
     self._outOffset, // out_off
     handle.availOutBefore, // out_len
@@ -440,11 +444,12 @@ function processCallback() {
   const availOutAfter = state[0];
   const availInAfter = state[1];
 
-  const inLen = handle.availInBefore > 0xffff_ffff ? 0xffff_ffff : handle.availInBefore;
+  const inLen = handle.availInBefore > U32_MAX ? U32_MAX : handle.availInBefore;
   const inDelta = inLen - availInAfter;
   self.bytesWritten += inDelta;
 
   const have = handle.availOutBefore - availOutAfter;
+  handle.availOutBefore = availOutAfter;
   let streamBufferIsFull = false;
   if (have > 0) {
     const out = self._outBuffer.slice(self._outOffset, self._outOffset + have);
@@ -476,29 +481,30 @@ function processCallback() {
     handle.inOff += inDelta;
     handle.availInBefore -= inDelta;
 
-    const nextInLen = handle.availInBefore > 0xffff_ffff ? 0xffff_ffff : handle.availInBefore;
+    const nextInLen = handle.availInBefore > U32_MAX ? U32_MAX : handle.availInBefore;
+    const nextFlush = nextInLen < handle.availInBefore ? self._defaultFlushFlag : handle.flushFlag;
     if (!streamBufferIsFull) {
       this.write(
-        handle.flushFlag, // flush
+        nextFlush, // flush
         this.buffer, // in
         handle.inOff, // in_off
         nextInLen, // in_len
         self._outBuffer, // out
         self._outOffset, // out_off
-        self._chunkSize, // out_len
+        handle.availOutBefore, // out_len
       );
     } else {
       const oldRead = self._read;
       self._read = n => {
         self._read = oldRead;
         this.write(
-          handle.flushFlag, // flush
+          nextFlush, // flush
           this.buffer, // in
           handle.inOff, // in_off
           nextInLen, // in_len
           self._outBuffer, // out
           self._outOffset, // out_off
-          self._chunkSize, // out_len
+          handle.availOutBefore, // out_len
         );
         self._read(n);
       };

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -332,11 +332,14 @@ function processChunkSync(self, chunk, flushFlag) {
   });
 
   while (true) {
+    // The native binding's in_len is a u32; a single chunk at
+    // buffer.constants.MAX_LENGTH (2^32) must be fed in u32-sized windows.
+    const inLen = availInBefore > 0xffff_ffff ? 0xffff_ffff : availInBefore;
     handle.writeSync(
       flushFlag,
       chunk, // in
       inOff, // in_off
-      availInBefore, // in_len
+      inLen, // in_len
       buffer, // out
       offset, // out_off
       availOutBefore, // out_len
@@ -353,7 +356,7 @@ function processChunkSync(self, chunk, flushFlag) {
     availOutAfter = state[0];
     availInAfter = state[1];
 
-    const inDelta = availInBefore - availInAfter;
+    const inDelta = inLen - availInAfter;
     inputRead += inDelta;
 
     const have = availOutBefore - availOutAfter;
@@ -379,13 +382,13 @@ function processChunkSync(self, chunk, flushFlag) {
       buffer = Buffer.allocUnsafe(chunkSize);
     }
 
-    if (availOutAfter === 0) {
+    if (availOutAfter === 0 || inLen < availInBefore) {
       // Not actually done. Need to reprocess.
       // Also, update the availInBefore to the availInAfter value,
       // so that if we have to hit it a third (fourth, etc.) time,
       // it'll have the correct byte counts.
       inOff += inDelta;
-      availInBefore = availInAfter;
+      availInBefore -= inDelta;
     } else {
       break;
     }
@@ -414,7 +417,7 @@ function processChunk(self, chunk, flushFlag, cb) {
     flushFlag, // flush
     chunk, // in
     0, // in_off
-    handle.availInBefore, // in_len
+    handle.availInBefore > 0xffff_ffff ? 0xffff_ffff : handle.availInBefore, // in_len
     self._outBuffer, // out
     self._outOffset, // out_off
     handle.availOutBefore, // out_len
@@ -438,7 +441,8 @@ function processCallback() {
   const availOutAfter = state[0];
   const availInAfter = state[1];
 
-  const inDelta = handle.availInBefore - availInAfter;
+  const inLen = handle.availInBefore > 0xffff_ffff ? 0xffff_ffff : handle.availInBefore;
+  const inDelta = inLen - availInAfter;
   self.bytesWritten += inDelta;
 
   const have = handle.availOutBefore - availOutAfter;
@@ -465,20 +469,21 @@ function processCallback() {
     self._outBuffer = Buffer.allocUnsafe(chunkSize);
   }
 
-  if (availOutAfter === 0) {
+  if (availOutAfter === 0 || inLen < handle.availInBefore) {
     // Not actually done. Need to reprocess.
     // Also, update the availInBefore to the availInAfter value,
     // so that if we have to hit it a third (fourth, etc.) time,
     // it'll have the correct byte counts.
     handle.inOff += inDelta;
-    handle.availInBefore = availInAfter;
+    handle.availInBefore -= inDelta;
 
+    const nextInLen = handle.availInBefore > 0xffff_ffff ? 0xffff_ffff : handle.availInBefore;
     if (!streamBufferIsFull) {
       this.write(
         handle.flushFlag, // flush
         this.buffer, // in
         handle.inOff, // in_off
-        handle.availInBefore, // in_len
+        nextInLen, // in_len
         self._outBuffer, // out
         self._outOffset, // out_off
         self._chunkSize, // out_len
@@ -491,7 +496,7 @@ function processCallback() {
           handle.flushFlag, // flush
           this.buffer, // in
           handle.inOff, // in_off
-          handle.availInBefore, // in_len
+          nextInLen, // in_len
           self._outBuffer, // out
           self._outOffset, // out_off
           self._chunkSize, // out_len

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -332,8 +332,7 @@ function processChunkSync(self, chunk, flushFlag) {
   });
 
   while (true) {
-    // The native binding's in_len is a u32; a single chunk at
-    // buffer.constants.MAX_LENGTH (2^32) must be fed in u32-sized windows.
+    // Native in_len is u32; feed a MAX_LENGTH (2^32) chunk in u32 windows.
     const inLen = availInBefore > 0xffff_ffff ? 0xffff_ffff : availInBefore;
     handle.writeSync(
       flushFlag,

--- a/test/js/node/zlib/zlib-4gib-chunk.test.ts
+++ b/test/js/node/zlib/zlib-4gib-chunk.test.ts
@@ -30,21 +30,20 @@ test.skipIf(skip)(
       bv.setUint8(${MAX_LENGTH - 2}, 0x59);
       bv.setUint8(${MAX_LENGTH - 1}, 0x5a);
 
-      const g = zlib.gzipSync(b);
-      b = null;
-      Bun.gc(true);
-
-      const r = zlib.gunzipSync(g);
-      const rv = new DataView(r.buffer, r.byteOffset, r.byteLength);
-      const at = i => (i < r.length ? rv.getUint8(i) : null);
-      console.log(
-        JSON.stringify({
+      const result = {};
+      for (const chunkSize of ["default", 64 * 1024 * 1024]) {
+        const g = zlib.gzipSync(b, chunkSize === "default" ? undefined : { chunkSize });
+        const r = zlib.gunzipSync(g);
+        const rv = new DataView(r.buffer, r.byteOffset, r.byteLength);
+        const at = i => (i < r.length ? rv.getUint8(i) : null);
+        result[chunkSize] = {
           rtLen: r.length,
           first: at(0),
           penult: at(${MAX_LENGTH - 2}),
           last: at(${MAX_LENGTH - 1}),
-        }),
-      );
+        };
+      }
+      console.log(JSON.stringify(result));
     `;
 
     await using proc = Bun.spawn({
@@ -62,13 +61,9 @@ test.skipIf(skip)(
     if (out === "SKIP") return;
 
     expect(stderr).toBe("");
-    // With the bug: { rtLen: 4294967295, first: 65, penult: 90, last: null }.
-    expect(out).toEqual({
-      rtLen: MAX_LENGTH,
-      first: 0x41,
-      penult: 0x59,
-      last: 0x5a,
-    });
+    // With the bug: default -> { rtLen: 4294967295, first: 65, penult: 90, last: null }.
+    const want = { rtLen: MAX_LENGTH, first: 0x41, penult: 0x59, last: 0x5a };
+    expect(out).toEqual({ default: want, [64 * 1024 * 1024]: want });
     expect(exitCode).toBe(0);
   },
   240_000,

--- a/test/js/node/zlib/zlib-4gib-chunk.test.ts
+++ b/test/js/node/zlib/zlib-4gib-chunk.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import * as os from "node:os";
+
+// zlib's z_stream.avail_in is a u32. node:zlib's processChunkSync passed
+// `chunk.byteLength` (up to buffer.constants.MAX_LENGTH = 2^32) straight to
+// the native writeSync() as in_len, where it saturated to 2^32 - 1. The JS
+// loop still book-kept inDelta against the unclamped 2^32, so one input byte
+// was silently skipped: gzipSync(Buffer.alloc(2^32)) round-tripped to
+// 2^32 - 1 bytes with the tail sentinel gone, on a success return.
+
+const MAX_LENGTH = 2 ** 32;
+const skip = os.totalmem() < 14 * 1024 * 1024 * 1024;
+
+test.skipIf(skip)("node:zlib gzipSync round-trips a 2^32-byte chunk without dropping a byte", async () => {
+  const script = `
+      const zlib = require("node:zlib");
+      let b;
+      try {
+        b = Buffer.alloc(${MAX_LENGTH});
+      } catch {
+        console.log(JSON.stringify("SKIP"));
+        process.exit(0);
+      }
+      // Uint8Array [] indexing tops out below 2^32-1; use DataView for the final byte.
+      const bv = new DataView(b.buffer, b.byteOffset, b.byteLength);
+      bv.setUint8(0, 0x41);
+      bv.setUint8(${MAX_LENGTH - 2}, 0x59);
+      bv.setUint8(${MAX_LENGTH - 1}, 0x5a);
+
+      const g = zlib.gzipSync(b);
+      b = null;
+      Bun.gc(true);
+
+      const r = zlib.gunzipSync(g);
+      const rv = new DataView(r.buffer, r.byteOffset, r.byteLength);
+      const at = i => (i < r.length ? rv.getUint8(i) : null);
+      console.log(
+        JSON.stringify({
+          rtLen: r.length,
+          first: at(0),
+          penult: at(${MAX_LENGTH - 2}),
+          last: at(${MAX_LENGTH - 1}),
+        }),
+      );
+    `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
+  if (out === "SKIP") return;
+
+  expect(stderr).toBe("");
+  // With the bug: { rtLen: 4294967295, first: 65, penult: 90, last: null }.
+  expect(out).toEqual({
+    rtLen: MAX_LENGTH,
+    first: 0x41,
+    penult: 0x59,
+    last: 0x5a,
+  });
+  expect(exitCode).toBe(0);
+}, 240_000);
+
+test.skipIf(skip)("node:zlib async gzip round-trips a 2^32-byte chunk without dropping a byte", async () => {
+  const script = `
+      const zlib = require("node:zlib");
+      const { promisify } = require("node:util");
+      let b;
+      try {
+        b = Buffer.alloc(${MAX_LENGTH});
+      } catch {
+        console.log(JSON.stringify("SKIP"));
+        process.exit(0);
+      }
+      new DataView(b.buffer, b.byteOffset, b.byteLength).setUint8(${MAX_LENGTH - 1}, 0x5a);
+
+      const g = await promisify(zlib.gzip)(b);
+      b = null;
+      Bun.gc(true);
+
+      const r = await promisify(zlib.gunzip)(g);
+      const rv = new DataView(r.buffer, r.byteOffset, r.byteLength);
+      console.log(
+        JSON.stringify({
+          rtLen: r.length,
+          last: ${MAX_LENGTH - 1} < r.length ? rv.getUint8(${MAX_LENGTH - 1}) : null,
+        }),
+      );
+    `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
+  if (out === "SKIP") return;
+
+  expect(stderr).toBe("");
+  expect(out).toEqual({ rtLen: MAX_LENGTH, last: 0x5a });
+  expect(exitCode).toBe(0);
+}, 240_000);

--- a/test/js/node/zlib/zlib-4gib-chunk.test.ts
+++ b/test/js/node/zlib/zlib-4gib-chunk.test.ts
@@ -12,8 +12,10 @@ import * as os from "node:os";
 const MAX_LENGTH = 2 ** 32;
 const skip = os.totalmem() < 14 * 1024 * 1024 * 1024;
 
-test.skipIf(skip)("node:zlib gzipSync round-trips a 2^32-byte chunk without dropping a byte", async () => {
-  const script = `
+test.skipIf(skip)(
+  "node:zlib gzipSync round-trips a 2^32-byte chunk without dropping a byte",
+  async () => {
+    const script = `
       const zlib = require("node:zlib");
       let b;
       try {
@@ -45,33 +47,37 @@ test.skipIf(skip)("node:zlib gzipSync round-trips a 2^32-byte chunk without drop
       );
     `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: {
-      ...bunEnv,
-      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
-  if (out === "SKIP") return;
+    const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
+    if (out === "SKIP") return;
 
-  expect(stderr).toBe("");
-  // With the bug: { rtLen: 4294967295, first: 65, penult: 90, last: null }.
-  expect(out).toEqual({
-    rtLen: MAX_LENGTH,
-    first: 0x41,
-    penult: 0x59,
-    last: 0x5a,
-  });
-  expect(exitCode).toBe(0);
-}, 240_000);
+    expect(stderr).toBe("");
+    // With the bug: { rtLen: 4294967295, first: 65, penult: 90, last: null }.
+    expect(out).toEqual({
+      rtLen: MAX_LENGTH,
+      first: 0x41,
+      penult: 0x59,
+      last: 0x5a,
+    });
+    expect(exitCode).toBe(0);
+  },
+  240_000,
+);
 
-test.skipIf(skip)("node:zlib async gzip round-trips a 2^32-byte chunk without dropping a byte", async () => {
-  const script = `
+test.skipIf(skip)(
+  "node:zlib async gzip round-trips a 2^32-byte chunk without dropping a byte",
+  async () => {
+    const script = `
       const zlib = require("node:zlib");
       const { promisify } = require("node:util");
       let b;
@@ -97,21 +103,23 @@ test.skipIf(skip)("node:zlib async gzip round-trips a 2^32-byte chunk without dr
       );
     `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: {
-      ...bunEnv,
-      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
-  if (out === "SKIP") return;
+    const out = JSON.parse(stdout.trim() || '"NO_OUTPUT"');
+    if (out === "SKIP") return;
 
-  expect(stderr).toBe("");
-  expect(out).toEqual({ rtLen: MAX_LENGTH, last: 0x5a });
-  expect(exitCode).toBe(0);
-}, 240_000);
+    expect(stderr).toBe("");
+    expect(out).toEqual({ rtLen: MAX_LENGTH, last: 0x5a });
+    expect(exitCode).toBe(0);
+  },
+  240_000,
+);


### PR DESCRIPTION
## Repro

```js
const zlib = require("node:zlib");
const N = 2 ** 32;                                  // buffer.constants.MAX_LENGTH
const b = Buffer.alloc(N);
new DataView(b.buffer).setUint8(N - 1, 0x5a);
const r = zlib.gunzipSync(zlib.gzipSync(b));
console.log(r.length);                               // 4294967295 (one short)
console.log(new DataView(r.buffer).getUint8(N - 2)); // 90 (0x5a shifted left one slot)
```

`zlib.gzipSync` on a `MAX_LENGTH` buffer returns success but the round-trip is 2^32 - 1 bytes with one input byte silently skipped. Same for the async `zlib.gzip` path and every other `node:zlib` buffer/stream write that hands the native layer a single 2^32-byte chunk.

## Cause

`CompressionStream::write`/`writeSync` read `in_len` via `v.as_number() as u32` (`jsv_to_u32`, `src/runtime/node/node_zlib_binding.rs:81`), so `2^32` saturates to `2^32 - 1`. `processChunkSync` / `processCallback` then compute `inDelta = availInBefore - availInAfter` with `availInBefore = chunk.byteLength = 2^32`, over-counting by one on the first iteration. The next `in_off` skips one input byte, and by the time the loop terminates the binding has been fed 2^32 - 1 bytes total.

Node v26.3.0 on the same script is worse: its own uint32 wrap yields a 20-byte empty gzip, so matching Node is not the goal.

## Fix

Cap `in_len` at `U32_MAX` at the JS call sites and derive `inDelta` from the capped window so the bookkeeping matches what the binding actually saw. The loop keeps `availInBefore` as the true remaining byte count and re-enters when a window was capped, so the final byte is fed on a follow-up call. On a capped window the caller's flush flag is replaced with `self._defaultFlushFlag` (Z_NO_FLUSH / BROTLI_OPERATION_PROCESS / ZSTD_e_continue, all 0) so a large `chunkSize` does not finish the stream before the trailing byte arrives, and `availOutBefore` is updated to the remaining output space so a non-reset re-entry stays within the buffer. Applies to both `processChunkSync` (sync convenience methods and `_processChunk`) and `processChunk`/`processCallback` (async streams).

No native-side change: with the JS clamp in place the binding is never handed an `in_len` above u32, and the `in_off = 2^32, in_len = 0` flush call that can arise at the tail is harmless (empty slice).

## Verification

`test/js/node/zlib/zlib-4gib-chunk.test.ts` spawns a child that writes sentinels at indices 0, 2^32-2, 2^32-1 via `DataView` (Uint8Array `[]` indexing itself tops out below 2^32-1), runs `gzipSync` + `gunzipSync` (and the async pair), and asserts the round-trip length is 2^32 with all sentinels in place, at both the default 16 KiB and a 64 MiB `chunkSize`. On stock Bun both tests fail with `rtLen: 4294967295` and the tail sentinel shifted. Gated on `os.totalmem() >= 14 GiB`.

## Related

The Bun-native `Bun.gzipSync` / `Bun.gunzipSync` counterparts of this u32-cast class are handled in #35859; the compression-output-over-4 GiB guard is #35856. The experimental `node:zlib/iter` path (`src/js/internal/streams/iter/transform.ts`, behind `--experimental-stream-iter`) has the same unclamped `in_len` shape at `processInputAsync` / `onWriteComplete` / `processSyncInput` and is intentionally left for a follow-up.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/zlib/zlib-4gib-chunk.test.ts"
bun test v1.4.0 (2d02987b2)

test/js/node/zlib/zlib-4gib-chunk.test.ts:
61 |     if (out === "SKIP") return;
62 | 
63 |     expect(stderr).toBe("");
64 |     // With the bug: default -> { rtLen: 4294967295, first: 65, penult: 90, last: null }.
65 |     const want = { rtLen: MAX_LENGTH, first: 0x41, penult: 0x59, last: 0x5a };
66 |     expect(out).toEqual({ default: want, [64 * 1024 * 1024]: want });
                     ^
error: expect(received).toEqual(expected)

  {
    "67108864": {
      "first": 65,
-     "last": 90,
+     "last": null,
      "penult": 89,
-     "rtLen": 4294967296,
+     "rtLen": 4294967295,
    },
    "default": {
      "first": 65,
-     "last": 90,
-     "penult": 89,
-     "rtLen": 4294967296,
+     "last": null,
+     "penult": 90,
+     "rtLen": 4294967295,
    },
  }

- Expected  - 5
+ Received  + 5

      at <anonymous> (/workspace/bun/test/js/node/zlib/zlib-4gib-chunk.test.ts:66:17)
(fail) node:zlib gzipSync round-trips a 2^32-byte chunk without dropping a byte
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2d02987b2)

test/js/node/zlib/zlib-4gib-chunk.test.ts:
(pass) node:zlib gzipSync round-trips a 2^32-byte chunk without dropping a byte [15367.16ms]
(pass) node:zlib async gzip round-trips a 2^32-byte chunk without dropping a byte [11421.13ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [27.04s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/zlib/zlib-4gib-chunk.test.ts"
bun test v1.4.0 (2d02987b2)

test/js/node/zlib/zlib-4gib-chunk.test.ts:
(pass) node:zlib gzipSync round-trips a 2^32-byte chunk without dropping a byte [113389.52ms]
(pass) node:zlib async gzip round-trips a 2^32-byte chunk without dropping a byte [125344.34ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [241.70s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 852ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (10331ms)
Bundle modules (61ms)
Postprocesss modules (224ms)
Bundle Functions (955ms)
Generate Code (30ms)

[11.62s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (2d02987b2)

test/js/node/zlib/zlib-4gib-chunk.test.ts:
(pass) node:zlib gzipSync round-trips a 2^32-byte chunk without dropping a byte [12069.89ms]
(pass) node:zlib async gzip round-trips a 2^32-byte chunk without dropping a byte [12987.04ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [25.38s]
__F:0:S:0
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/zlib.ts                       |  42 +++++++----
 test/js/node/zlib/zlib-4gib-chunk.test.ts | 120 ++++++++++++++++++++++++++++++
 2 files changed, 146 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/zlib.ts                            5     13      0
test/js/node/zlib/zlib-4gib-chunk.test.ts      2     10      0
```

</details>

<!-- robobun:evidence:end -->