### PR TITLE
js_parser: error on delete of bare identifier when bundling to ESM

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1219,6 +1219,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             Op::UnDelete => {
+                if let Data::EIdentifier(_) = e_.value.data {
+                    p.mark_strict_mode_feature(
+                        StrictModeFeature::DeleteBareName,
+                        js_lexer::range_of_identifier(p.source, e_.value.loc),
+                        b"",
+                    )
+                    .expect("unreachable");
+                }
                 p.visit_expr_in_out(&mut e_.value, ExprIn::default());
             }
             _ => {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -487,6 +487,53 @@ describe("bundler", () => {
     onAfterBundle: noNestedExport,
     run: { stdout: "[1,2]" },
   });
+  itBundled("cjs2esm/DeleteBareNameErrorsWithEsmOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./d.cjs";
+      `,
+      "/d.cjs": /* js */ `
+        var x = 1;
+        delete x;
+        console.log("del", typeof x);
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/d.cjs": ['"delete" of a bare identifier cannot be used with the ESM output format due to strict mode'],
+    },
+  });
+  itBundled("cjs2esm/DeleteBareNameAllowedWithCjsOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        require("./d.cjs");
+      `,
+      "/d.cjs": /* js */ `
+        var x = 1;
+        delete x;
+        console.log("del", typeof x);
+      `,
+    },
+    format: "cjs",
+    onAfterBundle: api => {
+      expect(api.readFile("out.js")).toContain("delete x");
+    },
+  });
+  itBundled("cjs2esm/DeletePropertyAllowedWithEsmOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./d.cjs";
+      `,
+      "/d.cjs": /* js */ `
+        var o = { x: 1 };
+        delete o.x;
+        delete o["y"];
+        console.log("del", typeof o.x);
+      `,
+    },
+    format: "esm",
+    run: { stdout: "del undefined" },
+  });
   itBundled("cjs2esm/ExportsAssignTopLevelStillConverts", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2527,7 +2527,10 @@ console.log(<div {...obj} key="after" />);`),
     });
 
     it("exponentiation", () => {
-      expectPrinted("(delete x) ** 0", "(delete x) ** 0");
+      // `delete x` is a strict-mode error; `expectPrinted` wraps the input in
+      // `export default (...)`, which makes it strict. Use the non-wrapping
+      // helper for the bare-identifier case.
+      expectPrinted_("(delete x) ** 0", "(delete x) ** 0");
       expectPrinted("(delete x.prop) ** 0", "(delete x.prop) ** 0");
       expectPrinted("(delete x[0]) ** 0", "(delete x[0]) ** 0");
 
@@ -2556,7 +2559,7 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted("(~1) ** 2", "(~1) ** 2");
       expectPrinted("(!1) ** 2", "false ** 2");
       expectPrinted("(void x) ** 2", "(void x) ** 2");
-      expectPrinted("(delete x) ** 2", "(delete x) ** 2");
+      expectPrinted_("(delete x) ** 2", "(delete x) ** 2");
       expectPrinted("(typeof x) ** 2", "(typeof x) ** 2");
       expectPrinted("undefined ** 2", "undefined ** 2");
 
@@ -3288,6 +3291,15 @@ console.log(resolve.length)
     expectPrinted_("delete foo.bar.baz", "delete foo.bar.baz");
     expectPrinted_("delete foo?.bar.baz", "delete foo?.bar.baz");
     expectPrinted_("delete foo?.bar?.baz", "delete foo?.bar?.baz");
+  });
+
+  it("delete bare identifier", () => {
+    expectPrinted_("delete x", "delete x");
+    expectPrinted_("var x; delete (x)", "var x;\ndelete x");
+    expectParseError("'use strict'; delete x", '"delete" of a bare identifier cannot be used in strict mode');
+    expectParseError("delete x; export {}", '"delete" of a bare identifier cannot be used in strict mode');
+    expectParseError("class C { f() { delete x } }", '"delete" of a bare identifier cannot be used in strict mode');
+    expectPrinted_("var o = {}; delete o.x; delete o['y']", 'var o = {};\ndelete o.x;\ndelete o["y"]');
   });
 
   it("useDefineForConst TypeScript class initialization", () => {


### PR DESCRIPTION
### Problem

When a CommonJS file containing `delete <bare identifier>` (a sloppy-mode-only construct) is bundled with `--format=esm`, bun silently emits it into the strict ESM output. The artifact is a whole-file `SyntaxError` under node. esbuild refuses the same build:

```console
$ printf 'var x = 1; delete x; console.log("del", typeof x);\n' > d.cjs
$ printf "import './d.cjs';\n" > entry.mjs
$ bun build entry.mjs --target=node --format=esm --outfile=out.mjs
Bundled 2 modules in 3ms
$ node out.mjs
SyntaxError: Delete of an unqualified identifier in strict mode.
```

esbuild:

```console
$ npx esbuild entry.mjs --bundle --format=esm --outfile=out.mjs
✘ [ERROR] Delete of a bare identifier cannot be used with the "esm" output format due to strict mode
    d.cjs:1:18:
      1 │ var x = 1; delete x; console.log("del", typeof x);
        ╵                   ^
```

### Root cause

`mark_strict_mode_feature` in `src/js_parser/p.rs` already carries the exact diagnostic text (`"\"delete\" of a bare identifier cannot be used with the ESM output format due to strict mode"`) and the `bundle && output_format.is_esm()` gate, but `StrictModeFeature::DeleteBareName` had zero callers. esbuild raises it in the `UnOpDelete` visit arm when the operand is an `EIdentifier`; bun's `Op::UnDelete` arm only visited the operand.

### Fix

Raise `StrictModeFeature::DeleteBareName` in the `Op::UnDelete` visit arm (`src/js_parser/visit/visit_expr.rs`) when `e_.value.data` is `EIdentifier`, before visiting the operand, matching esbuild's placement in `js_parser.go`:

```console
$ bun build entry.mjs --target=node --format=esm --outfile=out.mjs
1 | var x = 1; delete x; console.log("del", typeof x);
                      ^
error: "delete" of a bare identifier cannot be used with the ESM output format due to strict mode
    at d.cjs:1:19
```

Because the check routes through `mark_strict_mode_feature`, it also catches `delete x` in source that is already strict (explicit `"use strict"`, ESM keywords, class bodies), producing a parse error with the strict-mode note where JSC would have thrown `SyntaxError` at runtime. The runtime transpiler's sloppy path (`Bun.Transpiler` with no bundle, CJS files at runtime), `--format=cjs`, and `--format=iife` are unchanged: `is_strict_mode()` is false and `is_strict_mode_output_format()` requires `bundle && esm`.

### Tests

`test/bundler/bundler_cjs2esm.test.ts`:
- `DeleteBareNameErrorsWithEsmOutput`: CJS `delete x` into ESM fails the build (fails on the unfixed build because the bundle succeeds when an error is expected)
- `DeleteBareNameAllowedWithCjsOutput`: same input with `--format=cjs` still bundles and emits `delete x`
- `DeletePropertyAllowedWithEsmOutput`: `delete o.x` / `delete o["y"]` in CJS into ESM still bundles and runs

`test/bundler/transpiler/transpiler.test.js`:
- New `"delete bare identifier"` block mirroring esbuild's parser tests: sloppy `delete x` prints, strict (`"use strict"`, `export {}`, class body) errors, property delete prints.
- The two existing `expectPrinted("(delete x) ** N", ...)` assertions in the exponentiation test are switched to the non-autoExporting helper, since `expectPrinted` wraps the input in `export default (...)` which is strict; the intent of those assertions (parenthesization around `**`) is unchanged.

Verified no regressions: full `bundler_cjs2esm` (26), `transpiler.test.js` (183), `bundler_cjs` + `bundler_edgecase` (145), `esbuild/default` (151), `bundler_minify` + `bundler_npm` (41) all pass. Runtime CJS `delete x` and the forced-CJS `.mjs` interop path run unchanged.

Sibling of the `with` case (`StrictModeFeature::WithStatement` has the same zero-callers shape); this PR only wires `DeleteBareName`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (5ac7e4c68)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [928.15ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [466.87ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [393.94ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [428.77ms]
(pass) bundler > cjs2esm/ExportsFunction [393.14ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [570.88ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [688.12ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [851.75ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [684.63ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [482.01ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [794.05ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [489.22ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [1122.74ms]
(pass) bundler > cjs2esm/ModuleEx
... (truncated)

release without fix: 22 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [35.96ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [20.02ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [19.52ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [19.45ms]
(pass) bundler > cjs2esm/ExportsFunction [18.62ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [19.91ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [18.45ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [20.02ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [22.45ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [26.64ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [27.11ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [21.71ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [33.30ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [21.83ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingAssignDeOpt [28.88ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingAssignExportsDeOpt [20.72ms]
397 |   // converted to `var $x = ...; export 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (5ac7e4c68)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [825.76ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [393.69ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [458.60ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [447.25ms]
(pass) bundler > cjs2esm/ExportsFunction [396.30ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [464.43ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [410.02ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [580.80ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [639.76ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [404.69ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [517.36ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [940.80ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [1140.21ms]
(pass) bundler > cjs2esm/ModuleEx
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 798ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
ninja: no work to do.
[build] done
bun test v1.4.0-canary.1 (5ac7e4c68)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [26.21ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [15.34ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [14.13ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [13.21ms]
(pass) bundler > cjs2esm/ExportsFunction [14.06ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [15.56ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [13.62ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [23.98ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [22.34ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [15.45ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [15.59ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [15.00ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [25.76ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/visit_expr.rs          |  8 +++++
 test/bundler/bundler_cjs2esm.test.ts       | 47 ++++++++++++++++++++++++++++++
 test/bundler/transpiler/transpiler.test.js | 16 ++++++++--
 3 files changed, 69 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/visit/visit_expr.rs               3      1      0
test/bundler/bundler_cjs2esm.test.ts            2      2      0
test/bundler/transpiler/transpiler.test.js      3      2      0
```

</details>

<!-- robobun:evidence:end -->