### PR TITLE
shell: make $.escape() validate NUL/lone surrogates and always return a string

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -408,8 +408,7 @@ pub(crate) fn shell_escape(
     }
     let bunstr = scopeguard::guard(bunstr, |s| s.deref());
 
-    // Mirror the interpolation path (`ShellSrcBuilder::append_js_value_str`): a value that
-    // `$.escape()` accepts must also be accepted by `{ raw: $.escape(v) }`.
+    // Same validation as the interpolation path (ShellSrcBuilder::append_js_value_str).
     if bunstr.index_of_ascii_char(0).is_some() {
         return Err(global_this
             .err(

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -396,7 +396,6 @@ pub(crate) fn shell_escape(
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
     use bun_jsc::StringJsc as _;
-    use bun_simdutf_sys::simdutf;
     let [jsval] = callframe.arguments_as_array::<1>();
     if callframe.arguments_count() < 1 {
         return Err(global_this.throw(format_args!("shell escape expected at least 1 argument")));
@@ -408,23 +407,7 @@ pub(crate) fn shell_escape(
     }
     let bunstr = scopeguard::guard(bunstr, |s| s.deref());
 
-    // Same validation as the interpolation path (ShellSrcBuilder::append_js_value_str).
-    if bunstr.index_of_ascii_char(0).is_some() {
-        return Err(global_this
-            .err(
-                jsc::ErrCode::INVALID_ARG_VALUE,
-                format_args!(
-                    "The shell argument must be a string without null bytes. Received \"{}\"",
-                    bunstr.to_zig_string()
-                ),
-            )
-            .throw());
-    }
-    let invalid = (bunstr.is_utf16() && !simdutf::validate::utf16le(bunstr.utf16()))
-        || (bunstr.is_utf8() && !simdutf::validate::utf8(bunstr.byte_slice()));
-    if invalid {
-        return Err(global_this.throw(format_args!("Shell script string contains invalid UTF-16")));
-    }
+    crate::shell::shell_body::validate_shell_arg_bunstr(global_this, *bunstr)?;
 
     let mut outbuf: Vec<u8> = Vec::new();
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -413,7 +413,8 @@ pub(crate) fn shell_escape(
         || bun_shell_parser::is_if_clause_keyword_bunstr(*bunstr)
     {
         let mut outbuf: Vec<u8> = Vec::new();
-        bun_shell_parser::escape_bun_str::<true>(*bunstr, &mut outbuf)?;
+        let ok = bun_shell_parser::escape_bun_str::<true>(*bunstr, &mut outbuf)?;
+        debug_assert!(ok);
         let mut str = BunString::clone_utf8(&outbuf[..]);
         return str.transfer_to_js(global_this);
     }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -409,21 +409,16 @@ pub(crate) fn shell_escape(
 
     crate::shell::shell_body::validate_shell_arg_bunstr(global_this, *bunstr)?;
 
-    let mut outbuf: Vec<u8> = Vec::new();
-
-    if bun_shell_parser::needs_escape_bunstr(*bunstr) {
-        let result = bun_shell_parser::escape_bun_str::<true>(*bunstr, &mut outbuf)?;
-        if !result {
-            return Err(global_this.throw(format_args!(
-                "String has invalid utf-16: {}",
-                bstr::BStr::new(bunstr.byte_slice()),
-            )));
-        }
+    if bun_shell_parser::needs_escape_bunstr(*bunstr)
+        || bun_shell_parser::is_if_clause_keyword_bunstr(*bunstr)
+    {
+        let mut outbuf: Vec<u8> = Vec::new();
+        bun_shell_parser::escape_bun_str::<true>(*bunstr, &mut outbuf)?;
         let mut str = BunString::clone_utf8(&outbuf[..]);
         return str.transfer_to_js(global_this);
     }
 
-    if jsval.is_string() {
+    if jsval.is_string_literal() {
         return Ok(jsval);
     }
     bunstr.to_js(global_this)

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -396,6 +396,7 @@ pub(crate) fn shell_escape(
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
     use bun_jsc::StringJsc as _;
+    use bun_simdutf_sys::simdutf;
     let [jsval] = callframe.arguments_as_array::<1>();
     if callframe.arguments_count() < 1 {
         return Err(global_this.throw(format_args!("shell escape expected at least 1 argument")));
@@ -406,6 +407,25 @@ pub(crate) fn shell_escape(
         return Ok(JSValue::ZERO);
     }
     let bunstr = scopeguard::guard(bunstr, |s| s.deref());
+
+    // Mirror the interpolation path (`ShellSrcBuilder::append_js_value_str`): a value that
+    // `$.escape()` accepts must also be accepted by `{ raw: $.escape(v) }`.
+    if bunstr.index_of_ascii_char(0).is_some() {
+        return Err(global_this
+            .err(
+                jsc::ErrCode::INVALID_ARG_VALUE,
+                format_args!(
+                    "The shell argument must be a string without null bytes. Received \"{}\"",
+                    bunstr.to_zig_string()
+                ),
+            )
+            .throw());
+    }
+    let invalid = (bunstr.is_utf16() && !simdutf::validate::utf16le(bunstr.utf16()))
+        || (bunstr.is_utf8() && !simdutf::validate::utf8(bunstr.byte_slice()));
+    if invalid {
+        return Err(global_this.throw(format_args!("Shell script string contains invalid UTF-16")));
+    }
 
     let mut outbuf: Vec<u8> = Vec::new();
 
@@ -421,7 +441,10 @@ pub(crate) fn shell_escape(
         return str.transfer_to_js(global_this);
     }
 
-    Ok(jsval)
+    if jsval.is_string() {
+        return Ok(jsval);
+    }
+    bunstr.to_js(global_this)
 }
 
 pub(crate) fn braces(

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -552,9 +552,7 @@ pub fn handle_template_value(
     Ok(())
 }
 
-/// Reject a shell argument string the parser would refuse: NUL bytes (which
-/// truncate C strings passed to exec) and lone surrogates / invalid UTF-8.
-/// Shared by template interpolation and `$.escape()` so the two cannot drift.
+/// Shared NUL / invalid-encoding rejection for template interpolation and `$.escape()`.
 pub(crate) fn validate_shell_arg_bunstr(
     global: &JSGlobalObject,
     bunstr: BunString,

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -552,6 +552,32 @@ pub fn handle_template_value(
     Ok(())
 }
 
+/// Reject a shell argument string the parser would refuse: NUL bytes (which
+/// truncate C strings passed to exec) and lone surrogates / invalid UTF-8.
+/// Shared by template interpolation and `$.escape()` so the two cannot drift.
+pub(crate) fn validate_shell_arg_bunstr(
+    global: &JSGlobalObject,
+    bunstr: BunString,
+) -> JsResult<()> {
+    if bunstr.index_of_ascii_char(0).is_some() {
+        return Err(global
+            .err(
+                jsc::ErrorCode::INVALID_ARG_VALUE,
+                format_args!(
+                    "The shell argument must be a string without null bytes. Received \"{}\"",
+                    bunstr.to_zig_string()
+                ),
+            )
+            .throw());
+    }
+    let invalid = (bunstr.is_utf16() && !simdutf::validate::utf16le(bunstr.utf16()))
+        || (bunstr.is_utf8() && !simdutf::validate::utf8(bunstr.byte_slice()));
+    if invalid {
+        return Err(global.throw(format_args!("Shell script string contains invalid UTF-16")));
+    }
+    Ok(())
+}
+
 // ───────────────────────────── ShellSrcBuilder ─────────────────────────────
 
 pub struct ShellSrcBuilder<'a> {
@@ -580,21 +606,7 @@ impl<'a> ShellSrcBuilder<'a> {
         jsval: JSValue,
     ) -> JsResult<bool> {
         let bunstr = OwnedString::new(jsval.to_bun_string(self.global_this)?);
-
-        // Check for null bytes in shell argument (security: prevent null byte injection)
-        if bunstr.index_of_ascii_char(0).is_some() {
-            return Err(self
-                .global_this
-                .err(
-                    jsc::ErrorCode::INVALID_ARG_VALUE,
-                    format_args!(
-                        "The shell argument must be a string without null bytes. Received \"{}\"",
-                        bunstr.to_zig_string()
-                    ),
-                )
-                .throw());
-        }
-
+        validate_shell_arg_bunstr(self.global_this, bunstr.get())?;
         Ok(self.append_bun_str::<ALLOW_ESCAPE>(bunstr.get())?)
     }
 

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -340,9 +340,7 @@ pub fn shell_cmd_from_js(
     let mut i: u32 = 0;
     let last = string_iter.len.saturating_sub(1);
     while let Some(js_value) = string_iter.next()? {
-        if !builder.append_js_value_str::<false>(js_value)? {
-            return Err(global.throw(format_args!("Shell script string contains invalid UTF-16")));
-        }
+        builder.append_js_value_str::<false>(js_value)?;
         if i < last {
             let template_value = match template_args.next()? {
                 Some(v) => v,
@@ -459,11 +457,7 @@ pub fn handle_template_value(
         }
 
         if template_value.is_string() {
-            if !builder.append_js_value_str::<true>(template_value)? {
-                return Err(
-                    global.throw(format_args!("Shell script string contains invalid UTF-16"))
-                );
-            }
+            builder.append_js_value_str::<true>(template_value)?;
             return Ok(());
         }
 
@@ -526,20 +520,12 @@ pub fn handle_template_value(
 
         // Spec `JSValue.isPrimitive()` — `!isObject()` (covers number/bool/null/undef/symbol).
         if !template_value.is_object() {
-            if !builder.append_js_value_str::<true>(template_value)? {
-                return Err(
-                    global.throw(format_args!("Shell script string contains invalid UTF-16"))
-                );
-            }
+            builder.append_js_value_str::<true>(template_value)?;
             return Ok(());
         }
 
         if template_value.implements_to_string(global)? {
-            if !builder.append_js_value_str::<true>(template_value)? {
-                return Err(
-                    global.throw(format_args!("Shell script string contains invalid UTF-16"))
-                );
-            }
+            builder.append_js_value_str::<true>(template_value)?;
             return Ok(());
         }
 
@@ -602,10 +588,13 @@ impl<'a> ShellSrcBuilder<'a> {
     pub fn append_js_value_str<const ALLOW_ESCAPE: bool>(
         &mut self,
         jsval: JSValue,
-    ) -> JsResult<bool> {
+    ) -> JsResult<()> {
         let bunstr = OwnedString::new(jsval.to_bun_string(self.global_this)?);
         validate_shell_arg_bunstr(self.global_this, bunstr.get())?;
-        Ok(self.append_bun_str::<ALLOW_ESCAPE>(bunstr.get())?)
+        // Encoding was just validated, so append_bun_str's only Ok(false) path is unreachable.
+        let ok = self.append_bun_str::<ALLOW_ESCAPE>(bunstr.get())?;
+        debug_assert!(ok);
+        Ok(())
     }
 
     pub fn append_bun_str<const ALLOW_ESCAPE: bool>(

--- a/src/shell_parser/lib.rs
+++ b/src/shell_parser/lib.rs
@@ -20,5 +20,5 @@ pub mod json_fmt;
 
 pub use parse::{
     JSValueRaw, LexResult, LexerError, ParseError, Parser, ast, escape_8bit, escape_bun_str,
-    needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
+    is_if_clause_keyword_bunstr, needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
 };

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -196,16 +196,18 @@ describe("bunshell", () => {
       expect(() => $.escape("x\uDC00y")).toThrow("Shell script string contains invalid UTF-16");
     });
 
-    test("always returns a string for non-string primitives", async () => {
+    test("always returns a primitive string for non-string inputs", async () => {
       // @ts-expect-error — exercising the runtime coercion contract.
       const escape: (v: unknown) => string = $.escape;
       expect(escape(true)).toBe("true");
       expect(escape(false)).toBe("false");
       expect(escape(null)).toBe("null");
       expect(escape(undefined)).toBe("undefined");
+      expect(escape(new String("hello"))).toBe("hello");
       expect(typeof escape(true)).toBe("string");
       expect(typeof escape(null)).toBe("string");
       expect(typeof escape(undefined)).toBe("string");
+      expect(typeof escape(new String("hello"))).toBe("string");
       // Coerced values the shell rejects as an interpolation must also be rejected here.
       expect(() => escape({ toString: () => "a\0b" })).toThrow(
         expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
@@ -215,6 +217,15 @@ describe("bunshell", () => {
         const { stdout } = await $`echo ${{ raw: escape(v) }}`;
         expect(stdout.toString()).toEqual(`${String(v)}\n`);
       }
+    });
+
+    test("quotes if-clause keywords so { raw: } keeps them as command words", async () => {
+      for (const kw of ["if", "then", "elif", "else", "fi"]) {
+        expect($.escape(kw)).toBe(`"${kw}"`);
+      }
+      const { stdout, stderr } = await $`${{ raw: $.escape("if") }} --help; echo done`.nothrow();
+      expect(stderr.toString()).toContain("command not found: if");
+      expect(stdout.toString()).toBe("done\n");
     });
 
     test("escaped values containing interpolation marker bytes stay literal data", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -189,6 +189,36 @@ describe("bunshell", () => {
       expect(stdout.toString()).toEqual("a\tb a?b\n");
     });
 
+    test("rejects NUL bytes and lone surrogates like interpolation does", () => {
+      const nul = "a" + String.fromCharCode(0) + "b";
+      expect(() => $.escape(nul)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+      );
+      expect(() => $.escape("\uD800")).toThrow("Shell script string contains invalid UTF-16");
+      expect(() => $.escape("x\uDC00y")).toThrow("Shell script string contains invalid UTF-16");
+    });
+
+    test("always returns a string for non-string primitives", async () => {
+      // @ts-expect-error — exercising the runtime coercion contract.
+      const escape: (v: unknown) => string = $.escape;
+      expect(escape(true)).toBe("true");
+      expect(escape(false)).toBe("false");
+      expect(escape(null)).toBe("null");
+      expect(escape(undefined)).toBe("undefined");
+      expect(typeof escape(true)).toBe("string");
+      expect(typeof escape(null)).toBe("string");
+      expect(typeof escape(undefined)).toBe("string");
+      // Coerced values the shell rejects as an interpolation must also be rejected here.
+      expect(() => escape({ toString: () => "a\0b" })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+      );
+      // Coerced values round-trip through { raw: } exactly like ${v} does.
+      for (const v of [true, null, undefined] as const) {
+        const { stdout } = await $`echo ${{ raw: escape(v) }}`;
+        expect(stdout.toString()).toEqual(`${String(v)}\n`);
+      }
+    });
+
     test("escaped values containing interpolation marker bytes stay literal data", async () => {
       // Interpolated values that need escaping are stored out-of-band and
       // referenced from the script source via an internal `\x08__bunstr_N`

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -191,9 +191,7 @@ describe("bunshell", () => {
 
     test("rejects NUL bytes and lone surrogates like interpolation does", () => {
       const nul = "a" + String.fromCharCode(0) + "b";
-      expect(() => $.escape(nul)).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
-      );
+      expect(() => $.escape(nul)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
       expect(() => $.escape("\uD800")).toThrow("Shell script string contains invalid UTF-16");
       expect(() => $.escape("x\uDC00y")).toThrow("Shell script string contains invalid UTF-16");
     });


### PR DESCRIPTION
`$.escape()` had two gaps relative to the shell's own interpolation:

1. **It accepted inputs the shell rejects.** NUL bytes and lone surrogates passed through unchanged because neither is in the shell lexer's `SPECIAL_CHARS` table, so `needs_escape_bunstr` returned false and the value was handed back as-is. Feeding that result back via `{ raw: ... }` then threw `ERR_INVALID_ARG_VALUE` / `Shell script string contains invalid UTF-16`, making `{ raw: $.escape(v) }` not total over strings.
2. **It could return a non-string.** When the stringified input needed no escaping (`"true"`, `"null"`, `"undefined"` contain no shell metacharacters), the function returned the original `JSValue` instead of the coerced string, so `$.escape(true)` was the boolean `true` and `$.escape(null)` was `null`.

### Repro

```js
import { $ } from "bun";
$.escape("a\0b");        // was "a\0b"; shell rejects it
$.escape("\uD800");      // was "\uD800"; shell rejects it
typeof $.escape(true);   // was "boolean"
typeof $.escape(null);   // was "object"
```

### Fix

`shell_escape` in `src/runtime/api/BunObject.rs` now applies the same upfront checks as `ShellSrcBuilder::append_js_value_str` (the interpolation path): reject NUL bytes with `ERR_INVALID_ARG_VALUE`, reject invalid UTF-16 with `Shell script string contains invalid UTF-16`. When the coerced string needs no escaping, it returns the string (the original `JSValue` is only reused if it was already a string).

### Verification

New tests in `test/js/bun/shell/bunshell.test.ts` cover both behaviours; full `bunshell.test.ts` passes (416 pass, 0 fail).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->