### PR TITLE
fetch: reject a redirect that has multiple distinct Location headers

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -73,6 +73,8 @@ pub enum Error {
     InvalidRedirectURL,
     #[error("UnexpectedRedirect")]
     UnexpectedRedirect,
+    #[error("MultipleLocationHeaders")]
+    MultipleLocationHeaders,
     #[error("ShortRead")]
     ShortRead,
     #[error("WantRead")]
@@ -296,6 +298,7 @@ impl Error {
             Self::RedirectURLInvalid => "RedirectURLInvalid",
             Self::InvalidRedirectURL => "InvalidRedirectURL",
             Self::UnexpectedRedirect => "UnexpectedRedirect",
+            Self::MultipleLocationHeaders => "MultipleLocationHeaders",
             Self::ShortRead => "ShortRead",
             Self::WantRead => "WantRead",
             Self::WantWrite => "WantWrite",

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4735,6 +4735,8 @@ impl<'a> HTTPClient<'a> {
         response: &mut picohttp::Response,
     ) -> crate::Result<ShouldContinue> {
         let mut location: &[u8] = b"";
+        let mut location_seen = false;
+        let mut location_conflict = false;
         let mut pretend_304 = false;
         let mut is_server_sent_events = false;
         let mut content_codings: u32 = 0;
@@ -4830,6 +4832,11 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Location") => {
+                    // `Location = URI-reference` is single-valued; byte-identical repeats count as one (as browsers do).
+                    if location_seen && location != header.value() {
+                        location_conflict = true;
+                    }
+                    location_seen = true;
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Connection") => {
@@ -4945,11 +4952,13 @@ impl<'a> HTTPClient<'a> {
         // https://fetch.spec.whatwg.org/#redirect-status
         let is_redirect = matches!(status_code, 301 | 302 | 303 | 307 | 308);
         if is_redirect {
-            if !is_proxy_connect_failure
-                && self.redirect_type == FetchRedirect::Follow
-                && !location.is_empty()
-                && self.remaining_redirect_count > 0
-            {
+            let may_follow =
+                !is_proxy_connect_failure && self.redirect_type == FetchRedirect::Follow;
+            // https://fetch.spec.whatwg.org/#concept-response-location-url: >1 Location ⇒ failure ⇒ network error.
+            if may_follow && location_conflict {
+                return Err(crate::Error::MultipleLocationHeaders);
+            }
+            if may_follow && !location.is_empty() && self.remaining_redirect_count > 0 {
                 // https://fetch.spec.whatwg.org/#http-redirect-fetch step 11:
                 // "If internalResponse's status is not 303, request's body
                 // is non-null, and request's body's source is null, then

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1343,6 +1343,9 @@ impl FetchTasklet {
             http::Error::RedirectURLInvalid => {
                 BunString::static_("Redirect URL in Location header is invalid.")
             }
+            http::Error::MultipleLocationHeaders => BunString::static_(
+                "The redirect response has more than one Location header with different values, so there is no single URL to follow.",
+            ),
 
             http::Error::Cert(http::CertError::UNABLE_TO_GET_ISSUER_CERT) => {
                 BunString::static_("unable to get issuer certificate")

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -146,6 +146,79 @@ it("fetch() with redirect: 'manual' still exposes the 3xx response body", async 
   }
 });
 
+// `Location = URI-reference` is single-valued. Per the Fetch "location URL"
+// algorithm, more than one Location header makes the location a failure and
+// HTTP-redirect fetch returns a network error. Byte-identical repeats are
+// tolerated as one value, as Chromium and Firefox do.
+describe("fetch() with multiple Location header lines on a redirect", () => {
+  async function withServer(locations: string[], fn: (base: string, requests: string[]) => Promise<void>) {
+    const requests: string[] = [];
+    const server = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", chunk => {
+        const path = /^GET (\S+)/.exec(chunk.toString("latin1"))?.[1] ?? "/";
+        requests.push(path);
+        if (path === "/r") {
+          const lines = locations.map(l => `Location: ${l}\r\n`).join("");
+          socket.end(`HTTP/1.1 302 Found\r\n${lines}Content-Length: 0\r\nConnection: close\r\n\r\n`);
+        } else {
+          const body = `hit ${path}`;
+          socket.end(`HTTP/1.1 200 OK\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n${body}`);
+        }
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      await fn(`http://127.0.0.1:${port}`, requests);
+    } finally {
+      server.close();
+    }
+  }
+
+  it.each([
+    ["two relative", ["/first", "/second"]],
+    ["three relative", ["/first", "/second", "/third"]],
+    ["relative then absolute", ["/first", "http://127.0.0.1:1/"]],
+    ["value then empty", ["/first", ""]],
+  ] as const)("redirect: 'follow' rejects distinct values (%s) without re-requesting", async (_name, locations) => {
+    await withServer([...locations], async (base, requests) => {
+      const outcome = await fetch(`${base}/r`).then(
+        res => ({ rejected: false as const, url: res.url }),
+        e => ({ rejected: true as const, code: e.code }),
+      );
+      expect({ outcome, requests }).toEqual({
+        outcome: { rejected: true, code: "MultipleLocationHeaders" },
+        requests: ["/r"],
+      });
+    });
+  });
+
+  it("redirect: 'follow' treats byte-identical repeats as a single Location", async () => {
+    await withServer(["/same", "/same"], async (base, requests) => {
+      const res = await fetch(`${base}/r`);
+      expect({ url: res.url, redirected: res.redirected, body: await res.text(), requests }).toEqual({
+        url: `${base}/same`,
+        redirected: true,
+        body: "hit /same",
+        requests: ["/r", "/same"],
+      });
+    });
+  });
+
+  it("redirect: 'manual' still returns the 3xx with the combined header value", async () => {
+    await withServer(["/first", "/second"], async (base, requests) => {
+      const res = await fetch(`${base}/r`, { redirect: "manual" });
+      await res.arrayBuffer();
+      expect({ status: res.status, location: res.headers.get("location"), requests }).toEqual({
+        status: 302,
+        location: "/first, /second",
+        requests: ["/r"],
+      });
+    });
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/12701
 it("fetch() preserves body on redirect", async () => {
   using server = Bun.serve({


### PR DESCRIPTION
### Problem
- A 301/302/303/307/308 response with more than one `Location` header line redirects to the **last** line. For `Location: /first` plus `Location: /second`, Bun follows `/second`, while `res.headers.get('location')` reads `/first, /second`. The followed URL matches neither the header a `redirect: 'manual'` caller inspects nor any browser.
- The cause is the header loop in `handle_response_metadata` (`src/http/lib.rs:4834`). It did `location = header.value()` on every `Location` line, so only the last line survived.

### Fix
- Under `redirect: 'follow'`, a redirect status whose `Location` lines carry different values now rejects with `code: "MultipleLocationHeaders"` before any follow-up request is sent. Byte-identical repeats count as one value and are followed.
- Correct because `Location` is single-valued (`Location = URI-reference`, RFC 9110 §10.2.2). The Fetch "location URL" algorithm extracts it with "extract header list values", which returns failure for a repeated single-valued header, and HTTP-redirect fetch turns that failure into a network error. Chromium (`ERR_RESPONSE_HEADERS_MULTIPLE_LOCATION`) and Firefox (`NS_ERROR_CORRUPTED_CONTENT`) reject distinct values and tolerate identical repeats, which is the shape used here.
- `redirect: 'manual'` is unchanged: the 3xx is returned and `headers.get('location')` shows the combined value.
- Verified: `test/js/web/fetch/fetch-redirect.test.ts` (6 new cases, 4 fail on canary 1.4.3 f42e98025). All 36 tests in the file pass, plus `fetch-url-after-redirect.test.ts` and the h2 redirect case in `fetch-http2-client.test.ts`.

### Background
- `handle_response_metadata` runs once per response head for HTTP/1.1, h2, and h3. It scans the parsed header list, decides whether to follow a redirect, and rewrites the request URL in place. It is the only reader of `Location` in the client.
- The Fetch header list keeps duplicate field lines. `Headers.get()` joins them with `", "` with no single-value check, so the JS-visible header is correct. Only the internal redirect decision needed the check.
- `http::Error` variants surface to JS as a `TypeError` whose `code` is the variant name. `FetchTasklet.rs` maps a few of them to a friendlier `message`. The new variant gets one.

<details><summary>Notes</summary>

Peer behavior for `302` with `Location: /first` and `Location: /second`:

| | result |
| --- | --- |
| Bun canary 1.4.3 | follows `/second` |
| Node.js 26 / undici | follows `/first,%20/second` (URL-parses the joined value) |
| Chromium 148 | `net::ERR_RESPONSE_HEADERS_MULTIPLE_LOCATION`, fetch rejects. Follows when both lines are byte-identical. |
| Firefox | `NS_ERROR_CORRUPTED_CONTENT` for distinct values, keeps the first when identical (`nsHttpHeaderArray::SetHeaderFromNet`). |
| curl | follows the first |
| this branch | rejects with `MultipleLocationHeaders`. Follows when identical. |

The first revision of this PR followed the joined value like undici. Review pointed out that the Fetch spec makes this case a network error and that the joined value breaks down for mixed inputs: `Location: /a` plus `Location: http://x/` joined to `/a, http://x/`, which the `://` scheme sniffer then rejected as `UnsupportedRedirectProtocol`, and `Location: /a` twice joined to `/a,%20/a`. The spec and browser shape avoids both.

Strictly, the spec text returns failure for any repeat, identical or not. Both major browsers tolerate identical repeats for compatibility (a framework and a proxy that each add the same `Location`), so this does too.

Chromium applies its check at the HTTP parser for every status, including 200. This change is scoped to the redirect-follow decision. A 200 or a `redirect: 'manual'` 3xx with repeated `Location` lines is still delivered as-is.

User-facing error for the repro:

```
TypeError: The redirect response has more than one Location header with different values, so there is no single URL to follow.
  code: "MultipleLocationHeaders"
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch-redirect.test.ts

<!-- robobun:evidence:end -->