### PR TITLE
test(install): speed up bun-install-streaming-extract.test.ts (65s to 10s debug-asan)

### DIFF
--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -638,6 +638,13 @@ test.concurrent("buffered extract rejects a registry tarball whose decompressed 
   const prefixBlock = deflateRawSync(prefix, { finishFlush: zconst.Z_FULL_FLUSH });
   const zeroBlock = deflateRawSync(zeros, { level: 1, strategy: zconst.Z_RLE, finishFlush: zconst.Z_FULL_FLUSH });
   const tailBlock = deflateRawSync(tail); // default Z_FINISH → BFINAL=1
+  // Concatenation is only valid while finishFlush:Z_FULL_FLUSH keeps
+  // BFINAL=0 and ends on the byte-aligned 00 00 ff ff reset marker;
+  // bind that invariant here so a zlib.ts refactor that starts
+  // finishing sync deflate with Z_FINISH fails at the source.
+  for (const b of [prefixBlock, zeroBlock]) {
+    expect({ bfinal: b[0] & 1, tail: [...b.subarray(-4)] }).toEqual({ bfinal: 0, tail: [0, 0, 0xff, 0xff] });
+  }
 
   let crc = crc32(prefix);
   for (let i = 0; i < PAYLOAD_SIZE / BLOCK; i++) crc = crc32(zeros, crc);

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -7,13 +7,13 @@
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
-import { createHash } from "node:crypto";
+import { createHash, randomFillSync } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
-import { createGzip, gzipSync } from "node:zlib";
+import { constants as zconst, crc32, deflateRawSync, gzipSync } from "node:zlib";
 
-setDefaultTimeout(1000 * 60 * 5);
+setDefaultTimeout(1000 * 60);
 
 // -------------------------------------------------------------------
 // Tarball construction helpers. We build the .tgz in-process so the
@@ -109,18 +109,13 @@ function makeEntries(): Entry[] {
       body: Buffer.from("long path ok\n"),
     },
   ];
-  // Bulk entries: SHA-chained bytes so gzip can't collapse them away.
+  // Bulk entries: CSPRNG bytes so gzip can't collapse them away.
   // Sized so the compressed tarball exceeds the default
   // BUN_INSTALL_STREAMING_MIN_SIZE (2 MB) — streaming only commits
-  // when Content-Length is above that threshold.
+  // when Content-Length is above that threshold. Contents vary per
+  // run; the extraction check compares against these same buffers.
   for (let i = 0; i < 48; i++) {
-    const bytes = Buffer.alloc(48 * 1024);
-    let seed = createHash("sha256").update(`chunk-${i}`).digest();
-    for (let off = 0; off < bytes.length; off += 32) {
-      seed.copy(bytes, off);
-      seed = createHash("sha256").update(seed).digest();
-    }
-    entries.push({ path: `data/chunk-${i}.bin`, body: bytes });
+    entries.push({ path: `data/chunk-${i}.bin`, body: randomFillSync(Buffer.alloc(48 * 1024)) });
   }
   return entries;
 }
@@ -211,7 +206,9 @@ async function runInstall(cwd: string, extraEnv: Record<string, string> = {}) {
   return { stdout, stderr, exitCode };
 }
 
