### PR TITLE
AbortSignal: count abort algorithms as observers for GC reachability

### DIFF
--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -292,10 +292,7 @@ void AbortSignal::signalFollow(AbortSignal& signal)
 
 void AbortSignal::eventListenersDidChange()
 {
-    // HasAbortEventListener gates JSAbortSignalOwner::isReachableFromOpaqueRoots: it must
-    // reflect every kind of abort observer (JS listeners, native callbacks, m_algorithms,
-    // and m_abortAlgorithms), or consumers that register only via addAlgorithm /
-    // addAbortAlgorithmToSignal (pipeTo, addEventListener({signal})) lose their signal to GC.
+    // HasAbortEventListener gates the wrapper's GC reachability, so every observer kind counts.
     bool hasListeners = hasEventListeners(eventNames().abortEvent)
         || !m_native_callbacks.isEmpty()
         || !m_algorithms.isEmpty();

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -290,7 +290,7 @@ void AbortSignal::signalFollow(AbortSignal& signal)
     });
 }
 
-void AbortSignal::eventListenersDidChange()
+bool AbortSignal::updateHasAbortEventListener()
 {
     // HasAbortEventListener gates the wrapper's GC reachability, so every observer kind counts.
     bool hasListeners = hasEventListeners(eventNames().abortEvent)
@@ -301,6 +301,12 @@ void AbortSignal::eventListenersDidChange()
         hasListeners = !m_abortAlgorithms.isEmpty();
     }
     setHasAbortEventListener(hasListeners);
+    return hasListeners;
+}
+
+void AbortSignal::eventListenersDidChange()
+{
+    bool hasListeners = updateHasAbortEventListener();
 
     // When a timeout signal loses all observers (no JS listeners, no native
     // callbacks, no algorithms, no dependent signals), there is nothing left
@@ -328,7 +334,7 @@ uint32_t AbortSignal::addAbortAlgorithmToSignal(AbortSignal& signal, Ref<AbortAl
         Locker locker { signal.m_abortAlgorithmsLock };
         signal.m_abortAlgorithms.append(std::make_pair(identifier, WTF::move(algorithm)));
     }
-    signal.eventListenersDidChange();
+    signal.updateHasAbortEventListener();
     return identifier;
 }
 
@@ -340,13 +346,13 @@ void AbortSignal::removeAbortAlgorithmFromSignal(AbortSignal& signal, uint32_t a
             return pair.first == algorithmIdentifier;
         });
     }
-    signal.eventListenersDidChange();
+    signal.updateHasAbortEventListener();
 }
 
 uint32_t AbortSignal::addAlgorithm(Algorithm&& algorithm)
 {
     m_algorithms.append(std::make_pair(++m_algorithmIdentifier, WTF::move(algorithm)));
-    eventListenersDidChange();
+    updateHasAbortEventListener();
     return m_algorithmIdentifier;
 }
 
@@ -355,7 +361,7 @@ void AbortSignal::removeAlgorithm(uint32_t algorithmIdentifier)
     m_algorithms.removeFirstMatching([algorithmIdentifier](auto& pair) {
         return pair.first == algorithmIdentifier;
     });
