### PR TITLE
test(http): speed up and de-flake serve-async-stream-client-abort.test.ts

### DIFF
--- a/test/js/bun/http/serve-async-stream-client-abort.test.ts
+++ b/test/js/bun/http/serve-async-stream-client-abort.test.ts
@@ -2,67 +2,73 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
+async function runFixture(name: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, name)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+}
+
+// Each test spawns an independent fixture subprocess (own server, own port 0),
+// so they run concurrently to overlap the debug/ASAN startup cost.
+
 // An async-rejecting fetch() whose error() handler returns a streaming
 // Response must not have that stream ended underneath it by handle_reject's
 // render_missing() fallback: that truncated the body on the happy path and,
 // after a client abort, left the sink pointing at a freed uWS response
 // (ASAN: heap-use-after-free in uws_res_has_responded via end_from_js).
-test("streaming error() response from an async-rejecting fetch is not ended by render_missing", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "serve-error-stream-client-abort-fixture.ts")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+test.concurrent(
+  "streaming error() response from an async-rejecting fetch is not ended by render_missing",
+  async () => {
+    const { stdout, stderr, exitCode, signalCode } = await runFixture("serve-error-stream-client-abort-fixture.ts");
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
-    stderr: "",
-    stdout: expect.stringContaining('"ok":true'),
-    exitCode: 0,
-    signalCode: null,
-  });
-}, 60_000);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      ok: true,
+      lateCloseResults: [
+        expect.stringContaining("Controller is already closed"),
+        expect.stringContaining("Controller is already closed"),
+        expect.stringContaining("Controller is already closed"),
+      ],
+    });
+    expect({ exitCode, signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  },
+  60_000,
+);
 
 // https://github.com/oven-sh/bun/issues/32111
-test("client aborting an async-pull ReadableStream response does not crash the server", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "serve-async-stream-client-abort-fixture.ts")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+test.concurrent(
+  "client aborting an async-pull ReadableStream response does not crash the server",
+  async () => {
+    const { stdout, stderr, exitCode, signalCode } = await runFixture("serve-async-stream-client-abort-fixture.ts");
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
-    stderr: "",
-    stdout: expect.stringContaining('"ok":true'),
-    exitCode: 0,
-    signalCode: null,
-  });
-}, 60_000);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout);
+    expect(result).toEqual({ ok: true, completed: expect.any(Number), aborted: expect.any(Number) });
+    expect(result.aborted).toBeGreaterThan(0);
+    expect(result.completed + result.aborted).toBe(600);
+    expect({ exitCode, signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  },
+  60_000,
+);
 
 // Client abort while a native-source ReadableStream body (subprocess stdout
 // pipe) has a pull in flight. The sink's abort fires the stream's onClose,
 // whose cancel drains microtasks and frees the sink; the rest of abort()
 // then ran on the freed allocation (ASAN: heap-use-after-free in
 // HTTPServerWritable::flush_promise).
-test("client aborting a native-source stream response does not use the sink after free", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "serve-native-stream-client-abort-fixture.ts")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+test.concurrent(
+  "client aborting a native-source stream response does not use the sink after free",
+  async () => {
+    const { stdout, stderr, exitCode, signalCode } = await runFixture("serve-native-stream-client-abort-fixture.ts");
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
-    stderr: "",
-    stdout: expect.stringContaining('"ok":true'),
-    exitCode: 0,
-    signalCode: null,
-  });
-}, 60_000);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ ok: true, aborted: 3 });
+    expect({ exitCode, signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  },
+  60_000,
+);

--- a/test/js/bun/http/serve-error-stream-client-abort-fixture.ts
+++ b/test/js/bun/http/serve-error-stream-client-abort-fixture.ts
@@ -6,15 +6,18 @@
 // (ASAN: heap-use-after-free in uws_res_has_responded).
 
 import net from "node:net";
+import { once } from "node:events";
 
 let resolveStarted!: () => void;
 let resumeProducer!: Promise<void>;
 let resolveOutcome!: (late: string) => void;
