### PR TITLE
fix(wasi): bounds-check iovec pointers and buf+bufLen before memory access

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -860,26 +860,32 @@ var require_wasi = __commonJS({
           const { buffer } = memory;
           const { byteLength } = buffer;
 
+          // Validate iovs pointer is within bounds
+          if (iovs >= byteLength || iovs < 0) {
+            throw new types_1.WASIError(constants_1.WASI_EOVERFLOW);
+          }
+
+          // Validate total size needed for all iovecs
+          const total_size = iovs + iovsLen * 8;
+          if (total_size > byteLength || total_size < iovs) {
+            throw new types_1.WASIError(constants_1.WASI_EOVERFLOW);
+          }
+
           if (iovsLen === 1) {
             const ptr = iovs;
-            const buf = view.getUint32(ptr, true);
-            let bufLen = view.getUint32(ptr + 4, true);
-
-            if (bufLen > byteLength - buf) {
-              console.log({
-                buf,
-                bufLen,
-                total_memory: byteLength,
-              });
-              log("getiovs: warning -- truncating buffer to fit in memory");
-              bufLen = Math.min(bufLen, Math.max(0, byteLength - buf));
-            }
+            let buf;
+            let bufLen;
             try {
-              return [new Uint8Array(buffer, buf, bufLen)];
+              buf = view.getUint32(ptr, true);
+              bufLen = view.getUint32(ptr + 4, true);
             } catch (err) {
-              console.warn("WASI.getiovs -- invalid buffer", err);
-              throw new types_1.WASIError(constants_1.WASI_EINVAL);
+              throw new types_1.WASIError(constants_1.WASI_EOVERFLOW);
             }
+
+            if (buf > byteLength || bufLen > byteLength - buf) {
+              throw new types_1.WASIError(constants_1.WASI_EOVERFLOW);
+            }
+            return [new Uint8Array(buffer, buf, bufLen)];
           }
 
           // Avoid referencing Array because materializing the Array constructor can show up in profiling
@@ -887,28 +893,23 @@ var require_wasi = __commonJS({
           buffers.length = iovsLen;
 
           for (let i = 0, ptr = iovs; i < iovsLen; i++, ptr += 8) {
-            const buf = view.getUint32(ptr, true);
-            let bufLen = view.getUint32(ptr + 4, true);
-
-            if (bufLen > byteLength - buf) {
-              console.log({
-                buf,
-                bufLen,
-                total_memory: byteLength,
-              });
-              log("getiovs: warning -- truncating buffer to fit in memory");
-              bufLen = Math.min(bufLen, Math.max(0, byteLength - buf));
-            }
+            let buf;
+            let bufLen;
             try {
-              buffers[i] = new Uint8Array(buffer, buf, bufLen);
+              buf = view.getUint32(ptr, true);
+              bufLen = view.getUint32(ptr + 4, true);
             } catch (err) {
-              console.warn("WASI.getiovs -- invalid buffer", err);
-              throw new types_1.WASIError(constants_1.WASI_EINVAL);
+              throw new types_1.WASIError(constants_1.WASI_EOVERFLOW);
             }
+
+            if (buf > byteLength || bufLen > byteLength - buf) {
+              throw new types_1.WASIError(constants_1.WASI_EOVERFLOW);
+            }
+            buffers[i] = new Uint8Array(buffer, buf, bufLen);
           }
           return buffers;
         };
-        const CHECK_FD = (fd, rights) => {
+const CHECK_FD = (fd, rights) => {
           const stats = stat(this, fd);
           if (rights !== BigInt(0) && (stats.rights.base & rights) === BigInt(0)) {
             throw new types_1.WASIError(constants_1.WASI_EPERM);


### PR DESCRIPTION
## What does this PR do?

WASI `getiovs()` does not validate that iovec pointers or buffer ranges are within the guest's linear memory bounds. An attacker can supply out-of-bounds iovec arrays that either:

1. **Throw raw `RangeError`** (unmapped to WASI errno) when `ptr` is outside memory
2. **Silently truncate** buffer reads when `buf + bufLen > byteLength`
3. **Leak debug output** (`console.log`/`console.warn`) to host stdout/stderr

This matches Node.js behavior which returns `WASI_EOVERFLOW` (errno 61) for all out-of-bounds iovec shapes.

### Repro

```js
import { WASI } from "node:wasi";
const wasi = new WASI({ version: "preview1" });
wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
const view = new DataView(wasi.memory.buffer);

// iovec array pointer outside linear memory
console.log(wasi.wasiImport.fd_write(2, 65534, 1, 256));  // bun: throws RangeError; node: 61

// iov.len overruns memory
view.setUint32(0, 65530, true); view.setUint32(4, 4096, true);
console.log(wasi.wasiImport.fd_write(2, 0, 1, 256));      // bun: 0, plus debug output; node: 61
```

### Fix

- Bounds-check `iovs` pointer against memory
- Validate total iovec array size doesn't overflow
- Check each `buf + bufLen` combination before accessing memory
- Throw `WASI_EOVERFLOW` on any violation (matching Node.js)
- Remove `console.log`/`console.warn` debug output

### Testing

- Verified against Node.js WASI implementation behavior
- All three repro cases now return errno 61 (WOVERFLOW) instead of throwing or truncating silently

Fixes #34468