### PR TITLE
node:fs: recursive rm names the failing entry in err.path/err.syscall

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7688,9 +7688,12 @@ impl NodeFS {
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]
             let resolved = args.path.slice();
-            if let Err(mut err) =
-                zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::Directory)
-            {
+            if let Err(mut err) = zig_delete_tree(
+                &sys::Dir::cwd(),
+                resolved,
+                args.path.slice(),
+                sys::FileKind::Directory,
+            ) {
                 let mut errno = err.get_errno();
                 if errno == E::EACCES {
                     errno = E::EPERM;
@@ -7731,7 +7734,12 @@ impl NodeFS {
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]
             let resolved = args.path.slice();
-            if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File) {
+            if let Err(err) = zig_delete_tree(
+                &sys::Dir::cwd(),
+                resolved,
+                args.path.slice(),
+                sys::FileKind::File,
+            ) {
                 if err.get_errno() == E::ENOENT {
                     if args.force {
                         return Ok(());
@@ -9579,9 +9587,9 @@ fn dt_map_errno(errno: E) -> E {
     }
 }
 
-/// sub_path / stack[1..].name / leaf (stack[0] *is* sub_path, hence skipped).
-fn dt_join_path(sub_path: &[u8], stack: &[DeleteTreeStackItem], leaf: &[u8]) -> Vec<u8> {
-    let mut cap = sub_path.len();
+/// err_root / stack[1..].name / leaf (stack[0] *is* the root, hence skipped).
+fn dt_join_path(err_root: &[u8], stack: &[DeleteTreeStackItem], leaf: &[u8]) -> Vec<u8> {
+    let mut cap = err_root.len();
     for item in stack.iter().skip(1) {
         cap += 1 + item.name.len();
     }
@@ -9589,7 +9597,7 @@ fn dt_join_path(sub_path: &[u8], stack: &[DeleteTreeStackItem], leaf: &[u8]) -> 
         cap += 1 + leaf.len();
     }
     let mut out = Vec::with_capacity(cap);
-    out.extend_from_slice(sub_path);
+    out.extend_from_slice(err_root);
     for item in stack.iter().skip(1) {
         if !matches!(out.last(), Some(&paths::SEP)) {
             out.push(paths::SEP);
@@ -9695,9 +9703,14 @@ struct DeleteTreeStackItem {
 }
 
 /// Recursive delete; errors name the failing entry's full path and syscall. Top-level `ENOENT` propagates (for `{force:false}`).
-pub fn zig_delete_tree(self_: &sys::Dir, sub_path: &[u8], kind_hint: sys::FileKind) -> Maybe<()> {
+pub fn zig_delete_tree(
+    self_: &sys::Dir,
+    sub_path: &[u8],
+    err_root: &[u8],
+    kind_hint: sys::FileKind,
+) -> Maybe<()> {
     let initial_iterable_dir =
-        match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint, sub_path)? {
+        match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint, err_root)? {
             Some(d) => d,
             None => return Ok(()),
         };
@@ -9733,7 +9746,7 @@ pub fn zig_delete_tree(self_: &sys::Dir, sub_path: &[u8], kind_hint: sys::FileKi
                     return Err(dt_err(
                         err.get_errno(),
                         sys::Tag::scandir,
-                        &dt_join_path(sub_path, &stack[..=top_idx], b""),
+                        &dt_join_path(err_root, &stack[..=top_idx], b""),
                     ));
                 }
             };
@@ -9784,26 +9797,26 @@ pub fn zig_delete_tree(self_: &sys::Dir, sub_path: &[u8], kind_hint: sys::FileKi
                                     return Err(dt_err(
                                         E::ENOTEMPTY,
                                         sys::Tag::rmdir,
-                                        &dt_join_path(sub_path, &stack[..=top_idx], b""),
+                                        &dt_join_path(err_root, &stack[..=top_idx], b""),
                                     ));
                                 }
                                 return Err(dt_err(
                                     e,
                                     sys::Tag::open,
-                                    &dt_join_path(sub_path, &stack[..=top_idx], &entry_name),
+                                    &dt_join_path(err_root, &stack[..=top_idx], &entry_name),
                                 ));
                             }
                             Err(e) => {
                                 return Err(dt_err(
                                     e,
                                     sys::Tag::open,
-                                    &dt_join_path(sub_path, &stack[..=top_idx], &entry_name),
+                                    &dt_join_path(err_root, &stack[..=top_idx], &entry_name),
                                 ));
                             }
                         }
                     } else {
                         let top_fd = stack[top_idx].iter.iter.dir;
-                        let prefix = dt_join_path(sub_path, &stack[..=top_idx], &entry_name);
+                        let prefix = dt_join_path(err_root, &stack[..=top_idx], &entry_name);
                         zig_delete_tree_min_stack_size_with_kind_hint(
                             sys::Dir::borrow(&top_fd),
                             &entry_name,
@@ -9843,20 +9856,20 @@ pub fn zig_delete_tree(self_: &sys::Dir, sub_path: &[u8], kind_hint: sys::FileKi
                                 return Err(dt_err(
                                     E::ENOTEMPTY,
                                     sys::Tag::rmdir,
-                                    &dt_join_path(sub_path, &stack[..=top_idx], b""),
+                                    &dt_join_path(err_root, &stack[..=top_idx], b""),
                                 ));
                             }
                             return Err(dt_err(
                                 e,
                                 sys::Tag::unlink,
-                                &dt_join_path(sub_path, &stack[..=top_idx], &entry_name),
+                                &dt_join_path(err_root, &stack[..=top_idx], &entry_name),
                             ));
                         }
                         Err(e) => {
                             return Err(dt_err(
                                 e,
                                 sys::Tag::unlink,
-                                &dt_join_path(sub_path, &stack[..=top_idx], &entry_name),
+                                &dt_join_path(err_root, &stack[..=top_idx], &entry_name),
                             ));
                         }
                     }
@@ -9880,9 +9893,9 @@ pub fn zig_delete_tree(self_: &sys::Dir, sub_path: &[u8], kind_hint: sys::FileKi
         };
         let popped_path = |stack: &[DeleteTreeStackItem]| -> Vec<u8> {
             if top.name_is_borrowed {
-                sub_path.to_vec()
+                err_root.to_vec()
             } else {
-                dt_join_path(sub_path, stack, &top.name)
+                dt_join_path(err_root, stack, &top.name)
             }
         };
 
@@ -9914,7 +9927,7 @@ pub fn zig_delete_tree(self_: &sys::Dir, sub_path: &[u8], kind_hint: sys::FileKi
                         return Err(dt_err(
                             E::ENOTEMPTY,
                             sys::Tag::rmdir,
-                            &dt_join_path(sub_path, stack, b""),
+                            &dt_join_path(err_root, stack, b""),
                         ));
                     }
                 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -10004,9 +10004,7 @@ fn zig_delete_tree_open_initial_subpath(
         if treat_as_dir {
             return match dt_open_dir(self_, sub_path) {
                 Ok(d) => Ok(Some(d)),
-                // NotDir/FileNotFound surface here (no fall-through to
-                // deleteFile) — deliberate, so `FileNotFound` propagates
-                // (see the zig_delete_tree banner above).
+                // ENOTDIR/ENOENT surface here (no deleteFile fall-through) so top-level ENOENT propagates to the caller.
                 Err(e) => Err(dt_err(e, sys::Tag::open, err_path)),
             };
         } else {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -402,33 +402,6 @@ fn encoding_to_node(e: Encoding) -> bun_core::NodeEncoding {
 /// `super::stat` swaps to `pub use bun_sys::PosixStat` this alias collapses.
 use super::stat::PosixStat;
 
-/// Node `fs.rm` mapping helper — maps an error-set *name* string back to a
-/// `crate::Error` variant so the callers' `map_anyerror_to_errno*` tables (which
-/// match on `err.name()`) keep round-tripping.
-#[inline]
-fn err_from_static(name: &'static str) -> crate::Error {
-    match name {
-        "FileNotFound" => crate::Error::FileNotFound,
-        "AccessDenied" => crate::Error::AccessDenied,
-        "PermissionDenied" => crate::Error::PermissionDenied,
-        "SymLinkLoop" => crate::Error::SymLinkLoop,
-        "NameTooLong" => crate::Error::NameTooLong,
-        "SystemResources" => crate::Error::SystemResources,
-        "ReadOnlyFileSystem" => crate::Error::ReadOnlyFileSystem,
-        "FileSystem" => crate::Error::FileSystem,
-        "FileBusy" => crate::Error::FileBusy,
-        "NotDir" => crate::Error::NotDir,
-        "IsDir" => crate::Error::IsDir,
-        "DirNotEmpty" => crate::Error::DirNotEmpty,
-        "SystemFdQuotaExceeded" => crate::Error::SystemFdQuotaExceeded,
-        "ProcessFdQuotaExceeded" => crate::Error::ProcessFdQuotaExceeded,
-        "BadPathName" => crate::Error::BadPathName,
-        "FileTooBig" => crate::Error::FileTooBig,
-        "NoDevice" => crate::Error::NoDevice,
-        _ => crate::Error::Unexpected,
-    }
-}
-
 /// `preallocate_supported` / `preallocate_length` — these consts have
 /// no equivalent in `bun_sys` (only `preallocate_file()` exists there), so
 /// define them locally so the write-file fast path keeps its 2 MiB guard.
@@ -7715,13 +7688,18 @@ impl NodeFS {
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]
             let resolved = args.path.slice();
-            if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::Directory)
+            if let Err(mut err) =
+                zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::Directory)
             {
-                let mut errno: E = map_anyerror_to_errno(&err);
+                let mut errno = err.get_errno();
+                if errno == E::EACCES {
+                    errno = E::EPERM;
+                }
                 if cfg!(windows) && errno == E::ENOTDIR {
                     errno = E::ENOENT;
                 }
-                return Err(sys::Error::from_code(errno, sys::Tag::rmdir));
+                err.errno = errno as _;
+                return Err(err);
             }
             return Ok(());
         }
@@ -7754,7 +7732,7 @@ impl NodeFS {
             #[cfg(not(windows))]
             let resolved = args.path.slice();
             if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File) {
-                if matches!(err, crate::Error::FileNotFound) {
+                if err.get_errno() == E::ENOENT {
                     if args.force {
                         return Ok(());
                     }
@@ -7764,11 +7742,7 @@ impl NodeFS {
                     return Err(sys::Error::from_code(E::ENOENT, sys::Tag::lstat)
                         .with_path(args.path.slice()));
                 }
-                return Err(sys::Error::from_code(
-                    map_anyerror_to_errno_rm_tree(&err),
-                    sys::Tag::rm,
-                )
-                .with_path(args.path.slice()));
+                return Err(err);
             }
             return Ok(());
         }
@@ -9542,56 +9516,6 @@ impl ReaddirEntry for Buffer {
     }
 }
 
-// There are three distinct error→errno tables: rmdir-recursive,
-// rm-recursive, and rm non-recursive unlink/rmdir. An earlier draft
-// collapsed them into one, which silently mapped AccessDenied→EPERM for `rm`
-// (Node returns EACCES there) and widened the narrow table. Split back out
-// per call site.
-fn map_anyerror_to_errno(err: &crate::Error) -> E {
-    match err.name() {
-        "AccessDenied" => E::EPERM,
-        "PermissionDenied" => E::EPERM,
-        "FileTooBig" => E::EFBIG,
-        "SymLinkLoop" => E::ELOOP,
-        "ProcessFdQuotaExceeded" => E::ENFILE,
-        "NameTooLong" => E::ENAMETOOLONG,
-        "SystemFdQuotaExceeded" => E::EMFILE,
-        "SystemResources" => E::ENOMEM,
-        "ReadOnlyFileSystem" => E::EROFS,
-        "FileSystem" => E::EIO,
-        "FileBusy" | "DeviceBusy" => E::EBUSY,
-        "NotDir" => E::ENOTDIR,
-        "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
-        "FileNotFound" => E::ENOENT,
-        "IsDir" => E::EISDIR,
-        _ => E::EFAULT,
-    }
-}
-
-// `rm` recursive (zig_delete_tree) — same shape as the rmdir table above except
-// AccessDenied maps to EACCES, not EPERM.
-fn map_anyerror_to_errno_rm_tree(err: &crate::Error) -> E {
-    match err.name() {
-        "AccessDenied" => E::EACCES,
-        "PermissionDenied" => E::EPERM,
-        "DirNotEmpty" => E::ENOTEMPTY,
-        "FileTooBig" => E::EFBIG,
-        "SymLinkLoop" => E::ELOOP,
-        "ProcessFdQuotaExceeded" => E::ENFILE,
-        "NameTooLong" => E::ENAMETOOLONG,
-        "SystemFdQuotaExceeded" => E::EMFILE,
-        "SystemResources" => E::ENOMEM,
-        "ReadOnlyFileSystem" => E::EROFS,
-        "FileSystem" => E::EIO,
-        "FileBusy" | "DeviceBusy" => E::EBUSY,
-        "NotDir" => E::ENOTDIR,
-        "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
-        "FileNotFound" => E::ENOENT,
-        "IsDir" => E::EISDIR,
-        _ => E::EFAULT,
-    }
-}
-
 // `rm` non-recursive unlink/rmdir fallback — narrower table; anything not
 // listed here falls through to EFAULT.
 //
@@ -9627,41 +9551,76 @@ pub unsafe extern "C" fn Bun__mkdirp(global_this: &JSGlobalObject, path: *const 
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// zig_delete_tree — recursive delete-tree. Returns `FileNotFound`
-// instead of ignoring it, which is required to match the behavior of Node.js's
-// `fs.rm` { recursive: true, force: false }.
+// zig_delete_tree — recursive delete-tree. Returns `ENOENT` on the top-level
+// path instead of swallowing it so `fs.rm({recursive, force:false})` can
+// report the missing root. Errors carry the full path of the failing entry
+// and the real syscall tag (unlink/rmdir/open/scandir), matching node's
+// async rimraf.
 // ──────────────────────────────────────────────────────────────────────────
 
-// Implemented on top of
-// `bun_sys` primitives (`openat` + `unlinkat`) and *errno* values, mapping the
-// errno back to the error-set name strings the callers'
-// `map_anyerror_to_errno*` tables expect. The structure: 16-slot stack,
-// treat_as_dir flip-flop, close-then-deleteDir, retry-on-DirNotEmpty.
+// Implemented on top of `bun_sys` primitives (`openat` + `unlinkat`). The
+// structure: 16-slot stack, treat_as_dir flip-flop, close-then-deleteDir,
+// retry-on-DirNotEmpty.
 
 #[inline]
-fn dt_err(errno: E) -> crate::Error {
-    // Reverse of the `map_anyerror_to_errno*` tables above — round-trip through
-    // the error-set name so existing callers don't have to change.
-    err_from_static(match errno {
-        E::ENOENT => "FileNotFound",
-        E::EACCES => "AccessDenied",
-        E::EPERM => "PermissionDenied",
-        E::ELOOP => "SymLinkLoop",
-        E::ENAMETOOLONG => "NameTooLong",
-        E::ENOMEM => "SystemResources",
-        E::EROFS => "ReadOnlyFileSystem",
-        E::EIO => "FileSystem",
-        E::EBUSY => "FileBusy",
-        E::ENOTDIR => "NotDir",
-        E::EISDIR => "IsDir",
-        E::ENOTEMPTY => "DirNotEmpty",
-        E::EMFILE => "SystemFdQuotaExceeded",
-        E::ENFILE => "ProcessFdQuotaExceeded",
-        E::EINVAL => "BadPathName",
-        E::EFBIG => "FileTooBig",
-        E::ENODEV => "NoDevice",
-        _ => "Unexpected",
-    })
+fn dt_err(errno: E, syscall: sys::Tag, path: &[u8]) -> sys::Error {
+    sys::Error::from_code(dt_map_errno(errno), syscall).with_path(path)
+}
+
+/// The fixed errno set the delete-tree walker surfaces. Anything outside this
+/// set falls through to `EFAULT` so unexpected kernel errors stay visibly
+/// "wrong" rather than being mistaken for a known failure mode.
+#[inline]
+fn dt_map_errno(errno: E) -> E {
+    match errno {
+        E::ENOENT
+        | E::EACCES
+        | E::EPERM
+        | E::ELOOP
+        | E::ENAMETOOLONG
+        | E::ENOMEM
+        | E::EROFS
+        | E::EIO
+        | E::EBUSY
+        | E::ENOTDIR
+        | E::EISDIR
+        | E::ENOTEMPTY
+        | E::EMFILE
+        | E::ENFILE
+        | E::EINVAL
+        | E::EFBIG
+        | E::ENODEV => errno,
+        _ => E::EFAULT,
+    }
+}
+
+/// Reconstructs the user-visible path of the entry a delete-tree syscall
+/// failed on: `sub_path` joined with every stacked directory name (skipping
+/// the root frame, which *is* `sub_path`) and then `leaf`. The walker operates
+/// on dir-fd-relative names via `*at(2)`, so the full path only exists here.
+fn dt_join_path(sub_path: &[u8], stack: &[DeleteTreeStackItem], leaf: &[u8]) -> Vec<u8> {
+    let mut cap = sub_path.len();
+    for item in stack.iter().skip(1) {
+        cap += 1 + item.name.len();
+    }
+    if !leaf.is_empty() {
+        cap += 1 + leaf.len();
+    }
+    let mut out = Vec::with_capacity(cap);
+    out.extend_from_slice(sub_path);
+    for item in stack.iter().skip(1) {
+        if !matches!(out.last(), Some(&paths::SEP)) {
+            out.push(paths::SEP);
+        }
+        out.extend_from_slice(&item.name);
+    }
+    if !leaf.is_empty() {
+        if !matches!(out.last(), Some(&paths::SEP)) {
+            out.push(paths::SEP);
+        }
+        out.extend_from_slice(leaf);
+    }
+    out
 }
 
 #[inline]
@@ -9757,9 +9716,9 @@ pub fn zig_delete_tree(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<()> {
+) -> Maybe<()> {
     let initial_iterable_dir =
-        match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint)? {
+        match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint, sub_path)? {
             Some(d) => d,
             None => return Ok(()),
         };
@@ -9791,7 +9750,13 @@ pub fn zig_delete_tree(
             let entry = match stack[top_idx].iter.next() {
                 Ok(Some(e)) => e,
                 Ok(None) => break,
-                Err(err) => return Err(dt_err(err.get_errno())),
+                Err(err) => {
+                    return Err(dt_err(
+                        err.get_errno(),
+                        sys::Tag::scandir,
+                        &dt_join_path(sub_path, &stack[..=top_idx], b""),
+                    ));
+                }
             };
             // `entry.name` borrows the iterator's internal buffer and
             // is invalidated by the next `next()` call. Copy it once here so
@@ -9837,18 +9802,34 @@ pub fn zig_delete_tree(
                                     ),
                                     Err(E::ENOTEMPTY | E::EEXIST)
                                 ) {
-                                    return Err(dt_err(E::ENOTEMPTY));
+                                    return Err(dt_err(
+                                        E::ENOTEMPTY,
+                                        sys::Tag::rmdir,
+                                        &dt_join_path(sub_path, &stack[..=top_idx], b""),
+                                    ));
                                 }
-                                return Err(dt_err(e));
+                                return Err(dt_err(
+                                    e,
+                                    sys::Tag::open,
+                                    &dt_join_path(sub_path, &stack[..=top_idx], &entry_name),
+                                ));
                             }
-                            Err(e) => return Err(dt_err(e)),
+                            Err(e) => {
+                                return Err(dt_err(
+                                    e,
+                                    sys::Tag::open,
+                                    &dt_join_path(sub_path, &stack[..=top_idx], &entry_name),
+                                ));
+                            }
                         }
                     } else {
                         let top_fd = stack[top_idx].iter.iter.dir;
+                        let prefix = dt_join_path(sub_path, &stack[..=top_idx], &entry_name);
                         zig_delete_tree_min_stack_size_with_kind_hint(
                             sys::Dir::borrow(&top_fd),
                             &entry_name,
                             entry.kind,
+                            &prefix,
                         )?;
                         break 'handle_entry;
                     }
@@ -9880,15 +9861,25 @@ pub fn zig_delete_tree(
                                 ),
                                 Err(E::ENOTEMPTY | E::EEXIST)
                             ) {
-                                return Err(dt_err(E::ENOTEMPTY));
+                                return Err(dt_err(
+                                    E::ENOTEMPTY,
+                                    sys::Tag::rmdir,
+                                    &dt_join_path(sub_path, &stack[..=top_idx], b""),
+                                ));
                             }
-                            return Err(dt_err(e));
+                            return Err(dt_err(
+                                e,
+                                sys::Tag::unlink,
+                                &dt_join_path(sub_path, &stack[..=top_idx], &entry_name),
+                            ));
                         }
-                        // "EPERM because it's a directory" is OS-dependent
-                        // (Linux returns EISDIR; macOS returns EPERM). We only
-                        // get errno, so forward EPERM as PermissionDenied —
-                        // caller maps it.
-                        Err(e) => return Err(dt_err(e)),
+                        Err(e) => {
+                            return Err(dt_err(
+                                e,
+                                sys::Tag::unlink,
+                                &dt_join_path(sub_path, &stack[..=top_idx], &entry_name),
+                            ));
+                        }
                     }
                 }
             }
