### PR TITLE
Upgrade WebKit to 01aaa3e0be0c

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-352-39744305";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-352-39744305";
+export const WEBKIT_VERSION = "autobuild-preview-pr-352-642e4852";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-352-642e4852";
+export const WEBKIT_VERSION = "autobuild-preview-pr-352-f8c38e23";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -18,8 +18,6 @@ pub(crate) extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     vm: &VM,
     module_key: &IdentifierArray,
     source_code: &SourceCode,
-    declared_variables: &mut VariableEnvironment,
-    lexical_variables: &mut VariableEnvironment,
     res: &ModuleInfoDeserialized,
 ) -> *mut JSModuleRecord {
     // Ownership of `res` stays with the caller; this function only reads it.
@@ -81,8 +79,12 @@ pub(crate) extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
                 return core::ptr::null_mut();
             }
             match k {
-                RecordKind::DeclaredVariable => declared_variables.add(vm, identifiers, buffer[i]),
-                RecordKind::LexicalVariable => lexical_variables.add(vm, identifiers, buffer[i]),
+                // JSModuleRecord no longer stores the VariableEnvironments; the
+                // ModuleProgramCodeBlock built at bytecode-gen time carries the
+                // var declarations, and ModuleAnalyzer reads lexical variables
+                // from the parsed node. Kept in the serialized buffer for
+                // on-disk cache format compatibility but ignored here.
+                RecordKind::DeclaredVariable | RecordKind::LexicalVariable => {}
                 RecordKind::ImportInfoSingle
                 | RecordKind::ImportInfoSingleTypeScript
                 | RecordKind::ImportInfoNamespace
@@ -102,8 +104,6 @@ pub(crate) extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
         vm,
         module_key,
         source_code,
-        declared_variables,
-        lexical_variables,
         res.flags.contains_import_meta(),
         res.flags.is_typescript(),
         res.flags.has_tla(),
@@ -216,30 +216,6 @@ pub(crate) extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
 
 // ─── opaque FFI types ─────────────────────────────────────────────────────────
 
-bun_opaque::opaque_ffi! { pub struct VariableEnvironment; }
-unsafe extern "C" {
-    fn JSC__VariableEnvironment__add(
-        environment: *mut VariableEnvironment,
-        vm: *const VM,
-        identifier_array: *mut IdentifierArray,
-        identifier_index: StringID,
-    );
-}
-impl VariableEnvironment {
-    // Forwards `identifier_array` to C++ without dereferencing; not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    #[inline]
-    pub fn add(
-        &mut self,
-        vm: &VM,
-        identifier_array: *mut IdentifierArray,
-        identifier_index: StringID,
-    ) {
-        // SAFETY: self is a valid &mut VariableEnvironment from C++; identifier_array is live (scopeguard).
-        unsafe { JSC__VariableEnvironment__add(self, vm, identifier_array, identifier_index) }
-    }
-}
-
 bun_opaque::opaque_ffi! { pub struct IdentifierArray; }
 unsafe extern "C" {
     fn JSC__IdentifierArray__create(len: usize) -> *mut IdentifierArray;
@@ -284,8 +260,6 @@ unsafe extern "C" {
         vm: *const VM,
         module_key: *const IdentifierArray,
         source_code: *const SourceCode,
-        declared_variables: *mut VariableEnvironment,
-        lexical_variables: *mut VariableEnvironment,
         has_import_meta: bool,
         is_typescript: bool,
         has_tla: bool,
@@ -384,8 +358,6 @@ impl JSModuleRecord {
         vm: &VM,
         module_key: &IdentifierArray,
         source_code: &SourceCode,
-        declared_variables: &mut VariableEnvironment,
-        lexical_variables: &mut VariableEnvironment,
         has_import_meta: bool,
         is_typescript: bool,
         has_tla: bool,
@@ -397,8 +369,6 @@ impl JSModuleRecord {
                 vm,
                 module_key,
                 source_code,
-                declared_variables,
-                lexical_variables,
                 has_import_meta,
                 is_typescript,
                 has_tla,

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -79,13 +79,9 @@ pub(crate) extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
                 return core::ptr::null_mut();
             }
             match k {
-                // JSModuleRecord no longer stores the VariableEnvironments; the
-                // ModuleProgramCodeBlock built at bytecode-gen time carries the
-                // var declarations, and ModuleAnalyzer reads lexical variables
-                // from the parsed node. Kept in the serialized buffer for
-                // on-disk cache format compatibility but ignored here.
-                RecordKind::DeclaredVariable | RecordKind::LexicalVariable => {}
-                RecordKind::ImportInfoSingle
+                RecordKind::DeclaredVariable
+                | RecordKind::LexicalVariable
+                | RecordKind::ImportInfoSingle
                 | RecordKind::ImportInfoSingleTypeScript
                 | RecordKind::ImportInfoNamespace
                 | RecordKind::ImportInfoNamespaceDefer

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -39,7 +39,7 @@ Identifier getFromIdentifierArray(VM& vm, Identifier* identifierArray, uint32_t 
     return identifierArray[n];
 }
 
-extern "C" JSModuleRecord* zig__ModuleInfoDeserialized__toJSModuleRecord(JSGlobalObject* globalObject, VM& vm, const Identifier& module_key, const SourceCode& source_code, VariableEnvironment& declared_variables, VariableEnvironment& lexical_variables, bun_ModuleInfoDeserialized* module_info);
+extern "C" JSModuleRecord* zig__ModuleInfoDeserialized__toJSModuleRecord(JSGlobalObject* globalObject, VM& vm, const Identifier& module_key, const SourceCode& source_code, bun_ModuleInfoDeserialized* module_info);
 extern "C" void zig__renderDiff(const char* expected_ptr, size_t expected_len, const char* received_ptr, size_t received_len, JSGlobalObject* globalObject);
 
 extern "C" Identifier* JSC__IdentifierArray__create(size_t len)
@@ -55,23 +55,9 @@ extern "C" void JSC__IdentifierArray__setFromUtf8(Identifier* identifierArray, s
     identifierArray[n] = Identifier::fromString(vm, AtomString::fromUTF8(std::span<const char>(str, len)));
 }
 
-extern "C" void JSC__VariableEnvironment__add(VariableEnvironment& environment, VM& vm, Identifier* identifierArray, uint32_t index)
+extern "C" JSModuleRecord* JSC_JSModuleRecord__create(JSGlobalObject* globalObject, VM& vm, const Identifier* moduleKey, const SourceCode& sourceCode, bool hasImportMeta, bool isTypescript, bool hasTLA)
 {
-    environment.add(getFromIdentifierArray(vm, identifierArray, index));
-}
-
-extern "C" VariableEnvironment* JSC_JSModuleRecord__declaredVariables(JSModuleRecord* moduleRecord)
-{
-    return const_cast<VariableEnvironment*>(&moduleRecord->declaredVariables());
-}
-extern "C" VariableEnvironment* JSC_JSModuleRecord__lexicalVariables(JSModuleRecord* moduleRecord)
-{
-    return const_cast<VariableEnvironment*>(&moduleRecord->lexicalVariables());
-}
-
-extern "C" JSModuleRecord* JSC_JSModuleRecord__create(JSGlobalObject* globalObject, VM& vm, const Identifier* moduleKey, const SourceCode& sourceCode, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables, bool hasImportMeta, bool isTypescript, bool hasTLA)
-{
-    JSModuleRecord* result = JSModuleRecord::create(globalObject, vm, globalObject->moduleRecordStructure(), *moduleKey, sourceCode, declaredVariables, lexicalVariables, hasImportMeta ? ImportMetaFeature : 0);
+    JSModuleRecord* result = JSModuleRecord::create(globalObject, vm, globalObject->moduleRecordStructure(), *moduleKey, sourceCode, hasImportMeta ? ImportMetaFeature : 0);
     result->m_isTypeScript = isTypescript;
     result->setHasTLA(hasTLA);
     return result;
@@ -173,9 +159,6 @@ extern "C" EncodedJSValue Bun__analyzeTranspiledModule(JSGlobalObject* globalObj
         return promise;
     };
 
-    VariableEnvironment declaredVariables = VariableEnvironment();
-    VariableEnvironment lexicalVariables = VariableEnvironment();
-
     auto provider = static_cast<Zig::SourceProvider*>(sourceCode.provider());
 
     if (provider->m_resolvedSource.module_info == nullptr) {
@@ -184,7 +167,7 @@ extern "C" EncodedJSValue Bun__analyzeTranspiledModule(JSGlobalObject* globalObj
     }
 
     auto* moduleInfo = static_cast<bun_ModuleInfoDeserialized*>(provider->m_resolvedSource.module_info);
-    auto moduleRecord = zig__ModuleInfoDeserialized__toJSModuleRecord(globalObject, vm, moduleKey, sourceCode, declaredVariables, lexicalVariables, moduleInfo);
+    auto moduleRecord = zig__ModuleInfoDeserialized__toJSModuleRecord(globalObject, vm, moduleKey, sourceCode, moduleInfo);
     // Under --isolate the same SourceProvider is reused across globals via the
     // IsolatedModuleCache, so module_info must remain alive on the provider;
     // ~SourceProvider frees it. Otherwise, free now.
@@ -220,7 +203,7 @@ static EncodedJSValue fallbackParse(JSGlobalObject* globalObject, const Identifi
         RELEASE_AND_RETURN(scope, JSValue::encode(rejectWithError(error.toErrorObject(globalObject, sourceCode))));
     ASSERT(moduleProgramNode);
 
-    ModuleAnalyzer moduleAnalyzer(globalObject, moduleKey, sourceCode, moduleProgramNode->varDeclarations(), moduleProgramNode->lexicalVariables(), moduleProgramNode->features());
+    ModuleAnalyzer moduleAnalyzer(globalObject, moduleKey, sourceCode, moduleProgramNode->features());
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
 
     auto result = moduleAnalyzer.analyze(*moduleProgramNode);
@@ -253,30 +236,6 @@ static EncodedJSValue fallbackParse(JSGlobalObject* globalObject, const Identifi
 String dumpRecordInfo(JSModuleRecord* moduleRecord)
 {
     WTF::StringPrintStream stream;
-
-    {
-        Vector<String> sortedVars;
-        for (const auto& pair : moduleRecord->declaredVariables())
-            sortedVars.append(String(pair.key.get()));
-        std::sort(sortedVars.begin(), sortedVars.end(), [](const String& a, const String& b) {
-            return codePointCompare(a, b) < 0;
-        });
-        stream.print("  varDeclarations:\n");
-        for (const auto& name : sortedVars)
-            stream.print("  - ", name, "\n");
-    }
-
-    {
-        Vector<String> sortedVars;
-        for (const auto& pair : moduleRecord->lexicalVariables())
-            sortedVars.append(String(pair.key.get()));
-        std::sort(sortedVars.begin(), sortedVars.end(), [](const String& a, const String& b) {
-            return codePointCompare(a, b) < 0;
-        });
-        stream.print("  lexicalVariables:\n");
-        for (const auto& name : sortedVars)
-            stream.print("  - ", name, "\n");
-    }
 
     stream.print("  features: (not accessible)\n");
 

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -13,6 +13,7 @@
 #include "BunClientData.h"
 #include "wtf/Compiler.h"
 #include "wtf/Forward.h"
+#include <JavaScriptCore/IntlCache.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/StructureInlines.h>
@@ -489,7 +490,9 @@ static void applyTZFromString(JSGlobalObject* globalObject, const String& value)
 {
     if (value.length() < 32 && WTF::setTimeZoneOverride(value)) {
         WTF::timeZoneDidChange();
-        JSC::getVM(globalObject).dateCache.clearForTimeZoneChange();
+        auto& vm = JSC::getVM(globalObject);
+        vm.dateCache.clearForTimeZoneChange();
+        vm.intlCache().clearForTimeZoneChange();
     }
 }
 static void applyTLSRejectFromString(JSGlobalObject*, const String& value)

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -13,7 +13,6 @@
 #include "BunClientData.h"
 #include "wtf/Compiler.h"
 #include "wtf/Forward.h"
-#include <JavaScriptCore/IntlCache.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/StructureInlines.h>
@@ -490,9 +489,7 @@ static void applyTZFromString(JSGlobalObject* globalObject, const String& value)
 {
     if (value.length() < 32 && WTF::setTimeZoneOverride(value)) {
         WTF::timeZoneDidChange();
-        auto& vm = JSC::getVM(globalObject);
-        vm.dateCache.clearForTimeZoneChange();
-        vm.intlCache().clearForTimeZoneChange();
+        JSC::getVM(globalObject).clearForTimeZoneChange();
     }
 }
 static void applyTLSRejectFromString(JSGlobalObject*, const String& value)

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -183,7 +183,7 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
         return {};
     }
 
-    ModuleAnalyzer analyzer(globalObject, Identifier::fromString(vm, m_identifier), m_sourceCode, node->varDeclarations(), node->lexicalVariables(), AllFeatures);
+    ModuleAnalyzer analyzer(globalObject, Identifier::fromString(vm, m_identifier), m_sourceCode, AllFeatures);
 
     RETURN_IF_EXCEPTION(scope, {});
     ASSERT(node != nullptr);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -59,6 +59,7 @@
 #include "JavaScriptCore/StackFrame.h"
 #include "JavaScriptCore/StackVisitor.h"
 #include "JavaScriptCore/VM.h"
+#include <JavaScriptCore/IntlCache.h>
 #include "AddEventListenerOptions.h"
 #include "AsyncContextFrame.h"
 #include "BunClientData.h"
@@ -3356,6 +3357,7 @@ extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, c
     if (WTF::setTimeZoneOverride(Zig::toString(*timeZone))) {
         WTF::timeZoneDidChange();
         vm.dateCache.clearForTimeZoneChange();
+        vm.intlCache().clearForTimeZoneChange();
         return true;
     }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -59,7 +59,6 @@
 #include "JavaScriptCore/StackFrame.h"
 #include "JavaScriptCore/StackVisitor.h"
 #include "JavaScriptCore/VM.h"
-#include <JavaScriptCore/IntlCache.h>
 #include "AddEventListenerOptions.h"
 #include "AsyncContextFrame.h"
 #include "BunClientData.h"
@@ -3356,8 +3355,7 @@ extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, c
 
     if (WTF::setTimeZoneOverride(Zig::toString(*timeZone))) {
         WTF::timeZoneDidChange();
-        vm.dateCache.clearForTimeZoneChange();
-        vm.intlCache().clearForTimeZoneChange();
+        vm.clearForTimeZoneChange();
         return true;
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6047,7 +6047,7 @@ CPP_DECL void JSC__VM__setControlFlowProfiler(JSC::VM* vm, bool isEnabled)
 
 CPP_DECL void JSC__VM__performOpportunisticallyScheduledTasks(JSC::VM* vm, double until)
 {
-    vm->performOpportunisticallyScheduledTasks(MonotonicTime::now() + Seconds(until), {});
+    vm->performOpportunisticallyScheduledTasks(ApproximateTime::now() + Seconds(until), {});
 }
 
 extern "C" EncodedJSValue JSC__createError(JSC::JSGlobalObject* globalObject, const BunString* str)

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -838,7 +838,7 @@ static IterationRecord getIteratorAsync(JSC::VM& vm, JSGlobalObject* globalObjec
         }
         IterationRecord syncRecord = iteratorDirect(globalObject, syncIterator);
         RETURN_IF_EXCEPTION(scope, {});
-        auto* asyncFromSyncIterator = JSAsyncFromSyncIterator::create(vm, globalObject->asyncFromSyncIteratorStructure(), syncRecord.iterator, syncRecord.nextMethod);
+        auto* asyncFromSyncIterator = JSAsyncFromSyncIterator::create(vm, globalObject->asyncFromSyncIteratorStructure(), asObject(syncRecord.iterator), syncRecord.nextMethod, JSC::IterationMode::Generic);
         RETURN_IF_EXCEPTION(scope, {});
         RELEASE_AND_RETURN(scope, iteratorDirect(globalObject, asyncFromSyncIterator));
     }

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -21,6 +21,7 @@
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/HeapSnapshotBuilder.h>
+#include <JavaScriptCore/IntlCache.h>
 #include <JavaScriptCore/JIT.h>
 #include <JavaScriptCore/JSBasePrivate.h>
 #include <JavaScriptCore/JSCInlines.h>
@@ -653,6 +654,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeZone, (JSGlobalObject * globalObject, Ca
     }
     WTF::timeZoneDidChange();
     vm.dateCache.clearForTimeZoneChange();
+    vm.intlCache().clearForTimeZoneChange();
     WTF::Vector<char16_t, 32> buffer;
     WTF::getTimeZoneOverride(buffer);
     WTF::String timeZoneString(buffer.span());

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -21,7 +21,6 @@
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/HeapSnapshotBuilder.h>
-#include <JavaScriptCore/IntlCache.h>
 #include <JavaScriptCore/JIT.h>
 #include <JavaScriptCore/JSBasePrivate.h>
 #include <JavaScriptCore/JSCInlines.h>
@@ -653,8 +652,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeZone, (JSGlobalObject * globalObject, Ca
         return {};
     }
     WTF::timeZoneDidChange();
-    vm.dateCache.clearForTimeZoneChange();
-    vm.intlCache().clearForTimeZoneChange();
+    vm.clearForTimeZoneChange();
     WTF::Vector<char16_t, 32> buffer;
     WTF::getTimeZoneOverride(buffer);
     WTF::String timeZoneString(buffer.span());

--- a/test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts
@@ -1,0 +1,125 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression coverage for the WebKit 01aaa3e0be0c sync. Each case targets a
+// specific upstream API change that required a Bun-side adaptation.
+
+describe("WebKit 01aaa3e0be0c upgrade", () => {
+  test("Explicit Resource Management is enabled by default", async () => {
+    // https://bugs.webkit.org/show_bug.cgi?id=248707 shipped `using` /
+    // `await using` by default. Previously this syntax was rejected unless
+    // JSC_useExplicitResourceManagement=1 was set.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const order = [];
+          {
+            using a = { [Symbol.dispose]() { order.push("a"); } };
+            using b = { [Symbol.dispose]() { order.push("b"); } };
+            order.push("body");
+          }
+          process.stdout.write(JSON.stringify(order));
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(`["body","b","a"]`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("AsyncLocalStorage context survives for-await over an async generator", async () => {
+    // Upstream moved the cooperative-driver resolve path behind the new
+    // settleDriverWithIteratorResult helper (bug 319817). The fork's
+    // AsyncContextSwapScope wrapping had to be re-plumbed through that helper.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { AsyncLocalStorage } = require("node:async_hooks");
+          const als = new AsyncLocalStorage();
+          async function* gen() { yield 1; await 0; yield 2; }
+          als.run("CTX", async () => {
+            for await (const x of gen()) {
+              if (als.getStore() !== "CTX") throw new Error("lost at " + x);
+            }
+            process.stdout.write("ok");
+          });
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+
+  test("ReadableStream.from wraps a sync iterable", async () => {
+    // JSAsyncFromSyncIterator::create gained an IterationMode parameter
+    // (bug 319435). ReadableStreamOperations.cpp constructs one directly.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const rs = ReadableStream.from([10, 20, 30]);
+          const r = rs.getReader();
+          (async () => {
+            const out = [];
+            for (;;) {
+              const { value, done } = await r.read();
+              if (done) break;
+              out.push(value);
+            }
+            process.stdout.write(JSON.stringify(out));
+          })();
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("[10,20,30]");
+    expect(exitCode).toBe(0);
+  });
+
+  test("module linking initialises var bindings without JSModuleRecord VariableEnvironments", async () => {
+    // JSModuleRecord no longer stores the parser's VariableEnvironments
+    // (bug 320151); var-binding initialisation now reads them from the
+    // UnlinkedModuleProgramCodeBlock. Bun's fast-path record construction
+    // dropped its declared/lexical-env plumbing to match.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const vm = require("node:vm");
+          (async () => {
+            const m = new vm.SourceTextModule(
+              "var v = 1; function f() { return v + 1; } export { v, f };",
+              { identifier: "m" },
+            );
+            await m.link(() => { throw new Error("unreachable"); });
+            await m.evaluate();
+            const { v, f } = m.namespace;
+            process.stdout.write(JSON.stringify([v, f()]));
+          })().catch(e => { console.error(e); process.exit(1); });
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("[1,2]");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts
@@ -1,10 +1,54 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Regression coverage for the WebKit 01aaa3e0be0c sync. Each case targets a
 // specific upstream API change that required a Bun-side adaptation.
 
 describe.concurrent("WebKit 01aaa3e0be0c upgrade", () => {
+  test("process.env.TZ invalidates the Intl.DateTimeFormat cache", async () => {
+    // Upstream caches Intl.DateTimeFormat instances (bug 314337) and clears
+    // the cache on VM entry when hasTimeZoneChange() is set. Bun flips the
+    // zone mid-execution, so the TZ setter now clears vm.intlCache() directly.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const before = Intl.DateTimeFormat().resolvedOptions().timeZone;
+          process.env.TZ = "America/Anchorage";
+          const after = Intl.DateTimeFormat().resolvedOptions().timeZone;
+          process.stdout.write(JSON.stringify({ before, after }));
+        `,
+      ],
+      env: { ...bunEnv, TZ: "UTC" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ before: "UTC", after: "America/Anchorage" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("import with a HostDefined type attribute links without crashing", async () => {
+    // Upstream's m_dependencies removal (bug 320144) rewrote
+    // hostResolveImportedModule as a typed m_loadedModules probe; the fork's
+    // HostDefined ScriptFetchParameters::Type must be included in that probe.
+    using dir = tempDir("wk-hostdefined", {
+      "f.txt": "hello",
+      "entry.mjs": `import txt from "./f.txt" with { type: "text" }; process.stdout.write(txt);`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("hello");
+    expect(exitCode).toBe(0);
+  });
+
   test("AsyncLocalStorage context survives for-await over an async generator", async () => {
     // Upstream moved the cooperative-driver resolve path behind the new
     // settleDriverWithIteratorResult helper (bug 319817). The fork's

--- a/test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts
@@ -4,34 +4,7 @@ import { bunEnv, bunExe } from "harness";
 // Regression coverage for the WebKit 01aaa3e0be0c sync. Each case targets a
 // specific upstream API change that required a Bun-side adaptation.
 
-describe("WebKit 01aaa3e0be0c upgrade", () => {
-  test("Explicit Resource Management is enabled by default", async () => {
-    // https://bugs.webkit.org/show_bug.cgi?id=248707 shipped `using` /
-    // `await using` by default. Previously this syntax was rejected unless
-    // JSC_useExplicitResourceManagement=1 was set.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const order = [];
-          {
-            using a = { [Symbol.dispose]() { order.push("a"); } };
-            using b = { [Symbol.dispose]() { order.push("b"); } };
-            order.push("body");
-          }
-          process.stdout.write(JSON.stringify(order));
-        `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe(`["body","b","a"]`);
-    expect(exitCode).toBe(0);
-  });
-
+describe.concurrent("WebKit 01aaa3e0be0c upgrade", () => {
   test("AsyncLocalStorage context survives for-await over an async generator", async () => {
     // Upstream moved the cooperative-driver resolve path behind the new
     // settleDriverWithIteratorResult helper (bug 319817). The fork's

--- a/test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Regression coverage for the WebKit 01aaa3e0be0c sync. Each case targets a


### PR DESCRIPTION
Bumps `vendor/WebKit` to upstream `WebKit/WebKit@01aaa3e0be0c` (2026-07-25). 538 upstream commits since the last sync point (`2603e9eb41f0`); 76 touch `Source/JavaScriptCore`, 41 touch `Source/WTF`, 6 touch `Source/bmalloc` (117 combined).

The fork-side merge is in oven-sh/WebKit#352.

> [!NOTE]
> `WEBKIT_VERSION` currently points at the preview build `autobuild-preview-pr-352-f8c38e23`. Once oven-sh/WebKit#352 merges to `main`, bump it to the resulting `autobuild-<sha>` before merging this PR.

## Bun changes required by this upgrade

### `JSModuleRecord` no longer stores `VariableEnvironment`s (https://bugs.webkit.org/show_bug.cgi?id=320151)

`JSModuleRecord::create` and `ModuleAnalyzer` dropped their declared/lexical `VariableEnvironment` parameters; var-binding initialisation now reads `UnlinkedModuleProgramCodeBlock::variableDeclarations()` populated at bytecode-generation time.

- `src/jsc/bindings/BunAnalyzeTranspiledModule.cpp`, `src/bundler_jsc/analyze_jsc.rs`: drop the `VariableEnvironment` plumbing from the fast-path `JSModuleRecord` construction (`zig__ModuleInfoDeserialized__toJSModuleRecord`, `JSC_JSModuleRecord__create`). The serialized `DeclaredVariable`/`LexicalVariable` records are kept for on-disk cache format compatibility but are now skipped when reconstructing the record. `dumpRecordInfo` no longer prints the two environments, and the unused `JSC_JSModuleRecord__declaredVariables`/`lexicalVariables`/`JSC__VariableEnvironment__add` FFI shims are removed.
- `src/jsc/bindings/NodeVMSourceTextModule.cpp`: `ModuleAnalyzer` ctor ported to the new 4-argument form.

### `JSAsyncFromSyncIterator::create` takes `IterationMode` (https://bugs.webkit.org/show_bug.cgi?id=319435)

- `src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp`: pass `IterationMode::Generic` and cast the sync iterator to `JSObject*` (the wrapper already fetched `next`).

### `VM::performOpportunisticallyScheduledTasks` takes `ApproximateTime` (https://bugs.webkit.org/show_bug.cgi?id=319662)

- `src/jsc/bindings/bindings.cpp`: `MonotonicTime::now()` becomes `ApproximateTime::now()`.

### Cached `Intl.DateTimeFormat` instances (https://bugs.webkit.org/show_bug.cgi?id=314337)

Upstream now caches `Intl.DateTimeFormat` instances in `VM::intlCache()` and clears the cache on VM entry when `hasTimeZoneChange()` trips. Bun flips the zone mid-execution via `process.env.TZ` / `setTimeZone()`, so the setter sites now call `vm.intlCache().clearForTimeZoneChange()` alongside `vm.dateCache.clearForTimeZoneChange()`.

- `src/jsc/bindings/ZigGlobalObject.cpp`, `src/jsc/bindings/JSEnvironmentVariableMap.cpp`, `src/jsc/modules/BunJSCModule.h`

### `hostResolveImportedModule` typed-lookup probe (https://bugs.webkit.org/show_bug.cgi?id=320144)

The removal of `AbstractModuleRecord::m_dependencies` rewrote `hostResolveImportedModule` as a hardcoded loop over the four upstream `ScriptFetchParameters::Type` values. The fork adds a fifth, `HostDefined`, for `with { type: "text" }` / `"sqlite"` / `"toml"` etc.; requests keyed with it were no longer found, so the caller dereferenced null during link and segfaulted. The probe list now includes `HostDefined` under `USE(BUN_JSC_ADDITIONS)` (fork-side, in oven-sh/WebKit#352).

## Notes

Upstream now defaults Explicit Resource Management on (https://bugs.webkit.org/show_bug.cgi?id=248707). Bun already pinned `useExplicitResourceManagement=true` in `ZigGlobalObject.cpp`, so this is a no-op for Bun users; the pin is kept as a defensive option alongside the other forced JSC options.

## Upstream changelog

<details>
<summary>Memory safety and security</summary>

- Fix DFG `Object.defineProperty` descriptor cell-type confusion causing invalid cell dereference in JIT code (bug 318139)
- Fix `instanceof` prototype-chain IC condition mismatch triggering release assertion (bug 318144)
- Fix out-of-bounds buffer index in WTF `userVisibleURL` when probing for `xn--` (bug 319161)

</details>

<details>
<summary>Correctness</summary>

- YARR: `tryReadUnicodeChar` reads first code unit before testing whether a second is needed (bug 320088)
- YARR: fix interpreter ignore-case handling across ASCII/Unicode case folds (bug 320153)
- YARR: `InputStream::reread()` checks the code unit *before* a trail surrogate, not after (bug 319932)
- YARR: correct `surrogateTagMask` to `0xfc00` (was `0xdc00`) (bug 319651)
- Materialize `.length`/`.name` correctly for doubly-bound (`bind().bind()`) functions (bug 320017)
- `Iterator.prototype.includes` now propagates errors thrown during `IteratorClose` on match (bug 319569)
- WTF: `charactersToFloat()` now reports failure when value fits `double` but overflows `float` (bug 320069)
- WTF: fix `saturatingSum` variadic overload truncating 3+ argument sums to `uint32_t` (bug 319524)
- Revert "Use `InstanceOf` DFG node for `Object#isPrototypeOf`", which tripped a RELEASE_ASSERT (bug 320022)

</details>

<details>
<summary>Language features and spec alignment</summary>

- Enable Explicit Resource Management (`using` / `await using`) by default (bug 248707)
- Implement Joint Iteration proposal (`Iterator.zip` / `Iterator.zipKeyed`) (bug 319921)
- Temporal: resolve Chinese and Dangi calendar field resolution (bug 319814)
- Temporal: `japanese` calendar accepts ISO year/day/month/monthCode (bug 319964)
- Temporal: fix Japanese, ROC, and Buddhist calendar field handling (bug 319663)
- Temporal: fix fixed-solar non-ISO calendar arithmetic (Coptic/Ethiopic/Indian/Persian) (bug 319804)
- Temporal: fix Ethiopic AA era mapping (bug 319787)
- Temporal: fix Ethioaa arithmetic year to use `UCAL_YEAR` (bug 319785)
- Temporal: fix `PlainMonthDay` reference-year drop for Chinese leap months (bug 319656)
- Temporal: clean up `getNamedTimeZoneEpochNanoseconds` (bug 319296)

</details>

<details>
<summary>Performance</summary>

- `JSModuleRecord` no longer retains the parser's `VariableEnvironment`s after linking (bug 320151)
- Remove `AbstractModuleRecord::m_dependencies` to shrink module memory (bug 320144)
- Drop shared Baseline JIT code eagerly in `Heap::deleteAllUnlinkedCodeBlocks` (bug 320071)
- Generate Data IC code as fall-through (bug 318125)
- DFG/FTL: fast-fail filter for RegExp patterns with BOL anchors (bug 320128)
- YARR: enable Boyer-Moore lookahead optimization for Unicode patterns (bug 307635)
- YARR: `tryReadUnicodeChar` takes BMP fast path for any non-surrogate character (bug 319943)
- DFG/FTL: inline `ArrayBuffer.isView` via `IsCellWithType` JSType-range check (bug 319796)
- DFG: use `ArrayIndexOf`/`ArrayIncludes` intrinsic for RegExp match arrays (bug 319351)
- `Array#indexOf`/`includes` skip slow path for rope elements with mismatched length (bug 319237)
- Add JIT support for `BigInt64Array`/`BigUint64Array` allocation (bug 319872)
- Use `vectorLengthHint` from `ArrayAllocationProfile` for `NewArrayWithSize` (bug 317466)
- Avoid zero-fill + `gcSafeMemcpy` in `tryCreateObjectViaCloning` (bug 319850)
- `JSON.parse` creates 8-bit strings for Latin-1 values found in 16-bit input (bug 319782)
- `Symbol.keyFor` reuses the symbol's cached description string (bug 319843)
- Cache `Intl.DateTimeFormat` instances (bug 314337)
- Cooperative driving for top-level-await modules (bug 319867)
- Use cached iterator-result object for async-generator cooperative driving (bug 319817)
- Handle `AsyncFromSyncIterator` directly in `async_iterator_open`/`next` bytecodes (bug 319435)
- Use `op_async_iterator_open`/`op_async_iterator_next` for `yield*` (bug 319946)
- FTL: use `select` for more arithmetic ops (bug 319951)
- B3: `VectorZipX(a, all-zeros)` strength reduction (bug 319991)
- B3: match non-canonical SBFX form in `B3LowerToAir` (ARM64) (bug 271412)
- Wire ARM64 `Math.min`/`Math.max` specialized thunks into `thunkGeneratorForIntrinsic` (bug 319795)
- Fold `String.prototype.at` negative-index adjustment to branchless `csel` (bug 319789)
- Double to Bool conversion is now branchless (bug 319790)
- Use `moveConditionally32` in `prepareForTailCallSlow` (bug 319845)
- Put `emitWriteBarrier` slow path in `m_slowPaths` (bug 319688)
- Use `ApproximateTime` for deadlines in Opportunistic Task Scheduler and Incremental Sweeper (bug 319662)

</details>

<details>
<summary>Wasm</summary>

- Enable Wasm multi-memory by default (bug 319389)
- Enable Wasm relaxed SIMD by default (bug 319518)
- Implement Table64 in the parser and IPInt tier (bug 316710)
- Memory64: allow modules with oversized initial table size to compile (bug 320132)
- Evaluate element-segment expressions exactly once per instance (bug 320129)
- Zero-extend memory32 data-segment offsets (bug 314444)
- Wasm-backed resizable `ArrayBuffer`s now throw for all invalid resize sizes (bug 319705)
- Fix OMG inlined stack-origin lookup skipping deeper frames (bug 270832)
- Make `releaseBBQCallee` tolerate a missing BBQ callee (bug 290296)
- Skew small-function OMG tier-up call counts (bug 320046)
- Shrink `Wasm::Type` to a pointer-sized payload on 64-bit (bug 247454)

</details>

<details>
<summary>WTF / bmalloc / build system</summary>

- libpas: rework per-heap MTE tagging policy logic (bug 316145)
- Fix `PAS_ENABLE_MTE` breaking preprocessed distributed builds (bug 319895)
- TSan/Xcode: disable `USE(LIBPAS)`/`USE(TZONE_MALLOC)` when bmalloc falls back to system allocator (bug 319644)
- `RecursiveLockAdapter::unlock()` asserts against underflow / wrong-owner unlock (bug 320067)
- Mark crash-on-overflow functions in `OverflowHandler.h` as `NODELETE` (bug 318384)
- Clean up `ParkingLot::ensureHashtable()` dead check and variable shadowing (bug 320050)
- Linux: detect main thread and ensure its thread id is always 1 (bug 319887)
- `Vector::reverse()` now uses `std::ranges::reverse()` (bug 319857)
- Remove dead `deleteReleasedWeakBuckets()`/`isReleasedWeakBucket()` from `HashTable` (bug 319825)
- `CrossThreadCopierBase<HashSet<ObjectIdentifierGeneric>>` gains `IsNeeded` and move-copy overload (bug 319797)
- Rename `WeakPtr::is()`/`UniqueRef::is()` variadic overloads to `isAnyOf` (bug 319815)
- CMake: derive generator feature defines from `Platform.h` on Mac (bug 312033)
- CMake: make JavaScriptCore a real Clang module for the Mac Swift importer (bug 319625)
- CMake: centralize code signing and add missing entitlements (bug 319641)

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 4 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/12] cxx obj/unified/UnifiedSource-src_jsc_bindings-7.cpp.o
[2/12] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[3/12] cxx obj/unified/UnifiedSource-src_jsc_bindings-9.cpp.o
[4/12] gen cpp.rs (cppbind)
[4/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[5/12] cxx obj/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp.o
FAILED: obj/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -g3 -gz=zstd -glldb -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -Wno-c23-extensions -ffunction-sections -fdata-sections -faddrsig -fno-semantic-interposition -f
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (340781e06)

test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts:
(pass) WebKit 01aaa3e0be0c upgrade > import with a HostDefined type attribute links without crashing [27.52ms]
(pass) WebKit 01aaa3e0be0c upgrade > AsyncLocalStorage context survives for-await over an async generator [25.82ms]
(pass) WebKit 01aaa3e0be0c upgrade > ReadableStream.from wraps a sync iterable [24.99ms]
(pass) WebKit 01aaa3e0be0c upgrade > module linking initialises var bindings without JSModuleRecord VariableEnvironments [25.52ms]
(pass) WebKit 01aaa3e0be0c upgrade > process.env.TZ invalidates the Intl.DateTimeFormat cache [55.76ms]

 5 pass
 0 fail
 15 expect() calls
Ran 5 tests across 1 file. [225.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts"
bun test v1.4.0 (5e818852a)

test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts:
(pass) WebKit 01aaa3e0be0c upgrade > import with a HostDefined type attribute links without crashing [1127.98ms]
(pass) WebKit 01aaa3e0be0c upgrade > ReadableStream.from wraps a sync iterable [1117.41ms]
(pass) WebKit 01aaa3e0be0c upgrade > process.env.TZ invalidates the Intl.DateTimeFormat cache [1302.51ms]
(pass) WebKit 01aaa3e0be0c upgrade > AsyncLocalStorage context survives for-await over an async generator [1489.10ms]
(pass) WebKit 01aaa3e0be0c upgrade > module linking initialises var bindings without JSModuleRecord VariableEnvironments [1522.17ms]

 5 pass
 0 fail
 15 expect() calls
Ran 5 tests across 1 file. [3.91s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 725ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[4/13] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[5/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[6/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[7/13] cxx obj/src/jsc/bindings/bindings.cpp.o
[8/13] gen cpp.rs (cppbind)
[8/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compilin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 src/bundler_jsc/analyze_jsc.rs                     |  40 +-----
 src/jsc/bindings/BunAnalyzeTranspiledModule.cpp    |  51 +-------
 src/jsc/bindings/JSEnvironmentVariableMap.cpp      |   2 +-
 src/jsc/bindings/NodeVMSourceTextModule.cpp        |   2 +-
 src/jsc/bindings/ZigGlobalObject.cpp               |   2 +-
 src/jsc/bindings/bindings.cpp                      |   2 +-
 .../webcore/streams/ReadableStreamOperations.cpp   |   2 +-
 src/jsc/modules/BunJSCModule.h                     |   2 +-
 test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts    | 142 +++++++++++++++++++++
 10 files changed, 157 insertions(+), 90 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  1      6      0
src/bundler_jsc/analyze_jsc.rs                                3      6      0
src/jsc/bindings/BunAnalyzeTranspiledModule.cpp               1      5      0
src/jsc/bindings/JSEnvironmentVariableMap.cpp                 5      7      0
src/jsc/bindings/NodeVMSourceTextModule.cpp                   1      1      0
src/jsc/bindings/ZigGlobalObject.cpp                          4      5      0
src/jsc/bindings/bindings.cpp                                 1      1      0
…c/bindings/webcore/streams/ReadableStreamOperations.cpp      1      2      0
src/jsc/modules/BunJSCModule.h                                5      7      0
test/js/bun/jsc/webkit-upgrade-01aaa3e0.test.ts               2      4      0
```

</details>

<!-- robobun:evidence:end -->