-describe("streaming tarball extraction", () => {
+// Every test below owns its own registry (port:0), tempDir and install
+// subprocess, so they share no mutable state and can run concurrently.
+describe.concurrent("streaming tarball extraction", () => {
   const entries = makeEntries();
   const { tgz, shasum, integrity } = buildTarball(entries);
 
@@ -400,6 +397,8 @@ describe("streaming tarball extraction", () => {
 
     const { stderr, exitCode } = await runInstall(String(dir));
     expect(stderr).toContain("Integrity check failed");
+    // The streamed temp tree must not have been promoted into node_modules.
+    expect(existsSync(join(String(dir), "node_modules", "stream-pkg", "package.json"))).toBe(false);
     expect(exitCode).not.toBe(0);
   });
 
@@ -551,7 +550,7 @@ describe("streaming tarball extraction", () => {
 // behaviour change here is the libarchive patch leaking into the shared
 // buffered codepath.
 // -------------------------------------------------------------------
-test("buffered extract: damaged-block retry resets header state (upstream semantics)", async () => {
+test.concurrent("buffered extract: damaged-block retry resets header state (upstream semantics)", async () => {
   // One pax 'g' extended-header payload. libarchive's header_pax_global
   // just skips it, but parsing it sets `seen_headers |= seen_g_header`;
   // seeing a second one without an intervening state reset is what
@@ -611,41 +610,51 @@ test("buffered extract: damaged-block retry resets header state (upstream semant
 // growing the decompression buffer without limit and installing a
 // multi-gigabyte file.
 // -------------------------------------------------------------------
-test("buffered extract rejects a registry tarball whose decompressed size exceeds the limit", async () => {
+test.concurrent("buffered extract rejects a registry tarball whose decompressed size exceeds the limit", async () => {
   // 2.25 GiB of zeros: comfortably above the 2 GiB decompression cap,
   // a multiple of 512 so the tar entry needs no trailing pad block,
   // and its gzip ISIZE footer is far above the 64 MB libdeflate
   // preallocation cutoff so the streaming zlib reader is what runs.
   const PAYLOAD_SIZE = 2304 * 1024 * 1024;
-  const ZERO_CHUNK = Buffer.alloc(64 * 1024 * 1024);
+  const BLOCK = 64 * 1024 * 1024;
+  const zeros = Buffer.alloc(BLOCK);
 
   const pkgJson = Buffer.from(JSON.stringify({ name: "oversized-pkg", version: "1.0.0" }) + "\n");
 
-  // Stream the tar through gzip so the test process never holds the
-  // 2.25 GiB uncompressed archive in memory; only the small compressed
-  // tarball is kept around.
-  const gzip = createGzip({ level: 9 });
-  const compressed: Buffer[] = [];
-  gzip.on("data", c => compressed.push(c as Buffer));
-  const gzipDone = new Promise<void>((resolve, reject) => {
-    gzip.on("end", resolve);
-    gzip.on("error", reject);
-  });
-  const writeTar = (chunk: Buffer) =>
-    new Promise<void>((resolve, reject) => gzip.write(chunk, err => (err ? reject(err) : resolve())));
+  // Build a single gzip member whose deflate stream is a short prefix
+  // followed by one raw-deflate block of 64 MiB zeros repeated 36× and
+  // a BFINAL terminator. Z_FULL_FLUSH resets the dictionary so the
+  // block is self-contained and safe to concatenate; the result is a
+  // valid deflate stream that inflates to the full 2.25 GiB tar
+  // without ever materialising that much input in the test process.
+  const prefix = Buffer.concat([
+    tarHeader("package/package.json", pkgJson.length, "0"),
+    pkgJson,
+    pad512(pkgJson.length),
+    tarHeader("package/data.bin", PAYLOAD_SIZE, "0"),
+  ]);
+  const tail = Buffer.alloc(1024, 0); // two zero blocks = end-of-archive
 
-  await writeTar(tarHeader("package/package.json", pkgJson.length, "0"));
-  await writeTar(pkgJson);
-  await writeTar(pad512(pkgJson.length));
-  await writeTar(tarHeader("package/data.bin", PAYLOAD_SIZE, "0"));
-  for (let written = 0; written < PAYLOAD_SIZE; written += ZERO_CHUNK.length) {
-    await writeTar(ZERO_CHUNK);
-  }
-  await writeTar(Buffer.alloc(1024, 0)); // two zero blocks = end-of-archive
-  gzip.end();
-  await gzipDone;
+  const prefixBlock = deflateRawSync(prefix, { finishFlush: zconst.Z_FULL_FLUSH });
+  const zeroBlock = deflateRawSync(zeros, { level: 1, strategy: zconst.Z_RLE, finishFlush: zconst.Z_FULL_FLUSH });
+  const tailBlock = deflateRawSync(tail); // default Z_FINISH → BFINAL=1
 
-  const tgz = Buffer.concat(compressed);
+  let crc = crc32(prefix);
+  for (let i = 0; i < PAYLOAD_SIZE / BLOCK; i++) crc = crc32(zeros, crc);
+  crc = crc32(tail, crc);
+
+  const trailer = Buffer.alloc(8);
+  trailer.writeUInt32LE(crc >>> 0, 0);
+  trailer.writeUInt32LE((prefix.length + PAYLOAD_SIZE + tail.length) >>> 0, 4);
+
+  const parts: Buffer[] = [Buffer.from([0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0, 0, 0xff]), prefixBlock];
+  for (let i = 0; i < PAYLOAD_SIZE / BLOCK; i++) parts.push(zeroBlock);
+  parts.push(tailBlock, trailer);
+  const tgz = Buffer.concat(parts);
+  // The libdeflate preallocation path keys off the gzip ISIZE trailer;
+  // keeping it above the 64 MiB cutoff forces the zlib reader with the
+  // MAX_DECOMPRESSED_TARBALL_SIZE bound.
+  expect(trailer.readUInt32LE(4)).toBeGreaterThan(64 * 1024 * 1024);
   // Sanity: the download itself stays tiny even though it inflates far
   // past the cap — that is exactly the case the bound exists for.
   expect(tgz.length).toBeLessThan(8 * 1024 * 1024);

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -11,7 +11,7 @@ import { createHash, randomFillSync } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
-import { constants as zconst, crc32, deflateRawSync, gzipSync } from "node:zlib";
+import { crc32, deflateRawSync, gzipSync, constants as zconst } from "node:zlib";
 
 setDefaultTimeout(1000 * 60);
 

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -11,7 +11,7 @@ import { createHash, randomFillSync } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
-import { crc32, deflateRawSync, gzipSync, constants as zconst } from "node:zlib";
+import { crc32, deflateRawSync, gunzipSync, gzipSync, constants as zconst } from "node:zlib";
 
 setDefaultTimeout(1000 * 60);
 
@@ -658,6 +658,14 @@ test.concurrent("buffered extract rejects a registry tarball whose decompressed 
   // Sanity: the download itself stays tiny even though it inflates far
   // past the cap — that is exactly the case the bound exists for.
   expect(tgz.length).toBeLessThan(8 * 1024 * 1024);
+  // Sanity: the hand-assembled stream must be valid gzip. A bounded
+  // gunzip throws ERR_BUFFER_TOO_LARGE when a valid stream exceeds the
+  // limit but a zlib data/format error when the stream is malformed;
+  // both would surface below as the same `decompressing "oversized-pkg"`
+  // line, so this pins the failure mode to the 2 GiB cap.
+  expect(() => gunzipSync(tgz, { maxOutputLength: 4 * 1024 * 1024 })).toThrow(
+    expect.objectContaining({ code: "ERR_BUFFER_TOO_LARGE" }),
+  );
   const shasum = createHash("sha1").update(tgz).digest("hex");
   const integrity = "sha512-" + createHash("sha512").update(tgz).digest("base64");
 


### PR DESCRIPTION
Three test-only changes that take this file from **65.3s to 10.1s** locally on a debug+ASAN build (and 9.0s to 4.7s on a release build), with no tests removed, skipped, or weakened.

## What was slow

| phase | before | after |
| --- | --- | --- |
| `makeEntries()` (describe scope) | 5.7 s | ~5 ms |
| oversized-decompress fixture | ~35 s | ~0.5 s |
| `bun install` subprocesses | serial | concurrent |
| **file total (debug+asan)** | **65.3 s** | **10.1 s** |

## Changes

### 1. `randomFillSync` for the bulk entries
The SHA-chained filler ran ~73k `sha256` digests to produce 2.25 MB of incompressible bytes. `randomFillSync` yields equally incompressible bytes in a single syscall. The extraction check compares the installed files against the very buffers held in `entries`, so per-run nondeterminism is fine; there are no content snapshots.

### 2. Build the oversized-decompress tarball from a repeated deflate block
The 2 GiB decompression-cap test previously piped 2.25 GiB of zeros through `createGzip({ level: 9 })`, which cost ~35 s under ASAN just to build the ~2.2 MB fixture. It now deflates one 64 MiB block of zeros with `Z_FULL_FLUSH` (which resets the dictionary so the block is self-contained), concatenates it 36 times between a non-final prefix block and a `BFINAL` tail, and wraps the result in a hand-written gzip header plus a `crc32`/ISIZE trailer computed incrementally. Same 2.24 MB `.tgz`, same 2.25 GiB inflated tar, same assertions.

### 3. Run the suite concurrently
Each test already owns its own `port: 0` registry, its own `tempDir`, and its own `bun install` subprocess. `describe.concurrent` / `test.concurrent` overlap the nine independent installs.

## Assertion improvements
- Integrity-mismatch test now also asserts that `node_modules/stream-pkg/package.json` does **not** exist, so a regression that promotes the streamed temp tree despite the hash failure is caught directly rather than inferred from the exit code.
- Oversized-decompress test now pins the hand-built fixture's shape: `BFINAL=0` and the `00 00 ff ff` reset marker on both concatenated blocks (so a future sync-deflate change that stops honouring `finishFlush` fails at the source), an ISIZE-above-64-MiB check (keeps extraction on the bounded zlib reader), and a bounded `gunzipSync(tgz, { maxOutputLength })` that must throw `ERR_BUFFER_TOO_LARGE` rather than a zlib data error (proves the stream is valid gzip, so the install failure is the 2 GiB cap and not a malformed stream; both surface as the same `ZlibError decompressing ...` line otherwise).
- `setDefaultTimeout` lowered from 5 min to 60 s now that the slowest case is ~4 s.

## Verification

```
# before (main)
$ time bun bd test test/cli/install/bun-install-streaming-extract.test.ts
Ran 9 tests across 1 file. [65.31s]
real    1m8.432s

# after (this branch)
$ time bun bd test test/cli/install/bun-install-streaming-extract.test.ts
Ran 9 tests across 1 file. [10.12s]
real    0m11.172s
```

Three back-to-back runs on this branch all pass in 9.6-10.2 s with 405 `expect()` calls (up from 400).

Note: #33704 also touches this file but does so by deleting the tiny-first-chunk and drain-threshold tests; this PR keeps every test.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/bun-install-streaming-extract.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/bun-install-streaming-extract.test.ts
bun test v1.4.0 (bc32b31df)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > streaming extract succeeds when the first chunk is smaller than the gzip header [1146.84ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (default) [907.00ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [2596.79ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [2615.31ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [3190.95ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [3239.50ms]
(pass) buffered extract: damaged-block retry resets header state (upstream semantics) [797.90ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (override) [1674.99ms]
(pass) buffered extract rejects a registry tarball whose decompressed size exceeds the limit [3855.35ms]

 9 pass
 0 fail
 405 expect() calls
Ran 9 tests across 1 file. [10.38s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../install/bun-install-streaming-extract.test.ts  | 102 +++++++++++++--------
 1 file changed, 63 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
test/cli/install/bun-install-streaming-extract.test.ts      3      9      0
```

</details>

<!-- robobun:evidence:end -->