### PR TITLE
jsc: TypedArray indexed access at 4294967295 on a 2**32-length view

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-348-1535a8dc";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-348-1535a8dc";
+export const WEBKIT_VERSION = "autobuild-preview-pr-348-c106f67d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/typedarray-uint32max-index.test.ts
+++ b/test/js/bun/jsc/typedarray-uint32max-index.test.ts
@@ -78,6 +78,20 @@ const uc = new Uint8ClampedArray(u.buffer);
 uc[IDX] = 300;
 out.uc = uc[IDX];
 
+// Structure-keyed caches (HasOwnPropertyCache, GetBy/InBy IC miss entries)
+// must not be keyed on the shared TypedArray structure for this index, since
+// the answer is length-dependent. Allocate both views first so GC between the
+// two probes doesn't hide a stale entry by clearing the cache.
+const icSmall = new Uint8Array(u.buffer, 0, 8);
+new DataView(u.buffer).setUint8(IDX, 55);
+out.hasOwnSmallFirst = Object.hasOwn(icSmall, KEY);
+out.hasOwnBigAfter = Object.hasOwn(u, KEY);
+function probeGet(x) { return x["4294967295"]; }
+function probeIn(x) { return "4294967295" in x; }
+for (let i = 0; i < 200; i++) { probeGet(icSmall); probeIn(icSmall); }
+out.icGetBig = probeGet(u);
+out.icInBig = probeIn(u);
+
 console.log(JSON.stringify(out));
 `;
 
@@ -123,6 +137,10 @@ test("TypedArray indexed access at 4294967295 on a 2**32-length view", async () 
     smallDefineThrew: true,
     i8: -7,
     uc: 255,
+    hasOwnSmallFirst: false,
+    hasOwnBigAfter: true,
+    icGetBig: 55,
+    icInBig: true,
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/typedarray-uint32max-index.test.ts
+++ b/test/js/bun/jsc/typedarray-uint32max-index.test.ts
@@ -84,7 +84,10 @@ console.log(JSON.stringify(out));
 test("TypedArray indexed access at 4294967295 on a 2**32-length view", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
+    env: {
+      ...bunEnv,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+    },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/bun/jsc/typedarray-uint32max-index.test.ts
+++ b/test/js/bun/jsc/typedarray-uint32max-index.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // A Uint8Array can have length up to MAX_ARRAY_BUFFER_SIZE (2**32 on 64-bit),

--- a/test/js/bun/jsc/typedarray-uint32max-index.test.ts
+++ b/test/js/bun/jsc/typedarray-uint32max-index.test.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A Uint8Array can have length up to MAX_ARRAY_BUFFER_SIZE (2**32 on 64-bit),
+// so 4294967295 (UINT32_MAX) is a valid index. Regular JS arrays top out at
+// MAX_ARRAY_INDEX (2**32 - 2), and the TypedArray [[Get]]/[[Set]] paths were
+// reusing that cap, which left the last element unreachable via bracket access
+// while [[HasProperty]] and DataView could still see it.
+// https://tc39.es/ecma262/#sec-isvalidintegerindex
+
+const fixture = /* js */ `
+"use strict";
+const LEN = 2 ** 32;
+const IDX = LEN - 1; // 4294967295
+const KEY = String(IDX); // "4294967295"
+
+let u;
+try {
+  u = new Uint8Array(LEN);
+} catch {
+  console.log(JSON.stringify({ skipped: true }));
+  process.exit(0);
+}
+if (u.length !== LEN) throw new Error("unexpected length " + u.length);
+
+// Seed the last byte via a path that was never broken.
+new DataView(u.buffer).setUint8(IDX, 11);
+
+const out = {
+  initialGetNum: u[IDX],
+  initialGetStr: u[KEY],
+  at: u.at(IDX),
+  inNum: IDX in u,
+  inStr: KEY in u,
+  hasOwn: Object.hasOwn(u, KEY),
+  gopd: Object.getOwnPropertyDescriptor(u, KEY),
+};
+
+u[IDX] = 22;
+out.afterIndexedSet = u[IDX];
+out.afterIndexedSetDV = new DataView(u.buffer).getUint8(IDX);
+
+Reflect.set(u, KEY, 33);
+out.afterReflectSet = u[IDX];
+out.afterReflectSetDV = new DataView(u.buffer).getUint8(IDX);
+
+try {
+  Object.defineProperty(u, KEY, { value: 44, writable: true, enumerable: true, configurable: true });
+  out.afterDefine = new DataView(u.buffer).getUint8(IDX);
+} catch (e) {
+  out.afterDefine = "threw: " + e.constructor.name;
+}
+
+out.deleteInBounds = Reflect.deleteProperty(u, KEY);
+
+// Keep matching spec for adjacent cases:
+out.oneBeyond = u["4294967296"];
+out.minusZero = u["-0"];
+
+// On a short view, the same index is out of bounds.
+const small = new Uint8Array(8);
+out.smallGet = small[IDX];
+out.smallIn = KEY in small;
+out.smallDelete = Reflect.deleteProperty(small, KEY);
+let smallDefineThrew = false;
+try {
+  Object.defineProperty(small, KEY, { value: 1, writable: true, enumerable: true, configurable: true });
+} catch {
+  smallDefineThrew = true;
+}
+out.smallDefineThrew = smallDefineThrew;
+
+// Other 1-byte element types at max length.
+const i8 = new Int8Array(u.buffer);
+i8[IDX] = -7;
+out.i8 = i8[IDX];
+const uc = new Uint8ClampedArray(u.buffer);
+uc[IDX] = 300;
+out.uc = uc[IDX];
+
+console.log(JSON.stringify(out));
+`;
+
+test("TypedArray indexed access at 4294967295 on a 2**32-length view", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout.trim());
+  if (out.skipped) {
+    console.log("skipping: could not allocate a 2**32-byte Uint8Array");
+    expect(exitCode).toBe(0);
+    return;
+  }
+
+  expect(out).toEqual({
+    initialGetNum: 11,
+    initialGetStr: 11,
+    at: 11,
+    inNum: true,
+    inStr: true,
+    hasOwn: true,
+    gopd: { value: 11, writable: true, enumerable: true, configurable: true },
+    afterIndexedSet: 22,
+    afterIndexedSetDV: 22,
+    afterReflectSet: 33,
+    afterReflectSetDV: 33,
+    afterDefine: 44,
+    deleteInBounds: false,
+    oneBeyond: undefined,
+    minusZero: undefined,
+    smallGet: undefined,
+    smallIn: false,
+    smallDelete: true,
+    smallDefineThrew: true,
+    i8: -7,
+    uc: 255,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

```js
const u = new Uint8Array(2**32);
u.length;                        // 4294967296
u[4294967294];                   // 0
u[4294967295];                   // undefined   (V8: 0)
u[4294967295] = 42;
u[4294967295];                   // undefined   (V8: 42)
u.at(4294967295);                // undefined   (V8: 42)
4294967295 in u;                 // true        ([[HasProperty]] disagrees with [[Get]])
Object.hasOwn(u, "4294967295");  // false       (V8: true)
Object.getOwnPropertyDescriptor(u, 4294967295);  // undefined
Object.defineProperty(u, 4294967295, { value: 1, writable: true, enumerable: true, configurable: true });
  // TypeError: Attempting to store canonical numeric string property on a typed array
