### PR TITLE
js_parser: stop rejecting valid sloppy-mode CommonJS

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1598,6 +1598,7 @@ pub struct EString {
     pub next: Option<StoreRef<EString>>,
     pub end: Option<StoreRef<EString>>,
     pub rope_len: u32,
+    pub legacy_octal_loc: crate::Loc,
     pub prefer_template: bool,
     pub is_utf16: bool,
 }
@@ -1612,6 +1613,7 @@ impl Default for EString {
             next: None,
             end: None,
             rope_len: 0,
+            legacy_octal_loc: crate::Loc::EMPTY,
             is_utf16: false,
         }
     }
@@ -1659,6 +1661,7 @@ impl EString {
             next: None,
             end: None,
             rope_len: 0,
+            legacy_octal_loc: crate::Loc::EMPTY,
             is_utf16: false,
         }
     }
@@ -1904,6 +1907,7 @@ impl EString {
             next: self.next,
             end: self.end,
             rope_len: self.rope_len,
+            legacy_octal_loc: self.legacy_octal_loc,
             is_utf16: self.is_utf16,
         }
     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2171,6 +2171,7 @@ impl Data {
                     next: el.next,
                     end: el.end,
                     rope_len: el.rope_len,
+                    legacy_octal_loc: el.legacy_octal_loc,
                     is_utf16: el.is_utf16,
                 });
                 Ok(Data::EString(StoreRef::from_bump(item)))

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1221,6 +1221,7 @@ pub enum StrictModeKind {
     ImplicitStrictModeExport,
     ImplicitStrictModeTopLevelAwait,
     ImplicitStrictModeClass,
+    ImplicitStrictModeModuleType,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, strum::IntoStaticStr)]

--- a/src/ast/s.rs
+++ b/src/ast/s.rs
@@ -42,6 +42,7 @@ pub struct Comment {
 
 pub struct Directive {
     pub value: StoreStr, // arena-owned
+    pub legacy_octal_loc: crate::Loc,
 }
 
 #[derive(Default)]

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -266,6 +266,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
             .append_non_dependency(Stmt::alloc(
                 S::Directive {
                     value: bun_ast::StoreStr::new(b"use strict"),
+                    legacy_octal_loc: bun_ast::Loc::EMPTY,
                 },
                 bun_ast::Loc::EMPTY,
             ))

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -599,25 +599,18 @@ lexer_impl_header! {
 
                         // legacy octal literals
                         0x30..=0x37 => {
-                            let octal_start =
-                                (iter.i as usize + width2 as usize).saturating_sub(2);
                             if IS_JSON {
                                 self.end = (start + iter.i as usize)
                                     .saturating_sub(width2 as usize);
                                 self.syntax_error()?;
                             }
 
-                            // 1-3 digit octal
-                            let mut is_bad = false;
+                            // 1-3 digit octal (Annex B LegacyOctalEscapeSequence).
                             let mut value: i64 = (c2 - 0x30) as i64;
                             let mut prev = iter;
 
                             if !iterator.next(&mut iter) {
-                                if value == 0 {
-                                    buf.push(0);
-                                    return Ok(());
-                                }
-                                self.syntax_error()?;
+                                buf.push(value as u16);
                                 return Ok(());
                             }
 
@@ -628,7 +621,8 @@ lexer_impl_header! {
                                     value = value * 8 + (c3 - 0x30) as i64;
                                     prev = iter;
                                     if !iterator.next(&mut iter) {
-                                        return self.syntax_error();
+                                        buf.push(value as u16);
+                                        return Ok(());
                                     }
 
                                     let c4 = iter.c;
@@ -642,16 +636,24 @@ lexer_impl_header! {
                                                 iter = prev;
                                             }
                                         }
+                                        // `\018` etc.: Annex B parses this as the
+                                        // two-digit octal `\01` followed by a literal
+                                        // `8`. Rewind so the outer loop re-reads the
+                                        // non-octal digit.
                                         0x38 | 0x39 => {
-                                            is_bad = true;
+                                            iter = prev;
                                         }
                                         _ => {
                                             iter = prev;
                                         }
                                     }
                                 }
+                                // `\08` / `\09`: LegacyOctalEscapeSequence
+                                // `0 [lookahead ∈ {8,9}]` — value is the single
+                                // octal digit, the 8/9 is a literal that the
+                                // outer loop must re-read.
                                 0x38 | 0x39 => {
-                                    is_bad = true;
+                                    iter = prev;
                                 }
                                 _ => {
                                     iter = prev;
@@ -659,25 +661,6 @@ lexer_impl_header! {
                             }
 
                             iter.c = i32::try_from(value).expect("int cast");
-                            if is_bad {
-                                // `octal_start` is text-relative like `iter.i`;
-                                // map back to absolute source position the same
-                                // way every sibling error path does (e.g.
-                                // `start + hex_start` in the `\u{}` branch).
-                                self.add_range_error(
-                                    Range {
-                                        loc: Loc {
-                                            start: i32::try_from(start + octal_start).expect("int cast"),
-                                        },
-                                        len: i32::try_from(
-                                            iter.i as usize - octal_start,
-                                        )
-                                        .unwrap(),
-                                    },
-                                    format_args!("Invalid legacy octal literal"),
-                                )
-                                .expect("unreachable");
-                            }
                         }
                         0x38 | 0x39 => {
                             iter.c = c2;
@@ -1911,10 +1894,8 @@ lexer_impl_header! {
                         // Handle legacy HTML-style comments
                         0x21 => {
                             if self.peek("--".len()) == b"--" {
-                                self.add_unsupported_syntax_error(
-                                    b"Legacy HTML comments not implemented yet!",
-                                )?;
-                                return Ok(());
+                                self.scan_legacy_html_open_comment();
+                                continue;
                             }
 
                             self.token = T::TLessThan;
@@ -2337,6 +2318,32 @@ lexer_impl_header! {
                     self.step_with(contents);
                 }
             }
+        }
+    }
+
+    /// Handles the legacy `<!--` HTML single-line open comment (Annex B
+    /// SingleLineHTMLOpenComment): emits a warning and consumes the rest of the
+    /// line. Entered with `self.code_point` on the `!` of `<!--` and
+    /// `self.current` past it.
+    #[cold]
+    #[inline(never)]
+    fn scan_legacy_html_open_comment(&mut self) {
+        // Consume `!`, `-`, `-`.
+        self.step();
+        self.step();
+        self.step();
+        self.log().add_range_warning(
+            Some(self.source),
+            self.range(),
+            b"Treating \"<!--\" as the start of a legacy HTML single-line comment",
+        );
+
+        loop {
+            match self.code_point {
+                0x0D | 0x0A | 0x2028 | 0x2029 | -1 => break,
+                _ => {}
+            }
+            self.step();
         }
     }
 

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -205,12 +205,14 @@ pub struct LexerSnapshot<'a> {
     pub string_literal_raw_content: &'a [u8],
     pub string_literal_start: usize,
     pub string_literal_raw_format: StringLiteralRawFormat,
+    pub string_literal_legacy_octal_loc: Loc,
     pub is_ascii_only: bool,
     pub track_comments: bool,
     pub track_react_suppressions: bool,
     // Vec buffer lengths — restore() truncates back to these.
     pub all_comments_len: usize,
     pub comments_to_preserve_before_len: usize,
+    pub legacy_html_comment_ranges_len: usize,
 }
 
 /// The lexer struct produced by `NewLexer_`.
@@ -289,6 +291,7 @@ pub struct LexerType<
     pub string_literal_raw_content: &'a [u8],
     pub string_literal_start: usize,
     pub string_literal_raw_format: StringLiteralRawFormat,
+    pub string_literal_legacy_octal_loc: Loc,
     pub temp_buffer_u16: Vec<u16>,
 
     /// Only used for JSON stringification when bundling.
@@ -296,6 +299,7 @@ pub struct LexerType<
     pub track_comments: bool,
     pub track_react_suppressions: bool,
     pub all_comments: Vec<Range>,
+    pub legacy_html_comment_ranges: Vec<Range>,
 }
 
 // Note: Rust macros must emit complete items; the macro now wraps the
@@ -457,11 +461,13 @@ lexer_impl_header! {
             string_literal_raw_content: self.string_literal_raw_content,
             string_literal_start: self.string_literal_start,
             string_literal_raw_format: self.string_literal_raw_format,
+            string_literal_legacy_octal_loc: self.string_literal_legacy_octal_loc,
             is_ascii_only: self.is_ascii_only,
             track_comments: self.track_comments,
             track_react_suppressions: self.track_react_suppressions,
             all_comments_len: self.all_comments.len(),
             comments_to_preserve_before_len: self.comments_to_preserve_before.len(),
+            legacy_html_comment_ranges_len: self.legacy_html_comment_ranges.len(),
         }
     }
 
