### PR TITLE
test(serve): measure HTTPResponseSink leak via LeakSanitizer under ASAN

### DIFF
--- a/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
@@ -36,12 +36,11 @@ async function once() {
   if ((await res.text()) === "x") ok++;
 }
 
-const iterations = Number(process.env.ITERATIONS ?? 10000);
-
 // ASAN: run N requests and exit so LeakSanitizer reports the unfreed sinks
 // directly. No warmup, no RSS sampling; the caller diffs the SUMMARY bytes
 // between two iteration counts so fixed one-time leaks cancel out.
 if (process.env.SINK_LEAK_MODE === "lsan") {
+  const iterations = Number(process.env.SINK_LEAK_ITERATIONS);
   for (let i = 0; i < iterations; i++) await once();
   server.stop(true);
   Bun.gc(true);
@@ -50,6 +49,8 @@ if (process.env.SINK_LEAK_MODE === "lsan") {
   process.stdout.write(JSON.stringify({ ok, iterations }));
   process.exit(0);
 }
+
+const iterations = 10000;
 
 // RSS, not currentCommit (which ratchets under hole purging, a discarded hole
 // stays "committed"); a leaked sink keeps its page resident, so RSS sees it.

--- a/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
@@ -25,6 +25,7 @@ const server = Bun.serve({
 });
 
 const url = server.url.href;
+let ok = 0;
 
 async function once() {
   pulled = Promise.withResolvers();
@@ -32,7 +33,22 @@ async function once() {
   await pulled.promise;
   controller.end();
   const res = await resPromise;
-  await res.arrayBuffer();
+  if ((await res.text()) === "x") ok++;
+}
+
+const iterations = Number(process.env.ITERATIONS ?? 10000);
+
+// ASAN: run N requests and exit so LeakSanitizer reports the unfreed sinks
+// directly. No warmup, no RSS sampling; the caller diffs the SUMMARY bytes
+// between two iteration counts so fixed one-time leaks cancel out.
+if (process.env.SINK_LEAK_MODE === "lsan") {
+  for (let i = 0; i < iterations; i++) await once();
+  server.stop(true);
+  Bun.gc(true);
+  await Bun.sleep(0);
+  Bun.gc(true);
+  process.stdout.write(JSON.stringify({ ok, iterations }));
+  process.exit(0);
 }
 
 // RSS, not currentCommit (which ratchets under hole purging, a discarded hole
@@ -47,8 +63,6 @@ async function settledRss() {
   }
   return min;
 }
-
-const iterations = 10000;
 
 async function round() {
   for (let i = 0; i < iterations; i++) {
@@ -78,4 +92,4 @@ for (let r = 0; r < 3; r++) {
 server.stop(true);
 
 const delta = [...deltas].sort((a, b) => a - b)[Math.floor(deltas.length / 2)];
-process.stdout.write(JSON.stringify({ delta, deltas, iterations }));
+process.stdout.write(JSON.stringify({ delta, deltas, iterations, ok }));

--- a/test/js/bun/http/serve-response-stream-sink-leak.test.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak.test.ts
@@ -36,7 +36,10 @@ test("HTTPResponseSink is destroyed after a sync pull() that ends later", async 
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, exitCode }, stderr).toEqual({ stdout: JSON.stringify({ ok: iterations, iterations }), exitCode: 0 });
+      expect({ stdout, exitCode }, stderr).toEqual({
+        stdout: JSON.stringify({ ok: iterations, iterations }),
+        exitCode: 0,
+      });
       const m = /SUMMARY: AddressSanitizer: (\d+) byte\(s\) leaked/.exec(stderr);
       return { bytes: m ? Number(m[1]) : 0, stderr };
     }

--- a/test/js/bun/http/serve-response-stream-sink-leak.test.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak.test.ts
@@ -25,7 +25,7 @@ test("HTTPResponseSink is destroyed after a sync pull() that ends later", async 
         env: {
           ...bunEnv,
           SINK_LEAK_MODE: "lsan",
-          ITERATIONS: String(iterations),
+          SINK_LEAK_ITERATIONS: String(iterations),
           ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
           // exitcode=0: baseline one-time leaks (not all suppressed) would
           // otherwise make LSAN exit 1 on the fixed build too; the byte
@@ -36,7 +36,7 @@ test("HTTPResponseSink is destroyed after a sync pull() that ends later", async 
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, exitCode }).toEqual({ stdout: JSON.stringify({ ok: iterations, iterations }), exitCode: 0 });
+      expect({ stdout, exitCode }, stderr).toEqual({ stdout: JSON.stringify({ ok: iterations, iterations }), exitCode: 0 });
       const m = /SUMMARY: AddressSanitizer: (\d+) byte\(s\) leaked/.exec(stderr);
       return { bytes: m ? Number(m[1]) : 0, stderr };
     }
@@ -78,4 +78,4 @@ test("HTTPResponseSink is destroyed after a sync pull() that ends later", async 
   // explains RSS over currentCommit). macOS debug: 1.0 MB fixed vs 3.5 MB leaking
   // (~350 B/req); Linux release: flat fixed vs +4.1 MB on the original #29877 leak.
   expect(delta).toBeLessThan(2 * 1024 * 1024);
-}, 300_000);
+}, 60_000);

