### PR TITLE
usockets: keep READABLE off a half-open socket whose on_end already fired

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -347,6 +347,7 @@ static void us_internal_init_listen_socket(struct us_listen_socket_t *ls,
     s->flags.adopted = 0;
     s->flags.allow_half_open = (options & LIBUS_SOCKET_ALLOW_HALF_OPEN);
     s->unclassified_send_failures = 0;
+    s->readable_ended = 0;
     s->next = 0;
     s->prev = 0;
     s->connect_state = NULL;
@@ -491,6 +492,7 @@ static inline void us_internal_init_connect_socket(struct us_socket_t *s,
     s->flags.adopted = 0;
     s->flags.last_write_failed = 0;
     s->unclassified_send_failures = 0;
+    s->readable_ended = 0;
     s->connect_state = NULL;
     s->connect_next = NULL;
 }

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -305,6 +305,10 @@ struct us_socket_t {
    * the driver's epilogue via ssl_pending_detach. */
   unsigned char ssl_in_use : 1;
   unsigned char ssl_pending_detach : 1;
+  /* on_end has been dispatched for the half-open path; recv() can only return
+   * 0 now. Guards the callers that would otherwise re-arm READABLE (partial
+   * write, resume) so on_end is not re-derived and re-fired every tick. */
+  unsigned char readable_ended : 1;
   /* The close code passed to the deferred close (e.g. a reset requested from
    * inside a handshake callback must still RST, not FIN, when it is finally
    * performed). */

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -849,10 +849,12 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     return;
                 }
                 if (s->readable_ended) {
-                    /* on_end already fired (half-open); something re-armed
-                     * READABLE regardless (resume, or a partial write before
-                     * readable_ended latched). Don't re-dispatch or force
-                     * WRITABLE; just drop READABLE again. */
+                    /* on_end already fired (half-open). rearm_writable/resume
+                     * both honour readable_ended, so reaching here means an eof
+                     * hint that arrives without READABLE (Windows AFD
+                     * UV_DISCONNECT, the low-prio requeue) or a caller that
+                     * us_poll_change'd READABLE directly. Drop READABLE and
+                     * don't re-dispatch. */
                     us_poll_change(&s->p, loop, us_poll_events(&s->p) & LIBUS_SOCKET_WRITABLE);
                 } else if(s->flags.allow_half_open) {
                     /* EOF with half-open allowed: stop polling readable but KEEP

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -849,12 +849,11 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     return;
                 }
                 if (s->readable_ended) {
-                    /* on_end already fired (half-open). rearm_writable/resume
-                     * both honour readable_ended, so reaching here means an eof
-                     * hint that arrives without READABLE (Windows AFD
-                     * UV_DISCONNECT, the low-prio requeue) or a caller that
-                     * us_poll_change'd READABLE directly. Drop READABLE and
-                     * don't re-dispatch. */
+                    /* on_end already fired (half-open). A backpressured write's
+                     * rearm_writable (or resume/a level-triggered eof hint) put
+                     * READABLE back; absorb the 0-byte read here instead of
+                     * re-dispatching on_end. Drop READABLE so the next tick is
+                     * driven by WRITABLE alone. */
                     us_poll_change(&s->p, loop, us_poll_events(&s->p) & LIBUS_SOCKET_WRITABLE);
                 } else if(s->flags.allow_half_open) {
                     /* EOF with half-open allowed: stop polling readable but KEEP

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -536,6 +536,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         s->flags.adopted = 0;
                         s->flags.last_write_failed = 0;
                         s->unclassified_send_failures = 0;
+                        s->readable_ended = 0;
 
                         /* We always use nodelay */
                         bsd_socket_nodelay(client_fd, 1);
@@ -847,7 +848,13 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     s = us_internal_socket_close_raw(s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, NULL);
                     return;
                 }
-                if(s->flags.allow_half_open) {
+                if (s->readable_ended) {
+                    /* on_end already fired (half-open); something re-armed
+                     * READABLE regardless (resume, or a partial write before
+                     * readable_ended latched). Don't re-dispatch or force
+                     * WRITABLE; just drop READABLE again. */
+                    us_poll_change(&s->p, loop, us_poll_events(&s->p) & LIBUS_SOCKET_WRITABLE);
+                } else if(s->flags.allow_half_open) {
                     /* EOF with half-open allowed: stop polling readable but KEEP
                      * polling writable. Masking with the current events dropped
                      * writable when the EOF landed before the poll had been
@@ -858,6 +865,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                      * http response tests hung on every Linux target. The
                      * writable dispatch disables writable polling again once
                      * the buffer is drained, so this does not busy-poll. */
+                    s->readable_ended = 1;
                     us_poll_change(&s->p, loop, LIBUS_SOCKET_WRITABLE);
                     s = s->ssl ? us_internal_ssl_on_end(s) : us_dispatch_end(s);
                 } else {

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -868,14 +868,16 @@ void us_socket_resume(struct us_socket_t *s) {
     // closed cannot be resumed
     if (us_socket_is_closed(s)) return;
 
-    /* The peer's FIN was already delivered; recv() can only return 0 now.
-     * Re-arming READABLE would just re-derive eof on the next tick. */
-    int readable = s->readable_ended ? 0 : LIBUS_SOCKET_READABLE;
     if (us_socket_is_shut_down(s)) {
-        // we already sent FIN so we resume only readable side we are read-only
-        us_poll_change(&s->p, s->group->loop, readable);
+        /* We already sent FIN. Re-deriving eof here is what closes us (loop.c
+         * checks is_shut_down before readable_ended), so READABLE stays on
+         * even if readable_ended - same as raw_shutdown. */
+        us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_READABLE);
         return;
     }
-    // we are readable and writable so we resume everything
-    us_poll_change(&s->p, s->group->loop, readable | LIBUS_SOCKET_WRITABLE);
+    /* Peer FIN already delivered: recv() can only return 0 now, so skip
+     * READABLE and leave the half-open poll at WRITABLE-only. */
+    us_poll_change(&s->p, s->group->loop,
+                   LIBUS_SOCKET_WRITABLE |
+                       (s->readable_ended ? 0 : LIBUS_SOCKET_READABLE));
 }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -410,12 +410,14 @@ struct us_socket_t *us_socket_pair(struct us_socket_group_t *group, unsigned cha
 }
 
 /* Re-arm writable for a backpressured write without resuming the read side of
- * a paused socket: us_poll_change sets absolute flags, so including READABLE
- * unconditionally would silently undo us_socket_pause mid-backpressure and
- * deliver data the caller asked to defer. */
+ * a paused socket (caller asked to defer data) or a socket whose readable side
+ * has ended (recv()==0 would re-derive eof and re-fire on_end every tick).
+ * us_poll_change sets absolute flags, so READABLE is added back explicitly for
+ * the common case. */
 static void us_internal_rearm_writable(struct us_socket_t *s) {
     us_poll_change(&s->p, s->group->loop,
-                   LIBUS_SOCKET_WRITABLE | (s->flags.is_paused ? 0 : LIBUS_SOCKET_READABLE));
+                   LIBUS_SOCKET_WRITABLE |
+                       ((s->flags.is_paused || s->readable_ended) ? 0 : LIBUS_SOCKET_READABLE));
 }
 
 int us_socket_write2(struct us_socket_t *s, const char *header, int header_length, const char *payload, int payload_length) {
@@ -457,6 +459,7 @@ struct us_socket_t *us_socket_from_fd(struct us_socket_group_t *group, unsigned 
     s->flags.adopted = 0;
     s->flags.last_write_failed = 0;
     s->unclassified_send_failures = 0;
+    s->readable_ended = 0;
     s->connect_state = NULL;
 
     /* We always use nodelay */
@@ -703,12 +706,18 @@ int us_connecting_socket_is_shut_down(struct us_connecting_socket_t *c) {
 }
 
 void us_internal_socket_raw_shutdown(struct us_socket_t *s) {
-    /* Todo: should we emit on_close if calling shutdown on an already half-closed socket?
-     * We need more states in that case, we need to track RECEIVED_FIN
-     * so far, the app has to track this and call close as needed */
     if (!us_socket_is_closed(s) && us_internal_poll_type(&s->p) != POLL_TYPE_SOCKET_SHUT_DOWN) {
         us_internal_poll_set_type(&s->p, POLL_TYPE_SOCKET_SHUT_DOWN);
-        us_poll_change(&s->p, s->group->loop, us_poll_events(&s->p) & LIBUS_SOCKET_READABLE);
+        /* Peer FIN already delivered: the half-open poll sits at WRITABLE-only
+         * (or 0 after drain), so `events & READABLE` would be 0 and on
+         * kqueue/libuv nothing would wake the SHUT_DOWN close path (epoll gets
+         * it via unmaskable EPOLLHUP). Arm READABLE so the next poll reports
+         * the 0-byte read / DISCONNECT and closes via the existing SHUT_DOWN
+         * branch - next iteration, not synchronously, so callers still see a
+         * live socket after shutdown() returns. */
+        us_poll_change(&s->p, s->group->loop,
+                       s->readable_ended ? LIBUS_SOCKET_READABLE
+                                         : (us_poll_events(&s->p) & LIBUS_SOCKET_READABLE));
         bsd_shutdown_socket(us_poll_fd((struct us_poll_t *) s));
     }
 }
@@ -859,11 +868,14 @@ void us_socket_resume(struct us_socket_t *s) {
     // closed cannot be resumed
     if (us_socket_is_closed(s)) return;
 
+    /* The peer's FIN was already delivered; recv() can only return 0 now.
+     * Re-arming READABLE would just re-derive eof on the next tick. */
+    int readable = s->readable_ended ? 0 : LIBUS_SOCKET_READABLE;
     if (us_socket_is_shut_down(s)) {
         // we already sent FIN so we resume only readable side we are read-only
-        us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_READABLE);
+        us_poll_change(&s->p, s->group->loop, readable);
         return;
     }
     // we are readable and writable so we resume everything
-    us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
+    us_poll_change(&s->p, s->group->loop, readable | LIBUS_SOCKET_WRITABLE);
 }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -410,14 +410,16 @@ struct us_socket_t *us_socket_pair(struct us_socket_group_t *group, unsigned cha
 }
 
 /* Re-arm writable for a backpressured write without resuming the read side of
- * a paused socket (caller asked to defer data) or a socket whose readable side
- * has ended (recv()==0 would re-derive eof and re-fire on_end every tick).
- * us_poll_change sets absolute flags, so READABLE is added back explicitly for
- * the common case. */
+ * a paused socket: us_poll_change sets absolute flags, so including READABLE
+ * unconditionally would silently undo us_socket_pause mid-backpressure and
+ * deliver data the caller asked to defer. READABLE stays on even when
+ * readable_ended is set - loop.c's readable_ended guard absorbs the 0-byte
+ * read without re-dispatching, and the Windows/TLS half-close drain (libuv.c
+ * poll_cb's UV_DISCONNECT handling) relies on READABLE being present to keep
+ * the writable dispatch flowing after the eof branch drops it. */
 static void us_internal_rearm_writable(struct us_socket_t *s) {
     us_poll_change(&s->p, s->group->loop,
-                   LIBUS_SOCKET_WRITABLE |
-                       ((s->flags.is_paused || s->readable_ended) ? 0 : LIBUS_SOCKET_READABLE));
+                   LIBUS_SOCKET_WRITABLE | (s->flags.is_paused ? 0 : LIBUS_SOCKET_READABLE));
 }
 
 int us_socket_write2(struct us_socket_t *s, const char *header, int header_length, const char *payload, int payload_length) {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -314,8 +314,8 @@ it("allowHalfOpen: end() fires once when the handler's write is partially accept
     allowHalfOpen: true,
     socket: {
       open(s) {
-        // Clamp SO_SNDBUF so the 4 MiB write from end() is a partial write on
-        // every kernel (no-op on Windows, whose default already makes it so).
+        // Clamp SO_SNDBUF so the write from end() is a partial write on every
+        // POSIX kernel. No-op on Windows; the drainCount assertion is gated.
         setSocketOptions(s, 1, 4096);
         s.data = { sent: 0 };
       },

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -1,4 +1,5 @@
 import { connect, listen, SocketHandler, TCPSocketListener } from "bun";
+import { setSocketOptions } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { expectMaxObjectTypeCount, isWindows } from "harness";
 
@@ -301,20 +302,21 @@ describe("tcp socket binaryType", () => {
 // set it to WRITABLE-only, so the next epoll tick re-derived recv()==0 -> eof
 // and re-dispatched end(), forever. Drain fired at most once between re-entries.
 it("allowHalfOpen: end() fires once when the handler's write is partially accepted", async () => {
-  // 4 MiB reliably exceeds the loopback send buffer on every platform, so the
-  // write from inside end() lands partial and arms the writable poll.
-  const PAYLOAD = Buffer.alloc(4 * 1024 * 1024, 0x61);
+  const PAYLOAD = Buffer.alloc(256 * 1024, 0x61);
   let endCount = 0;
   let drainCount = 0;
   const serverClosed = Promise.withResolvers<void>();
   const clientClosed = Promise.withResolvers<void>();
 
-  using server = listen({
+  using server = listen<{ sent: number }>({
     hostname: "127.0.0.1",
     port: 0,
     allowHalfOpen: true,
     socket: {
       open(s) {
+        // Clamp SO_SNDBUF so the 4 MiB write from end() is a partial write on
+        // every kernel (no-op on Windows, whose default already makes it so).
+        setSocketOptions(s, 1, 4096);
         s.data = { sent: 0 };
       },
       data() {},
@@ -338,7 +340,6 @@ it("allowHalfOpen: end() fires once when the handler's write is partially accept
         serverClosed.resolve();
       },
     },
-    data: null! as { sent: number },
   });
 
   let received = 0;
@@ -363,10 +364,7 @@ it("allowHalfOpen: end() fires once when the handler's write is partially accept
   await Promise.all([serverClosed.promise, clientClosed.promise]);
 
   expect({ endCount, received }).toEqual({ endCount: 1, received: PAYLOAD.length });
-  // drainCount is informational: any platform where 4 MiB is a partial write
-  // (all of them, in practice) will fire drain at least once. Not asserted so
-  // a future kernel with a huge default send buffer cannot flake this.
-  void drainCount;
+  expect(drainCount).toBeGreaterThanOrEqual(1);
 });
 
 it("should not leak memory", async () => {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -364,7 +364,10 @@ it("allowHalfOpen: end() fires once when the handler's write is partially accept
   await Promise.all([serverClosed.promise, clientClosed.promise]);
 
   expect({ endCount, received }).toEqual({ endCount: 1, received: PAYLOAD.length });
-  expect(drainCount).toBeGreaterThanOrEqual(1);
+  // setSocketOptions is a POSIX-only no-op on Windows, where loopback
+  // auto-tuning can accept 256 KiB in one send(). The assertion above already
+  // proves the fix there (endCount == 1 with the whole payload delivered).
+  if (!isWindows) expect(drainCount).toBeGreaterThanOrEqual(1);
 });
 
 it("should not leak memory", async () => {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -295,6 +295,80 @@ describe("tcp socket binaryType", () => {
   }
 });
 
+// With allowHalfOpen, a server's end() handler that writes more than the kernel
+// send buffer accepts (a partial write) triggered us_internal_rearm_writable,
+// which re-added READABLE to the poll mask. The half-open eof branch had just
+// set it to WRITABLE-only, so the next epoll tick re-derived recv()==0 -> eof
+// and re-dispatched end(), forever. Drain fired at most once between re-entries.
+it("allowHalfOpen: end() fires once when the handler's write is partially accepted", async () => {
+  // 4 MiB reliably exceeds the loopback send buffer on every platform, so the
+  // write from inside end() lands partial and arms the writable poll.
+  const PAYLOAD = Buffer.alloc(4 * 1024 * 1024, 0x61);
+  let endCount = 0;
+  let drainCount = 0;
+  const serverClosed = Promise.withResolvers<void>();
+  const clientClosed = Promise.withResolvers<void>();
+
+  using server = listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    allowHalfOpen: true,
+    socket: {
+      open(s) {
+        s.data = { sent: 0 };
+      },
+      data() {},
+      end(s) {
+        if (++endCount > 1) {
+          // The bug re-enters end() every tick; terminate so the test fails on
+          // the assertion below instead of spinning.
+          s.terminate();
+          return;
+        }
+        s.data.sent = s.write(PAYLOAD);
+        if (s.data.sent >= PAYLOAD.length) s.shutdown();
+      },
+      drain(s) {
+        drainCount++;
+        if (s.data.sent === 0) return;
+        s.data.sent += s.write(PAYLOAD.subarray(s.data.sent));
+        if (s.data.sent >= PAYLOAD.length) s.shutdown();
+      },
+      close() {
+        serverClosed.resolve();
+      },
+    },
+    data: null! as { sent: number },
+  });
+
+  let received = 0;
+  await connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    socket: {
+      open(s) {
+        s.write("hi");
+        s.shutdown();
+      },
+      data(_s, chunk) {
+        received += chunk.byteLength;
+      },
+      end() {},
+      close() {
+        clientClosed.resolve();
+      },
+    },
+  });
+
+  await Promise.all([serverClosed.promise, clientClosed.promise]);
+
+  expect({ endCount, received }).toEqual({ endCount: 1, received: PAYLOAD.length });
+  // drainCount is informational: any platform where 4 MiB is a partial write
+  // (all of them, in practice) will fire drain at least once. Not asserted so
+  // a future kernel with a huge default send buffer cannot flake this.
+  void drainCount;
+});
+
 it("should not leak memory", async () => {
   // assert we don't leak the sockets
   // we expect 1 or 2 because that's the prototype / structure


### PR DESCRIPTION
### What does this PR do?

#### Problem

With `Bun.listen({ allowHalfOpen: true })`, if the server's `end` handler does a `socket.write()` that the kernel only partially accepts, `on_end` is re-dispatched on every loop iteration forever. `drain` fires at most once between re-entries, so the payload never finishes flushing.

```js
using server = Bun.listen({
  hostname: "127.0.0.1", port: 0, allowHalfOpen: true,
  socket: {
    open(s) { s.data = { sent: 0 }; },
    data() {},
    end(s) {                       // fires hundreds of times
      s.data.sent = s.write(Buffer.alloc(4 * 1024 * 1024, 0x61));
      if (s.data.sent >= 4 * 1024 * 1024) s.shutdown();
    },
    drain(s) { /* flush the rest */ },
    close() {},
  },
});
```

#### Cause

The half-open eof branch at `loop.c` sets the poll to `WRITABLE` only, then dispatches `on_end`. A partial write inside that handler calls `us_internal_rearm_writable`, which re-adds READABLE. On the next tick epoll reports the fd readable again (the peer's FIN is still there), `recv()` returns 0, eof is re-derived, and the half-open branch re-runs: `on_end` is re-dispatched, and the handler's partial write re-adds READABLE again.

#### Fix

Add a `readable_ended` bit to `us_socket_t` (in the existing bitfield gap; struct size unchanged) and set it the first time the half-open eof branch dispatches `on_end`. Then:

- `loop.c` eof branch: if `readable_ended` is already set, drop READABLE and skip the re-dispatch instead of re-firing `on_end`. A backpressured write's `rearm_writable` still re-adds READABLE (the Windows/TLS half-close drain in `libuv.c`'s `UV_DISCONNECT` handling relies on it being registered to keep the writable dispatch flowing), so this guard is what absorbs the 0-byte read.
- `us_internal_socket_raw_shutdown`: when the peer FIN was already delivered, the poll can sit at WRITABLE-only (or 0), so `events & READABLE` is 0 and on kqueue/libuv nothing would wake the SHUT_DOWN close path. Arm READABLE explicitly so the next tick reads 0 bytes and closes via the existing `is_shut_down` branch. epoll got this for free via unmaskable EPOLLHUP; this makes the other backends match.
- `us_socket_resume`: skip READABLE in the still-writable arm when `readable_ended` (the loop.c guard would catch it anyway; this saves one 0-byte read). The `is_shut_down` arm keeps READABLE unconditionally, same as `raw_shutdown`.

The bit is zero-initialized at every socket construction site (`us_create_poll` uses `us_malloc`, not calloc).

#34487 introduces the same `readable_ended` bit for the Windows `UV_DISCONNECT` level-triggered trigger of the same re-dispatch. This PR's loop.c guard covers both triggers and adds a Linux-reproducible test; the field placement is identical so whichever lands first, the other rebases cleanly.

### How did you verify your code works?

New test in `test/js/bun/net/tcp-server.test.ts` clamps `SO_SNDBUF` (POSIX) so the write from `end()` is a partial write on every kernel, and asserts `endCount == 1` with the full payload delivered.

Linux gate proof:

```
# packages/ reverted to main
$ bun bd test test/js/bun/net/tcp-server.test.ts -t allowHalfOpen
  { endCount: 2, received: 80384 }      # second end() terminates the socket
(fail)

# with this PR
$ bun bd test test/js/bun/net/tcp-server.test.ts -t allowHalfOpen
(pass)
```

Verified on windows-x64 at 30274ea: `node-http-backpressure.test.ts` "client FIN right after" 8/8, `serve.test.ts` "client half-close after the request" 5/5, `tcp-server.test.ts` allowHalfOpen pass.

`test/js/node/net/node-net-allowHalfOpen.test.js`, the `test-net-*half*` / `test-net-*end*` node parallel tests, `node-net.test.ts` and `socket.test.ts` all have the same pass/fail as main.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/tcp-server.test.ts

<!-- robobun:evidence:end -->