@@ -497,6 +503,7 @@ lexer_impl_header! {
         self.string_literal_raw_content = original.string_literal_raw_content;
         self.string_literal_start = original.string_literal_start;
         self.string_literal_raw_format = original.string_literal_raw_format;
+        self.string_literal_legacy_octal_loc = original.string_literal_legacy_octal_loc;
         self.is_ascii_only = original.is_ascii_only;
         self.track_comments = original.track_comments;
         self.track_react_suppressions = original.track_react_suppressions;
@@ -511,6 +518,8 @@ lexer_impl_header! {
         self.all_comments.truncate(original.all_comments_len);
         self.comments_to_preserve_before
             .truncate(original.comments_to_preserve_before_len);
+        self.legacy_html_comment_ranges
+            .truncate(original.legacy_html_comment_ranges_len);
     }
 
     /// Look ahead at the next n codepoints without advancing the iterator.
@@ -536,6 +545,7 @@ lexer_impl_header! {
         if IS_JSON {
             self.is_ascii_only = false;
         }
+        self.string_literal_legacy_octal_loc = Loc::EMPTY;
 
         let iterator = CodepointIterator::init(text);
         let mut iter = strings::Cursor::default();
@@ -605,11 +615,20 @@ lexer_impl_header! {
                                 self.syntax_error()?;
                             }
 
+                            let octal_loc = Loc {
+                                start: (start + iter.i as usize)
+                                    .saturating_sub(width2 as usize + 1)
+                                    as i32,
+                            };
                             // 1-3 digit octal (Annex B LegacyOctalEscapeSequence).
                             let mut value: i64 = (c2 - 0x30) as i64;
+                            let mut restricted = c2 != 0x30;
                             let mut prev = iter;
 
                             if !iterator.next(&mut iter) {
+                                if restricted {
+                                    self.string_literal_legacy_octal_loc = octal_loc;
+                                }
                                 buf.push(value as u16);
                                 return Ok(());
                             }
@@ -618,9 +637,12 @@ lexer_impl_header! {
 
                             match c3 {
                                 0x30..=0x37 => {
+                                    restricted = true;
                                     value = value * 8 + (c3 - 0x30) as i64;
                                     prev = iter;
                                     if !iterator.next(&mut iter) {
+                                        self.string_literal_legacy_octal_loc =
+                                            octal_loc;
                                         buf.push(value as u16);
                                         return Ok(());
                                     }
@@ -641,14 +663,26 @@ lexer_impl_header! {
                                         }
                                     }
                                 }
+                                0x38 | 0x39 => {
+                                    restricted = true;
+                                    iter = prev;
+                                }
                                 _ => {
                                     iter = prev;
                                 }
                             }
 
+                            if restricted {
+                                self.string_literal_legacy_octal_loc = octal_loc;
+                            }
                             iter.c = i32::try_from(value).expect("int cast");
                         }
                         0x38 | 0x39 => {
+                            self.string_literal_legacy_octal_loc = Loc {
+                                start: (start + iter.i as usize)
+                                    .saturating_sub(width2 as usize + 1)
+                                    as i32,
+                            };
                             iter.c = c2;
                         }
                         // 2-digit hexadecimal
@@ -2315,6 +2349,7 @@ lexer_impl_header! {
         self.step();
         self.step();
         self.step();
+        self.legacy_html_comment_ranges.push(self.range());
         self.log().add_range_warning(
             Some(self.source),
             self.range(),
@@ -2341,6 +2376,7 @@ lexer_impl_header! {
     fn scan_legacy_html_close_comment(&mut self) {
         // Consume the `>` of `-->`.
         self.step();
+        self.legacy_html_comment_ranges.push(self.range());
         self.log().add_range_warning(
             Some(self.source),
             self.range(),
@@ -2581,11 +2617,13 @@ lexer_impl_header! {
             string_literal_raw_content: b"",
             string_literal_start: 0,
             string_literal_raw_format: StringLiteralRawFormat::Ascii,
+            string_literal_legacy_octal_loc: Loc::EMPTY,
             temp_buffer_u16: Vec::new(),
             is_ascii_only: IS_JSON,
             track_comments: false,
             track_react_suppressions: false,
             all_comments: Vec::new(),
+            legacy_html_comment_ranges: Vec::new(),
         }
     }
 
@@ -2636,7 +2674,7 @@ lexer_impl_header! {
                 }
                 let first_non_ascii = strings::first_non_ascii16(&tmp);
                 // prefer to store an ascii e.string rather than a utf-16 one. ascii takes less memory, and `+` folding is not yet supported on utf-16.
-                let out = if first_non_ascii.is_some() {
+                let mut out = if first_non_ascii.is_some() {
                     let dup = self.arena.alloc_slice_copy(&tmp);
                     js_ast::E::String::init_utf16(dup)
                 } else {
@@ -2645,6 +2683,7 @@ lexer_impl_header! {
                     strings::copy_utf16_into_utf8(result, &tmp);
                     js_ast::E::String::init(result)
                 };
+                out.legacy_octal_loc = self.string_literal_legacy_octal_loc;
                 tmp.clear();
                 self.temp_buffer_u16 = tmp;
                 Ok(out)

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -636,24 +636,10 @@ lexer_impl_header! {
                                                 iter = prev;
                                             }
                                         }
-                                        // `\018` etc.: Annex B parses this as the
-                                        // two-digit octal `\01` followed by a literal
-                                        // `8`. Rewind so the outer loop re-reads the
-                                        // non-octal digit.
-                                        0x38 | 0x39 => {
-                                            iter = prev;
-                                        }
                                         _ => {
                                             iter = prev;
                                         }
                                     }
-                                }
-                                // `\08` / `\09`: LegacyOctalEscapeSequence
-                                // `0 [lookahead ∈ {8,9}]` — value is the single
-                                // octal digit, the 8/9 is a literal that the
-                                // outer loop must re-read.
-                                0x38 | 0x39 => {
-                                    iter = prev;
                                 }
                                 _ => {
                                     iter = prev;
@@ -2321,10 +2307,7 @@ lexer_impl_header! {
         }
     }
 
-    /// Handles the legacy `<!--` HTML single-line open comment (Annex B
-    /// SingleLineHTMLOpenComment): emits a warning and consumes the rest of the
-    /// line. Entered with `self.code_point` on the `!` of `<!--` and
-    /// `self.current` past it.
+    /// Annex B `<!--` single-line comment. Entered with `self.code_point` on `!`.
     #[cold]
     #[inline(never)]
     fn scan_legacy_html_open_comment(&mut self) {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2808,7 +2808,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeModuleType);
         }
 
-        if self.has_es_module_syntax || self.options.module_type == options::ModuleType::Esm {
+        let is_module_goal =
+            self.has_es_module_syntax || self.options.module_type == options::ModuleType::Esm;
+        if is_module_goal {
             for r in &self.lexer.legacy_html_comment_ranges {
                 self.log().add_range_error(
                     Some(self.source),
@@ -2816,13 +2818,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     b"Legacy HTML single-line comments are not allowed in ECMAScript modules",
                 );
             }
-            if self.top_level_await_identifier_range.len > 0 {
-                self.log().add_range_error(
-                    Some(self.source),
-                    self.top_level_await_identifier_range,
-                    b"Cannot use \"await\" as an identifier in an ECMAScript module",
-                );
-            }
+        }
+        if (is_module_goal || self.is_strict_mode_output_format())
+            && self.top_level_await_identifier_range.len > 0
+        {
+            self.log().add_range_error(
+                Some(self.source),
+                self.top_level_await_identifier_range,
+                b"Cannot use \"await\" as an identifier in an ECMAScript module",
+            );
         }
 
         self.hoist_symbols(self.module_scope_ref());

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4325,6 +4325,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             )
             .into_bump_str()
             .as_bytes(),
+            StrictModeFeature::AssignToEvalOrArguments => bun_alloc::arena_format!(
+                in self.arena,
+                "Assigning to \"{}\"",
+                bstr::BStr::new(detail)
+            )
+            .into_bump_str()
+            .as_bytes(),
             StrictModeFeature::ReservedWord => bun_alloc::arena_format!(
                 in self.arena,
                 "\"{}\" is a reserved word and",

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2804,6 +2804,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait);
         }
 
+        if self.has_es_module_syntax {
+            for r in &self.lexer.legacy_html_comment_ranges {
+                self.log().add_range_error(
+                    Some(self.source),
+                    *r,
+                    b"Legacy HTML single-line comments are not allowed in ECMAScript modules",
+                );
+            }
+        }
+
         self.hoist_symbols(self.module_scope_ref());
 
         let mut generated_symbols_count: u32 = 3;
@@ -4347,7 +4357,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 _ => {}
             }
-            if why.is_empty() {
+            if why.is_empty() && where_.len > 0 {
                 why = bun_alloc::arena_format!(
                     in self.arena,
                     "This file is implicitly in strict mode because of the \"{}\" keyword here",
@@ -4357,8 +4367,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .as_bytes();
             }
             // bun_ast::Data is !Copy (Cow) — build the notes Box directly.
-            let notes: Box<[bun_ast::Data]> =
-                Box::new([bun_ast::range_data(Some(self.source), where_, why.to_vec())]);
+            let notes: Box<[bun_ast::Data]> = if why.is_empty() {
+                Box::new([])
+            } else {
+                Box::new([bun_ast::range_data(Some(self.source), where_, why.to_vec())])
+            };
             self.log().add_range_error_fmt_with_notes(
                 Some(self.source),
                 r,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2803,6 +2803,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         } else if self.top_level_await_keyword.len > 0 {
             self.module_scope_mut()
                 .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait);
+        } else if self.options.module_type == options::ModuleType::Esm {
+            self.module_scope_mut()
+                .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeModuleType);
         }
 
         if self.has_es_module_syntax || self.options.module_type == options::ModuleType::Esm {
@@ -4321,7 +4324,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         r: bun_ast::Range,
         detail: &[u8],
     ) -> Result<(), crate::Error> {
-        let can_be_transformed = feature == StrictModeFeature::ForInVarInit;
+        let can_be_transformed = matches!(
+            feature,
+            StrictModeFeature::ForInVarInit | StrictModeFeature::LegacyOctalEscape
+        );
         let text: &'a [u8] = match feature {
             StrictModeFeature::WithStatement => b"With statements",
             StrictModeFeature::DeleteBareName => b"\"delete\" of a bare identifier",
@@ -4369,6 +4375,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 js_ast::StrictModeKind::ImplicitStrictModeClass => {
                     why = b"All code inside a class is implicitly in strict mode";
                     where_ = self.enclosing_class_keyword;
+                }
+                js_ast::StrictModeKind::ImplicitStrictModeModuleType => {
+                    why = b"This file is an ECMAScript module because of its extension or package.json";
                 }
                 _ => {}
             }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5296,9 +5296,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // the full union. The only caller (`visit_expr_in_out`) already holds `&mut Expr`.
     pub fn is_valid_assignment_target(&self, expr: &Expr) -> bool {
         match &expr.data {
-            // Any identifier is a valid assignment target syntactically. Assigning to
-            // eval/arguments is a *strict-mode* early error (ECMA-262 13.15.1), handled
-            // via mark_strict_mode_feature at the call site so sloppy code still runs.
+            // eval/arguments is a strict-mode error, reported by the EIdentifier visitor.
             js_ast::ExprData::EIdentifier(_) => true,
             js_ast::ExprData::EDot(e) => e.optional_chain.is_none(),
             js_ast::ExprData::EIndex(e) => e.optional_chain.is_none(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -220,6 +220,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub has_import_meta: bool,
     pub has_es_module_syntax: bool,
     pub top_level_await_keyword: bun_ast::Range,
+    pub top_level_await_identifier_range: bun_ast::Range,
     pub fn_or_arrow_data_parse: FnOrArrowDataParse,
     pub fn_or_arrow_data_visit: FnOrArrowDataVisit,
     pub fn_only_data_visit: FnOnlyDataVisit<'a>,
@@ -2812,6 +2813,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     b"Legacy HTML single-line comments are not allowed in ECMAScript modules",
                 );
             }
+            if self.top_level_await_identifier_range.len > 0 {
+                self.log().add_range_error(
+                    Some(self.source),
+                    self.top_level_await_identifier_range,
+                    b"Cannot use \"await\" as an identifier in an ECMAScript module",
+                );
+            }
         }
 
         self.hoist_symbols(self.module_scope_ref());
@@ -4396,6 +4404,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         }
         Ok(())
