### PR TITLE
Bun.serve websocket: send a Close frame with 1002/1007/1009 when failing the connection

### DIFF
--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -88,6 +88,14 @@ private:
         us_socket_close((us_socket_t *) s, (int) reason.length(), (void *) reason.data());
     }
 
+    /* RFC 6455 7.1.7 "Fail the WebSocket Connection": send a Close frame
+     * carrying the status code before dropping TCP. end() queues the Close,
+     * sets isShuttingDown so later inbound bytes are ignored, then half-closes
+     * (FIN) once drained. forceClose() remains for idle-timeout only. */
+    static void failConnection(WebSocketState<isServer> */*wState*/, void *s, uint16_t code, std::string_view reason) {
+        ((WebSocket<SSL, isServer, USERDATA> *) s)->end(code, reason);
+    }
+
     /* Returns true on breakage */
     static bool handleFragment(char *data, size_t length, unsigned int remainingBytes, int opCode, bool fin, WebSocketState<isServer> *webSocketState, void *s) {
         /* WebSocketData and WebSocketContextData */
@@ -113,7 +121,7 @@ private:
                         }
 
                         if (!inflatedFrame.has_value()) {
-                            forceClose(webSocketState, s, ERR_TOO_BIG_MESSAGE_INFLATION);
+                            failConnection(webSocketState, s, CLOSE_MESSAGE_TOO_BIG, ERR_TOO_BIG_MESSAGE_INFLATION);
                             return true;
                         } else {
                             data = (char *) inflatedFrame->data();
@@ -123,7 +131,7 @@ private:
 
                 /* Check text messages for Utf-8 validity */
                 if (opCode == 1 && !protocol::isValidUtf8((unsigned char *) data, length)) {
-                    forceClose(webSocketState, s, ERR_INVALID_TEXT);
+                    failConnection(webSocketState, s, CLOSE_INVALID_DATA, ERR_INVALID_TEXT);
                     return true;
                 }
 
@@ -141,7 +149,7 @@ private:
                 }
                 /* Fragments forming a big message are not caught until appending them */
                 if (refusePayloadLength(length + webSocketData->fragmentBuffer.length(), webSocketState, s)) {
-                    forceClose(webSocketState, s, ERR_TOO_BIG_MESSAGE);
+                    failConnection(webSocketState, s, CLOSE_MESSAGE_TOO_BIG, ERR_TOO_BIG_MESSAGE);
                     return true;
                 }
                 webSocketData->fragmentBuffer.append(data, length);
