### PR TITLE
udp: stop IP_RECVERR on unconnected sockets; never fatal-by-default for recv errors

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1456,8 +1456,9 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, size_t l
 
 /* Receive-path options every UDP socket needs, whether freshly created or
  * adopted from an existing fd: destination-address and TOS reporting for
- * recvmmsg, Windows ICMP-reset suppression, and Linux IP_RECVERR (opt-in). */
-static void bsd_apply_udp_recv_options(LIBUS_SOCKET_DESCRIPTOR fd, int family, int options) {
+ * recvmmsg, and Windows ICMP-reset suppression. IP_RECVERR is handled by
+ * bsd_udp_socket_set_recverr at connect time, not here. */
+static void bsd_apply_udp_recv_options(LIBUS_SOCKET_DESCRIPTOR fd) {
     /* We need destination address for udp packets in both ipv6 and ipv4 */
 
 /* On FreeBSD this option seems to be called like so */
@@ -1497,18 +1498,6 @@ static void bsd_apply_udp_recv_options(LIBUS_SOCKET_DESCRIPTOR fd, int family, i
     }
 #endif
 
-#if defined(__linux__)
-    /* IP_RECVERR/IPV6_RECVERR queues ICMP errors on the socket's error queue
-     * for on_recv_error to drain. libuv gates this on UV_UDP_LINUX_RECVERR
-     * (Node's dgram never passes it). Opt-in only: on a shared unconnected
-     * socket (the HTTP/3 fetch client) it also makes a queued ICMP fail the
-     * next send to a different, live peer. */
-    if (options & LIBUS_UDP_LINUX_RECVERR) {
-        bsd_udp_socket_set_recverr(fd, 1);
-    }
-#endif
-    (void) options;
-    (void) family;
 }
 
 /* Arm or disarm IP_RECVERR/IPV6_RECVERR. Disabling also purges the kernel's
@@ -1662,7 +1651,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
     }
 #endif
 
-    bsd_apply_udp_recv_options(listenFd, listenAddr->ai_family, options);
+    bsd_apply_udp_recv_options(listenFd);
 
     /* We bind here as well */
     if (bind(listenFd, listenAddr->ai_addr, (socklen_t) listenAddr->ai_addrlen)) {

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1504,17 +1504,30 @@ static void bsd_apply_udp_recv_options(LIBUS_SOCKET_DESCRIPTOR fd, int family, i
      * socket (the HTTP/3 fetch client) it also makes a queued ICMP fail the
      * next send to a different, live peer. */
     if (options & LIBUS_UDP_LINUX_RECVERR) {
+        bsd_udp_socket_set_recverr(fd, 1);
+    }
+#endif
+    (void) options;
+    (void) family;
+}
+
+/* Arm or disarm IP_RECVERR/IPV6_RECVERR. Disabling also purges the kernel's
+ * error queue (sk_err is NOT cleared; callers that need that read SO_ERROR). */
+void bsd_udp_socket_set_recverr(LIBUS_SOCKET_DESCRIPTOR fd, int enabled) {
+#if defined(__linux__)
 #ifdef IP_RECVERR
-        setsockopt(fd, IPPROTO_IP, IP_RECVERR, &enabled, sizeof(enabled));
+    setsockopt(fd, IPPROTO_IP, IP_RECVERR, &enabled, sizeof(enabled));
 #endif
 #ifdef IPV6_RECVERR
-        if (family == AF_INET6) {
-            setsockopt(fd, IPPROTO_IPV6, IPV6_RECVERR, &enabled, sizeof(enabled));
-        }
-#endif
+    int domain = AF_INET;
+    socklen_t domain_len = sizeof(domain);
+    if (getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &domain, &domain_len) == 0 && domain == AF_INET6) {
+        setsockopt(fd, IPPROTO_IPV6, IPV6_RECVERR, &enabled, sizeof(enabled));
     }
+#endif
 #else
-    (void) options;
+    (void) fd;
+    (void) enabled;
 #endif
 }
 

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -238,6 +238,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, size_t p
 LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int options, int *err);
 int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int port);
 int bsd_disconnect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd);
