### PR TITLE
bundler: pin CJS module-scope names when direct eval is present

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4807,22 +4807,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // symbols in an ESM file when bundling is enabled. We make no guarantee
                 // that "eval" will be able to reach these symbols and we allow them to be
                 // renamed or removed by tree shaking.
-                if self.options.bundle
-                    && current_scope.parent.is_none()
-                    && self.has_es_module_syntax
-                {
-                    continue;
-                }
+                //
+                // Note: the module scope is never popped through this function, so
+                // `current_scope.parent` is always `Some` here and the exception above
+                // never applies. The module-scope equivalent lives in `_parse`, where
+                // the wrapping decision (`exports_kind`) is already known.
 
                 self.symbols[member.1.ref_.inner_index() as usize].set_must_not_be_renamed(true);
             }
         }
 
-        // Popping the module scope leaves `current_scope` in place; only the
-        // terminal pop at the end of parsing reaches this.
-        if let Some(parent) = current_scope.parent {
-            self.current_scope = parent;
-        }
+        self.current_scope = current_scope.parent.unwrap_or_else(|| {
+            self.panic(
+                "Internal error: attempted to call popScope() on the topmost scope",
+                format_args!(""),
+            )
+        });
     }
 
     pub fn mark_expr_as_parenthesized(&mut self, expr: &mut Expr) {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4806,12 +4806,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // pinned when direct eval is present, we make an exception for top-level
                 // symbols in an ESM file when bundling is enabled. We make no guarantee
                 // that "eval" will be able to reach these symbols and we allow them to be
-                // renamed or removed by tree shaking.
-                //
-                // Note: the module scope is never popped through this function, so
-                // `current_scope.parent` is always `Some` here and the exception above
-                // never applies. The module-scope equivalent lives in `_parse`, where
-                // the wrapping decision (`exports_kind`) is already known.
+                // renamed or removed by tree shaking. The module scope itself is handled
+                // in `_parse` (after `exports_kind` is known), not here.
 
                 self.symbols[member.1.ref_.inner_index() as usize].set_must_not_be_renamed(true);
             }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4807,20 +4807,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // symbols in an ESM file when bundling is enabled. We make no guarantee
                 // that "eval" will be able to reach these symbols and we allow them to be
                 // renamed or removed by tree shaking.
-                // if (p.currentScope.parent == null and p.has_es_module_syntax) {
-                //     continue;
-                // }
+                if self.options.bundle
+                    && current_scope.parent.is_none()
+                    && self.has_es_module_syntax
+                {
+                    continue;
+                }
 
                 self.symbols[member.1.ref_.inner_index() as usize].set_must_not_be_renamed(true);
             }
         }
 
