### PR TITLE
fetch: reject the fetch when an HTTP proxy refuses CONNECT to an https origin

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -97,6 +97,8 @@ pub enum Error {
     InvalidCRL,
     #[error("UnsupportedProxyProtocol")]
     UnsupportedProxyProtocol,
+    #[error("ProxyConnectFailed")]
+    ProxyConnectFailed(u32),
     #[error(transparent)]
     Cert(#[from] CertError),
     #[error(transparent)]
@@ -308,6 +310,7 @@ impl Error {
             Self::FailedToOpenSocket => "FailedToOpenSocket",
             Self::InvalidCRL => "InvalidCRL",
             Self::UnsupportedProxyProtocol => "UnsupportedProxyProtocol",
+            Self::ProxyConnectFailed(_) => "ProxyConnectFailed",
             Self::Cert(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",
             Self::Hpack(e) => <&'static str>::from(e),

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -97,7 +97,7 @@ pub enum Error {
     InvalidCRL,
     #[error("UnsupportedProxyProtocol")]
     UnsupportedProxyProtocol,
-    #[error("ProxyConnectFailed")]
+    #[error("CONNECT tunnel failed, response {0}")]
     ProxyConnectFailed(u32),
     #[error(transparent)]
     Cert(#[from] CertError),

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4917,6 +4917,28 @@ impl<'a> HTTPClient<'a> {
             print_response(response);
         }
 
+        // RFC 9110 §9.3.6: any 2xx response to CONNECT means the tunnel is
+        // established and the bytes after the header section are from the
+        // origin. A non-2xx response means the tunnel was not established;
+        // the proxy's status/headers/body arrived over the plaintext
+        // client→proxy hop, so they MUST NOT be returned as an https-origin
+        // Response — reject the fetch instead (curl / Node undici / browsers
+        // all do this; see CVE-2009-2062). The socket is closed by the
+        // caller's close_and_fail on Err.
+        //
+        // This runs before the status-code-driven state writes below: none of
+        // the CONNECT reply's properties (pretend_304, the 204/304
+        // content_length = Some(0) write) may leak into the origin response's
+        // pass — ProxyTunnel does not reset `state` between the two legs.
+        if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
+            if response.status_code >= 200 && response.status_code < 300 {
+                // signal to continue the proxing
+                return Ok(ShouldContinue::ContinueStreaming);
+            }
+
+            return Err(crate::Error::ProxyConnectFailed(response.status_code));
+        }
+
         if pretend_304 {
             response.status_code = 304;
         }
@@ -4927,8 +4949,6 @@ impl<'a> HTTPClient<'a> {
         //      [...] cannot contain a message body or trailer section.
         // Therefore in these cases set content-length to 0, so the response body is always ignored
         // and is not waited for (which could cause a timeout).
-        // This applies regardless of whether we're using a proxy tunnel or not,
-        // since these status codes NEVER have a body per the HTTP spec.
         if (response.status_code >= 100 && response.status_code < 200)
             || response.status_code == 204
             || response.status_code == 304
@@ -4952,23 +4972,6 @@ impl<'a> HTTPClient<'a> {
             {
                 self.state.flags.allow_keepalive = false;
             }
-        }
-
-        // RFC 9110 §9.3.6: any 2xx response to CONNECT means the tunnel is
-        // established and the bytes after the header section are from the
-        // origin. A non-2xx response means the tunnel was not established;
-        // the proxy's status/headers/body arrived over the plaintext
-        // client→proxy hop, so they MUST NOT be returned as an https-origin
-        // Response — reject the fetch instead (curl / Node undici / browsers
-        // all do this; see CVE-2009-2062). The socket is closed by the
-        // caller's close_and_fail on Err.
-        if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
-            if response.status_code >= 200 && response.status_code < 300 {
-                // signal to continue the proxing
-                return Ok(ShouldContinue::ContinueStreaming);
-            }
-
-            return Err(crate::Error::ProxyConnectFailed(response.status_code));
         }
 
         let status_code = response.status_code;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4774,11 +4774,10 @@ impl<'a> HTTPClient<'a> {
                     // Content-Length in a successful response to CONNECT —
                     // the connection becomes an opaque tunnel and is never
                     // pooled, so the framing-desync concern below does not
-                    // apply.
-                    if self.flags.proxy_tunneling
-                        && self.proxy_tunnel.is_none()
-                        && response.status_code == 200
-                    {
+                    // apply. A non-2xx CONNECT reply is rejected outright
+                    // below (ProxyConnectFailed), so no framing is needed for
+                    // that case either.
+                    if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
                         continue;
                     }
                     // byte-level parse — header.value() is network bytes, not &str
@@ -4838,10 +4837,7 @@ impl<'a> HTTPClient<'a> {
                     // RFC 9110 section 9.3.6: as with Content-Length above, a
                     // client MUST ignore Transfer-Encoding in a successful
                     // response to CONNECT.
-                    if self.flags.proxy_tunneling
-                        && self.proxy_tunnel.is_none()
-                        && response.status_code == 200
-                    {
+                    if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
                         continue;
                     }
                     // RFC 9112 §7: transfer-coding names are case-insensitive.
@@ -4958,22 +4954,21 @@ impl<'a> HTTPClient<'a> {
             }
         }
 
-        // RFC 9110 §9.3.6: a non-200 response to CONNECT means the tunnel was
-        // not established. Surface the proxy's response to the caller, but
-        // never follow a Location header from it — a malicious proxy could
-        // otherwise redirect the request (body and custom headers included)
-        // to an attacker-chosen plaintext origin.
-        let mut is_proxy_connect_failure = false;
+        // RFC 9110 §9.3.6: any 2xx response to CONNECT means the tunnel is
+        // established and the bytes after the header section are from the
+        // origin. A non-2xx response means the tunnel was not established;
+        // the proxy's status/headers/body arrived over the plaintext
+        // client→proxy hop, so they MUST NOT be returned as an https-origin
+        // Response — reject the fetch instead (curl / Node undici / browsers
+        // all do this; see CVE-2009-2062). The socket is closed by the
+        // caller's close_and_fail on Err.
         if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
-            if response.status_code == 200 {
+            if response.status_code >= 200 && response.status_code < 300 {
                 // signal to continue the proxing
                 return Ok(ShouldContinue::ContinueStreaming);
             }
 
-            // proxy denied connection so return proxy result (407, 403 etc)
-            self.flags.proxy_tunneling = false;
-            self.flags.disable_keepalive = true;
-            is_proxy_connect_failure = true;
+            return Err(crate::Error::ProxyConnectFailed(response.status_code));
         }
 
         let status_code = response.status_code;
@@ -4986,8 +4981,7 @@ impl<'a> HTTPClient<'a> {
         // if is no redirect or if is redirect == "manual" just proceed
         let is_redirect = status_code >= 300 && status_code <= 399;
         if is_redirect {
-            if !is_proxy_connect_failure
-                && self.redirect_type == FetchRedirect::Follow
+            if self.redirect_type == FetchRedirect::Follow
                 && !location.is_empty()
                 && self.remaining_redirect_count > 0
             {
@@ -5246,7 +5240,7 @@ impl<'a> HTTPClient<'a> {
                     }
                     _ => {}
                 }
-            } else if !is_proxy_connect_failure && self.redirect_type == FetchRedirect::Error {
+            } else if self.redirect_type == FetchRedirect::Error {
                 // error out if redirect is not allowed
                 return Err(crate::Error::UnexpectedRedirect);
             }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4764,17 +4764,29 @@ impl<'a> HTTPClient<'a> {
         &mut self,
         response: &mut picohttp::Response,
     ) -> crate::Result<ShouldContinue> {
+        if self.verbose != HTTPVerboseLevel::None {
+            print_response(response);
+        }
+
+        // RFC 9110 §9.3.6: any 2xx to CONNECT establishes the tunnel; a
+        // non-2xx CONNECT reply travelled over the plaintext client→proxy
+        // hop so it must reject the fetch, never surface as an https-origin
+        // Response (CVE-2009-2062). Dispatched before the header loop so no
+        // CONNECT-leg header or status writes `self.state` — ProxyTunnel
+        // does not reset it between the CONNECT leg and the origin leg.
+        if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
+            if response.status_code >= 200 && response.status_code < 300 {
+                return Ok(ShouldContinue::ContinueStreaming);
+            }
+            return Err(crate::Error::ProxyConnectFailed(response.status_code));
+        }
+
         let mut location: &[u8] = b"";
         let mut pretend_304 = false;
         let mut is_server_sent_events = false;
         for (header_i, header) in response.headers.list.iter().enumerate() {
             match hash_header_name(header.name()) {
                 h if h == hash_header_const(b"Content-Length") => {
-                    // RFC 9110 §9.3.6: ignore Content-Length in a response to
-                    // CONNECT (2xx → opaque tunnel, non-2xx → rejected below).
-                    if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
-                        continue;
-                    }
                     // byte-level parse — header.value() is network bytes, not &str
                     //
                     // RFC 9112 section 6.3: an invalid or conflicting
@@ -4829,12 +4841,6 @@ impl<'a> HTTPClient<'a> {
                     }
                 }
                 h if h == hash_header_const(b"Transfer-Encoding") => {
-                    // RFC 9110 section 9.3.6: as with Content-Length above, a
-                    // client MUST ignore Transfer-Encoding in a successful
-                    // response to CONNECT.
-                    if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
-                        continue;
-                    }
                     // RFC 9112 §7: transfer-coding names are case-insensitive.
                     let value = header.value();
                     if strings::eql_case_insensitive_ascii_check_length(value, b"gzip")
@@ -4906,25 +4912,6 @@ impl<'a> HTTPClient<'a> {
                 }
                 _ => {}
             }
-        }
-
-        if self.verbose != HTTPVerboseLevel::None {
-            print_response(response);
-        }
-
-        // RFC 9110 §9.3.6: any 2xx to CONNECT establishes the tunnel; a
-        // non-2xx CONNECT reply travelled over the plaintext client→proxy
-        // hop so it must reject the fetch, never surface as an https-origin
-        // Response (CVE-2009-2062). Dispatched here, before the state writes
-        // below, because ProxyTunnel does not reset `state` between the
-        // CONNECT leg and the origin leg.
-        if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
-            if response.status_code >= 200 && response.status_code < 300 {
-                // signal to continue the proxing
-                return Ok(ShouldContinue::ContinueStreaming);
-            }
-
-            return Err(crate::Error::ProxyConnectFailed(response.status_code));
         }
 
         if pretend_304 {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4770,13 +4770,8 @@ impl<'a> HTTPClient<'a> {
         for (header_i, header) in response.headers.list.iter().enumerate() {
             match hash_header_name(header.name()) {
                 h if h == hash_header_const(b"Content-Length") => {
-                    // RFC 9110 section 9.3.6: a client MUST ignore
-                    // Content-Length in a successful response to CONNECT —
-                    // the connection becomes an opaque tunnel and is never
-                    // pooled, so the framing-desync concern below does not
-                    // apply. A non-2xx CONNECT reply is rejected outright
-                    // below (ProxyConnectFailed), so no framing is needed for
-                    // that case either.
+                    // RFC 9110 §9.3.6: ignore Content-Length in a response to
+                    // CONNECT (2xx → opaque tunnel, non-2xx → rejected below).
                     if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
                         continue;
                     }
@@ -4917,19 +4912,12 @@ impl<'a> HTTPClient<'a> {
             print_response(response);
         }
 
-        // RFC 9110 §9.3.6: any 2xx response to CONNECT means the tunnel is
-        // established and the bytes after the header section are from the
-        // origin. A non-2xx response means the tunnel was not established;
-        // the proxy's status/headers/body arrived over the plaintext
-        // client→proxy hop, so they MUST NOT be returned as an https-origin
-        // Response — reject the fetch instead (curl / Node undici / browsers
-        // all do this; see CVE-2009-2062). The socket is closed by the
-        // caller's close_and_fail on Err.
-        //
-        // This runs before the status-code-driven state writes below: none of
-        // the CONNECT reply's properties (pretend_304, the 204/304
-        // content_length = Some(0) write) may leak into the origin response's
-        // pass — ProxyTunnel does not reset `state` between the two legs.
+        // RFC 9110 §9.3.6: any 2xx to CONNECT establishes the tunnel; a
+        // non-2xx CONNECT reply travelled over the plaintext client→proxy
+        // hop so it must reject the fetch, never surface as an https-origin
+        // Response (CVE-2009-2062). Dispatched here, before the state writes
+        // below, because ProxyTunnel does not reset `state` between the
+        // CONNECT leg and the origin leg.
         if self.flags.proxy_tunneling && self.proxy_tunnel.is_none() {
             if response.status_code >= 200 && response.status_code < 300 {
                 // signal to continue the proxing

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -985,19 +985,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
             body = &me.body;
         }
 
-        // Check for HTTP 200 response from proxy
-        let is_first = me.body.is_empty();
-        const HTTP_200: &[u8] = b"HTTP/1.1 200 ";
-        const HTTP_200_ALT: &[u8] = b"HTTP/1.0 200 ";
-        if is_first && body.len() > HTTP_200.len() {
-            if !body.starts_with(HTTP_200) && !body.starts_with(HTTP_200_ALT) {
-                // Proxy connection failed
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this.as_ptr(), ErrorCode::ProxyConnectFailed) };
-                return;
-            }
-        }
-
         // Parse the response to find the end of headers
         let response = match picohttp::Response::parse(body, &mut me.headers_buf) {
             Ok(r) => r,
@@ -1021,15 +1008,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
         };
 
-        // Proxy returned non-200 status
-        if response.status_code != 200 {
-            if response.status_code == 407 {
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this.as_ptr(), ErrorCode::ProxyAuthenticationRequired) };
+        // RFC 9110 §9.3.6: any 2xx to CONNECT establishes the tunnel.
+        if !(200..300).contains(&response.status_code) {
+            let code = if response.status_code == 407 {
+                ErrorCode::ProxyAuthenticationRequired
             } else {
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this.as_ptr(), ErrorCode::ProxyConnectFailed) };
-            }
+                ErrorCode::ProxyConnectFailed
+            };
+            // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
+            unsafe { Self::terminate(this.as_ptr(), code) };
             return;
         }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1348,6 +1348,9 @@ impl FetchTasklet {
             http::Error::RedirectURLInvalid => {
                 BunString::static_("Redirect URL in Location header is invalid.")
             }
+            http::Error::ProxyConnectFailed(status) => BunString::create_format(format_args!(
+                "CONNECT tunnel failed, proxy responded with status {status}",
+            )),
 
             http::Error::Cert(http::CertError::UNABLE_TO_GET_ISSUER_CERT) => {
                 BunString::static_("unable to get issuer certificate")

--- a/test/js/bun/http/proxy-stress-errors.test.ts
+++ b/test/js/bun/http/proxy-stress-errors.test.ts
@@ -132,54 +132,57 @@ describe("CONNECT failure status", () => {
   // origin leg (ProxyTunnel does not reset state between the two), or the
   // origin's Content-Length: N would be rejected as a duplicate-CL conflict.
   for (const connectStatus of [202, 204] as const) {
-    test.concurrent(`CONNECT → ${connectStatus} establishes the tunnel and the origin body arrives intact`, async () => {
-      await using origin = await createAdversarialOrigin({ tls: true, body: "hello-through-2xx-tunnel" });
+    test.concurrent(
+      `CONNECT → ${connectStatus} establishes the tunnel and the origin body arrives intact`,
+      async () => {
+        await using origin = await createAdversarialOrigin({ tls: true, body: "hello-through-2xx-tunnel" });
 
-      const sockets = new Set<net.Socket>();
-      const proxy = net.createServer(client => {
-        sockets.add(client);
-        client.on("close", () => sockets.delete(client));
-        client.on("error", () => {});
-        let head = "";
-        const onHead = (d: Buffer) => {
-          head += d.toString("latin1");
-          const end = head.indexOf("\r\n\r\n");
-          if (end < 0) return;
-          client.removeListener("data", onHead);
-          const [, target] = head.split("\r\n")[0].split(" ");
-          const colon = target.lastIndexOf(":");
-          const upstream = net.connect(Number(target.slice(colon + 1)), "127.0.0.1");
-          sockets.add(upstream);
-          upstream.on("close", () => (sockets.delete(upstream), client.end()));
-          upstream.on("error", () => client.destroy());
-          upstream.once("connect", () => {
-            client.write(`HTTP/1.1 ${connectStatus} ${connectStatus === 204 ? "No Content" : "Accepted"}\r\n\r\n`);
-            client.pipe(upstream);
-            upstream.pipe(client);
-          });
-        };
-        client.on("data", onHead);
-      });
-      proxy.listen(0, "127.0.0.1");
-      await once(proxy, "listening");
-      const port = (proxy.address() as net.AddressInfo).port;
-
-      try {
-        const res = await fetch(origin.url, {
-          proxy: `http://127.0.0.1:${port}`,
-          keepalive: false,
-          tls: laxTls,
-          signal: AbortSignal.timeout(15_000),
+        const sockets = new Set<net.Socket>();
+        const proxy = net.createServer(client => {
+          sockets.add(client);
+          client.on("close", () => sockets.delete(client));
+          client.on("error", () => {});
+          let head = "";
+          const onHead = (d: Buffer) => {
+            head += d.toString("latin1");
+            const end = head.indexOf("\r\n\r\n");
+            if (end < 0) return;
+            client.removeListener("data", onHead);
+            const [, target] = head.split("\r\n")[0].split(" ");
+            const colon = target.lastIndexOf(":");
+            const upstream = net.connect(Number(target.slice(colon + 1)), "127.0.0.1");
+            sockets.add(upstream);
+            upstream.on("close", () => (sockets.delete(upstream), client.end()));
+            upstream.on("error", () => client.destroy());
+            upstream.once("connect", () => {
+              client.write(`HTTP/1.1 ${connectStatus} ${connectStatus === 204 ? "No Content" : "Accepted"}\r\n\r\n`);
+              client.pipe(upstream);
+              upstream.pipe(client);
+            });
+          };
+          client.on("data", onHead);
         });
-        expect(await res.text()).toBe("hello-through-2xx-tunnel");
-        expect(res.status).toBe(200);
-        expect(res.headers.get("content-length")).toBe(String("hello-through-2xx-tunnel".length));
-        expect(origin.requests.length).toBe(1);
-      } finally {
-        for (const s of sockets) s.destroy();
-        proxy.close();
-      }
-    });
+        proxy.listen(0, "127.0.0.1");
+        await once(proxy, "listening");
+        const port = (proxy.address() as net.AddressInfo).port;
+
+        try {
+          const res = await fetch(origin.url, {
+            proxy: `http://127.0.0.1:${port}`,
+            keepalive: false,
+            tls: laxTls,
+            signal: AbortSignal.timeout(15_000),
+          });
+          expect(await res.text()).toBe("hello-through-2xx-tunnel");
+          expect(res.status).toBe(200);
+          expect(res.headers.get("content-length")).toBe(String("hello-through-2xx-tunnel".length));
+          expect(origin.requests.length).toBe(1);
+        } finally {
+          for (const s of sockets) s.destroy();
+          proxy.close();
+        }
+      },
+    );
   }
 
   for (const proxyTls of [false, true] as const) {

--- a/test/js/bun/http/proxy-stress-errors.test.ts
+++ b/test/js/bun/http/proxy-stress-errors.test.ts
@@ -45,7 +45,7 @@ describe("CONNECT failure status", () => {
     proxyTls: [false, true] as const,
     status: STATUSES,
   })) {
-    test.concurrent(`${proxyTls ? "https" : "http"}-proxy CONNECT → ${status} is surfaced as-is`, async () => {
+    test.concurrent(`${proxyTls ? "https" : "http"}-proxy CONNECT → ${status} rejects the fetch`, async () => {
       await using origin = await createAdversarialOrigin({ tls: true, body: "unreachable" });
       await using proxy = await createAdversarialProxy({
         tls: proxyTls,
@@ -53,23 +53,27 @@ describe("CONNECT failure status", () => {
         connectStatusBody: `proxy-said-${status}`,
       });
 
-      const res = await fetch(origin.url, {
-        proxy: proxy.url,
-        keepalive: false,
-        tls: laxTls,
-        signal: AbortSignal.timeout(15_000),
+      // The proxy's reply came over the plaintext client→proxy hop with no
+      // TLS handshake to the origin; it must never surface as a Response
+      // attributed to the https origin. The proxy's status code is carried
+      // in the error message so auth/gateway failures are still debuggable.
+      await expect(
+        fetch(origin.url, {
+          proxy: proxy.url,
+          keepalive: false,
+          tls: laxTls,
+          signal: AbortSignal.timeout(15_000),
+        }),
+      ).rejects.toMatchObject({
+        code: "ProxyConnectFailed",
+        message: expect.stringContaining(String(status)),
       });
-      // The client surfaces the proxy's reply; it does NOT tunnel through.
-      expect(res.status).toBe(status);
-      expect(await res.text()).toBe(`proxy-said-${status}`);
       // The origin must never have been reached.
       expect(origin.requests.length).toBe(0);
     });
   }
 
-  // A 3xx CONNECT reply is surfaced, not followed (already covered for 307
-  // in proxy.test.ts; here we add 301/302 and assert the Location is not
-  // interpreted).
+  // A 3xx CONNECT reply rejects the fetch and its Location is never followed.
   for (const status of [301, 302] as const) {
     test.concurrent(`CONNECT → ${status} with Location is not followed`, async () => {
       await using origin = await createAdversarialOrigin({ tls: true, body: "unreachable" });
@@ -79,10 +83,46 @@ describe("CONNECT failure status", () => {
         connectReplyHeaders: { Location: bait.url },
       });
 
-      const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
-      expect(res.status).toBe(status);
-      expect(res.headers.get("location")).toBe(bait.url);
+      await expect(fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls })).rejects.toMatchObject({
+        code: "ProxyConnectFailed",
+        message: expect.stringContaining(String(status)),
+      });
       expect(bait.requests.length).toBe(0);
+      expect(origin.requests.length).toBe(0);
+    });
+  }
+
+  // RFC 9110 §9.3.6: any 2xx to CONNECT switches to tunnel mode. A proxy
+  // that sends a body alongside a non-200 2xx is violating the spec; the
+  // client must treat the post-header bytes as tunnel payload (so the inner
+  // TLS handshake fails), never as an https-origin Response body.
+  for (const proxyTls of [false, true] as const) {
+    test.concurrent(`${proxyTls ? "https" : "http"}-proxy CONNECT → 201 is treated as tunnel-established`, async () => {
+      await using origin = await createAdversarialOrigin({ tls: true, body: "unreachable" });
+      await using proxy = await createAdversarialProxy({
+        tls: proxyTls,
+        connectStatus: 201,
+        connectStatusBody: "BODY201x",
+      });
+
+      let outcome: { status: number; ok: boolean; body: string } | string;
+      try {
+        const res = await fetch(origin.url, {
+          proxy: proxy.url,
+          keepalive: false,
+          tls: laxTls,
+          signal: AbortSignal.timeout(15_000),
+        });
+        outcome = { status: res.status, ok: res.ok, body: await res.text() };
+      } catch (e) {
+        outcome = errcode(e);
+      }
+      // The proxy's plaintext body must not surface as origin content. The
+      // bytes after the 2xx header feed the TLS handshake, which fails; the
+      // exact error depends on whether the proxy hangs up first.
+      expect(outcome).not.toEqual({ status: 201, ok: true, body: "BODY201x" });
+      expect(typeof outcome).toBe("string");
+      expect(outcome).not.toBe("TimeoutError");
       expect(origin.requests.length).toBe(0);
     });
   }
@@ -153,13 +193,17 @@ describe("upstream unreachable via proxy", () => {
 
       // Point at a refused port directly — the client will CONNECT to it,
       // the proxy will fail to dial, and return 502.
-      const res = await fetch(`https://127.0.0.1:${dead.port}/`, {
-        proxy: proxy.url,
-        keepalive: false,
-        tls: laxTls,
-        signal: AbortSignal.timeout(15_000),
+      await expect(
+        fetch(`https://127.0.0.1:${dead.port}/`, {
+          proxy: proxy.url,
+          keepalive: false,
+          tls: laxTls,
+          signal: AbortSignal.timeout(15_000),
+        }),
+      ).rejects.toMatchObject({
+        code: "ProxyConnectFailed",
+        message: expect.stringContaining("502"),
       });
-      expect(res.status).toBe(502);
     });
 
     test.concurrent(`${proxyTls ? "https" : "http"}-proxy, absolute-form upstream refused → 502`, async () => {
@@ -193,9 +237,19 @@ describe("proxy authentication", () => {
         tls: proxyTls,
         auth: { user: "alice", pass: "s3cret" },
       });
-      const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
-      expect(res.status).toBe(407);
-      expect(res.headers.get("proxy-authenticate")).toContain("Basic");
+      const req = fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
+      if (originTls) {
+        // CONNECT denied: fetch rejects, status carried in the message.
+        await expect(req).rejects.toMatchObject({
+          code: "ProxyConnectFailed",
+          message: expect.stringContaining("407"),
+        });
+      } else {
+        // Absolute-form http:// proxying: the 407 is a real Response.
+        const res = await req;
+        expect(res.status).toBe(407);
+        expect(res.headers.get("proxy-authenticate")).toContain("Basic");
+      }
       expect(origin.requests.length).toBe(0);
     });
 
@@ -205,12 +259,20 @@ describe("proxy authentication", () => {
         tls: proxyTls,
         auth: { user: "alice", pass: "s3cret" },
       });
-      const res = await fetch(origin.url, {
+      const req = fetch(origin.url, {
         proxy: `${proxyTls ? "https" : "http"}://alice:wrong@127.0.0.1:${proxy.port}`,
         keepalive: false,
         tls: laxTls,
       });
-      expect(res.status).toBe(403);
+      if (originTls) {
+        await expect(req).rejects.toMatchObject({
+          code: "ProxyConnectFailed",
+          message: expect.stringContaining("403"),
+        });
+      } else {
+        const res = await req;
+        expect(res.status).toBe(403);
+      }
       expect(origin.requests.length).toBe(0);
     });
 

--- a/test/js/bun/http/proxy-stress-errors.test.ts
+++ b/test/js/bun/http/proxy-stress-errors.test.ts
@@ -127,6 +127,61 @@ describe("CONNECT failure status", () => {
     });
   }
 
+  // A 204 CONNECT reply is a valid 2xx tunnel-established status. The client
+  // must not let the CONNECT leg's 204 → content_length=0 write leak into the
+  // origin leg (ProxyTunnel does not reset state between the two), or the
+  // origin's Content-Length: N would be rejected as a duplicate-CL conflict.
+  for (const connectStatus of [202, 204] as const) {
+    test.concurrent(`CONNECT → ${connectStatus} establishes the tunnel and the origin body arrives intact`, async () => {
+      await using origin = await createAdversarialOrigin({ tls: true, body: "hello-through-2xx-tunnel" });
+
+      const sockets = new Set<net.Socket>();
+      const proxy = net.createServer(client => {
+        sockets.add(client);
+        client.on("close", () => sockets.delete(client));
+        client.on("error", () => {});
+        let head = "";
+        const onHead = (d: Buffer) => {
+          head += d.toString("latin1");
+          const end = head.indexOf("\r\n\r\n");
+          if (end < 0) return;
+          client.removeListener("data", onHead);
+          const [, target] = head.split("\r\n")[0].split(" ");
+          const colon = target.lastIndexOf(":");
+          const upstream = net.connect(Number(target.slice(colon + 1)), "127.0.0.1");
+          sockets.add(upstream);
+          upstream.on("close", () => (sockets.delete(upstream), client.end()));
+          upstream.on("error", () => client.destroy());
+          upstream.once("connect", () => {
+            client.write(`HTTP/1.1 ${connectStatus} ${connectStatus === 204 ? "No Content" : "Accepted"}\r\n\r\n`);
+            client.pipe(upstream);
+            upstream.pipe(client);
+          });
+        };
+        client.on("data", onHead);
+      });
+      proxy.listen(0, "127.0.0.1");
+      await once(proxy, "listening");
+      const port = (proxy.address() as net.AddressInfo).port;
+
+      try {
+        const res = await fetch(origin.url, {
+          proxy: `http://127.0.0.1:${port}`,
+          keepalive: false,
+          tls: laxTls,
+          signal: AbortSignal.timeout(15_000),
+        });
+        expect(await res.text()).toBe("hello-through-2xx-tunnel");
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-length")).toBe(String("hello-through-2xx-tunnel".length));
+        expect(origin.requests.length).toBe(1);
+      } finally {
+        for (const s of sockets) s.destroy();
+        proxy.close();
+      }
+    });
+  }
+
   for (const proxyTls of [false, true] as const) {
     test.concurrent(
       `${proxyTls ? "https" : "http"}-proxy CONNECT → 101 fails even when the request asked to upgrade`,

--- a/test/js/bun/http/proxy-stress-errors.test.ts
+++ b/test/js/bun/http/proxy-stress-errors.test.ts
@@ -127,62 +127,65 @@ describe("CONNECT failure status", () => {
     });
   }
 
-  // A 204 CONNECT reply is a valid 2xx tunnel-established status. The client
-  // must not let the CONNECT leg's 204 → content_length=0 write leak into the
-  // origin leg (ProxyTunnel does not reset state between the two), or the
-  // origin's Content-Length: N would be rejected as a duplicate-CL conflict.
-  for (const connectStatus of [202, 204] as const) {
-    test.concurrent(
-      `CONNECT → ${connectStatus} establishes the tunnel and the origin body arrives intact`,
-      async () => {
-        await using origin = await createAdversarialOrigin({ tls: true, body: "hello-through-2xx-tunnel" });
+  // The CONNECT reply's status and headers must not write `self.state` that
+  // then leaks into the origin leg (ProxyTunnel does not reset state between
+  // the two). Cover the three cases the header/status loop used to leak:
+  // 204 → content_length=Some(0), Content-Encoding → encoding=Gzip,
+  // Transfer-Encoding → transfer_encoding=Chunked.
+  for (const { name, reply } of [
+    { name: "202", reply: "HTTP/1.1 202 Accepted\r\n\r\n" },
+    { name: "204", reply: "HTTP/1.1 204 No Content\r\n\r\n" },
+    { name: "200 + Content-Encoding: gzip", reply: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\n\r\n" },
+    { name: "200 + Transfer-Encoding: chunked", reply: "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" },
+  ] as const) {
+    test.concurrent(`CONNECT → ${name} establishes the tunnel and the origin body arrives intact`, async () => {
+      await using origin = await createAdversarialOrigin({ tls: true, body: "hello-through-2xx-tunnel" });
 
-        const sockets = new Set<net.Socket>();
-        const proxy = net.createServer(client => {
-          sockets.add(client);
-          client.on("close", () => sockets.delete(client));
-          client.on("error", () => {});
-          let head = "";
-          const onHead = (d: Buffer) => {
-            head += d.toString("latin1");
-            const end = head.indexOf("\r\n\r\n");
-            if (end < 0) return;
-            client.removeListener("data", onHead);
-            const [, target] = head.split("\r\n")[0].split(" ");
-            const colon = target.lastIndexOf(":");
-            const upstream = net.connect(Number(target.slice(colon + 1)), "127.0.0.1");
-            sockets.add(upstream);
-            upstream.on("close", () => (sockets.delete(upstream), client.end()));
-            upstream.on("error", () => client.destroy());
-            upstream.once("connect", () => {
-              client.write(`HTTP/1.1 ${connectStatus} ${connectStatus === 204 ? "No Content" : "Accepted"}\r\n\r\n`);
-              client.pipe(upstream);
-              upstream.pipe(client);
-            });
-          };
-          client.on("data", onHead);
-        });
-        proxy.listen(0, "127.0.0.1");
-        await once(proxy, "listening");
-        const port = (proxy.address() as net.AddressInfo).port;
-
-        try {
-          const res = await fetch(origin.url, {
-            proxy: `http://127.0.0.1:${port}`,
-            keepalive: false,
-            tls: laxTls,
-            signal: AbortSignal.timeout(15_000),
+      const sockets = new Set<net.Socket>();
+      const proxy = net.createServer(client => {
+        sockets.add(client);
+        client.on("close", () => sockets.delete(client));
+        client.on("error", () => {});
+        let head = "";
+        const onHead = (d: Buffer) => {
+          head += d.toString("latin1");
+          const end = head.indexOf("\r\n\r\n");
+          if (end < 0) return;
+          client.removeListener("data", onHead);
+          const [, target] = head.split("\r\n")[0].split(" ");
+          const colon = target.lastIndexOf(":");
+          const upstream = net.connect(Number(target.slice(colon + 1)), "127.0.0.1");
+          sockets.add(upstream);
+          upstream.on("close", () => (sockets.delete(upstream), client.end()));
+          upstream.on("error", () => client.destroy());
+          upstream.once("connect", () => {
+            client.write(reply);
+            client.pipe(upstream);
+            upstream.pipe(client);
           });
-          expect(await res.text()).toBe("hello-through-2xx-tunnel");
-          expect(res.status).toBe(200);
-          expect(res.headers.get("content-length")).toBe(String("hello-through-2xx-tunnel".length));
-          expect(origin.requests.length).toBe(1);
-        } finally {
-          for (const s of sockets) s.destroy();
-          proxy.close();
-        }
-      },
-    );
+        };
+        client.on("data", onHead);
+      });
+      proxy.listen(0, "127.0.0.1");
+      await once(proxy, "listening");
+      const port = (proxy.address() as net.AddressInfo).port;
+
+      try {
+        const res = await fetch(origin.url, {
+          proxy: `http://127.0.0.1:${port}`,
+          keepalive: false,
+          tls: laxTls,
+          signal: AbortSignal.timeout(15_000),
+        });
+        expect(await res.text()).toBe("hello-through-2xx-tunnel");
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-length")).toBe(String("hello-through-2xx-tunnel".length));
+        expect(origin.requests.length).toBe(1);
+      } finally {
+        for (const s of sockets) s.destroy();
+        proxy.close();
+      }
+    });
   }
 
   for (const proxyTls of [false, true] as const) {

--- a/test/js/bun/http/proxy-stress-lifecycle.test.ts
+++ b/test/js/bun/http/proxy-stress-lifecycle.test.ts
@@ -180,14 +180,13 @@ describe("proxy kills upstream", () => {
         outcome = errcode(e);
       }
       // At "upstream-connected", the upstream's close happens before the
-      // tunnel is up; the proxy relays the 502 envelope it writes on
-      // upstream error, which the client surfaces as a 502 response.
-      // After the tunnel is up the close is relayed and the inner TLS
-      // fails. Either is acceptable; a hang is not.
+      // tunnel is up; the proxy's 502 CONNECT reply is surfaced as
+      // ProxyConnectFailed. After the tunnel is up the close is relayed
+      // and the inner TLS fails. Either is acceptable; a hang is not.
       expect(outcome).not.toBe("TimeoutError");
       expect(outcome).not.toBe("AbortError");
       expect(outcome).toMatch(
-        /^resolved:502$|ECONNRESET|ConnectionClosed|ECONNREFUSED|ConnectionRefused|SocketError|EPIPE|ERR_TLS/,
+        /ProxyConnectFailed|ECONNRESET|ConnectionClosed|ECONNREFUSED|ConnectionRefused|SocketError|EPIPE|ERR_TLS/,
       );
     });
   }

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -2086,12 +2086,14 @@ describe("http_proxy/NO_PROXY re-evaluated per redirect hop", () => {
   });
 });
 
-test("non-200 CONNECT response from proxy is surfaced and its Location header is not followed", async () => {
+test("non-2xx CONNECT response from proxy rejects the fetch and its Location header is not followed", async () => {
   // RFC 9110 §9.3.6: a non-2xx response to CONNECT means the tunnel was not
-  // established. The proxy's response must be returned to the caller, but a
-  // Location header on it must never be followed — otherwise the original
-  // method, body, and custom headers would be re-sent to whatever plaintext
-  // origin the proxy names.
+  // established. The proxy's reply travelled over the plaintext client→proxy
+  // hop with no TLS handshake to the https origin, so it must never surface
+  // as an https-origin Response; the fetch rejects. A Location header on it
+  // is never followed either — otherwise the original method, body, and
+  // custom headers would be re-sent to whatever plaintext origin the proxy
+  // names.
 
   // Records anything that reaches the address named in the proxy's Location
   // header. Nothing should ever arrive here.
@@ -2131,20 +2133,23 @@ test("non-200 CONNECT response from proxy is surfaced and its Location header is
   const proxyPort = (proxy.address() as net.AddressInfo).port;
 
   try {
-    const response = await fetch(httpsServer.url, {
-      method: "POST",
-      body: "secret request body",
-      headers: { "X-Api-Key": "super-secret" },
-      proxy: `http://localhost:${proxyPort}`,
-      keepalive: false,
-      tls: { ca: tlsCert.cert, rejectUnauthorized: false },
+    await expect(
+      fetch(httpsServer.url, {
+        method: "POST",
+        body: "secret request body",
+        headers: { "X-Api-Key": "super-secret" },
+        proxy: `http://localhost:${proxyPort}`,
+        keepalive: false,
+        tls: { ca: tlsCert.cert, rejectUnauthorized: false },
+      }),
+    ).rejects.toMatchObject({
+      code: "ProxyConnectFailed",
+      message: expect.stringContaining("307"),
     });
 
     // The request did go through the proxy as a CONNECT...
     expect(sawConnect.length).toBe(1);
     expect(sawConnect[0]!.startsWith("CONNECT ")).toBe(true);
-    // ...the proxy's refusal is surfaced to the caller as-is...
-    expect(response.status).toBe(307);
     // ...and the Location header on the failed CONNECT is never followed:
     // the body and the X-Api-Key header must not reach the plaintext server
     // it points at.
@@ -2154,6 +2159,122 @@ test("non-200 CONNECT response from proxy is surfaced and its Location header is
     proxy.close();
     await once(proxy, "close");
   }
+});
+
+describe("CONNECT response is never attributed to the https origin", () => {
+  // The CONNECT leg of an HTTP proxy is plaintext. A hostile proxy (or any
+  // MITM on the client→proxy hop) can answer CONNECT with arbitrary status,
+  // headers, and body without a single verified TLS byte from the origin.
+  // Surfacing that reply as a Response with res.url === "https://origin/..."
+  // hands JS attacker-controlled Set-Cookie / Location / body under the
+  // https origin's identity (the CVE-2009-2062 class). Bun must reject.
+  // curl (exit 56), Node/undici (TypeError: fetch failed), and browsers
+  // (ERR_TUNNEL_CONNECTION_FAILED) all reject here.
+  const replies = {
+    403:
+      "HTTP/1.1 403 Forbidden\r\n" +
+      "Content-Type: text/html\r\n" +
+      "Set-Cookie: sess=INJECTED-BY-PROXY; Path=/\r\n" +
+      "Content-Length: 28\r\n\r\n" +
+      "<h1>PROXY BODY UNDER TLS</h1>",
+    302: "HTTP/1.1 302 Found\r\nLocation: http://attacker.invalid/pwned\r\nContent-Length: 0\r\n\r\n",
+    407: 'HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="p"\r\nContent-Length: 0\r\n\r\n',
+    500: "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 4\r\n\r\nboom",
+  } as const;
+
+  for (const [status, raw] of Object.entries(replies)) {
+    test.concurrent(`CONNECT → ${status} rejects; proxy headers/body never surface`, async () => {
+      const sockets = new Set<net.Socket>();
+      const proxy = net.createServer(c => {
+        sockets.add(c);
+        c.on("close", () => sockets.delete(c));
+        c.on("error", () => {});
+        let buf = "";
+        c.on("data", d => {
+          buf += d.toString("latin1");
+          if (buf.includes("\r\n\r\n")) c.end(raw);
+        });
+      });
+      proxy.listen(0, "127.0.0.1");
+      await once(proxy, "listening");
+      const port = (proxy.address() as net.AddressInfo).port;
+      try {
+        // The https origin does not exist; nothing is ever fetched over TLS.
+        let err: any;
+        try {
+          const res = await fetch("https://origin.invalid/never-fetched-over-tls", {
+            proxy: `http://127.0.0.1:${port}`,
+            keepalive: false,
+            signal: AbortSignal.timeout(15_000),
+          });
+          err = {
+            resolved: true,
+            status: res.status,
+            ok: res.ok,
+            url: res.url,
+            setCookie: res.headers.get("set-cookie"),
+            location: res.headers.get("location"),
+            body: await res.text(),
+          };
+        } catch (e) {
+          err = e;
+        }
+        // Must reject — there is no Response for JS to see.
+        expect(err?.resolved).toBeUndefined();
+        expect(err).toMatchObject({
+          code: "ProxyConnectFailed",
+          message: expect.stringContaining(status),
+          path: "https://origin.invalid/never-fetched-over-tls",
+        });
+      } finally {
+        for (const s of sockets) s.destroy();
+        proxy.close();
+        await once(proxy, "close");
+      }
+    });
+  }
+
+  // RFC 9110 §9.3.6: "Any 2xx (Successful) response indicates that the
+  // sender ... will switch to tunnel mode". A proxy answering CONNECT with
+  // 201 + body is non-conforming; the client must start TLS over the
+  // post-header bytes (which then fails). Before the fix this resolved to
+  // { status: 201, ok: true, body: "BODY201x" } under the https URL.
+  test.concurrent("CONNECT → 201 with body is treated as tunnel-established, never as res.ok content", async () => {
+    const sockets = new Set<net.Socket>();
+    const proxy = net.createServer(c => {
+      sockets.add(c);
+      c.on("close", () => sockets.delete(c));
+      c.on("error", () => {});
+      let buf = "";
+      c.on("data", d => {
+        buf += d.toString("latin1");
+        if (buf.includes("\r\n\r\n")) c.end("HTTP/1.1 201 Created\r\nContent-Length: 8\r\n\r\nBODY201x");
+      });
+    });
+    proxy.listen(0, "127.0.0.1");
+    await once(proxy, "listening");
+    const port = (proxy.address() as net.AddressInfo).port;
+    try {
+      let outcome: unknown;
+      try {
+        const res = await fetch("https://origin.invalid/never-fetched-over-tls", {
+          proxy: `http://127.0.0.1:${port}`,
+          keepalive: false,
+          signal: AbortSignal.timeout(15_000),
+        });
+        outcome = { resolved: true, status: res.status, ok: res.ok, body: await res.text() };
+      } catch (e) {
+        outcome = { code: (e as any)?.code, name: (e as any)?.name };
+      }
+      expect(outcome).not.toEqual({ resolved: true, status: 201, ok: true, body: "BODY201x" });
+      expect((outcome as any).resolved).toBeUndefined();
+      expect((outcome as any).name).not.toBe("TimeoutError");
+    } finally {
+      for (const s of sockets) s.destroy();
+      proxy.close();
+      await once(proxy, "close");
+    }
+  });
 });
 
 // RFC 3986 §3.1: the URL scheme is case-insensitive. The explicit


### PR DESCRIPTION
## What

`fetch("https://...", { proxy })` now **rejects** when the proxy answers `CONNECT` with a non-2xx status, instead of resolving to a `Response` whose `url` is the https origin but whose status/headers/body came from the plaintext proxy hop. Any 2xx (not just 200) now establishes the tunnel, per RFC 9110.

## Why

The `CONNECT` leg of an HTTP proxy is plaintext. When a proxy (or any MITM on the client→proxy hop) replies to `CONNECT` with e.g. `403`, `407`, `302`, or even `201 Created`, no TLS handshake to the origin has happened. Before this change Bun handed that reply to JS as a `Response` attributed to the https origin:

```js
// proxy answers CONNECT with: HTTP/1.1 201 Created\r\nContent-Length: 8\r\n\r\nBODY201x
const res = await fetch("https://origin.invalid/never-fetched-over-tls", { proxy });
// res.status === 201, res.ok === true, res.url === "https://origin.invalid/...", await res.text() === "BODY201x"
```

A hostile proxy could inject `Set-Cookie`, `Location`, or HTML under the https origin's identity without a single verified TLS byte (the CVE-2009-2062 class). curl exits 56 (`CONNECT tunnel failed, response 403`); Node/undici throws `TypeError: fetch failed`; browsers report `ERR_TUNNEL_CONNECTION_FAILED`. None surface the body.

## How

[`handle_response_metadata`](https://github.com/oven-sh/bun/blob/main/src/http/lib.rs) now dispatches on the CONNECT reply **before** the header loop and the status-code-driven state writes, so nothing from the CONNECT leg touches `self.state` (`ProxyTunnel` does not reset it between the CONNECT leg and the origin leg):

- **2xx** → `ContinueStreaming` (start the inner TLS handshake). RFC 9110 §9.3.6: *"Any 2xx (Successful) response indicates that the sender ... will switch to tunnel mode immediately after the response header section."* A proxy that sends `201` + body is non-conforming; those bytes feed the TLS handshake and it fails, which is what curl does.
- **non-2xx** → `Err(ProxyConnectFailed(status))`. Surfaces to JS as `{ code: "ProxyConnectFailed", message: "CONNECT tunnel failed, proxy responded with status <n>" }` so 407/502 are still debuggable. The caller's `close_and_fail` tears the socket down.

Dispatching before the header loop also fixes a pre-existing leak where a proxy sending `Content-Encoding: gzip` on a `200` CONNECT reply left `state.encoding = Gzip` into the origin leg and fed the origin's identity body to the gzip decoder. The per-header Content-Length / Transfer-Encoding `continue` skips and the `is_proxy_connect_failure` redirect guard are removed as dead.

The WebSocket client's `handle_proxy_response` is widened to the same `200..300` range (and the byte-prefix fast path dropped) so `new WebSocket("wss://...", { proxy })` agrees with `fetch` on the same RFC point.

Absolute-form proxying (`http://` target through a proxy) is unchanged: there is no CONNECT and no origin TLS, so a proxy's 407/403 there remains a real `Response`.

`bun install` through a refusing proxy now reports `ProxyConnectFailed downloading package manifest ...` (and retries up to `max_retry_count`, since it is now a connect-level error) instead of `GET <url> - 407`. Skipping retry for `ProxyConnectFailed(s)` with `s < 500`, and surfacing the status through `err.name()`, are left for a follow-up rather than widening this PR into the install retry classifier.

## Verification

<details><summary>Before / after</summary>

```
# before (bun 1.4.0-canary)
=== MODE=403 ===
RESOLVED 403 ok=false url=https://origin.invalid/never-fetched-over-tls {"content-length":"26","content-type":"text/html","set-cookie":"sess=INJECTED-BY-PROXY; Path=/"} "<h1>PROXY BODY UNDER TLS</"
=== MODE=201 ===
RESOLVED 201 ok=true url=https://origin.invalid/never-fetched-over-tls {"content-length":"8"} "BODY201x"

# after
=== MODE=403 ===
REJECTED Error ProxyConnectFailed CONNECT tunnel failed, proxy responded with status 403
=== MODE=201 ===
REJECTED Error ConnectionRefused Unable to connect. Is the computer able to access the url?
```

</details>

New `describe("CONNECT response is never attributed to the https origin")` in `test/js/bun/http/proxy.test.ts` covers 403/302/407/500 + the 201 spec-break case; `proxy-stress-errors.test.ts` adds 202/204/`Content-Encoding: gzip`/`Transfer-Encoding: chunked` CONNECT-reply state-leak cases that tunnel to a real https origin. All fail on main and pass with this change. Existing `proxy-stress-errors.test.ts` / `proxy-stress-lifecycle.test.ts` assertions that codified the old contract are updated to expect rejection.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 35 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/proxy-stress-errors.test.ts test/js/bun/http/proxy-stress-lifecycle.test.ts test/js/bun/http/proxy.test.ts
bun test v1.4.0 (9dd5bbe00)

test/js/bun/http/proxy-stress-errors.test.ts:
62 |           proxy: proxy.url,
63 |           keepalive: false,
64 |           tls: laxTls,
65 |           signal: AbortSignal.timeout(15_000),
66 |         }),
67 |       ).rejects.toMatchObject({
                     ^
error: expect(received).rejects.toMatchObject(expected)

Expected promise that rejects
Received promise that resolved: Promise { <resolved> }

      at <anonymous> (/workspace/bun/test/js/bun/http/proxy-stress-errors.test.ts:67:17)
      at <anonymous> (/workspace/bun/test/js/bun/http/proxy-stress-errors.test.ts:67:17)
      at <anonymous> (/workspace/bun/test/js/bun/http/proxy-stress-errors.test.ts:67:17)
(fail) CONNECT failure status > http-proxy CONNECT → 502 rejects the fetch [695.09ms]
62 |           proxy: proxy.url,
63 |           keepalive: false,
64 |           tls: laxTls,
65 |           signal: AbortSignal.ti
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (5d4e1aee8)

test/js/bun/http/proxy-stress-errors.test.ts:
(pass) CONNECT failure status > http-proxy CONNECT → 201 is treated as tunnel-established [22.82ms]
(pass) CONNECT failure status > CONNECT → 302 with Location is not followed [30.27ms]
(pass) CONNECT failure status > CONNECT → 301 with Location is not followed [31.18ms]
(pass) CONNECT failure status > https-proxy CONNECT → 504 rejects the fetch [33.40ms]
(pass) CONNECT failure status > https-proxy CONNECT → 503 rejects the fetch [33.89ms]
(pass) CONNECT failure status > https-proxy CONNECT → 502 rejects the fetch [34.46ms]
(pass) CONNECT failure status > https-proxy CONNECT → 500 rejects the fetch [34.92ms]
(pass) CONNECT failure status > https-proxy CONNECT → 407 rejects the fetch [35.48ms]
(pass) CONNECT failure status > https-proxy CONNECT → 403 rejects the fetch [35.93ms]
(pass) CONNECT failure status > https-proxy CONNECT → 400 rejects the fetch [36.20ms]
(pass) CONNECT failure status > http-proxy CONNECT → 504 rejects the fetch [36.48ms]
(pass) CONNECT failure status > http-proxy CONNECT → 503 rejects the fetch [36.99ms]
(pass) CONNECT failure status > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/proxy-stress-errors.test.ts test/js/bun/http/proxy-stress-lifecycle.test.ts test/js/bun/http/proxy.test.ts
bun test v1.4.0 (9dd5bbe00)

test/js/bun/http/proxy-stress-errors.test.ts:
(pass) CONNECT failure status > http-proxy CONNECT → 502 rejects the fetch [600.17ms]
(pass) CONNECT failure status > http-proxy CONNECT → 500 rejects the fetch [618.49ms]
(pass) CONNECT failure status > http-proxy CONNECT → 407 rejects the fetch [636.05ms]
(pass) CONNECT failure status > http-proxy CONNECT → 403 rejects the fetch [657.01ms]
(pass) CONNECT failure status > http-proxy CONNECT → 400 rejects the fetch [936.73ms]
(pass) CONNECT failure status > https-proxy CONNECT → 407 rejects the fetch [303.81ms]
(pass) CONNECT failure status > https-proxy CONNECT → 403 rejects the fetch [324.66ms]
(pass) CONNECT failure status > https-proxy CONNECT → 400 rejects the fetch [342.22ms]
(pass) CONNECT failure status > http-proxy CONNECT → 504 rejects the fetch [360.49ms]
(pass) CONNECT failure status > http-proxy CONNECT → 50
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 780ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/error.rs                                  |   3 +
 src/http/lib.rs                                    |  66 +++-----
 .../websocket_client/WebSocketUpgradeClient.rs     |  29 +---
 src/runtime/webcore/fetch/FetchTasklet.rs          |   3 +
 test/js/bun/http/proxy-stress-errors.test.ts       | 175 ++++++++++++++++++---
 test/js/bun/http/proxy-stress-lifecycle.test.ts    |   9 +-
 test/js/bun/http/proxy.test.ts                     | 149 ++++++++++++++++--
 7 files changed, 321 insertions(+), 113 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/http/error.rs                                            2      4      0
src/http/lib.rs                                              8     12      0
src/http_jsc/websocket_client/WebSocketUpgradeClient.rs      1      2      0
src/runtime/webcore/fetch/FetchTasklet.rs                    2      1      0
test/js/bun/http/proxy-stress-errors.test.ts                 3      5      0
test/js/bun/http/proxy-stress-lifecycle.test.ts              1      1      0
test/js/bun/http/proxy.test.ts                               1      4      0
```

</details>

<!-- robobun:evidence:end -->