### PR TITLE
websocket client: send a Close frame before failing on a protocol error

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -2095,8 +2095,7 @@ impl ErrorCode {
             | ProtocolError => Some(1002),
             InvalidUtf8 => Some(1007),
             MessageTooBig => Some(1009),
-            // Handshake / transport / proxy: the socket is dead, never upgraded,
-            // or the write path itself failed, so no Close frame is attempted.
+            // Handshake / transport / proxy failures: nothing to write a Close frame to.
             Cancel | InvalidResponse | Expected101StatusCode | MissingUpgradeHeader
             | MissingConnectionHeader | MissingWebsocketAcceptHeader | InvalidUpgradeHeader
             | InvalidConnectionHeader | InvalidWebsocketVersion | MismatchWebsocketAcceptHeader

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -347,15 +347,14 @@ impl<const SSL: bool> WebSocket<SSL> {
                     return;
                 }
                 self.close_received.set(true);
+                // Dispatch now so C++ → CLOSED and later ws.send() is a no-op.
+                self.dispatch_abrupt_close(code);
                 if self.send_buffer.borrow().readable_length() == 0 {
-                    self.shutdown_after_close_frame();
-                    self.clear_data();
+                    self.close_tcp_after_failed_close();
                 } else {
                     self.close_dispatch_pending
                         .replace(Some(PendingClose::Failed(code)));
                 }
-                // Dispatch now so C++ → CLOSED and later ws.send() is a no-op.
-                self.dispatch_abrupt_close(code);
                 return;
             }
         }
@@ -1250,11 +1249,25 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
     }
 
