### PR TITLE
Intl.Locale: stop leaking ICU's "yes" sentinel from keyword getters

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-351-d568d3ad";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-351-d568d3ad";
+export const WEBKIT_VERSION = "autobuild-preview-pr-351-5b1aa0ae";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -223,6 +223,53 @@ describe("URL IDNA", () => {
   });
 });
 
+describe("Intl.Locale", () => {
+  // A -u- keyword written without a type has the implied value "true" (UTS #35
+  // §3.6.1), and -xx-true canonicalizes to -xx. The getters must expose that
+  // value, not ICU's internal "yes" sentinel that uloc_forLanguageTag stores.
+  // caseFirst is the lone outlier: "true" is not in its value set
+  // {"upper","lower","false"}, so it surfaces as "" (matches V8 and test262).
+  test("keyword getters normalize the no-type sentinel to 'true' (caseFirst: '')", () => {
+    const keys = [
+      ["ca", "calendar"],
+      ["co", "collation"],
+      ["hc", "hourCycle"],
+      ["nu", "numberingSystem"],
+      ["fw", "firstDayOfWeek"],
+    ] as const;
+    const probe = (tag: string) =>
+      Object.fromEntries([["kf", "caseFirst"] as const, ...keys].map(([, g]) => [g, (new Intl.Locale(tag) as any)[g]]));
+
+    for (const suffix of ["", "-true", "-yes"]) {
+      const tag = "en-u" + [["kf", ""] as const, ...keys].map(([k]) => `-${k}${suffix}`).join("");
+      expect({ [suffix || "(bare)"]: probe(tag) }).toEqual({
+        [suffix || "(bare)"]: {
+          caseFirst: "",
+          calendar: "true",
+          collation: "true",
+          hourCycle: "true",
+          numberingSystem: "true",
+          firstDayOfWeek: "true",
+        },
+      });
+    }
+
+    // Real values and false must be unaffected.
+    expect(new Intl.Locale("en-u-kf-upper").caseFirst).toBe("upper");
+    expect(new Intl.Locale("en-u-kf-false").caseFirst).toBe("false");
+    expect(new Intl.Locale("en-u-ca-gregory").calendar).toBe("gregory");
+  });
+
+  test("keyword getters survive a toString() round-trip", () => {
+    for (const tag of ["en-u-ca-co-fw-hc-kf-nu", "en-u-kf-true", "en-u-ca-gregory-kf-upper"]) {
+      const a = new Intl.Locale(tag);
+      const b = new Intl.Locale(a.toString());
+      for (const g of ["calendar", "caseFirst", "collation", "firstDayOfWeek", "hourCycle", "numberingSystem"] as const)
+        expect({ tag, [g]: (b as any)[g] }).toEqual({ tag, [g]: (a as any)[g] });
+    }
+  });
+});
+
 describe("Intl.getCanonicalLocales", () => {
   test("deprecated BCP-47 tags map to modern equivalents", () => {
     // ICU ships .res bundles under the deprecated tag names; canonicalization


### PR DESCRIPTION
Depends on oven-sh/WebKit#351 (the actual fix lives in `JSC::IntlLocale::keywordValue`).

### What does this PR do?

`Intl.Locale` keyword getters leak ICU's internal `"yes"` sentinel when a `-u-` key is spelled without a value:

```js
new Intl.Locale("en-u-kf").caseFirst   // "yes"  (want "")
new Intl.Locale("en-u-ca").calendar    // "yes"  (want "true")
new Intl.Locale("en-u-co").collation   // "yes"  (want "true")
```

`"en-u-kf"` and `"en-u-kf-true"` are the same canonical tag (`toString()` confirms), yet `caseFirst` returns `""` for the latter and `"yes"` for the former, so `new Intl.Locale(String(loc)).caseFirst !== loc.caseFirst`.

#### Cause

`uloc_forLanguageTag("en-u-ca")` → `"en@calendar=yes"`: ICU stores a keyword-without-type as the sentinel `"yes"`. `uloc_toUnicodeLocaleType` then passes `"yes"` through unchanged (it is a syntactically valid 3-char type not present in any key's type map), and the existing `result == "true"_s` guard never fires. That guard is also too broad: it maps `"true"` → `""` for every key, so `new Intl.Locale("en-u-ca-true").calendar` returns `""` where Node returns `"true"`.

#### Fix (in oven-sh/WebKit#351)

Normalize `"yes"` → `"true"` after `uloc_toUnicodeLocaleType`, and restrict the `"true"` → `""` mapping to `colcasefirst` (whose value set is `{upper, lower, false}`). Matches V8's `UnicodeKeywordValue` exactly.

#### This PR

- `scripts/build/deps/webkit.ts`: bump `WEBKIT_VERSION` to the preview build of oven-sh/WebKit#351. **Before merge** this should be replaced with the post-merge main autobuild sha.
- `test/js/web/intl/intl.test.ts`: adds an `Intl.Locale` block covering `ca`/`co`/`fw`/`hc`/`kf`/`nu` across the bare / `-true` / `-yes` spellings, plus real values (`gregory`, `upper`, `false`) and the `toString()` round-trip.

### How did you verify your code works?

Built locally against a JSC with the patched `IntlLocale.cpp`:

```
(pass) Intl.Locale > keyword getters normalize the no-type sentinel to 'true' (caseFirst: '')
(pass) Intl.Locale > keyword getters survive a toString() round-trip
```

Same test fails on stock bun with `"yes"` for every getter. Spot-checked 26 tag/getter pairs against Node v26.3.0; all match.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->