### PR TITLE
test(s3): retry R2 tests on transient ServiceUnavailable

### DIFF
--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1,12 +1,33 @@
 import type { S3Options } from "bun";
 import { S3Client, s3 as defaultS3, file, randomUUIDv7 } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it as bunIt } from "bun:test";
+import type { TestOptions } from "bun:test";
 import child_process from "child_process";
 import { randomUUID } from "crypto";
 import { bunEnv, bunExe, dockerExe, getSecret, isCI, isDockerEnabled, tempDirWithFiles } from "harness";
 import path from "path";
 const s3 = (...args) => defaultS3.file(...args);
 const S3 = (...args) => new S3Client(...args);
+
+// The R2 suite talks to a live Cloudflare endpoint which intermittently answers
+// 503 ServiceUnavailable / InternalError (the error body literally points at
+// cloudflarestatus.com). ~130 tests fire concurrently, so a brief outage reds
+// whichever few are in flight. MinIO (docker) runs the same suite without the
+// external dependency and keeps retry=0, so a real S3 regression still fails
+// there. For R2 only, let bun:test retry a failed test a few times so a
+// transient outage does not fail the lane.
+const it = bunIt;
+function itForService(service: string): typeof bunIt {
+  if (service !== "R2") return bunIt;
+  const withRetry = (opts?: number | TestOptions): TestOptions =>
+    typeof opts === "number" ? { timeout: opts, retry: 3 } : { retry: 3, ...opts };
+  const wrap = (base: typeof bunIt): typeof bunIt => {
+    const w = ((label: string, fn?: any, opts?: number | TestOptions) => base(label, fn, withRetry(opts))) as typeof bunIt;
+    w.skipIf = cond => wrap(base.skipIf(cond));
+    return w;
+  };
+  return wrap(bunIt);
+}
 
 // Import docker-compose helper
 import * as dockerCompose from "../../../docker/index.ts";