-        self.current_scope = current_scope.parent.unwrap_or_else(|| {
-            self.panic(
-                "Internal error: attempted to call popScope() on the topmost scope",
-                format_args!(""),
-            )
-        });
+        // Popping the module scope leaves `current_scope` in place; only the
+        // terminal pop at the end of parsing reaches this.
+        if let Some(parent) = current_scope.parent {
+            self.current_scope = parent;
+        }
     }
 
     pub fn mark_expr_as_parenthesized(&mut self, expr: &mut Expr) {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2163,7 +2163,7 @@ impl<'a> Parser<'a> {
         // `pop_scope`). Bundled ESM is exempt because its module scope is
         // hoisted into the shared chunk scope.
         if p.module_scope().contains_direct_eval
-            && !(p.options.bundle && exports_kind == js_ast::ExportsKind::Esm)
+            && !(p.options.bundle && exports_kind != js_ast::ExportsKind::Cjs)
         {
             let module_scope = p.module_scope_ref();
             let mut iter = module_scope.members.iter();

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2159,8 +2159,25 @@ impl<'a> Parser<'a> {
             parts.append(&mut after);
         }
 
-        // Pop the module scope to apply the "ContainsDirectEval" rules
-        p.pop_scope();
+        // Apply the "ContainsDirectEval" rules to the module scope. `pop_scope`
+        // does this for every nested scope; the module scope has no parent so
+        // it is handled here instead, after the wrapping decision is known.
+        //
+        // When bundling an ESM file, module-scope symbols are hoisted into the
+        // shared chunk scope and there is no way to guarantee direct eval can
+        // still reach them under their original names, so they stay renameable.
+        // A CJS-wrapped file keeps its module scope inside the `__commonJS`
+        // closure, so pinning there is both safe and required for eval to
+        // resolve the original names (including `exports` and `module`).
+        if p.module_scope().contains_direct_eval
+            && !(p.options.bundle && exports_kind == js_ast::ExportsKind::Esm)
+        {
+            let module_scope = p.module_scope_ref();
+            let mut iter = module_scope.members.iter();
+            while let Some(member) = iter.next() {
+                p.symbols[member.1.ref_.inner_index() as usize].set_must_not_be_renamed(true);
+            }
+        }
 
         #[cfg(not(target_arch = "wasm32"))]
         if bun_core::feature_flags::RUNTIME_TRANSPILER_CACHE {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2159,16 +2159,9 @@ impl<'a> Parser<'a> {
             parts.append(&mut after);
         }
 
-        // Apply the "ContainsDirectEval" rules to the module scope. `pop_scope`
-        // does this for every nested scope; the module scope has no parent so
-        // it is handled here instead, after the wrapping decision is known.
-        //
-        // When bundling an ESM file, module-scope symbols are hoisted into the
-        // shared chunk scope and there is no way to guarantee direct eval can
-        // still reach them under their original names, so they stay renameable.
-        // A CJS-wrapped file keeps its module scope inside the `__commonJS`
-        // closure, so pinning there is both safe and required for eval to
-        // resolve the original names (including `exports` and `module`).
+        // Apply the "ContainsDirectEval" rules to the module scope (see
+        // `pop_scope`). Bundled ESM is exempt because its module scope is
+        // hoisted into the shared chunk scope.
         if p.module_scope().contains_direct_eval
             && !(p.options.bundle && exports_kind == js_ast::ExportsKind::Esm)
         {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2160,7 +2160,7 @@ impl<'a> Parser<'a> {
         }
 
         // Pop the module scope to apply the "ContainsDirectEval" rules
-        // p.popScope();
+        p.pop_scope();
 
         #[cfg(not(target_arch = "wasm32"))]
         if bun_core::feature_flags::RUNTIME_TRANSPILER_CACHE {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1102,6 +1102,47 @@ describe("bundler", () => {
       stdout: "15",
     },
   });
+  itBundled("minify/DirectEvalPinsCjsModuleScopeWithImportMeta", {
+    files: {
+      "/entry.cjs": /* js */ `
+        module.exports = 1;
+        var outerX = 41;
+        console.log(typeof import.meta.url, eval("outerX + 1"));
+      `,
+    },
+    minifyIdentifiers: true,
+    minifyWhitespace: true,
+    minifySyntax: true,
+    target: "bun",
+    onAfterBundle(api) {
+      // `import.meta` marks the file as having ES module syntax, but it is
+      // still CJS-wrapped because `module.exports` is used. Module-scope
+      // names must stay pinned for eval.
+      api.expectFile("/out.js").toContain("var outerX=41");
+    },
+    run: {
+      stdout: "string 42",
+    },
+  });
+  itBundled("minify/DirectEvalMjsModuleScopeStillRenamed", {
+    files: {
+      "/main.mjs": `import "./a.mjs"; import "./b.mjs";`,
+      "/a.mjs": `let outerLongName = 41; eval("1"); console.log("a", outerLongName);`,
+      "/b.mjs": `let outerLongName = 99; eval("1"); console.log("b", outerLongName);`,
+    },
+    minifyIdentifiers: true,
+    target: "node",
+    onAfterBundle(api) {
+      // a.mjs and b.mjs are scope-hoisted via `module_type == Esm` even
+      // though neither contains an import/export/TLA token. The ESM
+      // exemption must still apply so the two declarations are
+      // deconflicted in the shared chunk scope, matching esbuild.
+      api.expectFile("/out.js").not.toContain("outerLongName");
+    },
+    run: {
+      stdout: "a 41\nb 99",
+    },
+  });
 
   itBundled("minify/AdditionalGlobalConstructorOptimization", {
     files: {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -981,6 +981,128 @@ describe("bundler", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/4692
+  itBundled("minify/DirectEvalPinsCjsModuleScope", {
+    files: {
+      "/entry.cjs": /* js */ `
+        var outerX = 41;
+        var outerY = "message";
+        console.log("via-eval", eval("outerX + 1"), eval("outerY"));
+        console.log("args", eval("typeof exports"), eval("typeof module"));
+      `,
+    },
+    minifyIdentifiers: true,
+    minifyWhitespace: true,
+    minifySyntax: true,
+    target: "node",
+    onAfterBundle(api) {
+      const text = api.readFile("/out.js");
+      expect(text).toContain("var outerX=41");
+      expect(text).toContain('outerY="message"');
+      // The CJS wrapper parameters must also keep their original names so
+      // that eval("exports") / eval("module") resolve.
+      expect(text).toContain("(exports,module)");
+    },
+    run: {
+      stdout: "via-eval 42 message\nargs object object",
+    },
+  });
+  itBundled("minify/DirectEvalPinsCjsModuleScopeTargetBun", {
+    files: {
+      "/entry.cjs": /* js */ `
+        var outerX = 41;
+        console.log("via-eval", eval("outerX + 1"));
+      `,
+    },
+    minifyIdentifiers: true,
+    minifyWhitespace: true,
+    minifySyntax: true,
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var outerX=41");
+    },
+    run: {
+      stdout: "via-eval 42",
+    },
+  });
+  itBundled("minify/DirectEvalPinsCjsModuleScopeNoBundle", {
+    files: {
+      "/entry.js": /* js */ `
+        module.exports = 1;
+        var outerX = 41;
+        console.log("via-eval", eval("outerX + 1"));
+      `,
+    },
+    bundling: false,
+    minifyIdentifiers: true,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var outerX = 41");
+    },
+    run: {
+      stdout: "via-eval 42",
+    },
+  });
+  itBundled("minify/IndirectEvalDoesNotPinCjsModuleScope", {
+    files: {
+      "/entry.cjs": /* js */ `
+        var outerLongName = 41;
+        (0, eval)("1");
+        console.log(outerLongName);
+      `,
+    },
+    minifyIdentifiers: true,
+    target: "node",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("outerLongName");
+    },
+    run: {
+      stdout: "41",
+    },
+  });
+  itBundled("minify/DirectEvalEsmModuleScopeStillRenamed", {
+    files: {
+      "/entry.js": /* js */ `
+        var outerLongName = 41;
+        eval("1");
+        console.log(outerLongName);
+        export {};
+      `,
+    },
+    minifyIdentifiers: true,
+    target: "node",
+    onAfterBundle(api) {
+      // ESM top-level symbols are exempt from pinning when bundling (scope
+      // hoisting cannot preserve them anyway), matching esbuild.
+      api.expectFile("/out.js").not.toContain("outerLongName");
+    },
+    run: {
+      stdout: "41",
+    },
+  });
+  itBundled("minify/DirectEvalPinsOuterCjsModuleScope", {
+    files: {
+      "/entry.cjs": /* js */ `
+        var outerX = 10;
+        function inner() {
+          var outerY = 5;
+          return eval("outerX + outerY");
+        }
+        console.log(inner());
+      `,
+    },
+    minifyIdentifiers: true,
+    minifyWhitespace: true,
+    target: "node",
+    onAfterBundle(api) {
+      const text = api.readFile("/out.js");
+      expect(text).toContain("var outerX=10");
+      expect(text).toContain("var outerY=5");
+    },
+    run: {
+      stdout: "15",
+    },
+  });
+
   itBundled("minify/AdditionalGlobalConstructorOptimization", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
Fixes #4692.

## Problem

`bun build --minify` renames top-level `var` declarations in a CommonJS module even when a direct `eval()` in the same module scope reads them by their original name, so the bundled artifact throws at runtime:

```js
// entry.cjs
var outerX = 41;
console.log('via-eval', eval('outerX + 1'));
```

```console
$ bun build entry.cjs --target=node --minify
var o=(l,a)=>()=>(a||l((a={exports:{}}).exports,a),a.exports);var r=o(function(v,e){var c=41;console.log("via-eval",eval("outerX + 1"))});export default r();

$ bun out.js
ReferenceError: outerX is not defined
```

esbuild pins every name visible to a direct eval in the CJS wrapper scope and the same program works.

## Cause

`pop_scope()` already marks every member of a scope containing direct eval as `must_not_be_renamed`, but it was never applied to the module scope (the terminal pop was commented out because `pop_scope()` panics on a `None` parent). So module-scope symbols in a CJS file never got the flag, and both the `MinifyRenamer` top-level slot pass and `assign_nested_scope_slots` treated them as freely renameable.

## Fix

Apply the direct-eval pinning to module-scope members at the end of `_parse`, after `exports_kind` is computed and before `assign_nested_scope_slots` / `compute_character_frequency` run in `to_ast`. The exemption for bundled ESM gates on `exports_kind == Esm` (the actual wrapping decision) rather than `has_es_module_syntax`, which is also set by `import.meta` and so would wrongly exempt a CJS-wrapped file that uses it. `pop_scope()` is left untouched so its over-pop invariant check stays in place for the ~50 nested call sites.

After:

```console
$ bun build entry.cjs --target=node --minify
var a=(o,e)=>()=>(e||o((e={exports:{}}).exports,e),e.exports);var l=a(function(exports,module){var outerX=41;console.log("via-eval",eval("outerX + 1"))});export default l();

$ bun out.js
via-eval 42
```

The `exports`/`module` wrapper parameters are module-scope members too, so they are pinned as well and reachable from eval.

## Verification

New `itBundled` cases in `test/bundler/bundler_minify.test.ts`:

- `DirectEvalPinsCjsModuleScope` (`--target=node`, checks `outerX`/`outerY`/`exports`/`module` kept and runtime result)
- `DirectEvalPinsCjsModuleScopeTargetBun` (`--target=bun`)
- `DirectEvalPinsCjsModuleScopeNoBundle` (`--no-bundle`)
- `DirectEvalPinsOuterCjsModuleScope` (eval nested in a function, module-scope name still pinned)
- `DirectEvalPinsCjsModuleScopeWithImportMeta` (CJS-wrapped file that also uses `import.meta`)
- `IndirectEvalDoesNotPinCjsModuleScope` (negative: `(0, eval)` still allows renaming)
- `DirectEvalEsmModuleScopeStillRenamed` (negative: ESM top-level still renamed when bundling, matching esbuild)
- `DirectEvalMjsModuleScopeStillRenamed` (negative: `.mjs` with no import/export/TLA still exempted via `module_type`)

The five positive cases fail on the released binary with `ReferenceError: outerX is not defined` and pass with this change. The rest of `bundler_minify.test.ts`, `bundler_cjs.test.ts`, `bundler_cjs2esm.test.ts`, `bundler_edgecase.test.ts`, `esbuild/default.test.ts` (including the existing `DirectEvalTainting*` cases) and `transpiler.test.js` all continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.0 (24d03cbd0)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [788.24ms]
(pass) bundler > minify/StringAdditionFolding [172.20ms]
(pass) bundler > minify/FunctionExpressionRemoveName [169.39ms]
(pass) bundler > minify/KeepNamesPreservesNames [164.67ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [121.61ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1717.30ms]
(pass) bundler > minify/MergeAdjacentVars [535.97ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [561.96ms]
(pass) bundler > minify/Infinity [144.79ms]
(pass) bundler > minify+whitespace/Infinity [156.82ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [528.16ms]
(pass) bundler > minify/InlineArraySpread [135.23ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [1014.25ms]
(pass) bundler > minify/MissingExpressionBlocks [593.87ms]
(pass) bundler > minify/BunRequireStatement [1436.85ms]
(pass) bundler > minify/SwitchUndefined [760.92ms]
(p
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e3eb1f4cb)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [16.90ms]
(pass) bundler > minify/StringAdditionFolding [4.25ms]
(pass) bundler > minify/FunctionExpressionRemoveName [3.93ms]
(pass) bundler > minify/KeepNamesPreservesNames [3.34ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [2.84ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [19.57ms]
(pass) bundler > minify/MergeAdjacentVars [12.67ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [13.37ms]
(pass) bundler > minify/Infinity [3.83ms]
(pass) bundler > minify+whitespace/Infinity [3.49ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [12.18ms]
(pass) bundler > minify/InlineArraySpread [3.48ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [12.34ms]
(pass) bundler > minify/MissingExpressionBlocks [12.79ms]
(pass) bundler > minify/BunRequireStatement [23.87ms]
(pass) bundler > minify/SwitchUndefined [14.60ms]
(pass) bundler > minify/RequireInDeadBranch [4.19ms]
(pass) bundler > minify/TypeOfRequire [4.78ms]
(pass) bundler > minify/RequireMainToImportMetaMain [4.00ms]
(pass) bundler > minify/Con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.0 (24d03cbd0)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [759.22ms]
(pass) bundler > minify/StringAdditionFolding [160.75ms]
(pass) bundler > minify/FunctionExpressionRemoveName [156.17ms]
(pass) bundler > minify/KeepNamesPreservesNames [186.94ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [137.43ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1542.34ms]
(pass) bundler > minify/MergeAdjacentVars [460.71ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [539.32ms]
(pass) bundler > minify/Infinity [123.02ms]
(pass) bundler > minify+whitespace/Infinity [114.22ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [490.23ms]
(pass) bundler > minify/InlineArraySpread [116.90ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [459.77ms]
(pass) bundler > minify/MissingExpressionBlocks [531.51ms]
(pass) bundler > minify/BunRequireStatement [1718.00ms]
(pass) bundler > minify/SwitchUndefined [734.35ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 867ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                  |   6 +-
 src/js_parser/parse/parse_entry.rs  |  14 +++-
 test/bundler/bundler_minify.test.ts | 163 ++++++++++++++++++++++++++++++++++++
 3 files changed, 177 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js_parser/p.rs                      10      4      0
src/js_parser/parse/parse_entry.rs       5      5      0
test/bundler/bundler_minify.test.ts      4      4      0
```

</details>

<!-- robobun:evidence:end -->