### PR TITLE
node errors: make .code an own property on ERR_* errors

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -237,9 +237,14 @@ JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code,
     if (auto* zigGlobalObject = dynamicDowncast<Zig::GlobalObject>(globalObject))
         return createError(vm, zigGlobalObject, code, message, jsUndefined());
 
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     const auto& data = errors[static_cast<size_t>(code)];
     auto* structure = createErrorStructure(vm, globalObject, data.type, data.name);
     auto* created_error = JSC::ErrorInstance::create(globalObject, structure, message, jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
+    if (auto* thrown_exception = scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return uncheckedDowncast<JSObject>(thrown_exception->value());
+    }
     created_error->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(data.code)), 0);
     return created_error;
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -101,7 +101,7 @@ namespace Bun {
 using namespace JSC;
 using namespace WTF;
 
-static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name, WTF::ASCIILiteral code)
+static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name)
 {
     JSC::JSObject* prototype;
 
@@ -135,9 +135,8 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
         break;
     }
 
-    prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), 0);
-    prototype->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), 0);
-    prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), 0);
+    prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), JSC::PropertyAttribute::DontEnum | 0);
+    prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), JSC::PropertyAttribute::DontEnum | 0);
 
     return prototype;
 }
@@ -189,9 +188,9 @@ static ErrorCodeCache* errorCache(Zig::GlobalObject* globalObject)
 }
 
 // clang-format on
-static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name, WTF::ASCIILiteral code)
+static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name)
 {
-    auto* prototype = createErrorPrototype(vm, globalObject, type, name, code);
+    auto* prototype = createErrorPrototype(vm, globalObject, type, name);
     return ErrorInstance::createStructure(vm, globalObject, prototype);
 }
 
@@ -201,7 +200,7 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto* cache = errorCache(globalObject);
     const auto& data = errors[static_cast<size_t>(code)];
     if (!cache->internalField(static_cast<unsigned>(code))) {
-        auto* structure = createErrorStructure(vm, globalObject, data.type, data.name, data.code);
+        auto* structure = createErrorStructure(vm, globalObject, data.type, data.name);
         cache->internalField(static_cast<unsigned>(code)).set(vm, cache, structure);
     }
 
@@ -214,6 +213,7 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
         // exception were thrown by ErrorInstance::create)
         return uncheckedDowncast<JSObject>(thrown_exception->value());
     }
+    created_error->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(data.code)), 0);
     return created_error;
 }
 
@@ -237,8 +237,11 @@ JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code,
     if (auto* zigGlobalObject = dynamicDowncast<Zig::GlobalObject>(globalObject))
         return createError(vm, zigGlobalObject, code, message, jsUndefined());
 
-    auto* structure = createErrorStructure(vm, globalObject, errors[static_cast<size_t>(code)].type, errors[static_cast<size_t>(code)].name, errors[static_cast<size_t>(code)].code);
-    return JSC::ErrorInstance::create(globalObject, structure, message, jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, errors[static_cast<size_t>(code)].type, true);
+    const auto& data = errors[static_cast<size_t>(code)];
+    auto* structure = createErrorStructure(vm, globalObject, data.type, data.name);
+    auto* created_error = JSC::ErrorInstance::create(globalObject, structure, message, jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
+    created_error->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(data.code)), 0);
+    return created_error;
 }
 
 JSC::JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, JSValue message, JSValue options)
@@ -1008,8 +1011,9 @@ JSC::EncodedJSValue INVALID_ARG_VALUE_RangeError(JSC::ThrowScope& throwScope, JS
     JSValueToStringSafe(globalObject, builder, value, true);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
-    auto* structure = createErrorStructure(vm, globalObject, ErrorType::RangeError, "RangeError"_s, "ERR_INVALID_ARG_VALUE"_s);
+    auto* structure = createErrorStructure(vm, globalObject, ErrorType::RangeError, "RangeError"_s);
     auto error = JSC::ErrorInstance::create(vm, structure, builder.toString(), jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, ErrorType::RangeError, true);
+    error->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String("ERR_INVALID_ARG_VALUE"_s)), 0);
     throwScope.throwException(globalObject, error);
     throwScope.release();
     return {};

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2376,7 +2376,7 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
         if (scope.exception()) {
             scope.clearException();
         } else {
-            result->putDirect(vm, clientData->builtinNames().codePublicName(), code, JSC::PropertyAttribute::DontDelete | 0);
+            result->putDirect(vm, clientData->builtinNames().codePublicName(), code, 0);
         }
     }
 
