### PR TITLE
fix(bundler): honor env: disable for process.env.NODE_ENV

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -918,8 +918,11 @@ pub fn defines_from_transform_options(
             Box::from(b"\"development\"".as_slice())
         };
 
-        user_defines.get_or_put_value(b"process.env.NODE_ENV", quoted_node_env.clone())?;
-        user_defines.get_or_put_value(b"process.env.BUN_ENV", quoted_node_env)?;
+        // Only inject NODE_ENV if env_behavior is not Disable
+        if self.env_behavior != DotEnv::Behavior::Disable {
+            user_defines.get_or_put_value(b"process.env.NODE_ENV", quoted_node_env.clone())?;
+            user_defines.get_or_put_value(b"process.env.BUN_ENV", quoted_node_env)?;
+        }
 
         // Automatically set `process.browser` to `true` for browsers and false for node+js
         // This enables some extra dead code elimination


### PR DESCRIPTION
## What does this PR do?

`Bun.build({ env: "disable" })` was still folding `process.env.NODE_ENV` (dot form) to the build-time value, while the bracket form `process.env["NODE_ENV"]` stayed dynamic. The CLI `bun build --env disable` already left both forms dynamic.

### Problem

```js
// e.mjs
console.log(JSON.stringify({ dot: process.env.NODE_ENV, bracket: process.env["NODE_ENV"] }));

// build.mjs
await Bun.build({ entrypoints: ["./e.mjs"], target: "node", env: "disable", outdir: "./dist" });

$ NODE_ENV=production node dist/e.js
{"dot":"development","bracket":"production"}
```

### Fix

Check `env_behavior` before injecting NODE_ENV define in `defines_from_transform_options`. When `env_behavior` is `Disable`, skip the NODE_ENV and BUN_ENV defines entirely.

Fixes #35952