### PR TITLE
Bun.connect: make end()/shutdown() a write-side half-close; fix timeout() docs

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5891,11 +5891,6 @@ declare module "bun" {
     end(data?: string | BufferSource, byteOffset?: number, byteLength?: number): number;
 
     /**
-     * Close the socket immediately
-     */
-    end(): void;
-
-    /**
      * Keep Bun's process alive at least until this socket is closed
      *
      * After the socket has closed, the socket is unref'd, the process may exit,
@@ -5904,11 +5899,20 @@ declare module "bun" {
     ref(): void;
 
     /**
-     * Set a timeout until the socket automatically closes.
+     * Arm an inactivity timeout that invokes the `timeout` handler after roughly
+     * `seconds` seconds of no reads or writes on this socket.
      *
-     * To reset the timeout, call this function again.
+     * This is a **notification only**: Bun does not close the socket for you. If
+     * you want the socket to close on timeout, call {@link end `end()`} or
+     * {@link terminate `terminate()`} from the `timeout` handler. If no
+     * `timeout` handler is registered the timer is a no-op.
      *
-     * When a timeout happens, the `timeout` callback is called and the socket is closed.
+     * Timeouts are coalesced into a shared sweep that runs every 4 seconds, so
+     * the requested duration is rounded **up** to the next multiple of 4 seconds
+     * (e.g. `timeout(1)` through `timeout(4)` all fire at ~4 s, `timeout(5)`
+     * at ~8 s). Pass `0` to disarm the timer.
+     *
+     * This mirrors Node's `net.Socket#setTimeout`, which is also notify-only.
      */
     timeout(seconds: number): void;
 
@@ -5925,19 +5929,20 @@ declare module "bun" {
     terminate(): void;
 
     /**
-     * Shuts down the write-half or both halves of the connection.
-     * This allows the socket to enter a half-closed state where it can still receive data
-     * but can no longer send data (`halfClose = true`), or close both read and write
-     * (`halfClose = false`, similar to `end()` but potentially more immediate depending on OS).
-     * Calls the `shutdown(2)` syscall internally.
+     * Half-closes the write side of the connection (sends a TCP FIN via
+     * `shutdown(fd, SHUT_WR)`).
      *
-     * @param halfClose If `true`, only shuts down the write side (allows receiving). If `false` or omitted, shuts down both read and write. Defaults to `false`.
+     * After `shutdown()` no more data can be written, but the socket stays open
+     * for reading: the peer's reply is still delivered to the `data` handler
+     * and the peer's FIN to the `end`/`close` handlers.
+     *
+     * This is equivalent to {@link end `end()`} without a data argument.
+     *
+     * @param halfClose Ignored. Present for backwards compatibility; every
+     *   call half-closes the write side regardless of this value.
      * @example
      * ```ts
-     * // Stop sending data, but allow receiving
-     * socket.shutdown(true);
-     *
-     * // Shutdown both reading and writing
+     * // Send FIN, keep receiving the peer's reply
      * socket.shutdown();
      * ```
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5933,8 +5933,8 @@ declare module "bun" {
      * `shutdown(fd, SHUT_WR)`).
      *
      * After `shutdown()` no more data can be written, but the socket stays open
-     * for reading: the peer's reply is still delivered to the `data` handler
-     * and the peer's FIN to the `end`/`close` handlers.
+     * for reading: the peer's reply is still delivered to the `data` handler,
+     * and the `close` handler runs once the peer closes its side.
      *
      * This is equivalent to {@link end `end()`} without a data argument.
      *
@@ -6237,14 +6237,14 @@ declare module "bun" {
     readonly bytesWritten: number;
 
     /**
-     * Alias for `socket.end()`. Allows the socket to be used with `using` declarations
-     * for automatic resource management.
+     * Alias for {@link close `socket.close()`}. Allows the socket to be used with
+     * `using` declarations for automatic resource management.
      * @example
      * ```ts
      * async function processSocket() {
      *   using socket = await Bun.connect({ ... });
      *   socket.write("Data");
-     *   // socket.end() is called automatically when exiting the scope
+     *   // socket.close() is called automatically when exiting the scope
      * }
      * ```
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5903,14 +5903,13 @@ declare module "bun" {
      * `seconds` seconds of no reads or writes on this socket.
      *
      * This is a **notification only**: Bun does not close the socket for you. If
-     * you want the socket to close on timeout, call {@link end `end()`} or
+     * you want the socket to close on timeout, call {@link close `close()`} or
      * {@link terminate `terminate()`} from the `timeout` handler. If no
      * `timeout` handler is registered the timer is a no-op.
      *
      * Timeouts are coalesced into a shared sweep that runs every 4 seconds, so
-     * the requested duration is rounded **up** to the next multiple of 4 seconds
-     * (e.g. `timeout(1)` through `timeout(4)` all fire at ~4 s, `timeout(5)`
-     * at ~8 s). Pass `0` to disarm the timer.
+     * the delivered duration is the requested value give or take 4 seconds.
+     * Pass `0` to disarm the timer.
      *
      * This mirrors Node's `net.Socket#setTimeout`, which is also notify-only.
      */
@@ -6295,12 +6294,10 @@ declare module "bun" {
     upgradeTLS<Data>(options: TLSUpgradeOptions<Data>): [raw: Socket<Data>, tls: Socket<Data>];
 
     /**
-     * Closes the socket.
+     * Closes the socket immediately in both directions.
      *
-     * This is a wrapper around `end()` and `shutdown()`.
-     *
-     * @see {@link end}
-     * @see {@link shutdown}
+     * For a graceful write-side half-close that keeps the read side open,
+     * use {@link end `end()`} or {@link shutdown `shutdown()`} instead.
      */
     close(): void;
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1167,7 +1167,7 @@ function onconnection(err, clientHandle) {
         remotePort: _socket.remotePort,
         remoteFamily: _socket.remoteFamily || "IPv4",
       };
-      clientHandle.end();
+      clientHandle.close();
       self.emit("drop", data);
       return;
     }
@@ -1182,7 +1182,7 @@ function onconnection(err, clientHandle) {
       remoteFamily: _socket.remoteFamily || "IPv4",
     };
 
-    clientHandle.end();
+    clientHandle.close();
     self.emit("drop", data);
     return;
   }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2981,7 +2981,14 @@ impl<const SSL: bool> NewSocket<SSL> {
         self.socket.get().flush();
 
         if self.can_end_after_flush() {
-            self.mark_inactive();
+            // `end()` is a write-side half-close: flush, then SHUT_WR. The
+            // socket stays readable; when the peer's FIN arrives uSockets sees
+            // eof on an already-shut-down socket and closes it cleanly
+            // (loop.c), so `on_close` → `mark_inactive()` runs the teardown
+            // that used to run here. Clear the flag so a later `flush()`
+            // cannot re-enter this arm.
+            self.update_flags(|f| f.remove(Flags::END_AFTER_FLUSH));
+            self.socket.get().shutdown();
         }
         0
     }
@@ -2989,14 +2996,8 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[bun_jsc::host_fn(method)]
     pub fn flush(this: &Self, _global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        // `end()` → `internalFlush` → `markInactive` → `closeAndDetach(.normal)`
-        // detaches `this.socket` and, for TLS, defers the raw close until the
-        // peer's close_notify arrives — leaving `is_active` set so the eventual
-        // `onClose` can run `handlers.markInactive()`. Without this guard a
-        // follow-up `flush()` re-enters `markInactive`, sees the detached
-        // socket as closed, and decrements `active_connections` a second time;
-        // the deferred `onClose` then underflows it. Every other
-        // `internalFlush` caller already has this check.
+        // Every other `internal_flush` caller already has this check; a detached
+        // socket has nothing to flush and its SocketHandler is the null sentinel.
         if this.socket.get().is_detached() {
             return Ok(JSValue::UNDEFINED);
         }
@@ -3038,16 +3039,15 @@ impl<const SSL: bool> NewSocket<SSL> {
     pub fn shutdown(
         this: &Self,
         _global: &JSGlobalObject,
-        callframe: &CallFrame,
+        _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        let [arg] = callframe.arguments_as_array::<1>();
-        if callframe.arguments_count() > 0 && arg.to_boolean() {
-            this.socket.get().shutdown_read();
-        } else {
-            this.socket.get().shutdown();
-        }
-
+        // The legacy `halfClose` boolean is accepted and ignored: every form is
+        // a write-side half-close (SHUT_WR). SHUT_RD has no safe user-facing
+        // use (the peer cannot observe it, and uSockets fabricates a local
+        // `end`), and node:net's `_final` already depends on the no-arg form
+        // being SHUT_WR.
+        this.socket.get().shutdown();
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2981,12 +2981,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         self.socket.get().flush();
 
         if self.can_end_after_flush() {
-            // `end()` is a write-side half-close: flush, then SHUT_WR. The
-            // socket stays readable; when the peer's FIN arrives uSockets sees
-            // eof on an already-shut-down socket and closes it cleanly
-            // (loop.c), so `on_close` → `mark_inactive()` runs the teardown
-            // that used to run here. Clear the flag so a later `flush()`
-            // cannot re-enter this arm.
+            // end() = flush + SHUT_WR; teardown runs via on_close once the peer FINs.
             self.update_flags(|f| f.remove(Flags::END_AFTER_FLUSH));
             self.socket.get().shutdown();
         }
@@ -2996,8 +2991,6 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[bun_jsc::host_fn(method)]
     pub fn flush(this: &Self, _global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        // Every other `internal_flush` caller already has this check; a detached
-        // socket has nothing to flush and its SocketHandler is the null sentinel.
         if this.socket.get().is_detached() {
             return Ok(JSValue::UNDEFINED);
         }
@@ -3042,11 +3035,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        // The legacy `halfClose` boolean is accepted and ignored: every form is
-        // a write-side half-close (SHUT_WR). SHUT_RD has no safe user-facing
-        // use (the peer cannot observe it, and uSockets fabricates a local
-        // `end`), and node:net's `_final` already depends on the no-arg form
-        // being SHUT_WR.
+        // `halfClose` is accepted and ignored; every form is SHUT_WR.
         this.socket.get().shutdown();
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/socket/sockets.classes.ts
+++ b/src/runtime/socket/sockets.classes.ts
@@ -162,7 +162,7 @@ function generate(ssl) {
       },
 
       "@@dispose": {
-        fn: "end",
+        fn: "close",
         length: 0,
       },
 

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3330,3 +3330,73 @@ describe("TLS handshake callback throw", () => {
     }
   });
 });
+
+// end(), shutdown(), shutdown(false) and shutdown(true) all half-close the
+// write side (SHUT_WR / TCP FIN) and leave the socket readable. Prior behavior
+// mapped end() to close(2) and shutdown(true) to SHUT_RD, so a peer's reply
+// after the half-close was lost. Pin the observable contract: the client can
+// still receive the server's full reply after each call.
+describe("Socket.end() / Socket.shutdown() are a write-side half-close", () => {
+  // Small enough to fit in one non-blocking send() on every target's loopback
+  // buffer so the server's write-on-end never needs a drain cycle.
+  const PAYLOAD = Buffer.alloc(16 * 1024, 0x61);
+
+  type Call = "end()" | "shutdown()" | "shutdown(false)" | "shutdown(true)";
+
+  async function halfClose(call: Call) {
+    let received = 0;
+    let writeAfter = 0;
+    let readyState: number | undefined;
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      allowHalfOpen: true,
+      socket: {
+        data() {},
+        // Client's FIN arrived: reply, then half-close back.
+        end(socket) {
+          socket.write(PAYLOAD);
+          socket.end();
+        },
+        close() {},
+      },
+    });
+
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        open(socket) {
+          socket.write("hi");
+          if (call === "end()") socket.end();
+          else if (call === "shutdown()") socket.shutdown();
+          else if (call === "shutdown(false)") socket.shutdown(false);
+          else socket.shutdown(true);
+          readyState = socket.readyState;
+          writeAfter = socket.write("x");
+        },
+        data(_socket, chunk) {
+          received += chunk.length;
+        },
+        end() {},
+        close() {
+          resolve();
+        },
+      },
+    });
+
+    await promise;
+    return { received, writeAfter, readyState };
+  }
+
+  for (const call of ["end()", "shutdown()", "shutdown(false)", "shutdown(true)"] as const) {
+    it.concurrent(`${call} sends FIN and keeps the read side open`, async () => {
+      // readyState 1: socket is still established (not detached).
+      // writeAfter -1: further writes on the half-closed side are rejected.
+      // received: the full reply made it through the still-open read side.
+      expect(await halfClose(call)).toEqual({ received: PAYLOAD.length, writeAfter: -1, readyState: 1 });
+    });
+  }
+});

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3341,7 +3341,7 @@ describe("Socket.end() / Socket.shutdown() are a write-side half-close", () => {
   // buffer so the server's write-on-end never needs a drain cycle.
   const PAYLOAD = Buffer.alloc(16 * 1024, 0x61);
 
-  type Call = "end()" | "shutdown()" | "shutdown(false)" | "shutdown(true)";
+  type Call = "end()" | "end(data)" | "shutdown()" | "shutdown(false)" | "shutdown(true)";
 
   async function halfClose(call: Call) {
     let received = 0;
@@ -3369,11 +3369,14 @@ describe("Socket.end() / Socket.shutdown() are a write-side half-close", () => {
       port: server.port,
       socket: {
         open(socket) {
-          socket.write("hi");
-          if (call === "end()") socket.end();
-          else if (call === "shutdown()") socket.shutdown();
-          else if (call === "shutdown(false)") socket.shutdown(false);
-          else socket.shutdown(true);
+          if (call === "end(data)") socket.end("hi");
+          else {
+            socket.write("hi");
+            if (call === "end()") socket.end();
+            else if (call === "shutdown()") socket.shutdown();
+            else if (call === "shutdown(false)") socket.shutdown(false);
+            else socket.shutdown(true);
+          }
           readyState = socket.readyState;
           writeAfter = socket.write("x");
         },
@@ -3391,7 +3394,7 @@ describe("Socket.end() / Socket.shutdown() are a write-side half-close", () => {
     return { received, writeAfter, readyState };
   }
 
-  for (const call of ["end()", "shutdown()", "shutdown(false)", "shutdown(true)"] as const) {
+  for (const call of ["end()", "end(data)", "shutdown()", "shutdown(false)", "shutdown(true)"] as const) {
     it.concurrent(`${call} sends FIN and keeps the read side open`, async () => {
       // readyState 1: socket is still established (not detached).
       // writeAfter -1: further writes on the half-closed side are rejected.


### PR DESCRIPTION
## What

`Socket.end()` and `Socket.shutdown()` on `Bun.connect`/`Bun.listen` sockets did not match their documented contract:

| Call | Documented | Actual (before) | Actual (after) |
| --- | --- | --- | --- |
| `end()` | SHUT_WR, stay readable | `close(2)`, nothing received | SHUT_WR, stay readable |
| `shutdown()` | SHUT_RDWR | `shutdown(SHUT_WR)` | `shutdown(SHUT_WR)` |
| `shutdown(false)` | SHUT_RDWR | `shutdown(SHUT_WR)` | `shutdown(SHUT_WR)` |
| `shutdown(true)` | SHUT_WR, stay readable | `shutdown(SHUT_RD)`, nothing received | `shutdown(SHUT_WR)` |

So an app that follows the docs for a request-then-read-reply protocol loses the peer's entire reply with `end()` or `shutdown(true)`.

## Cause

- `Socket.prototype.shutdown` mapped `arg.to_boolean()` to `shutdown_read()` (`SHUT_RD`) vs `shutdown()` (`SHUT_WR`) (`socket_body.rs`).
- `Socket.prototype.end` set `END_AFTER_FLUSH`, and `internal_flush()` turned that into `mark_inactive()` which calls `close_and_detach(Normal)` (`close(2)`), not a half-close.

## Fix

- `shutdown()` ignores its argument and always issues `SHUT_WR`. `SHUT_RD` has no safe user-facing use (the peer cannot observe it and uSockets fabricates a local `end`).
- `internal_flush()` replaces `mark_inactive()` with `socket.shutdown()` for the end-after-flush arm. The socket stays readable; when the peer's FIN arrives uSockets' existing `eof && is_shut_down` branch in `loop.c` closes it and `on_close` runs the same teardown that used to run here.
- `node:net`'s `_final` already called `shutdown()` directly, so its half-close behavior is unchanged. The server `onconnection` drop path (`blockList` / `maxConnections`) switches from `clientHandle.end()` to `clientHandle.close()` since it wants an immediate close, matching Node's `clientHandle.close()`.
- `bun.d.ts`: rewrite the `shutdown()` and `timeout()` JSDoc to describe the actual behavior; delete the self-contradictory `end(): void` "Close the socket immediately" overload. `timeout()` is notify-only (the handler must close the socket itself) and rounds up to the 4-second `LIBUS_TIMEOUT_GRANULARITY` sweep.

## Verification

Fail-before (released bun):

```
(fail) end() sends FIN and keeps the read side open      { received: 0,     readyState: -1, writeAfter: -1 }
(fail) shutdown(true) sends FIN and keeps the read side  { received: 0,     readyState:  1, writeAfter:  1 }
(pass) shutdown() sends FIN and keeps the read side open
(pass) shutdown(false) sends FIN and keeps the read side open
```

Pass-after (`bun bd test`):

```
(pass) end() sends FIN and keeps the read side open
(pass) shutdown() sends FIN and keeps the read side open
(pass) shutdown(false) sends FIN and keeps the read side open
(pass) shutdown(true) sends FIN and keeps the read side open
```

`test/js/bun/net/`, `test/js/node/net/`, `test/js/node/tls/`, `test/js/node/http/`, `test/js/node/http2/` all match `main` (pre-existing local failures only). `test-net-server-drop-connections.js`, `test-net-server-max-connections.js`, `test-net-server-blocklist.js`, `test-net-server-max-connections-close-makes-more-available.js` pass. bun-types integration test passes.

Supersedes #35932 (docs-only approach).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->