### PR TITLE
test: make sourcetextmodule-leak actually detect leaks and run 5x faster

### DIFF
--- a/test/js/node/vm/sourcetextmodule-leak.test.ts
+++ b/test/js/node/vm/sourcetextmodule-leak.test.ts
@@ -1,33 +1,53 @@
 const vm = require("vm");
 const { describe, it, expect } = require("bun:test");
-const { isASAN, isDebug } = require("harness");
+const { isASAN, isDebug, expectMaxObjectTypeCount } = require("harness");
+const { heapStats } = require("bun:jsc");
 
-// 50k×50KB ≈ 2.5 GB of source text — if module records leak their source we
-// blow past the threshold. Debug builds parse/link ~50× slower, so scale down.
-// ASAN's quarantine raises the RSS floor; keep a wide-but-bounded ceiling there.
-const ITERATIONS = isDebug ? 2_000 : 50_000;
-const THRESHOLD_MB = isDebug ? (isASAN ? 1500 : 300) : isASAN ? 3500 : 3000;
+// Each module carries ~50 KB of source so a retained SourceProvider shows up in
+// RSS. A full GC after every batch bounds the no-leak RSS to roughly one batch
+// of outstanding work; without that, the allocator's high-water mark dominates
+// and the leak and no-leak RSS end up within noise of each other (50k iters on
+// release both landed ~2.7 GB, under the old 3 GB threshold).
+//
+// Debug builds parse/link ~25× slower, so scale iterations down there. The
+// object-count check at the end is the authoritative leak signal: it is exact
+// and unaffected by ASAN's ~256 MB quarantine, which otherwise absorbs freed
+// pages and makes the RSS delta under-report on sanitized lanes.
+const ITERATIONS = isDebug ? 400 : 8_000;
+const BATCH = isDebug ? 50 : 500;
+// No-leak RSS settles at ~110-130 MB release / ~30 MB debug with the batch GC;
+// a per-module leak adds ~55 KB each (~430 MB at 8k iters). ASAN's quarantine
+// raises the floor by up to 256 MB regardless of leak state.
+const THRESHOLD_MB = isASAN ? 600 : 256;
 
 describe("vm.SourceTextModule", () => {
   it(
     "shouldn't leak memory",
     async () => {
+      const baseline = heapStats().objectTypeCounts.NodeVMSourceTextModule ?? 0;
       const initialUsage = process.memoryUsage.rss();
 
       {
-        const source = `/*\n${Buffer.alloc(50_000, " * aaaaa\n").toString("utf8")}\n*/ Buffer.alloc(10, 'hello');`;
+        const source = `/*\n${Buffer.alloc(50_000, " * aaaaa\n").toString("utf8")}\n*/ export const result = Buffer.alloc(10, 'hello').toString();`;
 
+        let last;
         async function go(i) {
           const mod = new vm.SourceTextModule(source + "//" + i, {
             identifier: Buffer.alloc(64, i.toString()).toString("utf8"),
           });
           await mod.link(() => {});
           await mod.evaluate();
+          last = mod;
         }
 
         for (let i = 0; i < ITERATIONS; ++i) {
           await go(i);
+          if ((i + 1) % BATCH === 0) Bun.gc(true);
         }
+
+        expect(last.status).toBe("evaluated");
+        expect(last.namespace.result).toBe("hellohello");
+        last = undefined;
       }
 
       Bun.gc(true);
@@ -35,7 +55,9 @@ describe("vm.SourceTextModule", () => {
       const finalUsage = process.memoryUsage.rss();
       const megabytes = Math.round(((finalUsage - initialUsage) / 1024 / 1024) * 100) / 100;
       expect(megabytes).toBeLessThan(THRESHOLD_MB);
+
+      await expectMaxObjectTypeCount(expect, "NodeVMSourceTextModule", baseline + 20);
     },
-    isDebug ? 60_000 : 30_000,
+    isDebug ? 30_000 : 15_000,
   );
 });


### PR DESCRIPTION
### What does this PR do?

`test/js/node/vm/sourcetextmodule-leak.test.ts` takes ~23 s on the linux x64-asan lane and ~8 s everywhere else, and in its current form cannot detect the leak it was written for.

**The existing test never fails on a leak.** With every one of the 50 000 modules artificially retained, release RSS lands at ~2738 MB versus ~2672 MB with nothing retained; both sit under the 3000 MB threshold. The loop never GCs, so the allocator's high-water mark dominates and retained vs freed pages end up in the same resident set. The debug/ASAN branch is the same story (130 MB retained vs 76 MB freed, threshold 1500 MB).

This change:

- forces a full GC after every batch so no-leak RSS is bounded to roughly one batch of outstanding work (~120 MB release, ~30 MB debug) instead of tracking total allocations,
- cuts iterations 50 000 → 8 000 (release) / 2 000 → 400 (debug) now that the per-iteration leak signal (~55 KB) is visible,
- adds an exact `NodeVMSourceTextModule` object-count assertion via `expectMaxObjectTypeCount`, which is immune to ASAN's ~256 MB quarantine that otherwise masks RSS deltas on sanitized lanes,
- asserts the last module's `status` and an exported `namespace.result` so the loop is verified to have linked and evaluated, not just allocated,
- tightens the RSS threshold from 3000/3500 MB to 256/600 MB.

### How did you verify your code works?

Timed locally, five runs each:

| build | before | after |
| --- | --- | --- |
| release | 9.8 s | 1.7–2.0 s |
| debug+ASAN (`bun bd`) | 11.5 s | 2.8–3.2 s |

Leak-sensitivity check: a copy of each variant with `leaked.push(mod)` injected into the loop.

| build | old test | new test |
| --- | --- | --- |
| release | **passes** (2738 MB < 3000 MB) | fails (`447.62` MB ≥ 256 MB) |
| debug+ASAN | **passes** (130 MB < 1500 MB) | fails (400 `NodeVMSourceTextModule` > 20) |

#33704 also reduces this file's release iteration count (50k → 20k) as part of a broader sweep; this change supersedes that hunk with a redesign that fixes the detection gap as well as the runtime.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/vm/sourcetextmodule-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/vm/sourcetextmodule-leak.test.ts
bun test v1.4.0 (3a5993309)

test/js/node/vm/sourcetextmodule-leak.test.ts:
(pass) vm.SourceTextModule > shouldn't leak memory [3133.28ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [5.73s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/vm/sourcetextmodule-leak.test.ts | 38 +++++++++++++++++++++------
 1 file changed, 30 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/node/vm/sourcetextmodule-leak.test.ts      1      1      0
```

</details>

**self-review** · no surviving concerns

32 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->