### PR TITLE
test: speed up req-url-leak.test.ts by asserting post-GC RSS growth

### DIFF
--- a/test/js/bun/http/req-url-leak-fixture.js
+++ b/test/js/bun/http/req-url-leak-fixture.js
@@ -2,6 +2,15 @@ let existingPromise = null;
 const server = Bun.serve({
   port: 0,
   async fetch(req) {
+    // Route by method so the long-URL GET path (the leak scenario from #16787)
+    // stays byte-for-byte the same as before: no req.url access, only the
+    // await-a-microtask + rss reply.
+    if (req.method === "POST") {
+      Bun.gc(true);
+      await Bun.sleep(10);
+      Bun.gc(true);
+      return new Response(process.memoryUsage.rss().toString());
+    }
     if (!existingPromise) {
       existingPromise = Bun.sleep(0);
     }
@@ -14,13 +23,6 @@ const server = Bun.serve({
   },
 });
 
-setInterval(() => {
-  console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0);
-}, 1000);
 console.log("Server started on", server.url.href);
 
-if (process.channel) {
-  process.send({
-    url: server.url.href,
-  });
-}
+process.send?.({ url: server.url.href });

--- a/test/js/bun/http/req-url-leak.test.ts
+++ b/test/js/bun/http/req-url-leak.test.ts
@@ -1,57 +1,59 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import path from "path";
+
 test(
   "req.url doesn't leak memory",
   async () => {
-    const { promise, resolve } = Promise.withResolvers();
-    await using process = Bun.spawn({
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "req-url-leak-fixture.js")],
       env: bunEnv,
-      stdout: "inherit",
-      stderr: "inherit",
-      stdin: "inherit",
-      ipc(message, child) {
-        if (message.url) {
-          resolve(message.url);
-        }
+      stdout: "pipe",
+      stderr: "pipe",
+      ipc(message) {
+        if (message.url) resolve(message.url);
       },
     });
+    proc.exited.then(code => reject(new Error(`req-url-leak fixture exited (${code}) before sending its URL`)));
 
     const baseURL = await promise;
-
     const url = new URL(Buffer.alloc(1024 * 15, "Z").toString(), baseURL);
+    // POST = GC-then-report RSS (routed by method so the long-URL GET path keeps
+    // the exact #16787 scenario: no req.url access in the handler).
+    const report = async () => parseInt(await (await fetch(baseURL, { method: "POST" })).text());
 
-    let maxRSS = 0;
-
-    for (let i = 0; i < 256; i++) {
-      const batchSize = 64;
-      const promises = [];
-      for (let j = 0; j < batchSize; j++) {
-        promises.push(
-          fetch(url)
-            .then(r => r.text())
-            .then(rssText => {
-              const rss = parseFloat(rssText);
-              if (Number.isSafeInteger(rss)) {
-                maxRSS = Math.max(maxRSS, rss);
-              }
-            }),
-        );
+    // 8 windows of 8×64 = 4096 GETs total. A leaked 15 KB url per request grows
+    // RSS linearly; between samples[1] (after 1024 requests, allocator warmed up)
+    // and samples[7] that is 3072×15 KB ≈ 45 MB. With the fix the post-GC samples
+    // are flat within ±3 MB on ASAN, so 4× fewer requests than the old 16 K sweep
+    // keep the same separation while asserting growth instead of absolute RSS.
+    const batchSize = 64;
+    const samples: number[] = [];
+    for (let window = 0; window < 8; window++) {
+      for (let i = 0; i < 8; i++) {
+        const batch = new Array(batchSize);
+        for (let j = 0; j < batchSize; j++) batch[j] = fetch(url).then(r => r.text());
+        await Promise.all(batch);
       }
-      await Promise.all(promises);
+      samples.push(await report());
     }
 
-    console.log("Max RSS", (maxRSS / 1024 / 1024) | 0, "MB");
+    proc.kill();
+    const [stderr] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
-    // 297 MB on Bun 1.2
-    //  44 MB on Bun 1.3
-    // ASAN's quarantine + shadow memory raise the absolute RSS floor; widen there.
-    expect(maxRSS).toBeLessThan(1024 * 1024 * (isASAN ? 450 : 150));
-    // Same calibration for the deadline: the 16K fetches that finish in ~3s on a
-    // release build run ~10x slower under ASAN's instrumentation (observed
-    // ~12-13s), and the run used to die on this timeout with the RSS assertion
-    // itself passing.
+    const growthMB = (samples.at(-1)! - samples[1]) / 1024 / 1024;
+    console.log(
+      "RSS samples (MB):",
+      samples.map(s => (s / 1024 / 1024) | 0).join(" "),
+      "growth:",
+      growthMB.toFixed(1) + "MB",
+    );
+
+    expect(stderr).toBe("");
+    // 297 MB on Bun 1.2 vs 44 MB on Bun 1.3 for the old 16 K absolute-RSS check;
+    // as a post-GC delta the leak shows as ~45 MB here versus ~0 on a fixed build.
+    expect(growthMB).toBeLessThan(20);
   },
-  isASAN ? 90_000 : 10_000,
+  isASAN || isDebug ? 30_000 : 10_000,
 );

--- a/test/js/bun/http/req-url-leak.test.ts
+++ b/test/js/bun/http/req-url-leak.test.ts
@@ -15,7 +15,10 @@ test(
         if (message.url) resolve(message.url);
       },
     });
