### PR TITLE
Intl.Locale: throw RangeError for structurally valid tags that exceed ICU capacity

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,12 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+// oven-sh/WebKit#350 preview, branched from 549170099226f816 (the previous
+// WEBKIT_VERSION): IntlLocale::initializeLocale throws RangeError (not
+// TypeError) when ICU canonicalization fails on a structurally valid tag,
+// matching canonicalizeLocaleList and V8. Revert to the merged-main sha once
+// #350 lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-350-db4518f8";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -223,6 +223,47 @@ describe("URL IDNA", () => {
   });
 });
 
+describe("Intl.Locale", () => {
+  test("structurally valid tag exceeding ICU capacity throws RangeError, consistent with every other Intl entry point", () => {
+    // 23 distinct 7-char variant subtags; each is a well-formed `unicode_variant_subtag`, so the
+    // whole tag is a structurally valid BCP-47 language tag. It only fails because it overflows
+    // ICU's internal ULOC_FULLNAME_CAPACITY buffer during canonicalization.
+    const tag = "en" + Array.from({ length: 23 }, (_, i) => "-" + String(i).padStart(5, "v") + "ab").join("");
+    const ctor = (f: () => unknown) => {
+      try {
+        f();
+        return "no throw";
+      } catch (e) {
+        return (e as Error).constructor.name;
+      }
+    };
+    // Every Intl path that canonicalizes this tag must agree on RangeError so that a
+    // `catch (e) { if (e instanceof RangeError) ... }` validation guard is not constructor-dependent.
+    expect({
+      "Intl.Locale": ctor(() => new Intl.Locale(tag)),
+      "Intl.Locale+options": ctor(() => new Intl.Locale(tag, { language: "en" })),
+      "Intl.DateTimeFormat": ctor(() => new Intl.DateTimeFormat(tag)),
+      "Intl.NumberFormat": ctor(() => new Intl.NumberFormat(tag)),
+      "Intl.Collator": ctor(() => new Intl.Collator(tag)),
+      "Intl.getCanonicalLocales": ctor(() => Intl.getCanonicalLocales(tag)),
+      "String#localeCompare": ctor(() => "a".localeCompare("b", tag)),
+    }).toEqual({
+      "Intl.Locale": "RangeError",
+      "Intl.Locale+options": "RangeError",
+      "Intl.DateTimeFormat": "RangeError",
+      "Intl.NumberFormat": "RangeError",
+      "Intl.Collator": "RangeError",
+      "Intl.getCanonicalLocales": "RangeError",
+      "String#localeCompare": "RangeError",
+    });
+  });
+
+  test("22 variants (under ICU capacity) still constructs", () => {
+    const tag = "en" + Array.from({ length: 22 }, (_, i) => "-" + String(i).padStart(5, "v") + "ab").join("");
+    expect(() => new Intl.Locale(tag)).not.toThrow();
+  });
+});
+
 describe("Intl.getCanonicalLocales", () => {
   test("deprecated BCP-47 tags map to modern equivalents", () => {
     // ICU ships .res bundles under the deprecated tag names; canonicalization

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -224,43 +224,68 @@ describe("URL IDNA", () => {
 });
 
 describe("Intl.Locale", () => {
-  test("structurally valid tag exceeding ICU capacity throws RangeError, consistent with every other Intl entry point", () => {
-    // 23 distinct 7-char variant subtags; each is a well-formed `unicode_variant_subtag`, so the
-    // whole tag is a structurally valid BCP-47 language tag. It only fails because it overflows
-    // ICU's internal ULOC_FULLNAME_CAPACITY buffer during canonicalization.
-    const tag = "en" + Array.from({ length: 23 }, (_, i) => "-" + String(i).padStart(5, "v") + "ab").join("");
-    const ctor = (f: () => unknown) => {
-      try {
-        f();
-        return "no throw";
-      } catch (e) {
-        return (e as Error).constructor.name;
-      }
-    };
-    // Every Intl path that canonicalizes this tag must agree on RangeError so that a
-    // `catch (e) { if (e instanceof RangeError) ... }` validation guard is not constructor-dependent.
-    expect({
-      "Intl.Locale": ctor(() => new Intl.Locale(tag)),
-      "Intl.Locale+options": ctor(() => new Intl.Locale(tag, { language: "en" })),
-      "Intl.DateTimeFormat": ctor(() => new Intl.DateTimeFormat(tag)),
-      "Intl.NumberFormat": ctor(() => new Intl.NumberFormat(tag)),
-      "Intl.Collator": ctor(() => new Intl.Collator(tag)),
-      "Intl.getCanonicalLocales": ctor(() => Intl.getCanonicalLocales(tag)),
-      "String#localeCompare": ctor(() => "a".localeCompare("b", tag)),
-    }).toEqual({
-      "Intl.Locale": "RangeError",
-      "Intl.Locale+options": "RangeError",
-      "Intl.DateTimeFormat": "RangeError",
-      "Intl.NumberFormat": "RangeError",
-      "Intl.Collator": "RangeError",
-      "Intl.getCanonicalLocales": "RangeError",
-      "String#localeCompare": "RangeError",
-    });
+  // N distinct 7-char variant subtags; each is a well-formed `unicode_variant_subtag`, so the
+  // whole tag is a structurally valid BCP-47 language tag for any N.
+  const makeTag = (n: number) =>
+    "en" + Array.from({ length: n }, (_, i) => "-" + String(i).padStart(5, "v") + "ab").join("");
+
+  // The capacity at which ICU's canonicalization fails is an internal detail that varies by ICU
+  // build: bundled ICU 75.1 (Linux) and Apple's libicucore (macOS) fail at 23 variants / 186 bytes;
+  // Windows ICU 73.2 grows its buffer and accepts arbitrarily long tags. Probe for the threshold
+  // via getCanonicalLocales (which already throws RangeError) rather than hard-coding it.
+  let overflowTag: string | undefined;
+  for (let n = 20; n <= 200; n++) {
+    try {
+      Intl.getCanonicalLocales(makeTag(n));
+    } catch {
+      overflowTag = makeTag(n);
+      break;
+    }
+  }
+
+  const hasLimit = overflowTag !== undefined ? test : test.skip;
+  hasLimit(
+    "structurally valid tag exceeding ICU capacity throws RangeError, consistent with every other Intl entry point",
+    () => {
+      const ctor = (f: () => unknown) => {
+        try {
+          f();
+          return "no throw";
+        } catch (e) {
+          return (e as Error).constructor.name;
+        }
+      };
+      // Every Intl path that canonicalizes this tag must agree on RangeError so that a
+      // `catch (e) { if (e instanceof RangeError) ... }` validation guard is not constructor-dependent.
+      expect({
+        "Intl.Locale": ctor(() => new Intl.Locale(overflowTag!)),
+        "Intl.Locale+options": ctor(() => new Intl.Locale(overflowTag!, { language: "en" })),
+        "Intl.DateTimeFormat": ctor(() => new Intl.DateTimeFormat(overflowTag!)),
+        "Intl.NumberFormat": ctor(() => new Intl.NumberFormat(overflowTag!)),
+        "Intl.Collator": ctor(() => new Intl.Collator(overflowTag!)),
+        "Intl.getCanonicalLocales": ctor(() => Intl.getCanonicalLocales(overflowTag!)),
+        "String#localeCompare": ctor(() => "a".localeCompare("b", overflowTag!)),
+      }).toEqual({
+        "Intl.Locale": "RangeError",
+        "Intl.Locale+options": "RangeError",
+        "Intl.DateTimeFormat": "RangeError",
+        "Intl.NumberFormat": "RangeError",
+        "Intl.Collator": "RangeError",
+        "Intl.getCanonicalLocales": "RangeError",
+        "String#localeCompare": "RangeError",
+      });
+    },
+  );
+
+  // Linux ICU 75.1 has the lowest observed capacity (23 variants); the probe must find it there so
+  // the RangeError assertion above never silently degrades to a skip on the platform where the bug
+  // was reported.
+  test.skipIf(!isLinux)("probe finds the capacity limit on bundled ICU", () => {
+    expect(overflowTag).toBeDefined();
   });
 
-  test("22 variants (under ICU capacity) still constructs", () => {
-    const tag = "en" + Array.from({ length: 22 }, (_, i) => "-" + String(i).padStart(5, "v") + "ab").join("");
-    expect(() => new Intl.Locale(tag)).not.toThrow();
+  test("valid tag with a handful of variants still constructs", () => {
+    expect(() => new Intl.Locale(makeTag(5))).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Problem

`new Intl.Locale(tag)` throws **TypeError** (`failed to initialize Locale`) for a structurally valid BCP-47 tag once it exceeds ICU's internal `ULOC_FULLNAME_CAPACITY` buffer (~180 chars, e.g. 23 distinct variant subtags). Every other Intl entry point throws **RangeError** for the same input, and so does Node:

```js
const tag = 'en' + Array.from({ length: 23 }, (_, i) => '-' + String(i).padStart(5, 'v') + 'ab').join('');
// tag.length === 186, structurally valid (23 x 7-char variants)
new Intl.Locale(tag);          // TypeError: failed to initialize Locale   <- only this one
new Intl.DateTimeFormat(tag);  // RangeError
new Intl.NumberFormat(tag);    // RangeError
new Intl.Collator(tag);        // RangeError
Intl.getCanonicalLocales(tag); // RangeError
'a'.localeCompare('b', tag);   // RangeError
```

So `catch (e) { if (e instanceof RangeError) /* invalid locale */ }` misses only the `Intl.Locale` constructor.

## Cause

`IntlLocale::initializeLocale` validates the tag with `isStructurallyValidLanguageTag` (throwing `RangeError` on failure) before reaching `LocaleIDBuilder::canonicalize()` / `toCanonical()`. At that point the tag is known to be well-formed; the only failure mode is ICU's fixed-size buffer overflow. Those two failure sites threw `throwTypeError`, while the equivalent path in `canonicalizeLocaleList` (used by every other Intl constructor) throws `createRangeError`.

## Fix

The source change is in JavaScriptCore: oven-sh/WebKit#350 switches both sites to `throwRangeError`.

This PR:
- Bumps `WEBKIT_VERSION` to the #350 preview tarball (`autobuild-preview-pr-350-db4518f8`, branched from the previous `WEBKIT_VERSION` `549170099226f816` so the only delta is the IntlLocale change).
- Adds a test in `test/js/web/intl/intl.test.ts` asserting all seven Intl paths agree on `RangeError` for the oversized tag, and that 22 variants (under capacity) still constructs.

Once oven-sh/WebKit#350 is merged, `WEBKIT_VERSION` should be updated to the merged main sha.

## Verification

```
fail-before (system bun):  Intl.Locale -> TypeError, Intl.Locale+options -> TypeError
pass-after  (bun bd):      Intl.Locale -> RangeError, Intl.Locale+options -> RangeError
bun bd test test/js/web/intl/intl.test.ts: 33 pass, 0 fail
```

Note: the source change lives in `scripts/build/deps/webkit.ts` (not `src/`), so the fail-before gate's `git stash -- src/` cannot revert it; both gate runs will link the fixed WebKit and pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->