### PR TITLE
HTMLRewriter: pass text bytes through unchanged when a text handler only observes

### DIFF
--- a/patches/lolhtml/text-chunk-raw-passthrough.patch
+++ b/patches/lolhtml/text-chunk-raw-passthrough.patch
@@ -1,132 +1,31 @@
---- a/src/rewritable_units/tokens/text_chunk.rs
-+++ b/src/rewritable_units/tokens/text_chunk.rs
-@@ -74,6 +74,12 @@
- /// [`last_in_text_node`]: #method.last_in_text_node
- pub struct TextChunk<'i> {
-     text: Cow<'i, str>,
-+    /// The input bytes this chunk's `text` was decoded from. `serialize_self`
-+    /// emits these verbatim when the handler has not mutated `text`, so that
-+    /// merely observing a chunk does not alter the output (the decode is lossy
-+    /// for input that is not valid in the document encoding). Cleared by
-+    /// [`as_mut_str`]/[`set_str`].
-+    raw: Option<&'i [u8]>,
-     text_type: TextType,
-     last_in_text_node: bool,
-     encoding: &'static Encoding,
-@@ -87,6 +93,7 @@
-     #[must_use]
-     pub(crate) fn new(
-         text: &'i str,
-+        raw: Option<&'i [u8]>,
-         text_type: TextType,
-         last_in_text_node: bool,
-         encoding: &'static Encoding,
-@@ -94,6 +101,7 @@
-     ) -> Self {
-         TextChunk {
-             text: text.into(),
-+            raw,
-             text_type,
-             last_in_text_node,
-             encoding,
-@@ -130,6 +138,7 @@
-     /// It may be necessary to buffer the text. See [`TextChunk::last_in_text_node`].
-     #[inline]
-     pub fn as_mut_str(&mut self) -> &mut String {
-+        self.raw = None;
-         self.text.to_mut()
-     }
- 
-@@ -139,6 +148,7 @@
-     /// See [`TextChunk::text_type`].
-     #[inline]
-     pub fn set_str(&mut self, text: String) {
-+        self.raw = None;
-         self.text = Cow::Owned(text);
-     }
- 
-@@ -354,7 +364,11 @@
- 
-     #[inline]
-     fn serialize_self(&self, sink: &mut StreamingHandlerSink<'_>) -> Result<(), RewritingError> {
--        if !self.text.is_empty() {
-+        if let Some(raw) = self.raw {
-+            if !raw.is_empty() {
-+                sink.output_handler()(raw);
-+            }
-+        } else if !self.text.is_empty() {
-             // The "text" here is actually markup
-             sink.write_str(&self.text, ContentType::Html);
-         }
-@@ -429,6 +443,7 @@
-         let encoding = Encoding::for_label_no_replacement(b"utf-8").unwrap();
-         let mut chunk = TextChunk::new(
-             "original text",
-+            None,
-             TextType::PlainText,
-             true,
-             encoding,
-@@ -561,12 +576,45 @@
- 
-         #[test]
-         fn last_flush_text_decoder() {
-+            // The handler only inserts after the chunk; the chunk's own bytes
-+            // are not mutated, so the raw input bytes pass through unchanged.
-+            let input = b"<p>\xF0\xF0\x9F\xF0\x9F\x98</p>";
-+            let mut out = Vec::new();
-+            rewrite_html_to_vec(
-+                input,
-+                UTF_8,
-+                vec![],
-+                vec![doc_text!(|c| {
-+                    if c.last_in_text_node() {
-+                        c.after(" last", ContentType::Text);
-+                    }
-+                    Ok(())
-+                })],
-+                &mut out,
-+            );
-+            assert_eq!(b"<p>\xF0\xF0\x9F\xF0\x9F\x98 last</p>"[..], out[..]);
-+        }
-+
-+        #[test]
-+        fn non_utf8_bytes_pass_through_when_unmodified() {
-+            let input = b"<p>a\x93\xE9\x94\xC0\xAF\xFF\xED\xA0\x80b</p>c\xE9d";
-+            let mut out = Vec::new();
-+            rewrite_html_to_vec(
-+                input,
-+                UTF_8,
-+                vec![],
-+                vec![doc_text!(|_| Ok(()))],
-+                &mut out,
-+            );
-+            assert_eq!(input[..], out[..]);
-+        }
-+
-+        #[test]
-+        fn non_utf8_bytes_replaced_when_modified() {
-             let rewritten = rewrite_text_chunk(b"<p>\xF0\xF0\x9F\xF0\x9F\x98</p>", UTF_8, |c| {
--                if c.last_in_text_node() {
--                    c.after(" last", ContentType::Text);
--                }
-+                c.as_mut_str();
-             });
--            assert_eq!("<p>\u{fffd}\u{fffd}\u{fffd} last</p>", rewritten);
-+            assert_eq!("<p>\u{fffd}\u{fffd}\u{fffd}</p>", rewritten);
-         }
-     }
- }
 --- a/src/rewritable_units/text_decoder.rs
 +++ b/src/rewritable_units/text_decoder.rs
-@@ -11,8 +11,14 @@
+@@ -1,6 +1,7 @@
+ use crate::base::{Bytes, SharedEncoding, SourceLocation, Spanned};
+ use crate::rewriter::RewritingError;
+ use encoding_rs::{CoderResult, Decoder, Encoding, UTF_8};
++use std::borrow::Cow;
+ 
+ const DEFAULT_BUFFER_LEN: usize = if cfg!(test) { 13 } else { 1024 };
+ 
+@@ -8,11 +9,23 @@
+     encoding: SharedEncoding,
+     pending_source_location_bytes_start: usize,
+     pending_text_streaming_decoder: Option<Decoder>,
++    // Raw input bytes the decoder has consumed whose decoded characters have
++    // NOT yet been delivered to `output_handler`. For UTF-8 this is exactly
++    // the incomplete-sequence tail encoding_rs keeps in its own state (<= 3
++    // bytes); it is owned here so the NEXT emitted chunk can expose those
++    // bytes as its `raw` prefix and preserve byte-identical passthrough.
++    pending_raw: Vec<u8>,
      text_buffer: String,
  }
  
 -pub(crate) type OutputHandlerCallback<'tmp> =
 -    dyn FnMut(&str, bool, &'static Encoding, SourceLocation) -> Result<(), RewritingError> + 'tmp;
-+pub(crate) type OutputHandlerCallback<'tmp> = dyn FnMut(
++pub(crate) type OutputHandlerCallback<'tmp, 'i> = dyn FnMut(
 +        &str,
-+        &[u8],
++        Option<Cow<'i, [u8]>>,
 +        bool,
 +        &'static Encoding,
 +        SourceLocation,
@@ -135,14 +34,54 @@
  
  impl TextDecoder {
      #[inline]
-@@ -63,7 +69,13 @@
+@@ -22,6 +35,7 @@
+             pending_source_location_bytes_start: 0,
+             encoding,
+             pending_text_streaming_decoder: None,
++            pending_raw: Vec::new(),
+             // this will be later initialized to DEFAULT_BUFFER_LEN,
+             // because encoding_rs wants a slice
+             text_buffer: String::new(),
+@@ -31,7 +45,7 @@
+     #[inline]
+     pub fn flush_pending(
+         &mut self,
+-        output_handler: &mut OutputHandlerCallback<'_>,
++        output_handler: &mut OutputHandlerCallback<'_, '_>,
+     ) -> Result<(), RewritingError> {
+         if self.pending_text_streaming_decoder.is_some() {
+             self.feed_text(
+@@ -44,11 +58,11 @@
+     }
+ 
+     #[inline(never)]
+-    pub fn feed_text(
++    pub fn feed_text<'i>(
+         &mut self,
+-        input_span: Spanned<Bytes<'_>>,
++        input_span: Spanned<Bytes<'i>>,
+         last_in_text_node: bool,
+-        output_handler: &mut OutputHandlerCallback<'_>,
++        output_handler: &mut OutputHandlerCallback<'_, 'i>,
+     ) -> Result<(), RewritingError> {
+         let mut raw_input = input_span.as_slice();
+         let mut next_source_location_bytes_start = input_span.source_location().bytes().start;
+@@ -56,6 +70,7 @@
+         let encoding = self.encoding.get();
+ 
+         if let Some((utf8_text, rest)) = self.split_utf8_start(raw_input, encoding) {
++            debug_assert!(self.pending_raw.is_empty());
+             raw_input = rest;
+             let really_last = last_in_text_node && rest.is_empty();
+ 
+@@ -63,7 +78,13 @@
                  SourceLocation::from_start_len(next_source_location_bytes_start, utf8_text.len());
              next_source_location_bytes_start = source_location.bytes().end;
  
 -            (output_handler)(utf8_text, really_last, encoding, source_location)?;
 +            (output_handler)(
 +                utf8_text,
-+                utf8_text.as_bytes(),
++                Some(Cow::Borrowed(utf8_text.as_bytes())),
 +                really_last,
 +                encoding,
 +                source_location,
@@ -150,81 +89,174 @@
  
              if really_last {
                  debug_assert!(self.pending_text_streaming_decoder.is_none());
-@@ -89,7 +101,16 @@
+@@ -89,6 +110,28 @@
                  SourceLocation::from_start_len(next_source_location_bytes_start, read);
              next_source_location_bytes_start = source_location.bytes().end;
  
--            if written > 0 || last_in_text_node {
-+            // The raw input bytes that this decode step consumed. A non-mutating
-+            // text handler re-emits these bytes verbatim so that registering a
-+            // handler does not itself change the output. On the flush call
-+            // (`last_in_text_node` with empty input) the decoder may still emit
-+            // replacement characters for bytes it buffered from an earlier
-+            // `feed_text`; those bytes already went out with that earlier
-+            // chunk's `raw`, so the raw slice here is correctly empty.
-+            let raw = raw_input.get(..read).unwrap_or_default();
++            // Raw-byte accounting for this chunk:
++            //   raw(chunk) = pending_raw ++ raw_input[..read - tail]
++            //   pending_raw' = raw_input[read - tail .. read]
++            // where `tail` is the number of bytes encoding_rs kept as internal
++            // state (an incomplete sequence at end-of-input). OutputFull and
++            // last=true never leave state, so `tail` is only nonzero on the
++            // final InputEmpty of a non-last call.
++            let consumed = raw_input.get(..read).unwrap_or_default();
++            let tail = if finished_decoding && !last_in_text_node && encoding == UTF_8 {
++                utf8_incomplete_tail_len(consumed)
++            } else {
++                0
++            };
++            let (emit, carry) = consumed.split_at(read - tail);
++            let raw: Cow<'i, [u8]> = if self.pending_raw.is_empty() {
++                Cow::Borrowed(emit)
++            } else {
++                let mut v = std::mem::take(&mut self.pending_raw);
++                v.extend_from_slice(emit);
++                Cow::Owned(v)
++            };
 +
-+            if written > 0 || last_in_text_node || !raw.is_empty() {
+             if written > 0 || last_in_text_node {
                  // the last call to feed_text() may make multiple calls to output_handler,
                  // but only one call to output_handler can be *the* last one.
-                 let really_last = last_in_text_node && finished_decoding;
-@@ -97,6 +118,7 @@
+@@ -97,15 +140,25 @@
                  (output_handler)(
                      // this will always be in bounds, but unwrap_or_default optimizes better
                      buffer.get(..written).unwrap_or_default(),
-+                    raw,
++                    Some(raw),
                      really_last,
                      encoding,
                      source_location,
---- a/src/rewritable_units/mod.rs
-+++ b/src/rewritable_units/mod.rs
-@@ -151,4 +151,27 @@
+                 )?;
++                self.pending_raw.clear();
++                self.pending_raw.extend_from_slice(carry);
++            } else {
++                // Handler call skipped: everything we would have emitted as raw
++                // (including any carried prefix) defers to the next chunk.
++                let mut deferred = raw.into_owned();
++                deferred.extend_from_slice(carry);
++                self.pending_raw = deferred;
+             }
  
-         output.into()
+             if finished_decoding {
+                 if last_in_text_node {
+                     self.pending_text_streaming_decoder = None;
++                    debug_assert!(self.pending_raw.is_empty());
+                 } else {
+                     self.pending_source_location_bytes_start = next_source_location_bytes_start;
+                 }
+@@ -152,3 +205,20 @@
+         }
      }
-+
-+    pub(crate) fn rewrite_html_to_vec<'h>(
-+        html: &[u8],
-+        encoding: &'static Encoding,
-+        element_content_handlers: Vec<(Cow<'_, Selector>, ElementContentHandlers<'h>)>,
-+        document_content_handlers: Vec<DocumentContentHandlers<'h>>,
-+        output: &mut Vec<u8>,
-+    ) {
-+        let mut rewriter = HtmlRewriter::new(
-+            Settings {
-+                element_content_handlers,
-+                document_content_handlers,
-+                encoding: AsciiCompatibleEncoding::new(encoding).unwrap(),
-+                ..Settings::new()
-+            },
-+            |c: &[u8]| output.extend_from_slice(c),
-+        );
-+
-+        for ch in html.chunks(15) {
-+            rewriter.write(ch).unwrap();
-+        }
-+        rewriter.end().unwrap();
-+    }
  }
++
++/// Length of the incomplete-but-still-valid UTF-8 sequence at the end of
++/// `input`: the bytes a WHATWG UTF-8 decoder holds as state when fed `input`
++/// with `last=false`. At most 3 bytes.
++#[inline]
++fn utf8_incomplete_tail_len(input: &[u8]) -> usize {
++    let mut tail = &input[input.len().saturating_sub(3)..];
++    loop {
++        match std::str::from_utf8(tail) {
++            Ok(_) => return 0,
++            Err(e) => match e.error_len() {
++                None => return tail.len() - e.valid_up_to(),
++                Some(n) => tail = &tail[e.valid_up_to() + n..],
++            },
++        }
++    }
++}
+--- a/src/rewritable_units/tokens/text_chunk.rs
++++ b/src/rewritable_units/tokens/text_chunk.rs
+@@ -74,6 +74,9 @@
+ /// [`last_in_text_node`]: #method.last_in_text_node
+ pub struct TextChunk<'i> {
+     text: Cow<'i, str>,
++    // Input bytes this chunk was decoded from. Cleared by any API that
++    // mutates `text` so `serialize_self` only uses it for true passthrough.
++    raw: Option<Cow<'i, [u8]>>,
+     text_type: TextType,
+     last_in_text_node: bool,
+     encoding: &'static Encoding,
+@@ -87,6 +90,7 @@
+     #[must_use]
+     pub(crate) fn new(
+         text: &'i str,
++        raw: Option<Cow<'i, [u8]>>,
+         text_type: TextType,
+         last_in_text_node: bool,
+         encoding: &'static Encoding,
+@@ -94,6 +98,7 @@
+     ) -> Self {
+         TextChunk {
+             text: text.into(),
++            raw,
+             text_type,
+             last_in_text_node,
+             encoding,
+@@ -130,6 +135,7 @@
+     /// It may be necessary to buffer the text. See [`TextChunk::last_in_text_node`].
+     #[inline]
+     pub fn as_mut_str(&mut self) -> &mut String {
++        self.raw = None;
+         self.text.to_mut()
+     }
+ 
+@@ -139,6 +145,7 @@
+     /// See [`TextChunk::text_type`].
+     #[inline]
+     pub fn set_str(&mut self, text: String) {
++        self.raw = None;
+         self.text = Cow::Owned(text);
+     }
+ 
+@@ -354,7 +361,11 @@
+ 
+     #[inline]
+     fn serialize_self(&self, sink: &mut StreamingHandlerSink<'_>) -> Result<(), RewritingError> {
+-        if !self.text.is_empty() {
++        if let Some(raw) = &self.raw {
++            if !raw.is_empty() {
++                (sink.output_handler())(raw);
++            }
++        } else if !self.text.is_empty() {
+             // The "text" here is actually markup
+             sink.write_str(&self.text, ContentType::Html);
+         }
+@@ -429,6 +440,7 @@
+         let encoding = Encoding::for_label_no_replacement(b"utf-8").unwrap();
+         let mut chunk = TextChunk::new(
+             "original text",
++            None,
+             TextType::PlainText,
+             true,
+             encoding,
 --- a/src/transform_stream/dispatcher.rs
 +++ b/src/transform_stream/dispatcher.rs
-@@ -149,6 +149,7 @@
+@@ -11,6 +11,7 @@
+ use crate::rewritable_units::{DocumentEnd, Serialize, ToToken, Token, TokenCaptureFlags};
+ use crate::rewriter::RewritingError;
+ use encoding_rs::Encoding;
++use std::borrow::Cow;
+ 
+ pub(crate) struct AuxStartTagInfo<'i> {
+     pub input: &'i Bytes<'i>,
+@@ -149,6 +150,7 @@
      fn text_token_produced(
          &mut self,
          text: &str,
-+        raw: &[u8],
++        raw: Option<Cow<'_, [u8]>>,
          encoding: &'static Encoding,
          text_type: TextType,
          is_last_in_node: bool,
-@@ -156,6 +157,7 @@
+@@ -156,6 +158,7 @@
      ) -> Result<(), RewritingError> {
          let mut token = Token::TextChunk(TextChunk::new(
              text,
-+            Some(raw),
++            raw,
              text_type,
              is_last_in_node,
              encoding,
-@@ -219,9 +221,10 @@
+@@ -219,9 +222,10 @@
                  self.text_decoder.feed_text(
                      lexeme.spanned(),
                      false,
@@ -236,7 +268,7 @@
                              encoding,
                              self.last_text_type,
                              is_last,
-@@ -331,9 +334,10 @@
+@@ -331,9 +335,10 @@
      #[inline]
      fn flush_pending_captured_text(&mut self) -> Result<(), RewritingError> {
          self.text_decoder

--- a/patches/lolhtml/text-chunk-raw-passthrough.patch
+++ b/patches/lolhtml/text-chunk-raw-passthrough.patch
@@ -89,47 +89,56 @@
  
              if really_last {
                  debug_assert!(self.pending_text_streaming_decoder.is_none());
-@@ -89,6 +110,28 @@
+@@ -89,6 +110,37 @@
                  SourceLocation::from_start_len(next_source_location_bytes_start, read);
              next_source_location_bytes_start = source_location.bytes().end;
  
-+            // Raw-byte accounting for this chunk:
++            // Raw-byte accounting for this chunk (UTF-8 only):
 +            //   raw(chunk) = pending_raw ++ raw_input[..read - tail]
 +            //   pending_raw' = raw_input[read - tail .. read]
 +            // where `tail` is the number of bytes encoding_rs kept as internal
 +            // state (an incomplete sequence at end-of-input). OutputFull and
 +            // last=true never leave state, so `tail` is only nonzero on the
-+            // final InputEmpty of a non-last call.
-+            let consumed = raw_input.get(..read).unwrap_or_default();
-+            let tail = if finished_decoding && !last_in_text_node && encoding == UTF_8 {
-+                utf8_incomplete_tail_len(consumed)
++            // final InputEmpty of a non-last call. For non-UTF-8 document
++            // encodings `raw` is `None` and the serializer re-encodes the
++            // decoded text, which is the pre-patch behaviour: the tail-length
++            // computation is UTF-8-specific and other multi-byte encodings are
++            // not worth the extra state.
++            let (raw, carry): (Option<Cow<'i, [u8]>>, &[u8]) = if encoding == UTF_8 {
++                let consumed = raw_input.get(..read).unwrap_or_default();
++                let tail = if finished_decoding && !last_in_text_node {
++                    utf8_incomplete_tail_len(consumed)
++                } else {
++                    0
++                };
++                let (emit, carry) = consumed.split_at(read - tail);
++                let raw = if self.pending_raw.is_empty() {
++                    Cow::Borrowed(emit)
++                } else {
++                    let mut v = std::mem::take(&mut self.pending_raw);
++                    v.extend_from_slice(emit);
++                    Cow::Owned(v)
++                };
++                (Some(raw), carry)
 +            } else {
-+                0
-+            };
-+            let (emit, carry) = consumed.split_at(read - tail);
-+            let raw: Cow<'i, [u8]> = if self.pending_raw.is_empty() {
-+                Cow::Borrowed(emit)
-+            } else {
-+                let mut v = std::mem::take(&mut self.pending_raw);
-+                v.extend_from_slice(emit);
-+                Cow::Owned(v)
++                (None, &[][..])
 +            };
 +
              if written > 0 || last_in_text_node {
                  // the last call to feed_text() may make multiple calls to output_handler,
                  // but only one call to output_handler can be *the* last one.
-@@ -97,15 +140,25 @@
+@@ -97,15 +149,25 @@
                  (output_handler)(
                      // this will always be in bounds, but unwrap_or_default optimizes better
                      buffer.get(..written).unwrap_or_default(),
-+                    Some(raw),
++                    raw,
                      really_last,
                      encoding,
                      source_location,
                  )?;
 +                self.pending_raw.clear();
 +                self.pending_raw.extend_from_slice(carry);
-+            } else {
++            } else if let Some(raw) = raw {
 +                // Handler call skipped: everything we would have emitted as raw
 +                // (including any carried prefix) defers to the next chunk.
 +                let mut deferred = raw.into_owned();
@@ -144,7 +153,7 @@
                  } else {
                      self.pending_source_location_bytes_start = next_source_location_bytes_start;
                  }
-@@ -152,3 +205,20 @@
+@@ -152,3 +214,20 @@
          }
      }
  }

--- a/patches/lolhtml/text-chunk-raw-passthrough.patch
+++ b/patches/lolhtml/text-chunk-raw-passthrough.patch
@@ -230,6 +230,102 @@
              TextType::PlainText,
              true,
              encoding,
+@@ -444,6 +456,7 @@
+ 
+     mod serialization {
+         use super::*;
++        use crate::{ElementContentHandlers, HandlerResult, HtmlRewriter, Settings};
+ 
+         const HTML: &str = "Lorem ipsum dolor sit amet, cÔnsectetur adipiscing elit, sed do eiusmod tempor \
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud \
+@@ -568,5 +581,87 @@
+             });
+             assert_eq!("<p>\u{fffd}\u{fffd}\u{fffd} last</p>", rewritten);
+         }
++
++        fn rewrite_with_writes(
++            writes: &[&[u8]],
++            handler: impl FnMut(&mut TextChunk<'_>) -> HandlerResult + 'static,
++        ) -> Vec<u8> {
++            let mut out = Vec::new();
++            let mut r = HtmlRewriter::new(
++                Settings {
++                    element_content_handlers: vec![(
++                        std::borrow::Cow::Owned("p".parse().unwrap()),
++                        ElementContentHandlers::default().text(handler),
++                    )],
++                    ..Settings::new()
++                },
++                |c: &[u8]| out.extend_from_slice(c),
++            );
++            for w in writes {
++                r.write(w).unwrap();
++            }
++            r.end().unwrap();
++            out
++        }
++
++        #[test]
++        fn unmodified_chunk_raw_bytes_stay_code_point_aligned_across_writes() {
++            // `<p>a😀b</p>` with the write boundary inside 😀 (F0 9F 98 80),
++            // and a handler that conditionally replaces only one of the two
++            // resulting chunks. Each unmodified chunk's raw bytes must begin
++            // and end on a code-point boundary, so the output stays valid
++            // UTF-8 regardless of which neighbour was replaced.
++            let writes: &[&[u8]] = &[b"<p>a\xF0\x9F", b"\x98\x80b</p>"];
++
++            assert_eq!(
++                rewrite_with_writes(writes, |t| {
++                    if t.as_str().contains('\u{1F600}') {
++                        t.replace(":)", ContentType::Text);
++                    }
++                    Ok(())
++                }),
++                b"<p>a:)</p>",
++            );
++
++            assert_eq!(
++                rewrite_with_writes(writes, |t| {
++                    if t.as_str() == "a" {
++                        t.replace("X", ContentType::Text);
++                    }
++                    Ok(())
++                }),
++                "<p>X\u{1F600}b</p>".as_bytes(),
++            );
++
++            assert_eq!(
++                rewrite_with_writes(writes, |_| Ok(())),
++                "<p>a\u{1F600}b</p>".as_bytes(),
++            );
++        }
++
++        #[test]
++        fn write_containing_only_an_incomplete_lead_does_not_emit_an_empty_chunk() {
++            // `<p>a€b</p>` with the € split as `E2 82` / `AC`. The first text
++            // write (lexeme "a") is followed by one whose decoded text would
++            // be empty (just the buffered `E2 82`): the handler must not be
++            // invoked for that empty chunk, and a later `before()` must not
++            // land between the lead bytes and the continuation.
++            let writes: &[&[u8]] = &[b"<p>a", b"\xE2\x82", b"\xACb</p>"];
++            let out = rewrite_with_writes(writes, |t| {
++                assert!(t.last_in_text_node() || !t.as_str().is_empty());
++                t.before("|", ContentType::Text);
++                Ok(())
++            });
++            assert_eq!(std::str::from_utf8(&out).unwrap(), "<p>|a|\u{20AC}b|</p>");
++        }
++
++        #[test]
++        fn non_utf8_bytes_pass_through_when_unmodified() {
++            let input: &[u8] = b"<p>a\x93\xE9\x94\xC0\xAF\xFF\xED\xA0\x80b</p>c\xE9d";
++            assert_eq!(
++                rewrite_with_writes(&[input], |_| Ok(())),
++                input,
++            );
++        }
+     }
+ }
 --- a/src/transform_stream/dispatcher.rs
 +++ b/src/transform_stream/dispatcher.rs
 @@ -11,6 +11,7 @@

--- a/patches/lolhtml/text-chunk-raw-passthrough.patch
+++ b/patches/lolhtml/text-chunk-raw-passthrough.patch
@@ -1,0 +1,250 @@
+--- a/src/rewritable_units/tokens/text_chunk.rs
++++ b/src/rewritable_units/tokens/text_chunk.rs
+@@ -74,6 +74,12 @@
+ /// [`last_in_text_node`]: #method.last_in_text_node
+ pub struct TextChunk<'i> {
+     text: Cow<'i, str>,
++    /// The input bytes this chunk's `text` was decoded from. `serialize_self`
++    /// emits these verbatim when the handler has not mutated `text`, so that
++    /// merely observing a chunk does not alter the output (the decode is lossy
++    /// for input that is not valid in the document encoding). Cleared by
++    /// [`as_mut_str`]/[`set_str`].
++    raw: Option<&'i [u8]>,
+     text_type: TextType,
+     last_in_text_node: bool,
+     encoding: &'static Encoding,
+@@ -87,6 +93,7 @@
+     #[must_use]
+     pub(crate) fn new(
+         text: &'i str,
++        raw: Option<&'i [u8]>,
+         text_type: TextType,
+         last_in_text_node: bool,
+         encoding: &'static Encoding,
+@@ -94,6 +101,7 @@
+     ) -> Self {
+         TextChunk {
+             text: text.into(),
++            raw,
+             text_type,
+             last_in_text_node,
+             encoding,
+@@ -130,6 +138,7 @@
+     /// It may be necessary to buffer the text. See [`TextChunk::last_in_text_node`].
+     #[inline]
+     pub fn as_mut_str(&mut self) -> &mut String {
++        self.raw = None;
+         self.text.to_mut()
+     }
+ 
+@@ -139,6 +148,7 @@
+     /// See [`TextChunk::text_type`].
+     #[inline]
+     pub fn set_str(&mut self, text: String) {
++        self.raw = None;
+         self.text = Cow::Owned(text);
+     }
+ 
+@@ -354,7 +364,11 @@
+ 
+     #[inline]
+     fn serialize_self(&self, sink: &mut StreamingHandlerSink<'_>) -> Result<(), RewritingError> {
+-        if !self.text.is_empty() {
++        if let Some(raw) = self.raw {
++            if !raw.is_empty() {
++                sink.output_handler()(raw);
++            }
++        } else if !self.text.is_empty() {
+             // The "text" here is actually markup
+             sink.write_str(&self.text, ContentType::Html);
+         }
+@@ -429,6 +443,7 @@
+         let encoding = Encoding::for_label_no_replacement(b"utf-8").unwrap();
+         let mut chunk = TextChunk::new(
+             "original text",
++            None,
+             TextType::PlainText,
+             true,
+             encoding,
+@@ -561,12 +576,45 @@
+ 
+         #[test]
+         fn last_flush_text_decoder() {
++            // The handler only inserts after the chunk; the chunk's own bytes
++            // are not mutated, so the raw input bytes pass through unchanged.
++            let input = b"<p>\xF0\xF0\x9F\xF0\x9F\x98</p>";
++            let mut out = Vec::new();
++            rewrite_html_to_vec(
++                input,
++                UTF_8,
++                vec![],
++                vec![doc_text!(|c| {
++                    if c.last_in_text_node() {
++                        c.after(" last", ContentType::Text);
++                    }
++                    Ok(())
++                })],
++                &mut out,
++            );
++            assert_eq!(b"<p>\xF0\xF0\x9F\xF0\x9F\x98 last</p>"[..], out[..]);
++        }
++
++        #[test]
++        fn non_utf8_bytes_pass_through_when_unmodified() {
++            let input = b"<p>a\x93\xE9\x94\xC0\xAF\xFF\xED\xA0\x80b</p>c\xE9d";
++            let mut out = Vec::new();
++            rewrite_html_to_vec(
++                input,
++                UTF_8,
++                vec![],
++                vec![doc_text!(|_| Ok(()))],
++                &mut out,
++            );
++            assert_eq!(input[..], out[..]);
++        }
++
++        #[test]
++        fn non_utf8_bytes_replaced_when_modified() {
+             let rewritten = rewrite_text_chunk(b"<p>\xF0\xF0\x9F\xF0\x9F\x98</p>", UTF_8, |c| {
+-                if c.last_in_text_node() {
+-                    c.after(" last", ContentType::Text);
+-                }
++                c.as_mut_str();
+             });
+-            assert_eq!("<p>\u{fffd}\u{fffd}\u{fffd} last</p>", rewritten);
++            assert_eq!("<p>\u{fffd}\u{fffd}\u{fffd}</p>", rewritten);
+         }
+     }
+ }
+--- a/src/rewritable_units/text_decoder.rs
++++ b/src/rewritable_units/text_decoder.rs
+@@ -11,8 +11,14 @@
+     text_buffer: String,
+ }
+ 
+-pub(crate) type OutputHandlerCallback<'tmp> =
+-    dyn FnMut(&str, bool, &'static Encoding, SourceLocation) -> Result<(), RewritingError> + 'tmp;
++pub(crate) type OutputHandlerCallback<'tmp> = dyn FnMut(
++        &str,
++        &[u8],
++        bool,
++        &'static Encoding,
++        SourceLocation,
++    ) -> Result<(), RewritingError>
++    + 'tmp;
+ 
+ impl TextDecoder {
+     #[inline]
+@@ -63,7 +69,13 @@
+                 SourceLocation::from_start_len(next_source_location_bytes_start, utf8_text.len());
+             next_source_location_bytes_start = source_location.bytes().end;
+ 
+-            (output_handler)(utf8_text, really_last, encoding, source_location)?;
++            (output_handler)(
++                utf8_text,
++                utf8_text.as_bytes(),
++                really_last,
++                encoding,
++                source_location,
++            )?;
+ 
+             if really_last {
+                 debug_assert!(self.pending_text_streaming_decoder.is_none());
+@@ -89,7 +101,16 @@
+                 SourceLocation::from_start_len(next_source_location_bytes_start, read);
+             next_source_location_bytes_start = source_location.bytes().end;
+ 
+-            if written > 0 || last_in_text_node {
++            // The raw input bytes that this decode step consumed. A non-mutating
++            // text handler re-emits these bytes verbatim so that registering a
++            // handler does not itself change the output. On the flush call
++            // (`last_in_text_node` with empty input) the decoder may still emit
++            // replacement characters for bytes it buffered from an earlier
++            // `feed_text`; those bytes already went out with that earlier
++            // chunk's `raw`, so the raw slice here is correctly empty.
++            let raw = raw_input.get(..read).unwrap_or_default();
++
++            if written > 0 || last_in_text_node || !raw.is_empty() {
+                 // the last call to feed_text() may make multiple calls to output_handler,
+                 // but only one call to output_handler can be *the* last one.
+                 let really_last = last_in_text_node && finished_decoding;
+@@ -97,6 +118,7 @@
+                 (output_handler)(
+                     // this will always be in bounds, but unwrap_or_default optimizes better
+                     buffer.get(..written).unwrap_or_default(),
++                    raw,
+                     really_last,
+                     encoding,
+                     source_location,
+--- a/src/rewritable_units/mod.rs
++++ b/src/rewritable_units/mod.rs
+@@ -151,4 +151,27 @@
+ 
+         output.into()
+     }
++
++    pub(crate) fn rewrite_html_to_vec<'h>(
++        html: &[u8],
++        encoding: &'static Encoding,
++        element_content_handlers: Vec<(Cow<'_, Selector>, ElementContentHandlers<'h>)>,
++        document_content_handlers: Vec<DocumentContentHandlers<'h>>,
++        output: &mut Vec<u8>,
++    ) {
++        let mut rewriter = HtmlRewriter::new(
++            Settings {
++                element_content_handlers,
++                document_content_handlers,
++                encoding: AsciiCompatibleEncoding::new(encoding).unwrap(),
++                ..Settings::new()
++            },
++            |c: &[u8]| output.extend_from_slice(c),
++        );
++
++        for ch in html.chunks(15) {
++            rewriter.write(ch).unwrap();
++        }
++        rewriter.end().unwrap();
++    }
+ }
+--- a/src/transform_stream/dispatcher.rs
++++ b/src/transform_stream/dispatcher.rs
+@@ -149,6 +149,7 @@
+     fn text_token_produced(
+         &mut self,
+         text: &str,
++        raw: &[u8],
+         encoding: &'static Encoding,
+         text_type: TextType,
+         is_last_in_node: bool,
+@@ -156,6 +157,7 @@
+     ) -> Result<(), RewritingError> {
+         let mut token = Token::TextChunk(TextChunk::new(
+             text,
++            Some(raw),
+             text_type,
+             is_last_in_node,
+             encoding,
+@@ -219,9 +221,10 @@
+                 self.text_decoder.feed_text(
+                     lexeme.spanned(),
+                     false,
+-                    &mut |text, is_last, encoding, source_location| {
++                    &mut |text, raw, is_last, encoding, source_location| {
+                         self.delegate.text_token_produced(
+                             text,
++                            raw,
+                             encoding,
+                             self.last_text_type,
+                             is_last,
+@@ -331,9 +334,10 @@
+     #[inline]
+     fn flush_pending_captured_text(&mut self) -> Result<(), RewritingError> {
+         self.text_decoder
+-            .flush_pending(&mut |text, is_last, encoding, source_location| {
++            .flush_pending(&mut |text, raw, is_last, encoding, source_location| {
+                 self.delegate.text_token_produced(
+                     text,
++                    raw,
+                     encoding,
+                     self.last_text_type,
+                     is_last,

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -33,6 +33,8 @@ export const lolhtml: Dependency = {
     commit: LOLHTML_COMMIT,
   }),
 
+  patches: ["patches/lolhtml/text-chunk-raw-passthrough.patch"],
+
   // No separate build — compiled as part of the workspace cargo build via
   // `bun_runtime`/`bun_bundler`'s path dep on `vendor/lolhtml`.
   build: () => ({ kind: "none" }),

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -726,6 +726,38 @@ describe("HTMLRewriter", () => {
     expect(lastInTextNode).toBeBoolean();
   });
 
+  describe("does not rewrite non-UTF-8 text bytes when the handler only observes", () => {
+    // <p>a + cp1252 quotes/é + overlong + FF + WTF-8 lone surrogate + b</p> c é d
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x3c, 0x70, 0x3e, 0x61, 0x93, 0xe9, 0x94, 0xc0, 0xaf, 0xff, 0xed, 0xa0,
+      0x80, 0x62, 0x3c, 0x2f, 0x70, 0x3e, 0x63, 0xe9, 0x64,
+    ]);
+    const transform = async setup => {
+      const rewriter = new HTMLRewriter();
+      setup(rewriter);
+      return new Uint8Array(await rewriter.transform(new Response(bytes)).arrayBuffer());
+    };
+
+    it.each([
+      ["no handlers", r => r],
+      ["element handler", r => r.on("p", { element() {} })],
+      ["comments handler", r => r.on("p", { comments() {} })],
+      ["text handler that reads .text", r => r.on("p", { text(t) { void t.text; } })], // prettier-ignore
+      ["onDocument text handler", r => r.onDocument({ text() {} })],
+      ["text handler that inserts around the chunk", r => r.on("p", { text(t) { t.before(""); t.after(""); } })], // prettier-ignore
+    ])("%s", async (_, setup) => {
+      expect(await transform(setup)).toEqual(bytes);
+    });
+
+    it("text outside the selector is untouched", async () => {
+      const out = await transform(r => r.on("p", { text(t) { t.replace("x"); } })); // prettier-ignore
+      // The <p> text is replaced (including the empty last-in-node chunk), but
+      // the trailing `c \xe9 d` outside the selector passes through verbatim.
+      expect(out).toEqual(new Uint8Array([...Buffer.from("<p>xx</p>c"), 0xe9, 0x64]));
+    });
+  });
+
   it("it supports selfClosing", async () => {
     const selfClosing = {};
     await new HTMLRewriter()

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -726,38 +726,6 @@ describe("HTMLRewriter", () => {
     expect(lastInTextNode).toBeBoolean();
   });
 
-  describe("does not rewrite non-UTF-8 text bytes when the handler only observes", () => {
-    // <p>a + cp1252 quotes/é + overlong + FF + WTF-8 lone surrogate + b</p> c é d
-    // prettier-ignore
-    const bytes = new Uint8Array([
-      0x3c, 0x70, 0x3e, 0x61, 0x93, 0xe9, 0x94, 0xc0, 0xaf, 0xff, 0xed, 0xa0,
-      0x80, 0x62, 0x3c, 0x2f, 0x70, 0x3e, 0x63, 0xe9, 0x64,
-    ]);
-    const transform = async setup => {
-      const rewriter = new HTMLRewriter();
-      setup(rewriter);
-      return new Uint8Array(await rewriter.transform(new Response(bytes)).arrayBuffer());
-    };
-
-    it.each([
-      ["no handlers", r => r],
-      ["element handler", r => r.on("p", { element() {} })],
-      ["comments handler", r => r.on("p", { comments() {} })],
-      ["text handler that reads .text", r => r.on("p", { text(t) { void t.text; } })], // prettier-ignore
-      ["onDocument text handler", r => r.onDocument({ text() {} })],
-      ["text handler that inserts around the chunk", r => r.on("p", { text(t) { t.before(""); t.after(""); } })], // prettier-ignore
-    ])("%s", async (_, setup) => {
-      expect(await transform(setup)).toEqual(bytes);
-    });
-
-    it("text outside the selector is untouched", async () => {
-      const out = await transform(r => r.on("p", { text(t) { t.replace("x"); } })); // prettier-ignore
-      // The <p> text is replaced (including the empty last-in-node chunk), but
-      // the trailing `c \xe9 d` outside the selector passes through verbatim.
-      expect(out).toEqual(new Uint8Array([...Buffer.from("<p>xx</p>c"), 0xe9, 0x64]));
-    });
-  });
-
   it("it supports selfClosing", async () => {
     const selfClosing = {};
     await new HTMLRewriter()
@@ -1401,5 +1369,17 @@ describe("text handler does not transcode unmodified non-UTF-8 bytes", () => {
     const src = wrap([0xa9]);
     expect(await rewrite(src, { text: t => t.replace("X", { html: true }) })).toEqual(Buffer.from("<p>XX</p>"));
     expect(await rewrite(src, { text: t => t.remove() })).toEqual(Buffer.from("<p></p>"));
+  });
+
+  it("text outside the selector passes through even when matched text is replaced", async () => {
+    // <p>a\xa9b</p>c\xe9d
+    const src = Buffer.concat([wrap([0x61, 0xa9, 0x62]), Buffer.from([0x63, 0xe9, 0x64])]);
+    const out = Buffer.from(
+      await new HTMLRewriter()
+        .on("p", { text: t => t.replace("x", { html: true }) })
+        .transform(new Response(src))
+        .arrayBuffer(),
+    );
+    expect(out).toEqual(Buffer.concat([Buffer.from("<p>xx</p>c"), Buffer.from([0xe9, 0x64])]));
   });
 });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1293,3 +1293,82 @@ describe("tagName, endTag.name, and comment.text setters", () => {
     expect(savedComment.text).toBeNull();
   });
 });
+
+describe("text handler does not transcode unmodified non-UTF-8 bytes", () => {
+  // A text handler forces every text token through encoding_rs's lossy decoder
+  // so the callback can observe `t.text` as a JS string. Previously the
+  // serializer then wrote that decoded string back, replacing every non-UTF-8
+  // input byte with U+FFFD even when the handler was a pure observer. The
+  // rewriter now re-emits the original input bytes for any chunk whose text
+  // was not replaced, so a no-op text handler is byte-identical to no handler.
+
+  const wrap = body => Buffer.concat([Buffer.from("<p>"), Buffer.from(body), Buffer.from("</p>")]);
+  const rewrite = async (src, spec) =>
+    Buffer.from(await new HTMLRewriter().on("*", spec).transform(new Response(src)).arrayBuffer());
+
+  // - lone continuation byte, multiple invalid bytes, invalid/valid UTF-8 mixed
+  // - truncated 2/3/4-byte sequence immediately before the closing tag (these
+  //   are the bytes encoding_rs holds as decoder state and flushes on the
+  //   lastInTextNode chunk)
+  // - text node that is ONLY a truncated sequence (handler call for the body
+  //   is skipped entirely; only the flush chunk fires)
+  // - invalid byte past 1 KB (fast-path prefix then slow path for the rest)
+  //   and before 1 KB (slow path loops past one decode-buffer fill)
+  // - ScriptData text-type and multiple sibling text nodes
+  const cases = [
+    ["lone continuation byte", wrap([0xa9])],
+    ["multiple invalid bytes", wrap([0xa9, 0xff, 0x80, 0xc0])],
+    ["mixed valid and invalid UTF-8", Buffer.concat([Buffer.from("<p>héllo"), Buffer.from([0xa9]), Buffer.from("wörld</p>")])],
+    ["truncated 3-byte lead before close tag", Buffer.concat([Buffer.from("<p>aa"), Buffer.from([0xe2]), Buffer.from("</p>")])],
+    ["truncated 3-byte prefix before close tag", Buffer.concat([Buffer.from("<p>aa"), Buffer.from([0xe2, 0x82]), Buffer.from("</p>")])],
+    ["truncated 4-byte prefix before close tag", wrap([0xf0, 0x9f, 0x98])],
+    ["text node that is only a truncated lead byte", wrap([0xe2])],
+    ["invalid byte after the 1 KB fast-path cutoff", Buffer.concat([Buffer.from("<p>"), Buffer.alloc(2000, 0x61), Buffer.from([0xa9]), Buffer.from("z</p>")])],
+    ["invalid byte before the 1 KB fast-path cutoff", Buffer.concat([Buffer.from("<p>"), Buffer.from([0xa9]), Buffer.alloc(3000, 0x62), Buffer.from("</p>")])],
+    ["script text", Buffer.concat([Buffer.from("<script>var x="), Buffer.from([0xa9]), Buffer.from(";</script>")])],
+    ["multiple text nodes", Buffer.concat([Buffer.from("<p>"), Buffer.from([0xa9]), Buffer.from("<b>"), Buffer.from([0xff]), Buffer.from("</b>"), Buffer.from([0xc0]), Buffer.from("</p>")])],
+  ];
+
+  describe.each(cases)("%s", (name, src) => {
+    it("no-op element text handler", async () => {
+      expect(await rewrite(src, { text() {} })).toEqual(src);
+    });
+    it("no-op onDocument text handler", async () => {
+      const out = Buffer.from(await new HTMLRewriter().onDocument({ text() {} }).transform(new Response(src)).arrayBuffer());
+      expect(out).toEqual(src);
+    });
+  });
+
+  it("reading .text observes U+FFFD but the output is still the raw bytes", async () => {
+    const src = Buffer.concat([Buffer.from("<p>x"), Buffer.from([0xa9]), Buffer.from("y</p>")]);
+    let seen = "";
+    const out = await rewrite(src, { text: t => void (seen += t.text) });
+    expect(seen).toBe("x\uFFFDy");
+    expect(out).toEqual(src);
+  });
+
+  it("a truncated lead byte is reported as U+FFFD on the lastInTextNode chunk and still round-trips", async () => {
+    const src = wrap([0xe2]);
+    const chunks = [];
+    const out = await rewrite(src, { text: t => chunks.push({ text: t.text, last: t.lastInTextNode }) });
+    expect(out).toEqual(src);
+    expect(chunks).toEqual([{ text: "\uFFFD", last: true }]);
+  });
+
+  it("before()/after() keep the chunk body as raw bytes", async () => {
+    const src = wrap([0xa9]);
+    const out = await rewrite(src, {
+      text(t) {
+        if (!t.lastInTextNode) t.before("[", { html: true });
+        if (t.lastInTextNode) t.after("]", { html: true });
+      },
+    });
+    expect(out).toEqual(Buffer.concat([Buffer.from("<p>["), Buffer.from([0xa9]), Buffer.from("]</p>")]));
+  });
+
+  it("replace() and remove() still drop the raw bytes", async () => {
+    const src = wrap([0xa9]);
+    expect(await rewrite(src, { text: t => t.replace("X", { html: true }) })).toEqual(Buffer.from("<p>XX</p>"));
+    expect(await rewrite(src, { text: t => t.remove() })).toEqual(Buffer.from("<p></p>"));
+  });
+});

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1318,15 +1318,41 @@ describe("text handler does not transcode unmodified non-UTF-8 bytes", () => {
   const cases = [
     ["lone continuation byte", wrap([0xa9])],
     ["multiple invalid bytes", wrap([0xa9, 0xff, 0x80, 0xc0])],
-    ["mixed valid and invalid UTF-8", Buffer.concat([Buffer.from("<p>héllo"), Buffer.from([0xa9]), Buffer.from("wörld</p>")])],
-    ["truncated 3-byte lead before close tag", Buffer.concat([Buffer.from("<p>aa"), Buffer.from([0xe2]), Buffer.from("</p>")])],
-    ["truncated 3-byte prefix before close tag", Buffer.concat([Buffer.from("<p>aa"), Buffer.from([0xe2, 0x82]), Buffer.from("</p>")])],
+    [
+      "mixed valid and invalid UTF-8",
+      Buffer.concat([Buffer.from("<p>héllo"), Buffer.from([0xa9]), Buffer.from("wörld</p>")]),
+    ],
+    [
+      "truncated 3-byte lead before close tag",
+      Buffer.concat([Buffer.from("<p>aa"), Buffer.from([0xe2]), Buffer.from("</p>")]),
+    ],
+    [
+      "truncated 3-byte prefix before close tag",
+      Buffer.concat([Buffer.from("<p>aa"), Buffer.from([0xe2, 0x82]), Buffer.from("</p>")]),
+    ],
     ["truncated 4-byte prefix before close tag", wrap([0xf0, 0x9f, 0x98])],
     ["text node that is only a truncated lead byte", wrap([0xe2])],
-    ["invalid byte after the 1 KB fast-path cutoff", Buffer.concat([Buffer.from("<p>"), Buffer.alloc(2000, 0x61), Buffer.from([0xa9]), Buffer.from("z</p>")])],
-    ["invalid byte before the 1 KB fast-path cutoff", Buffer.concat([Buffer.from("<p>"), Buffer.from([0xa9]), Buffer.alloc(3000, 0x62), Buffer.from("</p>")])],
+    [
+      "invalid byte after the 1 KB fast-path cutoff",
+      Buffer.concat([Buffer.from("<p>"), Buffer.alloc(2000, 0x61), Buffer.from([0xa9]), Buffer.from("z</p>")]),
+    ],
+    [
+      "invalid byte before the 1 KB fast-path cutoff",
+      Buffer.concat([Buffer.from("<p>"), Buffer.from([0xa9]), Buffer.alloc(3000, 0x62), Buffer.from("</p>")]),
+    ],
     ["script text", Buffer.concat([Buffer.from("<script>var x="), Buffer.from([0xa9]), Buffer.from(";</script>")])],
-    ["multiple text nodes", Buffer.concat([Buffer.from("<p>"), Buffer.from([0xa9]), Buffer.from("<b>"), Buffer.from([0xff]), Buffer.from("</b>"), Buffer.from([0xc0]), Buffer.from("</p>")])],
+    [
+      "multiple text nodes",
+      Buffer.concat([
+        Buffer.from("<p>"),
+        Buffer.from([0xa9]),
+        Buffer.from("<b>"),
+        Buffer.from([0xff]),
+        Buffer.from("</b>"),
+        Buffer.from([0xc0]),
+        Buffer.from("</p>"),
+      ]),
+    ],
   ];
 
   describe.each(cases)("%s", (name, src) => {
@@ -1334,7 +1360,12 @@ describe("text handler does not transcode unmodified non-UTF-8 bytes", () => {
       expect(await rewrite(src, { text() {} })).toEqual(src);
     });
     it("no-op onDocument text handler", async () => {
-      const out = Buffer.from(await new HTMLRewriter().onDocument({ text() {} }).transform(new Response(src)).arrayBuffer());
+      const out = Buffer.from(
+        await new HTMLRewriter()
+          .onDocument({ text() {} })
+          .transform(new Response(src))
+          .arrayBuffer(),
+      );
       expect(out).toEqual(src);
     });
   });


### PR DESCRIPTION
## Repro

```js
const bytes = Buffer.concat([Buffer.from("<p>"), Buffer.from([0xa9]), Buffer.from("</p>")]);
const r = new HTMLRewriter().on("p", { text() {} });
const out = Buffer.from(await r.transform(new Response(bytes)).arrayBuffer());
// before: <p> ef bf bd </p>
// after:  <p> a9 </p>        (identical to input)
```

Registering a no-op `text` handler (element or `onDocument`) rewrote every byte that is not valid UTF-8 in the covered text into U+FFFD in the output, while the same rewriter with only `element`/`comments`/`end` handlers (or none) emitted the input byte-for-byte. A legacy-encoded page, a mislabeled binary, or WTF-8 content was silently corrupted the moment a text callback was added, with no error.

## Cause

lol-html's `TextChunk` path decodes the raw lexeme bytes into a `&str` via `encoding_rs` (lossy: invalid sequences become U+FFFD) so the handler can read `.text`, then `serialize_self` re-emits that decoded string. Comments, tags and doctypes keep the original raw bytes and write them back when the handler has not mutated them; text chunks did not, so the decode-then-reencode round-trip was always applied.

## Fix

Patch the vendored lol-html (`patches/lolhtml/text-chunk-raw-passthrough.patch`):

- `TextChunk` gains `raw: Option<Cow<'i, [u8]>>`; `set_str`/`as_mut_str` clear it, and `serialize_self` writes `raw` verbatim when present.
- `TextDecoder::feed_text` passes each decode step's raw input slice alongside the decoded `&str`. For UTF-8 it computes exactly which tail bytes `encoding_rs` kept as internal state (an incomplete sequence at end-of-input, at most 3 bytes) via `std::str::from_utf8`'s `error_len() == None`, which agrees with encoding_rs's WHATWG UTF-8 state machine on every lead/2nd-byte validity case. Those bytes are owned in `TextDecoder::pending_raw` and prefixed onto the next emitted chunk's `raw`, so each chunk's `raw` is exactly the bytes its `text` was decoded from and the set of chunks the handler observes is unchanged.

`before`/`after`/`replace`/`remove` are unaffected (they act on `mutations`, not on the chunk's own text). `text.text` still returns the lossy-decoded string to JS.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/js/workerd/html-rewriter.test.js`: 28 of the 33 new tests fail (the 5 that pass are regression guards asserting mutation still works).
- `bun bd test test/js/workerd/html-rewriter.test.js`: 102 pass, 0 fail.
- `bun bd test` across the other four `html-rewriter*` test files: 11 pass, 0 fail.
- `cargo test --lib` in `vendor/lolhtml`: 146 pass.

The 33 new tests cover: lone continuation bytes; multiple invalid bytes; mixed valid/invalid UTF-8; truncated 2/3/4-byte sequences immediately before a close tag (the bytes encoding_rs holds as state and flushes on the `lastInTextNode` chunk); a text node that is only a truncated lead byte; invalid bytes before and after the 1 KB fast-path cutoff; `ScriptData` text; multiple sibling text nodes; `.text` reads still seeing U+FFFD while output stays raw; `before()`/`after()` keeping the chunk body raw; `replace()`/`remove()` still dropping it; and the handler's observed chunk sequence pinned to today's behavior.

The fix lives in `patches/` and `scripts/build/deps/` (not `src/`) since the bug is in the vendored dependency, so the `USE_SYSTEM_BUN=1` run above is the fail-before proof.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/workerd/html-rewriter.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (9c5e0c899)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [10.71ms]
(pass) HTMLRewriter > error inside element handler [6.47ms]
(pass) HTMLRewriter > error inside element handler (string) [4.74ms]
(pass) HTMLRewriter > fast async error inside element handler [21.59ms]
(pass) HTMLRewriter > slow async error inside element handler [17.49ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [127.67ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [12.54ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [357.97ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [70.25ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [47.38ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the transformed response is an errored stream [49.99ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > a read already pending on .body when the upstream fails rejects [52.86ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .clone() of a failed transformed body is also failed [62.52ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > does not invoke onDocument end for a document that never completed [59.70ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > transform() of a body that already failed throws the upstream error [48.59ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > transform() of an aborted body throws the abort reason [58.79ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement using fetch + Bun.serve [177.29ms]
(pass) H
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
patches/lolhtml/text-chunk-raw-passthrough.patch | 387 +++++++++++++++++++++++
 scripts/build/deps/lolhtml.ts                    |   2 +
 test/js/workerd/html-rewriter.test.js            | 122 +++++++
 3 files changed, 511 insertions(+)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
patches/lolhtml/text-chunk-raw-passthrough.patch      1      0      0
scripts/build/deps/lolhtml.ts                         1      1      0
test/js/workerd/html-rewriter.test.js                 3      3      0
```

</details>

<!-- robobun:evidence:end -->