@@ -2385,7 +2385,7 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
         if (scope.exception()) {
             scope.clearException();
         } else {
-            result->putDirect(vm, clientData->builtinNames().pathPublicName(), path, JSC::PropertyAttribute::DontDelete | 0);
+            result->putDirect(vm, clientData->builtinNames().pathPublicName(), path, 0);
         }
     }
 
@@ -2394,13 +2394,13 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
         if (scope.exception()) {
             scope.clearException();
         } else {
-            result->putDirect(vm, clientData->builtinNames().destPublicName(), dest, JSC::PropertyAttribute::DontDelete | 0);
+            result->putDirect(vm, clientData->builtinNames().destPublicName(), dest, 0);
         }
     }
 
     if (err.fd >= 0) {
         JSC::JSValue fd = jsNumber(err.fd);
-        result->putDirect(vm, names.fdPublicName(), fd, JSC::PropertyAttribute::DontDelete | 0);
+        result->putDirect(vm, names.fdPublicName(), fd, 0);
     }
 
     if (err.syscall.tag != BunStringTag::Empty) {
@@ -2408,7 +2408,7 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
         if (scope.exception()) {
             scope.clearException();
         } else {
-            result->putDirect(vm, names.syscallPublicName(), syscall, JSC::PropertyAttribute::DontDelete | 0);
+            result->putDirect(vm, names.syscallPublicName(), syscall, 0);
         }
     }
 
@@ -2417,11 +2417,11 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
         if (scope.exception()) {
             scope.clearException();
         } else {
-            result->putDirect(vm, names.hostnamePublicName(), hostname, JSC::PropertyAttribute::DontDelete | 0);
+            result->putDirect(vm, names.hostnamePublicName(), hostname, 0);
         }
     }
 
-    result->putDirect(vm, names.errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
+    result->putDirect(vm, names.errnoPublicName(), jsNumber(err.errno_), 0);
 
     return JSC::JSValue::encode(result);
 }
@@ -2444,21 +2444,19 @@ JSC::EncodedJSValue SystemError__toErrorInstanceWithInfoObject(const SystemError
     auto clientData = WebCore::clientData(vm);
 
     result->putDirect(vm, vm.propertyNames->name, jsString(vm, String("SystemError"_s)), JSC::PropertyAttribute::DontEnum | 0);
-    result->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, String("ERR_SYSTEM_ERROR"_s)), JSC::PropertyAttribute::DontEnum | 0);
+    result->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, String("ERR_SYSTEM_ERROR"_s)), 0);
 
-    info->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, codeString), JSC::PropertyAttribute::DontDelete | 0);
-
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "info"_s), info, JSC::PropertyAttribute::DontDelete | 0);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "info"_s), info, 0);
 
     auto syscallJsString = jsString(vm, syscallString);
-    result->putDirect(vm, clientData->builtinNames().syscallPublicName(), syscallJsString, JSC::PropertyAttribute::DontDelete | 0);
-    info->putDirect(vm, clientData->builtinNames().syscallPublicName(), syscallJsString, JSC::PropertyAttribute::DontDelete | 0);
+    result->putDirect(vm, clientData->builtinNames().syscallPublicName(), syscallJsString, 0);
+    info->putDirect(vm, clientData->builtinNames().syscallPublicName(), syscallJsString, 0);
 
-    info->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, codeString), JSC::PropertyAttribute::DontDelete | 0);
-    info->putDirect(vm, vm.propertyNames->message, jsString(vm, messageString), JSC::PropertyAttribute::DontDelete | 0);
+    info->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, codeString), 0);
+    info->putDirect(vm, vm.propertyNames->message, jsString(vm, messageString), 0);
 