@@ -168,7 +176,7 @@ private:
                             }
 
                             if (!inflatedFrame.has_value()) {
-                                forceClose(webSocketState, s, ERR_TOO_BIG_MESSAGE_INFLATION);
+                                failConnection(webSocketState, s, CLOSE_MESSAGE_TOO_BIG, ERR_TOO_BIG_MESSAGE_INFLATION);
                                 return true;
                             } else {
                                 data = (char *) inflatedFrame->data();
@@ -184,7 +192,7 @@ private:
 
                     /* Check text messages for Utf-8 validity */
                     if (opCode == 1 && !protocol::isValidUtf8((unsigned char *) data, length)) {
-                        forceClose(webSocketState, s, ERR_INVALID_TEXT);
+                        failConnection(webSocketState, s, CLOSE_INVALID_DATA, ERR_INVALID_TEXT);
                         return true;
                     }
 

--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -91,7 +91,14 @@ private:
     /* RFC 6455 7.1.7 "Fail the WebSocket Connection": send a Close frame
      * carrying the status code before dropping TCP. end() queues the Close,
      * sets isShuttingDown so later inbound bytes are ignored, then half-closes
-     * (FIN) once drained. forceClose() remains for idle-timeout only. */
+     * (FIN) once drained. forceClose() remains for idle-timeout only.
+     *
+     * noinline: called from a dozen error branches inside the templated
+     * consume()/consumeMessage()/handleFragment() hot path. Letting end()
+     * (and transitively send()) inline at every site bloats the parser by
+     * hundreds of KB; one out-of-line copy per instantiation is enough for
+     * a cold failure path. */
+    __attribute__((noinline))
     static void failConnection(WebSocketState<isServer> */*wState*/, void *s, uint16_t code, std::string_view reason) {
         ((WebSocket<SSL, isServer, USERDATA> *) s)->end(code, reason);
     }

--- a/packages/bun-uws/src/WebSocketProtocol.h
+++ b/packages/bun-uws/src/WebSocketProtocol.h
@@ -38,6 +38,12 @@ inline constexpr std::string_view ERR_TOO_BIG_MESSAGE_INFLATION("Received too bi
 inline constexpr std::string_view ERR_INVALID_CLOSE_PAYLOAD("Received invalid close payload");
 inline constexpr std::string_view ERR_INVALID_MASKING("Received an incorrectly masked frame");
 inline constexpr std::string_view ERR_INVALID_RSV1("Received unexpected RSV1 bit");
+inline constexpr std::string_view ERR_PROTOCOL("WebSocket protocol error");
+
+/* RFC 6455 7.4.1 status codes an endpoint sends when it Fails the connection. */
+inline constexpr uint16_t CLOSE_PROTOCOL_ERROR = 1002;
+inline constexpr uint16_t CLOSE_INVALID_DATA = 1007;
+inline constexpr uint16_t CLOSE_MESSAGE_TOO_BIG = 1009;
 
 enum OpCode : unsigned char {
     CONTINUATION = 0,
@@ -121,25 +127,32 @@ static bool isValidUtf8(unsigned char *s, size_t length)
 
 struct CloseFrame {
     uint16_t code;
-    char *message;
+    const char *message;
     size_t length;
 };
 
 static inline CloseFrame parseClosePayload(char *src, size_t length) {
-    /* If we get no code or message, default to reporting 1005 no status code present */
-    CloseFrame cf = {1005, nullptr, 0};
-    if (length >= 2) {
-        memcpy(&cf.code, src, 2);
-        cf = {cond_byte_swap<uint16_t>(cf.code), src + 2, length - 2};
-        // RFC 6455 §7.4: 1000-1015 defined, 1016-2999 reserved (MUST NOT be
-        // used), 3000-3999 IANA-registered for libraries/frameworks, 4000-4999
-        // private use. 1004/1005/1006/1015 are not valid on the wire.
-        if (cf.code < 1000 || cf.code > 4999 || (cf.code > 1015 && cf.code < 3000) ||
-            (cf.code >= 1004 && cf.code <= 1006) || cf.code == 1015 ||
-            !isValidUtf8((unsigned char *) cf.message, cf.length)) {
-            /* Even though we got a WebSocket close frame, it in itself is abnormal */
-            return {1006, nullptr, 0};
-        }
+    /* No body: report 1005 "no status code present". An empty Close is echoed back empty. */
+    if (length == 0) {
+        return {1005, nullptr, 0};
+    }
+    /* RFC 6455 5.5.1: if there is a body, its first two bytes MUST be a 2-byte
+     * status code. A 1-byte body is a protocol error, not "no status present". */
+    if (length < 2) {
+        return {CLOSE_PROTOCOL_ERROR, ERR_INVALID_CLOSE_PAYLOAD.data(), ERR_INVALID_CLOSE_PAYLOAD.length()};
+    }
+    CloseFrame cf;
+    memcpy(&cf.code, src, 2);
+    cf = {cond_byte_swap<uint16_t>(cf.code), src + 2, length - 2};
+    // RFC 6455 §7.4: 1000-1015 defined, 1016-2999 reserved (MUST NOT be
+    // used), 3000-3999 IANA-registered for libraries/frameworks, 4000-4999
+    // private use. 1004/1005/1006/1015 are not valid on the wire.
+    if (cf.code < 1000 || cf.code > 4999 || (cf.code > 1015 && cf.code < 3000) ||
+        (cf.code >= 1004 && cf.code <= 1006) || cf.code == 1015) {
+        return {CLOSE_PROTOCOL_ERROR, ERR_INVALID_CLOSE_PAYLOAD.data(), ERR_INVALID_CLOSE_PAYLOAD.length()};
+    }
+    if (!isValidUtf8((unsigned char *) cf.message, cf.length)) {
+        return {CLOSE_INVALID_DATA, ERR_INVALID_TEXT.data(), ERR_INVALID_TEXT.length()};
     }
     return cf;
 }
@@ -285,18 +298,18 @@ protected:
     static inline bool consumeMessage(T payLength, char *&src, unsigned int &length, WebSocketState<isServer> *wState, void *user) {
         if (getOpCode(src)) {
             if (wState->state.opStack == 1 || (!wState->state.lastFin && getOpCode(src) < 2)) {
-                Impl::forceClose(wState, user);
+                Impl::failConnection(wState, user, CLOSE_PROTOCOL_ERROR, ERR_PROTOCOL);
                 return true;
             }
             wState->state.opCode[++wState->state.opStack] = (OpCode) getOpCode(src);
         } else if (wState->state.opStack == -1) {
-            Impl::forceClose(wState, user);
+            Impl::failConnection(wState, user, CLOSE_PROTOCOL_ERROR, ERR_PROTOCOL);
             return true;
         }
         wState->state.lastFin = isFin(src);
 
         if (Impl::refusePayloadLength(payLength, wState, user)) {
-            Impl::forceClose(wState, user, ERR_TOO_BIG_MESSAGE);
+            Impl::failConnection(wState, user, CLOSE_MESSAGE_TOO_BIG, ERR_TOO_BIG_MESSAGE);
             return true;
         }
 
@@ -411,7 +424,7 @@ public:
                  * The MESSAGE_HEADER constants assume the mask bit matches our role, so a
                  * mismatched frame would otherwise desync the parser. */
                 if (isMasked(src) != isServer) {
-                    Impl::forceClose(wState, user, ERR_INVALID_MASKING);
+                    Impl::failConnection(wState, user, CLOSE_PROTOCOL_ERROR, ERR_INVALID_MASKING);
                     return;
                 }
 
@@ -419,14 +432,14 @@ public:
                  * only if negotiated (RFC 7692 6.1). A control frame or continuation must never
                  * reach setCompressed(): the armed flag would inflate the next data frame. */
                 if (rsv1(src) && (getOpCode(src) == 0 || getOpCode(src) > 2 || !Impl::setCompressed(wState, user))) {
-                    Impl::forceClose(wState, user, ERR_INVALID_RSV1);
+                    Impl::failConnection(wState, user, CLOSE_PROTOCOL_ERROR, ERR_INVALID_RSV1);
                     return;
                 }
 
                 // invalid reserved bits / invalid opcodes / invalid control frames
                 if (rsv23(src) || (getOpCode(src) > 2 && getOpCode(src) < 8) ||
                     getOpCode(src) > 10 || (getOpCode(src) > 2 && (!isFin(src) || payloadLength(src) > 125))) {
-                    Impl::forceClose(wState, user);
+                    Impl::failConnection(wState, user, CLOSE_PROTOCOL_ERROR, ERR_PROTOCOL);
                     return;
                 }
 
@@ -450,7 +463,7 @@ public:
              * bit is already visible once the 2-byte base header is in: an unmasked frame
              * must be refused now, not spilled until enough of a masked header arrives. */
             if (isServer && length >= 2 && !isMasked(src)) {
-                Impl::forceClose(wState, user, ERR_INVALID_MASKING);
+                Impl::failConnection(wState, user, CLOSE_PROTOCOL_ERROR, ERR_INVALID_MASKING);
                 return;
             }
             if (length) {

--- a/test/js/bun/websocket/websocket-server-fail-close-codes.test.ts
+++ b/test/js/bun/websocket/websocket-server-fail-close-codes.test.ts
@@ -1,0 +1,295 @@
+// RFC 6455 section 7.1.7: to Fail the WebSocket Connection, an endpoint SHOULD
+// send a Close frame with the appropriate status code before closing the
+// underlying TCP connection. Section 7.4.1 mandates the codes: 1002 for a
+// protocol error, 1007 for inconsistent data (bad UTF-8), 1009 for a message
+// that is too big. Bun.serve previously tore the TCP connection down without
+// ever writing a Close frame, so a conforming client only ever saw 1006.
+import { serve } from "bun";
+import { describe, expect, it } from "bun:test";
+import net from "node:net";
+
+describe.concurrent("Bun.serve WebSocket fail-the-connection close codes", () => {
+  // Build a client->server frame. Short (<126 byte) payloads only.
+  function frame(opcode: number, payload: Buffer, opts: { fin?: boolean; rsv1?: boolean; masked?: boolean } = {}) {
+    const { fin = true, rsv1 = false, masked = true } = opts;
+    if (payload.length > 125) throw new Error("short frames only");
+    const flags = (fin ? 0x80 : 0x00) | (rsv1 ? 0x40 : 0x00) | opcode;
+    if (!masked) return Buffer.concat([Buffer.from([flags, payload.length]), payload]);
+    const mask = Buffer.from([0x37, 0xfa, 0x21, 0x3d]);
+    const body = Buffer.from(payload.map((b, i) => b ^ mask[i % 4]));
+    return Buffer.concat([Buffer.from([flags, 0x80 | payload.length]), mask, body]);
+  }
+
+  // Build a client->server frame that declares an extended (>=126 byte) payload.
+  function mediumFrame(opcode: number, payload: Buffer) {
+    const mask = Buffer.from([0x37, 0xfa, 0x21, 0x3d]);
+    const body = Buffer.from(payload.map((b, i) => b ^ mask[i % 4]));
+    return Buffer.concat([
+      Buffer.from([0x80 | opcode, 0x80 | 126, payload.length >> 8, payload.length & 0xff]),
+      mask,
+      body,
+    ]);
+  }
+
+  type ServerView = { code: number; reason: string; messages: unknown[] };
+  type Wire = { closeFrame: Buffer | null; bytes: Buffer };
+
+  // Raw RFC 6455 client: do the upgrade handshake over a plain TCP socket,
+  // write `send`, and record (a) what the app's close() handler observed and
+  // (b) every byte the server wrote back so the test can look for a Close
+  // frame on the wire.
+  async function probe(
+    send: Buffer,
+    opts: { maxPayloadLength?: number } = {},
+  ): Promise<{ server: ServerView; wire: Wire }> {
+    const messages: unknown[] = [];
+    const appClose = Promise.withResolvers<ServerView>();
+    const server = serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("upgrade failed", { status: 400 });
+      },
+      websocket: {
+        maxPayloadLength: opts.maxPayloadLength,
+        message(_ws, message) {
+          messages.push(message);
+        },
+        close(_ws, code, reason) {
+          appClose.resolve({ code, reason, messages });
+        },
+      },
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    socket.setNoDelay(true);
+    const upgraded = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<void>();
+    socket.on("close", () => {
+      closed.resolve();
+      upgraded.reject(new Error("socket closed before the 101 response"));
+    });
+    socket.on("error", () => {
+      closed.resolve();
+      upgraded.reject(new Error("socket error before the 101 response"));
+    });
+
+    let wireBytes = Buffer.alloc(0);
+    const onFrameData = (chunk: Buffer) => {
+      wireBytes = Buffer.concat([wireBytes, chunk]);
+    };
+
+    let head = Buffer.alloc(0);
+    const onHead = (chunk: Buffer) => {
+      head = Buffer.concat([head, chunk]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      socket.off("data", onHead);
+      socket.on("data", onFrameData);
+      const text = head.subarray(0, end).toString();
+      if (!text.startsWith("HTTP/1.1 101")) {
+        upgraded.reject(new Error(`upgrade failed: ${text.split("\r\n")[0]}`));
+        return;
+      }
+      const rest = head.subarray(end + 4);
+      if (rest.length) onFrameData(rest);
+      upgraded.resolve();
+    };
+    socket.on("data", onHead);
+    socket.write(
+      "GET / HTTP/1.1\r\n" +
+        "Host: localhost\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Sec-WebSocket-Version: 13\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "\r\n",
+    );
+    try {
+      await upgraded.promise;
+    } catch (error) {
+      socket.destroy();
+      server.stop(true);
+      throw error;
+    }
+
+    socket.write(send);
+    const [serverView] = await Promise.all([appClose.promise, closed.promise]);
+    socket.destroy();
+    server.stop(true);
+
+    // Walk the server->client frame stream for the (only) Close frame. Server
+    // frames are never masked, so the header is 2 bytes for a <126-byte body.
+    let closeFrame: Buffer | null = null;
+    let i = 0;
+    while (i + 2 <= wireBytes.length) {
+      const op = wireBytes[i] & 0x0f;
+      const len = wireBytes[i + 1] & 0x7f;
+      if (len > 125 || i + 2 + len > wireBytes.length) break;
+      if (op === 0x8) {
+        closeFrame = wireBytes.subarray(i, i + 2 + len);
+        break;
+      }
+      i += 2 + len;
+    }
+
+    return { server: serverView, wire: { closeFrame, bytes: wireBytes } };
+  }
+
+  function closeCodeOf(closeFrame: Buffer | null): number | null {
+    if (!closeFrame || closeFrame.length < 4) return null;
+    return closeFrame.readUInt16BE(2);
+  }
+
+  function closeReasonOf(closeFrame: Buffer | null): string | null {
+    if (!closeFrame || closeFrame.length < 4) return null;
+    return closeFrame.subarray(4).toString();
+  }
+
+  // ── 1002: protocol errors ────────────────────────────────────────────────
+
+  it("unmasked client frame → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x1, Buffer.from("hi"), { masked: false }));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(closeReasonOf(wire.closeFrame)).toBe("Received an incorrectly masked frame");
+    expect(server).toEqual({ code: 1002, reason: "Received an incorrectly masked frame", messages: [] });
+  });
+
+  it("reserved opcode 3 → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x3, Buffer.alloc(0)));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+    expect(server.messages).toEqual([]);
+  });
+
+  it("reserved opcode 11 → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0xb, Buffer.alloc(0)));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+  });
+
+  it("RSV1 without negotiated compression → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x1, Buffer.from("hi"), { rsv1: true }));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(closeReasonOf(wire.closeFrame)).toBe("Received unexpected RSV1 bit");
+    expect(server).toEqual({ code: 1002, reason: "Received unexpected RSV1 bit", messages: [] });
+  });
+
+  it("fragmented ping (FIN=0 on a control frame) → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x9, Buffer.from("hi"), { fin: false }));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+  });
+
+  it("control frame with a >125-byte payload → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(mediumFrame(0x9, Buffer.alloc(126, 0x61)));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+  });
+
+  it("continuation frame with no message in progress → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x0, Buffer.from("hi")));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+    expect(server.messages).toEqual([]);
+  });
+
+  it("new data frame while a fragmented message is open → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(
+      Buffer.concat([frame(0x1, Buffer.from("he"), { fin: false }), frame(0x1, Buffer.from("llo"))]),
+    );
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+    expect(server.messages).toEqual([]);
+  });
+
+  // ── 1007: inconsistent data (invalid UTF-8 TEXT) ─────────────────────────
+
+  it("TEXT frame carrying invalid UTF-8 → Close 1007 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x1, Buffer.from([0xff, 0xfe, 0xfd])));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1007);
+    expect(closeReasonOf(wire.closeFrame)).toBe("Received invalid UTF-8");
+    expect(server).toEqual({ code: 1007, reason: "Received invalid UTF-8", messages: [] });
+  });
+
+  // ── 1009: message too big ────────────────────────────────────────────────
+
+  it("single frame over maxPayloadLength → Close 1009 on the wire", async () => {
+    const { server, wire } = await probe(mediumFrame(0x2, Buffer.alloc(200, 0x61)), { maxPayloadLength: 100 });
+    expect(closeCodeOf(wire.closeFrame)).toBe(1009);
+    expect(closeReasonOf(wire.closeFrame)).toBe("Received too big message");
+    expect(server).toEqual({ code: 1009, reason: "Received too big message", messages: [] });
+  });
+
+  it("fragmented message growing past maxPayloadLength → Close 1009 on the wire", async () => {
+    const { server, wire } = await probe(
+      Buffer.concat([
+        frame(0x2, Buffer.alloc(80, 0x61), { fin: false }),
+        frame(0x0, Buffer.alloc(80, 0x61), { fin: true }),
+      ]),
+      { maxPayloadLength: 100 },
+    );
+    expect(closeCodeOf(wire.closeFrame)).toBe(1009);
+    expect(server).toEqual({ code: 1009, reason: "Received too big message", messages: [] });
+  });
+
+  // ── invalid inbound Close frames must be answered with 1002/1007 ─────────
+
+  it("Close frame with an invalid status code (999) → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x8, Buffer.from([0x03, 0xe7]))); // 999
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+  });
+
+  it("Close frame with the reserved status code 1005 → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x8, Buffer.from([0x03, 0xed]))); // 1005
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+  });
+
+  it("Close frame with status code 5000 (above 4999) → Close 1002 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x8, Buffer.from([0x13, 0x88]))); // 5000
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+  });
+
+  it("Close frame with a 1-byte body → Close 1002 on the wire", async () => {
+    // RFC 6455 5.5.1: if there is a body, its first two bytes MUST be the code.
+    const { server, wire } = await probe(frame(0x8, Buffer.from([0x03])));
+    expect(closeCodeOf(wire.closeFrame)).toBe(1002);
+    expect(server.code).toBe(1002);
+  });
+
+  it("Close frame with an invalid-UTF-8 reason → Close 1007 on the wire", async () => {
+    const { server, wire } = await probe(frame(0x8, Buffer.from([0x03, 0xe8, 0xff, 0xfe]))); // 1000 + bad UTF-8
+    expect(closeCodeOf(wire.closeFrame)).toBe(1007);
+    expect(server.code).toBe(1007);
+  });
+
+  // ── controls: nothing well-formed is over-rejected ───────────────────────
+
+  it("a valid masked TEXT frame is still delivered", async () => {
+    // Send a well-formed message, then a clean close so probe() returns.
+    const { server, wire } = await probe(
+      Buffer.concat([frame(0x1, Buffer.from("ok")), frame(0x8, Buffer.from([0x03, 0xe8]))]),
+    );
+    expect(server.messages).toEqual(["ok"]);
+    expect(server.code).toBe(1000);
+    expect(closeCodeOf(wire.closeFrame)).toBe(1000);
+  });
+
+  it("an empty Close body is still answered with an empty Close (1005 locally)", async () => {
+    const { server, wire } = await probe(frame(0x8, Buffer.alloc(0)));
+    // 1005 means "no status code present" and is not sent on the wire: the
+    // reply is an empty-body Close.
+    expect(server.code).toBe(1005);
+    expect(wire.closeFrame).toEqual(Buffer.from([0x88, 0x00]));
+  });
+
+  it("a Close with code 1000 is echoed back as 1000", async () => {
+    const { server, wire } = await probe(frame(0x8, Buffer.from([0x03, 0xe8, 0x62, 0x79, 0x65])));
+    expect(server).toEqual({ code: 1000, reason: "bye", messages: [] });
+    expect(closeCodeOf(wire.closeFrame)).toBe(1000);
+    expect(closeReasonOf(wire.closeFrame)).toBe("bye");
+  });
+});

