### PR TITLE
js_parser: raise strict-mode errors for legacy octal, for-in var init, and if/label function statements

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -449,9 +449,6 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub module_scope: js_ast::StoreRef<js_ast::Scope>,
     pub module_scope_directive_loc: bun_ast::Loc,
     pub is_control_flow_dead: bool,
-
-    /// Ranges of legacy octal numeric literals (`010`), recorded during parse
-    /// and checked for strict-mode errors during visit.
     pub legacy_octal_literals: Vec<bun_ast::Range>,
 
     /// True while `visit_single_stmt` is visiting a non-block body. `if`,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -450,10 +450,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub module_scope_directive_loc: bun_ast::Loc,
     pub is_control_flow_dead: bool,
 
-    /// Legacy octal numeric literals (e.g. `010`) are only known to the lexer.
-    /// We record their ranges during the parse pass so the visit pass can emit
-    /// a strict-mode error once the scope's strict-mode kind is fully resolved
-    /// (which for ESM only happens after the whole file has been parsed).
+    /// Ranges of legacy octal numeric literals (`010`), recorded during parse
+    /// and checked for strict-mode errors during visit.
     pub legacy_octal_literals: Vec<bun_ast::Range>,
 
     /// True while `visit_single_stmt` is visiting a non-block body. `if`,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -450,6 +450,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub module_scope_directive_loc: bun_ast::Loc,
     pub is_control_flow_dead: bool,
 
+    /// Legacy octal numeric literals (e.g. `010`) are only known to the lexer.
+    /// We record their ranges during the parse pass so the visit pass can emit
+    /// a strict-mode error once the scope's strict-mode kind is fully resolved
+    /// (which for ESM only happens after the whole file has been parsed).
+    pub legacy_octal_literals: Vec<bun_ast::Range>,
+
     /// True while `visit_single_stmt` is visiting a non-block body. `if`,
     /// `else`, `while`, and `do` reach it without pushing a scope, so inside
     /// their unbraced body `current_scope == module_scope` is still true at
@@ -4297,6 +4303,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // TODO:
     pub fn check_for_non_bmp_code_point(&mut self, _: bun_ast::Loc, _: &[u8]) {}
 
+    #[inline]
+    pub fn check_for_legacy_octal_literal(&mut self) {
+        if self.lexer.is_legacy_octal_literal {
+            self.legacy_octal_literals.push(self.lexer.range());
+        }
+    }
+
     pub fn mark_strict_mode_feature(
         &mut self,
         feature: StrictModeFeature,
@@ -4325,6 +4338,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             StrictModeFeature::LegacyOctalLiteral => b"Legacy octal literals",
             StrictModeFeature::LegacyOctalEscape => b"Legacy octal escape sequences",
             StrictModeFeature::IfElseFunctionStmt => b"Function declarations inside if statements",
+            StrictModeFeature::LabelFunctionStmt => b"Function declarations inside labels",
         };
 
         let scope = self.current_scope();
@@ -4345,9 +4359,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     why = b"All code inside a class is implicitly in strict mode";
                     where_ = self.enclosing_class_keyword;
                 }
-                _ => {}
+                js_ast::StrictModeKind::ExplicitStrictMode => {
+                    why = b"Strict mode is triggered by the \"use strict\" directive here";
+                    where_ = self.source.range_of_string(self.module_scope_directive_loc);
+                }
+                js_ast::StrictModeKind::SloppyMode => {}
             }
