### PR TITLE
node:fs: Dir.close must not close an fd it did not open

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1054,8 +1054,9 @@ const kAlreadyValidated = Symbol("kAlreadyValidated");
 
 class Dir {
   /**
-   * `-1` when closed. stdio handles (0, 1, 2) don't actually get closed by
-   * {@link close} or {@link closeSync}.
+   * Open/closed state sentinel (`-1` once closed). This implementation is
+   * path-bound and never owns a real fd, so close() only flips this marker;
+   * it must not `fs.closeSync` a value the constructor was handed.
    */
   #handle: number;
   #path: PathLike;
@@ -1174,9 +1175,7 @@ class Dir {
   }
 
   #closeOp() {
-    const handle = this.#handle;
-    if (handle < 0) throw $ERR_DIR_CLOSED();
-    if (handle > 2) fs.closeSync(handle);
+    if (this.#handle < 0) throw $ERR_DIR_CLOSED();
     this.#handle = -1;
   }
 
@@ -1190,10 +1189,8 @@ class Dir {
   }
 
   closeSync() {
-    const handle = this.#handle;
-    if (handle < 0) throw $ERR_DIR_CLOSED();
+    if (this.#handle < 0) throw $ERR_DIR_CLOSED();
     if (this.#pendingCount > 0) throw this.#dirConcurrentError();
-    if (handle > 2) fs.closeSync(handle);
     this.#handle = -1;
   }
 

--- a/test/js/node/fs/dir.test.ts
+++ b/test/js/node/fs/dir.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { tempDir } from "harness";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -239,5 +240,52 @@ describe("Dir explicit resource management", () => {
     dir.closeSync();
     expect(() => dir[Symbol.dispose]()).not.toThrow();
     await expect(dir[Symbol.asyncDispose]()).resolves.toBeUndefined();
+  });
+});
+
+// A Dir constructed directly with a raw integer must not treat that integer as
+// an fd it owns: node's handle is an opaque DirHandle and calling close() on an
+// integer throws there without touching any descriptor.
+describe("new fs.Dir with a foreign integer handle", () => {
+  function openProbe(cwd: string) {
+    const fd = fs.openSync(path.join(cwd, "probe.txt"), "r");
+    return {
+      fd,
+      [Symbol.dispose]() {
+        try {
+          fs.closeSync(fd);
+        } catch {}
+      },
+    };
+  }
+
+  it("closeSync does not close the unrelated fd", () => {
+    using cwd = tempDir("dir-foreign-fd", { "probe.txt": "x" });
+    using probe = openProbe(String(cwd));
+    const d = new fs.Dir(probe.fd, String(cwd));
+    try {
+      d.closeSync();
+    } catch {
+      // node throws TypeError here; either way the fd must survive
+    }
+    expect(() => fs.fstatSync(probe.fd)).not.toThrow();
+  });
+
+  it("async close does not close the unrelated fd", async () => {
+    using cwd = tempDir("dir-foreign-fd", { "probe.txt": "x" });
+    using probe = openProbe(String(cwd));
+    const d = new fs.Dir(probe.fd, String(cwd));
+    await d.close().catch(() => {});
+    expect(() => fs.fstatSync(probe.fd)).not.toThrow();
+  });
+
+  it("Symbol.dispose does not close the unrelated fd", () => {
+    using cwd = tempDir("dir-foreign-fd", { "probe.txt": "x" });
+    using probe = openProbe(String(cwd));
+    {
+      using d = new fs.Dir(probe.fd, String(cwd));
+      void d;
+    }
+    expect(() => fs.fstatSync(probe.fd)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Repro

```js
import fs from "node:fs";
const fd = fs.openSync("/etc/hostname", "r");
const d = new fs.Dir(fd, "/never/opened/by/this/Dir");
d.closeSync();
fs.fstatSync(fd);   // bun: EBADF (fd was closed by Dir); node: fd still open
```

Node's `Dir` holds an opaque `DirHandle` and calls `.close()` on it; passing an integer there throws `TypeError: this[#handle].close is not a function` and leaves the descriptor untouched.

## Cause

`Dir` in the current path-bound implementation never opens a descriptor of its own: `opendir`/`opendirSync` pass the literal `1` as the handle sentinel, and reads go through `fs.readdir(path)`. The `if (handle > 2) fs.closeSync(handle)` in `#closeOp`/`closeSync` is therefore unreachable for any `Dir` Bun creates, and only fires when userland constructs `new fs.Dir(<integer>, path)` directly, closing an unrelated fd by number.

## Fix

Drop the `fs.closeSync(handle)` from both close paths. `#handle` is now purely the open/closed state marker its doc comment describes.

This is orthogonal to the fd-bound rewrite in #35928; that PR stores a real fd via a private `dirSetHandle` setter after the native open, so a userland integer passed to the constructor would still need to be kept out of the close path there too.

## Verification

```
# USE_SYSTEM_BUN=1
(fail) new fs.Dir with a foreign integer handle > closeSync does not close the unrelated fd
  EBADF: bad file descriptor, fstat
(fail) ... > async close does not close the unrelated fd
(fail) ... > Symbol.dispose does not close the unrelated fd

# bun bd test test/js/node/fs/dir.test.ts
26 pass, 0 fail
# bun bd test/js/node/test/parallel/test-fs-opendir.js
(exit 0)
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/dir.test.ts

<!-- robobun:evidence:end -->