### PR TITLE
node:buffer: accept write* offsets ending at the last byte of a 2**32 buffer

### DIFF
--- a/src/js/internal/buffer.ts
+++ b/src/js/internal/buffer.ts
@@ -11,8 +11,11 @@ function boundsError(value, length, type?) {
 
 function checkBounds(buf, offset, byteLength) {
   validateNumber(offset, "offset");
-  if (buf[offset] === undefined || buf[offset + byteLength - 1] === undefined)
-    boundsError(offset, buf.length - byteLength);
+  // Numeric bound check, not `buf[offset] === undefined`: JSC's TypedArray
+  // indexed get returns undefined for index 2**32 - 1 even when in range,
+  // which would misreport a valid last-byte offset on a kMaxLength buffer.
+  const last = buf.length - byteLength;
+  if (Math.floor(offset) !== offset || !(offset >= 0 && offset <= last)) boundsError(offset, last);
 }
 
 function checkInt(buf, value, offset, min, max, byteLength) {
@@ -39,7 +42,8 @@ function writeU_Int8(buf, value, offset, min, max) {
   if (value > max || value < min) {
     throw $ERR_OUT_OF_RANGE("value", `>= ${min} and <= ${max}`, value);
   }
-  if (buf[offset] === undefined) boundsError(offset, buf.length - 1);
+  const last = buf.length - 1;
+  if (Math.floor(offset) !== offset || !(offset >= 0 && offset <= last)) boundsError(offset, last);
 }
 
 export default {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4647,3 +4647,110 @@ it.skipIf(os.totalmem() < 10 * 1024 ** 3)(
     expect(exitCode).toBe(0);
   },
 );
+
+// A kMaxLength (2**32) buffer's final byte is at offset 2**32 - 1. The write*
+// bounds check must accept that offset even though JSC's TypedArray indexed
+// get currently reports undefined there; the slow path compares against
+// buf.length instead. Exercises every write-side path routed through
+// internal/buffer: writeU_Int8, checkBounds, checkInt.
+it.skipIf(os.totalmem() < 10 * 1024 ** 3)(
+  "Buffer read*/write* accept offsets ending at the last byte of a 2**32 buffer",
+  async () => {
+    const script = `
+      const N = 2 ** 32;
+      const b = Buffer.alloc(N);
+      const out = {};
+      const throws = fn => { try { fn(); return "no throw"; } catch (e) { return e.code; } };
+
+      out.writeUInt8 = b.writeUInt8(0xab, N - 1);
+      out.readUInt8 = b.readUInt8(N - 1);
+      out.writeInt8 = b.writeInt8(-1, N - 1);
+      out.readInt8 = b.readInt8(N - 1);
+
+      out.writeUInt16LE = b.writeUInt16LE(0xbeef, N - 2);
+      out.readUInt16LE = b.readUInt16LE(N - 2);
+      out.writeUInt16BE = b.writeUInt16BE(0xbeef, N - 2);
+      out.writeInt16LE = b.writeInt16LE(-2, N - 2);
+      out.writeInt16BE = b.writeInt16BE(-2, N - 2);
+
+      out.writeUInt32LE = b.writeUInt32LE(0xcafebabe, N - 4);
+      out.readUInt32LE = b.readUInt32LE(N - 4);
+      out.writeUInt32BE = b.writeUInt32BE(0xcafebabe, N - 4);
+      out.writeInt32LE = b.writeInt32LE(-3, N - 4);
+      out.writeInt32BE = b.writeInt32BE(-3, N - 4);
+
+      out.writeFloatLE = b.writeFloatLE(1.5, N - 4);
+      out.readFloatLE = b.readFloatLE(N - 4);
+      out.writeFloatBE = b.writeFloatBE(1.5, N - 4);
+      out.writeDoubleLE = b.writeDoubleLE(2.5, N - 8);
+      out.readDoubleLE = b.readDoubleLE(N - 8);
+      out.writeDoubleBE = b.writeDoubleBE(2.5, N - 8);
+
+      out.writeIntLE1 = b.writeIntLE(0x12, N - 1, 1);
+      out.writeIntBE6 = b.writeIntBE(0x1122334455, N - 6, 6);
+      out.writeUIntLE6 = b.writeUIntLE(0x1122334455, N - 6, 6);
+      out.readUIntLE6 = b.readUIntLE(N - 6, 6);
+      out.writeUIntBE1 = b.writeUIntBE(0x12, N - 1, 1);
+
+      out.writeBigUInt64LE = b.writeBigUInt64LE(0x0102030405060708n, N - 8);
+      out.readBigUInt64LE = b.readBigUInt64LE(N - 8).toString(16);
+
+      out.oob_writeUInt8 = throws(() => b.writeUInt8(1, N));
+      out.oob_writeInt16LE = throws(() => b.writeInt16LE(1, N - 1));
+      out.oob_writeDoubleLE = throws(() => b.writeDoubleLE(1, N - 7));
+      out.oob_writeUIntLE6 = throws(() => b.writeUIntLE(1, N - 5, 6));
+
+      out.frac_writeUInt8 = throws(() => b.writeUInt8(1, N - 1.5));
+      out.neg_writeUInt8 = throws(() => b.writeUInt8(1, -1));
+
+      console.log(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const N = 2 ** 32;
+    expect({ out: stdout.trim() && JSON.parse(stdout), stderr }).toEqual({
+      out: {
+        writeUInt8: N,
+        readUInt8: 0xab,
+        writeInt8: N,
+        readInt8: -1,
+        writeUInt16LE: N,
+        readUInt16LE: 0xbeef,
+        writeUInt16BE: N,
+        writeInt16LE: N,
+        writeInt16BE: N,
+        writeUInt32LE: N,
+        readUInt32LE: 0xcafebabe,
+        writeUInt32BE: N,
+        writeInt32LE: N,
+        writeInt32BE: N,
+        writeFloatLE: N,
+        readFloatLE: 1.5,
+        writeFloatBE: N,
+        writeDoubleLE: N,
+        readDoubleLE: 2.5,
+        writeDoubleBE: N,
+        writeIntLE1: N,
+        writeIntBE6: N,
+        writeUIntLE6: N,
+        readUIntLE6: 0x1122334455,
+        writeUIntBE1: N,
+        writeBigUInt64LE: N,
+        readBigUInt64LE: "102030405060708",
+        oob_writeUInt8: "ERR_OUT_OF_RANGE",
+        oob_writeInt16LE: "ERR_OUT_OF_RANGE",
+        oob_writeDoubleLE: "ERR_OUT_OF_RANGE",
+        oob_writeUIntLE6: "ERR_OUT_OF_RANGE",
+        frac_writeUInt8: "ERR_OUT_OF_RANGE",
+        neg_writeUInt8: "ERR_OUT_OF_RANGE",
+      },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## Repro

```js
const b = Buffer.alloc(2 ** 32);
b.writeUInt8(1, 4294967295);
// RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range.
// It must be >= 0 and <= 4294967295. Received 4294967295
```

The message contradicts itself. `readUInt8(4294967295)` on the same buffer already works, as does `DataView.setUint8`. Affects every `write*` whose last byte lands at index `2**32 - 1`: `write[U]Int8/16/32{LE,BE}`, `writeFloat/Double{LE,BE}`, `write[U]Int{LE,BE}`.

## Cause

The slow-path bounds checks in `internal/buffer.ts` (`checkBounds`, `writeU_Int8`) decide in/out of range by probing `buf[offset] === undefined`. In JSC a TypedArray indexed get at `2**32 - 1` currently returns `undefined` even when the view has `2**32` elements (V8 returns the element), so the probe false-positives at exactly the last byte of a `kMaxLength` buffer and `boundsError` throws on a valid offset. The read side's native `$checkBufferRead` already compares `offset <= length - byteLength` numerically, which is why `readUInt8` works.

## Fix

Switch `checkBounds` and `writeU_Int8` to the same numeric comparison the read side uses, with an explicit `Math.floor(offset) !== offset` guard so fractional offsets still report "an integer" like Node. The inline fast-path probes in `JSBufferPrototype.ts` stay as-is: at the boundary index they fall through to the now-correct slow path, and DataView performs the store.

The engine-level indexed-get gap is being tracked separately; this change makes the `Buffer` write family correct regardless of that behaviour.

## Verification

New test in `test/js/node/buffer.test.js` allocates a `2**32` buffer in a subprocess, writes to the final byte(s) with each affected `write*`, reads the values back, and checks that one-past-end / fractional / negative offsets still throw `ERR_OUT_OF_RANGE`. `test-buffer-write*.js` / `test-buffer-read*.js` vendored Node tests pass; the full `buffer.test.js` suite is green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
bun test v1.4.0 (c90c7ed50)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [91.62ms]
(pass) with native Buffer.write > #9120 alloc [70.40ms]
(pass) with native Buffer.write > isAscii [69.91ms]
(pass) with native Buffer.write > isUtf8 [91.75ms]
(pass) with native Buffer.write > Buffer global is settable [68.01ms]
(pass) with native Buffer.write > length overflow [75.46ms]
(pass) with native Buffer.write > truncate input values [187.97ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [70.82ms]
(pass) with native Buffer.write > Buffer.from() [73.82ms]
(pass) with native Buffer.write > offset properties [65.95ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [92.65ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [75.05ms]
(pass) with native Buffer.write > invalid encoding [76.60ms]
(pass) with native Buffer.write > create 0-length buffers [69.19ms]
(pass) with native Buffer.write > write() beyond end of buff
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (c90c7ed50)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [6.12ms]
(pass) with native Buffer.write > #9120 alloc [3.60ms]
(pass) with native Buffer.write > isAscii [3.59ms]
(pass) with native Buffer.write > isUtf8 [4.14ms]
(pass) with native Buffer.write > Buffer global is settable [3.89ms]
(pass) with native Buffer.write > length overflow [5.16ms]
(pass) with native Buffer.write > truncate input values [4.08ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [3.89ms]
(pass) with native Buffer.write > Buffer.from() [3.52ms]
(pass) with native Buffer.write > offset properties [3.74ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [4.87ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [3.22ms]
(pass) with native Buffer.write > invalid encoding [3.58ms]
(pass) with native Buffer.write > create 0-length buffers [5.21ms]
(pass) with native Buffer.write > write() beyond end of buffer [3.94ms]
(pass) with native Buffer.write > write BigInt beyond 64-bit range [3.76ms]
(pass) with native Buffer.write > write BigInt64 with insufficient buffer space
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
bun test v1.4.0 (c90c7ed50)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [107.17ms]
(pass) with native Buffer.write > #9120 alloc [80.34ms]
(pass) with native Buffer.write > isAscii [69.60ms]
(pass) with native Buffer.write > isUtf8 [76.20ms]
(pass) with native Buffer.write > Buffer global is settable [64.41ms]
(pass) with native Buffer.write > length overflow [81.32ms]
(pass) with native Buffer.write > truncate input values [198.40ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [100.38ms]
(pass) with native Buffer.write > Buffer.from() [72.41ms]
(pass) with native Buffer.write > offset properties [71.68ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [69.19ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [68.48ms]
(pass) with native Buffer.write > invalid encoding [111.14ms]
(pass) with native Buffer.write > create 0-length buffers [63.90ms]
(pass) with native Buffer.write > write() beyond end of b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 841ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (9839ms)
Bundle modules (200ms)
Postprocesss modules (332ms)
Bundle Functions (988ms)
Generate Code (36ms)

[11.41s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 0.64s
[2/7] cc obj/codegen/InternalModuleRegistryConstants.S.o
[4/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[4/7] link bun-profile
[5/7] bun-profile --revision
1.4.0-canary.1+c90c7ed50
[7/7] strip bun
[build] done
bun test v1.4.0-canary.1 (c90c7ed50)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [4.57ms]
(pass) with native Buffer.write > #9120 alloc [2.73ms]
(pass) with native Buffer.write > isAscii [2.17ms]
(pass
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/buffer.ts   |  10 +++--
 test/js/node/buffer.test.js | 107 ++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 114 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/js/internal/buffer.ts        1      2      0
test/js/node/buffer.test.js      1      1      0
```

</details>

**self-review** · no surviving concerns

34 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->