### PR TITLE
runtime: one module record for a .json imported with and without the type attribute

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6201,10 +6201,7 @@ pub mod __gated_printer {
                 return false;
             }
             let text = record.path.text;
-            let end = text
-                .iter()
-                .position(|&c| c == b'?' || c == b'#')
-                .unwrap_or(text.len());
+            let end = text.iter().position(|&c| c == b'?').unwrap_or(text.len());
             // `?raw` selects the text loader; a synthesized attribute would override it.
             if &text[end..] == b"?raw" {
                 return false;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6194,8 +6194,8 @@ pub mod __gated_printer {
 
         /// No `with { type }` on a `.json` specifier: emit one so JSC's
         /// `(specifier, ScriptFetchParameters::Type)` module-map key matches
-        /// the attributed form. Skips filenames `loader_for_path` routes to
-        /// jsonc, where a synthesized `type: "json"` would force strict JSON.
+        /// the attributed form. Must agree with `specifierImpliesJsonType` in
+        /// `ZigGlobalObject.cpp` (both inspect the as-written specifier).
         fn record_implies_json_type(record: &ImportRecord) -> bool {
             if record.loader.is_some() {
                 return false;
@@ -6205,10 +6205,15 @@ pub mod __gated_printer {
                 .iter()
                 .position(|&c| c == b'?' || c == b'#')
                 .unwrap_or(text.len());
+            // `?raw` selects the text loader; a synthesized attribute would override it.
+            if &text[end..] == b"?raw" {
+                return false;
+            }
             let path = &text[..end];
             if !strings::has_suffix_comptime(path, b".json") {
                 return false;
             }
+            // `loader_for_path` routes these to jsonc; a synthesized attribute would force strict JSON.
             let filename = bun_paths::basename(path);
             !(filename == b"package.json"
                 || strings::has_prefix_comptime(filename, b"tsconfig.")

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -5244,18 +5244,22 @@ pub mod __gated_printer {
                         self.print_whitespacer(ws!(b"from "));
                     }
 
-                    let irp = &self.import_record(s.import_record_index as usize).path.text;
-                    self.print_import_record_path(
-                        self.import_record(s.import_record_index as usize),
-                    );
+                    let record = self.import_record(s.import_record_index as usize);
+                    let irp = &record.path.text;
+                    let implies_json = Self::record_implies_json_type(record);
+                    self.print_import_record_path(record);
+                    if IS_BUN_PLATFORM && implies_json {
+                        self.print_whitespacer(ws!(b" with { type: \"json\" }"));
+                    }
                     self.print_semicolon_after_statement();
 
                     if Self::MAY_HAVE_MODULE_INFO {
                         if let Some(mi) = self.module_info() {
                             let irp_id = mi.str(irp);
+                            use analyze_transpiled_module::FetchParameters as FP;
                             mi.request_module(
                                 irp_id,
-                                analyze_transpiled_module::FetchParameters::None,
+                                if implies_json { FP::Json } else { FP::None },
                             );
                             if let Some(alias) = &s.alias {
                                 let alias_id = mi.str(alias.original_name.slice());
@@ -5481,7 +5485,11 @@ pub mod __gated_printer {
 
                     self.print_whitespacer(ws!(b"} from "));
                     let irp = &import_record.path.text;
+                    let implies_json = Self::record_implies_json_type(import_record);
                     self.print_import_record_path(import_record);
+                    if IS_BUN_PLATFORM && implies_json {
+                        self.print_whitespacer(ws!(b" with { type: \"json\" }"));
+                    }
                     self.print_semicolon_after_statement();
 
                     if Self::MAY_HAVE_MODULE_INFO && self.module_info.is_some() {
@@ -5490,7 +5498,8 @@ pub mod __gated_printer {
                         let irp_id = {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let id = mi.str(irp);
-                            mi.request_module(id, analyze_transpiled_module::FetchParameters::None);
+                            use analyze_transpiled_module::FetchParameters as FP;
+                            mi.request_module(id, if implies_json { FP::Json } else { FP::None });
                             id
                         };
                         for item in slice_of(s.items).iter() {
@@ -5999,6 +6008,8 @@ pub mod __gated_printer {
                                     self.print_whitespacer(ws!(b" with { type: \"md\" }"))
                                 }
                             }
+                        } else if Self::record_implies_json_type(record) {
+                            self.print_whitespacer(ws!(b" with { type: \"json\" }"));
                         }
                     }
                     self.print_semicolon_after_statement();
@@ -6039,6 +6050,8 @@ pub mod __gated_printer {
                                         Loader::Json5 => FP::host_defined(mi.str(b"json5")),
                                         Loader::Md => FP::host_defined(mi.str(b"md")),
                                     }
+                                } else if Self::record_implies_json_type(record) {
+                                    FP::Json
                                 } else {
                                     FP::None
                                 }
@@ -6177,6 +6190,38 @@ pub mod __gated_printer {
         #[inline]
         pub fn print_module_export_symbol(&mut self) {
             self.print(b"module.exports");
+        }
+
+        /// True when `record` carries no `with { type }` attribute but its
+        /// specifier would be loaded with Bun's JSON loader. For such records
+        /// the Bun-target printer emits an explicit `with { type: "json" }`
+        /// clause so JSC's module map (keyed on
+        /// `(specifier, ScriptFetchParameters::Type)`) hashes the attribute-less
+        /// and attributed forms to the same slot; without it the former keys on
+        /// `Type::JavaScript`, the latter on `Type::JSON`, and one file becomes
+        /// two live module instances.
+        ///
+        /// Filenames Bun routes to the `jsonc` loader instead of `json`
+        /// (`loader_for_path` in `jsc_hooks.rs`) are excluded: emitting
+        /// `with { type: "json" }` for those would force strict JSON at fetch
+        /// time and break empty/commented `package.json` / `tsconfig.json`.
+        fn record_implies_json_type(record: &ImportRecord) -> bool {
+            if record.loader.is_some() {
+                return false;
+            }
+            let text = record.path.text;
+            let end = text
+                .iter()
+                .position(|&c| c == b'?' || c == b'#')
+                .unwrap_or(text.len());
+            let path = &text[..end];
+            if !strings::has_suffix_comptime(path, b".json") {
+                return false;
+            }
+            let filename = bun_paths::basename(path);
+            !(filename == b"package.json"
+                || strings::has_prefix_comptime(filename, b"tsconfig.")
+                || strings::has_prefix_comptime(filename, b"jsconfig."))
         }
 
         pub fn print_import_record_path(&mut self, import_record: &ImportRecord) {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6192,19 +6192,10 @@ pub mod __gated_printer {
             self.print(b"module.exports");
         }
 
-        /// True when `record` carries no `with { type }` attribute but its
-        /// specifier would be loaded with Bun's JSON loader. For such records
-        /// the Bun-target printer emits an explicit `with { type: "json" }`
-        /// clause so JSC's module map (keyed on
-        /// `(specifier, ScriptFetchParameters::Type)`) hashes the attribute-less
-        /// and attributed forms to the same slot; without it the former keys on
-        /// `Type::JavaScript`, the latter on `Type::JSON`, and one file becomes
-        /// two live module instances.
-        ///
-        /// Filenames Bun routes to the `jsonc` loader instead of `json`
-        /// (`loader_for_path` in `jsc_hooks.rs`) are excluded: emitting
-        /// `with { type: "json" }` for those would force strict JSON at fetch
-        /// time and break empty/commented `package.json` / `tsconfig.json`.
+        /// No `with { type }` on a `.json` specifier: emit one so JSC's
+        /// `(specifier, ScriptFetchParameters::Type)` module-map key matches
+        /// the attributed form. Skips filenames `loader_for_path` routes to
+        /// jsonc, where a synthesized `type: "json"` would force strict JSON.
         fn record_implies_json_type(record: &ImportRecord) -> bool {
             if record.loader.is_some() {
                 return false;

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,9 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-const EXPECTED_VERSION: u32 = 23;
+/// Version 24: attribute-less `.json` imports emit `with { type: "json" }` and
+/// record `FetchParameters::Json` for the Bun target (#35914).
+const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3650,14 +3650,10 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     }
 }
 
-// Bun loads a `.json` path with the JSON loader whether or not the request
-// carried `with { type: "json" }`. JSC's module map is keyed on
-// (specifier, ScriptFetchParameters::Type), so an attribute-less request must
-// reach it as Type::JSON too or the two forms become two live module
-// instances. Applied only when the caller supplied no attributes (an explicit
-// `with { type: ... }` is left untouched) and the filename is not one Bun
-// routes to the jsonc loader (`loader_for_path` in jsc_hooks.rs), for which an
-// inferred `type: "json"` would force strict JSON at fetch time.
+// Attribute-less dynamic import() of a `.json`: supply Type::JSON so JSC's
+// (specifier, Type) module-map key matches the `with { type: "json" }` form.
+// Skips filenames `loader_for_path` routes to jsonc, where a synthesized
+// attribute would force strict JSON at fetch time.
 static ALWAYS_INLINE void normalizeFetchParametersForResolvedPath(RefPtr<JSC::ScriptFetchParameters>& parameters, const JSC::Identifier& resolved)
 {
     if (parameters)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3650,29 +3650,29 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     }
 }
 
-// Attribute-less dynamic import() of a `.json`: supply Type::JSON so JSC's
-// (specifier, Type) module-map key matches the `with { type: "json" }` form.
-// Skips filenames `loader_for_path` routes to jsonc, where a synthesized
-// attribute would force strict JSON at fetch time.
-static ALWAYS_INLINE void normalizeFetchParametersForResolvedPath(RefPtr<JSC::ScriptFetchParameters>& parameters, const JSC::Identifier& resolved)
+// Attribute-less dynamic import() whose specifier ends in `.json`: supply
+// Type::JSON so JSC's (specifier, Type) module-map key matches the
+// `with { type: "json" }` form and the printer's static-side normalization.
+// Must inspect the as-written specifier, not the resolved path, so a specifier
+// that resolves to a `.json` file but doesn't literally end in one stays
+// consistent with the printer (which never resolves).
+static ALWAYS_INLINE bool specifierImpliesJsonType(StringView specifier)
 {
-    if (parameters)
-        return;
-    auto* impl = resolved.impl();
-    if (!impl || impl->isSymbol())
-        return;
-    StringView path(*impl);
-    if (size_t q = path.find([](char16_t c) { return c == '?' || c == '#'; }); q != notFound)
-        path = path.left(q);
-    if (!path.endsWith(".json"_s))
-        return;
-    size_t slash = path.reverseFind('/');
-    size_t backslash = path.reverseFind('\\');
+    size_t q = specifier.find([](char16_t c) { return c == '?' || c == '#'; });
+    if (q != notFound) {
+        // `?raw` selects the text loader; a synthesized `type: "json"` would override it.
+        if (specifier.substring(q) == "?raw"_s)
+            return false;
+        specifier = specifier.left(q);
+    }
+    if (!specifier.endsWith(".json"_s))
+        return false;
+    size_t slash = specifier.reverseFind('/');
+    size_t backslash = specifier.reverseFind('\\');
     size_t sep = slash == notFound ? backslash : (backslash == notFound ? slash : std::max(slash, backslash));
-    StringView filename = sep == notFound ? path : path.substring(sep + 1);
-    if (filename == "package.json"_s || filename.startsWith("tsconfig."_s) || filename.startsWith("jsconfig."_s))
-        return;
-    parameters = JSC::ScriptFetchParameters::create(JSC::ScriptFetchParameters::Type::JSON);
+    StringView filename = sep == notFound ? specifier : specifier.substring(sep + 1);
+    // `loader_for_path` routes these to jsonc; a synthesized `type: "json"` would force strict JSON.
+    return filename != "package.json"_s && !filename.startsWith("tsconfig."_s) && !filename.startsWith("jsconfig."_s);
 }
 
 JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalObject,
@@ -3701,6 +3701,9 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     auto moduleName = moduleNameValue->value(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
+    if (!parameters && specifierImpliesJsonType(moduleName))
+        parameters = JSC::ScriptFetchParameters::create(JSC::ScriptFetchParameters::Type::JSON);
+
     auto sourceURL = sourceOrigin.url();
     String sourceOriginStringHolder;
     int64_t referrerAsyncOrder = -1;
@@ -3723,7 +3726,6 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     if (globalObject->onLoadPlugins.hasVirtualModules()) {
         if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(moduleName, sourceURL.protocolIsFile() ? sourceOriginStringHolder : String())) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());
-            normalizeFetchParametersForResolvedPath(parameters, resolvedIdentifier);
 
             auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, /* deferred */ false, referrerAsyncOrder);
             if (scope.exception()) [[unlikely]] {
@@ -3784,7 +3786,6 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     // The C++ module loader now extracts `with.type` into a
     // ScriptFetchParameters before calling this hook, so `parameters` is
     // already the parsed RefPtr (or null). Just forward it.
-    normalizeFetchParametersForResolvedPath(parameters, resolvedIdentifier);
     auto result = JSC::importModule(globalObject, resolvedIdentifier,
         JSC::Identifier(), WTF::move(parameters), nullptr, /* deferred */ false, referrerAsyncOrder);
     if (scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3658,7 +3658,7 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
 // consistent with the printer (which never resolves).
 static ALWAYS_INLINE bool specifierImpliesJsonType(StringView specifier)
 {
-    size_t q = specifier.find([](char16_t c) { return c == '?' || c == '#'; });
+    size_t q = specifier.find('?');
     if (q != notFound) {
         // `?raw` selects the text loader; a synthesized `type: "json"` would override it.
         if (specifier.substring(q) == "?raw"_s)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3650,6 +3650,35 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     }
 }
 
+// Bun loads a `.json` path with the JSON loader whether or not the request
+// carried `with { type: "json" }`. JSC's module map is keyed on
+// (specifier, ScriptFetchParameters::Type), so an attribute-less request must
+// reach it as Type::JSON too or the two forms become two live module
+// instances. Applied only when the caller supplied no attributes (an explicit
+// `with { type: ... }` is left untouched) and the filename is not one Bun
+// routes to the jsonc loader (`loader_for_path` in jsc_hooks.rs), for which an
+// inferred `type: "json"` would force strict JSON at fetch time.
+static ALWAYS_INLINE void normalizeFetchParametersForResolvedPath(RefPtr<JSC::ScriptFetchParameters>& parameters, const JSC::Identifier& resolved)
+{
+    if (parameters)
+        return;
+    auto* impl = resolved.impl();
+    if (!impl || impl->isSymbol())
+        return;
+    StringView path(*impl);
+    if (size_t q = path.find([](char16_t c) { return c == '?' || c == '#'; }); q != notFound)
+        path = path.left(q);
+    if (!path.endsWith(".json"_s))
+        return;
+    size_t slash = path.reverseFind('/');
+    size_t backslash = path.reverseFind('\\');
+    size_t sep = slash == notFound ? backslash : (backslash == notFound ? slash : std::max(slash, backslash));
+    StringView filename = sep == notFound ? path : path.substring(sep + 1);
+    if (filename == "package.json"_s || filename.startsWith("tsconfig."_s) || filename.startsWith("jsconfig."_s))
+        return;
+    parameters = JSC::ScriptFetchParameters::create(JSC::ScriptFetchParameters::Type::JSON);
+}
+
 JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalObject,
     JSModuleLoader*,
     JSString* moduleNameValue,
@@ -3698,6 +3727,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     if (globalObject->onLoadPlugins.hasVirtualModules()) {
         if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(moduleName, sourceURL.protocolIsFile() ? sourceOriginStringHolder : String())) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());
+            normalizeFetchParametersForResolvedPath(parameters, resolvedIdentifier);
 
             auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, /* deferred */ false, referrerAsyncOrder);
             if (scope.exception()) [[unlikely]] {
@@ -3758,6 +3788,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     // The C++ module loader now extracts `with.type` into a
     // ScriptFetchParameters before calling this hook, so `parameters` is
     // already the parsed RefPtr (or null). Just forward it.
+    normalizeFetchParametersForResolvedPath(parameters, resolvedIdentifier);
     auto result = JSC::importModule(globalObject, resolvedIdentifier,
         JSC::Identifier(), WTF::move(parameters), nullptr, /* deferred */ false, referrerAsyncOrder);
     if (scope.exception()) [[unlikely]] {

--- a/test/js/bun/resolve/json-import-identity.test.ts
+++ b/test/js/bun/resolve/json-import-identity.test.ts
@@ -145,8 +145,9 @@ test('the bun-target transpiler emits `with { type: "json" }` for attribute-less
       `import d from "./cfg.json?raw";`,
       `import e from "pkg/data";`,
       `import f from "#cfg";`,
-      `export { default as g } from "./other.json";`,
-      `export * as h from "./more.json";`,
+      `import g from "#cfg/data.json";`,
+      `export { default as h } from "./other.json";`,
+      `export * as i from "./more.json";`,
     ].join("\n"),
   );
   expect(out).toMatchInlineSnapshot(`
@@ -156,8 +157,9 @@ import c from "./data.json" with { type: "text" };
 import d from "./cfg.json?raw";
 import e from "pkg/data";
 import f from "#cfg";
-export { default as g } from "./other.json" with { type: "json" };
-export * as h from "./more.json" with { type: "json" };
+import g from "#cfg/data.json" with { type: "json" };
+export { default as h } from "./other.json" with { type: "json" };
+export * as i from "./more.json" with { type: "json" };
 "
 `);
   // Other targets are untouched.
@@ -233,6 +235,27 @@ describe("specifiers that resolve to a .json but don't end in one keep a shared 
     expect(stdout).toMatchInlineSnapshot(`"same: true"`);
     expect(exitCode).toBe(0);
   });
+});
+
+test.concurrent("a #subpath specifier that ends in .json shares one module with the attributed form", async () => {
+  const { stdout, exitCode } = await run({
+    "package.json": `{"imports":{"#cfg/*":"./src/*"}}`,
+    "src/data.json": `{"n":1}`,
+    "plain.mjs": `import a from "#cfg/data.json"; export default a;`,
+    "attr.mjs": `import b from "#cfg/data.json" with { type: "json" }; export default b;`,
+    "index.mjs": `
+      const plain = (await import("./plain.mjs")).default;
+      const attr = (await import("./attr.mjs")).default;
+      const dyn = (await import("#cfg/data.json")).default;
+      console.log("plain === attr:", plain === attr);
+      console.log("plain === dyn:", plain === dyn);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`
+"plain === attr: true
+plain === dyn: true"
+`);
+  expect(exitCode).toBe(0);
 });
 
 describe("the ?raw query on a .json specifier still selects the text loader", () => {

--- a/test/js/bun/resolve/json-import-identity.test.ts
+++ b/test/js/bun/resolve/json-import-identity.test.ts
@@ -118,6 +118,50 @@ test("export-from of a .json shares one module with an attributed import", async
   expect(exitCode).toBe(0);
 });
 
+test("export * as of a .json shares one module with an attributed import", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "reex.mjs": `export * as cfg from "./cfg.json";`,
+    "imp.mjs": `import b from "./cfg.json" with { type: "json" }; export default b;`,
+    "index.mjs": `
+      const a = (await import("./reex.mjs")).cfg;
+      const b = (await import("./imp.mjs")).default;
+      console.log("same:", a.default === b);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`"same: true"`);
+  expect(exitCode).toBe(0);
+});
+
+test('the bun-target transpiler emits `with { type: "json" }` for attribute-less .json specifiers', () => {
+  // Static child imports go through `hostLoadImportedModule`, not the
+  // dynamic-import hook, so the printer change is load bearing on its own.
+  const t = new Bun.Transpiler({ target: "bun" });
+  const out = t.transformSync(
+    [
+      `import a from "./cfg.json";`,
+      `import b from "./package.json";`,
+      `import c from "./data.json" with { type: "text" };`,
+      `export { default as d } from "./other.json";`,
+      `export * as e from "./more.json";`,
+    ].join("\n"),
+  );
+  expect(out).toMatchInlineSnapshot(`
+"import a from "./cfg.json" with { type: "json" };
+import b from "./package.json";
+import c from "./data.json" with { type: "text" };
+export { default as d } from "./other.json" with { type: "json" };
+export * as e from "./more.json" with { type: "json" };
+"
+`);
+  // Other targets are untouched.
+  for (const target of ["browser", "node"] as const) {
+    expect(new Bun.Transpiler({ target }).transformSync(`import a from "./cfg.json";`)).toBe(
+      `import a from "./cfg.json";\n`,
+    );
+  }
+});
+
 test("an explicit non-json type attribute still produces a distinct module", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,

--- a/test/js/bun/resolve/json-import-identity.test.ts
+++ b/test/js/bun/resolve/json-import-identity.test.ts
@@ -17,11 +17,7 @@ async function run(files: Record<string, string>) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout: normalizeBunSnapshot(stdout, dir), stderr, exitCode };
 }
 

--- a/test/js/bun/resolve/json-import-identity.test.ts
+++ b/test/js/bun/resolve/json-import-identity.test.ts
@@ -18,7 +18,8 @@ async function run(files: Record<string, string>) {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout: normalizeBunSnapshot(stdout, dir), stderr, exitCode };
+  expect(stderr).toBe("");
+  return { stdout: normalizeBunSnapshot(stdout, dir), exitCode };
 }
 
 test.concurrent("static .json imports with and without the type attribute share one module across files", async () => {
@@ -293,7 +294,7 @@ describe("jsonc-loaded filenames are left alone", () => {
   // handling of empty / commented config files.
   for (const name of ["package.json", "tsconfig.json", "jsconfig.json"]) {
     test.concurrent(`static import of an empty ${name} still works`, async () => {
-      const { stdout, stderr, exitCode } = await run({
+      const { stdout, exitCode } = await run({
         [name]: ``,
         "plain.mjs": `import a from "./${name}"; export default a;`,
         "index.mjs": `
@@ -301,20 +302,18 @@ describe("jsonc-loaded filenames are left alone", () => {
           console.log(JSON.stringify(a));
         `,
       });
-      expect(stderr).not.toContain("JSON Parse error");
       expect(stdout).toMatchInlineSnapshot(`"{}"`);
       expect(exitCode).toBe(0);
     });
 
     test.concurrent(`dynamic import of an empty ${name} still works`, async () => {
-      const { stdout, stderr, exitCode } = await run({
+      const { stdout, exitCode } = await run({
         [name]: ``,
         "index.mjs": `
           const a = (await import("./${name}")).default;
           console.log(JSON.stringify(a));
         `,
       });
-      expect(stderr).not.toContain("JSON Parse error");
       expect(stdout).toMatchInlineSnapshot(`"{}"`);
       expect(exitCode).toBe(0);
     });

--- a/test/js/bun/resolve/json-import-identity.test.ts
+++ b/test/js/bun/resolve/json-import-identity.test.ts
@@ -21,7 +21,7 @@ async function run(files: Record<string, string>) {
   return { stdout: normalizeBunSnapshot(stdout, dir), stderr, exitCode };
 }
 
-test("static .json imports with and without the type attribute share one module across files", async () => {
+test.concurrent("static .json imports with and without the type attribute share one module across files", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "plain.mjs": `import a from "./cfg.json"; export default a;`,
@@ -41,7 +41,7 @@ mutation: 42"
   expect(exitCode).toBe(0);
 });
 
-test("static .json imports share one module regardless of load order", async () => {
+test.concurrent("static .json imports share one module regardless of load order", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "plain.mjs": `import a from "./cfg.json"; export default a;`,
@@ -56,7 +56,7 @@ test("static .json imports share one module regardless of load order", async () 
   expect(exitCode).toBe(0);
 });
 
-test("dynamic import() of a .json with and without the type attribute returns one module", async () => {
+test.concurrent("dynamic import() of a .json with and without the type attribute returns one module", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "index.mjs": `
@@ -76,7 +76,7 @@ mutation: 99"
   expect(exitCode).toBe(0);
 });
 
-test("dynamic import() of a .json shares one module regardless of order", async () => {
+test.concurrent("dynamic import() of a .json shares one module regardless of order", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "index.mjs": `
@@ -89,7 +89,7 @@ test("dynamic import() of a .json shares one module regardless of order", async 
   expect(exitCode).toBe(0);
 });
 
-test("a static attribute-less .json import and a dynamic attributed one share one module", async () => {
+test.concurrent("a static attribute-less .json import and a dynamic attributed one share one module", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "plain.mjs": `import a from "./cfg.json"; export default a;`,
@@ -103,7 +103,7 @@ test("a static attribute-less .json import and a dynamic attributed one share on
   expect(exitCode).toBe(0);
 });
 
-test("export-from of a .json shares one module with an attributed import", async () => {
+test.concurrent("export-from of a .json shares one module with an attributed import", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "reex.mjs": `export { default as cfg } from "./cfg.json";`,
@@ -118,7 +118,7 @@ test("export-from of a .json shares one module with an attributed import", async
   expect(exitCode).toBe(0);
 });
 
-test("export * as of a .json shares one module with an attributed import", async () => {
+test.concurrent("export * as of a .json shares one module with an attributed import", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "reex.mjs": `export * as cfg from "./cfg.json";`,
@@ -142,16 +142,22 @@ test('the bun-target transpiler emits `with { type: "json" }` for attribute-less
       `import a from "./cfg.json";`,
       `import b from "./package.json";`,
       `import c from "./data.json" with { type: "text" };`,
-      `export { default as d } from "./other.json";`,
-      `export * as e from "./more.json";`,
+      `import d from "./cfg.json?raw";`,
+      `import e from "pkg/data";`,
+      `import f from "#cfg";`,
+      `export { default as g } from "./other.json";`,
+      `export * as h from "./more.json";`,
     ].join("\n"),
   );
   expect(out).toMatchInlineSnapshot(`
 "import a from "./cfg.json" with { type: "json" };
 import b from "./package.json";
 import c from "./data.json" with { type: "text" };
-export { default as d } from "./other.json" with { type: "json" };
-export * as e from "./more.json" with { type: "json" };
+import d from "./cfg.json?raw";
+import e from "pkg/data";
+import f from "#cfg";
+export { default as g } from "./other.json" with { type: "json" };
+export * as h from "./more.json" with { type: "json" };
 "
 `);
   // Other targets are untouched.
@@ -162,7 +168,7 @@ export * as e from "./more.json" with { type: "json" };
   }
 });
 
-test("an explicit non-json type attribute still produces a distinct module", async () => {
+test.concurrent("an explicit non-json type attribute still produces a distinct module", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "index.mjs": `
@@ -181,7 +187,7 @@ distinct: true"
   expect(exitCode).toBe(0);
 });
 
-test("a .json specifier with a query string still normalizes to one module", async () => {
+test.concurrent("a .json specifier with a query string still normalizes to one module", async () => {
   const { stdout, exitCode } = await run({
     "cfg.json": `{"n":1}`,
     "index.mjs": `
@@ -194,6 +200,68 @@ test("a .json specifier with a query string still normalizes to one module", asy
   expect(exitCode).toBe(0);
 });
 
+describe("specifiers that resolve to a .json but don't end in one keep a shared module", () => {
+  // The normalization keys on the as-written specifier in both the printer and
+  // `moduleLoaderImportModule`; keying on the resolved path on only one side
+  // would fork static vs dynamic for these.
+  test.concurrent("package exports: `pkg/data` -> data.json, static vs dynamic", async () => {
+    const { stdout, exitCode } = await run({
+      "node_modules/pkg/package.json": `{"name":"pkg","exports":{"./data":"./data.json"}}`,
+      "node_modules/pkg/data.json": `{"n":1}`,
+      "a.mjs": `import a from "pkg/data"; export default a;`,
+      "index.mjs": `
+        const s = (await import("./a.mjs")).default;
+        const d = (await import("pkg/data")).default;
+        console.log("same:", s === d);
+      `,
+    });
+    expect(stdout).toMatchInlineSnapshot(`"same: true"`);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("subpath import: `#cfg` -> cfg.json, static vs dynamic", async () => {
+    const { stdout, exitCode } = await run({
+      "package.json": `{"imports":{"#cfg":"./cfg.json"}}`,
+      "cfg.json": `{"n":1}`,
+      "a.mjs": `import a from "#cfg"; export default a;`,
+      "index.mjs": `
+        const s = (await import("./a.mjs")).default;
+        const d = (await import("#cfg")).default;
+        console.log("same:", s === d);
+      `,
+    });
+    expect(stdout).toMatchInlineSnapshot(`"same: true"`);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("the ?raw query on a .json specifier still selects the text loader", () => {
+  test.concurrent("static", async () => {
+    const { stdout, exitCode } = await run({
+      "cfg.json": `{"n":1}`,
+      "a.mjs": `import a from "./cfg.json?raw"; export default a;`,
+      "index.mjs": `
+        const a = (await import("./a.mjs")).default;
+        console.log(typeof a, a.trimEnd());
+      `,
+    });
+    expect(stdout).toMatchInlineSnapshot(`"string {"n":1}"`);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("dynamic", async () => {
+    const { stdout, exitCode } = await run({
+      "cfg.json": `{"n":1}`,
+      "index.mjs": `
+        const a = (await import("./cfg.json?raw")).default;
+        console.log(typeof a, a.trimEnd());
+      `,
+    });
+    expect(stdout).toMatchInlineSnapshot(`"string {"n":1}"`);
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("jsonc-loaded filenames are left alone", () => {
   // package.json / tsconfig.json / jsconfig.json use Bun's jsonc loader even
   // though the extension is `.json`. The normalization must not synthesize
@@ -201,7 +269,7 @@ describe("jsonc-loaded filenames are left alone", () => {
   // explicit `type` override and force strict JSON, breaking Bun's lenient
   // handling of empty / commented config files.
   for (const name of ["package.json", "tsconfig.json", "jsconfig.json"]) {
-    test(`static import of an empty ${name} still works`, async () => {
+    test.concurrent(`static import of an empty ${name} still works`, async () => {
       const { stdout, stderr, exitCode } = await run({
         [name]: ``,
         "plain.mjs": `import a from "./${name}"; export default a;`,
@@ -215,7 +283,7 @@ describe("jsonc-loaded filenames are left alone", () => {
       expect(exitCode).toBe(0);
     });
 
-    test(`dynamic import of an empty ${name} still works`, async () => {
+    test.concurrent(`dynamic import of an empty ${name} still works`, async () => {
       const { stdout, stderr, exitCode } = await run({
         [name]: ``,
         "index.mjs": `

--- a/test/js/bun/resolve/json-import-identity.test.ts
+++ b/test/js/bun/resolve/json-import-identity.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+// Bun accepts `import "./x.json"` without `with { type: "json" }`. Both forms
+// load the same file with the same loader, so they must resolve to the same
+// module record in JSC's registry. Before this was fixed the attribute-less
+// form keyed on ScriptFetchParameters::Type::JavaScript and the attributed
+// form on Type::JSON, so two module instances were created and a mutation via
+// one was invisible via the other.
+
+async function run(files: Record<string, string>) {
+  using dir = tempDir("json-import-identity", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  return { stdout: normalizeBunSnapshot(stdout, dir), stderr, exitCode };
+}
+
+test("static .json imports with and without the type attribute share one module across files", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "plain.mjs": `import a from "./cfg.json"; export default a;`,
+    "attr.mjs": `import b from "./cfg.json" with { type: "json" }; export default b;`,
+    "index.mjs": `
+      const plain = (await import("./plain.mjs")).default;
+      const attr = (await import("./attr.mjs")).default;
+      console.log("same:", plain === attr);
+      plain.n = 42;
+      console.log("mutation:", attr.n);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`
+"same: true
+mutation: 42"
+`);
+  expect(exitCode).toBe(0);
+});
+
+test("static .json imports share one module regardless of load order", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "plain.mjs": `import a from "./cfg.json"; export default a;`,
+    "attr.mjs": `import b from "./cfg.json" with { type: "json" }; export default b;`,
+    "index.mjs": `
+      const attr = (await import("./attr.mjs")).default;
+      const plain = (await import("./plain.mjs")).default;
+      console.log("same:", plain === attr);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`"same: true"`);
+  expect(exitCode).toBe(0);
+});
+
+test("dynamic import() of a .json with and without the type attribute returns one module", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "index.mjs": `
+      const plain = await import("./cfg.json");
+      const attr = await import("./cfg.json", { with: { type: "json" } });
+      console.log("ns:", plain === attr);
+      console.log("default:", plain.default === attr.default);
+      plain.default.n = 99;
+      console.log("mutation:", attr.default.n);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`
+"ns: true
+default: true
+mutation: 99"
+`);
+  expect(exitCode).toBe(0);
+});
+
+test("dynamic import() of a .json shares one module regardless of order", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "index.mjs": `
+      const attr = await import("./cfg.json", { with: { type: "json" } });
+      const plain = await import("./cfg.json");
+      console.log("ns:", plain === attr);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`"ns: true"`);
+  expect(exitCode).toBe(0);
+});
+
+test("a static attribute-less .json import and a dynamic attributed one share one module", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "plain.mjs": `import a from "./cfg.json"; export default a;`,
+    "index.mjs": `
+      const plain = (await import("./plain.mjs")).default;
+      const attr = (await import("./cfg.json", { with: { type: "json" } })).default;
+      console.log("same:", plain === attr);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`"same: true"`);
+  expect(exitCode).toBe(0);
+});
+
+test("export-from of a .json shares one module with an attributed import", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "reex.mjs": `export { default as cfg } from "./cfg.json";`,
+    "imp.mjs": `import b from "./cfg.json" with { type: "json" }; export default b;`,
+    "index.mjs": `
+      const a = (await import("./reex.mjs")).cfg;
+      const b = (await import("./imp.mjs")).default;
+      console.log("same:", a === b);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`"same: true"`);
+  expect(exitCode).toBe(0);
+});
+
+test("an explicit non-json type attribute still produces a distinct module", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "index.mjs": `
+      const asJson = (await import("./cfg.json", { with: { type: "json" } })).default;
+      const asText = (await import("./cfg.json", { with: { type: "text" } })).default;
+      console.log("json:", JSON.stringify(asJson));
+      console.log("text:", asText);
+      console.log("distinct:", asJson !== asText);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`
+"json: {"n":1}
+text: {"n":1}
+distinct: true"
+`);
+  expect(exitCode).toBe(0);
+});
+
+test("a .json specifier with a query string still normalizes to one module", async () => {
+  const { stdout, exitCode } = await run({
+    "cfg.json": `{"n":1}`,
+    "index.mjs": `
+      const plain = await import("./cfg.json?v=1");
+      const attr = await import("./cfg.json?v=1", { with: { type: "json" } });
+      console.log("same:", plain.default === attr.default);
+    `,
+  });
+  expect(stdout).toMatchInlineSnapshot(`"same: true"`);
+  expect(exitCode).toBe(0);
+});
+
+describe("jsonc-loaded filenames are left alone", () => {
+  // package.json / tsconfig.json / jsconfig.json use Bun's jsonc loader even
+  // though the extension is `.json`. The normalization must not synthesize
+  // `with { type: "json" }` for them: that would reach the fetch hook as an
+  // explicit `type` override and force strict JSON, breaking Bun's lenient
+  // handling of empty / commented config files.
+  for (const name of ["package.json", "tsconfig.json", "jsconfig.json"]) {
+    test(`static import of an empty ${name} still works`, async () => {
+      const { stdout, stderr, exitCode } = await run({
+        [name]: ``,
+        "plain.mjs": `import a from "./${name}"; export default a;`,
+        "index.mjs": `
+          const a = (await import("./plain.mjs")).default;
+          console.log(JSON.stringify(a));
+        `,
+      });
+      expect(stderr).not.toContain("JSON Parse error");
+      expect(stdout).toMatchInlineSnapshot(`"{}"`);
+      expect(exitCode).toBe(0);
+    });
+
+    test(`dynamic import of an empty ${name} still works`, async () => {
+      const { stdout, stderr, exitCode } = await run({
+        [name]: ``,
+        "index.mjs": `
+          const a = (await import("./${name}")).default;
+          console.log(JSON.stringify(a));
+        `,
+      });
+      expect(stderr).not.toContain("JSON Parse error");
+      expect(stdout).toMatchInlineSnapshot(`"{}"`);
+      expect(exitCode).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
Importing the same `.json` file both without an attribute and with `with { type: "json" }` produced two live module instances, so a mutation via one was invisible via the other.

### Reproduction

```js
// plain.mjs
import a from "./cfg.json"; export default a;
// attr.mjs
import b from "./cfg.json" with { type: "json" }; export default b;
// index.mjs
const plain = (await import("./plain.mjs")).default;
const attr  = (await import("./attr.mjs")).default;
plain.n = 42;
console.log(plain === attr, attr.n);   // bun: false 1   expected: true 42
```

Deterministic on main. Within a single source file the two static forms coalesce (the printer deduplicates `requestedModules` by specifier), so the fork only shows across files or via dynamic `import()`.

Node cannot exhibit it because the attribute-less form is `ERR_IMPORT_ATTRIBUTE_MISSING` there; Bun accepts both, so both forms resolve to the same JSON loader and must be one module.

### Cause

JSC's module map is keyed on `(specifier, ScriptFetchParameters::Type)`. An attribute-less request falls back to `Type::JavaScript` (`AbstractModuleRecord::ModuleRequest::type()` / `JSModuleLoader::loadModule`), while `with { type: "json" }` parses to `Type::JSON`, so the two requests hash to different slots and fetch twice.

### Fix

Normalize the attribute-less form to `Type::JSON` at the two points Bun controls before JSC's key is built, keying the decision on the **as-written specifier** so both sides agree:

- **Static imports / re-exports** (`src/js_printer/lib.rs`): for `target: "bun"`, when an import / `export ... from` record has no `with { type }` and its specifier ends in `.json`, emit `with { type: "json" }` in the printed source (and mirror `FetchParameters::Json` in `module_info` so the isolation-cache path and the debug `fallbackParse` diff stay consistent). JSC's `ModuleAnalyzer` then produces `Type::JSON` for both forms.
- **Dynamic `import()`** (`src/jsc/bindings/ZigGlobalObject.cpp`): in `moduleLoaderImportModule`, before resolving, if the caller supplied no attributes and the specifier ends in `.json`, synthesize `ScriptFetchParameters::create(Type::JSON)`.

Both predicates skip the same cases a synthesized `type: "json"` would change the loader for:

- `?raw`, which selects the text loader.
- The filenames `loader_for_path` routes to jsonc (`package.json`, `tsconfig.*`, `jsconfig.*`), where it would force strict JSON and break empty/commented config files.

An explicit user-written `with { type: ... }` is never rewritten, and other `target` values are untouched (the printer path is behind `IS_BUN_PLATFORM`).

The dynamic-import side originally inspected the resolved path; that forked a specifier like `pkg/data` or `#cfg` (resolves to a `.json`, does not end in one) between static and dynamic, which the printer cannot match because the runtime transpiler never resolves. Both sides now inspect the same representation and are covered by tests.

### Verification

Against the installed canary (`/usr/local/bin/bun`, 1.3.14): 9 of 20 tests in `test/js/bun/resolve/json-import-identity.test.ts` fail; the passing half is the regression-guard set (`?raw`, jsonc filenames, `pkg/data` / `#cfg` static-vs-dynamic, the negative `type: "text"` contract).

`bun bd test test/js/bun/resolve/json-import-identity.test.ts`: 20 pass / 0 fail.

Also green on the debug build: `jsonc.test.ts`, `import-query.test.ts`, `import-defer.test.ts`, `esModule.test.ts`, `import-attributes.test.ts`, `resolve.test.ts`, `require.test.ts`, `import-meta.test.js`, `bundler_loader.test.ts`, `transpiler.test.js`, `regression/issue/16476`.

### Known limitation

A specifier that does *not* literally end in `.json` but resolves to one (e.g. `"pkg/data"` via package `exports`) keys on `Type::JavaScript`, while the literal path to the same file keys on `Type::JSON`. On main both were `Type::JavaScript`, so an attribute-less `import "pkg/data"` and an attribute-less `import "./node_modules/pkg/data.json"` shared a module; now the literal form joins the `Type::JSON` slot alongside every attributed form instead. Net module count is unchanged, the partition moved. Closing that completely needs the key's type component rewritten after `resolve()` inside `hostLoadImportedModule`, which is a WebKit change (same territory as #32999).

A bunfig `[loader] ".json" = "jsonc"` remap is not touched here: it already fails on main the same way (the fetch-time `type` override is unaware of the bunfig remap), verified against 1.3.14.

### Related

#32999 fixes the adjacent collapse where two *different* `with { type }` values hash to one slot (HostDefined string not in the key). This PR is the converse: no-attribute vs `type: "json"` on a `.json` specifier hashing to two slots when Bun loads them identically. The two are independent.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/json-import-identity.test.ts
bun test v1.4.0 (280ee2d73)

test/js/bun/resolve/json-import-identity.test.ts:
33 |       console.log("same:", plain === attr);
34 |       plain.n = 42;
35 |       console.log("mutation:", attr.n);
36 |     `,
37 |   });
38 |   expect(stdout).toMatchInlineSnapshot(`
                      ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "same: true
- mutation: 42"
- 
+ "same: false
+ mutation: 1"
+ 

- Expected  - 3
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/resolve/json-import-identity.test.ts:38:18)
(fail) static .json imports with and without the type attribute share one module across files [364.45ms]
84 |       const attr = await import("./cfg.json", { with: { type: "json" } });
85 |       const plain = await import("./cfg.json");
86 |       console.log("ns:", plain === attr);
87 |     `,
88 |   });
89 |   expect(stdout).toMatchInlineSnapshot(`"ns: true"`);
                      ^
error: expect(received).toMatchInlineSnapshot(expected)

Expected: 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ce0b6665b)

test/js/bun/resolve/json-import-identity.test.ts:
(pass) dynamic import() of a .json with and without the type attribute returns one module [8.83ms]
(pass) dynamic import() of a .json shares one module regardless of order [8.43ms]
(pass) static .json imports share one module regardless of load order [10.06ms]
(pass) static .json imports with and without the type attribute share one module across files [12.33ms]
(pass) a static attribute-less .json import and a dynamic attributed one share one module [8.30ms]
(pass) export-from of a .json shares one module with an attributed import [7.67ms]
(pass) export * as of a .json shares one module with an attributed import [7.42ms]
(pass) the bun-target transpiler emits `with { type: "json" }` for attribute-less .json specifiers [0.60ms]
(pass) an explicit non-json type attribute still produces a distinct module [15.57ms]
(pass) a .json specifier with a query string still normalizes to one module [14.91ms]
(pass) specifiers that resolve to a .json but don't end in one keep a shared module > package exports: `pkg/data` -> data.json, static vs dynamic [14.37ms]
(pass) specifiers that resolve
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/json-import-identity.test.ts
bun test v1.4.0 (280ee2d73)

test/js/bun/resolve/json-import-identity.test.ts:
(pass) dynamic import() of a .json with and without the type attribute returns one module [326.99ms]
(pass) dynamic import() of a .json shares one module regardless of order [371.32ms]
(pass) static .json imports with and without the type attribute share one module across files [472.11ms]
(pass) a static attribute-less .json import and a dynamic attributed one share one module [391.11ms]
(pass) static .json imports share one module regardless of load order [422.10ms]
(pass) export-from of a .json shares one module with an attributed import [338.19ms]
(pass) export * as of a .json shares one module with an attributed import [340.36ms]
(pass) the bun-target transpiler emits `with { type: "json" }` for attribute-less .json specifiers [16.89ms]
(pass) an explicit non-json type attribute still produces a distinct module [291.17ms]
(pass) a .json specifier with a query string still normalizes to one module [291.52ms
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/8] gen cpp.rs (cppbind)
[3/8] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_pico
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs                            |  50 +++-
 src/jsc/RuntimeTranspilerCache.rs                |   4 +-
 src/jsc/bindings/ZigGlobalObject.cpp             |  28 ++
 test/js/bun/resolve/json-import-identity.test.ts | 321 +++++++++++++++++++++++
 4 files changed, 396 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/js_printer/lib.rs                                13     16      0
src/jsc/RuntimeTranspilerCache.rs                     1      1      0
src/jsc/bindings/ZigGlobalObject.cpp                  6     12      0
test/js/bun/resolve/json-import-identity.test.ts      3      8      0
```

</details>

<!-- robobun:evidence:end -->