@@ -9907,6 +9898,13 @@ pub fn zig_delete_tree(
             sub_path
         } else {
             &top.name
+        };
+        let popped_path = |stack: &[DeleteTreeStackItem]| -> Vec<u8> {
+            if top.name_is_borrowed {
+                sub_path.to_vec()
+            } else {
+                dt_join_path(sub_path, stack, &top.name)
+            }
         };
 
         let mut need_to_retry = false;
@@ -9934,12 +9932,18 @@ pub fn zig_delete_tree(
                         dt_delete_dir(sys::Dir::borrow(&ancestor.parent_dir), ancestor_name),
                         Err(E::ENOTEMPTY | E::EEXIST)
                     ) {
-                        return Err(dt_err(E::ENOTEMPTY));
+                        return Err(dt_err(
+                            E::ENOTEMPTY,
+                            sys::Tag::rmdir,
+                            &dt_join_path(sub_path, stack, b""),
+                        ));
                     }
                 }
-                return Err(dt_err(e));
+                return Err(dt_err(e, sys::Tag::rmdir, &popped_path(stack)));
             }
-            Err(e) => return Err(dt_err(e)),
+            Err(e) => {
+                return Err(dt_err(e, sys::Tag::rmdir, &popped_path(stack)));
+            }
         }
 
         if need_to_retry {
@@ -9958,7 +9962,9 @@ pub fn zig_delete_tree(
                             // That's fine, we were trying to remove this directory anyway.
                             continue 'process_stack;
                         }
-                        Err(e) => return Err(dt_err(e)),
+                        Err(e) => {
+                            return Err(dt_err(e, sys::Tag::open, &popped_path(stack)));
+                        }
                     }
                 } else {
                     match dt_delete_file(sys::Dir::borrow(&parent_dir), name) {
@@ -9971,11 +9977,12 @@ pub fn zig_delete_tree(
                         Err(E::ENOTDIR) => {
                             #[cfg(debug_assertions)]
                             unreachable!();
-                            // "Unexpected" → caller's fallthrough arm = EFAULT.
                             #[cfg(not(debug_assertions))]
-                            return Err(err_from_static("Unexpected"));
+                            return Err(dt_err(E::EFAULT, sys::Tag::unlink, &popped_path(stack)));
                         }
-                        Err(e) => return Err(dt_err(e)),
+                        Err(e) => {
+                            return Err(dt_err(e, sys::Tag::unlink, &popped_path(stack)));
+                        }
                     }
                 }
             };
