### PR TITLE
Bun.write: poll instead of spin when a nonblocking stdout pipe returns EAGAIN

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5321,8 +5321,19 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
                 bun_sys::Result::Err(err) => {
                     truncate.set(false);
                     if err.get_errno() == bun_sys::E::EAGAIN {
-                        *needs_async = true;
-                        return JSValue::ZERO;
+                        if written.get() == 0 {
+                            *needs_async = true;
+                            return JSValue::ZERO;
+                        }
+                        // The async path re-sends the whole input, so after a partial
+                        // write finish synchronously via poll(POLLOUT).
+                        let mut pfd = [bun_sys::posix::PollFd {
+                            fd: fd.native(),
+                            events: bun_sys::posix::POLL_OUT,
+                            revents: 0,
+                        }];
+                        let _ = bun_sys::posix::poll(&mut pfd, -1);
+                        continue;
                     }
                     let err_js = if !NEEDS_OPEN {
                         err.to_js(global_this)
@@ -5396,8 +5407,17 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
             bun_sys::Result::Err(err) => {
                 #[cfg(not(windows))]
                 if err.get_errno() == bun_sys::E::EAGAIN {
-                    *_needs_async = true;
-                    return JSValue::ZERO;
+                    if written == 0 {
+                        *_needs_async = true;
+                        return JSValue::ZERO;
+                    }
+                    let mut pfd = [bun_sys::posix::PollFd {
+                        fd: fd.native(),
+                        events: bun_sys::posix::POLL_OUT,
+                        revents: 0,
+                    }];
+                    let _ = bun_sys::posix::poll(&mut pfd, -1);
+                    continue;
                 }
                 let err_js = if !NEEDS_OPEN {
                     err.to_js(global_this)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4427,11 +4427,14 @@ fn write_file_with_empty_source_to_destination(
     ))
 }
 
+/// `already_written` is the byte count the synchronous fast path committed to
+/// the destination before it fell back; the bytes source resumes after it.
 pub(crate) fn write_file_with_source_destination(
     ctx: &JSGlobalObject,
     source_blob: &mut Blob,
     destination_blob: &mut Blob,
     options: &WriteFileOptions,
+    already_written: usize,
 ) -> JsResult<JSValue> {
     let destination_store = destination_blob
         .store
@@ -4461,6 +4464,8 @@ pub(crate) fn write_file_with_source_destination(
         // `WriteFile::create` takes its own ref.
         #[cfg(windows)]
         {
+            // Windows has no synchronous fast path, so nothing was written yet.
+            debug_assert_eq!(already_written, 0);
             let promise = JSPromise::create(ctx);
             let promise_value = promise.as_value(ctx);
             promise_value.ensure_still_alive();
@@ -4483,7 +4488,7 @@ pub(crate) fn write_file_with_source_destination(
 
         #[cfg(not(windows))]
         {
-            let file_copier = write_file_mod::WriteFile::create(
+            let mut file_copier = write_file_mod::WriteFile::create(
                 destination_blob.borrowed_view(),
                 source_blob.borrowed_view(),
                 write_file_promise,
@@ -4491,6 +4496,7 @@ pub(crate) fn write_file_with_source_destination(
                 options.mkdirp_if_not_exists.unwrap_or(true),
             )
             .expect("unreachable");
+            file_copier.total_written = already_written;
             // Defer promise creation until we're just about to schedule the task.
             // SAFETY: write_file_promise was just produced by heap::alloc above; sole owner.
             unsafe { (*write_file_promise).promise = jsc::JSPromiseStrong::init(ctx) };
@@ -4781,9 +4787,15 @@ pub(crate) fn write_file_internal(
     // This is a heuristic, but it's a good one.
     //
     // except if you're on Windows. Windows I/O is slower. Let's not even try.
+    //
+    // When the fast path hits EAGAIN after a partial write it hands off to the
+    // async `WriteFile`, which resumes at `already_written` instead of
+    // re-sending the prefix.
+    #[cfg(windows)]
+    let already_written: usize = 0;
     #[cfg(not(windows))]
-    {
-        let mut needs_async = false;
+    let already_written: usize = {
+        let mut resume_async_at: Option<usize> = None;
         let fast_path_ok = matches!(*path_or_blob, PathOrBlob::Path(_))
             || (matches!(*path_or_blob, PathOrBlob::Blob(ref b)
                 if b.offset.get() == 0 && !b.is_s3()
@@ -4810,17 +4822,17 @@ pub(crate) fn write_file_internal(
                             global_this,
                             pathlike,
                             &str,
-                            &mut needs_async,
+                            &mut resume_async_at,
                         )
                     } else {
                         write_string_to_file_fast::<false>(
                             global_this,
                             pathlike,
                             &str,
-                            &mut needs_async,
+                            &mut resume_async_at,
                         )
                     };
-                    if !needs_async {
+                    if resume_async_at.is_none() {
                         return Ok(result);
                     }
                 }
@@ -4841,23 +4853,24 @@ pub(crate) fn write_file_internal(
                             global_this,
                             pathlike,
                             buffer_view.byte_slice(),
-                            &mut needs_async,
+                            &mut resume_async_at,
                         )
                     } else {
                         write_bytes_to_file_fast::<false>(
                             global_this,
                             pathlike,
                             buffer_view.byte_slice(),
-                            &mut needs_async,
+                            &mut resume_async_at,
                         )
                     };
-                    if !needs_async {
+                    if resume_async_at.is_none() {
                         return Ok(result);
                     }
                 }
             }
         }
-    }
+        resume_async_at.unwrap_or(0)
+    };
 
     // if path_or_blob is a path, convert it into a file blob
     let mut destination_blob: Blob = match path_or_blob {
@@ -5134,6 +5147,7 @@ pub(crate) fn write_file_internal(
         &mut *source_blob,
         &mut destination_blob,
         &options,
+        already_written,
     )
 }
 
@@ -5262,7 +5276,7 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
     global_this: &JSGlobalObject,
     pathlike: &PathOrFileDescriptor,
     str: &BunString,
-    needs_async: &mut bool,
+    resume_async_at: &mut Option<usize>,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
         pathlike.fd()
@@ -5278,7 +5292,7 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
             bun_sys::Result::Ok(result) => result,
             bun_sys::Result::Err(err) => {
                 if err.get_errno() == bun_sys::E::ENOENT {
-                    *needs_async = true;
+                    *resume_async_at = Some(0);
                     return JSValue::ZERO;
                 }
                 return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
@@ -5321,19 +5335,8 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
                 bun_sys::Result::Err(err) => {
                     truncate.set(false);
                     if err.get_errno() == bun_sys::E::EAGAIN {
-                        if written.get() == 0 {
-                            *needs_async = true;
-                            return JSValue::ZERO;
-                        }
-                        // The async path re-sends the whole input, so after a partial
-                        // write finish synchronously via poll(POLLOUT).
-                        let mut pfd = [bun_sys::posix::PollFd {
-                            fd: fd.native(),
-                            events: bun_sys::posix::POLL_OUT,
-                            revents: 0,
-                        }];
-                        let _ = bun_sys::posix::poll(&mut pfd, -1);
-                        continue;
+                        *resume_async_at = Some(written.get());
+                        return JSValue::ZERO;
                     }
                     let err_js = if !NEEDS_OPEN {
                         err.to_js(global_this)
@@ -5357,7 +5360,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     global_this: &JSGlobalObject,
     pathlike: &PathOrFileDescriptor,
     bytes: &[u8],
-    _needs_async: &mut bool,
+    _resume_async_at: &mut Option<usize>,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
         pathlike.fd()
@@ -5377,7 +5380,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
             bun_sys::Result::Err(err) => {
                 #[cfg(not(windows))]
                 if err.get_errno() == bun_sys::E::ENOENT {
-                    *_needs_async = true;
+                    *_resume_async_at = Some(0);
                     return JSValue::ZERO;
                 }
                 return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
@@ -5407,17 +5410,8 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
             bun_sys::Result::Err(err) => {
                 #[cfg(not(windows))]
                 if err.get_errno() == bun_sys::E::EAGAIN {
-                    if written == 0 {
-                        *_needs_async = true;
-                        return JSValue::ZERO;
-                    }
-                    let mut pfd = [bun_sys::posix::PollFd {
-                        fd: fd.native(),
-                        events: bun_sys::posix::POLL_OUT,
-                        revents: 0,
-                    }];
-                    let _ = bun_sys::posix::poll(&mut pfd, -1);
-                    continue;
+                    *_resume_async_at = Some(written);
+                    return JSValue::ZERO;
                 }
                 let err_js = if !NEEDS_OPEN {
                     err.to_js(global_this)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4427,8 +4427,7 @@ fn write_file_with_empty_source_to_destination(
     ))
 }
 
-/// `already_written` is the byte count the synchronous fast path committed to
-/// the destination before it fell back; the bytes source resumes after it.
+/// `already_written`: bytes the sync fast path wrote before it fell back.
 pub(crate) fn write_file_with_source_destination(
     ctx: &JSGlobalObject,
     source_blob: &mut Blob,
@@ -4787,10 +4786,6 @@ pub(crate) fn write_file_internal(
     // This is a heuristic, but it's a good one.
     //
     // except if you're on Windows. Windows I/O is slower. Let's not even try.
-    //
-    // When the fast path hits EAGAIN after a partial write it hands off to the
-    // async `WriteFile`, which resumes at `already_written` instead of
-    // re-sending the prefix.
     #[cfg(windows)]
     let already_written: usize = 0;
     #[cfg(not(windows))]

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -538,53 +538,41 @@ impl ReadFile {
         read_len: &mut usize,
         retry: &mut bool,
     ) -> bool {
-        let result: bun_sys::Result<usize> = 'brk: {
-            if bun_sys::S::ISSOCK(self.file_store.mode) {
-                break 'brk bun_sys::recv_non_block(self.opened_fd, buf);
-            }
-            break 'brk bun_sys::read(self.opened_fd, buf);
+        let result: bun_sys::Result<usize> = if bun_sys::S::ISSOCK(self.file_store.mode) {
+            bun_sys::recv_non_block(self.opened_fd, buf)
+        } else {
+            bun_sys::read(self.opened_fd, buf)
         };
 
-        loop {
-            match &result {
-                Ok(res) => {
-                    *read_len = *res as usize; // @truncate — usize→usize is identity here
-                    self.read_eof = *res == 0;
-                }
-                Err(err) => {
-                    match err.get_errno() {
-                        e if e == io::RETRY => {
-                            if !self.could_block {
-                                // regular files cannot use epoll.
-                                // this is fine on kqueue, but not on epoll.
-                                continue;
-                            }
-                            *retry = true;
-                            self.read_eof = false;
-                            return true;
-                        }
-                        _ => {
-                            self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-                            self.system_error = Some(err.to_system_error().into());
-                            if self.system_error.as_ref().unwrap().path.is_empty() {
-                                self.system_error.as_mut().unwrap().path =
-                                    if self.file_store.pathlike.is_path() {
-                                        BunString::clone_utf8(
-                                            self.file_store.pathlike.path().slice(),
-                                        )
-                                    } else {
-                                        BunString::EMPTY
-                                    };
-                            }
-                            return false;
-                        }
-                    }
-                }
+        match result {
+            Ok(res) => {
+                *read_len = res;
+                self.read_eof = res == 0;
+                true
             }
-            break;
+            Err(err) => match err.get_errno() {
+                e if e == io::RETRY => {
+                    // EAGAIN is impossible on a regular file, so the fd is pollable.
+                    self.could_block = true;
+                    *retry = true;
+                    self.read_eof = false;
+                    true
+                }
+                _ => {
+                    self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                    self.system_error = Some(err.to_system_error().into());
+                    if self.system_error.as_ref().unwrap().path.is_empty() {
+                        self.system_error.as_mut().unwrap().path =
+                            if self.file_store.pathlike.is_path() {
+                                BunString::clone_utf8(self.file_store.pathlike.path().slice())
+                            } else {
+                                BunString::EMPTY
+                            };
+                    }
+                    false
+                }
+            },
         }
-
-        true
     }
 
     pub(crate) fn then(

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -341,21 +341,20 @@ impl WriteFile {
         //
         // On macOS, it is an error to use pwrite() on a
         // non-seekable file.
-        loop {
-            match sys::write(fd, &self.bytes_blob.shared_view()[off..off + len]) {
-                Ok(wrote) => {
-                    self.total_written += wrote;
-                    return WriteStep::Wrote(wrote);
-                }
-                // regular files cannot use epoll.
-                // this is fine on kqueue, but not on epoll.
-                Err(err) if err.get_errno() == io::RETRY && !self.could_block => continue,
-                Err(err) if err.get_errno() == io::RETRY => return WriteStep::WouldBlock,
-                Err(err) => {
-                    self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-                    self.system_error = Some(err.to_system_error().into());
-                    return WriteStep::Failed;
-                }
+        match sys::write(fd, &self.bytes_blob.shared_view()[off..off + len]) {
+            Ok(wrote) => {
+                self.total_written += wrote;
+                WriteStep::Wrote(wrote)
+            }
+            Err(err) if err.get_errno() == io::RETRY => {
+                // EAGAIN is impossible on a regular file, so the fd is pollable.
+                self.could_block = true;
+                WriteStep::WouldBlock
+            }
+            Err(err) => {
+                self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                self.system_error = Some(err.to_system_error().into());
+                WriteStep::Failed
             }
         }
     }
@@ -400,7 +399,8 @@ impl WriteFile {
 
     #[cfg(not(windows))]
     pub(crate) fn is_allowed_to_close(&self) -> bool {
-        self.file_blob
+        match self
+            .file_blob
             .store
             .get()
             .as_ref()
@@ -408,7 +408,11 @@ impl WriteFile {
             .data
             .as_file()
             .pathlike
-            .is_path()
+        {
+            PathOrFileDescriptor::Path(_) => true,
+            // opened_fd differs from the caller's fd only when run_with_fd duped it.
+            PathOrFileDescriptor::Fd(fd) => self.opened_fd != Fd::INVALID && self.opened_fd != fd,
+        }
     }
 
     #[cfg(not(windows))]
@@ -435,26 +439,37 @@ impl WriteFile {
 
         let fd = self.opened_fd;
 
-        self.could_block = 'brk: {
-            if let Some(store) = self.file_blob.store.get().as_ref() {
-                if let blob::store::Data::File(file) = &store.data {
-                    if file.pathlike.is_fd() {
-                        // If seekable was set, then so was mode
-                        if file.seekable.is_some() {
-                            // This is mostly to handle pipes which were passsed to the process somehow
-                            // such as stderr, stdout. Bun.stdin and Bun.stderr will automatically set `mode` for us.
-                            break 'brk !bun_sys::is_regular_file(file.mode);
-                        }
+        let caller_supplied_fd = match self.file_blob.store.get().as_ref() {
+            Some(store) => match &store.data {
+                blob::store::Data::File(file) => match file.pathlike {
+                    PathOrFileDescriptor::Fd(_) => {
+                        self.could_block = file.mode != 0 && !bun_sys::is_regular_file(file.mode);
+                        true
                     }
+                    PathOrFileDescriptor::Path(_) => {
+                        // Opened with O_NONBLOCK; don't fstat.
+                        self.could_block = false;
+                        false
+                    }
+                },
+                _ => false,
+            },
+            None => false,
+        };
+
+        // The IO thread's epoll/kqueue keys interest by fd number, so concurrent WriteFiles on
+        // one caller-supplied fd would collide; dup so this instance polls a private fd number.
+        if caller_supplied_fd {
+            match bun_sys::dup(fd) {
+                bun_sys::Result::Ok(duped) => self.opened_fd = duped,
+                bun_sys::Result::Err(err) => {
+                    self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                    self.system_error = Some(err.to_system_error().into());
+                    self.on_finish();
+                    return;
                 }
             }
-
-            // We opened the file descriptor with O_NONBLOCK, so we
-            // shouldn't have to worry about blocking reads/writes
-            //
-            // We do not call fstat() because that is very expensive.
-            false
-        };
+        }
 
         // We have never supported offset in Bun.write().
         // and properly adding support means we need to also support it

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -437,8 +437,6 @@ impl WriteFile {
             return;
         }
 
-        let fd = self.opened_fd;
-
         let caller_supplied_fd = match self.file_blob.store.get().as_ref() {
             Some(store) => match &store.data {
                 blob::store::Data::File(file) => match file.pathlike {
@@ -460,7 +458,7 @@ impl WriteFile {
         // The IO thread's epoll/kqueue keys interest by fd number, so concurrent WriteFiles on
         // one caller-supplied fd would collide; dup so this instance polls a private fd number.
         if caller_supplied_fd {
-            match bun_sys::dup(fd) {
+            match bun_sys::dup(self.opened_fd) {
                 bun_sys::Result::Ok(duped) => self.opened_fd = duped,
                 bun_sys::Result::Err(err) => {
                     self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
@@ -470,6 +468,7 @@ impl WriteFile {
                 }
             }
         }
+        let fd = self.opened_fd;
 
         // We have never supported offset in Bun.write().
         // and properly adding support means we need to also support it

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1317,6 +1317,7 @@ impl WriteFileWaitFromLockedValueTask {
                         mkdirp_if_not_exists: Some(this.mkdirp_if_not_exists),
                         ..Default::default()
                     },
+                    0,
                 ) {
                     Ok(p) => p,
                     Err(err) => {

--- a/test/js/bun/io/bun-write-fifo-fixture.js
+++ b/test/js/bun/io/bun-write-fifo-fixture.js
@@ -1,0 +1,28 @@
+// Bun.write() into a FIFO that only this process drains. The synchronous fast
+// path fills the pipe buffer, gets EAGAIN, and must hand the rest to the async
+// path without blocking the thread: the reader below is the only thing that
+// can make the fd writable again, and it runs on this event loop.
+import { closeSync, constants, openSync } from "node:fs";
+import { mkfifo } from "../../../mkfifo";
+
+const path = process.argv.at(-1);
+mkfifo(path, 0o666);
+const rfd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK);
+const wfd = openSync(path, constants.O_WRONLY | constants.O_NONBLOCK);
+
+// Below the 256 KiB fast-path cutoff, above any FIFO buffer size.
+const big = Buffer.alloc(200 * 1024, 65);
+const wrote = Bun.write(Bun.file(wfd), big);
+
+let got = 0;
+const drained = (async () => {
+  for await (const chunk of Bun.file(path).stream()) got += chunk.byteLength;
+})();
+
+const n = await wrote;
+// No writers left: the reader sees EOF once the FIFO is empty.
+closeSync(wfd);
+closeSync(rfd);
+await drained;
+
+console.log(JSON.stringify({ n, got }));

--- a/test/js/bun/io/bun-write-fifo-fixture.js
+++ b/test/js/bun/io/bun-write-fifo-fixture.js
@@ -2,20 +2,34 @@
 // path fills the pipe buffer, gets EAGAIN, and must hand the rest to the async
 // path without blocking the thread: the reader below is the only thing that
 // can make the fd writable again, and it runs on this event loop.
-import { closeSync, constants, openSync, writeSync } from "node:fs";
+import { closeSync, constants, fstatSync, openSync, readdirSync, writeSync } from "node:fs";
 import { mkfifo } from "../../../mkfifo";
 
 // Progress markers on stderr. If the process hangs, the parent sees how far it got.
 const mark = s => writeSync(2, s + "\n");
 
-const path = process.argv.at(-1);
+const path = process.argv.at(-2);
+const size = Number(process.argv.at(-1));
 mkfifo(path, 0o666);
 const rfd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK);
 const wfd = openSync(path, constants.O_WRONLY | constants.O_NONBLOCK);
+const fifoIno = fstatSync(wfd).ino;
 mark(`opened rfd=${rfd} wfd=${wfd}`);
 
-// Below the 256 KiB fast-path cutoff, above any FIFO buffer size.
-const big = Buffer.alloc(200 * 1024, 65);
+const fdDir = process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd";
+const fifoFds = () =>
+  readdirSync(fdDir)
+    .map(Number)
+    .filter(fd => {
+      try {
+        return fstatSync(fd).ino === fifoIno;
+      } catch {
+        return false;
+      }
+    })
+    .sort((a, b) => a - b);
+
+const big = Buffer.alloc(size, 65);
 const wrote = Bun.write(Bun.file(wfd), big);
 mark("write returned");
 
@@ -23,17 +37,16 @@ let got = 0;
 const drained = (async () => {
   for await (const chunk of Bun.file(path).stream()) {
     got += chunk.byteLength;
-    mark(`read ${got}`);
   }
   mark("eof");
 })();
 
 const n = await wrote;
-mark(`resolved ${n}`);
+mark(`resolved ${n} fifoFds=${JSON.stringify(fifoFds())}`);
 // No writers left: the reader sees EOF once the FIFO is empty.
 closeSync(wfd);
 closeSync(rfd);
-mark("closed");
+mark(`closed fifoFds=${JSON.stringify(fifoFds())}`);
 await drained;
 
 console.log(JSON.stringify({ n, got }));

--- a/test/js/bun/io/bun-write-fifo-fixture.js
+++ b/test/js/bun/io/bun-write-fifo-fixture.js
@@ -2,27 +2,38 @@
 // path fills the pipe buffer, gets EAGAIN, and must hand the rest to the async
 // path without blocking the thread: the reader below is the only thing that
 // can make the fd writable again, and it runs on this event loop.
-import { closeSync, constants, openSync } from "node:fs";
+import { closeSync, constants, openSync, writeSync } from "node:fs";
 import { mkfifo } from "../../../mkfifo";
+
+// Progress markers on stderr. If the process hangs, the parent sees how far it got.
+const mark = s => writeSync(2, s + "\n");
 
 const path = process.argv.at(-1);
 mkfifo(path, 0o666);
 const rfd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK);
 const wfd = openSync(path, constants.O_WRONLY | constants.O_NONBLOCK);
+mark(`opened rfd=${rfd} wfd=${wfd}`);
 
 // Below the 256 KiB fast-path cutoff, above any FIFO buffer size.
 const big = Buffer.alloc(200 * 1024, 65);
 const wrote = Bun.write(Bun.file(wfd), big);
+mark("write returned");
 
 let got = 0;
 const drained = (async () => {
-  for await (const chunk of Bun.file(path).stream()) got += chunk.byteLength;
+  for await (const chunk of Bun.file(path).stream()) {
+    got += chunk.byteLength;
+    mark(`read ${got}`);
+  }
+  mark("eof");
 })();
 
 const n = await wrote;
+mark(`resolved ${n}`);
 // No writers left: the reader sees EOF once the FIFO is empty.
 closeSync(wfd);
 closeSync(rfd);
+mark("closed");
 await drained;
 
 console.log(JSON.stringify({ n, got }));

--- a/test/js/bun/io/bun-write-fifo-fixture.js
+++ b/test/js/bun/io/bun-write-fifo-fixture.js
@@ -2,7 +2,11 @@
 // path fills the pipe buffer, gets EAGAIN, and must hand the rest to the async
 // path without blocking the thread: the reader below is the only thing that
 // can make the fd writable again, and it runs on this event loop.
-import { closeSync, constants, fstatSync, openSync, readdirSync, writeSync } from "node:fs";
+//
+// The payload is a byte counter modulo a prime. If the async path re-sent the
+// prefix the fast path already wrote, the sequence breaks where the prefix
+// restarts, and a power-of-two pipe buffer cannot line up with the period.
+import { closeSync, constants, openSync, writeSync } from "node:fs";
 import { mkfifo } from "../../../mkfifo";
 
 // Progress markers on stderr. If the process hangs, the parent sees how far it got.
@@ -13,40 +17,27 @@ const size = Number(process.argv.at(-1));
 mkfifo(path, 0o666);
 const rfd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK);
 const wfd = openSync(path, constants.O_WRONLY | constants.O_NONBLOCK);
-const fifoIno = fstatSync(wfd).ino;
 mark(`opened rfd=${rfd} wfd=${wfd}`);
 
-const fdDir = process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd";
-const fifoFds = () =>
-  readdirSync(fdDir)
-    .map(Number)
-    .filter(fd => {
-      try {
-        return fstatSync(fd).ino === fifoIno;
-      } catch {
-        return false;
-      }
-    })
-    .sort((a, b) => a - b);
-
-const big = Buffer.alloc(size, 65);
+const big = Buffer.alloc(size);
+for (let i = 0; i < size; i++) big[i] = i % 251;
 const wrote = Bun.write(Bun.file(wfd), big);
 mark("write returned");
 
 let got = 0;
-const drained = (async () => {
-  for await (const chunk of Bun.file(path).stream()) {
-    got += chunk.byteLength;
+let firstBadByte = -1;
+for await (const chunk of Bun.file(path).stream()) {
+  for (let i = 0; i < chunk.length && firstBadByte < 0; i++) {
+    if (chunk[i] !== (got + i) % 251) firstBadByte = got + i;
   }
-  mark("eof");
-})();
+  got += chunk.length;
+  if (got >= size || firstBadByte >= 0) break;
+}
+mark(`read ${got} firstBadByte=${firstBadByte}`);
 
 const n = await wrote;
-mark(`resolved ${n} fifoFds=${JSON.stringify(fifoFds())}`);
-// No writers left: the reader sees EOF once the FIFO is empty.
+mark(`resolved ${n}`);
 closeSync(wfd);
 closeSync(rfd);
-mark(`closed fifoFds=${JSON.stringify(fifoFds())}`);
-await drained;
 
-console.log(JSON.stringify({ n, got }));
+console.log(JSON.stringify({ n, got, firstBadByte }));

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1206,3 +1206,25 @@ it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) to a full nonblocking pipe comp
     signalCode: null,
   });
 });
+
+// The sync fast path used to re-enter the async path with the whole payload after a partial
+// write, so the bytes already in the pipe were sent twice. It must also not block the thread
+// while the pipe is full: here the only reader runs on the same event loop.
+it.skipIf(isWindows)("Bun.write to a full pipe resumes async after a partial write", async () => {
+  using dir = tempDir("bun-write-fifo", {});
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "bun-write-fifo-fixture.js"), join(String(dir), "fifo")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: JSON.stringify({ n: 200 * 1024, got: 200 * 1024 }) + "\n",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1161,3 +1161,51 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     expect(f.name).toBe(filePath);
   });
 });
+
+// Once fd 1 is O_NONBLOCK (process.stdout.write's FileSink sets it on the shared open file
+// description via a dup), a Bun.write that overflowed the pipe buffer used to wedge a
+// thread-pool worker at 100% CPU: the async WriteFile path's could_block stayed false for
+// stdio and its EAGAIN handler re-matched a cached write() result without re-issuing the
+// syscall. Runs outside describe.concurrent so an unfixed build's spin doesn't starve
+// neighbours into their default timeout.
+it.skipIf(isWindows)(
+  "Bun.write(Bun.stdout, ...) to a full nonblocking pipe completes",
+  async () => {
+    // Below 256 KiB exercises the sync fast path's EAGAIN -> needs_async fallback; at/above
+    // 256 KiB goes straight to the thread-pool WriteFile path.
+    const script = `
+    process.stdout.write("x"); // constructs the fd 1 FileSink, which flips the pipe O_NONBLOCK
+    const fdDir = process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd";
+    const fdCount = () => require("fs").readdirSync(fdDir).length;
+    const small = Buffer.alloc(64 * 1024, 65).toString();
+    const large = Buffer.alloc(256 * 1024, 66).toString();
+    let wrote = 0, fdsBefore, fdsAfter;
+    for (let round = 0; round < 2; round++) {
+      fdsBefore = fdCount();
+      const ps = [];
+      for (let i = 0; i < 16; i++) ps.push(Bun.write(Bun.stdout, small));
+      for (let i = 0; i < 4; i++) ps.push(Bun.write(Bun.stdout, large));
+      for (const n of await Promise.all(ps)) wrote += n;
+      fdsAfter = fdCount();
+    }
+    process.stderr.write("wrote=" + wrote + " fdDelta=" + (fdsAfter - fdsBefore));
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
+    const expected = 1 + 2 * (16 * 64 * 1024 + 4 * 256 * 1024);
+    expect({ length: stdout.length, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      length: expected,
+      stderr: "wrote=" + (expected - 1) + " fdDelta=0",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+  30_000,
+);

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1168,15 +1168,14 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
 // stdio and its EAGAIN handler re-matched a cached write() result without re-issuing the
 // syscall. Runs outside describe.concurrent so an unfixed build's spin doesn't starve
 // neighbours into their default timeout.
-it.skipIf(isWindows)(
-  "Bun.write(Bun.stdout, ...) to a full nonblocking pipe completes",
-  async () => {
-    // Below 256 KiB exercises the sync fast path's EAGAIN -> needs_async fallback; at/above
-    // 256 KiB goes straight to the thread-pool WriteFile path.
-    const script = `
+it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) to a full nonblocking pipe completes", async () => {
+  // Below 256 KiB exercises the sync fast path's EAGAIN -> needs_async fallback; at/above
+  // 256 KiB goes straight to the thread-pool WriteFile path.
+  const script = `
+    import { readdirSync } from "node:fs";
     process.stdout.write("x"); // constructs the fd 1 FileSink, which flips the pipe O_NONBLOCK
     const fdDir = process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd";
-    const fdCount = () => require("fs").readdirSync(fdDir).length;
+    const fdCount = () => readdirSync(fdDir).length;
     const small = Buffer.alloc(64 * 1024, 65).toString();
     const large = Buffer.alloc(256 * 1024, 66).toString();
     let wrote = 0, fdsBefore, fdsAfter;
@@ -1190,22 +1189,20 @@ it.skipIf(isWindows)(
     }
     process.stderr.write("wrote=" + wrote + " fdDelta=" + (fdsAfter - fdsBefore));
   `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 20_000,
-      killSignal: "SIGKILL",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
-    const expected = 1 + 2 * (16 * 64 * 1024 + 4 * 256 * 1024);
-    expect({ length: stdout.length, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      length: expected,
-      stderr: "wrote=" + (expected - 1) + " fdDelta=0",
-      exitCode: 0,
-      signalCode: null,
-    });
-  },
-  30_000,
-);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
+  const expected = 1 + 2 * (16 * 64 * 1024 + 4 * 256 * 1024);
+  expect({ length: stdout.length, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    length: expected,
+    stderr: "wrote=" + (expected - 1) + " fdDelta=0",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1172,22 +1172,32 @@ it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) to a full nonblocking pipe comp
   // Below 256 KiB exercises the sync fast path's EAGAIN -> needs_async fallback; at/above
   // 256 KiB goes straight to the thread-pool WriteFile path.
   const script = `
-    import { readdirSync } from "node:fs";
+    import { fstatSync, readdirSync } from "node:fs";
     process.stdout.write("x"); // constructs the fd 1 FileSink, which flips the pipe O_NONBLOCK
     const fdDir = process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd";
-    const fdCount = () => readdirSync(fdDir).length;
+    const fds = () => readdirSync(fdDir).map(Number).sort((a, b) => a - b);
+    const describe = fd => {
+      try {
+        const st = fstatSync(fd);
+        return { fd, mode: st.mode.toString(8), fifo: st.isFIFO(), sock: st.isSocket(), file: st.isFile(), chr: st.isCharacterDevice() };
+      } catch (e) {
+        return { fd, err: e.code };
+      }
+    };
     const small = Buffer.alloc(64 * 1024, 65).toString();
     const large = Buffer.alloc(256 * 1024, 66).toString();
     let wrote = 0, fdsBefore, fdsAfter;
     for (let round = 0; round < 2; round++) {
-      fdsBefore = fdCount();
+      fdsBefore = fds();
       const ps = [];
       for (let i = 0; i < 16; i++) ps.push(Bun.write(Bun.stdout, small));
       for (let i = 0; i < 4; i++) ps.push(Bun.write(Bun.stdout, large));
       for (const n of await Promise.all(ps)) wrote += n;
-      fdsAfter = fdCount();
+      fdsAfter = fds();
     }
-    process.stderr.write("wrote=" + wrote + " fdDelta=" + (fdsAfter - fdsBefore));
+    const newFds = fdsAfter.filter(fd => !fdsBefore.includes(fd)).map(describe);
+    const goneFds = fdsBefore.filter(fd => !fdsAfter.includes(fd));
+    process.stderr.write(JSON.stringify({ wrote, fdDelta: fdsAfter.length - fdsBefore.length, newFds, goneFds }));
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
@@ -1201,7 +1211,7 @@ it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) to a full nonblocking pipe comp
   const expected = 1 + 2 * (16 * 64 * 1024 + 4 * 256 * 1024);
   expect({ length: stdout.length, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
     length: expected,
-    stderr: "wrote=" + (expected - 1) + " fdDelta=0",
+    stderr: JSON.stringify({ wrote: expected - 1, fdDelta: 0, newFds: [], goneFds: [] }),
     exitCode: 0,
     signalCode: null,
   });
@@ -1221,7 +1231,8 @@ it.skipIf(isWindows)("Bun.write to a full pipe resumes async after a partial wri
     killSignal: "SIGKILL",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+  // stderr carries the fixture's progress markers. It is only shown on failure.
+  expect({ stdout, exitCode, signalCode: proc.signalCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
     stdout: JSON.stringify({ n: 200 * 1024, got: 200 * 1024 }) + "\n",
     stderr: "",
     exitCode: 0,

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1175,29 +1175,30 @@ it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) to a full nonblocking pipe comp
     import { fstatSync, readdirSync } from "node:fs";
     process.stdout.write("x"); // constructs the fd 1 FileSink, which flips the pipe O_NONBLOCK
     const fdDir = process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd";
-    const fds = () => readdirSync(fdDir).map(Number).sort((a, b) => a - b);
-    const describe = fd => {
-      try {
-        const st = fstatSync(fd);
-        return { fd, mode: st.mode.toString(8), fifo: st.isFIFO(), dupOfStdout: st.ino === fstatSync(1).ino };
-      } catch (e) {
-        return { fd, err: e.code };
-      }
-    };
+    const stdoutIno = fstatSync(1).ino;
+    // Every fd that refers to stdout's pipe. WriteFile dups fd 1 and must close the dup.
+    // A plain fd count would also see the IO thread's kqueue/epoll fd, which is created
+    // the first time a write has to wait.
+    const stdoutDups = () =>
+      readdirSync(fdDir).filter(name => {
+        try {
+          return fstatSync(Number(name)).ino === stdoutIno;
+        } catch {
+          return false;
+        }
+      }).length;
     const small = Buffer.alloc(64 * 1024, 65).toString();
     const large = Buffer.alloc(256 * 1024, 66).toString();
-    let wrote = 0, fdsBefore, fdsAfter;
+    let wrote = 0, dupsBefore, dupsAfter;
     for (let round = 0; round < 2; round++) {
-      fdsBefore = fds();
+      dupsBefore = stdoutDups();
       const ps = [];
       for (let i = 0; i < 16; i++) ps.push(Bun.write(Bun.stdout, small));
       for (let i = 0; i < 4; i++) ps.push(Bun.write(Bun.stdout, large));
       for (const n of await Promise.all(ps)) wrote += n;
-      fdsAfter = fds();
+      dupsAfter = stdoutDups();
     }
-    const newFds = fdsAfter.filter(fd => !fdsBefore.includes(fd)).map(describe);
-    const goneFds = fdsBefore.filter(fd => !fdsAfter.includes(fd));
-    process.stderr.write(JSON.stringify({ wrote, fdDelta: fdsAfter.length - fdsBefore.length, newFds, goneFds }));
+    process.stderr.write(JSON.stringify({ wrote, dupDelta: dupsAfter - dupsBefore }));
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
@@ -1211,7 +1212,7 @@ it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) to a full nonblocking pipe comp
   const expected = 1 + 2 * (16 * 64 * 1024 + 4 * 256 * 1024);
   expect({ length: stdout.length, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
     length: expected,
-    stderr: JSON.stringify({ wrote: expected - 1, fdDelta: 0, newFds: [], goneFds: [] }),
+    stderr: JSON.stringify({ wrote: expected - 1, dupDelta: 0 }),
     exitCode: 0,
     signalCode: null,
   });
@@ -1235,7 +1236,7 @@ describe.skipIf(isWindows)("Bun.write to a full pipe", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // stderr carries the fixture's progress markers. It is only shown on failure.
     expect({ stdout, exitCode, signalCode: proc.signalCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
-      stdout: JSON.stringify({ n: size, got: size }) + "\n",
+      stdout: JSON.stringify({ n: size, got: size, firstBadByte: -1 }) + "\n",
       stderr: "",
       exitCode: 0,
       signalCode: null,

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1179,7 +1179,7 @@ it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) to a full nonblocking pipe comp
     const describe = fd => {
       try {
         const st = fstatSync(fd);
-        return { fd, mode: st.mode.toString(8), fifo: st.isFIFO(), sock: st.isSocket(), file: st.isFile(), chr: st.isCharacterDevice() };
+        return { fd, mode: st.mode.toString(8), fifo: st.isFIFO(), dupOfStdout: st.ino === fstatSync(1).ino };
       } catch (e) {
         return { fd, err: e.code };
       }
@@ -1220,22 +1220,25 @@ it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) to a full nonblocking pipe comp
 // The sync fast path used to re-enter the async path with the whole payload after a partial
 // write, so the bytes already in the pipe were sent twice. It must also not block the thread
 // while the pipe is full: here the only reader runs on the same event loop.
-it.skipIf(isWindows)("Bun.write to a full pipe resumes async after a partial write", async () => {
-  using dir = tempDir("bun-write-fifo", {});
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "bun-write-fifo-fixture.js"), join(String(dir), "fifo")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-    timeout: 20_000,
-    killSignal: "SIGKILL",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // stderr carries the fixture's progress markers. It is only shown on failure.
-  expect({ stdout, exitCode, signalCode: proc.signalCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
-    stdout: JSON.stringify({ n: 200 * 1024, got: 200 * 1024 }) + "\n",
-    stderr: "",
-    exitCode: 0,
-    signalCode: null,
+// 200 KiB takes the sync fast path first and resumes async. 300 KiB goes async directly.
+describe.skipIf(isWindows)("Bun.write to a full pipe", () => {
+  it.each([200 * 1024, 300 * 1024])("completes a %d byte write that only this process drains", async size => {
+    using dir = tempDir("bun-write-fifo", {});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "bun-write-fifo-fixture.js"), join(String(dir), "fifo"), String(size)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr carries the fixture's progress markers. It is only shown on failure.
+    expect({ stdout, exitCode, signalCode: proc.signalCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
+      stdout: JSON.stringify({ n: size, got: size }) + "\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 });


### PR DESCRIPTION
### Problem
- Once `process.stdout.write` has run, fd 1 is `O_NONBLOCK`. A `Bun.write(Bun.stdout, big)` that overflows the pipe wedges every pool thread at 100% CPU and the promise never resolves. `strace` shows the pool threads spinning with zero syscalls and main parked in `epoll_wait`.
- Three causes. `WriteFile::run_with_fd` (`src/runtime/webcore/blob/write_file.rs`) derived `could_block` from `seekable`, which the stdio stores do not set, so on `EAGAIN` `do_write` looped on `write()` at 100% CPU instead of parking. `ReadFile::do_read` re-matched one cached `read()` result in its loop and never re-issued the syscall. Two concurrent `WriteFile`s on one fd both registered fd 1 with the IO thread's epoll, and the second got `EEXIST`.
- The sync fast path in `Blob.rs` (`write_{string,bytes}_to_file_fast`) set `needs_async` after a partial write. The async path then re-sent the whole payload and the prefix went out twice.

### Fix
- `do_write` and `do_read`: `EAGAIN` is impossible on a regular file, so on `EAGAIN` set `could_block = true` and park on the IO loop. The cached-result loop is gone.
- `run_with_fd`: derive `could_block` from `mode`. Dup every caller-supplied fd so each `WriteFile` polls a private fd number. `is_allowed_to_close` closes the dup on finish.
- Fast path: report the byte count already written. `write_file_internal` passes it to `write_file_with_source_destination`, which seeds `WriteFile.total_written`, so the async write resumes at that offset. The JS thread never blocks in `poll`.
- Verified: `test/js/bun/io/bun-write.test.js`, three new tests. On stock bun the stdout test receives 4413569 bytes instead of 4194305 (the re-sent prefix), and the 200 KiB FIFO test hangs. Also ran all of `test/js/bun/io/`.

### Background
- `Bun.write(dest, data)` for data under 256 KiB first tries a synchronous `write()` loop on the JS thread. On `EAGAIN` it falls back to `WriteFile`, a thread-pool task that writes and, when the fd is a pipe or socket, waits for writability on the IO thread's epoll/kqueue.
- `could_block` tells `WriteFile` whether the fd can be polled. Regular files cannot be added to epoll, so the flag gates every `wait_for_writable` call.
- `O_NONBLOCK` lives on the open file description, which dups share. `process.stdout`'s FileSink sets it on a dup of fd 1, so fd 1 itself becomes nonblocking.

<details><summary>Notes</summary>

Repro for the wedge:

```js
// bun repro.mjs | (sleep 2; cat >/dev/null)   -> never exits, every core at 100%
process.stdout.write("x");
const big = Buffer.alloc(1024 * 1024, 65).toString();
await Promise.all(Array.from({ length: 20 }, () => Bun.write(Bun.stdout, big)));
```

Earlier revisions of this PR finished a partial fast-path write synchronously with `poll(POLLOUT, -1)`. Review pointed out that this blocks the JS thread, and when the pipe's only reader depends on that event loop it never returns. The FIFO test (`bun-write-fifo-fixture.js`) covers that case: the reader is `Bun.file(path).stream()` in the same process. The payload is a byte counter modulo 251, so a re-sent prefix breaks the sequence where it restarts. The fixture stops at `size` bytes and does not wait for EOF: on macOS the stream reader did not see EOF after every writer closed, with the dup already closed (checked by inode), which is outside this change.

The stdout test counts fds that share stdout's inode rather than all fds. A plain count also sees the IO thread's kqueue or epoll fd, created the first time a write has to wait. On macOS `fstat` reports a kqueue as `S_IFIFO`, which looked like a leaked pipe dup until the inode check.

The dup is unconditional for caller-supplied fds because `Bun.file(rawFd)` stores can have `mode == 0`. `could_block` is then only learned from the first `EAGAIN`, and the fd must already be private at that point. The stdout test asserts `fdDelta=0` across a round of writes to check the dup is released.

Windows is unaffected. Its async write path is libuv's `uv_fs_write`, and it has no sync fast path.

Related: #35949 keeps stdio writes on the sync fast path for regular files. #32890 stops `Bun.write` from truncating an fd destination for an empty source.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->