### PR TITLE
fetch: never derive TLS SNI or certificate identity from the Host request header

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -24,7 +24,7 @@ bun_core::declare_scope!(AsyncHTTP, visible);
 
 // Lifetime `'a` covers every borrowed input the caller hands in: `url`,
 // `http_proxy`, `request_header_buf`, the borrowed `HTTPRequestBody::Bytes`
-// payload, and `client.{header_buf,hostname,unix_socket_path,if_modified_since}`.
+// payload, and `client.{header_buf,unix_socket_path,if_modified_since}`.
 // Intrusive fields (`real`, `next`) are raw pointers and thus lifetime-erased;
 // the HTTP-thread copy uses the same `'a` as the JS-thread original it mirrors.
 pub struct AsyncHTTP<'a> {
@@ -149,7 +149,6 @@ fn make_client<'a>(
     url: URL<'a>,
     header_entries: headers::EntryList,
     header_buf: &'a [u8],
-    hostname: Option<&'a [u8]>,
     signals: Signals,
     async_http_id: u32,
     http_proxy: Option<URL<'a>>,
@@ -190,7 +189,6 @@ fn make_client<'a>(
         pending_h2: None,
         signals,
         async_http_id,
-        hostname,
         unix_socket_path: b"",
         compress: None,
         compressed_request_body: Vec::new(),
@@ -243,7 +241,6 @@ pub struct Options<'a> {
     pub http_proxy: Option<URL<'a>>,
     pub proxy_settings: Option<Box<crate::ProxySettings>>,
     pub proxy_headers: Option<Headers>,
-    pub hostname: Option<&'a [u8]>,
     pub signals: Option<Signals>,
     pub unix_socket_path: Option<&'a [u8]>,
     pub disable_timeout: Option<bool>,
