### PR TITLE
Bun.JSONL.parse/parseChunk: avoid whole-buffer UTF-16 conversion for byte input

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -541,8 +541,7 @@ static JSC::StreamingJSONParseResult::Status parseJSONLFromBytes(
             if (segAscii) {
                 from = segStart + localBytes;
             } else {
-                // localBytes is derived from the *converted* string and can exceed
-                // the original byte span when invalid UTF-8 was replaced, so rewind.
+                // localBytes may overshoot the input when invalid UTF-8 was replaced; rewind.
                 while (values.size() > sizeBefore)
                     values.removeLast();
                 consumedBytes = consumedBefore;

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -485,6 +485,7 @@ static JSC::StreamingJSONParseResult::Status parseJSONLFromBytes(
             localBytes = str.is8Bit()
                 ? simdutf::utf8_length_from_latin1(reinterpret_cast<const char*>(str.span8().data()), r.charactersConsumed)
                 : simdutf::utf8_length_from_utf16le(reinterpret_cast<const char16_t*>(str.span16().data()), r.charactersConsumed);
+            localBytes = std::min(localBytes, n);
         }
         return true;
     };

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -444,12 +444,7 @@ static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
 JSC_DECLARE_HOST_FUNCTION(jsFunctionJSONLParse);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionJSONLParseChunk);
 
