### PR TITLE
runner: keep docker-build and test-buffer-constants out of the N-wide phase

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -599,8 +599,24 @@ async function runTests() {
   const parallelSafeCap = isWindows ? 2 : 4;
   const parallelSafeWidth = parallelism > 1 ? parallelism : Math.min(parallelSafeCap, availableParallelism());
   const parallelSafeLimit = parallelism > 1 ? limit : pLimit(parallelSafeWidth);
+  // Files in the parallel-safe directories whose resource footprint makes them
+  // unsafe to overlap on an 8 GiB no-swap runner:
+  //   * test-docker-build-*: `docker build --no-cache` for 10-20 s, GB-scale RSS
+  //     while layers are pulled and dpkg/apk runs.
+  //   * test-buffer-constants.js: `' '.repeat(MAX_STRING_LENGTH)` is a 2 GiB
+  //     Latin-1 allocation under JSC (V8's limit is ~512 MiB, so upstream
+  //     node's parallel/ placement is fine there). With overcommit the malloc
+  //     succeeds and the memset page-faults, so the OOM killer SIGKILLs the
+  //     process instead of JSC throwing a catchable RangeError.
+  // Shard 19/20 bin-packs the docker builds and test-buffer-constants together,
+  // and once this phase starts them 2-wide the buffer test reliably gets
+  // OOM-killed (builds 82231/82241/82296). Run both serially in phase 1.
+  const parallelSafeMemoryHeavy = p =>
+    p.includes("js/bun/test/parallel/test-docker-build-") ||
+    p.endsWith("js/node/test/parallel/test-buffer-constants.js");
   const isParallelSafeTest = testPath => {
     const p = testPath.replaceAll("\\", "/");
+    if (parallelSafeMemoryHeavy(p)) return false;
     return p.includes("js/node/test/parallel/") || p.includes("js/bun/test/parallel/");
   };
   console.log("parallel-safe width", parallelSafeWidth);

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -608,9 +608,8 @@ async function runTests() {
   //     node's parallel/ placement is fine there). With overcommit the malloc
   //     succeeds and the memset page-faults, so the OOM killer SIGKILLs the
   //     process instead of JSC throwing a catchable RangeError.
-  // Shard 19/20 bin-packs the docker builds and test-buffer-constants together,
-  // and once this phase starts them 2-wide the buffer test reliably gets
-  // OOM-killed (builds 82231/82241/82296). Run both serially in phase 1.
+  // LPT bin-packing can co-locate these on one shard; when this phase starts
+  // them 2-wide the buffer test gets OOM-killed. Run both serially in phase 1.
   const parallelSafeMemoryHeavy = p =>
     p.includes("js/bun/test/parallel/test-docker-build-") ||
     p.endsWith("js/node/test/parallel/test-buffer-constants.js");

--- a/test/internal/expected-durations.test.ts
+++ b/test/internal/expected-durations.test.ts
@@ -31,8 +31,14 @@ describe("test/expected-durations.json", () => {
   test("covers the parallel-safe phase and clamps its spans", () => {
     // js/{node,bun}/test/parallel/ run N-wide and log without a `--- ` group
     // prefix; a parser that only matches `--- [N/M]` drops ~3k entries here.
+    // Keep this predicate in sync with isParallelSafeTest in
+    // scripts/runner.node.mjs: the memory-heavy opt-outs run in the serial
+    // phase, so their recorded spans are real wall clock, not clamped
+    // inter-dispatch gaps.
+    const memoryHeavy = (k: string) =>
+      k.startsWith("js/bun/test/parallel/test-docker-build-") || k === "js/node/test/parallel/test-buffer-constants.js";
     const parallelSafe = entries.filter(
-      ([k]) => k.startsWith("js/node/test/parallel/") || k.startsWith("js/bun/test/parallel/"),
+      ([k]) => (k.startsWith("js/node/test/parallel/") || k.startsWith("js/bun/test/parallel/")) && !memoryHeavy(k),
     );
     expect(parallelSafe.length).toBeGreaterThan(1000);
     // Concurrent-phase spans are inter-dispatch gaps; without the clamp the


### PR DESCRIPTION
Fixes `test/js/node/test/parallel/test-buffer-constants.js` going red with SIGKILL on shard 19/20 of the linux x64 test lanes.

## Repro

Builds [82231](https://buildkite.com/bun/bun/builds/82231), [82241](https://buildkite.com/bun/bun/builds/82241) and [82296](https://buildkite.com/bun/bun/builds/82296), all on unrelated feature branches with base `44f6469e0d`, shard 19/20 of `ubuntu 25.04 x64` / `debian 13 x64`:

```
Mem: total 7780  used 643  free 6504  ...  Swap: 0
--- Running 179 parallel-safe tests (2-wide)
[104/282] test/js/bun/test/parallel/test-docker-build-alpine.ts
[105/282] test/js/bun/test/parallel/test-docker-build-debian.ts
[106/282] test/js/bun/test/parallel/test-unref-timer-under-socket-wait.ts
[107/282] test/js/node/test/parallel/test-async-hooks-asyncresource-constructor.js
[108/282] test/js/node/test/parallel/test-async-wrap-constructor.js
[109/282] test/js/node/test/parallel/test-buffer-badhex.js
[110/282] test/js/node/test/parallel/test-buffer-constants.js
[110/282] test/js/node/test/parallel/test-buffer-constants.js - SIGKILL
main process killed by SIGKILL but no core file found
```

One slot is still running `test-docker-build-debian.ts` (10-20 s `docker build --no-cache`) when the other slot reaches `test-buffer-constants.js`.

## Cause

`test-buffer-constants.js` does `' '.repeat(MAX_STRING_LENGTH)` to prove the constant is not off by one. Under V8 that limit is 536 870 888 (~512 MiB), but JSC's `WTF::StringImpl::MaxLength` is `2^31 - 1`, so the single-char repeat path (`repeatCharacter` in `JSStringInlines.h`) allocates and memsets a 2 GiB Latin-1 buffer:

```
$ bun -e 'const b=process.memoryUsage().rss; " ".repeat(require("buffer").constants.MAX_STRING_LENGTH); console.log(((process.memoryUsage().rss-b)/1024/1024).toFixed(1))'
2049.0
```

The x64 test runners are 7.8 GiB with no swap. With a concurrent `docker build --no-cache` pulling `debian:trixie-slim` and running `apt-get install`, there is not always 2 GiB free for the memset, and Linux overcommit means the `tryCreateUninitialized` malloc succeeds, so the process is OOM-killed during the page-fault loop instead of JSC throwing a catchable `RangeError`. The same shard/ordering passed on build 80215, so whether the 2 GiB fits depends on where the docker build is at that instant.

The overlap exists since #33622 (c464531628) made `js/*/test/parallel/` a 2-4-wide phase. The `test-docker-build-*` files were placed there in #25210, before the directory name was a concurrency signal, and LPT bin-packing currently puts both on shard 19.

## Fix

Add a `parallelSafeMemoryHeavy` exclusion to `isParallelSafeTest` so `test-docker-build-*.ts` and `test-buffer-constants.js` run in the serial phase. They still run exactly as before (same `bun run --config=bunfig.node-test.toml` path), just one at a time with the machine to themselves. Shard assignment is unchanged; the four docker builds already bin-pack across shards, so wall-time impact is one extra ~12 s serial slot on the shard that carries them.

The test file itself is left verbatim (modulo the existing JSC-error-message patch); it only needs to not share the box with a docker build.

## Verification

This is a runner-scheduling change with no `src/**` diff; the failure only reproduces when the two processes overlap on an 8 GiB no-swap host, so there is no fail-before test the gate can re-derive locally. Evidence that the fix removes the overlap:

- `isParallelSafeTest` now returns `false` for all four `test-docker-build-*.ts` and for `test-buffer-constants.js` (Windows-separator paths included), `true` for the neighbouring `test-buffer-badhex.js` / `test-http-*` files (inline probe in the commit log of this branch).
- `bun test/js/node/test/parallel/test-buffer-constants.js` passes standalone.
- `node --check scripts/runner.node.mjs` is clean.
- Three independent failing CI job logs (links above) all show the same slot-B `test-docker-build-debian.ts` still running when slot A reaches `test-buffer-constants.js`.

## Side effect: docker-build output now reaches the log

In the parallel-safe phase these tests ran with `concurrent=true`, so `spawnBun`'s stdout/stderr callbacks were `() => {}` and the ~350 lines of `docker build --progress=plain` per image were silently dropped. In the serial phase they run inside a `startGroup`, so that output is now written to the job log (folded under the test's group header, so not visible unless expanded). This is intentional: a `docker build` failure is currently invisible in CI beyond the exit code, and the extra lines are bounded (four files across all shards, folded).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/expected-durations.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/expected-durations.test.ts
bun test v1.4.0 (ca250f681)

test/internal/expected-durations.test.ts:
(pass) test/expected-durations.json > every lane the runner selects is declared and populated [151.32ms]
(pass) test/expected-durations.json > keys are relative test paths, not runner retry/error labels [199.60ms]
(pass) test/expected-durations.json > covers the parallel-safe phase and clamps its spans [355.04ms]
(pass) test/expected-durations.json > every entry is {lane: non-negative ms} [428.34ms]

 4 pass
 0 fail
 15 expect() calls
Ran 4 tests across 1 file. [3.47s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/runner.node.mjs                  | 15 +++++++++++++++
 test/internal/expected-durations.test.ts |  8 +++++++-
 2 files changed, 22 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
scripts/runner.node.mjs                       8      2      0
test/internal/expected-durations.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->