### PR TITLE
resolver: reject multi-star exports pattern keys and empty '*' captures

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1750,11 +1750,13 @@ impl<'a> ESModule<'a> {
                         let pattern_trailer = &expansion.key[star + 1..];
 
                         // If patternTrailer has zero length, or if matchKey ends with
-                        // patternTrailer and the length of matchKey is greater than or
-                        // equal to the length of expansionKey, then
-                        if pattern_trailer.is_empty()
-                            || (strings::ends_with(match_key, pattern_trailer)
-                                && match_key.len() >= expansion.key.len())
+                        // patternTrailer, and the length of matchKey is greater than or
+                        // equal to the length of expansionKey, and patternTrailer does
+                        // not contain "*" (the key must have exactly one "*"), then
+                        if (pattern_trailer.is_empty()
+                            || strings::ends_with(match_key, pattern_trailer))
+                            && match_key.len() >= expansion.key.len()
+                            && !strings::contains_char(pattern_trailer, b'*')
                         {
                             let target = &expansion.value;
                             let subpath = &match_key

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -2019,11 +2019,12 @@ describe("bundler", () => {
 
 describe("bundler", () => {
   // An exports pattern target may spell ".." as "..*": the literal segment passes the
-  // pre-substitution target validation because it is not exactly "..", and a specifier that
-  // equals the pattern base ("pkg1/x" against the key "./x*") substitutes an empty string
-  // for "*", turning "./..*/..*/outside.js" into "./../../outside.js". The resolved path must
-  // be re-validated after substitution so the import fails instead of loading a file that
-  // lives above the package directory. The plain "pkg1" import must keep working.
+  // pre-substitution target validation because it is not exactly "..", so an empty "*"
+  // capture would turn "./..*/..*/outside.js" into "./../../outside.js". "pkg1/x" against
+  // the key "./x*" is now rejected at match time (Node requires "*" to capture at least
+  // one character), closing this escape before substitution; the test remains as a guard
+  // that outside.js is unreachable through either mechanism. The plain "pkg1" import must
+  // keep working.
   itBundled("packagejson/ExportsPatternTargetRejectsParentSegmentsAfterSubstitution", {
     files: {
       "/Users/user/project/src/entry.js": /* js */ `

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1361,10 +1361,13 @@ describe("bundler", () => {
       stdout: "SUCCESS\nSUCCESS",
     },
   });
+  // Diverges from esbuild's upstream test: Node requires the "*" to capture at least
+  // one character (matchKey.length >= expansionKey.length), so "pkg1/foo" against
+  // "./foo*" is ERR_PACKAGE_PATH_NOT_EXPORTED in every supported Node release.
   itBundled("packagejson/ExportsWildcard", {
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
-        import 'pkg1/foo'
+        import 'pkg1/foo1'
         import 'pkg1/foo2'
       `,
       "/Users/user/project/node_modules/pkg1/package.json": /* json */ `
@@ -1374,7 +1377,7 @@ describe("bundler", () => {
           }
         }
       `,
-      "/Users/user/project/node_modules/pkg1/file.js": `console.log('SUCCESS')`,
+      "/Users/user/project/node_modules/pkg1/file1.js": `console.log('SUCCESS')`,
       "/Users/user/project/node_modules/pkg1/file2.js": `console.log('SUCCESS')`,
     },
     run: {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -589,6 +589,71 @@ describe("wildcard exports with @ in matched subpath", () => {
   });
 });
 
+// Node's PACKAGE_IMPORTS_EXPORTS_RESOLVE only treats an `exports` key as a
+// pattern when it contains exactly one "*", and only matches when the subpath
+// is at least as long as the key (so the "*" captures at least one character).
+// Both constraints are enforced for parity: a map that resolves under Bun but
+// throws ERR_PACKAGE_PATH_NOT_EXPORTED under Node is a portability hazard.
+describe("package.json exports pattern-key constraints", () => {
+  it.concurrent("does not match a key that contains more than one '*'", () => {
+    using dir = tempDir("resolver-exports-two-star-key", {
+      "package.json": JSON.stringify({ name: "host" }),
+      "node_modules/pat/package.json": JSON.stringify({
+        name: "pat",
+        exports: { "./two/*/*": "./src/two/*/*.js", "./f/*.js": "./src/f/*.js" },
+      }),
+      "node_modules/pat/src/two/q/q.js": "module.exports = 1;",
+      "node_modules/pat/src/f/deep/y.js": "module.exports = 2;",
+    });
+    const root = String(dir);
+
+    expect(() => Bun.resolveSync("pat/two/q/*", root)).toThrow();
+    expect(() => Bun.resolveSync("pat/two/q/anything", root)).toThrow();
+    // single-"*" control: must still match, including across "/"
+    expect(Bun.resolveSync("pat/f/deep/y.js", root)).toBe(join(root, "node_modules/pat/src/f/deep/y.js"));
+  });
+
+  it.concurrent("does not match a key whose '*' would capture the empty string", () => {
+    using dir = tempDir("resolver-exports-empty-capture", {
+      "package.json": JSON.stringify({ name: "host" }),
+      "node_modules/pat/package.json": JSON.stringify({
+        name: "pat",
+        exports: { "./e/*": "./src/e/*.js", "./mid/*.js": "./src/mid/*.js" },
+      }),
+      "node_modules/pat/src/e/.js": "module.exports = 1;",
+      "node_modules/pat/src/e/x.js": "module.exports = 2;",
+      "node_modules/pat/src/mid/.js": "module.exports = 3;",
+      "node_modules/pat/src/mid/x.js": "module.exports = 4;",
+    });
+    const root = String(dir);
+
+    // subpath exactly equals the key's base: "*" would capture ""
+    expect(() => Bun.resolveSync("pat/e/", root)).toThrow();
+    // trailer present, subpath length == key length - 1: "*" would capture ""
+    expect(() => Bun.resolveSync("pat/mid/.js", root)).toThrow();
+    // one-character captures must still match
+    expect(Bun.resolveSync("pat/e/x", root)).toBe(join(root, "node_modules/pat/src/e/x.js"));
+    expect(Bun.resolveSync("pat/mid/x.js", root)).toBe(join(root, "node_modules/pat/src/mid/x.js"));
+  });
+
+  it.concurrent("applies the same constraints to the imports field", () => {
+    using dir = tempDir("resolver-imports-pattern-key", {
+      "package.json": JSON.stringify({
+        name: "host",
+        imports: { "#two/*/*": "./src/two/*/*.js", "#e/*": "./src/e/*.js" },
+      }),
+      "src/two/q/q.js": "module.exports = 1;",
+      "src/e/.js": "module.exports = 2;",
+      "src/e/x.js": "module.exports = 3;",
+    });
+    const root = String(dir);
+
+    expect(() => Bun.resolveSync("#two/q/*", root)).toThrow();
+    expect(() => Bun.resolveSync("#e/", root)).toThrow();
+    expect(Bun.resolveSync("#e/x", root)).toBe(join(root, "src/e/x.js"));
+  });
+});
+
 describe("package.json exports target percent-encoding", () => {
   // ESModule.finalize short-circuits when the resolved path contains no '%'.
   // These cases exercise both that branch and the decode branch to keep them in lockstep.

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -589,12 +589,22 @@ describe("wildcard exports with @ in matched subpath", () => {
   });
 });
 
+const resolveError = (spec: string, root: string) => {
+  try {
+    return { resolved: Bun.resolveSync(spec, root) };
+  } catch (e: any) {
+    return { name: e.name, code: e.code };
+  }
+};
+
 // Node's PACKAGE_IMPORTS_EXPORTS_RESOLVE only treats an `exports` key as a
 // pattern when it contains exactly one "*", and only matches when the subpath
 // is at least as long as the key (so the "*" captures at least one character).
 // Both constraints are enforced for parity: a map that resolves under Bun but
 // throws ERR_PACKAGE_PATH_NOT_EXPORTED under Node is a portability hazard.
 describe("package.json exports pattern-key constraints", () => {
+  const notExported = { name: "ResolveMessage", code: "ERR_MODULE_NOT_FOUND" };
+
   it.concurrent("does not match a key that contains more than one '*'", () => {
     using dir = tempDir("resolver-exports-two-star-key", {
       "package.json": JSON.stringify({ name: "host" }),
@@ -607,8 +617,8 @@ describe("package.json exports pattern-key constraints", () => {
     });
     const root = String(dir);
 
-    expect(() => Bun.resolveSync("pat/two/q/*", root)).toThrow();
-    expect(() => Bun.resolveSync("pat/two/q/anything", root)).toThrow();
+    expect(resolveError("pat/two/q/*", root)).toEqual(notExported);
+    expect(resolveError("pat/two/q/anything", root)).toEqual(notExported);
     // single-"*" control: must still match, including across "/"
     expect(Bun.resolveSync("pat/f/deep/y.js", root)).toBe(join(root, "node_modules/pat/src/f/deep/y.js"));
   });
@@ -628,9 +638,9 @@ describe("package.json exports pattern-key constraints", () => {
     const root = String(dir);
 
     // subpath exactly equals the key's base: "*" would capture ""
-    expect(() => Bun.resolveSync("pat/e/", root)).toThrow();
+    expect(resolveError("pat/e/", root)).toEqual(notExported);
     // trailer present, subpath length == key length - 1: "*" would capture ""
-    expect(() => Bun.resolveSync("pat/mid/.js", root)).toThrow();
+    expect(resolveError("pat/mid/.js", root)).toEqual(notExported);
     // one-character captures must still match
     expect(Bun.resolveSync("pat/e/x", root)).toBe(join(root, "node_modules/pat/src/e/x.js"));
     expect(Bun.resolveSync("pat/mid/x.js", root)).toBe(join(root, "node_modules/pat/src/mid/x.js"));
@@ -648,8 +658,8 @@ describe("package.json exports pattern-key constraints", () => {
     });
     const root = String(dir);
 
-    expect(() => Bun.resolveSync("#two/q/*", root)).toThrow();
-    expect(() => Bun.resolveSync("#e/", root)).toThrow();
+    expect(resolveError("#two/q/*", root)).toEqual(notExported);
+    expect(resolveError("#e/", root)).toEqual(notExported);
     expect(Bun.resolveSync("#e/x", root)).toBe(join(root, "src/e/x.js"));
   });
 });
@@ -657,14 +667,6 @@ describe("package.json exports pattern-key constraints", () => {
 describe("package.json exports target percent-encoding", () => {
   // ESModule.finalize short-circuits when the resolved path contains no '%'.
   // These cases exercise both that branch and the decode branch to keep them in lockstep.
-  const resolveError = (spec: string, root: string) => {
-    try {
-      return { resolved: Bun.resolveSync(spec, root) };
-    } catch (e: any) {
-      return { name: e.name, code: e.code };
-    }
-  };
-
   it.concurrent("resolves a plain target and rejects a directory target", () => {
     using dir = tempDir("resolver-exports-finalize-plain", {
       "package.json": JSON.stringify({ name: "host" }),


### PR DESCRIPTION
## Problem

Two `package.json` `exports` pattern-key constraints that Node enforces and Bun did not, so a map that resolves under Bun throws `ERR_PACKAGE_PATH_NOT_EXPORTED` under every supported Node release:

1. **A key with more than one `*`** is never a pattern in Node (`StringPrototypeLastIndexOf(key, '*') === patternIndex`). Bun matched on the first `*` and treated the rest of the key as a literal trailer, so `"./two/*/*": "./src/two/*/*.js"` matched `pat/two/q/*` and substituted `q` for both target `*`s.
2. **An empty `*` capture** is rejected by Node (`matchKey.length >= key.length` is required regardless of trailer). Bun only applied the length check when the trailer was non-empty, so `"./e/*": "./src/e/*.js"` matched subpath `./e/` and loaded `./src/e/.js`.

| subpath | key | node v26.3.0 | bun (before) |
| --- | --- | --- | --- |
| `pat/two/q/*` | `"./two/*/*"` | `ERR_PACKAGE_PATH_NOT_EXPORTED` | `src/two/q/q.js` |
| `pat/e/` | `"./e/*"` | `ERR_PACKAGE_PATH_NOT_EXPORTED` | `src/e/.js` |
| `pat/f/deep/y.js` | `"./f/*.js"` | `src/f/deep/y.js` | `src/f/deep/y.js` |

## Fix

In `ESModule::resolve_imports_exports`, hoist the `match_key.len() >= expansion.key.len()` check out of the non-empty-trailer branch so it gates every pattern match, and reject the match when `pattern_trailer` contains `*` (equivalent to Node's `lastIndexOf('*') === indexOf('*')`). The same function serves `imports`, so `#name/*` keys get the same treatment.

`test/bundler/esbuild/packagejson.test.ts`'s `ExportsWildcard` relied on the empty-capture behaviour (it imported `pkg1/foo` against `"./foo*"`); updated to use a non-empty capture to match Node. esbuild still accepts the empty capture; Bun follows Node here as with #35197.

## Verification

New `test/js/bun/resolve/resolve.test.ts` cases cover both constraints for `exports` and `imports` with single-`*` controls; all three fail on `main` and pass with this change.

```
bun bd test test/js/bun/resolve/resolve.test.ts -t "pattern-key constraints"
bun bd test test/bundler/esbuild/packagejson.test.ts
```

Related: #35197 (DEP0148 trailing-slash key removal, touches the same loop).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->