-// Parse JSONL from a UTF-8 byte slice. Runs of consecutive ASCII-only lines are
-// parsed via the Latin-1 fast path without any encoding conversion; only the
-// non-ASCII line runs are converted with fromUTF8ReplacingInvalidSequences. On
-// return, consumedBytes is the byte offset (relative to data) immediately after
-// the last successfully parsed value. May throw via scope; callers must
-// RETURN_IF_EXCEPTION afterwards.
+// consumedBytes: byte offset in data after the last parsed value. Caller must RETURN_IF_EXCEPTION.
 static JSC::StreamingJSONParseResult::Status parseJSONLFromBytes(
     JSGlobalObject* globalObject, JSC::ThrowScope& scope,
     const uint8_t* data, size_t length,
@@ -468,10 +463,6 @@ static JSC::StreamingJSONParseResult::Status parseJSONLFromBytes(
         return r.status;
     }
 
-    // Convert [from, to) via fromUTF8ReplacingInvalidSequences and parse it.
-    // Sets localBytes to the UTF-8 byte length of the consumed prefix of the
-    // converted string (0 when nothing was consumed). Returns false if an
-    // exception was thrown.
     const auto parseConverted = [&](size_t from, size_t to, Status& status, size_t& localBytes) -> bool {
         localBytes = 0;
         size_t n = to - from;
@@ -546,16 +537,12 @@ static JSC::StreamingJSONParseResult::Status parseJSONLFromBytes(
             if (isLast)
                 return status;
 
-            // A value spans the segment boundary. Fall back to converting the
-            // remainder as a single string. For an ASCII segment the consumed
-            // byte count is exact, so resume from there; for a converted
-            // segment the byte count may disagree with the original bytes when
-            // invalid sequences were replaced, so discard this segment's
-            // values and re-parse from its start.
             size_t from;
             if (segAscii) {
                 from = segStart + localBytes;
             } else {
+                // localBytes is derived from the *converted* string and can exceed
+                // the original byte span when invalid UTF-8 was replaced, so rewind.
                 while (values.size() > sizeBefore)
                     values.removeLast();
                 consumedBytes = consumedBefore;

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -444,6 +444,139 @@ static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
 JSC_DECLARE_HOST_FUNCTION(jsFunctionJSONLParse);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionJSONLParseChunk);
 
+// Parse JSONL from a UTF-8 byte slice. Runs of consecutive ASCII-only lines are
+// parsed via the Latin-1 fast path without any encoding conversion; only the
+// non-ASCII line runs are converted with fromUTF8ReplacingInvalidSequences. On
+// return, consumedBytes is the byte offset (relative to data) immediately after
+// the last successfully parsed value. May throw via scope; callers must
+// RETURN_IF_EXCEPTION afterwards.
+static JSC::StreamingJSONParseResult::Status parseJSONLFromBytes(
+    JSGlobalObject* globalObject, JSC::ThrowScope& scope,
+    const uint8_t* data, size_t length,
+    MarkedArgumentBuffer& values, size_t& consumedBytes)
+{
+    using Status = JSC::StreamingJSONParseResult::Status;
+    consumedBytes = 0;
+
+    if (length <= WTF::String::MaxLength
+        && simdutf::validate_ascii(reinterpret_cast<const char*>(data), length)) {
+        auto r = JSC::streamingJSONParse(
+            globalObject,
+            StringView { std::span { reinterpret_cast<const char8_t*>(data), length } },
+            values);
+        consumedBytes = r.charactersConsumed;
+        return r.status;
+    }
+
+    // Convert [from, to) via fromUTF8ReplacingInvalidSequences and parse it.
+    // Sets localBytes to the UTF-8 byte length of the consumed prefix of the
+    // converted string (0 when nothing was consumed). Returns false if an
+    // exception was thrown.
+    const auto parseConverted = [&](size_t from, size_t to, Status& status, size_t& localBytes) -> bool {
+        localBytes = 0;
+        size_t n = to - from;
+        size_t u16Length = simdutf::utf16_length_from_utf8(reinterpret_cast<const char*>(data + from), n);
+        if (u16Length > WTF::String::MaxLength) {
+            throwOutOfMemoryError(globalObject, scope);
+            return false;
+        }
+        auto str = WTF::String::fromUTF8ReplacingInvalidSequences(
+            std::span { reinterpret_cast<const char8_t*>(data + from), n });
+        if (str.isNull()) {
+            throwOutOfMemoryError(globalObject, scope);
+            return false;
+        }
+        auto r = JSC::streamingJSONParse(globalObject, str, values);
+        if (scope.exception()) [[unlikely]]
+            return false;
+        status = r.status;
+        if (r.charactersConsumed > 0) {
+            localBytes = str.is8Bit()
+                ? simdutf::utf8_length_from_latin1(reinterpret_cast<const char*>(str.span8().data()), r.charactersConsumed)
+                : simdutf::utf8_length_from_utf16le(reinterpret_cast<const char16_t*>(str.span16().data()), r.charactersConsumed);
+        }
+        return true;
+    };
+
+    size_t segStart = 0;
+    while (segStart < length) {
+        const uint8_t* nl = static_cast<const uint8_t*>(memchr(data + segStart, '\n', length - segStart));
+        size_t segEnd = nl ? static_cast<size_t>(nl - data) + 1 : length;
+        bool segAscii = (segEnd - segStart) <= WTF::String::MaxLength
+            && simdutf::validate_ascii(reinterpret_cast<const char*>(data + segStart), segEnd - segStart);
+
+        // Extend with consecutive lines of the same kind.
+        while (segEnd < length) {
+            const uint8_t* nl2 = static_cast<const uint8_t*>(memchr(data + segEnd, '\n', length - segEnd));
+            size_t lineEnd = nl2 ? static_cast<size_t>(nl2 - data) + 1 : length;
+            bool lineAscii = simdutf::validate_ascii(reinterpret_cast<const char*>(data + segEnd), lineEnd - segEnd);
+            if (lineAscii != segAscii)
+                break;
+            if (segAscii && (lineEnd - segStart) > WTF::String::MaxLength)
+                break;
+            segEnd = lineEnd;
+        }
+
+        bool isLast = segEnd >= length;
+        size_t sizeBefore = values.size();
+        size_t consumedBefore = consumedBytes;
+
+        Status status;
+        size_t localBytes;
+        if (segAscii) {
+            auto r = JSC::streamingJSONParse(
+                globalObject,
+                StringView { std::span { reinterpret_cast<const char8_t*>(data + segStart), segEnd - segStart } },
+                values);
+            if (scope.exception()) [[unlikely]]
+                return Status::Error;
+            status = r.status;
+            localBytes = r.charactersConsumed;
+        } else if (!parseConverted(segStart, segEnd, status, localBytes)) {
+            return Status::Error;
+        }
+
+        if (localBytes > 0)
+            consumedBytes = segStart + localBytes;
+
+        if (status == Status::Error)
+            return status;
+
+        if (status == Status::NeedMoreData) {
+            if (isLast)
+                return status;
+
+            // A value spans the segment boundary. Fall back to converting the
+            // remainder as a single string. For an ASCII segment the consumed
+            // byte count is exact, so resume from there; for a converted
+            // segment the byte count may disagree with the original bytes when
+            // invalid sequences were replaced, so discard this segment's
+            // values and re-parse from its start.
+            size_t from;
+            if (segAscii) {
+                from = segStart + localBytes;
+            } else {
+                while (values.size() > sizeBefore)
+                    values.removeLast();
+                consumedBytes = consumedBefore;
+                from = segStart;
+            }
+
+            Status fbStatus;
+            size_t fbBytes;
+            if (!parseConverted(from, length, fbStatus, fbBytes))
+                return Status::Error;
+            if (fbBytes > 0)
+                consumedBytes = from + fbBytes;
+            return fbStatus;
+        }
+
+        segStart = segEnd;
+    }
+
+    return Status::Complete;
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParse, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -473,22 +606,9 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParse, (JSGlobalObject * globalObject, C
             length -= 3;
         }
 
-        if (length <= String::MaxLength && simdutf::validate_ascii(reinterpret_cast<const char*>(data), length)) {
-            auto chars = std::span { reinterpret_cast<const char8_t*>(data), length };
-            result = JSC::streamingJSONParse(globalObject, StringView(chars), values);
-        } else {
-            size_t u16Length = simdutf::utf16_length_from_utf8(reinterpret_cast<const char*>(data), length);
-            if (u16Length > String::MaxLength) {
-                throwOutOfMemoryError(globalObject, scope);
-                return {};
-            }
-            auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const char8_t*>(data), length });
-            if (str.isNull()) {
-                throwOutOfMemoryError(globalObject, scope);
-                return {};
-            }
-            result = JSC::streamingJSONParse(globalObject, str, values);
-        }
+        size_t consumedBytes;
+        auto status = parseJSONLFromBytes(globalObject, scope, data, length, values, consumedBytes);
+        result = { consumedBytes, status };
     } else {
         auto* inputString = arg.toString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
@@ -570,30 +690,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParseChunk, (JSGlobalObject * globalObje
             bomOffset = 3;
         }
 
-        if (sliceLen <= String::MaxLength && simdutf::validate_ascii(reinterpret_cast<const char*>(sliceData), sliceLen)) {
-            auto chars = std::span { reinterpret_cast<const char8_t*>(sliceData), sliceLen };
-            result = JSC::streamingJSONParse(globalObject, StringView(chars), values);
-            // For ASCII, byte offset = character offset
-            readBytes = start + bomOffset + result.charactersConsumed;
-        } else {
-            size_t u16Length = simdutf::utf16_length_from_utf8(reinterpret_cast<const char*>(sliceData), sliceLen);
-            if (u16Length > String::MaxLength) {
-                throwOutOfMemoryError(globalObject, scope);
-                return {};
-            }
-            auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const char8_t*>(sliceData), sliceLen });
-            if (str.isNull()) {
-                throwOutOfMemoryError(globalObject, scope);
-                return {};
-            }
-            result = JSC::streamingJSONParse(globalObject, str, values);
-            // Convert character offset back to UTF-8 byte offset
-            if (str.is8Bit()) {
-                readBytes = start + bomOffset + simdutf::utf8_length_from_latin1(reinterpret_cast<const char*>(str.span8().data()), result.charactersConsumed);
-            } else {
-                readBytes = start + bomOffset + simdutf::utf8_length_from_utf16le(reinterpret_cast<const char16_t*>(str.span16().data()), result.charactersConsumed);
-            }
-        }
+        size_t consumedBytes;
+        auto status = parseJSONLFromBytes(globalObject, scope, sliceData, sliceLen, values, consumedBytes);
+        result = { consumedBytes, status };
+        readBytes = start + bomOffset + consumedBytes;
     } else {
         auto* inputString = arg.toString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -2529,8 +2529,10 @@ describe("Bun.JSONL", () => {
         };
         const [asciiBytes, mixedBytes] = await Promise.all([run(false), run(true)]);
         const deltaMB = (mixedBytes - asciiBytes) / (1024 * 1024);
-        // Without segmentation the delta is roughly 2x the buffer (the UTF-16
-        // copy). With segmentation the two runs are within noise.
+        // Without segmentation every 200-byte ASCII value ends up as a 16-bit
+        // JSString (LiteralParser<char16_t> source), which alone is ~bufMB of
+        // residual over the 8-bit baseline; observed unfixed delta is ~2x bufMB
+        // on linux-x64. With segmentation the two runs match within noise.
         expect(deltaMB).toBeLessThan(bufMB);
       },
       30_000,

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -2457,6 +2457,15 @@ describe("Bun.JSONL", () => {
       const r = Bun.JSONL.parseChunk(buf);
       expect(r.values).toStrictEqual([{ a: 1 }, "\uFFFD", { b: 2 }]);
       expect(r.done).toBe(true);
+      expect(r.read).toBeLessThanOrEqual(buf.byteLength);
+      expect(r.read).toBe(line1.length + line2.length + '{"b":2}'.length);
+
+      // Same with the invalid-UTF-8 line last: `read` must not overshoot the
+      // input even though U+FFFD re-encodes to 3 bytes.
+      const tail = buf.subarray(0, line1.length + line2.length);
+      const r2 = Bun.JSONL.parseChunk(tail);
+      expect(r2.values).toStrictEqual([{ a: 1 }, "\uFFFD"]);
+      expect(r2.read).toBeLessThanOrEqual(tail.byteLength);
     });
 
     test("interleaved lines: many values match string-path results exactly", () => {
@@ -2486,10 +2495,11 @@ describe("Bun.JSONL", () => {
         // String::fromUTF8ReplacingInvalidSequences, costing roughly 2x the
         // buffer size in peak memory. With per-line segmentation the peak
         // should match the all-ASCII case.
+        const bufMB = 16;
         const prog = `
           const mixed = process.env.JSONL_MIXED === "1";
           const line = '{"id":0,"s":"' + Buffer.alloc(200, "x").toString() + '"}\\n';
-          const nLines = Math.floor((16 * 1024 * 1024) / line.length);
+          const nLines = Math.floor((${bufMB} * 1024 * 1024) / line.length);
           const buf = Buffer.alloc(nLines * line.length + 32);
           for (let i = 0; i < nLines; i++) buf.write(line, i * line.length, "latin1");
           let end = nLines * line.length;
@@ -2519,9 +2529,9 @@ describe("Bun.JSONL", () => {
         };
         const [asciiBytes, mixedBytes] = await Promise.all([run(false), run(true)]);
         const deltaMB = (mixedBytes - asciiBytes) / (1024 * 1024);
-        // Without segmentation the delta is roughly 2x the 16 MB buffer (the
-        // UTF-16 copy). With segmentation the two runs are within noise.
-        expect(deltaMB).toBeLessThan(16);
+        // Without segmentation the delta is roughly 2x the buffer (the UTF-16
+        // copy). With segmentation the two runs are within noise.
+        expect(deltaMB).toBeLessThan(bufMB);
       },
       30_000,
     );

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 describe("Bun.JSONL", () => {
   test("has Symbol.toStringTag", () => {
@@ -2247,5 +2248,288 @@ describe("Bun.JSONL", () => {
         expect(true).toBe(true);
       });
     });
+  });
+
+  describe("per-line ASCII segmentation (typed array input)", () => {
+    const enc = (s: string) => new TextEncoder().encode(s);
+
+    // The byte path should match the string path on every input. The string
+    // path is unchanged by the segmentation optimization, so it serves as the
+    // reference.
+    const checkSame = (text: string) => {
+      const ref = Bun.JSONL.parseChunk(text);
+      const buf = enc(text);
+      const got = Bun.JSONL.parseChunk(buf);
+      expect(got.values).toStrictEqual(ref.values);
+      expect(got.done).toBe(ref.done);
+      expect(got.error === null).toBe(ref.error === null);
+      // `read` is bytes for the typed array path, chars for the string path.
+      // For the success cases the last value ends on an ASCII byte, so the
+      // byte offset of that position equals the UTF-8 byte length of the
+      // string prefix up to ref.read.
+      expect(got.read).toBe(enc(text.slice(0, ref.read)).byteLength);
+      return got;
+    };
+
+    describe("equivalence with string path", () => {
+      const ascii = '{"a":1}';
+      const cjk = '{"jp":"\u65e5\u672c\u8a9e"}';
+      const emoji = '{"e":"\u{1f389}"}';
+      const latin1 = '{"s":"\u00f1\u00e9\u00fc"}';
+
+      test("all ASCII lines", () => {
+        checkSame([ascii, ascii, ascii, ascii].join("\n") + "\n");
+      });
+
+      test("all non-ASCII lines", () => {
+        checkSame([cjk, emoji, latin1, cjk].join("\n") + "\n");
+      });
+
+      test("interleaved ASCII / non-ASCII lines", () => {
+        checkSame([ascii, cjk, ascii, emoji, ascii, latin1, ascii].join("\n") + "\n");
+      });
+
+      test("non-ASCII first, ASCII last, no trailing newline", () => {
+        checkSame([cjk, ascii, emoji, ascii].join("\n"));
+      });
+
+      test("runs of same kind batched together", () => {
+        // 5 ASCII, 3 non-ASCII, 4 ASCII, 2 non-ASCII
+        const lines = [ascii, ascii, ascii, ascii, ascii, cjk, emoji, latin1, ascii, ascii, ascii, ascii, cjk, emoji];
+        const r = checkSame(lines.join("\n") + "\n");
+        expect(r.values.length).toBe(lines.length);
+      });
+
+      test("empty lines between segments of different kinds", () => {
+        checkSame([ascii, "", "", cjk, "", ascii].join("\n") + "\n");
+      });
+
+      test("error inside non-ASCII segment after ASCII values", () => {
+        const r = checkSame([ascii, ascii, '{"\u65e5":BAD}', ascii].join("\n") + "\n");
+        expect(r.values).toStrictEqual([{ a: 1 }, { a: 1 }]);
+        expect(r.error).toBeInstanceOf(SyntaxError);
+      });
+
+      test("error inside ASCII segment after non-ASCII values", () => {
+        const r = checkSame([cjk, emoji, "{bad}", ascii].join("\n") + "\n");
+        expect(r.values.length).toBe(2);
+        expect(r.error).toBeInstanceOf(SyntaxError);
+      });
+
+      test("trailing incomplete ASCII line after non-ASCII segment", () => {
+        const r = checkSame([cjk, ascii, '{"x":'].join("\n"));
+        expect(r.values.length).toBe(2);
+        expect(r.done).toBe(false);
+        expect(r.error).toBeNull();
+      });
+
+      test("trailing incomplete non-ASCII line after ASCII segment", () => {
+        const r = checkSame([ascii, ascii, '{"jp":"\u65e5'].join("\n"));
+        expect(r.values.length).toBe(2);
+        expect(r.done).toBe(false);
+        expect(r.error).toBeNull();
+      });
+    });
+
+    describe("multi-line values straddling a segment boundary", () => {
+      test("opens in ASCII segment, closes in non-ASCII segment", () => {
+        // `{` and `}` are on their own ASCII lines; the non-ASCII key is on
+        // the middle line.
+        checkSame('{"a":1}\n{\n  "\u65e5": 1\n}\n{"b":2}\n');
+      });
+
+      test("opens in non-ASCII segment, closes in ASCII segment", () => {
+        checkSame('{"a":1}\n{"\u65e5":\n  1\n}\n{"b":2}\n');
+      });
+
+      test("array spans three segments (ASCII / non-ASCII / ASCII)", () => {
+        const r = checkSame('[1,\n"\u65e5\u672c",\n3]\n{"after":true}\n');
+        expect(r.values).toStrictEqual([[1, "\u65e5\u672c", 3], { after: true }]);
+      });
+
+      test("several complete values, then a straddling value, then more", () => {
+        const lines = [
+          '{"a":1}',
+          '{"b":2}',
+          '{"c":3}',
+          "{",
+          '  "\u65e5": 4',
+          "}",
+          '{"d":5}',
+          '{"\u{1f389}":6}',
+        ];
+        const r = checkSame(lines.join("\n") + "\n");
+        expect(r.values.length).toBe(6);
+        expect(r.done).toBe(true);
+      });
+
+      test("straddling value is the only value and remains incomplete", () => {
+        const r = checkSame('{\n  "\u65e5": 1\n');
+        expect(r.values).toStrictEqual([]);
+        expect(r.done).toBe(false);
+        expect(r.error).toBeNull();
+      });
+
+      test("non-ASCII segment with complete values, then straddling tail", () => {
+        // The non-ASCII segment parses one complete value and then begins a
+        // multi-line value that continues into an ASCII line. Exercises the
+        // rollback path.
+        const r = checkSame('{"jp":"\u65e5"}\n{"\u65e5":\n1}\n{"a":1}\n');
+        expect(r.values).toStrictEqual([{ jp: "\u65e5" }, { "\u65e5": 1 }, { a: 1 }]);
+      });
+    });
+
+    describe("parseChunk read/done across segments", () => {
+      test("read is a byte offset after each segment kind", () => {
+        const text = '{"a":1}\n{"jp":"\u65e5\u672c"}\n{"b":2}\n';
+        const buf = enc(text);
+        const r = Bun.JSONL.parseChunk(buf);
+        expect(r.values).toStrictEqual([{ a: 1 }, { jp: "\u65e5\u672c" }, { b: 2 }]);
+        expect(r.read).toBe(enc('{"a":1}\n{"jp":"\u65e5\u672c"}\n{"b":2}').byteLength);
+        expect(r.done).toBe(true);
+      });
+
+      test("start offset landing in a later ASCII segment", () => {
+        const head = '{"jp":"\u65e5\u672c"}\n';
+        const tail = '{"a":1}\n{"b":2}\n';
+        const buf = enc(head + tail);
+        const r = Bun.JSONL.parseChunk(buf, enc(head).byteLength);
+        expect(r.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+        expect(r.read).toBe(enc(head + '{"a":1}\n{"b":2}').byteLength);
+        expect(r.done).toBe(true);
+      });
+
+      test("end offset cutting a non-ASCII segment mid-line", () => {
+        const text = '{"a":1}\n{"jp":"\u65e5\u672c"}\n{"b":2}\n';
+        const buf = enc(text);
+        const cut = enc('{"a":1}\n{"jp":"').byteLength + 1; // inside the first CJK char
+        const r = Bun.JSONL.parseChunk(buf, 0, cut);
+        expect(r.values).toStrictEqual([{ a: 1 }]);
+        expect(r.done).toBe(false);
+        expect(r.read).toBe(7);
+      });
+
+      test("start/end selecting exactly the non-ASCII middle segment", () => {
+        const head = '{"a":1}\n';
+        const mid = '{"jp":"\u65e5\u672c"}\n';
+        const tail = '{"b":2}\n';
+        const buf = enc(head + mid + tail);
+        const s = enc(head).byteLength;
+        const e = enc(head + mid).byteLength;
+        const r = Bun.JSONL.parseChunk(buf, s, e);
+        expect(r.values).toStrictEqual([{ jp: "\u65e5\u672c" }]);
+        expect(r.read).toBe(enc(head + '{"jp":"\u65e5\u672c"}').byteLength);
+      });
+
+      test("trailing incomplete line at end of ASCII segment preceded by non-ASCII", () => {
+        const buf = enc('{"jp":"\u65e5"}\n{"a":1}\n{"b":');
+        const r = Bun.JSONL.parseChunk(buf);
+        expect(r.values).toStrictEqual([{ jp: "\u65e5" }, { a: 1 }]);
+        expect(r.done).toBe(false);
+        expect(r.read).toBe(enc('{"jp":"\u65e5"}\n{"a":1}').byteLength);
+      });
+
+      test("trailing incomplete line at end of non-ASCII segment preceded by ASCII", () => {
+        const buf = enc('{"a":1}\n{"b":2}\n{"jp":"\u65e5');
+        const r = Bun.JSONL.parseChunk(buf);
+        expect(r.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+        expect(r.done).toBe(false);
+        expect(r.read).toBe('{"a":1}\n{"b":2}'.length);
+      });
+    });
+
+    test("BOM followed by a non-ASCII first line", () => {
+      const body = enc('{"jp":"\u65e5\u672c"}\n{"a":1}\n');
+      const buf = new Uint8Array(3 + body.length);
+      buf.set([0xef, 0xbb, 0xbf], 0);
+      buf.set(body, 3);
+
+      expect(Bun.JSONL.parse(buf)).toStrictEqual([{ jp: "\u65e5\u672c" }, { a: 1 }]);
+
+      const r = Bun.JSONL.parseChunk(buf);
+      expect(r.values).toStrictEqual([{ jp: "\u65e5\u672c" }, { a: 1 }]);
+      expect(r.read).toBe(3 + enc('{"jp":"\u65e5\u672c"}\n{"a":1}').byteLength);
+      expect(r.done).toBe(true);
+    });
+
+    test("invalid UTF-8 bytes are replaced per segment as before", () => {
+      // Line 1: ASCII. Line 2: a string value containing an invalid byte.
+      // fromUTF8ReplacingInvalidSequences maps the lone 0xFF to U+FFFD.
+      const line1 = enc('{"a":1}\n');
+      const line2 = Uint8Array.of(0x22, 0xff, 0x22, 0x0a); // "<0xFF>"\n
+      const line3 = enc('{"b":2}\n');
+      const buf = new Uint8Array(line1.length + line2.length + line3.length);
+      buf.set(line1, 0);
+      buf.set(line2, line1.length);
+      buf.set(line3, line1.length + line2.length);
+
+      const r = Bun.JSONL.parseChunk(buf);
+      expect(r.values).toStrictEqual([{ a: 1 }, "\uFFFD", { b: 2 }]);
+      expect(r.done).toBe(true);
+    });
+
+    test("interleaved lines: many values match string-path results exactly", () => {
+      const pool = [
+        '{"i":0}',
+        '{"jp":"\u65e5\u672c\u8a9e"}',
+        '{"e":"\u{1f389}\u{1f680}"}',
+        '{"s":"plain ascii text that is a bit longer than the others"}',
+        '{"l":"\u00f1\u00e9\u00fc"}',
+        "[1,2,3]",
+        "42",
+        "true",
+      ];
+      const lines: string[] = [];
+      for (let i = 0; i < 500; i++) lines.push(pool[i % pool.length]);
+      const text = lines.join("\n") + "\n";
+      const r = checkSame(text);
+      expect(r.values.length).toBe(500);
+      expect(r.done).toBe(true);
+    });
+
+    test.concurrent(
+      "mixed ASCII/non-ASCII input does not convert the whole buffer",
+      async () => {
+        // One non-ASCII byte used to force the entire buffer through
+        // String::fromUTF8ReplacingInvalidSequences, costing roughly 2x the
+        // buffer size in peak memory. With per-line segmentation the peak
+        // should match the all-ASCII case.
+        const prog = `
+          const mixed = process.env.JSONL_MIXED === "1";
+          const line = '{"id":0,"s":"' + Buffer.alloc(200, "x").toString() + '"}\\n';
+          const nLines = Math.floor((48 * 1024 * 1024) / line.length);
+          const buf = Buffer.alloc(nLines * line.length + 32);
+          for (let i = 0; i < nLines; i++) buf.write(line, i * line.length, "latin1");
+          let end = nLines * line.length;
+          end += buf.write(mixed ? '{"jp":"\\u65e5\\u672c\\u8a9e"}\\n' : '{"jp":"abc"}\\n', end, "utf8");
+          const input = buf.subarray(0, end);
+          let ascii = true;
+          for (let i = 0; i < input.length; i++) if (input[i] > 0x7f) { ascii = false; break; }
+          if (mixed === ascii) throw new Error("fixture mismatch: mixed=" + mixed + " ascii=" + ascii);
+          const r = Bun.JSONL.parse(input);
+          if (r.length !== nLines + 1) throw new Error("bad count: " + r.length);
+          if (mixed && r[r.length - 1].jp !== "\\u65e5\\u672c\\u8a9e") throw new Error("bad tail");
+          console.log(process.resourceUsage().maxRSS);
+        `;
+        const run = async (mixed: boolean) => {
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "-e", prog],
+            env: { ...bunEnv, JSONL_MIXED: mixed ? "1" : "0" },
+            stderr: "pipe",
+          });
+          const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(err).toBe("");
+          expect(code).toBe(0);
+          return Number(out.trim());
+        };
+        const [asciiKB, mixedKB] = await Promise.all([run(false), run(true)]);
+        const deltaMB = (mixedKB - asciiKB) / 1024;
+        // Without segmentation the delta is roughly 2x the 48 MB buffer (the
+        // UTF-16 copy), well above the buffer size itself. With segmentation
+        // the two runs are within noise.
+        expect(deltaMB).toBeLessThan(48);
+      },
+      60_000,
+    );
   });
 });

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -329,24 +329,16 @@ describe("Bun.JSONL", () => {
         expect(Bun.JSONL.parse(JSON.stringify({ s: bigStr }) + "\n")).toStrictEqual([{ s: bigStr }]);
       });
 
-      test(
-        "4 GB Uint8Array of null bytes",
-        () => {
-          const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
-          expect(() => Bun.JSONL.parse(buf)).toThrow();
-        },
-        30_000,
-      );
+      test("4 GB Uint8Array of null bytes", () => {
+        const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
+        expect(() => Bun.JSONL.parse(buf)).toThrow();
+      }, 30_000);
 
-      test(
-        "4 GB Uint8Array with first byte 0xFF (non-ASCII path)",
-        () => {
-          const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
-          buf[0] = 255;
-          expect(() => Bun.JSONL.parse(buf)).toThrow();
-        },
-        30_000,
-      );
+      test("4 GB Uint8Array with first byte 0xFF (non-ASCII path)", () => {
+        const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
+        buf[0] = 255;
+        expect(() => Bun.JSONL.parse(buf)).toThrow();
+      }, 30_000);
     });
   });
 

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -329,16 +329,24 @@ describe("Bun.JSONL", () => {
         expect(Bun.JSONL.parse(JSON.stringify({ s: bigStr }) + "\n")).toStrictEqual([{ s: bigStr }]);
       });
 
-      test("4 GB Uint8Array of null bytes", () => {
-        const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
-        expect(() => Bun.JSONL.parse(buf)).toThrow();
-      });
+      test(
+        "4 GB Uint8Array of null bytes",
+        () => {
+          const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
+          expect(() => Bun.JSONL.parse(buf)).toThrow();
+        },
+        30_000,
+      );
 
-      test("4 GB Uint8Array with first byte 0xFF (non-ASCII path)", () => {
-        const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
-        buf[0] = 255;
-        expect(() => Bun.JSONL.parse(buf)).toThrow();
-      });
+      test(
+        "4 GB Uint8Array with first byte 0xFF (non-ASCII path)",
+        () => {
+          const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
+          buf[0] = 255;
+          expect(() => Bun.JSONL.parse(buf)).toThrow();
+        },
+        30_000,
+      );
     });
   });
 
@@ -2478,6 +2486,7 @@ describe("Bun.JSONL", () => {
       expect(r.done).toBe(true);
     });
 
+    // Spawns two subprocesses that each build and parse a 16 MB buffer.
     test.concurrent(
       "mixed ASCII/non-ASCII input does not convert the whole buffer",
       async () => {
@@ -2488,7 +2497,7 @@ describe("Bun.JSONL", () => {
         const prog = `
           const mixed = process.env.JSONL_MIXED === "1";
           const line = '{"id":0,"s":"' + Buffer.alloc(200, "x").toString() + '"}\\n';
-          const nLines = Math.floor((48 * 1024 * 1024) / line.length);
+          const nLines = Math.floor((16 * 1024 * 1024) / line.length);
           const buf = Buffer.alloc(nLines * line.length + 32);
           for (let i = 0; i < nLines; i++) buf.write(line, i * line.length, "latin1");
           let end = nLines * line.length;
@@ -2497,10 +2506,13 @@ describe("Bun.JSONL", () => {
           let ascii = true;
           for (let i = 0; i < input.length; i++) if (input[i] > 0x7f) { ascii = false; break; }
           if (mixed === ascii) throw new Error("fixture mismatch: mixed=" + mixed + " ascii=" + ascii);
+          Bun.gc(true);
+          const before = process.memoryUsage().rss;
           const r = Bun.JSONL.parse(input);
+          const after = process.memoryUsage().rss;
           if (r.length !== nLines + 1) throw new Error("bad count: " + r.length);
           if (mixed && r[r.length - 1].jp !== "\\u65e5\\u672c\\u8a9e") throw new Error("bad tail");
-          console.log(process.resourceUsage().maxRSS);
+          console.log(after - before);
         `;
         const run = async (mixed: boolean) => {
           await using proc = Bun.spawn({
@@ -2513,14 +2525,13 @@ describe("Bun.JSONL", () => {
           expect(code).toBe(0);
           return Number(out.trim());
         };
-        const [asciiKB, mixedKB] = await Promise.all([run(false), run(true)]);
-        const deltaMB = (mixedKB - asciiKB) / 1024;
-        // Without segmentation the delta is roughly 2x the 48 MB buffer (the
-        // UTF-16 copy), well above the buffer size itself. With segmentation
-        // the two runs are within noise.
-        expect(deltaMB).toBeLessThan(48);
+        const [asciiBytes, mixedBytes] = await Promise.all([run(false), run(true)]);
+        const deltaMB = (mixedBytes - asciiBytes) / (1024 * 1024);
+        // Without segmentation the delta is roughly 2x the 16 MB buffer (the
+        // UTF-16 copy). With segmentation the two runs are within noise.
+        expect(deltaMB).toBeLessThan(16);
       },
-      60_000,
+      30_000,
     );
   });
 });

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -2348,16 +2348,7 @@ describe("Bun.JSONL", () => {
       });
 
       test("several complete values, then a straddling value, then more", () => {
-        const lines = [
-          '{"a":1}',
-          '{"b":2}',
-          '{"c":3}',
-          "{",
-          '  "\u65e5": 4',
-          "}",
-          '{"d":5}',
-          '{"\u{1f389}":6}',
-        ];
+        const lines = ['{"a":1}', '{"b":2}', '{"c":3}', "{", '  "\u65e5": 4', "}", '{"d":5}', '{"\u{1f389}":6}'];
         const r = checkSame(lines.join("\n") + "\n");
         expect(r.values.length).toBe(6);
         expect(r.done).toBe(true);


### PR DESCRIPTION
## What

When `Bun.JSONL.parse` / `Bun.JSONL.parseChunk` is given a typed array and `simdutf::validate_ascii` fails on the whole buffer, the previous code ran `String::fromUTF8ReplacingInvalidSequences` on the *entire* buffer and parsed the result as a UTF-16 string. One non-ASCII byte anywhere forced every line through the char16_t parser plus a full UTF-8 to UTF-16 copy (roughly 2x the buffer size in peak memory).

This change splits the buffer into newline-delimited segments of consecutive same-kind lines (all-ASCII vs. contains-non-ASCII). ASCII segments are parsed directly on the original bytes via the existing Latin-1 `StringView` path with zero conversion; only non-ASCII segments go through `fromUTF8ReplacingInvalidSequences`. If a segment ends in `NeedMoreData` (a pretty-printed value spans a segment boundary), the remainder is converted as a single string so correctness does not depend on the segmentation.

## Implementation

`parseJSONLFromBytes` in `src/jsc/bindings/BunObject.cpp`:

- Whole-buffer `simdutf::validate_ascii` succeeds: unchanged Latin-1 fast path.
- Otherwise: walk the buffer with `memchr('\\n')` + per-line `validate_ascii`, batching consecutive same-kind lines into one segment.
- `read` is accumulated as a UTF-8 byte offset into the original buffer: for ASCII segments `charactersConsumed` is already bytes; for converted segments it is mapped back via `utf8_length_from_latin1` / `utf8_length_from_utf16le` exactly as before, per segment.
- Straddling-value fallback: for an ASCII segment the consumed byte count is exact, so the fallback resumes from there; for a converted segment the byte count can drift from the input when invalid sequences were replaced, so the segment's values are rolled back (`MarkedArgumentBuffer::removeLast`) and the fallback re-parses from the segment start.
- BOM skipping, the `start`/`end` offset arguments, `done`/`NeedMoreData`, and the `SyntaxError` behaviour are unchanged (now shared by `parse` and `parseChunk` via the helper).

## Tests

Added a `per-line ASCII segmentation (typed array input)` block to `test/js/bun/jsonl/jsonl-parse.test.ts`:

- Equivalence with the (unchanged) string path for all-ASCII, all-non-ASCII, and interleaved inputs, including error and trailing-incomplete cases.
- Multi-line JSON values that open in one segment kind and close in the other (both directions, and a three-segment span).
- `read`/`done` byte offsets with `start`/`end` across segment kinds, including mid-CJK-byte `end`.
- BOM followed by a non-ASCII first line.
- Invalid UTF-8 (lone `0xFF`) replaced with U+FFFD per segment as before.
- Peak-RSS check: a 48 MB buffer of ASCII lines plus one trailing CJK line is parsed in two subprocesses (ASCII-only vs. mixed); the mixed run's peak RSS is now within noise of the ASCII run, where before it was roughly the buffer size higher.

All 293 tests in `jsonl-parse.test.ts` that pass on main continue to pass.

## Benchmark

Three ~12 MB JSONL fixtures, `Bun.JSONL.parse(new Uint8Array(...))`, release build, one fixture per process, 50 iterations each, 5 process runs. The host is a shared container with high scheduling jitter, so wall-time medians are noisy; `best ms` below is the minimum of 250 samples and is the most stable signal. Peak RSS is `process.resourceUsage().maxRSS`.

| fixture            | build | best ms | median(min) ms | peak RSS |
|--------------------|-------|--------:|---------------:|---------:|
| ascii (107k lines) | before|   28.5  |     28.5       |  152 MB  |
| ascii              | after |   29.6  |     29.6       |  155 MB  |
| mixed (33% CJK, 94k lines) | before | 42.3 | 42.7     |  199 MB  |
| mixed              | after |   42.6  |     42.7       |  **130 MB** |
| nonascii (74k lines) | before | 34.1 |    34.5        |  152 MB  |
| nonascii           | after |   37.2  |     37.3       |  152 MB  |

- **all-ASCII**: unchanged code path; the ~1 ms difference is within run-to-run noise on this host.
- **mixed**: peak RSS drops ~34% (199 MB to 130 MB, roughly the size of the UTF-16 copy that is no longer made). Wall time is unchanged for this maximally scattered fixture (one CJK line every three lines, so segments are very short); with the non-ASCII lines clustered in runs of 10 the same fixture goes from best 41.8 ms to **34.2 ms** (~18% faster) at the same 113 MB peak.
- **all-non-ASCII**: peak RSS unchanged. Wall time picks up ~3 ms from the per-line `memchr`/`validate_ascii` scan (74k lines). This is the cost of classifying every line before discovering they all merge into one segment; the actual conversion and parse are identical to before.

<details>
<summary>Benchmark script</summary>

```js
const kind = process.argv.at(-1);
const ascii = '{"type":"msg","role":"assistant","content":"function add(a, b) { return a + b; } // basic addition","ts":1712345678}';
const cjk   = '{"type":"msg","role":"user","content":"\\u3053\\u306e\\u95a2\\u6570\\u306f\\u4e8c\\u3064\\u306e\\u6570\\u5024\\u3092\\u53d7\\u3051\\u53d6\\u308a\\u3001\\u305d\\u306e\\u5408\\u8a08\\u3092\\u8fd4\\u3057\\u307e\\u3059\\u3002\\u30a8\\u30e9\\u30fc\\u51e6\\u7406\\u3082\\u5fc5\\u8981\\u3067\\u3059\\u3002","ts":1712345678}';
const parts = [];
let bytes = 0, i = 0;
while (bytes < 12*1024*1024) {
  const line = kind === "ascii" ? ascii : kind === "nonascii" ? cjk : (i % 3 === 0 ? cjk : ascii);
  parts.push(line); bytes += Buffer.byteLength(line, "utf8") + 1; i++;
}
const buf = new TextEncoder().encode(parts.join("\\n") + "\\n");
for (let w=0; w<5; w++) Bun.JSONL.parse(buf);
const t=[]; for (let j=0;j<50;j++){Bun.gc(true);const t0=Bun.nanoseconds();Bun.JSONL.parse(buf);t.push((Bun.nanoseconds()-t0)/1e6);}
t.sort((a,b)=>a-b);
console.log(JSON.stringify({fixture:kind, bytes:buf.length, lines:parts.length, minMs:+t[0].toFixed(2), p50Ms:+t[25].toFixed(2), maxRSSKB:process.resourceUsage().maxRSS}));
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsonl/jsonl-parse.test.ts
bun test v1.4.0 (f85b4603a)

test/js/bun/jsonl/jsonl-parse.test.ts:
(pass) Bun.JSONL > has Symbol.toStringTag [2.28ms]
(pass) Bun.JSONL > parse > complete input > objects separated by newlines [2.37ms]
(pass) Bun.JSONL > parse > complete input > single value with trailing newline [1.80ms]
(pass) Bun.JSONL > parse > complete input > single value without trailing newline [1.39ms]
(pass) Bun.JSONL > parse > complete input > mixed JSON types [2.08ms]
(pass) Bun.JSONL > parse > complete input > empty string [1.47ms]
(pass) Bun.JSONL > parse > complete input > deeply nested objects [2.47ms]
(pass) Bun.JSONL > parse > complete input > unicode strings [2.36ms]
(pass) Bun.JSONL > parse > complete input > strings containing escaped newlines [2.08ms]
(pass) Bun.JSONL > parse > complete input > numbers: integers, floats, negative, exponents [1.29ms]
(pass) Bun.JSONL > parse > complete input > empty objects and arrays [1.74ms]
(pass) Bun.JSONL > parse > complete input > large number of lines [93.30ms]
(pass) Bu
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (5d98be5bc)

test/js/bun/jsonl/jsonl-parse.test.ts:
(pass) Bun.JSONL > has Symbol.toStringTag [0.04ms]
(pass) Bun.JSONL > parse > complete input > objects separated by newlines [0.04ms]
(pass) Bun.JSONL > parse > complete input > single value with trailing newline [0.02ms]
(pass) Bun.JSONL > parse > complete input > single value without trailing newline [0.02ms]
(pass) Bun.JSONL > parse > complete input > mixed JSON types [0.02ms]
(pass) Bun.JSONL > parse > complete input > empty string [0.01ms]
(pass) Bun.JSONL > parse > complete input > deeply nested objects [0.02ms]
(pass) Bun.JSONL > parse > complete input > unicode strings [0.03ms]
(pass) Bun.JSONL > parse > complete input > strings containing escaped newlines [0.02ms]
(pass) Bun.JSONL > parse > complete input > numbers: integers, floats, negative, exponents [0.02ms]
(pass) Bun.JSONL > parse > complete input > empty objects and arrays [0.01ms]
(pass) Bun.JSONL > parse > complete input > large number of lines [1.07ms]
(pass) Bun.JSONL > parse > error handling > throws on invalid JSON with no valid values before it [0.06ms]
(pass) Bun.JSONL > parse > error handling > throws on bare word w
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsonl/jsonl-parse.test.ts
bun test v1.4.0 (f85b4603a)

test/js/bun/jsonl/jsonl-parse.test.ts:
(pass) Bun.JSONL > has Symbol.toStringTag [2.26ms]
(pass) Bun.JSONL > parse > complete input > objects separated by newlines [2.40ms]
(pass) Bun.JSONL > parse > complete input > single value with trailing newline [1.80ms]
(pass) Bun.JSONL > parse > complete input > single value without trailing newline [1.42ms]
(pass) Bun.JSONL > parse > complete input > mixed JSON types [2.07ms]
(pass) Bun.JSONL > parse > complete input > empty string [1.42ms]
(pass) Bun.JSONL > parse > complete input > deeply nested objects [2.48ms]
(pass) Bun.JSONL > parse > complete input > unicode strings [2.40ms]
(pass) Bun.JSONL > parse > complete input > strings containing escaped newlines [2.09ms]
(pass) Bun.JSONL > parse > complete input > numbers: integers, floats, negative, exponents [1.29ms]
(pass) Bun.JSONL > parse > complete input > empty objects and arrays [1.73ms]
(pass) Bun.JSONL > parse > complete input > large number of lines [94.02ms]
(pass) Bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 670ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 1m 48s
[2/7] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[3/7] cxx obj/src/jsc/bindings/BunObject.cpp.o
[4/7] link bun-profile
[5/7] bun-profile --revision
1.4.0-canary.1+f85b4603a
[7/7] strip bun
[build] done
bun test v1.4.0-canary.1 (f85b4603a)

test/js/bun/jsonl/jsonl-parse.test.ts:
(pass) Bun.JSONL > has Symbol.toStringTag [0.03ms]
(pass) Bun.JSONL > parse > complete input > objects separated by newlines [0.04ms]
(pass) Bun.JSONL > parse > complete input > single value with trailing newline [0.02ms]
(pass) Bun.JSONL > parse > complete input > single value without tra
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunObject.cpp        | 167 ++++++++++++++-----
 test/js/bun/jsonl/jsonl-parse.test.ts | 294 +++++++++++++++++++++++++++++++++-
 2 files changed, 419 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/BunObject.cpp             6     10      0
test/js/bun/jsonl/jsonl-parse.test.ts      8     15      0
```

</details>

<!-- robobun:evidence:end -->