### PR TITLE
fs.promises.watch: implement maxQueue and overflow options

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -7,6 +7,7 @@ const {
   validateInteger,
   validateBoolean,
   validateObject,
+  validateOneOf,
   validateAbortSignal,
   validateEncoding,
 } = require("internal/validators");
@@ -69,6 +70,10 @@ function watch(
   const queue = $createFIFO();
   const ignoreMatcher = require("internal/fs/watch").createIgnoreMatcher(options?.ignore);
   const signal = options?.signal;
+  const maxQueue = options?.maxQueue ?? 2048;
+  const overflow = options?.overflow ?? "ignore";
+  validateInteger(maxQueue, "options.maxQueue");
+  validateOneOf(overflow, "options.overflow", ["ignore", "error"]);
   validateAbortSignal(signal, "options.signal");
   function makeAbortError() {
     return $makeAbortError(undefined, { cause: signal!.reason });
@@ -98,10 +103,25 @@ function watch(
   }
 
   const watcher = fs.watch(filename, options || {}, (eventType: string, filename: string | Buffer | undefined) => {
-    if (eventType !== "close" && eventType !== "error" && filename != null && ignoreMatcher?.(filename)) {
+    const isControl = eventType === "close" || eventType === "error";
+    if (!isControl && filename != null && ignoreMatcher?.(filename)) {
       return;
     }
-    queue.push({ __proto__: null, eventType, filename });
+    if (!isControl && queue.size() >= maxQueue) {
+      if (overflow === "error") {
+        queue.clear();
+        queue.push({
+          __proto__: null,
+          eventType: "error",
+          filename: $ERR_FS_WATCH_QUEUE_OVERFLOW(`fs.watch() queued more than ${maxQueue} events`),
+        });
+      } else {
+        process.emitWarning("fs.watch maxQueue exceeded");
+        return;
+      }
+    } else {
+      queue.push({ __proto__: null, eventType, filename });
+    }
     if (nextEventResolve) {
       const resolve = nextEventResolve;
       nextEventResolve = null;

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -109,6 +109,11 @@ function watch(
     }
     if (!isControl && queue.size() >= maxQueue) {
       if (overflow === "error") {
+        // The consumer's `next()` throws on eventType "error" without closing
+        // the watcher (the pre-existing "error" path assumes the native handle
+        // already tore itself down). Close it here so the overflow error is
+        // terminal, matching node's `finally { handle.close() }`.
+        watcher.close();
         queue.clear();
         queue.push({
           __proto__: null,

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -109,10 +109,6 @@ function watch(
     }
     if (!isControl && queue.size() >= maxQueue) {
       if (overflow === "error") {
-        // The consumer's `next()` throws on eventType "error" without closing
-        // the watcher (the pre-existing "error" path assumes the native handle
-        // already tore itself down). Close it here so the overflow error is
-        // terminal, matching node's `finally { handle.close() }`.
         watcher.close();
         queue.clear();
         queue.push({
@@ -168,6 +164,7 @@ function watch(
               }
               if (event.eventType === "error") {
                 closed = true;
+                watcher.close();
                 removeAbortListener();
                 throw event.filename;
               }

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -82,6 +82,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_FS_CP_SOCKET", Error],
   ["ERR_FS_CP_UNKNOWN", Error],
   ["ERR_FS_EISDIR", Error],
+  ["ERR_FS_WATCH_QUEUE_OVERFLOW", Error],
   ["ERR_HTTP_BODY_NOT_ALLOWED", Error],
   ["ERR_HTTP_HEADERS_SENT", Error],
   ["ERR_HTTP_CONTENT_LENGTH_MISMATCH", Error],

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -964,7 +964,10 @@ describe("fs.promises.watch", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.trim(), stderr }).toEqual({
-        stdout: JSON.stringify({ code: "ERR_FS_WATCH_QUEUE_OVERFLOW", message: "fs.watch() queued more than 0 events" }),
+        stdout: JSON.stringify({
+          code: "ERR_FS_WATCH_QUEUE_OVERFLOW",
+          message: "fs.watch() queued more than 0 events",
+        }),
         stderr: "",
       });
       expect(exitCode).toBe(0);

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -933,6 +933,110 @@ describe("fs.promises.watch", () => {
     expect(() => String(event)).toThrow(TypeError);
     expect(Object.keys(event!).sort()).toEqual(["eventType", "filename"]);
   });
+
+  describe("maxQueue / overflow", () => {
+    // With maxQueue: 0 the very first event is already an overflow, so these
+    // tests do not depend on the platform's batching or coalescing behaviour.
+    test("overflow: 'error' rejects with ERR_FS_WATCH_QUEUE_OVERFLOW", async () => {
+      using dir = tempDir("watch-maxqueue-error", {});
+      const fixture = /* js */ `
+        const fs = require("node:fs");
+        const fsp = require("node:fs/promises");
+        const path = require("node:path");
+        const dir = process.cwd();
+        const it = fsp.watch(dir, { maxQueue: 0, overflow: "error" })[Symbol.asyncIterator]();
+        const armed = it.next();
+        let n = 0;
+        const iv = setInterval(() => {
+          fs.writeFileSync(path.join(dir, "f" + n++), "");
+        }, 20);
+        armed.then(
+          r => { console.log(JSON.stringify({ resolved: r.value && { ...r.value } })); process.exit(1); },
+          e => { console.log(JSON.stringify({ code: e.code, message: e.message })); process.exit(0); },
+        ).finally(() => clearInterval(iv));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr }).toEqual({
+        stdout: JSON.stringify({ code: "ERR_FS_WATCH_QUEUE_OVERFLOW", message: "fs.watch() queued more than 0 events" }),
+        stderr: "",
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    test("overflow: 'ignore' (default) drops events and emits a warning", async () => {
+      using dir = tempDir("watch-maxqueue-ignore", {});
+      const fixture = /* js */ `
+        const fs = require("node:fs");
+        const fsp = require("node:fs/promises");
+        const path = require("node:path");
+        const dir = process.cwd();
+        let warnings = 0;
+        process.on("warning", w => {
+          if (String(w.message ?? w).includes("fs.watch maxQueue exceeded")) warnings++;
+        });
+        const it = fsp.watch(dir, { maxQueue: 0 })[Symbol.asyncIterator]();
+        const armed = it.next();
+        let settled = null;
+        armed.then(() => { settled = "resolved"; }, () => { settled = "rejected"; });
+        let n = 0;
+        const iv = setInterval(() => {
+          fs.writeFileSync(path.join(dir, "f" + n++), "");
+          if (warnings > 0 || settled !== null || n > 100) {
+            clearInterval(iv);
+            setImmediate(() => {
+              console.log(JSON.stringify({ warnings, settled, writes: n }));
+              process.exit(0);
+            });
+          }
+        }, 20);
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const out = JSON.parse(stdout.trim() || "{}");
+      // maxQueue: 0 means every event is dropped, so armed never settles.
+      expect(out.settled).toBe(null);
+      expect(out.warnings).toBeGreaterThan(0);
+      expect(exitCode).toBe(0);
+    });
+
+    test("validates option values", async () => {
+      const root = path.join(testDir, "maxqueue-validate-dir");
+      fs.mkdirSync(root, { recursive: true });
+      async function firstError(opts: any) {
+        // Pre-aborted signal bounds next() so a build that skips validation
+        // fails fast (AbortError) instead of hanging.
+        const signal = AbortSignal.abort();
+        try {
+          const it = (fs.promises.watch as any)(root, { ...opts, signal })[Symbol.asyncIterator]();
+          try {
+            await it.next();
+          } catch (e) {
+            return e;
+          }
+          await it.return?.();
+        } catch (e) {
+          return e;
+        }
+      }
+      expect((await firstError({ maxQueue: "x" }))?.code).toBe("ERR_INVALID_ARG_TYPE");
+      expect((await firstError({ maxQueue: 1.5 }))?.code).toBe("ERR_OUT_OF_RANGE");
+      expect((await firstError({ overflow: "throw" }))?.code).toBe("ERR_INVALID_ARG_VALUE");
+      expect((await firstError({ overflow: 3 }))?.code).toBe("ERR_INVALID_ARG_VALUE");
+    });
+  });
 });
 
 describe("immediately closing", () => {

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -937,23 +937,33 @@ describe("fs.promises.watch", () => {
   describe("maxQueue / overflow", () => {
     // With maxQueue: 0 the very first event is already an overflow, so these
     // tests do not depend on the platform's batching or coalescing behaviour.
-    test("overflow: 'error' rejects with ERR_FS_WATCH_QUEUE_OVERFLOW", async () => {
+    test("overflow: 'error' rejects with ERR_FS_WATCH_QUEUE_OVERFLOW and closes the watcher", async () => {
       using dir = tempDir("watch-maxqueue-error", {});
+      // No process.exit() on the success path: natural exit after the rejection
+      // proves the native watcher was closed (a leaked watcher would keep the
+      // event loop ref'd forever).
       const fixture = /* js */ `
         const fs = require("node:fs");
         const fsp = require("node:fs/promises");
         const path = require("node:path");
         const dir = process.cwd();
-        const it = fsp.watch(dir, { maxQueue: 0, overflow: "error" })[Symbol.asyncIterator]();
-        const armed = it.next();
         let n = 0;
         const iv = setInterval(() => {
           fs.writeFileSync(path.join(dir, "f" + n++), "");
         }, 20);
-        armed.then(
-          r => { console.log(JSON.stringify({ resolved: r.value && { ...r.value } })); process.exit(1); },
-          e => { console.log(JSON.stringify({ code: e.code, message: e.message })); process.exit(0); },
-        ).finally(() => clearInterval(iv));
+        (async () => {
+          let code = null, message = null, delivered = 0;
+          try {
+            for await (const e of fsp.watch(dir, { maxQueue: 0, overflow: "error" })) {
+              if (++delivered > 3) break;
+            }
+          } catch (e) {
+            code = e.code;
+            message = e.message;
+          }
+          clearInterval(iv);
+          console.log(JSON.stringify({ code, message, delivered }));
+        })();
       `;
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture],
@@ -967,6 +977,7 @@ describe("fs.promises.watch", () => {
         stdout: JSON.stringify({
           code: "ERR_FS_WATCH_QUEUE_OVERFLOW",
           message: "fs.watch() queued more than 0 events",
+          delivered: 0,
         }),
         stderr: "",
       });


### PR DESCRIPTION
## What does this PR do?

`fs.promises.watch()` buffered every delivered event with no upper bound. A slow or stalled consumer under an fs burst grew memory without limit, `overflow: 'error'` was silently accepted but never fired, and neither option value was validated.

Node bounds the iterator's internal queue at `maxQueue` (default 2048):
- `overflow: 'ignore'` (default): events past the bound are dropped and a `fs.watch maxQueue exceeded` process warning is emitted.
- `overflow: 'error'`: the queue is cleared and the next iterator pull rejects with `ERR_FS_WATCH_QUEUE_OVERFLOW`.

This change:
- reads `maxQueue` (default 2048) and `overflow` (default `'ignore'`) from options and validates them with `validateInteger`/`validateOneOf`, matching Node
- registers `ERR_FS_WATCH_QUEUE_OVERFLOW` with message `fs.watch() queued more than %d events`
- enforces the bound in the event callback: when `queue.size() >= maxQueue`, the event is either dropped with a warning or the queue is cleared and the overflow error is pushed
- control events (`close`/`error` from the underlying watcher) bypass the bound so iterator termination is never lost to a full queue

## Repro

```js
import fs from 'node:fs'; import fsp from 'node:fs/promises'; import path from 'node:path';
const d = fs.mkdtempSync('/tmp/pwmq-');
const it = fsp.watch(d, { maxQueue: 16, overflow: 'error' })[Symbol.asyncIterator]();
const armed = it.next(); await new Promise(r => setTimeout(r, 300));
for (let i = 0; i < 200; i++) fs.writeFileSync(path.join(d, 'f' + i), '');
await new Promise(r => setTimeout(r, 2000));
const got = new Set(); let thrown = null;
try { const r1 = await armed; if (r1.value) got.add(r1.value.filename);
  for (;;) { const nx = await Promise.race([it.next(), new Promise(r => setTimeout(() => r('Q'), 800))]);
    if (nx === 'Q' || nx.done) break; got.add(nx.value.filename); }
} catch (e) { thrown = e.code || e.name; }
console.log({ distinctDelivered: got.size, thrown }); process.exit(0);
```

Before: `{ distinctDelivered: 200, thrown: null }`
After (matches Node v26): `{ distinctDelivered: 1, thrown: 'ERR_FS_WATCH_QUEUE_OVERFLOW' }`

## How did you verify your code works?

Three tests added to `test/js/node/watch/fs.watch.test.ts` under the existing `fs.promises.watch` describe. The overflow tests use `maxQueue: 0` so the very first event is already an overflow, which keeps them independent of platform batching/coalescing. All three fail on the released binary and pass with the fix. Full `fs.promises.watch` describe: 12 pass, 0 fail.

Related: #34718 restructures this function as a real async generator; this change is orthogonal (option handling in the event callback) and should rebase cleanly onto it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/watch/fs.watch.test.ts

<!-- robobun:evidence:end -->