### PR TITLE
HTMLRewriter: fix quadratic selector-VM stack scans on hostile nesting

### DIFF
--- a/patches/lolhtml/selectors-vm-quadratic.patch
+++ b/patches/lolhtml/selectors-vm-quadratic.patch
@@ -1,3 +1,54 @@
+--- a/src/html/local_name.rs
++++ b/src/html/local_name.rs
+@@ -134,12 +134,31 @@
+ /// `LocalName` is used for the comparison of tag names.
+ /// In the majority of cases it will be represented as a hash, however for long
+ /// non-standard tag names it fallsback to the Name representation.
+-#[derive(Clone, Debug, Eq, Hash)]
++#[derive(Clone, Debug, Eq)]
+ pub enum LocalName<'i> {
+     Hash(LocalNameHash),
+     Bytes(BytesCow<'i>),
+ }
+ 
++// NOTE: `PartialEq` compares the `Bytes` variant case-insensitively, so `Hash`
++// must case-fold too or two equal names would land in different hash-map
++// buckets. This matters for any name that falls off `LocalNameHash` (custom
++// elements, >12 chars, chars outside a-zA-Z1-6).
++impl std::hash::Hash for LocalName<'_> {
++    #[inline]
++    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
++        core::mem::discriminant(self).hash(state);
++        match self {
++            LocalName::Hash(h) => h.hash(state),
++            LocalName::Bytes(b) => {
++                for &byte in b.iter() {
++                    byte.to_ascii_lowercase().hash(state);
++                }
++            }
++        }
++    }
++}
++
+ impl<'i> LocalName<'i> {
+     #[inline]
+     #[must_use]
+@@ -219,4 +238,15 @@
+     fn hash_invalidation_for_long_values() {
+         assert!(LocalNameHash::from("aaaaaaaaaaaaaa").is_empty());
+     }
++
++    #[test]
++    fn bytes_variant_hash_matches_case_insensitive_eq() {
++        use std::hash::{BuildHasher, RandomState};
++        let s = RandomState::new();
++        let a = LocalName::from_str_without_replacements("My-Widget", encoding_rs::UTF_8).unwrap();
++        let b = LocalName::from_str_without_replacements("my-widget", encoding_rs::UTF_8).unwrap();
++        assert!(matches!(a, LocalName::Bytes(_)));
++        assert_eq!(a, b);
++        assert_eq!(s.hash_one(&a), s.hash_one(&b));
++    }
+ }
 --- a/src/selectors_vm/mod.rs
 +++ b/src/selectors_vm/mod.rs
 @@ -59,7 +59,6 @@

