### PR TITLE
Bun.serve: require Connection: Upgrade token and single Sec-WebSocket-Key in server.upgrade()

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -427,6 +427,15 @@ fn is_valid_sec_websocket_key(key: &[u8]) -> bool {
             .all(|&c| c.is_ascii_alphanumeric() || c == b'+' || c == b'/')
 }
 
+/// RFC 7230 §3.2.2 / §6.1: |Connection| and |Upgrade| are comma-separated
+/// token lists; match one token ASCII-case-insensitively.
+#[inline]
+fn header_value_has_token(value: &[u8], lower_token: &[u8]) -> bool {
+    value
+        .split(|&c| c == b',')
+        .any(|t| strings::eql_case_insensitive_ascii(t.trim_ascii(), lower_token, true))
+}
+
 pub(super) type ServerRequestContext<const SSL: bool, const DEBUG: bool> =
     NewRequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, false>;
 pub(super) type ServerH3RequestContext<const SSL: bool, const DEBUG: bool> =
@@ -1909,6 +1918,7 @@ where
         let mut sec_websocket_extensions = ZigString::EMPTY;
         let mut sec_websocket_version = ZigString::EMPTY;
         let mut upgrade_header = ZigString::EMPTY;
+        let mut connection_header = ZigString::EMPTY;
 
         // Owned backing storage for sec_websocket_*.
         // `ZigStringSlice` impls `Drop`; reassignment drops the previous value.
@@ -1917,6 +1927,7 @@ where
         let mut _sec_websocket_extensions_owned = bun_core::ZigStringSlice::empty();
         let mut _sec_websocket_version_owned = bun_core::ZigStringSlice::empty();
         let mut _upgrade_header_owned = bun_core::ZigStringSlice::empty();
+        let mut _connection_header_owned = bun_core::ZigStringSlice::empty();
 
         // NOTE: `FetchHeaders::fast_get` takes `&mut self` (FFI signature
         // is `*mut`), so go through the `BodyMixin` accessor which yields a
@@ -1947,10 +1958,15 @@ where
                 _upgrade_header_owned = up.to_slice_clone();
                 upgrade_header = ZigString::init(_upgrade_header_owned.slice());
             }
+            if let Some(conn) = head.fast_get(HTTPHeaderName::Connection) {
+                _connection_header_owned = conn.to_slice_clone();
+                connection_header = ZigString::init(_connection_header_owned.slice());
+            }
         }
 
         // SAFETY: upgrader_ptr is live (ref_() above)
         let upgrader = unsafe { &mut *upgrader_ptr };
+        let mut connection_has_upgrade: Option<bool> = None;
         if let Some(req_ptr) = upgrader.req {
             // NOTE: `RequestContext.req` is type-erased to `*mut c_void`
             // (RequestContext.rs:82). `server.upgrade()` is HTTP/1-only — H3
@@ -1979,17 +1995,30 @@ where
             if upgrade_header.len == 0 {
                 upgrade_header = ZigString::init(r.header(b"upgrade").unwrap_or(b""));
             }
+            // `r.header()` returns only the first field line, so it cannot
+            // answer whether |Connection|'s token list (which may span several
+            // field lines) contains "upgrade", nor whether |Sec-WebSocket-Key|
+            // was sent more than once; scan once for both.
+            let (key_count, conn_upgrade) = r.ws_handshake_scan();
+            connection_has_upgrade = Some(conn_upgrade);
+            if key_count > 1 {
+                return Ok(JSValue::FALSE);
+            }
         }
 
         // RFC 6455 §4.2.1: validate the client's opening handshake.
         // A request that does not name "websocket" in its |Upgrade| token list,