-    info->putDirect(vm, clientData->builtinNames().errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
-    result->putDirect(vm, clientData->builtinNames().errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
+    info->putDirect(vm, clientData->builtinNames().errnoPublicName(), jsNumber(err.errno_), 0);
+    result->putDirect(vm, clientData->builtinNames().errnoPublicName(), jsNumber(err.errno_), 0);
 
     return JSC::JSValue::encode(result);
 }

--- a/test/js/node/errors/error-code-own-property.test.ts
+++ b/test/js/node/errors/error-code-own-property.test.ts
@@ -1,7 +1,7 @@
-import { describe, test, expect } from "bun:test";
-import fs from "node:fs";
+import { describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
 
 // Node.js defines `code` on ERR_* errors as an own, enumerable, writable,
 // configurable data property on the instance. That makes it visible to

--- a/test/js/node/errors/error-code-own-property.test.ts
+++ b/test/js/node/errors/error-code-own-property.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
+import os from "node:os";
 
 // Node.js defines `code` on ERR_* errors as an own, enumerable, writable,
 // configurable data property on the instance. That makes it visible to
@@ -66,9 +67,29 @@ describe("Node.js ERR_* error .code is an own property", () => {
     expect(err.name).toBe("RangeError");
   });
 
-  test("errno errors (control) also have own 'code'", () => {
-    const err = capture(() => fs.openSync("/nonexistent-" + Math.random().toString(36).slice(2), "r"));
+  test("errno errors have own 'code' with Node's descriptor", () => {
+    const err = capture(() => fs.openSync("/nonexistent-robobun-probe", "r"));
     expect(err.code).toBe("ENOENT");
-    expect(Object.prototype.hasOwnProperty.call(err, "code")).toBe(true);
+    for (const prop of ["code", "errno", "syscall", "path"] as const) {
+      expect(Object.getOwnPropertyDescriptor(err, prop)).toEqual({
+        value: (err as any)[prop],
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  test("ERR_SYSTEM_ERROR 'code' is own and enumerable", () => {
+    const err = capture(() => os.setPriority(0x7ffffffe, 0));
+    expect(err.code).toBe("ERR_SYSTEM_ERROR");
+    expect(Object.getOwnPropertyDescriptor(err, "code")).toEqual({
+      value: "ERR_SYSTEM_ERROR",
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    expect(Object.keys(err)).toContain("code");
+    expect({ ...err }.code).toBe("ERR_SYSTEM_ERROR");
   });
 });

--- a/test/js/node/errors/error-code-own-property.test.ts
+++ b/test/js/node/errors/error-code-own-property.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from "bun:test";
+import fs from "node:fs";
+import { Buffer } from "node:buffer";
+import { EventEmitter } from "node:events";
+
+// Node.js defines `code` on ERR_* errors as an own, enumerable, writable,
+// configurable data property on the instance. That makes it visible to
+// Object.keys, JSON.stringify, spread and hasOwnProperty, which structured
+// error loggers rely on.
+
+function capture(fn: () => void): Error & { code?: string } {
+  try {
+    fn();
+  } catch (e) {
+    return e as Error & { code?: string };
+  }
+  throw new Error("expected throw");
+}
+
+describe("Node.js ERR_* error .code is an own property", () => {
+  const cases: Array<[string, string, () => void]> = [
+    ["fs options ERR_INVALID_ARG_TYPE", "ERR_INVALID_ARG_TYPE", () => fs.rmSync("/x", { recursive: "yes" as any })],
+    ["fs ERR_OUT_OF_RANGE", "ERR_OUT_OF_RANGE", () => fs.mkdirSync("/x", { mode: -1 })],
+    ["Buffer ERR_OUT_OF_RANGE", "ERR_OUT_OF_RANGE", () => Buffer.alloc(-1)],
+    ["URL ERR_INVALID_URL", "ERR_INVALID_URL", () => new URL("nope")],
+    ["events ERR_INVALID_ARG_TYPE", "ERR_INVALID_ARG_TYPE", () => new EventEmitter().setMaxListeners("x" as any)],
+  ];
+
+  test.each(cases)("%s", (_label, expectedCode, fn) => {
+    const err = capture(fn);
+
+    expect(err.code).toBe(expectedCode);
+
+    const desc = Object.getOwnPropertyDescriptor(err, "code");
+    expect(desc).toEqual({
+      value: expectedCode,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(err, "code")).toBe(true);
+    expect(Object.keys(err)).toContain("code");
+    expect({ ...err }.code).toBe(expectedCode);
+    expect(JSON.parse(JSON.stringify(err)).code).toBe(expectedCode);
+  });
+
+  test("for...in only enumerates own 'code', not prototype name/toString", () => {
+    const err = capture(() => Buffer.alloc(-1));
+    const keys: string[] = [];
+    for (const k in err) keys.push(k);
+    expect(keys).toContain("code");
+    expect(keys).not.toContain("name");
+    expect(keys).not.toContain("toString");
+  });
+
+  test("prototype does not carry 'code'", () => {
+    const err = capture(() => Buffer.alloc(-1));
+    const proto = Object.getPrototypeOf(err);
+    expect(Object.prototype.hasOwnProperty.call(proto, "code")).toBe(false);
+  });
+
+  test("toString() still includes the code", () => {
+    const err = capture(() => Buffer.alloc(-1));
+    expect(String(err)).toContain("[ERR_OUT_OF_RANGE]");
+    expect(err.name).toBe("RangeError");
+  });
+
+  test("errno errors (control) also have own 'code'", () => {
+    const err = capture(() => fs.openSync("/nonexistent-" + Math.random().toString(36).slice(2), "r"));
+    expect(err.code).toBe("ENOENT");
+    expect(Object.prototype.hasOwnProperty.call(err, "code")).toBe(true);
+  });
+});

--- a/test/js/node/errors/error-code-own-property.test.ts
+++ b/test/js/node/errors/error-code-own-property.test.ts
@@ -81,7 +81,7 @@ describe("Node.js ERR_* error .code is an own property", () => {
   });
 
   test("ERR_SYSTEM_ERROR 'code' is own and enumerable", () => {
-    const err = capture(() => os.setPriority(0x7ffffffe, 0));
+    const err = capture(() => os.setPriority(-1, 0));
     expect(err.code).toBe("ERR_SYSTEM_ERROR");
     expect(Object.getOwnPropertyDescriptor(err, "code")).toEqual({
       value: "ERR_SYSTEM_ERROR",


### PR DESCRIPTION
## Repro

```js
import fs from "node:fs";
import { Buffer } from "node:buffer";
import { EventEmitter } from "node:events";
const probe = (label, fn) => { try { fn(); } catch (e) {
  console.log(label.padEnd(30), JSON.stringify({ code: e.code, own: Object.prototype.hasOwnProperty.call(e, "code"), keys: Object.keys(e), json: JSON.stringify(e) })); } };
probe("fs option ERR_INVALID_ARG_TYPE", () => fs.rmSync("/x", { recursive: "yes" }));
probe("Buffer ERR_OUT_OF_RANGE", () => Buffer.alloc(-1));
probe("URL ERR_INVALID_URL", () => new URL("nope"));
probe("events ERR_INVALID_ARG_TYPE", () => new EventEmitter().setMaxListeners("x"));
```

Node v26.3.0:
```
fs option ERR_INVALID_ARG_TYPE {"code":"ERR_INVALID_ARG_TYPE","own":true,"keys":["code"],"json":"{\"code\":\"ERR_INVALID_ARG_TYPE\"}"}
Buffer ERR_OUT_OF_RANGE        {"code":"ERR_OUT_OF_RANGE","own":true,"keys":["code"],"json":"{\"code\":\"ERR_OUT_OF_RANGE\"}"}
URL ERR_INVALID_URL            {"code":"ERR_INVALID_URL","own":true,"keys":["code","input"],"json":"{\"code\":\"ERR_INVALID_URL\",\"input\":\"nope\"}"}
events ERR_INVALID_ARG_TYPE    {"code":"ERR_INVALID_ARG_TYPE","own":true,"keys":["code"],"json":"{\"code\":\"ERR_INVALID_ARG_TYPE\"}"}
```

Bun before:
```
fs option ERR_INVALID_ARG_TYPE {"code":"ERR_INVALID_ARG_TYPE","own":false,"keys":[],"json":"{}"}
Buffer ERR_OUT_OF_RANGE        {"code":"ERR_OUT_OF_RANGE","own":false,"keys":[],"json":"{}"}
URL ERR_INVALID_URL            {"code":"ERR_INVALID_URL","own":false,"keys":[],"json":"{}"}
events ERR_INVALID_ARG_TYPE    {"code":"ERR_INVALID_ARG_TYPE","own":false,"keys":[],"json":"{}"}
```

`for (k in err)` on the same errors yielded `["name","code","toString"]` (leaked from the prototype) in Bun and `["code"]` in Node.

## Cause

`createErrorPrototype` in `src/jsc/bindings/ErrorCode.cpp` wrote `code` (along with `name` and `toString`) as enumerable data properties on a per-`ErrorCode` prototype object. The error instance itself never received an own `code`, so `Object.keys`, `JSON.stringify`, spread and `hasOwnProperty` all missed it, and `for...in` picked up the three enumerable prototype properties instead. In Node.js, `makeNodeErrorWithCode` assigns `error.code = key` directly on the instance.

## Fix

- Drop `code` from the per-code prototype and `putDirect` it on the instance at the three `ErrorInstance::create` sites (`ErrorCodeCache::createError`, the non-Zig-global fallback, and `INVALID_ARG_VALUE_RangeError`) with attributes `0` (writable, enumerable, configurable).
- Mark the remaining prototype `name` and `toString` as `DontEnum` so they no longer appear in `for...in`.
- In `SystemError__toErrorInstance` (errno errors: `ENOENT`, `EACCES`, ...), drop `DontDelete` from `code`/`errno`/`syscall`/`path`/`dest`/`fd`/`hostname` so they are `configurable:true` like Node's `uvException`.
- In `SystemError__toErrorInstanceWithInfoObject` (`ERR_SYSTEM_ERROR` from `node:os`), drop `DontEnum` from `code` so `Object.keys`/spread/`JSON.stringify` see it, and drop `DontDelete` from the remaining properties.

All ERR_* creation paths (C++ `Bun::throwError`/`Bun::ERR::*`, Rust `ErrorCode::throw`, and JS-side `$ERR_*` macros via `jsFunctionMakeErrorWithCode`) funnel through these sites, so one change covers fs, buffer, url, net, events, child_process, etc.

As a side effect, `util.inspect(err)` now shows the trailing `{ code: 'ERR_...' }` block like Node, since `code` is now own and enumerable.

## Verification

New `test/js/node/errors/error-code-own-property.test.ts` asserts, for errors from `node:fs`, `node:buffer`, `URL`, `node:events` and `node:os`, that `code` has the Node descriptor `{value, writable:true, enumerable:true, configurable:true}`, shows up in `Object.keys`/spread/`JSON.stringify`, that `for...in` does not yield `name`/`toString`, that `toString()` still includes the bracketed code, and that errno-family error properties are `configurable:true`.

```
USE_SYSTEM_BUN=1 bun test test/js/node/errors/error-code-own-property.test.ts   9 fail / 1 pass
bun bd test test/js/node/errors/error-code-own-property.test.ts                 10 pass
bun bd test test/js/node/buffer.test.js                                         617 pass
bun bd test test/js/node/os/os.test.js                                          52 pass (1 pre-existing env fail)
bun bd test test/js/node/v8/capture-stack-trace.test.js                         43 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/errors/error-code-own-property.test.ts
bun test v1.4.0 (1a59c335f)

test/js/node/errors/error-code-own-property.test.ts:
31 |     const err = capture(fn);
32 | 
33 |     expect(err.code).toBe(expectedCode);
34 | 
35 |     const desc = Object.getOwnPropertyDescriptor(err, "code");
36 |     expect(desc).toEqual({
                      ^
error: expect(received).toEqual(expected)

- {
-   "configurable": true,
-   "enumerable": true,
-   "value": "ERR_INVALID_ARG_TYPE",
-   "writable": true,
- }
+ undefined

- Expected  - 6
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/errors/error-code-own-property.test.ts:36:18)
(fail) Node.js ERR_* error .code is an own property > fs options ERR_INVALID_ARG_TYPE [14.08ms]
31 |     const err = capture(fn);
32 | 
33 |     expect(err.code).toBe(expectedCode);
34 | 
35 |     const desc = Object.getOwnPropertyDescriptor(err, "code");
36 |     expect(desc).toEqual({
                      ^
error: expect(received).toEqual(expected)

- {
-   "configurable": true,
-   "enumerabl
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (702932229)

test/js/node/errors/error-code-own-property.test.ts:
(pass) Node.js ERR_* error .code is an own property > fs options ERR_INVALID_ARG_TYPE [0.33ms]
(pass) Node.js ERR_* error .code is an own property > fs ERR_OUT_OF_RANGE [0.07ms]
(pass) Node.js ERR_* error .code is an own property > Buffer ERR_OUT_OF_RANGE [0.04ms]
(pass) Node.js ERR_* error .code is an own property > URL ERR_INVALID_URL [0.05ms]
(pass) Node.js ERR_* error .code is an own property > events ERR_INVALID_ARG_TYPE [0.11ms]
(pass) Node.js ERR_* error .code is an own property > for...in only enumerates own 'code', not prototype name/toString [0.07ms]
(pass) Node.js ERR_* error .code is an own property > prototype does not carry 'code' [0.03ms]
(pass) Node.js ERR_* error .code is an own property > toString() still includes the code [0.04ms]
(pass) Node.js ERR_* error .code is an own property > errno errors have own 'code' with Node's descriptor [0.10ms]
(pass) Node.js ERR_* error .code is an own property > ERR_SYSTEM_ERROR 'code' is own and enumerable [0.08ms]

 10 pass
 0 fail
 45 expect() calls
Ran 10 tests across 1 file. [158.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/errors/error-code-own-property.test.ts
bun test v1.4.0 (1a59c335f)

test/js/node/errors/error-code-own-property.test.ts:
(pass) Node.js ERR_* error .code is an own property > fs options ERR_INVALID_ARG_TYPE [21.82ms]
(pass) Node.js ERR_* error .code is an own property > fs ERR_OUT_OF_RANGE [6.51ms]
(pass) Node.js ERR_* error .code is an own property > Buffer ERR_OUT_OF_RANGE [4.28ms]
(pass) Node.js ERR_* error .code is an own property > URL ERR_INVALID_URL [4.36ms]
(pass) Node.js ERR_* error .code is an own property > events ERR_INVALID_ARG_TYPE [9.18ms]
(pass) Node.js ERR_* error .code is an own property > for...in only enumerates own 'code', not prototype name/toString [6.10ms]
(pass) Node.js ERR_* error .code is an own property > prototype does not carry 'code' [4.74ms]
(pass) Node.js ERR_* error .code is an own property > toString() still includes the code [3.90ms]
(pass) Node.js ERR_* error .code is an own property > errno errors have own 'code' with Node's descriptor [6.29ms]
(pass) Node.js ERR_* error .code is an ow
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 805ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/72] gen ErrorCode+*.h
[2/9] cxx obj/src/jsc/bindings/bindings.cpp.o
[3/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[4/9] gen cpp.rs (cppbind)
[4/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compilin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorCode.cpp                     | 29 ++++---
 src/jsc/bindings/bindings.cpp                      | 32 ++++----
 .../js/node/errors/error-code-own-property.test.ts | 95 ++++++++++++++++++++++
 3 files changed, 129 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/jsc/bindings/ErrorCode.cpp                           6      9      0
src/jsc/bindings/bindings.cpp                            0      0      0
test/js/node/errors/error-code-own-property.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->