-    eventListenersDidChange();
+    updateHasAbortEventListener();
 }
 
 void AbortSignal::throwIfAborted(JSC::JSGlobalObject& lexicalGlobalObject)

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -292,7 +292,17 @@ void AbortSignal::signalFollow(AbortSignal& signal)
 
 void AbortSignal::eventListenersDidChange()
 {
-    bool hasListeners = hasEventListeners(eventNames().abortEvent) or !m_native_callbacks.isEmpty();
+    // HasAbortEventListener gates JSAbortSignalOwner::isReachableFromOpaqueRoots: it must
+    // reflect every kind of abort observer (JS listeners, native callbacks, m_algorithms,
+    // and m_abortAlgorithms), or consumers that register only via addAlgorithm /
+    // addAbortAlgorithmToSignal (pipeTo, addEventListener({signal})) lose their signal to GC.
+    bool hasListeners = hasEventListeners(eventNames().abortEvent)
+        || !m_native_callbacks.isEmpty()
+        || !m_algorithms.isEmpty();
+    if (!hasListeners) {
+        Locker locker { m_abortAlgorithmsLock };
+        hasListeners = !m_abortAlgorithms.isEmpty();
+    }
     setHasAbortEventListener(hasListeners);
 
     // When a timeout signal loses all observers (no JS listeners, no native
@@ -301,20 +311,11 @@ void AbortSignal::eventListenersDidChange()
     // ref that timeout() took to keep the signal alive, so the C++ object can
     // be destroyed normally.
     if (!hasListeners && m_timeout && !aborted()
-        && m_algorithms.isEmpty() && !hasPendingActivity()
+        && !hasPendingActivity()
         && m_dependentSignals.isEmptyIgnoringNullReferences()) {
-        bool shouldDeref = false;
-        {
-            Locker locker { m_abortAlgorithmsLock };
-            if (m_abortAlgorithms.isEmpty()) {
-                cancelTimer();
-                shouldDeref = true;
-            }
-        }
-        // Release the extra ref after the lock is released, since deref()
-        // may destroy `this` (and m_abortAlgorithmsLock with it).
-        if (shouldDeref)
-            deref(); // balances the ref() in AbortSignal::timeout()
+        cancelTimer();
+        // balances the ref() in AbortSignal::timeout(); may destroy `this`.
+        deref();
     }
 }
 
@@ -326,22 +327,29 @@ uint32_t AbortSignal::addAbortAlgorithmToSignal(AbortSignal& signal, Ref<AbortAl
         return 0;
     }
     auto identifier = ++signal.m_algorithmIdentifier;
-    Locker locker { signal.m_abortAlgorithmsLock };
-    signal.m_abortAlgorithms.append(std::make_pair(identifier, WTF::move(algorithm)));
+    {
+        Locker locker { signal.m_abortAlgorithmsLock };
+        signal.m_abortAlgorithms.append(std::make_pair(identifier, WTF::move(algorithm)));
+    }
+    signal.eventListenersDidChange();
     return identifier;
 }
 
 void AbortSignal::removeAbortAlgorithmFromSignal(AbortSignal& signal, uint32_t algorithmIdentifier)
 {
-    Locker locker { signal.m_abortAlgorithmsLock };
-    signal.m_abortAlgorithms.removeFirstMatching([algorithmIdentifier](auto& pair) {
-        return pair.first == algorithmIdentifier;
-    });
+    {
+        Locker locker { signal.m_abortAlgorithmsLock };
+        signal.m_abortAlgorithms.removeFirstMatching([algorithmIdentifier](auto& pair) {
+            return pair.first == algorithmIdentifier;
+        });
+    }
+    signal.eventListenersDidChange();
 }
 
 uint32_t AbortSignal::addAlgorithm(Algorithm&& algorithm)
 {
     m_algorithms.append(std::make_pair(++m_algorithmIdentifier, WTF::move(algorithm)));
+    eventListenersDidChange();
     return m_algorithmIdentifier;
 }
 
@@ -350,6 +358,7 @@ void AbortSignal::removeAlgorithm(uint32_t algorithmIdentifier)
     m_algorithms.removeFirstMatching([algorithmIdentifier](auto& pair) {
         return pair.first == algorithmIdentifier;
     });
+    eventListenersDidChange();
 }
 
 void AbortSignal::throwIfAborted(JSC::JSGlobalObject& lexicalGlobalObject)

--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -149,6 +149,7 @@ private:
     void addSourceSignal(AbortSignal&);
     void addDependentSignal(AbortSignal&);
     void cancelTimer();
+    bool updateHasAbortEventListener();
 
     void applyFlags(uint8_t flags) { m_flags |= flags; }
     void setIsDependent(bool isDependent)

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -170,6 +170,30 @@ describe("AbortSignal", () => {
       et.dispatchEvent(new Event("x"));
       expect(calls).toBe(0);
     });
