### PR TITLE
Validate before mutating in Bun.CookieMap.delete()

### DIFF
--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -189,19 +189,18 @@ void CookieMap::set(Ref<Cookie> cookie)
 
 ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
 {
-    removeInternal(options.name);
-
     String name = options.name;
     String domain = options.domain;
     String path = options.path;
     bool secure = name.startsWithIgnoringASCIICase("__Secure-"_s) || name.startsWithIgnoringASCIICase("__Host-"_s);
 
-    // Add the new cookie
     auto cookie_exception = Cookie::create(name, ""_s, domain, path, 1, secure, CookieSameSite::Lax, false, std::numeric_limits<double>::quiet_NaN(), false);
     if (cookie_exception.hasException()) {
         return cookie_exception.releaseException();
     }
     auto cookie = cookie_exception.releaseReturnValue();
+
+    removeInternal(name);
     m_modifiedCookies.append(WTF::move(cookie));
     return {};
 }

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -465,4 +465,45 @@ describe("invalid delete usage", () => {
       v2.delete(v2);
     }).toThrow("Cookie name is required");
   });
+
+  describe.each([
+    ["path", { path: "/;bad" }, "Invalid cookie path"],
+    ["domain", { domain: "bad domain" }, "Invalid cookie domain"],
+  ])("delete() that throws on an invalid %s does not mutate the map", (_, options, message) => {
+    test("leaves an existing entry in place and queues no Set-Cookie", () => {
+      const map = new Bun.CookieMap("session=tok; other=1");
+      expect(() => map.delete("session", options)).toThrow(message);
+      expect(map.toJSON()).toEqual({ session: "tok", other: "1" });
+      expect(map.has("session")).toBe(true);
+      expect(map.size).toBe(2);
+      expect(map.toSetCookieHeaders()).toEqual([]);
+    });
+
+    test("leaves a previously set() entry in place", () => {
+      const map = new Bun.CookieMap();
+      map.set("session", "tok");
+      expect(() => map.delete({ name: "session", ...options })).toThrow(message);
+      expect(map.get("session")).toBe("tok");
+      expect(map.toSetCookieHeaders()).toEqual(["session=tok; Path=/; SameSite=Lax"]);
+    });
+  });
+
+  test("delete() that throws on an invalid name does not mutate the map", () => {
+    // The Cookie-header parser accepts names the write APIs reject; a throwing
+    // delete() must not evict such a cookie without queuing its deletion header.
+    const map = new Bun.CookieMap("a b=1; ok=2");
+    expect(map.get("a b")).toBe("1");
+    expect(() => map.delete("a b")).toThrow("Invalid cookie name");
+    expect(map.toJSON()).toEqual({ "a b": "1", ok: "2" });
+    expect(map.has("a b")).toBe(true);
+    expect(map.toSetCookieHeaders()).toEqual([]);
+  });
+
+  test("set() that throws on invalid options does not mutate the map", () => {
+    const map = new Bun.CookieMap("x=1");
+    expect(() => map.set("y", "v", { domain: "bad domain" })).toThrow("Invalid cookie domain");
+    expect(() => map.set("x", "replaced", { path: "/;bad" })).toThrow("Invalid cookie path");
+    expect([...map.entries()]).toEqual([["x", "1"]]);
+    expect(map.toSetCookieHeaders()).toEqual([]);
+  });
 });


### PR DESCRIPTION
## What

`Bun.CookieMap.prototype.delete()` evicted the entry from the map *before* validating the name/domain/path, so a `delete()` that threw on invalid options had already removed the cookie and queued no deletion `Set-Cookie`. The server-side map said the cookie was gone; the client was never told to clear it. `set()` with the same invalid options throws without mutating, so only `delete()` was torn.

```js
const m = new Bun.CookieMap("session=tok; other=1");
try { m.delete("session", { path: "/;bad" }); } catch {}
m.has("session");          // false  <- entry gone despite the throw
m.toSetCookieHeaders();    // []     <- no deletion header queued either
```

A second face: request-cookie names the `Cookie`-header parser accepts (space, control characters) are rejected by `isValidCookieName`, so such a cookie is readable via `req.cookies.get()` but can never be deleted or overwritten, and the throwing `delete()` still evicted it from the map.

```js
const m = new Bun.CookieMap("a b=1; ok=2");
m.get("a b");              // "1"
try { m.delete("a b"); } catch {}   // Invalid cookie name
m.has("a b");              // false  <- unmanageable cookie, still evicted
```

## Why

`CookieMap::remove` ran `removeInternal(options.name)` first, then called `Cookie::create(...)` which validates and may return an exception (src/jsc/bindings/CookieMap.cpp).

## Fix

Build (and thereby validate) the tombstone cookie first; only call `removeInternal` once `Cookie::create` succeeds. A throwing `delete()` now leaves the map unchanged, matching `set()`.

This does not change the fact that cookie names the parser accepts but `isValidCookieName` rejects remain read-only in the map; it only stops `delete()` from half-evicting them.

## Verification

New tests in `test/js/bun/cookie/cookie-map.test.ts` cover an invalid path, domain, and name across both original (`Cookie`-header parsed) and `set()`-added entries, plus a `set()` control case. The five `delete()` tests fail on `main` and pass with this change; the full cookie suite (192 tests) still passes.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-map.test.ts
bun test v1.4.0 (125c19ebf)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [5.42ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [4.81ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [4.88ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [153.88ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.33ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [5.62ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [4.81ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [4.98ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.20ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [10.31ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.seriali
... (truncated)

release without fix: 15 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.08ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.10ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [0.11ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.07ms]
93 |   test("Cookie.isExpired() gives Max-Age precedence over Expires", () => {
94 |     const past = new Date(Date.now() - 1000);
95 |     const future = new Date(Date.now() + 86_400_000);
96 | 
97 |     // Max-Age wins over Expires regardless of which one the header listed first.
98 |     expect(new Bun.Cookie("name", "value", { maxAge: 3600, expires: past }).isExpired()).toBe(false);
                                                                                              ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/workspace/bun/test/js/bun/cookie/cookie-map.test.ts:98:90)
(fail) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-map.test.ts
bun test v1.4.0 (125c19ebf)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [5.03ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [4.52ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [4.76ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [151.96ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.31ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [5.57ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [4.65ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [4.84ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.28ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [10.44ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.seriali
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 672ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 2m 56s
[3/6] link bun-profile
[4/6] bun-profile --revision
1.4.0-canary.1+125c19ebf
[6/6] strip bun
[build] done
bun test v1.4.0-canary.1 (125c19ebf)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.10ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.09ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.11ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [5.25ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.08ms]
(pass) Bun.Cooki
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/CookieMap.cpp        |  5 ++---
 test/js/bun/cookie/cookie-map.test.ts | 41 +++++++++++++++++++++++++++++++++++
 2 files changed, 43 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/CookieMap.cpp             1      1      0
test/js/bun/cookie/cookie-map.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->