### PR TITLE
fetch: run "extract a MIME type" over Content-Type for blob() and formData()

### DIFF
--- a/src/http_types/lib.rs
+++ b/src/http_types/lib.rs
@@ -8,6 +8,7 @@ pub mod FetchRequestMode;
 pub mod Method;
 pub mod URLPath;
 pub mod h2;
+pub mod mime_sniff;
 pub mod mime_type_list_enum;
 pub use ETag::wtf;
 

--- a/src/http_types/mime_sniff.rs
+++ b/src/http_types/mime_sniff.rs
@@ -1,0 +1,326 @@
+//! WHATWG MIME type parsing and serialization.
+//!
+//! Implements "parse a MIME type" / "serialize a MIME type" from the MIME
+//! Sniffing standard (<https://mimesniff.spec.whatwg.org/#parsing-a-mime-type>)
+//! and "extract a MIME type" from the Fetch standard
+//! (<https://fetch.spec.whatwg.org/#concept-header-extract-mime-type>),
+//! including the "get, decode, and split" step over a comma-combined header
+//! value. Body consumers (`blob()`, `formData()`) use this: the result is the
+//! serialized extraction, not the raw header bytes.
+//!
+//! Everything operates on bytes. Non-ASCII UTF-8 bytes (all >= 0x80) are never
+//! HTTP token code points and are always HTTP quoted-string token code points,
+//! exactly like the non-ASCII code points they encode, so byte-wise iteration
+//! is equivalent to the spec's code-point iteration.
+
+/// <https://fetch.spec.whatwg.org/#http-whitespace>
+#[inline]
+fn is_http_whitespace(b: u8) -> bool {
+    matches!(b, b'\t' | b'\n' | b'\r' | b' ')
+}
+
+/// <https://fetch.spec.whatwg.org/#http-tab-or-space>
+#[inline]
+fn is_http_tab_or_space(b: u8) -> bool {
+    matches!(b, b'\t' | b' ')
+}
+
+/// <https://mimesniff.spec.whatwg.org/#http-token-code-point>
+#[inline]
+fn is_http_token(b: u8) -> bool {
+    b.is_ascii_alphanumeric()
+        || matches!(
+            b,
+            b'!' | b'#'
+                | b'$'
+                | b'%'
+                | b'&'
+                | b'\''
+                | b'*'
+                | b'+'
+                | b'-'
+                | b'.'
+                | b'^'
+                | b'_'
+                | b'`'
+                | b'|'
+                | b'~'
+        )
+}
+
+/// <https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point>
+/// HTAB, U+0020..=U+007E, or U+0080..=U+00FF. `"` and `\` are allowed; the
+/// serializer re-escapes them.
+#[inline]
+fn is_http_quoted_string_token(b: u8) -> bool {
+    matches!(b, b'\t' | 0x20..=0x7E | 0x80..=0xFF)
+}
+
+fn trim_start(mut s: &[u8], pred: fn(u8) -> bool) -> &[u8] {
+    while let [first, rest @ ..] = s {
+        if pred(*first) {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    s
+}
+
+fn trim_end(mut s: &[u8], pred: fn(u8) -> bool) -> &[u8] {
+    while let [rest @ .., last] = s {
+        if pred(*last) {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    s
+}
+
+fn trim(s: &[u8], pred: fn(u8) -> bool) -> &[u8] {
+    trim_end(trim_start(s, pred), pred)
+}
+
+/// <https://mimesniff.spec.whatwg.org/#mime-type> — the parsed record.
+struct MimeRecord {
+    /// `type "/" subtype`, ASCII-lowercased.
+    essence: Vec<u8>,
+    /// Parameters in first-seen order; names ASCII-lowercased and unique.
+    parameters: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+impl MimeRecord {
+    fn has_parameter(&self, name: &[u8]) -> bool {
+        self.parameters.iter().any(|(n, _)| n == name)
+    }
+
+    fn parameter(&self, name: &[u8]) -> Option<&[u8]> {
+        self.parameters
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| &v[..])
+    }
+
+    /// <https://mimesniff.spec.whatwg.org/#serialize-a-mime-type>
+    fn serialize(&self) -> Vec<u8> {
+        let mut out = self.essence.clone();
+        for (name, value) in &self.parameters {
+            out.push(b';');
+            out.extend_from_slice(name);
+            out.push(b'=');
+            if value.is_empty() || !value.iter().copied().all(is_http_token) {
+                out.push(b'"');
+                for &b in value {
+                    if b == b'"' || b == b'\\' {
+                        out.push(b'\\');
+                    }
+                    out.push(b);
+                }
+                out.push(b'"');
+            } else {
+                out.extend_from_slice(value);
+            }
+        }
+        out
+    }
+}
+
+/// <https://fetch.spec.whatwg.org/#collect-an-http-quoted-string>
+///
+/// `input[*pos]` must be `"`. Advances `*pos` past the quoted string. With
+/// `extract_value` the unescaped contents are returned; without it, the raw
+/// source span including the quotes.
+fn collect_http_quoted_string(input: &[u8], pos: &mut usize, extract_value: bool) -> Vec<u8> {
+    let start = *pos;
+    let mut value = Vec::new();
+    debug_assert_eq!(input[*pos], b'"');
+    *pos += 1;
+    loop {
+        let chunk_start = *pos;
+        while *pos < input.len() && input[*pos] != b'"' && input[*pos] != b'\\' {
+            *pos += 1;
+        }
+        value.extend_from_slice(&input[chunk_start..*pos]);
+        if *pos >= input.len() {
+            break;
+        }
+        let quote_or_backslash = input[*pos];
+        *pos += 1;
+        if quote_or_backslash == b'\\' {
+            if *pos >= input.len() {
+                value.push(b'\\');
+                break;
+            }
+            value.push(input[*pos]);
+            *pos += 1;
+        } else {
+            break;
+        }
+    }
+    if extract_value {
+        value
+    } else {
+        input[start..*pos].to_vec()
+    }
+}
+
+/// <https://fetch.spec.whatwg.org/#header-value-get-decode-and-split>
+///
+/// Splits a comma-combined header value into its individual values, leaving
+/// commas inside quoted strings alone and trimming HTTP tab-or-space from each.
+fn get_decode_split(input: &[u8]) -> Vec<&[u8]> {
+    let mut values = Vec::new();
+    let mut pos = 0usize;
+    let mut start = 0usize;
+    while pos < input.len() {
+        while pos < input.len() && input[pos] != b'"' && input[pos] != b',' {
+            pos += 1;
+        }
+        if pos < input.len() {
+            if input[pos] == b'"' {
+                collect_http_quoted_string(input, &mut pos, false);
+                if pos < input.len() {
+                    continue;
+                }
+            } else {
+                values.push(trim(&input[start..pos], is_http_tab_or_space));
+                pos += 1;
+                start = pos;
+                continue;
+            }
+        }
+        values.push(trim(&input[start..pos], is_http_tab_or_space));
+        start = pos;
+    }
+    values
+}
+
+/// <https://mimesniff.spec.whatwg.org/#parse-a-mime-type>
+fn parse_mime_type(input: &[u8]) -> Option<MimeRecord> {
+    // Step 1: remove leading and trailing HTTP whitespace.
+    let input = trim(input, is_http_whitespace);
+
+    // Steps 3-6: `type` is everything before the first `/`, which must exist
+    // (step 5), be non-empty, and solely contain HTTP token code points.
+    let slash = input.iter().position(|&b| b == b'/')?;
+    let type_ = &input[..slash];
+    if type_.is_empty() || !type_.iter().copied().all(is_http_token) {
+        return None;
+    }
+    let mut pos = slash + 1;
+
+    // Steps 7-9: `subtype` runs to the first `;`, with trailing HTTP
+    // whitespace removed.
+    let subtype_end = input[pos..]
+        .iter()
+        .position(|&b| b == b';')
+        .map_or(input.len(), |i| pos + i);
+    let subtype = trim_end(&input[pos..subtype_end], is_http_whitespace);
+    if subtype.is_empty() || !subtype.iter().copied().all(is_http_token) {
+        return None;
+    }
+    pos = subtype_end;
+
+    // Step 10.
+    let mut essence = Vec::with_capacity(type_.len() + 1 + subtype.len());
+    essence.extend_from_slice(type_);
+    essence.push(b'/');
+    essence.extend_from_slice(subtype);
+    essence.make_ascii_lowercase();
+    let mut record = MimeRecord {
+        essence,
+        parameters: Vec::new(),
+    };
+
+    // Step 11: parameters.
+    while pos < input.len() {
+        // 11.1: advance past `;`. 11.2: skip HTTP whitespace.
+        pos += 1;
+        while pos < input.len() && is_http_whitespace(input[pos]) {
+            pos += 1;
+        }
+        // 11.3-11.4: parameter name runs to `;` or `=`, ASCII-lowercased.
+        let name_start = pos;
+        while pos < input.len() && input[pos] != b';' && input[pos] != b'=' {
+            pos += 1;
+        }
+        let mut name = input[name_start..pos].to_vec();
+        name.make_ascii_lowercase();
+        // 11.5
+        if pos < input.len() {
+            if input[pos] == b';' {
+                continue;
+            }
+            pos += 1;
+        }
+        // 11.6
+        if pos >= input.len() {
+            break;
+        }
+        // 11.7-11.9
+        let value: Vec<u8> = if input[pos] == b'"' {
+            let v = collect_http_quoted_string(input, &mut pos, true);
+            while pos < input.len() && input[pos] != b';' {
+                pos += 1;
+            }
+            v
+        } else {
+            let value_start = pos;
+            while pos < input.len() && input[pos] != b';' {
+                pos += 1;
+            }
+            let v = trim_end(&input[value_start..pos], is_http_whitespace);
+            if v.is_empty() {
+                continue;
+            }
+            v.to_vec()
+        };
+        // 11.10: first occurrence of a valid name/value pair wins.
+        if !name.is_empty()
+            && name.iter().copied().all(is_http_token)
+            && value.iter().copied().all(is_http_quoted_string_token)
+            && !record.has_parameter(&name)
+        {
+            record.parameters.push((name, value));
+        }
+    }
+
+    Some(record)
+}
+
+/// Fetch's "extract a MIME type" applied to the comma-combined `Content-Type`
+/// header value, serialized per "serialize a MIME type".
+///
+/// `None` means extraction failed (no valid MIME type among the values).
+/// <https://fetch.spec.whatwg.org/#concept-header-extract-mime-type>
+pub fn extract_mime_type(combined_value: &[u8]) -> Option<Vec<u8>> {
+    let mut charset: Option<Vec<u8>> = None;
+    let mut essence: Option<Vec<u8>> = None;
+    let mut mime: Option<MimeRecord> = None;
+
+    for value in get_decode_split(combined_value) {
+        // 6.1-6.2
+        let Some(mut parsed) = parse_mime_type(value) else {
+            continue;
+        };
+        if parsed.essence == b"*/*" {
+            continue;
+        }
+        if essence.as_deref() != Some(&parsed.essence[..]) {
+            // 6.4: a new essence resets the carried charset.
+            charset = parsed.parameter(b"charset").map(<[u8]>::to_vec);
+            essence = Some(parsed.essence.clone());
+        } else if !parsed.has_parameter(b"charset") {
+            // 6.5: same essence without a charset inherits the carried one.
+            if let Some(charset) = &charset {
+                parsed
+                    .parameters
+                    .push((b"charset".to_vec(), charset.clone()));
+            }
+        }
+        mime = Some(parsed);
+    }
+
+    Some(mime?.serialize())
+}

--- a/src/http_types/mime_sniff.rs
+++ b/src/http_types/mime_sniff.rs
@@ -1,17 +1,4 @@
-//! WHATWG MIME type parsing and serialization.
-//!
-//! Implements "parse a MIME type" / "serialize a MIME type" from the MIME
-//! Sniffing standard (<https://mimesniff.spec.whatwg.org/#parsing-a-mime-type>)
-//! and "extract a MIME type" from the Fetch standard
-//! (<https://fetch.spec.whatwg.org/#concept-header-extract-mime-type>),
-//! including the "get, decode, and split" step over a comma-combined header
-//! value. Body consumers (`blob()`, `formData()`) use this: the result is the
-//! serialized extraction, not the raw header bytes.
-//!
-//! Everything operates on bytes. Non-ASCII UTF-8 bytes (all >= 0x80) are never
-//! HTTP token code points and are always HTTP quoted-string token code points,
-//! exactly like the non-ASCII code points they encode, so byte-wise iteration
-//! is equivalent to the spec's code-point iteration.
+//! <https://mimesniff.spec.whatwg.org/> / <https://fetch.spec.whatwg.org/#concept-header-extract-mime-type>
 
 /// <https://fetch.spec.whatwg.org/#http-whitespace>
 #[inline]
@@ -49,8 +36,6 @@ fn is_http_token(b: u8) -> bool {
 }
 
 /// <https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point>
-/// HTAB, U+0020..=U+007E, or U+0080..=U+00FF. `"` and `\` are allowed; the
-/// serializer re-escapes them.
 #[inline]
 fn is_http_quoted_string_token(b: u8) -> bool {
     matches!(b, b'\t' | 0x20..=0x7E | 0x80..=0xFF)
@@ -82,11 +67,9 @@ fn trim(s: &[u8], pred: fn(u8) -> bool) -> &[u8] {
     trim_end(trim_start(s, pred), pred)
 }
 
-/// <https://mimesniff.spec.whatwg.org/#mime-type> — the parsed record.
+/// <https://mimesniff.spec.whatwg.org/#mime-type>
 struct MimeRecord {
-    /// `type "/" subtype`, ASCII-lowercased.
     essence: Vec<u8>,
-    /// Parameters in first-seen order; names ASCII-lowercased and unique.
     parameters: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
@@ -126,11 +109,7 @@ impl MimeRecord {
     }
 }
 
-/// <https://fetch.spec.whatwg.org/#collect-an-http-quoted-string>
-///
-/// `input[*pos]` must be `"`. Advances `*pos` past the quoted string. With
-/// `extract_value` the unescaped contents are returned; without it, the raw
-/// source span including the quotes.
+/// <https://fetch.spec.whatwg.org/#collect-an-http-quoted-string> — `input[*pos]` must be `"`.
 fn collect_http_quoted_string(input: &[u8], pos: &mut usize, extract_value: bool) -> Vec<u8> {
     let start = *pos;
     let mut value = Vec::new();
@@ -166,9 +145,6 @@ fn collect_http_quoted_string(input: &[u8], pos: &mut usize, extract_value: bool
 }
 
 /// <https://fetch.spec.whatwg.org/#header-value-get-decode-and-split>
-///
-/// Splits a comma-combined header value into its individual values, leaving
-/// commas inside quoted strings alone and trimming HTTP tab-or-space from each.
 fn get_decode_split(input: &[u8]) -> Vec<&[u8]> {
     let mut values = Vec::new();
     let mut pos = 0usize;
@@ -198,11 +174,8 @@ fn get_decode_split(input: &[u8]) -> Vec<&[u8]> {
 
 /// <https://mimesniff.spec.whatwg.org/#parse-a-mime-type>
 fn parse_mime_type(input: &[u8]) -> Option<MimeRecord> {
-    // Step 1: remove leading and trailing HTTP whitespace.
     let input = trim(input, is_http_whitespace);
 
-    // Steps 3-6: `type` is everything before the first `/`, which must exist
-    // (step 5), be non-empty, and solely contain HTTP token code points.
     let slash = input.iter().position(|&b| b == b'/')?;
     let type_ = &input[..slash];
     if type_.is_empty() || !type_.iter().copied().all(is_http_token) {
@@ -210,8 +183,6 @@ fn parse_mime_type(input: &[u8]) -> Option<MimeRecord> {
     }
     let mut pos = slash + 1;
 
-    // Steps 7-9: `subtype` runs to the first `;`, with trailing HTTP
-    // whitespace removed.
     let subtype_end = input[pos..]
         .iter()
         .position(|&b| b == b';')
@@ -222,7 +193,6 @@ fn parse_mime_type(input: &[u8]) -> Option<MimeRecord> {
     }
     pos = subtype_end;
 
-    // Step 10.
     let mut essence = Vec::with_capacity(type_.len() + 1 + subtype.len());
     essence.extend_from_slice(type_);
     essence.push(b'/');
@@ -233,32 +203,26 @@ fn parse_mime_type(input: &[u8]) -> Option<MimeRecord> {
         parameters: Vec::new(),
     };
 
-    // Step 11: parameters.
     while pos < input.len() {
-        // 11.1: advance past `;`. 11.2: skip HTTP whitespace.
         pos += 1;
         while pos < input.len() && is_http_whitespace(input[pos]) {
             pos += 1;
         }
-        // 11.3-11.4: parameter name runs to `;` or `=`, ASCII-lowercased.
         let name_start = pos;
         while pos < input.len() && input[pos] != b';' && input[pos] != b'=' {
             pos += 1;
         }
         let mut name = input[name_start..pos].to_vec();
         name.make_ascii_lowercase();
-        // 11.5
         if pos < input.len() {
             if input[pos] == b';' {
                 continue;
             }
             pos += 1;
         }
-        // 11.6
         if pos >= input.len() {
             break;
         }
-        // 11.7-11.9
         let value: Vec<u8> = if input[pos] == b'"' {
             let v = collect_http_quoted_string(input, &mut pos, true);
             while pos < input.len() && input[pos] != b';' {
@@ -276,7 +240,6 @@ fn parse_mime_type(input: &[u8]) -> Option<MimeRecord> {
             }
             v.to_vec()
         };
-        // 11.10: first occurrence of a valid name/value pair wins.
         if !name.is_empty()
             && name.iter().copied().all(is_http_token)
             && value.iter().copied().all(is_http_quoted_string_token)
@@ -289,18 +252,13 @@ fn parse_mime_type(input: &[u8]) -> Option<MimeRecord> {
     Some(record)
 }
 
-/// Fetch's "extract a MIME type" applied to the comma-combined `Content-Type`
-/// header value, serialized per "serialize a MIME type".
-///
-/// `None` means extraction failed (no valid MIME type among the values).
-/// <https://fetch.spec.whatwg.org/#concept-header-extract-mime-type>
+/// <https://fetch.spec.whatwg.org/#concept-header-extract-mime-type> over a comma-combined value.
 pub fn extract_mime_type(combined_value: &[u8]) -> Option<Vec<u8>> {
     let mut charset: Option<Vec<u8>> = None;
     let mut essence: Option<Vec<u8>> = None;
     let mut mime: Option<MimeRecord> = None;
 
     for value in get_decode_split(combined_value) {
-        // 6.1-6.2
         let Some(mut parsed) = parse_mime_type(value) else {
             continue;
         };
@@ -308,11 +266,9 @@ pub fn extract_mime_type(combined_value: &[u8]) -> Option<Vec<u8>> {
             continue;
         }
         if essence.as_deref() != Some(&parsed.essence[..]) {
-            // 6.4: a new essence resets the carried charset.
             charset = parsed.parameter(b"charset").map(<[u8]>::to_vec);
             essence = Some(parsed.essence.clone());
         } else if !parsed.has_parameter(b"charset") {
-            // 6.5: same essence without a charset inherits the carried one.
             if let Some(charset) = &charset {
                 parsed
                     .parameters

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -68,10 +68,7 @@ fn set_blob_content_type(blob: &Blob, mime_type: MimeType) {
         .set(blob::BlobContentType::from(mime_type));
 }
 
-/// Fetch's "extract a MIME type" over the comma-combined `Content-Type` header
-/// value, then the File API's `Blob.type` normalization (drop if any byte is
-/// outside U+0020..=U+007E, else ASCII-lowercase). Sets `content_type_was_set`
-/// regardless so a failed extraction surfaces as an empty `type`.
+/// <https://fetch.spec.whatwg.org/#concept-header-extract-mime-type> + `Blob.type` lowercasing.
 fn set_blob_content_type_from_header(blob: &Blob, header_value: &[u8]) {
     blob.content_type_was_set.set(true);
     let content_type = bun_http_types::mime_sniff::extract_mime_type(header_value)

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -68,6 +68,25 @@ fn set_blob_content_type(blob: &Blob, mime_type: MimeType) {
         .set(blob::BlobContentType::from(mime_type));
 }
 
+/// Fetch's "extract a MIME type" over the comma-combined `Content-Type` header
+/// value, then the File API's `Blob.type` normalization (drop if any byte is
+/// outside U+0020..=U+007E, else ASCII-lowercase). Sets `content_type_was_set`
+/// regardless so a failed extraction surfaces as an empty `type`.
+fn set_blob_content_type_from_header(blob: &Blob, header_value: &[u8]) {
+    blob.content_type_was_set.set(true);
+    let content_type = bun_http_types::mime_sniff::extract_mime_type(header_value)
+        .filter(|ty| blob::is_valid_blob_type(ty))
+        .map(|mut ty| {
+            ty.make_ascii_lowercase();
+            blob::BlobContentType::Owned(std::sync::Arc::from(ty))
+        })
+        .unwrap_or_default();
+    if let Some(store) = blob_store_mut(blob) {
+        store.mime_type = MimeType::init(content_type.as_slice(), true, None);
+    }
+    blob.content_type.set(content_type);
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Local shims for upstream-gated `JsClass` impls / `AnyPromise` methods.
 // These adapt call sites in this file without editing `bun_jsc` (orphan rule).
@@ -1097,8 +1116,7 @@ impl Value {
                                 fetch_headers.fast_get(HTTPHeaderName::ContentType)
                             {
                                 let content_slice = content_type.to_slice();
-                                let mime_type = MimeType::init(content_slice.slice(), true, None);
-                                set_blob_content_type(blob, mime_type);
+                                set_blob_content_type_from_header(blob, content_slice.slice());
                                 // content_slice dropped (replaces defer content_slice.deinit())
                             }
                         }
@@ -2113,8 +2131,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 let fetch_headers = bun_opaque::opaque_deref_mut(fetch_headers.as_ptr());
                 if let Some(content_type) = fetch_headers.fast_get(HTTPHeaderName::ContentType) {
                     let content_slice = content_type.to_slice();
-                    let mime_type = MimeType::init(content_slice.slice(), true, None);
-                    set_blob_content_type(blob, mime_type);
+                    set_blob_content_type_from_header(blob, content_slice.slice());
                     // content_slice dropped (replaces defer content_slice.deinit())
                 }
             }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -476,8 +476,12 @@ impl Request {
         let Some(content_type_slice) = self.get_content_type()? else {
             return Ok(None);
         };
-        let Some(encoding) = crate::webcore::form_data::Encoding::get(content_type_slice.slice())
+        let Some(extracted) =
+            bun_http_types::mime_sniff::extract_mime_type(content_type_slice.slice())
         else {
+            return Ok(None);
+        };
+        let Some(encoding) = crate::webcore::form_data::Encoding::get(&extracted) else {
             return Ok(None);
         };
         Ok(Some(crate::webcore::form_data::AsyncFormData::init(

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -395,7 +395,12 @@ impl Response {
             return Ok(None);
         };
         // content_type_slice drops at scope exit
-        let Some(encoding) = bun_core::form_data::Encoding::get(content_type_slice.slice()) else {
+        let Some(extracted) =
+            bun_http_types::mime_sniff::extract_mime_type(content_type_slice.slice())
+        else {
+            return Ok(None);
+        };
+        let Some(encoding) = bun_core::form_data::Encoding::get(&extracted) else {
             return Ok(None);
         };
         Ok(Some(bun_core::form_data::AsyncFormData::init(encoding)))

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -796,7 +796,7 @@ describe("extract a MIME type from Content-Type", () => {
       ];
       const fd = await fn(multipartBody("B2"), headers).formData();
       expect(fd.get("f")).toBe("val");
-      await expect(fn(multipartBody("B1"), headers).formData()).rejects.toThrow();
+      await expect(fn(multipartBody("B1"), headers).formData()).rejects.toThrow(TypeError);
     });
   }
 

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,6 +1,8 @@
 import { file, spawn, version } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, exampleSite } from "harness";
+import net from "node:net";
+import { once } from "node:events";
 
 const exampleServer = exampleSite("http");
 
@@ -747,6 +749,92 @@ describe.concurrent("string body consumption does not leak", () => {
       expect(exitCode).toBe(0);
     });
   }
+});
+
+// https://fetch.spec.whatwg.org/#concept-header-extract-mime-type
+// blob()/formData() must run "extract a MIME type" over the header list (split
+// the comma-combined value, keep the last valid MIME, serialize canonically).
+describe("extract a MIME type from Content-Type", () => {
+  // Input header value(s) -> expected blob().type (verified against Node v26).
+  const blobTypeCases: [string | string[], string][] = [
+    ["TEXT/HTML ;  Charset=UTF-8", "text/html;charset=utf-8"],
+    ["application/json", "application/json"],
+    ["text/plain; charset=UTF-8; charset=iso-8859-1", "text/plain;charset=utf-8"],
+    ["multipart/form-data; boundary=B1", "multipart/form-data;boundary=b1"],
+    ['text/plain; a="b,c"; d=e', 'text/plain;a="b,c";d=e'],
+    ["not a mime type", ""],
+    ["*/*", ""],
+    ["text / html", ""],
+    [["not a type", "application/json"], "application/json"],
+    [["text/html", "*/*"], "text/html"],
+    [["text/html;charset=gbk", "text/html;x=y"], "text/html;x=y;charset=gbk"],
+    [["text/html;charset=gbk", "text/plain", "text/html"], "text/html"],
+    [["multipart/form-data; boundary=B1", "multipart/form-data; boundary=B2"], "multipart/form-data;boundary=b2"],
+  ];
+  for (const { body, fn } of bodyTypes) {
+    describe(`${body.name}.blob() type`, () => {
+      for (const [raw, expected] of blobTypeCases) {
+        test(JSON.stringify(raw), async () => {
+          const headers = Array.isArray(raw)
+            ? (raw.map(v => ["content-type", v]) as [string, string][])
+            : { "content-type": raw };
+          expect((await fn("x", headers).blob()).type).toBe(expected);
+        });
+      }
+    });
+  }
+
+  function multipartBody(boundary: string) {
+    return `--${boundary}\r\nContent-Disposition: form-data; name="f"\r\n\r\nval\r\n--${boundary}--\r\n`;
+  }
+
+  for (const { body, fn } of bodyTypes) {
+    test(`${body.name}.formData() uses the last multipart boundary`, async () => {
+      const headers: [string, string][] = [
+        ["content-type", "multipart/form-data; boundary=B1"],
+        ["content-type", "multipart/form-data; boundary=B2"],
+      ];
+      const fd = await fn(multipartBody("B2"), headers).formData();
+      expect(fd.get("f")).toBe("val");
+      await expect(fn(multipartBody("B1"), headers).formData()).rejects.toThrow();
+    });
+  }
+
+  test("fetch() response with duplicated Content-Type", async () => {
+    const server = net.createServer(sock => {
+      sock.once("data", d => {
+        const path = /^GET (\S+)/.exec(String(d))?.[1] || "/";
+        const lines: Record<string, string[]> = {
+          "/case": ["Content-Type: TEXT/HTML ;  Charset=UTF-8"],
+          "/dup-json": ["Content-Type: not a type", "Content-Type: application/json"],
+          "/dup-form": ["Content-Type: multipart/form-data; boundary=B1", "Content-Type: multipart/form-data; boundary=B2"],
+        };
+        const body = path === "/dup-form" ? multipartBody("B2") : '{"a":1}';
+        sock.end(
+          "HTTP/1.1 200 OK\r\n" +
+            (lines[path] ?? ["Content-Type: text/plain"]).join("\r\n") +
+            "\r\nContent-Length: " +
+            body.length +
+            "\r\nConnection: close\r\n\r\n" +
+            body,
+        );
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const base = `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
+      expect((await (await fetch(base + "/case")).blob()).type).toBe("text/html;charset=utf-8");
+      const dup = await fetch(base + "/dup-json");
+      expect(dup.headers.get("content-type")).toBe("not a type, application/json");
+      expect((await dup.blob()).type).toBe("application/json");
+      expect((await (await fetch(base + "/dup-form")).blob()).type).toBe("multipart/form-data;boundary=b2");
+      const fd = await (await fetch(base + "/dup-form")).formData();
+      expect(fd.get("f")).toBe("val");
+    } finally {
+      server.close();
+    }
+  });
 });
 
 // https://github.com/oven-sh/bun/issues/6860

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,8 +1,8 @@
 import { file, spawn, version } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, exampleSite } from "harness";
-import net from "node:net";
 import { once } from "node:events";
+import net from "node:net";
 
 const exampleServer = exampleSite("http");
 
@@ -807,7 +807,10 @@ describe("extract a MIME type from Content-Type", () => {
         const lines: Record<string, string[]> = {
           "/case": ["Content-Type: TEXT/HTML ;  Charset=UTF-8"],
           "/dup-json": ["Content-Type: not a type", "Content-Type: application/json"],
-          "/dup-form": ["Content-Type: multipart/form-data; boundary=B1", "Content-Type: multipart/form-data; boundary=B2"],
+          "/dup-form": [
+            "Content-Type: multipart/form-data; boundary=B1",
+            "Content-Type: multipart/form-data; boundary=B2",
+          ],
         };
         const body = path === "/dup-form" ? multipartBody("B2") : '{"a":1}';
         sock.end(

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -61,7 +61,9 @@ test("should set type of blob object to the value of the `Content-Type` header f
   await once(server, "listening");
 
   const response = await fetch(`http://localhost:${server.address().port}`);
-  expect("application/json;charset=utf-8").toBe((await response.blob()).type);
+  // https://fetch.spec.whatwg.org/#concept-header-extract-mime-type: the
+  // extracted MIME type is serialized as-is, so no charset is appended.
+  expect((await response.blob()).type).toBe("application/json");
 });
 
 test("pre aborted with readable request body", async () => {


### PR DESCRIPTION
The Fetch spec's ["extract a MIME type"](https://fetch.spec.whatwg.org/#concept-header-extract-mime-type) algorithm iterates the `Content-Type` header values (via [get, decode, and split](https://fetch.spec.whatwg.org/#header-value-get-decode-and-split)), keeps the last valid MIME type with charset carry-over, and serializes it canonically. Body consumers (`blob().type`, `formData()`) must use that result, not the raw header field.

Bun was handing the raw comma-combined field straight through, so:

```
Content-Type: TEXT/HTML ;  Charset=UTF-8
  bun:  blob.type === "TEXT/HTML ;  Charset=UTF-8"
  node: blob.type === "text/html;charset=utf-8"

Content-Type: not a type
Content-Type: application/json
  bun:  blob.type === "not a type, application/json"
  node: blob.type === "application/json"

Content-Type: multipart/form-data; boundary=B1
Content-Type: multipart/form-data; boundary=B2
  bun:  blob.type === "multipart/form-data; boundary=B1, multipart/form-data; boundary=B2"
        formData() throws ERR_FORMDATA_PARSE_ERROR "missing final boundary"
        for a body framed with either B1 or B2
  node: blob.type === "multipart/form-data;boundary=b2"
        formData() parses a B2-framed body
```

The `formData()` failure is a functional break for any origin or CDN that stacks a `Content-Type` header line.

### Fix

`src/http_types/mime_sniff.rs` implements ["parse a MIME type"](https://mimesniff.spec.whatwg.org/#parse-a-mime-type), ["serialize a MIME type"](https://mimesniff.spec.whatwg.org/#serialize-a-mime-type), and "extract a MIME type", including the get-decode-split step over a comma-combined header value.

The two `blob()` header-reading sites in `Body.rs` route through `extract_mime_type()` and then apply the File API's `Blob.type` normalization (drop if any byte is outside U+0020..U+007E, else ASCII-lowercase). `get_form_data_encoding()` in `Request` and `Response` routes the header through `extract_mime_type()` before `Encoding::get()`, so the boundary is taken from the last valid `multipart/form-data` value.


`Blob.prototype.formData()` (`Blob.rs`) is not routed through `extract_mime_type()`: `Blob.type` is a single File-API-normalized value, not a comma-combined header list, so the get-decode-and-split step does not apply.

### Tests

`test/js/web/fetch/body.test.ts` gains a 13-vector header table for `blob().type` on both `Request` and `Response` (each verified byte-equal against Node), a duplicated-boundary `formData()` case for both, and a raw-socket `fetch()` round trip that sends the three header shapes above. 27 of the 29 new tests fail on stock Bun.

`client-fetch.test.ts`'s ported undici assertion is restored to undici's `"application/json"`; Bun's port had changed it to `"application/json;charset=utf-8"` to match the old category-table behaviour.

### Related

#33128 is a broader overhaul of `blob().type` that also handles `File` identity, the `ReadableStream` body path, `.body`-before-`blob()` tracking, and the generated multipart boundary prefix. It shares the same `mime_sniff.rs` module but does not route `formData()` through it; whichever lands second rebases onto the shared module.


Fixes #19603

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 28 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body.test.ts test/js/web/fetch/client-fetch.test.ts
bun test v1.4.0 (86c2d9373)

test/js/web/fetch/client-fetch.test.ts:
(pass) function signature [2.78ms]
(pass) args validation [6.16ms]
(pass) request json [664.37ms]
(pass) request text [117.57ms]
(pass) request arrayBuffer [110.85ms]
61 |   await once(server, "listening");
62 | 
63 |   const response = await fetch(`http://localhost:${server.address().port}`);
64 |   // https://fetch.spec.whatwg.org/#concept-header-extract-mime-type: the
65 |   // extracted MIME type is serialized as-is, so no charset is appended.
66 |   expect((await response.blob()).type).toBe("application/json");
                                            ^
error: expect(received).toBe(expected)

Expected: "application/json"
Received: "application/json;charset=utf-8"

      at <anonymous> (/workspace/bun/test/js/web/fetch/client-fetch.test.ts:66:40)
(fail) should set type of blob object to the value of the `Content-Type` header from response [141.12ms]
(pass) pre aborted with readable request bo
... (truncated)

release without fix: 6 skipped
bun test v1.4.0-canary.1 (c611551a8)

test/js/web/fetch/client-fetch.test.ts:
(pass) function signature [0.78ms]
(pass) args validation [1.16ms]
(pass) request json [11.44ms]
(pass) request text [3.61ms]
(pass) request arrayBuffer [2.82ms]
(pass) should set type of blob object to the value of the `Content-Type` header from response [2.65ms]
(pass) pre aborted with readable request body [2.09ms]
(pass) pre aborted with closed readable request body [1.84ms]
(pass) unsupported formData 1 [2.27ms]
(pass) multipart formdata not base64 [2.93ms]
(todo) multipart formdata base64
(pass) multipart fromdata non-ascii filed names [0.12ms]
(pass) busboy emit error [2.94ms]
(pass) parsing formData preserve full path on files [0.12ms]
(pass) urlencoded formData [2.39ms]
(pass) text with BOM [2.45ms]
(todo) formData with BOM
(pass) locked blob body [2.95ms]
(pass) disturbed blob body [2.35ms]
(pass) redirect with body [5.35ms]
(pass) redirect with stream [306.45ms]
(pass) fail to extract locked body [0.23ms]
(pass) fail to extract locked body [0.11ms]
(pass) post FormData with Blob [5.94ms]
(pass) post FormData with File [2.96ms]
(pass) unresolvable hostname rejects with the resolv
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body.test.ts test/js/web/fetch/client-fetch.test.ts
bun test v1.4.0 (86c2d9373)

test/js/web/fetch/client-fetch.test.ts:
(pass) function signature [9.07ms]
(pass) args validation [16.87ms]
(pass) request json [412.93ms]
(pass) request text [73.04ms]
(pass) request arrayBuffer [68.11ms]
(pass) should set type of blob object to the value of the `Content-Type` header from response [86.38ms]
(pass) pre aborted with readable request body [38.60ms]
(pass) pre aborted with closed readable request body [40.46ms]
(pass) unsupported formData 1 [70.03ms]
(pass) multipart formdata not base64 [107.84ms]
(todo) multipart formdata base64
(pass) multipart fromdata non-ascii filed names [5.98ms]
(pass) busboy emit error [68.19ms]
(pass) parsing formData preserve full path on files [6.08ms]
(pass) urlencoded formData [79.84ms]
(pass) text with BOM [67.27ms]
(todo) formData with BOM
(pass) locked blob body [64.37ms]
(pass) disturbed blob body [62.08ms]
(pass) redirect with body [125.52ms]
(pass) redirect with stream [395.97ms]
(pass) fa
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 672ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_types/lib.rs                  |   1 +
 src/http_types/mime_sniff.rs           | 282 +++++++++++++++++++++++++++++++++
 src/runtime/webcore/Body.rs            |  22 ++-
 src/runtime/webcore/Request.rs         |   6 +-
 src/runtime/webcore/Response.rs        |   7 +-
 test/js/web/fetch/body.test.ts         |  91 +++++++++++
 test/js/web/fetch/client-fetch.test.ts |   4 +-
 7 files changed, 406 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/http_types/lib.rs                       1      1      0
src/http_types/mime_sniff.rs                1      3      0
src/runtime/webcore/Body.rs                 5      6      0
src/runtime/webcore/Request.rs              1      1      0
src/runtime/webcore/Response.rs             1      1      0
test/js/web/fetch/body.test.ts              3      3      0
test/js/web/fetch/client-fetch.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->