### PR TITLE
node errors: include [ERR_*] code bracket in .stack header

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -137,8 +137,9 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
 
     prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), 0);
     prototype->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), 0);
-    // Private marker read by nodeErrorCodeForStackHeader to emit `name [code]: message` in .stack.
-    prototype->putDirect(vm, WebCore::builtinNames(vm).codePrivateName(), jsString(vm, String(code)), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | 0);
+    // Private marker read by nodeErrorCodeForStackHeader to emit `name [code]: message` in .stack; only ERR_* codes carry Node's kIsNodeError.
+    if (StringView(code).startsWith("ERR_"_s))
+        prototype->putDirect(vm, WebCore::builtinNames(vm).codePrivateName(), jsString(vm, String(code)), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | 0);
     prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), 0);
 
     return prototype;

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -137,6 +137,9 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
 
     prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), 0);
     prototype->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), 0);
+    // Private-name marker so the stack formatter can render the header as
+    // `${name} [${code}]: ${message}` without changing the public .name.
+    prototype->putDirect(vm, WebCore::builtinNames(vm).codePrivateName(), jsString(vm, String(code)), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | 0);
     prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), 0);
 
     return prototype;

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -137,8 +137,7 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
 
     prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), 0);
     prototype->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), 0);
-    // Private-name marker so the stack formatter can render the header as
-    // `${name} [${code}]: ${message}` without changing the public .name.
+    // Private marker read by nodeErrorCodeForStackHeader to emit `name [code]: message` in .stack.
     prototype->putDirect(vm, WebCore::builtinNames(vm).codePrivateName(), jsString(vm, String(code)), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | 0);
     prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), 0);
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -32,6 +32,35 @@ using namespace WebCore;
 
 namespace Bun {
 
+// If errorObject was created via Bun::createError (its direct prototype carries the
+// private @code marker from createErrorPrototype), return the error's current
+// public .code value so the stack header can include `[${code}]`, matching
+// Node's prepareStackTraceCallback (which gates on kIsNodeError).
+static String nodeErrorCodeForStackHeader(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject)
+{
+    JSValue proto = errorObject->getPrototypeDirect();
+    JSObject* protoObj = proto.getObject();
+    if (!protoObj)
+        return {};
+
+    const auto& builtinNames = WebCore::builtinNames(vm);
+    PropertySlot markerSlot(protoObj, PropertySlot::InternalMethodType::VMInquiry, &vm);
+    if (!JSObject::getOwnPropertySlot(protoObj, lexicalGlobalObject, builtinNames.codePrivateName(), markerSlot) || !markerSlot.isValue())
+        return {};
+
+    JSValue codeValue;
+    PropertySlot codeSlot(errorObject, PropertySlot::InternalMethodType::VMInquiry, &vm);
+    if (JSObject::getOwnPropertySlot(errorObject, lexicalGlobalObject, builtinNames.codePublicName(), codeSlot) && codeSlot.isValue()) {
+        codeValue = codeSlot.getValue(lexicalGlobalObject, builtinNames.codePublicName());
+    } else {
+        codeValue = markerSlot.getValue(lexicalGlobalObject, builtinNames.codePrivateName());
+    }
+    auto* codeString = dynamicDowncast<JSC::JSString>(codeValue);
+    if (!codeString)
+        return {};
+    return codeString->getString(lexicalGlobalObject);
+}
+
 static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -41,19 +70,45 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
 
     WTF::StringBuilder sb;
 
+    WTF::String name = "Error"_s;
+    auto errorName = errorObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->name);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (errorName && !errorName.isUndefined()) {
+        auto* nameStr = errorName.toString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto nameView = nameStr->view(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        name = nameView->toString();
+    }
+
+    WTF::String code = nodeErrorCodeForStackHeader(vm, lexicalGlobalObject, errorObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    WTF::String message;
     auto errorMessage = errorObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->message);
     RETURN_IF_EXCEPTION(scope, {});
-    if (errorMessage) {
+    if (errorMessage && !errorMessage.isUndefined()) {
         auto* str = errorMessage.toString(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        if (str->length() > 0) {
-            auto value = str->view(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, {});
-            sb.append("Error: "_s);
-            sb.append(value.data);
-        } else {
-            sb.append("Error"_s);
+        auto value = str->view(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        message = value->toString();
+    }
+
+    if (!code.isEmpty()) {
+        sb.append(name);
+        sb.append(" ["_s);
+        sb.append(code);
+        sb.append("]: "_s);
+        sb.append(message);
+    } else if (!name.isEmpty()) {
+        sb.append(name);
+        if (!message.isEmpty()) {
+            sb.append(": "_s);
+            sb.append(message);
         }
+    } else if (!message.isEmpty()) {
+        sb.append(message);
     } else {
         sb.append("Error"_s);
     }
@@ -418,6 +473,11 @@ static String computeErrorInfoWithoutPrepareStackTrace(
             RETURN_IF_EXCEPTION(scope, {});
             message = instance->sanitizedMessageString(lexicalGlobalObject);
             RETURN_IF_EXCEPTION(scope, {});
+
+            WTF::String code = nodeErrorCodeForStackHeader(vm, lexicalGlobalObject, instance);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!code.isEmpty())
+                name = makeString(name, " ["_s, code, ']');
         }
     }
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -32,10 +32,7 @@ using namespace WebCore;
 
 namespace Bun {
 
-// If errorObject was created via Bun::createError (its direct prototype carries the
-// private @code marker from createErrorPrototype), return the error's current
-// public .code value so the stack header can include `[${code}]`, matching
-// Node's prepareStackTraceCallback (which gates on kIsNodeError).
+// Returns .code when errorObject's direct prototype has the private @code marker from createErrorPrototype (Node's kIsNodeError analogue).
 static String nodeErrorCodeForStackHeader(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject)
 {
     JSValue proto = errorObject->getPrototypeDirect();
@@ -44,21 +41,22 @@ static String nodeErrorCodeForStackHeader(JSC::VM& vm, JSC::JSGlobalObject* lexi
         return {};
 
     const auto& builtinNames = WebCore::builtinNames(vm);
-    PropertySlot markerSlot(protoObj, PropertySlot::InternalMethodType::VMInquiry, &vm);
-    if (!JSObject::getOwnPropertySlot(protoObj, lexicalGlobalObject, builtinNames.codePrivateName(), markerSlot) || !markerSlot.isValue())
-        return {};
-
+    JSValue markerValue;
     JSValue codeValue;
-    PropertySlot codeSlot(errorObject, PropertySlot::InternalMethodType::VMInquiry, &vm);
-    if (JSObject::getOwnPropertySlot(errorObject, lexicalGlobalObject, builtinNames.codePublicName(), codeSlot) && codeSlot.isValue()) {
-        codeValue = codeSlot.getValue(lexicalGlobalObject, builtinNames.codePublicName());
-    } else {
-        codeValue = markerSlot.getValue(lexicalGlobalObject, builtinNames.codePrivateName());
+    {
+        PropertySlot markerSlot(protoObj, PropertySlot::InternalMethodType::VMInquiry, &vm);
+        if (!JSObject::getOwnPropertySlot(protoObj, lexicalGlobalObject, builtinNames.codePrivateName(), markerSlot) || !markerSlot.isValue())
+            return {};
+        markerValue = markerSlot.getValue(lexicalGlobalObject, builtinNames.codePrivateName());
+
+        PropertySlot codeSlot(errorObject, PropertySlot::InternalMethodType::VMInquiry, &vm);
+        if (JSObject::getOwnPropertySlot(errorObject, lexicalGlobalObject, builtinNames.codePublicName(), codeSlot) && codeSlot.isValue())
+            codeValue = codeSlot.getValue(lexicalGlobalObject, builtinNames.codePublicName());
     }
-    auto* codeString = dynamicDowncast<JSC::JSString>(codeValue);
-    if (!codeString)
-        return {};
-    return codeString->getString(lexicalGlobalObject);
+
+    if (codeValue && !codeValue.isObject() && !codeValue.isUndefined())
+        return codeValue.toWTFString(lexicalGlobalObject);
+    return markerValue.getString(lexicalGlobalObject);
 }
 
 static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites)

--- a/test/js/node/errors/error-stack-code.test.ts
+++ b/test/js/node/errors/error-stack-code.test.ts
@@ -57,6 +57,18 @@ describe("Node.js ERR_* error .stack header includes [code]", () => {
     expect(header).toStartWith("TypeError [OVERWRITTEN_CODE]: ");
   });
 
+  test("non-string .code is coerced (primitive) or falls back (object)", () => {
+    const e1 = capture(() => fs.rmSync("/x", { recursive: "yes" as any }));
+    (e1 as any).code = 42;
+    Error.captureStackTrace(e1);
+    expect(String(e1.stack).split("\n")[0]).toStartWith("TypeError [42]: ");
+
+    const e2 = capture(() => fs.rmSync("/x", { recursive: "yes" as any }));
+    (e2 as any).code = { toString: () => "ignored" };
+    Error.captureStackTrace(e2);
+    expect(String(e2.stack).split("\n")[0]).toStartWith("TypeError [ERR_INVALID_ARG_TYPE]: ");
+  });
+
   test("plain errors with .code do not get a bracket", () => {
     const err: any = new TypeError("hi");
     err.code = "ERR_FAKE";

--- a/test/js/node/errors/error-stack-code.test.ts
+++ b/test/js/node/errors/error-stack-code.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import util from "node:util";
+import { Buffer } from "node:buffer";
+import { EventEmitter } from "node:events";
+
+function capture(fn: () => unknown): NodeJS.ErrnoException {
+  try {
+    fn();
+  } catch (e) {
+    return e as NodeJS.ErrnoException;
+  }
+  throw new Error("expected function to throw");
+}
+
+describe("Node.js ERR_* error .stack header includes [code]", () => {
+  const cases: Array<[string, () => unknown, string, string]> = [
+    ["fs ERR_INVALID_ARG_TYPE", () => fs.rmSync("/x", { recursive: "yes" as any }), "TypeError", "ERR_INVALID_ARG_TYPE"],
+    ["Buffer ERR_OUT_OF_RANGE", () => Buffer.alloc(-1), "RangeError", "ERR_OUT_OF_RANGE"],
+    ["URL ERR_INVALID_URL", () => new URL("nope"), "TypeError", "ERR_INVALID_URL"],
+    ["events ERR_INVALID_ARG_TYPE", () => new EventEmitter().setMaxListeners("x" as any), "TypeError", "ERR_INVALID_ARG_TYPE"],
+  ];
+
+  test.each(cases)("%s", (_, fn, expectedName, expectedCode) => {
+    const err = capture(fn);
+
+    // .name stays the plain constructor name (Node compat: tests assert name === 'TypeError')
+    expect(err.name).toBe(expectedName);
+    expect(err.code).toBe(expectedCode);
+
+    // .stack's first line is `${name} [${code}]: ${message}`
+    const header = String(err.stack).split("\n")[0];
+    expect(header).toStartWith(`${expectedName} [${expectedCode}]: `);
+
+    // toString() already returned the bracketed form; still does
+    expect(err.toString()).toStartWith(`${expectedName} [${expectedCode}]: `);
+
+    // util.inspect(err) renders .stack as its header, so the code must appear
+    expect(util.inspect(err)).toContain(expectedCode);
+  });
+
+  test("header reflects overwritten instance .code", () => {
+    const err = capture(() => fs.rmSync("/x", { recursive: "yes" as any }));
+    err.code = "OVERWRITTEN_CODE";
+    Error.captureStackTrace(err);
+    const header = String(err.stack).split("\n")[0];
+    expect(header).toStartWith("TypeError [OVERWRITTEN_CODE]: ");
+  });
+
+  test("plain errors with .code do not get a bracket", () => {
+    const err: any = new TypeError("hi");
+    err.code = "ERR_FAKE";
+    Error.captureStackTrace(err);
+    expect(String(err.stack).split("\n")[0]).toBe("TypeError: hi");
+  });
+
+  test("errno errors do not get a bracket", () => {
+    const err = capture(() => fs.readFileSync("/nonexistent-path-for-bun-errno-test"));
+    expect(err.code).toBe("ENOENT");
+    expect(String(err.stack).split("\n")[0]).not.toContain("[ENOENT]");
+  });
+
+  test("default Error.prepareStackTrace() uses name and bracketed code", () => {
+    const err = capture(() => fs.rmSync("/x", { recursive: "yes" as any }));
+    const out = Error.prepareStackTrace!(err, []);
+    expect(out).toStartWith("TypeError [ERR_INVALID_ARG_TYPE]: ");
+
+    const plain = new RangeError("hello");
+    expect(Error.prepareStackTrace!(plain, [])).toStartWith("RangeError: hello");
+  });
+});

--- a/test/js/node/errors/error-stack-code.test.ts
+++ b/test/js/node/errors/error-stack-code.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import fs from "node:fs";
-import util from "node:util";
 import { Buffer } from "node:buffer";
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import util from "node:util";
 
 function capture(fn: () => unknown): NodeJS.ErrnoException {
   try {
@@ -15,10 +15,20 @@ function capture(fn: () => unknown): NodeJS.ErrnoException {
 
 describe("Node.js ERR_* error .stack header includes [code]", () => {
   const cases: Array<[string, () => unknown, string, string]> = [
-    ["fs ERR_INVALID_ARG_TYPE", () => fs.rmSync("/x", { recursive: "yes" as any }), "TypeError", "ERR_INVALID_ARG_TYPE"],
+    [
+      "fs ERR_INVALID_ARG_TYPE",
+      () => fs.rmSync("/x", { recursive: "yes" as any }),
+      "TypeError",
+      "ERR_INVALID_ARG_TYPE",
+    ],
     ["Buffer ERR_OUT_OF_RANGE", () => Buffer.alloc(-1), "RangeError", "ERR_OUT_OF_RANGE"],
     ["URL ERR_INVALID_URL", () => new URL("nope"), "TypeError", "ERR_INVALID_URL"],
-    ["events ERR_INVALID_ARG_TYPE", () => new EventEmitter().setMaxListeners("x" as any), "TypeError", "ERR_INVALID_ARG_TYPE"],
+    [
+      "events ERR_INVALID_ARG_TYPE",
+      () => new EventEmitter().setMaxListeners("x" as any),
+      "TypeError",
+      "ERR_INVALID_ARG_TYPE",
+    ],
   ];
 
   test.each(cases)("%s", (_, fn, expectedName, expectedCode) => {

--- a/test/js/node/errors/error-stack-code.test.ts
+++ b/test/js/node/errors/error-stack-code.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
+import { addAbortSignal, Readable } from "node:stream";
 import util from "node:util";
 
 function capture(fn: () => unknown): NodeJS.ErrnoException {
@@ -80,6 +81,20 @@ describe("Node.js ERR_* error .stack header includes [code]", () => {
     const err = capture(() => fs.readFileSync("/nonexistent-path-for-bun-errno-test"));
     expect(err.code).toBe("ENOENT");
     expect(String(err.stack).split("\n")[0]).not.toContain("[ENOENT]");
+  });
+
+  test("AbortError (ABORT_ERR) does not get a bracket", async () => {
+    const ac = new AbortController();
+    const r = new Readable({ read() {} });
+    addAbortSignal(ac.signal, r);
+    const { promise, resolve } = Promise.withResolvers<NodeJS.ErrnoException>();
+    r.on("error", resolve);
+    ac.abort();
+    const err = await promise;
+    expect(err.code).toBe("ABORT_ERR");
+    expect(err.name).toBe("AbortError");
+    Error.captureStackTrace(err);
+    expect(String(err.stack).split("\n")[0]).toStartWith("AbortError: ");
   });
 
   test("default Error.prepareStackTrace() uses name and bracketed code", () => {


### PR DESCRIPTION
## Repro

```js
import fs from "node:fs";
import util from "node:util";
let e; try { fs.rmSync("/x", { recursive: "yes" }); } catch (x) { e = x; }
console.log(JSON.stringify(e.stack.split("\n")[0]));
console.log(util.inspect(e).includes("ERR_INVALID_ARG_TYPE"));
```

Node v26.3.0:
```
"TypeError [ERR_INVALID_ARG_TYPE]: The \"options.recursive\" property must be of type boolean. Received type string ('yes')"
true
```

Bun before:
```
"TypeError: The \"options.recursive\" property must be of type boolean."
false
```

`err.toString()` already carried the bracket (the per-code prototype installs a `toString` override), but the `.stack` header is built from `name + ": " + message` and never consulted it. `util.inspect(err)` renders `.stack` as its header, so together with `.code` not being an own property (#35926) the code string appeared nowhere in the inspect output that winston/debug-style formatters use.

## Cause

Node's `prepareStackTraceCallback` (`lib/internal/errors.js`) checks `kIsNodeError in error` and, when set, renders the header as `` `${error.name} [${error.code}]: ${error.message}` ``; otherwise it falls back to `ErrorPrototypeToString(error)`. `err.name` itself stays the plain `"TypeError"` so `{ code: 'ERR_...', name: 'TypeError' }` assertions in Node's test suite continue to hold.

Bun's lazy `.stack` getter routes through `computeErrorInfoWithoutPrepareStackTrace`, which reads `ErrorInstance::sanitizedNameString` (finds `"TypeError"` on the per-code prototype) and emits `name: message` with no way to detect the node-error case. The default `Error.prepareStackTrace` implementation (`formatStackTraceToJSValue`) was worse: it hard-coded the literal `"Error: "` and ignored `.name` entirely.

## Fix

`createErrorPrototype` now writes the code string under the existing `code` private name (a JSC private symbol, invisible to `for..in`/`Object.getOwnPropertySymbols`) on each per-`ErrorCode` prototype.

A new `nodeErrorCodeForStackHeader` helper looks up that private-name marker on the error's direct prototype (VMInquiry own-slot, no accessor invocation); when present it returns the instance's public `.code` (falling back to the marker value) so a user-overwritten `err.code` is reflected, matching Node.

Both header builders now use it:
- `computeErrorInfoWithoutPrepareStackTrace` appends `" [code]"` to the sanitized name before calling `formatStackTrace`.
- `formatStackTraceToJSValue` (the default `Error.prepareStackTrace`) now reads `.name` and emits `name [code]: message` for node errors and the spec `Error.prototype.toString` shape (`name: message` / `name` / `message`) for everything else.

`err.name`, `err.toString()`, errno errors (`ENOENT` etc.), and plain user errors with an own `.code` property are unchanged.

## Verification

New `test/js/node/errors/error-stack-code.test.ts` covers fs/buffer/URL/events, overwritten `.code`, the two negative cases (errno and plain errors do not get a bracket), and the default `Error.prepareStackTrace()` output.

```
USE_SYSTEM_BUN=1 bun test test/js/node/errors/error-stack-code.test.ts   6 fail / 2 pass
bun bd test test/js/node/errors/error-stack-code.test.ts                 8 pass
bun bd test test/js/node/v8/capture-stack-trace.test.js                 43 pass
bun bd test test/js/node/buffer.test.js                                617 pass
bun bd test test/js/node/vm/vm.test.ts                                 212 pass
```

Related: #35926 moves `.code` to an own instance property so the `{ code: '...' }` trailer also appears in `util.inspect` output; this change is independent of it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/errors/error-stack-code.test.ts
bun test v1.4.0 (80e0c5f76)

test/js/node/errors/error-stack-code.test.ts:
39 |     expect(err.name).toBe(expectedName);
40 |     expect(err.code).toBe(expectedCode);
41 | 
42 |     // .stack's first line is `${name} [${code}]: ${message}`
43 |     const header = String(err.stack).split("\n")[0];
44 |     expect(header).toStartWith(`${expectedName} [${expectedCode}]: `);
                        ^
error: expect(received).toStartWith(expected)

Expected to start with: "TypeError [ERR_INVALID_ARG_TYPE]: "
Received: "TypeError: The \"options.recursive\" property must be of type boolean."

      at <anonymous> (/workspace/bun/test/js/node/errors/error-stack-code.test.ts:44:20)
(fail) Node.js ERR_* error .stack header includes [code] > fs ERR_INVALID_ARG_TYPE [14.60ms]
39 |     expect(err.name).toBe(expectedName);
40 |     expect(err.code).toBe(expectedCode);
41 | 
42 |     // .stack's first line is `${name} [${code}]: ${message}`
43 |     const header = String(err.stack).split("\n")[0];
44 |     
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (a6620b7dd)

test/js/node/errors/error-stack-code.test.ts:
(pass) Node.js ERR_* error .stack header includes [code] > fs ERR_INVALID_ARG_TYPE [1.61ms]
(pass) Node.js ERR_* error .stack header includes [code] > Buffer ERR_OUT_OF_RANGE [0.09ms]
(pass) Node.js ERR_* error .stack header includes [code] > URL ERR_INVALID_URL [0.06ms]
(pass) Node.js ERR_* error .stack header includes [code] > events ERR_INVALID_ARG_TYPE [0.12ms]
(pass) Node.js ERR_* error .stack header includes [code] > header reflects overwritten instance .code [0.09ms]
(pass) Node.js ERR_* error .stack header includes [code] > non-string .code is coerced (primitive) or falls back (object) [0.09ms]
(pass) Node.js ERR_* error .stack header includes [code] > plain errors with .code do not get a bracket [0.03ms]
(pass) Node.js ERR_* error .stack header includes [code] > errno errors do not get a bracket [0.07ms]
92 |     ac.abort();
93 |     const err = await promise;
94 |     expect(err.code).toBe("ABORT_ERR");
95 |     expect(err.name).toBe("AbortError");
96 |     Error.captureStackTrace(err);
97 |     expect(String(err.stack).split("\n")[0]).toStartWith("AbortError: ");
         
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/errors/error-stack-code.test.ts
bun test v1.4.0 (80e0c5f76)

test/js/node/errors/error-stack-code.test.ts:
(pass) Node.js ERR_* error .stack header includes [code] > fs ERR_INVALID_ARG_TYPE [80.04ms]
(pass) Node.js ERR_* error .stack header includes [code] > Buffer ERR_OUT_OF_RANGE [6.58ms]
(pass) Node.js ERR_* error .stack header includes [code] > URL ERR_INVALID_URL [4.84ms]
(pass) Node.js ERR_* error .stack header includes [code] > events ERR_INVALID_ARG_TYPE [9.75ms]
(pass) Node.js ERR_* error .stack header includes [code] > header reflects overwritten instance .code [4.75ms]
(pass) Node.js ERR_* error .stack header includes [code] > non-string .code is coerced (primitive) or falls back (object) [7.39ms]
(pass) Node.js ERR_* error .stack header includes [code] > plain errors with .code do not get a bracket [2.84ms]
(pass) Node.js ERR_* error .stack header includes [code] > errno errors do not get a bracket [4.89ms]
(pass) Node.js ERR_* error .stack header includes [code] > AbortError (ABORT_ERR) does not get a bracket 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 719ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/72] gen ErrorCode+*.h
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorCode.cpp               |   3 +
 src/jsc/bindings/FormatStackTraceForJS.cpp   |  74 ++++++++++++++++--
 test/js/node/errors/error-stack-code.test.ts | 108 +++++++++++++++++++++++++++
 3 files changed, 177 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/ErrorCode.cpp                    4      5      0
src/jsc/bindings/FormatStackTraceForJS.cpp        8      4      0
test/js/node/errors/error-stack-code.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->