### PR TITLE
Bun.Transpiler: encode string source as WTF-8 so unpaired surrogates survive

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1670,6 +1670,49 @@ pub(crate) mod strings_impl {
         convert_utf16_to_utf8(Vec::new(), utf16)
     }
 
+    /// WTF-8 sibling of [`to_utf8_alloc`]: unpaired surrogates are encoded as
+    /// their 3-byte WTF-8 sequence (via [`decode_wtf16_raw`]) instead of being
+    /// replaced with U+FFFD. Use this when the consumer is a WTF-8 reader
+    /// (e.g. the JS lexer) and must observe the same code units the JS engine
+    /// does. For well-formed UTF-16 the output is identical to [`to_utf8_alloc`].
+    pub fn to_wtf8_alloc(utf16: &[u16]) -> Vec<u8> {
+        let need = simdutf::length::utf8::from::utf16::le(utf16);
+        let mut list = Vec::with_capacity(need + 16);
+        // SAFETY: same contract as `convert_utf16_to_utf8_append` — simdutf
+        // writes only initialized bytes into the spare slice and reports the
+        // count; on SURROGATE we commit 0 and fall back to the scalar loop.
+        let r = unsafe {
+            crate::vec::fill_spare(&mut list, 0, |spare| {
+                let r = simdutf::simdutf__convert_utf16le_to_utf8_with_errors(
+                    utf16.as_ptr(),
+                    utf16.len(),
+                    spare.as_mut_ptr(),
+                );
+                (
+                    if r.status == simdutf::Status::SURROGATE {
+                        0
+                    } else {
+                        r.count
+                    },
+                    r,
+                )
+            })
+        };
+        if r.status == simdutf::Status::SURROGATE {
+            // A lone surrogate encodes to 3 WTF-8 bytes, same width as U+FFFD,
+            // so `need` above is already the exact size.
+            let mut i = 0usize;
+            let mut buf = [0u8; 4];
+            while i < utf16.len() {
+                let (cp, adv) = decode_wtf16_raw(&utf16[i..]);
+                i += adv as usize;
+                let n = encode_wtf8_rune(&mut buf, cp);
+                list.extend_from_slice(&buf[..n]);
+            }
+        }
+        list
+    }
+
     /// Transcode raw UTF-16-LE *bytes* (no alignment requirement) to a fresh
     /// UTF-8 `Vec`.
     ///

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1670,8 +1670,7 @@ pub(crate) mod strings_impl {
         convert_utf16_to_utf8(Vec::new(), utf16)
     }
 