--- a/patches/lolhtml/selectors-vm-quadratic.patch
+++ b/patches/lolhtml/selectors-vm-quadratic.patch
@@ -1,0 +1,317 @@
+--- a/src/selectors_vm/mod.rs
++++ b/src/selectors_vm/mod.rs
+@@ -59,7 +59,6 @@
+ 
+ #[derive(Default)]
+ struct HereditaryJumpPtr {
+-    stack_offset: usize,
+     instr_set_idx: usize,
+     offset: usize,
+ }
+@@ -485,22 +484,15 @@
+         ctx: &mut ExecutionCtx<'_, E>,
+         match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
+     ) -> Result<(), Bailout<HereditaryJumpPtr>> {
+-        for (i, ancestor) in self.stack.items().iter().rev().enumerate() {
+-            for (j, jumps) in ancestor.hereditary_jumps.iter().enumerate() {
+-                self.try_exec_instr_set_without_attrs(jumps.clone(), ctx, match_handler)
+-                    .map_err(move |b| Bailout {
+-                        at_addr: b.at_addr,
+-                        recovery_point: HereditaryJumpPtr {
+-                            stack_offset: i,
+-                            instr_set_idx: j,
+-                            offset: b.recovery_point,
+-                        },
+-                    })?;
+-            }
+-
+-            if !ancestor.has_ancestor_with_hereditary_jumps {
+-                break;
+-            }
++        for (i, (jumps, _)) in self.stack.active_hereditary_jumps().iter().enumerate() {
++            self.try_exec_instr_set_without_attrs(jumps.clone(), ctx, match_handler)
++                .map_err(move |b| Bailout {
++                    at_addr: b.at_addr,
++                    recovery_point: HereditaryJumpPtr {
++                        instr_set_idx: i,
++                        offset: b.recovery_point,
++                    },
++                })?;
+         }
+ 
+         Ok(())
+@@ -513,47 +505,13 @@
+         ptr: HereditaryJumpPtr,
+         match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
+     ) {
+-        let items = self.stack.items();
+-
+-        if items.is_empty() {
+-            return;
+-        }
+-
+-        let ptr_ancestor_idx = items.len() - 1 - ptr.stack_offset;
+-
+-        // NOTE: first find pointed ancestor, then jump instruction
+-        // set and execute it with the offset.
+-        if let Some(ptr_ancestor) = items.get(ptr_ancestor_idx) {
+-            if let Some(ptr_jumps) = ptr_ancestor.hereditary_jumps.get(ptr.instr_set_idx) {
+-                self.exec_instr_set_with_attrs(
+-                    ptr_jumps,
+-                    attr_matcher,
+-                    ctx,
+-                    ptr.offset,
+-                    match_handler,
+-                );
++        let active = self.stack.active_hereditary_jumps();
+ 
+-                // NOTE: execute the rest of jump instruction sets in the pointed ancestor as usual.
+-                for jumps in ptr_ancestor
+-                    .hereditary_jumps
+-                    .iter()
+-                    .skip(ptr.instr_set_idx + 1)
+-                {
+-                    self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0, match_handler);
+-                }
+-            }
++        if let Some((ptr_jumps, _)) = active.get(ptr.instr_set_idx) {
++            self.exec_instr_set_with_attrs(ptr_jumps, attr_matcher, ctx, ptr.offset, match_handler);
+ 
+-            // NOTE: execute hereditary jumps in remaining ancestors as usual.
+-            if ptr_ancestor.has_ancestor_with_hereditary_jumps {
+-                for ancestor in items.iter().rev().skip(ptr.stack_offset + 1) {
+-                    for jumps in &ancestor.hereditary_jumps {
+-                        self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0, match_handler);
+-                    }
+-
+-                    if !ancestor.has_ancestor_with_hereditary_jumps {
+-                        break;
+-                    }
+-                }
++            for (jumps, _) in active.iter().skip(ptr.instr_set_idx + 1) {
++                self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0, match_handler);
+             }
+         }
+     }
+--- a/src/selectors_vm/stack.rs
++++ b/src/selectors_vm/stack.rs
+@@ -178,7 +178,6 @@
+     pub jumps: Vec<AddressRange>,
+     pub hereditary_jumps: Vec<AddressRange>,
+     pub child_counter: ChildCounter,
+-    pub has_ancestor_with_hereditary_jumps: bool,
+     pub stack_directive: StackDirective,
+ }
+ 
+@@ -192,7 +191,6 @@
+             jumps: Vec::default(),
+             hereditary_jumps: Vec::default(),
+             child_counter: Default::default(),
+-            has_ancestor_with_hereditary_jumps: false,
+             stack_directive: StackDirective::Push,
+         }
+     }
+@@ -205,7 +203,6 @@
+             jumps: self.jumps,
+             hereditary_jumps: self.hereditary_jumps,
+             child_counter: self.child_counter,
+-            has_ancestor_with_hereditary_jumps: self.has_ancestor_with_hereditary_jumps,
+             stack_directive: self.stack_directive,
+         }
+     }
+@@ -217,6 +214,13 @@
+     /// A typed counter for all elements on all frames. This is optional to indicate if types are actually being counted.
+     typed_child_counters: Option<TypedChildCounterMap>,
+     items: LimitedVec<StackItem<'static, E>>,
++    /// Number of open items per tag name, so a stray end tag can be rejected in O(1)
++    /// instead of scanning the whole stack (see `pop_up_to`).
++    open_name_counts: HashMap<LocalName<'static>, usize>,
++    /// Distinct hereditary-jump address ranges currently contributed by any open item,
++    /// paired with the shallowest depth that introduced each. Descendant-combinator
++    /// matching iterates this flat list instead of walking every ancestor.
++    active_hereditary_jumps: Vec<(AddressRange, usize)>,
+ }
+ 
+ impl<E: ElementData> Stack<E> {
+@@ -230,6 +234,8 @@
+             root_child_counter: Default::default(),
+             typed_child_counters: enable_nth_of_type.map(TypedChildCounterMap::new),
+             items: LimitedVec::new(memory_limiter),
++            open_name_counts: HashMap::default(),
++            active_hereditary_jumps: Vec::new(),
+         }
+     }
+ 
+@@ -285,8 +291,16 @@
+     pub fn pop_up_to(
+         &mut self,
+         local_name: LocalName<'_>,
+-        popped_element_data_handler: impl FnMut(E),
++        mut popped_element_data_handler: impl FnMut(E),
+     ) {
++        // NOTE: a stray end tag that matches nothing on the stack is O(1) here.
++        // On a hit, `rposition` below only visits items that are about to be
++        // drained, so the scan cost is bounded by the drain cost and stays
++        // linear over the document.
++        if !self.open_name_counts.contains_key(&local_name) {
++            return;
++        }
++
+         let pop_to_index = self
+             .items
+             .iter()
+@@ -295,15 +309,31 @@
+             if let Some(c) = self.typed_child_counters.as_mut() {
+                 c.pop_to(index);
+             }
+-            self.items
+-                .drain(index..)
+-                .map(|i| i.element_data)
+-                .for_each(popped_element_data_handler);
++            self.active_hereditary_jumps.retain(|(_, d)| *d < index);
++            for item in self.items.drain(index..) {
++                match self.open_name_counts.raw_entry_mut().from_key(&item.local_name) {
++                    RawEntryMut::Occupied(mut e) => {
++                        if *e.get() <= 1 {
++                            e.remove();
++                        } else {
++                            *e.get_mut() -= 1;
++                        }
++                    }
++                    RawEntryMut::Vacant(_) => debug_assert!(false, "open_name_counts out of sync"),
++                }
++                popped_element_data_handler(item.element_data);
++            }
+         }
+     }
+ 
+     #[inline]
+     #[must_use]
++    pub fn active_hereditary_jumps(&self) -> &[(AddressRange, usize)] {
++        &self.active_hereditary_jumps
++    }
++
++    #[inline]
++    #[must_use]
+     pub fn items(&self) -> &[StackItem<'_, E>] {
+         &self.items
+     }
+@@ -316,15 +346,32 @@
+     #[inline]
+     pub fn push_item(
+         &mut self,
+-        mut item: StackItem<'static, E>,
++        item: StackItem<'static, E>,
+     ) -> Result<(), MemoryLimitExceededError> {
+-        if let Some(last) = self.items.last() {
+-            if last.has_ancestor_with_hereditary_jumps || !last.hereditary_jumps.is_empty() {
+-                item.has_ancestor_with_hereditary_jumps = true;
++        let depth = self.items.len();
++        self.items.push(item)?;
++
++        let item = self.items.last().expect("just pushed");
++        match self
++            .open_name_counts
++            .raw_entry_mut()
++            .from_key(&item.local_name)
++        {
++            RawEntryMut::Occupied(mut e) => *e.get_mut() += 1,
++            RawEntryMut::Vacant(e) => {
++                e.insert(item.local_name.clone(), 1);
+             }
+         }
+ 
+-        self.items.push(item)?;
++        for r in &item.hereditary_jumps {
++            if !self
++                .active_hereditary_jumps
++                .iter()
++                .any(|(active, _)| active == r)
++            {
++                self.active_hereditary_jumps.push((r.clone(), depth));
++            }
++        }
+         Ok(())
+     }
+ }
+@@ -361,31 +408,62 @@
+         item
+     }
+ 
++    fn active_hj(stack: &Stack<TestElementData>) -> Vec<AddressRange> {
++        stack
++            .active_hereditary_jumps()
++            .iter()
++            .map(|(r, _)| r.clone())
++            .collect()
++    }
++
+     #[test]
+-    #[allow(clippy::reversed_empty_ranges)]
+-    fn hereditary_jumps_flag() {
++    fn active_hereditary_jumps_dedup_and_prune() {
+         let mut stack = Stack::new(SharedMemoryLimiter::new(2048), None);
+ 
+-        stack.push_item(item("item1", 0)).unwrap();
++        stack.push_item(item("a", 0)).unwrap();
+ 
+-        let mut item2 = item("item2", 1);
+-        item2.hereditary_jumps.push(0..0);
+-        stack.push_item(item2).unwrap();
++        let mut b = item("b", 1);
++        b.hereditary_jumps.push(0..1);
++        stack.push_item(b).unwrap();
++        assert_eq!(active_hj(&stack), vec![0..1]);
++
++        let mut c = item("c", 2);
++        c.hereditary_jumps.push(0..1);
++        c.hereditary_jumps.push(2..4);
++        stack.push_item(c).unwrap();
++        assert_eq!(active_hj(&stack), vec![0..1, 2..4]);
+ 
+-        let mut item3 = item("item3", 2);
+-        item3.hereditary_jumps.push(0..0);
+-        stack.push_item(item3).unwrap();
++        stack.push_item(item("d", 3)).unwrap();
++        assert_eq!(active_hj(&stack), vec![0..1, 2..4]);
+ 
+-        stack.push_item(item("item4", 3)).unwrap();
++        stack.pop_up_to(local_name("c"), |_| {});
++        assert_eq!(active_hj(&stack), vec![0..1]);
+ 
+-        assert_eq!(
+-            stack
+-                .items()
+-                .iter()
+-                .map(|i| i.has_ancestor_with_hereditary_jumps)
+-                .collect::<Vec<_>>(),
+-            [false, false, true, true]
+-        );
++        stack.pop_up_to(local_name("a"), |_| {});
++        assert!(active_hj(&stack).is_empty());
++    }
++
++    #[test]
++    fn open_name_counts_track_push_and_drain() {
++        let mut stack = Stack::new(SharedMemoryLimiter::new(2048), None);
++
++        stack.push_item(item("a", 0)).unwrap();
++        stack.push_item(item("b", 1)).unwrap();
++        stack.push_item(item("a", 2)).unwrap();
++
++        stack.pop_up_to(local_name("c"), |_| unreachable!("should not pop"));
++        assert_eq!(stack.items().len(), 3);
++
++        let mut popped = Vec::new();
++        stack.pop_up_to(local_name("a"), |d| popped.push(d.0));
++        assert_eq!(popped, vec![2]);
++        assert_eq!(stack.items().len(), 2);
++
++        stack.pop_up_to(local_name("a"), |d| popped.push(d.0));
++        assert_eq!(popped, vec![2, 0, 1]);
++        assert!(stack.items().is_empty());
++
++        stack.pop_up_to(local_name("a"), |_| unreachable!("stack is empty"));
+     }
+ 
+     #[test]

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -33,6 +33,12 @@ export const lolhtml: Dependency = {
     commit: LOLHTML_COMMIT,
   }),
 
