### PR TITLE
node:http: honor server.maxHeadersCount above the uWS 198-field cap

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -788,6 +788,11 @@ public:
         return std::move(*this);
     }
 
+    TemplatedApp &&setMaxHeadersCount(uint32_t maxHeadersCount) {
+        httpContext->getSocketContextData()->maxHeadersCount = maxHeadersCount;
+        return std::move(*this);
+    }
+
 };
 
 typedef TemplatedApp<false> App;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -336,7 +336,7 @@ private:
             nodeHttpRequestTrailers = &nodeHttpResponseData->nodeHttpRequestTrailers;
         }
 
-        auto result = httpResponseData->template consumePostPadded<IsNodeHttp>(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.useInsecureHTTPParser, nodeHttpRequestTrailers, &httpResponseData->chunkedExtensionsByteCount, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
+        auto result = httpResponseData->template consumePostPadded<IsNodeHttp>(httpContextData->maxHeaderSize, httpContextData->maxHeadersCount, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.useInsecureHTTPParser, nodeHttpRequestTrailers, &httpResponseData->chunkedExtensionsByteCount, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
 
 
             /* For every request we reset the timeout and hang until user makes action */

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -80,6 +80,7 @@ private:
     OnClientErrorCallback onClientError = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
+    uint32_t maxHeadersCount = 0; // 0 keeps the compiled-in UWS_HTTP_MAX_HEADERS_COUNT cap
 
     // TODO: SNI
     void clearRoutes() {

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -190,11 +190,19 @@ struct HttpResponseData;
 
         friend struct HttpParser;
 
-    private:
+    public:
         struct Header
         {
             std::string_view key, value;
-        } headers[UWS_HTTP_MAX_HEADERS_COUNT];
+        };
+
+    private:
+        /* The parser points `headers` at `inlineHeaders` by default; a server
+         * configured with a larger maxHeadersCount repoints it at the
+         * per-connection overflow vector in HttpParser before parsing. */
+        Header inlineHeaders[UWS_HTTP_MAX_HEADERS_COUNT];
+        Header *headers = inlineHeaders;
+        unsigned int headerCapacity = UWS_HTTP_MAX_HEADERS_COUNT;
         bool ancientHttp;
         bool didYield;
         unsigned int querySeparator;
@@ -587,6 +595,11 @@ struct HttpResponseData;
 
     private:
         std::string fallback;
+        /* Backing storage for HttpRequest::headers when the server's
+         * maxHeadersCount exceeds the inline UWS_HTTP_MAX_HEADERS_COUNT slots.
+         * Empty unless that option is raised; reused across requests on this
+         * connection. */
+        std::vector<HttpRequest::Header> headerOverflow;
          /* This guy really has only 30 bits since we reserve two highest bits to chunked encoding parsing state */
         uint64_t remainingStreamingBytes = 0;
         /* node:http compat: a completed request on this connection forbade keep-alive
@@ -908,7 +921,7 @@ struct HttpResponseData;
         }
 
         /* End is only used for the proxy parser. The HTTP parser recognizes "\ra" as invalid "\r\n" scan and breaks. */
-        static HttpParserResult getHeaders(char *postPaddedBuffer, char *end, struct HttpRequest::Header *headers, void *reserved, bool &isAncientHTTP, bool &isConnectRequest, bool useStrictMethodValidation, bool useInsecureHTTPParser, uint64_t maxHeaderSize) {
+        static HttpParserResult getHeaders(char *postPaddedBuffer, char *end, struct HttpRequest::Header *headers, unsigned int headerCapacity, void *reserved, bool &isAncientHTTP, bool &isConnectRequest, bool useStrictMethodValidation, bool useInsecureHTTPParser, uint64_t maxHeaderSize) {
             char *preliminaryKey, *preliminaryValue, *start = postPaddedBuffer;
             #ifdef UWS_WITH_PROXY
                 /* ProxyParser is passed as reserved parameter */
@@ -985,7 +998,7 @@ struct HttpResponseData;
 
             headers++;
 
-            for (unsigned int i = 1; i < UWS_HTTP_MAX_HEADERS_COUNT - 1; i++) {
+            for (unsigned int i = 1; i < headerCapacity - 1; i++) {
                 /* Lower case and consume the field name */
                 preliminaryKey = postPaddedBuffer;
                 postPaddedBuffer = consumeFieldName(postPaddedBuffer);
@@ -1133,7 +1146,7 @@ struct HttpResponseData;
                     }
                 }
             }
-            auto result = getHeaders(data, data + length, req->headers, reserved, req->ancientHttp, isConnectRequest, useStrictMethodValidation, useInsecureHTTPParser, maxHeaderSize);
+            auto result = getHeaders(data, data + length, req->headers, req->headerCapacity, reserved, req->ancientHttp, isConnectRequest, useStrictMethodValidation, useInsecureHTTPParser, maxHeaderSize);
             if(result.isError()) {
                 return result;
             }
@@ -1366,13 +1379,23 @@ struct HttpResponseData;
 
 public:
     template <bool IsNodeHttp>
-    HttpParserResult consumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, bool useInsecureHTTPParser, std::string *nodeHttpRequestTrailers, uint64_t *chunkedExtensionsByteCount, char *data, unsigned int length, void *user, void *reserved, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler) {
+    HttpParserResult consumePostPadded(uint64_t maxHeaderSize, uint32_t maxHeadersCount, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, bool useInsecureHTTPParser, std::string *nodeHttpRequestTrailers, uint64_t *chunkedExtensionsByteCount, char *data, unsigned int length, void *user, void *reserved, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler) {
         /* The fallback buffer may not exceed the configured per-request header
          * limit (per-server maxHeaderSize can raise it above the default). */
         const size_t maxFallbackSize = maxHeaderSize ? (size_t) maxHeaderSize : MAX_FALLBACK_SIZE;
         /* This resets BloomFilter by construction, but later we also reset it again.
         * Optimize this to skip resetting twice (req could be made global) */
         HttpRequest req;
+        /* Two slots are reserved (request line + null-key terminator), so the
+         * inline array holds UWS_HTTP_MAX_HEADERS_COUNT - 2 field lines. */
+        if (maxHeadersCount > UWS_HTTP_MAX_HEADERS_COUNT - 2) [[unlikely]] {
+            unsigned int want = maxHeadersCount + 2;
+            if (headerOverflow.size() < want) {
+                headerOverflow.resize(want);
+            }
+            req.headers = headerOverflow.data();
+            req.headerCapacity = want;
+        }
         if (remainingStreamingBytes) {
             if (isConnectRequest) {
                 dataHandler(user, std::string_view(data, length), false);

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1387,14 +1387,21 @@ public:
         * Optimize this to skip resetting twice (req could be made global) */
         HttpRequest req;
         /* Two slots are reserved (request line + null-key terminator), so the
-         * inline array holds UWS_HTTP_MAX_HEADERS_COUNT - 2 field lines. */
+         * inline array holds UWS_HTTP_MAX_HEADERS_COUNT - 2 field lines.
+         * The minimum field line is 4 bytes ("a:\r\n"), so maxFallbackSize/4
+         * is the highest count a request can reach before the byte-size check
+         * 431s it; clamping there keeps +2 from overflowing and bounds the
+         * per-connection overflow vector to what the byte cap already admits. */
         if (maxHeadersCount > UWS_HTTP_MAX_HEADERS_COUNT - 2) [[unlikely]] {
-            unsigned int want = maxHeadersCount + 2;
-            if (headerOverflow.size() < want) {
-                headerOverflow.resize(want);
+            size_t capByBytes = (maxFallbackSize / 4) + 2;
+            size_t want = std::min<size_t>((size_t) maxHeadersCount + 2, capByBytes);
+            if (want > UWS_HTTP_MAX_HEADERS_COUNT) {
+                if (headerOverflow.size() < want) {
+                    headerOverflow.resize(want);
+                }
+                req.headers = headerOverflow.data();
+                req.headerCapacity = (unsigned int) want;
             }
-            req.headers = headerOverflow.data();
-            req.headerCapacity = want;
         }
         if (remainingStreamingBytes) {
             if (isConnectRequest) {

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -28,7 +28,9 @@ const {
     insecureHTTPParser: boolean,
     maxHeaderSize: number,
     onClientError: (ssl: boolean, socket: any, errorCode: number, rawPacket: ArrayBuffer) => undefined,
-    onConnection?: (socketHandle: any) => undefined,
+    onConnection: ((socketHandle: any) => undefined) | undefined,
+    httpAllowHalfOpen: boolean,
+    maxHeadersCount: number,
   ) => void;
   setServerAppFlags: (
     server: any,

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1169,6 +1169,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
 function applyServerCustomOptions(server: Server) {
   const handle = server[serverSymbol];
   if (!handle) return;
+  const maxHeadersCount = server.maxHeadersCount;
   setServerCustomOptions(
     handle,
     server.requireHostHeader,
@@ -1178,6 +1179,7 @@ function applyServerCustomOptions(server: Server) {
     onServerClientError.bind(server),
     onServerConnection.bind(server),
     !!server.httpAllowHalfOpen,
+    typeof maxHeadersCount === "number" && maxHeadersCount > 0 ? maxHeadersCount : 0,
   );
 }
 

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -42,6 +42,7 @@ extern "C" EncodedJSValue Server__setAppFlags(JSC::JSGlobalObject*, EncodedJSVal
 extern "C" EncodedJSValue Server__setOnClientError(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
 extern "C" EncodedJSValue Server__setOnConnection(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
 extern "C" EncodedJSValue Server__setMaxHTTPHeaderSize(JSC::JSGlobalObject*, EncodedJSValue, uint64_t);
+extern "C" EncodedJSValue Server__setMaxHeadersCount(JSC::JSGlobalObject*, EncodedJSValue, uint32_t);
 
 static EncodedJSValue assignHeadersFromFetchHeaders(FetchHeaders& impl, JSObject* prototype, JSObject* objectValue, JSC::InternalFieldTuple* tuple, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
 {
@@ -1258,7 +1259,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject,
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    ASSERT(callFrame->argumentCount() == 8);
+    ASSERT(callFrame->argumentCount() == 9);
     // This is an internal binding.
     JSValue serverValue = callFrame->uncheckedArgument(0);
     JSValue requireHostHeader = callFrame->uncheckedArgument(1);
@@ -1268,6 +1269,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject,
     JSValue callback = callFrame->uncheckedArgument(5);
     JSValue onConnectionCallback = callFrame->argument(6);
     JSValue httpAllowHalfOpen = callFrame->argument(7);
+    JSValue maxHeadersCount = callFrame->argument(8);
 
     double maxHeaderSizeNumber = maxHeaderSize.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -1277,6 +1279,14 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject,
 
     Server__setMaxHTTPHeaderSize(globalObject, JSValue::encode(serverValue), maxHeaderSizeNumber);
     RETURN_IF_EXCEPTION(scope, {});
+
+    if (maxHeadersCount.isNumber()) {
+        double maxHeadersCountNumber = maxHeadersCount.asNumber();
+        if (maxHeadersCountNumber > 0 && maxHeadersCountNumber <= (double)UINT32_MAX) {
+            Server__setMaxHeadersCount(globalObject, JSValue::encode(serverValue), (uint32_t)maxHeadersCountNumber);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    }
 
     Server__setOnClientError(globalObject, JSValue::encode(serverValue), JSValue::encode(callback));
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1538,6 +1538,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
     }
 
+    pub fn set_max_headers_count(&mut self, max_headers_count: u32) {
+        if let Some(app) = self.app {
+            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+            bun_opaque::opaque_deref_mut(app).set_max_headers_count(max_headers_count);
+        }
+    }
+
     pub fn ref_(&mut self) {
         if self.poll_ref.is_active() {
             return;

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3947,6 +3947,49 @@ extern "C" fn server_set_max_http_header_size_shim(
     )
 }
 
+pub(super) fn server_set_max_headers_count_(
+    global: &JSGlobalObject,
+    server: JSValue,
+    max_headers_count: u32,
+) -> JsResult<JSValue> {
+    if !server.is_object() {
+        return Err(global.throw(format_args!(
+            "Failed to set maxHeadersCount: The 'this' value is not a Server."
+        )));
+    }
+
+    if let Some(this) = server.as_::<HTTPServer>() {
+        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
+        unsafe { &mut *this }.set_max_headers_count(max_headers_count);
+    } else if let Some(this) = server.as_::<HTTPSServer>() {
+        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
+        unsafe { &mut *this }.set_max_headers_count(max_headers_count);
+    } else if let Some(this) = server.as_::<DebugHTTPServer>() {
+        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
+        unsafe { &mut *this }.set_max_headers_count(max_headers_count);
+    } else if let Some(this) = server.as_::<DebugHTTPSServer>() {
+        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
+        unsafe { &mut *this }.set_max_headers_count(max_headers_count);
+    } else {
+        return Err(global.throw(format_args!(
+            "Failed to set maxHeadersCount: The 'this' value is not a Server."
+        )));
+    }
+    Ok(JSValue::UNDEFINED)
+}
+
+#[unsafe(export_name = "Server__setMaxHeadersCount")]
+extern "C" fn server_set_max_headers_count_shim(
+    global: &JSGlobalObject,
+    server: JSValue,
+    max_headers_count: u32,
+) -> JSValue {
+    host_fn::to_js_host_fn_result(
+        global,
+        server_set_max_headers_count_(global, server, max_headers_count),
+    )
+}
+
 // ─── Externs ─────────────────────────────────────────────────────────────────
 // C++-implemented (bindings/BunServer.cpp). Declared here (not `bun_jsc`)
 // because the signatures name `bun_runtime` types (`NodeHTTPResponse`,

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -143,6 +143,10 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_set_max_http_header_size(Self::SSL_FLAG, self.as_raw(), max_header_size)
     }
 
+    pub fn set_max_headers_count(&mut self, max_headers_count: u32) {
+        c::uws_app_set_max_headers_count(Self::SSL_FLAG, self.as_raw(), max_headers_count)
+    }
+
     pub fn clear_routes(&mut self) {
         c::uws_app_clear_routes(Self::SSL_FLAG, self.as_raw())
     }
@@ -489,6 +493,11 @@ pub mod c {
             ssl: i32,
             app: &mut uws_app_t,
             max_header_size: u64,
+        );
+        pub(crate) safe fn uws_app_set_max_headers_count(
+            ssl: i32,
+            app: &mut uws_app_t,
+            max_headers_count: u32,
         );
         pub(crate) fn uws_app_get(
             ssl: i32,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -541,6 +541,15 @@ extern "C"
       uwsApp->setMaxHTTPHeaderSize(max_header_size);
     }
   }
+  void uws_app_set_max_headers_count(int ssl, uws_app_t *app, uint32_t max_headers_count) {
+    if (ssl) {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->setMaxHeadersCount(max_headers_count);
+    } else {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->setMaxHeadersCount(max_headers_count);
+    }
+  }
   void uws_app_set_flags(int ssl, uws_app_t *app, bool require_host_header, bool use_strict_method_validation, bool use_insecure_http_parser, bool http_allow_half_open) {
     if (ssl) {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;

--- a/test/js/node/http/node-http-maxHeadersCount.test.ts
+++ b/test/js/node/http/node-http-maxHeadersCount.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+
+// Sends a raw HTTP/1.1 request with `extra` additional x-N header lines
+// (plus Host and Connection: close) and resolves to { status, body }.
+function rawRequest(port: number, extra: number): Promise<{ status: number; body: string }> {
+  return new Promise(resolve => {
+    const sock = net.connect(port, "127.0.0.1");
+    let buf = "";
+    sock.on("data", d => (buf += d));
+    sock.on("close", () => {
+      const statusLine = buf.slice(0, buf.indexOf("\r\n"));
+      const status = Number(statusLine.split(" ")[1]) || 0;
+      const body = buf.split("\r\n\r\n")[1] ?? "";
+      resolve({ status, body });
+    });
+    sock.on("connect", () => {
+      let head = `GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n`;
+      for (let i = 0; i < extra; i++) head += `x-${i}: v${i}\r\n`;
+      sock.write(head + "\r\n");
+    });
+  });
+}
+
+async function withServer(
+  configure: (server: http.Server) => void,
+  body: (port: number) => Promise<void>,
+): Promise<void> {
+  const server = http.createServer((req, res) => {
+    const headers = req.headers as Record<string, string>;
+    res.end(JSON.stringify({ count: req.rawHeaders.length / 2, x0: headers["x-0"], xlast: headers["x-last"] }));
+  });
+  configure(server);
+  await new Promise<void>(r => server.listen(0, () => r()));
+  const port = (server.address() as AddressInfo).port;
+  try {
+    await body(port);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+// Host + Connection + `extra` custom lines.
+const total = (extra: number) => extra + 2;
+
+test.concurrent("server.maxHeadersCount raises the request-header field count ceiling", async () => {
+  // https://github.com/oven-sh/bun/issues/6982
+  await withServer(
+    server => {
+      server.maxHeadersCount = 400;
+      // isolate the count cap from the byte-size cap
+      (server as any).maxHeaderSize = 1 << 20;
+    },
+    async port => {
+      // 300 custom headers (302 total): would 431 without a raised count cap.
+      {
+        const { status, body } = await rawRequest(port, 300);
+        expect(status).toBe(200);
+        expect(JSON.parse(body)).toEqual({ count: total(300), x0: "v0", xlast: undefined });
+      }
+      // exactly at the configured cap
+      {
+        const { status, body } = await rawRequest(port, 400 - 2);
+        expect(status).toBe(200);
+        expect(JSON.parse(body).count).toBe(400);
+      }
+      // one past the configured cap → 431
+      {
+        const { status } = await rawRequest(port, 400 - 1);
+        expect(status).toBe(431);
+      }
+    },
+  );
+});
+
+test.concurrent("server.maxHeadersCount preserves every header value across the overflow path", async () => {
+  const server = http.createServer((req, res) => {
+    const headers = req.headers as Record<string, string>;
+    res.end(
+      JSON.stringify({
+        count: req.rawHeaders.length / 2,
+        first: headers["x-0"],
+        mid: headers["x-175"],
+        last: headers["x-349"],
+      }),
+    );
+  });
+  server.maxHeadersCount = 400;
+  (server as any).maxHeaderSize = 1 << 20;
+  await new Promise<void>(r => server.listen(0, () => r()));
+  const port = (server.address() as AddressInfo).port;
+  try {
+    const { status, body } = await rawRequest(port, 350);
+    expect(status).toBe(200);
+    expect(JSON.parse(body)).toEqual({ count: total(350), first: "v0", mid: "v175", last: "v349" });
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test.concurrent("default server still rejects beyond the compiled-in header-field count cap", async () => {
+  await withServer(
+    server => {
+      (server as any).maxHeaderSize = 1 << 20;
+    },
+    async port => {
+      {
+        const { status } = await rawRequest(port, 196);
+        expect(status).toBe(200);
+      }
+      {
+        const { status } = await rawRequest(port, 250);
+        expect(status).toBe(431);
+      }
+    },
+  );
+});

--- a/test/js/node/http/node-http-maxHeadersCount.test.ts
+++ b/test/js/node/http/node-http-maxHeadersCount.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import http from "node:http";
-import net from "node:net";
 import type { AddressInfo } from "node:net";
+import net from "node:net";
 
 // Sends a raw HTTP/1.1 request with `extra` additional x-N header lines
 // (plus Host and Connection: close) and resolves to { status, body }.

--- a/test/js/node/http/node-http-maxHeadersCount.test.ts
+++ b/test/js/node/http/node-http-maxHeadersCount.test.ts
@@ -6,9 +6,10 @@ import net from "node:net";
 // Sends a raw HTTP/1.1 request with `extra` additional x-N header lines
 // (plus Host and Connection: close) and resolves to { status, body }.
 function rawRequest(port: number, extra: number): Promise<{ status: number; body: string }> {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     const sock = net.connect(port, "127.0.0.1");
     let buf = "";
+    sock.on("error", reject);
     sock.on("data", d => (buf += d));
     sock.on("close", () => {
       const statusLine = buf.slice(0, buf.indexOf("\r\n"));
@@ -24,6 +25,13 @@ function rawRequest(port: number, extra: number): Promise<{ status: number; body
   });
 }
 
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, () => resolve((server.address() as AddressInfo).port));
+  });
+}
+
 async function withServer(
   configure: (server: http.Server) => void,
   body: (port: number) => Promise<void>,
@@ -33,8 +41,7 @@ async function withServer(
     res.end(JSON.stringify({ count: req.rawHeaders.length / 2, x0: headers["x-0"], xlast: headers["x-last"] }));
   });
   configure(server);
-  await new Promise<void>(r => server.listen(0, () => r()));
-  const port = (server.address() as AddressInfo).port;
+  const port = await listen(server);
   try {
     await body(port);
   } finally {
@@ -89,8 +96,7 @@ test.concurrent("server.maxHeadersCount preserves every header value across the 
   });
   server.maxHeadersCount = 400;
   (server as any).maxHeaderSize = 1 << 20;
-  await new Promise<void>(r => server.listen(0, () => r()));
-  const port = (server.address() as AddressInfo).port;
+  const port = await listen(server);
   try {
     const { status, body } = await rawRequest(port, 350);
     expect(status).toBe(200);
@@ -98,6 +104,20 @@ test.concurrent("server.maxHeadersCount preserves every header value across the 
   } finally {
     await new Promise<void>(r => server.close(() => r()));
   }
+});
+
+test.concurrent("server.maxHeadersCount near UINT32_MAX is clamped (no overflow, no giant allocation)", async () => {
+  await withServer(
+    server => {
+      server.maxHeadersCount = 0xffff_fffe;
+      (server as any).maxHeaderSize = 1 << 20;
+    },
+    async port => {
+      const { status, body } = await rawRequest(port, 300);
+      expect(status).toBe(200);
+      expect(JSON.parse(body).count).toBe(total(300));
+    },
+  );
 });
 
 test.concurrent("default server still rejects beyond the compiled-in header-field count cap", async () => {


### PR DESCRIPTION
## What does this PR do?

The uWS request parser stores header string_views in a fixed `Header[UWS_HTTP_MAX_HEADERS_COUNT=200]` array inside `HttpRequest`, giving a hard ceiling of **198** request header fields (slot 0 is the request line, the last slot is the null-key terminator) that no option could raise. `server.maxHeadersCount` was accepted but never reached the native parser, so setting it above ~198 had no effect and the server answered `431 Request Header Fields Too Large`.

```
HTTP/1.1 431 Request Header Fields Too Large
```

`HttpRequest` now holds a `Header*` that defaults to the inline[200] array and can be repointed at a per-connection `std::vector<Header>` owned by `HttpParser`. The vector is sized once (on the first parse after the server raised `maxHeadersCount`) and reused for every request on that connection, so connections on a server that never raises the option see no allocation and no layout change. `getHeaders`' field-line loop bound is now the live capacity instead of the compile-time constant.

`node:http`'s `applyServerCustomOptions` forwards `server.maxHeadersCount` (when `> 0`) through `setServerCustomOptions` → `Server__setMaxHeadersCount` → `uws_app_set_max_headers_count` → `HttpContextData::maxHeadersCount` → `consumePostPadded`. The JS-side `rawHeaders` truncation for values below the compiled-in cap is unchanged (matches Node's truncate-not-431 behavior).

Fixes #6982

## How did you verify your code works?

`test/js/node/http/node-http-maxHeadersCount.test.ts`:
- `server.maxHeadersCount = 400` + 300 custom header lines → 200 OK with all 302 pairs in `rawHeaders`; 400 total → 200 OK; 401 total → 431 (cap enforced at the configured value).
- Header values at index 0 / 175 / 349 are intact on the overflow path.
- Default server (no `maxHeadersCount` set) still 431s at >198 fields.

Fail-before: on the released bun the first two tests fail with `Expected: 200 / Received: 431`.

### Notes

- `Bun.serve` has no per-server option surface for this yet (same as `maxHeaderSize`, which it reads from the process global); the plumbing added here (`Server__setMaxHeadersCount` over all four server variants) is ready for that follow-up.
- `maxHeadersCount = 0` ("no limit" in Node) currently keeps the compiled-in cap; the byte-size `maxHeaderSize` already bounds memory, so wiring 0 as "uncapped count" is a small follow-up if wanted.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 12 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-maxHeadersCount.test.ts
bun test v1.4.0 (100e7f591)

test/js/node/http/node-http-maxHeadersCount.test.ts:
62 |     },
63 |     async port => {
64 |       // 300 custom headers (302 total): would 431 without a raised count cap.
65 |       {
66 |         const { status, body } = await rawRequest(port, 300);
67 |         expect(status).toBe(200);
                            ^
error: expect(received).toBe(expected)

Expected: 200
Received: 431

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-maxHeadersCount.test.ts:67:24)
      at async withServer (/workspace/bun/test/js/node/http/node-http-maxHeadersCount.test.ts:46:11)
      at async <anonymous> (/workspace/bun/test/js/node/http/node-http-maxHeadersCount.test.ts:57:9)
 97 |   server.maxHeadersCount = 400;
 98 |   (server as any).maxHeaderSize = 1 << 20;
 99 |   const port = await listen(server);
100 |   try {
101 |     const { status, body } = await rawRequest(port, 350);
102 |     expect(status).toBe(200);
                         ^
error: ex
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1dbe57925)

test/js/node/http/node-http-maxHeadersCount.test.ts:
============================================================
Bun Canary v1.4.0-canary.1 (1dbe57925) Linux x64
Linux Kernel v6.17.0 | glibc v2.41
CPU: sse42 popcnt avx avx2 avx512
Args: "bun" "test" "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http/node-http-maxHeadersCount.test.ts"
Features: bunfig http_server(4) jsc transpiler_cache(2) tsconfig(3) tsconfig_paths 
Builtins: "bun:internal-for-testing" "bun:jsc" "bun:test" "node:child_process" "node:fs" "node:fs/promises" "node:http" "node:net" "node:os" "node:path" 

Elapsed: 180ms | User: 54ms | Sys: 47ms
RSS: 54.47 MB | Peak: 50.72 MB | Commit: 75.10 MB | Faults: 0 | Machine: 34.36 GB

panic(main thread): Segmentation fault at address 0x0
oh no: Bun has crashed. This indicates a bug in Bun, not your code.

To send a redacted crash report to Bun's team,
please file a GitHub issue using the link below:

 https://bun.report/1.4.0/lt21dbe579gHgkgoC8hg+wB4+69wBgqw9wBw+p9wBi0o+wB87pz5B61nz5B4/9y5B+tp24CmmvmhD4tkmhDmxvq1BuorjjDm+wwiDyzpwiD0ys0lCA2AA

curl: (22) The requested URL returned error: 403
/bin/ba
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-maxHeadersCount.test.ts
bun test v1.4.0 (100e7f591)

test/js/node/http/node-http-maxHeadersCount.test.ts:
(pass) server.maxHeadersCount preserves every header value across the overflow path [1076.94ms]
(pass) server.maxHeadersCount near UINT32_MAX is clamped (no overflow, no giant allocation) [1057.26ms]
(pass) default server still rejects beyond the compiled-in header-field count cap [1285.01ms]
(pass) server.maxHeadersCount raises the request-header field count ceiling [1422.75ms]

 4 pass
 0 fail
 11 expect() calls
Ran 4 tests across 1 file. [4.23s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 641ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen cpp.rs (cppbind)
[2/26] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/26] gen JS modules (bundle-modules)
Preprocess modules (8924ms)
Bundle modules (39ms)
Postprocesss modules (198ms)
Bundle Functions (722ms)
Generate Code (25ms)

[9.93s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/15] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/App.h                         |   5 +
 packages/bun-uws/src/HttpContext.h                 |   2 +-
 packages/bun-uws/src/HttpContextData.h             |   1 +
 packages/bun-uws/src/HttpParser.h                  |  42 ++++++-
 src/js/internal/http.ts                            |   4 +-
 src/js/node/_http_server.ts                        |   2 +
 src/jsc/bindings/NodeHTTP.cpp                      |  12 +-
 src/runtime/server/mod.rs                          |   7 ++
 src/runtime/server/server_body.rs                  |  43 +++++++
 src/uws_sys/App.rs                                 |   9 ++
 src/uws_sys/libuwsockets.cpp                       |   9 ++
 .../js/node/http/node-http-maxHeadersCount.test.ts | 139 +++++++++++++++++++++
 12 files changed, 266 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
packages/bun-uws/src/App.h                               1      1      0
packages/bun-uws/src/HttpContext.h                       1      1      0
packages/bun-uws/src/HttpContextData.h                   1      1      0
packages/bun-uws/src/HttpParser.h                        5      8      0
src/js/internal/http.ts                                  2      1      0
src/js/node/_http_server.ts                              3      1      0
src/jsc/bindings/NodeHTTP.cpp                            2      2      0
src/runtime/server/mod.rs                                1      1      0
src/runtime/server/server_body.rs                        1      1      0
src/uws_sys/App.rs                                       2      2      0
src/uws_sys/libuwsockets.cpp                             1      1      0
test/js/node/http/node-http-maxHeadersCount.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->