### PR TITLE
crypto: accept DER X509Certificate input larger than 100 KiB

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1424,12 +1424,12 @@ Result<X509Pointer, int> X509Pointer::Parse(
         PEM_read_bio_X509_AUX(bio.get(), nullptr, NoPasswordCallback, nullptr));
     if (pem) return Result<X509Pointer, int>(WTF::move(pem));
 
-    // BoringSSL's d2i_X509_bio caps input at 100 KiB via BIO_read_asn1, which
-    // would reject large certificates that Node.js (OpenSSL) accepts. We already
-    // have the full buffer in memory, so decode it directly.
-    const unsigned char* der_data = buffer.data;
-    X509Pointer der(d2i_X509(nullptr, &der_data, static_cast<long>(buffer.len)));
-    if (der) return Result<X509Pointer, int>(WTF::move(der));
+    // d2i_X509_bio in BoringSSL caps input at 100 KiB; decode the buffer directly.
+    if (buffer.len <= LONG_MAX) {
+        const unsigned char* der_data = buffer.data;
+        X509Pointer der(d2i_X509(nullptr, &der_data, static_cast<long>(buffer.len)));
+        if (der) return Result<X509Pointer, int>(WTF::move(der));
+    }
 
     return Result<X509Pointer, int>(ERR_get_error());
 }

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1423,9 +1423,12 @@ Result<X509Pointer, int> X509Pointer::Parse(
     X509Pointer pem(
         PEM_read_bio_X509_AUX(bio.get(), nullptr, NoPasswordCallback, nullptr));
     if (pem) return Result<X509Pointer, int>(WTF::move(pem));
-    BIO_reset(bio.get());
 
-    X509Pointer der(d2i_X509_bio(bio.get(), nullptr));
+    // BoringSSL's d2i_X509_bio caps input at 100 KiB via BIO_read_asn1, which
+    // would reject large certificates that Node.js (OpenSSL) accepts. We already
+    // have the full buffer in memory, so decode it directly.
+    const unsigned char* der_data = buffer.data;
+    X509Pointer der(d2i_X509(nullptr, &der_data, static_cast<long>(buffer.len)));
     if (der) return Result<X509Pointer, int>(WTF::move(der));
 
     return Result<X509Pointer, int>(ERR_get_error());

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -114,7 +114,10 @@ describe("new X509Certificate() from DER", () => {
     const der = seq(Buffer.concat([tbs, alg, tlv(0x03, Buffer.concat([Buffer.from([0]), sig]))]));
     const pem =
       "-----BEGIN CERTIFICATE-----\n" +
-      der.toString("base64").match(/.{1,64}/g)!.join("\n") +
+      der
+        .toString("base64")
+        .match(/.{1,64}/g)!
+        .join("\n") +
       "\n-----END CERTIFICATE-----\n";
     return { der, pem };
   }

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { X509Certificate } from "node:crypto";
+import crypto, { X509Certificate } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
@@ -70,5 +70,86 @@ describe("X509Certificate.checkHost()", () => {
     expect(cnOnly.checkEmail("ry@TINYCLOUDS.ORG")).toBe("ry@TINYCLOUDS.ORG");
     expect(cnOnly.checkEmail("sally@example.com")).toBeUndefined();
     expect(cnOnly.checkIP("127.0.0.1")).toBeUndefined();
+  });
+});
+
+describe("new X509Certificate() from DER", () => {
+  // Build a self-signed EC certificate whose SAN extension contains a single
+  // DNS name of `sanBytes` bytes, so the resulting DER can be sized precisely
+  // above and below BoringSSL's 100 KiB d2i_X509_bio limit.
+  function makeCert(sanBytes: number) {
+    const tlv = (tag: number, body: Buffer) => {
+      const n = body.length;
+      // DER requires the shortest possible length encoding.
+      const len =
+        n < 0x80
+          ? Buffer.from([n])
+          : n < 0x100
+            ? Buffer.from([0x81, n])
+            : n < 0x10000
+              ? Buffer.from([0x82, n >> 8, n & 255])
+              : Buffer.from([0x83, n >> 16, (n >> 8) & 255, n & 255]);
+      return Buffer.concat([Buffer.from([tag]), len, body]);
+    };
+    const seq = (body: Buffer) => tlv(0x30, body);
+    const oid = (hex: string) => tlv(0x06, Buffer.from(hex, "hex"));
+
+    const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+    const name = seq(tlv(0x31, seq(Buffer.concat([oid("550403"), tlv(0x0c, Buffer.from("big.test"))]))));
+    const alg = seq(oid("2a8648ce3d040302"));
+    const san = seq(seq(Buffer.concat([oid("551d11"), tlv(0x04, seq(tlv(0x82, Buffer.alloc(sanBytes, "a"))))])));
+    const tbs = seq(
+      Buffer.concat([
+        Buffer.from([0xa0, 3, 2, 1, 2]),
+        tlv(0x02, Buffer.from([7])),
+        alg,
+        name,
+        seq(Buffer.concat([tlv(0x17, Buffer.from("240101000000Z")), tlv(0x17, Buffer.from("340101000000Z"))])),
+        name,
+        publicKey.export({ type: "spki", format: "der" }),
+        Buffer.concat([Buffer.from([0xa3]), tlv(0x30, san).subarray(1)]),
+      ]),
+    );
+    const sig = crypto.sign("sha256", tbs, privateKey);
+    const der = seq(Buffer.concat([tbs, alg, tlv(0x03, Buffer.concat([Buffer.from([0]), sig]))]));
+    const pem =
+      "-----BEGIN CERTIFICATE-----\n" +
+      der.toString("base64").match(/.{1,64}/g)!.join("\n") +
+      "\n-----END CERTIFICATE-----\n";
+    return { der, pem };
+  }
+
+  test("parses DER larger than 100 KiB", () => {
+    const { der, pem } = makeCert(101 * 1024);
+    expect(der.length).toBeGreaterThan(100 * 1024);
+
+    const fromPem = new X509Certificate(pem);
+    expect(fromPem.subject).toBe("CN=big.test");
+
+    const fromDer = new X509Certificate(der);
+    expect(fromDer.subject).toBe("CN=big.test");
+    expect(fromDer.raw.equals(der)).toBe(true);
+
+    // round-trip through .raw
+    const roundTrip = new X509Certificate(fromPem.raw);
+    expect(roundTrip.subject).toBe("CN=big.test");
+  });
+
+  test("parses DER as a Uint8Array view with a byte offset", () => {
+    const { der } = makeCert(101 * 1024);
+    const backing = new ArrayBuffer(der.length + 16);
+    const view = new Uint8Array(backing, 8, der.length);
+    view.set(der);
+
+    const fromView = new X509Certificate(view);
+    expect(fromView.subject).toBe("CN=big.test");
+  });
+
+  test("still parses small DER and rejects invalid input", () => {
+    const { der } = makeCert(16);
+    expect(der.length).toBeLessThan(100 * 1024);
+    expect(new X509Certificate(der).subject).toBe("CN=big.test");
+
+    expect(() => new X509Certificate(Buffer.from([0x30, 0x03, 0x02, 0x01, 0x00]))).toThrow();
   });
 });

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -153,6 +153,8 @@ describe("new X509Certificate() from DER", () => {
     expect(der.length).toBeLessThan(100 * 1024);
     expect(new X509Certificate(der).subject).toBe("CN=big.test");
 
-    expect(() => new X509Certificate(Buffer.from([0x30, 0x03, 0x02, 0x01, 0x00]))).toThrow();
+    expect(() => new X509Certificate(Buffer.from([0x30, 0x03, 0x02, 0x01, 0x00]))).toThrow(
+      expect.objectContaining({ code: "ERR_CRYPTO_INVALID_STATE" }),
+    );
   });
 });


