### PR TITLE
resolver: gate pkg/package.json behind the exports map (Node parity)

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2765,38 +2765,6 @@ impl<'a> Resolver<'a> {
                                         }
                                     }
 
-                                    // if they hid "package.json" from "exports", still allow importing it.
-                                    if esm.subpath == b"./package.json" {
-                                        self.extension_order = prev_extension_order;
-                                        if let Some(d) = self.debug_logs.as_mut() {
-                                            d.decrease_indent();
-                                        }
-                                        *out = MatchResult {
-                                            // NOTE: PackageJSON.source.path is bun_paths::fs::Path<'static>; convert
-                                            // to the resolver's interned crate::fs::Path<'static> via its text.
-                                            path_pair: PathPair {
-                                                primary: Path::init(package_json.source.path.text),
-                                                secondary: None,
-                                            },
-                                            dirname_fd: pkg_dir_info.get_file_descriptor(),
-                                            file_fd: FD::INVALID,
-                                            // `Path.isNodeModule()` checks
-                                            // `lastIndexOf(name.dir, SEP++"node_modules"++SEP)`, i.e. a
-                                            // separator-bounded directory component on `name.dir` (not a
-                                            // bare substring of the full text). `bun_paths::fs::Path<'static>`
-                                            // doesn't carry that method, so re-derive via the resolver's
-                                            // `Path` (already done one line up for `path_pair.primary`).
-                                            is_node_module: Path::init(
-                                                package_json.source.path.text,
-                                            )
-                                            .is_node_module(),
-                                            package_json: Some(std::ptr::from_ref(package_json)),
-                                            dir_info: Some(dir_info),
-                                            ..Default::default()
-                                        };
-                                        return MatchStatus::Success;
-                                    }
-
                                     self.extension_order = prev_extension_order;
                                     if let Some(d) = self.debug_logs.as_mut() {
                                         d.decrease_indent();
@@ -3238,31 +3206,6 @@ impl<'a> Resolver<'a> {
                                             }
                                             return MatchStatus::Success;
                                         }