--- a/test/js/bun/websocket/websocket-server-fail-close-codes.test.ts
+++ b/test/js/bun/websocket/websocket-server-fail-close-codes.test.ts
@@ -44,7 +44,7 @@ describe.concurrent("Bun.serve WebSocket fail-the-connection close codes", () =>
   ): Promise<{ server: ServerView; wire: Wire }> {
     const messages: unknown[] = [];
     const appClose = Promise.withResolvers<ServerView>();
-    const server = serve({
+    using server = serve({
       port: 0,
       fetch(req, server) {
         if (server.upgrade(req)) return;
@@ -62,62 +62,62 @@ describe.concurrent("Bun.serve WebSocket fail-the-connection close codes", () =>
     });
 
     const socket = net.connect(server.port, "127.0.0.1");
-    socket.setNoDelay(true);
-    const upgraded = Promise.withResolvers<void>();
-    const closed = Promise.withResolvers<void>();
-    socket.on("close", () => {
-      closed.resolve();
-      upgraded.reject(new Error("socket closed before the 101 response"));
-    });
-    socket.on("error", () => {
-      closed.resolve();
-      upgraded.reject(new Error("socket error before the 101 response"));
-    });
-
-    let wireBytes = Buffer.alloc(0);
-    const onFrameData = (chunk: Buffer) => {
-      wireBytes = Buffer.concat([wireBytes, chunk]);
-    };
-
-    let head = Buffer.alloc(0);
-    const onHead = (chunk: Buffer) => {
-      head = Buffer.concat([head, chunk]);
-      const end = head.indexOf("\r\n\r\n");
-      if (end === -1) return;
-      socket.off("data", onHead);
-      socket.on("data", onFrameData);
-      const text = head.subarray(0, end).toString();
-      if (!text.startsWith("HTTP/1.1 101")) {
-        upgraded.reject(new Error(`upgrade failed: ${text.split("\r\n")[0]}`));
-        return;
-      }
-      const rest = head.subarray(end + 4);
-      if (rest.length) onFrameData(rest);
-      upgraded.resolve();
-    };
-    socket.on("data", onHead);
-    socket.write(
-      "GET / HTTP/1.1\r\n" +
-        "Host: localhost\r\n" +
-        "Connection: Upgrade\r\n" +
-        "Upgrade: websocket\r\n" +
-        "Sec-WebSocket-Version: 13\r\n" +
-        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
-        "\r\n",
-    );
     try {
+      socket.setNoDelay(true);
+      const upgraded = Promise.withResolvers<void>();
+      const closed = Promise.withResolvers<void>();
+      socket.on("close", () => {
+        closed.resolve();
+        upgraded.reject(new Error("socket closed before the 101 response"));
+      });
+      socket.on("error", () => {
+        closed.resolve();
+        upgraded.reject(new Error("socket error before the 101 response"));
+      });
+
+      let wireBytes = Buffer.alloc(0);
+      const onFrameData = (chunk: Buffer) => {
+        wireBytes = Buffer.concat([wireBytes, chunk]);
+      };
+
+      let head = Buffer.alloc(0);
+      const onHead = (chunk: Buffer) => {
+        head = Buffer.concat([head, chunk]);
+        const end = head.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        socket.off("data", onHead);
+        socket.on("data", onFrameData);
+        const text = head.subarray(0, end).toString();
+        if (!text.startsWith("HTTP/1.1 101")) {
+          upgraded.reject(new Error(`upgrade failed: ${text.split("\r\n")[0]}`));
+          return;
+        }
+        const rest = head.subarray(end + 4);
+        if (rest.length) onFrameData(rest);
+        upgraded.resolve();
+      };
+      socket.on("data", onHead);
+      socket.write(
+        "GET / HTTP/1.1\r\n" +
+          "Host: localhost\r\n" +
+          "Connection: Upgrade\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Sec-WebSocket-Version: 13\r\n" +
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+          "\r\n",
+      );
       await upgraded.promise;
-    } catch (error) {
+
+      socket.write(send);
+      const [serverView] = await Promise.all([appClose.promise, closed.promise]);
+
+      return { server: serverView, wire: parseWire(wireBytes) };
+    } finally {
       socket.destroy();
-      server.stop(true);
-      throw error;
     }
+  }
 
-    socket.write(send);
-    const [serverView] = await Promise.all([appClose.promise, closed.promise]);
-    socket.destroy();
-    server.stop(true);
-
+  function parseWire(wireBytes: Buffer): Wire {
     // Walk the server->client frame stream for the (only) Close frame. Server
     // frames are never masked, so the header is 2 bytes for a <126-byte body.
     let closeFrame: Buffer | null = null;
@@ -133,7 +133,7 @@ describe.concurrent("Bun.serve WebSocket fail-the-connection close codes", () =>
       i += 2 + len;
     }
 
-    return { server: serverView, wire: { closeFrame, bytes: wireBytes } };
+    return { closeFrame, bytes: wireBytes };
   }
 
   function closeCodeOf(closeFrame: Buffer | null): number | null {

--- a/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "bun:test";
 import net from "node:net";
 import { constants, deflateRawSync } from "node:zlib";
 
-const RSV1_CLOSE = { code: 1006, reason: "Received unexpected RSV1 bit" };
+const RSV1_CLOSE = { code: 1002, reason: "Received unexpected RSV1 bit" };
 
 // A permessage-deflate message payload: raw deflate, sync flushed, with the
 // trailing 0x00 0x00 0xff 0xff removed (RFC 7692 section 7.2.1).
@@ -147,13 +147,18 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
     };
   }
 
-  // A conforming server neither answers an RSV1 ping nor lets it reach ping().
-  it("a ping with RSV1 set fails the connection and is not answered", async () => {
+  // A conforming server does not answer an RSV1 ping with a pong; it writes a
+  // Close frame carrying 1002 and never lets the ping reach ping().
+  it("a ping with RSV1 set fails the connection with a 1002 Close frame", async () => {
     using raw = await connectDeflated();
     raw.socket.write(frame(0x9, pmdDeflate(Buffer.from("pingy")), { rsv1: true }));
-    expect(await Promise.race([raw.serverClose, raw.waitForFrameBytes(1)])).toEqual(RSV1_CLOSE);
+    expect(await raw.serverClose).toEqual(RSV1_CLOSE);
     expect(raw.pings).toEqual([]);
-    expect(raw.frames()).toEqual(Buffer.alloc(0));
+    await Promise.race([raw.waitForFrameBytes(4), raw.closed]);
+    // The first (and only) frame the server writes is a Close with code 1002,
+    // not a pong (0x8a).
+    expect(raw.frames()[0]).toBe(0x88);
+    expect(raw.frames().readUInt16BE(2)).toBe(1002);
   });
 
   it("an RSV1 ping must not make the next uncompressed data frame get inflated", async () => {

--- a/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
@@ -115,7 +115,7 @@ describe.concurrent("unmasked client frames", () => {
     raw.socket.write(Buffer.concat([unmaskedFrame(0x1, Buffer.alloc(0)), maskedFrame(0x1, Buffer.from("hi"))]));
     expect(await Promise.race([raw.closed, raw.firstMessage])).toBe("socket-closed-by-server");
     expect(raw.received).toEqual([]);
-    expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
+    expect(await raw.serverClose).toEqual({ code: 1002, reason: "Received an incorrectly masked frame" });
   });
 
   it("an unmasked text frame is not delivered and fails the connection", async () => {
@@ -125,14 +125,14 @@ describe.concurrent("unmasked client frames", () => {
     raw.socket.write(Buffer.concat([unmaskedFrame(0x1, Buffer.from("hello")), Buffer.from("XYZW")]));
     expect(await Promise.race([raw.closed, raw.firstMessage])).toBe("socket-closed-by-server");
     expect(raw.received).toEqual([]);
-    expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
+    expect(await raw.serverClose).toEqual({ code: 1002, reason: "Received an incorrectly masked frame" });
   });
 
   it("an unmasked close frame fails the connection instead of completing the handshake", async () => {
     using raw = await connectRaw();
     // Trailing bytes so the parser sees a full server-role header in one read.
     raw.socket.write(Buffer.concat([unmaskedFrame(0x8, Buffer.alloc(0)), Buffer.alloc(4)]));
-    expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
+    expect(await raw.serverClose).toEqual({ code: 1002, reason: "Received an incorrectly masked frame" });
   });
 
   // The mask bit is in the 2-byte base header. The server must not sit on a
@@ -142,7 +142,7 @@ describe.concurrent("unmasked client frames", () => {
     raw.socket.write(unmaskedFrame(0x1, Buffer.alloc(0)));
     expect(await raw.closed).toBe("socket-closed-by-server");
     expect(raw.received).toEqual([]);
-    expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
+    expect(await raw.serverClose).toEqual({ code: 1002, reason: "Received an incorrectly masked frame" });
   });
 
   // Control: the same raw client with correct masking is parsed and delivered,

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -592,7 +592,7 @@ describe("Server", () => {
         ws.send("Hello!");
       },
       close(_, code) {
-        expect(code).toBe(1006);
+        expect(code).toBe(1009);
         done();
       },
     }));


### PR DESCRIPTION
## What

When `Bun.serve`'s WebSocket parser detects a protocol violation (bad masking, reserved opcode/RSV bits, invalid fragment state, invalid UTF-8, oversized payload, or an invalid inbound Close body), it now writes a Close frame carrying the RFC 6455 7.4.1 status code before closing TCP, instead of tearing the socket down bare.

## Why

RFC 6455 7.1.7 says an endpoint that Fails the WebSocket Connection SHOULD send a Close frame with the appropriate status code before closing the underlying TCP connection. Every violation-detection branch in `WebSocketProtocol.h` / `WebSocketContext.h` previously called `forceClose()` = a bare `us_socket_close()`. A conforming client therefore only ever saw **1006** (abnormal closure) no matter why the server rejected the frame, and the diagnostic reason string only rode the socket-close side channel into the app's `close(1006, "...")` callback.

Separately, `parseClosePayload` mapped an invalid inbound close code, an invalid-UTF-8 reason, or a 1-byte body to the sentinels `{1006, ...}` / `{1005, ...}`, which `formatClosePayload` refuses to serialize, so the server answered with an empty-payload Close (peer sees 1005) instead of 1002/1007.

## How

- Added `Impl::failConnection(wState, s, code, reason)` in `WebSocketContext.h` that routes through the existing `WebSocket::end()` path: format Close payload, `send(..., OpCode::CLOSE)`, set `isShuttingDown` so later inbound bytes are ignored, half-close (FIN) once drained.
- Pointed all twelve violation sites at it:
  - **1002** `CLOSE_PROTOCOL_ERROR`: masking mismatch, RSV1/RSV2/RSV3, reserved/unknown opcode, fragmented or >125-byte control frame, continuation with no message in progress, new data frame interleaved in a fragmented message.
  - **1007** `CLOSE_INVALID_DATA`: TEXT frame or Close reason that is not valid UTF-8.
  - **1009** `CLOSE_MESSAGE_TOO_BIG`: single frame, fragmented total, or post-inflation size over `maxPayloadLength`.
- `parseClosePayload` now returns 1002 for an invalid/reserved code and for a 1-byte body (RFC 6455 5.5.1: if there is a body, its first two bytes MUST be the status code), and 1007 for an invalid-UTF-8 reason.
- `forceClose()` is retained only for the idle-timeout path.

The app's `close()` handler now receives the same code and reason that go out on the wire (matching the `ws` module) instead of `1006` plus the side-channel diagnostic.

## Verification

`test/js/bun/websocket/websocket-server-fail-close-codes.test.ts` is a raw RFC 6455 TCP client against `Bun.serve({websocket})` that asserts a Close frame (0x88) with the mandated code arrives on the wire before the TCP close, plus what the app handler observed. 16 violation cells + 3 controls.

```
# without the fix (USE_SYSTEM_BUN=1)
 3 pass
 16 fail

# with the fix (bun bd)
 19 pass
 0 fail
```

Existing `websocket-server-unmasked-frames.test.ts`, `websocket-server-rsv-frames.test.ts`, and the `maxPayloadLength` case in `websocket-server.test.ts` are updated to expect the new codes (1002/1009) that the app handler now sees.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->