### PR TITLE
S3Client: surface 3xx responses as errors instead of following them

### DIFF
--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -361,7 +361,9 @@ pub(crate) fn list_objects(
             // HTTP thread invokes this with that exact pointer.
             S3HttpSimpleTask::http_callback,
         ),
-        bun_http::FetchRedirect::Follow,
+        // See `execute_simple_s3_request`: never follow a 3xx on a signed
+        // request; surface it so `on_response` can turn the body into an error.
+        bun_http::FetchRedirect::Manual,
         bun_http::async_http::Options {
             http_proxy,
             verbose: Some(vm.get_verbose_fetch()),
@@ -1073,7 +1075,10 @@ pub(crate) fn download_stream(
             // HTTP thread invokes this with that exact pointer.
             S3HttpDownloadStreamingTask::http_callback,
         ),
-        bun_http::FetchRedirect::Follow,
+        // See `execute_simple_s3_request`: never follow a 3xx on a signed
+        // request; surface it so `report_progress` can turn the body into an
+        // error.
+        bun_http::FetchRedirect::Manual,
         bun_http::async_http::Options {
             http_proxy,
             verbose: Some(verbose),

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -361,8 +361,6 @@ pub(crate) fn list_objects(
             // HTTP thread invokes this with that exact pointer.
             S3HttpSimpleTask::http_callback,
         ),
-        // See `execute_simple_s3_request`: never follow a 3xx on a signed
-        // request; surface it so `on_response` can turn the body into an error.
         bun_http::FetchRedirect::Manual,
         bun_http::async_http::Options {
             http_proxy,
@@ -1075,9 +1073,6 @@ pub(crate) fn download_stream(
             // HTTP thread invokes this with that exact pointer.
             S3HttpDownloadStreamingTask::http_callback,
         ),
-        // See `execute_simple_s3_request`: never follow a 3xx on a signed
-        // request; surface it so `report_progress` can turn the body into an
-        // error.
         bun_http::FetchRedirect::Manual,
         bun_http::async_http::Options {
             http_proxy,

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -692,11 +692,7 @@ pub(crate) fn execute_simple_s3_request(
             // the HTTP thread as a live pointer for the duration of the callback.
             S3HttpSimpleTask::http_callback,
         ),
-        // A signed S3 request is only valid against the endpoint it was signed
-        // for. Following a 3xx would replay the SigV4 headers, the session
-        // token and (for PUT) the body to whatever host `Location` names, so
-        // surface the 3xx to `on_response` instead; its `_` arm turns the
-        // <Error><Code>PermanentRedirect</Code>... body into an S3Error.
+        // Signed requests are only valid at the signed host; surface 3xx as an error.
         FetchRedirect::Manual,
         HttpOptions {
             http_proxy,

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -692,7 +692,12 @@ pub(crate) fn execute_simple_s3_request(
             // the HTTP thread as a live pointer for the duration of the callback.
             S3HttpSimpleTask::http_callback,
         ),
-        FetchRedirect::Follow,
+        // A signed S3 request is only valid against the endpoint it was signed
+        // for. Following a 3xx would replay the SigV4 headers, the session
+        // token and (for PUT) the body to whatever host `Location` names, so
+        // surface the 3xx to `on_response` instead; its `_` arm turns the
+        // <Error><Code>PermanentRedirect</Code>... body into an S3Error.
+        FetchRedirect::Manual,
         HttpOptions {
             http_proxy,
             verbose: Some(verbose),

--- a/test/js/bun/s3/s3-redirect.test.ts
+++ b/test/js/bun/s3/s3-redirect.test.ts
@@ -130,8 +130,8 @@ describe("S3Client does not follow HTTP redirects", () => {
     expect(ops.write).toEqual({ name: "write", resolved: null, code: "TemporaryRedirect" });
     expect(ops.delete).toEqual({ name: "delete", resolved: null, code: "TemporaryRedirect" });
     expect(ops.list).toEqual({ name: "list", resolved: null, code: "TemporaryRedirect" });
+    expect(ops.stream).toEqual({ name: "stream", resolved: null, code: "TemporaryRedirect" });
     expect(ops.exists.resolved).toBeNull();
-    expect(ops.stream.resolved).toBeNull();
 
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/s3/s3-redirect.test.ts
+++ b/test/js/bun/s3/s3-redirect.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// S3 endpoints signal wrong-region / wrong-endpoint with a 301/307 whose body
+// is an <Error><Code>PermanentRedirect</Code>... document. The AWS SDKs surface
+// that as an error so the caller can re-target and re-sign; they never replay
+// the signed request (credentials + body) to whatever host the Location header
+// names. These tests pin that behaviour: a 3xx from the configured endpoint
+// must reject, and the Location target must see nothing.
+
+const fixture = `
+import { S3Client } from "bun";
+
+type Seen = { method: string; securityToken: string | null; date: string | null; bodyLength: number };
+const targetSeen: Seen[] = [];
+
+// The host the origin's Location header points at. It records any request it
+// receives; the S3 client must never reach it.
+const target = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    const body = await req.arrayBuffer();
+    targetSeen.push({
+      method: req.method,
+      securityToken: req.headers.get("x-amz-security-token"),
+      date: req.headers.get("x-amz-date"),
+      bodyLength: body.byteLength,
+    });
+    return new Response(req.method === "HEAD" ? null : "TARGET-BODY", {
+      headers: { "Content-Length": "11", ETag: '"etag"' },
+    });
+  },
+});
+
+// The configured S3 endpoint. Always answers 307 -> target, with an
+// S3-shaped XML error body so the surfaced error carries a useful code.
+const origin = Bun.serve({
+  port: 0,
+  fetch(req) {
+    const url = new URL(req.url);
+    const body =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      "<Error><Code>TemporaryRedirect</Code>" +
+      "<Message>Please re-send this request to the specified temporary endpoint.</Message>" +
+      "<Endpoint>" + target.url.host + "</Endpoint></Error>";
+    return new Response(req.method === "HEAD" ? null : body, {
+      status: 307,
+      headers: {
+        Location: new URL(url.pathname + url.search, target.url).href,
+        "Content-Type": "application/xml",
+        "Content-Length": String(body.length),
+      },
+    });
+  },
+});
+
+const s3 = new S3Client({
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "secretexample",
+  sessionToken: "STS-SESSION-TOKEN-MUST-NOT-LEAVE-ORIGIN",
+  region: "us-east-1",
+  endpoint: origin.url.href,
+  bucket: "bkt",
+});
+
+type Op = { name: string; resolved: unknown; code: unknown };
+async function attempt(name: string, p: Promise<unknown>): Promise<Op> {
+  try {
+    return { name, resolved: await p, code: null };
+  } catch (e) {
+    return { name, resolved: null, code: (e as { code?: unknown }).code ?? (e as Error).name };
+  }
+}
+
+async function drain(stream: ReadableStream): Promise<string> {
+  let out = "";
+  for await (const chunk of stream) out += Buffer.from(chunk).toString();
+  return out;
+}
+
+const ops = await Promise.all([
+  attempt("text", s3.file("object.txt").text()),
+  attempt("write", s3.write("object.txt", "PAYLOAD-THAT-MUST-NOT-LEAVE-ORIGIN")),
+  attempt("exists", s3.exists("object.txt")),
+  attempt("delete", s3.delete("object.txt")),
+  attempt("list", s3.list()),
+  attempt("stream", drain(s3.file("object.txt").stream())),
+]);
+
+process.stdout.write(JSON.stringify({ ops, targetSeen }));
+target.stop(true);
+origin.stop(true);
+`;
+
+// The S3 client does not honour NO_PROXY, so an inherited proxy would hijack
+// the request to the loopback servers.
+const envWithoutProxy = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
+describe("S3Client does not follow HTTP redirects", () => {
+  test("3xx from the endpoint rejects and nothing is sent to the Location host", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: envWithoutProxy,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout) as {
+      ops: { name: string; resolved: unknown; code: unknown }[];
+      targetSeen: unknown[];
+    };
+    const ops = Object.fromEntries(result.ops.map(o => [o.name, o]));
+
+    // The security-relevant assertion: no signed header, no session token and no
+    // request body was ever delivered to the host named in Location.
+    expect(result.targetSeen).toEqual([]);
+
+    // Every operation must reject. Operations whose response carries the XML
+    // error body surface its <Code>; HEAD has no body so exists() only needs
+    // to reject.
+    expect(ops.text).toEqual({ name: "text", resolved: null, code: "TemporaryRedirect" });
+    expect(ops.write).toEqual({ name: "write", resolved: null, code: "TemporaryRedirect" });
+    expect(ops.delete).toEqual({ name: "delete", resolved: null, code: "TemporaryRedirect" });
+    expect(ops.list).toEqual({ name: "list", resolved: null, code: "TemporaryRedirect" });
+    expect(ops.exists.resolved).toBeNull();
+    expect(ops.stream.resolved).toBeNull();
+
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
#### What

`Bun.S3Client` built its HTTP requests with `FetchRedirect::Follow`, so a 3xx from the configured endpoint was followed to whatever host `Location` named. The followed hop carried the original signing headers (minus `Authorization`, which the generic cross-origin strip removes) and, for `PUT`, the original body. `write()` then resolved against the redirect target's `200`, not the origin's.

S3 never expects a client to follow these. A 301/307 from S3 is an error whose body is `<Error><Code>PermanentRedirect</Code>...<Endpoint>...</Endpoint></Error>`; the caller re-signs against that endpoint. The AWS SDKs surface it as an error, and a request signed for host A is never valid at host B anyway.

#### Fix

Switch the three `AsyncHTTP::init` call sites (simple request, list-objects GET, streaming download) from `FetchRedirect::Follow` to `FetchRedirect::Manual`. The 3xx then reaches the existing `_ => error_with_body(Failure)` / `report_progress` arms, which already extract `<Code>` and `<Message>` from the XML body, so the operation rejects with e.g. `code: "PermanentRedirect"` like any other S3 error status.

#### Tests

`test/js/bun/s3/s3-redirect.test.ts` runs a loopback origin that answers every request with `307 Location: <other loopback server>` and asserts that `text()`, `write()`, `exists()`, `delete()`, `list()` and `stream()` all reject (with the body's `<Code>` where one exists) and that the `Location` target receives no request at all.

Before this change the target received every method, including the `PUT` body and the `x-amz-security-token` / `x-amz-date` headers.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-redirect.test.ts"
bun test v1.4.0 (69efc7f5e)

test/js/bun/s3/s3-redirect.test.ts:
119 |     };
120 |     const ops = Object.fromEntries(result.ops.map(o => [o.name, o]));
121 | 
122 |     // The security-relevant assertion: no signed header, no session token and no
123 |     // request body was ever delivered to the host named in Location.
124 |     expect(result.targetSeen).toEqual([]);
                                    ^
error: expect(received).toEqual(expected)

- []
+ [
+   {
+     "bodyLength": 0,
+     "date": "20260726T050631Z",
+     "method": "GET",
+     "securityToken": "STS-SESSION-TOKEN-MUST-NOT-LEAVE-ORIGIN",
+   },
+   {
+     "bodyLength": 34,
+     "date": "20260726T050631Z",
+     "method": "PUT",
+     "securityToken": "STS-SESSION-TOKEN-MUST-NOT-LEAVE-ORIGIN",
+   },
+   {
+     "bodyLength": 0,
+     "date": "20260726T050631Z",
+     "method": "HEAD",
+     "securityToken": "STS-SESSION-TOKEN-MUST-NOT-LEAVE-ORIGIN",
+   },
+   {
+     "bodyLength": 0,
+     "date": "20260726T050631Z",
+     "m
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (570b0b92e)

test/js/bun/s3/s3-redirect.test.ts:
(pass) S3Client does not follow HTTP redirects > 3xx from the endpoint rejects and nothing is sent to the Location host [37.47ms]

 1 pass
 0 fail
 9 expect() calls
Ran 1 test across 1 file. [408.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-redirect.test.ts"
bun test v1.4.0 (69efc7f5e)

test/js/bun/s3/s3-redirect.test.ts:
(pass) S3Client does not follow HTTP redirects > 3xx from the endpoint rejects and nothing is sent to the Location host [1267.80ms]

 1 pass
 0 fail
 9 expect() calls
Ran 1 test across 1 file. [3.60s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 745ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/s3/client.rs         |   4 +-
 src/runtime/webcore/s3/simple_request.rs |   3 +-
 test/js/bun/s3/s3-redirect.test.ts       | 138 +++++++++++++++++++++++++++++++
 3 files changed, 142 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/runtime/webcore/s3/client.rs              3      3      0
src/runtime/webcore/s3/simple_request.rs      2      3      0
test/js/bun/s3/s3-redirect.test.ts            1      3      0
```

</details>

<!-- robobun:evidence:end -->