### PR TITLE
resolver: accept "#/"-prefixed subpath imports

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4986,10 +4986,11 @@ impl<'a> Resolver<'a> {
         }
         let imports_map = package_json.imports.as_ref().unwrap();
 
-        if import_path.len() == 1 || import_path.starts_with(b"#/") {
+        // PACKAGE_IMPORTS_RESOLVE, as of nodejs/node#60864: only these two are invalid.
+        if import_path == b"#" || import_path == b"#/" {
             if let Some(debug) = self.debug_logs.as_mut() {
                 debug.add_note_fmt(format_args!(
-                    "The path \"{}\" must not equal \"#\" and must not start with \"#/\"",
+                    "The path \"{}\" must not equal \"#\" or \"#/\"",
                     bstr::BStr::new(import_path)
                 ));
             }

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1827,7 +1827,27 @@ describe("bundler", () => {
       "/Users/user/project/src/entry.js": [`Could not resolve: "#". Maybe you need to "bun install"?`],
     },
   });
-  itBundled("packagejson/ImportsErrorStartsWithHashSlash", {
+  // Exactly "#/" is an invalid specifier (PACKAGE_IMPORTS_RESOLVE), even with
+  // an "imports" entry that would otherwise match it. esbuild resolves it.
+  itBundled("packagejson/ImportsErrorEqualsHashSlash", {
+    skipOnEsbuild: true,
+    files: {
+      "/Users/user/project/src/entry.js": `import '#/'`,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#/": "./index.js",
+            "#/*": "./src/*"
+          }
+        }
+      `,
+      "/Users/user/project/src/index.js": `console.log('index.js')`,
+    },
+    bundleErrors: {
+      "/Users/user/project/src/entry.js": [`Could not resolve: "#/". Maybe you need to "bun install"?`],
+    },
+  });
+  itBundled("packagejson/ImportsErrorHashSlashNotDefined", {
     files: {
       "/Users/user/project/src/entry.js": `import '#/foo'`,
       "/Users/user/project/src/package.json": /* json */ `
@@ -1838,6 +1858,90 @@ describe("bundler", () => {
     },
     bundleErrors: {
       "/Users/user/project/src/entry.js": [`Could not resolve: "#/foo". Maybe you need to "bun install"?`],
+    },
+  });
+  // Specifiers that start with "#/" are valid since Node.js 25.4 (nodejs/node#60864).
+  itBundled("packagejson/ImportsHashSlashWithWildcard", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import '#/foo.js'
+        import '#/bar/baz.js'
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#/*": "./src/*"
+          }
+        }
+      `,
+      "/Users/user/project/src/src/foo.js": `console.log('foo.js')`,
+      "/Users/user/project/src/src/bar/baz.js": `console.log('bar/baz.js')`,
+    },
+    run: {
+      stdout: `foo.js\nbar/baz.js`,
+    },
+  });
+  itBundled("packagejson/ImportsHashSlashExactMatch", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import '#/utils'
+        import '#/config.js'
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#/utils": "./utils.js",
+            "#/config.js": "./config.js"
+          }
+        }
+      `,
+      "/Users/user/project/src/utils.js": `console.log('utils.js')`,
+      "/Users/user/project/src/config.js": `console.log('config.js')`,
+    },
+    run: {
+      stdout: `utils.js\nconfig.js`,
+    },
+  });
+  itBundled("packagejson/ImportsHashSlashWithConditions", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import '#/lib'
+        require('#/lib')
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#/*": {
+              "import": "./esm/*.js",
+              "require": "./cjs/*.js"
+            }
+          }
+        }
+      `,
+      "/Users/user/project/src/esm/lib.js": `console.log('esm/lib.js')`,
+      "/Users/user/project/src/cjs/lib.js": `console.log('cjs/lib.js')`,
+    },
+    run: {
+      stdout: `esm/lib.js\ncjs/lib.js`,
+    },
+  });
+  itBundled("packagejson/ImportsHashSlashSymmetricWithExports", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import '#/components/button.js'
+        import '#/utils/format.js'
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "exports": { "./*": "./src/*" },
+          "imports": { "#/*": "./src/*" }
+        }
+      `,
+      "/Users/user/project/src/src/components/button.js": `console.log('button.js')`,
+      "/Users/user/project/src/src/utils/format.js": `console.log('format.js')`,
+    },
+    run: {
+      stdout: `button.js\nformat.js`,
     },
   });
   itBundled("packagejson/MainFieldsErrorMessageDefault", {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1689,3 +1689,103 @@ describe.concurrent("dot specifiers resolve to the directory index, not a siblin
     expect(exitCode).toBe(0);
   });
 });