--- a/test/js/bun/http/serve-response-stream-sink-leak.test.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak.test.ts
@@ -2,6 +2,9 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 import { join } from "node:path";
 
+const fixture = join(import.meta.dir, "serve-response-stream-sink-leak-fixture.ts");
+const leaksanSupp = join(import.meta.dir, "..", "..", "..", "leaksan.supp");
+
 // Regression: doRenderStream allocates a ResponseStream.JSSink on the heap
 // and stores it in RequestContext.sink. A direct stream whose pull() returns
 // synchronously without ending the sink keeps the request alive until
@@ -10,8 +13,50 @@ import { join } from "node:path";
 // RequestContext.sink), otherwise the allocation plus its pooled buffer
 // leaks on every such request.
 test("HTTPResponseSink is destroyed after a sync pull() that ends later", async () => {
+  if (isASAN) {
+    // LeakSanitizer reports the unfreed Box<ResponseStreamJSSink> allocated in
+    // do_render_stream directly, so there is no need for the RSS-sampling
+    // heuristic (which needs ~60k requests to settle under ASAN quarantine).
+    // Run two sizes so fixed one-time leaks (server setup, timer, module
+    // loader) cancel out; only a per-request leak survives the subtraction.
+    async function run(iterations: number) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture],
+        env: {
+          ...bunEnv,
+          SINK_LEAK_MODE: "lsan",
+          ITERATIONS: String(iterations),
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+          // exitcode=0: baseline one-time leaks (not all suppressed) would
+          // otherwise make LSAN exit 1 on the fixed build too; the byte
+          // differential below is the actual assertion.
+          LSAN_OPTIONS: `suppressions=${leaksanSupp}:exitcode=0`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, exitCode }).toEqual({ stdout: JSON.stringify({ ok: iterations, iterations }), exitCode: 0 });
+      const m = /SUMMARY: AddressSanitizer: (\d+) byte\(s\) leaked/.exec(stderr);
+      return { bytes: m ? Number(m[1]) : 0, stderr };
+    }
+    const [small, large] = await Promise.all([run(10), run(100)]);
+    const perRequestLeak = large.bytes - small.bytes;
+    console.log({ small: small.bytes, large: large.bytes, perRequestLeak });
+    // #29877 leaks ~176 B/req (sizeof ResponseStreamJSSink), so 90 extra
+    // requests leak ~15840 B; fixed the delta hovers around 0 (±~500 B of
+    // conservative-stack-scan jitter for the final in-flight Response). stderr
+    // is attached so a new unsuppressed leak that tips the threshold is
+    // diagnosable.
+    expect(perRequestLeak, large.stderr).toBeLessThan(2000);
+    return;
+  }
+
+  // Release (and non-ASAN debug): fall back to the RSS-delta heuristic. This
+  // is already fast without ASAN (~5 s for 10000x6 requests) and keeps the
+  // leak observable on lanes where LeakSanitizer is unavailable.
   await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "serve-response-stream-sink-leak-fixture.ts")],
+    cmd: [bunExe(), fixture],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -25,11 +70,12 @@ test("HTTPResponseSink is destroyed after a sync pull() that ends later", async 
     printedResult: true,
     exitCode: 0,
   });
-  const { delta, deltas, iterations } = JSON.parse(stdout);
+  const { delta, deltas, iterations, ok } = JSON.parse(stdout);
   console.log({ deltas, iterations, perRequest: (delta / iterations).toFixed(1) });
+  expect(ok).toBe(iterations * 6);
 
   // `delta` is the median RSS growth per 10k requests (settledRss in the fixture
   // explains RSS over currentCommit). macOS debug: 1.0 MB fixed vs 3.5 MB leaking
   // (~350 B/req); Linux release: flat fixed vs +4.1 MB on the original #29877 leak.