-    proc.exited.then(code => reject(new Error(`req-url-leak fixture exited (${code}) before sending its URL`)));
+    const stderr = proc.stderr.text();
+    proc.exited.then(async code =>
+      reject(new Error(`req-url-leak fixture exited (${code}) before sending its URL: ${await stderr}`)),
+    );
 
     const baseURL = await promise;
     const url = new URL(Buffer.alloc(1024 * 15, "Z").toString(), baseURL);
@@ -40,7 +43,7 @@ test(
     }
 
     proc.kill();
-    const [stderr] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    await Promise.all([proc.stdout.text(), proc.exited]);
 
     const growthMB = (samples.at(-1)! - samples[1]) / 1024 / 1024;
     console.log(
@@ -50,7 +53,7 @@ test(
       growthMB.toFixed(1) + "MB",
     );
 
-    expect(stderr).toBe("");
+    expect(await stderr).toBe("");
     // 297 MB on Bun 1.2 vs 44 MB on Bun 1.3 for the old 16 K absolute-RSS check;
     // as a post-GC delta the leak shows as ~30 MB here versus ~0 on a fixed build.
     expect(growthMB).toBeLessThan(15);

--- a/test/js/bun/http/req-url-leak.test.ts
+++ b/test/js/bun/http/req-url-leak.test.ts
@@ -23,14 +23,14 @@ test(
     // the exact #16787 scenario: no req.url access in the handler).
     const report = async () => parseInt(await (await fetch(baseURL, { method: "POST" })).text());
 
-    // 8 windows of 8×64 = 4096 GETs total. A leaked 15 KB url per request grows
+    // 6 windows of 8×64 = 3072 GETs total. A leaked 15 KB url per request grows
     // RSS linearly; between samples[1] (after 1024 requests, allocator warmed up)
-    // and samples[7] that is 3072×15 KB ≈ 45 MB. With the fix the post-GC samples
-    // are flat within ±3 MB on ASAN, so 4× fewer requests than the old 16 K sweep
-    // keep the same separation while asserting growth instead of absolute RSS.
+    // and samples[5] that is 2048×15 KB ≈ 30 MB. With the fix the post-GC samples
+    // are flat within ±3 MB on ASAN, so the old 16 K sweep's absolute-RSS check
+    // becomes a growth bound at a fifth of the requests.
     const batchSize = 64;
     const samples: number[] = [];
-    for (let window = 0; window < 8; window++) {
+    for (let window = 0; window < 6; window++) {
       for (let i = 0; i < 8; i++) {
         const batch = new Array(batchSize);
         for (let j = 0; j < batchSize; j++) batch[j] = fetch(url).then(r => r.text());
@@ -52,8 +52,8 @@ test(
 
     expect(stderr).toBe("");
     // 297 MB on Bun 1.2 vs 44 MB on Bun 1.3 for the old 16 K absolute-RSS check;
-    // as a post-GC delta the leak shows as ~45 MB here versus ~0 on a fixed build.
-    expect(growthMB).toBeLessThan(20);
+    // as a post-GC delta the leak shows as ~30 MB here versus ~0 on a fixed build.
+    expect(growthMB).toBeLessThan(15);
   },
-  isASAN || isDebug ? 30_000 : 10_000,
+  isASAN || isDebug ? 90_000 : 10_000,
 );


### PR DESCRIPTION
### What

Speeds up `test/js/bun/http/req-url-leak.test.ts` by ~5× without weakening (actually tightening) the leak check.

### Why this is correct

The original test sends 16,384 GETs with a 15 KB URL and asserts `maxRSS < (isASAN ? 450 : 150) MB`. That absolute-RSS threshold has to be wide enough to cover ASAN quarantine/shadow memory and future baseline drift, so it needs a lot of requests to push a real leak clearly past it.

Asserting **post-GC RSS growth** instead removes the platform-dependent baseline from the equation. The fixture now exposes a `POST` = `Bun.gc(true)` + report-RSS endpoint (routed by method so the long-URL `GET` handler stays byte-for-byte the #16787 scenario: no `req.url` access, just await-a-microtask + reply). The test samples RSS after GC every 512 requests and compares the final sample against the one after the first 1024 (allocator warmed up):

- with the leak, 2048 requests × 15 KB ≈ **30 MB** of growth (verified by pinning the url strings in the fixture: linear growth observed under ASAN)
- without the leak, the post-GC samples are flat: **~4-5 MB** under ASAN+debug, **±1 MB** on release across repeated runs

So a `< 15 MB` growth bound sits comfortably between the two at a fifth of the requests. It also drops the `isASAN` threshold branching, since growth is comparable across build variants.

### Timing

| | requests | release | ASAN+debug (slow host) | assertion |
|---|---|---|---|---|
| before | 16,384 | 2.56 s | 301.8 s | `maxRSS < (isASAN ? 450 : 150) MB` |
| after | 3,072 | 0.58 s | 47-51 s | `stderr == ""`, `growth < 15 MB` |

CI `debian 13 x64-asan` on build #82361 (at 4096 req): 3.5 s vs ~15 s before; 3072 req should land around 2-3 s there. ASAN/debug timeout stays at the original 90 s.

### Assertion improvements

- `stderr` is now piped and asserted empty (was `"inherit"`, so a fixture warning/crash only showed in CI logs)
- `stdout`/`stdin` no longer inherited
- `proc.exited.then(reject)` fails fast with a clear message if the fixture dies before IPCing its URL, instead of hanging until the timeout
- the fixture's 1 s `setInterval` RSS log is gone (was pure noise in test output)
- RSS growth bound is tighter and needs no per-variant calibration; the old absolute bound had ~80 MB of slack under ASAN

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/req-url-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/req-url-leak.test.ts
bun test v1.4.0 (f97a6cd38)

test/js/bun/http/req-url-leak.test.ts:
RSS samples (MB): 352 352 354 353 352 353 growth: 1.9MB
(pass) req.url doesn't leak memory [46859.04ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [48.91s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/req-url-leak-fixture.js | 18 +++----
 test/js/bun/http/req-url-leak.test.ts    | 81 +++++++++++++++++---------------
 2 files changed, 53 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/bun/http/req-url-leak-fixture.js      2      3      0
test/js/bun/http/req-url-leak.test.ts         4      9      0
```

</details>

<!-- robobun:evidence:end -->