### PR TITLE
bundler: hoist object/array --define values to a shared var

### DIFF
--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -232,6 +232,7 @@ impl DefineExt for Define {
         let mut define = Box::new(Define {
             identifiers: StringHashMap::default(),
             dots: StringHashMap::default(),
+            injected: Vec::new(),
             drop_debugger,
         });
         define.dots.reserve(124);
@@ -448,6 +449,7 @@ impl DefineDataExt for DefineData {
                     /* method_call_must_be_replaced_with_undefined: */
                     method_call_must_be_replaced_with_undefined_,
                 ),
+                injected_define_index: None,
             });
         }
 
@@ -476,6 +478,7 @@ impl DefineDataExt for DefineData {
                     /* method_call_must_be_replaced_with_undefined: */
                     method_call_must_be_replaced_with_undefined_,
                 ),
+                injected_define_index: None,
             });
         }
 
@@ -522,6 +525,7 @@ impl DefineDataExt for DefineData {
                 /* method_call_must_be_replaced_with_undefined: */
                 method_call_must_be_replaced_with_undefined_,
             ),
+            injected_define_index: None,
         })
     }
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1366,6 +1366,7 @@ impl<'a> BundleOptions<'a> {
             define: Box::new(defines::Define {
                 identifiers: self.define.identifiers.clone(),
                 dots: self.define.dots.clone(),
+                injected: self.define.injected.clone(),
                 drop_debugger: self.define.drop_debugger,
             }),
             drop: self.drop.clone(),
@@ -1633,6 +1634,7 @@ impl<'a> BundleOptions<'a> {
             define: Box::new(defines::Define {
                 identifiers: Default::default(),
                 dots: Default::default(),
+                injected: Vec::new(),
                 drop_debugger: false,
             }),
             loaders,

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -506,9 +506,10 @@ pub mod defines {
         pub value: ExprData,
     }
 
-    // SAFETY: see `Send`/`Sync` for DefineData — `value` points at immutable
+    // SAFETY: see `Send` for DefineData — `value` points at immutable
     // process-lifetime AST stores and is only read after `Define::init`.
     unsafe impl Send for InjectedDefine {}
+    // SAFETY: see `Send` impl above.
     unsafe impl Sync for InjectedDefine {}
 
     #[derive(Default)]

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -373,6 +373,11 @@ pub mod defines {
         // tier up for json-parser access) can construct directly.
         pub original_name: Option<Box<[u8]>>,
         pub flags: Flags,
+        /// Set when `value` is an object or array literal. Index into
+        /// `Define.injected`. The parser substitutes the value with a
+        /// reference to a hoisted `var` so every use site shares one
+        /// allocation (matching esbuild's `<define:X>` behaviour).
+        pub injected_define_index: Option<u32>,
     }
 
     // SAFETY: `ExprData` contains `StoreRef` raw pointers into immutable,
@@ -389,6 +394,7 @@ pub mod defines {
                 value: ExprData::EMissing(E::Missing),
                 original_name: None,
                 flags: Flags::default(),
+                injected_define_index: None,
             }
         }
     }
@@ -427,6 +433,7 @@ pub mod defines {
                     options.method_call_must_be_replaced_with_undefined,
                 ),
                 original_name: options.original_name.map(Box::<[u8]>::from),
+                injected_define_index: None,
             }
         }
 
@@ -490,14 +497,30 @@ pub mod defines {
                         || b.method_call_must_be_replaced_with_undefined(),
                 ),
                 original_name: b.original_name,
+                injected_define_index: b.injected_define_index,
             }
         }
     }
+
+    /// An object/array `--define` value that the parser materializes once as a
+    /// hoisted `var` and references by identifier, so repeated uses share one
+    /// object (esbuild's `<define:X>` synthetic-module analogue, per-file).
+    #[derive(Clone)]
+    pub struct InjectedDefine {
+        pub name: Box<[u8]>,
+        pub value: ExprData,
+    }
+
+    // SAFETY: see `Send`/`Sync` for DefineData — `value` points at immutable
+    // process-lifetime AST stores and is only read after `Define::init`.
+    unsafe impl Send for InjectedDefine {}
+    unsafe impl Sync for InjectedDefine {}
 
     #[derive(Default)]
     pub struct Define {
         pub identifiers: StringHashMap<IdentifierDefine>,
         pub dots: StringHashMap<Vec<DotDefine>>,
+        pub injected: Vec<InjectedDefine>,
         pub drop_debugger: bool,
     }
 
