### PR TITLE
Bun.gunzipSync/zstdDecompress: cap decompressed output at the ArrayBuffer limit

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2510,6 +2510,7 @@ pub mod JSZlib {
 
         match library {
             Library::Zlib => {
+                let max_output = ArrayBuffer::MAX_SIZE as usize;
                 let mut reader = match zlib::ZlibReaderArrayList::init_with_options(
                     compressed,
                     &mut list,
@@ -2531,8 +2532,20 @@ pub mod JSZlib {
                         return Err(global_this.throw_error(crate::Error::from(err), "Zlib error"));
                     }
                 };
+                reader.max_output_size = max_output;
 
-                if reader.read_all(true).is_err() {
+                if let Err(err) = reader.read_all(true) {
+                    if err == zlib::ZlibError::OutputTooLarge {
+                        drop(reader);
+                        return Err(global_this
+                            .err(
+                                jsc::ErrCode::BUFFER_TOO_LARGE,
+                                format_args!(
+                                    "Cannot create a Buffer larger than {max_output} bytes",
+                                ),
+                            )
+                            .throw());
+                    }
                     let msg = reader.error_message().unwrap_or(b"Zlib returned an error");
                     return Err(global_this
                         .throw_value(ZigString::init(msg).to_error_instance(global_this)));
@@ -2840,8 +2853,17 @@ pub mod JSZstd {
 
         let input = buffer.slice();
 
-        let output = match bun_zstd::decompress_alloc(input) {
+        let max_output = ArrayBuffer::MAX_SIZE as usize;
+        let output = match bun_zstd::decompress_alloc_with_limit(input, max_output) {
             Ok(v) => v,
+            Err(bun_zstd::ZstdError::OutputTooLarge) => {
+                return Err(global_this
+                    .err(
+                        jsc::ErrCode::BUFFER_TOO_LARGE,
+                        format_args!("Cannot create a Buffer larger than {max_output} bytes"),
+                    )
+                    .throw());
+            }
             Err(err) => {
                 return Err(global_this
                     .err(
@@ -2865,6 +2887,7 @@ pub mod JSZstd {
         pub level: i32,
         pub output: Vec<u8>,
         pub error_message: Option<&'static [u8]>,
+        pub output_too_large: bool,
         pub promise: jsc::JSPromiseStrong,
     }
 
@@ -2907,8 +2930,13 @@ pub mod JSZstd {
                 };
             } else {
                 // Decompression path
-                self.output = match bun_zstd::decompress_alloc(input) {
+                let max_output = ArrayBuffer::MAX_SIZE as usize;
+                self.output = match bun_zstd::decompress_alloc_with_limit(input, max_output) {
                     Ok(v) => v,
+                    Err(bun_zstd::ZstdError::OutputTooLarge) => {
+                        self.output_too_large = true;
+                        return;
+                    }
                     Err(_) => {
                         self.error_message = Some(b"Decompression failed");
                         return;
@@ -2919,6 +2947,20 @@ pub mod JSZstd {
 
         fn then(&mut self, global_this: &JSGlobalObject) -> JsResult<()> {
             let promise = self.promise.swap();
+
+            if self.output_too_large {
+                let max_output = ArrayBuffer::MAX_SIZE as usize;
+                promise.reject_with_async_stack(
+                    global_this,
+                    Ok(global_this
+                        .err(
+                            jsc::ErrCode::BUFFER_TOO_LARGE,
+                            format_args!("Cannot create a Buffer larger than {max_output} bytes"),
+                        )
+                        .to_js()),
+                )?;
+                return Ok(());
+            }
 
             if let Some(err_msg) = self.error_message {
                 promise.reject_with_async_stack(
@@ -2963,6 +3005,7 @@ pub mod JSZstd {
                 level,
                 output: Vec::new(),
                 error_message: None,
+                output_too_large: false,
                 promise,
             },
         )

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -190,8 +190,8 @@ impl<'a, W, const BUFFER_SIZE: usize> ZlibReader<'a, W, BUFFER_SIZE> {
 
         zlib_reader.zlib = zStream_struct {
             next_in: input.as_ptr(),
-            avail_in: u32::try_from(input.len()).expect("int cast"),
-            total_in: u32::try_from(input.len()).expect("int cast") as _,
+            avail_in: input.len().min(uInt::MAX as usize) as uInt,
+            total_in: input.len().min(uInt::MAX as usize) as _,
 
             next_out: zlib_reader.buf.as_mut_ptr(),
             avail_out: BUFFER_SIZE as uInt,
@@ -248,6 +248,8 @@ pub enum ZlibError {
     InvalidArgument,
     ZlibError,
     ShortRead,
+    /// Decompressed output would exceed `max_output_size`.
+    OutputTooLarge,
 }
 
 bun_core::impl_tag_error!(ZlibError);
@@ -422,7 +424,7 @@ impl<'a> ZlibReaderArrayList<'a> {
                     let remaining_budget = self.max_output_size.saturating_sub(produced);
                     if remaining_budget == 0 {
                         self.state = ZlibReaderArrayListState::Error;
-                        return Err(ZlibError::ZlibError);
+                        return Err(ZlibError::OutputTooLarge);
                     }
                     // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
                     let (next_out, avail_out) = unsafe {
@@ -1185,7 +1187,7 @@ impl InflateDecoder {
             let remaining = self.max_output_size.saturating_sub(out.len());
             if remaining == 0 {
                 self.state = State::Error;
-                return Err(ZlibError::ZlibError);
+                return Err(ZlibError::OutputTooLarge);
             }
             let reserve = remaining.min(4096);
             let (consumed, rc) = self.step(input, out, reserve, FlushValue::NoFlush);
@@ -1193,7 +1195,7 @@ impl InflateDecoder {
             self.state = State::Inflating;
             if out.len() > self.max_output_size {
                 self.state = State::Error;
-                return Err(ZlibError::ZlibError);
+                return Err(ZlibError::OutputTooLarge);
             }
             match rc {
                 ReturnCode::StreamEnd => {

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -193,6 +193,8 @@ pub enum ZstdError {
     ZstdFailedToCreateInstance,
     ZstdDecompressionError,
     ShortRead,
+    /// Decompressed output would exceed `max_output_size`.
+    OutputTooLarge,
 }
 
 bun_core::impl_tag_error!(ZstdError);
@@ -295,6 +297,15 @@ pub fn decompress(dest: &mut [u8], src: &[u8]) -> Result {
 /// Handles both frames with known and unknown content sizes.
 /// For safety, if the reported decompressed size exceeds 16MB, streaming decompression is used instead.
 pub fn decompress_alloc(src: &[u8]) -> core::result::Result<Vec<u8>, ZstdError> {
+    decompress_alloc_with_limit(src, usize::MAX)
+}
+
+/// [`decompress_alloc`] with a hard cap on the output size. Returns
+/// [`ZstdError::OutputTooLarge`] instead of allocating past `max_output_size`.
+pub fn decompress_alloc_with_limit(
+    src: &[u8],
+    max_output_size: usize,
+) -> core::result::Result<Vec<u8>, ZstdError> {
     let size = get_decompressed_size(src);
 
     const ZSTD_CONTENTSIZE_UNKNOWN: usize = c_ulonglong::MAX as usize; // 0ULL - 1
@@ -311,6 +322,7 @@ pub fn decompress_alloc(src: &[u8]) -> core::result::Result<Vec<u8>, ZstdError> 
     if size == ZSTD_CONTENTSIZE_UNKNOWN || size > MAX_PREALLOCATE_SIZE {
         let mut list: Vec<u8> = Vec::new();
         let mut reader = ZstdReaderArrayList::init(src, &mut list)?;
+        reader.max_output_size = max_output_size;
 
         reader.read_all(true)?;
         drop(reader);
@@ -420,7 +432,7 @@ impl<'a> ZstdReaderArrayList<'a> {
             let remaining_output = self.max_output_size.saturating_sub(self.list_ptr.len());
             if remaining_output == 0 {
                 self.state = State::Error;
-                return Err(ZstdError::ZstdDecompressionError);
+                return Err(ZstdError::OutputTooLarge);
             }
 
             // SAFETY: write-only spare; ZSTD_decompressStream initializes the
@@ -570,7 +582,7 @@ impl StreamingDecoder {
             let remaining_output = self.max_output_size.saturating_sub(out.len());
             if remaining_output == 0 {
                 self.state = State::Error;
-                return Err(ZstdError::ZstdDecompressionError);
+                return Err(ZstdError::OutputTooLarge);
             }
 
             out.reserve(4096);

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -300,8 +300,6 @@ pub fn decompress_alloc(src: &[u8]) -> core::result::Result<Vec<u8>, ZstdError> 
     decompress_alloc_with_limit(src, usize::MAX)
 }
 
-/// [`decompress_alloc`] with a hard cap on the output size. Returns
-/// [`ZstdError::OutputTooLarge`] instead of allocating past `max_output_size`.
 pub fn decompress_alloc_with_limit(
     src: &[u8],
     max_output_size: usize,

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -328,6 +328,9 @@ pub fn decompress_alloc_with_limit(
     }
 
     // Fast path: size is known and within reasonable limits
+    if size > max_output_size {
+        return Err(ZstdError::OutputTooLarge);
+    }
     let mut output = vec![0u8; size];
 
     match decompress(&mut output, src) {

--- a/test/js/bun/util/decompress-output-cap.test.ts
+++ b/test/js/bun/util/decompress-output-cap.test.ts
@@ -52,8 +52,10 @@ test.skipIf(!hasMemory)(
   300_000,
 );
 
-test.skipIf(!hasMemory)("Bun.gunzipSync rejects a > 4 GiB output with ERR_BUFFER_TOO_LARGE", async () => {
-  const script = `
+test.skipIf(!hasMemory)(
+  "Bun.gunzipSync rejects a > 4 GiB output with ERR_BUFFER_TOO_LARGE",
+  async () => {
+    const script = `
     const zlib = require("node:zlib");
     const chunks = [];
     const gz = zlib.createGzip({ level: 1 });
@@ -79,17 +81,19 @@ test.skipIf(!hasMemory)("Bun.gunzipSync rejects a > 4 GiB output with ERR_BUFFER
       console.log(JSON.stringify({ threw: true, code: e.code, isRangeError: e instanceof RangeError }));
     }
   `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const out = JSON.parse(stdout.trim() || "null");
-  expect({ out, stderr }).toEqual({
-    out: { threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true },
-    stderr: "",
-  });
-  expect(exitCode).toBe(0);
-}, 300_000);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = JSON.parse(stdout.trim() || "null");
+    expect({ out, stderr }).toEqual({
+      out: { threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  },
+  300_000,
+);

--- a/test/js/bun/util/decompress-output-cap.test.ts
+++ b/test/js/bun/util/decompress-output-cap.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import os from "os";
+
+// The Bun-native decompress APIs must throw ERR_BUFFER_TOO_LARGE (a RangeError)
+// instead of aborting when the decompressed output would exceed the ArrayBuffer
+// limit. The reader's max_output_size caps the output Vec at the limit so an
+// arbitrarily large bomb (here 500 x 64 MiB = 31.25 GiB) stops growing at the
+// cap instead of allocating the whole thing and then failing at the sink.
+// Spawned so the multi-GB allocation dies with the child and so a regression
+// (process abort / OOM kill) fails the test instead of killing the runner.
+const hasMemory = os.totalmem() >= 16 * 1024 ** 3;
+
+test.skipIf(!hasMemory)(
+  "Bun.zstdDecompressSync / Bun.zstdDecompress reject a > 4 GiB output with ERR_BUFFER_TOO_LARGE without allocating it",
+  async () => {
+    const script = `
+      const frame = Bun.zstdCompressSync(Buffer.alloc(64 << 20));
+      const bomb = Buffer.concat(Array(500).fill(frame));
+      const results = {};
+      try {
+        Bun.zstdDecompressSync(bomb);
+        results.sync = { threw: false };
+      } catch (e) {
+        results.sync = { threw: true, code: e.code, isRangeError: e instanceof RangeError };
+      }
+      try {
+        await Bun.zstdDecompress(bomb);
+        results.async = { threw: false };
+      } catch (e) {
+        results.async = { threw: true, code: e.code, isRangeError: e instanceof RangeError };
+      }
+      console.log(JSON.stringify(results));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = JSON.parse(stdout.trim() || "null");
+    expect({ out, stderr }).toEqual({
+      out: {
+        sync: { threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true },
+        async: { threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true },
+      },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  },
+  300_000,
+);
+
+test.skipIf(!hasMemory)("Bun.gunzipSync rejects a > 4 GiB output with ERR_BUFFER_TOO_LARGE", async () => {
+  const script = `
+    const zlib = require("node:zlib");
+    const chunks = [];
+    const gz = zlib.createGzip({ level: 1 });
+    gz.on("data", c => chunks.push(c));
+    const done = new Promise(r => gz.on("end", r));
+    const zero = Buffer.alloc(64 << 20);
+    let left = 4 * 1024 ** 3;
+    const feed = () => {
+      while (left > 0) {
+        const n = Math.min(zero.length, left);
+        left -= n;
+        if (!gz.write(zero.subarray(0, n))) return gz.once("drain", feed);
+      }
+      gz.end();
+    };
+    feed();
+    await done;
+    const bomb = Buffer.concat(chunks);
+    try {
+      Bun.gunzipSync(bomb);
+      console.log(JSON.stringify({ threw: false }));
+    } catch (e) {
+      console.log(JSON.stringify({ threw: true, code: e.code, isRangeError: e instanceof RangeError }));
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const out = JSON.parse(stdout.trim() || "null");
+  expect({ out, stderr }).toEqual({
+    out: { threw: true, code: "ERR_BUFFER_TOO_LARGE", isRangeError: true },
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+}, 300_000);

--- a/test/js/bun/util/decompress-output-cap.test.ts
+++ b/test/js/bun/util/decompress-output-cap.test.ts
@@ -60,7 +60,9 @@ test.skipIf(!hasMemory)(
     const chunks = [];
     const gz = zlib.createGzip({ level: 1 });
     gz.on("data", c => chunks.push(c));
-    const done = new Promise(r => gz.on("end", r));
+    const { promise: done, resolve, reject } = Promise.withResolvers();
+    gz.on("end", resolve);
+    gz.on("error", reject);
     const zero = Buffer.alloc(64 << 20);
     let left = 4 * 1024 ** 3;
     const feed = () => {


### PR DESCRIPTION
Part of the compression u32 / 4 GiB sweep. Completes the "fail fast" half of the output-size guard: set `max_output_size` on the zlib and zstd readers so a decompression bomb stops growing the output Vec at `ArrayBuffer::MAX_SIZE` and returns a typed error, instead of allocating the entire decompressed payload before a sink-side length check.

Siblings from the same sweep: #35856 (sink-side `BUFFER_TOO_LARGE` guards at the wrap sites), #35859 (`Bun.gzipSync` / `Bun.deflateSync` u32 input windowing), #35865 (`node:zlib` `processChunkSync` u32 input windowing).

## Repro

```js
// ~1 MB of attacker input, 31.25 GiB decompressed
const frame = Bun.zstdCompressSync(Buffer.alloc(64 << 20));
const bomb = Buffer.concat(Array(500).fill(frame));
Bun.zstdDecompressSync(bomb);  // allocates 31 GiB then SIGABRT, uncatchable
```

## Cause

`ZstdReaderArrayList` / `ZlibReaderArrayList` already carry a `max_output_size` guard (defaulted to `usize::MAX`) and bail with an error when the output would exceed it, but the Bun-native decompress callers never set it. So `read_all` grows the output Vec to the bomb's full decompressed size; the process either aborts at the `JSValue::create_buffer` `RELEASE_ASSERT` / `ArrayBuffer::from_bytes` `int cast` panic, or is OOM-killed first.

## Fix

- Add `ZlibError::OutputTooLarge` / `ZstdError::OutputTooLarge` and return them from the readers' budget check instead of the generic decompression error.
- Add `bun_zstd::decompress_alloc_with_limit(src, max_output_size)` that forwards the cap to `ZstdReaderArrayList`.
- In `BunObject.rs`, set `reader.max_output_size = ArrayBuffer::MAX_SIZE` on the zlib reader and route the zstd paths (sync + async) through `decompress_alloc_with_limit`; map `OutputTooLarge` to `RangeError [ERR_BUFFER_TOO_LARGE]`.
- Replace the `u32::try_from().expect("int cast")` panic in `ZlibReader::init` with a saturating clamp.

The oversized Vec drops on the error return, so the allocation is released before control returns to JS.

## Verification

`test/js/bun/util/decompress-output-cap.test.ts` (spawned subprocess, gated on `os.totalmem() >= 16 GiB`). The zstd test feeds a 500-frame bomb (31.25 GiB decompressed): on stock bun the child is OOM-killed or aborts (test fails); with the cap it throws `ERR_BUFFER_TOO_LARGE` in ~11 s with a ~4 GiB peak. The gunzip test feeds a single-member gzip stream that decompresses to exactly `2**32` bytes: on stock bun `int cast: TryFromIntError(PosOverflow)` panics; with the cap it throws `ERR_BUFFER_TOO_LARGE`.

`test/js/bun/util/zstd.test.ts` and `test/js/node/zlib/zlib.test.js` (467 tests) continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/decompress-output-cap.test.ts
bun test v1.4.0 (5c8d3d38c)

test/js/bun/util/decompress-output-cap.test.ts:
38 |       stdout: "pipe",
39 |       stderr: "pipe",
40 |     });
41 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
42 |     const out = JSON.parse(stdout.trim() || "null");
43 |     expect({ out, stderr }).toEqual({
                                 ^
error: expect(received).toEqual(expected)

  {
-   "out": {
-     "async": {
-       "code": "ERR_BUFFER_TOO_LARGE",
-       "isRangeError": true,
-       "threw": true,
-     },
-     "sync": {
-       "code": "ERR_BUFFER_TOO_LARGE",
-       "isRangeError": true,
-       "threw": true,
-     },
-   },
-   "stderr": "",
+   "out": null,
+   "stderr": 
+ "ASSERTION FAILED: m_sizeInBytes <= (1ull << 32)
+ vendor/WebKit/Source/JavaScriptCore/runtime/ArrayBuffer.cpp(150) : JSC::ArrayBufferContents::ArrayBufferContents(void *, size_t, std::optional<size_t>, ArrayBufferDestructorFunction &&)
+ no stacktra
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (5c8d3d38c)

test/js/bun/util/decompress-output-cap.test.ts:
(pass) Bun.zstdDecompressSync / Bun.zstdDecompress reject a > 4 GiB output with ERR_BUFFER_TOO_LARGE without allocating it [9653.05ms]
(pass) Bun.gunzipSync rejects a > 4 GiB output with ERR_BUFFER_TOO_LARGE [6768.56ms]

 2 pass
 0 fail
 4 expect() calls
Ran 2 tests across 1 file. [16.70s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/decompress-output-cap.test.ts
bun test v1.4.0 (5c8d3d38c)

test/js/bun/util/decompress-output-cap.test.ts:
(pass) Bun.zstdDecompressSync / Bun.zstdDecompress reject a > 4 GiB output with ERR_BUFFER_TOO_LARGE without allocating it [10146.03ms]
(pass) Bun.gunzipSync rejects a > 4 GiB output with ERR_BUFFER_TOO_LARGE [28446.25ms]

 2 pass
 0 fail
 4 expect() calls
Ran 2 tests across 1 file. [40.82s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 990ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_zlib v0.0.0 (/workspace/bun/src/zlib)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/BunObject.rs                   |  49 +++++++++++-
 src/zlib/lib.rs                                |  12 +--
 src/zstd/lib.rs                                |  17 ++++-
 test/js/bun/util/decompress-output-cap.test.ts | 101 +++++++++++++++++++++++++
 4 files changed, 169 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/runtime/api/BunObject.rs                        7      9      0
src/zlib/lib.rs                                     1      4      0
src/zstd/lib.rs                                     6      7      0
test/js/bun/util/decompress-output-cap.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->