### PR TITLE
fetch: verify certificate against URL authority (not Host header); apply per-request tls options over unix sockets

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -724,8 +724,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 continue;
             }
 
-            // The hash covers the Host-header SNI override that the handshake
-            // was verified against (see get_tls_hostname / connect()).
+            // The hash covers the Host-header SNI override the handshake sent
+            // (see get_tls_sni_hostname / connect()).
             if socket.proxy_auth_hash != proxy_auth_hash {
                 continue;
             }
@@ -923,10 +923,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
             } else {
                 0
             };
-            // For a direct TLS connection the handshake verifies the peer
-            // against get_tls_hostname() — which prefers the Host-header
-            // override (client.hostname) over url.hostname — so the override
-            // must discriminate the pool key there too, not just for CONNECT
+            // For a direct TLS connection the handshake SNI is derived from
+            // get_tls_sni_hostname() — which prefers the Host-header override
+            // (client.hostname) over url.hostname — so the override must
+            // discriminate the pool key there too, not just for CONNECT
             // tunnels. proxy_auth_hash() reduces to exactly the override hash
             // (or 0) for a non-proxied request.
             let proxy_auth_hash: u64 = if want_tunnel || (SSL && client.http_proxy.is_none()) {

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -481,13 +481,8 @@ impl HttpThread {
         // `bun_ptr::RawSlice` (encapsulated outlives-holder invariant) so the
         // borrow of `client` ends before we hand `&mut client` to
         // `connect_socket`. Backing storage is `client.unix_socket_path`, which
-        // `connect_socket` does not touch.
+        // neither `connect_socket` nor the `'custom_ctx` block touches.
         let unix_path = bun_ptr::RawSlice::new(client.unix_socket_path.slice());
-        if !unix_path.is_empty() {
-            return self
-                .context::<IS_SSL>()
-                .connect_socket(client, unix_path.slice());
-        }
 
         if IS_SSL {
             'custom_ctx: {
@@ -509,7 +504,9 @@ impl HttpThread {
                     client.set_custom_ssl_ctx(entry.ctx);
                     let ctx = entry.ctx_mut();
                     // Keepalive is now supported for custom SSL contexts
-                    return if let Some(url) = client.http_proxy.clone() {
+                    return if !unix_path.is_empty() {
+                        ctx.connect_socket(client, unix_path.slice())
+                    } else if let Some(url) = client.http_proxy.clone() {
                         ctx.connect(client, url.hostname, url.get_port_auto())
                     } else {
                         let (hn, pt) = (client.url.hostname, client.url.get_port_auto());
@@ -569,7 +566,9 @@ impl HttpThread {
 
                 client.set_custom_ssl_ctx(ctx_nn);
                 // Keepalive is now supported for custom SSL contexts
-                let result = if let Some(url) = client.http_proxy.clone() {
+                let result = if !unix_path.is_empty() {
+                    custom_context.connect_socket(client, unix_path.slice())
+                } else if let Some(url) = client.http_proxy.clone() {
                     if url.protocol.is_empty() || url.has_http_like_protocol() {
                         custom_context.connect(client, url.hostname, url.get_port_auto())
                     } else {
@@ -582,6 +581,11 @@ impl HttpThread {
                 // Note: NewHttpContext<true> == NewHttpContext<IS_SSL> here (IS_SSL branch).
                 return result.map(|o| o.map(|s| s.cast_ssl::<IS_SSL>()));
             }
+        }
+        if !unix_path.is_empty() {
+            return self
+                .context::<IS_SSL>()
+                .connect_socket(client, unix_path.slice());
         }
         if let Some(url) = client.http_proxy.clone() {
             if !url.href.is_empty() {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1172,35 +1172,65 @@ pub(crate) fn unregister_abort_tracker_for_socket(socket: uws::InternalSocket) {
     }
 }
 
-/// Returns the hostname to use for TLS SNI and certificate verification.
-/// Priority: tls_props.server_name > client.hostname > client.url.hostname
-/// The Host header value (client.hostname) may contain a port suffix which
-/// must be stripped because it is not part of the DNS name in certificates.
-fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
+/// Returns the hostname to send in the TLS ClientHello SNI extension.
+/// Priority: tls_props.server_name > client.hostname (Host header) >
+/// client.url.hostname. The Host header value may contain a port suffix which
+/// must be stripped because SNI is a bare DNS name.
+fn get_tls_sni_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
     if allow_proxy_url {
         if let Some(proxy) = &client.http_proxy {
             return proxy.hostname;
         }
     }
-    // Prefer the explicit TLS server_name (e.g. from Node.js servername option)
-    if let Some(props) = &client.tls_props {
-        let sn = props.get().server_name;
-        if !sn.is_null() {
-            // SAFETY: server_name is a NUL-terminated CStr owned by the
-            // SSLConfig; `ffi::cstr` yields an unbound-lifetime borrow of that
-            // C allocation, so `to_bytes()` already satisfies `'c` (tied to
-            // `client.tls_props`) without a `(ptr,len)` round-trip.
-            let sn_slice = unsafe { bun_core::ffi::cstr(sn) }.to_bytes();
-            if !sn_slice.is_empty() {
-                return sn_slice;
-            }
-        }
+    if let Some(sn) = tls_props_server_name(client) {
+        return sn;
     }
     // client.hostname comes from the Host header and may include ":port"
     if let Some(host) = &client.hostname {
         return strip_port_from_host(host);
     }
     client.url.hostname
+}
+
+/// Returns the hostname to verify the peer certificate against (both the
+/// native SAN match and the hostname handed to a JS `checkServerIdentity`).
+/// Priority: tls_props.server_name > client.url.hostname. Unlike the SNI
+/// variant this deliberately skips the Host request header: per RFC 9110 the
+/// Host header is routing metadata chosen by the caller, whereas RFC 6125/9525
+/// bind the verified identity to the reference identifier the client intended
+/// to reach, i.e. the URL authority. `tls.serverName` remains the documented
+/// opt-in override for the "dial an IP, verify a name" case.
+fn get_tls_verify_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
+    if allow_proxy_url {
+        if let Some(proxy) = &client.http_proxy {
+            return proxy.hostname;
+        }
+    }
+    if let Some(sn) = tls_props_server_name(client) {
+        return sn;
+    }
+    client.url.hostname
+}
+
+/// Shared first-priority arm of [`get_tls_sni_hostname`] /
+/// [`get_tls_verify_hostname`]: the explicit `tls.serverName` /
+/// `tls.servername` option, if present and non-empty.
+#[inline]
+fn tls_props_server_name<'c>(client: &'c HTTPClient<'_>) -> Option<&'c [u8]> {
+    let props = client.tls_props.as_ref()?;
+    let sn = props.get().server_name;
+    if sn.is_null() {
+        return None;
+    }
+    // SAFETY: server_name is a NUL-terminated CStr owned by the
+    // SSLConfig; `ffi::cstr` yields an unbound-lifetime borrow of that
+    // C allocation, so `to_bytes()` already satisfies `'c` (tied to
+    // `client.tls_props`) without a `(ptr,len)` round-trip.
+    let sn_slice = unsafe { bun_core::ffi::cstr(sn) }.to_bytes();
+    if sn_slice.is_empty() {
+        return None;
+    }
+    Some(sn_slice)
 }
 
 // ── support types ───────────────────────────────────────────────────────
@@ -1670,7 +1700,7 @@ impl<'a> HTTPClient<'a> {
                 // SAFETY: cert_chain is a live STACK_OF(X509) owned by the SSL session; index 0 is in bounds when non-null is returned
                 let x509 = unsafe { boringssl::c::sk_X509_value(cert_chain, 0) };
                 if !x509.is_null() {
-                    let hostname = get_tls_hostname(self, allow_proxy_url);
+                    let hostname = get_tls_verify_hostname(self, allow_proxy_url);
 
                     // check if we need to report the error (probably to `checkServerIdentity` was informed from JS side)
                     // this is the slow path
@@ -1807,7 +1837,7 @@ impl<'a> HTTPClient<'a> {
                 .unwrap_or(core::ptr::null_mut());
             // SAFETY: ssl_ptr is a live *mut SSL for the just-opened TLS socket
             if !ssl_ptr.is_null() && unsafe { boringssl::c::SSL_is_init_finished(ssl_ptr) } == 0 {
-                let raw_hostname = get_tls_hostname(self, self.http_proxy.is_some());
+                let raw_hostname = get_tls_sni_hostname(self, self.http_proxy.is_some());
 
                 // Build a NUL-terminated SNI string only when the hostname is not an
                 // IP literal (RFC 6066 forbids IP SNI). ALPN/SCT/OCSP must still be
@@ -2182,11 +2212,11 @@ impl<'a> HTTPClient<'a> {
     /// none apply.
     ///
     /// target_hostname in the pool stores url.hostname (the CONNECT TCP target
-    /// at writeProxyConnect line 346). But the inner TLS SNI/cert verification
-    /// uses `hostname`, falling back to url.hostname. If a Host header
-    /// override sets hostname != url.hostname, two requests to different IPs
-    /// with the same Host header must NOT share a tunnel — they're physically
-    /// connected to different servers. Hashing hostname here catches that.
+    /// at writeProxyConnect line 346). But the inner TLS SNI uses `hostname`,
+    /// falling back to url.hostname. If a Host header override sets
+    /// hostname != url.hostname, two requests to different IPs with the same
+    /// Host header must NOT share a tunnel — they're physically connected to
+    /// different servers. Hashing hostname here catches that.
     ///
     /// Per-header hashes are combined with wrapping add so insertion order
     /// doesn't matter and duplicate headers don't cancel to zero.
@@ -2594,10 +2624,11 @@ impl<'a> HTTPClient<'a> {
         } else if self.state.request_stage == RequestStage::Done
             && self.is_keep_alive_possible()
             && !socket.is_closed_or_has_error()
-            // A direct TLS socket verified against a Host-header override
-            // (get_tls_hostname) must not be pooled here: this.url has already
-            // been repointed at the redirect destination, so proxy_auth_hash()
-            // can no longer compute the correct pool key. Close it instead.
+            // A direct TLS socket whose SNI was set from a Host-header override
+            // (get_tls_sni_hostname) must not be pooled here: this.url has
+            // already been repointed at the redirect destination, so
+            // proxy_auth_hash() can no longer compute the correct pool key.
+            // Close it instead.
             && (!IS_SSL || self.http_proxy.is_some() || self.hostname.is_none())
         {
             // request_stage == .done: a 303 to a streaming POST can arrive before
@@ -4191,8 +4222,8 @@ impl<'a> HTTPClient<'a> {
                         0
                     },
                     if had_tunnel || (IS_SSL && self.http_proxy.is_none()) {
-                        // Direct TLS: the handshake verified the peer against
-                        // the Host-header override (get_tls_hostname), so the
+                        // Direct TLS: the handshake SNI was set from the
+                        // Host-header override (get_tls_sni_hostname), so the
                         // override hash must be part of the pool key. Matches
                         // the lookup in HTTPContext::connect.
                         self.proxy_auth_hash()

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1192,14 +1192,10 @@ fn get_tls_sni_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -
     client.url.hostname
 }
 
-/// Returns the hostname to verify the peer certificate against (both the
-/// native SAN match and the hostname handed to a JS `checkServerIdentity`).
-/// Priority: tls_props.server_name > client.url.hostname. Unlike the SNI
-/// variant this deliberately skips the Host request header: per RFC 9110 the
-/// Host header is routing metadata chosen by the caller, whereas RFC 6125/9525
-/// bind the verified identity to the reference identifier the client intended
-/// to reach, i.e. the URL authority. `tls.serverName` remains the documented
-/// opt-in override for the "dial an IP, verify a name" case.
+/// Returns the hostname to verify the peer certificate against (native SAN
+/// match and the JS `checkServerIdentity` hostname argument).
+/// Priority: tls_props.server_name > client.url.hostname. The Host request
+/// header is never consulted here (RFC 6125/9525: verify the URL authority).
 fn get_tls_verify_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
     if allow_proxy_url {
         if let Some(proxy) = &client.http_proxy {
@@ -1212,9 +1208,7 @@ fn get_tls_verify_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool
     client.url.hostname
 }
 
-/// Shared first-priority arm of [`get_tls_sni_hostname`] /
-/// [`get_tls_verify_hostname`]: the explicit `tls.serverName` /
-/// `tls.servername` option, if present and non-empty.
+/// The explicit `tls.serverName` option, if present and non-empty.
 #[inline]
 fn tls_props_server_name<'c>(client: &'c HTTPClient<'_>) -> Option<&'c [u8]> {
     let props = client.tls_props.as_ref()?;

--- a/test/js/web/fetch/fetch-http2-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http2-adversarial.test.ts
@@ -439,9 +439,9 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
 });
 
 // ─── session-key regressions ─────────────────────────────────────────────────
-// The TLS handshake verifies the peer against the Host-header override when one
-// is present (get_tls_hostname), so the override must be part of the HTTP/2
-// session key — mirroring the HTTP/1.1 keep-alive pool's proxy_auth_hash.
+// The TLS handshake sends the Host-header override as SNI when one is present
+// (get_tls_sni_hostname), so the override must be part of the HTTP/2 session
+// key — mirroring the HTTP/1.1 keep-alive pool's proxy_auth_hash.
 test("HTTP/2 session keyed by a Host header override is not reused for a request without one", async () => {
   await withAdversarialServer(
     {
@@ -454,15 +454,15 @@ test("HTTP/2 session keyed by a Host header override is not reused for a request
       const h2 = { protocol: "http2" as const, tls: { rejectUnauthorized: false } };
       const errcode = (e: any) => e.code || e.name;
 
-      // 1. Request with a Host override: TLS verification (when enabled) runs
-      //    against "other.example", not the URL hostname.
+      // 1. Request with a Host override: the TLS ClientHello sends
+      //    SNI="other.example", not the URL hostname.
       const a = await fetch(url, { ...h2, headers: { Host: "other.example" } }).then(r => r.status, errcode);
       expect(a).toBe(200);
       expect(state.connections).toBe(1);
 
-      // 2. A request without an override expects verification against the URL
-      //    hostname. It must not multiplex onto the session that was verified
-      //    against the override — a fresh connection is required.
+      // 2. A request without an override sends the URL hostname as SNI. It
+      //    must not multiplex onto the session that was negotiated with the
+      //    override SNI — a fresh connection is required.
       const b = await fetch(url, h2).then(r => r.status, errcode);
       expect(b).toBe(200);
       expect(state.connections).toBe(2);

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -58,17 +58,17 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
     return await res.text();
   };
 
-  // Two requests whose TLS handshake used the Host-header override
-  // "wrong.example" for SNI/certificate verification share one pooled
-  // connection (legitimate keep-alive still works).
+  // Two requests whose TLS handshake sent the Host-header override
+  // "wrong.example" as SNI share one pooled connection (legitimate
+  // keep-alive still works).
   const overrideA = await get({ Host: "wrong.example" });
   const overrideB = await get({ Host: "wrong.example" });
   expect(overrideB).toBe(overrideA);
 
-  // A request without the override expects the server identity to match
-  // url.hostname ("localhost"), so it must not be handed the connection
-  // that was only ever negotiated as "wrong.example". It has to open a new
-  // connection, which cannot have the same client port.
+  // A request without the override sends the URL hostname ("localhost") as
+  // SNI, so it must not be handed the connection that was negotiated with
+  // SNI "wrong.example". It has to open a new connection, which cannot have
+  // the same client port.
   const plain = await get();
   expect(plain).not.toBe(overrideA);
 });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -138,6 +138,17 @@ describe.concurrent("fetch-tls", () => {
     });
     expect(await res.text()).toBe("ok");
     expect(res.status).toBe(200);
+
+    // Inverse of the rejection case above (issue #26579): a garbage Host
+    // header must not cause a request to a server whose certificate matches
+    // the URL authority to fail verification.
+    const ok = await fetch(`https://localhost:${server.port}/`, {
+      keepalive: false,
+      headers: { Host: "whatever.invalid" },
+      tls: { ca: localhostOnlyTls.cert },
+    });
+    expect(await ok.text()).toBe("ok");
+    expect(ok.status).toBe(200);
   });
 
   // The Host request header is still forwarded as the TLS ClientHello SNI so a

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
 import { join } from "node:path";
 import tls from "node:tls";
@@ -53,15 +54,12 @@ describe.concurrent("fetch-tls", () => {
       },
     });
 
-    // An explicit Host header overrides both the wire Host header and the
-    // hostname used for TLS SNI / certificate verification. checkServerIdentity
-    // receives the verification hostname as its first argument.
-    //
-    // fetch() invokes the JS checkServerIdentity callback once per connection
-    // in the redirect chain, before that connection's request is written: the
-    // request (and any cookies/credentials it carries) must not reach a hop
-    // whose certificate the callback has not approved. So a redirect chain
-    // yields one observation per hop, in order.
+    // An explicit Host header overrides the wire Host header and the TLS SNI,
+    // but not the identity the peer certificate is verified against:
+    // checkServerIdentity receives the URL authority (or `tls.serverName` when
+    // set) regardless of the Host header. fetch() invokes the callback once
+    // per connection in the redirect chain, before that connection's request
+    // is written, so a redirect chain yields one observation per hop.
     const verifiedHostnames: string[] = [];
     const res = await fetch(`https://127.0.0.1:${origin.port}/`, {
       keepalive: false,
@@ -76,16 +74,96 @@ describe.concurrent("fetch-tls", () => {
     });
     expect(await res.text()).toBe("from-target");
 
-    // The first hop is verified against the explicit Host override
-    // ("localhost"). The Host override names the previous origin, so on a
-    // cross-origin redirect it must be dropped and the verification hostname
-    // re-derived from the redirect target's URL ("127.0.0.1"). The vulnerable
-    // behavior carries the stale override and verifies the second connection
-    // against "localhost" instead.
-    expect(verifiedHostnames).toEqual(["localhost", "127.0.0.1"]);
+    // Each hop is verified against the URL it dialled. The Host override is
+    // request-layer routing metadata and must never become the verify target;
+    // a proxy that forwards an inbound Host header must not let that header
+    // steer which certificate its upstream connection accepts.
+    expect(verifiedHostnames).toEqual(["127.0.0.1", "127.0.0.1"]);
     // The redirect target must see a Host header derived from its own URL,
     // not the override that was supplied for the previous origin.
     expect(receivedHostHeaders).toEqual([`127.0.0.1:${target.port}`]);
+  });
+
+  // The peer certificate is matched against the URL authority (RFC 6125 /
+  // RFC 9525), never against a caller-supplied Host request header. A leaf
+  // whose only SAN is DNS:localhost must be rejected for a request dialled to
+  // 127.0.0.1, whether or not the caller sends `Host: localhost`. An explicit
+  // `tls.serverName` is the documented opt-in for "dial an IP, verify a name"
+  // and remains the only header-independent way to accept such a leaf.
+  it("verifies the certificate against the URL authority, not the Host request header", async () => {
+    const localhostOnlyTls = {
+      cert: readFileSync(join(import.meta.dir, "../../../regression/issue/27890-localhost-only.crt"), "utf8"),
+      key: readFileSync(join(import.meta.dir, "../../../regression/issue/27890-localhost-only.key"), "utf8"),
+    };
+    using server = Bun.serve({
+      port: 0,
+      tls: localhostOnlyTls,
+      fetch: () => new Response("ok"),
+    });
+
+    const opts = { keepalive: false, tls: { ca: localhostOnlyTls.cert } } as const;
+
+    // Baseline: no Host header, IP URL → cert has no matching IP SAN.
+    await expect(fetch(`https://127.0.0.1:${server.port}/`, opts)).rejects.toMatchObject({
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    });
+
+    // Adding `Host: localhost` must not change the verify target.
+    await expect(
+      fetch(`https://127.0.0.1:${server.port}/`, { ...opts, headers: { Host: "localhost" } }),
+    ).rejects.toMatchObject({ code: "ERR_TLS_CERT_ALTNAME_INVALID" });
+
+    // The same hostname handed to a JS checkServerIdentity is the URL host,
+    // not the Host header value.
+    let seenHostname = "";
+    await expect(
+      fetch(`https://127.0.0.1:${server.port}/`, {
+        keepalive: false,
+        headers: { Host: "localhost" },
+        tls: {
+          ca: localhostOnlyTls.cert,
+          checkServerIdentity(hostname, cert) {
+            seenHostname = hostname;
+            return tls.checkServerIdentity(hostname, cert);
+          },
+        },
+      }),
+    ).rejects.toMatchObject({ code: "ERR_TLS_CERT_ALTNAME_INVALID" });
+    expect(seenHostname).toBe("127.0.0.1");
+
+    // `tls.serverName` is the sanctioned override: verify against it and succeed.
+    const res = await fetch(`https://127.0.0.1:${server.port}/`, {
+      keepalive: false,
+      tls: { ca: localhostOnlyTls.cert, serverName: "localhost" },
+    });
+    expect(await res.text()).toBe("ok");
+    expect(res.status).toBe(200);
+  });
+
+  // The Host request header is still forwarded as the TLS ClientHello SNI so a
+  // fetch to an IP with `Host: <name>` reaches the right SNI-routed virtual
+  // host. Only certificate verification is now header-independent.
+  it("still sends the Host request header as the ClientHello SNI", async () => {
+    const receivedSni: (string | false)[] = [];
+    const server = tls.createServer({ key: validTls.key, cert: validTls.cert }, socket => {
+      receivedSni.push(socket.servername);
+      socket.once("data", () => {
+        socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+      });
+    });
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+    try {
+      const port = (server.address() as import("node:net").AddressInfo).port;
+      const res = await fetch(`https://127.0.0.1:${port}/`, {
+        keepalive: false,
+        headers: { Host: "localhost" },
+        tls: { ca: validTls.cert },
+      });
+      expect(await res.text()).toBe("ok");
+      expect(receivedSni).toEqual(["localhost"]);
+    } finally {
+      server.close();
+    }
   });
 
   it("can handle multiple requests with non native checkServerIdentity", async () => {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import tls from "node:tls";
 

--- a/test/js/web/fetch/fetch.unix.test.ts
+++ b/test/js/web/fetch/fetch.unix.test.ts
@@ -1,7 +1,7 @@
 import { serve, ServeOptions, Server } from "bun";
-import { afterAll, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync } from "fs";
-import { isWindows, tmpdirSync } from "harness";
+import { isWindows, tempDir, tmpdirSync, tls as validTls } from "harness";
 import { request } from "http";
 import { join } from "path";
 const tmp_dir = tmpdirSync();
@@ -243,4 +243,64 @@ it("handle redirect to non-unix", async () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("world");
   }
+});
+
+// Per-request `tls` options that require a custom SSL_CTX (ca / cert / key /
+// ciphers / minVersion / ...) must be applied when the transport is a unix
+// socket, exactly as they are for a TCP connect to the same server. The
+// failure mode was that the unix-socket connect path returned on the default
+// HTTPS context before the per-request SSL_CTX was resolved, so every
+// context-level option was silently dropped.
+describe.skipIf(isWindows)("tls over unix socket", () => {
+  it("honors tls.ca for server verification", async () => {
+    using dir = tempDir("fetch-unix-tls-ca", {});
+    const unix = join(String(dir), "s.sock");
+    using server = Bun.serve({
+      unix,
+      tls: { cert: validTls.cert, key: validTls.key },
+      fetch: () => new Response("ok"),
+    });
+    const res = await fetch("https://localhost/", { unix, tls: { ca: validTls.cert } });
+    expect(await res.text()).toBe("ok");
+    expect(res.status).toBe(200);
+  });
+
+  it("presents tls.cert + tls.key to a requestCert server (mTLS)", async () => {
+    using dir = tempDir("fetch-unix-tls-mtls", {});
+    const unix = join(String(dir), "s.sock");
+    using server = Bun.serve({
+      unix,
+      tls: {
+        cert: validTls.cert,
+        key: validTls.key,
+        ca: validTls.cert,
+        requestCert: true,
+        rejectUnauthorized: true,
+      },
+      fetch: () => new Response("ok-mtls"),
+    });
+    const res = await fetch("https://localhost/", {
+      unix,
+      tls: { ca: validTls.cert, cert: validTls.cert, key: validTls.key },
+    });
+    expect(await res.text()).toBe("ok-mtls");
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an invalid tls.ciphers string the same way a TCP connect does", async () => {
+    using dir = tempDir("fetch-unix-tls-ciphers", {});
+    const unix = join(String(dir), "s.sock");
+    using server = Bun.serve({
+      unix,
+      tls: { cert: validTls.cert, key: validTls.key },
+      fetch: () => new Response("ok"),
+    });
+    // A ciphers string BoringSSL cannot parse fails SSL_CTX creation. Over
+    // TCP this surfaces as FailedToOpenSocket; over a unix socket it must
+    // fail the same way rather than being ignored. rejectUnauthorized is off
+    // so the only failure source is the ciphers option itself.
+    await expect(
+      fetch("https://localhost/", { unix, tls: { rejectUnauthorized: false, ciphers: "NOT-A-REAL-CIPHER" } }),
+    ).rejects.toThrow();
+  });
 });

--- a/test/js/web/fetch/fetch.unix.test.ts
+++ b/test/js/web/fetch/fetch.unix.test.ts
@@ -301,6 +301,6 @@ describe.skipIf(isWindows)("tls over unix socket", () => {
     // so the only failure source is the ciphers option itself.
     await expect(
       fetch("https://localhost/", { unix, tls: { rejectUnauthorized: false, ciphers: "NOT-A-REAL-CIPHER" } }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ code: "FailedToOpenSocket" });
   });
 });


### PR DESCRIPTION
Two independent TLS option-handling bugs in the fetch HTTP client.

### 1. The Host request header decided which certificate name to accept

`get_tls_hostname()` fed both the ClientHello SNI and the hostname passed to `check_server_identity()`, with priority `tls.serverName` > `Host` request header > URL host. A proxy that forwards an inbound `Host` header to an upstream IP:

```js
fetch(`https://${upstreamIp}:${port}`, { headers: incomingHeaders, tls: { ca } })
```

therefore let the remote client's `Host` header choose the identity the upstream certificate was matched against. Against a leaf whose only SAN is `DNS:localhost`:

```
fetch https://127.0.0.1:P, Host: localhost   -> 200                           (bug)
fetch https://127.0.0.1:P  (no Host header)  -> ERR_TLS_CERT_ALTNAME_INVALID
```

Node/undici ignore the `Host` header for identity and verify the URL host.

**Fix:** split the helper into `get_tls_sni_hostname` (keeps the Host-header branch) and `get_tls_verify_hostname` (`tls.serverName` > URL authority, per RFC 6125/9525), and swap the single call at the identity check. `tls.serverName` remains the documented opt-in for the "dial an IP, verify a name" case; the `Host` header is no longer an identity source. The Host header still drives SNI, so pool/session keying is unchanged.

### 2. `fetch({ unix, tls })` dropped every `SSL_CTX`-level option

`HttpThread::connect` took the unix-socket early return before the per-request `SSL_CTX` was resolved, so `ca` / `cert` / `key` / `ciphers` / `minVersion` / `maxVersion` / `ecdhCurve` / `secureOptions` were all silently ignored and the connect ran on the default HTTPS context:

```
unix + tls.ca        -> DEPTH_ZERO_SELF_SIGNED_CERT (ca ignored)
unix + mTLS cert/key -> ECONNRESET                  (client cert never presented)
unix + bad ciphers   -> 200                         (option never parsed)
```

**Fix:** resolve the custom context first, then branch unix-vs-TCP for the connect, in both the cache-hit and cache-miss arms.

### Verification

| cell | request | before | after |
| --- | --- | --- | --- |
| a | `https://127.0.0.1` + `Host: localhost` vs `DNS:localhost`-only leaf | 200 | `ERR_TLS_CERT_ALTNAME_INVALID` |
| b | unix + `tls.ca` | `DEPTH_ZERO_SELF_SIGNED_CERT` | 200 |
| c | unix + mTLS `cert`/`key` | `ECONNRESET` | 200 |
| d | `tls.serverName: "localhost"` override | 200 | 200 |

New tests in `fetch.tls.test.ts` (cells a/d, plus a check that the `Host` header still reaches the server as SNI) and `fetch.unix.test.ts` (cells b/c, plus the `ciphers` parity case). The existing cross-origin-redirect `checkServerIdentity` test is updated to assert the URL host on both hops. `fetch-keepalive.test.ts`, `fetch-http2-adversarial.test.ts`, `27890.test.ts`, `fetch.tls.wildcard.test.ts`, and `ssl-ctx-cache.test.ts` remain green.

Related: #35885 (same unix-socket fix), #35886 (removes `Host`→SNI routing entirely; this PR keeps it and changes only the verify target).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.unix.test.ts

<!-- robobun:evidence:end -->

Fixes #26579