@@ -59,6 +80,7 @@ describe.concurrent.skipIf(!r2Credentials.endpoint && !isCI)("Virtual Hosted-Sty
   if (!r2Credentials.endpoint) {
     return;
   }
+  const it = itForService("R2");
   const r2Url = new URL(r2Credentials.endpoint);
   // R2 do support virtual hosted style lets use it
   r2Url.hostname = `${r2Credentials.bucket}.${r2Url.hostname}`;
@@ -178,6 +200,7 @@ describe.concurrent.skipIf(!r2Credentials.endpoint && !isCI)("Virtual Hosted-Sty
 });
 for (let credentials of allCredentials) {
   describe.concurrent(`${credentials.service}`, () => {
+    const it = itForService(credentials.service);
     const s3Options: S3Options = {
       accessKeyId: credentials.accessKeyId,
       secretAccessKey: credentials.secretAccessKey,

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -16,11 +16,19 @@ const S3 = (...args) => new S3Client(...args);
 // external dependency and keeps retry=0, so a real S3 regression still fails
 // there. For R2 only, let bun:test retry a failed test a few times so a
 // transient outage does not fail the lane.
+//
+// Large-transfer tests pass an explicit timeout above 30s. Those stay at
+// retry=0 because 4 x 100s would exceed the 180s per-file CI wall in
+// scripts/runner.node.mjs and SIGTERM the whole file; the 503 flake was
+// observed on the small/fast requests, and the slow-transfer timeouts are
+// covered by #35057.
 const it = bunIt;
 function itForService(service: string): typeof bunIt {
   if (service !== "R2") return bunIt;
-  const withRetry = (opts?: number | TestOptions): TestOptions =>
-    typeof opts === "number" ? { timeout: opts, retry: 3 } : { retry: 3, ...opts };
+  const withRetry = (opts?: number | TestOptions): number | TestOptions | undefined => {
+    if (typeof opts === "number") return opts > 30_000 ? opts : { timeout: opts, retry: 3 };
+    return { retry: 3, ...opts };
+  };
   const wrap = (base: typeof bunIt): typeof bunIt => {
     const w = ((label: string, fn?: any, opts?: number | TestOptions) =>
       base(label, fn, withRetry(opts))) as typeof bunIt;

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1,7 +1,7 @@
 import type { S3Options } from "bun";
 import { S3Client, s3 as defaultS3, file, randomUUIDv7 } from "bun";
-import { describe, expect, it as bunIt } from "bun:test";
 import type { TestOptions } from "bun:test";
+import { it as bunIt, describe, expect } from "bun:test";
 import child_process from "child_process";
 import { randomUUID } from "crypto";
 import { bunEnv, bunExe, dockerExe, getSecret, isCI, isDockerEnabled, tempDirWithFiles } from "harness";
@@ -22,7 +22,8 @@ function itForService(service: string): typeof bunIt {
   const withRetry = (opts?: number | TestOptions): TestOptions =>
     typeof opts === "number" ? { timeout: opts, retry: 3 } : { retry: 3, ...opts };
   const wrap = (base: typeof bunIt): typeof bunIt => {
-    const w = ((label: string, fn?: any, opts?: number | TestOptions) => base(label, fn, withRetry(opts))) as typeof bunIt;
+    const w = ((label: string, fn?: any, opts?: number | TestOptions) =>
+      base(label, fn, withRetry(opts))) as typeof bunIt;
     w.skipIf = cond => wrap(base.skipIf(cond));
     return w;
   };

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1818,7 +1818,9 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The S3 client reads HTTP_PROXY from the environment without a target host, so NO_PROXY never
+      // exempts the localhost endpoint. Strip proxy vars so this test is independent of ambient config.
+      env: { ...bunEnv, HTTP_PROXY: undefined, http_proxy: undefined, HTTPS_PROXY: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
Deflakes `test/js/bun/s3/s3.test.ts` for the case where Cloudflare R2 briefly returns `ServiceUnavailable` / `InternalError`.

## What happened

```
S3Error: Please look at https://www.cloudflarestatus.com for issues or contact customer support.
 code: "ServiceUnavailable"

✗ R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-disposition [10930.09ms]
```

Seen across at least seven unrelated builds: 78962, 78968, 80830, 80971, 81977, 82230, 82231. In each case ~130 R2 tests run concurrently; one to four of them happen to be in flight during a brief R2 blip, fail on `ServiceUnavailable` / `InternalError` / `503`, and the lane goes red on every retry because each retry hits a fresh blip somewhere in the batch.

Bun's S3 `retry` option only covers uploads and has no backoff; downloads / `stat` / `delete` do not retry at all. That is documented behaviour and outside the scope of this deflake.

## Fix

Inside the two R2-backed `describe` blocks (`Virtual Hosted-Style` and the per-service loop when `service === "R2"`), shadow `it` with a wrapper that passes `{retry: 3}` to `bun:test`. Any existing timeout number is preserved as `{timeout, retry: 3}`; `it.skipIf` is re-wrapped so the two `skipIf` call sites keep working.

Tests that pass a numeric timeout above 30 000 ms (the 50_000 / 100_000 ms large-transfer tests) keep `retry=0`. With `retry: 3` a 100 s per-attempt timeout could hold the file open for 400 s against the 180 s per-file wall in `scripts/runner.node.mjs` and SIGTERM the whole file. Those slow-transfer timeouts are covered by #35057; this PR targets the fast requests where 503 was actually observed.

For every other backend (`MinIO`), `itForService` returns the real `it` unchanged, so those tests keep `retry=0`.

## Why this is correct

- The failure is external: the error body literally says "look at cloudflarestatus.com", and the same request succeeds moments later.
- MinIO (docker) runs **the same** test bodies against a local server without `retry`. A real S3 regression would still fail there on the first attempt, so the retry cannot mask a Bun bug.
- A retry re-runs the whole test body: each one creates a fresh `randomUUID()` object key, so attempts are independent and idempotent.
- Cost is bounded to the tests that fail: healthy R2 adds zero extra work, and a real bug costs three extra attempts before failing.

No `src/` changes. Related to but distinct from #35057, which addresses R2 large-upload timeouts rather than 503s.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/s3/s3.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/s3/s3.test.ts"
bun test v1.4.0 (269d3fdb9)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key does not exist
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-type
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-disposition
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-disposition in writer
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-encoding
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-encoding in writer
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to upload large files using bucket.write + readable Request
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to upload large files in one go using bucket.write
(skip) R2 > s3 > Bun.S3Client > bucke
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/s3/s3.test.ts | 38 ++++++++++++++++++++++++++++++++++++--
 1 file changed, 36 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                       reads  edits  tests
test/js/bun/s3/s3.test.ts      6      6      0
```

</details>

<!-- robobun:evidence:end -->