### PR TITLE
test: run 3613 handleProtocols tests in-process

### DIFF
--- a/test/regression/issue/3613.test.ts
+++ b/test/regression/issue/3613.test.ts
@@ -1,180 +1,84 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { once } from "node:events";
+import type { IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import { WebSocketServer } from "ws";
 
 // https://github.com/oven-sh/bun/issues/3613
-// WebSocketServer handleProtocols option should set the selected protocol in the upgrade response
+// WebSocketServer handleProtocols option should set the selected protocol in the upgrade response.
+
+async function upgradeRequest(wss: WebSocketServer, clientProtocols: string) {
+  await once(wss, "listening");
+  const { port } = wss.address() as AddressInfo;
+
+  const connection = once(wss, "connection");
+  const res = await fetch(`http://127.0.0.1:${port}`, {
+    headers: {
+      Upgrade: "websocket",
+      Connection: "Upgrade",
+      "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+      "Sec-WebSocket-Version": "13",
+      "Sec-WebSocket-Protocol": clientProtocols,
+    },
+  });
+  const [ws] = await connection;
+  await res.body?.cancel();
+  return { res, ws };
+}
+
 test("ws WebSocketServer handleProtocols sets selected protocol", async () => {
-  using dir = tempDir("ws-handle-protocols", {
-    "server.js": `
-import { WebSocketServer } from 'ws';
-
-const wss = new WebSocketServer({
-  port: 0,
-  handleProtocols: (protocols, request) => {
-    return 'selected-protocol';
-  }
-});
-
-wss.on('listening', async () => {
-  const port = wss.address().port;
-  console.log('PORT:' + port);
-
-  // Test using fetch to verify the actual response headers
+  let receivedProtocols: Set<string> | undefined;
+  let receivedRequest: IncomingMessage | undefined;
+  const wss = new WebSocketServer({
+    port: 0,
+    handleProtocols: (protocols, request) => {
+      receivedProtocols = protocols;
+      receivedRequest = request;
+      return "selected-protocol";
+    },
+  });
   try {
-    const res = await fetch('http://127.0.0.1:' + port, {
-      headers: {
-        "Upgrade": "websocket",
-        "Connection": "Upgrade",
-        "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
-        "Sec-WebSocket-Version": "13",
-        "Sec-WebSocket-Protocol": "custom-protocol, selected-protocol"
-      }
-    });
-    console.log("STATUS:" + res.status);
-    console.log("PROTOCOL:" + res.headers.get("sec-websocket-protocol"));
-  } catch (e) {
-    console.log("ERROR:" + e.message);
+    const { res, ws } = await upgradeRequest(wss, "custom-protocol, selected-protocol");
+
+    expect(receivedProtocols).toBeInstanceOf(Set);
+    expect([...receivedProtocols!]).toEqual(["custom-protocol", "selected-protocol"]);
+    expect(receivedRequest?.headers["sec-websocket-protocol"]).toBe("custom-protocol, selected-protocol");
+
+    expect(res.status).toBe(101);
+    expect(res.headers.get("sec-websocket-protocol")).toBe("selected-protocol");
+    expect(ws.protocol).toBe("selected-protocol");
+    ws.close();
+  } finally {
+    wss.close();
   }
-
-  wss.close();
-  process.exit(0);
-});
-
-wss.on('connection', (ws) => {
-  console.log('SERVER_WS_PROTOCOL:' + ws.protocol);
-});
-`,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "server.js"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // The server should respond with the protocol selected by handleProtocols
-  expect(stdout).toContain("STATUS:101");
-  expect(stdout).toContain("PROTOCOL:selected-protocol");
-  expect(stdout).toContain("SERVER_WS_PROTOCOL:selected-protocol");
-  expect(exitCode).toBe(0);
 });
 
 test("ws WebSocketServer handleProtocols with no protocol", async () => {
-  using dir = tempDir("ws-handle-protocols-empty", {
-    "server.js": `
-import { WebSocketServer } from 'ws';
-
-const wss = new WebSocketServer({
-  port: 0,
-  handleProtocols: (protocols, request) => {
-    // Return empty string - should not set a protocol header
-    return '';
-  }
-});
-
-wss.on('listening', async () => {
-  const port = wss.address().port;
-  console.log('PORT:' + port);
-
+  const wss = new WebSocketServer({
+    port: 0,
+    handleProtocols: () => "",
+  });
   try {
-    const res = await fetch('http://127.0.0.1:' + port, {
-      headers: {
-        "Upgrade": "websocket",
-        "Connection": "Upgrade",
-        "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
-        "Sec-WebSocket-Version": "13",
-        "Sec-WebSocket-Protocol": "custom-protocol"
-      }
-    });
-    console.log("STATUS:" + res.status);
-    // When handleProtocols returns empty, Bun falls back to client's first protocol
-    console.log("PROTOCOL:" + res.headers.get("sec-websocket-protocol"));
-  } catch (e) {
-    console.log("ERROR:" + e.message);
+    const { res, ws } = await upgradeRequest(wss, "custom-protocol");
+
+    expect(res.status).toBe(101);
+    expect(ws.protocol).toBe("");
+    ws.close();
+  } finally {
+    wss.close();
   }
-
-  wss.close();
-  process.exit(0);
-});
-
-wss.on('connection', (ws) => {
-  console.log('SERVER_WS_PROTOCOL:' + JSON.stringify(ws.protocol));
-});
-`,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "server.js"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // The server should respond with 101 status
-  expect(stdout).toContain("STATUS:101");
-  expect(exitCode).toBe(0);
 });
 
 test("ws WebSocketServer without handleProtocols uses first client protocol", async () => {
-  using dir = tempDir("ws-no-handle-protocols", {
-    "server.js": `
-import { WebSocketServer } from 'ws';
-
-const wss = new WebSocketServer({
-  port: 0,
-  // No handleProtocols - should default to first client protocol
-});
-
-wss.on('listening', async () => {
-  const port = wss.address().port;
-  console.log('PORT:' + port);
-
+  const wss = new WebSocketServer({ port: 0 });
   try {
-    const res = await fetch('http://127.0.0.1:' + port, {
-      headers: {
-        "Upgrade": "websocket",
-        "Connection": "Upgrade",
-        "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
-        "Sec-WebSocket-Version": "13",
-        "Sec-WebSocket-Protocol": "first-protocol, second-protocol"
-      }
-    });
-    console.log("STATUS:" + res.status);
-    console.log("PROTOCOL:" + res.headers.get("sec-websocket-protocol"));
-  } catch (e) {
-    console.log("ERROR:" + e.message);
+    const { res, ws } = await upgradeRequest(wss, "first-protocol, second-protocol");
+
+    expect(res.status).toBe(101);
+    expect(res.headers.get("sec-websocket-protocol")).toBe("first-protocol");
+    expect(ws.protocol).toBe("first-protocol");
+    ws.close();
+  } finally {
+    wss.close();
   }
-
-  wss.close();
-  process.exit(0);
-});
-
-wss.on('connection', (ws) => {
-  console.log('SERVER_WS_PROTOCOL:' + ws.protocol);
-});
-`,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "server.js"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // Without handleProtocols, should default to first client protocol
-  expect(stdout).toContain("STATUS:101");
-  expect(stdout).toContain("PROTOCOL:first-protocol");
-  expect(stdout).toContain("SERVER_WS_PROTOCOL:first-protocol");
-  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/3613.test.ts
+++ b/test/regression/issue/3613.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { once } from "node:events";
 import type { IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
-import { WebSocketServer } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
 
 // https://github.com/oven-sh/bun/issues/3613
 // WebSocketServer handleProtocols option should set the selected protocol in the upgrade response.
@@ -21,8 +21,10 @@ async function upgradeRequest(wss: WebSocketServer, clientProtocols: string) {
       "Sec-WebSocket-Protocol": clientProtocols,
     },
   });
-  const [ws] = await connection;
   await res.body?.cancel();
+  // If the upgrade was rejected, let the caller's status assertion fail with the
+  // actual status instead of hanging on a connection event that will never fire.
+  const ws = res.status === 101 ? ((await connection)[0] as WebSocket) : undefined;
   return { res, ws };
 }
 
@@ -37,18 +39,20 @@ test("ws WebSocketServer handleProtocols sets selected protocol", async () => {
       return "selected-protocol";
     },
   });
+  let ws: WebSocket | undefined;
   try {
-    const { res, ws } = await upgradeRequest(wss, "custom-protocol, selected-protocol");
+    const result = await upgradeRequest(wss, "custom-protocol, selected-protocol");
+    ws = result.ws;
 
     expect(receivedProtocols).toBeInstanceOf(Set);
     expect([...receivedProtocols!]).toEqual(["custom-protocol", "selected-protocol"]);
     expect(receivedRequest?.headers["sec-websocket-protocol"]).toBe("custom-protocol, selected-protocol");
 
-    expect(res.status).toBe(101);
-    expect(res.headers.get("sec-websocket-protocol")).toBe("selected-protocol");
-    expect(ws.protocol).toBe("selected-protocol");
-    ws.close();
+    expect(result.res.status).toBe(101);
+    expect(result.res.headers.get("sec-websocket-protocol")).toBe("selected-protocol");
+    expect(ws?.protocol).toBe("selected-protocol");
   } finally {
+    ws?.close();
     wss.close();
   }
 });
@@ -58,27 +62,31 @@ test("ws WebSocketServer handleProtocols with no protocol", async () => {
     port: 0,
     handleProtocols: () => "",
   });
+  let ws: WebSocket | undefined;
   try {
-    const { res, ws } = await upgradeRequest(wss, "custom-protocol");
+    const result = await upgradeRequest(wss, "custom-protocol");
+    ws = result.ws;
 
-    expect(res.status).toBe(101);
-    expect(ws.protocol).toBe("");
-    ws.close();
+    expect(result.res.status).toBe(101);
+    expect(ws?.protocol).toBe("");
   } finally {
+    ws?.close();
     wss.close();
   }
 });
 
 test("ws WebSocketServer without handleProtocols uses first client protocol", async () => {
   const wss = new WebSocketServer({ port: 0 });
+  let ws: WebSocket | undefined;
   try {
-    const { res, ws } = await upgradeRequest(wss, "first-protocol, second-protocol");
+    const result = await upgradeRequest(wss, "first-protocol, second-protocol");
+    ws = result.ws;
 
-    expect(res.status).toBe(101);
-    expect(res.headers.get("sec-websocket-protocol")).toBe("first-protocol");
-    expect(ws.protocol).toBe("first-protocol");
-    ws.close();
+    expect(result.res.status).toBe(101);
+    expect(result.res.headers.get("sec-websocket-protocol")).toBe("first-protocol");
+    expect(ws?.protocol).toBe("first-protocol");
   } finally {
+    ws?.close();
     wss.close();
   }
 });


### PR DESCRIPTION
`test/regression/issue/3613.test.ts` was 17s on the debian 13 x64-asan lane (build #81338). Each of the three cases spawned a fresh `bun` subprocess that imported `ws`, which under a debug+ASAN build is ~2s of cold startup per spawn.

### Change

The behavior under test is the `handleProtocols` path in the `ws` thirdparty shim (`src/js/thirdparty/ws.js`), which has no process-level dependency. Import `WebSocketServer` directly in the test process and issue the upgrade `fetch` there, the same pattern `test/regression/issue/012040.test.ts` already uses for this module. `require.resolve("ws")` from the test tree resolves to the built-in shim, so the code path is identical.

### Timing (local, debug+ASAN)

|        | file wall | test bodies |
| ------ | --------- | ----------- |
| before | 8.37s     | 6.30s       |
| after  | 3.57s     | 0.55s       |

The remaining wall time is test-runner startup; the test bodies themselves are ~11x faster.

### Assertions

Same three cases, tighter checks (10 -> 11 `expect()` calls):

- `handleProtocols` return value: now also asserts the callback's `protocols` argument is a `Set` with the client-offered entries, and that `request.headers["sec-websocket-protocol"]` carries the raw header. Previously only the response header was checked.
- Empty `handleProtocols` return: now asserts the server-side `ws.protocol` is `""`. Previously only the 101 status was checked.
- No `handleProtocols`: unchanged semantics, asserted directly instead of via stdout substring match.

No `setTimeout`, `port: 0`, `once()` for listening/connection, `try/finally` for server cleanup.

#33704 also touches this file (adds `test.concurrent` across ~53 files); this change supersedes that one-line edit for this file by removing the subprocess spawns entirely.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/3613.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/3613.test.ts"
bun test v1.4.0 (687e411cc)

test/regression/issue/3613.test.ts:
(pass) ws WebSocketServer handleProtocols sets selected protocol [372.60ms]
(pass) ws WebSocketServer handleProtocols with no protocol [97.31ms]
(pass) ws WebSocketServer without handleProtocols uses first client protocol [74.22ms]

 3 pass
 0 fail
 11 expect() calls
Ran 3 tests across 1 file. [3.55s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/3613.test.ts | 238 ++++++++++++-------------------------
 1 file changed, 75 insertions(+), 163 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
test/regression/issue/3613.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->