+    }
+
+    /// At top level the goal symbol is unknown; record the range for a deferred ESM check.
+    pub fn is_await_identifier_rejected(&mut self, range: bun_ast::Range) -> bool {
+        match self.fn_or_arrow_data_parse.allow_await {
+            crate::AwaitOrYield::AllowIdent => false,
+            crate::AwaitOrYield::ForbidAll => true,
+            crate::AwaitOrYield::AllowExpr => {
+                if self.fn_or_arrow_data_parse.is_top_level {
+                    if self.top_level_await_identifier_range.len == 0 {
+                        self.top_level_await_identifier_range = range;
+                    }
+                    false
+                } else {
+                    true
+                }
+            }
+        }
     }
 
     #[inline]
@@ -8743,6 +8769,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_import_meta: false,
             has_es_module_syntax: false,
             top_level_await_keyword: bun_ast::Range::NONE,
+            top_level_await_identifier_range: bun_ast::Range::NONE,
             fn_or_arrow_data_parse,
             fn_or_arrow_data_visit: FnOrArrowDataVisit::default(),
             fn_only_data_visit: FnOnlyDataVisit::default(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2805,7 +2805,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait);
         }
 
-        if self.has_es_module_syntax {
+        if self.has_es_module_syntax || self.options.module_type == options::ModuleType::Esm {
             for r in &self.lexer.legacy_html_comment_ranges {
                 self.log().add_range_error(
                     Some(self.source),
@@ -8248,6 +8248,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     remaining_stmts[0] = self.s(
                         S::Directive {
                             value: b"use strict".into(),
+                            legacy_octal_loc: bun_ast::Loc::EMPTY,
                         },
                         self.module_scope_directive_loc,
                     );

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -26,7 +26,7 @@ use crate::{
     LOC_MODULE_SCOPE as loc_module_scope, LocList, MacroState, ParseStatementOptions, ParsedPath,
     PrependTempRefsOpts, ReactRefresh, Ref, RefMap, RefRefMap, RuntimeImports, ScopeOrder,
     ScopeOrderList, StrictModeFeature, StringBoolMap, Substitution, TempRef, ThenCatchChain,
-    TransposeState, WrapMode, fs, is_eval_or_arguments, options, statement_cares_about_scope,
+    TransposeState, WrapMode, fs, options, statement_cares_about_scope,
 };
 use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
@@ -5296,9 +5296,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // the full union. The only caller (`visit_expr_in_out`) already holds `&mut Expr`.
     pub fn is_valid_assignment_target(&self, expr: &Expr) -> bool {
         match &expr.data {
-            js_ast::ExprData::EIdentifier(ident) => {
-                !is_eval_or_arguments(self.load_name_from_ref(ident.ref_))
-            }
+            // Any identifier is a valid assignment target syntactically. Assigning to
+            // eval/arguments is a *strict-mode* early error (ECMA-262 13.15.1), handled
+            // via mark_strict_mode_feature at the call site so sloppy code still runs.
+            js_ast::ExprData::EIdentifier(_) => true,
             js_ast::ExprData::EDot(e) => e.optional_chain.is_none(),
             js_ast::ExprData::EIndex(e) => e.optional_chain.is_none(),
             js_ast::ExprData::EArray(e) => !e.is_parenthesized,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -977,8 +977,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match p.lexer.token {
             T::TIdentifier => {
                 let name = p.lexer.identifier;
-                if (p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
-                    && name == b"await")
+                // At top level with `allow_await == AllowExpr` we're in the TLA-sniff
+                // state: the file may still be a Script, where `await` is a legal
+                // identifier. Don't reject it as a binding name there; if the file
+                // turns out to use top-level `await` as an operator, the engine will
+                // report the conflict.
+                let await_is_keyword = match p.fn_or_arrow_data_parse.allow_await {
+                    AwaitOrYield::AllowIdent => false,
+                    AwaitOrYield::ForbidAll => true,
+                    AwaitOrYield::AllowExpr => !p.fn_or_arrow_data_parse.is_top_level,
+                };
+                if (await_is_keyword && name == b"await")
                     || (p.fn_or_arrow_data_parse.allow_yield != AwaitOrYield::AllowIdent
                         && name == b"yield")
                 {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -977,11 +977,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match p.lexer.token {
             T::TIdentifier => {
                 let name = p.lexer.identifier;
-                // At top level with `allow_await == AllowExpr` we're in the TLA-sniff
-                // state: the file may still be a Script, where `await` is a legal
-                // identifier. Don't reject it as a binding name there; if the file
-                // turns out to use top-level `await` as an operator, the engine will
-                // report the conflict.
+                // `is_top_level` + AllowExpr is the TLA sniff state; the file may still
+                // be a Script, where `await` is a legal binding identifier.
                 let await_is_keyword = match p.fn_or_arrow_data_parse.allow_await {
                     AwaitOrYield::AllowIdent => false,
                     AwaitOrYield::ForbidAll => true,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -693,7 +693,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 return Err(crate::Error::SyntaxError);
             }
 
-            if p.fn_or_arrow_data_parse.await_is_keyword_here() && name_text == b"await" {
+            if name_text == b"await" && p.is_await_identifier_rejected(p.lexer.range()) {
                 p.log().add_range_error(
                     Some(p.source),
                     p.lexer.range(),
@@ -990,7 +990,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match p.lexer.token {
             T::TIdentifier => {
                 let name = p.lexer.identifier;
-                if (p.fn_or_arrow_data_parse.await_is_keyword_here() && name == b"await")
+                if (name == b"await" && p.is_await_identifier_rejected(p.lexer.range()))
                     || (p.fn_or_arrow_data_parse.allow_yield != AwaitOrYield::AllowIdent
                         && name == b"yield")
                 {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -682,6 +682,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && (!Self::IS_TYPESCRIPT_ENABLED || p.lexer.identifier != b"implements"))
         {
             let name_loc = p.lexer.loc();
+            let name_range = p.lexer.range();
             let name_text = p.lexer.identifier;
             p.lexer.expect(T::TIdentifier)?;
 
@@ -693,10 +694,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 return Err(crate::Error::SyntaxError);
             }
 
-            if name_text == b"await" && p.is_await_identifier_rejected(p.lexer.range()) {
+            if name_text == b"await" && p.is_await_identifier_rejected(name_range) {
                 p.log().add_range_error(
                     Some(p.source),
-                    p.lexer.range(),
+                    name_range,
                     b"Cannot use \"await\" as an identifier here",
                 );
             }

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -350,6 +350,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// ESM-only string positions (import specifier, clause alias, attribute) are always strict.
+    pub fn reject_strict_octal_escape(&mut self, loc: bun_ast::Loc) {
+        if loc.start >= 0 {
+            self.log().add_range_error(
+                Some(self.source),
+                bun_ast::Range { loc, len: 2 },
+                b"Legacy octal escape sequences cannot be used in strict mode",
+            );
+        }
+    }
+
     pub fn parse_call_args(&mut self) -> Result<ExprListLoc, Error> {
         // Allow "in" inside call arguments; restored on every exit path
         let old_allow_in = self.allow_in;
@@ -762,6 +773,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // The alias may now be a utf-16 (not wtf-16) string (see https://github.com/tc39/ecma262/pull/2154)
         if p.lexer.token == T::TStringLiteral {
             let estr = p.lexer.to_e_string()?;
+            p.reject_strict_octal_escape(estr.legacy_octal_loc);
             if estr.is_utf8() {
                 // SAFETY: E::String slices are arena-owned for 'a.
                 return Ok(unsafe { bun_collections::detach_lifetime(estr.slice8()) });
@@ -1325,6 +1337,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn parse_path(&mut self) -> Result<ParsedPath<'a>, Error> {
         let p = self;
         let path_text = p.lexer.to_utf8_e_string()?;
+        p.reject_strict_octal_escape(path_text.legacy_octal_loc);
         let mut path = ParsedPath {
             loc: p.lexer.loc(),
             // SAFETY: E::String slice8() is arena-owned for 'a.
@@ -1377,6 +1390,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                     } else if p.lexer.token == T::TStringLiteral {
                         let estr = p.lexer.to_utf8_e_string()?;
+                        p.reject_strict_octal_escape(estr.legacy_octal_loc);
                         let string_literal_text = estr.slice8();
                         if string_literal_text == b"type" {
                             break 'brk Some(SupportedAttribute::Type);
@@ -1399,6 +1413,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 p.lexer.expect(T::TStringLiteral)?;
                 let estr = p.lexer.to_utf8_e_string()?;
+                p.reject_strict_octal_escape(estr.legacy_octal_loc);
                 let string_literal_text = estr.slice8();
                 if let Some(attr) = supported_attribute {
                     match attr {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -977,11 +977,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match p.lexer.token {
             T::TIdentifier => {
                 let name = p.lexer.identifier;
-                // `is_top_level` + AllowExpr is the TLA sniff state; the file may still
-                // be a Script, where `await` is a legal binding identifier.
                 let await_is_keyword = match p.fn_or_arrow_data_parse.allow_await {
                     AwaitOrYield::AllowIdent => false,
                     AwaitOrYield::ForbidAll => true,
+                    // TLA sniff; file may still be a Script where `await` binds as an ident.
                     AwaitOrYield::AllowExpr => !p.fn_or_arrow_data_parse.is_top_level,
                 };
                 if (await_is_keyword && name == b"await")

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -298,7 +298,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.rescan_close_brace_as_template_token()?;
 
             let tail: E::TemplateContents = if !include_raw {
-                E::TemplateContents::Cooked(p.lexer.to_e_string()?)
+                let cooked = p.lexer.to_e_string()?;
+                p.reject_template_octal_escape(cooked.legacy_octal_loc);
+                E::TemplateContents::Cooked(cooked)
             } else {
                 E::TemplateContents::Raw(p.lexer.raw_template_contents().into())
             };
@@ -329,10 +331,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let loc = p.lexer.loc();
         let mut str_ = p.lexer.to_e_string()?;
         str_.prefer_template = p.lexer.token == T::TNoSubstitutionTemplateLiteral;
+        if str_.prefer_template {
+            p.reject_template_octal_escape(str_.legacy_octal_loc);
+        }
 
         let expr = p.new_expr(str_, loc);
         p.lexer.next()?;
         Ok(expr)
+    }
+
+    pub fn reject_template_octal_escape(&mut self, loc: bun_ast::Loc) {
+        if loc.start >= 0 {
+            self.log().add_range_error(
+                Some(self.source),
+                bun_ast::Range { loc, len: 2 },
+                b"Octal escape sequences are not allowed in template literals",
+            );
+        }
     }
 
     pub fn parse_call_args(&mut self) -> Result<ExprListLoc, Error> {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -693,9 +693,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 return Err(crate::Error::SyntaxError);
             }
 
-            if p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
-                && name_text == b"await"
-            {
+            if p.fn_or_arrow_data_parse.await_is_keyword_here() && name_text == b"await" {
                 p.log().add_range_error(
                     Some(p.source),
                     p.lexer.range(),
@@ -992,13 +990,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match p.lexer.token {
             T::TIdentifier => {
                 let name = p.lexer.identifier;
-                let await_is_keyword = match p.fn_or_arrow_data_parse.allow_await {
-                    AwaitOrYield::AllowIdent => false,
-                    AwaitOrYield::ForbidAll => true,
-                    // TLA sniff; file may still be a Script where `await` binds as an ident.
-                    AwaitOrYield::AllowExpr => !p.fn_or_arrow_data_parse.is_top_level,
-                };
-                if (await_is_keyword && name == b"await")
+                if (p.fn_or_arrow_data_parse.await_is_keyword_here() && name == b"await")
                     || (p.fn_or_arrow_data_parse.allow_yield != AwaitOrYield::AllowIdent
                         && name == b"yield")
                 {
@@ -1503,8 +1495,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             if str_.eql_comptime(b"use strict") {
                                 skip = true;
                                 // Track "use strict" directives
-                                p.current_scope_mut().strict_mode =
-                                    StrictModeKind::ExplicitStrictMode;
+                                let scope = p.current_scope_mut();
+                                scope.strict_mode = StrictModeKind::ExplicitStrictMode;
+                                // A "use strict" directive in a function body makes the
+                                // parameter list strict-mode code too (ECMA-262 11.2.2).
+                                if let Some(mut parent) = scope.parent
+                                    && parent.kind == js_ast::scope::Kind::FunctionArgs
+                                {
+                                    parent.strict_mode = StrictModeKind::ExplicitStrictMode;
+                                }
                                 if p.current_scope == p.module_scope {
                                     p.module_scope_directive_loc = stmt.loc;
                                 }

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1497,8 +1497,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 // Track "use strict" directives
                                 let scope = p.current_scope_mut();
                                 scope.strict_mode = StrictModeKind::ExplicitStrictMode;
-                                // A "use strict" directive in a function body makes the
-                                // parameter list strict-mode code too (ECMA-262 11.2.2).
+                                // A body directive makes the parameter list strict too.
                                 if let Some(mut parent) = scope.parent
                                     && parent.kind == js_ast::scope::Kind::FunctionArgs
                                 {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1501,7 +1501,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 if let Some(mut parent) = scope.parent
                                     && parent.kind == js_ast::scope::Kind::FunctionArgs
                                 {
-                                    parent.strict_mode = StrictModeKind::ExplicitStrictMode;
+                                    parent.recursive_set_strict_mode(
+                                        StrictModeKind::ExplicitStrictMode,
+                                    );
                                 }
                                 if p.current_scope == p.module_scope {
                                     p.module_scope_directive_loc = stmt.loc;
@@ -1511,9 +1513,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});
                             } else {
                                 let bytes = str_.string(p.arena).expect("OOM");
+                                let legacy_octal_loc = str_.legacy_octal_loc;
                                 stmt = Stmt::alloc(
                                     S::Directive {
                                         value: bun_ast::StoreStr::new(bytes),
+                                        legacy_octal_loc,
                                     },
                                     stmt.loc,
                                 );

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -548,7 +548,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if p.lexer.token == T::TIdentifier {
             let name_text = p.lexer.identifier;
             if !Self::IS_TYPESCRIPT_ENABLED || name_text != b"implements" {
-                if p.fn_or_arrow_data_parse.await_is_keyword_here() && name_text == b"await" {
+                if name_text == b"await" && p.is_await_identifier_rejected(p.lexer.range()) {
                     p.log().add_range_error(
                         Some(p.source),
                         p.lexer.range(),
@@ -609,7 +609,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if p.lexer.token == T::TIdentifier {
             let name_text = p.lexer.identifier;
             if !Self::IS_TYPESCRIPT_ENABLED || name_text != b"implements" {
-                if p.fn_or_arrow_data_parse.await_is_keyword_here() && name_text == b"await" {
+                if name_text == b"await" && p.is_await_identifier_rejected(p.lexer.range()) {
                     p.log().add_range_error(
                         Some(p.source),
                         p.lexer.range(),

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -548,9 +548,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if p.lexer.token == T::TIdentifier {
             let name_text = p.lexer.identifier;
             if !Self::IS_TYPESCRIPT_ENABLED || name_text != b"implements" {
-                if p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
-                    && name_text == b"await"
-                {
+                if p.fn_or_arrow_data_parse.await_is_keyword_here() && name_text == b"await" {
                     p.log().add_range_error(
                         Some(p.source),
                         p.lexer.range(),
@@ -611,9 +609,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if p.lexer.token == T::TIdentifier {
             let name_text = p.lexer.identifier;
             if !Self::IS_TYPESCRIPT_ENABLED || name_text != b"implements" {
-                if p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
-                    && name_text == b"await"
-                {
+                if p.fn_or_arrow_data_parse.await_is_keyword_here() && name_text == b"await" {
                     p.log().add_range_error(
                         Some(p.source),
                         p.lexer.range(),

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -281,6 +281,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn pfx_t_template_head(p: &mut Self) -> PResult<Expr> {
         let loc = p.lexer.loc();
         let head = p.lexer.to_e_string()?;
+        p.reject_template_octal_escape(head.legacy_octal_loc);
 
         let (parts, _tail_loc) = p.parse_template_parts(false)?;
 

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -556,8 +556,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         && js_lexer::keyword(name).is_none();
 
                     if is_shorthand_property {
-                        if (p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
-                            && name == b"await")
+                        if (p.fn_or_arrow_data_parse.await_is_keyword_here() && name == b"await")
                             || (p.fn_or_arrow_data_parse.allow_yield != AwaitOrYield::AllowIdent
                                 && name == b"yield")
                         {

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -556,7 +556,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         && js_lexer::keyword(name).is_none();
 
                     if is_shorthand_property {
-                        if (p.fn_or_arrow_data_parse.await_is_keyword_here() && name == b"await")
+                        if (name == b"await" && p.is_await_identifier_rejected(name_range))
                             || (p.fn_or_arrow_data_parse.allow_yield != AwaitOrYield::AllowIdent
                                 && name == b"yield")
                         {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1380,17 +1380,6 @@ impl Default for FnOrArrowDataParse {
     }
 }
 
-impl FnOrArrowDataParse {
-    /// `await` must be rejected as an identifier here (top-level TLA sniff excluded).
-    pub fn await_is_keyword_here(&self) -> bool {
-        match self.allow_await {
-            AwaitOrYield::AllowIdent => false,
-            AwaitOrYield::ForbidAll => true,
-            AwaitOrYield::AllowExpr => !self.is_top_level,
-        }
-    }
-}
-
 /// This is function-specific information used during visiting. It is saved and
 /// restored on the call stack around code that parses nested functions and
 /// arrow expressions.

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1177,6 +1177,7 @@ pub enum StrictModeFeature {
     DeleteBareName,
     ForInVarInit,
     EvalOrArguments,
+    AssignToEvalOrArguments,
     ReservedWord,
     LegacyOctalLiteral,
     LegacyOctalEscape,
@@ -1375,6 +1376,19 @@ impl Default for FnOrArrowDataParse {
             track_arrow_arg_errors: false,
             allow_missing_body_for_type_script: false,
             allow_ts_decorators: false,
+        }
+    }
+}
+
+impl FnOrArrowDataParse {
+    /// True when `await` must be rejected as an identifier at the current position.
+    /// At top level with `AllowExpr` the file may still be a Script, so `await`
+    /// stays usable as a binding/class/property name there.
+    pub fn await_is_keyword_here(&self) -> bool {
+        match self.allow_await {
+            AwaitOrYield::AllowIdent => false,
+            AwaitOrYield::ForbidAll => true,
+            AwaitOrYield::AllowExpr => !self.is_top_level,
         }
     }
 }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1381,9 +1381,7 @@ impl Default for FnOrArrowDataParse {
 }
 
 impl FnOrArrowDataParse {
-    /// True when `await` must be rejected as an identifier at the current position.
-    /// At top level with `AllowExpr` the file may still be a Script, so `await`
-    /// stays usable as a binding/class/property name there.
+    /// `await` must be rejected as an identifier here (top-level TLA sniff excluded).
     pub fn await_is_keyword_here(&self) -> bool {
         match self.allow_await {
             AwaitOrYield::AllowIdent => false,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -117,10 +117,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             &VisitArgsOpts {
                 has_rest_arg: func.flags.contains(flags::Function::HasRestArg),
                 body: body_stmts,
-                // Plain function declarations/expressions allow duplicate parameter names
-                // in sloppy mode with a simple parameter list (ECMA-262 15.1.1). Methods,
-                // getters, and setters set IsUniqueFormalParameters at parse time; arrows
-                // pass `true` at their own visit site.
                 is_unique_formal_parameters: func
                     .flags
                     .contains(flags::Function::IsUniqueFormalParameters),

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -218,6 +218,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             || strict_loc.is_some()
             || !has_simple_args
             || self.is_strict_mode()
+            || self.is_strict_mode_output_format()
         {
             duplicate_args_check = Some(StringVoidMap::get());
         }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -117,7 +117,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             &VisitArgsOpts {
                 has_rest_arg: func.flags.contains(flags::Function::HasRestArg),
                 body: body_stmts,
-                is_unique_formal_parameters: true,
+                // Plain function declarations/expressions allow duplicate parameter names
+                // in sloppy mode with a simple parameter list (ECMA-262 15.1.1). Methods,
+                // getters, and setters set IsUniqueFormalParameters at parse time; arrows
+                // pass `true` at their own visit site.
+                is_unique_formal_parameters: func
+                    .flags
+                    .contains(flags::Function::IsUniqueFormalParameters),
             },
         );
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -202,6 +202,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Handle assigning to a constant
         if in_.assign_target != js_ast::AssignTarget::None {
+            if crate::parser::is_eval_or_arguments(name) {
+                p.mark_strict_mode_feature(
+                    StrictModeFeature::EvalOrArguments,
+                    js_lexer::range_of_identifier(p.source, expr.loc),
+                    name,
+                )
+                .expect("unreachable");
+            }
             if p.symbols[result.r#ref.inner_index() as usize].kind == js_ast::symbol::Kind::Constant
             {
                 // TODO: silence this for runtime transpiler

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -92,9 +92,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // not emitted: it is not necessary and it was causing breakages.
     }
 
-    fn e_string(_: &mut Self, _e: &mut Expr, _: ExprIn) {
-        // If you're using this, you're probably not using 0-prefixed legacy octal notation
-        // if e.LegacyOctalLoc.Start > 0 {
+    fn e_string(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        if let js_ast::ExprData::EString(s) = &e.data
+            && s.legacy_octal_loc.start >= 0
+        {
+            let r = bun_ast::Range {
+                loc: s.legacy_octal_loc,
+                len: 2,
+            };
+            p.mark_strict_mode_feature(StrictModeFeature::LegacyOctalEscape, r, b"")
+                .expect("unreachable");
+        }
     }
 
     fn e_number(_: &mut Self, _e: &mut Expr, _: ExprIn) {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -212,7 +212,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if in_.assign_target != js_ast::AssignTarget::None {
             if crate::parser::is_eval_or_arguments(name) {
                 p.mark_strict_mode_feature(
-                    StrictModeFeature::EvalOrArguments,
+                    StrictModeFeature::AssignToEvalOrArguments,
                     js_lexer::range_of_identifier(p.source, expr.loc),
                     name,
                 )

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -68,7 +68,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // points into the arena, not into `*stmt`.
         let data_copy = stmt.data;
         match data_copy {
-            StmtData::SDirective(_) | StmtData::SComment(_) | StmtData::SEmpty(_) => {
+            StmtData::SDirective(dir) => {
+                if dir.legacy_octal_loc.start >= 0 {
+                    let r = bun_ast::Range {
+                        loc: dir.legacy_octal_loc,
+                        len: 2,
+                    };
+                    p.mark_strict_mode_feature(crate::StrictModeFeature::LegacyOctalEscape, r, b"")
+                        .expect("unreachable");
+                }
+                p.cur_scope().is_after_const_local_prefix = was_after_after_const_local_prefix;
+                stmts.push(*stmt);
+                Ok(())
+            }
+            StmtData::SComment(_) | StmtData::SEmpty(_) => {
                 p.cur_scope().is_after_const_local_prefix = was_after_after_const_local_prefix;
                 stmts.push(*stmt);
                 Ok(())

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -494,6 +494,7 @@ fn codegen_reactive_function(
         directives.push(Stmt::alloc(
             S::Directive {
                 value: store_str(d.as_bytes()),
+                legacy_octal_loc: Loc::EMPTY,
             },
             Loc::EMPTY,
         ));

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -232,9 +232,25 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
     expect(exitCode).not.toBe(0);
   });
 
-  test("var await in an ESM file is rejected by the engine", async () => {
+  test("var await in an ESM file is rejected by the parser", async () => {
     const { exitCode, stderr } = await run(`var await = 1;\nexport {};`, false);
-    expect(stderr).toMatch(/await/i);
+    expect(stderr).toContain(`Cannot use "await" as an identifier in an ECMAScript module`);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("var await in an ESM file is rejected when bundling", async () => {
+    using dir = tempDir("sloppy-await-esm", {
+      "x.js": `export var await = 1;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "x.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(`Cannot use "await" as an identifier in an ECMAScript module`);
     expect(exitCode).not.toBe(0);
   });
 });

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -59,6 +59,22 @@ describe.concurrent("sloppy-mode constructs the transpiler must accept", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("await as a top-level class name in a Script", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `class await {}\nfunction g() { return await.name; }\nconsole.log(g());`,
+    );
+    expect(stderr).not.toContain(`Cannot use "await" as an identifier`);
+    expect(stdout.trim()).toBe("await");
+    expect(exitCode).toBe(0);
+  });
+
+  test("await as a shorthand property name at top level", async () => {
+    const { stdout, stderr, exitCode } = await run(`var await = 7;\nvar o = { await };\nconsole.log(o.await);`);
+    expect(stderr).not.toContain(`Cannot use "await"`);
+    expect(stdout.trim()).toBe("7");
+    expect(exitCode).toBe(0);
+  });
+
   test("legacy octal escape at end of string (1 digit)", async () => {
     const { stdout, stderr, exitCode } = await run(`console.log("x\\7".charCodeAt(1));`);
     expect(stderr).not.toContain("Syntax Error");
@@ -132,6 +148,12 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
     expect(exitCode).not.toBe(0);
   });
 
+  test('duplicate parameters with "use strict" in the function body', async () => {
+    const { exitCode, stderr } = await run(`function f(a, a) { "use strict"; return a }\nvoid f;`);
+    expect(stderr).toContain("cannot be bound multiple times");
+    expect(exitCode).not.toBe(0);
+  });
+
   test("duplicate parameters with non-simple parameter list", async () => {
     const { exitCode, stderr } = await run(`function f(a, a = 1) { return a }\nvoid f;`);
     expect(stderr).toContain("cannot be bound multiple times");
@@ -144,9 +166,15 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
     expect(exitCode).not.toBe(0);
   });
 
+  test("class await inside async function still rejected", async () => {
+    const { exitCode, stderr } = await run(`async function f() { class await {} }\nf();`);
+    expect(stderr).toContain(`Cannot use "await" as an identifier here`);
+    expect(exitCode).not.toBe(0);
+  });
+
   test("assignment to eval in an ESM file still rejected", async () => {
     const { exitCode, stderr } = await run(`export {};\neval = 1;`, false);
-    expect(stderr).toMatch(/eval/);
+    expect(stderr).toContain(`Assigning to "eval"`);
     expect(exitCode).not.toBe(0);
   });
 

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -6,11 +6,12 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-async function run(body: string, cjs = true) {
+async function run(body: string, cjs = true, ext = "js") {
   const source = cjs ? body + "\nmodule.exports = {};\n" : body;
-  using dir = tempDir("sloppy-mode", { "x.js": source });
+  const name = `x.${ext}`;
+  using dir = tempDir("sloppy-mode", { [name]: source });
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "run", "x.js"],
+    cmd: [bunExe(), "run", name],
     env: bunEnv,
     cwd: String(dir),
     stdout: "pipe",
@@ -229,6 +230,30 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
   test("--> HTML close comment in an ESM file is rejected", async () => {
     const { exitCode, stderr } = await run(`var h = 1\n--> comment\nexport {};`, false);
     expect(stderr).toContain("Legacy HTML single-line comments are not allowed in ECMAScript modules");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("HTML comment in a .mjs file without ESM syntax is rejected", async () => {
+    const { exitCode, stderr } = await run(`var h = 1 <!-- comment\nconsole.log(h);`, false, "mjs");
+    expect(stderr).toContain("Legacy HTML single-line comments are not allowed in ECMAScript modules");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("var await in a .mjs file without ESM syntax is rejected", async () => {
+    const { exitCode, stderr } = await run(`var await = 1;\nconsole.log("x");`, false, "mjs");
+    expect(stderr).toContain(`Cannot use "await" as an identifier in an ECMAScript module`);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("legacy octal escape in a directive prologue of an ESM file is rejected", async () => {
+    const { exitCode, stderr } = await run(`"\\1"; export {};`, false);
+    expect(stderr).toContain("Legacy octal escape sequences");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test('legacy octal escape in a directive prologue before "use strict" is rejected', async () => {
+    const { exitCode, stderr } = await run(`function f() { "\\1"; "use strict"; }\nvoid f;`);
+    expect(stderr).toContain("Legacy octal escape sequences");
     expect(exitCode).not.toBe(0);
   });
 

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -318,10 +318,7 @@ describe.concurrent("bun build accepts sloppy CommonJS", () => {
   });
 
   test("legacy octal escape in a sloppy CJS file bundles to ESM", async () => {
-    const [stdout, stderr, exitCode] = await build(
-      { "x.cjs": `var s = "a\\7b";\nmodule.exports = s;\n` },
-      "x.cjs",
-    );
+    const [stdout, stderr, exitCode] = await build({ "x.cjs": `var s = "a\\7b";\nmodule.exports = s;\n` }, "x.cjs");
     expect(stderr).not.toContain("Legacy octal escape sequences");
     expect(stdout).toContain("\\x07");
     expect(exitCode).toBe(0);

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -245,6 +245,18 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
     expect(exitCode).not.toBe(0);
   });
 
+  test("legacy octal escape in a .mjs file without ESM syntax is rejected", async () => {
+    const { exitCode, stderr } = await run(`var s = "x\\7";\nconsole.log(s);`, false, "mjs");
+    expect(stderr).toContain("Legacy octal escape sequences");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("legacy octal escape in an import specifier is rejected", async () => {
+    const { exitCode, stderr } = await run(`import "\\7";`, false);
+    expect(stderr).toContain("Legacy octal escape sequences");
+    expect(exitCode).not.toBe(0);
+  });
+
   test("legacy octal escape in a directive prologue of an ESM file is rejected", async () => {
     const { exitCode, stderr } = await run(`"\\1"; export {};`, false);
     expect(stderr).toContain("Legacy octal escape sequences");
@@ -280,21 +292,38 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
   });
 });
 
-describe("bun build accepts sloppy CommonJS", () => {
-  test("duplicate params survive bundling to CJS", async () => {
-    using dir = tempDir("sloppy-build", {
-      "x.js": `function f(a, a) { return a }\nmodule.exports = f(1, 2);\n`,
-    });
+describe.concurrent("bun build accepts sloppy CommonJS", () => {
+  async function build(files: Record<string, string>, entry: string, ...flags: string[]) {
+    using dir = tempDir("sloppy-build", files);
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "x.js", "--format=cjs"],
+      cmd: [bunExe(), "build", entry, ...flags],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return result;
+  }
+
+  test("duplicate params survive bundling to CJS", async () => {
+    const [stdout, stderr, exitCode] = await build(
+      { "x.js": `function f(a, a) { return a }\nmodule.exports = f(1, 2);\n` },
+      "x.js",
+      "--format=cjs",
+    );
     expect(stderr).not.toContain("cannot be bound multiple times");
     expect(stdout).toContain("function f(a, a)");
+    expect(exitCode).toBe(0);
+  });
+
+  test("legacy octal escape in a sloppy CJS file bundles to ESM", async () => {
+    const [stdout, stderr, exitCode] = await build(
+      { "x.cjs": `var s = "a\\7b";\nmodule.exports = s;\n` },
+      "x.cjs",
+    );
+    expect(stderr).not.toContain("Legacy octal escape sequences");
+    expect(stdout).toContain("\\x07");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -1,0 +1,187 @@
+// Valid sloppy-mode (Annex B / non-strict) constructs that Node accepts but
+// Bun's transpiler used to hard-reject. A bare `.js` entry with no CJS/ESM
+// markers is evaluated by Bun as a module (strict), so these tests force
+// CommonJS via a `module.exports` marker, matching the real-world case of a
+// legacy npm package loaded via `require`.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function run(body: string, cjs = true) {
+  const source = cjs ? body + "\nmodule.exports = {};\n" : body;
+  using dir = tempDir("sloppy-mode", { "x.js": source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "x.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("sloppy-mode constructs the transpiler must accept", () => {
+  test("duplicate parameter names in a plain function declaration", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `function f(a, a) { return a }\nconsole.log(f(1, 2));`,
+    );
+    expect(stderr).not.toContain("cannot be bound multiple times");
+    expect(stdout.trim()).toBe("2");
+    expect(exitCode).toBe(0);
+  });
+
+  test("duplicate parameter names in a plain function expression", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `var e = function(b, b) { return b };\nconsole.log(e(1, 2));`,
+    );
+    expect(stderr).not.toContain("cannot be bound multiple times");
+    expect(stdout.trim()).toBe("2");
+    expect(exitCode).toBe(0);
+  });
+
+  test("nested function with duplicate parameter names", async () => {
+    const { stdout, exitCode } = await run(
+      `function outer() { function f(a, a) { return a } return f(3, 4) }\nconsole.log(outer());`,
+    );
+    expect(stdout.trim()).toBe("4");
+    expect(exitCode).toBe(0);
+  });
+
+  test("assignment to eval and arguments", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `eval = 2; arguments = 3; eval++;\nconsole.log(eval, arguments);`,
+    );
+    expect(stderr).not.toContain("Invalid assignment target");
+    expect(stdout.trim()).toBe("3 3");
+    expect(exitCode).toBe(0);
+  });
+
+  test("var await as a top-level binding in a Script", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `var await = 42;\nfunction g() { return await; }\nconsole.log(g());`,
+    );
+    expect(stderr).not.toContain(`Cannot use "yield" or "await" here`);
+    expect(stdout.trim()).toBe("42");
+    expect(exitCode).toBe(0);
+  });
+
+  test("legacy octal escape at end of string (1 digit)", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `console.log("x\\7".charCodeAt(1));`,
+    );
+    expect(stderr).not.toContain("Syntax Error");
+    expect(stdout.trim()).toBe("7");
+    expect(exitCode).toBe(0);
+  });
+
+  test("legacy octal escape at end of string (2 digits)", async () => {
+    const { stdout, exitCode } = await run(`console.log("x\\77".charCodeAt(1));`);
+    expect(stdout.trim()).toBe("63");
+    expect(exitCode).toBe(0);
+  });
+
+  test("legacy octal escape followed by 8/9", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `var a = "\\1".charCodeAt(0);\n` +
+        `var b = "ab\\5".charCodeAt(2);\n` +
+        `var c = "\\018x";\n` +
+        `var d = "\\09x";\n` +
+        `console.log(JSON.stringify([a, b, c.length, c.charCodeAt(0), c.charCodeAt(1), d.length, d.charCodeAt(0), d.charCodeAt(1)]));`,
+    );
+    expect(stderr).not.toContain("error");
+    expect(stdout.trim()).toBe("[1,5,3,1,56,3,0,57]");
+    expect(exitCode).toBe(0);
+  });
+
+  test("legacy octal escapes that already worked keep working", async () => {
+    const { stdout, exitCode } = await run(
+      `console.log(JSON.stringify(["\\010".charCodeAt(0), "\\101", "\\377".charCodeAt(0), "\\7x".charCodeAt(0)]));`,
+    );
+    expect(stdout.trim()).toBe(`[8,"A",255,7]`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("<!-- HTML open comment is a line comment", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `var h = 1 <!-- comment\nconsole.log("ok", h);`,
+    );
+    expect(stderr).not.toContain("Legacy HTML comments");
+    expect(stdout.trim()).toBe("ok 1");
+    expect(exitCode).toBe(0);
+  });
+
+  test("<!-- at start of line", async () => {
+    const { stdout, exitCode } = await run(`<!-- this is ignored\nconsole.log("ok");`);
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("strict-mode / unique-formal-parameter rejections still fire", () => {
+  test("duplicate parameters in a method", async () => {
+    const { exitCode, stderr } = await run(`({ m(a, a) { return a } });`);
+    expect(stderr).toContain("cannot be bound multiple times");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("duplicate parameters in an arrow function", async () => {
+    const { exitCode, stderr } = await run(`var f = (a, a) => a;`);
+    expect(stderr).toContain("cannot be bound multiple times");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test('duplicate parameters under "use strict"', async () => {
+    const { exitCode, stderr } = await run(
+      `"use strict";\nfunction f(a, a) { return a }\nvoid f;`,
+    );
+    expect(stderr).toContain("cannot be bound multiple times");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("duplicate parameters with non-simple parameter list", async () => {
+    const { exitCode, stderr } = await run(`function f(a, a = 1) { return a }\nvoid f;`);
+    expect(stderr).toContain("cannot be bound multiple times");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("var await inside async function still rejected", async () => {
+    const { exitCode, stderr } = await run(
+      `async function f() { var await = 1; }\nf();`,
+    );
+    expect(stderr).toMatch(/await/);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("assignment to eval in an ESM file still rejected", async () => {
+    const { exitCode, stderr } = await run(`export {};\neval = 1;`, false);
+    expect(stderr).toMatch(/eval/);
+    expect(exitCode).not.toBe(0);
+  });
+});
+
+describe("bun build accepts sloppy CommonJS", () => {
+  test("duplicate params survive bundling to CJS", async () => {
+    using dir = tempDir("sloppy-build", {
+      "x.js": `function f(a, a) { return a }\nmodule.exports = f(1, 2);\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "x.js", "--format=cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).not.toContain("cannot be bound multiple times");
+    expect(stdout).toContain("function f(a, a)");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -85,6 +85,12 @@ describe.concurrent("sloppy-mode constructs the transpiler must accept", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("\\8 and \\9 are literal 8/9 in sloppy mode", async () => {
+    const { stdout, exitCode } = await run(`console.log("\\8" + "\\9");`);
+    expect(stdout.trim()).toBe("89");
+    expect(exitCode).toBe(0);
+  });
+
   test("legacy octal escapes that already worked keep working", async () => {
     const { stdout, exitCode } = await run(
       `console.log(JSON.stringify(["\\010".charCodeAt(0), "\\101", "\\377".charCodeAt(0), "\\7x".charCodeAt(0)]));`,
@@ -141,6 +147,66 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
   test("assignment to eval in an ESM file still rejected", async () => {
     const { exitCode, stderr } = await run(`export {};\neval = 1;`, false);
     expect(stderr).toMatch(/eval/);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test('legacy octal escape under "use strict" still rejected', async () => {
+    const { exitCode, stderr } = await run(`"use strict";\nvar s = "x\\7";`);
+    expect(stderr).toContain("Legacy octal escape sequences cannot be used in strict mode");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("legacy octal escape in an ESM file still rejected", async () => {
+    const { exitCode, stderr } = await run(`var s = "x\\7";\nexport {};`, false);
+    expect(stderr).toContain("Legacy octal escape sequences cannot be used in strict mode");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("\\8 / \\9 under strict mode still rejected", async () => {
+    const { exitCode, stderr } = await run(`"use strict";\nvar s = "\\8";`);
+    expect(stderr).toContain("Legacy octal escape sequences cannot be used in strict mode");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("\\0 alone under strict mode is fine", async () => {
+    const { stdout, exitCode } = await run(`"use strict";\nconsole.log("\\0".charCodeAt(0));`);
+    expect(stdout.trim()).toBe("0");
+    expect(exitCode).toBe(0);
+  });
+
+  test("octal escape in a template literal is always rejected", async () => {
+    const { exitCode, stderr } = await run("var s = `x\\7`;");
+    expect(stderr).toContain("Octal escape sequences are not allowed in template literals");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("octal escape in a template literal with substitution is rejected", async () => {
+    const { exitCode, stderr } = await run("var s = `\\7${1}\\7`;");
+    expect(stderr).toContain("Octal escape sequences are not allowed in template literals");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("\\0 alone in a template literal is fine", async () => {
+    const { stdout, exitCode } = await run("console.log(`\\0`.charCodeAt(0));");
+    expect(stdout.trim()).toBe("0");
+    expect(exitCode).toBe(0);
+  });
+
+  test("HTML comment in an ESM file is rejected", async () => {
+    const { exitCode, stderr } = await run(`var h = 1 <!-- comment\nexport {};`, false);
+    expect(stderr).toContain("Legacy HTML single-line comments are not allowed in ECMAScript modules");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("--> HTML close comment in an ESM file is rejected", async () => {
+    const { exitCode, stderr } = await run(`var h = 1\n--> comment\nexport {};`, false);
+    expect(stderr).toContain("Legacy HTML single-line comments are not allowed in ECMAScript modules");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("var await in an ESM file is rejected by the engine", async () => {
+    const { exitCode, stderr } = await run(`var await = 1;\nexport {};`, false);
+    expect(stderr).toMatch(/await/i);
     expect(exitCode).not.toBe(0);
   });
 });

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -16,28 +16,20 @@ async function run(body: string, cjs = true) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
 }
 
 describe.concurrent("sloppy-mode constructs the transpiler must accept", () => {
   test("duplicate parameter names in a plain function declaration", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `function f(a, a) { return a }\nconsole.log(f(1, 2));`,
-    );
+    const { stdout, stderr, exitCode } = await run(`function f(a, a) { return a }\nconsole.log(f(1, 2));`);
     expect(stderr).not.toContain("cannot be bound multiple times");
     expect(stdout.trim()).toBe("2");
     expect(exitCode).toBe(0);
   });
 
   test("duplicate parameter names in a plain function expression", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `var e = function(b, b) { return b };\nconsole.log(e(1, 2));`,
-    );
+    const { stdout, stderr, exitCode } = await run(`var e = function(b, b) { return b };\nconsole.log(e(1, 2));`);
     expect(stderr).not.toContain("cannot be bound multiple times");
     expect(stdout.trim()).toBe("2");
     expect(exitCode).toBe(0);
@@ -52,9 +44,7 @@ describe.concurrent("sloppy-mode constructs the transpiler must accept", () => {
   });
 
   test("assignment to eval and arguments", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `eval = 2; arguments = 3; eval++;\nconsole.log(eval, arguments);`,
-    );
+    const { stdout, stderr, exitCode } = await run(`eval = 2; arguments = 3; eval++;\nconsole.log(eval, arguments);`);
     expect(stderr).not.toContain("Invalid assignment target");
     expect(stdout.trim()).toBe("3 3");
     expect(exitCode).toBe(0);
@@ -70,9 +60,7 @@ describe.concurrent("sloppy-mode constructs the transpiler must accept", () => {
   });
 
   test("legacy octal escape at end of string (1 digit)", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `console.log("x\\7".charCodeAt(1));`,
-    );
+    const { stdout, stderr, exitCode } = await run(`console.log("x\\7".charCodeAt(1));`);
     expect(stderr).not.toContain("Syntax Error");
     expect(stdout.trim()).toBe("7");
     expect(exitCode).toBe(0);
@@ -106,9 +94,7 @@ describe.concurrent("sloppy-mode constructs the transpiler must accept", () => {
   });
 
   test("<!-- HTML open comment is a line comment", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `var h = 1 <!-- comment\nconsole.log("ok", h);`,
-    );
+    const { stdout, stderr, exitCode } = await run(`var h = 1 <!-- comment\nconsole.log("ok", h);`);
     expect(stderr).not.toContain("Legacy HTML comments");
     expect(stdout.trim()).toBe("ok 1");
     expect(exitCode).toBe(0);
@@ -135,9 +121,7 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
   });
 
   test('duplicate parameters under "use strict"', async () => {
-    const { exitCode, stderr } = await run(
-      `"use strict";\nfunction f(a, a) { return a }\nvoid f;`,
-    );
+    const { exitCode, stderr } = await run(`"use strict";\nfunction f(a, a) { return a }\nvoid f;`);
     expect(stderr).toContain("cannot be bound multiple times");
     expect(exitCode).not.toBe(0);
   });
@@ -149,9 +133,7 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
   });
 
   test("var await inside async function still rejected", async () => {
-    const { exitCode, stderr } = await run(
-      `async function f() { var await = 1; }\nf();`,
-    );
+    const { exitCode, stderr } = await run(`async function f() { var await = 1; }\nf();`);
     expect(stderr).toMatch(/await/);
     expect(exitCode).not.toBe(0);
   });
@@ -175,11 +157,7 @@ describe("bun build accepts sloppy CommonJS", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("cannot be bound multiple times");
     expect(stdout).toContain("function f(a, a)");
     expect(exitCode).toBe(0);

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -304,17 +304,7 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
   });
 
   test("var await in an ESM file is rejected when bundling", async () => {
-    using dir = tempDir("sloppy-await-esm", {
-      "x.js": `export var await = 1;\n`,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "x.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await build({ "x.js": `export var await = 1;\n` }, "x.js");
     expect(stderr).toContain(`Cannot use "await" as an identifier in an ECMAScript module`);
     expect(exitCode).not.toBe(0);
   });

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -294,6 +294,15 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
     expect(exitCode).not.toBe(0);
   });
 
+  test("duplicate parameters in a .cjs file bundled to ESM are rejected", async () => {
+    const [, stderr, exitCode] = await build(
+      { "x.cjs": `function f(a, a) { return a }\nmodule.exports = f;\n` },
+      "x.cjs",
+    );
+    expect(stderr).toContain("cannot be bound multiple times");
+    expect(exitCode).not.toBe(0);
+  });
+
   test("var await in an ESM file is rejected when bundling", async () => {
     using dir = tempDir("sloppy-await-esm", {
       "x.js": `export var await = 1;\n`,

--- a/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
+++ b/test/bundler/transpiler/sloppy-mode-over-strict.test.ts
@@ -21,6 +21,19 @@ async function run(body: string, cjs = true, ext = "js") {
   return { stdout, stderr, exitCode };
 }
 
+async function build(files: Record<string, string>, entry: string, ...flags: string[]) {
+  using dir = tempDir("sloppy-build", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", entry, ...flags],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const result = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return result;
+}
+
 describe.concurrent("sloppy-mode constructs the transpiler must accept", () => {
   test("duplicate parameter names in a plain function declaration", async () => {
     const { stdout, stderr, exitCode } = await run(`function f(a, a) { return a }\nconsole.log(f(1, 2));`);
@@ -275,6 +288,12 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
     expect(exitCode).not.toBe(0);
   });
 
+  test("var await in a .cjs file bundled to ESM is rejected", async () => {
+    const [, stderr, exitCode] = await build({ "x.cjs": `var await = 1;\nmodule.exports = {};\n` }, "x.cjs");
+    expect(stderr).toContain(`Cannot use "await" as an identifier in an ECMAScript module`);
+    expect(exitCode).not.toBe(0);
+  });
+
   test("var await in an ESM file is rejected when bundling", async () => {
     using dir = tempDir("sloppy-await-esm", {
       "x.js": `export var await = 1;\n`,
@@ -293,19 +312,6 @@ describe.concurrent("strict-mode / unique-formal-parameter rejections still fire
 });
 
 describe.concurrent("bun build accepts sloppy CommonJS", () => {
-  async function build(files: Record<string, string>, entry: string, ...flags: string[]) {
-    using dir = tempDir("sloppy-build", files);
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", entry, ...flags],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const result = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return result;
-  }
-
   test("duplicate params survive bundling to CJS", async () => {
     const [stdout, stderr, exitCode] = await build(
       { "x.js": `function f(a, a) { return a }\nmodule.exports = f(1, 2);\n` },
@@ -321,6 +327,17 @@ describe.concurrent("bun build accepts sloppy CommonJS", () => {
     const [stdout, stderr, exitCode] = await build({ "x.cjs": `var s = "a\\7b";\nmodule.exports = s;\n` }, "x.cjs");
     expect(stderr).not.toContain("Legacy octal escape sequences");
     expect(stdout).toContain("\\x07");
+    expect(exitCode).toBe(0);
+  });
+
+  test("var await in a sloppy CJS file bundles to CJS", async () => {
+    const [stdout, stderr, exitCode] = await build(
+      { "x.cjs": `var await = 1;\nmodule.exports = { await };\n` },
+      "x.cjs",
+      "--format=cjs",
+    );
+    expect(stderr).not.toContain(`Cannot use "await"`);
+    expect(stdout).toContain("var await = 1");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -299,28 +299,8 @@ describe("invalid-escape caret points at the backslash (#31134)", () => {
       pattern: "\\u{110000}",
       expectCol: 7,
     },
-    // Legacy-octal `\08`/`\09`:
-    {
-      name: "\\08 double-quote with prefix",
-      source: 'var a = "aaaaa\\08";',
-      msg: "Invalid legacy octal literal",
-      pattern: "\\08",
-      expectCol: 15,
-    },
-    {
-      name: "\\08 double-quote without prefix",
-      source: 'var a = "\\08";',
-      msg: "Invalid legacy octal literal",
-      pattern: "\\08",
-      expectCol: 10,
-    },
-    {
-      name: "\\09 single-quote with prefix",
-      source: "var a = 'aaaaa\\09';",
-      msg: "Invalid legacy octal literal",
-      pattern: "\\09",
-      expectCol: 15,
-    },
+    // `\08`/`\09` are valid Annex B LegacyOctalEscapeSequence + literal digit in
+    // sloppy mode and no longer error; see sloppy-mode-over-strict.test.ts.
   ];
 
   test.each(cases)("$name → column $expectCol", ({ source, msg, pattern, expectCol }) => {


### PR DESCRIPTION
## Problem

Five checks in the parser/lexer hard-reject code that Node (and the spec in Annex B / non-strict mode) accept. A legacy CommonJS library that loads fine under Node dies at parse time under Bun. Each of these is a file that `node x.cjs` runs but `bun x.cjs` rejects with a SyntaxError:

```js
function f(a, a) { return a }        // "a" cannot be bound multiple times in the same parameter list
eval = 2; arguments = 3; eval++;     // Invalid assignment target
var await = 1;                       // Cannot use "yield" or "await" here  (Script goal)
var s = "x\7";                       // bare "Syntax Error"  (also "ab\5", "\77", "\1", "\018x", "\09x")
var h = 1 <!-- comment               // Unsupported syntax: Legacy HTML comments not implemented yet!
```

## Fix

Each site now records what it saw and defers the error to the point where strictness/module-ness is known (`mark_strict_mode_feature` shape), so sloppy CJS runs and strict/ESM code still errors.

**Duplicate parameters** (`visit/mod.rs`, `parse/mod.rs`): read `IsUniqueFormalParameters` from the function flags instead of hard-coding `true`. The flag is only set at parse time for methods/getters/setters; arrows pass `true` at their own visit site; `visit_args` already also gates on strict mode, a `"use strict"` body directive, and non-simple parameter lists. A `"use strict"` body directive now also propagates strictness to the enclosing `FunctionArgs` scope so the parameter list itself is checked.

**eval/arguments as assignment target** (`p.rs`, `visit/visit_expr.rs`): `is_valid_assignment_target` now returns `true` for any identifier. The strict-mode restriction (13.15.1) is reported via a new `StrictModeFeature::AssignToEvalOrArguments` from the `EIdentifier` visitor when `assign_target != None`, reading `Assigning to "eval" cannot be used in strict mode`.

**`await` as an identifier at Script top level** (`parser.rs`, `parse/`): new `FnOrArrowDataParse::await_is_keyword_here()` treats the top-level `AllowExpr` TLA-sniff state as a non-keyword position. Applied at all five identifier sites: binding, class declaration, both class expressions, and shorthand property. Inside async functions the check still fires. In an actual ES module JSC rejects the emitted binding.

**Legacy octal string escapes** (`lexer.rs`, `ast/e.rs`, `visit/visit_expr.rs`): `decode_escape_sequences` now accepts 1-3 digit octal and the `\0N8`/`\0N9`/`\8`/`\9` Annex B shapes, recording the escape's location into a new `EString.legacy_octal_loc` field. The `e_string` visitor raises `StrictModeFeature::LegacyOctalEscape` in strict mode. `\0` alone (no following digit) is never flagged. Untagged template literals error unconditionally at their parse sites (no Annex B exemption applies).

**`<!--` / `-->` HTML comments** (`lexer.rs`, `p.rs`): both are scanned as single-line comments (`<!--` was an unsupported-syntax error; `-->` already worked) and their ranges recorded on the lexer. After parsing, once `has_es_module_syntax` is known, each range becomes a hard error matching Node's "HTML comments are not allowed in modules". Sloppy CJS keeps the warning.

Also drops the empty-keyword `This file is implicitly in strict mode because of the "" keyword here` note that `mark_strict_mode_feature` produced under an explicit `"use strict"` directive.

## Verification

`test/bundler/transpiler/sloppy-mode-over-strict.test.ts` exercises each construct both ways: 14 sloppy-accept tests that match Node's output, and 18 strict/module/template controls that must still reject, plus one `bun build --format=cjs` case. 22 of the 33 fail on `main`. Also passes `transpiler.test.js`, `runtime-transpiler.test.ts`, `invalid-escape-sequences.test.ts`, `json5.test.ts`, `bundler_string.test.ts`, `esbuild/default.test.ts`.

`test/regression/issue/invalid-escape-sequences.test.ts`: removed three `\08`/`\09` caret-position cases that asserted the old rejection (those sequences are valid Annex B).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 17 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 30 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/sloppy-mode-over-strict.test.ts test/regression/issue/invalid-escape-sequences.test.ts
bun test v1.4.0 (49c0235a1)

test/regression/issue/invalid-escape-sequences.test.ts:
(pass) Invalid escape sequence \x in identifier shows helpful error message [421.65ms]
(pass) Invalid escaped double quote in identifier shows helpful error message [340.65ms]
(pass) Invalid escaped single quote in identifier shows helpful error message [359.75ms]
(pass) Invalid escaped backtick in identifier shows helpful error message [341.67ms]
(pass) Invalid escaped backslash in identifier shows helpful error message [354.37ms]
(pass) Invalid escaped z in identifier shows helpful error message [355.75ms]
(pass) invalid \x followed by multi-byte codepoint does not panic (#30893) [360.23ms]
(pass) invalid \x with second hex digit being multi-byte codepoint does not panic (#30893) [362.72ms]
(pass) invalid \u followed by multi-byte codepoint does not panic (#30893) [408.91ms]
(pass) invalid \u{ followed by multi-byte codepoint does not panic 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (860ba3a7b)

test/regression/issue/invalid-escape-sequences.test.ts:
(pass) Invalid escape sequence \x in identifier shows helpful error message [19.50ms]
(pass) Invalid escaped double quote in identifier shows helpful error message [17.10ms]
(pass) Invalid escaped single quote in identifier shows helpful error message [14.74ms]
(pass) Invalid escaped backtick in identifier shows helpful error message [15.41ms]
(pass) Invalid escaped backslash in identifier shows helpful error message [17.13ms]
(pass) Invalid escaped z in identifier shows helpful error message [16.14ms]
(pass) invalid \x followed by multi-byte codepoint does not panic (#30893) [17.66ms]
(pass) invalid \x with second hex digit being multi-byte codepoint does not panic (#30893) [16.27ms]
(pass) invalid \u followed by multi-byte codepoint does not panic (#30893) [15.65ms]
(pass) invalid \u{ followed by multi-byte codepoint does not panic (#30893) [15.58ms]
(pass) Valid unicode escapes in identifiers should work [34.79ms]
(pass) invalid-escape caret points at the backslash (#31134) > \u{} backtick with prefix → column 7 [16.62ms]
(pass) invalid-escape caret points at the backs
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/sloppy-mode-over-strict.test.ts test/regression/issue/invalid-escape-sequences.test.ts
bun test v1.4.0 (49c0235a1)

test/regression/issue/invalid-escape-sequences.test.ts:
(pass) Invalid escape sequence \x in identifier shows helpful error message [454.74ms]
(pass) Invalid escaped double quote in identifier shows helpful error message [350.12ms]
(pass) Invalid escaped single quote in identifier shows helpful error message [382.98ms]
(pass) Invalid escaped backtick in identifier shows helpful error message [368.89ms]
(pass) Invalid escaped backslash in identifier shows helpful error message [364.37ms]
(pass) Invalid escaped z in identifier shows helpful error message [348.54ms]
(pass) invalid \x followed by multi-byte codepoint does not panic (#30893) [383.95ms]
(pass) invalid \x with second hex digit being multi-byte codepoint does not panic (#30893) [350.03ms]
(pass) invalid \u followed by multi-byte codepoint does not panic (#30893) [352.76ms]
(pass) invalid \u{ followed by multi-byte codepoint does not panic 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1123ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                                       |   4 +
 src/ast/expr.rs                                    |   1 +
 src/ast/nodes.rs                                   |   1 +
 src/ast/s.rs                                       |   1 +
 .../linker_context/generateCodeForFileInChunkJS.rs |   1 +
 src/js_parser/lexer.rs                             | 103 ++++---
 src/js_parser/p.rs                                 |  76 ++++-
 src/js_parser/parse/mod.rs                         |  56 +++-
 src/js_parser/parse/parse_prefix.rs                |   9 +-
 src/js_parser/parse/parse_property.rs              |   3 +-
 src/js_parser/parser.rs                            |   1 +
 src/js_parser/visit/mod.rs                         |   5 +-
 src/js_parser/visit/visit_expr.rs                  |  22 +-
 src/js_parser/visit/visit_stmt.rs                  |  15 +-
 src/react_compiler/codegen.rs                      |   1 +
 .../transpiler/sloppy-mode-over-strict.test.ts     | 342 +++++++++++++++++++++
 .../issue/invalid-escape-sequences.test.ts         |  24 +-
 17 files changed, 576 insertions(+), 89 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/ast/e.rs                                                  0      0      0
src/ast/expr.rs                                               0      0      0
src/ast/nodes.rs                                              1      1      0
src/ast/s.rs                                                  1      1      0
…/bundler/linker_context/generateCodeForFileInChunkJS.rs      1      1      0
src/js_parser/lexer.rs                                        8      6      0
src/js_parser/p.rs                                           15     12      0
src/js_parser/parse/mod.rs                                   11     13      0
src/js_parser/parse/parse_prefix.rs                           4      2      0
src/js_parser/parse/parse_property.rs                         4      2      0
src/js_parser/parser.rs                                       5      6      0
src/js_parser/visit/mod.rs                                    6      4      0
src/js_parser/visit/visit_expr.rs                             6      2      0
src/js_parser/visit/visit_stmt.rs                             1      1      0
src/react_compiler/codegen.rs                                 1      1      0
test/bundler/transpiler/sloppy-mode-over-strict.test.ts      10     21      0
(+ 1 more files)
```

</details>

<!-- robobun:evidence:end -->