+
+    // Registering/removing an abort algorithm must not disarm a user-held timeout signal.
+    test("timeout still fires after a pipeTo using it completes early", async () => {
+      const s = AbortSignal.timeout(50);
+      await new ReadableStream({ start: c => c.close() }).pipeTo(new WritableStream({}), { signal: s });
+      const result = await Promise.race([
+        new Promise(r => s.addEventListener("abort", () => r("aborted"), { once: true })),
+        Bun.sleep(2000).then(() => "timeout-never-fired"),
+      ]);
+      expect({ result, aborted: s.aborted }).toEqual({ result: "aborted", aborted: true });
+    });
+
+    test("timeout still fires after addEventListener({signal})+removeEventListener", async () => {
+      const s = AbortSignal.timeout(50);
+      const et = new EventTarget();
+      const fn = () => {};
+      et.addEventListener("x", fn, { signal: s });
+      et.removeEventListener("x", fn);
+      const result = await Promise.race([
+        new Promise(r => s.addEventListener("abort", () => r("aborted"), { once: true })),
+        Bun.sleep(2000).then(() => "timeout-never-fired"),
+      ]);
+      expect({ result, aborted: s.aborted }).toEqual({ result: "aborted", aborted: true });
+    });
   });
 
   // https://wpt.fyi/results/dom/abort/timeout.any.html "AbortSignal timeouts fire in order"

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -173,8 +173,9 @@ describe("AbortSignal", () => {
 
     // Registering/removing an abort algorithm must not disarm a user-held timeout signal.
     test("timeout still fires after a pipeTo using it completes early", async () => {
-      const s = AbortSignal.timeout(50);
+      const s = AbortSignal.timeout(100);
       await new ReadableStream({ start: c => c.close() }).pipeTo(new WritableStream({}), { signal: s });
+      expect(s.aborted).toBe(false);
       const result = await Promise.race([
         new Promise(r => s.addEventListener("abort", () => r("aborted"), { once: true })),
         Bun.sleep(2000).then(() => "timeout-never-fired"),
@@ -183,11 +184,12 @@ describe("AbortSignal", () => {
     });
 
     test("timeout still fires after addEventListener({signal})+removeEventListener", async () => {
-      const s = AbortSignal.timeout(50);
+      const s = AbortSignal.timeout(100);
       const et = new EventTarget();
       const fn = () => {};
       et.addEventListener("x", fn, { signal: s });
       et.removeEventListener("x", fn);
+      expect(s.aborted).toBe(false);
       const result = await Promise.race([
         new Promise(r => s.addEventListener("abort", () => r("aborted"), { once: true })),
         Bun.sleep(2000).then(() => "timeout-never-fired"),

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -117,6 +117,61 @@ describe("AbortSignal", () => {
     });
   });
 
+  // A signal's abort algorithms (pipeTo's abort handler, addEventListener({signal})'s
+  // listener-removal callback) must count as abort observers for the wrapper's GC
+  // reachability check. Previously HasAbortEventListener only reflected JS "abort"
+  // listeners and native callbacks, so a timeout/any() signal passed inline with no
+  // other JS reference was collected before it could abort.
+  describe("abort algorithms keep the signal reachable across GC", () => {
+    const stalled = () => new ReadableStream({ pull: () => new Promise(() => {}) });
+    const settle = (p: Promise<unknown>) =>
+      p.then(
+        () => "resolved",
+        e => `rejected:${e?.name ?? e}`,
+      );
+    // Yield before the forced GC so nothing from the synchronous setup frame is
+    // still conservatively rooted on the stack.
+    async function forceGC() {
+      await Bun.sleep(0);
+      Bun.gc(true);
+      await Bun.sleep(0);
+      Bun.gc(true);
+    }
+
+    test("pipeTo({signal: AbortSignal.timeout(n)}) aborts after GC", async () => {
+      const p = settle(stalled().pipeTo(new WritableStream({}), { signal: AbortSignal.timeout(100) }));
+      await forceGC();
+      expect(await Promise.race([p, Bun.sleep(2000).then(() => "STILL-PENDING")])).toBe("rejected:TimeoutError");
+    });
+
+    test("pipeTo({signal: AbortSignal.any([c.signal])}) aborts after GC", async () => {
+      const c = new AbortController();
+      const p = settle(stalled().pipeTo(new WritableStream({}), { signal: AbortSignal.any([c.signal]) }));
+      await forceGC();
+      c.abort(new Error("go"));
+      expect(await Promise.race([p, Bun.sleep(2000).then(() => "STILL-PENDING")])).toBe("rejected:Error");
+    });
+
+    test("pipeTo({signal: AbortSignal.any([AbortSignal.timeout(n)])}) aborts after GC", async () => {
+      const p = settle(
+        stalled().pipeTo(new WritableStream({}), { signal: AbortSignal.any([AbortSignal.timeout(100)]) }),
+      );
+      await forceGC();
+      expect(await Promise.race([p, Bun.sleep(2000).then(() => "STILL-PENDING")])).toBe("rejected:TimeoutError");
+    });
+
+    test("addEventListener({signal: AbortSignal.any([c.signal])}) removes listener after GC", async () => {
+      const et = new EventTarget();
+      let calls = 0;
+      const c = new AbortController();
+      et.addEventListener("x", () => calls++, { signal: AbortSignal.any([c.signal]) });
+      await forceGC();
+      c.abort();
+      et.dispatchEvent(new Event("x"));
+      expect(calls).toBe(0);
+    });
+  });
+
   // https://wpt.fyi/results/dom/abort/timeout.any.html "AbortSignal timeouts fire in order"
   test("AbortSignal.timeout with equal deadlines fire in creation order", async () => {
     const src = `


### PR DESCRIPTION
`pipeTo({signal: AbortSignal.timeout(n)})` and `pipeTo({signal: AbortSignal.any([...])})` never abort, and `addEventListener(t, fn, {signal: AbortSignal.any([...])})` listeners are never removed, when the signal is passed inline (no other JS reference).

```js
const stalled = () => new ReadableStream({ pull: () => new Promise(() => {}) });
// Never rejects (Node: rejects with TimeoutError):
await stalled().pipeTo(new WritableStream({}), { signal: AbortSignal.timeout(50) });
```

## Cause

`JSAbortSignalOwner::isReachableFromOpaqueRoots` keeps a signal wrapper alive when it has an abort observer AND an independent abort source (an active timeout timer, or live source signals for a dependent `any()` composite). The observer check (`HasAbortEventListener`) only covered JS `"abort"` listeners and native callbacks, not `m_algorithms` or `m_abortAlgorithms`. Consumers that register via those paths (`pipeTo`'s abort handler, `addEventListener({signal})`'s listener-removal callback) therefore did not keep the wrapper reachable.

For `pipeTo({signal: AbortSignal.timeout(n)})` this meant the wrapper was collected before the timer fired; the native signal survived (`ref()`'d by the timer) and ran `runAbortSteps`, but the weak `JSBoundFunction` callback in `JSCallbackData` had been cleared, so the pipe never aborted.

For `pipeTo` / `addEventListener` with `{signal: AbortSignal.any([c.signal])}` the wrapper collection took the native composite with it (the source's `m_dependentSignals` is a `WeakListHashSet`), so aborting the source never propagated to the dependent.

## Fix

Include `m_algorithms` and `m_abortAlgorithms` in the `hasListeners` computation in `eventListenersDidChange()`, and call `eventListenersDidChange()` from `addAlgorithm` / `removeAlgorithm` / `addAbortAlgorithmToSignal` / `removeAbortAlgorithmFromSignal` so the flag stays current. The existing timeout-timer-cancellation logic simplifies since `hasListeners` now subsumes the separate algorithm-vector emptiness checks it performed.

## Verification

New tests in `test/js/web/abort/abort.test.ts` force GC between registration and abort. All four fail on main (`STILL-PENDING` / listener still registered) and pass with the fix. The existing `abort.test.ts`, `abort-signal-event-listener-leak.test.ts`, `abort-controller-gc-reason.test.ts`, and `pipeTo-signal-leak.test.ts` suites continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/abort/abort.test.ts
bun test v1.4.0 (5746eef73)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [248.91ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [401.40ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [26.41ms]
(pass) AbortSignal > .signal.reason should be a DOMException [10.48ms]
(pass) AbortSignal > .signal.reason should be a DOMException for timeout [20.28ms]
(pass) AbortSignal > awaiting AbortSignal.timeout(n) abort event with nothing else ref'd does not hang (#33334) [341.25ms]
139 |     }
140 | 
141 |     test("pipeTo({signal: AbortSignal.timeout(n)}) aborts after GC", async () => {
142 |       const p = settle(stalled().pipeTo(new WritableStream({}), { signal: AbortSignal.timeout(100) }));
143 |       await forceGC();
144 |       expect(await Promise.race([p, Bun.sleep(2000).then(() => "STILL-PENDING")])).toBe("rejected:TimeoutError");
                                                                                         ^
error: expect(receive
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3192466ac)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [6.27ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [23.47ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [0.80ms]
(pass) AbortSignal > .signal.reason should be a DOMException [0.15ms]
(pass) AbortSignal > .signal.reason should be a DOMException for timeout [10.80ms]
(pass) AbortSignal > awaiting AbortSignal.timeout(n) abort event with nothing else ref'd does not hang (#33334) [10.47ms]
(pass) AbortSignal > abort algorithms keep the signal reachable across GC > pipeTo({signal: AbortSignal.timeout(n)}) aborts after GC [100.95ms]
(pass) AbortSignal > abort algorithms keep the signal reachable across GC > pipeTo({signal: AbortSignal.any([c.signal])}) aborts after GC [5.10ms]
(pass) AbortSignal > abort algorithms keep the signal reachable across GC > pipeTo({signal: AbortSignal.any([AbortSignal.timeout(n)])}) aborts after GC [100.74ms]
(pass) AbortSignal > abort algorithms keep the signal reachable across GC > addEventListener({signal: AbortSignal.any([c.signal])}) removes listener after GC [4.60ms]
(pass) AbortSignal >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/abort/abort.test.ts
bun test v1.4.0 (5746eef73)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [238.60ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [402.84ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [25.08ms]
(pass) AbortSignal > .signal.reason should be a DOMException [9.90ms]
(pass) AbortSignal > .signal.reason should be a DOMException for timeout [19.38ms]
(pass) AbortSignal > awaiting AbortSignal.timeout(n) abort event with nothing else ref'd does not hang (#33334) [331.31ms]
(pass) AbortSignal > abort algorithms keep the signal reachable across GC > pipeTo({signal: AbortSignal.timeout(n)}) aborts after GC [127.38ms]
(pass) AbortSignal > abort algorithms keep the signal reachable across GC > pipeTo({signal: AbortSignal.any([c.signal])}) aborts after GC [99.16ms]
(pass) AbortSignal > abort algorithms keep the signal reachable across GC > pipeTo({signal: AbortSignal.any([AbortSignal.timeout(n)])}) aborts after GC [119.40ms]
(pass) AbortSignal > abor
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 708ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/18] cxx obj/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp.o
[2/18] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStream.cpp.o
[3/18] cxx obj/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp.o
[4/18] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/18] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[6/18] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[7/18] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[8/18] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[9/18] cxx obj/src/jsc/bindings/bindings.cpp.o
[10/18] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[11/18] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[12/18] gen cpp.rs (cppbind)
[12/18] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/AbortSignal.cpp | 54 ++++++++++++---------
 src/jsc/bindings/webcore/AbortSignal.h   |  1 +
 test/js/web/abort/abort.test.ts          | 81 ++++++++++++++++++++++++++++++++
 3 files changed, 115 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/bindings/webcore/AbortSignal.cpp      6      8      0
src/jsc/bindings/webcore/AbortSignal.h        2      2      0
test/js/web/abort/abort.test.ts               4      6      0
```

</details>

<!-- robobun:evidence:end -->