### PR TITLE
bundler: error on 'with' statements that would land in strict-mode ESM output

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4345,6 +4345,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     why = b"All code inside a class is implicitly in strict mode";
                     where_ = self.enclosing_class_keyword;
                 }
+                js_ast::StrictModeKind::ExplicitStrictMode => {
+                    why = b"Strict mode is triggered by the \"use strict\" directive here";
+                    where_ = self.source.range_of_string(self.module_scope_directive_loc);
+                }
                 _ => {}
             }
             if why.is_empty() {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -4,7 +4,7 @@ use crate::lexer as js_lexer;
 use crate::p::{P, ReactRefreshExportKind};
 use crate::parser::{
     PrependTempRefsOpts, ReactRefresh, Ref, RelocateVarsMode, SideEffects, StmtsKind,
-    statement_cares_about_scope,
+    StrictModeFeature, statement_cares_about_scope,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast::flags;
@@ -1623,6 +1623,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::With,
     ) -> Result<(), Error> {
+        p.mark_strict_mode_feature(
+            StrictModeFeature::WithStatement,
+            js_lexer::range_of_identifier(p.source, stmt.loc),
+            b"",
+        )?;
+
         p.visit_expr(&mut data.value);
 
         p.push_scope_for_visit_pass(js_ast::scope::Kind::With, data.body_loc)

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2887,6 +2887,18 @@ describe("bundler", () => {
       "/entry.js": [`With statements cannot be used in strict mode`],
     },
   });
+  itBundled("edgecase/WithStatementUseStrictSourceError", {
+    files: {
+      "/entry.js": /* js */ `
+        "use strict";
+        with (globalThis) { console.log(1); }
+      `,
+    },
+    format: "cjs",
+    bundleErrors: {
+      "/entry.js": [`With statements cannot be used in strict mode`],
+    },
+  });
   itBundled("edgecase/WithStatementCJSOutputAllowed", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2916,6 +2916,7 @@ describe("bundler", () => {
     onAfterBundle(api) {
       expect(api.readFile("/out.js")).toContain("with (scope)");
     },
+    run: { stdout: "hi" },
   });
 });
 

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2858,6 +2858,65 @@ describe("bundler", () => {
       expect(out).not.toContain("require_foo\u2014bar");
     },
   });
+  itBundled("edgecase/WithStatementESMOutputError", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import w from './w.cjs';
+        console.log(w.read());
+      `,
+      "/w.cjs": /* js */ `
+        var scope = { greeting: 'hi' };
+        function read() { with (scope) { return greeting; } }
+        module.exports = { read };
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/w.cjs": [`With statements cannot be used with the ESM output format due to strict mode`],
+    },
+  });
+  itBundled("edgecase/WithStatementESMSourceError", {
+    files: {
+      "/entry.js": /* js */ `
+        with (globalThis) { console.log(1); }
+        export {};
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/entry.js": [`With statements cannot be used in strict mode`],
+    },
+  });
+  itBundled("edgecase/WithStatementCJSOutputAllowed", {
+    files: {
+      "/entry.js": /* js */ `
+        const w = require('./w.cjs');
+        console.log(w.read());
+      `,
+      "/w.cjs": /* js */ `
+        var scope = { greeting: 'hi' };
+        function read() { with (scope) { return greeting; } }
+        module.exports = { read };
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toContain("with (scope)");
+    },
+    run: { stdout: "hi" },
+  });
+  itBundled("edgecase/WithStatementIIFEOutputAllowed", {
+    files: {
+      "/entry.js": /* js */ `
+        var scope = { greeting: 'hi' };
+        with (scope) { console.log(greeting); }
+      `,
+    },
+    format: "iife",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toContain("with (scope)");
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {


### PR DESCRIPTION
## What

`bun build --format=esm` now refuses to bundle a `with` statement into the output, matching esbuild. Previously the build succeeded (exit 0) and produced an artifact that is a whole-file `SyntaxError` under Node.

## Repro

```js
// w.cjs (sloppy CJS, legal on its own)
var scope = { greeting: 'hi-from-with' };
function read(){ with (scope) { return greeting; } }
module.exports = { read };

// entry.mjs
import w from './w.cjs';
console.log('read()', w.read());
```

```
$ bun build entry.mjs --target=node --outfile=out.mjs   # before: exits 0
$ node out.mjs
SyntaxError: Strict mode code may not include a with statement
```

esbuild rejects this:
```
✘ [ERROR] With statements cannot be used with the "esm" output format due to strict mode
```

## Cause

`mark_strict_mode_feature` in `src/js_parser/p.rs` already has a `StrictModeFeature::WithStatement` arm and an `is_strict_mode_output_format()` branch that produces the esbuild-style error, but nothing ever called it for `with`. The visit pass now calls it in `s_with`.

This also covers the already-strict source case (`with` in a file that has `import`/`export`/`"use strict"`), which now fails at parse with a note pointing at what made the file strict instead of falling through to a JSC SyntaxError. Filled in the `ExplicitStrictMode` arm of that note so it reads `Strict mode is triggered by the "use strict" directive here` instead of `because of the "" keyword here`.

## After

```
$ bun build entry.mjs --target=node --outfile=out.mjs
2 | function read(){ with (scope) { return greeting; } }
                     ^
error: With statements cannot be used with the ESM output format due to strict mode
    at w.cjs:2:18
```

`--format=cjs` and `--format=iife` still accept `with` and emit it unchanged. Runtime execution of sloppy CJS containing `with` is unaffected.

## Tests

Added to `test/bundler/bundler_edgecase.test.ts`:
- `WithStatementESMOutputError`: CJS `with` bundled to ESM fails with the new error
- `WithStatementESMSourceError`: `with` alongside `export {}` fails with "cannot be used in strict mode"
- `WithStatementCJSOutputAllowed` / `WithStatementIIFEOutputAllowed`: `with` still passes through for non-ESM output

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->