@@ -432,7 +429,6 @@ impl<'a> AsyncHTTP<'a> {
             // and `client.header_entries`; `MultiArrayList` owns its allocation, so clone here.
             headers.clone().expect("OOM"),
             headers_buf,
-            options.hostname,
             signals,
             async_http_id,
             options.http_proxy,
@@ -499,11 +495,10 @@ impl<'a> AsyncHTTP<'a> {
     /// Construct an `AsyncHTTP` for a synchronous request driven via
     /// [`send_sync`].
     ///
-    /// Borrowed inputs (`url`, `headers_buf`, `request_body`, `http_proxy`,
-    /// `hostname`) are tied to lifetime `'a` and must outlive the returned
-    /// value — in practice they live on the calling stack frame and the
-    /// request is driven to completion via `send_sync` before that frame
-    /// returns.
+    /// Borrowed inputs (`url`, `headers_buf`, `request_body`, `http_proxy`)
+    /// are tied to lifetime `'a` and must outlive the returned value — in
+    /// practice they live on the calling stack frame and the request is driven
+    /// to completion via `send_sync` before that frame returns.
     pub fn init_sync(
         method: Method,
         url: URL<'a>,
@@ -511,7 +506,6 @@ impl<'a> AsyncHTTP<'a> {
         headers_buf: &'a [u8],
         request_body: &'a [u8],
         http_proxy: Option<URL<'a>>,
-        hostname: Option<&'a [u8]>,
         redirect_type: FetchRedirect,
     ) -> AsyncHTTP<'a> {
         Self::init(
@@ -524,7 +518,6 @@ impl<'a> AsyncHTTP<'a> {
             redirect_type,
             Options {
                 http_proxy,
-                hostname,
                 ..Options::default()
             },
         )

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -730,8 +730,6 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 continue;
             }
 
-            // The hash covers the Host-header SNI override that the handshake
-            // was verified against (see get_tls_hostname / connect()).
             if socket.proxy_auth_hash != proxy_auth_hash {
                 continue;
             }
@@ -860,7 +858,6 @@ impl<const SSL: bool> HTTPContext<SSL> {
         if SSL {
             if client.can_offer_h2() {
                 let cfg = SSLConfig::raw_ptr(client.tls_props.as_ref());
-                let host_header_hash = client.proxy_auth_hash();
                 // Listed sessions are kept alive by the registry's ref. The
                 // scan only reads; `adopt` runs after the iteration is over
                 // because it may end by unregistering the session it was
@@ -875,7 +872,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     })
                     .find(|s| {
                         s.has_headroom()
-                            && s.matches(hostname, port, cfg, host_header_hash)
+                            && s.matches(hostname, port, cfg)
                             // Same guard as the pool path (`existing_socket`).
                             && client.socket_verification().admits(s.verification)
                     });
@@ -887,7 +884,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 for pc in &mut self.pending_h2_connects {
                     // Same guard as the active-session loop above, applied to
                     // an in-flight connect before its session exists.
-                    if pc.matches(hostname, port, cfg_nn, host_header_hash)
+                    if pc.matches(hostname, port, cfg_nn)
                         && client.socket_verification().admits(pc.verification)
                     {
                         // client outlives the pending connect (resolved before
@@ -902,8 +899,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
         client.flags.reused_socket_verification = PeerVerification::None;
         if client.is_keep_alive_possible() {
             let want_tunnel = client.http_proxy.is_some() && client.url.is_https();
-            // CONNECT TCP target (writeProxyConnect line 346). The SNI
-            // override (client.hostname) is hashed into proxyAuthHash.
+            // CONNECT TCP target (writeProxyConnect line 346).
             let target_hostname: &[u8] = if want_tunnel {
                 client.url.hostname
             } else {
@@ -914,13 +910,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
             } else {
                 0
             };
-            // For a direct TLS connection the handshake verifies the peer
-            // against get_tls_hostname() — which prefers the Host-header
-            // override (client.hostname) over url.hostname — so the override
-            // must discriminate the pool key there too, not just for CONNECT
-            // tunnels. proxy_auth_hash() reduces to exactly the override hash
-            // (or 0) for a non-proxied request.
-            let proxy_auth_hash: u64 = if want_tunnel || (SSL && client.http_proxy.is_none()) {
+            let proxy_auth_hash: u64 = if want_tunnel {
                 client.proxy_auth_hash()
             } else {
                 0
@@ -1012,7 +1002,6 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     port,
                     ssl_config: cfg,
                     verification: client.socket_verification(),
-                    host_header_hash: client.proxy_auth_hash(),
                     ..Default::default()
                 });
                 // `client.pending_h2 = pc` stores a *borrowed* backref into the

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -63,12 +63,6 @@ pub struct InternalStateFlags {
     pub(crate) is_redirect_pending: bool,
     pub(crate) is_libdeflate_fast_path_disabled: bool,
     pub(crate) resend_request_body_on_redirect: bool,
-    /// Cross-origin redirect: the per-request Host override must be dropped so
-    /// the follow-up connection re-derives SNI/Host from the redirect target.
-    /// The actual clear is deferred to `do_redirect`, after the old socket's
-    /// pool/close decision — that decision needs `hostname` still set to know
-    /// the handshake was verified against an override.
-    pub(crate) clear_hostname_on_redirect: bool,
     /// Set when the TLS handshake completed but the user-supplied JS
     /// `checkServerIdentity` callback has not yet approved the peer
     /// certificate. While set, `on_writable` must not write any HTTP
@@ -96,7 +90,6 @@ impl InternalStateFlags {
             is_redirect_pending: false,
             is_libdeflate_fast_path_disabled: false,
             resend_request_body_on_redirect: false,
-            clear_hostname_on_redirect: false,
             is_waiting_for_cert_check: false,
             receive_paused: false,
             body_compressed: false,

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -216,7 +216,7 @@ fn on_open(ctx: *mut HTTPClient) {
     // `&mut ProxyTunnel` — see ALIASING NOTE.
     let _guard = ProxyTunnel::ref_guard(proxy_nn);
     if let Some(ssl_ptr) = ProxyTunnel::wrapper_ssl(proxy_nn) {
-        let _hostname = this.hostname.unwrap_or(this.url.hostname);
+        let _hostname = crate::get_tls_hostname(this, false);
 
         // SAFETY: `ssl_ptr` is the live SSL handle from the tunnel's SSLWrapper.
         let ssl = unsafe { &mut *ssl_ptr.as_ptr() };

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -62,7 +62,6 @@ pub struct ClientSession {
     /// checked by the coalescing path so a caller only multiplexes onto a
     /// session verified the way it would verify a fresh one.
     pub(crate) verification: PeerVerification,
-    pub(crate) host_header_hash: u64,
 
     /// Queued bytes for the socket; whole frames are written here and
     /// `flush()` drains as much as the socket accepts.
@@ -346,7 +345,6 @@ impl ClientSession {
             ssl_config: client.tls_props.clone(),
             did_have_handshaking_error: client.flags.did_have_handshaking_error,
             verification: client.socket_verification(),
-            host_header_hash: client.proxy_auth_hash(),
             write_buffer: bun_io::StreamBuffer::default(),
             read_buffer: Vec::new(),
             streams: ArrayHashMap::default(),
@@ -394,16 +392,12 @@ impl ClientSession {
         hostname: &[u8],
         port: u16,
         ssl_config: Option<*const ssl_config::SSLConfig>,
-        host_header_hash: u64,
     ) -> bool {
         let mine: Option<*const ssl_config::SSLConfig> = self
             .ssl_config
             .as_ref()
             .map(|p| std::ptr::from_ref(p.get()));
-        self.port == port
-            && mine == ssl_config
-            && self.host_header_hash == host_header_hash
-            && strings::eql_long(&self.hostname, hostname, true)
+        self.port == port && mine == ssl_config && strings::eql_long(&self.hostname, hostname, true)
     }
 
     fn adopt_client(&mut self, client: &mut HTTPClient) {
@@ -1063,7 +1057,7 @@ impl ClientSession {
                 None,
                 b"",
                 0,
-                self.host_header_hash,
+                0,
                 Some(self_ref),
             );
         } else {

--- a/src/http/h2_client/PendingConnect.rs
+++ b/src/http/h2_client/PendingConnect.rs
@@ -22,7 +22,6 @@ pub struct PendingConnect {
     /// it here lets the coalescing path apply the guard *before* the session
     /// exists, so a strict caller never waits on a connect started by a lax one.
     pub(crate) verification: PeerVerification,
-    pub(crate) host_header_hash: u64,
     // BACKREF: waiters are borrowed HTTP clients owned elsewhere; lifetime-erased.
     pub(crate) waiters: Vec<NonNull<HTTPClient<'static>>>,
 }
@@ -50,11 +49,9 @@ impl PendingConnect {
         hostname: &[u8],
         port: u16,
         ssl_config: Option<NonNull<SSLConfig>>,
-        host_header_hash: u64,
     ) -> bool {
         self.port == port
             && self.ssl_config == ssl_config
-            && self.host_header_hash == host_header_hash
             && strings::eql_long(&self.hostname, hostname, true)
     }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -359,27 +359,6 @@ pub(crate) fn h3_alt_svc_enabled() -> bool {
         .unwrap_or(false)
 }
 
-/// Strips an optional port suffix from a host string (e.g. "example.com:443" -> "example.com").
-/// Handles IPv6 bracket notation correctly (e.g. "[::1]:443" -> "[::1]").
-pub(crate) fn strip_port_from_host(host: &[u8]) -> &[u8] {
-    if host.is_empty() {
-        return host;
-    }
-    // IPv6 with brackets: "[::1]:port"
-    if host[0] == b'[' {
-        if let Some(bracket) = strings::last_index_of_char(host, b']') {
-            // Return everything up to and including ']'
-            return &host[0..bracket + 1];
-        }
-        return host;
-    }
-    // IPv4 or hostname: find last colon
-    if let Some(colon) = strings::last_index_of_char(host, b':') {
-        return &host[0..colon];
-    }
-    host
-}
-
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum ShouldContinue {
     ContinueStreaming,
@@ -791,7 +770,7 @@ fn no_proxy_matches(no_proxy_text: &[u8], hostname: &[u8], host: &[u8]) -> bool 
 // Many of these fields can be moved to a packed struct and use less space
 //
 // Lifetime `'a` ties every borrowed input — `url`, `http_proxy`, `header_buf`,
-// `if_modified_since`, `hostname`, `unix_socket_path`, and the borrowed
+// `if_modified_since`, `unix_socket_path`, and the borrowed
 // `HTTPRequestBody::Bytes` payload — to the caller's storage. The original port erased these to `'static`
 // and lifetime-erased at every call site; threading the lifetime removes that hazard.
 // Intrusive raw-pointer backrefs (socket ext, h2/h3 streams) store the
@@ -864,7 +843,6 @@ pub struct HTTPClient<'a> {
     pub(crate) pending_h2: Option<NonNull<h2::PendingConnect>>,
     pub(crate) signals: Signals,
     pub(crate) async_http_id: u32,
-    pub(crate) hostname: Option<&'a [u8]>,
     pub(crate) unix_socket_path: &'a [u8],
     /// `fetch({ compress })` — when set, the body is compressed lazily at
     /// write time (h1: `send_initial_request_payload`; h2/h3: at attach) so
@@ -1217,10 +1195,9 @@ fn unregister_abort_tracker_for_socket(socket: uws::InternalSocket) {
 }
 
 /// Returns the hostname to use for TLS SNI and certificate verification.
-/// Priority: tls_props.server_name > client.hostname > client.url.hostname
-/// The Host header value (client.hostname) may contain a port suffix which
-/// must be stripped because it is not part of the DNS name in certificates.
-fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
+/// Priority: tls_props.server_name > client.url.hostname. The Host request
+/// header is an HTTP field only and never selects the TLS peer identity.
+pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
     if allow_proxy_url {
         if let Some(proxy) = &client.http_proxy {
             return proxy.hostname;
@@ -1239,10 +1216,6 @@ fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'
                 return sn_slice;
             }
         }
-    }
-    // client.hostname comes from the Host header and may include ":port"
-    if let Some(host) = &client.hostname {
-        return strip_port_from_host(host);
     }
     client.url.hostname
 }
@@ -1884,7 +1857,7 @@ impl<'a> HTTPClient<'a> {
                             self.get_ssl_ctx::<true>(),
                             self.connected_url.hostname,
                             self.connected_url.get_port_auto(),
-                            if want_tunnel || self.http_proxy.is_none() {
+                            if want_tunnel {
                                 self.proxy_auth_hash()
                             } else {
                                 0
@@ -2255,17 +2228,9 @@ impl<'a> HTTPClient<'a> {
 
     /// Hash of the per-request tunnel discriminators beyond the (proxy, target
     /// url.hostname/port, ssl_config) tuple already covered by separate pool-key
-    /// fields. Covers the Host-header SNI override (hostname) plus everything
-    /// writeProxyConnect sends: all proxy_headers entries and the auto-generated
-    /// Proxy-Authorization (if not overridden by a user header). Returns 0 if
-    /// none apply.
-    ///
-    /// target_hostname in the pool stores url.hostname (the CONNECT TCP target
-    /// at writeProxyConnect line 346). But the inner TLS SNI/cert verification
-    /// uses `hostname`, falling back to url.hostname. If a Host header
-    /// override sets hostname != url.hostname, two requests to different IPs
-    /// with the same Host header must NOT share a tunnel — they're physically
-    /// connected to different servers. Hashing hostname here catches that.
+    /// fields. Covers everything writeProxyConnect sends: all proxy_headers
+    /// entries and the auto-generated Proxy-Authorization (if not overridden by
+    /// a user header). Returns 0 if none apply.
     ///
     /// Per-header hashes are combined with wrapping add so insertion order
     /// doesn't matter and duplicate headers don't cancel to zero.
@@ -2273,25 +2238,6 @@ impl<'a> HTTPClient<'a> {
         let mut combined: u64 = 0;
         let mut any = false;
         let mut name_lower_buf = [0u8; 256];
-
-        // SNI override — distinct from url.hostname which is stored separately
-        // as the CONNECT target. Normalize before hashing: strip port (Host
-        // header may include ":443"), lowercase (DNS is case-insensitive per
-        // RFC 1035), and skip if it matches url.hostname (no actual override —
-        // a request with an explicit but identical Host header should hit the
-        // same pool entry as one without).
-        if let Some(sni_raw) = &self.hostname {
-            let sni = strip_port_from_host(sni_raw);
-            if !strings::eql_case_insensitive_ascii(sni, self.url.hostname, true) {
-                let sni_lower: &[u8] = if sni.len() <= name_lower_buf.len() {
-                    strings::copy_lowercase(sni, &mut name_lower_buf[0..sni.len()])
-                } else {
-                    sni
-                };
-                combined = combined.wrapping_add(bun_wyhash::hash(sni_lower));
-                any = true;
-            }
-        }
 
         let mut user_provided_auth = false;
         if let Some(hdrs) = &self.proxy_headers {
@@ -2646,11 +2592,6 @@ impl<'a> HTTPClient<'a> {
         } else if keep_alive_possible
             && self.is_request_fully_sent()
             && !socket.is_closed_or_has_error()
-            // A direct TLS socket verified against a Host-header override
-            // (get_tls_hostname) must not be pooled here: this.url has already
-            // been repointed at the redirect destination, so proxy_auth_hash()
-            // can no longer compute the correct pool key. Close it instead.
-            && (!IS_SSL || self.http_proxy.is_some() || self.hostname.is_none())
         {
             bun_core::scoped_log!(fetch, "Keep-Alive release in redirect");
             debug_assert!(!self.connected_url.hostname.is_empty());
@@ -2674,13 +2615,6 @@ impl<'a> HTTPClient<'a> {
         // connected_url was the last borrower of the previous hop's URL buffer
         // (handleResponseMetadata already repointed this.url at the new one).
         self.prev_redirect = Vec::new();
-
-        // Deferred until after the pool/close decision above — see
-        // `InternalStateFlags::clear_hostname_on_redirect`.
-        if self.state.flags.clear_hostname_on_redirect {
-            self.state.flags.clear_hostname_on_redirect = false;
-            self.hostname = None;
-        }
 
         // TODO: should this check be before decrementing the redirect count?
         // the current logic will allow one less redirect than requested
@@ -4213,9 +4147,7 @@ impl<'a> HTTPClient<'a> {
                 }
                 let had_tunnel = tunnel.is_some();
                 // target_hostname = url.hostname (the CONNECT TCP target at
-                // writeProxyConnect line 346). The SNI override (hostname) is
-                // hashed into proxyAuthHash separately — both must match, but
-                // they're distinct values when a Host header override is set.
+                // writeProxyConnect line 346).
                 Self::ssl_ctx_mut(ctx).release_socket(
                     socket,
                     self.flags.did_have_handshaking_error && !self.flags.reject_unauthorized,
@@ -4230,11 +4162,7 @@ impl<'a> HTTPClient<'a> {
                     } else {
                         0
                     },
-                    if had_tunnel || (IS_SSL && self.http_proxy.is_none()) {
-                        // Direct TLS: the handshake verified the peer against
-                        // the Host-header override (get_tls_hostname), so the
-                        // override hash must be part of the pool key. Matches
-                        // the lookup in HTTPContext::connect.
+                    if had_tunnel {
                         self.proxy_auth_hash()
                     } else {
                         0
@@ -4318,15 +4246,6 @@ impl<'a> HTTPClient<'a> {
     fn do_redirect_multiplexed(&mut self) {
         debug_assert!(self.flags.protocol != Protocol::Http1_1);
         bun_core::scoped_log!(fetch, "doRedirectMultiplexed");
-        // See `do_redirect`: the cross-origin redirect must drop the
-        // per-request Host override before the follow-up connection derives
-        // its SNI / certificate-verification hostname. The h2/h3 path never
-        // reaches `do_redirect`'s consume-and-clear, so mirror it here before
-        // `state.reset()` discards the flag.
-        if self.state.flags.clear_hostname_on_redirect {
-            self.state.flags.clear_hostname_on_redirect = false;
-            self.hostname = None;
-        }
         if matches!(self.state.original_request_body, HTTPRequestBody::Stream(_)) {
             self.flags.is_streaming_request_body = false;
         }
@@ -5218,13 +5137,6 @@ impl<'a> HTTPClient<'a> {
                             }
                         }
                     }
-                }
-
-                // Cross-origin redirect: re-derive SNI / cert
-                // verification / Host from the redirect target. See
-                // `InternalStateFlags::clear_hostname_on_redirect`.
-                if !is_same_origin {
-                    self.state.flags.clear_hostname_on_redirect = true;
                 }
 
                 // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -161,7 +161,6 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
         header_buf,
         b"",
         None,
-        None,
         http::FetchRedirect::Follow,
     );
 

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -752,7 +752,6 @@ fn send_audit_request(
         headers_buf,
         &final_compressed_body,
         http_proxy,
-        None,
         http::FetchRedirect::Follow,
     );
     let reason = match req.send_sync(&mut response_buf) {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1951,7 +1951,6 @@ impl Example {
             headers_buf,
             b"",
             http_proxy,
-            None,
             HTTP::FetchRedirect::Follow,
         ));
         async_http.client.progress_node = Some(core::ptr::NonNull::from(&mut *progress));
@@ -2054,7 +2053,6 @@ impl Example {
                 b"",
                 b"",
                 http_proxy,
-                None,
                 HTTP::FetchRedirect::Follow,
             ));
         async_http.client.progress_node = Some(core::ptr::NonNull::from(&mut *progress));
@@ -2147,7 +2145,6 @@ impl Example {
             b"",
             b"",
             http_proxy,
-            None,
             HTTP::FetchRedirect::Follow,
         );
         async_http.client.progress_node = Some(core::ptr::NonNull::from(&mut *progress));
@@ -2192,7 +2189,6 @@ impl Example {
             b"",
             b"",
             http_proxy,
-            None,
             HTTP::FetchRedirect::Follow,
         ));
         async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -901,7 +901,6 @@ fn registry_get(
         headers.content.written_slice(),
         b"",
         http_proxy,
-        None,
         http::FetchRedirect::Follow,
     );
     req.client.flags.reject_unauthorized = pm.tls_reject_unauthorized();

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -129,7 +129,6 @@ pub(crate) fn view(
         header_buf,
         b"",
         http_proxy,
-        None,
         http::FetchRedirect::Follow,
     );
     req.client.flags.reject_unauthorized = manager.tls_reject_unauthorized();

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -814,7 +814,6 @@ impl PublishCommand {
             headers.content.written_slice(),
             b"",
             None,
-            None,
             http::FetchRedirect::Follow,
         );
 
@@ -940,7 +939,6 @@ impl PublishCommand {
             publish_headers.content.written_slice(),
             publish_req_body,
             None,
-            None,
             http::FetchRedirect::Follow,
         );
 
@@ -1033,7 +1031,6 @@ impl PublishCommand {
                     otp_headers.entries,
                     otp_headers.content.written_slice(),
                     publish_req_body,
-                    None,
                     None,
                     http::FetchRedirect::Follow,
                 );
@@ -1263,7 +1260,6 @@ impl PublishCommand {
                         auth_headers.entries.clone()?,
                         auth_headers.content.written_slice(),
                         b"",
-                        None,
                         None,
                         http::FetchRedirect::Follow,
                     );

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -265,7 +265,6 @@ impl UpgradeCommand {
             headers_buf,
             b"",
             http_proxy,
-            None,
             HTTP::FetchRedirect::Follow,
         ));
         async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
@@ -657,7 +656,6 @@ impl UpgradeCommand {
                 b"",
                 b"",
                 http_proxy,
-                None,
                 HTTP::FetchRedirect::Follow,
             ));
             // `progress` is intentionally leaked (process-lifetime), so the

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -443,8 +443,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // `SignalRef`'s Drop on every early-return path, and disarmed via `take()`
     // when ownership is moved into `FetchOptions`.
     let mut signal = SignalRef(None);
-    // Custom Hostname
-    let mut hostname: Option<Box<[u8]>> = None;
     let mut range: Option<bun_core::ZBox> = None;
     let mut unix_socket_path: Box<[u8]> = Box::default();
 
@@ -467,7 +465,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     let mut reject_unauthorized = vm.get_tls_reject_unauthorized();
     let mut check_server_identity: JSValue = JSValue::ZERO;
 
-    // signal/unix_socket_path/url_proxy_buffer/headers/body/hostname/range/
+    // signal/unix_socket_path/url_proxy_buffer/headers/body/range/
     // ssl_config are all owning types whose Drop runs on early return
     // (`signal` via `SignalRef`).
 
@@ -1228,9 +1226,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // refcounted via `fetch_headers_to_deref` above). `FetchHeaders` is
             // an opaque ZST FFI handle (S008) — safe `*mut → &mut` deref.
             let headers_ref = bun_opaque::opaque_deref_mut(headers_);
-            if let Some(hostname_) = headers_ref.fast_get(HTTPHeaderName::Host) {
-                hostname = Some(hostname_.to_owned_slice().into_boxed_slice());
-            }
             if url.is_s3() {
                 if let Some(range_) = headers_ref.fast_get(HTTPHeaderName::Range) {
                     range = Some(range_.to_owned_slice_z());
@@ -1918,7 +1913,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         url_proxy_buffer: url_proxy_boxed,
         signal: signal.take(),
         ssl_config: ssl_config.take(),
-        hostname: hostname.take(),
         upgraded_connection,
         forced_protocol,
         is_node_http_client: ALLOW_GET_BODY,

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -148,8 +148,6 @@ pub struct FetchTasklet {
     pub(crate) check_server_identity: StrongOptional,
     pub(crate) reject_unauthorized: bool,
     pub(crate) upgraded_connection: bool,
-    // Custom Hostname
-    pub(crate) hostname: Option<Box<[u8]>>,
     pub(crate) unix_socket_path: Box<[u8]>,
     pub(crate) is_waiting_body: bool,
     pub(crate) is_waiting_abort: bool,
@@ -457,13 +455,12 @@ impl FetchTasklet {
 
     fn clear_data(&mut self) {
         bun_output::scoped_log!(FetchTasklet, "clearData ");
-        // `http.client` borrows `url_proxy_buffer` / `hostname` / `unix_socket_path` / `request_headers`.
+        // `http.client` borrows `url_proxy_buffer` / `unix_socket_path` / `request_headers`.
         self.http = None;
         if !self.url_proxy_buffer.is_empty() {
             self.url_proxy_buffer = Box::default();
         }
 
-        self.hostname = None;
         self.unix_socket_path = Box::default();
 
         if let Some(certificate) = self.result.certificate_info.take() {
@@ -1901,7 +1898,6 @@ impl FetchTasklet {
             check_server_identity: fetch_options.check_server_identity,
             reject_unauthorized: fetch_options.reject_unauthorized,
             upgraded_connection: fetch_options.upgraded_connection,
-            hostname: fetch_options.hostname,
             unix_socket_path: fetch_options.unix_socket_path,
             is_waiting_body: false,
             is_waiting_abort: false,
@@ -1964,17 +1960,16 @@ impl FetchTasklet {
 
         // This task gets queued on the HTTP thread.
         // `AsyncHTTP::init` takes several `&'static [u8]` borrows
-        // (headers_buf, request_body, hostname, unix_socket_path) that point
-        // into FetchTasklet-owned storage. The tasklet is heap-pinned via
+        // (headers_buf, request_body, unix_socket_path) that point into
+        // FetchTasklet-owned storage. The tasklet is heap-pinned via
         // `heap::alloc`, so erase the borrow lifetimes through raw pointers.
         // SAFETY: `fetch_tasklet_ptr` is a stable heap allocation that outlives
         // the AsyncHTTP (dropped together in `deinit`); the slices below borrow
-        // its `request_headers.buf`, `request_body`, `hostname`, and
-        // `unix_socket_path` fields which are not reallocated for the lifetime
-        // of the request.
+        // its `request_headers.buf`, `request_body`, and `unix_socket_path`
+        // fields which are not reallocated for the lifetime of the request.
         // SAFETY (`Interned::assume` — Population B, holder-backed):
         // `fetch_tasklet_ptr` is a `heap::alloc`'d `FetchTasklet` whose
-        // `request_headers.buf` / `request_body` / `hostname` /
+        // `request_headers.buf` / `request_body` /
         // `unix_socket_path` fields are not reallocated for the request's
         // lifetime, and the tasklet is freed in `deinit` only after the owned
         // `AsyncHTTP` is dropped. NOT process-lifetime — these should become
@@ -1986,11 +1981,6 @@ impl FetchTasklet {
         // SAFETY: see `Interned::assume` note above — same heap-pinned `FetchTasklet` owner.
         let request_body_slice: &'static [u8] =
             unsafe { bun_ptr::Interned::assume(fetch_tasklet.request_body.slice()) }.as_bytes();
-        let hostname: Option<&'static [u8]> = fetch_tasklet
-            .hostname
-            .as_deref()
-            // SAFETY: see block note above — same `FetchTasklet` owner.
-            .map(|s| unsafe { bun_ptr::Interned::assume(s) }.as_bytes());
         // SAFETY: see block note above — same `FetchTasklet` owner.
         let unix_socket_path: &'static [u8] =
             unsafe { bun_ptr::Interned::assume(&fetch_tasklet.unix_socket_path) }.as_bytes();
@@ -2020,7 +2010,6 @@ impl FetchTasklet {
                 http_proxy: proxy,
                 proxy_settings,
                 proxy_headers: fetch_options.proxy_headers,
-                hostname,
                 signals: Some(fetch_tasklet.signals),
                 unix_socket_path: Some(unix_socket_path),
                 disable_timeout: Some(fetch_options.disable_timeout),
@@ -2632,8 +2621,6 @@ pub struct FetchOptions {
     pub(crate) proxy_headers: Option<Headers>,
     pub(crate) url_proxy_buffer: Box<[u8]>,
     pub(crate) signal: Option<*mut AbortSignal>,
-    // Custom Hostname
-    pub(crate) hostname: Option<Box<[u8]>>,
     pub(crate) check_server_identity: StrongOptional,
     pub(crate) unix_socket_path: Box<[u8]>,
     pub(crate) ssl_config: Option<http::ssl_config::SharedPtr>,

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2203,7 +2203,6 @@ pub(crate) fn download_to_path(
                 b"",
                 b"",
                 http_proxy,
-                None,
                 bun_http::FetchRedirect::Follow,
             ));
             async_http.client.progress_node =

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -781,6 +781,45 @@ test("HTTPS proxy tunnel keep-alive does not share tunnel across different targe
   expect(connects.sort()).toEqual([`CONNECT localhost:${serverA.port}`, `CONNECT localhost:${serverB.port}`].sort());
 });
 
+// The TLS handshake inside a CONNECT tunnel is keyed to the URL host like a
+// direct connection: the ClientHello SNI and the certificate verification use
+// the URL host, and a caller-supplied Host header only travels as an HTTP
+// field on the tunneled request.
+test("HTTPS proxy tunnel keeps a caller-supplied Host header out of SNI and certificate verification", async () => {
+  const seen: { sni: string | null; host: string | undefined }[] = [];
+  const target = tls.createServer(
+    {
+      ...tlsCert,
+      SNICallback(servername, cb) {
+        if (servername !== "localhost") return cb(new Error(`unexpected SNI ${servername}`));
+        cb(null, tls.createSecureContext(tlsCert));
+      },
+    },
+    socket => {
+      socket.once("data", data => {
+        const host = /^host:\s*(.*)\r\n/im.exec(data.toString())?.[1];
+        seen.push({ sni: socket.servername || null, host });
+        socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+      });
+    },
+  );
+  target.listen(0, "127.0.0.1");
+  await once(target, "listening");
+  try {
+    const port = (target.address() as net.AddressInfo).port;
+    const res = await fetch(`https://localhost:${port}/`, {
+      proxy: httpProxyServer.url,
+      keepalive: false,
+      headers: { Host: "other.example" },
+      tls: { ca: tlsCert.cert },
+    });
+    expect(`${res.status} ${await res.text()}`).toBe("200 ok");
+    expect(seen).toEqual([{ sni: "localhost", host: "other.example" }]);
+  } finally {
+    target.close();
+  }
+});
+
 test("HTTPS proxy tunnel keep-alive does not share tunnel across different credentials", async () => {
   using target = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("ok") });
 

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -803,7 +803,7 @@ test("HTTPS proxy tunnel keeps a caller-supplied Host header out of SNI and cert
       });
     },
   );
-  target.listen(0, "127.0.0.1");
+  target.listen(0);
   await once(target, "listening");
   try {
     const port = (target.address() as net.AddressInfo).port;

--- a/test/js/web/fetch/fetch-http2-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http2-adversarial.test.ts
@@ -582,10 +582,11 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
 });
 
 // ─── session-key regressions ─────────────────────────────────────────────────
-// The TLS handshake verifies the peer against the Host-header override when one
-// is present (get_tls_hostname), so the override must be part of the HTTP/2
-// session key — mirroring the HTTP/1.1 keep-alive pool's proxy_auth_hash.
-test("HTTP/2 session keyed by a Host header override is not reused for a request without one", async () => {
+// The TLS handshake (SNI and certificate verification) is keyed to the URL
+// host. A request-level Host header is only an HTTP/2 :authority pseudo-header
+// and plays no part in the session's identity, so it must not partition the
+// session pool.
+test("HTTP/2 session is reused across requests with different Host headers", async () => {
   await withAdversarialServer(
     {
       onStream: (socket, id) => {
@@ -597,24 +598,17 @@ test("HTTP/2 session keyed by a Host header override is not reused for a request
       const h2 = { protocol: "http2" as const, tls: { rejectUnauthorized: false } };
       const errcode = (e: any) => e.code || e.name;
 
-      // 1. Request with a Host override: TLS verification (when enabled) runs
-      //    against "other.example", not the URL hostname.
       const a = await fetch(url, { ...h2, headers: { Host: "other.example" } }).then(r => r.status, errcode);
       expect(a).toBe(200);
       expect(state.connections).toBe(1);
 
-      // 2. A request without an override expects verification against the URL
-      //    hostname. It must not multiplex onto the session that was verified
-      //    against the override — a fresh connection is required.
       const b = await fetch(url, h2).then(r => r.status, errcode);
       expect(b).toBe(200);
-      expect(state.connections).toBe(2);
+      expect(state.connections).toBe(1);
 
-      // 3. Same override again → same session key → the first session is
-      //    reused and no third connection is opened.
-      const c = await fetch(url, { ...h2, headers: { Host: "other.example" } }).then(r => r.status, errcode);
+      const c = await fetch(url, { ...h2, headers: { Host: "another.example" } }).then(r => r.status, errcode);
       expect(c).toBe(200);
-      expect(state.connections).toBe(2);
+      expect(state.connections).toBe(1);
     },
   );
 });

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -36,7 +36,7 @@ test("keepalive", async () => {
   }
 });
 
-test("fetch does not reuse a pooled TLS connection for a request with a different Host header", async () => {
+test("fetch reuses a pooled TLS connection across requests with different Host headers", async () => {
   using server = Bun.serve({
     port: 0,
     tls,
@@ -58,19 +58,14 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
     return await res.text();
   };
 
-  // Two requests whose TLS handshake used the Host-header override
-  // "wrong.example" for SNI/certificate verification share one pooled
-  // connection (legitimate keep-alive still works).
-  const overrideA = await get({ Host: "wrong.example" });
-  const overrideB = await get({ Host: "wrong.example" });
-  expect(overrideB).toBe(overrideA);
-
-  // A request without the override expects the server identity to match
-  // url.hostname ("localhost"), so it must not be handed the connection
-  // that was only ever negotiated as "wrong.example". It has to open a new
-  // connection, which cannot have the same client port.
-  const plain = await get();
-  expect(plain).not.toBe(overrideA);
+  // The TLS handshake is keyed to the URL host (SNI and certificate
+  // verification both use url.hostname). A request-level Host header is only
+  // an HTTP field, so three requests with differing Host headers share one
+  // pooled connection.
+  const first = await get({ Host: "wrong.example" });
+  const second = await get({ Host: "another.example" });
+  const third = await get();
+  expect({ second, third }).toEqual({ second: first, third: first });
 });
 
 // Whether a completed response leaves its connection in the keep-alive pool is

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2968,8 +2968,7 @@ it("combines duplicate response headers per the Fetch spec", async () => {
 
 it("drops a custom Host header when following a cross-origin redirect", async () => {
   // A per-request Host override must not survive a change of origin: the
-  // follow-up request's Host header (and the TLS SNI / certificate identity
-  // derived from the same field) has to be re-computed from the redirect
+  // follow-up request's Host header has to be re-computed from the redirect
   // target's URL, not carried over from the previous origin.
   await using target = Bun.serve({
     port: 0,

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -13,6 +14,12 @@ import { expiredTls, invalidTls, tls as validTls } from "harness";
 
 const CERT_LOCALHOST_IP = { ...validTls };
 const CERT_EXPIRED = { ...expiredTls };
+// Self-signed leaf whose only SAN is DNS:localhost (no iPAddress SAN), so a
+// connection dialled to 127.0.0.1 must fail hostname verification.
+const CERT_LOCALHOST_ONLY = {
+  cert: readFileSync(join(import.meta.dir, "../../../regression/issue/27890-localhost-only.crt"), "utf8"),
+  key: readFileSync(join(import.meta.dir, "../../../regression/issue/27890-localhost-only.key"), "utf8"),
+};
 
 // Note: Do not use bun.sh as the example domain
 // Cloudflare sometimes blocks automated requests to it.
@@ -29,7 +36,7 @@ async function createServer(cert: TLSOptions, callback: (port: number) => Promis
 }
 
 describe.concurrent("fetch-tls", () => {
-  it("re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect", async () => {
+  it("drops a caller-supplied Host header on a cross-origin redirect and never verifies TLS against it", async () => {
     // The redirect target records the Host header it actually receives.
     const receivedHostHeaders: (string | null)[] = [];
     using target = Bun.serve({
@@ -53,15 +60,13 @@ describe.concurrent("fetch-tls", () => {
       },
     });
 
-    // An explicit Host header overrides both the wire Host header and the
-    // hostname used for TLS SNI / certificate verification. checkServerIdentity
-    // receives the verification hostname as its first argument.
-    //
     // fetch() invokes the JS checkServerIdentity callback once per connection
     // in the redirect chain, before that connection's request is written: the
     // request (and any cookies/credentials it carries) must not reach a hop
     // whose certificate the callback has not approved. So a redirect chain
-    // yields one observation per hop, in order.
+    // yields one observation per hop, in order. The hostname handed to the
+    // callback is the URL host of that hop: a request-level Host header is an
+    // HTTP field only and never becomes the TLS identity.
     const verifiedHostnames: string[] = [];
     const res = await fetch(`https://127.0.0.1:${origin.port}/`, {
       keepalive: false,
@@ -76,16 +81,129 @@ describe.concurrent("fetch-tls", () => {
     });
     expect(await res.text()).toBe("from-target");
 
-    // The first hop is verified against the explicit Host override
-    // ("localhost"). The Host override names the previous origin, so on a
-    // cross-origin redirect it must be dropped and the verification hostname
-    // re-derived from the redirect target's URL ("127.0.0.1"). The vulnerable
-    // behavior carries the stale override and verifies the second connection
-    // against "localhost" instead.
-    expect(verifiedHostnames).toEqual(["localhost", "127.0.0.1"]);
+    expect(verifiedHostnames).toEqual(["127.0.0.1", "127.0.0.1"]);
     // The redirect target must see a Host header derived from its own URL,
     // not the override that was supplied for the previous origin.
     expect(receivedHostHeaders).toEqual([`127.0.0.1:${target.port}`]);
+  });
+
+  // The peer certificate is matched against the URL host (RFC 6125 / RFC 9525),
+  // never against a caller-supplied Host request header. Otherwise a
+  // header-forwarding caller (a reverse proxy passing inbound headers to an
+  // upstream IP) lets the remote client pick which certificate name the
+  // upstream connection accepts. Node's fetch behaves the same way: it verifies
+  // the URL host and ignores the Host header for TLS.
+  it("does not let a caller-supplied Host header become the certificate-verification target", async () => {
+    const receivedHostHeaders: (string | null)[] = [];
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: CERT_LOCALHOST_ONLY,
+      fetch: req => {
+        receivedHostHeaders.push(req.headers.get("host"));
+        return new Response("ok");
+      },
+    });
+    const ipUrl = `https://127.0.0.1:${server.port}/`;
+
+    const attempt = (url: string, init?: RequestInit & { tls?: object }) =>
+      fetch(url, { keepalive: false, ...init, tls: { ca: CERT_LOCALHOST_ONLY.cert, ...(init?.tls ?? {}) } }).then(
+        r => ({ ok: true, status: r.status }),
+        e => ({ ok: false, code: e.code }),
+      );
+
+    // Baseline: the certificate has no IP SAN, so verifying against the URL
+    // host (127.0.0.1) must fail.
+    expect(await attempt(ipUrl)).toEqual({ ok: false, code: "ERR_TLS_CERT_ALTNAME_INVALID" });
+
+    // A Host header naming the certificate's DNS SAN must not make the IP
+    // connection acceptable, and neither must any other value.
+    expect(await attempt(ipUrl, { headers: { host: "localhost" } })).toEqual({
+      ok: false,
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    });
+    expect(await attempt(ipUrl, { headers: { host: "evil.test" } })).toEqual({
+      ok: false,
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    });
+
+    // The hostname handed to a JS checkServerIdentity is the URL host too.
+    let seenHostname = "";
+    expect(
+      await attempt(ipUrl, {
+        headers: { host: "localhost" },
+        tls: {
+          checkServerIdentity(hostname: string, cert: tls.PeerCertificate) {
+            seenHostname = hostname;
+            return tls.checkServerIdentity(hostname, cert);
+          },
+        },
+      }),
+    ).toEqual({ ok: false, code: "ERR_TLS_CERT_ALTNAME_INVALID" });
+    expect(seenHostname).toBe("127.0.0.1");
+
+    // tls.servername is the documented opt-in for "dial an IP, verify a name".
+    // It keeps working, and the Host header still has no say.
+    expect(await attempt(ipUrl, { tls: { servername: "localhost" } })).toEqual({ ok: true, status: 200 });
+    expect(await attempt(ipUrl, { headers: { host: "evil.test" }, tls: { servername: "localhost" } })).toEqual({
+      ok: true,
+      status: 200,
+    });
+
+    // The inverse (issue #26579): a Host header that names nothing in the
+    // certificate must not break a request whose URL host the certificate does
+    // cover. The header still reaches the server as given.
+    expect(await attempt(`https://localhost:${server.port}/`, { headers: { host: "whatever.invalid" } })).toEqual({
+      ok: true,
+      status: 200,
+    });
+    expect(receivedHostHeaders).toEqual(["127.0.0.1:" + server.port, "evil.test", "whatever.invalid"]);
+  });
+
+  // SNI follows the URL host as well. A server that selects its certificate by
+  // SNI (or rejects unknown names) would otherwise answer with a certificate
+  // for the Host header value, which can never match the URL host it is then
+  // verified against.
+  it("sends the URL host as the ClientHello SNI, not the Host request header", async () => {
+    const seen: { sni: string | null; host: string | undefined }[] = [];
+    const server = tls.createServer(
+      {
+        ...CERT_LOCALHOST_IP,
+        SNICallback(servername, cb) {
+          if (servername !== "localhost") return cb(new Error(`unexpected SNI ${servername}`));
+          cb(null, tls.createSecureContext(CERT_LOCALHOST_IP));
+        },
+      },
+      socket => {
+        socket.once("data", data => {
+          const host = /^host:\s*(.*)\r\n/im.exec(data.toString())?.[1];
+          seen.push({ sni: socket.servername || null, host });
+          socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        });
+      },
+    );
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const port = (server.address() as import("node:net").AddressInfo).port;
+      const get = async (url: string, host?: string) => {
+        const res = await fetch(url, {
+          keepalive: false,
+          headers: host ? { Host: host } : {},
+          tls: { ca: CERT_LOCALHOST_IP.cert },
+        });
+        return `${res.status} ${await res.text()}`;
+      };
+      // DNS URL host with a foreign Host header: SNI is the URL host.
+      expect(await get(`https://localhost:${port}/`, "other.example")).toBe("200 ok");
+      // IP URL host: no SNI at all (RFC 6066), whatever the Host header says.
+      expect(await get(`https://127.0.0.1:${port}/`, "localhost")).toBe("200 ok");
+      expect(seen).toEqual([
+        { sni: "localhost", host: "other.example" },
+        { sni: null, host: "localhost" },
+      ]);
+    } finally {
+      server.close();
+    }
   });
 
   it("can handle multiple requests with non native checkServerIdentity", async () => {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -97,7 +97,6 @@ describe.concurrent("fetch-tls", () => {
     const receivedHostHeaders: (string | null)[] = [];
     using server = Bun.serve({
       port: 0,
-      hostname: "127.0.0.1",
       tls: CERT_LOCALHOST_ONLY,
       fetch: req => {
         receivedHostHeaders.push(req.headers.get("host"));
@@ -182,7 +181,7 @@ describe.concurrent("fetch-tls", () => {
         });
       },
     );
-    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>(resolve => server.listen(0, resolve));
     try {
       const port = (server.address() as import("node:net").AddressInfo).port;
       const get = async (url: string, host?: string) => {


### PR DESCRIPTION
### Problem
- `Host: whatever` on a request to `https://a.example/` fails with `ERR_TLS_CERT_ALTNAME_INVALID` because the server answers for the header's name (#26579).
- Cause: `get_tls_hostname()` (`src/http/lib.rs`) preferred the Host header over `url.hostname` for SNI and the certificate hostname check.

### Fix
- `get_tls_hostname()` resolves to `tls.servername` when set, otherwise `url.hostname`. The Host header still goes on the wire and no longer touches TLS.
- Remove the plumbing that carried the header to TLS, including its term in the connection pool keys (list in Notes). The proxy-tunnel inner SNI uses `get_tls_hostname()` too.
- Correct because the TLS identity is the authority the client dialled (RFC 6125 / RFC 9525). Node's `fetch` (undici) and curl do the same. `tls.servername` stays the opt-in for "dial an IP, verify a name".
- Verified: `test/js/web/fetch/fetch.tls.test.ts` (three cases) and `test/js/bun/http/proxy.test.ts` (tunnel case) fail on stock bun and pass here. Neighbouring TLS, proxy, keep-alive and h2 suites pass (Notes).

### Breaking change
- `fetch("https://10.0.0.5/", { headers: { Host: "internal.example" } })` against a certificate for `internal.example` used to pass verification and now fails with `ERR_TLS_CERT_ALTNAME_INVALID`. Migration: add `tls: { servername: "internal.example" }`. Node's `fetch` already fails this case, so the migrated code is also portable.

### Background
- SNI is the hostname in the TLS ClientHello. A server with several certificates picks one by it.
- Certificate verification compares the SAN entries to the name the client meant to reach. If SNI and that name differ, an SNI-routing server returns a certificate that cannot pass.
- The keep-alive pool, h2 session registry and TLS session cache share one key. Requests with different Host headers now share one connection, as for plain HTTP.
- #35889 changed only the verification target and kept the Host header as SNI. Against an SNI-routing server that fails every request.

<details><summary>Notes</summary>

Node's `fetch` deletes a caller-supplied Host header before dispatch (undici `lib/web/fetch/index.js`, `httpRequest.headersList.delete('host')`, present since undici 5). Bun keeps sending the header, which users rely on (#20173); only its effect on TLS changes here. Node's `https.request` is different: its agent derives `servername` from the Host header in JS (`calculateServerName`). Bun's `node:http` client is a socket-based port of that code and does not go through this HTTP client, so it is unaffected.

Removed plumbing, in full: `HTTPClient.hostname`, `FetchOptions.hostname`, `FetchTasklet.hostname`, `async_http::Options.hostname`, the `init_sync` hostname parameter (15 call sites), `InternalStateFlags.clear_hostname_on_redirect` and its set/consume sites in `do_redirect`, `do_redirect_multiplexed` and `handle_response_metadata`, the Host branch of `proxy_auth_hash()`, the direct-TLS `proxy_auth_hash()` terms in `HTTPContext::connect`, `release_socket` and `session_cache::install` (now CONNECT tunnels only, which is what the hash covers), `h2::ClientSession.host_header_hash`, `h2::PendingConnect.host_header_hash`, `strip_port_from_host()`.

Suites run with the fix: `fetch.tls`, `fetch-keepalive`, `fetch-http2-adversarial`, `fetch.tls.wildcard`, `fetch.unix`, `fetch-proxy-tls-intern-race`, `fetch-tls-abortsignal-timeout`, `regression/issue/27890`, `bun-serve-ssl`, `node/tls/ssl-ctx-cache`, all of `bun/http/proxy.test.ts`. `fetch.test.ts` has 41 failures in my container that reproduce on stock bun too (`localhost` binds to `::1` there); none touch this diff.

Branch history: the first version of this PR (July) conflicted with main after the h2 `PeerVerification` and TLS session cache changes. This is the same change re-applied on current main, plus the tests from #35889 that fit this design (the URL-host verify cases and the `checkServerIdentity` hostname check) and a CONNECT tunnel case. #35889's unix-socket `SSL_CTX` fix is a separate bug and lives in #35885.

</details>

Fixes #26579