@@ -9997,7 +10004,8 @@ fn zig_delete_tree_open_initial_subpath(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<Option<sys::Dir>> {
+    err_path: &[u8],
+) -> Maybe<Option<sys::Dir>> {
     // Treat as a file by default
     let mut treat_as_dir = kind_hint == sys::FileKind::Directory;
     loop {
@@ -10007,7 +10015,7 @@ fn zig_delete_tree_open_initial_subpath(
                 // NotDir/FileNotFound surface here (no fall-through to
                 // deleteFile) — deliberate, so `FileNotFound` propagates
                 // (see the zig_delete_tree banner above).
-                Err(e) => Err(dt_err(e)),
+                Err(e) => Err(dt_err(e, sys::Tag::open, err_path)),
             };
         } else {
             match dt_delete_file(self_, sub_path) {
@@ -10016,7 +10024,7 @@ fn zig_delete_tree_open_initial_subpath(
                     treat_as_dir = true;
                     continue;
                 }
-                Err(e) => return Err(dt_err(e)),
+                Err(e) => return Err(dt_err(e, sys::Tag::unlink, err_path)),
             }
         }
     }
@@ -10026,12 +10034,25 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<()> {
+    err_prefix: &[u8],
+) -> Maybe<()> {
+    let join = |dir_path: &[u8], leaf: &[u8]| -> Vec<u8> {
+        let mut out = Vec::with_capacity(dir_path.len() + 1 + leaf.len());
+        out.extend_from_slice(dir_path);
+        if !leaf.is_empty() {
+            if !matches!(out.last(), Some(&paths::SEP)) {
+                out.push(paths::SEP);
+            }
+            out.extend_from_slice(leaf);
+        }
+        out
+    };
     'start_over: loop {
-        let mut dir = match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint)? {
-            Some(d) => d,
-            None => return Ok(()),
-        };
+        let mut dir =
+            match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint, err_prefix)? {
+                Some(d) => d,
+                None => return Ok(()),
+            };
         let mut cleanup_dir_parent: Option<sys::Dir> = None;
 
         // Valid use of MAX_PATH_BYTES because dir_name_buf will only
