### PR TITLE
ci(binary-size): warn instead of fail, compare against the PR merge-base

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1049,20 +1049,18 @@ function getWindowsSignStep(windowsPlatforms, options) {
 }
 
 /**
- * Aggregates stripped-binary sizes from every release build, compares them
- * against the latest main build's binary-sizes.json, and fails if any grew
- * past the threshold. Runs on PR builds (comparison) and main (record-only,
- * to produce the baseline artifact).
+ * Aggregates stripped-binary sizes from every release build and annotates the
+ * delta against the main build at this PR's merge-base. Growth past the
+ * threshold is a warning annotation, never a failed step. On main the same
+ * step records the baseline for later PRs.
  *
  * @param {Platform[]} releasePlatforms
  * @param {PipelineOptions} options
- * @param {{ recordOnly: boolean }} [extra]
  * @returns {Step}
  */
-function getBinarySizeStep(releasePlatforms, options, { recordOnly = false } = {}) {
+function getBinarySizeStep(releasePlatforms, options) {
   const targets = releasePlatforms.map(p => ({ triplet: getTargetTriplet(p) }));
   const args = [`--targets '${JSON.stringify(targets)}'`, `--threshold-mb ${BINARY_SIZE_THRESHOLD_MB}`];
-  if (recordOnly) args.push("--no-fail");
   if (!options.canary) args.push("--release");
 
   return {
@@ -1071,7 +1069,6 @@ function getBinarySizeStep(releasePlatforms, options, { recordOnly = false } = {
     agents: getEc2Agent(buildHostPlatform, options, { instanceType: "c8g.large" }),
     depends_on: releasePlatforms.map(p => `${getTargetKey(p)}-build-bun`),
     allow_dependency_failure: true,
-    soft_fail: !!options.skipSizeCheck,
     retry: {
       manual: { permit_on_passed: true },
       automatic: [{ exit_status: "*", limit: 2 }],
@@ -1200,7 +1197,6 @@ function getReleaseStep(releasePlatforms, options, { signed = false, testStepKey
  * @property {string | boolean} [skipEverything]
  * @property {string | boolean} [skipBuilds]
  * @property {string | boolean} [skipTests]
- * @property {string | boolean} [skipSizeCheck]
  * @property {string | boolean} [forceBuilds]
  * @property {string | boolean} [forceTests]
  * @property {string | boolean} [buildImages]
@@ -1504,7 +1500,6 @@ async function getPipelineOptions() {
     skipBuilds: parseOption(/\[(skip builds?|no builds?|only tests?)\]/i),
     forceBuilds: parseOption(/\[(force builds?)\]/i),
     skipTests: parseOption(/\[(skip tests?|no tests?|only builds?)\]/i),
-    skipSizeCheck: parseOption(/\[(skip size( check)?|allow size)\]/i),
     signWindows: parseOption(/\[(sign windows)\]/i),
     buildImages,
     dryRun: parseOption(/\[(dry run)\]/i),
@@ -1828,10 +1823,10 @@ async function getPipeline(options = {}) {
 
   steps.push(...binaryCheckSteps);
 
-  // Binary-size tracking: main records the baseline, PRs enforce the threshold.
+  // Binary-size tracking: main records the baseline, PRs get a warning annotation past the threshold.
   const strippedPlatforms = buildPlatforms.filter(p => (p.profile ?? "release") === "release");
   if (!buildId && strippedPlatforms.length) {
-    steps.push(getBinarySizeStep(strippedPlatforms, options, { recordOnly: isMainBranch() }));
+    steps.push(getBinarySizeStep(strippedPlatforms, options));
   }
 
   // Sign Windows builds on release (non-canary main) or when [sign windows]

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -128,7 +128,7 @@ async function buildNumberForCommit(sha: string): Promise<number | undefined> {
 async function sizesFromBuild(n: number, want: string[]): Promise<{ sizes: Sizes; release?: boolean } | undefined> {
   const res = await fetch(`${bkWeb}/${org}/${pipeline}/builds/${n}.json`);
   if (!res.ok) return;
-  const { id, message } = (await res.json()) as { id: string; message?: string };
+  const { id, message, source } = (await res.json()) as { id: string; message?: string; source?: string };
   // Fast path: the binary-size step on this build ran and uploaded a complete
   // snapshot (with the canary/release flag).
   const dir = "binary-size-tmp";
@@ -142,19 +142,27 @@ async function sizesFromBuild(n: number, want: string[]): Promise<{ sizes: Sizes
   // timed out, which Buildkite does not treat as a "failure" that
   // allow_dependency_failure recovers from). Each *-build-bun job that DID
   // finish still set its own binary-size:<triplet> meta-data; read those
-  // directly. Recover the release flag from the commit message (same regex as
-  // .buildkite/ci.mjs) so a [release] baseline still gets filtered by the
-  // like-for-like check below; the meta-data fallback itself is only used for
-  // canary comparisons because release baselines are rare and artifact-backed.
+  // directly.
+  //
+  // The meta-data itself carries no canary/release distinction, so this
+  // fallback is restricted to builds we are confident are canary:
+  //   - the current build is canary (the normal PR path); and
+  //   - the baseline build is webhook-triggered and its commit message carries
+  //     no [release] tag (ci.mjs's commit-message signal). Real Bun releases
+  //     are manual (source:"ui") triggers with RELEASE=1 in the environment;
+  //     the commit message alone does not identify them.
+  // Builds that fail either check return undefined, so the caller claims the
+  // anchor without sizes and everything older is treated as stale (never a
+  // false positive).
   if (isRelease) return;
-  const release = /\[(release|build release|release build)\]/i.test(message ?? "");
+  if ((source && source !== "webhook") || /\[(release|build release|release build)\]/i.test(message ?? "")) return;
   const sizes: Sizes = {};
   for (const triplet of want) {
     const v = agent(["meta-data", "get", `binary-size:${triplet}`, "--build", id], { quiet: true });
     const bytes = v ? parseInt(v, 10) : NaN;
     if (Number.isFinite(bytes)) sizes[triplet] = bytes;
   }
-  return Object.keys(sizes).length > 0 ? { sizes, release } : undefined;
+  return Object.keys(sizes).length > 0 ? { sizes } : undefined;
 }
 
 // Canary: walk main commits starting at this PR's merge-base (so the delta is

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -176,23 +176,31 @@ const canary: Baseline | undefined = await (async () => {
   const acc: Sizes = {};
   const from: Record<string, number> = {};
   const stale = new Set<string>();
-  // The anchor is the first build we consult (the merge-base for PRs, the
-  // previous main commit for main builds). A triplet whose size came from an
-  // older build is stale: its delta folds in main commits this build already
-  // contains, so we show it but never fail on it.
+  // The anchor is the first like-for-like build we consult (the merge-base for
+  // PRs, the previous main commit for main builds). A triplet whose size came
+  // from an older build is stale: its delta folds in main commits this build
+  // already contains, so we show it but never fail on it.
   let anchor: number | undefined;
   for (const { sha } of commits) {
     if (want.size === 0) break;
     const n = await buildNumberForCommit(sha);
     if (!n || String(n) === String(buildNumber)) continue;
-    anchor ??= n;
     const record = await sizesFromBuild(n, [...want]);
-    if (!record) continue;
+    if (!record) {
+      // This commit had no usable sizes at all (every build-bun job canceled).
+      // It may carry real growth, so claim the anchor here: anything older is
+      // stale and won't be blamed on this PR.
+      anchor ??= n;
+      continue;
+    }
     // Only compare like-for-like: canary builds against canary baselines,
     // release against release. Windows binaries differ by several MB between
-    // the two, so a release build on main would otherwise trip every PR's
-    // threshold.
+    // the two. A mismatched-kind build (e.g. [release] merge-base for a canary
+    // PR) is skipped without claiming the anchor: a release-tag commit does not
+    // itself change canary-mode sizes, so the next canary build back is still a
+    // fair anchor to enforce against.
     if ((record.release ?? false) !== isRelease) continue;
+    anchor ??= n;
     for (const t of want) {
       const s = record.sizes[t];
       if (s === undefined) continue;

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -52,6 +52,8 @@ const org = process.env.BUILDKITE_ORGANIZATION_SLUG || "bun";
 const pipeline = process.env.BUILDKITE_PIPELINE_SLUG || "bun";
 const buildNumber = process.env.BUILDKITE_BUILD_NUMBER;
 const branch = process.env.BUILDKITE_BRANCH;
+const commit = process.env.BUILDKITE_COMMIT;
+const baseBranch = process.env.BUILDKITE_PULL_REQUEST_BASE_BRANCH || "main";
 
 function agent(args: string[], opts: { quiet?: boolean } = {}): string | undefined {
   const { exitCode, stdout } = Bun.spawnSync(["buildkite-agent", ...args], {
@@ -90,13 +92,26 @@ agent(["artifact", "upload", "binary-sizes.json"]);
 
 // ─── Baselines ───
 
-type Baseline = { label: string; href?: string; sizes: Sizes };
+type Baseline = {
+  label: string;
+  href?: string;
+  sizes: Sizes;
+  // Triplets whose size came from a build older than the walk's starting
+  // commit (the PR's merge-base). Their delta includes growth from main
+  // commits this PR already contains, so it is shown but never enforced.
+  stale: Set<string>;
+  // Per-triplet source build number, for the annotation.
+  from: Record<string, number>;
+};
 
 const ghToken = (await getSecret("GITHUB_TOKEN")) ?? process.env.GITHUB_TOKEN;
 const ghHeaders: Record<string, string> = ghToken ? { Authorization: `Bearer ${ghToken}` } : {};
+// Overridable for test/internal/binary-size-baseline.test.ts.
+const ghApi = process.env.BINARY_SIZE_GITHUB_API || "https://api.github.com";
+const bkWeb = process.env.BINARY_SIZE_BUILDKITE_WEB || "https://buildkite.com";
 
 async function githubJson<T>(path: string): Promise<T> {
-  const res = await fetch(`https://api.github.com/repos/oven-sh/bun/${path}`, { headers: ghHeaders });
+  const res = await fetch(`${ghApi}/repos/oven-sh/bun/${path}`, { headers: ghHeaders });
   if (!res.ok) throw new Error(`github ${path}: ${res.status}`);
   return res.json() as Promise<T>;
 }
@@ -110,41 +125,90 @@ async function buildNumberForCommit(sha: string): Promise<number | undefined> {
   return m ? parseInt(m[1], 10) : undefined;
 }
 
-async function sizesFromBuild(n: number): Promise<{ sizes: Sizes; release?: boolean } | undefined> {
-  const res = await fetch(`https://buildkite.com/${org}/${pipeline}/builds/${n}.json`);
+async function sizesFromBuild(n: number, want: string[]): Promise<{ sizes: Sizes; release?: boolean } | undefined> {
+  const res = await fetch(`${bkWeb}/${org}/${pipeline}/builds/${n}.json`);
   if (!res.ok) return;
   const { id } = (await res.json()) as { id: string };
+  // Fast path: the binary-size step on this build ran and uploaded a complete
+  // snapshot (with the canary/release flag).
   const dir = "binary-size-tmp";
   rmSync(dir, { recursive: true, force: true });
   mkdirSync(dir, { recursive: true });
   const ok = agent(["artifact", "download", "binary-sizes.json", dir, "--build", id], { quiet: true });
-  if (ok === undefined) return;
-  return (await Bun.file(`${dir}/binary-sizes.json`).json()) as { sizes: Sizes; release?: boolean };
+  if (ok !== undefined) {
+    return (await Bun.file(`${dir}/binary-sizes.json`).json()) as { sizes: Sizes; release?: boolean };
+  }
+  // Fallback: the aggregator step never ran (a build-bun dep was canceled or
+  // timed out, which Buildkite does not treat as a "failure" that
+  // allow_dependency_failure recovers from). Each *-build-bun job that DID
+  // finish still set its own binary-size:<triplet> meta-data; read those
+  // directly. We can't recover the release flag here, so only use this for
+  // canary comparisons (the normal PR path).
+  if (isRelease) return;
+  const sizes: Sizes = {};
+  for (const triplet of want) {
+    const v = agent(["meta-data", "get", `binary-size:${triplet}`, "--build", id], { quiet: true });
+    if (v) sizes[triplet] = parseInt(v, 10);
+  }
+  return Object.keys(sizes).length > 0 ? { sizes } : undefined;
 }
 
-async function baselineFromCommit(sha: string, label: (n: number) => string): Promise<Baseline | undefined> {
-  const n = await buildNumberForCommit(sha);
-  if (!n || String(n) === String(buildNumber)) return;
-  const record = await sizesFromBuild(n);
-  if (!record) return;
-  // Only compare like-for-like: canary builds against canary baselines, release
-  // against release. Windows binaries differ by several MB between the two, so
-  // a release build on main would otherwise trip every PR's threshold.
-  if ((record.release ?? false) !== isRelease) return;
-  return { label: label(n), href: `https://buildkite.com/${org}/${pipeline}/builds/${n}`, sizes: record.sizes };
-}
-
-// Canary: walk recent main commits until one whose build has a matching
-// (canary vs release) binary-sizes.json.
+// Canary: walk main commits starting at this PR's merge-base (so the delta is
+// the PR's own contribution, not main's growth since an older baseline). For
+// each triplet we take the first size we see; triplets that only resolve from
+// a build older than the merge-base are marked stale and are not enforced.
 console.log(`--- Fetching ${buildKind} baseline`);
 let canaryNote = "";
 const canary: Baseline | undefined = await (async () => {
-  const commits = await githubJson<{ sha: string }[]>("commits?sha=main&per_page=15");
-  for (const { sha } of commits) {
-    const b = await baselineFromCommit(sha, n => `main #${n}`);
-    if (b) return b;
+  let walkFrom = baseBranch;
+  if (commit && branch !== baseBranch) {
+    const cmp = await githubJson<{ merge_base_commit?: { sha: string } }>(
+      `compare/${encodeURIComponent(baseBranch)}...${commit}`,
+    ).catch(() => undefined);
+    if (cmp?.merge_base_commit?.sha) walkFrom = cmp.merge_base_commit.sha;
   }
-  canaryNote = `no recent main ${buildKind} build has binary-sizes.json yet`;
+  const commits = await githubJson<{ sha: string }[]>(`commits?sha=${walkFrom}&per_page=30`);
+  const want = new Set(Object.keys(sizes));
+  const acc: Sizes = {};
+  const from: Record<string, number> = {};
+  const stale = new Set<string>();
+  // The anchor is the first build we consult (the merge-base for PRs, the
+  // previous main commit for main builds). A triplet whose size came from an
+  // older build is stale: its delta folds in main commits this build already
+  // contains, so we show it but never fail on it.
+  let anchor: number | undefined;
+  for (const { sha } of commits) {
+    if (want.size === 0) break;
+    const n = await buildNumberForCommit(sha);
+    if (!n || String(n) === String(buildNumber)) continue;
+    anchor ??= n;
+    const record = await sizesFromBuild(n, [...want]);
+    if (!record) continue;
+    // Only compare like-for-like: canary builds against canary baselines,
+    // release against release. Windows binaries differ by several MB between
+    // the two, so a release build on main would otherwise trip every PR's
+    // threshold.
+    if ((record.release ?? false) !== isRelease) continue;
+    for (const t of want) {
+      const s = record.sizes[t];
+      if (s === undefined) continue;
+      acc[t] = s;
+      from[t] = n;
+      if (n !== anchor) stale.add(t);
+      want.delete(t);
+    }
+  }
+  if (anchor === undefined) {
+    canaryNote = `no recent ${baseBranch} ${buildKind} build has binary sizes yet`;
+    return;
+  }
+  return {
+    label: `${baseBranch} #${anchor}`,
+    href: `https://buildkite.com/${org}/${pipeline}/builds/${anchor}`,
+    sizes: acc,
+    stale,
+    from,
+  };
 })().catch(e => ((canaryNote = String(e?.message || e)), undefined));
 console.log(canary ? `  ${canary.label}` : `  unavailable: ${canaryNote}`);
 
@@ -152,12 +216,13 @@ console.log(canary ? `  ${canary.label}` : `  unavailable: ${canaryNote}`);
 
 console.log("--- Results");
 
-type Delta = { base: number; bytes: number };
+type Delta = { base: number; bytes: number; from?: number; stale: boolean };
 type Row = { triplet: string; now: number; canary?: Delta };
 
-function delta(now: number, base: number | undefined): Delta | undefined {
+function delta(now: number, triplet: string): Delta | undefined {
+  const base = canary?.sizes[triplet];
   if (!base) return undefined;
-  return { base, bytes: now - base };
+  return { base, bytes: now - base, from: canary?.from[triplet], stale: canary?.stale.has(triplet) ?? false };
 }
 
 // Preserve --targets order (buildPlatforms in ci.mjs) so OS families stay grouped.
@@ -166,19 +231,25 @@ const rows: Row[] = targets
   .map(({ triplet }) => ({
     triplet,
     now: sizes[triplet],
-    canary: delta(sizes[triplet], canary?.sizes[triplet]),
+    canary: delta(sizes[triplet], triplet),
   }));
 
-const overThreshold = rows.filter(r => r.canary && r.canary.bytes > thresholdBytes);
+// Stale rows (baseline older than this PR's merge-base) are annotated but never
+// enforced: that delta includes main's growth, not just this PR's.
+const overThreshold = rows.filter(r => r.canary && !r.canary.stale && r.canary.bytes > thresholdBytes);
+const staleOver = rows.filter(r => r.canary?.stale && r.canary.bytes > thresholdBytes);
 const failed = !noFail && overThreshold.length > 0;
 
 const link = (b: Baseline | undefined, fallback: string) =>
   b?.href ? `<a href="${b.href}">${b.label}</a>` : (b?.label ?? `${fallback} (n/a)`);
 
+const buildLink = (n: number) => `<a href="https://buildkite.com/${org}/${pipeline}/builds/${n}">#${n}</a>`;
+
 const deltaCells = (d: Delta | undefined, over: boolean) => {
   if (!d) return `<td align="right">—</td><td align="right">—</td>`;
+  const note = d.stale ? ` <sup>${buildLink(d.from!)}</sup>` : "";
   return (
-    `<td align="right">${fmtBytes(d.base)}</td>` +
+    `<td align="right">${fmtBytes(d.base)}${note}</td>` +
     `<td align="right">${over ? "<b>" : ""}${fmtDelta(d.bytes)}${over ? "</b>" : ""}</td>`
   );
 };
@@ -186,8 +257,9 @@ const deltaCells = (d: Delta | undefined, over: boolean) => {
 const tableRows = rows
   .map(r => {
     const over = !!r.canary && r.canary.bytes > thresholdBytes;
+    const mark = over ? (r.canary!.stale ? "⚠️ " : "❌ ") : "";
     return (
-      `<tr><td>${over ? "❌ " : ""}<code>${r.triplet}</code></td>` +
+      `<tr><td>${mark}<code>${r.triplet}</code></td>` +
       `<td align="right">${fmtBytes(r.now)}</td>` +
       deltaCells(r.canary, over) +
       `</tr>`
@@ -200,8 +272,15 @@ const header =
   overThreshold.length > 0
     ? `<b>${overThreshold.length}</b> over ${limit}`
     : canary
-      ? `all within ${limit}`
+      ? `all within ${limit}${staleOver.length ? ` (${staleOver.length} stale ignored)` : ""}`
       : `no ${buildKind} comparison (${canaryNote})`;
+
+const staleNote =
+  canary && canary.stale.size > 0
+    ? `<p>⚠️ ${canary.stale.size} target(s) had no size recorded for the merge-base build ` +
+      `${link(canary, baseBranch)}; their Δ is against the older build linked in the size column ` +
+      `and includes ${baseBranch}'s own growth, so it is not enforced.</p>`
+    : "";
 
 const annotation = `
 <details${failed ? " open" : ""}>
@@ -209,11 +288,12 @@ const annotation = `
 <table>
 <tr>
   <th rowspan="2">target</th><th rowspan="2">this build</th>
-  <th colspan="2">${buildKind}: ${link(canary, "main")}</th>
+  <th colspan="2">${buildKind}: ${link(canary, baseBranch)}</th>
 </tr>
 <tr><th>size</th><th>Δ</th></tr>
 ${tableRows}
 </table>
+${staleNote}
 ${failed ? `<p>Add <code>[skip size check]</code> to the commit message if this increase is intentional.</p>` : ""}
 </details>`;
 
@@ -232,7 +312,9 @@ Bun.spawnSync(
 );
 
 for (const r of rows) {
-  const c = r.canary ? `  ${buildKind} ${fmtDelta(r.canary.bytes).padStart(10)}` : "";
+  const c = r.canary
+    ? `  ${buildKind} ${fmtDelta(r.canary.bytes).padStart(10)}` + (r.canary.stale ? `  (stale: #${r.canary.from})` : "")
+    : "";
   console.log(`  ${r.triplet.padEnd(30)} ${fmtBytes(r.now).padStart(10)}${c}`);
 }
 

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -128,7 +128,7 @@ async function buildNumberForCommit(sha: string): Promise<number | undefined> {
 async function sizesFromBuild(n: number, want: string[]): Promise<{ sizes: Sizes; release?: boolean } | undefined> {
   const res = await fetch(`${bkWeb}/${org}/${pipeline}/builds/${n}.json`);
   if (!res.ok) return;
-  const { id } = (await res.json()) as { id: string };
+  const { id, message } = (await res.json()) as { id: string; message?: string };
   // Fast path: the binary-size step on this build ran and uploaded a complete
   // snapshot (with the canary/release flag).
   const dir = "binary-size-tmp";
@@ -142,16 +142,19 @@ async function sizesFromBuild(n: number, want: string[]): Promise<{ sizes: Sizes
   // timed out, which Buildkite does not treat as a "failure" that
   // allow_dependency_failure recovers from). Each *-build-bun job that DID
   // finish still set its own binary-size:<triplet> meta-data; read those
-  // directly. We can't recover the release flag here, so only use this for
-  // canary comparisons (the normal PR path).
+  // directly. Recover the release flag from the commit message (same regex as
+  // .buildkite/ci.mjs) so a [release] baseline still gets filtered by the
+  // like-for-like check below; the meta-data fallback itself is only used for
+  // canary comparisons because release baselines are rare and artifact-backed.
   if (isRelease) return;
+  const release = /\[(release|build release|release build)\]/i.test(message ?? "");
   const sizes: Sizes = {};
   for (const triplet of want) {
     const v = agent(["meta-data", "get", `binary-size:${triplet}`, "--build", id], { quiet: true });
     const bytes = v ? parseInt(v, 10) : NaN;
     if (Number.isFinite(bytes)) sizes[triplet] = bytes;
   }
-  return Object.keys(sizes).length > 0 ? { sizes } : undefined;
+  return Object.keys(sizes).length > 0 ? { sizes, release } : undefined;
 }
 
 // Canary: walk main commits starting at this PR's merge-base (so the delta is
@@ -199,7 +202,7 @@ const canary: Baseline | undefined = await (async () => {
       want.delete(t);
     }
   }
-  if (anchor === undefined) {
+  if (anchor === undefined || Object.keys(acc).length === 0) {
     canaryNote = `no recent ${baseBranch} ${buildKind} build has binary sizes yet`;
     return;
   }

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -148,7 +148,8 @@ async function sizesFromBuild(n: number, want: string[]): Promise<{ sizes: Sizes
   const sizes: Sizes = {};
   for (const triplet of want) {
     const v = agent(["meta-data", "get", `binary-size:${triplet}`, "--build", id], { quiet: true });
-    if (v) sizes[triplet] = parseInt(v, 10);
+    const bytes = v ? parseInt(v, 10) : NaN;
+    if (Number.isFinite(bytes)) sizes[triplet] = bytes;
   }
   return Object.keys(sizes).length > 0 ? { sizes } : undefined;
 }

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -171,7 +171,7 @@ const canary: Baseline | undefined = await (async () => {
     ).catch(() => undefined);
     if (cmp?.merge_base_commit?.sha) walkFrom = cmp.merge_base_commit.sha;
   }
-  const commits = await githubJson<{ sha: string }[]>(`commits?sha=${walkFrom}&per_page=30`);
+  const commits = await githubJson<{ sha: string }[]>(`commits?sha=${encodeURIComponent(walkFrom)}&per_page=30`);
   const want = new Set(Object.keys(sizes));
   const acc: Sizes = {};
   const from: Record<string, number> = {};

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -1,5 +1,5 @@
 // Measure stripped binary sizes for every release platform and compare them
-// against the latest finished `main` build ("canary").
+// against the main build at this PR's merge-base ("canary").
 //
 // CI mode (invoked from .buildkite/ci.mjs after all *-build-bun jobs finish):
 //   bun scripts/binary-size.ts \
@@ -7,11 +7,10 @@
 //     --threshold-mb 0.5 \
 //     [--release]
 //
-//   Always posts an annotation with sizes and deltas against the build at this
-//   PR's merge-base on main. A binary that grew by more than --threshold-mb is
-//   called out with a warning-style annotation. The step itself never fails:
-//   binary size is advisory, and a hard gate here has mostly produced false
-//   positives when the baseline went stale.
+//   Always posts an annotation with sizes and deltas. A binary that grew by
+//   more than --threshold-mb is called out with a warning-style annotation.
+//   The step itself never fails: binary size is advisory, and a hard gate here
+//   has mostly produced false positives when the baseline went stale.
 //
 // Local mode (no args):
 //   bun scripts/binary-size.ts
@@ -19,74 +18,51 @@
 //   Compares the current `canary` GitHub release against the latest tagged
 //   release by reading uncompressed binary sizes straight from each zip's
 //   central directory (Range request — no full download, no BuildKite access).
+//
+// The CI logic is `run()`, with the agent and HTTP calls injected so
+// test/internal/binary-size-baseline.test.ts can drive it in-process.
 
 import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
 
-type Target = { triplet: string };
-type Sizes = Record<string, number>;
+export type Target = { triplet: string };
+export type Sizes = Record<string, number>;
 
-const { values } = parseArgs({
-  options: {
-    targets: { type: "string" },
-    "threshold-mb": { type: "string", default: "0.5" },
-    release: { type: "boolean", default: false },
-  },
-});
+export type Io = {
+  /** `buildkite-agent <args>`: stdout on exit 0, undefined otherwise. */
+  agent(args: string[], opts?: { quiet?: boolean; stdin?: string }): string | undefined;
+  fetch(url: string, init?: RequestInit): Promise<Response>;
+  /** Where binary-sizes.json and the artifact scratch dir are written. */
+  workDir: string;
+  log(line: string): void;
+  githubApi?: string;
+  buildkiteWeb?: string;
+};
 
-if (!values.targets) {
-  await compareGithubReleases();
-  process.exit(0);
-}
+export type Options = {
+  targets: Target[];
+  thresholdBytes: number;
+  isRelease: boolean;
+  env: {
+    org: string;
+    pipeline: string;
+    buildNumber?: string;
+    branch?: string;
+    commit?: string;
+    baseBranch: string;
+    githubToken?: string;
+  };
+  io: Io;
+};
 
-const targets: Target[] = JSON.parse(values.targets!);
-const thresholdBytes = parseFloat(values["threshold-mb"]!) * 1024 * 1024;
-const isRelease = values.release;
-const buildKind = isRelease ? "release" : "canary";
-
-const org = process.env.BUILDKITE_ORGANIZATION_SLUG || "bun";
-const pipeline = process.env.BUILDKITE_PIPELINE_SLUG || "bun";
-const buildNumber = process.env.BUILDKITE_BUILD_NUMBER;
-const branch = process.env.BUILDKITE_BRANCH;
-const commit = process.env.BUILDKITE_COMMIT;
-const baseBranch = process.env.BUILDKITE_PULL_REQUEST_BASE_BRANCH || "main";
-
-function agent(args: string[], opts: { quiet?: boolean } = {}): string | undefined {
-  const { exitCode, stdout } = Bun.spawnSync(["buildkite-agent", ...args], {
-    stderr: opts.quiet ? "ignore" : "inherit",
-  });
-  return exitCode === 0 ? stdout.toString().trim() : undefined;
-}
-
-async function getSecret(name: string): Promise<string | undefined> {
-  const { exitCode, stdout } = Bun.spawnSync(["buildkite-agent", "secret", "get", name], { stderr: "ignore" });
-  if (exitCode !== 0) return undefined;
-  return stdout.toString().trim() || undefined;
-}
-
-// ─── Collect current build's sizes from meta-data ───
-// Each *-build-bun job sets `binary-size:<triplet>` after stripping
-// (scripts/build/ci.ts).
-
-console.log("--- Reading sizes from build meta-data");
-const sizes: Sizes = {};
-for (const { triplet } of targets) {
-  const v = agent(["meta-data", "get", `binary-size:${triplet}`], { quiet: true });
-  if (!v) {
-    console.log(`  ${triplet}: not set (build may have failed), skipping`);
-    continue;
-  }
-  sizes[triplet] = parseInt(v, 10);
-  console.log(`  ${triplet.padEnd(30)} ${fmtBytes(sizes[triplet]).padStart(10)}`);
-}
-
-await Bun.write(
-  "binary-sizes.json",
-  JSON.stringify({ build: buildNumber, branch, release: isRelease, sizes }, null, 2),
-);
-agent(["artifact", "upload", "binary-sizes.json"]);
-
-// ─── Baselines ───
+export type Result = {
+  sizes: Sizes;
+  rows: Row[];
+  annotation: string;
+  style: "info" | "warning";
+  overThreshold: string[];
+};
 
 type Baseline = {
   label: string;
@@ -94,212 +70,239 @@ type Baseline = {
   sizes: Sizes;
   // Triplets whose size came from a build older than the walk's starting
   // commit (the PR's merge-base). Their delta includes growth from main
-  // commits this PR already contains, so it is shown but never enforced.
+  // commits this PR already contains, so it is shown but never warned on.
   stale: Set<string>;
   // Per-triplet source build number, for the annotation.
   from: Record<string, number>;
 };
 
-const ghToken = (await getSecret("GITHUB_TOKEN")) ?? process.env.GITHUB_TOKEN;
-const ghHeaders: Record<string, string> = ghToken ? { Authorization: `Bearer ${ghToken}` } : {};
-// Overridable for test/internal/binary-size-baseline.test.ts.
-const ghApi = process.env.BINARY_SIZE_GITHUB_API || "https://api.github.com";
-const bkWeb = process.env.BINARY_SIZE_BUILDKITE_WEB || "https://buildkite.com";
+export type Delta = { base: number; bytes: number; from?: number; stale: boolean };
+export type Row = { triplet: string; now: number; canary?: Delta };
 
-async function githubJson<T>(path: string): Promise<T> {
-  const res = await fetch(`${ghApi}/repos/oven-sh/bun/${path}`, { headers: ghHeaders });
-  if (!res.ok) throw new Error(`github ${path}: ${res.status}`);
-  return res.json() as Promise<T>;
-}
+export async function run({ targets, thresholdBytes, isRelease, env, io }: Options): Promise<Result> {
+  const { agent, log } = io;
+  const { org, pipeline, buildNumber, branch, commit, baseBranch } = env;
+  const buildKind = isRelease ? "release" : "canary";
+  const ghApi = io.githubApi ?? "https://api.github.com";
+  const bkWeb = io.buildkiteWeb ?? "https://buildkite.com";
 
-async function buildNumberForCommit(sha: string): Promise<number | undefined> {
-  const { statuses } = await githubJson<{ statuses: { context: string; target_url: string }[] }>(
-    `commits/${sha}/status`,
-  );
-  const bk = statuses.find(s => s.context.startsWith("buildkite/"));
-  const m = bk?.target_url.match(/\/builds\/(\d+)/);
-  return m ? parseInt(m[1], 10) : undefined;
-}
+  // ─── Collect current build's sizes from meta-data ───
+  // Each *-build-bun job sets `binary-size:<triplet>` after stripping
+  // (scripts/build/ci.ts).
 
-async function sizesFromBuild(n: number, want: string[]): Promise<{ sizes: Sizes; release?: boolean } | undefined> {
-  const res = await fetch(`${bkWeb}/${org}/${pipeline}/builds/${n}.json`);
-  if (!res.ok) return;
-  const { id, message, source } = (await res.json()) as { id: string; message?: string; source?: string };
-  // Fast path: the binary-size step on this build ran and uploaded a complete
-  // snapshot (with the canary/release flag).
-  const dir = "binary-size-tmp";
-  rmSync(dir, { recursive: true, force: true });
-  mkdirSync(dir, { recursive: true });
-  const ok = agent(["artifact", "download", "binary-sizes.json", dir, "--build", id], { quiet: true });
-  if (ok !== undefined) {
-    return (await Bun.file(`${dir}/binary-sizes.json`).json()) as { sizes: Sizes; release?: boolean };
-  }
-  // Fallback: the aggregator step never ran (a build-bun dep was canceled or
-  // timed out, which Buildkite does not treat as a "failure" that
-  // allow_dependency_failure recovers from). Each *-build-bun job that DID
-  // finish still set its own binary-size:<triplet> meta-data; read those
-  // directly.
-  //
-  // The meta-data itself carries no canary/release distinction, so this
-  // fallback is restricted to builds we are confident are canary:
-  //   - the current build is canary (the normal PR path); and
-  //   - the baseline build is webhook-triggered and its commit message carries
-  //     no [release] tag (ci.mjs's commit-message signal). Real Bun releases
-  //     are manual (source:"ui") triggers with RELEASE=1 in the environment;
-  //     the commit message alone does not identify them.
-  // Builds that fail either check return undefined, so the caller claims the
-  // anchor without sizes and everything older is treated as stale (never a
-  // false positive).
-  if (isRelease) return;
-  if ((source && source !== "webhook") || /\[(release|build release|release build)\]/i.test(message ?? "")) return;
+  log("--- Reading sizes from build meta-data");
   const sizes: Sizes = {};
-  for (const triplet of want) {
-    const v = agent(["meta-data", "get", `binary-size:${triplet}`, "--build", id], { quiet: true });
-    const bytes = v ? parseInt(v, 10) : NaN;
-    if (Number.isFinite(bytes)) sizes[triplet] = bytes;
-  }
-  return Object.keys(sizes).length > 0 ? { sizes } : undefined;
-}
-
-// Canary: walk main commits starting at this PR's merge-base (so the delta is
-// the PR's own contribution, not main's growth since an older baseline). For
-// each triplet we take the first size we see; triplets that only resolve from
-// a build older than the merge-base are marked stale and are not enforced.
-console.log(`--- Fetching ${buildKind} baseline`);
-let canaryNote = "";
-const canary: Baseline | undefined = await (async () => {
-  let walkFrom = baseBranch;
-  if (commit && branch !== baseBranch) {
-    const cmp = await githubJson<{ merge_base_commit?: { sha: string } }>(
-      `compare/${encodeURIComponent(baseBranch)}...${commit}`,
-    ).catch(() => undefined);
-    if (cmp?.merge_base_commit?.sha) walkFrom = cmp.merge_base_commit.sha;
-  }
-  const commits = await githubJson<{ sha: string }[]>(`commits?sha=${encodeURIComponent(walkFrom)}&per_page=30`);
-  const want = new Set(Object.keys(sizes));
-  const acc: Sizes = {};
-  const from: Record<string, number> = {};
-  const stale = new Set<string>();
-  // The anchor is the first like-for-like build we consult (the merge-base for
-  // PRs, the previous main commit for main builds). A triplet whose size came
-  // from an older build is stale: its delta folds in main commits this build
-  // already contains, so we show it but never fail on it.
-  let anchor: number | undefined;
-  for (const { sha } of commits) {
-    if (want.size === 0) break;
-    const n = await buildNumberForCommit(sha);
-    if (!n || String(n) === String(buildNumber)) continue;
-    const record = await sizesFromBuild(n, [...want]);
-    if (!record) {
-      // This commit had no usable sizes at all (every build-bun job canceled).
-      // It may carry real growth, so claim the anchor here: anything older is
-      // stale and won't be blamed on this PR.
-      anchor ??= n;
+  for (const { triplet } of targets) {
+    const v = agent(["meta-data", "get", `binary-size:${triplet}`], { quiet: true });
+    if (!v) {
+      log(`  ${triplet}: not set (build may have failed), skipping`);
       continue;
     }
-    // Only compare like-for-like: canary builds against canary baselines,
-    // release against release. Windows binaries differ by several MB between
-    // the two. A mismatched-kind build (e.g. [release] merge-base for a canary
-    // PR) is skipped without claiming the anchor: a release-tag commit does not
-    // itself change canary-mode sizes, so the next canary build back is still a
-    // fair anchor to enforce against.
-    if ((record.release ?? false) !== isRelease) continue;
-    anchor ??= n;
-    for (const t of want) {
-      const s = record.sizes[t];
-      if (s === undefined) continue;
-      acc[t] = s;
-      from[t] = n;
-      if (n !== anchor) stale.add(t);
-      want.delete(t);
-    }
+    sizes[triplet] = parseInt(v, 10);
+    log(`  ${triplet.padEnd(30)} ${fmtBytes(sizes[triplet]).padStart(10)}`);
   }
-  if (anchor === undefined || Object.keys(acc).length === 0) {
-    canaryNote = `no recent ${baseBranch} ${buildKind} build has binary sizes yet`;
-    return;
-  }
-  return {
-    label: `${baseBranch} #${anchor}`,
-    href: `https://buildkite.com/${org}/${pipeline}/builds/${anchor}`,
-    sizes: acc,
-    stale,
-    from,
-  };
-})().catch(e => ((canaryNote = String(e?.message || e)), undefined));
-console.log(canary ? `  ${canary.label}` : `  unavailable: ${canaryNote}`);
 
-// ─── Compare & annotate ───
-
-console.log("--- Results");
-
-type Delta = { base: number; bytes: number; from?: number; stale: boolean };
-type Row = { triplet: string; now: number; canary?: Delta };
-
-function delta(now: number, triplet: string): Delta | undefined {
-  const base = canary?.sizes[triplet];
-  if (!base) return undefined;
-  return { base, bytes: now - base, from: canary?.from[triplet], stale: canary?.stale.has(triplet) ?? false };
-}
-
-// Preserve --targets order (buildPlatforms in ci.mjs) so OS families stay grouped.
-const rows: Row[] = targets
-  .filter(t => sizes[t.triplet] !== undefined)
-  .map(({ triplet }) => ({
-    triplet,
-    now: sizes[triplet],
-    canary: delta(sizes[triplet], triplet),
-  }));
-
-// A row whose baseline is the merge-base build is a real signal about this
-// PR: over the threshold it gets the warning treatment. A stale row (baseline
-// older than the merge-base) folds in main's own growth, so it is shown with
-// its source build but does not raise the warning.
-const overThreshold = rows.filter(r => r.canary && !r.canary.stale && r.canary.bytes > thresholdBytes);
-const staleOver = rows.filter(r => r.canary?.stale && r.canary.bytes > thresholdBytes);
-const warn = overThreshold.length > 0;
-
-const link = (b: Baseline | undefined, fallback: string) =>
-  b?.href ? `<a href="${b.href}">${b.label}</a>` : (b?.label ?? `${fallback} (n/a)`);
-
-const buildLink = (n: number) => `<a href="https://buildkite.com/${org}/${pipeline}/builds/${n}">#${n}</a>`;
-
-const deltaCells = (d: Delta | undefined, over: boolean) => {
-  if (!d) return `<td align="right">—</td><td align="right">—</td>`;
-  const note = d.stale ? ` <sup>${buildLink(d.from!)}</sup>` : "";
-  return (
-    `<td align="right">${fmtBytes(d.base)}${note}</td>` +
-    `<td align="right">${over ? "<b>" : ""}${fmtDelta(d.bytes)}${over ? "</b>" : ""}</td>`
+  await Bun.write(
+    join(io.workDir, "binary-sizes.json"),
+    JSON.stringify({ build: buildNumber, branch, release: isRelease, sizes }, null, 2),
   );
-};
+  agent(["artifact", "upload", "binary-sizes.json"]);
 
-const tableRows = rows
-  .map(r => {
-    const over = !!r.canary && r.canary.bytes > thresholdBytes;
-    const mark = over && !r.canary!.stale ? "⚠️ " : "";
-    return (
-      `<tr><td>${mark}<code>${r.triplet}</code></td>` +
-      `<td align="right">${fmtBytes(r.now)}</td>` +
-      deltaCells(r.canary, over) +
-      `</tr>`
+  // ─── Baselines ───
+
+  const ghHeaders: Record<string, string> = env.githubToken ? { Authorization: `Bearer ${env.githubToken}` } : {};
+
+  async function githubJson<T>(path: string): Promise<T> {
+    const res = await io.fetch(`${ghApi}/repos/oven-sh/bun/${path}`, { headers: ghHeaders });
+    if (!res.ok) throw new Error(`github ${path}: ${res.status}`);
+    return res.json() as Promise<T>;
+  }
+
+  async function buildNumberForCommit(sha: string): Promise<number | undefined> {
+    const { statuses } = await githubJson<{ statuses: { context: string; target_url: string }[] }>(
+      `commits/${sha}/status`,
     );
-  })
-  .join("\n");
+    const bk = statuses.find(s => s.context.startsWith("buildkite/"));
+    const m = bk?.target_url.match(/\/builds\/(\d+)/);
+    return m ? parseInt(m[1], 10) : undefined;
+  }
 
-const limit = fmtBytes(thresholdBytes);
-const header = warn
-  ? `<b>${overThreshold.length}</b> over ${limit}`
-  : canary
-    ? `all within ${limit}${staleOver.length ? ` (${staleOver.length} stale ignored)` : ""}`
-    : `no ${buildKind} comparison (${canaryNote})`;
+  async function sizesFromBuild(n: number, want: string[]): Promise<{ sizes: Sizes; release?: boolean } | undefined> {
+    const res = await io.fetch(`${bkWeb}/${org}/${pipeline}/builds/${n}.json`);
+    if (!res.ok) return;
+    const { id, message, source } = (await res.json()) as { id: string; message?: string; source?: string };
+    // Fast path: the binary-size step on this build ran and uploaded a complete
+    // snapshot (with the canary/release flag).
+    const dir = join(io.workDir, "binary-size-tmp");
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+    const ok = agent(["artifact", "download", "binary-sizes.json", dir, "--build", id], { quiet: true });
+    if (ok !== undefined) {
+      return (await Bun.file(join(dir, "binary-sizes.json")).json()) as { sizes: Sizes; release?: boolean };
+    }
+    // Fallback: the aggregator step never ran (a build-bun dep was canceled or
+    // timed out, which Buildkite does not treat as a "failure" that
+    // allow_dependency_failure recovers from). Each *-build-bun job that DID
+    // finish still set its own binary-size:<triplet> meta-data; read those
+    // directly.
+    //
+    // The meta-data itself carries no canary/release distinction, so this
+    // fallback is restricted to builds we are confident are canary:
+    //   - the current build is canary (the normal PR path); and
+    //   - the baseline build is webhook-triggered and its commit message carries
+    //     no [release] tag (ci.mjs's commit-message signal). Real Bun releases
+    //     are manual (source:"ui") triggers with RELEASE=1 in the environment;
+    //     the commit message alone does not identify them.
+    // Builds that fail either check return undefined, so the caller claims the
+    // anchor without sizes and everything older is treated as stale (never a
+    // false positive).
+    if (isRelease) return;
+    if ((source && source !== "webhook") || /\[(release|build release|release build)\]/i.test(message ?? "")) return;
+    const sizes: Sizes = {};
+    for (const triplet of want) {
+      const v = agent(["meta-data", "get", `binary-size:${triplet}`, "--build", id], { quiet: true });
+      const bytes = v ? parseInt(v, 10) : NaN;
+      if (Number.isFinite(bytes)) sizes[triplet] = bytes;
+    }
+    return Object.keys(sizes).length > 0 ? { sizes } : undefined;
+  }
 
-const staleNote =
-  canary && canary.stale.size > 0
-    ? `<p>${canary.stale.size} target(s) had no size recorded for the merge-base build ` +
-      `${link(canary, baseBranch)}; their Δ is against the older build linked in the size column ` +
-      `and includes ${baseBranch}'s own growth.</p>`
-    : "";
+  // Canary: walk main commits starting at this PR's merge-base (so the delta is
+  // the PR's own contribution, not main's growth since an older baseline). For
+  // each triplet we take the first size we see; triplets that only resolve from
+  // a build older than the merge-base are marked stale and are not warned on.
+  log(`--- Fetching ${buildKind} baseline`);
+  let canaryNote = "";
+  const canary: Baseline | undefined = await (async () => {
+    let walkFrom = baseBranch;
+    if (commit && branch !== baseBranch) {
+      const cmp = await githubJson<{ merge_base_commit?: { sha: string } }>(
+        `compare/${encodeURIComponent(baseBranch)}...${commit}`,
+      ).catch(() => undefined);
+      if (cmp?.merge_base_commit?.sha) walkFrom = cmp.merge_base_commit.sha;
+    }
+    const commits = await githubJson<{ sha: string }[]>(`commits?sha=${encodeURIComponent(walkFrom)}&per_page=30`);
+    const want = new Set(Object.keys(sizes));
+    const acc: Sizes = {};
+    const from: Record<string, number> = {};
+    const stale = new Set<string>();
+    // The anchor is the first like-for-like build we consult (the merge-base for
+    // PRs, the previous main commit for main builds). A triplet whose size came
+    // from an older build is stale: its delta folds in main commits this build
+    // already contains, so we show it but never warn on it.
+    let anchor: number | undefined;
+    for (const { sha } of commits) {
+      if (want.size === 0) break;
+      const n = await buildNumberForCommit(sha);
+      if (!n || String(n) === String(buildNumber)) continue;
+      const record = await sizesFromBuild(n, [...want]);
+      if (!record) {
+        // This commit had no usable sizes at all (every build-bun job canceled).
+        // It may carry real growth, so claim the anchor here: anything older is
+        // stale and won't be blamed on this PR.
+        anchor ??= n;
+        continue;
+      }
+      // Only compare like-for-like: canary builds against canary baselines,
+      // release against release. Windows binaries differ by several MB between
+      // the two. A mismatched-kind build (e.g. [release] merge-base for a canary
+      // PR) is skipped without claiming the anchor: a release-tag commit does not
+      // itself change canary-mode sizes, so the next canary build back is still a
+      // fair anchor to compare against.
+      if ((record.release ?? false) !== isRelease) continue;
+      anchor ??= n;
+      for (const t of want) {
+        const s = record.sizes[t];
+        if (s === undefined) continue;
+        acc[t] = s;
+        from[t] = n;
+        if (n !== anchor) stale.add(t);
+        want.delete(t);
+      }
+    }
+    if (anchor === undefined || Object.keys(acc).length === 0) {
+      canaryNote = `no recent ${baseBranch} ${buildKind} build has binary sizes yet`;
+      return;
+    }
+    return {
+      label: `${baseBranch} #${anchor}`,
+      href: `${bkWeb}/${org}/${pipeline}/builds/${anchor}`,
+      sizes: acc,
+      stale,
+      from,
+    };
+  })().catch(e => ((canaryNote = String(e?.message || e)), undefined));
+  log(canary ? `  ${canary.label}` : `  unavailable: ${canaryNote}`);
 
-const annotation = `
+  // ─── Compare & annotate ───
+
+  log("--- Results");
+
+  function delta(now: number, triplet: string): Delta | undefined {
+    const base = canary?.sizes[triplet];
+    if (!base) return undefined;
+    return { base, bytes: now - base, from: canary?.from[triplet], stale: canary?.stale.has(triplet) ?? false };
+  }
+
+  // Preserve --targets order (buildPlatforms in ci.mjs) so OS families stay grouped.
+  const rows: Row[] = targets
+    .filter(t => sizes[t.triplet] !== undefined)
+    .map(({ triplet }) => ({
+      triplet,
+      now: sizes[triplet],
+      canary: delta(sizes[triplet], triplet),
+    }));
+
+  // A row whose baseline is the merge-base build is a real signal about this
+  // PR: over the threshold it gets the warning treatment. A stale row (baseline
+  // older than the merge-base) folds in main's own growth, so it is shown with
+  // its source build but does not raise the warning.
+  const overThreshold = rows.filter(r => r.canary && !r.canary.stale && r.canary.bytes > thresholdBytes);
+  const staleOver = rows.filter(r => r.canary?.stale && r.canary.bytes > thresholdBytes);
+  const warn = overThreshold.length > 0;
+
+  const link = (b: Baseline | undefined, fallback: string) =>
+    b?.href ? `<a href="${b.href}">${b.label}</a>` : (b?.label ?? `${fallback} (n/a)`);
+
+  const buildLink = (n: number) => `<a href="${bkWeb}/${org}/${pipeline}/builds/${n}">#${n}</a>`;
+
+  const deltaCells = (d: Delta | undefined, over: boolean) => {
+    if (!d) return `<td align="right">—</td><td align="right">—</td>`;
+    const note = d.stale ? ` <sup>${buildLink(d.from!)}</sup>` : "";
+    return (
+      `<td align="right">${fmtBytes(d.base)}${note}</td>` +
+      `<td align="right">${over ? "<b>" : ""}${fmtDelta(d.bytes)}${over ? "</b>" : ""}</td>`
+    );
+  };
+
+  const tableRows = rows
+    .map(r => {
+      const over = !!r.canary && r.canary.bytes > thresholdBytes;
+      const mark = over && !r.canary!.stale ? "⚠️ " : "";
+      return (
+        `<tr><td>${mark}<code>${r.triplet}</code></td>` +
+        `<td align="right">${fmtBytes(r.now)}</td>` +
+        deltaCells(r.canary, over) +
+        `</tr>`
+      );
+    })
+    .join("\n");
+
+  const limit = fmtBytes(thresholdBytes);
+  const header = warn
+    ? `<b>${overThreshold.length}</b> over ${limit}`
+    : canary
+      ? `all within ${limit}${staleOver.length ? ` (${staleOver.length} stale ignored)` : ""}`
+      : `no ${buildKind} comparison (${canaryNote})`;
+
+  const staleNote =
+    canary && canary.stale.size > 0
+      ? `<p>${canary.stale.size} target(s) had no size recorded for the merge-base build ` +
+        `${link(canary, baseBranch)}; their Δ is against the older build linked in the size column ` +
+        `and includes ${baseBranch}'s own growth.</p>`
+      : "";
+
+  const annotation = `
 <details${warn ? " open" : ""}>
 <summary>📦 Binary size — ${header}</summary>
 <table>
@@ -313,29 +316,68 @@ ${tableRows}
 ${staleNote}
 </details>`;
 
-Bun.spawnSync(
-  [
-    "buildkite-agent",
-    "annotate",
-    "--style",
-    warn ? "warning" : "info",
-    "--context",
-    "binary-size",
-    "--priority",
-    warn ? "5" : "2",
-  ],
-  { stdin: new Blob([annotation]), stderr: "inherit" },
-);
+  const style = warn ? "warning" : "info";
+  agent(["annotate", "--style", style, "--context", "binary-size", "--priority", warn ? "5" : "2"], {
+    stdin: annotation,
+  });
 
-for (const r of rows) {
-  const c = r.canary
-    ? `  ${buildKind} ${fmtDelta(r.canary.bytes).padStart(10)}` + (r.canary.stale ? `  (stale: #${r.canary.from})` : "")
-    : "";
-  console.log(`  ${r.triplet.padEnd(30)} ${fmtBytes(r.now).padStart(10)}${c}`);
+  for (const r of rows) {
+    const c = r.canary
+      ? `  ${buildKind} ${fmtDelta(r.canary.bytes).padStart(10)}` +
+        (r.canary.stale ? `  (stale: #${r.canary.from})` : "")
+      : "";
+    log(`  ${r.triplet.padEnd(30)} ${fmtBytes(r.now).padStart(10)}${c}`);
+  }
+
+  if (warn) {
+    log(`\nwarning: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`);
+  }
+
+  return { sizes, rows, annotation, style, overThreshold: overThreshold.map(r => r.triplet) };
 }
 
-if (warn) {
-  console.log(`\nwarning: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`);
+// ─── CI entry point ───
+
+function realAgent(args: string[], opts: { quiet?: boolean; stdin?: string } = {}): string | undefined {
+  const { exitCode, stdout } = Bun.spawnSync(["buildkite-agent", ...args], {
+    stderr: opts.quiet ? "ignore" : "inherit",
+    stdin: opts.stdin !== undefined ? new Blob([opts.stdin]) : undefined,
+  });
+  return exitCode === 0 ? stdout.toString().trim() : undefined;
+}
+
+async function ciMain(values: { targets: string; "threshold-mb": string; release: boolean }) {
+  const targets: Target[] = JSON.parse(values.targets);
+  await run({
+    targets,
+    thresholdBytes: parseFloat(values["threshold-mb"]) * 1024 * 1024,
+    isRelease: values.release,
+    env: {
+      org: process.env.BUILDKITE_ORGANIZATION_SLUG || "bun",
+      pipeline: process.env.BUILDKITE_PIPELINE_SLUG || "bun",
+      buildNumber: process.env.BUILDKITE_BUILD_NUMBER,
+      branch: process.env.BUILDKITE_BRANCH,
+      commit: process.env.BUILDKITE_COMMIT,
+      baseBranch: process.env.BUILDKITE_PULL_REQUEST_BASE_BRANCH || "main",
+      githubToken: realAgent(["secret", "get", "GITHUB_TOKEN"], { quiet: true }) || process.env.GITHUB_TOKEN,
+    },
+    io: { agent: realAgent, fetch: (url, init) => fetch(url, init), workDir: process.cwd(), log: console.log },
+  });
+}
+
+if (import.meta.main) {
+  const { values } = parseArgs({
+    options: {
+      targets: { type: "string" },
+      "threshold-mb": { type: "string", default: "0.5" },
+      release: { type: "boolean", default: false },
+    },
+  });
+  if (values.targets) {
+    await ciMain(values as { targets: string; "threshold-mb": string; release: boolean });
+  } else {
+    await compareGithubReleases();
+  }
 }
 
 // ─── helpers ───

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -5,13 +5,13 @@
 //   bun scripts/binary-size.ts \
 //     --targets '[{"triplet":"bun-darwin-aarch64"},...]' \
 //     --threshold-mb 0.5 \
-//     [--no-fail] [--release]
+//     [--release]
 //
-//   Always posts an annotation with sizes and deltas. On PR builds it fails if
-//   any binary grew by more than --threshold-mb vs canary; on main it never
-//   fails (--no-fail) but still shows the comparison against the previous main
-//   build. Escape hatch: put `[skip size check]` in the commit message, which
-//   makes ci.mjs set soft_fail on this step (it still runs and annotates).
+//   Always posts an annotation with sizes and deltas against the build at this
+//   PR's merge-base on main. A binary that grew by more than --threshold-mb is
+//   called out with a warning-style annotation. The step itself never fails:
+//   binary size is advisory, and a hard gate here has mostly produced false
+//   positives when the baseline went stale.
 //
 // Local mode (no args):
 //   bun scripts/binary-size.ts
@@ -22,8 +22,6 @@
 
 import { mkdirSync, rmSync } from "node:fs";
 import { parseArgs } from "node:util";
-// @ts-ignore — utils.mjs has JSDoc types but no .d.ts
-import { markBuildkiteStepReported } from "./utils.mjs";
 
 type Target = { triplet: string };
 type Sizes = Record<string, number>;
@@ -32,7 +30,6 @@ const { values } = parseArgs({
   options: {
     targets: { type: "string" },
     "threshold-mb": { type: "string", default: "0.5" },
-    "no-fail": { type: "boolean", default: false },
     release: { type: "boolean", default: false },
   },
 });
@@ -44,7 +41,6 @@ if (!values.targets) {
 
 const targets: Target[] = JSON.parse(values.targets!);
 const thresholdBytes = parseFloat(values["threshold-mb"]!) * 1024 * 1024;
-const noFail = values["no-fail"];
 const isRelease = values.release;
 const buildKind = isRelease ? "release" : "canary";
 
@@ -254,11 +250,13 @@ const rows: Row[] = targets
     canary: delta(sizes[triplet], triplet),
   }));
 
-// Stale rows (baseline older than this PR's merge-base) are annotated but never
-// enforced: that delta includes main's growth, not just this PR's.
+// A row whose baseline is the merge-base build is a real signal about this
+// PR: over the threshold it gets the warning treatment. A stale row (baseline
+// older than the merge-base) folds in main's own growth, so it is shown with
+// its source build but does not raise the warning.
 const overThreshold = rows.filter(r => r.canary && !r.canary.stale && r.canary.bytes > thresholdBytes);
 const staleOver = rows.filter(r => r.canary?.stale && r.canary.bytes > thresholdBytes);
-const failed = !noFail && overThreshold.length > 0;
+const warn = overThreshold.length > 0;
 
 const link = (b: Baseline | undefined, fallback: string) =>
   b?.href ? `<a href="${b.href}">${b.label}</a>` : (b?.label ?? `${fallback} (n/a)`);
@@ -277,7 +275,7 @@ const deltaCells = (d: Delta | undefined, over: boolean) => {
 const tableRows = rows
   .map(r => {
     const over = !!r.canary && r.canary.bytes > thresholdBytes;
-    const mark = over ? (r.canary!.stale ? "⚠️ " : "❌ ") : "";
+    const mark = over && !r.canary!.stale ? "⚠️ " : "";
     return (
       `<tr><td>${mark}<code>${r.triplet}</code></td>` +
       `<td align="right">${fmtBytes(r.now)}</td>` +
@@ -288,22 +286,21 @@ const tableRows = rows
   .join("\n");
 
 const limit = fmtBytes(thresholdBytes);
-const header =
-  overThreshold.length > 0
-    ? `<b>${overThreshold.length}</b> over ${limit}`
-    : canary
-      ? `all within ${limit}${staleOver.length ? ` (${staleOver.length} stale ignored)` : ""}`
-      : `no ${buildKind} comparison (${canaryNote})`;
+const header = warn
+  ? `<b>${overThreshold.length}</b> over ${limit}`
+  : canary
+    ? `all within ${limit}${staleOver.length ? ` (${staleOver.length} stale ignored)` : ""}`
+    : `no ${buildKind} comparison (${canaryNote})`;
 
 const staleNote =
   canary && canary.stale.size > 0
-    ? `<p>⚠️ ${canary.stale.size} target(s) had no size recorded for the merge-base build ` +
+    ? `<p>${canary.stale.size} target(s) had no size recorded for the merge-base build ` +
       `${link(canary, baseBranch)}; their Δ is against the older build linked in the size column ` +
-      `and includes ${baseBranch}'s own growth, so it is not enforced.</p>`
+      `and includes ${baseBranch}'s own growth.</p>`
     : "";
 
 const annotation = `
-<details${failed ? " open" : ""}>
+<details${warn ? " open" : ""}>
 <summary>📦 Binary size — ${header}</summary>
 <table>
 <tr>
@@ -314,7 +311,6 @@ const annotation = `
 ${tableRows}
 </table>
 ${staleNote}
-${failed ? `<p>Add <code>[skip size check]</code> to the commit message if this increase is intentional.</p>` : ""}
 </details>`;
 
 Bun.spawnSync(
@@ -322,11 +318,11 @@ Bun.spawnSync(
     "buildkite-agent",
     "annotate",
     "--style",
-    failed ? "error" : "info",
+    warn ? "warning" : "info",
     "--context",
     "binary-size",
     "--priority",
-    failed ? "5" : "2",
+    warn ? "5" : "2",
   ],
   { stdin: new Blob([annotation]), stderr: "inherit" },
 );
@@ -338,12 +334,8 @@ for (const r of rows) {
   console.log(`  ${r.triplet.padEnd(30)} ${fmtBytes(r.now).padStart(10)}${c}`);
 }
 
-if (failed) {
-  console.error(`\nerror: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`);
-  // Suppress the generic fallback in .buildkite/hooks/pre-exit; this script
-  // owns its failure annotation.
-  markBuildkiteStepReported();
-  process.exit(1);
+if (warn) {
+  console.log(`\nwarning: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`);
 }
 
 // ─── helpers ───

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -35,9 +35,9 @@ const META: Record<string, Record<string, number>> = {
 };
 const UUID = Object.fromEntries(Object.values(SHA2BUILD).map(n => [String(n), `uuid-${n}`]));
 
-// Per-build commit messages: canary by default; tests override to exercise the
-// [release] filter in the meta-data fallback.
-let commitMessages: Record<string, string> = {};
+// Per-build .json overrides: webhook canary by default; tests override to
+// exercise the release filter in the meta-data fallback.
+let buildJsonOverrides: Record<string, { message?: string; source?: string }> = {};
 
 function githubHandler(url: URL): unknown {
   if (url.pathname === "/repos/oven-sh/bun/compare/main...sha-pr") {
@@ -67,10 +67,15 @@ beforeAll(() => {
     port: 0,
     fetch(req) {
       const url = new URL(req.url);
-      // buildkite.com public .json → build UUID + commit message
+      // buildkite.com public .json → build UUID + commit message + trigger source
       const mBuild = url.pathname.match(/^\/bun\/bun\/builds\/(\d+)\.json$/);
       if (mBuild)
-        return Response.json({ id: UUID[mBuild[1]] ?? "uuid-unknown", message: commitMessages[mBuild[1]] ?? "commit" });
+        return Response.json({
+          id: UUID[mBuild[1]] ?? "uuid-unknown",
+          message: "commit",
+          source: "webhook",
+          ...buildJsonOverrides[mBuild[1]],
+        });
       // everything else → GitHub API
       return Response.json(githubHandler(url));
     },
@@ -120,8 +125,8 @@ case "$cmd" in
   *) exit 1 ;;
 esac`;
 
-async function runBinarySize(meta: typeof META, messages: Record<string, string> = {}) {
-  commitMessages = messages;
+async function runBinarySize(meta: typeof META, overrides: typeof buildJsonOverrides = {}) {
+  buildJsonOverrides = overrides;
   using dir = tempDir("binary-size-baseline", { ".keep": "" });
   const agentPath = join(String(dir), "buildkite-agent");
   await Bun.write(agentPath, agentScript);
@@ -182,6 +187,7 @@ test.skipIf(!isPosix)(
     expect(stdout).toMatch(/bun-darwin-aarch64\s+.*\+562\.9 KB\s+\(stale: #100\)/);
     expect(annotation).toContain("all within 0.50 MB (1 stale ignored)");
     expect(annotation).toContain("⚠️ <code>bun-darwin-aarch64</code>");
+    expect(annotation).toContain('<sup><a href="https://buildkite.com/bun/bun/builds/100">#100</a></sup>');
     expect(annotation).not.toContain("❌");
     expect(exitCode).toBe(0);
   },
@@ -197,16 +203,28 @@ test.skipIf(!isPosix)("PR still fails when the merge-base baseline itself is ove
   expect(exitCode).toBe(1);
 });
 
-test.skipIf(!isPosix)("[release] merge-base does not claim the anchor (next canary build is enforced)", async () => {
-  // Merge-base #200 is a [release] build: the like-for-like check rejects it for a
-  // canary PR, and it must NOT claim the anchor (a release-tag commit doesn't itself
-  // change canary sizes). Anchor becomes #150 (next canary back), whose linux-x64 is
-  // 75_560_000; PR is +600 KB over that and must fail rather than being waved through
-  // as "stale".
-  const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["150"]["bun-linux-x64"] + 600_000 } };
-  const { stdout, stderr, annotation, exitCode } = await runBinarySize(big, { "200": "bump version [release]" });
-  expect(stdout).toContain("main #150");
-  expect(stderr).toContain("error: 1 target(s) exceeded 0.50 MB");
-  expect(annotation).toContain("❌ <code>bun-linux-x64</code>");
-  expect(exitCode).toBe(1);
-});
+for (const [how, override] of [
+  ["source:ui (real Bun releases are manual triggers with RELEASE=1)", { source: "ui" }],
+  ["[release] in the commit message", { message: "bump [release]" }],
+] as const) {
+  test.skipIf(!isPosix)(
+    `meta-data fallback does not enforce release-mode sizes from a merge-base build with ${how}`,
+    async () => {
+      // Merge-base #200's meta-data is from a release build (whose Windows sizes
+      // differ from canary by several MB). The fallback cannot recover an
+      // authoritative release flag from meta-data, so it declines the build
+      // entirely; the walk claims the anchor with no sizes and every row resolves
+      // stale from an older canary build. Even with the PR's linux-x64 +600 KB
+      // over #150, the step annotates the growth but does not hard-fail on a
+      // baseline it cannot prove is like-for-like.
+      const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["150"]["bun-linux-x64"] + 600_000 } };
+      const { stdout, stderr, annotation, exitCode } = await runBinarySize(big, { "200": override });
+      expect(stderr).not.toContain("error:");
+      expect(stdout).toContain("main #200");
+      expect(stdout).toMatch(/bun-linux-x64\s+.*\+585\.9 KB\s+\(stale: #150\)/);
+      expect(annotation).toContain("all within 0.50 MB (2 stale ignored)");
+      expect(annotation).not.toContain("❌");
+      expect(exitCode).toBe(0);
+    },
+  );
+}

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -1,0 +1,187 @@
+// Verifies that scripts/binary-size.ts does not fail a PR build when the only
+// available main baseline predates the PR's merge-base. This is the scenario
+// that trips every PR when a run of main builds gets canceled/timed out so the
+// binary-size aggregator never runs, leaving a stale baseline that already
+// carries several hundred KB of main's own growth.
+//
+// The test stands up a fake GitHub + Buildkite frontend and a fake
+// buildkite-agent, then runs the real script against them.
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+
+// The world:
+//   main:  sha-old (build 100, full sizes)  →  sha-mid (build 150, +550KB;
+//          its darwin build was canceled so only linux-x64 is recorded)
+//          →  sha-base (build 200, partial sizes: only linux-x64)
+//   PR:    branched from sha-base; adds ~16 KB on both targets.
+// So the only darwin-aarch64 baseline available is two commits behind the PR's
+// merge-base and predates a +550 KB main change the PR already contains.
+const TRIPLETS = ["bun-linux-x64", "bun-darwin-aarch64"] as const;
+
+const META: Record<string, Record<string, number>> = {
+  "100": { "bun-linux-x64": 75_000_000, "bun-darwin-aarch64": 60_000_000 },
+  "150": { "bun-linux-x64": 75_560_000 },
+  "200": { "bun-linux-x64": 75_560_000 },
+  // the PR's own build
+  "999": { "bun-linux-x64": 75_576_384, "bun-darwin-aarch64": 60_576_384 },
+};
+const UUID = { "100": "uuid-100", "150": "uuid-150", "200": "uuid-200" };
+
+function githubHandler(url: URL): unknown {
+  if (url.pathname === "/repos/oven-sh/bun/compare/main...sha-pr") {
+    return { merge_base_commit: { sha: "sha-base" }, ahead_by: 1, behind_by: 0 };
+  }
+  if (url.pathname === "/repos/oven-sh/bun/commits") {
+    const from = url.searchParams.get("sha");
+    // History as returned by the list-commits endpoint, newest first.
+    const chain = ["sha-base", "sha-mid", "sha-old"];
+    const start = from === "main" ? 0 : chain.indexOf(from ?? "");
+    return chain.slice(start < 0 ? 0 : start).map(sha => ({ sha }));
+  }
+  const mStatus = url.pathname.match(/^\/repos\/oven-sh\/bun\/commits\/(.+)\/status$/);
+  if (mStatus) {
+    const sha = mStatus[1];
+    const build = sha === "sha-base" ? 200 : sha === "sha-mid" ? 150 : sha === "sha-old" ? 100 : undefined;
+    return {
+      statuses: build ? [{ context: "buildkite/bun", target_url: `http://127.0.0.1/bun/bun/builds/${build}` }] : [],
+    };
+  }
+  return { error: "not found" };
+}
+
+let server: ReturnType<typeof Bun.serve>;
+let base: string;
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      // buildkite.com public .json → build UUID
+      const mBuild = url.pathname.match(/^\/bun\/bun\/builds\/(\d+)\.json$/);
+      if (mBuild) return Response.json({ id: UUID[mBuild[1] as keyof typeof UUID] ?? "uuid-unknown" });
+      // everything else → GitHub API
+      return Response.json(githubHandler(url));
+    },
+  });
+  base = `http://127.0.0.1:${server.port}`;
+});
+afterAll(() => server?.stop(true));
+
+// Flatten META into env vars so the bash shim can answer without spawning
+// another interpreter (debug+ASAN bun startup would push this over the timeout).
+function metaEnv(meta: typeof META): Record<string, string> {
+  const out: Record<string, string> = {};
+  const key = (num: string, triplet: string) => `M_${num}_${triplet.replaceAll("-", "_")}`;
+  for (const [num, sizes] of Object.entries(meta))
+    for (const [t, v] of Object.entries(sizes)) out[key(num, t)] = String(v);
+  for (const [num, uuid] of Object.entries(UUID)) out[`UUID_${uuid.replaceAll("-", "_")}`] = num;
+  return out;
+}
+
+const agentScript = `#!/usr/bin/env bash
+set -eu
+cmd="$1"; shift
+case "$cmd" in
+  secret) exit 1 ;;                      # no GITHUB_TOKEN secret
+  annotate) cat > "$ANNOTATION_OUT"; exit 0 ;;
+  artifact)
+    [[ "$1" == "upload" ]] && exit 0
+    exit 1                               # no binary-sizes.json artifact anywhere
+    ;;
+  meta-data)
+    sub="$1"; shift
+    key=""; build=""
+    while (($#)); do
+      case "$1" in --build) shift; build="$1" ;; *) key="$1" ;; esac; shift
+    done
+    [[ "$sub" == "get" ]] || exit 1
+    if [[ -n "$build" ]]; then
+      uvar="UUID_\${build//-/_}"; num="\${!uvar:-}"
+    else
+      num="$BUILDKITE_BUILD_NUMBER"
+    fi
+    triplet="\${key#binary-size:}"
+    mvar="M_\${num}_\${triplet//-/_}"; val="\${!mvar:-}"
+    [[ -n "$val" ]] || exit 1
+    printf '%s' "$val"
+    ;;
+  *) exit 1 ;;
+esac`;
+
+async function runBinarySize(meta: typeof META) {
+  using dir = tempDir("binary-size-baseline", { ".keep": "" });
+  const agentPath = join(String(dir), "buildkite-agent");
+  await Bun.write(agentPath, agentScript);
+  chmodSync(agentPath, 0o755);
+
+  const annotationOut = join(String(dir), "annotation.html");
+  const root = join(import.meta.dir, "..", "..");
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      join(root, "scripts", "binary-size.ts"),
+      "--targets",
+      JSON.stringify(TRIPLETS.map(t => ({ triplet: t }))),
+      "--threshold-mb",
+      "0.5",
+    ],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      ...metaEnv(meta),
+      GITHUB_TOKEN: "",
+      PATH: `${dir}:${bunEnv.PATH ?? process.env.PATH}`,
+      ANNOTATION_OUT: annotationOut,
+      BUILDKITE_ORGANIZATION_SLUG: "bun",
+      BUILDKITE_PIPELINE_SLUG: "bun",
+      BUILDKITE_BUILD_NUMBER: "999",
+      BUILDKITE_BRANCH: "pr/branch",
+      BUILDKITE_COMMIT: "sha-pr",
+      BUILDKITE_PULL_REQUEST_BASE_BRANCH: "main",
+      // Route both GitHub and buildkite.com through the local server.
+      BINARY_SIZE_GITHUB_API: base,
+      BINARY_SIZE_BUILDKITE_WEB: base,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const annotation = await Bun.file(annotationOut)
+    .text()
+    .catch(() => "");
+  return { stdout, stderr, exitCode, annotation };
+}
+
+// The fake buildkite-agent is a bash script.
+test.skipIf(!isPosix)(
+  "PR is not failed when the only over-threshold rows have a baseline older than merge-base",
+  async () => {
+    const { stdout, stderr, exitCode, annotation } = await runBinarySize(META);
+    // linux-x64 baseline is from the merge-base build (#200): delta = 16 KB, under threshold.
+    // darwin-aarch64 has to fall back to #100: delta = +563 KB. That row is stale (baseline
+    // predates merge-base) so it is shown as ⚠️ but does not fail the step. Before this fix
+    // the walk used a single build for every target, so both rows compared against #100 and
+    // both read "+550 KB" → the step hard-failed with "2 target(s) exceeded 0.50 MB".
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toContain("main #200");
+    expect(stdout).toMatch(/bun-linux-x64\s+.*\+16\.0 KB\s*$/m);
+    expect(stdout).toMatch(/bun-darwin-aarch64\s+.*\+562\.9 KB\s+\(stale: #100\)/);
+    expect(annotation).toContain("all within 0.50 MB (1 stale ignored)");
+    expect(annotation).toContain("⚠️ <code>bun-darwin-aarch64</code>");
+    expect(annotation).not.toContain("❌");
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.skipIf(!isPosix)("PR still fails when the merge-base baseline itself is over threshold", async () => {
+  // Bump the PR's own linux-x64 size by 600 KB over merge-base. The baseline for
+  // linux-x64 is the merge-base build (#200), so this row is fresh and must fail.
+  const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["200"]["bun-linux-x64"] + 600_000 } };
+  const { stderr, annotation, exitCode } = await runBinarySize(big);
+  expect(stderr).toContain("error: 1 target(s) exceeded 0.50 MB");
+  expect(annotation).toContain("❌ <code>bun-linux-x64</code>");
+  expect(exitCode).toBe(1);
+});

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -59,9 +59,10 @@ beforeAll(() => {
     port: 0,
     fetch(req) {
       const url = new URL(req.url);
-      // buildkite.com public .json → build UUID
+      // buildkite.com public .json → build UUID + commit message
       const mBuild = url.pathname.match(/^\/bun\/bun\/builds\/(\d+)\.json$/);
-      if (mBuild) return Response.json({ id: UUID[mBuild[1] as keyof typeof UUID] ?? "uuid-unknown" });
+      if (mBuild)
+        return Response.json({ id: UUID[mBuild[1] as keyof typeof UUID] ?? "uuid-unknown", message: "commit" });
       // everything else → GitHub API
       return Response.json(githubHandler(url));
     },

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -7,7 +7,7 @@
 // The test stands up a fake GitHub + Buildkite frontend and a fake
 // buildkite-agent, then runs the real script against them.
 
-import { test, expect, beforeAll, afterAll } from "bun:test";
+import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 import { chmodSync } from "node:fs";
 import { join } from "node:path";

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -16,35 +16,43 @@ import { join } from "node:path";
 //   main:  sha-old (build 100, full sizes)  →  sha-mid (build 150, +550KB;
 //          its darwin build was canceled so only linux-x64 is recorded)
 //          →  sha-base (build 200, partial sizes: only linux-x64)
+//          →  sha-head (build 250, full sizes; main HEAD, landed AFTER the PR
+//          branched)
 //   PR:    branched from sha-base; adds ~16 KB on both targets.
-// So the only darwin-aarch64 baseline available is two commits behind the PR's
-// merge-base and predates a +550 KB main change the PR already contains.
+// So the only darwin-aarch64 baseline at or before the merge-base is two
+// commits behind it and predates a +550 KB main change the PR already contains.
 const TRIPLETS = ["bun-linux-x64", "bun-darwin-aarch64"] as const;
+const SHA2BUILD = { "sha-head": 250, "sha-base": 200, "sha-mid": 150, "sha-old": 100 } as const;
 
 const META: Record<string, Record<string, number>> = {
   "100": { "bun-linux-x64": 75_000_000, "bun-darwin-aarch64": 60_000_000 },
   "150": { "bun-linux-x64": 75_560_000 },
   "200": { "bun-linux-x64": 75_560_000 },
+  // main HEAD, one commit ahead of the PR's merge-base
+  "250": { "bun-linux-x64": 76_000_000, "bun-darwin-aarch64": 60_700_000 },
   // the PR's own build
   "999": { "bun-linux-x64": 75_576_384, "bun-darwin-aarch64": 60_576_384 },
 };
-const UUID = { "100": "uuid-100", "150": "uuid-150", "200": "uuid-200" };
+const UUID = Object.fromEntries(Object.values(SHA2BUILD).map(n => [String(n), `uuid-${n}`]));
+
+// Per-build commit messages: canary by default; tests override to exercise the
+// [release] filter in the meta-data fallback.
+let commitMessages: Record<string, string> = {};
 
 function githubHandler(url: URL): unknown {
   if (url.pathname === "/repos/oven-sh/bun/compare/main...sha-pr") {
-    return { merge_base_commit: { sha: "sha-base" }, ahead_by: 1, behind_by: 0 };
+    return { merge_base_commit: { sha: "sha-base" }, ahead_by: 1, behind_by: 1 };
   }
   if (url.pathname === "/repos/oven-sh/bun/commits") {
     const from = url.searchParams.get("sha");
     // History as returned by the list-commits endpoint, newest first.
-    const chain = ["sha-base", "sha-mid", "sha-old"];
+    const chain = Object.keys(SHA2BUILD);
     const start = from === "main" ? 0 : chain.indexOf(from ?? "");
     return chain.slice(start < 0 ? 0 : start).map(sha => ({ sha }));
   }
   const mStatus = url.pathname.match(/^\/repos\/oven-sh\/bun\/commits\/(.+)\/status$/);
   if (mStatus) {
-    const sha = mStatus[1];
-    const build = sha === "sha-base" ? 200 : sha === "sha-mid" ? 150 : sha === "sha-old" ? 100 : undefined;
+    const build = SHA2BUILD[mStatus[1] as keyof typeof SHA2BUILD];
     return {
       statuses: build ? [{ context: "buildkite/bun", target_url: `http://127.0.0.1/bun/bun/builds/${build}` }] : [],
     };
@@ -62,7 +70,7 @@ beforeAll(() => {
       // buildkite.com public .json → build UUID + commit message
       const mBuild = url.pathname.match(/^\/bun\/bun\/builds\/(\d+)\.json$/);
       if (mBuild)
-        return Response.json({ id: UUID[mBuild[1] as keyof typeof UUID] ?? "uuid-unknown", message: "commit" });
+        return Response.json({ id: UUID[mBuild[1]] ?? "uuid-unknown", message: commitMessages[mBuild[1]] ?? "commit" });
       // everything else → GitHub API
       return Response.json(githubHandler(url));
     },
@@ -112,7 +120,8 @@ case "$cmd" in
   *) exit 1 ;;
 esac`;
 
-async function runBinarySize(meta: typeof META) {
+async function runBinarySize(meta: typeof META, messages: Record<string, string> = {}) {
+  commitMessages = messages;
   using dir = tempDir("binary-size-baseline", { ".keep": "" });
   const agentPath = join(String(dir), "buildkite-agent");
   await Bun.write(agentPath, agentScript);
@@ -156,8 +165,9 @@ async function runBinarySize(meta: typeof META) {
   return { stdout, stderr, exitCode, annotation };
 }
 
-// The fake buildkite-agent is a bash script.
-test.concurrent.skipIf(!isPosix)(
+// The fake buildkite-agent is a bash script. Tests share one mock server with a
+// mutable commit-message map, so they run sequentially.
+test.skipIf(!isPosix)(
   "PR is not failed when the only over-threshold rows have a baseline older than merge-base",
   async () => {
     const { stdout, stderr, exitCode, annotation } = await runBinarySize(META);
@@ -177,11 +187,25 @@ test.concurrent.skipIf(!isPosix)(
   },
 );
 
-test.concurrent.skipIf(!isPosix)("PR still fails when the merge-base baseline itself is over threshold", async () => {
+test.skipIf(!isPosix)("PR still fails when the merge-base baseline itself is over threshold", async () => {
   // Bump the PR's own linux-x64 size by 600 KB over merge-base. The baseline for
   // linux-x64 is the merge-base build (#200), so this row is fresh and must fail.
   const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["200"]["bun-linux-x64"] + 600_000 } };
   const { stderr, annotation, exitCode } = await runBinarySize(big);
+  expect(stderr).toContain("error: 1 target(s) exceeded 0.50 MB");
+  expect(annotation).toContain("❌ <code>bun-linux-x64</code>");
+  expect(exitCode).toBe(1);
+});
+
+test.skipIf(!isPosix)("[release] merge-base does not claim the anchor (next canary build is enforced)", async () => {
+  // Merge-base #200 is a [release] build: the like-for-like check rejects it for a
+  // canary PR, and it must NOT claim the anchor (a release-tag commit doesn't itself
+  // change canary sizes). Anchor becomes #150 (next canary back), whose linux-x64 is
+  // 75_560_000; PR is +600 KB over that and must fail rather than being waved through
+  // as "stale".
+  const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["150"]["bun-linux-x64"] + 600_000 } };
+  const { stdout, stderr, annotation, exitCode } = await runBinarySize(big, { "200": "bump version [release]" });
+  expect(stdout).toContain("main #150");
   expect(stderr).toContain("error: 1 target(s) exceeded 0.50 MB");
   expect(annotation).toContain("❌ <code>bun-linux-x64</code>");
   expect(exitCode).toBe(1);

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -156,7 +156,7 @@ async function runBinarySize(meta: typeof META) {
 }
 
 // The fake buildkite-agent is a bash script.
-test.skipIf(!isPosix)(
+test.concurrent.skipIf(!isPosix)(
   "PR is not failed when the only over-threshold rows have a baseline older than merge-base",
   async () => {
     const { stdout, stderr, exitCode, annotation } = await runBinarySize(META);
@@ -176,7 +176,7 @@ test.skipIf(!isPosix)(
   },
 );
 
-test.skipIf(!isPosix)("PR still fails when the merge-base baseline itself is over threshold", async () => {
+test.concurrent.skipIf(!isPosix)("PR still fails when the merge-base baseline itself is over threshold", async () => {
   // Bump the PR's own linux-x64 size by 600 KB over merge-base. The baseline for
   // linux-x64 is the merge-base build (#200), so this row is fresh and must fail.
   const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["200"]["bun-linux-x64"] + 600_000 } };

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -1,6 +1,6 @@
-// Verifies that scripts/binary-size.ts does not fail a PR build when the only
-// available main baseline predates the PR's merge-base. This is the scenario
-// that trips every PR when a run of main builds gets canceled/timed out so the
+// Verifies that scripts/binary-size.ts resolves baselines from the PR merge-base
+// and only warns (never fails) on growth. The stale-baseline scenario is what
+// tripped every PR when a run of main builds got canceled/timed out so the
 // binary-size aggregator never runs, leaving a stale baseline that already
 // carries several hundred KB of main's own growth.
 //
@@ -100,7 +100,7 @@ set -eu
 cmd="$1"; shift
 case "$cmd" in
   secret) exit 1 ;;                      # no GITHUB_TOKEN secret
-  annotate) cat > "$ANNOTATION_OUT"; exit 0 ;;
+  annotate) printf '%s\\n' "$@" > "$ANNOTATION_OUT.args"; cat > "$ANNOTATION_OUT"; exit 0 ;;
   artifact)
     [[ "$1" == "upload" ]] && exit 0
     exit 1                               # no binary-sizes.json artifact anywhere
@@ -167,40 +167,48 @@ async function runBinarySize(meta: typeof META, overrides: typeof buildJsonOverr
   const annotation = await Bun.file(annotationOut)
     .text()
     .catch(() => "");
-  return { stdout, stderr, exitCode, annotation };
+  // buildkite-agent annotate --style <x> --context <y> --priority <z>
+  const args = await Bun.file(`${annotationOut}.args`)
+    .text()
+    .catch(() => "");
+  const style = args.split("\n")[args.split("\n").indexOf("--style") + 1] ?? "";
+  return { stdout, stderr, exitCode, annotation, style };
 }
 
 // The fake buildkite-agent is a bash script. Tests share one mock server with a
-// mutable commit-message map, so they run sequentially.
-test.skipIf(!isPosix)(
-  "PR is not failed when the only over-threshold rows have a baseline older than merge-base",
-  async () => {
-    const { stdout, stderr, exitCode, annotation } = await runBinarySize(META);
-    // linux-x64 baseline is from the merge-base build (#200): delta = 16 KB, under threshold.
-    // darwin-aarch64 has to fall back to #100: delta = +563 KB. That row is stale (baseline
-    // predates merge-base) so it is shown as ⚠️ but does not fail the step. Before this fix
-    // the walk used a single build for every target, so both rows compared against #100 and
-    // both read "+550 KB" → the step hard-failed with "2 target(s) exceeded 0.50 MB".
-    expect(stderr).not.toContain("error:");
-    expect(stdout).toContain("main #200");
-    expect(stdout).toMatch(/bun-linux-x64\s+.*\+16\.0 KB\s*$/m);
-    expect(stdout).toMatch(/bun-darwin-aarch64\s+.*\+562\.9 KB\s+\(stale: #100\)/);
-    expect(annotation).toContain("all within 0.50 MB (1 stale ignored)");
-    expect(annotation).toContain("⚠️ <code>bun-darwin-aarch64</code>");
-    expect(annotation).toContain('<sup><a href="https://buildkite.com/bun/bun/builds/100">#100</a></sup>');
-    expect(annotation).not.toContain("❌");
-    expect(exitCode).toBe(0);
-  },
-);
+// mutable build-json override map, so they run sequentially.
+test.skipIf(!isPosix)("rows whose only baseline predates the merge-base are shown but not warned on", async () => {
+  const { stdout, stderr, exitCode, annotation, style } = await runBinarySize(META);
+  // linux-x64 baseline is from the merge-base build (#200): delta = 16 KB, under threshold.
+  // darwin-aarch64 has to fall back to #100: delta = +563 KB. That row is stale (baseline
+  // predates merge-base) so it is listed with its source build but raises no warning.
+  // Before this change the walk used one build for every target, so both rows compared
+  // against #100, both read "+550 KB", and the step failed the PR.
+  expect(stderr).toBe("");
+  expect(stdout).toContain("main #200");
+  expect(stdout).toMatch(/bun-linux-x64\s+.*\+16\.0 KB\s*$/m);
+  expect(stdout).toMatch(/bun-darwin-aarch64\s+.*\+562\.9 KB\s+\(stale: #100\)/);
+  expect(stdout).not.toContain("warning:");
+  expect(annotation).toContain("all within 0.50 MB (1 stale ignored)");
+  expect(annotation).toContain('<sup><a href="https://buildkite.com/bun/bun/builds/100">#100</a></sup>');
+  expect(annotation).not.toContain("⚠️");
+  expect(style).toBe("info");
+  expect(exitCode).toBe(0);
+});
 
-test.skipIf(!isPosix)("PR still fails when the merge-base baseline itself is over threshold", async () => {
+test.skipIf(!isPosix)("growth over the merge-base baseline is a warning, not a failure", async () => {
   // Bump the PR's own linux-x64 size by 600 KB over merge-base. The baseline for
-  // linux-x64 is the merge-base build (#200), so this row is fresh and must fail.
+  // linux-x64 is the merge-base build (#200), so this row is fresh: it gets the
+  // warning annotation, and the step still exits 0.
   const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["200"]["bun-linux-x64"] + 600_000 } };
-  const { stderr, annotation, exitCode } = await runBinarySize(big);
-  expect(stderr).toContain("error: 1 target(s) exceeded 0.50 MB");
-  expect(annotation).toContain("❌ <code>bun-linux-x64</code>");
-  expect(exitCode).toBe(1);
+  const { stdout, stderr, annotation, style, exitCode } = await runBinarySize(big);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("warning: 1 target(s) exceeded 0.50 MB");
+  expect(annotation).toContain("<b>1</b> over 0.50 MB");
+  expect(annotation).toContain("⚠️ <code>bun-linux-x64</code>");
+  expect(annotation).toContain("<details open>");
+  expect(style).toBe("warning");
+  expect(exitCode).toBe(0);
 });
 
 for (const [how, override] of [
@@ -208,22 +216,22 @@ for (const [how, override] of [
   ["[release] in the commit message", { message: "bump [release]" }],
 ] as const) {
   test.skipIf(!isPosix)(
-    `meta-data fallback does not enforce release-mode sizes from a merge-base build with ${how}`,
+    `meta-data fallback does not compare against release-mode sizes from a merge-base build with ${how}`,
     async () => {
       // Merge-base #200's meta-data is from a release build (whose Windows sizes
       // differ from canary by several MB). The fallback cannot recover an
       // authoritative release flag from meta-data, so it declines the build
       // entirely; the walk claims the anchor with no sizes and every row resolves
       // stale from an older canary build. Even with the PR's linux-x64 +600 KB
-      // over #150, the step annotates the growth but does not hard-fail on a
-      // baseline it cannot prove is like-for-like.
+      // over #150, no warning is raised on a baseline that is not like-for-like.
       const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["150"]["bun-linux-x64"] + 600_000 } };
-      const { stdout, stderr, annotation, exitCode } = await runBinarySize(big, { "200": override });
-      expect(stderr).not.toContain("error:");
+      const { stdout, stderr, annotation, style, exitCode } = await runBinarySize(big, { "200": override });
+      expect(stderr).toBe("");
       expect(stdout).toContain("main #200");
       expect(stdout).toMatch(/bun-linux-x64\s+.*\+585\.9 KB\s+\(stale: #150\)/);
       expect(annotation).toContain("all within 0.50 MB (2 stale ignored)");
-      expect(annotation).not.toContain("❌");
+      expect(annotation).not.toContain("⚠️");
+      expect(style).toBe("info");
       expect(exitCode).toBe(0);
     },
   );

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -1,16 +1,15 @@
 // Verifies that scripts/binary-size.ts resolves baselines from the PR merge-base
 // and only warns (never fails) on growth. The stale-baseline scenario is what
 // tripped every PR when a run of main builds got canceled/timed out so the
-// binary-size aggregator never runs, leaving a stale baseline that already
-// carries several hundred KB of main's own growth.
+// binary-size aggregator never ran, leaving a stale baseline that already
+// carried several hundred KB of main's own growth.
 //
-// The test stands up a fake GitHub + Buildkite frontend and a fake
-// buildkite-agent, then runs the real script against them.
+// `run()` takes its buildkite-agent and HTTP calls through an `Io` object, so
+// the tests drive it in-process with a fake agent and a fake GitHub/Buildkite.
 
-import { afterAll, beforeAll, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, tempDir } from "harness";
-import { chmodSync } from "node:fs";
-import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { run, type Io, type Sizes } from "../../scripts/binary-size";
 
 // The world:
 //   main:  sha-old (build 100, full sizes)  →  sha-mid (build 150, +550KB;
@@ -21,10 +20,10 @@ import { join } from "node:path";
 //   PR:    branched from sha-base; adds ~16 KB on both targets.
 // So the only darwin-aarch64 baseline at or before the merge-base is two
 // commits behind it and predates a +550 KB main change the PR already contains.
-const TRIPLETS = ["bun-linux-x64", "bun-darwin-aarch64"] as const;
-const SHA2BUILD = { "sha-head": 250, "sha-base": 200, "sha-mid": 150, "sha-old": 100 } as const;
+const TRIPLETS = ["bun-linux-x64", "bun-darwin-aarch64"];
+const SHA2BUILD: Record<string, number> = { "sha-head": 250, "sha-base": 200, "sha-mid": 150, "sha-old": 100 };
 
-const META: Record<string, Record<string, number>> = {
+const META: Record<string, Sizes> = {
   "100": { "bun-linux-x64": 75_000_000, "bun-darwin-aarch64": 60_000_000 },
   "150": { "bun-linux-x64": 75_560_000 },
   "200": { "bun-linux-x64": 75_560_000 },
@@ -33,13 +32,12 @@ const META: Record<string, Record<string, number>> = {
   // the PR's own build
   "999": { "bun-linux-x64": 75_576_384, "bun-darwin-aarch64": 60_576_384 },
 };
-const UUID = Object.fromEntries(Object.values(SHA2BUILD).map(n => [String(n), `uuid-${n}`]));
+const uuidOf = (n: string | number) => `uuid-${n}`;
+const numOf = (uuid: string) => uuid.replace(/^uuid-/, "");
 
-// Per-build .json overrides: webhook canary by default; tests override to
-// exercise the release filter in the meta-data fallback.
-let buildJsonOverrides: Record<string, { message?: string; source?: string }> = {};
+type BuildJson = { message?: string; source?: string };
 
-function githubHandler(url: URL): unknown {
+function fakeGithub(url: URL): unknown {
   if (url.pathname === "/repos/oven-sh/bun/compare/main...sha-pr") {
     return { merge_base_commit: { sha: "sha-base" }, ahead_by: 1, behind_by: 1 };
   }
@@ -52,172 +50,108 @@ function githubHandler(url: URL): unknown {
   }
   const mStatus = url.pathname.match(/^\/repos\/oven-sh\/bun\/commits\/(.+)\/status$/);
   if (mStatus) {
-    const build = SHA2BUILD[mStatus[1] as keyof typeof SHA2BUILD];
+    const build = SHA2BUILD[mStatus[1]];
     return {
-      statuses: build ? [{ context: "buildkite/bun", target_url: `http://127.0.0.1/bun/bun/builds/${build}` }] : [],
+      statuses: build ? [{ context: "buildkite/bun", target_url: `https://buildkite.com/bun/bun/builds/${build}` }] : [],
     };
   }
-  return { error: "not found" };
+  throw new Error(`unexpected GitHub request: ${url.pathname}`);
 }
 
-let server: ReturnType<typeof Bun.serve>;
-let base: string;
-beforeAll(() => {
-  server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      // buildkite.com public .json → build UUID + commit message + trigger source
-      const mBuild = url.pathname.match(/^\/bun\/bun\/builds\/(\d+)\.json$/);
-      if (mBuild)
-        return Response.json({
-          id: UUID[mBuild[1]] ?? "uuid-unknown",
-          message: "commit",
-          source: "webhook",
-          ...buildJsonOverrides[mBuild[1]],
-        });
-      // everything else → GitHub API
-      return Response.json(githubHandler(url));
+function fakeIo(meta: Record<string, Sizes>, buildJson: Record<string, BuildJson>, workDir: string) {
+  const log: string[] = [];
+  let annotate: { args: string[]; stdin?: string } | undefined;
+  const io: Io = {
+    workDir,
+    log: line => log.push(line),
+    async fetch(url) {
+      const u = new URL(url);
+      const mBuild = u.pathname.match(/^\/bun\/bun\/builds\/(\d+)\.json$/);
+      if (u.host === "buildkite.com" && mBuild) {
+        return Response.json({ id: uuidOf(mBuild[1]), message: "commit", source: "webhook", ...buildJson[mBuild[1]] });
+      }
+      if (u.host === "api.github.com") return Response.json(fakeGithub(u));
+      throw new Error(`unexpected request: ${url}`);
     },
-  });
-  base = `http://127.0.0.1:${server.port}`;
-});
-afterAll(() => server?.stop(true));
-
-// Flatten META into env vars so the bash shim can answer without spawning
-// another interpreter (debug+ASAN bun startup would push this over the timeout).
-function metaEnv(meta: typeof META): Record<string, string> {
-  const out: Record<string, string> = {};
-  const key = (num: string, triplet: string) => `M_${num}_${triplet.replaceAll("-", "_")}`;
-  for (const [num, sizes] of Object.entries(meta))
-    for (const [t, v] of Object.entries(sizes)) out[key(num, t)] = String(v);
-  for (const [num, uuid] of Object.entries(UUID)) out[`UUID_${uuid.replaceAll("-", "_")}`] = num;
-  return out;
+    agent(args, opts) {
+      const [cmd, sub, ...rest] = args;
+      if (cmd === "annotate") {
+        annotate = { args: args.slice(1), stdin: opts?.stdin };
+        return "";
+      }
+      if (cmd === "artifact") return sub === "upload" ? "" : undefined; // no binary-sizes.json artifact anywhere
+      if (cmd === "meta-data" && sub === "get") {
+        const key = rest[0].replace(/^binary-size:/, "");
+        const buildIdx = rest.indexOf("--build");
+        const num = buildIdx >= 0 ? numOf(rest[buildIdx + 1]) : "999";
+        const v = meta[num]?.[key];
+        return v === undefined ? undefined : String(v);
+      }
+      return undefined;
+    },
+  };
+  const style = () => annotate?.args[annotate.args.indexOf("--style") + 1];
+  return { io, log, annotation: () => annotate?.stdin ?? "", style };
 }
 
-const agentScript = `#!/usr/bin/env bash
-set -eu
-cmd="$1"; shift
-case "$cmd" in
-  secret) exit 1 ;;                      # no GITHUB_TOKEN secret
-  annotate) printf '%s\\n' "$@" > "$ANNOTATION_OUT.args"; cat > "$ANNOTATION_OUT"; exit 0 ;;
-  artifact)
-    [[ "$1" == "upload" ]] && exit 0
-    exit 1                               # no binary-sizes.json artifact anywhere
-    ;;
-  meta-data)
-    sub="$1"; shift
-    key=""; build=""
-    while (($#)); do
-      case "$1" in --build) shift; build="$1" ;; *) key="$1" ;; esac; shift
-    done
-    [[ "$sub" == "get" ]] || exit 1
-    if [[ -n "$build" ]]; then
-      uvar="UUID_\${build//-/_}"; num="\${!uvar:-}"
-    else
-      num="$BUILDKITE_BUILD_NUMBER"
-    fi
-    triplet="\${key#binary-size:}"
-    mvar="M_\${num}_\${triplet//-/_}"; val="\${!mvar:-}"
-    [[ -n "$val" ]] || exit 1
-    printf '%s' "$val"
-    ;;
-  *) exit 1 ;;
-esac`;
-
-async function runBinarySize(meta: typeof META, overrides: typeof buildJsonOverrides = {}) {
-  buildJsonOverrides = overrides;
+async function runBinarySize(meta: Record<string, Sizes>, buildJson: Record<string, BuildJson> = {}) {
   using dir = tempDir("binary-size-baseline", { ".keep": "" });
-  const agentPath = join(String(dir), "buildkite-agent");
-  await Bun.write(agentPath, agentScript);
-  chmodSync(agentPath, 0o755);
-
-  const annotationOut = join(String(dir), "annotation.html");
-  const root = join(import.meta.dir, "..", "..");
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      join(root, "scripts", "binary-size.ts"),
-      "--targets",
-      JSON.stringify(TRIPLETS.map(t => ({ triplet: t }))),
-      "--threshold-mb",
-      "0.5",
-    ],
-    cwd: String(dir),
+  const fake = fakeIo(meta, buildJson, String(dir));
+  const result = await run({
+    targets: TRIPLETS.map(triplet => ({ triplet })),
+    thresholdBytes: 0.5 * 1024 * 1024,
+    isRelease: false,
     env: {
-      ...bunEnv,
-      ...metaEnv(meta),
-      GITHUB_TOKEN: "",
-      PATH: `${dir}:${bunEnv.PATH ?? process.env.PATH}`,
-      ANNOTATION_OUT: annotationOut,
-      BUILDKITE_ORGANIZATION_SLUG: "bun",
-      BUILDKITE_PIPELINE_SLUG: "bun",
-      BUILDKITE_BUILD_NUMBER: "999",
-      BUILDKITE_BRANCH: "pr/branch",
-      BUILDKITE_COMMIT: "sha-pr",
-      BUILDKITE_PULL_REQUEST_BASE_BRANCH: "main",
-      // Route both GitHub and buildkite.com through the local server.
-      BINARY_SIZE_GITHUB_API: base,
-      BINARY_SIZE_BUILDKITE_WEB: base,
+      org: "bun",
+      pipeline: "bun",
+      buildNumber: "999",
+      branch: "pr/branch",
+      commit: "sha-pr",
+      baseBranch: "main",
     },
-    stdout: "pipe",
-    stderr: "pipe",
+    io: fake.io,
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const annotation = await Bun.file(annotationOut)
-    .text()
-    .catch(() => "");
-  // buildkite-agent annotate --style <x> --context <y> --priority <z>
-  const args = await Bun.file(`${annotationOut}.args`)
-    .text()
-    .catch(() => "");
-  const style = args.split("\n")[args.split("\n").indexOf("--style") + 1] ?? "";
-  return { stdout, stderr, exitCode, annotation, style };
+  return { result, stdout: fake.log.join("\n"), annotation: fake.annotation(), style: fake.style() };
 }
 
-// The fake buildkite-agent is a bash script. Tests share one mock server with a
-// mutable build-json override map, so they run sequentially.
-test.skipIf(!isPosix)("rows whose only baseline predates the merge-base are shown but not warned on", async () => {
-  const { stdout, stderr, exitCode, annotation, style } = await runBinarySize(META);
-  // linux-x64 baseline is from the merge-base build (#200): delta = 16 KB, under threshold.
-  // darwin-aarch64 has to fall back to #100: delta = +563 KB. That row is stale (baseline
-  // predates merge-base) so it is listed with its source build but raises no warning.
-  // Before this change the walk used one build for every target, so both rows compared
-  // against #100, both read "+550 KB", and the step failed the PR.
-  expect(stderr).toBe("");
-  expect(stdout).toContain("main #200");
-  expect(stdout).toMatch(/bun-linux-x64\s+.*\+16\.0 KB\s*$/m);
-  expect(stdout).toMatch(/bun-darwin-aarch64\s+.*\+562\.9 KB\s+\(stale: #100\)/);
-  expect(stdout).not.toContain("warning:");
-  expect(annotation).toContain("all within 0.50 MB (1 stale ignored)");
-  expect(annotation).toContain('<sup><a href="https://buildkite.com/bun/bun/builds/100">#100</a></sup>');
-  expect(annotation).not.toContain("⚠️");
-  expect(style).toBe("info");
-  expect(exitCode).toBe(0);
-});
+describe.concurrent("binary-size baseline", () => {
+  test("rows whose only baseline predates the merge-base are shown but not warned on", async () => {
+    const { result, stdout, annotation, style } = await runBinarySize(META);
+    // linux-x64 baseline is from the merge-base build (#200): delta = 16 KB, under threshold.
+    // darwin-aarch64 has to fall back to #100: delta = +563 KB. That row is stale (baseline
+    // predates merge-base) so it is listed with its source build but raises no warning.
+    // Before this change the walk used one build for every target, so both rows compared
+    // against #100, both read "+550 KB", and the step failed the PR.
+    expect(stdout).toContain("main #200");
+    expect(stdout).toMatch(/bun-linux-x64\s+.*\+16\.0 KB\s*$/m);
+    expect(stdout).toMatch(/bun-darwin-aarch64\s+.*\+562\.9 KB\s+\(stale: #100\)/);
+    expect(stdout).not.toContain("warning:");
+    expect(annotation).toContain("all within 0.50 MB (1 stale ignored)");
+    expect(annotation).toContain('<sup><a href="https://buildkite.com/bun/bun/builds/100">#100</a></sup>');
+    expect(annotation).not.toContain("⚠️");
+    expect(style).toBe("info");
+    expect(result.overThreshold).toEqual([]);
+  });
 
-test.skipIf(!isPosix)("growth over the merge-base baseline is a warning, not a failure", async () => {
-  // Bump the PR's own linux-x64 size by 600 KB over merge-base. The baseline for
-  // linux-x64 is the merge-base build (#200), so this row is fresh: it gets the
-  // warning annotation, and the step still exits 0.
-  const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["200"]["bun-linux-x64"] + 600_000 } };
-  const { stdout, stderr, annotation, style, exitCode } = await runBinarySize(big);
-  expect(stderr).toBe("");
-  expect(stdout).toContain("warning: 1 target(s) exceeded 0.50 MB");
-  expect(annotation).toContain("<b>1</b> over 0.50 MB");
-  expect(annotation).toContain("⚠️ <code>bun-linux-x64</code>");
-  expect(annotation).toContain("<details open>");
-  expect(style).toBe("warning");
-  expect(exitCode).toBe(0);
-});
+  test("growth over the merge-base baseline is a warning, not a failure", async () => {
+    // Bump the PR's own linux-x64 size by 600 KB over merge-base. The baseline for
+    // linux-x64 is the merge-base build (#200), so this row is fresh: it gets the
+    // warning annotation.
+    const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["200"]["bun-linux-x64"] + 600_000 } };
+    const { result, stdout, annotation, style } = await runBinarySize(big);
+    expect(stdout).toContain("warning: 1 target(s) exceeded 0.50 MB");
+    expect(annotation).toContain("<b>1</b> over 0.50 MB");
+    expect(annotation).toContain("⚠️ <code>bun-linux-x64</code>");
+    expect(annotation).toContain("<details open>");
+    expect(style).toBe("warning");
+    expect(result.overThreshold).toEqual(["bun-linux-x64"]);
+  });
 
-for (const [how, override] of [
-  ["source:ui (real Bun releases are manual triggers with RELEASE=1)", { source: "ui" }],
-  ["[release] in the commit message", { message: "bump [release]" }],
-] as const) {
-  test.skipIf(!isPosix)(
-    `meta-data fallback does not compare against release-mode sizes from a merge-base build with ${how}`,
-    async () => {
+  for (const [how, override] of [
+    ["source:ui (real Bun releases are manual triggers with RELEASE=1)", { source: "ui" }],
+    ["[release] in the commit message", { message: "bump [release]" }],
+  ] as const) {
+    test(`meta-data fallback does not compare against release-mode sizes from a merge-base build with ${how}`, async () => {
       // Merge-base #200's meta-data is from a release build (whose Windows sizes
       // differ from canary by several MB). The fallback cannot recover an
       // authoritative release flag from meta-data, so it declines the build
@@ -225,14 +159,13 @@ for (const [how, override] of [
       // stale from an older canary build. Even with the PR's linux-x64 +600 KB
       // over #150, no warning is raised on a baseline that is not like-for-like.
       const big = { ...META, "999": { ...META["999"], "bun-linux-x64": META["150"]["bun-linux-x64"] + 600_000 } };
-      const { stdout, stderr, annotation, style, exitCode } = await runBinarySize(big, { "200": override });
-      expect(stderr).toBe("");
+      const { result, stdout, annotation, style } = await runBinarySize(big, { "200": override });
       expect(stdout).toContain("main #200");
       expect(stdout).toMatch(/bun-linux-x64\s+.*\+585\.9 KB\s+\(stale: #150\)/);
       expect(annotation).toContain("all within 0.50 MB (2 stale ignored)");
       expect(annotation).not.toContain("⚠️");
       expect(style).toBe("info");
-      expect(exitCode).toBe(0);
-    },
-  );
-}
+      expect(result.overThreshold).toEqual([]);
+    });
+  }
+});

--- a/test/internal/binary-size-baseline.test.ts
+++ b/test/internal/binary-size-baseline.test.ts
@@ -52,7 +52,9 @@ function fakeGithub(url: URL): unknown {
   if (mStatus) {
     const build = SHA2BUILD[mStatus[1]];
     return {
-      statuses: build ? [{ context: "buildkite/bun", target_url: `https://buildkite.com/bun/bun/builds/${build}` }] : [],
+      statuses: build
+        ? [{ context: "buildkite/bun", target_url: `https://buildkite.com/bun/bun/builds/${build}` }]
+        : [],
     };
   }
   throw new Error(`unexpected GitHub request: ${url.pathname}`);


### PR DESCRIPTION
### Problem
- The binary-size step was failing unrelated PRs with `12 over 0.50 MB` (every target ~+550 KB), e.g. [build 82300](https://buildkite.com/bun/bun/builds/82300). Those PRs added on the order of 16 KB.
- The step compared against the newest main build whose aggregator had run. The 12 main builds after #79916 all had a `*-build-bun` dep time out or get canceled, which Buildkite treats as not-a-failure for `allow_dependency_failure`, so the aggregator never ran and the baseline stayed at #79916 (pre-QUIC, #32602).

### Fix
- Binary size is now a warning, not a gate. Growth past the threshold posts a warning-style annotation and the step exits 0. The `--no-fail` flag, `recordOnly` plumbing, and `[skip size check]` escape hatch are removed.
- The baseline is resolved per target from the PR's merge-base on main (GitHub compare API), with a fallback to the per-triplet `binary-size:<triplet>` meta-data each `*-build-bun` job sets even when the aggregator never ran. A target whose only baseline is older than the merge-base is listed with its source build and does not raise the warning, because that delta folds in main's own growth.
- The meta-data fallback declines builds it cannot prove are canary (non-webhook triggers, or a `[release]` commit subject), so release-mode sizes are never compared against a canary PR.
- Verified: `test/internal/binary-size-baseline.test.ts` drives the exported `run()` in-process with a fake `buildkite-agent` and fake GitHub/Buildkite responses (the agent and HTTP calls are injected through an `Io` object). Also [build 82347](https://buildkite.com/bun/bun/builds/82347) on the pre-warning version of this branch: "all within 0.50 MB" against merge-base #81770, 9 stale rows annotated.

### Background
- `scripts/binary-size.ts` runs once per build after every `*-build-bun` job. It reads each job's stripped size from Buildkite meta-data and compares against a baseline.
- A "canary" build is the normal webhook-triggered build of main. Real releases are manual (`source: "ui"`) triggers with `RELEASE=1`; their Windows binaries differ from canary by several MB, so the two must never be compared.
- The merge-base is the main commit a PR branched from. Comparing against it measures the PR's own contribution.

<details><summary>Notes</summary>

Applied to build 82300 (PR #35901, merge-base = main HEAD at the time): `bun-darwin-x64` was 66,565,564 in the PR vs 66,565,548 in main #81770's meta-data (+16 B), but against #79916 (66,008,012) it read +544.5 KB.

Review history: two rounds each from claude[bot] and coderabbit, plus a self-review. Findings addressed: empty-baseline header, anchor pinned before the release-kind filter, meta-data fallback accepting release sizes, merge-base walk not load-bearing in the fixture, stale-row link not asserted. Withdrawn (with reasons in-thread): fetch timeouts, absolute temp dir, `parseInt` strictness, zero-as-absent checks.

Rebased onto current main (d316760) when switching to warning mode; `scripts/binary-size.ts` had no intervening changes.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 5 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/binary-size-baseline.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/binary-size-baseline.test.ts
bun test v1.4.3 (f42e98025)

test/internal/binary-size-baseline.test.ts:
(pass) binary-size baseline > rows whose only baseline predates the merge-base are shown but not warned on [2030.15ms]
(pass) binary-size baseline > growth over the merge-base baseline is a warning, not a failure [98.35ms]
(pass) binary-size baseline > meta-data fallback does not compare against release-mode sizes from a merge-base build with source:ui (real Bun releases are manual triggers with RELEASE=1) [251.06ms]
(pass) binary-size baseline > meta-data fallback does not compare against release-mode sizes from a merge-base build with [release] in the commit message [250.15ms]

 4 pass
 0 fail
 27 expect() calls
Ran 4 tests across 1 file. [9.90s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.buildkite/ci.mjs                          |  19 +-
 scripts/binary-size.ts                     | 522 ++++++++++++++++++-----------
 test/internal/binary-size-baseline.test.ts | 173 ++++++++++
 3 files changed, 509 insertions(+), 205 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
.buildkite/ci.mjs                               3      1     47
scripts/binary-size.ts                         12     20     45
test/internal/binary-size-baseline.test.ts      6     29     44
```

</details>

**root cause** · written by the author bot

The binary-size check compared every PR build against a fixed, stale canary reference (main #79916) that had stopped advancing, so the roughly 550KB that main itself had grown since that build was attributed to each unrelated PR and tripped the 0.50 MB threshold. The fix makes `scripts/binary-size.ts` resolve the baseline from the PR's merge-base main build via the GitHub and Buildkite APIs, with artifact and per-triplet metadata fallback, so each PR is measured only against its own contribution. When a triplet's baseline is stale or unavailable, the comparison is reported as a warning with…

<!-- robobun:evidence:end -->