### PR TITLE
crypto: return empty string for present-but-empty X509 subjectAltName

### DIFF
--- a/src/jsc/bindings/JSX509Certificate.cpp
+++ b/src/jsc/bindings/JSX509Certificate.cpp
@@ -46,9 +46,6 @@ WTF::String toWTFString(ncrypto::BIOPointer& bio)
 {
     BUF_MEM* bptr;
     BIO_get_mem_ptr(bio.get(), &bptr);
-    // A mem BIO that was never written to has bptr->data == nullptr. Constructing
-    // an ExternalStringImpl over {nullptr, 0} trips the m_data8 assertion in
-    // debug/ASAN builds, so return the empty singleton instead.
     if (bptr->length == 0) {
         return emptyString();
     }
@@ -1157,9 +1154,6 @@ JSString* JSX509Certificate::computeSubjectAltName(ncrypto::X509View view, JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Node returns undefined when the extension is absent and "" when it is
-    // present but prints nothing (e.g. an empty GeneralNames sequence), so
-    // signal absence with nullptr and leave the empty string to the caller.
     auto bio = view.getSubjectAltName();
     if (!bio) {
         return nullptr;

--- a/src/jsc/bindings/JSX509Certificate.cpp
+++ b/src/jsc/bindings/JSX509Certificate.cpp
@@ -46,6 +46,12 @@ WTF::String toWTFString(ncrypto::BIOPointer& bio)
 {
     BUF_MEM* bptr;
     BIO_get_mem_ptr(bio.get(), &bptr);
+    // A mem BIO that was never written to has bptr->data == nullptr. Constructing
+    // an ExternalStringImpl over {nullptr, 0} trips the m_data8 assertion in
+    // debug/ASAN builds, so return the empty singleton instead.
+    if (bptr->length == 0) {
+        return emptyString();
+    }
     std::span<const char> span(bptr->data, bptr->length);
     if (simdutf::validate_ascii(span.data(), span.size())) {
         return toExternalStringImpl(bio, span);
@@ -753,7 +759,10 @@ JSC::JSObject* JSX509Certificate::toLegacyObject(ncrypto::X509View view, JSGloba
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     // Set subjectaltname
-    object->putDirect(vm, Identifier::fromString(vm, "subjectaltname"_s), valueOrUndefined(computeSubjectAltName(view, globalObject)));
+    {
+        JSString* san = computeSubjectAltName(view, globalObject);
+        object->putDirect(vm, Identifier::fromString(vm, "subjectaltname"_s), san ? JSValue(san) : jsUndefined());
+    }
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     // Set infoAccess
@@ -927,7 +936,10 @@ JSC::JSObject* JSX509Certificate::toLegacyObject(JSGlobalObject* globalObject)
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     // Set subjectaltname
-    object->putDirect(vm, Identifier::fromString(vm, "subjectaltname"_s), valueOrUndefined(subjectAltName()));
+    {
+        JSString* san = subjectAltName();
+        object->putDirect(vm, Identifier::fromString(vm, "subjectaltname"_s), san ? JSValue(san) : jsUndefined());
+    }
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     // Set infoAccess
@@ -1145,9 +1157,12 @@ JSString* JSX509Certificate::computeSubjectAltName(ncrypto::X509View view, JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Node returns undefined when the extension is absent and "" when it is
+    // present but prints nothing (e.g. an empty GeneralNames sequence), so
+    // signal absence with nullptr and leave the empty string to the caller.
     auto bio = view.getSubjectAltName();
     if (!bio) {
-        return jsEmptyString(vm);
+        return nullptr;
     }
 
     return jsString(vm, toWTFString(bio));

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -587,7 +587,8 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_subjectAltName, (JSGlobalObject
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(undefinedIfEmpty(thisObject->subjectAltName())));
+    JSString* san = thisObject->subjectAltName();
+    return JSValue::encode(san ? JSValue(san) : jsUndefined());
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_infoAccess, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -588,7 +588,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_subjectAltName, (JSGlobalObject
     }
 
     JSString* san = thisObject->subjectAltName();
-    return JSValue::encode(san ? JSValue(san) : jsUndefined());
+    RELEASE_AND_RETURN(scope, JSValue::encode(san ? JSValue(san) : jsUndefined()));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_infoAccess, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -29,6 +29,19 @@ xoF/4xgOUMNvA8O5H/sm5QwghflFqkpuvqdeYHLNzb0yWUvPvtTfYiA7+vo=
 // CN=agent1, no subjectAltName, so the subject is the only thing to match against.
 const cnOnlyCertPem = readFileSync(path.join(import.meta.dir, "..", "test", "fixtures", "keys", "agent1-cert.pem"));
 
+// Self-signed, CN=emptysan.test. The subjectAltName extension is present but holds an empty
+// GeneralNames SEQUENCE, so the extension prints as the empty string.
+const emptySanCertPem = `-----BEGIN CERTIFICATE-----
+MIIBLDCB0qADAgECAgEJMAoGCCqGSM49BAMCMBgxFjAUBgNVBAMMDWVtcHR5c2Fu
+LnRlc3QwHhcNMjQwMTAxMDAwMDAwWhcNMzQwMTAxMDAwMDAwWjAYMRYwFAYDVQQD
+DA1lbXB0eXNhbi50ZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERZd4TI3L
+9hB6mAqrzlK/lZtnTN1HQRh8noNVV9rHms6RFBhYp/mSU2JrMPIEGB8DP4YEnoin
+Og/IJjctZ/WG6qMNMAswCQYDVR0RBAIwADAKBggqhkjOPQQDAgNJADBGAiEAlvDe
+VqtVe0NtY8U5uwa7lqNLtkqjXClGQl4fgCV4KloCIQCwni1CVvWLJa0cZm3BQtwH
+lGNHf1nq+j8dNaMGmheHKQ==
+-----END CERTIFICATE-----
+`;
+
 describe("X509Certificate.checkHost()", () => {
   const cert = new X509Certificate(wildcardSanCertPem);
   const cnOnly = new X509Certificate(cnOnlyCertPem);
@@ -70,5 +83,27 @@ describe("X509Certificate.checkHost()", () => {
     expect(cnOnly.checkEmail("ry@TINYCLOUDS.ORG")).toBe("ry@TINYCLOUDS.ORG");
     expect(cnOnly.checkEmail("sally@example.com")).toBeUndefined();
     expect(cnOnly.checkIP("127.0.0.1")).toBeUndefined();
+  });
+});
+
+describe("X509Certificate.subjectAltName", () => {
+  test("is the printed extension when present", () => {
+    const cert = new X509Certificate(wildcardSanCertPem);
+    expect(cert.subjectAltName).toBe("DNS:*.wildcard.example.com, DNS:exact.example.com");
+  });
+
+  test("is undefined when the extension is absent", () => {
+    const cert = new X509Certificate(cnOnlyCertPem);
+    expect(cert.subjectAltName).toBeUndefined();
+    expect(cert.toLegacyObject().subjectaltname).toBeUndefined();
+  });
+
+  // A present-but-empty SAN prints nothing into the mem BIO. Previously that nullptr/0
+  // span was fed to ExternalStringImpl::create, which aborts the ASAN build with
+  // "ASSERTION FAILED: m_data8" and made release builds return undefined instead of "".
+  test("is the empty string when the extension holds an empty GeneralNames sequence", () => {
+    const cert = new X509Certificate(emptySanCertPem);
+    expect(cert.subjectAltName).toBe("");
+    expect(cert.toLegacyObject().subjectaltname).toBe("");
   });
 });

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -98,9 +98,6 @@ describe("X509Certificate.subjectAltName", () => {
     expect(cert.toLegacyObject().subjectaltname).toBeUndefined();
   });
 
-  // A present-but-empty SAN prints nothing into the mem BIO. Previously that nullptr/0
-  // span was fed to ExternalStringImpl::create, which aborts the ASAN build with
-  // "ASSERTION FAILED: m_data8" and made release builds return undefined instead of "".
   test("is the empty string when the extension holds an empty GeneralNames sequence", () => {
     const cert = new X509Certificate(emptySanCertPem);
     expect(cert.subjectAltName).toBe("");


### PR DESCRIPTION
## Problem

Reading `X509Certificate.subjectAltName` on a certificate whose SAN extension holds an **empty** `GeneralNames` sequence aborts the debug/ASAN build:

```
ASSERTION FAILED: m_data8
vendor/WebKit/Source/WTF/wtf/text/StringImpl.h(1020) : WTF::StringImpl::StringImpl(std::span<const Latin1Character>, ConstructWithoutCopyingTag)
```

Release builds survive but return `undefined`; Node returns `""` and distinguishes that from an absent extension. The same value surfaces through `toLegacyObject().subjectaltname` and `getPeerX509Certificate()` on a live TLS connection.

## Cause

`X509View::getSubjectAltName()` returns a valid mem BIO for a present-but-empty SAN, but nothing is written to it so its `BUF_MEM` has `data == nullptr, length == 0`. `toWTFString` unconditionally builds an `ExternalStringImpl` over that span, which hits WTF's non-null `m_data8` assertion. In release the zero-length string was then collapsed to `undefined` by `undefinedIfEmpty`, so the absent vs present-but-empty distinction Node makes was lost.

## Fix

- `toWTFString` returns `emptyString()` when the BIO length is zero, before constructing the external string. This also protects `computeInfoAccess`, which shares the helper.
- `computeSubjectAltName` returns `nullptr` when the extension is absent (previously an empty string), and the `subjectAltName` getter plus both `toLegacyObject` overloads map only `nullptr` to `undefined`, so a present-but-empty SAN now yields `""` like Node.

## Not changed

`checkHost` with `subject: 'default'` still does not fall back to the CN when the SAN is present but empty. BoringSSL's `X509_check_host` never consults the subject once a SAN extension exists (and defines `X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT` as `0`), whereas OpenSSL falls back when no SAN entry of the requested type was seen. Matching OpenSSL here would require reimplementing the CN fallback; it is left out of this fix.

## Verification

```
$ bun bd test test/js/node/crypto/x509.test.ts
 17 pass, 0 fail
$ bun bd test/js/node/test/parallel/test-crypto-x509.js
(exit 0)
```

Without the `src/` change the new test aborts with `ASSERTION FAILED: m_data8` under `bun bd`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/crypto/x509.test.ts"
bun test v1.4.0 (d2628e64d)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [1.56ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.47ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched [0.27ms]
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched [0.25ms]
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [1.41ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match [0.37ms]
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match [0.23ms]
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match [0.23ms]
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [2.30ms]
(pass) X509Certificate.checkHost() > "agent1" falls 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (4bbc551da)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [0.04ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [0.02ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [0.03ms]
(pass) X509Certificate.checkHost() > "agent1" falls back to the subject CN and returns it [0.02ms]
(pass) X509Certificate.checkHost() > "AGENT1" falls back to the subject CN and returns it
(pass) X509Certificate.checkHost() > "AgEnT1" falls back to the subject CN a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/crypto/x509.test.ts"
bun test v1.4.0 (d2628e64d)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [1.69ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.55ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched [0.28ms]
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched [0.32ms]
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [1.53ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match [0.43ms]
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match [0.24ms]
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match [0.29ms]
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [2.51ms]
(pass) X509Certificate.checkHost() > "agent1" falls 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 702ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSX509Certificate.cpp          | 15 +++++++++---
 src/jsc/bindings/JSX509CertificatePrototype.cpp |  3 ++-
 test/js/node/crypto/x509.test.ts                | 32 +++++++++++++++++++++++++
 3 files changed, 46 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/jsc/bindings/JSX509Certificate.cpp               8      7      0
src/jsc/bindings/JSX509CertificatePrototype.cpp      4      2      0
test/js/node/crypto/x509.test.ts                     2      3      0
```

</details>

<!-- robobun:evidence:end -->