-        // or whose |Sec-WebSocket-Key| is not base64 of 16 bytes, is not a
-        // WebSocket handshake; fall through so the caller's fetch() can respond.
-        if !upgrade_header
-            .slice()
-            .split(|&c| c == b',')
-            .any(|t| strings::eql_case_insensitive_ascii(t.trim_ascii(), b"websocket", true))
-        {
+        // whose |Connection| token list does not contain "upgrade", or whose
+        // |Sec-WebSocket-Key| is not exactly one base64-of-16-bytes value, is
+        // not a WebSocket handshake; fall through so the caller's fetch() can
+        // respond.
+        if !header_value_has_token(upgrade_header.slice(), b"websocket") {
+            return Ok(JSValue::FALSE);
+        }
+        if !connection_has_upgrade.unwrap_or_else(|| {
+            // `FetchHeaders` comma-joins repeated field lines (HTTPHeaderMap::add).
+            header_value_has_token(connection_header.slice(), b"upgrade")
+        }) {
             return Ok(JSValue::FALSE);
         }
         if !is_valid_sec_websocket_key(sec_websocket_key_str.slice()) {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -427,8 +427,6 @@ fn is_valid_sec_websocket_key(key: &[u8]) -> bool {
             .all(|&c| c.is_ascii_alphanumeric() || c == b'+' || c == b'/')
 }
 
-/// RFC 7230 §3.2.2 / §6.1: |Connection| and |Upgrade| are comma-separated
-/// token lists; match one token ASCII-case-insensitively.
 #[inline]
 fn header_value_has_token(value: &[u8], lower_token: &[u8]) -> bool {
     value
@@ -1995,10 +1993,7 @@ where
             if upgrade_header.len == 0 {
                 upgrade_header = ZigString::init(r.header(b"upgrade").unwrap_or(b""));
             }
-            // `r.header()` returns only the first field line, so it cannot
-            // answer whether |Connection|'s token list (which may span several
-            // field lines) contains "upgrade", nor whether |Sec-WebSocket-Key|
-            // was sent more than once; scan once for both.
+            // `r.header()` returns only the first field line; scan all of them.
             let (key_count, conn_upgrade) = r.ws_handshake_scan();
             connection_has_upgrade = Some(conn_upgrade);
             if key_count > 1 {
@@ -2006,19 +2001,14 @@ where
             }
         }
 
-        // RFC 6455 §4.2.1: validate the client's opening handshake.
-        // A request that does not name "websocket" in its |Upgrade| token list,
-        // whose |Connection| token list does not contain "upgrade", or whose
-        // |Sec-WebSocket-Key| is not exactly one base64-of-16-bytes value, is
-        // not a WebSocket handshake; fall through so the caller's fetch() can
-        // respond.
+        // RFC 6455 §4.2.1: not a WebSocket handshake; fall through so the
+        // caller's fetch() can respond.
         if !header_value_has_token(upgrade_header.slice(), b"websocket") {
             return Ok(JSValue::FALSE);
         }
-        if !connection_has_upgrade.unwrap_or_else(|| {
-            // `FetchHeaders` comma-joins repeated field lines (HTTPHeaderMap::add).
-            header_value_has_token(connection_header.slice(), b"upgrade")
-        }) {
+        if !connection_has_upgrade
+            .unwrap_or_else(|| header_value_has_token(connection_header.slice(), b"upgrade"))
+        {
             return Ok(JSValue::FALSE);
         }
         if !is_valid_sec_websocket_key(sec_websocket_key_str.slice()) {

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -82,8 +82,6 @@ impl Request {
         // ffi::slice tolerates the (null, 0) shape uWS returns when no parameter is present.
         unsafe { bun_core::ffi::slice(ptr, len) }
     }
-    /// One pass over all request headers for the WebSocket opening-handshake
-    /// checks that [`header`](Self::header) (first match only) cannot answer.
     /// Returns `(sec_websocket_key_count, connection_has_upgrade_token)`.
     pub fn ws_handshake_scan(&self) -> (u32, bool) {
         let mut conn_has_upgrade = false;

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -82,6 +82,14 @@ impl Request {
         // ffi::slice tolerates the (null, 0) shape uWS returns when no parameter is present.
         unsafe { bun_core::ffi::slice(ptr, len) }
     }
+    /// One pass over all request headers for the WebSocket opening-handshake
+    /// checks that [`header`](Self::header) (first match only) cannot answer.
+    /// Returns `(sec_websocket_key_count, connection_has_upgrade_token)`.
+    pub fn ws_handshake_scan(&self) -> (u32, bool) {
+        let mut conn_has_upgrade = false;
+        let key_count = c::uws_req_ws_handshake_scan(self, &mut conn_has_upgrade);
+        (key_count, conn_has_upgrade)
+    }
 }
 
 mod c {
@@ -106,5 +114,9 @@ mod c {
             index: c_ushort,
             dest: &mut *const u8,
         ) -> usize;
+        pub(super) safe fn uws_req_ws_handshake_scan(
+            res: &Request,
+            conn_has_upgrade: &mut bool,
+        ) -> u32;
     }
 }

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1656,12 +1656,9 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     }
   }
 
-  // One pass over all request headers for the WebSocket opening-handshake
-  // checks that uws_req_get_header (first match only) cannot answer: the
-  // |Connection| field is a comma-separated token list that may span multiple
-  // field lines, and |Sec-WebSocket-Key| must not appear more than once.
-  // Returns the number of |Sec-WebSocket-Key| field lines; writes whether any
-  // |Connection| token is an ASCII case-insensitive match for "upgrade".
+  // RFC 6455 §4.2.1 handshake checks that uws_req_get_header (first match
+  // only) cannot answer: returns the |Sec-WebSocket-Key| count and whether
+  // any |Connection| token equals "upgrade".
   uint32_t uws_req_ws_handshake_scan(uws_req_t *res, bool *conn_has_upgrade)
   {
     uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1656,6 +1656,39 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     }
   }
 