-            if why.is_empty() {
+            if why.is_empty() && !where_.is_empty() {
                 why = bun_alloc::arena_format!(
                     in self.arena,
                     "This file is implicitly in strict mode because of the \"{}\" keyword here",
@@ -4356,9 +4374,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .into_bump_str()
                 .as_bytes();
             }
-            // bun_ast::Data is !Copy (Cow) — build the notes Box directly.
-            let notes: Box<[bun_ast::Data]> =
-                Box::new([bun_ast::range_data(Some(self.source), where_, why.to_vec())]);
+            let notes: Box<[bun_ast::Data]> = if why.is_empty() {
+                Box::new([])
+            } else {
+                Box::new([bun_ast::range_data(Some(self.source), where_, why.to_vec())])
+            };
             self.log().add_range_error_fmt_with_notes(
                 Some(self.source),
                 r,
@@ -8786,6 +8806,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             is_import_item: Default::default(),
             scope_order_to_visit: &[],
             module_scope_directive_loc: bun_ast::Loc::default(),
+            legacy_octal_literals: Vec::new(),
             is_control_flow_dead: false,
             is_inside_single_stmt_body: false,
             is_revisit_for_substitution: false,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1167,7 +1167,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             T::TNumericLiteral => {
                 key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
-                // check for legacy octal literal
+                p.check_for_legacy_octal_literal();
                 p.lexer.next()?;
             }
             T::TStringLiteral => {

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -301,7 +301,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn pfx_t_numeric_literal(p: &mut Self) -> PResult<Expr> {
         let loc = p.lexer.loc();
         let value = p.new_expr(E::Number::new(p.lexer.number), loc);
-        // p.checkForLegacyOctalLiteral()
+        p.check_for_legacy_octal_literal();
         p.lexer.next()?;
         Ok(value)
     }

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -262,7 +262,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             match p.lexer.token {
                 T::TNumericLiteral => {
                     key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
-                    // p.checkForLegacyOctalLiteral()
+                    p.check_for_legacy_octal_literal();
                     p.lexer.next()?;
                 }
                 T::TStringLiteral => {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1181,6 +1181,7 @@ pub enum StrictModeFeature {
     LegacyOctalLiteral,
     LegacyOctalEscape,
     IfElseFunctionStmt,
+    LabelFunctionStmt,
 }
 
 #[derive(Clone, Copy)]

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -762,6 +762,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if has_if_scope {
             self.push_scope_for_visit_pass(ScopeKind::Block, stmt.loc)
                 .expect("unreachable");
+            if self.is_strict_mode() {
+                self.mark_strict_mode_feature(
+                    StrictModeFeature::IfElseFunctionStmt,
+                    js_lexer::range_of_identifier(self.source, stmt.loc),
+                    b"",
+                )
+                .expect("unreachable");
+            }
         }
 
         let old_is_inside_single_stmt_body = self.is_inside_single_stmt_body;

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -98,6 +98,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     fn e_number(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        if p.is_revisit_for_substitution {
+            return;
+        }
         if !p.legacy_octal_literals.is_empty() && p.is_strict_mode() {
             let loc = e.loc;
             if let Some(r) = p

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -97,8 +97,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // if e.LegacyOctalLoc.Start > 0 {
     }
 
-    fn e_number(_: &mut Self, _e: &mut Expr, _: ExprIn) {
-        // idc about legacy octal loc
+    fn e_number(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        if !p.legacy_octal_literals.is_empty() && p.is_strict_mode() {
+            let loc = e.loc;
+            if let Some(r) = p
+                .legacy_octal_literals
+                .iter()
+                .find(|r| r.loc.start == loc.start)
+                .copied()
+            {
+                p.mark_strict_mode_feature(StrictModeFeature::LegacyOctalLiteral, r, b"")
+                    .expect("unreachable");
+            }
+        }
     }
 
     fn e_this(p: &mut Self, e: &mut Expr, _: ExprIn) {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -4,7 +4,7 @@ use crate::lexer as js_lexer;
 use crate::p::{P, ReactRefreshExportKind};
 use crate::parser::{
     PrependTempRefsOpts, ReactRefresh, Ref, RelocateVarsMode, SideEffects, StmtsKind,
-    statement_cares_about_scope,
+    StrictModeFeature, statement_cares_about_scope,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast::flags;
@@ -1328,6 +1328,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::Label,
     ) -> Result<(), Error> {
+        // Forbid functions inside labels in strict mode
+        if p.is_strict_mode() {
+            if let StmtData::SFunction(_) = data.stmt.data {
+                p.mark_strict_mode_feature(
+                    StrictModeFeature::LabelFunctionStmt,
+                    js_lexer::range_of_identifier(p.source, data.stmt.loc),
+                    b"",
+                )?;
+            }
+        }
+
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Label, stmt.loc)
             .expect("unreachable");
         let name = p.load_name_from_ref(data.name.ref_);
@@ -1893,6 +1904,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let decl: &mut G::Decl = &mut local.decls.slice_mut()[0];
                         if let js_ast::binding::Data::BIdentifier(b_id) = decl.binding.data {
                             if let Some(val) = decl.value {
+                                p.mark_strict_mode_feature(
+                                    StrictModeFeature::ForInVarInit,
+                                    js_lexer::range_of_identifier(p.source, decl.binding.loc),
+                                    b"",
+                                )?;
                                 let id_ref = b_id.r#ref;
                                 stmts.push(Stmt::assign(
                                     Expr::init_identifier(id_ref, decl.binding.loc),

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,8 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-const EXPECTED_VERSION: u32 = 23;
+/// Version 24: Strict-mode early errors for legacy octal / for-in var init / if-label fn.
+const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/strict-mode-errors.test.ts
+++ b/test/bundler/transpiler/strict-mode-errors.test.ts
@@ -106,10 +106,7 @@ describe.concurrent("strict-mode early errors", () => {
   });
 
   test("legacy octal literal is allowed in a sloppy function inside a sloppy file", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `function f() { return 010; } console.log(f());\n`,
-      "entry.cjs",
-    );
+    const { stdout, stderr, exitCode } = await run(`function f() { return 010; } console.log(f());\n`, "entry.cjs");
     expect(stderr).not.toContain("cannot be used in strict mode");
     expect(stdout.trim()).toBe("8");
     expect(exitCode).toBe(0);

--- a/test/bundler/transpiler/strict-mode-errors.test.ts
+++ b/test/bundler/transpiler/strict-mode-errors.test.ts
@@ -149,10 +149,20 @@ describe.concurrent("bundler strict-mode early errors", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  test("for-in var initializer in sloppy CJS bundles to ESM via lowering", async () => {
+  // Legacy octal literals, for-in var initializers, and function declarations
+  // in if/label bodies are all lowered to valid strict-mode code when bundling
+  // a sloppy CJS file into ESM, so they must not be rejected by the
+  // `is_strict_mode_output_format()` fallback. This matches esbuild.
+  test("sloppy CJS constructs are lowered (not rejected) when bundled to ESM", async () => {
     using dir = tempDir("strict-mode-bundle-cjs", {
-      "entry.js": `import "./loop.cjs";\n`,
-      "loop.cjs": `for (var i = 0 in { a: 1 }) { console.log(i); }\n`,
+      "entry.js": `import "./sloppy.cjs";\n`,
+      "sloppy.cjs": [
+        `for (var i = 0 in { a: 1 }) { console.log(i); }`,
+        `if (1) function f() { return 1; }`,
+        `lab: function g() {}`,
+        `console.log(010);`,
+        ``,
+      ].join("\n"),
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build", "--format=esm", "entry.js"],
@@ -164,6 +174,7 @@ describe.concurrent("bundler strict-mode early errors", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("cannot be used");
     expect(stdout).not.toMatch(/for\s*\(\s*var\s+\w+\s*=/);
+    expect(stdout).not.toMatch(/\b010\b/);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/bundler/transpiler/strict-mode-errors.test.ts
+++ b/test/bundler/transpiler/strict-mode-errors.test.ts
@@ -132,6 +132,23 @@ describe.concurrent("bundler strict-mode early errors", () => {
     });
   }
 
+  test("legacy octal literal error is emitted once under minify-syntax substitution", async () => {
+    using dir = tempDir("strict-mode-bundle-minify", {
+      "entry.js": `"use strict";\nfunction f() { let x = 010; return x + 1; }\nf();\nexport {};\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--format=esm", "--minify-syntax", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const count = (stderr.match(/Legacy octal literals cannot be used/g) || []).length;
+    expect(count).toBe(1);
+    expect(exitCode).not.toBe(0);
+  });
+
   test("for-in var initializer in sloppy CJS bundles to ESM via lowering", async () => {
     using dir = tempDir("strict-mode-bundle-cjs", {
       "entry.js": `import "./loop.cjs";\n`,

--- a/test/bundler/transpiler/strict-mode-errors.test.ts
+++ b/test/bundler/transpiler/strict-mode-errors.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Annex B constructs that are legal in sloppy mode but a SyntaxError in strict
+// mode (and therefore in any ES module). Node, esbuild, and tsc all reject
+// these; bun's parser previously accepted them silently because the
+// corresponding `StrictModeFeature` variants were never wired up.
+
+type Case = {
+  name: string;
+  body: string;
+  errorSubstring: string;
+};
+
+const cases: Case[] = [
+  {
+    name: "legacy octal literal",
+    body: "console.log(010);",
+    errorSubstring: "Legacy octal literals cannot be used in strict mode",
+  },
+  {
+    name: "legacy octal literal as property key",
+    body: "var o = { 010: 1 }; console.log(o);",
+    errorSubstring: "Legacy octal literals cannot be used in strict mode",
+  },
+  {
+    name: "for-in var initializer",
+    body: "for (var i = 0 in { a: 1 }) { console.log(i); }",
+    errorSubstring: "Variable initializers within for-in loops cannot be used in strict mode",
+  },
+  {
+    name: "function declaration in if body",
+    body: "if (1) function f() {}",
+    errorSubstring: "Function declarations inside if statements cannot be used in strict mode",
+  },
+  {
+    name: "function declaration in else body",
+    body: "if (0) ; else function f() {}",
+    errorSubstring: "Function declarations inside if statements cannot be used in strict mode",
+  },
+  {
+    name: "labeled function declaration",
+    body: "lab: function g() {}",
+    errorSubstring: "Function declarations inside labels cannot be used in strict mode",
+  },
+];
+
+async function run(source: string, filename: string) {
+  using dir = tempDir("strict-mode-errors", { [filename]: source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), filename],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("strict-mode early errors", () => {
+  for (const c of cases) {
+    describe(c.name, () => {
+      test('is rejected after "use strict"', async () => {
+        const { stderr, exitCode } = await run(`"use strict";\n${c.body}\n`, "entry.js");
+        expect(stderr).toContain(c.errorSubstring);
+        expect(exitCode).toBe(1);
+      });
+
+      test("is rejected in an ES module via export", async () => {
+        const { stderr, exitCode } = await run(`${c.body}\nexport {};\n`, "entry.mjs");
+        expect(stderr).toContain(c.errorSubstring);
+        expect(exitCode).toBe(1);
+      });
+
+      test("is rejected inside a strict-mode function body", async () => {
+        const { stderr, exitCode } = await run(`function outer() { "use strict";\n${c.body}\n} outer();\n`, "entry.js");
+        expect(stderr).toContain(c.errorSubstring);
+        expect(exitCode).toBe(1);
+      });
+
+      test("is rejected inside a class body", async () => {
+        const { stderr, exitCode } = await run(`class C { m() { ${c.body} } } new C().m();\n`, "entry.js");
+        expect(stderr).toContain(c.errorSubstring);
+        expect(exitCode).toBe(1);
+      });
+
+      test("is allowed in sloppy mode", async () => {
+        const { stderr, exitCode } = await run(`${c.body}\n`, "entry.cjs");
+        expect(stderr).not.toContain("cannot be used in strict mode");
+        expect(exitCode).toBe(0);
+      });
+    });
+  }
+
+  // The for-in var-initializer case is special: bun lowers it to a separate
+  // assignment, so sloppy CJS code that uses it should keep running (and the
+  // bundler can still emit it into ESM output without producing invalid code).
+  test("for-in var initializer is lowered in sloppy mode", async () => {
+    const { stdout, exitCode } = await run(
+      `var keys = []; for (var i = 0 in { a: 1, b: 2 }) { keys.push(i); } console.log(keys.join(","));\n`,
+      "entry.cjs",
+    );
+    expect(stdout.trim()).toBe("a,b");
+    expect(exitCode).toBe(0);
+  });
+
+  test("legacy octal literal is allowed in a sloppy function inside a sloppy file", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `function f() { return 010; } console.log(f());\n`,
+      "entry.cjs",
+    );
+    expect(stderr).not.toContain("cannot be used in strict mode");
+    expect(stdout.trim()).toBe("8");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("bundler strict-mode early errors", () => {
+  for (const c of cases) {
+    test(`${c.name} fails to bundle as ESM`, async () => {
+      using dir = tempDir("strict-mode-bundle", {
+        "entry.js": `${c.body}\nexport {};\n`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--format=esm", "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(c.errorSubstring);
+      expect(exitCode).not.toBe(0);
+    });
+  }
+
+  test("for-in var initializer in sloppy CJS bundles to ESM via lowering", async () => {
+    using dir = tempDir("strict-mode-bundle-cjs", {
+      "entry.js": `import "./loop.cjs";\n`,
+      "loop.cjs": `for (var i = 0 in { a: 1 }) { console.log(i); }\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--format=esm", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("cannot be used");
+    expect(stdout).not.toMatch(/for\s*\(\s*var\s+\w+\s*=/);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Bun's parser had the `StrictModeFeature` diagnostic machinery (`mark_strict_mode_feature()` in `p.rs`) but four of its variants were never called, so strict-mode/ESM code that every other engine rejects at parse time was accepted silently:

```js
"use strict";
console.log(010);                 // node: Octal literals are not allowed in strict mode
for (var i = 0 in { a: 1 }) {}    // node: for-in loop variable declaration may not have an initializer
if (1) function f() {}            // node: functions can only be declared at top level or inside a block
lab: function g() {}              // node: functions can only be declared at top level or inside a block
```

All four are also accepted with a trailing `export {}` (implicit ESM strict mode) and by `bun build --format=esm`.

### Cause

`StrictModeFeature::{LegacyOctalLiteral, ForInVarInit, IfElseFunctionStmt}` had zero call sites (the parse-time hooks were either commented-out stubs or returned early), and there was no variant for labeled function declarations.

### Fix

Wire each check in the **visit** pass so the scope's strict-mode kind (including implicit ESM from a trailing `import`/`export`) is fully resolved, matching esbuild:

* **Legacy octal literals**: `check_for_legacy_octal_literal()` records the lexer range at the three `TNumericLiteral` consumption sites; `e_number` looks it up during visiting when the scope is strict.
* **for-in var initializer**: `s_for_in` calls `mark_strict_mode_feature(ForInVarInit, ..)` before the existing lowering. `ForInVarInit` keeps `can_be_transformed = true`, so sloppy CJS bundled into ESM is still lowered rather than rejected.
* **Function declaration in `if`/`else` body**: `visit_single_stmt` already inspects `HasIfScope`; it now also emits `IfElseFunctionStmt` when strict.
* **Labeled function declaration**: new `StrictModeFeature::LabelFunctionStmt`, emitted from `s_label` when its body is an `SFunction`.

Also fixes `mark_strict_mode_feature` to produce a sensible note for `ExplicitStrictMode` instead of formatting an empty keyword range.

### Not in this PR

* `WithStatement` / `DeleteBareName`: covered by #35959 and #35962 respectively.
* Duplicate lexical function declarations: covered by #35784.
* `LegacyOctalEscape` (`"\010"`, `"\8"`) and noctal literals (`08`/`09`): require adding a `legacy_octal_loc` field to `E::String` and exposing the lexer's noctal flag; follow-up.

### How did you verify your code works?

New `test/bundler/transpiler/strict-mode-errors.test.ts` exercises each construct under `"use strict"`, `export {}` (ESM), a strict-mode function body, a class body, and sloppy CJS (positive case), plus `bun build --format=esm`. 39 tests total, all of which fail on main (except the 9 sloppy-mode baselines).

Also verified no regressions in `transpiler.test.js`, `bundler_edgecase.test.ts`, `esbuild/extra.test.ts`, `esbuild/default.test.ts`.