### PR TITLE
audit: decompress gzip responses served without Content-Encoding

### DIFF
--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -501,7 +501,48 @@ fn send_audit_request(
         Global::crash();
     }
 
-    Ok(Box::<[u8]>::from(response_buf.list.as_slice()))
+    let body = response_buf.list.as_slice();
+
+    // The registry's bulk advisory endpoint serves gzip-compressed bodies
+    // without a Content-Encoding header, so the HTTP client leaves them
+    // compressed. Sniff the gzip magic and decompress before parsing.
+    if body.starts_with(&[0x1f, 0x8b]) {
+        return gunzip_audit_response(body);
+    }
+
+    Ok(Box::<[u8]>::from(body))
+}
+
+fn gunzip_audit_response(body: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError> {
+    const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
+
+    let mut decompressor = libdeflate::OwnedDecompressor::new().ok_or(bun_alloc::AllocError)?;
+
+    // The gzip ISIZE trailer holds the uncompressed size mod 2^32; use it as
+    // the initial capacity and let the grow loop correct a lying trailer.
+    let size_hint = match body.last_chunk::<4>() {
+        Some(trailer) => (u32::from_le_bytes(*trailer) as usize).clamp(1024, MAX_DECOMPRESSED_SIZE),
+        None => 1024,
+    };
+    let mut decompressed = Vec::new();
+    decompressed
+        .try_reserve_exact(size_hint)
+        .map_err(|_| bun_alloc::AllocError)?;
+
+    let result = decompressor.decompress_to_vec_grow(
+        body,
+        &mut decompressed,
+        libdeflate::Encoding::Gzip,
+        MAX_DECOMPRESSED_SIZE,
+    );
+    if result.status != libdeflate::Status::Success {
+        bun_core::pretty_errorln!(
+            "<red>error<r>: audit request returned an invalid compressed response. Is the registry down?"
+        );
+        Global::crash();
+    }
+
+    Ok(decompressed.into_boxed_slice())
 }
 
 fn parse_vulnerability(

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -519,9 +519,18 @@ fn gunzip_audit_response(body: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError
     let mut decompressor = libdeflate::OwnedDecompressor::new().ok_or(bun_alloc::AllocError)?;
 
     // The gzip ISIZE trailer holds the uncompressed size mod 2^32; use it as
-    // the initial capacity and let the grow loop correct a lying trailer.
+    // the initial capacity. The trailer is untrusted network data, so an
+    // implausibly large value starts small instead and lets the grow loop
+    // expand on demand.
     let size_hint = match body.last_chunk::<4>() {
-        Some(trailer) => (u32::from_le_bytes(*trailer) as usize).clamp(1024, MAX_DECOMPRESSED_SIZE),
+        Some(trailer) => {
+            let isize_hint = u32::from_le_bytes(*trailer) as usize;
+            if isize_hint < MAX_DECOMPRESSED_SIZE {
+                isize_hint.max(1024)
+            } else {
+                body.len().max(1024)
+            }
+        }
         None => 1024,
     };
     let mut decompressed = Vec::new();

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -503,9 +503,8 @@ fn send_audit_request(
 
     let body = response_buf.list.as_slice();
 
-    // The registry's bulk advisory endpoint serves gzip-compressed bodies
-    // without a Content-Encoding header, so the HTTP client leaves them
-    // compressed. Sniff the gzip magic and decompress before parsing.
+    // The registry serves gzip bodies without a Content-Encoding header, so
+    // the HTTP client leaves them compressed (#35887).
     if body.starts_with(&[0x1f, 0x8b]) {
         return gunzip_audit_response(body);
     }
@@ -518,10 +517,8 @@ fn gunzip_audit_response(body: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError
 
     let mut decompressor = libdeflate::OwnedDecompressor::new().ok_or(bun_alloc::AllocError)?;
 
-    // The gzip ISIZE trailer holds the uncompressed size mod 2^32; use it as
-    // the initial capacity. The trailer is untrusted network data, so an
-    // implausibly large value starts small instead and lets the grow loop
-    // expand on demand.
+    // Initial capacity from the gzip ISIZE trailer (uncompressed size mod
+    // 2^32); it is untrusted network data, so oversized values start small.
     let size_hint = match body.last_chunk::<4>() {
         Some(trailer) => {
             let isize_hint = u32::from_le_bytes(*trailer) as usize;

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -28,6 +28,14 @@ beforeAll(() => {
         return new Response("No fixture found", { status: 404 });
       }
 
+      // The real registry's bulk advisory endpoint serves gzip bodies without
+      // a Content-Encoding header; replicate that under this path prefix.
+      if (new URL(req.url).pathname.startsWith("/gzip-no-content-encoding/")) {
+        return new Response(Bun.gzipSync(JSON.stringify(fixture)), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+
       return Response.json(fixture);
     },
   });
@@ -43,6 +51,7 @@ function doAuditTest(
     args?: string[];
     exitCode: number;
     files: DirectoryTree | string;
+    registryPathPrefix?: string;
     fn: (std: { stdout: PromiseLike<string>; stderr: PromiseLike<string>; dir: string }) => Promise<void>;
   },
 ) {
@@ -51,7 +60,7 @@ function doAuditTest(
 
     const cmd = [bunExe(), "audit", ...(options.args ?? [])];
 
-    const url = server.url.toString().slice(0, -1);
+    const url = server.url.toString().slice(0, -1) + (options.registryPathPrefix ?? "");
 
     const proc = spawn({
       cmd,
@@ -329,6 +338,30 @@ describe("`bun audit`", () => {
     fn: async ({ stdout, stderr }) => {
       expect(await stderr).not.toContain("error");
       expect(await stdout).toContain("vulnerabilities");
+    },
+  });
+
+  // https://github.com/oven-sh/bun/issues/35887
+  doAuditTest("decompresses a gzip response that has no Content-Encoding header", {
+    exitCode: 1,
+    files: fixture("express@3"),
+    registryPathPrefix: "/gzip-no-content-encoding",
+    fn: async ({ stdout }) => {
+      const out = await stdout;
+      expect(out).toContain("express");
+      expect(out).toContain("vulnerabilities");
+      expect(out).not.toContain("\u{FFFD}");
+    },
+  });
+
+  doAuditTest("--json prints valid JSON for a gzip response that has no Content-Encoding header", {
+    exitCode: 1,
+    files: fixture("express@3"),
+    registryPathPrefix: "/gzip-no-content-encoding",
+    args: ["--json"],
+    fn: async ({ stdout }) => {
+      const json = JSON.parse(await stdout);
+      expect(Object.keys(json)).not.toBeEmpty();
     },
   });
 


### PR DESCRIPTION
Fixes #35887

### Repro

```sh
bun add lodash@4.17.20
bun audit
# bun audit v1.4.0-canary.1 (ae4b17de6)
# ���j�0�W�A�8�ѫv�cW� ...
```

### Cause

The npm registry's bulk advisory endpoint (`POST /-/npm/v1/security/advisories/bulk`) currently returns a gzip-compressed body with no `Content-Encoding` response header whenever the result set is non-empty (verified with curl: `Transfer-Encoding: chunked`, no `Content-Encoding`, body starts with the gzip magic `1f 8b 08`). Bun's HTTP client decompression correctly does nothing because the header is absent, so the raw gzip bytes land in the response buffer and `bun audit` prints them verbatim. npm 11 fails on the same response ("invalid json response body ... Unexpected token '\u001f'"), so this is registry-side behavior that clients need to tolerate.

### Fix

In `send_audit_request` (src/runtime/cli/audit_command.rs), sniff the response body for the gzip magic and gunzip it with libdeflate before returning it to the parser. The initial output capacity comes from the gzip ISIZE trailer, with a doubling retry loop capped at 256 MiB; a body that fails to decompress reports a readable registry error instead of dumping binary to the terminal.

### Verification

Two new tests in `test/cli/install/bun-audit.test.ts` run the audit against a local server that replicates the registry behavior (gzip body, no `Content-Encoding`). Both fail on current bun (garbage output, invalid JSON) and pass with this change; the other 16 audit tests still pass. Also verified end to end against the real registry: `bun audit` with `lodash@4.17.20` now prints the advisory report.
