### PR TITLE
bundler: inline module.filename/module.path to match __filename/__dirname

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -358,18 +358,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             && name == b"filename"
                             && identifier_opts.assign_target() == js_ast::AssignTarget::None
                         {
-                            // inline module.filename
+                            // inline module.filename (== __filename)
                             p.ignore_usage(p.module_ref);
-                            return Some(
-                                p.new_expr(e_string_init(p.source.path.name().filename), name_loc),
-                            );
+                            return Some(p.new_expr(e_string_init(p.source.path.text), name_loc));
                         } else if p.options.bundle
                             && name == b"path"
                             && identifier_opts.assign_target() == js_ast::AssignTarget::None
                         {
-                            // inline module.path
+                            // inline module.path (== __dirname)
                             p.ignore_usage(p.module_ref);
-                            return Some(p.new_expr(e_string_init(p.source.path.pretty), name_loc));
+                            return Some(
+                                p.new_expr(e_string_init(p.source.path.name().dir), name_loc),
+                            );
                         }
                     }
 

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "./expectBundled";
 
 // Tests for CommonJS <> ESM interop, specifically the __toESM helper behavior.
@@ -597,4 +597,36 @@ describe("bundler", () => {
       stdout: "loaded ok",
     },
   });
+
+  // module.filename and module.path are inlined at bundle time. They must match
+  // Node's semantics: module.filename === __filename (full resolved path) and
+  // module.path === __dirname (the directory). Previously module.filename folded
+  // to the basename and module.path to the pretty (relative) path.
+  for (const target of ["bun", "node"] as const) {
+    itBundled(`cjs/ModuleFilenameAndPathInlining_${target}`, {
+      files: {
+        "/entry.cjs": /* js */ `
+          console.log(module.filename === __filename);
+          console.log(module.path === __dirname);
+          console.log(JSON.stringify({ filename: module.filename, path: module.path }));
+        `,
+      },
+      target,
+      run: {
+        validate({ stdout }) {
+          const lines = stdout.trim().split("\n");
+          expect(lines[0]).toBe("true");
+          expect(lines[1]).toBe("true");
+          const parsed = JSON.parse(lines[2]);
+          // Full path, not the bare basename.
+          expect(parsed.filename).not.toBe("entry.cjs");
+          expect(parsed.filename.endsWith("entry.cjs")).toBe(true);
+          expect(parsed.filename.length).toBeGreaterThan("entry.cjs".length);
+          // module.path is the dirname of module.filename.
+          expect(parsed.filename.startsWith(parsed.path)).toBe(true);
+          expect(parsed.path.endsWith("entry.cjs")).toBe(false);
+        },
+      },
+    });
+  }
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { dirname, isAbsolute } from "node:path";
 import { itBundled } from "./expectBundled";
 
 // Tests for CommonJS <> ESM interop, specifically the __toESM helper behavior.