-    /// WTF-8 sibling of [`to_utf8_alloc`]: unpaired surrogates are passed
-    /// through via [`decode_wtf16_raw`] instead of replaced with U+FFFD.
+    /// [`to_utf8_alloc`] but unpaired surrogates are kept as WTF-8, not replaced with U+FFFD.
     pub fn to_wtf8_alloc(utf16: &[u16]) -> Vec<u8> {
         // 3 bytes per unpaired surrogate == WTF-8 width, so `need` is exact.
         let need = simdutf::length::utf8::from::utf16::le_with_replacement(utf16);

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1676,7 +1676,9 @@ pub(crate) mod strings_impl {
     /// (e.g. the JS lexer) and must observe the same code units the JS engine
     /// does. For well-formed UTF-16 the output is identical to [`to_utf8_alloc`].
     pub fn to_wtf8_alloc(utf16: &[u16]) -> Vec<u8> {
-        let need = simdutf::length::utf8::from::utf16::le(utf16);
+        // `le_with_replacement` charges 3 bytes per unpaired surrogate, which
+        // is also the WTF-8 width, so `need` is exact for both paths below.
+        let need = simdutf::length::utf8::from::utf16::le_with_replacement(utf16);
         let mut list = Vec::with_capacity(need + 16);
         // SAFETY: same contract as `convert_utf16_to_utf8_append` — simdutf
         // writes only initialized bytes into the spare slice and reports the
@@ -1699,8 +1701,6 @@ pub(crate) mod strings_impl {
             })
         };
         if r.status == simdutf::Status::SURROGATE {
-            // A lone surrogate encodes to 3 WTF-8 bytes, same width as U+FFFD,
-            // so `need` above is already the exact size.
             let mut i = 0usize;
             let mut buf = [0u8; 4];
             while i < utf16.len() {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1670,14 +1670,10 @@ pub(crate) mod strings_impl {
         convert_utf16_to_utf8(Vec::new(), utf16)
     }
 
-    /// WTF-8 sibling of [`to_utf8_alloc`]: unpaired surrogates are encoded as
-    /// their 3-byte WTF-8 sequence (via [`decode_wtf16_raw`]) instead of being
-    /// replaced with U+FFFD. Use this when the consumer is a WTF-8 reader
-    /// (e.g. the JS lexer) and must observe the same code units the JS engine
-    /// does. For well-formed UTF-16 the output is identical to [`to_utf8_alloc`].
+    /// WTF-8 sibling of [`to_utf8_alloc`]: unpaired surrogates are passed
+    /// through via [`decode_wtf16_raw`] instead of replaced with U+FFFD.
     pub fn to_wtf8_alloc(utf16: &[u16]) -> Vec<u8> {
-        // `le_with_replacement` charges 3 bytes per unpaired surrogate, which
-        // is also the WTF-8 width, so `need` is exact for both paths below.
+        // 3 bytes per unpaired surrogate == WTF-8 width, so `need` is exact.
         let need = simdutf::length::utf8::from::utf16::le_with_replacement(utf16);
         let mut list = Vec::with_capacity(need + 16);
         // SAFETY: same contract as `convert_utf16_to_utf8_append` — simdutf

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2277,6 +2277,7 @@ pub use crate::strings_impl::{
     allocate_latin1_into_utf8_with_list, convert_utf16_to_utf8, convert_utf16_to_utf8_append,
     encode_wtf8_rune, is_all_ascii, latin1_to_codepoint_bytes_assume_not_ascii, narrow_ascii_u16,
     to_utf8_alloc, to_utf8_alloc_from_le_bytes, to_utf8_append_to_list, to_utf8_from_latin1,
+    to_wtf8_alloc,
 };
 
 #[inline]

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -146,6 +146,24 @@ fn clone_macro_map(src: &MacroMap) -> MacroMap {
     out
 }
 
+/// Source-code flavoured [`StringOrBuffer::from_js`]: a JS string backed by
+/// 16-bit storage is encoded as WTF-8 (unpaired surrogates preserved) so the
+/// lexer, which reads WTF-8, sees the same code units `eval` would. 8-bit
+/// strings and array buffers cannot carry a lone surrogate and take the
+/// normal path.
+fn source_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<StringOrBuffer>> {
+    if value.is_string() {
+        let str = OwnedString::new(BunString::from_js(value, global)?);
+        if str.is_utf16() {
+            let bytes = bun_core::strings::to_wtf8_alloc(str.utf16());
+            return Ok(Some(StringOrBuffer::EncodedSlice(
+                bun_core::ZigStringSlice::init_owned(bytes),
+            )));
+        }
+    }
+    StringOrBuffer::from_js(global, value)
+}
+
 const PROP_ITER_OPTS: JSPropertyIteratorOptions = JSPropertyIteratorOptions {
     skip_empty_name: true,
     include_value: true,
@@ -1311,7 +1329,7 @@ impl JSTranspiler {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
 
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+        let Some(code_holder) = source_from_js(global, code_arg)? else {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
         // defer code_holder.deinit() → Drop
@@ -1402,21 +1420,36 @@ impl JSTranspiler {
         };
 
         let allow_string_object = true;
-        let Some(code) = StringOrBuffer::from_js_with_encoding_maybe_async(
-            global,
-            code_arg,
-            Encoding::Utf8,
-            true,
-            allow_string_object,
-        )?
-        else {
+        let code = if code_arg.is_string() {
+            // 16-bit strings go through the WTF-8 encoder so unpaired
+            // surrogates survive; 8-bit strings cannot carry any. Either way
+            // the result is an owned `Vec<u8>`, already thread-safe.
+            let str = OwnedString::new(BunString::from_js(code_arg, global)?);
+            let bytes = if str.is_utf16() {
+                bun_core::strings::to_wtf8_alloc(str.utf16())
+            } else {
+                str.to_utf8_bytes()
+            };
+            global.vm().report_extra_memory(bytes.len());
+            Some(StringOrBuffer::EncodedSlice(
+                bun_core::ZigStringSlice::init_owned(bytes),
+            ))
+        } else {
+            StringOrBuffer::from_js_with_encoding_maybe_async(
+                global,
+                code_arg,
+                Encoding::Utf8,
+                true,
+                allow_string_object,
+            )?
+        };
+        let Some(mut code) = code else {
             return Err(global.throw_invalid_argument_type(
                 "transform",
                 "code",
                 "string or Uint8Array",
             ));
         };
-        let mut code = code;
         if matches!(code, StringOrBuffer::Buffer(_)) {
             let bytes = code.slice().to_vec();
             global.vm().report_extra_memory(bytes.len());
@@ -1469,7 +1502,7 @@ impl JSTranspiler {
         };
 
         let arena = Arena::new();
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+        let Some(code_holder) = source_from_js(global, code_arg)? else {
             return Err(global.throw_invalid_argument_type(
                 "transformSync",
                 "code",
@@ -1680,7 +1713,7 @@ impl JSTranspiler {
             ));
         };
 
-        let code_holder = match StringOrBuffer::from_js(global, code_arg)? {
+        let code_holder = match source_from_js(global, code_arg)? {
             Some(h) => h,
             None => {
                 if !global.has_exception() {

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -146,8 +146,7 @@ fn clone_macro_map(src: &MacroMap) -> MacroMap {
     out
 }
 
-/// [`StringOrBuffer::from_js`] but 16-bit strings are encoded as WTF-8 so the
-/// lexer sees unpaired surrogates instead of U+FFFD.
+/// [`StringOrBuffer::from_js`] with 16-bit strings encoded as WTF-8 (keeps unpaired surrogates).
 fn source_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<StringOrBuffer>> {
     if value.is_string() {
         let str = OwnedString::new(BunString::from_js(value, global)?);

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -149,13 +149,14 @@ fn clone_macro_map(src: &MacroMap) -> MacroMap {
 /// [`StringOrBuffer::from_js`] with 16-bit strings encoded as WTF-8 (keeps unpaired surrogates).
 fn source_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<StringOrBuffer>> {
     if value.is_string() {
-        let str = OwnedString::new(BunString::from_js(value, global)?);
-        if str.is_utf16() {
+        let mut str = BunString::from_js(value, global)?;
+        return Ok(Some(if str.is_utf16() {
             let bytes = bun_core::strings::to_wtf8_alloc(str.utf16());
-            return Ok(Some(StringOrBuffer::EncodedSlice(
-                bun_core::ZigStringSlice::init_owned(bytes),
-            )));
-        }
+            str.deref();
+            StringOrBuffer::EncodedSlice(bun_core::ZigStringSlice::init_owned(bytes))
+        } else {
+            StringOrBuffer::String(str.to_slice())
+        }));
     }
     StringOrBuffer::from_js(global, value)
 }

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1416,7 +1416,6 @@ impl JSTranspiler {
             ));
         };
 
-        let allow_string_object = true;
         let code = if code_arg.is_string() {
             // WTF-8 so unpaired surrogates survive; owned Vec is thread-safe.
             let str = OwnedString::new(BunString::from_js(code_arg, global)?);
@@ -1430,13 +1429,7 @@ impl JSTranspiler {
                 bun_core::ZigStringSlice::init_owned(bytes),
             ))
         } else {
-            StringOrBuffer::from_js_with_encoding_maybe_async(
-                global,
-                code_arg,
-                Encoding::Utf8,
-                true,
-                allow_string_object,
-            )?
+            StringOrBuffer::from_js_with_encoding_maybe_async(global, code_arg, Encoding::Utf8, true, true)?
         };
         let Some(mut code) = code else {
             return Err(global.throw_invalid_argument_type(

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1429,7 +1429,13 @@ impl JSTranspiler {
                 bun_core::ZigStringSlice::init_owned(bytes),
             ))
         } else {
-            StringOrBuffer::from_js_with_encoding_maybe_async(global, code_arg, Encoding::Utf8, true, true)?
+            StringOrBuffer::from_js_with_encoding_maybe_async(
+                global,
+                code_arg,
+                Encoding::Utf8,
+                true,
+                true,
+            )?
         };
         let Some(mut code) = code else {
             return Err(global.throw_invalid_argument_type(

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -146,11 +146,8 @@ fn clone_macro_map(src: &MacroMap) -> MacroMap {
     out
 }
 
-/// Source-code flavoured [`StringOrBuffer::from_js`]: a JS string backed by
-/// 16-bit storage is encoded as WTF-8 (unpaired surrogates preserved) so the
-/// lexer, which reads WTF-8, sees the same code units `eval` would. 8-bit
-/// strings and array buffers cannot carry a lone surrogate and take the
-/// normal path.
+/// [`StringOrBuffer::from_js`] but 16-bit strings are encoded as WTF-8 so the
+/// lexer sees unpaired surrogates instead of U+FFFD.
 fn source_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<StringOrBuffer>> {
     if value.is_string() {
         let str = OwnedString::new(BunString::from_js(value, global)?);
@@ -1421,9 +1418,7 @@ impl JSTranspiler {
 
         let allow_string_object = true;
         let code = if code_arg.is_string() {
-            // 16-bit strings go through the WTF-8 encoder so unpaired
-            // surrogates survive; 8-bit strings cannot carry any. Either way
-            // the result is an owned `Vec<u8>`, already thread-safe.
+            // WTF-8 so unpaired surrogates survive; owned Vec is thread-safe.
             let str = OwnedString::new(BunString::from_js(code_arg, global)?);
             let bytes = if str.is_utf16() {
                 bun_core::strings::to_wtf8_alloc(str.utf16())

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2698,6 +2698,45 @@ console.log(<div {...obj} key="after" />);`),
       expectPrintedMin_(`console.log("\\uD800" + "\\uDF34")`, 'console.log("\\uD800" + "\\uDF34")');
     });
 
+    it("raw unpaired surrogates in string source", async () => {
+      // A JS string passed to transformSync can contain unpaired surrogate code
+      // units. The lexer reads WTF-8, so the string-to-bytes conversion must
+      // preserve them instead of substituting U+FFFD.
+      const t = new Bun.Transpiler({ loader: "js" });
+      const evalT = src => (0, eval)("(function(){" + src + " return t})()");
+      const cases = [
+        { unit: 0xd800, lit: c => `const t = "a${c}b";` },
+        { unit: 0xdc00, lit: c => `const t = "a${c}b";` },
+        { unit: 0xdbff, lit: c => `const t = "a${c}b";` },
+        { unit: 0xd800, lit: c => "const t = `a" + c + "b`;" },
+      ];
+      for (const { unit, lit } of cases) {
+        const src = lit(String.fromCharCode(unit));
+        const out = t.transformSync(src);
+        expect(out).not.toContain("\uFFFD");
+        expect(evalT(out).charCodeAt(1)).toBe(unit);
+        expect(evalT(out)).toBe(evalT(src));
+
+        // String input and buffer (WTF-8) input must agree.
+        const wtf8 = Buffer.concat([
+          Buffer.from(lit("").slice(0, lit("").indexOf("ab"))),
+          Buffer.from("a"),
+          Buffer.from([0xe0 | (unit >> 12), 0x80 | ((unit >> 6) & 0x3f), 0x80 | (unit & 0x3f)]),
+          Buffer.from("b"),
+          Buffer.from(lit("").slice(lit("").indexOf("ab") + 2)),
+        ]);
+        expect(out).toBe(t.transformSync(wtf8));
+      }
+
+      // A well-formed pair embedded as raw code units must still combine.
+      const pairSrc = `const t = "a${String.fromCharCode(0xd800, 0xdf34)}b";`;
+      expect(evalT(t.transformSync(pairSrc)).codePointAt(1)).toBe(0x10334);
+
+      // Async transform goes through the same encoder.
+      const asyncOut = await t.transform(cases[0].lit(String.fromCharCode(0xd800)));
+      expect(evalT(asyncOut).charCodeAt(1)).toBe(0xd800);
+    });
+
     it("fold string addition", () => {
       expectPrinted_(
         `


### PR DESCRIPTION
## Reproduction

```js
const src = 'const t = "a' + String.fromCharCode(0xD800) + 'b";';
const out = new Bun.Transpiler({ loader: "js" }).transformSync(src);
(0,eval)("(function(){"+src+" return t.charCodeAt(1)})()").toString(16); // "d800"
(0,eval)("(function(){"+out+" return t.charCodeAt(1)})()").toString(16); // "fffd"  <- literal value changed
```

The escaped form `"\\uD800"` is preserved; only raw WTF-16 code units in the *source string* are mangled. Passing the same source as a `Uint8Array` of WTF-8 bytes (`ed a0 80`), or reading a WTF-8 file via `bun run`, prints `"a\\uD800b"` and round-trips.

## Cause

`transformSync` / `transform` / `scan` / `scanImports` take the source string through `StringOrBuffer::from_js` -> `bun_core::String::to_slice` -> `to_utf8_alloc`. For 16-bit `WTFStringImpl` input that hits the surrogate fallback (`append_wtf8_from_utf16`, which despite its name calls `decode_utf16_with_fffd`), so a lone surrogate becomes U+FFFD before the lexer ever sees it. The lexer itself reads WTF-8, which is why the buffer/file paths were already correct.

## Fix

Add `strings::to_wtf8_alloc`, a WTF-8-preserving sibling of `to_utf8_alloc`: the simdutf fast path is unchanged (well-formed UTF-16 has no lone surrogates), and the scalar fallback uses `decode_wtf16_raw` + `encode_wtf8_rune` so a lone surrogate is encoded as its 3-byte WTF-8 sequence.

In `JSTranspiler`, route 16-bit string arguments through `to_wtf8_alloc` via a small `source_from_js` helper (sync methods) and an inline branch in `transform` (async, needs a thread-safe owned copy anyway). 8-bit strings and array buffers cannot carry a lone surrogate and keep the existing path. The printer already escapes lone surrogates in string/template literals, so string input now matches buffer input exactly.

The global `to_utf8_alloc` behaviour is left alone; per the note at `bun_core/lib.rs` surrogate policy is caller-specific, and several consumers (sourcemap URLs, encoded output) expect replacement.

## Verification

New `raw unpaired surrogates in string source` case in `test/bundler/transpiler/transpiler.test.js` covers lead / trail / high-lead surrogates in string and template literals, checks string input and WTF-8 buffer input produce identical output, asserts a well-formed pair still combines, and exercises the async `transform` path.

```
USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t "raw unpaired surrogates"
# 1 fail  (expect(received).not.toContain("\uFFFD"))

bun bd test test/bundler/transpiler/transpiler.test.js -t "raw unpaired surrogates"
# 1 pass, 18 expect() calls

bun bd test test/bundler/transpiler/transpiler.test.js
# 183 pass, 1 skip, 21 todo, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (b9c1aac50)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.33ms]
(pass) Bun.Transpiler > normalizes \r\n [5.69ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.66ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.63ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.36ms]
(pass) Bun.Transpiler > property access inlining > works [2.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.86ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [17.04ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.71ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.30ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [7.56ms]
(pass) Bun.Transpiler > TypeScript > contextual
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (8282441c2)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.08ms]
(pass) Bun.Transpiler > normalizes \r\n [0.12ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.04ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.29ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.05ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [0.14ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.26ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords followed by a newline apply ASI instead of a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (b9c1aac50)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.64ms]
(pass) Bun.Transpiler > normalizes \r\n [5.88ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.71ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.69ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.34ms]
(pass) Bun.Transpiler > property access inlining > works [2.02ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.10ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [17.18ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.82ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.36ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [7.64ms]
(pass) Bun.Transpiler > TypeScript > contextual
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 677ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/lib.rs                        | 38 +++++++++++++++++++++
 src/bun_core/string/immutable.rs           |  1 +
 src/runtime/api/JSTranspiler.rs            | 53 ++++++++++++++++++++++--------
 test/bundler/transpiler/transpiler.test.js | 39 ++++++++++++++++++++++
 4 files changed, 118 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/bun_core/lib.rs                             4      4      0
src/bun_core/string/immutable.rs                1      1      0
src/runtime/api/JSTranspiler.rs                 9      9      0
test/bundler/transpiler/transpiler.test.js      3      1      0
```

</details>

<!-- robobun:evidence:end -->