### PR TITLE
bun test: surface unhandled errors that fire after the final test settles

### DIFF
--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -213,6 +213,7 @@ impl Tag {
         match self {
             Tag::WTFTimer // internal
             | Tag::BunTest // for test timeouts
+            | Tag::TimerCallback // internal runtime-scheduled callbacks
             | Tag::EventLoopDelayMonitor // probably important
             | Tag::StatWatcherScheduler
             | Tag::GcOneShot | Tag::GcRepeating // internal GC pacing

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -920,8 +920,12 @@ fn drain_for_late_errors(vm: &mut VirtualMachine) {
     use bun_core::{Timespec, TimespecMockMode};
 
     let deadline = Timespec::now(TimespecMockMode::ForceRealTime).add_ms(POST_FILE_DRAIN_GRACE_MS);
+    let el_ptr = vm.event_loop();
 
     loop {
+        vm.tick();
+        // SAFETY: `el_ptr` is the VM-owned event loop; `vm` passed as *mut.
+        unsafe { (*el_ptr).tick_immediate_tasks(vm) };
         vm.tick();
 
         let el = vm.event_loop_shared();
@@ -945,16 +949,28 @@ fn drain_for_late_errors(vm: &mut VirtualMachine) {
         if Timespec::now(TimespecMockMode::ForceRealTime).greater(&deadline) {
             break;
         }
-        // Don't let `auto_tick_active()` park on a heap min past the deadline.
-        if !has_queued && immediate_refs <= 0 && !timers.is_null() {
-            // SAFETY: live per-thread `All`; single JS thread; null-checked.
-            match unsafe { (*timers).timers.peek() } {
-                None => break,
-                Some(min) => {
-                    // SAFETY: `peek()` returns a live heap node.
-                    if unsafe { (*min).next }.greater(&deadline) {
-                        break;
-                    }
+        if has_queued {
+            continue;
+        }
+        // `auto_tick_active()` parks until the soonest heap timer. Internal
+        // runtime timers (GC, WTFTimer) may sit at the heap min, so walk for
+        // the soonest user `TimeoutObject` and only park while one is due
+        // within the deadline; otherwise a far-future user timer cannot
+        // make `auto_tick_active()` park past it.
+        if timers.is_null() {
+            break;
+        }
+        // SAFETY: live per-thread `All`; single JS thread; null-checked.
+        let next_heap_min = unsafe { (*timers).timers.peek() };
+        // SAFETY: live per-thread `All`; walk reads only heap-node fields.
+        let has_js_timer_due = unsafe { (*timers).timers.any_js_timer_due_by(&deadline) };
+        match next_heap_min {
+            None => break,
+            Some(min) => {
+                // SAFETY: `peek()` returns a live heap node.
+                let heap_min_past = unsafe { (*min).next }.greater(&deadline);
+                if heap_min_past || !has_js_timer_due {
+                    break;
                 }
             }
         }
@@ -3410,6 +3426,8 @@ impl TestCommand {
                 // Process event loop while bun_test tests are running
                 vm.event_loop_ref().tick();
 
+                let fail_before = reporter.jest.summary.fail;
+                let unhandled_before = reporter.jest.unhandled_errors_between_tests;
                 let mut prev_unhandled_count = vm.unhandled_error_counter;
                 while buntest.phase != bun_test::Phase::Done {
                     if buntest.wants_wakeup {
@@ -3433,11 +3451,11 @@ impl TestCommand {
                 unsafe { (*el).tick_immediate_tasks(vm) };
 
                 // Only for the final file (earlier files' late errors surface
-                // in the next file's phase loop) and only while the run is
-                // green so a timed-out test body is not waited on.
+                // in the next file's phase loop) and only when this file did
+                // not fail so a timed-out test body is not waited on.
                 if first_last.last
-                    && reporter.jest.summary.fail == 0
-                    && reporter.jest.unhandled_errors_between_tests == 0
+                    && reporter.jest.summary.fail == fail_before
+                    && reporter.jest.unhandled_errors_between_tests == unhandled_before
                 {
                     drain_for_late_errors(vm);
                 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3437,10 +3437,12 @@ impl TestCommand {
                 // SAFETY: el is the VM-owned event loop; vm is passed back as *mut.
                 unsafe { (*el).tick_immediate_tasks(vm) };
 
-                // Only for the final file (earlier files' late errors surface
-                // in the next file's phase loop) and only when this file did
-                // not fail so a timed-out test body is not waited on.
+                // Only for the final repeat of the final file (earlier files'
+                // and earlier repeats' late errors surface in the next phase
+                // loop) and only when this repeat did not fail, so a timed-out
+                // test body is not waited on.
                 if first_last.last
+                    && repeat_index + 1 == repeat_count
                     && reporter.jest.summary.fail == fail_before
                     && reporter.jest.unhandled_errors_between_tests == unhandled_before
                 {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3432,9 +3432,11 @@ impl TestCommand {
                 // SAFETY: el is the VM-owned event loop; vm is passed back as *mut.
                 unsafe { (*el).tick_immediate_tasks(vm) };
 
-                // Skip once the run already failed so a timed-out test body
-                // is not waited on.
-                if reporter.jest.summary.fail == 0
+                // Only for the final file (earlier files' late errors surface
+                // in the next file's phase loop) and only while the run is
+                // green so a timed-out test body is not waited on.
+                if first_last.last
+                    && reporter.jest.summary.fail == 0
                     && reporter.jest.unhandled_errors_between_tests == 0
                 {
                     drain_for_late_errors(vm);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -930,11 +930,12 @@ fn drain_for_late_errors(vm: &mut VirtualMachine) {
             || !el.next_immediate_tasks.is_empty();
 
         let timers = crate::jsc_hooks::timer_all();
-        // SAFETY: `timer_all()` is the live per-thread `All` once RuntimeState
-        // is installed (always true by the time a test file has run).
         let (timer_refs, immediate_refs) = if timers.is_null() {
             (0, 0)
         } else {
+            // SAFETY: `timer_all()` is the live per-thread `All` once
+            // RuntimeState is installed (always true by the time a test file
+            // has run); null-checked above.
             unsafe { ((*timers).active_timer_count, (*timers).immediate_ref_count) }
         };
 
@@ -946,11 +947,11 @@ fn drain_for_late_errors(vm: &mut VirtualMachine) {
         }
         // Don't let `auto_tick_active()` park on a heap min past the deadline.
         if !has_queued && immediate_refs <= 0 && !timers.is_null() {
-            // SAFETY: live per-thread `All`; single JS thread.
+            // SAFETY: live per-thread `All`; single JS thread; null-checked.
             match unsafe { (*timers).timers.peek() } {
                 None => break,
-                // SAFETY: `peek()` returns a live heap node.
                 Some(min) => {
+                    // SAFETY: `peek()` returns a live heap node.
                     if unsafe { (*min).next }.greater(&deadline) {
                         break;
                     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -918,9 +918,37 @@ const POST_FILE_DRAIN_GRACE_MS: i64 = 1000;
 /// timer cannot stall the run.
 fn drain_for_late_errors(vm: &mut VirtualMachine) {
     use bun_core::{Timespec, TimespecMockMode};
+    use bun_event_loop::EventLoopTimer::{EventLoopTimer, InHeap, Tag, TimerCallback};
 
     let deadline = Timespec::now(TimespecMockMode::ForceRealTime).add_ms(POST_FILE_DRAIN_GRACE_MS);
     let el_ptr = vm.event_loop();
+    let timers = crate::jsc_hooks::timer_all();
+    if timers.is_null() {
+        return;
+    }
+
+    fn sentinel_fired(c: *mut TimerCallback) {
+        // SAFETY: `c` is the live stack sentinel just popped by `drain_timers`.
+        unsafe { (*c).event_loop_timer.in_heap = InHeap::None };
+    }
+    // A no-op timer at `deadline` caps `get_timeout` inside `auto_tick_active`
+    // so JS that runs between the park-guard and the park (a setImmediate
+    // clearing the near-term timer that admitted us) cannot leave only a
+    // far-future heap min for `tick_with_timeout` to park on.
+    let mut sentinel = TimerCallback {
+        callback: sentinel_fired,
+        ctx: None,
+        event_loop_timer: EventLoopTimer::init_paused(Tag::TimerCallback),
+    };
+    sentinel.event_loop_timer.next = deadline;
+    // SAFETY: live per-thread `All`; `sentinel` lives for this frame.
+    unsafe { (*timers).insert(&raw mut sentinel.event_loop_timer) };
+    scopeguard::defer! {
+        if sentinel.event_loop_timer.in_heap != InHeap::None {
+            // SAFETY: live per-thread `All`; sentinel still in the heap.
+            unsafe { (*timers).remove(&raw mut sentinel.event_loop_timer) };
+        }
+    }
 
     loop {
         vm.tick();
@@ -933,15 +961,9 @@ fn drain_for_late_errors(vm: &mut VirtualMachine) {
             || !el.immediate_tasks.is_empty()
             || !el.next_immediate_tasks.is_empty();
 
-        let timers = crate::jsc_hooks::timer_all();
-        let (timer_refs, immediate_refs) = if timers.is_null() {
-            (0, 0)
-        } else {
-            // SAFETY: `timer_all()` is the live per-thread `All` once
-            // RuntimeState is installed (always true by the time a test file
-            // has run); null-checked above.
-            unsafe { ((*timers).active_timer_count, (*timers).immediate_ref_count) }
-        };
+        // SAFETY: `timer_all()` is the live per-thread `All`; null-checked.
+        let (timer_refs, immediate_refs) =
+            unsafe { ((*timers).active_timer_count, (*timers).immediate_ref_count) };
 
         if !has_queued && timer_refs <= 0 && immediate_refs <= 0 {
             break;
@@ -949,16 +971,12 @@ fn drain_for_late_errors(vm: &mut VirtualMachine) {
         if Timespec::now(TimespecMockMode::ForceRealTime).greater(&deadline) {
             break;
         }
-        // Only park while a user `TimeoutObject` is due within the deadline;
-        // the heap min may be an internal runtime timer, but the min-heap
-        // invariant then bounds the park to that `TimeoutObject`'s due time.
-        // A self-rescheduling setImmediate alone (no near-term user timer)
-        // breaks here instead of busy-spinning.
-        if timers.is_null() {
-            break;
-        }
+        // Only park while a ref'd user `TimeoutObject` is due within the
+        // deadline; a self-rescheduling setImmediate or an unref'd interval
+        // alone breaks here instead of busy-spinning to the wall-clock cap.
+        //
         // SAFETY: live per-thread `All`; walk reads only heap-node fields.
-        if !unsafe { (*timers).timers.any_js_timer_due_by(&deadline) } {
+        if !unsafe { (*timers).timers.any_refd_js_timer_due_by(&deadline) } {
             break;
         }
         vm.auto_tick_active();

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -908,21 +908,14 @@ pub(crate) fn should_drain_event_loop() -> bool {
     env_var::BUN_TEST_DRAIN_EVENT_LOOP.get().unwrap_or(false)
 }
 
-/// Grace window for the post-file drain; long enough for "a few ms later"
-/// fire-and-forget errors to surface under ASAN, short enough that a test
-/// leaking a far-future `setTimeout`/`setInterval` does not stall the run.
 const POST_FILE_DRAIN_GRACE_MS: i64 = 1000;
 
-/// Drain ref'd JS timers, queued tasks, and setImmediate callbacks that are
-/// due within `POST_FILE_DRAIN_GRACE_MS` of now, so an unhandled rejection or
-/// late `setTimeout` throw from a file's final test still surfaces while
-/// `active_file` is set and is counted as an unhandled-between-tests error.
-///
-/// Deliberately excludes `platform_loop.is_active()` and `vm.active_tasks`
-/// so a leaked `Bun.serve()` / open socket / `node:http` response does not
-/// wedge the drain (passive handles that make no progress on their own).
-/// The wall-clock deadline and the timer-heap peek keep a leaked 1h
-/// `setTimeout` / `setInterval` from blocking `auto_tick_active()`.
+/// Drain ref'd JS timers, queued tasks and setImmediate callbacks due within
+/// `POST_FILE_DRAIN_GRACE_MS`, so a late rejection or `setTimeout` throw from
+/// a file's final test still surfaces while `active_file` is set. Ignores
+/// `platform_loop.is_active()` / `vm.active_tasks` (leaked `Bun.serve()` /
+/// sockets never make progress) and is wall-clock bounded so a far-future
+/// timer cannot stall the run.
 fn drain_for_late_errors(vm: &mut VirtualMachine) {
     use bun_core::{Timespec, TimespecMockMode};
 
@@ -951,12 +944,7 @@ fn drain_for_late_errors(vm: &mut VirtualMachine) {
         if Timespec::now(TimespecMockMode::ForceRealTime).greater(&deadline) {
             break;
         }
-        // `auto_tick_active()` parks until the soonest heap timer; when nothing
-        // else is queued and that soonest timer is already past the deadline,
-        // stop now rather than wait for it. Internal runtime timers (GC,
-        // WTFTimer) usually sit closer than any far-future user timer, so
-        // this is a best-effort fast-path; the wall-clock check above is the
-        // guaranteed bound.
+        // Don't let `auto_tick_active()` park on a heap min past the deadline.
         if !has_queued && immediate_refs <= 0 && !timers.is_null() {
             // SAFETY: live per-thread `All`; single JS thread.
             match unsafe { (*timers).timers.peek() } {
@@ -3443,15 +3431,8 @@ impl TestCommand {
                 // SAFETY: el is the VM-owned event loop; vm is passed back as *mut.
                 unsafe { (*el).tick_immediate_tasks(vm) };
 
-                // Drain ref'd timers and queued tasks so a fire-and-forget
-                // rejection or a late `setTimeout` throw from this file's
-                // final test still surfaces while `active_file` is set and
-                // bumps `unhandled_errors_between_tests`. jest and
-                // `node --test` both wait for the loop and fail the run;
-                // without this the tail of the final file was a silent-green
-                // window (1 pass, exit 0, error never printed). Skipped once
-                // the run is already failing so a timed-out test body is not
-                // waited on.
+                // Skip once the run already failed so a timed-out test body
+                // is not waited on.
                 if reporter.jest.summary.fail == 0
                     && reporter.jest.unhandled_errors_between_tests == 0
                 {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -949,30 +949,17 @@ fn drain_for_late_errors(vm: &mut VirtualMachine) {
         if Timespec::now(TimespecMockMode::ForceRealTime).greater(&deadline) {
             break;
         }
-        if has_queued {
-            continue;
-        }
-        // `auto_tick_active()` parks until the soonest heap timer. Internal
-        // runtime timers (GC, WTFTimer) may sit at the heap min, so walk for
-        // the soonest user `TimeoutObject` and only park while one is due
-        // within the deadline; otherwise a far-future user timer cannot
-        // make `auto_tick_active()` park past it.
+        // Only park while a user `TimeoutObject` is due within the deadline;
+        // the heap min may be an internal runtime timer, but the min-heap
+        // invariant then bounds the park to that `TimeoutObject`'s due time.
+        // A self-rescheduling setImmediate alone (no near-term user timer)
+        // breaks here instead of busy-spinning.
         if timers.is_null() {
             break;
         }
-        // SAFETY: live per-thread `All`; single JS thread; null-checked.
-        let next_heap_min = unsafe { (*timers).timers.peek() };
         // SAFETY: live per-thread `All`; walk reads only heap-node fields.
-        let has_js_timer_due = unsafe { (*timers).timers.any_js_timer_due_by(&deadline) };
-        match next_heap_min {
-            None => break,
-            Some(min) => {
-                // SAFETY: `peek()` returns a live heap node.
-                let heap_min_past = unsafe { (*min).next }.greater(&deadline);
-                if heap_min_past || !has_js_timer_due {
-                    break;
-                }
-            }
+        if !unsafe { (*timers).timers.any_js_timer_due_by(&deadline) } {
+            break;
         }
         vm.auto_tick_active();
     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -926,8 +926,7 @@ const POST_FILE_DRAIN_GRACE_MS: i64 = 1000;
 fn drain_for_late_errors(vm: &mut VirtualMachine) {
     use bun_core::{Timespec, TimespecMockMode};
 
-    let deadline =
-        Timespec::now(TimespecMockMode::ForceRealTime).add_ms(POST_FILE_DRAIN_GRACE_MS);
+    let deadline = Timespec::now(TimespecMockMode::ForceRealTime).add_ms(POST_FILE_DRAIN_GRACE_MS);
 
     loop {
         vm.tick();

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -908,6 +908,72 @@ pub(crate) fn should_drain_event_loop() -> bool {
     env_var::BUN_TEST_DRAIN_EVENT_LOOP.get().unwrap_or(false)
 }
 
+/// Grace window for the post-file drain; long enough for "a few ms later"
+/// fire-and-forget errors to surface under ASAN, short enough that a test
+/// leaking a far-future `setTimeout`/`setInterval` does not stall the run.
+const POST_FILE_DRAIN_GRACE_MS: i64 = 1000;
+
+/// Drain ref'd JS timers, queued tasks, and setImmediate callbacks that are
+/// due within `POST_FILE_DRAIN_GRACE_MS` of now, so an unhandled rejection or
+/// late `setTimeout` throw from a file's final test still surfaces while
+/// `active_file` is set and is counted as an unhandled-between-tests error.
+///
+/// Deliberately excludes `platform_loop.is_active()` and `vm.active_tasks`
+/// so a leaked `Bun.serve()` / open socket / `node:http` response does not
+/// wedge the drain (passive handles that make no progress on their own).
+/// The wall-clock deadline and the timer-heap peek keep a leaked 1h
+/// `setTimeout` / `setInterval` from blocking `auto_tick_active()`.
+fn drain_for_late_errors(vm: &mut VirtualMachine) {
+    use bun_core::{Timespec, TimespecMockMode};
+
+    let deadline =
+        Timespec::now(TimespecMockMode::ForceRealTime).add_ms(POST_FILE_DRAIN_GRACE_MS);
+
+    loop {
+        vm.tick();
+
+        let el = vm.event_loop_shared();
+        let has_queued = el.tasks.readable_length() > 0
+            || !el.immediate_tasks.is_empty()
+            || !el.next_immediate_tasks.is_empty();
+
+        let timers = crate::jsc_hooks::timer_all();
+        // SAFETY: `timer_all()` is the live per-thread `All` once RuntimeState
+        // is installed (always true by the time a test file has run).
+        let (timer_refs, immediate_refs) = if timers.is_null() {
+            (0, 0)
+        } else {
+            unsafe { ((*timers).active_timer_count, (*timers).immediate_ref_count) }
+        };
+
+        if !has_queued && timer_refs <= 0 && immediate_refs <= 0 {
+            break;
+        }
+        if Timespec::now(TimespecMockMode::ForceRealTime).greater(&deadline) {
+            break;
+        }
+        // `auto_tick_active()` parks until the soonest heap timer; when nothing
+        // else is queued and that soonest timer is already past the deadline,
+        // stop now rather than wait for it. Internal runtime timers (GC,
+        // WTFTimer) usually sit closer than any far-future user timer, so
+        // this is a best-effort fast-path; the wall-clock check above is the
+        // guaranteed bound.
+        if !has_queued && immediate_refs <= 0 && !timers.is_null() {
+            // SAFETY: live per-thread `All`; single JS thread.
+            match unsafe { (*timers).timers.peek() } {
+                None => break,
+                // SAFETY: `peek()` returns a live heap node.
+                Some(min) => {
+                    if unsafe { (*min).next }.greater(&deadline) {
+                        break;
+                    }
+                }
+            }
+        }
+        vm.auto_tick_active();
+    }
+}
+
 pub struct CommandLineReporter {
     // `TestRunner<'a>` borrows `TestOptions`/regex from the CLI ctx; the
     // reporter is held in a `Box` local to `TestCommand::exec` which never
@@ -3377,6 +3443,21 @@ impl TestCommand {
                 let el = vm.event_loop();
                 // SAFETY: el is the VM-owned event loop; vm is passed back as *mut.
                 unsafe { (*el).tick_immediate_tasks(vm) };
+
+                // Drain ref'd timers and queued tasks so a fire-and-forget
+                // rejection or a late `setTimeout` throw from this file's
+                // final test still surfaces while `active_file` is set and
+                // bumps `unhandled_errors_between_tests`. jest and
+                // `node --test` both wait for the loop and fail the run;
+                // without this the tail of the final file was a silent-green
+                // window (1 pass, exit 0, error never printed). Skipped once
+                // the run is already failing so a timed-out test body is not
+                // waited on.
+                if reporter.jest.summary.fail == 0
+                    && reporter.jest.unhandled_errors_between_tests == 0
+                {
+                    drain_for_late_errors(vm);
+                }
 
                 // Node parity: a node test file exits only when its loop drains.
                 // on_before_exit() drains and dispatches 'beforeExit' like `bun run`;

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -342,9 +342,9 @@ impl TimerHeap {
         unsafe { self.0.count() }
     }
 
-    /// `true` iff any `TimeoutObject` (user `setTimeout`/`setInterval`) node
+    /// `true` iff any ref'd `TimeoutObject` (user `setTimeout`/`setInterval`)
     /// is due at or before `deadline`. O(n) worklist walk.
-    pub(crate) fn any_js_timer_due_by(&self, deadline: &Timespec) -> bool {
+    pub(crate) fn any_refd_js_timer_due_by(&self, deadline: &Timespec) -> bool {
         let mut stack: Vec<*mut EventLoopTimer> = Vec::new();
         if !self.0.root.is_null() {
             stack.push(self.0.root);
@@ -354,7 +354,13 @@ impl TimerHeap {
             // nodes stay live for the heap's lifetime (intrusive invariant).
             let t = unsafe { &*node };
             if t.tag == EventLoopTimerTag::TimeoutObject && !t.next.greater(deadline) {
-                return true;
+                // SAFETY: `node` is a live `TimeoutObject`'s timer slot per tag.
+                if let Some(flags) = unsafe { js_timer_flags_ptr(node) } {
+                    // SAFETY: `flags` points into the live container.
+                    if unsafe { (*flags.as_ptr()).has_js_ref() } {
+                        return true;
+                    }
+                }
             }
             if !t.heap.next.is_null() {
                 stack.push(t.heap.next);

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -343,22 +343,27 @@ impl TimerHeap {
     }
 
     /// `true` iff any `TimeoutObject` (user `setTimeout`/`setInterval`) node
-    /// is due at or before `deadline`. O(n) walk; the heap is small.
+    /// is due at or before `deadline`. O(n) worklist walk.
     pub(crate) fn any_js_timer_due_by(&self, deadline: &Timespec) -> bool {
-        unsafe fn walk(node: *mut EventLoopTimer, deadline: &Timespec) -> bool {
-            if node.is_null() {
-                return false;
-            }
-            // SAFETY: reachable heap nodes are live (intrusive invariant).
+        let mut stack: Vec<*mut EventLoopTimer> = Vec::new();
+        if !self.0.root.is_null() {
+            stack.push(self.0.root);
+        }
+        while let Some(node) = stack.pop() {
+            // SAFETY: every pushed pointer is a non-null reachable heap node;
+            // nodes stay live for the heap's lifetime (intrusive invariant).
             let t = unsafe { &*node };
             if t.tag == EventLoopTimerTag::TimeoutObject && !t.next.greater(deadline) {
                 return true;
             }
-            // SAFETY: `child`/`next` are valid-or-null heap links.
-            unsafe { walk(t.heap.child, deadline) || walk(t.heap.next, deadline) }
+            if !t.heap.next.is_null() {
+                stack.push(t.heap.next);
+            }
+            if !t.heap.child.is_null() {
+                stack.push(t.heap.child);
+            }
         }
-        // SAFETY: `self.0.root` is valid-or-null; all reachable nodes are live.
-        unsafe { walk(self.0.root, deadline) }
+        false
     }
 }
 

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -341,6 +341,25 @@ impl TimerHeap {
         // live for the heap's lifetime (intrusive invariant maintained by `All`).
         unsafe { self.0.count() }
     }
+
+    /// `true` iff any `TimeoutObject` (user `setTimeout`/`setInterval`) node
+    /// is due at or before `deadline`. O(n) walk; the heap is small.
+    pub(crate) fn any_js_timer_due_by(&self, deadline: &Timespec) -> bool {
+        unsafe fn walk(node: *mut EventLoopTimer, deadline: &Timespec) -> bool {
+            if node.is_null() {
+                return false;
+            }
+            // SAFETY: reachable heap nodes are live (intrusive invariant).
+            let t = unsafe { &*node };
+            if t.tag == EventLoopTimerTag::TimeoutObject && !t.next.greater(deadline) {
+                return true;
+            }
+            // SAFETY: `child`/`next` are valid-or-null heap links.
+            unsafe { walk(t.heap.child, deadline) || walk(t.heap.next, deadline) }
+        }
+        // SAFETY: `self.0.root` is valid-or-null; all reachable nodes are live.
+        unsafe { walk(self.0.root, deadline) }
+    }
 }
 
 /// i32 is exposed to JavaScript and can be used with clearTimeout, clearInterval, etc.

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -742,11 +742,13 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
   });
 
   test("long setTimeout/setInterval left pending", async () => {
+    // .unref()'d so the post-file drain doesn't wait on them; the Strong on
+    // the wrapper (what pins the global) is independent of the ref state.
     using dir = tempDir(
       "isolate-leak-timers",
       makeLeakFixture(`
-        setTimeout(() => {}, 3_600_000);
-        setInterval(() => {}, 3_600_000);
+        setTimeout(() => {}, 3_600_000).unref();
+        setInterval(() => {}, 3_600_000).unref();
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -742,13 +742,11 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
   });
 
   test("long setTimeout/setInterval left pending", async () => {
-    // .unref()'d so the post-file drain doesn't wait on them; the Strong on
-    // the wrapper (what pins the global) is independent of the ref state.
     using dir = tempDir(
       "isolate-leak-timers",
       makeLeakFixture(`
-        setTimeout(() => {}, 3_600_000).unref();
-        setInterval(() => {}, 3_600_000).unref();
+        setTimeout(() => {}, 3_600_000);
+        setInterval(() => {}, 3_600_000);
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -844,6 +844,27 @@ test("only test", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent(
+    "does not hang when a near-term timer queues setImmediate with a far-future timer pending",
+    async () => {
+      const { stderr, exitCode, signalCode } = await runFixture({
+        "imm.test.js": `
+import { test, expect } from "bun:test";
+test("only test", () => {
+  setTimeout(() => {}, 3_600_000);
+  setTimeout(() => setImmediate(() => {}), 5);
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      expect(stderr).toContain("1 pass");
+      expect(stderr).toContain("0 fail");
+      expect(signalCode).toBeNull();
+      expect(exitCode).toBe(0);
+    },
+  );
+
   test.concurrent("does not hang when the last test leaks a ref'd Bun.serve()", async () => {
     const { stderr, exitCode, signalCode } = await runFixture({
       "serve.test.js": `

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -887,11 +887,9 @@ test("only test", () => {
     },
   );
 
-  test.concurrent(
-    "does not stall on an unref'd near-term interval with a ref'd far-future timer",
-    async () => {
-      const { stderr, exitCode, signalCode } = await runFixture({
-        "unref-near.test.js": `
+  test.concurrent("does not stall on an unref'd near-term interval with a ref'd far-future timer", async () => {
+    const { stderr, exitCode, signalCode } = await runFixture({
+      "unref-near.test.js": `
 import { test, expect } from "bun:test";
 test("only test", () => {
   setInterval(() => {}, 5).unref();
@@ -899,14 +897,13 @@ test("only test", () => {
   expect(1).toBe(1);
 });
 `,
-      });
+    });
 
-      expect(stderr).toContain("1 pass");
-      expect(stderr).toContain("0 fail");
-      expect(signalCode).toBeNull();
-      expect(exitCode).toBe(0);
-    },
-  );
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("0 fail");
+    expect(signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  });
 
   test.concurrent("does not busy-spin on a self-rescheduling setImmediate", async () => {
     const { stderr, exitCode, signalCode } = await runFixture({

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -865,6 +865,49 @@ test("only test", () => {
     },
   );
 
+  test.concurrent(
+    "does not hang when a nested setImmediate clears the near-term timer with a far-future timer pending",
+    async () => {
+      const { stderr, exitCode, signalCode } = await runFixture({
+        "clear.test.js": `
+import { test, expect } from "bun:test";
+test("only test", () => {
+  const near = setTimeout(() => {}, 200);
+  setTimeout(() => {}, 3_600_000);
+  setTimeout(() => setImmediate(() => setImmediate(() => clearTimeout(near))), 5);
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      expect(stderr).toContain("1 pass");
+      expect(stderr).toContain("0 fail");
+      expect(signalCode).toBeNull();
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test.concurrent(
+    "does not stall on an unref'd near-term interval with a ref'd far-future timer",
+    async () => {
+      const { stderr, exitCode, signalCode } = await runFixture({
+        "unref-near.test.js": `
+import { test, expect } from "bun:test";
+test("only test", () => {
+  setInterval(() => {}, 5).unref();
+  setTimeout(() => {}, 3_600_000);
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      expect(stderr).toContain("1 pass");
+      expect(stderr).toContain("0 fail");
+      expect(signalCode).toBeNull();
+      expect(exitCode).toBe(0);
+    },
+  );
+
   test.concurrent("does not busy-spin on a self-rescheduling setImmediate", async () => {
     const { stderr, exitCode, signalCode } = await runFixture({
       "spin.test.js": `

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -864,31 +864,28 @@ test("only test", async () => {
     expect(exitCode).toBe(1);
   });
 
-  test.concurrent(
-    "a short-period interval leaked by an earlier file does not stall later files",
-    async () => {
-      const { stderr, exitCode, signalCode } = await runFixture({
-        "a.test.js": `
+  test.concurrent("a short-period interval leaked by an earlier file does not stall later files", async () => {
+    const { stderr, exitCode, signalCode } = await runFixture({
+      "a.test.js": `
 import { test, expect } from "bun:test";
 test("a", () => {
   setInterval(() => {}, 100);
   expect(1).toBe(1);
 });
 `,
-        "b.test.js": `
+      "b.test.js": `
 import { test, expect } from "bun:test";
 test("b", () => { expect(1).toBe(1); });
 `,
-        "c.test.js": `
+      "c.test.js": `
 import { test, expect } from "bun:test";
 test("c", () => { expect(1).toBe(1); });
 `,
-      });
+    });
 
-      expect(stderr).toContain("3 pass");
-      expect(stderr).toContain("0 fail");
-      expect(signalCode).toBeNull();
-      expect(exitCode).toBe(0);
-    },
-  );
+    expect(stderr).toContain("3 pass");
+    expect(stderr).toContain("0 fail");
+    expect(signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -749,3 +749,140 @@ test("my-test", () => {
     });
   }
 });
+
+describe("unhandled errors after the final test are reported", () => {
+  // jest and `node --test` both drain the event loop after the last test
+  // settles; a fire-and-forget rejection or a throw inside a leaked
+  // setTimeout must fail the run, not exit 0 with the error dropped.
+  const cases = [
+    [
+      "unhandled rejection from a fire-and-forget async IIFE",
+      `(async () => { await Bun.sleep(5); throw new Error("POST-END-REJECT"); })();`,
+      "POST-END-REJECT",
+    ],
+    [
+      "rejection scheduled from setTimeout(0)",
+      `setTimeout(() => { Promise.reject(new Error("T0-REJECT")); }, 0);`,
+      "T0-REJECT",
+    ],
+    [
+      "failing expect inside a leaked setTimeout",
+      `setTimeout(() => { expect("late").toBe("never"); }, 10);`,
+      `expect(received).toBe(expected)`,
+    ],
+  ] as const;
+
+  for (const [name, stmt, needle] of cases) {
+    test(name, () => {
+      const dir = tempDirWithFiles("unhandled-after-last", {
+        "late.test.js": `
+import { test, expect } from "bun:test";
+test("only test", async () => {
+  await Bun.sleep(1);
+  ${stmt}
+  expect(1).toBe(1);
+});
+`,
+        "package.json": "{}",
+      });
+
+      const { stderr, exitCode } = spawnSync({
+        cmd: [bunExe(), "test", "late.test.js"],
+        cwd: dir,
+        stdout: "inherit",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+      const output = stderr.toString();
+
+      expect(output).toContain(needle);
+      expect(output).toContain("Unhandled error between tests");
+      expect(output).toContain("1 pass");
+      expect(output).toContain("0 fail");
+      expect(output).toContain("1 error");
+      expect(exitCode).toBe(1);
+    });
+  }
+
+  test("does not hang when the last test leaves an unref'd handle", () => {
+    const dir = tempDirWithFiles("unhandled-after-last-unref", {
+      "unref.test.js": `
+import { test, expect } from "bun:test";
+test("only test", () => {
+  setInterval(() => {}, 100000).unref();
+  expect(1).toBe(1);
+});
+`,
+      "package.json": "{}",
+    });
+
+    const { stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "test", "unref.test.js"],
+      cwd: dir,
+      stdout: "inherit",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const output = stderr.toString();
+
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("does not hang on a far-future ref'd setTimeout/setInterval", () => {
+    const dir = tempDirWithFiles("unhandled-after-last-far", {
+      "far.test.js": `
+import { test, expect } from "bun:test";
+test("only test", () => {
+  setTimeout(() => {}, 3_600_000);
+  setInterval(() => {}, 3_600_000);
+  expect(1).toBe(1);
+});
+`,
+      "package.json": "{}",
+    });
+
+    const { stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "test", "far.test.js"],
+      cwd: dir,
+      stdout: "inherit",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const output = stderr.toString();
+
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("does not hang when the last test leaks a ref'd Bun.serve()", () => {
+    const dir = tempDirWithFiles("unhandled-after-last-serve", {
+      "serve.test.js": `
+import { test, expect } from "bun:test";
+test("only test", async () => {
+  Bun.serve({ port: 0, fetch: () => new Response("ok") });
+  setTimeout(() => { throw new Error("LATE-THROW"); }, 5);
+  expect(1).toBe(1);
+});
+`,
+      "package.json": "{}",
+    });
+
+    const { stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "test", "serve.test.js"],
+      cwd: dir,
+      stdout: "inherit",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const output = stderr.toString();
+
+    expect(output).toContain("LATE-THROW");
+    expect(output).toContain("Unhandled error between tests");
+    expect(output).toContain("1 pass");
+    expect(output).toContain("1 error");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -754,6 +754,20 @@ describe("unhandled errors after the final test are reported", () => {
   // jest and `node --test` both drain the event loop after the last test
   // settles; a fire-and-forget rejection or a throw inside a leaked
   // setTimeout must fail the run, not exit 0 with the error dropped.
+  async function runFixture(files: Record<string, string>) {
+    const dir = tempDirWithFiles("unhandled-after-last", { ...files, "package.json": "{}" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...Object.keys(files)],
+      cwd: dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env: bunEnv,
+      timeout: 30_000,
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr, exitCode, signalCode: proc.signalCode };
+  }
+
   const cases = [
     [
       "unhandled rejection from a fire-and-forget async IIFE",
@@ -773,8 +787,8 @@ describe("unhandled errors after the final test are reported", () => {
   ] as const;
 
   for (const [name, stmt, needle] of cases) {
-    test(name, () => {
-      const dir = tempDirWithFiles("unhandled-after-last", {
+    test.concurrent(name, async () => {
+      const { stderr, exitCode, signalCode } = await runFixture({
         "late.test.js": `
 import { test, expect } from "bun:test";
 test("only test", async () => {
@@ -783,29 +797,20 @@ test("only test", async () => {
   expect(1).toBe(1);
 });
 `,
-        "package.json": "{}",
       });
 
-      const { stderr, exitCode } = spawnSync({
-        cmd: [bunExe(), "test", "late.test.js"],
-        cwd: dir,
-        stdout: "inherit",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-      const output = stderr.toString();
-
-      expect(output).toContain(needle);
-      expect(output).toContain("Unhandled error between tests");
-      expect(output).toContain("1 pass");
-      expect(output).toContain("0 fail");
-      expect(output).toContain("1 error");
+      expect(stderr).toContain(needle);
+      expect(stderr).toContain("Unhandled error between tests");
+      expect(stderr).toContain("1 pass");
+      expect(stderr).toContain("0 fail");
+      expect(stderr).toContain("1 error");
+      expect(signalCode).toBeNull();
       expect(exitCode).toBe(1);
     });
   }
 
-  test("does not hang when the last test leaves an unref'd handle", () => {
-    const dir = tempDirWithFiles("unhandled-after-last-unref", {
+  test.concurrent("does not hang when the last test leaves an unref'd handle", async () => {
+    const { stderr, exitCode, signalCode } = await runFixture({
       "unref.test.js": `
 import { test, expect } from "bun:test";
 test("only test", () => {
@@ -813,25 +818,16 @@ test("only test", () => {
   expect(1).toBe(1);
 });
 `,
-      "package.json": "{}",
     });
 
-    const { stderr, exitCode } = spawnSync({
-      cmd: [bunExe(), "test", "unref.test.js"],
-      cwd: dir,
-      stdout: "inherit",
-      stderr: "pipe",
-      env: bunEnv,
-    });
-    const output = stderr.toString();
-
-    expect(output).toContain("1 pass");
-    expect(output).toContain("0 fail");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("0 fail");
+    expect(signalCode).toBeNull();
     expect(exitCode).toBe(0);
   });
 
-  test("does not hang on a far-future ref'd setTimeout/setInterval", () => {
-    const dir = tempDirWithFiles("unhandled-after-last-far", {
+  test.concurrent("does not hang on a far-future ref'd setTimeout/setInterval", async () => {
+    const { stderr, exitCode, signalCode } = await runFixture({
       "far.test.js": `
 import { test, expect } from "bun:test";
 test("only test", () => {
@@ -840,25 +836,16 @@ test("only test", () => {
   expect(1).toBe(1);
 });
 `,
-      "package.json": "{}",
     });
 
-    const { stderr, exitCode } = spawnSync({
-      cmd: [bunExe(), "test", "far.test.js"],
-      cwd: dir,
-      stdout: "inherit",
-      stderr: "pipe",
-      env: bunEnv,
-    });
-    const output = stderr.toString();
-
-    expect(output).toContain("1 pass");
-    expect(output).toContain("0 fail");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("0 fail");
+    expect(signalCode).toBeNull();
     expect(exitCode).toBe(0);
   });
 
-  test("does not hang when the last test leaks a ref'd Bun.serve()", () => {
-    const dir = tempDirWithFiles("unhandled-after-last-serve", {
+  test.concurrent("does not hang when the last test leaks a ref'd Bun.serve()", async () => {
+    const { stderr, exitCode, signalCode } = await runFixture({
       "serve.test.js": `
 import { test, expect } from "bun:test";
 test("only test", async () => {
@@ -867,22 +854,41 @@ test("only test", async () => {
   expect(1).toBe(1);
 });
 `,
-      "package.json": "{}",
     });
 
-    const { stderr, exitCode } = spawnSync({
-      cmd: [bunExe(), "test", "serve.test.js"],
-      cwd: dir,
-      stdout: "inherit",
-      stderr: "pipe",
-      env: bunEnv,
-    });
-    const output = stderr.toString();
-
-    expect(output).toContain("LATE-THROW");
-    expect(output).toContain("Unhandled error between tests");
-    expect(output).toContain("1 pass");
-    expect(output).toContain("1 error");
+    expect(stderr).toContain("LATE-THROW");
+    expect(stderr).toContain("Unhandled error between tests");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("1 error");
+    expect(signalCode).toBeNull();
     expect(exitCode).toBe(1);
   });
+
+  test.concurrent(
+    "a short-period interval leaked by an earlier file does not stall later files",
+    async () => {
+      const { stderr, exitCode, signalCode } = await runFixture({
+        "a.test.js": `
+import { test, expect } from "bun:test";
+test("a", () => {
+  setInterval(() => {}, 100);
+  expect(1).toBe(1);
+});
+`,
+        "b.test.js": `
+import { test, expect } from "bun:test";
+test("b", () => { expect(1).toBe(1); });
+`,
+        "c.test.js": `
+import { test, expect } from "bun:test";
+test("c", () => { expect(1).toBe(1); });
+`,
+      });
+
+      expect(stderr).toContain("3 pass");
+      expect(stderr).toContain("0 fail");
+      expect(signalCode).toBeNull();
+      expect(exitCode).toBe(0);
+    },
+  );
 });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -987,26 +987,23 @@ test("c", () => { expect(1).toBe(1); });
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent(
-    "a short-period interval under --rerun-each does not stall later repeats",
-    async () => {
-      const { stderr, exitCode, signalCode } = await runFixture(
-        {
-          "leak.test.js": `
+  test.concurrent("a short-period interval under --rerun-each does not stall later repeats", async () => {
+    const { stderr, exitCode, signalCode } = await runFixture(
+      {
+        "leak.test.js": `
 import { test, expect } from "bun:test";
 test("t", () => {
   setInterval(() => {}, 100);
   expect(1).toBe(1);
 });
 `,
-        },
-        ["--rerun-each=3"],
-      );
+      },
+      ["--rerun-each=3"],
+    );
 
-      expect(stderr).toContain("3 pass");
-      expect(stderr).toContain("0 fail");
-      expect(signalCode).toBeNull();
-      expect(exitCode).toBe(0);
-    },
-  );
+    expect(stderr).toContain("3 pass");
+    expect(stderr).toContain("0 fail");
+    expect(signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -882,11 +882,9 @@ test("only test", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent(
-    "surfaces a late setTimeout throw alongside a self-rescheduling setImmediate",
-    async () => {
-      const { stderr, exitCode, signalCode } = await runFixture({
-        "spin-throw.test.js": `
+  test.concurrent("surfaces a late setTimeout throw alongside a self-rescheduling setImmediate", async () => {
+    const { stderr, exitCode, signalCode } = await runFixture({
+      "spin-throw.test.js": `
 import { test, expect } from "bun:test";
 test("only test", () => {
   setImmediate(function f() { setImmediate(f); });
@@ -894,16 +892,15 @@ test("only test", () => {
   expect(1).toBe(1);
 });
 `,
-      });
+    });
 
-      expect(stderr).toContain("LATE-THROW");
-      expect(stderr).toContain("Unhandled error between tests");
-      expect(stderr).toContain("1 pass");
-      expect(stderr).toContain("1 error");
-      expect(signalCode).toBeNull();
-      expect(exitCode).toBe(1);
-    },
-  );
+    expect(stderr).toContain("LATE-THROW");
+    expect(stderr).toContain("Unhandled error between tests");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("1 error");
+    expect(signalCode).toBeNull();
+    expect(exitCode).toBe(1);
+  });
 
   test.concurrent("does not hang when the last test leaks a ref'd Bun.serve()", async () => {
     const { stderr, exitCode, signalCode } = await runFixture({

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -865,6 +865,46 @@ test("only test", () => {
     },
   );
 
+  test.concurrent("does not busy-spin on a self-rescheduling setImmediate", async () => {
+    const { stderr, exitCode, signalCode } = await runFixture({
+      "spin.test.js": `
+import { test, expect } from "bun:test";
+test("only test", () => {
+  setImmediate(function f() { setImmediate(f); });
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("0 fail");
+    expect(signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent(
+    "surfaces a late setTimeout throw alongside a self-rescheduling setImmediate",
+    async () => {
+      const { stderr, exitCode, signalCode } = await runFixture({
+        "spin-throw.test.js": `
+import { test, expect } from "bun:test";
+test("only test", () => {
+  setImmediate(function f() { setImmediate(f); });
+  setTimeout(() => { throw new Error("LATE-THROW"); }, 50);
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      expect(stderr).toContain("LATE-THROW");
+      expect(stderr).toContain("Unhandled error between tests");
+      expect(stderr).toContain("1 pass");
+      expect(stderr).toContain("1 error");
+      expect(signalCode).toBeNull();
+      expect(exitCode).toBe(1);
+    },
+  );
+
   test.concurrent("does not hang when the last test leaks a ref'd Bun.serve()", async () => {
     const { stderr, exitCode, signalCode } = await runFixture({
       "serve.test.js": `

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -754,10 +754,10 @@ describe("unhandled errors after the final test are reported", () => {
   // jest and `node --test` both drain the event loop after the last test
   // settles; a fire-and-forget rejection or a throw inside a leaked
   // setTimeout must fail the run, not exit 0 with the error dropped.
-  async function runFixture(files: Record<string, string>) {
+  async function runFixture(files: Record<string, string>, extraArgs: string[] = []) {
     const dir = tempDirWithFiles("unhandled-after-last", { ...files, "package.json": "{}" });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", ...Object.keys(files)],
+      cmd: [bunExe(), "test", ...extraArgs, ...Object.keys(files)],
       cwd: dir,
       stdout: "ignore",
       stderr: "pipe",
@@ -986,4 +986,27 @@ test("c", () => { expect(1).toBe(1); });
     expect(signalCode).toBeNull();
     expect(exitCode).toBe(0);
   });
+
+  test.concurrent(
+    "a short-period interval under --rerun-each does not stall later repeats",
+    async () => {
+      const { stderr, exitCode, signalCode } = await runFixture(
+        {
+          "leak.test.js": `
+import { test, expect } from "bun:test";
+test("t", () => {
+  setInterval(() => {}, 100);
+  expect(1).toBe(1);
+});
+`,
+        },
+        ["--rerun-each=3"],
+      );
+
+      expect(stderr).toContain("3 pass");
+      expect(stderr).toContain("0 fail");
+      expect(signalCode).toBeNull();
+      expect(exitCode).toBe(0);
+    },
+  );
 });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -877,7 +877,7 @@ it.if(isWindows)(
     }
 
     const batch = [];
-    const before = heapStats().objectTypeCounts.TLSSocket || 0;
+    const before = heapStats().objectTypeCounts.TCPSocket || 0;
     for (let i = 0; i < 100; i++) {
       batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
       batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
@@ -892,7 +892,7 @@ it.if(isWindows)(
       }
     }
     await Promise.all(batch);
-    expectMaxObjectTypeCount(expect, "TCPSocket", before);
+    await expectMaxObjectTypeCount(expect, "TCPSocket", before);
   },
   20_000,
 );


### PR DESCRIPTION
## Repro

```js
// bun test ./repro.test.ts  ->  1 pass, exit 0 (should be exit 1)
import { test, expect } from "bun:test";
test("last test spawns un-awaited work that fails after it ends", async () => {
  await Bun.sleep(10);
  (async () => { await Bun.sleep(5); throw new Error("POST-END-REJECT"); })();
  setTimeout(() => { Promise.reject(new Error("T0-REJECT")); }, 0);
  setTimeout(() => { expect("late").toBe("never"); }, 20);
  expect(1).toBe(1);
});
```

Before: `1 pass / 0 fail`, exit 0, nothing printed. jest 30.4 and `node --test` both print the rejection and exit 1. The same shape from any earlier test (or earlier file) was already caught as `Unhandled error between tests`; the escape was exactly the tail of the final file.

## Cause

After the last test in a file sets `phase = Done`, the `while buntest.phase != Done` loop in `TestCommand::run` exits. The only follow-up work was `tick_immediate_tasks` (setImmediate only) and a single `handle_rejected_promises()` (drains JSC's queue, does not tick the loop). Pending timers never fired, so any `setTimeout` / `Bun.sleep` scheduled by the last test never ran its callback. `exit_file()` then cleared `active_file`, and the exit-code check reads only `unhandled_errors_between_tests` (still 0), so the process exited 0.

## Fix

After the final repeat of the final file's phase loop, while `active_file` is still set, drain ref'd JS timers, queued tasks and setImmediate callbacks for a short grace window so the late error routes through `BunTest::on_uncaught_exception` and bumps `unhandled_errors_between_tests`.

The drain is bounded so `bun test` keeps its "does not hang on leaked handles" guarantee:

- a no-op `TimerCallback` sentinel is inserted at the 1s deadline before the loop and removed on scope exit, so `get_timeout` inside `auto_tick_active` is capped regardless of what JS clears between the park-guard and the park;
- `TimerHeap::any_refd_js_timer_due_by` walks the heap for the soonest ref'd user `TimeoutObject` and only parks while one is due within the deadline, so internal runtime timers at the heap min, far-future `setTimeout`/`setInterval`, unref'd intervals, and self-rescheduling `setImmediate` alone all break out instead of spinning to the wall-clock cap;
- ignores `platform_loop.is_active()` / `vm.active_tasks`, so a leaked `Bun.serve()` / open socket / `node:http` response does not wedge it;
- gated on `first_last.last && repeat_index + 1 == repeat_count` and on this repeat not having failed (snapshot-vs-delta on the run-wide counters), so earlier files / earlier repeats / a timed-out test body are not waited on;
- `Tag::TimerCallback` is opted out of `allow_fake_timers()` so the sentinel lands in the real heap even when `jest.useFakeTimers()` is left active.

The drain already caught one pre-existing bug: `node-net.test.ts`'s Windows named-pipe leak check was un-awaited and read `TLSSocket` for the baseline while asserting on `TCPSocket`, so the assertion had never run (fixed here).

## After

```
(pass) last test spawns un-awaited work that fails after it ends
# Unhandled error between tests
error: T0-REJECT
# Unhandled error between tests
error: POST-END-REJECT
# Unhandled error between tests
error: expect(received).toBe(expected)
 1 pass
 0 fail
 3 errors
→ exit 1
```

`test/js/bun/test/test-test.test.ts` gains 13 cases: the three leak shapes above fail the run, and 10 hang-guards (unref'd interval; far-future ref'd timer; near-term timer + setImmediate + far-future; nested setImmediate clears the near-term timer; unref'd near interval + ref'd far timer; self-rescheduling setImmediate alone; self-rescheduling setImmediate + late throw; leaked `Bun.serve()`; multi-file with leaked interval; `--rerun-each=3` with leaked interval) each spawned with `timeout: 30_000` and asserting `signalCode === null`.
