### PR TITLE
jsc: avoid quadratic basic block linking and liveness for deeply nested array destructuring

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-356-6f3056df";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/deep-array-destructuring.test.ts
+++ b/test/js/bun/jsc/deep-array-destructuring.test.ts
@@ -1,0 +1,38 @@
+// Deeply nested array binding patterns emit O(N) basic blocks with O(N) branches
+// (each level wraps IteratorClose in a synthesized try/finally). BytecodeBasicBlock
+// linked successor blocks by linearly scanning the basic block list for every branch
+// and throw target, making basic block / liveness analysis O(N^2): a 2500-deep
+// pattern took ~4s in a release build and minutes under debug+ASAN. The lookup is
+// now a binary search over the already-sorted block list, the same lookup
+// BytecodeGraph::findBasicBlockWithLeaderOffset uses.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("deeply nested array binding pattern compiles in time linear in nesting depth", async () => {
+  // Large enough that the old O(N^2) basic block linking blows the spawn timeout under
+  // the debug+ASAN build while staying comfortably under the bindValue native stack
+  // budget on every platform.
+  const depth = 1200;
+  const src =
+    "try { let " +
+    Buffer.alloc(depth, "[").toString() +
+    "z" +
+    Buffer.alloc(depth, "]").toString() +
+    " = w } catch (e) { console.log('caught', e.constructor.name) }";
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 15_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "caught ReferenceError\n",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+}, 30_000);


### PR DESCRIPTION
Bumps WebKit to oven-sh/WebKit#356 and adds a regression test.

## Problem

A deeply nested array destructuring pattern emits O(depth) basic blocks, O(depth) exception handlers, and O(depth) callee locals in JSC bytecode: each nesting level wraps IteratorClose in a synthesized try/finally. When such a pattern sits inside a `try`/`catch`, the first time the catch executes `op_catch` triggers `BytecodeLivenessAnalysis` over the whole code block, and two separate quadratic costs dominate:

1. `BytecodeBasicBlock::computeImpl` links each branch and throw to its successor block by scanning the entire basic block list per branch.
2. `BytecodeLivenessPropagation::stepOverInstruction` re-scans the exception handler table and re-merges the handler block's live-in set bit by bit, per instruction, per fixpoint iteration.

```js
const N = 3000;
const src = "try { let " + "[".repeat(N) + "z" + "]".repeat(N) + " = w } catch (e) { console.log('caught', e.constructor.name) }";
(0, eval)(src);
```

Release build, per-run wall-clock:

| depth | before | after |
| --- | --- | --- |
| 500 | 155 ms | 38 ms |
| 1000 | 543 ms | 95 ms |
| 2000 | 2346 ms | 325 ms |
| 3000 | 5692 ms | 701 ms |
| 5000 | 16584 ms | 1808 ms |

The debug+ASAN build is roughly 50x these numbers on both sides, so a 1200-deep pattern went from ~35s to ~3s there.

## Fix

oven-sh/WebKit#356 replaces the successor-block scan with a binary search (blocks are already sorted by `leaderOffset`), and hoists the handler lookup to once per basic block with a word-wise `|=` merge of the handler block's live-in set. The def step leaves locals the handler keeps live in place so the merge does not need to be re-applied after every instruction. `--dumpBytecodeLivenessResults=true` output is byte-identical before and after on code exercising nested try/catch and array destructuring, and 80 JSC stress tests covering catch/try/destructuring/for-of/iterator/finally/liveness produce identical output and exit codes against an unpatched build.

The remaining growth past depth 2000 is the inherent O(blocks x numCalleeLocals / 64) bitvector dataflow in the liveness fixpoint.

## Note

`WEBKIT_VERSION` currently points at the preview autobuild for oven-sh/WebKit#356; it will be updated to the main `autobuild-<sha>` tag once that PR merges. The fix lives entirely in WebKit, so the fail-before/fail-after gate cannot exercise it by stashing `src/`.