+
+// Specifiers that start with "#/" are valid subpath imports since Node.js 25.4
+// (nodejs/node#60864). Only exactly "#" and "#/" are invalid.
+describe.concurrent('package.json "imports" keys that start with "#/"', () => {
+  const fixture = {
+    "package.json": JSON.stringify({
+      name: "app",
+      type: "module",
+      imports: {
+        "#/*": "./src/*",
+        "#/config": "./src/config.js",
+        "#/lib/*": { import: "./src/lib/*.mjs", default: "./src/lib/*.cjs" },
+        "#plain": "./src/plain.js",
+        "#dep": "dep",
+      },
+    }),
+    "src/foo.js": `export const v = 42;`,
+    "src/config.js": `export const config = "config";`,
+    "src/lib/util.mjs": `export const util = "esm";`,
+    "src/lib/util.cjs": `exports.util = "cjs";`,
+    "src/plain.js": `export const plain = "plain";`,
+    "node_modules/dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+    "node_modules/dep/index.js": `export const d = "dep";`,
+  };
+
+  it("wildcard, exact, and conditional entries resolve with import", async () => {
+    using dir = tempDir("imports-hash-slash", {
+      ...fixture,
+      "index.js": `
+        import { v } from "#/foo.js";
+        import { config } from "#/config";
+        import { util } from "#/lib/util";
+        import { plain } from "#plain";
+        import { d } from "#dep";
+        const { config: dynamic } = await import("#/config");
+        console.log(JSON.stringify({ v, config, util, plain, d, dynamic }));
+      `,
+    });
+    expect(await runWildcardScript(String(dir), "index.js")).toEqual({
+      stdout: JSON.stringify({ v: 42, config: "config", util: "esm", plain: "plain", d: "dep", dynamic: "config" }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("wildcard, exact, and conditional entries resolve with require", async () => {
+    using dir = tempDir("imports-hash-slash-cjs", {
+      ...fixture,
+      "index.cjs": `
+        const { v } = require("#/foo.js");
+        const { config } = require("#/config");
+        const { util } = require("#/lib/util");
+        const { plain } = require("#plain");
+        console.log(JSON.stringify({ v, config, util, plain }));
+      `,
+    });
+    expect(await runWildcardScript(String(dir), "index.cjs")).toEqual({
+      stdout: JSON.stringify({ v: 42, config: "config", util: "cjs", plain: "plain" }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("import.meta.resolve and require.resolve map them to the file", async () => {
+    using dir = tempDir("imports-hash-slash-resolve", {
+      ...fixture,
+      "index.js": `
+        import { createRequire } from "node:module";
+        import { sep } from "node:path";
+        const require = createRequire(import.meta.url);
+        console.log(import.meta.resolve("#/foo.js").endsWith("/src/foo.js"));
+        console.log(require.resolve("#/config").replaceAll(sep, "/").endsWith("/src/config.js"));
+      `,
+    });
+    expect(await runWildcardScript(String(dir), "index.js")).toEqual({
+      stdout: "true\ntrue",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.each(["#", "#/"])("exactly %j is rejected", async (specifier: string) => {
+    using dir = tempDir("imports-hash-slash-invalid", {
+      ...fixture,
+      "index.js": `
+        try {
+          await import(${JSON.stringify(specifier)});
+          console.log("resolved");
+        } catch (e) {
+          console.log(e.code);
+        }
+      `,
+    });
+    expect(await runWildcardScript(String(dir), "index.js")).toEqual({
+      stdout: "ERR_MODULE_NOT_FOUND",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- A `package.json` `"imports"` key that starts with `#/` never resolves. `import "#/config"` fails with `ERR_MODULE_NOT_FOUND` in `bun run`, and `bun build` reports `Could not resolve: "#/config"`. The same happens for `"#/lib/*"` and the root alias `"#/*": "./src/*"`.
- The cause is `load_package_imports` in `src/resolver/resolver.rs:4989`. It rejected every specifier that starts with `#/` before it consulted the `imports` map. Node.js 25.4 and 24.14 (nodejs/node#60864) reject only exactly `#` and exactly `#/`.

### Fix
- `load_package_imports` rejects only exactly `#` and exactly `#/`. Every other `#` specifier is looked up in the `imports` map.
- Matches Node. This is the PACKAGE_IMPORTS_RESOLVE check, and nothing else in the lookup depends on the `#/` prefix.
- Verified: `test/js/bun/resolve/resolve.test.ts` (the `"#/"` block, 3 of 5 cases fail on the released bun) and `test/bundler/esbuild/packagejson.test.ts` (`ImportsHashSlash*`, 4 cases fail on the released bun). Both files pass in full on this branch.

### Background
- A subpath import is a `#` specifier that the nearest `package.json` `imports` map rewrites to a file, a package, or a conditions object. Node resolves it only from inside that package.
- The `#/` ban came from the original spec text. It was lifted so that a package can use `#/` as a root alias, like `"exports": { "./*": "./src/*" }` does for consumers.
- Exactly `#/` still fails. Bun reports `ERR_MODULE_NOT_FOUND` where Node reports `ERR_INVALID_MODULE_SPECIFIER`. That code difference predates this PR.

<details><summary>Notes</summary>

- esbuild accepts exactly `#/` when an exact `"#/"` key exists. Node rejects it. This PR follows Node, so `ImportsErrorEqualsHashSlash` is `skipOnEsbuild`.
- The `"#/"` test block covers static and dynamic `import`, `require`, `import.meta.resolve`, `require.resolve`, a conditions object, a plain `#plain` file target as control, and the rejection of exactly `#` and `#/`.
- #40798 carries the same two-line change together with a `--packages=external` change. The `#/` fix lands here on its own. #40798 keeps the `--packages=external` part.
- This branch was rebuilt from main with the test matrix from #40798. The original version of this PR had the same resolver change with a smaller test.

</details>

Fixes #28995

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->