@@ -10044,17 +10065,22 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
         // the borrow checker won't let that alias survive the copy/reassignment
         // below, so track `(is_sub_path, len)` and re-slice on each use.
         let mut dir_name_is_sub_path = true;
+        // User-visible absolute-ish path of `dir`, rooted at `err_prefix`.
+        // Grows on each descent; resets on `'start_over`.
+        let mut dir_path: Vec<u8> = err_prefix.to_vec();
 
         // Here we must avoid recursion, in order to provide O(1) memory guarantee of this function.
         // Go through each entry and if it is not a directory, delete it. If it is a directory,
         // open it, and close the original directory. Repeat. Then start the entire operation over.
-        let result: crate::Result<()> = 'scan_dir: loop {
+        let result: Maybe<()> = 'scan_dir: loop {
             let mut dir_it = DirIterator::WrappedIterator::init(dir.fd);
             'dir_it: loop {
                 let entry = match dir_it.next() {
                     Ok(Some(e)) => e,
                     Ok(None) => break 'dir_it,
-                    Err(err) => break 'scan_dir Err(dt_err(err.get_errno())),
+                    Err(err) => {
+                        break 'scan_dir Err(dt_err(err.get_errno(), sys::Tag::scandir, &dir_path));
+                    }
                 };
                 let entry_name: Vec<u8> = entry.name.slice().to_vec();
                 let mut treat_as_dir = entry.kind == sys::FileKind::Directory;