@@ -600,8 +601,7 @@ describe("bundler", () => {
 
   // module.filename and module.path are inlined at bundle time. They must match
   // Node's semantics: module.filename === __filename (full resolved path) and
-  // module.path === __dirname (the directory). Previously module.filename folded
-  // to the basename and module.path to the pretty (relative) path.
+  // module.path === __dirname (the directory).
   for (const target of ["bun", "node"] as const) {
     itBundled(`cjs/ModuleFilenameAndPathInlining_${target}`, {
       files: {
@@ -620,11 +620,10 @@ describe("bundler", () => {
           const parsed = JSON.parse(lines[2]);
           // Full path, not the bare basename.
           expect(parsed.filename).not.toBe("entry.cjs");
+          expect(isAbsolute(parsed.filename)).toBe(true);
           expect(parsed.filename.endsWith("entry.cjs")).toBe(true);
-          expect(parsed.filename.length).toBeGreaterThan("entry.cjs".length);
           // module.path is the dirname of module.filename.
-          expect(parsed.filename.startsWith(parsed.path)).toBe(true);
-          expect(parsed.path.endsWith("entry.cjs")).toBe(false);
+          expect(dirname(parsed.filename)).toBe(parsed.path);
         },
       },
     });


### PR DESCRIPTION
## What

When bundling, `module.filename` was folded to the **basename** (e.g. `"entry.cjs"`) and `module.path` to the relative pretty path (e.g. `"../../tmp/entry.cjs"`). Node defines `module.filename` as the fully resolved filename (identical to `__filename`) and `module.path` as the module's directory (identical to `__dirname`).

## Repro

```sh
$ printf 'console.log(module.filename, module.path)\n' > /tmp/mf.cjs
$ bun build --target=node /tmp/mf.cjs | grep console
  console.log("mf.cjs", "../../tmp/mf.cjs");   # before
  console.log("/tmp/mf.cjs", "/tmp");           # after
$ node /tmp/mf.cjs
/tmp/mf.cjs /tmp
```

## Fix

In `src/js_parser/fold.rs`, use the same values the bundler already emits for the `__filename`/`__dirname` var decls (`parse_entry.rs`):

- `module.filename` → `p.source.path.text` (was `p.source.path.name().filename`)
- `module.path` → `p.source.path.name().dir` (was `p.source.path.pretty`)

`module.id` is left unchanged.

## Verification

New `cjs/ModuleFilenameAndPathInlining_{bun,node}` tests in `test/bundler/bundler_cjs.test.ts` assert that the bundled output satisfies `module.filename === __filename` and `module.path === __dirname` at runtime, and that `module.filename` is a full path (not the bare basename). Fails on main with `Received: "false"`, passes with this change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.0 (d08673f9a)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1064.65ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [537.53ms]
(pass) bundler > cjs/__toESM_import_syntax_function [524.42ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [522.89ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [517.12ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [547.86ms]
(pass) bundler > cjs/__toESM_target_node [540.87ms]
(pass) bundler > cjs/__toESM_target_browser [502.84ms]
(pass) bundler > cjs/__toESM_target_bun [700.61ms]
(pass) bundler > cjs/__toESM_format_esm [559.29ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [994.43ms]
(pass) bundler > cjs/__toESM_mjs_reexport [573.38ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [484.54ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [571.30ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [586.85ms]
(pass) bundler > cjs/__toESM_default_pr
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d08673f9a)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [109.64ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [53.91ms]
(pass) bundler > cjs/__toESM_import_syntax_function [19.02ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [61.59ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [34.81ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [53.86ms]
(pass) bundler > cjs/__toESM_target_node [70.36ms]
(pass) bundler > cjs/__toESM_target_browser [40.77ms]
(pass) bundler > cjs/__toESM_target_bun [51.70ms]
(pass) bundler > cjs/__toESM_format_esm [92.62ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [54.87ms]
(pass) bundler > cjs/__toESM_mjs_reexport [22.28ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [62.78ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [59.21ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [69.86ms]
(pass) bundler > cjs/__toESM_default_prop_no_esModule [30.46ms]
(pass) bundler > cjs/__toESM_mixed_import_styles [41.79ms]
(pass) bundler > cjs/__toESM_esModule_non_true [30.95ms]
(pass) bundler > cjs/__toESM_es
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.0 (d08673f9a)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1123.56ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [523.75ms]
(pass) bundler > cjs/__toESM_import_syntax_function [565.12ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [697.17ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [513.60ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [568.75ms]
(pass) bundler > cjs/__toESM_target_node [660.54ms]
(pass) bundler > cjs/__toESM_target_browser [665.47ms]
(pass) bundler > cjs/__toESM_target_bun [567.91ms]
(pass) bundler > cjs/__toESM_format_esm [1045.35ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [575.45ms]
(pass) bundler > cjs/__toESM_mjs_reexport [570.03ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [633.49ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [583.28ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [582.91ms]
(pass) bundler > cjs/__toESM_default_p
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1001ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/fold.rs            | 12 ++++++------
 test/bundler/bundler_cjs.test.ts | 33 ++++++++++++++++++++++++++++++++-
 2 files changed, 38 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/js_parser/fold.rs                 1      1      0
test/bundler/bundler_cjs.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->