+  // Fixes two O(depth^2) paths in the selectors_vm open-element stack that
+  // turn sub-MB hostile HTML into a CPU pin: a full reverse scan on every
+  // unmatched end tag, and per-ancestor re-execution of the same hereditary
+  // jump for descendant combinators. Drop once the fix is upstream.
+  patches: ["patches/lolhtml/selectors-vm-quadratic.patch"],
+
   // No separate build — compiled as part of the workspace cargo build via
   // `bun_runtime`/`bun_bundler`'s path dep on `vendor/lolhtml`.
   build: () => ({ kind: "none" }),

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1261,3 +1261,36 @@ describe("tagName, endTag.name, and comment.text setters", () => {
     expect(savedComment.text).toBeNull();
   });
 });
+
+describe("HTMLRewriter pathological nesting stays linear", () => {
+  it("stray end tags with a deep open-element stack", () => {
+    // Each </b> used to trigger a full reverse scan of the open-element
+    // stack in lol-html's selectors_vm, so N unclosed <a> plus N stray </b>
+    // was O(N^2). At this N the old behaviour pins a core for >10s; after
+    // the fix the miss is O(1) and this completes in a few hundred ms.
+    const N = 80_000;
+    const doc = Buffer.alloc(7 * N, "<a></b>").toString();
+    const out = new HTMLRewriter().on("nomatch", { element() {} }).transform(doc);
+    expect(out.length).toBe(doc.length);
+    expect(out).toBe(doc);
+  });
+
+  it("descendant combinator over deeply nested matching elements", () => {
+    // Matching "div div" used to re-execute the same hereditary jump once
+    // per ancestor for every start tag, giving O(depth^2). With the
+    // deduplicated active-jump set it is O(depth).
+    const N = 25_000;
+    const open = Buffer.alloc(5 * N, "<div>").toString();
+    const close = Buffer.alloc(6 * N, "</div>").toString();
+    let matches = 0;
+    const out = new HTMLRewriter()
+      .on("div div", {
+        element() {
+          matches++;
+        },
+      })
+      .transform(open + close);
+    expect(matches).toBe(N - 1);
+    expect(out).toBe(open + close);
+  });
+});

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1263,6 +1263,24 @@ describe("tagName, endTag.name, and comment.text setters", () => {
 });
 
 describe("HTMLRewriter pathological nesting stays linear", () => {
+  it("mixed-case custom element end tag still matches its start tag", () => {
+    // Custom elements (and any name containing '-', '_', 0/7/8/9, or >12 chars)
+    // take lol-html's LocalName::Bytes path, which must hash case-insensitively
+    // for the O(1) stray-end-tag guard in the selector VM stack.
+    let end = "";
+    const out = new HTMLRewriter()
+      .on("my-widget", {
+        element(el) {
+          el.onEndTag(t => {
+            end = t.name;
+          });
+        },
+      })
+      .transform("<My-Widget>x</MY-WIDGET><p>y</p>");
+    expect(end).toBe("my-widget");
+    expect(out).toBe("<My-Widget>x</MY-WIDGET><p>y</p>");
+  });
+
   it("stray end tags with a deep open-element stack", () => {
     // Each </b> used to trigger a full reverse scan of the open-element
     // stack in lol-html's selectors_vm, so N unclosed <a> plus N stray </b>


### PR DESCRIPTION
## What

Fixes two O(depth^2) paths in lol-html's `selectors_vm` open-element stack that let sub-MB hostile HTML pin a CPU core through `HTMLRewriter`. Applied as a vendor patch to `cloudflare/lol-html`.

## Repro

```js
// 1) stray end tags: O(depth) reverse scan per end tag
const doc = "<a></b>".repeat(100_000); // 684 KB
await new HTMLRewriter().on("nomatch", { element() {} })
  .transform(new Response(doc)).text();
// before: ~25s, after: ~50ms

// 2) descendant combinator over deep nesting: O(depth) ancestor walk per start tag
const deep = "<div>".repeat(40_000) + "</div>".repeat(40_000); // 200 KB
await new HTMLRewriter().on("div div", { element() {} })
  .transform(new Response(deep)).text();
// before: ~30s, after: ~30ms
```

Any `.on(selector, ...)` registration (even one that never matches) enables the selector VM, so any surface that feeds untrusted HTML to `HTMLRewriter` was exposed.

## Cause

`selectors_vm/stack.rs` `pop_up_to` did `items.iter().rposition(|i| i.local_name == name)` for every end tag. A stray end tag that matches nothing still scanned the entire open-element stack: N unclosed opens plus N stray closes is N full scans.

`selectors_vm/mod.rs` `try_exec_hereditary_jumps_without_attrs` walked every ancestor for every start tag, re-executing the same hereditary-jump address range once per matching ancestor. For `div div` over N nested `<div>`, every item carries the same range so the walk is O(depth) per tag.

## Fix

`Stack` now maintains:

- `open_name_counts: HashMap<LocalName, usize>` so `pop_up_to` rejects a name not on the stack in O(1). When the name is present the `rposition` scan length equals the subsequent drain length, so total scan work over a document is bounded by total pushes.
- `active_hereditary_jumps: Vec<(AddressRange, usize)>`, the distinct hereditary-jump ranges currently contributed by any open item, each paired with the shallowest depth that introduced it. Descendant matching iterates this flat list (bounded by program size, not depth); `pop_up_to` prunes it by depth. The per-item `has_ancestor_with_hereditary_jumps` flag and the `HereditaryJumpPtr.stack_offset` resume coordinate are gone.

Re-executing the same address range against the same start tag was already a no-op after payload dedup in `add_execution_branch`, so dedup-once execution is observationally equivalent.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/js/workerd/html-rewriter.test.js -t "pathological"` times out on both cases (>5s default).
- `bun bd test test/js/workerd/html-rewriter.test.js` passes: 439ms and 1.4s under debug+ASAN; all 71 existing HTMLRewriter tests pass.
- `cargo test --lib` in `vendor/lolhtml`: 147 passed. `cargo test --features integration_test`: 3 passed including the selector-matching fixture suite.

Note: the fix lives in `patches/` + `scripts/`, not `src/`, so a `git stash -- src/ packages/` fail-before check won't revert it. The `USE_SYSTEM_BUN=1` run above is the fail-before proof.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/workerd/html-rewriter.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (e96793baa)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [10.29ms]
(pass) HTMLRewriter > error inside element handler [5.84ms]
(pass) HTMLRewriter > error inside element handler (string) [4.41ms]
(pass) HTMLRewriter > fast async error inside element handler [20.47ms]
(pass) HTMLRewriter > slow async error inside element handler [18.12ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [116.11ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [12.24ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [333.68ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [58.12ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [33.74ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the transformed response is an errored stream [48.15ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > a read already pending on .body when the upstream fails rejects [35.45ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .clone() of a failed transformed body is also failed [43.14ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > does not invoke onDocument end for a document that never completed [38.30ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > transform() of a body that already failed throws the upstream error [61.88ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > transform() of an aborted body throws the abort reason [57.38ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement using fetch + Bun.serve [157.07ms]
(pass) H
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
patches/lolhtml/selectors-vm-quadratic.patch | 368 +++++++++++++++++++++++++++
 scripts/build/deps/lolhtml.ts                |   6 +
 test/js/workerd/html-rewriter.test.js        |  51 ++++
 3 files changed, 425 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
patches/lolhtml/selectors-vm-quadratic.patch      0      0      0
scripts/build/deps/lolhtml.ts                     1      1      0
test/js/workerd/html-rewriter.test.js             1      3      0
```

</details>

<!-- robobun:evidence:end -->