### PR TITLE
FileSink: record the opened fd in setup() so stdio force-sync clears O_NONBLOCK

### DIFF
--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -657,6 +657,7 @@ impl FileSink {
                         return sys::Result::Err(err);
                     }
                     sys::Result::Ok(()) => {
+                        self.fd.set(fd);
                         self.writer
                             .with_mut(|w| w.update_ref(self.io_evtloop(), false));
                     }
@@ -672,6 +673,7 @@ impl FileSink {
                 return sys::Result::Err(err);
             }
             sys::Result::Ok(()) => {
+                self.fd.set(fd);
                 // Only keep the event loop ref'd while there's a pending write in progress.
                 // If there's no pending write, no need to keep the event loop ref'd.
                 self.writer

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -508,54 +508,41 @@ impl ReadFile {
 
     /// Never touches `self.buffer`; the caller moves it out for the duration.
     pub fn do_read(&mut self, buf: &mut [u8], read_len: &mut usize, retry: &mut bool) -> bool {
-        let result: bun_sys::Result<usize> = 'brk: {
-            if bun_sys::S::ISSOCK(self.file_store.mode) {
-                break 'brk bun_sys::recv_non_block(self.opened_fd, buf);
-            }
-            break 'brk bun_sys::read(self.opened_fd, buf);
+        let result: bun_sys::Result<usize> = if bun_sys::S::ISSOCK(self.file_store.mode) {
+            bun_sys::recv_non_block(self.opened_fd, buf)
+        } else {
+            bun_sys::read(self.opened_fd, buf)
         };
 
-        loop {
-            match &result {
-                Ok(res) => {
-                    *read_len = *res as usize; // @truncate — usize→usize is identity here
-                    self.read_eof = *res == 0;
-                }
-                Err(err) => {
-                    match err.get_errno() {
-                        e if e == io::RETRY => {
-                            if !self.could_block {
-                                // regular files cannot use epoll.
-                                // this is fine on kqueue, but not on epoll.
-                                continue;
-                            }
-                            *retry = true;
-                            self.read_eof = false;
-                            return true;
-                        }
-                        _ => {
-                            self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-                            self.system_error = Some(err.to_system_error().into());
-                            if self.system_error.as_ref().unwrap().path.is_empty() {
-                                self.system_error.as_mut().unwrap().path =
-                                    if self.file_store.pathlike.is_path() {
-                                        BunString::clone_utf8(
-                                            self.file_store.pathlike.path().slice(),
-                                        )
-                                        .into()
-                                    } else {
-                                        BunString::EMPTY.into()
-                                    };
-                            }
-                            return false;
-                        }
-                    }
-                }
+        match result {
+            Ok(res) => {
+                *read_len = res;
+                self.read_eof = res == 0;
+                true
             }
-            break;
+            Err(err) => {
+                if err.get_errno() == io::RETRY {
+                    // Regular files never return EAGAIN, so receiving it here
+                    // means the fd is pollable regardless of what `could_block`
+                    // inferred from fstat.
+                    self.could_block = true;
+                    *retry = true;
+                    self.read_eof = false;
+                    return true;
+                }
+                self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                self.system_error = Some(err.to_system_error().into());
+                if self.system_error.as_ref().unwrap().path.is_empty() {
+                    self.system_error.as_mut().unwrap().path = if self.file_store.pathlike.is_path()
+                    {
+                        BunString::clone_utf8(self.file_store.pathlike.path().slice()).into()
+                    } else {
+                        BunString::EMPTY.into()
+                    };
+                }
+                false
+            }
         }
-
-        true
     }
 
     pub fn then(this: Box<Self>, _: &JSGlobalObject) -> jsc::JsTerminatedResult<()> {

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -522,9 +522,7 @@ impl ReadFile {
             }
             Err(err) => {
                 if err.get_errno() == io::RETRY {
-                    // Regular files never return EAGAIN, so receiving it here
-                    // means the fd is pollable regardless of what `could_block`
-                    // inferred from fstat.
+                    // EAGAIN is impossible on a regular file, so the fd is pollable.
                     self.could_block = true;
                     *retry = true;
                     self.read_eof = false;

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -338,32 +338,24 @@ impl WriteFile {
         //
         // On macOS, it is an error to use pwrite() on a
         // non-seekable file.
-        let result: bun_sys::Result<usize> =
-            sys::write(fd, &self.bytes_blob.shared_view()[off..off + len]);
-
-        loop {
-            match &result {
-                bun_sys::Result::Ok(res) => {
-                    *wrote = *res;
-                    self.total_written += *res;
-                }
-                bun_sys::Result::Err(err) => {
-                    if err.get_errno() == io::RETRY {
-                        if !self.could_block {
-                            // regular files cannot use epoll.
-                            // this is fine on kqueue, but not on epoll.
-                            continue;
-                        }
-                        self.wait_for_writable();
-                        return false;
-                    } else {
-                        self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-                        self.system_error = Some(err.to_system_error().into());
-                        return false;
-                    }
-                }
+        match sys::write(fd, &self.bytes_blob.shared_view()[off..off + len]) {
+            bun_sys::Result::Ok(res) => {
+                *wrote = res;
+                self.total_written += res;
             }
-            break;
+            bun_sys::Result::Err(err) => {
+                if err.get_errno() == io::RETRY {
+                    // Regular files never return EAGAIN, so receiving it here
+                    // means the fd is pollable regardless of what `could_block`
+                    // inferred from the store.
+                    self.could_block = true;
+                    self.wait_for_writable();
+                    return false;
+                }
+                self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                self.system_error = Some(err.to_system_error().into());
+                return false;
+            }
         }
 
         true

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -345,9 +345,7 @@ impl WriteFile {
             }
             bun_sys::Result::Err(err) => {
                 if err.get_errno() == io::RETRY {
-                    // Regular files never return EAGAIN, so receiving it here
-                    // means the fd is pollable regardless of what `could_block`
-                    // inferred from the store.
+                    // EAGAIN is impossible on a regular file, so the fd is pollable.
                     self.could_block = true;
                     self.wait_for_writable();
                     return false;

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -679,7 +679,10 @@ describe.concurrent("process.stdout leaves fd 1 blocking on a pipe", () => {
     "console.log / process.stdout.write / Bun.write(Bun.stdout) interleaved deliver every line",
     async () => {
       const N = 200;
-      const PAD = 512;
+      // Longest line "C199 " + PAD + "\n" stays within macOS PIPE_BUF (512) so
+      // the un-awaited Bun.write running on a work-pool thread cannot interleave
+      // mid-line with the main thread's writes.
+      const PAD = 500;
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -622,3 +622,93 @@ it("fs.promises.writeFile with iterables under GC pressure does not crash", asyn
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
 });
+
+// Accessing process.stdout creates a FileSink on a dup of fd 1. openForWriting
+// sets O_NONBLOCK on that dup, which also flips fd 1 itself (shared open file
+// description). The sink is then forced into synchronous mode, which is meant
+// to clear O_NONBLOCK again, but FileSink.setup() never recorded the fd so the
+// undo was a no-op. With fd 1 left non-blocking, console.log silently dropped
+// bytes on EAGAIN and Bun.write(Bun.stdout, ...) spun forever in WriteFile.
+describe.concurrent("process.stdout leaves fd 1 blocking on a pipe", () => {
+  it.skipIf(!isLinux)("O_NONBLOCK is cleared after process.stdout is materialized", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.stdout.write("x");
+          const fs = require("fs");
+          const fdinfo = fs.readFileSync("/proc/self/fdinfo/1", "utf8");
+          const flags = parseInt(fdinfo.match(/flags:\\s*(\\d+)/)[1], 8);
+          process.stderr.write((flags & 0o4000) ? "nonblock" : "blocking");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("x");
+    expect(stderr).toBe("blocking");
+    expect(exitCode).toBe(0);
+  });
+
+  it.skipIf(isWindows)("Bun.write(Bun.stdout, ...) completes after process.stdout is materialized", async () => {
+    const SIZE = 1024 * 1024;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const _ = process.stdout;
+          await Bun.write(Bun.stdout, Buffer.alloc(${SIZE}, "A").toString());
+          process.stderr.write("done");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("done");
+    expect(stdout.length).toBe(SIZE);
+    expect(exitCode).toBe(0);
+  });
+
+  it.skipIf(isWindows)(
+    "console.log / process.stdout.write / Bun.write(Bun.stdout) interleaved deliver every line",
+    async () => {
+      const N = 200;
+      const PAD = 512;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const pad = Buffer.alloc(${PAD}, "x").toString();
+            for (let i = 0; i < ${N}; i++) {
+              console.log("A" + i + " " + pad);
+              process.stdout.write("B" + i + " " + pad + "\\n");
+              Bun.write(Bun.stdout, "C" + i + " " + pad + "\\n");
+            }
+            await Bun.write(Bun.stdout, "");
+            process.stderr.write("done");
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("done");
+      const lines = stdout.split("\n").filter(Boolean);
+      expect({
+        A: lines.filter(l => l.startsWith("A")).length,
+        B: lines.filter(l => l.startsWith("B")).length,
+        C: lines.filter(l => l.startsWith("C")).length,
+        total: lines.length,
+      }).toEqual({ A: N, B: N, C: N, total: 3 * N });
+      expect(exitCode).toBe(0);
+    },
+  );
+});


### PR DESCRIPTION
## Repro

```js
// r.mjs  (bun r.mjs | cat > out.txt); echo exit=$? lines=$(wc -l < out.txt)
for (let i = 0; i < 10000; i++) {
  console.log("A" + i);
  process.stdout.write("B" + i + "\n");
  Bun.write(Bun.stdout, "C" + i + "\n");
}
await Bun.write(Bun.stdout, "");
process.stderr.write("done\n");
```

On a pipe, roughly 1/4 of runs hang forever (`wchan=ep_poll` after "done" reaches stderr) and another 1/4 exit 0 with the last few hundred lines missing. A deterministic minimal form:

```js
const _ = process.stdout;
await Bun.write(Bun.stdout, Buffer.alloc(1024 * 1024, "A").toString());
// never resolves; process spins at 100% CPU with 8 KB written
```

## Cause

`process.stdout` on a pipe goes through `getStdioWriteStream` → `Bun.file(1).writer()`. On POSIX that reaches `FileSink::setup()`, which calls `open_for_writing` with the fd. `open_for_writing` dups fd 1 and sets `O_NONBLOCK` on the dup; the flag lives on the open file description, so fd 1 itself becomes non-blocking.

`BunProcess.cpp` then calls `Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio`, which sets `force_sync` and clears `O_NONBLOCK` via `update_nonblocking(this.fd, false)`. But `setup()` never wrote `self.fd` (only `self.writer` received the fd), so `this.fd == Fd::INVALID` and the undo is skipped. fd 1 stays non-blocking for the rest of the process.

With fd 1 non-blocking and the pipe buffer full:

- `console.log` goes through `fd_write_all_quiet`, which treats any `Err` (including `EAGAIN`) as "give up" and discards the unwritten tail, hence the silently short output.
- `Bun.write(Bun.stdout, ...)` goes through `WriteFile::do_write`. `Bun.stdout`'s store has `seekable: None`, so `could_block` computes to `false`. On `EAGAIN` with `could_block == false`, the retry arm did `continue` on a `loop { match &result { ... } }` whose `result` binding was computed once before the loop, so it re-matched the same `Err(EAGAIN)` forever without re-issuing the write.

## Fix

- `FileSink::setup()` records `self.fd` in the success arms of `writer.start()`/`start_sync()`, so the force-sync callback can actually clear `O_NONBLOCK`.
- `WriteFile::do_write()` on `EAGAIN` now sets `could_block = true` and calls `wait_for_writable()`. Regular files never return `EAGAIN`, so reaching that arm proves the fd is pollable regardless of what the store implied.

## Verification

New tests in `test/js/bun/util/filesink.test.ts`:

- asserts fd 1 reads as blocking in `/proc/self/fdinfo/1` after `process.stdout.write` (Linux);
- `process.stdout; await Bun.write(Bun.stdout, 1 MiB)` completes and delivers every byte;
- the three-way `console.log` / `process.stdout.write` / `Bun.write(Bun.stdout)` loop delivers every line.

All three fail on `main` (the first with `nonblock`, the other two hang) and pass with this change. The original 30 000-line repro runs clean 8/8 including with a delayed reader.

Related: #33560 adds an `EAGAIN` retry to `fd_write_all_quiet`; #31180 sets `force_sync` up front for `Bun.file(1).writer()`. Both are complementary but neither addresses the `setup()`-not-recording-fd bug or the `WriteFile` spin.

Closes #28145.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesink.test.ts

<!-- robobun:evidence:end -->