new DataView(u.buffer).getUint8(4294967295);     // 0 (DataView path is fine)
```

[`IsValidIntegerIndex(O, index)`](https://tc39.es/ecma262/#sec-isvalidintegerindex) only requires `0 <= index < O.[[ArrayLength]]`. A `Uint8Array` can have length up to `MAX_ARRAY_BUFFER_SIZE` (`2**32` on 64-bit), so `4294967295` is a valid index there, and V8 treats it as one.

## Cause

`JSGenericTypedArrayView::{getOwnPropertySlot, put, defineOwnProperty, deleteProperty}(PropertyName)` call `parseIndex()`, which is capped at `MAX_ARRAY_INDEX = 0xFFFFFFFE` because a regular JS Array's length is a uint32 and the largest index is `length - 1`. For `"4294967295"` `parseIndex` returns `nullopt`, and the `isCanonicalNumericIndexString` fallback treats it as always out of bounds. The `unsigned`-index overloads (`getOwnPropertySlotByIndex` etc.) already compare against the full `size_t` length via `inBounds()`, which is why `4294967295 in u` (routed through `getUInt32` → `hasProperty(unsigned)`) returns `true` while `u[4294967295]` returns `undefined`.

## Fix

[oven-sh/WebKit#348](https://github.com/oven-sh/WebKit/pull/348) adds `parseTypedArrayIndex(PropertyName)` in `PropertyName.h` that extends `parseIndex()` to the full uint32 range (`UINT32_MAX` is the only extra value, handled as a literal compare after `parseIndex` returns `nullopt`) and routes the four `JSGenericTypedArrayView` PropertyName overloads through it.

TypedArray structures are shared per type, not per length, so once `getOwnPropertySlot("4294967295")` becomes length-dependent the structure-keyed caches that previously memoised "always absent" must be told not to: `HasOwnPropertyCache::tryAdd` widens its index guard to `parseTypedArrayIndex`, and the `isTypedArrayType && isCanonicalNumericIndexString` short-circuits in `generateConditions` / `prepareChainForCaching` / `PolyProtoAccessChain::tryCreate` return invalid instead of a valid empty condition set when `parseTypedArrayIndex` accepts the key, so no `Miss`/`InMiss` IC is installed for it on a TypedArray. Without those guards, `Object.hasOwn(short, "4294967295"); Object.hasOwn(long, "4294967295")` trips `ASSERT(*result == hasOwnProperty(...))` in `ObjectPrototype.cpp` on assert-enabled builds, and a warmed IC returns the stale miss in release builds.

The DFG/FTL inline fast paths speculate Int32 for the index and OSR-exit or fall to the C++ slow path for `0xFFFFFFFF`, so no JIT change is needed.

This PR bumps `WEBKIT_VERSION` to the `autobuild-preview-pr-348-c106f67d` preview build and adds `test/js/bun/jsc/typedarray-uint32max-index.test.ts`, which spawns a child that allocates a `2**32`-byte `Uint8Array` and exercises `[[Get]]`, `[[Set]]`, `.at`, `in`, `Object.hasOwn`, `Object.getOwnPropertyDescriptor`, `Object.defineProperty`, `Reflect.set` and `Reflect.deleteProperty` at index `4294967295`, the same key on a short view (still out of bounds), the adjacent canonical numeric strings `"4294967296"` / `"-0"` (still `undefined`), `Int8Array`/`Uint8ClampedArray` views over the same buffer, and the `hasOwn(small)→hasOwn(big)` / warmed-IC `probe(small)→probe(big)` orderings that exercise the cache guards. The child skips cleanly if the allocation is refused.

## Also in this range (549170099226..c106f67d)

- [oven-sh/WebKit#328](https://github.com/oven-sh/WebKit/pull/328) inspector: release throw scope before tail-calling impl in injected-script prototype host functions
- [oven-sh/WebKit#317](https://github.com/oven-sh/WebKit/pull/317) LiteralParser: throw RangeError on OOM when copying a JSON string value
- [oven-sh/WebKit#331](https://github.com/oven-sh/WebKit/pull/331) SignalsWin: fix VEH return value and register behind AddressSanitizer's handler
- [oven-sh/WebKit#332](https://github.com/oven-sh/WebKit/pull/332) Heap: make `minEdenToOldGenerationRatio` a JSC option (same default; behaviour unchanged)
- [oven-sh/WebKit#347](https://github.com/oven-sh/WebKit/pull/347) getAsyncStackTrace: unwrap InternalFieldTuple in reaction context

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/typedarray-uint32max-index.test.ts
(fail)    # initialGetNum undefined, afterDefine "threw: TypeError", hasOwn false, ...

$ bun bd test test/js/bun/jsc/typedarray-uint32max-index.test.ts
(pass)
```

Node 26.3.0 on the same fixture prints the direct-access values exactly. For the warmed-IC ordering Node returns `undefined`/`false` (V8 shares the stale-miss behaviour), which is a V8 bug against `IsValidIntegerIndex`; this change gives the spec answer there.

Found while fixing `Buffer.writeUInt8` rejecting offset `4294967295` (#35867 works around it at the Buffer layer; this closes the engine-level gap).

Once oven-sh/WebKit#348 merges, `WEBKIT_VERSION` should be repointed at the merged main sha (the preview release is deleted at that point).

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/typedarray-uint32max-index.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/jsc/typedarray-uint32max-index.test.ts"
bun test v1.4.0 (e83092d93)

test/js/bun/jsc/typedarray-uint32max-index.test.ts:
(pass) TypedArray indexed access at 4294967295 on a 2**32-length view [420.38ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [2.79s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 test/js/bun/jsc/typedarray-uint32max-index.test.ts | 146 +++++++++++++++++++++
 2 files changed, 147 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
scripts/build/deps/webkit.ts                            1      2      0
test/js/bun/jsc/typedarray-uint32max-index.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->