-                                    }
-
-                                    // if they hid "package.json" from "exports", still allow importing it.
-                                    if esm.subpath == b"./package.json" {
-                                        if let Some(d) = self.debug_logs.as_mut() {
-                                            d.decrease_indent();
-                                        }
-                                        *out = MatchResult {
-                                            path_pair: PathPair {
-                                                primary: Fs::Path::init(
-                                                    package_json.source.path.text,
-                                                ),
-                                                secondary: None,
-                                            },
-                                            dirname_fd: pkg_dir_info.get_file_descriptor(),
-                                            file_fd: FD::INVALID,
-                                            is_node_module: package_json
-                                                .source
-                                                .path
-                                                .is_node_module(),
-                                            package_json: Some(std::ptr::from_ref(package_json)),
-                                            dir_info: Some(dir_info),
-                                            ..Default::default()
-                                        };
-                                        return MatchStatus::Success;
                                     }
 
                                     if let Some(d) = self.debug_logs.as_mut() {

--- a/test/js/bun/resolve/exports-package-json-gated.test.ts
+++ b/test/js/bun/resolve/exports-package-json-gated.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Node gates `pkg/package.json` behind the "exports" map like every other subpath:
+// https://nodejs.org/api/packages.html#package-entry-points
+//   "all subpaths of the package will be encapsulated ... including the package.json"
+// Prior to this change Bun exempted the manifest, so require('pkg/package.json') resolved
+// even when the package's exports map did not list "./package.json".
+
+const fixtureFiles = {
+  "package.json": JSON.stringify({ name: "app", private: true }),
+
+  // object-form exports that do NOT list "./package.json"
+  "node_modules/objx/package.json": JSON.stringify({
+    name: "objx",
+    main: "./m.js",
+    exports: { ".": "./m.js", "./sub": "./sub.js" },
+  }),
+  "node_modules/objx/m.js": 'module.exports = "objx/m.js"',
+  "node_modules/objx/sub.js": 'module.exports = "objx/sub.js"',
+  "node_modules/objx/internal.js": 'module.exports = "objx/internal.js"',
+
+  // string-sugar exports
+  "node_modules/strx/package.json": JSON.stringify({
+    name: "strx",
+    exports: "./m.js",
+  }),
+  "node_modules/strx/m.js": 'module.exports = "strx/m.js"',
+
+  // `exports: {}` — package fully encapsulated, nothing importable at all
+  "node_modules/empx/package.json": JSON.stringify({
+    name: "empx",
+    main: "./m.js",
+    exports: {},
+  }),
+  "node_modules/empx/m.js": 'module.exports = "empx/m.js"',
+
+  // package that explicitly exports "./package.json" — must keep working
+  "node_modules/openx/package.json": JSON.stringify({
+    name: "openx",
+    exports: { ".": "./m.js", "./package.json": "./package.json" },
+  }),
+  "node_modules/openx/m.js": 'module.exports = "openx/m.js"',
+
+  // no exports map at all — deep paths are not gated
+  "node_modules/bare/package.json": JSON.stringify({ name: "bare", main: "./m.js" }),
+  "node_modules/bare/m.js": 'module.exports = "bare/m.js"',
+
+  "probe.mjs": `
+    import { createRequire } from "node:module";
+    const req = createRequire(import.meta.url);
+    const out = {};
+    async function cell(id, fn) {
+      try {
+        const v = await fn();
+        out[id] = v && v.name ? "manifest name=" + v.name : typeof v === "string" ? "resolved" : String(v);
+      } catch (e) {
+        out[id] = "ERR:" + (e.code || e.name);
+      }
+    }
+    await cell("require objx/package.json", () => req("objx/package.json"));
+    await cell("require.resolve objx/package.json", () => req.resolve("objx/package.json"));
+    await cell("import objx/package.json {type:json}", async () => (await import("objx/package.json", { with: { type: "json" } })).default);
+    await cell("import.meta.resolve objx/package.json", () => import.meta.resolve("objx/package.json"));
+    await cell("require strx/package.json (exports: string)", () => req("strx/package.json"));
+    await cell("require empx/package.json (exports: {})", () => req("empx/package.json"));
+    await cell("require objx/internal.js (deep, control)", () => req("objx/internal.js"));
+    await cell("require openx/package.json (explicitly exported)", () => req("openx/package.json"));
+    await cell("require bare/package.json (no exports map)", () => req("bare/package.json"));
+    await cell("require objx (root, control)", () => req("objx"));
+    console.log(JSON.stringify(out));
+  `,
+};
+
+// Node uses ERR_PACKAGE_PATH_NOT_EXPORTED; Bun historically used MODULE_NOT_FOUND for
+// exports-gated subpaths. The invariant under test here is that resolution *fails*
+// (the manifest is not returned), so accept either code.
+const gated = expect.stringMatching(/^ERR:(ERR_PACKAGE_PATH_NOT_EXPORTED|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND)$/);
+
+describe("pkg/package.json is gated by the exports map", () => {
+  test.concurrent("require / import / resolve", async () => {
+    using dir = tempDir("exports-pjson-gate", fixtureFiles);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "probe.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "require objx/package.json": gated,
+      "require.resolve objx/package.json": gated,
+      "import objx/package.json {type:json}": gated,
+      "import.meta.resolve objx/package.json": gated,
+      "require strx/package.json (exports: string)": gated,
+      "require empx/package.json (exports: {})": gated,
+      "require objx/internal.js (deep, control)": gated,
+      "require openx/package.json (explicitly exported)": "manifest name=openx",
+      "require bare/package.json (no exports map)": "manifest name=bare",
+      "require objx (root, control)": "resolved",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("self-reference from inside the package", async () => {
+    using dir = tempDir("exports-pjson-self", {
+      ...fixtureFiles,
+      "node_modules/objx/self.cjs": `
+        try {
+          require("objx/package.json");
+          console.log("RESOLVED");
+        } catch (e) {
+          console.log("ERR:" + (e.code || e.name));
+        }
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "node_modules/objx/self.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect({ out: stdout.trim() }).toEqual({ out: gated });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/resolve/resolve-test.js
+++ b/test/js/bun/resolve/resolve-test.js
@@ -75,7 +75,7 @@ it("import.meta.resolveSync", async () => {
   );
 
   // "./package.json" is gated by the exports map like every other subpath (Node parity)
-  expect(() => import.meta.resolveSync("package-json-exports/package.json")).toThrow();
+  expect(() => import.meta.resolveSync("package-json-exports/package.json")).toThrow(ResolveMessage);
 
   // if an unnecessary ".js" extension was added, try against /baz
   expect(import.meta.resolveSync("package-json-exports/baz.js")).toBe(

--- a/test/js/bun/resolve/resolve-test.js
+++ b/test/js/bun/resolve/resolve-test.js
@@ -74,10 +74,8 @@ it("import.meta.resolveSync", async () => {
     join(import.meta.path, "../node_modules/package-json-exports/foo/bar.js"),
   );
 
-  // if they never exported /package.json, allow reading from it too
-  expect(import.meta.resolveSync("package-json-exports/package.json")).toBe(
-    join(import.meta.path, "../node_modules/package-json-exports/package.json"),
-  );
+  // "./package.json" is gated by the exports map like every other subpath (Node parity)
+  expect(() => import.meta.resolveSync("package-json-exports/package.json")).toThrow();
 
   // if an unnecessary ".js" extension was added, try against /baz
   expect(import.meta.resolveSync("package-json-exports/baz.js")).toBe(


### PR DESCRIPTION
## What

Bun exempted the `./package.json` subpath from package.json `"exports"` encapsulation: `require('pkg/package.json')`, `import('pkg/package.json', {with:{type:'json'}})`, `require.resolve` and `import.meta.resolve` all returned the manifest even when the package's exports map did not list `"./package.json"`. Every other non-listed subpath was correctly blocked; the manifest was the one exempted path.

Node rejects all of these with `ERR_PACKAGE_PATH_NOT_EXPORTED` unless the package explicitly exports `"./package.json"`. The Node docs call this out by name:

> all subpaths of the package will be encapsulated and no longer available to importers ... including the `package.json` (this will likely be a breaking change)

The practical problem is that tooling which reads `pkg/package.json` works on Bun and then hard-fails on Node once the package ships an `exports` map.

## Repro

```js
// node_modules/objx/package.json
{ "name": "objx", "main": "./m.js", "exports": { ".": "./m.js" } }
```
```js
require("objx/package.json")
// node:  Error [ERR_PACKAGE_PATH_NOT_EXPORTED]
// bun (before): { name: 'objx', main: './m.js', exports: { '.': './m.js' } }
// bun (after):  ResolveMessage (same as objx/anything-else)
```

## Cause

Two fallback blocks in `load_node_modules` (the node_modules walk and the global-cache path) short-circuited to the manifest path when `esm.subpath == "./package.json"` after exports resolution had already failed. Added in e2f709b2a5.

## Fix

Remove the two fallback blocks. `./package.json` now flows through the same `MatchStatus::NotFound` return as every other non-exported subpath.

Unchanged:
- packages that explicitly export `"./package.json"` (e.g. react, socket.io-client) still resolve it
- packages with no `exports` field still expose their `package.json` via the legacy deep-path rules
- the bundler uses the same resolver, so `bun build` now errors on these imports too (Node parity, and esbuild's behavior)

## Verification

New `test/js/bun/resolve/exports-package-json-gated.test.ts` covers object-form exports, string-sugar exports, `exports: {}`, self-reference from inside the package, and the positive controls (explicit `"./package.json"` entry, no exports map, package root). The existing `resolve-test.js` assertion that encoded the old exemption is inverted to expect a throw.

```
bun bd test test/js/bun/resolve/exports-package-json-gated.test.ts  # 2 pass
bun bd test test/js/bun/resolve/resolve.test.ts                     # 46 pass, 2 skip (pre-existing)
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/exports-package-json-gated.test.ts
bun test v1.4.0 (1ce6460ad)

test/js/bun/resolve/exports-package-json-gated.test.ts:
121 |       cwd: String(dir),
122 |       stderr: "pipe",
123 |     });
124 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
125 |     expect(stderr).toBe("");
126 |     expect({ out: stdout.trim() }).toEqual({ out: gated });
                                         ^
error: expect(received).toEqual(expected)

  {
-   "out": StringMatching /^ERR:(ERR_PACKAGE_PATH_NOT_EXPORTED|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND)$/,
+   "out": "RESOLVED",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/resolve/exports-package-json-gated.test.ts:126:36)
(fail) pkg/package.json is gated by the exports map > self-reference from inside the package [310.49ms]
86 |       cwd: String(dir),
87 |       stderr: "pipe",
88 |     });
89 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.st
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1ce6460ad)

test/js/bun/resolve/exports-package-json-gated.test.ts:
(pass) pkg/package.json is gated by the exports map > require / import / resolve [11.72ms]
(pass) pkg/package.json is gated by the exports map > self-reference from inside the package [9.22ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [161.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/exports-package-json-gated.test.ts
bun test v1.4.0 (1ce6460ad)

test/js/bun/resolve/exports-package-json-gated.test.ts:
(pass) pkg/package.json is gated by the exports map > self-reference from inside the package [296.34ms]
(pass) pkg/package.json is gated by the exports map > require / import / resolve [377.26ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [2.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 653ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs                           |  57 ---------
 .../bun/resolve/exports-package-json-gated.test.ts | 129 +++++++++++++++++++++
 test/js/bun/resolve/resolve-test.js                |   6 +-
 3 files changed, 131 insertions(+), 61 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/resolver/resolver.rs                                    2      2      0
test/js/bun/resolve/exports-package-json-gated.test.ts      0      2      0
test/js/bun/resolve/resolve-test.js                         2      2      0
```

</details>

<!-- robobun:evidence:end -->