### PR DESCRIPTION
## Repro

```js
import crypto from "node:crypto";
// Build a self-signed EC cert with a ~101 KiB SAN so the DER exceeds 100 KiB.
const der = /* ...see test... */;
const pem = `-----BEGIN CERTIFICATE-----\n${der.toString("base64").match(/.{1,64}/g).join("\n")}\n-----END CERTIFICATE-----\n`;
new crypto.X509Certificate(pem).subject;                       // ok
new crypto.X509Certificate(der).subject;                       // bun: throws, node: ok
new crypto.X509Certificate(new crypto.X509Certificate(pem).raw).subject;  // bun: throws, node: ok
```

```
error: error:0900006e:PEM routines:OPENSSL_internal:NO_START_LINE
 code: "ERR_CRYPTO_INVALID_STATE"
```

Deterministic on 1.4.0-canary and main. Node v26.3.0 parses all sizes.

## Cause

`X509Pointer::Parse` in `src/jsc/bindings/ncrypto.cpp` tries `PEM_read_bio_X509_AUX` then falls back to `d2i_X509_bio`. BoringSSL implements `d2i_X509_bio` via `IMPLEMENT_D2I_BIO` (`vendor/boringssl/crypto/x509/x_all.cc`), which calls `BIO_read_asn1(bio, &data, &len, 100 * 1024)`, hard-capping the input at 100 KiB. OpenSSL has no such cap, and the PEM path decodes base64 into memory first and then calls `d2i_X509` on that, so only the raw-DER constructor form is affected. The reported error is the leftover `NO_START_LINE` from the PEM attempt because `d2i_X509_bio` failed without pushing an error for oversized input.

