### PR TITLE
udp: do not let remote ICMP kill an unconnected socket

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -457,6 +457,46 @@ void us_internal_loop_post(struct us_loop_t *loop) {
 #define us_ioctl ioctl
 #endif
 
+#if defined(__linux__)
+/* Drain a UDP socket's MSG_ERRQUEUE. Each remote-origin (ICMP/ICMP6) entry is
+ * surfaced via on_recv_error with is_errqueue=1; SO_EE_ORIGIN_LOCAL entries are
+ * skipped — the failing syscall already returned that errno synchronously, so
+ * redelivering it here is a double report. After draining, SO_ERROR is read to
+ * clear any mirrored sk_err so EPOLLERR does not stay level-set with an empty
+ * queue (which would fall through to recvmmsg and surface the same errno again
+ * without the errqueue flag). Returns the number of entries dequeued. */
+static int us_internal_udp_drain_errqueue(struct us_udp_socket_t *u, LIBUS_SOCKET_DESCRIPTOR fd) {
+    int drained = 0;
+    struct msghdr eh; char ectrl[512]; char ebuf[1];
+    struct iovec eiov = { ebuf, sizeof(ebuf) };
+    while (!u->closed) {
+        memset(&eh, 0, sizeof(eh));
+        eh.msg_iov = &eiov; eh.msg_iovlen = 1;
+        eh.msg_control = ectrl; eh.msg_controllen = sizeof(ectrl);
+        if (recvmsg(fd, &eh, MSG_ERRQUEUE) < 0) break;
+        drained++;
+        if (!u->on_recv_error) continue;
+        int ee = 0, origin = -1;
+        for (struct cmsghdr *cm = CMSG_FIRSTHDR(&eh); cm; cm = CMSG_NXTHDR(&eh, cm)) {
+            if ((cm->cmsg_level == IPPROTO_IP   && cm->cmsg_type == IP_RECVERR) ||
+                (cm->cmsg_level == IPPROTO_IPV6 && cm->cmsg_type == IPV6_RECVERR)) {
+                struct sock_extended_err *se = (struct sock_extended_err *) CMSG_DATA(cm);
+                ee = se->ee_errno;
+                origin = se->ee_origin;
+                break;
+            }
+        }
+        if (origin == SO_EE_ORIGIN_LOCAL) continue;
+        u->on_recv_error(u, ee ? ee : ECONNREFUSED, 1);
+    }
+    if (drained && !u->closed) {
+        int so_err = 0; socklen_t sl = sizeof(so_err);
+        getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_err, &sl);
+    }
+    return drained;
+}
+#endif
+
 void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, int events) {
     switch (us_internal_poll_type(p)) {
     case POLL_TYPE_CALLBACK: {
@@ -904,28 +944,8 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             int recv_error_surfaced = 0;
             int recv_would_block_only = 0;
             if (error) {
-                struct msghdr eh; char ectrl[512]; char ebuf[1];
-                struct iovec eiov = { ebuf, sizeof(ebuf) };
-                while (!u->closed) {
-                    memset(&eh, 0, sizeof(eh));
-                    eh.msg_iov = &eiov; eh.msg_iovlen = 1;
-                    eh.msg_control = ectrl; eh.msg_controllen = sizeof(ectrl);
-                    if (recvmsg(us_poll_fd(p), &eh, MSG_ERRQUEUE) < 0) break;
-                    recv_error_surfaced = 1;
-                    if (u->on_recv_error) {
-                        /* The queued ICMP error is in sock_extended_err,
-                         * not errno. */
-                        int ee = 0;
-                        for (struct cmsghdr *cm = CMSG_FIRSTHDR(&eh); cm; cm = CMSG_NXTHDR(&eh, cm)) {
-                            if ((cm->cmsg_level == IPPROTO_IP   && cm->cmsg_type == IP_RECVERR) ||
-                                (cm->cmsg_level == IPPROTO_IPV6 && cm->cmsg_type == IPV6_RECVERR)) {
-                                ee = ((struct sock_extended_err *) CMSG_DATA(cm))->ee_errno;
-                                break;
-                            }
-                        }
-                        u->on_recv_error(u, ee ? ee : ECONNREFUSED, 1);
-                    }
-                }
+                recv_error_surfaced =
+                    us_internal_udp_drain_errqueue(u, us_poll_fd(p)) > 0;
             }
 
             /* An EPOLLERR with no EPOLLIN and an empty error queue still has to
@@ -967,6 +987,18 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                                 if (u->on_recv_error) {
 #if defined(__linux__)
                                     recv_error_surfaced = 1;
+                                    /* On Linux the kernel mirrors a queued
+                                     * ICMP into sk_err, so recvmmsg can return
+                                     * it here before EPOLLERR is dispatched
+                                     * (e.g. on_data just sent a reply to a
+                                     * port that already closed). If the error
+                                     * queue has the entry, that is the source
+                                     * and the recvmmsg errno is its mirror —
+                                     * surface the queue (is_errqueue=1), not a
+                                     * second un-flagged copy. */
+                                    if (us_internal_udp_drain_errqueue(u, us_poll_fd(p)) > 0) {
+                                        break;
+                                    }
 #endif
                                     u->on_recv_error(u, recv_err, 0);
                                 } else {

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -724,12 +724,6 @@ function startBunSocket(self, state, createOptions) {
         },
         error: error => {
           if (error?.syscall === "recv") {
-            // Drop errqueue-origin ICMP errors on unconnected sockets like
-            // Node (which never enables IP_RECVERR); always emit real
-            // recvmmsg failures — the errno namespaces overlap.
-            if (error.errqueue === true && state.connectState !== CONNECT_STATE_CONNECTED) {
-              return;
-            }
             // Node reports receive-path failures as `recvmsg` errors; keep
             // the native error so its code stays platform-correct.
             error.syscall = "recvmsg";

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -95,9 +95,19 @@ extern "C" fn on_recv_error(socket: *mut uws::udp::Socket, errno: c_int, is_errq
     // Reached on every POSIX platform. `is_errqueue` distinguishes an ICMP
     // errno drained from Linux's MSG_ERRQUEUE from a real recvmmsg failure —
     // which on the BSDs (no error queue) is also how a connected socket's
-    // ICMP error (so_error) arrives. node:dgram must drop only the former on
-    // unconnected sockets, and the errno namespaces overlap.
+    // ICMP error (so_error) arrives.
     let this: &UDPSocket = UDPSocket::from_uws(socket);
+    // Node never enables IP_RECVERR, so Linux drops ICMP for an unconnected
+    // UDP socket before it can reach sk_err (`__udp4_lib_err`: `if (!harderr
+    // || sk->sk_state != TCP_ESTABLISHED) goto out;`). Bun keeps IP_RECVERR
+    // on to drain the queue, but the only observable effect that matches
+    // Node is to discard those entries here — one layer below node:dgram's
+    // own filter so Bun.udpSocket inherits the same behavior and a reply
+    // server without an error handler is not killed by a vanished client.
+    // Connected sockets keep the error: Node surfaces that via recvmsg too.
+    if is_errqueue != 0 && this.connect_info.get().is_none() {
+        return;
+    }
     let sys_err = bun_sys::Error::from_code_int(errno, bun_sys::Tag::recv);
     let global_this = this.global_this.get();
     // A callback earlier in the same poll dispatch may have left a

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -95,11 +95,9 @@ extern "C" fn on_recv_error(socket: *mut uws::udp::Socket, errno: c_int, is_errq
     // Reached on every POSIX platform. `is_errqueue` distinguishes an ICMP
     // errno drained from Linux's MSG_ERRQUEUE from a real recvmmsg failure —
     // which on the BSDs (no error queue) is also how a connected socket's
-    // ICMP error (so_error) arrives.
+    // ICMP error (so_error) arrives. Node never enables IP_RECVERR, so its
+    // kernel drops ICMP for an unconnected socket; do the same here.
     let this: &UDPSocket = UDPSocket::from_uws(socket);
-    // Node never enables IP_RECVERR, so the kernel drops ICMP for an
-    // unconnected socket; match that here so a reply server is not killed
-    // by a vanished client. Connected sockets keep the error.
     if is_errqueue != 0 && this.connect_info.get().is_none() {
         return;
     }

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -97,14 +97,9 @@ extern "C" fn on_recv_error(socket: *mut uws::udp::Socket, errno: c_int, is_errq
     // which on the BSDs (no error queue) is also how a connected socket's
     // ICMP error (so_error) arrives.
     let this: &UDPSocket = UDPSocket::from_uws(socket);
-    // Node never enables IP_RECVERR, so Linux drops ICMP for an unconnected
-    // UDP socket before it can reach sk_err (`__udp4_lib_err`: `if (!harderr
-    // || sk->sk_state != TCP_ESTABLISHED) goto out;`). Bun keeps IP_RECVERR
-    // on to drain the queue, but the only observable effect that matches
-    // Node is to discard those entries here, so Bun.udpSocket and node:dgram
-    // both inherit Node's semantics and a reply server without an error
-    // handler is not killed by a vanished client. Connected sockets keep the
-    // error: Node surfaces that via recvmsg too.
+    // Node never enables IP_RECVERR, so the kernel drops ICMP for an
+    // unconnected socket; match that here so a reply server is not killed
+    // by a vanished client. Connected sockets keep the error.
     if is_errqueue != 0 && this.connect_info.get().is_none() {
         return;
     }

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -101,10 +101,10 @@ extern "C" fn on_recv_error(socket: *mut uws::udp::Socket, errno: c_int, is_errq
     // UDP socket before it can reach sk_err (`__udp4_lib_err`: `if (!harderr
     // || sk->sk_state != TCP_ESTABLISHED) goto out;`). Bun keeps IP_RECVERR
     // on to drain the queue, but the only observable effect that matches
-    // Node is to discard those entries here — one layer below node:dgram's
-    // own filter so Bun.udpSocket inherits the same behavior and a reply
-    // server without an error handler is not killed by a vanished client.
-    // Connected sockets keep the error: Node surfaces that via recvmsg too.
+    // Node is to discard those entries here, so Bun.udpSocket and node:dgram
+    // both inherit Node's semantics and a reply server without an error
+    // handler is not killed by a vanished client. Connected sockets keep the
+    // error: Node surfaces that via recvmsg too.
     if is_errqueue != 0 && this.connect_info.get().is_none() {
         return;
     }
@@ -119,11 +119,7 @@ extern "C" fn on_recv_error(socket: *mut uws::udp::Socket, errno: c_int, is_errq
     if global_this.has_exception() {
         return;
     }
-    let err_value = sys_err.to_js(global_this);
-    if is_errqueue != 0 {
-        err_value.put(global_this, b"errqueue", JSValue::TRUE);
-    }
-    this.call_error_handler(JSValue::ZERO, err_value);
+    this.call_error_handler(JSValue::ZERO, sys_err.to_js(global_this));
 }
 
 extern "C" fn on_drain(socket: *mut uws::udp::Socket) {

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, jest, test } from "bun:test";
 import { createSocket } from "dgram";
 import { Worker } from "node:worker_threads";
 
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isLinux, isWindows } from "harness";
 import path from "path";
 import { nodeDataCases } from "./testdata";
 
@@ -437,6 +437,51 @@ test("setBroadcast()/setMulticastLoopback() before bind() throw EBADF", () => {
     expect(() => socket[method](true)).toThrow(`${method} EBADF`);
   }
   socket.close();
+});
+
+// An echo server in the Node docs shape (no 'error' listener) must survive a
+// client that sends one datagram and closes before the reply arrives. Linux
+// only: without IP_RECVERR the kernel never sets sk_err for an unconnected
+// socket, so the failure mode this guards does not exist elsewhere.
+test.skipIf(!isLinux)("unconnected echo server without an 'error' listener survives a vanished client", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import dgram from "node:dgram";
+      const server = dgram.createSocket("udp4");
+      server.on("message", (msg, rinfo) => server.send(msg, rinfo.port, rinfo.address));
+      await new Promise(r => server.bind(0, "127.0.0.1", r));
+      const port = server.address().port;
+      // First client: send and close immediately so the reply hits a dead port.
+      const c1 = dgram.createSocket("udp4");
+      await new Promise(r => c1.bind(0, "127.0.0.1", r));
+      c1.send("gone", port, "127.0.0.1", () => c1.close());
+      // Second client: must receive its echo after the ICMP.
+      const c2 = dgram.createSocket("udp4");
+      await new Promise(r => c2.bind(0, "127.0.0.1", r));
+      const got = await new Promise((resolve, reject) => {
+        let n = 0;
+        const t = setInterval(() => {
+          if (++n > 400) { clearInterval(t); return reject(new Error("timeout")); }
+          c2.send("probe", port, "127.0.0.1");
+        }, 10);
+        c2.on("message", m => { clearInterval(t); resolve(m.toString()); });
+      });
+      console.log(JSON.stringify({ got }));
+      c2.close();
+      server.close();
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(`{"got":"probe"}`);
+  expect(exitCode).toBe(0);
 });
 
 // An oversized datagram fails send(2) with EMSGSIZE; on the connected path no

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -1,7 +1,7 @@
 import { udpSocket } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows, randomPort } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isLinux, isWindows, randomPort } from "harness";
 import path from "node:path";
 import { dataCases, dataTypes } from "./testdata";
 
@@ -582,6 +582,100 @@ describe("udpSocket()", () => {
       },
       30_000,
     );
+  });
+});
+
+// IP_RECVERR is Linux-only: on macOS/BSD the kernel never queues ICMP for an
+// unconnected UDP socket, and on Windows SIO_UDP_CONNRESET is already off.
+describe.skipIf(!isLinux)("unconnected socket vs. remote ICMP", () => {
+  // A reply server in the shape the docs show (no error handler) must not be
+  // killed by a client that sends one datagram and closes before the reply
+  // arrives: the reply hits a closed port, the kernel answers with ICMP port
+  // unreachable, and that used to surface as an uncaught ECONNREFUSED.
+  test("reply server without an error handler survives a vanished client", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import dgram from "node:dgram";
+        const server = await Bun.udpSocket({
+          port: 0,
+          hostname: "127.0.0.1",
+          socket: {
+            data(socket, data, port, address) { socket.send(data, port, address); },
+          },
+        });
+        // First client: send and close immediately so the reply hits a dead port.
+        const c1 = dgram.createSocket("udp4");
+        await new Promise(r => c1.bind(0, "127.0.0.1", r));
+        c1.send("gone", server.port, "127.0.0.1", () => c1.close());
+        // Second client: the server MUST answer it after the ICMP.
+        const c2 = dgram.createSocket("udp4");
+        await new Promise(r => c2.bind(0, "127.0.0.1", r));
+        const got = await new Promise((resolve, reject) => {
+          let n = 0;
+          const t = setInterval(() => {
+            if (server.closed) { clearInterval(t); return reject(new Error("server closed")); }
+            if (++n > 400) { clearInterval(t); return reject(new Error("timeout")); }
+            c2.send("probe", server.port, "127.0.0.1");
+          }, 10);
+          c2.on("message", m => { clearInterval(t); resolve(m.toString()); });
+        });
+        console.log(JSON.stringify({ got, closed: server.closed }));
+        c2.close();
+        server.close();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(`{"got":"probe","closed":false}`);
+    expect(exitCode).toBe(0);
+  });
+
+  // send() rejects an oversized payload synchronously with EMSGSIZE; the same
+  // error used to also be queued on the socket's error queue (SO_EE_ORIGIN_LOCAL)
+  // and redelivered asynchronously, turning a caught throw into a process kill.
+  test("oversized send() throws EMSGSIZE once and does not redeliver it asynchronously", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const errs = [];
+        const s = await Bun.udpSocket({
+          port: 0,
+          hostname: "127.0.0.1",
+          socket: {
+            data() {},
+            error(err) { errs.push(err?.code ?? String(err)); },
+          },
+        });
+        let syncErr = null;
+        try {
+          s.send(new Uint8Array(65510), 1, "127.0.0.1");
+        } catch (e) {
+          syncErr = e?.code ?? String(e);
+        }
+        // Drive the loop past the EPOLLERR that draining the local-origin
+        // errqueue entry produces.
+        for (let i = 0; i < 10; i++) await new Promise(r => setImmediate(r));
+        console.log(JSON.stringify({ syncErr, asyncErrs: errs, closed: s.closed }));
+        s.close();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(`{"syncErr":"EMSGSIZE","asyncErrs":[],"closed":false}`);
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -631,7 +631,11 @@ describe.skipIf(!isLinux)("unconnected socket vs. remote ICMP", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const stderr = rawStderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe(`{"got":"probe","closed":false}`);
     expect(exitCode).toBe(0);
@@ -639,7 +643,8 @@ describe.skipIf(!isLinux)("unconnected socket vs. remote ICMP", () => {
 
   // send() rejects an oversized payload synchronously with EMSGSIZE; the same
   // error used to also be queued on the socket's error queue (SO_EE_ORIGIN_LOCAL)
-  // and redelivered asynchronously, turning a caught throw into a process kill.
+  // and redelivered asynchronously. A connected socket exercises the origin
+  // check directly (on an unconnected one the errqueue drop would mask it).
   test("oversized send() throws EMSGSIZE once and does not redeliver it asynchronously", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -647,9 +652,9 @@ describe.skipIf(!isLinux)("unconnected socket vs. remote ICMP", () => {
         "-e",
         `
         const errs = [];
+        const peer = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1" });
         const s = await Bun.udpSocket({
-          port: 0,
-          hostname: "127.0.0.1",
+          connect: { hostname: "127.0.0.1", port: peer.port },
           socket: {
             data() {},
             error(err) { errs.push(err?.code ?? String(err)); },
@@ -657,7 +662,7 @@ describe.skipIf(!isLinux)("unconnected socket vs. remote ICMP", () => {
         });
         let syncErr = null;
         try {
-          s.send(new Uint8Array(65510), 1, "127.0.0.1");
+          s.send(new Uint8Array(65510));
         } catch (e) {
           syncErr = e?.code ?? String(e);
         }
@@ -666,13 +671,18 @@ describe.skipIf(!isLinux)("unconnected socket vs. remote ICMP", () => {
         for (let i = 0; i < 10; i++) await new Promise(r => setImmediate(r));
         console.log(JSON.stringify({ syncErr, asyncErrs: errs, closed: s.closed }));
         s.close();
+        peer.close();
         `,
       ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const stderr = rawStderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe(`{"syncErr":"EMSGSIZE","asyncErrs":[],"closed":false}`);
     expect(exitCode).toBe(0);

--- a/test/js/bun/udp/udp_socket_recv_flags.test.ts
+++ b/test/js/bun/udp/udp_socket_recv_flags.test.ts
@@ -37,23 +37,19 @@ describe("udpSocket() receive flags", () => {
   });
 
   // IP_RECVERR is Linux-specific. On BSDs and Windows, ICMP errors on
-  // unconnected UDP sockets either propagate by default or are delivered
-  // through different channels that we don't currently surface.
+  // unconnected UDP sockets are not queued by the kernel at all.
   test.skipIf(!isLinux)(
-    "surfaces ECONNREFUSED from ICMP port unreachable (IP_RECVERR) and keeps the socket usable",
+    "connected socket surfaces ECONNREFUSED from ICMP port unreachable and stays usable",
     async () => {
       const { promise: errPromise, resolve: resolveErr } = Promise.withResolvers<Error & { code?: string }>();
-      const { promise: msgPromise, resolve: resolveMsg } = Promise.withResolvers<string>();
 
-      const receiver = await udpSocket({
-        socket: {
-          data(_socket, data) {
-            resolveMsg(data.toString());
-          },
-        },
-      });
+      // Bind then close a probe so the port is known-dead.
+      const probe = await udpSocket({});
+      const deadPort = probe.port;
+      probe.close();
 
       const sender = await udpSocket({
+        connect: { hostname: "127.0.0.1", port: deadPort },
         socket: {
           error(err: Error & { code?: string }) {
             resolveErr(err);
@@ -61,12 +57,10 @@ describe("udpSocket() receive flags", () => {
         },
       });
 
-      // Send to a closed port on localhost. The kernel replies with ICMP
-      // port unreachable; with IP_RECVERR the next recv surfaces ECONNREFUSED.
       let gotError = false;
       function sendDead() {
         if (!gotError && !sender.closed) {
-          sender.send("dead", 1, "127.0.0.1");
+          sender.send("dead");
           setTimeout(sendDead, 10);
         }
       }
@@ -76,20 +70,9 @@ describe("udpSocket() receive flags", () => {
         const err = await errPromise;
         gotError = true;
         expect(err?.code).toBe("ECONNREFUSED");
-        // The sender socket must remain usable after an ICMP error.
         expect(sender.closed).toBe(false);
-
-        function sendAlive() {
-          if (!sender.closed && !receiver.closed) {
-            sender.send("alive", receiver.port, "127.0.0.1");
-            setTimeout(sendAlive, 10);
-          }
-        }
-        sendAlive();
-        expect(await msgPromise).toBe("alive");
       } finally {
         sender.close();
-        receiver.close();
       }
     },
   );

--- a/test/js/bun/udp/udp_socket_recv_flags.test.ts
+++ b/test/js/bun/udp/udp_socket_recv_flags.test.ts
@@ -37,9 +37,12 @@ describe("udpSocket() receive flags", () => {
   });
 
   // IP_RECVERR is Linux-specific. On BSDs and Windows, ICMP errors on
-  // unconnected UDP sockets are not queued by the kernel at all.
+  // unconnected UDP sockets are not queued by the kernel at all. The
+  // I/O-after-ICMP round-trip is covered by the reply-server test in
+  // udp_socket.test.ts; Bun.udpSocket exposes no public reconnect to
+  // exercise it on the connected path.
   test.skipIf(!isLinux)(
-    "connected socket surfaces ECONNREFUSED from ICMP port unreachable and stays usable",
+    "connected socket surfaces ECONNREFUSED from ICMP port unreachable and stays open",
     async () => {
       const { promise: errPromise, resolve: resolveErr } = Promise.withResolvers<Error & { code?: string }>();
 


### PR DESCRIPTION
## Repro

A docs-shape `Bun.udpSocket` reply server, no error handler:

```js
const server = await Bun.udpSocket({
  port: 0, hostname: "127.0.0.1",
  socket: { data(socket, data, port, address) { socket.send(data, port, address); } },
});
// client: send one datagram then close before the reply arrives
import dgram from "node:dgram";
const c = dgram.createSocket("udp4");
c.send("query", server.port, "127.0.0.1", () => c.close());
```

On `main` the process dies with `ECONNREFUSED errno: -111` as soon as the reply hits the closed port and the kernel answers with ICMP port unreachable. Node survives. The same happens to a `node:dgram` echo server with no `'error'` listener.

Separately, a `send()` that already throws `EMSGSIZE` synchronously is redelivered a second time via the error queue, so a caught oversize send still kills the process.

## Cause

Bun enables `IP_RECVERR` on every UDP socket so Linux queues the ICMP instead of dropping it. Three delivery paths turn that into an uncaught:

- `loop.c` drains `MSG_ERRQUEUE` and calls `on_recv_error(.., is_errqueue=1)`; `udp_socket.rs` routes that to `uncaught_exception` when there is no error handler.
- The kernel also mirrors the queued ICMP into `sk_err`, so the next `recvmmsg` in the same dispatch (right after `on_data` sent the reply) fails with the same errno. That reaches `on_recv_error(.., is_errqueue=0)`, which `node:dgram`'s errqueue filter cannot drop, so `'error'` is emitted on a socket with no listener.
- `ip_local_error()` queues the `EMSGSIZE` from the failing `sendmsg` with `SO_EE_ORIGIN_LOCAL`; the drain loop never read `ee_origin`, so it redelivered an errno the syscall had already returned.

## Fix

- `packages/bun-usockets/src/loop.c`: factor the errqueue drain into a helper that reads `ee_origin`, skips `SO_EE_ORIGIN_LOCAL` entries, and reads `SO_ERROR` afterwards to clear the mirrored `sk_err`. When `recvmmsg` fails with a non-`EAGAIN` errno on Linux, drain the error queue first; if it has the entry, surface that (flagged) instead of a second un-flagged copy.
- `src/runtime/socket/udp_socket.rs`: drop `is_errqueue=1` errors on unconnected sockets. Node never enables `IP_RECVERR`, so the kernel drops these before they reach `sk_err`; dropping them here gives `Bun.udpSocket` and `node:dgram` the same semantics. Connected sockets keep the error.

## Verification

New tests (all Linux-only, `IP_RECVERR` is Linux-specific), each fail on `main` and pass here, 5/5 runs:

- `test/js/bun/udp/udp_socket.test.ts`: reply server with no error handler survives a vanished client and answers the next one; oversized `send()` throws `EMSGSIZE` once and is not redelivered
- `test/js/bun/udp/dgram.test.ts`: `node:dgram` echo server with no `'error'` listener survives a vanished client

`test/js/bun/udp/udp_socket_recv_flags.test.ts` now uses a connected socket to exercise the ECONNREFUSED path (unconnected sockets intentionally no longer surface remote ICMP).

262/262 in `test/js/bun/udp/`, 75/75 `test/js/node/test/parallel/test-dgram-*.js`, 52/52 in `fetch-http3-client.test.ts` (shares the UDP poll path).

Related: #29135 took the alternative of toggling `IP_RECVERR` on connect/disconnect; this PR keeps `IP_RECVERR` on and filters at dispatch instead, so the `sk_err` mirror on a reply server's own `recvmmsg` loop is handled and `SO_EE_ORIGIN_LOCAL` is distinguished.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/dgram.test.ts test/js/bun/udp/udp_socket.test.ts test/js/bun/udp/udp_socket_recv_flags.test.ts

<!-- robobun:evidence:end -->