@@ -522,8 +545,25 @@ pub mod defines {
         pub fn insert(
             &mut self,
             key: &[u8],
-            value: DefineData,
+            mut value: DefineData,
         ) -> Result<(), bun_alloc::AllocError> {
+            // Object/array literals: hoist to a single shared `var` so every
+            // reference resolves to the same object instead of emitting a fresh
+            // `{...}` at each use site. `parse_env_json` + `deep_clone` produce
+            // `EObject`/`EArray` (not the JSON variants) for user `--define` values.
+            if !value.valueless()
+                && matches!(
+                    value.value.tag(),
+                    bun_ast::expr::Tag::EObject | bun_ast::expr::Tag::EArray
+                )
+            {
+                value.injected_define_index = Some(self.injected.len() as u32);
+                self.injected.push(InjectedDefine {
+                    name: Box::from(key),
+                    value: value.value,
+                });
+            }
+
             // If it has a dot, then it's a DotDefine. e.g. process.env.NODE_ENV
             if let Some(last_dot) = strings::last_index_of_char(key, b'.') {
                 let tail = &key[last_dot + 1..key.len()];

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -373,10 +373,7 @@ pub mod defines {
         // tier up for json-parser access) can construct directly.
         pub original_name: Option<Box<[u8]>>,
         pub flags: Flags,
-        /// Set when `value` is an object or array literal. Index into
-        /// `Define.injected`. The parser substitutes the value with a
-        /// reference to a hoisted `var` so every use site shares one
-        /// allocation (matching esbuild's `<define:X>` behaviour).
+        /// Index into `Define.injected` when `value` is an object/array literal.
         pub injected_define_index: Option<u32>,
     }
 
@@ -502,9 +499,7 @@ pub mod defines {
         }
     }
 
-    /// An object/array `--define` value that the parser materializes once as a
-    /// hoisted `var` and references by identifier, so repeated uses share one
-    /// object (esbuild's `<define:X>` synthetic-module analogue, per-file).
+    /// An object/array `--define` value the parser hoists to one shared `var`.
     #[derive(Clone)]
     pub struct InjectedDefine {
         pub name: Box<[u8]>,
@@ -547,10 +542,7 @@ pub mod defines {
             key: &[u8],
             mut value: DefineData,
         ) -> Result<(), bun_alloc::AllocError> {
-            // Object/array literals: hoist to a single shared `var` so every
-            // reference resolves to the same object instead of emitting a fresh
-            // `{...}` at each use site. `parse_env_json` + `deep_clone` produce
-            // `EObject`/`EArray` (not the JSON variants) for user `--define` values.
+            // `deep_clone` normalises JSON-parsed values to EObject/EArray.
             if !value.valueless()
                 && matches!(
                     value.value.tag(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -536,6 +536,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub temp_refs_to_declare: List<'a, TempRef>,
     pub temp_ref_count: i32,
 
+    // Indexed by DefineData.injected_define_index. Symbol each object/array
+    // `--define` value is hoisted to in this file.
+    pub injected_define_refs: List<'a, Ref>,
+
     // When bundling, hoisted top-level local variables declared with "var" in
     // nested scopes are moved up to be declared in the top-level scope instead.
     // The old "var" statements are turned into regular assignments instead. This
@@ -2834,6 +2838,42 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.declare_common_js_symbol(js_ast::symbol::Kind::Unbound, b"__dirname")?;
         self.filename_ref =
             self.declare_common_js_symbol(js_ast::symbol::Kind::Unbound, b"__filename")?;
+
+        // Pre-declare one module-scoped symbol per hoistable (object/array)
+        // `--define` value so `value_for_define` can substitute an identifier
+        // instead of inlining a fresh literal at every use site.
+        if !self.define.injected.is_empty() {
+            self.injected_define_refs
+                .reserve(self.define.injected.len());
+            let will_use_renamer = self.will_use_renamer();
+            for injected in self.define.injected.iter() {
+                let sanitized =
+                    bun_core::MutableString::ensure_valid_identifier(&injected.name)
+                        .unwrap_or_else(|_| Box::from(b"_".as_slice()));
+                // Without a renamer (transform-only, no minify) the printer emits
+                // `original_name` verbatim, so suffix a hash of the key bytes to
+                // keep it collision-resistant against user bindings.
+                let name: &'a [u8] = if will_use_renamer {
+                    bun_alloc::arena_format!(
+                        in self.arena,
+                        "define_{}_default",
+                        bstr::BStr::new(&sanitized)
+                    )
+                } else {
+                    bun_alloc::arena_format!(
+                        in self.arena,
+                        "define_{}_default_{}",
+                        bstr::BStr::new(&sanitized),
+                        bun_core::fmt::truncated_hash32(bun_wyhash::hash(&injected.name))
+                    )
+                }
+                .into_bump_str()
+                .as_bytes();
+                let ref_ = self.new_symbol(js_ast::symbol::Kind::Other, name);
+                VecExt::append(&mut self.module_scope_mut().generated, ref_);
+                self.injected_define_refs.push(ref_);
+            }
+        }
 
         if self.options.features.inject_jest_globals {
             self.jest.test =
@@ -6303,6 +6343,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         is_delete_target: bool,
         define_data: &DefineData,
     ) -> Expr {
+        // Object/array define values are hoisted to a single `var` so every use
+        // site shares one allocation and `a === b` holds. The index was assigned
+        // by `Define::insert`; the symbol was pre-declared in
+        // `prepare_for_visit_pass`.
+        if let Some(idx) = define_data.injected_define_index {
+            if let Some(&ref_) = self.injected_define_refs.get(idx as usize) {
+                self.record_usage(ref_);
+                return Expr {
+                    data: js_ast::ExprData::EIdentifier(
+                        E::Identifier::init(ref_).with_can_be_removed_if_unused(true),
+                    ),
+                    loc,
+                };
+            }
+        }
+
         // Callers gate on `!valueless()` before reaching here, so `value` is a
         // real Expr.Data by contract.
         let value = define_data.value;
@@ -8794,6 +8850,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             await_target: None,
             temp_refs_to_declare: BumpVec::new_in(arena),
             temp_ref_count: 0,
+            injected_define_refs: BumpVec::new_in(arena),
             relocated_top_level_vars: BumpVec::new_in(arena),
             after_arrow_body_loc: bun_ast::Loc::EMPTY,
             const_values: Default::default(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2847,9 +2847,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .reserve(self.define.injected.len());
             let will_use_renamer = self.will_use_renamer();
             for injected in self.define.injected.iter() {
-                let sanitized =
-                    bun_core::MutableString::ensure_valid_identifier(&injected.name)
-                        .unwrap_or_else(|_| Box::from(b"_".as_slice()));
+                let sanitized = bun_core::MutableString::ensure_valid_identifier(&injected.name)
+                    .unwrap_or_else(|_| Box::from(b"_".as_slice()));
                 // Without a renamer (transform-only, no minify) the printer emits
                 // `original_name` verbatim, so suffix a hash of the key bytes to
                 // keep it collision-resistant against user bindings.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2843,8 +2843,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .reserve(self.define.injected.len());
             let will_use_renamer = self.will_use_renamer();
             for injected in self.define.injected.iter() {
-                let sanitized =
-                    bun_core::MutableString::ensure_valid_identifier(&injected.name)?;
+                let sanitized = bun_core::MutableString::ensure_valid_identifier(&injected.name)?;
                 // No renamer => printed verbatim, so suffix a hash for collision safety.
                 let name: &'a [u8] = if will_use_renamer {
                     bun_alloc::arena_format!(

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -536,8 +536,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub temp_refs_to_declare: List<'a, TempRef>,
     pub temp_ref_count: i32,
 
-    // Indexed by DefineData.injected_define_index. Symbol each object/array
-    // `--define` value is hoisted to in this file.
+    // Indexed by `DefineData.injected_define_index`.
     pub injected_define_refs: List<'a, Ref>,
 
     // When bundling, hoisted top-level local variables declared with "var" in
@@ -2839,9 +2838,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.filename_ref =
             self.declare_common_js_symbol(js_ast::symbol::Kind::Unbound, b"__filename")?;
 
-        // Pre-declare one module-scoped symbol per hoistable (object/array)
-        // `--define` value so `value_for_define` can substitute an identifier
-        // instead of inlining a fresh literal at every use site.
         if !self.define.injected.is_empty() {
             self.injected_define_refs
                 .reserve(self.define.injected.len());
@@ -2849,9 +2845,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             for injected in self.define.injected.iter() {
                 let sanitized = bun_core::MutableString::ensure_valid_identifier(&injected.name)
                     .unwrap_or_else(|_| Box::from(b"_".as_slice()));
-                // Without a renamer (transform-only, no minify) the printer emits
-                // `original_name` verbatim, so suffix a hash of the key bytes to
-                // keep it collision-resistant against user bindings.
+                // No renamer => printed verbatim, so suffix a hash for collision safety.
                 let name: &'a [u8] = if will_use_renamer {
                     bun_alloc::arena_format!(
                         in self.arena,
@@ -6342,10 +6336,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         is_delete_target: bool,
         define_data: &DefineData,
     ) -> Expr {
-        // Object/array define values are hoisted to a single `var` so every use
-        // site shares one allocation and `a === b` holds. The index was assigned
-        // by `Define::insert`; the symbol was pre-declared in
-        // `prepare_for_visit_pass`.
         if let Some(idx) = define_data.injected_define_index {
             if let Some(&ref_) = self.injected_define_refs.get(idx as usize) {
                 self.record_usage(ref_);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2843,8 +2843,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .reserve(self.define.injected.len());
             let will_use_renamer = self.will_use_renamer();
             for injected in self.define.injected.iter() {
-                let sanitized = bun_core::MutableString::ensure_valid_identifier(&injected.name)
-                    .unwrap_or_else(|_| Box::from(b"_".as_slice()));
+                let sanitized =
+                    bun_core::MutableString::ensure_valid_identifier(&injected.name)?;
                 // No renamer => printed verbatim, so suffix a hash for collision safety.
                 let name: &'a [u8] = if will_use_renamer {
                     bun_alloc::arena_format!(

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1091,6 +1091,48 @@ impl<'a> Parser<'a> {
             }
         }
 
+        // Emit `var define_X_default = {...}` for each object/array `--define`
+        // value that was referenced during the visit. Each goes in its own part
+        // so an unreferenced one can be tree-shaken independently.
+        for i in 0..p.injected_define_refs.len() {
+            let ref_ = p.injected_define_refs[i];
+            if p.symbols.as_slice()[ref_.inner_index() as usize].use_count_estimate == 0 {
+                continue;
+            }
+            let value = p.define.injected[i].value;
+            let mut declared_symbols =
+                bun_ast::DeclaredSymbolList::init_capacity(1).expect("unreachable");
+            declared_symbols.append_assume_capacity(DeclaredSymbol {
+                ref_,
+                is_top_level: true,
+            });
+            let binding = p.b(B::Identifier { r#ref: ref_ }, bun_ast::Loc::EMPTY);
+            let part_stmts = p.arena.alloc_slice_fill_with(1, |_| {
+                let mut decls = G::DeclList::init_capacity(1);
+                decls.append_assume_capacity(G::Decl {
+                    binding,
+                    value: Some(Expr {
+                        data: value,
+                        loc: bun_ast::Loc::EMPTY,
+                    }),
+                });
+                p.s(
+                    S::Local {
+                        kind: js_ast::LocalKind::KVar,
+                        decls,
+                        ..Default::default()
+                    },
+                    bun_ast::Loc::EMPTY,
+                )
+            });
+            before.push(js_ast::Part {
+                stmts: part_stmts.into(),
+                declared_symbols,
+                can_be_removed_if_unused: true,
+                ..Default::default()
+            });
+        }
+
         // This is a workaround for broken module environment checks in packages like lodash-es
         // https://github.com/lodash/lodash/issues/5660
         let mut force_esm = false;

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1091,9 +1091,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // Emit `var define_X_default = {...}` for each object/array `--define`
-        // value that was referenced during the visit. Each goes in its own part
-        // so an unreferenced one can be tree-shaken independently.
+        // `var define_X_default = {...}` for each referenced injected define.
         for i in 0..p.injected_define_refs.len() {
             let ref_ = p.injected_define_refs[i];
             if p.symbols.as_slice()[ref_.inner_index() as usize].use_count_estimate == 0 {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1221,9 +1221,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             Op::UnDelete => {
                 let id_before = matches!(e_.value.data, Data::EIdentifier(..));
                 p.visit_expr_in_out(&mut e_.value, ExprIn::default());
-                // A define substitution can turn the property-access operand into a
-                // bare identifier; `delete <identifier>` is a strict-mode early
-                // error, so wrap it so the printer emits `delete (0, x)`.
+                // `delete <identifier>` is a strict-mode early error; wrap as `(0, x)`.
                 if !id_before && matches!(e_.value.data, Data::EIdentifier(..)) {
                     e_.value = Expr {
                         loc: e_.value.loc,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1219,15 +1219,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             Op::UnDelete => {
-                let id_before = matches!(e_.value.data, Data::EIdentifier(..));
+                let name_before = match e_.value.data {
+                    Data::EIdentifier(id) => Some(p.load_name_from_ref(id.ref_)),
+                    _ => None,
+                };
                 p.visit_expr_in_out(&mut e_.value, ExprIn::default());
-                // `delete <identifier>` is a strict-mode early error; wrap as `(0, x)`.
-                if !id_before && matches!(e_.value.data, Data::EIdentifier(..)) {
-                    e_.value = Expr {
-                        loc: e_.value.loc,
-                        data: prefill::data::ZERO,
+                // `delete <identifier>` is a strict-mode early error; wrap as `(0, x)`
+                // when define substitution produced an identifier the source didn't name.
+                if let Data::EIdentifier(id) = e_.value.data {
+                    let name_after =
+                        p.symbols[id.ref_.inner_index() as usize].original_name.slice();
+                    if name_before != Some(name_after) {
+                        e_.value = Expr {
+                            loc: e_.value.loc,
+                            data: prefill::data::ZERO,
+                        }
+                        .join_with_comma(e_.value);
                     }
-                    .join_with_comma(e_.value);
                 }
             }
             _ => {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1219,7 +1219,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             Op::UnDelete => {
+                let id_before = matches!(e_.value.data, Data::EIdentifier(..));
                 p.visit_expr_in_out(&mut e_.value, ExprIn::default());
+                // A define substitution can turn the property-access operand into a
+                // bare identifier; `delete <identifier>` is a strict-mode early
+                // error, so wrap it so the printer emits `delete (0, x)`.
+                if !id_before && matches!(e_.value.data, Data::EIdentifier(..)) {
+                    e_.value = Expr {
+                        loc: e_.value.loc,
+                        data: prefill::data::ZERO,
+                    }
+                    .join_with_comma(e_.value);
+                }
             }
             _ => {
                 let assign_target = Op::unary_assign_target(e_.op);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1226,8 +1226,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.visit_expr_in_out(&mut e_.value, ExprIn::default());
                 // `delete <ident>` is a strict-mode early error; wrap substituted operands.
                 if let Data::EIdentifier(id) = e_.value.data {
-                    let name_after =
-                        p.symbols[id.ref_.inner_index() as usize].original_name.slice();
+                    let name_after = p.symbols[id.ref_.inner_index() as usize]
+                        .original_name
+                        .slice();
                     if name_before != Some(name_after) {
                         e_.value = Expr {
                             loc: e_.value.loc,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1224,8 +1224,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     _ => None,
                 };
                 p.visit_expr_in_out(&mut e_.value, ExprIn::default());
-                // `delete <identifier>` is a strict-mode early error; wrap as `(0, x)`
-                // when define substitution produced an identifier the source didn't name.
+                // `delete <ident>` is a strict-mode early error; wrap substituted operands.
                 if let Data::EIdentifier(id) = e_.value.data {
                     let name_after =
                         p.symbols[id.ref_.inner_index() as usize].original_name.slice();

--- a/test/bundler/esbuild/extra.test.ts
+++ b/test/bundler/esbuild/extra.test.ts
@@ -747,7 +747,10 @@ describe("bundler", () => {
         console.log(delete CFG, delete ARR, delete keep);
       `,
     },
+    format: "iife",
     define: { CFG: '{"k":1}', ARR: "[1,2,3]" },
+    // iife + node keeps the bundle sloppy so `delete keep` stays valid syntax at runtime.
+    run: { runtime: "node", stdout: "true true false" },
     onAfterBundle(api) {
       const out = api.readFile("out.js");
       if (/\bdelete\s+define_[\w$]*\s*[,;)]/.test(out)) {

--- a/test/bundler/esbuild/extra.test.ts
+++ b/test/bundler/esbuild/extra.test.ts
@@ -721,6 +721,24 @@ describe("bundler", () => {
     define: { CFG: '{"k":1}' },
     run: { stdout: "ok" },
   });
+  // `delete` on a hoisted-object dot define must not print `delete <bare identifier>`
+  // (strict-mode early error); the operand has to be wrapped.
+  itBundled("extra/DefineObjectDeleteTarget", {
+    files: {
+      "in.mjs": /* js */ `
+        export {};
+        console.log(delete process.env.CFG, delete import.meta.CFG, process.env.CFG.x);
+      `,
+    },
+    define: { "process.env.CFG": '{"x":1}', "import.meta.CFG": "[1,2]" },
+    run: { stdout: "true true 1" },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      if (/\bdelete\s+[A-Za-z_$][\w$]*\s*[,;]/.test(out)) {
+        throw new Error("output contains `delete <bare identifier>` (strict-mode SyntaxError):\n" + out);
+      }
+    },
+  });
 
   // Various ESM cases
   itBundled("extra/CatchScope1", {

--- a/test/bundler/esbuild/extra.test.ts
+++ b/test/bundler/esbuild/extra.test.ts
@@ -671,6 +671,57 @@ describe("bundler", () => {
     run: true,
   });
 
+  // Object/array define values should be hoisted to a single shared binding so
+  // identity holds and mutations are visible across references (esbuild parity).
+  itBundled("extra/DefineObjectIdentity", {
+    files: {
+      "in.js": /* js */ `
+        const a = CFG, b = CFG;
+        if (a !== b) throw "identity: a !== b";
+        if (a.nested !== b.nested) throw "identity: a.nested !== b.nested";
+        a.k = 99;
+        if (b.k !== 99) throw "mutation: b.k !== 99";
+        console.log("ok");
+      `,
+    },
+    define: { CFG: '{"k":1,"nested":{"x":2}}' },
+    run: { stdout: "ok" },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      const literals = out.match(/\{\s*k:\s*1/g);
+      if ((literals?.length ?? 0) !== 1) {
+        throw new Error("expected exactly one { k: 1 ... } literal in output, got " + (literals?.length ?? 0));
+      }
+    },
+  });
+  itBundled("extra/DefineObjectIdentityDot", {
+    files: {
+      "in.js": /* js */ `
+        const a = process.env.CFG, b = process.env.CFG;
+        if (a !== b) throw "identity: a !== b";
+        if (ARR !== ARR) throw "identity: ARR !== ARR";
+        const arr = ARR;
+        arr.push(4);
+        if (ARR.length !== 4) throw "mutation: ARR.length !== 4";
+        console.log("ok");
+      `,
+    },
+    define: { "process.env.CFG": '{"k":1}', "ARR": "[1,2,3]" },
+    run: { stdout: "ok" },
+  });
+  itBundled("extra/DefineObjectIdentityNoBundle", {
+    files: {
+      "in.js": /* js */ `
+        const a = CFG, b = CFG;
+        if (a !== b) throw "identity: a !== b";
+        console.log("ok");
+      `,
+    },
+    bundling: false,
+    define: { CFG: '{"k":1}' },
+    run: { stdout: "ok" },
+  });
+
   // Various ESM cases
   itBundled("extra/CatchScope1", {
     files: {

--- a/test/bundler/esbuild/extra.test.ts
+++ b/test/bundler/esbuild/extra.test.ts
@@ -721,7 +721,7 @@ describe("bundler", () => {
     define: { CFG: '{"k":1}' },
     run: { stdout: "ok" },
   });
-  // `delete` on a hoisted-object dot define must not print `delete <bare identifier>`
+  // `delete` on a hoisted-object define must not print `delete <bare identifier>`
   // (strict-mode early error); the operand has to be wrapped.
   itBundled("extra/DefineObjectDeleteTarget", {
     files: {
@@ -736,6 +736,26 @@ describe("bundler", () => {
       const out = api.readFile("out.js");
       if (/\bdelete\s+[A-Za-z_$][\w$]*\s*[,;]/.test(out)) {
         throw new Error("output contains `delete <bare identifier>` (strict-mode SyntaxError):\n" + out);
+      }
+    },
+  });
+  itBundled("extra/DefineObjectDeleteBareIdentifier", {
+    files: {
+      "in.js": /* js */ `
+        // sloppy-mode source: delete <unbound> is valid here
+        var keep = 1;
+        console.log(delete CFG, delete ARR, delete keep);
+      `,
+    },
+    define: { CFG: '{"k":1}', ARR: "[1,2,3]" },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      if (/\bdelete\s+define_[\w$]*\s*[,;)]/.test(out)) {
+        throw new Error("hoisted define emitted as bare `delete <identifier>`:\n" + out);
+      }
+      // Source-written `delete keep` must stay a bare identifier reference.
+      if (!/\bdelete\s+keep\b/.test(out)) {
+        throw new Error("source-written `delete keep` was wrapped:\n" + out);
       }
     },
   });


### PR DESCRIPTION
## What

When `--define` is given an object or array literal, emit it once as `var define_KEY_default = {...}` at module scope and substitute every reference with that identifier, instead of inlining a fresh `{...}` at each use site.

## Repro

```js
// entry.mjs, built with: --define 'CFG={"k":1,"nested":{"x":2}}'
const a = CFG, b = CFG;
console.log(a === b, a.nested === b.nested);   // real global: true true
a.k = 99; console.log(b.k);                    // real global: 99
```

Before:
```js
var a = { k: 1, nested: { x: 2 } };
var b = { k: 1, nested: { x: 2 } };            // fresh copy per site
// prints: false false / 1
```

After (matches esbuild):
```js
var define_CFG_default = { k: 1, nested: { x: 2 } };
var a = define_CFG_default;
var b = define_CFG_default;
// prints: true true / 99
```

## Cause

`value_for_define` in `p.rs` returned `Expr { data: define_data.value, loc }` for anything that wasn't an identifier or string. For `EObject`/`EArray` that meant the same AST node was printed inline at every substitution site, so the output contained N independent literals. esbuild instead routes compound define values through its `--inject` path as a synthetic `<define:KEY>` module and substitutes a reference to its default export.

## Fix

- `Define::insert` assigns an `injected_define_index` to any `DefineData` whose value is `EObject`/`EArray` and records it on `Define.injected`.
- `prepare_for_visit_pass` pre-declares one module-scope symbol per injected define (`define_<key>_default`, hash-suffixed when the renamer isn't in use).
- `value_for_define` returns `EIdentifier(ref)` for injected defines and records the usage.
- After the visit, `parse_entry.rs` emits `var define_X_default = {...}` as its own `before` part (marked `can_be_removed_if_unused`) for each injected define that was actually referenced.

This also fixes a latent bug where assigning to an object-valued define printed `{"k":1} = x;`, which is a runtime SyntaxError.

Cross-module identity (a single object shared across every bundled file, esbuild's `<define:X>` virtual module) is not included; it needs the `--inject` infrastructure which bun has not ported. Each module now materializes the literal once instead of once per reference.

## Verification

```
USE_SYSTEM_BUN=1 bun test bundler/esbuild/extra.test.ts -t DefineObjectIdentity   # 3 fail
bun bd test bundler/esbuild/extra.test.ts -t DefineObjectIdentity                 # 3 pass
```

Also ran the full `extra.test.ts` (223 pass), `transpiler.test.js` (182 pass), `bundler_env.test.ts`, `bundler_jsx.test.ts`, and the `bun-build-api.test.ts` define cases.

Fixes #21319
Fixes #21312

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/extra.test.ts
bun test v1.4.0 (9c4f9f976)

test/bundler/esbuild/extra.test.ts:
(pass) bundler > extra/FileAsDirectoryBreak [499.88ms]
(todo) bundler > extra/PathWithQuestionMark
(pass) bundler > extra/JSXEscaping1 [131.11ms]
(pass) bundler > extra/JSXEscaping2 [152.24ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers1 [431.19ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers2 [396.61ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers3 [417.30ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers4 [423.55ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers5 [374.85ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers6 [466.56ms]
(pass) bundler > extra/RemoveASMDirective [448.24ms]
(pass) bundler > extra/ImportOrder1 [386.23ms]
(pass) bundler > extra/ImportOrder2 [441.48ms]
(pass) bundler > extra/CyclicImport1 [383.81ms]
(pass) bundler > extra/TypeofRequireESM [1433.45ms]
(pass) bundler > extra/CJSExport1 [919.59ms]
(pass) bundler > extra/CJSExport2 [428.0
... (truncated)

release without fix: 12 skipped
bun test v1.4.0-canary.1 (9c4f9f976)

test/bundler/esbuild/extra.test.ts:
(pass) bundler > extra/FileAsDirectoryBreak [17.96ms]
(todo) bundler > extra/PathWithQuestionMark
(pass) bundler > extra/JSXEscaping1 [3.67ms]
(pass) bundler > extra/JSXEscaping2 [3.85ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers1 [19.66ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers2 [18.14ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers3 [17.73ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers4 [23.71ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers5 [18.77ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers6 [24.21ms]
(pass) bundler > extra/RemoveASMDirective [19.47ms]
(pass) bundler > extra/ImportOrder1 [18.95ms]
(pass) bundler > extra/ImportOrder2 [28.79ms]
(pass) bundler > extra/CyclicImport1 [18.59ms]
(pass) bundler > extra/TypeofRequireESM [42.13ms]
(pass) bundler > extra/CJSExport1 [22.73ms]
(pass) bundler > extra/CJSExport2 [18.42ms]
(pass) bundler > extra/CJSExport3 [20.11ms]
(pass) bundler > extra/CJSExport4 [23.32ms]
(pass) bundler > extra/CJSExport5 [24.08ms]
(pass) bundler > extra/CJSExport6 [21.66m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/extra.test.ts
bun test v1.4.0 (9c4f9f976)

test/bundler/esbuild/extra.test.ts:
(pass) bundler > extra/FileAsDirectoryBreak [471.72ms]
(todo) bundler > extra/PathWithQuestionMark
(pass) bundler > extra/JSXEscaping1 [103.74ms]
(pass) bundler > extra/JSXEscaping2 [80.14ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers1 [373.93ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers2 [411.65ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers3 [404.21ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers4 [399.03ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers5 [362.78ms]
(pass) bundler > extra/ArbitraryModuleNamespaceIdentifiers6 [394.97ms]
(pass) bundler > extra/RemoveASMDirective [408.94ms]
(pass) bundler > extra/ImportOrder1 [384.28ms]
(pass) bundler > extra/ImportOrder2 [408.29ms]
(pass) bundler > extra/CyclicImport1 [403.53ms]
(pass) bundler > extra/TypeofRequireESM [1339.66ms]
(pass) bundler > extra/CJSExport1 [383.73ms]
(pass) bundler > extra/CJSExport2 [701.54
... (truncated)

release with fix: 12 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 739ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/defines.rs             |  4 ++
 src/bundler/options.rs             |  2 +
 src/js_parser/lib.rs               | 35 ++++++++++++++-
 src/js_parser/p.rs                 | 45 +++++++++++++++++++
 src/js_parser/parse/parse_entry.rs | 40 +++++++++++++++++
 src/js_parser/visit/visit_expr.rs  | 17 +++++++
 test/bundler/esbuild/extra.test.ts | 92 ++++++++++++++++++++++++++++++++++++++
 7 files changed, 234 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/bundler/defines.rs                  2      4      0
src/bundler/options.rs                  1      2      0
src/js_parser/lib.rs                    5     10      0
src/js_parser/p.rs                     11     10      0
src/js_parser/parse/parse_entry.rs      4      4      0
src/js_parser/visit/visit_expr.rs       7      5      0
test/bundler/esbuild/extra.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->