Certificates above 100 KiB are uncommon but real: very large SAN lists, embedded CT data, and any code that persists `cert.raw` and re-hydrates via `new X509Certificate(raw)`.

## Fix

We already have the full buffer in memory, so decode DER with `d2i_X509(nullptr, &p, len)` directly over it instead of going through a BIO. This removes the 100 KiB ceiling and matches what the PEM path effectively already does after base64-decoding.

## Verification

`test/js/node/crypto/x509.test.ts` gains a describe block that builds a self-signed EC certificate with a configurable SAN size. On `main` the two >100 KiB cases (Buffer and offset Uint8Array) throw `ERR_CRYPTO_INVALID_STATE`; with this change all 17 tests pass. A small-DER control case and an invalid-input case confirm the existing behaviour is preserved. `test-crypto-x509.js` and `x509-subclass.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/crypto/x509.test.ts"
bun test v1.4.0 (83d3c4ee9)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [1.86ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.48ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched [0.56ms]
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched [0.30ms]
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [1.23ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match [0.37ms]
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match [0.23ms]
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match [0.23ms]
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [2.44ms]
(pass) X509Certificate.checkHost() > "agent1" falls 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e6a4e447f)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [0.04ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [0.02ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [0.04ms]
(pass) X509Certificate.checkHost() > "agent1" falls back to the subject CN and returns it [0.02ms]
(pass) X509Certificate.checkHost() > "AGENT1" falls back to the subject CN and returns it
(pass) X509Certificate.checkHost() > "AgEnT1" falls back to the subject CN a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/crypto/x509.test.ts"
bun test v1.4.0 (83d3c4ee9)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [1.93ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.80ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched [0.27ms]
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched [0.26ms]
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [1.27ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match [0.37ms]
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match [0.25ms]
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match [0.23ms]
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [2.45ms]
(pass) X509Certificate.checkHost() > "agent1" falls 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 688ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+e6a4e447f
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (e6a4e447f)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [0.04ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [0.02ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match
(pas
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ncrypto.cpp     |  9 ++--
 test/js/node/crypto/x509.test.ts | 88 +++++++++++++++++++++++++++++++++++++++-
 2 files changed, 93 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/jsc/bindings/ncrypto.cpp          4      4      0
test/js/node/crypto/x509.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->