@@ -10068,6 +10094,10 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                                 dir_name_buf[..n].copy_from_slice(&entry_name[..n]);
                                 dir_name_len = n;
                                 dir_name_is_sub_path = false;
+                                if !matches!(dir_path.last(), Some(&paths::SEP)) {
+                                    dir_path.push(paths::SEP);
+                                }
+                                dir_path.extend_from_slice(&entry_name);
                                 continue 'scan_dir;
                             }
                             Err(E::ENOTDIR) => {
@@ -10078,7 +10108,13 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                                 // That's fine, we were trying to remove this directory anyway.
                                 continue 'dir_it;
                             }
-                            Err(e) => break 'scan_dir Err(dt_err(e)),
+                            Err(e) => {
+                                break 'scan_dir Err(dt_err(
+                                    e,
+                                    sys::Tag::open,
+                                    &join(&dir_path, &entry_name),
+                                ));
+                            }
                         }
                     } else {
                         match dt_delete_file(&dir, &entry_name) {
@@ -10091,11 +10127,20 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                             Err(E::ENOTDIR) => {
                                 #[cfg(debug_assertions)]
                                 unreachable!();
-                                // "Unexpected" → caller's fallthrough arm = EFAULT.
                                 #[cfg(not(debug_assertions))]
-                                break 'scan_dir Err(err_from_static("Unexpected"));
+                                break 'scan_dir Err(dt_err(
+                                    E::EFAULT,
+                                    sys::Tag::unlink,
+                                    &join(&dir_path, &entry_name),
+                                ));
                             }