+    /// §7.1.1: after failing, close the transport ourselves rather than waiting on the peer.
+    fn close_tcp_after_failed_close(&self) {
+        self.shutdown_after_close_frame();
+        self.clear_data();
+        if SSL {
+            // shutdown_after_close_frame is a no-op for SSL; match cancel()'s SSL branch.
+            self.tcp.get().close(uws::CloseKind::Normal);
+        }
+    }
+
     fn finish_pending_close(&self) {
-        if let Some(pending) = self.close_dispatch_pending.take() {
-            self.shutdown_after_close_frame();
-            self.clear_data();
-            self.dispatch_pending_close(pending);
+        match self.close_dispatch_pending.take() {
+            Some(PendingClose::Clean { code, mut reason }) => {
+                self.shutdown_after_close_frame();
+                self.clear_data();
+                self.dispatch_close(code, &mut reason);
+            }
+            Some(PendingClose::Failed(_)) => self.close_tcp_after_failed_close(),
+            None => {}
         }
     }
 

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -2096,13 +2096,30 @@ impl ErrorCode {
             InvalidUtf8 => Some(1007),
             MessageTooBig => Some(1009),
             // Handshake / transport / proxy failures: nothing to write a Close frame to.
-            Cancel | InvalidResponse | Expected101StatusCode | MissingUpgradeHeader
-            | MissingConnectionHeader | MissingWebsocketAcceptHeader | InvalidUpgradeHeader
-            | InvalidConnectionHeader | InvalidWebsocketVersion | MismatchWebsocketAcceptHeader
-            | MissingClientProtocol | MismatchClientProtocol | Timeout | Closed | FailedToWrite
-            | FailedToConnect | HeadersTooLarge | Ended | FailedToAllocateMemory
-            | TlsHandshakeFailed | ProxyConnectFailed | ProxyAuthenticationRequired
-            | ProxyConnectionRefused | ProxyTunnelFailed => None,
+            Cancel
+            | InvalidResponse
+            | Expected101StatusCode
+            | MissingUpgradeHeader
+            | MissingConnectionHeader
+            | MissingWebsocketAcceptHeader
+            | InvalidUpgradeHeader
+            | InvalidConnectionHeader
+            | InvalidWebsocketVersion
+            | MismatchWebsocketAcceptHeader
+            | MissingClientProtocol
+            | MismatchClientProtocol
+            | Timeout
+            | Closed
+            | FailedToWrite
+            | FailedToConnect
+            | HeadersTooLarge
+            | Ended
+            | FailedToAllocateMemory
+            | TlsHandshakeFailed
+            | ProxyConnectFailed
+            | ProxyAuthenticationRequired
+            | ProxyConnectionRefused
+            | ProxyTunnelFailed => None,
         }
     }
 }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -82,9 +82,7 @@ pub struct WebSocket<const SSL: bool> {
     /// A Ping/Pong/Close payload is mid-accumulation in `ping_frame_bytes`.
     pub control_frame_started: Cell<bool>,
     pub close_received: Cell<bool>,
-    /// `Some` once a Close frame has been enqueued: blocks further outbound
-    /// writes and drives `clear_data` + the JS dispatch once the frame is
-    /// fully flushed (or the socket dies).
+    /// Set once a Close frame is enqueued; drives teardown + JS dispatch after it drains.
     pub close_dispatch_pending: RefCell<Option<PendingClose>>,
 
     pub receive_body_remain: Cell<usize>,
@@ -313,9 +311,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         log!("onClose");
         jsc::mark_binding!();
         if let Some(pending) = self.close_dispatch_pending.take() {
-            // The socket closed while our close frame was mid-flush; the peer
-            // either got it or didn't, but JS should still see the original
-            // close code/reason (not an abrupt 1006).
+            // Socket died mid-flush; JS still sees the original code, not 1006.
             self.detach_tcp();
             self.clear_data();
             self.dispatch_pending_close(pending);
@@ -338,23 +334,17 @@ impl<const SSL: bool> WebSocket<SSL> {
 
     pub fn terminate(&self, code: ErrorCode) {
         log!("terminate");
-        // RFC 6455 §7.1.7: an endpoint that fails the connection because of a
-        // protocol error SHOULD send a Close frame with the status code first
-        // so the peer sees 1002/1007/1009 instead of an abnormal 1006.
+        // RFC 6455 §7.1.7: send a Close frame with the status code before failing.
         if let Some(wire_code) = code.close_frame_code() {
             if self.outgoing_websocket.get().is_none() || self.has_pending_close_dispatch() {
-                // A Close frame is already on the wire or draining; a second
-                // protocol error in the same read must not fall through to
-                // fail() → cancel() → close(Failure) and RST it away.
+                // Already failing; don't fall through to fail() → RST the queued Close.
                 return;
             }
             if self.has_tcp() {
                 if !self.write_close_frame(wire_code) {
-                    // enqueue_encoded_bytes already tore down via
-                    // terminate(FailedToWrite) → fail().
+                    // enqueue_encoded_bytes → terminate(FailedToWrite) already tore down.
                     return;
                 }
-                // §7.1.7: stop processing data from the peer once failed.
                 self.close_received.set(true);
                 if self.send_buffer.borrow().readable_length() == 0 {
                     self.shutdown_after_close_frame();
@@ -363,8 +353,7 @@ impl<const SSL: bool> WebSocket<SSL> {
                     self.close_dispatch_pending
                         .replace(Some(PendingClose::Failed(code)));
                 }
-                // Dispatch now (not after the drain) so C++ transitions to
-                // CLOSED and JS/ws.send() cannot queue data after the Close.
+                // Dispatch now so C++ → CLOSED and later ws.send() is a no-op.
                 self.dispatch_abrupt_close(code);
                 return;
             }
@@ -372,9 +361,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.fail(code);
     }
 
-    /// Enqueue an 8-byte masked Close frame carrying just `code` (no reason).
-    /// Returns `false` if the write failed, in which case the nested
-    /// `terminate(FailedToWrite)` → `fail()` has already run the teardown.
+    /// Enqueue a masked Close frame carrying `code` (no reason).
     fn write_close_frame(&self, code: u16) -> bool {
         let mut frame = [0u8; CONTROL_HEADER_SIZE + 2];
         let header = WebsocketHeader::new(2, true, Opcode::Close);
@@ -1288,9 +1275,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
     }
 
-    // `reason` is transferred to C++ inside `dispatch_close` (via `&mut`),
-    // so the by-value `pending` is in fact consumed.
-    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value)] // `reason` is transferred to C++ via &mut
     fn dispatch_pending_close(&self, pending: PendingClose) {
         match pending {
             PendingClose::Clean { code, mut reason } => self.dispatch_close(code, &mut reason),
@@ -2110,9 +2095,7 @@ pub enum ErrorCode {
 }
 
 impl ErrorCode {
-    /// RFC 6455 §7.4.1 status code to put on the wire when this error fails
-    /// the connection (§7.1.7). `None` for transport-level failures where the
-    /// socket is already dead or never established.
+    /// RFC 6455 §7.4.1 wire status code for this failure; `None` for transport errors.
     fn close_frame_code(self) -> Option<u16> {
         match self {
             ErrorCode::ControlFrameIsFragmented

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -342,7 +342,7 @@ impl<const SSL: bool> WebSocket<SSL> {
                 return;
             }
             if self.has_tcp() {
-                if !self.write_close_frame(wire_code) {
+                if !self.write_close_frame(wire_code, &[]) {
                     // enqueue_encoded_bytes → terminate(FailedToWrite) already tore down.
                     return;
                 }
@@ -362,20 +362,23 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.fail(code);
     }
 
-    /// Enqueue a masked Close frame carrying `code` (no reason).
-    fn write_close_frame(&self, code: u16) -> bool {
-        let mut frame = [0u8; CONTROL_HEADER_SIZE + 2];
-        let header = WebsocketHeader::new(2, true, Opcode::Close);
+    /// Enqueue a masked Close frame carrying `code` and an optional UTF-8 reason.
+    fn write_close_frame(&self, code: u16, body: &[u8]) -> bool {
+        debug_assert!(body.len() <= MAX_CLOSE_REASON);
+        let payload_len = 2 + body.len();
+        let mut frame = [0u8; CONTROL_HEADER_SIZE + 2 + MAX_CLOSE_REASON];
+        let header = WebsocketHeader::new((payload_len & 0x7F) as u8, true, Opcode::Close);
         frame[..2].copy_from_slice(&header.slice());
-        frame[CONTROL_HEADER_SIZE..].copy_from_slice(&code.to_be_bytes());
+        frame[CONTROL_HEADER_SIZE..][..2].copy_from_slice(&code.to_be_bytes());
+        frame[CONTROL_HEADER_SIZE + 2..][..body.len()].copy_from_slice(body);
         {
             let (head, payload) = frame.split_at_mut(CONTROL_HEADER_SIZE);
             let mask_buf: &mut [u8; 4] = (&mut head[2..CONTROL_HEADER_SIZE])
                 .try_into()
                 .expect("infallible: size matches");
-            Mask::fill_in_place(&self.global_this, mask_buf, payload);
+            Mask::fill_in_place(&self.global_this, mask_buf, &mut payload[..payload_len]);
         }
-        self.enqueue_encoded_bytes(&frame)
+        self.enqueue_encoded_bytes(&frame[..CONTROL_HEADER_SIZE + payload_len])
     }
 
     fn clear_receive_buffers(&self, free: bool) {
@@ -1203,40 +1206,18 @@ impl<const SSL: bool> WebSocket<SSL> {
             self.clear_data();
             return;
         }
-        // shutdown_read/shutdown are deferred to shutdown_after_close_frame()
-        // so the close frame can finish writing first: SHUT_RD on Linux makes
-        // the socket immediately readable (recv → 0), and the resulting on_end
-        // → terminate → cancel(Failure) would RST and discard the buffered
-        // frame.
-        let mut frame = [0u8; CONTROL_HEADER_SIZE + 2 + MAX_CLOSE_REASON];
-        let header = WebsocketHeader::new(((body_len + 2) & 0x7F) as u8, true, Opcode::Close);
-        frame[..2].copy_from_slice(&header.slice());
-        // the 4-byte masking key lives at frame[2..6]
-        frame[CONTROL_HEADER_SIZE..][..2].copy_from_slice(&code.to_be_bytes());
 
+        let body = &body[..body_len];
         let mut reason = bun_core::String::empty();
         if body_len > 0 {
-            let body = &body[..body_len];
-            // close is always utf8
             if !strings::is_valid_utf8(body) {
                 self.terminate(ErrorCode::InvalidUtf8);
                 return;
             }
             reason = bun_core::String::clone_utf8(body);
-            frame[CONTROL_HEADER_SIZE + 2..][..body_len].copy_from_slice(body);
         }
 
-        // we must mask the code (and the reason, if any)
-        let frame_len = CONTROL_HEADER_SIZE + 2 + body_len;
-        {
-            let (head, payload) = frame.split_at_mut(CONTROL_HEADER_SIZE);
-            let mask_buf: &mut [u8; 4] = (&mut head[2..CONTROL_HEADER_SIZE])
-                .try_into()
-                .expect("infallible: size matches");
-            Mask::fill_in_place(&self.global_this, mask_buf, &mut payload[..2 + body_len]);
-        }
-
-        if self.enqueue_encoded_bytes(&frame[..frame_len]) {
+        if self.write_close_frame(code, body) {
             let dispatch_code = dispatch_code.unwrap_or(code);
             if self.send_buffer.borrow().readable_length() == 0 {
                 self.shutdown_after_close_frame();
@@ -2099,21 +2080,30 @@ pub enum ErrorCode {
 impl ErrorCode {
     /// RFC 6455 §7.4.1 wire status code for this failure; `None` for transport errors.
     fn close_frame_code(self) -> Option<u16> {
+        use ErrorCode::*;
         match self {
-            ErrorCode::ControlFrameIsFragmented
-            | ErrorCode::InvalidControlFrame
-            | ErrorCode::CompressionUnsupported
-            | ErrorCode::InvalidCompressedData
-            | ErrorCode::CompressionFailed
-            | ErrorCode::UnexpectedMaskFromServer
-            | ErrorCode::ExpectedControlFrame
-            | ErrorCode::UnsupportedControlFrame
-            | ErrorCode::UnexpectedOpcode
-            | ErrorCode::UnexpectedRsv1
-            | ErrorCode::ProtocolError => Some(1002),
-            ErrorCode::InvalidUtf8 => Some(1007),
-            ErrorCode::MessageTooBig => Some(1009),
-            _ => None,
+            ControlFrameIsFragmented
+            | InvalidControlFrame
+            | CompressionUnsupported
+            | InvalidCompressedData
+            | CompressionFailed
+            | UnexpectedMaskFromServer
+            | ExpectedControlFrame
+            | UnsupportedControlFrame
+            | UnexpectedOpcode
+            | UnexpectedRsv1
+            | ProtocolError => Some(1002),
+            InvalidUtf8 => Some(1007),
+            MessageTooBig => Some(1009),
+            // Handshake / transport / proxy: the socket is dead, never upgraded,
+            // or the write path itself failed, so no Close frame is attempted.
+            Cancel | InvalidResponse | Expected101StatusCode | MissingUpgradeHeader
+            | MissingConnectionHeader | MissingWebsocketAcceptHeader | InvalidUpgradeHeader
+            | InvalidConnectionHeader | InvalidWebsocketVersion | MismatchWebsocketAcceptHeader
+            | MissingClientProtocol | MismatchClientProtocol | Timeout | Closed | FailedToWrite
+            | FailedToConnect | HeadersTooLarge | Ended | FailedToAllocateMemory
+            | TlsHandshakeFailed | ProxyConnectFailed | ProxyAuthenticationRequired
+            | ProxyConnectionRefused | ProxyTunnelFailed => None,
         }
     }
 }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -342,20 +342,30 @@ impl<const SSL: bool> WebSocket<SSL> {
         // protocol error SHOULD send a Close frame with the status code first
         // so the peer sees 1002/1007/1009 instead of an abnormal 1006.
         if let Some(wire_code) = code.close_frame_code() {
-            if self.has_tcp() && !self.has_pending_close_dispatch() && !self.close_received.get() {
+            if self.outgoing_websocket.get().is_none() || self.has_pending_close_dispatch() {
+                // A Close frame is already on the wire or draining; a second
+                // protocol error in the same read must not fall through to
+                // fail() → cancel() → close(Failure) and RST it away.
+                return;
+            }
+            if self.has_tcp() {
                 if !self.write_close_frame(wire_code) {
                     // enqueue_encoded_bytes already tore down via
                     // terminate(FailedToWrite) → fail().
                     return;
                 }
+                // §7.1.7: stop processing data from the peer once failed.
+                self.close_received.set(true);
                 if self.send_buffer.borrow().readable_length() == 0 {
                     self.shutdown_after_close_frame();
                     self.clear_data();
-                    self.dispatch_abrupt_close(code);
                 } else {
                     self.close_dispatch_pending
                         .replace(Some(PendingClose::Failed(code)));
                 }
+                // Dispatch now (not after the drain) so C++ transitions to
+                // CLOSED and JS/ws.send() cannot queue data after the Close.
+                self.dispatch_abrupt_close(code);
                 return;
             }
         }
@@ -1156,6 +1166,10 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     fn send_pong(&self) -> bool {
+        if self.has_pending_close_dispatch() {
+            // §5.5.1: nothing follows a Close frame on the wire.
+            return true;
+        }
         if !self.has_tcp() {
             self.dispatch_abrupt_close(ErrorCode::Ended);
             return false;
@@ -1367,6 +1381,9 @@ impl<const SSL: bool> WebSocket<SSL> {
         // SAFETY: called from C++ with a valid pointer; guarded above.
         let this = unsafe { &*this_ptr };
 
+        if this.has_pending_close_dispatch() {
+            return;
+        }
         if !this.has_tcp() || op > 0xF {
             this.dispatch_abrupt_close(ErrorCode::Ended);
             return;
@@ -1418,6 +1435,9 @@ impl<const SSL: bool> WebSocket<SSL> {
         // SAFETY: called from C++ with a valid pointer; guarded above.
         let this = unsafe { &*this_ptr };
 
+        if this.has_pending_close_dispatch() {
+            return;
+        }
         if !this.has_tcp() || op > 0xF {
             this.dispatch_abrupt_close(ErrorCode::Ended);
             return;
@@ -1457,6 +1477,9 @@ impl<const SSL: bool> WebSocket<SSL> {
 
         // SAFETY: str_ is a valid pointer from C++
         let str = unsafe { &*str_ };
+        if this.has_pending_close_dispatch() {
+            return;
+        }
         if !this.has_tcp() {
             this.dispatch_abrupt_close(ErrorCode::Ended);
             return;

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1207,16 +1207,17 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
 
         let body = &body[..body_len];
-        let mut reason = bun_core::String::empty();
-        if body_len > 0 {
-            if !strings::is_valid_utf8(body) {
-                self.terminate(ErrorCode::InvalidUtf8);
-                return;
-            }
-            reason = bun_core::String::clone_utf8(body);
+        if body_len > 0 && !strings::is_valid_utf8(body) {
+            self.terminate(ErrorCode::InvalidUtf8);
+            return;
         }
 
         if self.write_close_frame(code, body) {
+            let mut reason = if body_len > 0 {
+                bun_core::String::clone_utf8(body)
+            } else {
+                bun_core::String::empty()
+            };
             let dispatch_code = dispatch_code.unwrap_or(code);
             if self.send_buffer.borrow().readable_length() == 0 {
                 self.shutdown_after_close_frame();

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -165,8 +165,9 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.clear_send_buffers(true);
         self.control_frame_started.set(false);
         self.ping_len.set(0);
-        if let Some(PendingClose::Clean { reason, .. }) = self.close_dispatch_pending.take() {
-            reason.deref();
+        match self.close_dispatch_pending.take() {
+            Some(PendingClose::Clean { reason, .. }) => reason.deref(),
+            Some(PendingClose::Failed(_)) | None => {}
         }
         self.receiving_compressed.set(false);
         self.message_is_compressed.set(false);
@@ -651,6 +652,7 @@ impl<const SSL: bool> WebSocket<SSL> {
                 ReceiveState::Fail => self.recv_failed(ErrorCode::UnsupportedControlFrame),
             };
             match step {
+                Step::Continue if self.close_received.get() => break true,
                 Step::Continue => {}
                 Step::NeedMoreData => break false,
                 Step::Terminated => break true,

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -82,10 +82,10 @@ pub struct WebSocket<const SSL: bool> {
     /// A Ping/Pong/Close payload is mid-accumulation in `ping_frame_bytes`.
     pub control_frame_started: Cell<bool>,
     pub close_received: Cell<bool>,
-    /// `Some` once `send_close_with_body` has enqueued the close frame: blocks
-    /// further outbound writes and drives `clear_data` + `dispatch_close` once
-    /// the frame is fully flushed (or the socket dies).
-    pub close_dispatch_pending: RefCell<Option<(u16, bun_core::String)>>,
+    /// `Some` once a Close frame has been enqueued: blocks further outbound
+    /// writes and drives `clear_data` + the JS dispatch once the frame is
+    /// fully flushed (or the socket dies).
+    pub close_dispatch_pending: RefCell<Option<PendingClose>>,
 
     pub receive_body_remain: Cell<usize>,
     pub receive_buffer: RefCell<LinearFifo<u8, DynamicBuffer<u8>>>,
@@ -167,7 +167,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.clear_send_buffers(true);
         self.control_frame_started.set(false);
         self.ping_len.set(0);
-        if let Some((_, reason)) = self.close_dispatch_pending.take() {
+        if let Some(PendingClose::Clean { reason, .. }) = self.close_dispatch_pending.take() {
             reason.deref();
         }
         self.receiving_compressed.set(false);
@@ -312,13 +312,13 @@ impl<const SSL: bool> WebSocket<SSL> {
     pub fn handle_close(&self, _socket: Socket<SSL>, _code: c_int, _reason: *mut c_void) {
         log!("onClose");
         jsc::mark_binding!();
-        if let Some((code, mut reason)) = self.close_dispatch_pending.take() {
+        if let Some(pending) = self.close_dispatch_pending.take() {
             // The socket closed while our close frame was mid-flush; the peer
-            // either got it or didn't, but JS should still see the
-            // user-initiated code/reason (not an abrupt 1006).
+            // either got it or didn't, but JS should still see the original
+            // close code/reason (not an abrupt 1006).
             self.detach_tcp();
             self.clear_data();
-            self.dispatch_close(code, &mut reason);
+            self.dispatch_pending_close(pending);
             // For the socket.
             // SAFETY: this is the terminal release of the socket's
             // I/O-layer ref.
@@ -338,7 +338,46 @@ impl<const SSL: bool> WebSocket<SSL> {
 
     pub fn terminate(&self, code: ErrorCode) {
         log!("terminate");
+        // RFC 6455 §7.1.7: an endpoint that fails the connection because of a
+        // protocol error SHOULD send a Close frame with the status code first
+        // so the peer sees 1002/1007/1009 instead of an abnormal 1006.
+        if let Some(wire_code) = code.close_frame_code() {
+            if self.has_tcp() && !self.has_pending_close_dispatch() && !self.close_received.get() {
+                if !self.write_close_frame(wire_code) {
+                    // enqueue_encoded_bytes already tore down via
+                    // terminate(FailedToWrite) → fail().
+                    return;
+                }
+                if self.send_buffer.borrow().readable_length() == 0 {
+                    self.shutdown_after_close_frame();
+                    self.clear_data();
+                    self.dispatch_abrupt_close(code);
+                } else {
+                    self.close_dispatch_pending
+                        .replace(Some(PendingClose::Failed(code)));
+                }
+                return;
+            }
+        }
         self.fail(code);
+    }
+
+    /// Enqueue an 8-byte masked Close frame carrying just `code` (no reason).
+    /// Returns `false` if the write failed, in which case the nested
+    /// `terminate(FailedToWrite)` → `fail()` has already run the teardown.
+    fn write_close_frame(&self, code: u16) -> bool {
+        let mut frame = [0u8; CONTROL_HEADER_SIZE + 2];
+        let header = WebsocketHeader::new(2, true, Opcode::Close);
+        frame[..2].copy_from_slice(&header.slice());
+        frame[CONTROL_HEADER_SIZE..].copy_from_slice(&code.to_be_bytes());
+        {
+            let (head, payload) = frame.split_at_mut(CONTROL_HEADER_SIZE);
+            let mask_buf: &mut [u8; 4] = (&mut head[2..CONTROL_HEADER_SIZE])
+                .try_into()
+                .expect("infallible: size matches");
+            Mask::fill_in_place(&self.global_this, mask_buf, payload);
+        }
+        self.enqueue_encoded_bytes(&frame)
     }
 
     fn clear_receive_buffers(&self, free: bool) {
@@ -1206,7 +1245,10 @@ impl<const SSL: bool> WebSocket<SSL> {
                 // proxy_tunnel needed to flush it), so defer teardown until
                 // handle_writable drains the buffer or the socket dies.
                 self.close_dispatch_pending
-                    .replace(Some((dispatch_code, reason)));
+                    .replace(Some(PendingClose::Clean {
+                        code: dispatch_code,
+                        reason,
+                    }));
             }
         }
     }
@@ -1225,10 +1267,20 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     fn finish_pending_close(&self) {
-        if let Some((code, mut reason)) = self.close_dispatch_pending.take() {
+        if let Some(pending) = self.close_dispatch_pending.take() {
             self.shutdown_after_close_frame();
             self.clear_data();
-            self.dispatch_close(code, &mut reason);
+            self.dispatch_pending_close(pending);
+        }
+    }
+
+    // `reason` is transferred to C++ inside `dispatch_close` (via `&mut`),
+    // so the by-value `pending` is in fact consumed.
+    #[allow(clippy::needless_pass_by_value)]
+    fn dispatch_pending_close(&self, pending: PendingClose) {
+        match pending {
+            PendingClose::Clean { code, mut reason } => self.dispatch_close(code, &mut reason),
+            PendingClose::Failed(code) => self.dispatch_abrupt_close(code),
         }
     }
 
@@ -2032,6 +2084,38 @@ pub enum ErrorCode {
     ProxyConnectionRefused = 35,
     ProxyTunnelFailed = 36,
     UnexpectedRsv1 = 37,
+}
+
+impl ErrorCode {
+    /// RFC 6455 §7.4.1 status code to put on the wire when this error fails
+    /// the connection (§7.1.7). `None` for transport-level failures where the
+    /// socket is already dead or never established.
+    fn close_frame_code(self) -> Option<u16> {
+        match self {
+            ErrorCode::ControlFrameIsFragmented
+            | ErrorCode::InvalidControlFrame
+            | ErrorCode::CompressionUnsupported
+            | ErrorCode::InvalidCompressedData
+            | ErrorCode::CompressionFailed
+            | ErrorCode::UnexpectedMaskFromServer
+            | ErrorCode::ExpectedControlFrame
+            | ErrorCode::UnsupportedControlFrame
+            | ErrorCode::UnexpectedOpcode
+            | ErrorCode::UnexpectedRsv1
+            | ErrorCode::ProtocolError => Some(1002),
+            ErrorCode::InvalidUtf8 => Some(1007),
+            ErrorCode::MessageTooBig => Some(1009),
+            _ => None,
+        }
+    }
+}
+
+/// Deferred JS dispatch for a Close frame that is still draining.
+pub enum PendingClose {
+    /// Close handshake — JS sees `did_close` (wasClean = true).
+    Clean { code: u16, reason: bun_core::String },
+    /// §7.1.7 failure — JS sees `did_abrupt_close` (wasClean = false).
+    Failed(ErrorCode),
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -676,12 +676,14 @@ describe.concurrent("WebSocket client writes a Close frame when failing on a bad
     await once(server.listen(0, "127.0.0.1"), "listening");
     const port = (server.address() as import("node:net").AddressInfo).port;
     const closed = Promise.withResolvers<{ code: number; wasClean: boolean }>();
+    const messages: unknown[] = [];
     const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+    ws.onmessage = e => messages.push(e.data);
     ws.onclose = e => closed.resolve({ code: e.code, wasClean: e.wasClean });
     ws.onerror = () => {};
     const [wire, js] = await Promise.all([received, closed.promise]);
     await new Promise<void>(r => server.close(() => r()));
-    return { wire, js };
+    return { wire, js, messages };
   }
 
   it("masked TEXT from server → Close(1002)", async () => {
@@ -714,6 +716,22 @@ describe.concurrent("WebSocket client writes a Close frame when failing on a bad
 
   it("invalid UTF-8 in a TEXT frame → Close(1007)", async () => {
     const { wire, js } = await run(Buffer.from([0x81, 0x02, 0xc3, 0x28]));
+    expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1007 });
+    expect(js).toEqual({ code: 1007, wasClean: false });
+  });
+
+  it("frames trailing the protocol error in the same read are dropped", async () => {
+    // §7.1.7: once failed, the endpoint MUST NOT continue to process data
+    // from the peer. A valid TEXT and a Ping packed after the bad frame must
+    // not dispatch onmessage or put a Pong on the wire after the Close.
+    const { wire, js, messages } = await run(
+      Buffer.concat([
+        Buffer.from([0x81, 0x02, 0xc3, 0x28]), // TEXT with invalid UTF-8
+        Buffer.from([0x81, 0x02, 0x68, 0x69]), // TEXT "hi"
+        Buffer.from([0x89, 0x00]), // Ping
+      ]),
+    );
+    expect(messages).toEqual([]);
     expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1007 });
     expect(js).toEqual({ code: 1007, wasClean: false });
   });

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -5,8 +5,8 @@ import { bunEnv, bunExe, nodeExe, tls as tlsCerts } from "harness";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:net";
-import { createServer as createTlsServer } from "node:tls";
 import * as path from "node:path";
+import { createServer as createTlsServer } from "node:tls";
 import { WebSocket as NodeWS, WebSocketServer } from "ws";
 function test(
   label: string,

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -630,7 +630,9 @@ describe.concurrent("WebSocket client writes a Close frame when failing on a bad
 
   function hostileServer(frame: Buffer) {
     const received = Promise.withResolvers<WireResult>();
+    const sockets = new Set<import("node:net").Socket>();
     const server = createServer(sock => {
+      sockets.add(sock);
       let buf = Buffer.alloc(0);
       let shaken = false;
       let got = Buffer.alloc(0);
@@ -655,6 +657,7 @@ describe.concurrent("WebSocket client writes a Close frame when failing on a bad
         sock.write(frame);
       });
       sock.on("close", () => {
+        sockets.delete(sock);
         let code = 0;
         // client frames are masked: 2-byte header + 4-byte mask + 2-byte status
         if (got.length >= 8 && (got[1] & 0x80) === 0x80) {
@@ -668,22 +671,34 @@ describe.concurrent("WebSocket client writes a Close frame when failing on a bad
         });
       });
     });
-    return { server, received: received.promise };
+    return {
+      server,
+      received: received.promise,
+      close: () =>
+        new Promise<void>(r => {
+          for (const s of sockets) s.destroy();
+          server.close(() => r());
+        }),
+    };
   }
 
   async function run(frame: Buffer) {
-    const { server, received } = hostileServer(frame);
+    const { server, received, close } = hostileServer(frame);
     await once(server.listen(0, "127.0.0.1"), "listening");
     const port = (server.address() as import("node:net").AddressInfo).port;
     const closed = Promise.withResolvers<{ code: number; wasClean: boolean }>();
     const messages: unknown[] = [];
     const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
-    ws.onmessage = e => messages.push(e.data);
-    ws.onclose = e => closed.resolve({ code: e.code, wasClean: e.wasClean });
-    ws.onerror = () => {};
-    const [wire, js] = await Promise.all([received, closed.promise]);
-    await new Promise<void>(r => server.close(() => r()));
-    return { wire, js, messages };
+    try {
+      ws.onmessage = e => messages.push(e.data);
+      ws.onclose = e => closed.resolve({ code: e.code, wasClean: e.wasClean });
+      ws.onerror = () => {};
+      const [wire, js] = await Promise.all([received, closed.promise]);
+      return { wire, js, messages };
+    } finally {
+      ws.terminate();
+      await close();
+    }
   }
 
   it("masked TEXT from server → Close(1002)", async () => {

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -619,6 +619,106 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
   });
 });
 
+// RFC 6455 §7.1.7: when the client fails the connection because of a protocol
+// error in a received frame, it SHOULD send a Close frame carrying the status
+// code (1002/1007/1009) before closing TCP. Without it the server only ever
+// sees an abnormal 1006.
+describe.concurrent("WebSocket client writes a Close frame when failing on a bad server frame", () => {
+  const GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+  type WireResult = { bytes: number; opcode: number; masked: boolean; code: number };
+
+  function hostileServer(frame: Buffer) {
+    const received = Promise.withResolvers<WireResult>();
+    const server = createServer(sock => {
+      let buf = Buffer.alloc(0);
+      let shaken = false;
+      let got = Buffer.alloc(0);
+      sock.on("error", () => {});
+      sock.on("data", chunk => {
+        if (shaken) {
+          got = Buffer.concat([got, chunk]);
+          return;
+        }
+        buf = Buffer.concat([buf, chunk]);
+        const i = buf.indexOf("\r\n\r\n");
+        if (i < 0) return;
+        const key = /sec-websocket-key: *([^\r\n]+)/i.exec(buf.toString("latin1"))![1];
+        const accept = createHash("sha1")
+          .update(key + GUID)
+          .digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+        );
+        shaken = true;
+        sock.write(frame);
+      });
+      sock.on("close", () => {
+        let code = 0;
+        // client frames are masked: 2-byte header + 4-byte mask + 2-byte status
+        if (got.length >= 8 && (got[1] & 0x80) === 0x80) {
+          code = ((got[6] ^ got[2]) << 8) | (got[7] ^ got[3]);
+        }
+        received.resolve({
+          bytes: got.length,
+          opcode: got.length >= 1 ? got[0] & 0x0f : -1,
+          masked: got.length >= 2 && (got[1] & 0x80) === 0x80,
+          code,
+        });
+      });
+    });
+    return { server, received: received.promise };
+  }
+
+  async function run(frame: Buffer) {
+    const { server, received } = hostileServer(frame);
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    const closed = Promise.withResolvers<{ code: number; wasClean: boolean }>();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+    ws.onclose = e => closed.resolve({ code: e.code, wasClean: e.wasClean });
+    ws.onerror = () => {};
+    const [wire, js] = await Promise.all([received, closed.promise]);
+    await new Promise<void>(r => server.close(() => r()));
+    return { wire, js };
+  }
+
+  it("masked TEXT from server → Close(1002)", async () => {
+    // §5.1: a server MUST NOT mask; a client MUST fail the connection on a
+    // masked server frame.
+    const { wire, js } = await run(Buffer.from([0x81, 0x82, 1, 2, 3, 4, 0x68 ^ 1, 0x69 ^ 2]));
+    expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1002 });
+    expect(js).toEqual({ code: 1002, wasClean: false });
+  });
+
+  it("reserved opcode 3 → Close(1002)", async () => {
+    const { wire, js } = await run(Buffer.from([0x83, 0x00]));
+    expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1002 });
+    expect(js).toEqual({ code: 1002, wasClean: false });
+  });
+
+  it("RSV1 set with no extension negotiated → Close(1002)", async () => {
+    const { wire, js } = await run(Buffer.from([0xc1, 0x02, 0x68, 0x69]));
+    expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1002 });
+    // JS-side code for this case is owned by WebSocket.cpp; only assert the
+    // wire half here.
+    expect(js.code).toBeGreaterThan(0);
+  });
+
+  it("126-byte Ping (oversized control payload) → Close(1002)", async () => {
+    const { wire, js } = await run(Buffer.concat([Buffer.from([0x89, 0x7e, 0x00, 0x7e]), Buffer.alloc(126, 0x41)]));
+    expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1002 });
+    expect(js).toEqual({ code: 1002, wasClean: false });
+  });
+
+  it("invalid UTF-8 in a TEXT frame → Close(1007)", async () => {
+    const { wire, js } = await run(Buffer.from([0x81, 0x02, 0xc3, 0x28]));
+    expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1007 });
+    expect(js).toEqual({ code: 1007, wasClean: false });
+  });
+});
+
 async function listen(): Promise<URL> {
   const pathname = path.join(import.meta.dir, "./websocket-server-echo.mjs");
   const { promise, resolve, reject } = Promise.withResolvers();

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -1,10 +1,11 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, nodeExe } from "harness";
+import { bunEnv, bunExe, nodeExe, tls as tlsCerts } from "harness";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:net";
+import { createServer as createTlsServer } from "node:tls";
 import * as path from "node:path";
 import { WebSocket as NodeWS, WebSocketServer } from "ws";
 function test(
@@ -628,10 +629,13 @@ describe.concurrent("WebSocket client writes a Close frame when failing on a bad
 
   type WireResult = { bytes: number; opcode: number; masked: boolean; code: number };
 
-  function hostileServer(frame: Buffer) {
+  function hostileServer(frame: Buffer, tls = false) {
     const received = Promise.withResolvers<WireResult>();
     const sockets = new Set<import("node:net").Socket>();
-    const server = createServer(sock => {
+    const makeServer = tls
+      ? (h: (s: import("node:net").Socket) => void) => createTlsServer({ key: tlsCerts.key, cert: tlsCerts.cert }, h)
+      : createServer;
+    const server = makeServer(sock => {
       sockets.add(sock);
       let buf = Buffer.alloc(0);
       let shaken = false;
@@ -682,13 +686,14 @@ describe.concurrent("WebSocket client writes a Close frame when failing on a bad
     };
   }
 
-  async function run(frame: Buffer) {
-    const { server, received, close } = hostileServer(frame);
+  async function run(frame: Buffer, tls = false) {
+    const { server, received, close } = hostileServer(frame, tls);
     await once(server.listen(0, "127.0.0.1"), "listening");
     const port = (server.address() as import("node:net").AddressInfo).port;
     const closed = Promise.withResolvers<{ code: number; wasClean: boolean }>();
     const messages: unknown[] = [];
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+    const scheme = tls ? "wss" : "ws";
+    const ws = new WebSocket(`${scheme}://127.0.0.1:${port}/`, { tls: { rejectUnauthorized: false } });
     try {
       ws.onmessage = e => messages.push(e.data);
       ws.onclose = e => closed.resolve({ code: e.code, wasClean: e.wasClean });
@@ -733,6 +738,23 @@ describe.concurrent("WebSocket client writes a Close frame when failing on a bad
     const { wire, js } = await run(Buffer.from([0x81, 0x02, 0xc3, 0x28]));
     expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1007 });
     expect(js).toEqual({ code: 1007, wasClean: false });
+  });
+
+  it("declared payload > 128 MiB → Close(1009)", async () => {
+    // recv_body checks the header-declared length before reading, so a 10-byte
+    // frame with an 8-byte extended length of 128 MiB + 1 trips MessageTooBig.
+    const { wire, js } = await run(Buffer.from([0x82, 0x7f, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x01]));
+    expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1009 });
+    expect(js).toEqual({ code: 1009, wasClean: false });
+  });
+
+  it("masked TEXT over wss:// → Close(1002) and the client closes the TLS socket", async () => {
+    // shutdown_after_close_frame is a no-op for SSL; the client must still
+    // close the transport itself (§7.1.1) so this does not hang on a hostile
+    // server that never sends close_notify.
+    const { wire, js } = await run(Buffer.from([0x81, 0x82, 1, 2, 3, 4, 0x68 ^ 1, 0x69 ^ 2]), true);
+    expect(wire).toEqual({ bytes: 8, opcode: 8, masked: true, code: 1002 });
+    expect(js).toEqual({ code: 1002, wasClean: false });
   });
 
   it("frames trailing the protocol error in the same read are dropped", async () => {


### PR DESCRIPTION
When Bun's WebSocket **client** fails the connection because of a hostile server frame (masked server frame per RFC 6455 section 5.1, reserved opcode, RSV1 with no extension, oversized control payload, invalid UTF-8), it writes **0 bytes** and RSTs the TCP connection. The JS-side `CloseEvent.code` is correct (1002/1007/1009) but nothing reaches the wire, so a server operator only ever sees abnormal 1006 closures from Bun clients.

## Repro

```js
import net from "node:net"; import crypto from "node:crypto";
const srv = net.createServer(c => {
  let h = Buffer.alloc(0), up = false, got = Buffer.alloc(0);
  c.on("data", d => {
    if (up) { got = Buffer.concat([got, d]); return; }
    h = Buffer.concat([h, d]); const s = h.toString("latin1");
    if (s.indexOf("\r\n\r\n") < 0) return;
    const key = /Sec-WebSocket-Key: (\S+)/i.exec(s)[1];
    const acc = crypto.createHash("sha1").update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").digest("base64");
    c.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + acc + "\r\n\r\n");
    up = true;
    c.write(Buffer.from([0x81, 0x82, 1, 2, 3, 4, 0x68 ^ 1, 0x69 ^ 2])); // masked TEXT from server: MUST fail
  });
  c.on("close", () => console.log("client wrote", got.length, "bytes:", got.toString("hex"),
    got.length && (got[0] & 15) === 8 ? "(Close frame)" : "(NO CLOSE FRAME)"));
});
srv.listen(0, "127.0.0.1", () => {
  const ws = new WebSocket("ws://127.0.0.1:" + srv.address().port + "/");
  ws.onclose = e => console.log("JS code =", e.code, "wasClean =", e.wasClean);
});
```

Before: `client wrote 0 bytes: (NO CLOSE FRAME)` / `JS code = 1002 wasClean = false`
Node/undici: writes a 30-byte masked `Close(1002 "Frame cannot be masked")`.

## Cause

Every parser failure goes `recv_failed(code)` -> `terminate()` -> `fail()` -> `cancel()` -> `tcp.close(Failure)`. `close(Failure)` arms `SO_LINGER{1,0}` and RSTs, so even if a Close frame were queued it would be dropped. The masked-Close writer `send_close_with_body` is only reached for received-Close echoes and user `ws.close()`.

## Fix

`terminate()` now maps protocol-error `ErrorCode`s to their RFC 6455 section 7.4.1 status code (1002/1007/1009), writes an 8-byte masked Close frame via `enqueue_encoded_bytes`, and takes the existing `shutdown_after_close_frame()` path (graceful FIN, drains the kernel buffer) instead of RST. `close_dispatch_pending` becomes a two-variant enum so a backpressured Close still dispatches via `did_abrupt_close` (`wasClean=false`) rather than `did_close`. Transport-level codes (`FailedToWrite`, `Ended`, `Timeout`, `FailedToConnect`) keep the direct `fail()` path.

The JS-visible `CloseEvent` (code, wasClean, reason) is unchanged.

## Verification

After: `client wrote 8 bytes: 8882... (Close frame)` with status 1002, JS still sees `code = 1002 wasClean = false`.

```
bun bd test test/js/web/websocket/websocket-client.test.ts -t "Close frame when failing"
```

Five cases (masked frame, reserved opcode, unnegotiated RSV1, 126-byte Ping, invalid UTF-8): all fail on 1.4.0 with `bytes: 0`, all pass with this change. The rest of `websocket-client.test.ts`, `websocket-close-code.test.ts`, `websocket-close-fragmented.test.ts`, `websocket-permessage-deflate*.test.ts` and `websocket-client-short-read.test.ts` stay green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (a5fd0319e)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:44351/
(pass) WebSocket > url [10.32ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [3.57ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [5.43ms]
Received upgrade: {
  host: '127.0.0.1:44351',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'ifQvMNSTRtORF+
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (34cd8f6fb)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:37995/
(pass) WebSocket > url [0.54ms]
(pass) WebSocket > binaryType > (default) [0.11ms]
(pass) WebSocket > binaryType > (invalid) [0.18ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:37995',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': '4KzBakf3Qe2JiMyMdpqtHg=='
}
(pass) WebSocket > readyState [4.70ms]
Received connection: 127.0.0.1
Received bytes: <Buffer 88 82 e6 f6 47 63 e5 1e>
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received close: 1000 <Buffer >
Received
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (a5fd0319e)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:38747/
(pass) WebSocket > url [7.35ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [2.23ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [4.13ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:38747',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': '4ck9szdYTVmLcWi
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 932ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/websocket_client.rs               | 206 +++++++++++++++++++------
 test/js/web/websocket/websocket-client.test.ts | 157 ++++++++++++++++++-
 2 files changed, 315 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/http_jsc/websocket_client.rs                   24     29      0
test/js/web/websocket/websocket-client.test.ts      8     10      0
```

</details>

<!-- robobun:evidence:end -->