+  // One pass over all request headers for the WebSocket opening-handshake
+  // checks that uws_req_get_header (first match only) cannot answer: the
+  // |Connection| field is a comma-separated token list that may span multiple
+  // field lines, and |Sec-WebSocket-Key| must not appear more than once.
+  // Returns the number of |Sec-WebSocket-Key| field lines; writes whether any
+  // |Connection| token is an ASCII case-insensitive match for "upgrade".
+  uint32_t uws_req_ws_handshake_scan(uws_req_t *res, bool *conn_has_upgrade)
+  {
+    uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;
+    uint32_t key_count = 0;
+    bool upgrade = false;
+    for (const auto &h : *uwsReq) {
+      const auto &name = h.first;
+      if (name.length() == 17 && !strncasecmp(name.data(), "sec-websocket-key", 17)) {
+        key_count++;
+      } else if (name.length() == 10 && !strncasecmp(name.data(), "connection", 10)) {
+        const auto &v = h.second;
+        size_t i = 0;
+        while (i < v.length()) {
+          while (i < v.length() && (v[i] == ',' || v[i] == ' ' || v[i] == '\t')) i++;
+          size_t j = i;
+          while (j < v.length() && v[j] != ',') j++;
+          size_t end = j;
+          while (end > i && (v[end - 1] == ' ' || v[end - 1] == '\t')) end--;
+          if (end - i == 7 && !strncasecmp(v.data() + i, "upgrade", 7)) upgrade = true;
+          i = j;
+        }
+      }
+    }
+    *conn_has_upgrade = upgrade;
+    return key_count;
+  }
+
   size_t uws_req_get_query(uws_req_t *res, const char *key, size_t key_length,
                            const char **dest)
   {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1706,9 +1706,7 @@ describe("server.upgrade() validates the opening handshake", () => {
 
     // Sec-WebSocket-Key sent more than once (RFC 6455 §11.3.1).
     expect(
-      (
-        await rawHandshake([U, C, `Sec-WebSocket-Key: ${K}`, "Sec-WebSocket-Key: eHh4eHh4eHh4eHh4eHh4eA==", V])
-      ).status,
+      (await rawHandshake([U, C, `Sec-WebSocket-Key: ${K}`, "Sec-WebSocket-Key: eHh4eHh4eHh4eHh4eHh4eA==", V])).status,
     ).toBe(400);
 
     // Sec-WebSocket-Key is not valid base64 of 16 bytes.

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1685,10 +1685,31 @@ describe("server.upgrade() validates the opening handshake", () => {
     expect((await rawHandshake(["Upgrade: WebSocket", C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
     // Upgrade is an RFC 7230 token list; any "websocket" token suffices.
     expect((await rawHandshake(["Upgrade: keep-alive, websocket", C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
-    expect(opened).toBe(3);
+    // Connection is a token list; any "upgrade" token suffices (case-insensitive).
+    expect((await rawHandshake([U, "Connection: keep-alive, Upgrade", `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
+    expect((await rawHandshake([U, "Connection: upgrade", `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
+    // ...and may be split across field lines (RFC 7230 §3.2.2).
+    expect(
+      (await rawHandshake([U, "Connection: keep-alive", "Connection: Upgrade", `Sec-WebSocket-Key: ${K}`, V])).status,
+    ).toBe(101);
+    expect(opened).toBe(6);
 
     // Upgrade token other than "websocket": not a WebSocket handshake.
     expect((await rawHandshake(["Upgrade: h2c", C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(400);
+
+    // Connection header missing, or without an "upgrade" token.
+    expect((await rawHandshake([U, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(400);
+    expect((await rawHandshake([U, "Connection: close", `Sec-WebSocket-Key: ${K}`, V])).status).toBe(400);
+    expect((await rawHandshake([U, "Connection: keep-alive", `Sec-WebSocket-Key: ${K}`, V])).status).toBe(400);
+    // Substring is not a token.
+    expect((await rawHandshake([U, "Connection: Upgrade-Insecure", `Sec-WebSocket-Key: ${K}`, V])).status).toBe(400);
+
+    // Sec-WebSocket-Key sent more than once (RFC 6455 §11.3.1).
+    expect(
+      (
+        await rawHandshake([U, C, `Sec-WebSocket-Key: ${K}`, "Sec-WebSocket-Key: eHh4eHh4eHh4eHh4eHh4eA==", V])
+      ).status,
+    ).toBe(400);
 
     // Sec-WebSocket-Key is not valid base64 of 16 bytes.
     for (const key of [
@@ -1711,7 +1732,7 @@ describe("server.upgrade() validates the opening handshake", () => {
     }
 
     // None of the rejected handshakes reached open().
-    expect(opened).toBe(3);
+    expect(opened).toBe(6);
   });
 
   it("returns false for an invalid handshake even when fetch() is async", async () => {
@@ -1733,6 +1754,25 @@ describe("server.upgrade() validates the opening handshake", () => {
     const h2c = await rawHandshake(["Upgrade: h2c", C, `Sec-WebSocket-Key: ${K}`, V]);
     expect(h2c.status).toBe(400);
     expect(upgradeResult).toBe(false);
+
+    const noConn = await rawHandshake([U, `Sec-WebSocket-Key: ${K}`, V]);
+    expect({ status: noConn.status, upgradeResult }).toEqual({ status: 400, upgradeResult: false });
+
+    const connClose = await rawHandshake([U, "Connection: close", `Sec-WebSocket-Key: ${K}`, V]);
+    expect({ status: connClose.status, upgradeResult }).toEqual({ status: 400, upgradeResult: false });
+
+    const dupKey = await rawHandshake([
+      U,
+      C,
+      `Sec-WebSocket-Key: ${K}`,
+      "Sec-WebSocket-Key: eHh4eHh4eHh4eHh4eHh4eA==",
+      V,
+    ]);
+    expect({ status: dupKey.status, upgradeResult }).toEqual({ status: 400, upgradeResult: false });
+
+    // Connection as a token list via the FetchHeaders path still upgrades.
+    const connList = await rawHandshake([U, "Connection: keep-alive, Upgrade", `Sec-WebSocket-Key: ${K}`, V]);
+    expect({ status: connList.status, upgradeResult }).toEqual({ status: 101, upgradeResult: true });
 
     // The 426 path writes the response itself and detaches it; the Response
     // returned from fetch() after the await must not be written a second time.


### PR DESCRIPTION
Follow-up to #35298. Three more RFC-invalid opening handshakes were still answered with `101 Switching Protocols` and reached the app's `open()`:

```js
import net from "node:net";
const server = Bun.serve({
  port: 0,
  fetch(req, srv) { if (srv.upgrade(req)) return; return new Response("no", { status: 400 }); },
  websocket: { open() {}, message() {} },
});
const KEY = "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==";
const V = "Sec-WebSocket-Version: 13";
// all three get "HTTP/1.1 101 Switching Protocols":
await hs(["Upgrade: websocket", "Connection: close", KEY, V]);                        // want 400
await hs(["Upgrade: websocket", KEY, V]);                                             // Connection absent, want 400
await hs(["Upgrade: websocket", "Connection: Upgrade", KEY,
          "Sec-WebSocket-Key: eHh4eHh4eHh4eHh4eHh4eA==", V]);                          // two keys, want 400
```

RFC 6455 section 4.2.1 requires the client handshake to carry a `Connection` header whose token list includes `Upgrade`, and section 11.3.1 says `Sec-WebSocket-Key` MUST NOT appear more than once.

## Cause

The validation added in #35298 checks the `Upgrade` token, the `Sec-WebSocket-Key` shape, and `Sec-WebSocket-Version`, but never reads `Connection`. On the synchronous path the key is read via `uws_req_get_header`, which returns only the first field line for a given name, so a second `Sec-WebSocket-Key` is invisible to the shape check.

## Fix

`server.upgrade()` now also returns `false` (so the caller's `fetch()` responds) when `Connection` is absent or its token list does not contain `upgrade`, and when `Sec-WebSocket-Key` appears more than once.

The raw-uWS path walks the request's header list once via a new `uws_req_ws_handshake_scan` shim to count `Sec-WebSocket-Key` field lines and test every `Connection` value's token list; `uws_req_get_header` cannot answer either question. On the async/`FetchHeaders` path, `HTTPHeaderMap::add` already comma-joins repeated field lines, so a token scan over `fast_get(Connection)` covers every line and a repeated key fails the existing `is_valid_sec_websocket_key` length check.

`Connection: keep-alive, Upgrade`, lowercase `Connection: upgrade`, and the token split across two `Connection` field lines are still accepted.

## Verification

Extended the existing `server.upgrade() validates the opening handshake` block in `test/js/bun/websocket/websocket-server.test.ts` with the three rejected cases, the substring-is-not-a-token case, and the accepted token-list / multi-line cases, on both the synchronous and async/`req.headers`-materialized paths. With `src/` reverted the new `Connection`-missing assertions fail with status 101; with the fix, both tests pass (30 assertions).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->