### PR TITLE
Bun.CookieMap: validate before mutating in delete(), accept any existing key, O(1) lookup

### DIFF
--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -135,8 +135,7 @@ std::optional<String> CookieMap::get(const String& name) const
 
     if (auto it = m_modifiedIndex.find(name); it != m_modifiedIndex.end()) {
         const auto& cookie = m_modifiedCookies[it->value];
-        // A set cookie with an empty value is treated as absent, because that is what
-        // delete() queues as its Set-Cookie tombstone.
+        // delete() queues an empty-value tombstone; treat it as absent.
         if (cookie->value().isEmpty())
             return std::nullopt;
         return cookie->value();
@@ -175,8 +174,6 @@ void CookieMap::removeOriginal(const String& name)
 
 void CookieMap::setModified(const String& name, RefPtr<Cookie>&& cookie)
 {
-    // Reuse an existing slot so repeated set()/delete() on one name does not
-    // accumulate tombstones; live Set-Cookie order is first-write position.
     if (auto it = m_modifiedIndex.find(name); it != m_modifiedIndex.end()) {
         m_modifiedCookies[it->value] = WTF::move(cookie);
         if (!m_modifiedCookies[it->value])
@@ -209,10 +206,7 @@ ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
 
     removeOriginal(name);
 
-    // The Cookie-header parser accepts names that the Set-Cookie emission grammar
-    // (isValidCookieName) rejects. Such a cookie is still evicted above; there is no
-    // well-formed Set-Cookie header we could emit to clear it on the client, so drop
-    // any earlier modified entry and queue nothing.
+    // Names the parser accepts but the Set-Cookie grammar rejects: evict, queue nothing.
     if (!Cookie::isValidCookieName(name)) {
         setModified(name, nullptr);
         return {};

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -204,17 +204,19 @@ ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
     if (!Cookie::isValidCookieDomain(domain))
         return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
 
-    removeOriginal(name);
-
     // Names the parser accepts but the Set-Cookie grammar rejects: evict, queue nothing.
     if (!Cookie::isValidCookieName(name)) {
+        removeOriginal(name);
         setModified(name, nullptr);
         return {};
     }
 
     bool secure = name.startsWithIgnoringASCIICase("__Secure-"_s) || name.startsWithIgnoringASCIICase("__Host-"_s);
     auto cookieOr = Cookie::create(name, ""_s, domain, path, 1, secure, CookieSameSite::Lax, false, std::numeric_limits<double>::quiet_NaN(), false);
-    ASSERT(!cookieOr.hasException());
+    if (cookieOr.hasException()) [[unlikely]]
+        return cookieOr.releaseException();
+
+    removeOriginal(name);
     setModified(name, cookieOr.releaseReturnValue());
     return {};
 }

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -54,14 +54,12 @@ CookieMap::CookieMap()
 {
 }
 
-CookieMap::CookieMap(Vector<Ref<Cookie>>&& cookies)
-    : m_modifiedCookies(WTF::move(cookies))
-{
-}
-
 CookieMap::CookieMap(Vector<KeyValuePair<String, String>>&& cookies)
     : m_originalCookies(WTF::move(cookies))
 {
+    for (size_t i = 0; i < m_originalCookies.size(); ++i) {
+        m_originalIndex.add(m_originalCookies[i].key, Vector<size_t> {}).iterator->value.append(i);
+    }
 }
 
 ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>>, HashMap<String, String>, String>&& variant, bool throwOnInvalidCookieString)
@@ -132,36 +130,34 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
 
 std::optional<String> CookieMap::get(const String& name) const
 {
-    auto modifiedCookieIndex = m_modifiedCookies.findIf([&](auto& cookie) {
-        return cookie->name() == name;
-    });
-    if (modifiedCookieIndex != notFound) {
-        // a set cookie with an empty value is treated as not existing, because that is what delete() sets
-        if (m_modifiedCookies[modifiedCookieIndex]->value().isEmpty()) {
+    if (name.isNull())
+        return std::nullopt;
+
+    if (auto it = m_modifiedIndex.find(name); it != m_modifiedIndex.end()) {
+        const auto& cookie = m_modifiedCookies[it->value];
+        // A set cookie with an empty value is treated as absent, because that is what
+        // delete() queues as its Set-Cookie tombstone.
+        if (cookie->value().isEmpty())
             return std::nullopt;
-        }
-        return std::optional<String>(m_modifiedCookies[modifiedCookieIndex]->value());
+        return cookie->value();
     }
-    auto originalCookieIndex = m_originalCookies.findIf([&](auto& cookie) {
-        return cookie.key == name;
-    });
-    if (originalCookieIndex != notFound) {
-        return std::optional<String>(m_originalCookies[originalCookieIndex].value);
+
+    if (auto it = m_originalIndex.find(name); it != m_originalIndex.end()) {
+        return m_originalCookies[it->value.first()].value;
     }
+
     return std::nullopt;
 }
 
-Vector<KeyValuePair<String, String>> CookieMap::getAll() const
+Vector<Ref<Cookie>> CookieMap::getAllChanges() const
 {
-    Vector<KeyValuePair<String, String>> all;
-    for (const auto& cookie : m_modifiedCookies) {
-        if (cookie->value().isEmpty()) continue;
-        all.append(KeyValuePair<String, String>(cookie->name(), cookie->value()));
+    Vector<Ref<Cookie>> result;
+    result.reserveInitialCapacity(m_modifiedIndex.size());
+    for (auto& cookie : m_modifiedCookies) {
+        if (cookie)
+            result.append(*cookie);
     }
-    for (const auto& cookie : m_originalCookies) {
-        all.append(KeyValuePair<String, String>(cookie.key, cookie.value));
-    }
-    return all;
+    return result;
 }
 
 bool CookieMap::has(const String& name) const
@@ -171,38 +167,54 @@ bool CookieMap::has(const String& name) const
 
 void CookieMap::removeInternal(const String& name)
 {
-    // Remove any existing matching cookies
-    m_originalCookies.removeAllMatching([&](auto& cookie) {
-        return cookie.key == name;
-    });
-    m_modifiedCookies.removeAllMatching([&](auto& cookie) {
-        return cookie->name() == name;
-    });
+    if (name.isNull())
+        return;
+
+    if (auto indices = m_originalIndex.takeOptional(name)) {
+        for (auto i : *indices)
+            m_originalCookies[i].key = String();
+    }
+
+    if (auto index = m_modifiedIndex.takeOptional(name)) {
+        m_modifiedCookies[*index] = nullptr;
+    }
+}
+
+void CookieMap::appendModified(Ref<Cookie>&& cookie)
+{
+    m_modifiedIndex.set(cookie->name(), m_modifiedCookies.size());
+    m_modifiedCookies.append(WTF::move(cookie));
 }
 
 void CookieMap::set(Ref<Cookie> cookie)
 {
     removeInternal(cookie->name());
-    // Add the new cookie
-    m_modifiedCookies.append(WTF::move(cookie));
+    appendModified(WTF::move(cookie));
 }
 
 ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
 {
-    removeInternal(options.name);
+    const String& name = options.name;
+    const String& domain = options.domain;
+    const String& path = options.path;
 
-    String name = options.name;
-    String domain = options.domain;
-    String path = options.path;
+    if (!Cookie::isValidCookiePath(path))
+        return Exception { TypeError, "Invalid cookie path: contains invalid characters"_s };
+    if (!Cookie::isValidCookieDomain(domain))
+        return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
+
+    removeInternal(name);
+
+    // The Cookie-header parser accepts names that the Set-Cookie emission grammar
+    // (isValidCookieName) rejects. Such a cookie is still evicted from the map above;
+    // there is no well-formed Set-Cookie header we could emit to clear it on the client.
+    if (!Cookie::isValidCookieName(name))
+        return {};
+
     bool secure = name.startsWithIgnoringASCIICase("__Secure-"_s) || name.startsWithIgnoringASCIICase("__Host-"_s);
-
-    // Add the new cookie
-    auto cookie_exception = Cookie::create(name, ""_s, domain, path, 1, secure, CookieSameSite::Lax, false, std::numeric_limits<double>::quiet_NaN(), false);
-    if (cookie_exception.hasException()) {
-        return cookie_exception.releaseException();
-    }
-    auto cookie = cookie_exception.releaseReturnValue();
-    m_modifiedCookies.append(WTF::move(cookie));
+    auto cookieOr = Cookie::create(name, ""_s, domain, path, 1, secure, CookieSameSite::Lax, false, std::numeric_limits<double>::quiet_NaN(), false);
+    ASSERT(!cookieOr.hasException());
+    appendModified(cookieOr.releaseReturnValue());
     return {};
 }
 
@@ -211,18 +223,22 @@ Ref<CookieMap> CookieMap::clone()
     auto clone = adoptRef(*new CookieMap());
     clone->m_originalCookies = m_originalCookies;
     clone->m_modifiedCookies = m_modifiedCookies;
+    clone->m_originalIndex = m_originalIndex;
+    clone->m_modifiedIndex = m_modifiedIndex;
     return clone;
 }
 
-size_t
-CookieMap::size() const
+size_t CookieMap::size() const
 {
     size_t size = 0;
-    for (const auto& cookie : m_modifiedCookies) {
-        if (cookie->value().isEmpty()) continue;
-        size += 1;
+    for (const auto& cookie : m_originalCookies) {
+        if (!cookie.key.isNull())
+            size += 1;
     }
-    size += m_originalCookies.size();
+    for (const auto& entry : m_modifiedIndex) {
+        if (!m_modifiedCookies[entry.value]->value().isEmpty())
+            size += 1;
+    }
     return size;
 }
 
@@ -231,24 +247,22 @@ JSC::JSValue CookieMap::toJSON(JSC::JSGlobalObject* globalObject) const
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Create an object to hold cookie key-value pairs
     auto* object = JSC::constructEmptyObject(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     HashSet<String> seenKeys;
 
-    // Add modified cookies to the object
     for (const auto& cookie : m_modifiedCookies) {
-        if (!cookie->value().isEmpty()) {
+        if (cookie && !cookie->value().isEmpty()) {
             seenKeys.add(cookie->name());
             object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, cookie->name()), JSC::jsString(vm, cookie->value()));
             RETURN_IF_EXCEPTION(scope, {});
         }
     }
 
-    // Add original cookies to the object
     for (const auto& cookie : m_originalCookies) {
-        // Skip if this cookie name was already added from modified cookies
+        if (cookie.key.isNull())
+            continue;
         if (seenKeys.add(cookie.key).isNewEntry) {
             object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, cookie.key), JSC::jsString(vm, cookie.value));
             RETURN_IF_EXCEPTION(scope, {});
@@ -266,25 +280,29 @@ size_t CookieMap::memoryCost() const
         cost += cookie.value.sizeInBytes();
     }
     for (auto& cookie : m_modifiedCookies) {
+        if (!cookie)
+            continue;
         cost += cookie->name().sizeInBytes();
         cost += cookie->value().sizeInBytes();
     }
+    cost += m_originalIndex.capacity() * (sizeof(String) + sizeof(Vector<size_t>));
+    cost += m_modifiedIndex.capacity() * (sizeof(String) + sizeof(size_t));
     return cost;
 }
 
 std::optional<KeyValuePair<String, String>> CookieMap::Iterator::next()
 {
-    while (m_index < m_target->m_modifiedCookies.size() + m_target->m_originalCookies.size()) {
-        if (m_index >= m_target->m_modifiedCookies.size()) {
-            return m_target->m_originalCookies[(m_index++) - m_target->m_modifiedCookies.size()];
-        }
-
-        auto result = m_target->m_modifiedCookies[m_index++];
-        if (result->value().isEmpty()) {
-            continue; // deleted; skip
-        }
-
-        return KeyValuePair<String, String>(result->name(), result->value());
+    while (m_modifiedIndex < m_target->m_modifiedCookies.size()) {
+        const auto& cookie = m_target->m_modifiedCookies[m_modifiedIndex++];
+        if (!cookie || cookie->value().isEmpty())
+            continue;
+        return KeyValuePair<String, String>(cookie->name(), cookie->value());
+    }
+    while (m_originalIndex < m_target->m_originalCookies.size()) {
+        const auto& pair = m_target->m_originalCookies[m_originalIndex++];
+        if (pair.key.isNull())
+            continue;
+        return pair;
     }
     return std::nullopt;
 }

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -165,31 +165,35 @@ bool CookieMap::has(const String& name) const
     return get(name).has_value();
 }
 
-void CookieMap::removeInternal(const String& name)
+void CookieMap::removeOriginal(const String& name)
 {
-    if (name.isNull())
-        return;
-
     if (auto indices = m_originalIndex.takeOptional(name)) {
         for (auto i : *indices)
             m_originalCookies[i].key = String();
     }
-
-    if (auto index = m_modifiedIndex.takeOptional(name)) {
-        m_modifiedCookies[*index] = nullptr;
-    }
 }
 
-void CookieMap::appendModified(Ref<Cookie>&& cookie)
+void CookieMap::setModified(const String& name, RefPtr<Cookie>&& cookie)
 {
-    m_modifiedIndex.set(cookie->name(), m_modifiedCookies.size());
+    // Reuse an existing slot so repeated set()/delete() on one name does not
+    // accumulate tombstones; live Set-Cookie order is first-write position.
+    if (auto it = m_modifiedIndex.find(name); it != m_modifiedIndex.end()) {
+        m_modifiedCookies[it->value] = WTF::move(cookie);
+        if (!m_modifiedCookies[it->value])
+            m_modifiedIndex.remove(it);
+        return;
+    }
+    if (!cookie)
+        return;
+    m_modifiedIndex.set(name, m_modifiedCookies.size());
     m_modifiedCookies.append(WTF::move(cookie));
 }
 
 void CookieMap::set(Ref<Cookie> cookie)
 {
-    removeInternal(cookie->name());
-    appendModified(WTF::move(cookie));
+    const String& name = cookie->name();
+    removeOriginal(name);
+    setModified(name, WTF::move(cookie));
 }
 
 ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
@@ -203,18 +207,21 @@ ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
     if (!Cookie::isValidCookieDomain(domain))
         return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
 
-    removeInternal(name);
+    removeOriginal(name);
 
     // The Cookie-header parser accepts names that the Set-Cookie emission grammar
-    // (isValidCookieName) rejects. Such a cookie is still evicted from the map above;
-    // there is no well-formed Set-Cookie header we could emit to clear it on the client.
-    if (!Cookie::isValidCookieName(name))
+    // (isValidCookieName) rejects. Such a cookie is still evicted above; there is no
+    // well-formed Set-Cookie header we could emit to clear it on the client, so drop
+    // any earlier modified entry and queue nothing.
+    if (!Cookie::isValidCookieName(name)) {
+        setModified(name, nullptr);
         return {};
+    }
 
     bool secure = name.startsWithIgnoringASCIICase("__Secure-"_s) || name.startsWithIgnoringASCIICase("__Host-"_s);
     auto cookieOr = Cookie::create(name, ""_s, domain, path, 1, secure, CookieSameSite::Lax, false, std::numeric_limits<double>::quiet_NaN(), false);
     ASSERT(!cookieOr.hasException());
-    appendModified(cookieOr.releaseReturnValue());
+    setModified(name, cookieOr.releaseReturnValue());
     return {};
 }
 

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -26,13 +26,10 @@ class CookieMap : public RefCounted<CookieMap> {
 public:
     ~CookieMap();
 
-    // Define a simple struct to hold the key-value pair
-
     static ExceptionOr<Ref<CookieMap>> create(std::variant<Vector<Vector<String>>, HashMap<String, String>, String>&& init, bool throwOnInvalidCookieString = true);
 
     std::optional<String> get(const String& name) const;
-    Vector<KeyValuePair<String, String>> getAll() const;
-    Vector<Ref<Cookie>> getAllChanges() const { return m_modifiedCookies; }
+    Vector<Ref<Cookie>> getAllChanges() const;
 
     bool has(const String& name) const;
 
@@ -54,7 +51,8 @@ public:
 
     private:
         Ref<CookieMap> m_target;
-        size_t m_index { 0 };
+        size_t m_modifiedIndex { 0 };
+        size_t m_originalIndex { 0 };
     };
 
     Iterator createIterator() { return Iterator { *this }; }
@@ -62,13 +60,22 @@ public:
 
 private:
     CookieMap();
-    CookieMap(Vector<Ref<Cookie>>&& cookies);
     CookieMap(Vector<KeyValuePair<String, String>>&& cookies);
 
     void removeInternal(const String& name);
+    void appendModified(Ref<Cookie>&&);
 
+    // Insertion-ordered storage. removeInternal() tombstones in place (null key / null
+    // RefPtr) so the hashed indices below stay valid; readers skip tombstones.
     Vector<KeyValuePair<String, String>> m_originalCookies;
-    Vector<Ref<Cookie>> m_modifiedCookies;
+    Vector<RefPtr<Cookie>> m_modifiedCookies;
+
+    // Name -> indices in m_originalCookies. A Cookie header may legally repeat a name;
+    // get() returns the first, remove() evicts all.
+    HashMap<String, Vector<size_t>> m_originalIndex;
+    // Name -> index in m_modifiedCookies. set()/remove() keep at most one live entry
+    // per name.
+    HashMap<String, size_t> m_modifiedIndex;
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -65,17 +65,12 @@ private:
     void removeOriginal(const String& name);
     void setModified(const String& name, RefPtr<Cookie>&&);
 
-    // Insertion-ordered storage. removeOriginal() tombstones in place (null key) so the
-    // hashed indices below stay valid; setModified() reuses an existing slot for the
-    // same name. Readers skip tombstones.
+    // Ordered storage; removed originals are tombstoned (null key) so indices stay valid.
     Vector<KeyValuePair<String, String>> m_originalCookies;
     Vector<RefPtr<Cookie>> m_modifiedCookies;
 
-    // Name -> indices in m_originalCookies. A Cookie header may legally repeat a name;
-    // get() returns the first, remove() evicts all.
+    // Name -> index. Originals may repeat a name (get() = first, remove() evicts all).
     HashMap<String, Vector<size_t>> m_originalIndex;
-    // Name -> index in m_modifiedCookies. set()/remove() keep at most one live entry
-    // per name.
     HashMap<String, size_t> m_modifiedIndex;
 };
 

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -62,11 +62,12 @@ private:
     CookieMap();
     CookieMap(Vector<KeyValuePair<String, String>>&& cookies);
 
-    void removeInternal(const String& name);
-    void appendModified(Ref<Cookie>&&);
+    void removeOriginal(const String& name);
+    void setModified(const String& name, RefPtr<Cookie>&&);
 
-    // Insertion-ordered storage. removeInternal() tombstones in place (null key / null
-    // RefPtr) so the hashed indices below stay valid; readers skip tombstones.
+    // Insertion-ordered storage. removeOriginal() tombstones in place (null key) so the
+    // hashed indices below stay valid; setModified() reuses an existing slot for the
+    // same name. Readers skip tombstones.
     Vector<KeyValuePair<String, String>> m_originalCookies;
     Vector<RefPtr<Cookie>> m_modifiedCookies;
 

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -556,9 +556,12 @@ describe("hashed lookup", () => {
     const N = 2000;
     const map = new Bun.CookieMap();
     for (let i = 0; i < N; i++) map.set("c" + i, "v" + i);
-    let ok = true;
-    for (let i = 0; i < N; i++) ok &&= map.get("c" + i) === "v" + i;
-    expect(ok).toBe(true);
+    const mismatches: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const got = map.get("c" + i);
+      if (got !== "v" + i) mismatches.push(`c${i}=${got}`);
+    }
+    expect(mismatches).toEqual([]);
     for (let i = 0; i < N; i++) map.delete("c" + i);
     expect(map.size).toBe(0);
     expect(map.toSetCookieHeaders().length).toBe(N);

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -372,8 +372,7 @@ describe("iterator", () => {
     for (const key of map.keys()) {
       map.delete(key);
     }
-    // expect(map.size).toBe(0);
-    expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+    expect(map.size).toBe(0);
   });
   test("delete in a loop with predefined entries", () => {
     const entries: [string, string][] = [];
@@ -398,8 +397,7 @@ describe("iterator", () => {
     for (const key of map.keys()) {
       map.delete(key);
     }
-    // expect(map.size).toBe(0);
-    expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+    expect(map.size).toBe(0);
   });
   test("basic iterator", () => {
     const cookies = new Bun.CookieMap({ a: "b", c: "d" });
@@ -464,5 +462,124 @@ describe("invalid delete usage", () => {
       // @ts-ignore
       v2.delete(v2);
     }).toThrow("Cookie name is required");
+  });
+});
+
+describe("delete() validates before mutating", () => {
+  test.each([
+    ["path", { path: "/;bad" }, "Invalid cookie path"],
+    ["domain", { domain: "bad domain" }, "Invalid cookie domain"],
+  ])("an invalid %s leaves a parsed entry in place and queues no Set-Cookie", (_, options, message) => {
+    const map = new Bun.CookieMap("session=tok; other=1");
+    expect(() => map.delete("session", options)).toThrow(message);
+    expect(map.toJSON()).toEqual({ session: "tok", other: "1" });
+    expect(map.has("session")).toBe(true);
+    expect(map.size).toBe(2);
+    expect(map.toSetCookieHeaders()).toEqual([]);
+  });
+
+  test.each([
+    ["path", { path: "/;bad" }, "Invalid cookie path"],
+    ["domain", { domain: "bad domain" }, "Invalid cookie domain"],
+  ])("an invalid %s leaves a set() entry in place", (_, options, message) => {
+    const map = new Bun.CookieMap();
+    map.set("session", "tok");
+    expect(() => map.delete({ name: "session", ...options })).toThrow(message);
+    expect(map.get("session")).toBe("tok");
+    expect(map.toSetCookieHeaders()).toEqual(["session=tok; Path=/; SameSite=Lax"]);
+  });
+
+  test("set() that throws on invalid options does not mutate the map", () => {
+    const map = new Bun.CookieMap("x=1");
+    expect(() => map.set("y", "v", { domain: "bad domain" })).toThrow("Invalid cookie domain");
+    expect(() => map.set("x", "replaced", { path: "/;bad" })).toThrow("Invalid cookie path");
+    expect([...map.entries()]).toEqual([["x", "1"]]);
+    expect(map.toSetCookieHeaders()).toEqual([]);
+  });
+});
+
+describe("delete() accepts any existing key", () => {
+  test("a name the Cookie-header parser accepted but isValidCookieName rejects is evicted without throwing", () => {
+    const map = new Bun.CookieMap("a b=1; ok=2");
+    expect(map.get("a b")).toBe("1");
+    expect(() => map.delete("a b")).not.toThrow();
+    expect(map.has("a b")).toBe(false);
+    expect([...map.entries()]).toEqual([["ok", "2"]]);
+    // No well-formed Set-Cookie tombstone can be emitted for such a name.
+    expect(map.toSetCookieHeaders()).toEqual([]);
+  });
+
+  test.each(["\u0001ctl", "x\u007f", "é", "name\u00a0"])(
+    "deleting a parsed cookie with unwritable name %j evicts it without throwing",
+    raw => {
+      const map = new Bun.CookieMap(`${raw}=1; ok=2`);
+      expect(map.get(raw)).toBe("1");
+      expect(() => map.delete(raw)).not.toThrow();
+      expect(map.toJSON()).toEqual({ ok: "2" });
+      expect(map.toSetCookieHeaders()).toEqual([]);
+    },
+  );
+
+  test("an unwritable name with an invalid path still throws without mutating", () => {
+    const map = new Bun.CookieMap("a b=1; ok=2");
+    expect(() => map.delete("a b", { path: "/;bad" })).toThrow("Invalid cookie path");
+    expect(map.get("a b")).toBe("1");
+    expect(map.toSetCookieHeaders()).toEqual([]);
+  });
+
+  test("deleting a writable name still queues a Set-Cookie tombstone", () => {
+    const map = new Bun.CookieMap("good=1");
+    map.delete("good");
+    expect(map.has("good")).toBe(false);
+    expect(map.toSetCookieHeaders()).toEqual(["good=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"]);
+  });
+
+  test("set()/new Cookie() keep rejecting unwritable names", () => {
+    const map = new Bun.CookieMap();
+    expect(() => map.set("a b", "1")).toThrow("Invalid cookie name");
+    expect(() => new Bun.Cookie("a b", "1")).toThrow("Invalid cookie name");
+  });
+});
+
+describe("hashed lookup", () => {
+  test("get()/set()/delete() stay correct over many keys", () => {
+    const N = 2000;
+    const map = new Bun.CookieMap();
+    for (let i = 0; i < N; i++) map.set("c" + i, "v" + i);
+    let ok = true;
+    for (let i = 0; i < N; i++) ok &&= map.get("c" + i) === "v" + i;
+    expect(ok).toBe(true);
+    for (let i = 0; i < N; i++) map.delete("c" + i);
+    expect(map.size).toBe(0);
+    expect(map.toSetCookieHeaders().length).toBe(N);
+  });
+
+  test("duplicate names in a Cookie header: get() returns the first, delete() evicts all", () => {
+    const map = new Bun.CookieMap("dup=first; k=v; dup=second");
+    expect(map.get("dup")).toBe("first");
+    expect(map.size).toBe(3);
+    map.delete("dup");
+    expect(map.has("dup")).toBe(false);
+    expect([...map.entries()]).toEqual([["k", "v"]]);
+    expect(map.size).toBe(1);
+  });
+
+  test("iteration, toJSON and toSetCookieHeaders skip entries removed mid-sequence", () => {
+    const map = new Bun.CookieMap("a=1; b=2; c=3");
+    map.set("d", "4");
+    map.delete("b");
+    map.set("e", "5");
+    expect([...map.entries()]).toEqual([
+      ["d", "4"],
+      ["e", "5"],
+      ["a", "1"],
+      ["c", "3"],
+    ]);
+    expect(map.toJSON()).toEqual({ a: "1", c: "3", d: "4", e: "5" });
+    expect(map.toSetCookieHeaders()).toEqual([
+      "d=4; Path=/; SameSite=Lax",
+      "b=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+      "e=5; Path=/; SameSite=Lax",
+    ]);
   });
 });

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -261,8 +261,8 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     // Get changes
     expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`
       [
-        "foo=bar; Path=/; Secure; HttpOnly; Partitioned; SameSite=Lax",
         "name=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+        "foo=bar; Path=/; Secure; HttpOnly; Partitioned; SameSite=Lax",
       ]
     `);
   });