+void bsd_udp_socket_set_recverr(LIBUS_SOCKET_DESCRIPTOR fd, int enabled);
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options);
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -155,11 +155,6 @@ enum {
      * Safe for HTTP/TLS where the client always sends first; do not use for protocols where
      * the server sends the first bytes. */
     LIBUS_LISTEN_DEFER_ACCEPT = 64,
-    /* Enable IP_RECVERR on a UDP socket so ICMP errors land on the error
-     * queue for on_recv_error to drain. Off by default: on a shared
-     * unconnected socket it also makes the next send fail for a datagram
-     * bound to a different, live peer. */
-    LIBUS_UDP_LINUX_RECVERR = 128,
 };
 
 /* Library types publicly available */

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -929,12 +929,12 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             }
 
             /* An EPOLLERR with no EPOLLIN and an empty error queue still has to
-             * run the receive path: that is how a pending sk_err — an ICMP for
-             * a socket that never enabled IP_RECVERR, e.g. one adopted from an
-             * external descriptor by bsd_udp_open() and then connected — is
-             * reaped by recvmmsg and reported instead of the socket being
-             * closed below. libuv folds a bare EPOLLERR into EPOLLIN for the
-             * same reason (uv__io_poll, deps/uv/src/unix/linux.c). */
+             * run the receive path: that is how a pending sk_err — an ICMP on
+             * a socket without IP_RECVERR (a NULL on_recv_error caller, or an
+             * fd already connected before adoption) — is reaped by recvmmsg
+             * and reported instead of the socket being closed below. libuv
+             * folds a bare EPOLLERR into EPOLLIN for the same reason
+             * (uv__io_poll, deps/uv/src/unix/linux.c). */
             const int run_recv =
                 (events & LIBUS_SOCKET_READABLE) || (error && !recv_error_surfaced);
 #else