+let currentSignal!: AbortSignal;
 
 const server = Bun.serve({
   port: 0,
   development: false,
-  fetch: async () => {
+  fetch: async req => {
+    currentSignal = req.signal;
     throw new Error("boom");
   },
   error() {
@@ -23,11 +26,12 @@ const server = Bun.serve({
         async pull(c) {
           c.enqueue("EB");
           resolveStarted();
-          // Park until the driver releases us (after the client has RST'd on
-          // the abort path), then yield once more so uSockets' post-tick
-          // closed-socket sweep has run before the late controller touch.
+          // Park until the driver releases us. On the abort path the driver
+          // waits for req.signal to fire (server observed the RST) before
+          // releasing, so the sink is already detached by the time we resume;
+          // one more event-loop turn lets the detach microtask settle.
           await resumeProducer;
-          await Bun.sleep(1);
+          await Bun.sleep(0);
           try {
             c.enqueue("MORE");
             c.close();
@@ -70,17 +74,17 @@ const closedMsg = "Controller is already closed";
 const lateCloseResults: string[] = [];
 for (let i = 0; i < 3; i++) {
   const { started, releaseProducer, outcome } = armRequest();
-  await new Promise<void>((resolve, reject) => {
-    const s = net.connect(server.port, "127.0.0.1", () => {
-      s.write("GET /x HTTP/1.1\r\nHost: x\r\n\r\n");
-    });
-    s.once("data", () => {
-      s.resetAndDestroy();
-      resolve();
-    });
-    s.once("error", reject);
+  const s = net.connect(server.port, "127.0.0.1", () => {
+    s.write("GET /x HTTP/1.1\r\nHost: x\r\n\r\n");
   });
+  s.on("error", () => {});
+  await once(s, "data");
+  s.resetAndDestroy();
   await started;
+  // Releasing before the server has processed the RST would let the late
+  // enqueue land on a still-live sink (fixture flake: first iteration reports
+  // "ok"). req.signal's abort event is the server-side observation point.
+  if (!currentSignal.aborted) await once(currentSignal, "abort");
   releaseProducer();
   lateCloseResults.push(await outcome);
 }

--- a/test/js/bun/http/serve-native-stream-client-abort-fixture.ts
+++ b/test/js/bun/http/serve-native-stream-client-abort-fixture.ts
@@ -8,17 +8,22 @@
 // still executing. ASAN: heap-use-after-free in
 // HTTPServerWritable::flush_promise.
 
-const children: Bun.Subprocess[] = [];
+const children: Bun.Subprocess<"pipe", "pipe", "ignore">[] = [];
 
-// Writes a single chunk, then holds its stdout pipe open without writing.
-// The 30s timer is a backstop so nothing outlives a crashed run.
+// A subprocess whose stdout pipe emits one byte then stalls with the pipe held
+// open. Using `cat` on posix avoids a second debug/ASAN bun startup per
+// iteration (~1.5s each); the parent writes the byte to its stdin and cat
+// blocks on the next read until killed. Windows has no `cat` and no ASAN lane,
+// so it keeps a bun child that pipes stdin to stdout.
 function spawnStalledChild() {
   const child = Bun.spawn({
-    cmd: [process.execPath, "-e", 'process.stdout.write("x"); setTimeout(() => {}, 30_000)'],
+    cmd: process.platform === "win32" ? [process.execPath, "-e", "process.stdin.pipe(process.stdout)"] : ["cat"],
+    stdin: "pipe",
     stdout: "pipe",
-    stdin: "ignore",
     stderr: "ignore",
   });
+  child.stdin.write("x");
+  child.stdin.flush();
   children.push(child);
   return child;
 }


### PR DESCRIPTION
## What

Cuts `test/js/bun/http/serve-async-stream-client-abort.test.ts` from ~14 s to ~6 s under debug+ASAN and fixes a pre-existing ~30% flake in the error-stream fixture.

## Why it was slow

The file runs three tests, each spawning a fixture subprocess. Under debug+ASAN a `bun-debug` startup is ~1.5 s, and the native-stream fixture spawns three *more* `bun-debug` children just to obtain a stalled stdout pipe. That is six ASAN startups in series.

## Changes

- **All three tests run concurrently.** Each owns an independent subprocess with its own `port: 0` server, so there is no shared state.
- **native-stream fixture uses `cat` for the stalled child on posix.** The test only needs a subprocess stdout pipe (native-source `ReadableStream`) that emits one byte and then blocks. `cat` with a piped stdin is that, without a JS runtime boot per iteration. Windows keeps a bun child (`process.stdin.pipe(process.stdout)`): there is no `cat` there and no ASAN lane, so startup cost is not the bottleneck. Fixture time under ASAN: 4.2 s → 0.5 s.
- **error-stream fixture waits for `req.signal` instead of `Bun.sleep(1)`.** The abort-path loop released the parked producer after `resetAndDestroy()` plus a 1 ms sleep and hoped the server had processed the RST by then. On a loaded box the first iteration's late `enqueue()` often landed on a still-live sink and reported `"ok"` instead of the expected closed-controller error (4/30 solo runs, 5/15 runs of the unmodified test file on current main). `req.signal`'s `abort` event is the server-side observation point, so the driver now awaits it before releasing: 0/40 solo runs, 0/20 full-file runs after.
- **Assertions parse the fixture JSON.** Each test now checks the actual payload (`lateCloseResults` entries, `aborted`/`completed` counts, `aborted: 3`) instead of `expect.stringContaining('"ok":true')`, and asserts `stderr`/`exitCode`/`signalCode` separately so a failure names the field.

## Coverage

No tests removed or skipped. Iteration counts are unchanged. The native-stream repro mechanism is unchanged: the Response body is still a subprocess stdout pipe, which is the native-source `ReadableStream` path the original UAF was on.

## Timing (local, debug+ASAN)

```
before: Ran 3 tests across 1 file. [13.88s]   (wall 15.3 s)
after:  Ran 3 tests across 1 file. [ 6.20s]   (wall  6.5 s, 20/20 consecutive passes)
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/serve-async-stream-client-abort.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/serve-async-stream-client-abort.test.ts
bun test v1.4.0 (f73ce7dbe)

test/js/bun/http/serve-async-stream-client-abort.test.ts:
(pass) client aborting a native-source stream response does not use the sink after free [424.01ms]
(pass) streaming error() response from an async-rejecting fetch is not ended by render_missing [1678.21ms]
(pass) client aborting an async-pull ReadableStream response does not crash the server [2611.49ms]

 3 pass
 0 fail
 11 expect() calls
Ran 3 tests across 1 file. [4.72s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../http/serve-async-stream-client-abort.test.ts   | 100 +++++++++++----------
 .../serve-error-stream-client-abort-fixture.ts     |  32 ++++---
 .../serve-native-stream-client-abort-fixture.ts    |  15 ++--
 3 files changed, 81 insertions(+), 66 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/js/bun/http/serve-async-stream-client-abort.test.ts      1      1      0
…/js/bun/http/serve-error-stream-client-abort-fixture.ts      2      2      0
…js/bun/http/serve-native-stream-client-abort-fixture.ts      2      1      0
```

</details>

**self-review** · no surviving concerns

29 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->