-  expect(delta).toBeLessThan(2 * 1024 * 1024 * (isASAN ? 2 : 1));
+  expect(delta).toBeLessThan(2 * 1024 * 1024);
 }, 300_000);


### PR DESCRIPTION
## What

`serve-response-stream-sink-leak.test.ts` was one of the slower files on ASAN lanes (~23 s on debian 13 x64-asan, build #81338; ~183 s locally). Almost all of that time is the RSS-delta heuristic fighting ASAN's allocator quarantine: freed allocations park in a 256 MB quarantine instead of being returned, so RSS keeps climbing for ~25-30k requests before it settles enough to take a baseline, and the fixture runs 6 rounds x 10k = 60k requests to compensate.

Under ASAN the leak being guarded against (the `Box<ResponseStreamJSSink>` allocated in `do_render_stream` that #29877 / #32140 ensure is `destroy_sink`'d) is exactly what LeakSanitizer reports directly. This PR branches the test on `isASAN`:

* **ASAN**: run the fixture with `ASAN_OPTIONS=detect_leaks=1` at two iteration counts (10 and 100) and assert the reported-bytes delta is under 2 kB. Fixed one-time leaks (server setup, timers, module loader) cancel out of the subtraction; a per-request sink leak does not. `LSAN_OPTIONS=exitcode=0` plus the existing `test/leaksan.supp` keep known baseline leaks from failing the subprocess, and the LSAN stderr is attached to the failing assertion so a future unsuppressed leak is immediately diagnosable.
* **Non-ASAN**: unchanged RSS heuristic (10k x 6 rounds, 2 MB median threshold). The now-unreachable `* (isASAN ? 2 : 1)` threshold multiplier is dropped.

The fixture also now counts responses whose body is `"x"` and the test asserts the count matches, so a behaviour regression in the sync-`pull()`/later-`end()` path fails the test instead of silently passing the leak check.

## Why LSAN here and not RSS-with-quarantine-disabled

I first tried `quarantine_size_mb=0` + fewer iterations. That kills the warmup tail cleanly, but it also strips the quarantine's amplification of the leak signal: the actual `ResponseStreamJSSink` is only ~176 B, so at 4k iterations the per-round RSS growth is ~1 MB, indistinguishable from page-return noise, and the test *passed with the leak reintroduced*. LSAN counts the unfreed boxes directly and needs no amplification.

## Timing

`bun bd test test/js/bun/http/serve-response-stream-sink-leak.test.ts` on Linux x64 debug+ASAN (this container):

| | before | after |
|---|---|---|
| debug+ASAN | 180-183 s | 7-10 s |
| release (`USE_SYSTEM_BUN=1`) | ~5.1 s | ~5.5 s |

## Verification

Reintroduced the leak by replacing `Self::destroy_sink(wrapper_ptr)` with `let _ = wrapper_ptr;` in `handle_resolve_stream`:

```
{ small: 6064, large: 21904, perRequestLeak: 15840 }
Expected: < 2000
Received: 15840
(fail) HTTPResponseSink is destroyed after a sync pull() that ends later [6885ms]
```

With the fix in place, 5 consecutive ASAN runs report `{ small: 4480, large: 4480, perRequestLeak: 0 }` and pass; 3 release runs pass with median RSS deltas at or below zero.

This is a test-only change: `src/` is untouched, so the fail-before/pass-after re-derivation that stashes `src/` will see the test pass both ways. The regression it guards is verified above by manually reverting the fix.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/serve-response-stream-sink-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/serve-response-stream-sink-leak.test.ts
bun test v1.4.0 (5a754855a)

test/js/bun/http/serve-response-stream-sink-leak.test.ts:
{
  small: 4480,
  large: 4480,
  perRequestLeak: 0,
}
(pass) HTTPResponseSink is destroyed after a sync pull() that ends later [8997.63ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [12.12s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../serve-response-stream-sink-leak-fixture.ts     | 23 +++++++--
 .../http/serve-response-stream-sink-leak.test.ts   | 57 ++++++++++++++++++++--
 2 files changed, 72 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…/js/bun/http/serve-response-stream-sink-leak-fixture.ts      4     13      0
test/js/bun/http/serve-response-stream-sink-leak.test.ts      4      7      0
```

</details>

<!-- robobun:evidence:end -->