--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -148,11 +148,32 @@ int us_udp_socket_set_ttl_multicast(struct us_udp_socket_t *s, int ttl) {
 }
 
 int us_udp_socket_connect(struct us_udp_socket_t *s, const char* host, unsigned short port) {
-    return bsd_connect_udp_socket(us_poll_fd((struct us_poll_t *)s), host, port);
+    LIBUS_SOCKET_DESCRIPTOR fd = us_poll_fd((struct us_poll_t *)s);
+    int rc = bsd_connect_udp_socket(fd, host, port);
+    if (rc == 0) {
+        s->connected = 1;
+        /* Only a connected socket has one peer to attribute ICMP to; without an
+         * on_recv_error handler the error queue would never be drained. */
+        if (s->on_recv_error) bsd_udp_socket_set_recverr(fd, 1);
+    }
+    return rc;
 }
 
 int us_udp_socket_disconnect(struct us_udp_socket_t *s) {
-    return bsd_disconnect_udp_socket(us_poll_fd((struct us_poll_t *)s));
+    LIBUS_SOCKET_DESCRIPTOR fd = us_poll_fd((struct us_poll_t *)s);
+    int rc = bsd_disconnect_udp_socket(fd);
+    if (rc == 0) {
+        s->connected = 0;
+        /* Disabling IP_RECVERR purges the error queue but not sk_err; reading
+         * SO_ERROR clears that too so a stale ICMP from the connected phase
+         * cannot surface on the now-unconnected socket. */
+        bsd_udp_socket_set_recverr(fd, 0);
+#if !defined(_WIN32)
+        int so_err = 0; socklen_t so_len = sizeof(so_err);
+        getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_err, &so_len);
+#endif
+    }
+    return rc;
 }
 
 int us_udp_socket_set_multicast_loopback(struct us_udp_socket_t *s, int enabled) {
@@ -184,11 +205,12 @@ struct us_udp_socket_t *us_create_udp_socket(
     void *user
 ) {
 
-    /* IP_RECVERR is only useful when there is an on_recv_error handler to
-     * drain the error queue; without one it only poisons subsequent sends. */
-    if (recv_error_cb) flags |= LIBUS_UDP_LINUX_RECVERR;
-    else flags &= ~LIBUS_UDP_LINUX_RECVERR;
-    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_udp_socket(host, port, flags, err);
+    /* IP_RECVERR is NOT enabled at creation time. On an unconnected socket it
+     * turns an ICMP from any one peer into an async error (and poisons sk_err
+     * for the next send to a different peer), which is a single-packet DoS for
+     * a DNS/statsd/echo server. us_udp_socket_connect arms it once there is a
+     * peer to attribute the error to; Node's dgram never sets it at all. */
+    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_udp_socket(host, port, flags & ~LIBUS_UDP_LINUX_RECVERR, err);
     if (fd == LIBUS_SOCKET_ERROR) {
         return 0;
     }

--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -150,12 +150,9 @@ int us_udp_socket_set_ttl_multicast(struct us_udp_socket_t *s, int ttl) {
 int us_udp_socket_connect(struct us_udp_socket_t *s, const char* host, unsigned short port) {
     LIBUS_SOCKET_DESCRIPTOR fd = us_poll_fd((struct us_poll_t *)s);
     int rc = bsd_connect_udp_socket(fd, host, port);
-    if (rc == 0) {
-        s->connected = 1;
-        /* Only a connected socket has one peer to attribute ICMP to; without an
-         * on_recv_error handler the error queue would never be drained. */
-        if (s->on_recv_error) bsd_udp_socket_set_recverr(fd, 1);
-    }
+    /* Only a connected socket has one peer to attribute ICMP to; without an
+     * on_recv_error handler the error queue would never be drained. */
+    if (rc == 0 && s->on_recv_error) bsd_udp_socket_set_recverr(fd, 1);
     return rc;
 }
 
@@ -163,7 +160,6 @@ int us_udp_socket_disconnect(struct us_udp_socket_t *s) {
     LIBUS_SOCKET_DESCRIPTOR fd = us_poll_fd((struct us_poll_t *)s);
     int rc = bsd_disconnect_udp_socket(fd);
     if (rc == 0) {
-        s->connected = 0;
         /* Disabling IP_RECVERR purges the error queue but not sk_err; reading
          * SO_ERROR clears that too so a stale ICMP from the connected phase
          * cannot surface on the now-unconnected socket. */
@@ -210,7 +206,7 @@ struct us_udp_socket_t *us_create_udp_socket(
      * for the next send to a different peer), which is a single-packet DoS for
      * a DNS/statsd/echo server. us_udp_socket_connect arms it once there is a
      * peer to attribute the error to; Node's dgram never sets it at all. */
-    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_udp_socket(host, port, flags & ~LIBUS_UDP_LINUX_RECVERR, err);
+    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_udp_socket(host, port, flags, err);
     if (fd == LIBUS_SOCKET_ERROR) {
         return 0;
     }

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -98,6 +98,20 @@ extern "C" fn on_recv_error(socket: *mut uws::udp::Socket, errno: c_int, is_errq
     // ICMP error (so_error) arrives. node:dgram must drop only the former on
     // unconnected sockets, and the errno namespaces overlap.
     let this: &UDPSocket = UDPSocket::from_uws(socket);
+    let Some(this_value) = this.this_value.get().try_get() else {
+        return;
+    };
+    // A receive-path error on a UDP socket is advisory: the socket stays open
+    // and the next datagram is independent. With no `error` handler registered
+    // the documented contract is a `data`-only socket, so an ICMP report about
+    // a peer that stopped listening (or a locally originated EMSGSIZE echoed
+    // through the error queue) must not become an uncaught exception. A caller
+    // that wants these errors registers a handler. node:dgram always does, so
+    // its own connected-socket filter still decides what reaches user code.
+    let callback = js::on_error_get_cached(this_value).unwrap_or(JSValue::ZERO);
+    if callback.is_empty_or_undefined_or_null() {
+        return;
+    }
     let sys_err = bun_sys::Error::from_code_int(errno, bun_sys::Tag::recv);
     let global_this = this.global_this.get();
     // A callback earlier in the same poll dispatch may have left a
@@ -113,7 +127,7 @@ extern "C" fn on_recv_error(socket: *mut uws::udp::Socket, errno: c_int, is_errq
     if is_errqueue != 0 {
         err_value.put(global_this, b"errqueue", JSValue::TRUE);
     }
-    this.call_error_handler(JSValue::ZERO, err_value);
+    this.call_error_handler(this_value, err_value);
 }
 
 extern "C" fn on_drain(socket: *mut uws::udp::Socket) {

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -101,13 +101,8 @@ extern "C" fn on_recv_error(socket: *mut uws::udp::Socket, errno: c_int, is_errq
     let Some(this_value) = this.this_value.get().try_get() else {
         return;
     };
-    // A receive-path error on a UDP socket is advisory: the socket stays open
-    // and the next datagram is independent. With no `error` handler registered
-    // the documented contract is a `data`-only socket, so an ICMP report about
-    // a peer that stopped listening (or a locally originated EMSGSIZE echoed
-    // through the error queue) must not become an uncaught exception. A caller
-    // that wants these errors registers a handler. node:dgram always does, so
-    // its own connected-socket filter still decides what reaches user code.
+    // Recv-path errors are advisory (socket stays open); with no handler drop
+    // them instead of uncaught_exception. node:dgram always registers one.
     let callback = js::on_error_get_cached(this_value).unwrap_or(JSValue::ZERO);
     if callback.is_empty_or_undefined_or_null() {
         return;

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -829,12 +829,14 @@ async function getDeadPort() {
 // flag forced on, the same ICMP poisoned sk_err and surfaced through the
 // plain recv path (no errqueue flag), bypassing the unconnected filter and
 // killing the process.
-test.skipIf(!isLinux)("unconnected echo server without 'error' listener survives ICMP from a vanished client", async () => {
-  // The reply must go out from inside the 'message' handler so it happens
-  // inside loop.c's recvmmsg do-while; on loopback the ICMP lands before the
-  // next iteration and poisons sk_err, which surfaces as a recv-path error
-  // without the errqueue flag and so bypasses the errqueue-only filter.
-  const src = `
+test.skipIf(!isLinux)(
+  "unconnected echo server without 'error' listener survives ICMP from a vanished client",
+  async () => {
+    // The reply must go out from inside the 'message' handler so it happens
+    // inside loop.c's recvmmsg do-while; on loopback the ICMP lands before the
+    // next iteration and poisons sk_err, which surfaces as a recv-path error
+    // without the errqueue flag and so bypasses the errqueue-only filter.
+    const src = `
     const dgram = require("node:dgram");
     const server = dgram.createSocket("udp4");
     const client = dgram.createSocket("udp4");
@@ -861,18 +863,19 @@ test.skipIf(!isLinux)("unconnected echo server without 'error' listener survives
       });
     });
   `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  // Node delivers no error at all for ICMP on an unconnected socket.
-  expect(JSON.parse(stdout.trim())).toEqual({ handled: true });
-  expect(exitCode).toBe(0);
-});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Node delivers no error at all for ICMP on an unconnected socket.
+    expect(JSON.parse(stdout.trim())).toEqual({ handled: true });
+    expect(exitCode).toBe(0);
+  },
+);
 
 // A connected socket's ICMP error must be *emitted*, not treated as fatal.
 // On the BSDs there is no error queue, so the kernel only delivers it via the

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, jest, test } from "bun:test";
 import { createSocket } from "dgram";
 import { Worker } from "node:worker_threads";
 
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isLinux, isWindows } from "harness";
 import path from "path";
 import { nodeDataCases } from "./testdata";
 
@@ -822,6 +822,57 @@ async function getDeadPort() {
   await new Promise<void>(resolve => target.close(resolve));
   return deadPort;
 }
+
+// An unconnected echo server (reply from the 'message' handler, no 'error'
+// listener) is the documented shape. Node never enables IP_RECVERR, so ICMP
+// port-unreachable from a vanished client is dropped by the kernel. With the
+// flag forced on, the same ICMP poisoned sk_err and surfaced through the
+// plain recv path (no errqueue flag), bypassing the unconnected filter and
+// killing the process.
+test.skipIf(!isLinux)("unconnected echo server without 'error' listener survives ICMP from a vanished client", async () => {
+  // The reply must go out from inside the 'message' handler so it happens
+  // inside loop.c's recvmmsg do-while; on loopback the ICMP lands before the
+  // next iteration and poisons sk_err, which surfaces as a recv-path error
+  // without the errqueue flag and so bypasses the errqueue-only filter.
+  const src = `
+    const dgram = require("node:dgram");
+    const server = dgram.createSocket("udp4");
+    const client = dgram.createSocket("udp4");
+    const probe = dgram.createSocket("udp4");
+    let deadPort, handled = 0;
+    server.on("message", msg => {
+      handled++;
+      server.send(msg, deadPort, "127.0.0.1");
+    });
+    server.bind(0, "127.0.0.1", () => {
+      probe.bind(0, "127.0.0.1", () => {
+        deadPort = probe.address().port;
+        probe.close(() => {
+          const pump = () => {
+            if (handled < 5) {
+              client.send("q", server.address().port, "127.0.0.1");
+              return setTimeout(pump, 10);
+            }
+            console.log(JSON.stringify({ handled: handled >= 5 }));
+            process.exit(0);
+          };
+          pump();
+        });
+      });
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // Node delivers no error at all for ICMP on an unconnected socket.
+  expect(JSON.parse(stdout.trim())).toEqual({ handled: true });
+  expect(exitCode).toBe(0);
+});
 
 // A connected socket's ICMP error must be *emitted*, not treated as fatal.
 // On the BSDs there is no error queue, so the kernel only delivers it via the

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -850,8 +850,9 @@ test.skipIf(!isLinux)(
       probe.bind(0, "127.0.0.1", () => {
         deadPort = probe.address().port;
         probe.close(() => {
+          let i = 0;
           const pump = () => {
-            if (handled < 5) {
+            if (handled < 5 && i++ < 200) {
               client.send("q", server.address().port, "127.0.0.1");
               return setTimeout(pump, 10);
             }
@@ -879,11 +880,10 @@ test.skipIf(!isLinux)(
 
 // A connected socket's ICMP error must be *emitted*, not treated as fatal.
 // On the BSDs there is no error queue, so the kernel only delivers it via the
-// next recvmsg failing with so_error. On Linux an adopted descriptor has no
-// IP_RECVERR (that deliberately matches libuv's uv_udp_open), so its error
-// queue is empty and the kernel reports a bare EPOLLERR with no EPOLLIN.
-// Either way loop.c used to treat the failure as fatal and silently close the
-// socket; Node emits `recvmsg ECONNREFUSED` and keeps it open.
+// next recvmsg failing with so_error. On Linux us_udp_socket_connect arms
+// IP_RECVERR (for both created and adopted descriptors) so the error arrives
+// via MSG_ERRQUEUE; loop.c's bare-EPOLLERR sk_err fallback is covered by the
+// BSD lanes. Node emits `recvmsg ECONNREFUSED` and keeps the socket open.
 const icmpBindModes = {
   connected: async (socket: any) => {
     await new Promise<void>(resolve => socket.bind(0, "127.0.0.1", resolve));

--- a/test/js/bun/udp/udp_socket_recv_flags.test.ts
+++ b/test/js/bun/udp/udp_socket_recv_flags.test.ts
@@ -137,8 +137,10 @@ test.skipIf(!isLinux)("unconnected socket with no error handler survives ICMP po
 // the caller catches. With IP_RECVERR on, the kernel also queues the same
 // EMSGSIZE on the error queue and it was re-delivered as an async uncaught
 // error. Without an error handler the process must still survive.
-test.skipIf(!isLinux)("oversized send caught synchronously does not also kill the process via the error queue", async () => {
-  const src = `
+test.skipIf(!isLinux)(
+  "oversized send caught synchronously does not also kill the process via the error queue",
+  async () => {
+    const src = `
     const rx = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
     const tx = await Bun.udpSocket({ socket: { data() {} } });
     let caught = "none";
@@ -149,17 +151,18 @@ test.skipIf(!isLinux)("oversized send caught synchronously does not also kill th
     console.log(JSON.stringify({ caught, txClosed: tx.closed }));
     process.exit(0);
   `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout.trim())).toEqual({ caught: "EMSGSIZE", txClosed: false });
-  expect(exitCode).toBe(0);
-});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ caught: "EMSGSIZE", txClosed: false });
+    expect(exitCode).toBe(0);
+  },
+);
 
 // Belt-and-suspenders for the same contract on a connected socket: even when
 // IP_RECVERR is armed and the error queue delivers, a socket with no error

--- a/test/js/bun/udp/udp_socket_recv_flags.test.ts
+++ b/test/js/bun/udp/udp_socket_recv_flags.test.ts
@@ -37,8 +37,8 @@ describe("udpSocket() receive flags", () => {
   });
 
   // IP_RECVERR is armed on connect (Linux only). An unconnected socket never
-  // sees ICMP at all; a connected one surfaces it through the error handler,
-  // stays open, and can still send.
+  // sees ICMP at all; a connected one surfaces it through the error handler
+  // and stays open.
   test.skipIf(!isLinux)("connected socket surfaces ECONNREFUSED from ICMP and stays open", async () => {
     const errors: (Error & { code?: string; errqueue?: boolean })[] = [];
     const { promise: errPromise, resolve: resolveErr } = Promise.withResolvers<void>();

--- a/test/js/bun/udp/udp_socket_recv_flags.test.ts
+++ b/test/js/bun/udp/udp_socket_recv_flags.test.ts
@@ -37,68 +37,50 @@ describe("udpSocket() receive flags", () => {
   });
 
   // IP_RECVERR is armed on connect (Linux only). An unconnected socket never
-  // sees ICMP at all; a connected one surfaces it through the error handler
-  // and stays open.
-  test.skipIf(!isLinux)(
-    "connected socket surfaces ECONNREFUSED from ICMP port unreachable and keeps the socket usable",
-    async () => {
-      const { promise: errPromise, resolve: resolveErr } = Promise.withResolvers<Error & { code?: string }>();
-      const { promise: msgPromise, resolve: resolveMsg } = Promise.withResolvers<string>();
+  // sees ICMP at all; a connected one surfaces it through the error handler,
+  // stays open, and can still send.
+  test.skipIf(!isLinux)("connected socket surfaces ECONNREFUSED from ICMP and stays open", async () => {
+    const errors: (Error & { code?: string; errqueue?: boolean })[] = [];
+    const { promise: errPromise, resolve: resolveErr } = Promise.withResolvers<void>();
 
-      const receiver = await udpSocket({
-        socket: {
-          data(_socket, data) {
-            resolveMsg(data.toString());
-          },
+    // Bind and close a probe so we own a port nothing is listening on.
+    const probe = await udpSocket({ hostname: "127.0.0.1" });
+    const deadPort = probe.port;
+    probe.close();
+
+    const sender = await udpSocket({
+      connect: { hostname: "127.0.0.1", port: deadPort },
+      socket: {
+        error(err: Error & { code?: string }) {
+          errors.push(err);
+          resolveErr();
         },
-      });
+      },
+    });
 
-      // Bind and close a probe so we own a port nothing is listening on.
-      const probe = await udpSocket({ hostname: "127.0.0.1" });
-      const deadPort = probe.port;
-      probe.close();
-
-      const sender = await udpSocket({
-        connect: { hostname: "127.0.0.1", port: deadPort },
-        socket: {
-          error(err: Error & { code?: string }) {
-            resolveErr(err);
-          },
-        },
-      });
-
+    try {
       let gotError = false;
       function sendDead() {
         if (!gotError && !sender.closed) {
-          sender.send("dead");
+          try {
+            sender.send("dead");
+          } catch {}
           setTimeout(sendDead, 10);
         }
       }
       sendDead();
 
-      try {
-        const err = await errPromise;
-        gotError = true;
-        expect(err?.code).toBe("ECONNREFUSED");
-        expect(sender.closed).toBe(false);
-
-        // A fresh unconnected socket must not inherit any poisoned state.
-        const relay = await udpSocket({});
-        function sendAlive() {
-          if (!relay.closed && !receiver.closed) {
-            relay.send("alive", receiver.port, "127.0.0.1");
-            setTimeout(sendAlive, 10);
-          }
-        }
-        sendAlive();
-        expect(await msgPromise).toBe("alive");
-        relay.close();
-      } finally {
-        sender.close();
-        receiver.close();
-      }
-    },
-  );
+      await errPromise;
+      gotError = true;
+      expect({ code: errors[0]?.code, errqueue: errors[0]?.errqueue, closed: sender.closed }).toEqual({
+        code: "ECONNREFUSED",
+        errqueue: true,
+        closed: false,
+      });
+    } finally {
+      sender.close();
+    }
+  });
 });
 
 // A reply-style server (DNS, statsd, echo) written to the documented shape

--- a/test/js/bun/udp/udp_socket_recv_flags.test.ts
+++ b/test/js/bun/udp/udp_socket_recv_flags.test.ts
@@ -159,7 +159,7 @@ test.skipIf(!isLinux)("connected socket with no error handler survives ICMP port
       connect: { hostname: "127.0.0.1", port: deadPort },
       socket: { data() {} },
     });
-    for (let i = 0; i < 5; i++) { s.send("x"); await Bun.sleep(20); }
+    for (let i = 0; i < 5; i++) { try { s.send("x"); } catch {} await Bun.sleep(20); }
     console.log(JSON.stringify({ closed: s.closed }));
     process.exit(0);
   `;

--- a/test/js/bun/udp/udp_socket_recv_flags.test.ts
+++ b/test/js/bun/udp/udp_socket_recv_flags.test.ts
@@ -4,7 +4,7 @@
 
 import { udpSocket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isLinux } from "harness";
+import { bunEnv, bunExe, isLinux } from "harness";
 
 describe("udpSocket() receive flags", () => {
   test("data callback receives flags object with truncated=false for normal packets", async () => {
@@ -36,11 +36,11 @@ describe("udpSocket() receive flags", () => {
     }
   });
 
-  // IP_RECVERR is Linux-specific. On BSDs and Windows, ICMP errors on
-  // unconnected UDP sockets either propagate by default or are delivered
-  // through different channels that we don't currently surface.
+  // IP_RECVERR is armed on connect (Linux only). An unconnected socket never
+  // sees ICMP at all; a connected one surfaces it through the error handler
+  // and stays open.
   test.skipIf(!isLinux)(
-    "surfaces ECONNREFUSED from ICMP port unreachable (IP_RECVERR) and keeps the socket usable",
+    "connected socket surfaces ECONNREFUSED from ICMP port unreachable and keeps the socket usable",
     async () => {
       const { promise: errPromise, resolve: resolveErr } = Promise.withResolvers<Error & { code?: string }>();
       const { promise: msgPromise, resolve: resolveMsg } = Promise.withResolvers<string>();
@@ -53,7 +53,13 @@ describe("udpSocket() receive flags", () => {
         },
       });
 
+      // Bind and close a probe so we own a port nothing is listening on.
+      const probe = await udpSocket({ hostname: "127.0.0.1" });
+      const deadPort = probe.port;
+      probe.close();
+
       const sender = await udpSocket({
+        connect: { hostname: "127.0.0.1", port: deadPort },
         socket: {
           error(err: Error & { code?: string }) {
             resolveErr(err);
@@ -61,12 +67,10 @@ describe("udpSocket() receive flags", () => {
         },
       });
 
-      // Send to a closed port on localhost. The kernel replies with ICMP
-      // port unreachable; with IP_RECVERR the next recv surfaces ECONNREFUSED.
       let gotError = false;
       function sendDead() {
         if (!gotError && !sender.closed) {
-          sender.send("dead", 1, "127.0.0.1");
+          sender.send("dead");
           setTimeout(sendDead, 10);
         }
       }
@@ -76,21 +80,112 @@ describe("udpSocket() receive flags", () => {
         const err = await errPromise;
         gotError = true;
         expect(err?.code).toBe("ECONNREFUSED");
-        // The sender socket must remain usable after an ICMP error.
         expect(sender.closed).toBe(false);
 
+        // A fresh unconnected socket must not inherit any poisoned state.
+        const relay = await udpSocket({});
         function sendAlive() {
-          if (!sender.closed && !receiver.closed) {
-            sender.send("alive", receiver.port, "127.0.0.1");
+          if (!relay.closed && !receiver.closed) {
+            relay.send("alive", receiver.port, "127.0.0.1");
             setTimeout(sendAlive, 10);
           }
         }
         sendAlive();
         expect(await msgPromise).toBe("alive");
+        relay.close();
       } finally {
         sender.close();
         receiver.close();
       }
     },
   );
+});
+
+// A reply-style server (DNS, statsd, echo) written to the documented shape
+// has a `data` handler and no `error` handler. A reply sent to a client
+// that has stopped listening triggers ICMP port-unreachable at the server;
+// that must not kill the process.
+test.skipIf(!isLinux)("unconnected socket with no error handler survives ICMP port unreachable", async () => {
+  const src = `
+    const server = await Bun.udpSocket({
+      port: 0, hostname: "127.0.0.1",
+      socket: { data(s, d, port, addr) { s.send(d, port, addr); } },
+    });
+    const probe = await Bun.udpSocket({ hostname: "127.0.0.1" });
+    const deadPort = probe.port;
+    probe.close();
+    for (let i = 0; i < 5; i++) {
+      server.send("reply", deadPort, "127.0.0.1");
+      await Bun.sleep(20);
+    }
+    console.log(JSON.stringify({ closed: server.closed }));
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ closed: false });
+  expect(exitCode).toBe(0);
+});
+
+// A 65508..65535-byte datagram is rejected synchronously with EMSGSIZE, which
+// the caller catches. With IP_RECVERR on, the kernel also queues the same
+// EMSGSIZE on the error queue and it was re-delivered as an async uncaught
+// error. Without an error handler the process must still survive.
+test.skipIf(!isLinux)("oversized send caught synchronously does not also kill the process via the error queue", async () => {
+  const src = `
+    const rx = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
+    const tx = await Bun.udpSocket({ socket: { data() {} } });
+    let caught = "none";
+    try {
+      tx.send(new Uint8Array(65510), rx.port, "127.0.0.1");
+    } catch (e) { caught = e.code; }
+    await Bun.sleep(100);
+    console.log(JSON.stringify({ caught, txClosed: tx.closed }));
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ caught: "EMSGSIZE", txClosed: false });
+  expect(exitCode).toBe(0);
+});
+
+// Belt-and-suspenders for the same contract on a connected socket: even when
+// IP_RECVERR is armed and the error queue delivers, a socket with no error
+// handler must not turn that into an uncaught exception.
+test.skipIf(!isLinux)("connected socket with no error handler survives ICMP port unreachable", async () => {
+  const src = `
+    const probe = await Bun.udpSocket({ hostname: "127.0.0.1" });
+    const deadPort = probe.port;
+    probe.close();
+    const s = await Bun.udpSocket({
+      hostname: "127.0.0.1",
+      connect: { hostname: "127.0.0.1", port: deadPort },
+      socket: { data() {} },
+    });
+    for (let i = 0; i < 5; i++) { s.send("x"); await Bun.sleep(20); }
+    console.log(JSON.stringify({ closed: s.closed }));
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ closed: false });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes #4500. Supersedes #29135 (same root approach, rebased onto the current two-arg `on_recv_error` signature and extended to cover the no-handler fatal and the sk_err recv-path cases).

#### Repro

```ts
// server with the documented shape: data handler only, no error handler
const server = await Bun.udpSocket({
  port: 0, hostname: '127.0.0.1',
  socket: { data(s, d, port, addr) { s.send(d, port, addr); } },
});
const c = await Bun.udpSocket({ hostname: '127.0.0.1' });
c.send('q', server.port, '127.0.0.1');
c.close();                               // gone before the reply -> ICMP at the server
```
```
ECONNREFUSED: connection refused, recv
 syscall: "recv", errno: -111, code: "ECONNREFUSED"
```

and the process exits 1. Any DNS/statsd/game/echo server that replies to an ephemeral client is killed by one datagram from a peer that stops listening before the answer. The identical service under Node's `dgram` stays alive because libuv never enables `IP_RECVERR`.

A second face of the same dispatch: `send(new Uint8Array(65510), ...)` throws `EMSGSIZE` synchronously (caught by the caller), but with `IP_RECVERR` on the kernel also queues the same `EMSGSIZE` on the error queue, and the async redelivery becomes an uncaught exception.

The node:dgram echo server hits a third path: the reply goes out from inside the `'message'` handler, so on loopback the ICMP lands during `loop.c`'s `recvmmsg` do-while and poisons `sk_err`; the next iteration fails with `ECONNREFUSED` and `is_errqueue=0`, which bypasses the errqueue-only filter added in the earlier dgram fix.

#### Cause

`us_create_udp_socket` forced `LIBUS_UDP_LINUX_RECVERR` whenever an `on_recv_error` callback existed, which is always for `Bun.udpSocket` and `node:dgram`. With `IP_RECVERR` set the Linux kernel both queues the ICMP on the error queue and sets `sk_err`. `on_recv_error`'s no-handler path in `udp_socket.rs` went straight to `vm.uncaught_exception`.

#### Fix

- `udp.c`: stop forcing `IP_RECVERR` at socket creation. Arm it in `us_udp_socket_connect` (the only state with a single peer to attribute an ICMP to) and disarm it, clearing `sk_err` via `SO_ERROR`, in `us_udp_socket_disconnect`. Unconnected sockets now match Node/libuv: the kernel drops the ICMP, nothing reaches the error queue, and `sk_err` is never set.
- `bsd.c`: `bsd_udp_socket_set_recverr()` helper shared by the creation-time opt-in and the connect/disconnect toggle.
- `udp_socket.rs` `on_recv_error`: with no JS `error` handler registered, drop the recv-path error instead of routing it to `uncaught_exception`. A UDP receive-path error is advisory (the socket stays open); a caller that wants it registers a handler. `node:dgram` always registers one, so its own connected-socket semantics are unchanged.

#### Verification

- `test/js/bun/udp/udp_socket_recv_flags.test.ts`
  - unconnected socket with no error handler survives ICMP port unreachable
  - oversized send caught synchronously does not also kill via the error queue
  - connected socket with no error handler survives ICMP (RECVERR armed, dispatch non-fatal)
  - connected socket with an error handler still surfaces `ECONNREFUSED` and stays open
- `test/js/bun/udp/dgram.test.ts`
  - unconnected echo server without an `'error'` listener survives ICMP from a vanished client (the reply-from-`'message'`-handler shape, sk_err path)
- 263/263 in `test/js/bun/udp/`, 75/75 `test/js/node/test/parallel/test-dgram-*`, 14/14 `test/js/node/quic/`, 52/52 `test/js/web/fetch/fetch-http3-client.test.ts` (shared `us_create_udp_socket` path).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/dgram.test.ts test/js/bun/udp/udp_socket_recv_flags.test.ts

<!-- robobun:evidence:end -->