### PR TITLE
Bun.write: keep stdio writes in call order when stdout/stderr is a regular file

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5047,12 +5047,13 @@ pub fn write_file_internal(
     #[cfg(not(windows))]
     {
         let mut needs_async = false;
+        // The fast path writes synchronously on the JS thread. Routing an fd through the thread
+        // pool instead would drain the pool's LIFO run queue out of submission order, so fd
+        // destinations always stay on this path; the blocking-pipe case falls through to the
+        // async path via `needs_async` on EAGAIN.
         let fast_path_ok = matches!(*path_or_blob, PathOrBlob::Path(_))
-            || (matches!(*path_or_blob, PathOrBlob::Blob(ref b)
-                if b.offset.get() == 0 && !b.is_s3()
-                    && !(b.store.get().is_some()
-                        && matches!(b.store().expect("infallible: store present").data, store::Data::File(ref f)
-                            if f.mode != 0 && bun_core::kind_from_mode(f.mode) == bun_core::FileKind::File))));
+            || matches!(*path_or_blob, PathOrBlob::Blob(ref b)
+                if b.offset.get() == 0 && !b.is_s3());
         if fast_path_ok {
             if data.is_string() {
                 let len = data.get_length(global_this)?;

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -727,4 +727,54 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
 
     expect(f.name).toBe(filePath);
   });
+
+  // On Windows all Bun.write() goes through uv_fs_write on the libuv thread pool, which has its
+  // own (different) reordering behaviour; this covers the POSIX synchronous fast path.
+  describe.skipIf(isWindows).each(["stdout", "stderr"])("Bun.write(Bun.%s, ...) ordering", stream => {
+    const otherStream = stream === "stdout" ? "stderr" : "stdout";
+    const script = `
+      const p = [];
+      for (let i = 0; i < 5; i++) p.push(Bun.write(Bun.${stream}, "C" + i + "\\n"));
+      const pending = p.filter(x => Bun.peek.status(x) === "pending").length;
+      await Promise.all(p);
+      process.${otherStream}.write("pending=" + pending + "\\n");
+    `;
+
+    it("writes in call order when redirected to a file", async () => {
+      using dir = tempDir("bun-write-stdio-order-file", {});
+      const outPath = join(String(dir), "out.txt");
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: stream === "stdout" ? Bun.file(outPath) : "pipe",
+        stderr: stream === "stderr" ? Bun.file(outPath) : "pipe",
+      });
+      const other = stream === "stdout" ? proc.stderr : proc.stdout;
+      const [otherText, exitCode] = await Promise.all([other.text(), proc.exited]);
+      // Small writes to a regular-file stdio fd take the same synchronous path as pipes, so they
+      // land in call order and their promises are already settled when Bun.write() returns.
+      // Previously they were dispatched to the thread pool, whose LIFO run queue reversed them.
+      expect({ output: await Bun.file(outPath).text(), status: otherText }).toEqual({
+        output: "C0\nC1\nC2\nC3\nC4\n",
+        status: "pending=0\n",
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    it("writes in call order when redirected to a pipe", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [target, other] = stream === "stdout" ? [stdout, stderr] : [stderr, stdout];
+      expect({ output: target, status: other }).toEqual({
+        output: "C0\nC1\nC2\nC3\nC4\n",
+        status: "pending=0\n",
+      });
+      expect(exitCode).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
### What's wrong

Un-awaited `Bun.write(Bun.stdout, ...)` calls land out of order when fd 1 is a regular file:

```js
// bun r.mjs > out.txt && cat out.txt  ->  C0 C4 C3 C2 C1
// bun r.mjs | cat                     ->  C0 C1 C2 C3 C4
for (let i = 0; i < 5; i++) Bun.write(Bun.stdout, "C" + i + "\n");
```

Mixed with `console.log`, all console lines come out first and the `Bun.write` batch after them, reversed. `await`-ing each write or using `Bun.stdout.writer()` stays in order; only the fire-and-forget queue on a file destination drains as a stack. Log/report writers that fire-and-forget to a redirected stdout produce a correctly-sized but reordered file with exit 0.

### Cause

`write_file_internal`'s synchronous fast path is gated on the destination blob's `mode`. The condition (added in #7470) excludes fd-backed blobs whose fstat mode is `S_IFREG`, which is exactly what `Bun.stdout` / `Bun.stderr` become under `> out.txt`. Those writes are instead wrapped in a `WriteFileTask` and scheduled onto the `WorkPool`, whose global `run_queue` is a Treiber stack: the first write is picked up immediately by a worker, the remaining four pile onto the stack while that worker is in `write()`, and the worker then drains them LIFO. Hence `C0 C4 C3 C2 C1`.

The guard is inverted relative to its own comment, which says it is meant to keep *pipes* off the main thread. Pipes, ttys and unknown-mode fds have always taken the synchronous path (and so have always been ordered); only regular-file fds were routed to the thread pool.

### Fix

Drop the `mode` exclusion so every non-S3 fd blob at offset 0 takes `write_{string,bytes}_to_file_fast`, the same synchronous path pipes and ttys already use. Small writes to a redirected stdout/stderr now complete on the JS thread in call order, with an already-settled promise, matching the pipe case. A pipe that would block still falls through to the async path via `needs_async` on `EAGAIN`, which is the existing behaviour.

### Verification

New tests in `test/js/bun/io/bun-write.test.js` spawn a child that issues five `Bun.write(Bun.{stdout,stderr}, ...)` calls with the stream redirected to a file and to a pipe, and assert both that the output is `C0..C4` and that none of the returned promises were still pending when `Bun.write()` returned. Against `main`'s `src/` the file cases fail with `pending=5` and reversed output; with this change all four pass.

Windows is skipped: `Bun.write()` there always goes through `uv_fs_write` on the libuv thread pool, which can also race writes to a file-backed stdio fd, but via a different mechanism (worker concurrency rather than a LIFO stack) that the POSIX fast path does not touch.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->