### PR TITLE
test(spawn): wait for echo instead of sleeping in spawn-streaming-stdin

### DIFF
--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -58,9 +58,7 @@ test("spawn can write to stdin multiple chunks", async () => {
             while (echoed < line.length * w) {
               if (stdoutClosed) {
                 const err = await stderrPromise;
-                throw new Error(
-                  `child stdout closed after ${echoed}/${line.length * writes} bytes; stderr:\n${err}`,
-                );
+                throw new Error(`child stdout closed after ${echoed}/${line.length * writes} bytes; stderr:\n${err}`);
               }
               await new Promise<void>(resolve => {
                 notifyEcho = resolve;
@@ -71,12 +69,7 @@ test("spawn can write to stdin multiple chunks", async () => {
           await proc.stdin!.end();
         })();
 
-        const [received, stderr, , exitCode] = await Promise.all([
-          readerTask,
-          stderrPromise,
-          writerTask,
-          proc.exited,
-        ]);
+        const [received, stderr, , exitCode] = await Promise.all([readerTask, stderrPromise, writerTask, proc.exited]);
 
         expect(stderr).toBe("");
         expect(received).toBe(line.repeat(writes));

--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -1,11 +1,15 @@
 import { spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, dumpStats, expectMaxObjectTypeCount, getMaxFD, isASAN } from "harness";
+import { bunEnv, bunExe, dumpStats, expectMaxObjectTypeCount, getMaxFD } from "harness";
 import { join } from "path";
 
-const N = 50;
+// Two batches of `concurrency` spawns are enough for the fd/object-count
+// leak checks below: any per-spawn leak of one fd or one retained object
+// already blows past the asserted thresholds after 32 iterations.
+const N = 32;
 const concurrency = 16;
-const delay = isASAN ? 500 : 150;
+const line = "Wrote to stdin!\n";
+const writes = 7;
 
 test("spawn can write to stdin multiple chunks", async () => {
   const interval = setInterval(dumpStats, 1000).unref();
@@ -21,41 +25,55 @@ test("spawn can write to stdin multiple chunks", async () => {
           cmd: [bunExe(), join(import.meta.dir, "stdin-repro.js")],
           stdout: "pipe",
           stdin: "pipe",
-          stderr: "inherit",
+          stderr: "pipe",
           env: { ...bunEnv },
         });
 
-        const prom2 = (async function () {
-          let inCounter = 0;
-          while (true) {
-            proc.stdin!.write("Wrote to stdin!\n");
-            await proc.stdin!.flush();
-            await Bun.sleep(delay);
+        // The reader accumulates echoed bytes from the child and resolves any
+        // writer that is waiting for its echo. This lets the writer know the
+        // child has consumed the previous chunk, so the next write is observed
+        // as a distinct chunk by the child's `for await` loop without needing a
+        // fixed Bun.sleep() between writes.
+        let echoed = 0;
+        let stdoutClosed = false;
+        let notifyEcho: (() => void) | undefined;
 
-            if (inCounter++ === 6) break;
+        const readerTask = (async function () {
+          const chunks: Uint8Array[] = [];
+          for await (const chunk of proc.stdout) {
+            chunks.push(chunk);
+            echoed += chunk.byteLength;
+            notifyEcho?.();
+          }
+          stdoutClosed = true;
+          notifyEcho?.();
+          return Buffer.concat(chunks).toString();
+        })();
+
+        const writerTask = (async function () {
+          for (let w = 1; w <= writes; w++) {
+            proc.stdin!.write(line);
+            await proc.stdin!.flush();
+            while (echoed < line.length * w) {
+              if (stdoutClosed) throw new Error(`child stdout closed after ${echoed} bytes (expected ${line.length * w})`);
+              await new Promise<void>(resolve => {
+                notifyEcho = resolve;
+              });
+              notifyEcho = undefined;
+            }
           }
           await proc.stdin!.end();
-          return inCounter;
         })();
 
-        const prom = (async function () {
-          let chunks: any[] = [];
+        const [received, stderr, , exitCode] = await Promise.all([
+          readerTask,
+          proc.stderr.text(),
+          writerTask,
+          proc.exited,
+        ]);
 
-          try {
-            for await (var chunk of proc.stdout) {
-              chunks.push(chunk);
-            }
-          } catch (e: any) {
-            console.log(e.stack);
-            throw e;
-          }
-
-          return Buffer.concat(chunks).toString().trim();
-        })();
-
-        const [chunks, , exitCode] = await Promise.all([prom, prom2, proc.exited]);
-
-        expect(chunks).toBe("Wrote to stdin!\n".repeat(7).trim());
+        expect(stderr).toBe("");
+        expect(received).toBe(line.repeat(writes));
         expect(exitCode).toBe(0);
       })();
     }

--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -57,8 +57,14 @@ test("spawn can write to stdin multiple chunks", async () => {
             await proc.stdin!.flush();
             while (echoed < line.length * w) {
               if (stdoutClosed) {
-                const err = await stderrPromise;
-                throw new Error(`child stdout closed after ${echoed}/${line.length * writes} bytes; stderr:\n${err}`);
+                // stdout ended before we got our echo. Kill the child so stderr
+                // reaches EOF even if the child is still blocked on stdin, then
+                // surface whatever it wrote.
+                proc.kill();
+                const [err, code] = await Promise.all([stderrPromise, proc.exited]);
+                throw new Error(
+                  `child stdout closed after ${echoed}/${line.length * writes} bytes (exit ${code}); stderr:\n${err}`,
+                );
               }
               await new Promise<void>(resolve => {
                 notifyEcho = resolve;

--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -55,7 +55,8 @@ test("spawn can write to stdin multiple chunks", async () => {
             proc.stdin!.write(line);
             await proc.stdin!.flush();
             while (echoed < line.length * w) {
-              if (stdoutClosed) throw new Error(`child stdout closed after ${echoed} bytes (expected ${line.length * w})`);
+              if (stdoutClosed)
+                throw new Error(`child stdout closed after ${echoed} bytes (expected ${line.length * w})`);
               await new Promise<void>(resolve => {
                 notifyEcho = resolve;
               });

--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -37,6 +37,7 @@ test("spawn can write to stdin multiple chunks", async () => {
         let echoed = 0;
         let stdoutClosed = false;
         let notifyEcho: (() => void) | undefined;
+        const stderrPromise = proc.stderr.text();
 
         const readerTask = (async function () {
           const chunks: Uint8Array[] = [];
@@ -55,8 +56,12 @@ test("spawn can write to stdin multiple chunks", async () => {
             proc.stdin!.write(line);
             await proc.stdin!.flush();
             while (echoed < line.length * w) {
-              if (stdoutClosed)
-                throw new Error(`child stdout closed after ${echoed} bytes (expected ${line.length * w})`);
+              if (stdoutClosed) {
+                const err = await stderrPromise;
+                throw new Error(
+                  `child stdout closed after ${echoed}/${line.length * writes} bytes; stderr:\n${err}`,
+                );
+              }
               await new Promise<void>(resolve => {
                 notifyEcho = resolve;
               });
@@ -68,7 +73,7 @@ test("spawn can write to stdin multiple chunks", async () => {
 
         const [received, stderr, , exitCode] = await Promise.all([
           readerTask,
-          proc.stderr.text(),
+          stderrPromise,
           writerTask,
           proc.exited,
         ]);


### PR DESCRIPTION
### What does this PR do?

Speeds up `test/js/bun/spawn/spawn-streaming-stdin.test.ts` by replacing the fixed `Bun.sleep(delay)` between stdin writes with an event-driven wait for the child's echo.

The test writes 7 lines to a child that echoes stdin back to stdout, and previously slept 150ms (500ms under ASAN) between each write so the child's `for await (chunk of Bun.stdin.stream())` loop would observe them as separate chunks. Across 4 batches of 16 spawns that was ~14s of pure sleep on ASAN lanes.

The writer now waits until the reader has received the echo of the previous write before sending the next one. Because the child has already flushed the echo by that point, the next write is guaranteed to arrive as a distinct `for await` iteration, so the fixture's `count >= 2` assertion is preserved deterministically rather than probabilistically.

While here:
- `stderr` is now piped and asserted empty instead of inherited, so a child-side throw surfaces as a test failure with the message instead of noise on the runner's stderr.
- The echoed output is compared exactly (`line.repeat(7)`) instead of after `.trim()`.
- `N` reduced from 50 to 32 (two batches of 16). The fd and object-count leak assertions compare against fixed thresholds, so a per-spawn leak still trips them after 32 spawns.
- The concurrent `for await` reader and the `FileSink` writer run in separate tasks exactly as before; only the pacing mechanism changed.

### How did you verify your code works?

`bun bd test test/js/bun/spawn/spawn-streaming-stdin.test.ts`, debug+ASAN build:

| | before | after |
|---|---|---|
| test body | 15600ms | ~2030ms (5 runs: 2047/2037/2017/2003/2081) |
| file wall | 18.0s | 4.0s |

Release build: 98ms.

Related: #33704 reduces `N` in this file as part of a broader sweep but leaves the sleep in place; this change removes the sleep entirely so the ASAN-specific `N` split there is no longer needed.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 4 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/spawn/spawn-streaming-stdin.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/spawn/spawn-streaming-stdin.test.ts
bun test v1.4.0 (ce600d64b)

test/js/bun/spawn/spawn-streaming-stdin.test.ts:
{
  objects: {
    "Array Iterator": 1,
    Array: 176,
    ArrayBuffer: 2,
    AsyncDisposableStack: 1,
    AsyncFromSyncIterator: 1,
    AsyncFunction: 152,
    AsyncFunctionGenerator: 51,
    AsyncGenerator: 1,
    AsyncGeneratorFunction: 2,
    AsyncIterator: 1,
    BigInt: 3,
    BigInt64ArrayPrototype: 1,
    BigUint64ArrayPrototype: 1,
    Blob: 1,
    Boolean: 1,
    Buffer: 1,
    Bun: 1,
    Callee: 3,
    "Cell Butterfly": 32,
    CustomEvent: 2,
    CustomGetterSetter: 83,
    DOMAttributeGetterSetter: 89,
    Dirent: 2,
    DisposableStack: 1,
    Error: 2,
    ErrorCodeCache: 1,
    Event: 2,
    EventEmitter: 1,
    EventTarget: 2,
    Expect: 1,
    ExpectStatic: 1,
    ExpectTypeOf: 1,
    FileInternalReadableStreamSource: 35,
    FileSink: 21,
    FinalizationRegistry: 1,
    Float16ArrayPrototype: 1,
    Float32ArrayPrototype: 1,
    Float64ArrayPrototype: 1,
    FrameworkFileSystemRouter: 1,
    FullPromiseReaction: 101,
    Function: 2779,
    FunctionCodeBlock: 132,
    FunctionExecutable: 1409,
    FunctionRareData: 263,
    Generator: 1,
    GeneratorFunction: 2,
    GetterSetter: 183,
    GlobalObject: 1,
    ImportMeta: 3,
    Int16ArrayPrototype: 1,
    Int32ArrayPrototype: 1,
    Int8Array: 1,
    Int8ArrayPrototype: 1,
    InternalFieldTuple: 105,
    InternalModuleRegistry: 1,
    Intl: 1,
    "Iterator Helper": 1,
    Iterator: 2,
    JSAsyncGeneratorFunction: 8,
    JSGlobalLexicalEnvironment: 1,
    JSGlobalProxy: 1,
    JSLexicalEnvironment: 309,
    JSModuleEnvironment: 11,
    JSON: 1,
    JSPropertyNameEnumerator: 5,
    JSSourceCode: 11,
    "Map Iterator": 1,
    Map: 6,
    Math: 1,
    Module: 3,
    ModuleLoader: 1,
    ModuleNamespaceObject: 4,
    ModuleProgramCodeBlock: 3,
    ModuleProgramExecutable: 3,
    
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/spawn/spawn-streaming-stdin.test.ts | 75 ++++++++++++++++---------
 1 file changed, 49 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/js/bun/spawn/spawn-streaming-stdin.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->