-                            Err(e) => break 'scan_dir Err(dt_err(e)),
+                            Err(e) => {
+                                break 'scan_dir Err(dt_err(
+                                    e,
+                                    sys::Tag::unlink,
+                                    &join(&dir_path, &entry_name),
+                                ));
+                            }
                         }
                     }
                 }
@@ -10116,14 +10161,14 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                         continue 'start_over;
                     }
                     Err(e) => {
-                        return Err(dt_err(e));
+                        return Err(dt_err(e, sys::Tag::rmdir, &dir_path));
                     }
                 }
             } else {
                 match dt_delete_dir(self_, sub_path) {
                     Ok(()) | Err(E::ENOENT) => return Ok(()),
                     Err(E::ENOTEMPTY) | Err(E::EEXIST) => continue 'start_over,
-                    Err(e) => return Err(dt_err(e)),
+                    Err(e) => return Err(dt_err(e, sys::Tag::rmdir, err_prefix)),
                 }
             }
         };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9550,12 +9550,6 @@ pub unsafe extern "C" fn Bun__mkdirp(global_this: &JSGlobalObject, path: *const 
         .is_ok()
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// zig_delete_tree — recursive delete-tree. Top-level `ENOENT` propagates (for
-// `force:false`); other errors carry the failing entry's full path + real
-// syscall tag, matching node's async rimraf.
-// ──────────────────────────────────────────────────────────────────────────
-
 #[inline]
 fn dt_err(errno: E, syscall: sys::Tag, path: &[u8]) -> sys::Error {
     sys::Error::from_code(dt_map_errno(errno), syscall).with_path(path)
@@ -9585,8 +9579,7 @@ fn dt_map_errno(errno: E) -> E {
     }
 }
 
-/// `sub_path` / stack[1..].name / leaf. `stack[0]` is the `sub_path` frame
-/// itself and skipped.
+/// sub_path / stack[1..].name / leaf (stack[0] *is* sub_path, hence skipped).
 fn dt_join_path(sub_path: &[u8], stack: &[DeleteTreeStackItem], leaf: &[u8]) -> Vec<u8> {
     let mut cap = sub_path.len();
     for item in stack.iter().skip(1) {
@@ -9701,6 +9694,7 @@ struct DeleteTreeStackItem {
     iter: DirIterator::WrappedIterator,
 }
 
+/// Recursive delete; errors name the failing entry's full path and syscall. Top-level `ENOENT` propagates (for `{force:false}`).
 pub fn zig_delete_tree(self_: &sys::Dir, sub_path: &[u8], kind_hint: sys::FileKind) -> Maybe<()> {
     let initial_iterable_dir =
         match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint, sub_path)? {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9712,11 +9712,7 @@ struct DeleteTreeStackItem {
     iter: DirIterator::WrappedIterator,
 }
 
-pub fn zig_delete_tree(
-    self_: &sys::Dir,
-    sub_path: &[u8],
-    kind_hint: sys::FileKind,
-) -> Maybe<()> {
+pub fn zig_delete_tree(self_: &sys::Dir, sub_path: &[u8], kind_hint: sys::FileKind) -> Maybe<()> {
     let initial_iterable_dir =
         match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint, sub_path)? {
             Some(d) => d,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9551,25 +9551,16 @@ pub unsafe extern "C" fn Bun__mkdirp(global_this: &JSGlobalObject, path: *const 
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// zig_delete_tree — recursive delete-tree. Returns `ENOENT` on the top-level
-// path instead of swallowing it so `fs.rm({recursive, force:false})` can
-// report the missing root. Errors carry the full path of the failing entry
-// and the real syscall tag (unlink/rmdir/open/scandir), matching node's
-// async rimraf.
+// zig_delete_tree — recursive delete-tree. Top-level `ENOENT` propagates (for
+// `force:false`); other errors carry the failing entry's full path + real
+// syscall tag, matching node's async rimraf.
 // ──────────────────────────────────────────────────────────────────────────
-
-// Implemented on top of `bun_sys` primitives (`openat` + `unlinkat`). The
-// structure: 16-slot stack, treat_as_dir flip-flop, close-then-deleteDir,
-// retry-on-DirNotEmpty.
 
 #[inline]
 fn dt_err(errno: E, syscall: sys::Tag, path: &[u8]) -> sys::Error {
     sys::Error::from_code(dt_map_errno(errno), syscall).with_path(path)
 }
 
-/// The fixed errno set the delete-tree walker surfaces. Anything outside this
-/// set falls through to `EFAULT` so unexpected kernel errors stay visibly
-/// "wrong" rather than being mistaken for a known failure mode.
 #[inline]
 fn dt_map_errno(errno: E) -> E {
     match errno {
@@ -9594,10 +9585,8 @@ fn dt_map_errno(errno: E) -> E {
     }
 }
 
-/// Reconstructs the user-visible path of the entry a delete-tree syscall
-/// failed on: `sub_path` joined with every stacked directory name (skipping
-/// the root frame, which *is* `sub_path`) and then `leaf`. The walker operates
-/// on dir-fd-relative names via `*at(2)`, so the full path only exists here.
+/// `sub_path` / stack[1..].name / leaf. `stack[0]` is the `sub_path` frame
+/// itself and skipped.
 fn dt_join_path(sub_path: &[u8], stack: &[DeleteTreeStackItem], leaf: &[u8]) -> Vec<u8> {
     let mut cap = sub_path.len();
     for item in stack.iter().skip(1) {
@@ -10061,8 +10050,7 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
         // the borrow checker won't let that alias survive the copy/reassignment
         // below, so track `(is_sub_path, len)` and re-slice on each use.
         let mut dir_name_is_sub_path = true;
-        // User-visible absolute-ish path of `dir`, rooted at `err_prefix`.
-        // Grows on each descent; resets on `'start_over`.
+        // User-visible path of `dir`; grows on descent, resets on 'start_over.
         let mut dir_path: Vec<u8> = err_prefix.to_vec();
 
         // Here we must avoid recursion, in order to provide O(1) memory guarantee of this function.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2951,11 +2951,7 @@ describe("rm", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const out = JSON.parse(stdout.trim());
     // On Linux the unlink of /tree/a/locked/keep is denied. On macOS node

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -8,6 +8,7 @@ import {
   isDebug,
   isIntelMacOS,
   isLinux,
+  isMacOS,
   isPosix,
   isWindows,
   tempDir,
@@ -2966,12 +2967,12 @@ describe("rm", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const out = JSON.parse(stdout.trim());
-    // On Linux the unlink of /tree/a/locked/keep is denied. On macOS node
-    // (and Bun) report the containing directory's ENOTEMPTY instead. Either
-    // way err.path must point inside the tree, not at its root.
-    const expected = isLinux
-      ? { code: "EACCES", syscall: "unlink", path: "/tree/a/locked/keep" }
-      : { code: "ENOTEMPTY", syscall: "rmdir", path: "/tree/a/locked" };
+    // On Linux/FreeBSD the unlink of /tree/a/locked/keep is denied. On macOS
+    // node (and Bun) report the containing directory's ENOTEMPTY instead.
+    // Either way err.path must point inside the tree, not at its root.
+    const expected = isMacOS
+      ? { code: "ENOTEMPTY", syscall: "rmdir", path: "/tree/a/locked" }
+      : { code: "EACCES", syscall: "unlink", path: "/tree/a/locked/keep" };
     expect({ sync: JSON.parse(out.sync), promise: JSON.parse(out.promise), cb: JSON.parse(out.cb) }).toEqual({
       sync: expected,
       promise: expected,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2926,6 +2926,12 @@ describe("rm", () => {
           syscall: e.syscall,
           path: String(e.path).slice(R.length).split(path.sep).join("/"),
         });
+      const rearm = () => {
+        fs.chmodSync(path.join(root, "a", "locked"), 0o755);
+        fs.mkdirSync(path.join(root, "a", "locked"), { recursive: true });
+        fs.writeFileSync(path.join(root, "a", "locked", "keep"), "");
+        fs.chmodSync(path.join(root, "a", "locked"), 0o555);
+      };
       const out = {};
       try {
         fs.rmSync(root, { recursive: true });
@@ -2933,18 +2939,24 @@ describe("rm", () => {
       } catch (e) {
         out.sync = report(e);
       }
-      fs.chmodSync(path.join(root, "a", "locked"), 0o755);
-      fs.mkdirSync(path.join(root, "a", "locked"), { recursive: true });
-      fs.writeFileSync(path.join(root, "a", "locked", "keep"), "");
-      fs.chmodSync(path.join(root, "a", "locked"), 0o555);
-      fs.promises.rm(root, { recursive: true }).then(
-        () => (out.promise = "no-error"),
-        e => (out.promise = report(e)),
-      ).then(() => {
-        fs.chmodSync(path.join(root, "a", "locked"), 0o755);
-        fs.rmSync(R, { recursive: true, force: true });
-        console.log(JSON.stringify(out));
-      });
+      rearm();
+      fs.promises
+        .rm(root, { recursive: true })
+        .then(() => (out.promise = "no-error"), e => (out.promise = report(e)))
+        .then(() => {
+          rearm();
+          return new Promise(r =>
+            fs.rm(root, { recursive: true }, e => {
+              out.cb = e ? report(e) : "no-error";
+              r();
+            }),
+          );
+        })
+        .then(() => {
+          fs.chmodSync(path.join(root, "a", "locked"), 0o755);
+          fs.rmSync(R, { recursive: true, force: true });
+          console.log(JSON.stringify(out));
+        });
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
@@ -2960,9 +2972,10 @@ describe("rm", () => {
     const expected = isLinux
       ? { code: "EACCES", syscall: "unlink", path: "/tree/a/locked/keep" }
       : { code: "ENOTEMPTY", syscall: "rmdir", path: "/tree/a/locked" };
-    expect({ sync: JSON.parse(out.sync), promise: JSON.parse(out.promise) }).toEqual({
+    expect({ sync: JSON.parse(out.sync), promise: JSON.parse(out.promise), cb: JSON.parse(out.cb) }).toEqual({
       sync: expected,
       promise: expected,
+      cb: expected,
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2898,6 +2898,78 @@ describe("rm", () => {
     fs.rmSync(dir, { recursive: true, force: true });
     expect(fs.existsSync(dir)).toBe(false);
   });
+
+  // A recursive rm that fails part-way through must identify the entry the
+  // syscall actually failed on (node's async rimraf behavior), not report the
+  // root path with a generic "rm" syscall. Needs POSIX permissions; when
+  // running as root the subprocess drops to nobody so the chmod sticks.
+  // https://github.com/oven-sh/bun/issues/4522
+  it.skipIf(!isPosix)("recursive rm error names the failing entry, not the root", async () => {
+    const fixture = /* js */ `
+      const fs = require("node:fs");
+      const os = require("node:os");
+      const path = require("node:path");
+      const R = fs.mkdtempSync(path.join(os.tmpdir(), "rm-fid-"));
+      if (process.getuid() === 0) {
+        fs.chownSync(R, 65534, 65534);
+        process.setgid(65534);
+        process.setuid(65534);
+      }
+      const root = path.join(R, "tree");
+      fs.mkdirSync(path.join(root, "a", "locked"), { recursive: true });
+      fs.writeFileSync(path.join(root, "a", "locked", "keep"), "");
+      fs.writeFileSync(path.join(root, "free"), "");
+      fs.chmodSync(path.join(root, "a", "locked"), 0o555);
+      const report = e =>
+        JSON.stringify({
+          code: e.code,
+          syscall: e.syscall,
+          path: String(e.path).slice(R.length).split(path.sep).join("/"),
+        });
+      const out = {};
+      try {
+        fs.rmSync(root, { recursive: true });
+        out.sync = "no-error";
+      } catch (e) {
+        out.sync = report(e);
+      }
+      fs.chmodSync(path.join(root, "a", "locked"), 0o755);
+      fs.mkdirSync(path.join(root, "a", "locked"), { recursive: true });
+      fs.writeFileSync(path.join(root, "a", "locked", "keep"), "");
+      fs.chmodSync(path.join(root, "a", "locked"), 0o555);
+      fs.promises.rm(root, { recursive: true }).then(
+        () => (out.promise = "no-error"),
+        e => (out.promise = report(e)),
+      ).then(() => {
+        fs.chmodSync(path.join(root, "a", "locked"), 0o755);
+        fs.rmSync(R, { recursive: true, force: true });
+        console.log(JSON.stringify(out));
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    // On Linux the unlink of /tree/a/locked/keep is denied. On macOS node
+    // (and Bun) report the containing directory's ENOTEMPTY instead. Either
+    // way err.path must point inside the tree, not at its root.
+    const expected = isLinux
+      ? { code: "EACCES", syscall: "unlink", path: "/tree/a/locked/keep" }
+      : { code: "ENOTEMPTY", syscall: "rmdir", path: "/tree/a/locked" };
+    expect({ sync: JSON.parse(out.sync), promise: JSON.parse(out.promise) }).toEqual({
+      sync: expected,
+      promise: expected,
+    });
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("rmdir", () => {


### PR DESCRIPTION
## Problem

`fs.rm` / `fs.rmSync` / `fs.promises.rm` with `{recursive: true}` reports `{code:'EACCES', syscall:'rm', path:<root>}` when a child entry cannot be removed, discarding which entry actually failed. Node's async rimraf reports the real syscall and the full path to the failing entry.

## Repro

```js
import fs from "node:fs"; import path from "node:path"; import os from "node:os";
const R = fs.mkdtempSync(path.join(os.tmpdir(), "rmfid-"));
if (process.getuid() === 0) { fs.chownSync(R, 65534, 65534); process.setgid(65534); process.setuid(65534); }
const t = R + "/tree"; fs.mkdirSync(t + "/locked", { recursive: true });
fs.writeFileSync(t + "/locked/keep", ""); fs.chmodSync(t + "/locked", 0o555);
try { await fs.promises.rm(t, { recursive: true }); }
catch (e) { console.log({ code: e.code, syscall: e.syscall, path: e.path.slice(R.length) }); }
```

| | before | after | node (async) |
|---|---|---|---|
| `syscall` | `"rm"` | `"unlink"` | `"unlink"` |
| `path` | `"/tree"` | `"/tree/locked/keep"` | `"/tree/locked/keep"` |

## Cause

`zig_delete_tree` operates on dir-fd-relative names via `*at(2)` and returned only a bare error-set name (`crate::Error::AccessDenied`, etc). The `rm()` caller round-tripped that name back to an errno via `map_anyerror_to_errno_rm_tree` and wrapped it with `Tag::rm` + the root path, because that was the only path it had.

## Fix

The walker now returns `sys::Error` directly, carrying the real syscall tag (`unlink`/`rmdir`/`open`/`scandir`) and the full path reconstructed from `sub_path` + the stacked directory names + the leaf entry. The `errno -> name -> errno` round-trip tables are gone; `dt_map_errno` preserves the same `EFAULT` fallthrough for unexpected kernel errors. The deep-tree (`>16` levels) fallback maintains a running path buffer for the same result.

All three shapes (sync, callback, promises) now match Node's async behavior, which is also more useful than Node's own `rmSync` (which reports the root with `errno: +13`).

Fixes #4522

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->