@@ -542,6 +542,16 @@ describe("delete() accepts any existing key", () => {
 });
 
 describe("hashed lookup", () => {
+  test("repeated set()/delete() on one name reuses the Set-Cookie slot", () => {
+    const map = new Bun.CookieMap();
+    for (let i = 0; i < 1000; i++) map.set("x", String(i));
+    expect(map.toSetCookieHeaders()).toEqual(["x=999; Path=/; SameSite=Lax"]);
+    for (let i = 0; i < 1000; i++) map.delete("x");
+    expect(map.toSetCookieHeaders()).toEqual(["x=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"]);
+    map.set("x", "v");
+    expect(map.toSetCookieHeaders()).toEqual(["x=v; Path=/; SameSite=Lax"]);
+  });
+
   test("get()/set()/delete() stay correct over many keys", () => {
     const N = 2000;
     const map = new Bun.CookieMap();

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -262,8 +262,8 @@ describe("Bun.serve() cookies", () => {
     map.set("do_modify", "FIVE");
     expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`
       [
-        "do_delete=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
         "do_modify=FIVE; Path=/; SameSite=Lax",
+        "do_delete=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
       ]
     `);
     expect(map.toJSON()).toMatchInlineSnapshot(`

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -391,9 +391,11 @@ test("delete cookie invalid path option", () => {
   expect(() => map.delete("a", { domain: "\n" })).toThrowErrorMatchingInlineSnapshot(
     `"Invalid cookie domain: contains invalid characters"`,
   );
-  expect(() => map.delete("\n", {})).toThrowErrorMatchingInlineSnapshot(
-    `"Invalid cookie name: contains invalid characters"`,
-  );
+  // Deleting by a name the Set-Cookie grammar rejects removes any matching entry and
+  // queues no tombstone, rather than throwing; the Cookie-header parser accepts such
+  // names, so a throwing delete() would leave them unmanageable.
+  expect(() => map.delete("\n", {})).not.toThrow();
+  expect(map.toSetCookieHeaders()).toEqual([]);
 });
 
 describe("Bun.CookieMap constructor", () => {


### PR DESCRIPTION
Three related `Bun.CookieMap` fixes.

## delete() mutated before it validated

```js
const m = new Bun.CookieMap("session=tok; other=1");
try { m.delete("session", { path: "/;bad" }); } catch {}
m.has("session");          // false  (entry already evicted)
m.toSetCookieHeaders();    // []     (no deletion header queued)
```

`CookieMap::remove()` called `removeInternal(name)` before `Cookie::create(name, "", domain, path, ...)`, which is where name/path/domain are validated. A throwing delete() had therefore already evicted the entry without queuing the Set-Cookie tombstone, leaving the server-side map and the client out of sync. `set()` with the same invalid options threw without mutating, so only `delete()` was torn.

`remove()` now validates `path` and `domain` up front and returns the exception before any mutation.

## delete() rejected names the Cookie-header parser accepted

```js
const m = new Bun.CookieMap("a b=1; ok=2");
m.get("a b");              // "1"
m.delete("a b");           // threw "Invalid cookie name", entry already evicted
```

The Cookie-header parser accepts names (spaces, CTLs, DEL, 0x80-0xFF) that `isValidCookieName` (the Set-Cookie emission grammar) rejects. Such cookies were readable via `get()`/`has()` but could never be deleted, and the throwing `delete()` still half-evicted them.

`remove()` now evicts by name unconditionally (removal is not creation), and queues a Set-Cookie tombstone only when the name is emittable. `set()` and `new Bun.Cookie()` keep the strict name validator unchanged. No parser change.

## O(n) get/has/set/delete

```js
const m = new Bun.CookieMap();
for (let i = 0; i < 20000; i++) m.set("c" + i, "v");
for (let i = 0; i < 20000; i++) m.get("c" + i);
for (let i = 0; i < 20000; i++) m.delete("c" + i);
// before: ~10900 ms release; after: 21 ms release
```

`get()`/`has()`/`set()`/`delete()` each scanned the backing vectors linearly (`findIf` / `removeAllMatching`), so a loop over N cookies was O(n^2). Both vectors are now indexed by a `HashMap<String, ...>` keyed on the cookie name. Originals are tombstoned in place (null key) so indices stay valid; `set()`/`remove()` reuse an existing `m_modifiedCookies` slot for the same name rather than appending, so repeated writes to one key do not grow the vector. The `m_originalCookies` index maps to a `Vector<size_t>` because a Cookie header may legally repeat a name: `get()` returns the first, `delete()` evicts all.

The iterator now tracks separate cursors for the modified and original vectors, so `delete()` during iteration no longer skips half the entries. The two `iterator > delete in a loop` tests now end at `size === 0` (matching `Map`/`Set`), as the test comment had already asked for. Re-writing a name keeps its first-write position in `toSetCookieHeaders()` instead of moving to the end; two snapshots are updated accordingly.

Dead `CookieMap::getAll()` and the unused `Vector<Ref<Cookie>>` constructor are removed.

Supersedes #35908.

## Verification

New tests in `test/js/bun/cookie/cookie-map.test.ts` cover each face (invalid path/domain on both parsed and `set()` entries; deleting unwritable names across space/CTL/DEL/non-ASCII; duplicate-name Cookie header; correctness over 2000 keys; repeated same-key writes staying at one Set-Cookie header; iteration/toJSON/toSetCookieHeaders with mid-sequence removals). `test/js/bun/cookie/cookie.test.ts` is updated for the new delete-by-name policy and header order.

Without `src/` changes the new/updated tests fail; with them the full `test/js/bun/cookie/` suite (178 tests) and the `Bun.serve`/bake cookie tests pass.