### PR TITLE
jsc: throw RangeError for deeply nested array destructuring instead of SIGSEGV

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-355-ebad754e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/deep-destructuring-bindvalue.test.ts
+++ b/test/js/bun/jsc/deep-destructuring-bindvalue.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A deeply nested array destructuring pattern used to SIGSEGV in a release
+// build: ArrayPatternNode::bindValue recursed through its try/finally wrapper
+// into the nested pattern with no isSafeToRecurse() check, so bytecode
+// generation ran the native stack past the guard page. Under debug/ASAN the
+// fatter frames tripped the parser's own limit first, so the crash was a
+// release-only silent exit 139.
+//
+// The source is fed through (0, eval) so JavaScriptCore compiles it directly;
+// bun's own transpiler never sees the deep pattern and cannot mask the bug.
+
+async function run(label: string, source: string) {
+  const script = `
+    try {
+      (0, eval)(${JSON.stringify(source)});
+      console.log("ran");
+    } catch (e) {
+      console.log(e?.constructor?.name ?? "threw");
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { label, stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+}
+
+const N = 12000;
+const open = Buffer.alloc(N, "[").toString();
+const close = Buffer.alloc(N, "]").toString();
+
+test.concurrent("let declaration", async () => {
+  expect(await run("let", `let ${open}z${close} = [];`)).toMatchObject({
+    stdout: "RangeError",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+test.concurrent("for-of binding", async () => {
+  expect(await run("for-of", `for (let ${open}z${close} of [[]]){}`)).toMatchObject({
+    stdout: "RangeError",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+test.concurrent("catch parameter", async () => {
+  expect(await run("catch", `try{throw []}catch(${open}z${close}){}`)).toMatchObject({
+    stdout: "RangeError",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+test.concurrent("function parameter", async () => {
+  expect(await run("param", `(function(${open}z${close}){})([]);`)).toMatchObject({
+    stdout: "RangeError",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+// Sanity: a pattern that is deep but well within any build's limit still
+// compiles and runs, and the error it throws comes from evaluating the
+// destructuring at runtime, not from the new guard.
+test.concurrent("shallow pattern still runs", async () => {
+  const n = 64;
+  const o = Buffer.alloc(n, "[").toString();
+  const c = Buffer.alloc(n, "]").toString();
+  expect(await run("shallow", `let ${o}z${c} = [];`)).toMatchObject({
+    stdout: "TypeError",
+    exitCode: 0,
+    signalCode: null,
+  });
+});


### PR DESCRIPTION
Depends on oven-sh/WebKit#355. This PR bumps `WEBKIT_VERSION` to the preview build of that fix and adds a regression test; the preview release is `autobuild-preview-pr-355-ebad754e`.

## Reproduction

```js
const N = 12000;
const src = "let " + "[".repeat(N) + "z" + "]".repeat(N) + " = w;\n";
(0, eval)(src);   // SIGSEGV on a stock release build, silent exit 139
```

Every evaluation entry point hits it: `bun run file.js`, module import, `eval`, `for (let [[…]] of x)`, `catch ([[…]])`, function parameters. Node throws `RangeError: Maximum call stack size exceeded` for the same input. Debug/ASAN builds are unaffected because their fatter frames make the parser's own stack check fire first.

## Cause

`parseDestructuringPattern` guards its recursion with `failIfStackOverflow()` and can parse ~20k levels. Once parsing succeeds, `BytecodeGenerator` walks the AST via `ArrayPatternNode::bindValue`, which recurses through `emitTryWithFinallyThatDoesNotShadowException` and a `ScopedLambda` into the nested pattern's `bindValue` with no stack check at all. Each level costs roughly 1 KB of native stack (iterator / `done` / `value` temporaries, `CallArguments`, `FinallyContext`, the try-data wrapper), so a pattern ~8.5k levels deep runs past `maxPerThreadStackUsage` and through the OS guard page.

The object binding pattern `let {a:{a:…}}` has the same unbounded recursion but does not crash today only because its per-level frame is small enough that the parser limit trips first.

Bun's own transpiler is not involved: `Bun.Transpiler.transformSync` and `bun build` handle the same file without crashing.

<details>
<summary>Sampled crash backtrace (release, symbols from a local RelWithDebInfo link)</summary>

```
ArrayPatternNode::bindValue
  emitTryWithFinallyThatDoesNotShadowException
    ScopedLambda<void(BytecodeGenerator&)>::operator()
      ArrayPatternNode::bindValue(...)::$_1::operator()    <- target.pattern->bindValue(...)
        ArrayPatternNode::bindValue
          ...  (repeats until rsp lands on the guard page)
```

</details>

## Fix

oven-sh/WebKit#355 adds the same `isSafeToRecurse()` check that `emitNode()` already performs to the top of `ArrayPatternNode::bindValue` and `ObjectPatternNode::bindValue`. On failure it calls `emitThrowExpressionTooDeepException()` and returns; `BytecodeGenerator::generate` then reports `ParserError::OutOfMemory` and the caller sees a catchable `RangeError`.

## Verification

Against a release `bun` linked with the patched WebKit, every entry point that previously segfaulted now throws a `RangeError` at all tested depths; shallow destructuring is unchanged.

```
                no fix              with fix
eval N=12000    SIGSEGV             RangeError (30 ms)
file N=12000    SIGSEGV             RangeError
for-of/catch/param N=12000  SIGSEGV RangeError
let [[...x64...z]] = []     TypeError (runs)   TypeError (runs)
```

`USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/deep-destructuring-bindvalue.test.ts` fails 4/5 with `signalCode: "SIGSEGV"`. The new test drives JSC through `(0, eval)` so bun's transpiler never touches the deep pattern; under the debug/ASAN lanes the child throws `RangeError` for a different reason (the parser's own check), which the test accepts.
