### PR TITLE
js_parser: fix error location for rest-default and parenthesized binding patterns

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2772,11 +2772,10 @@ impl Source {
 
     pub fn range_of_operator_before(&self, loc: Loc, op: &[u8]) -> Range {
         let text = &self.contents[0..loc.i()];
-        let index = bun_core::strings::index(text, op);
-        if index >= 0 {
+        if let Some(index) = bun_core::strings::last_index_of(text, op) {
             return Range {
                 loc: Loc {
-                    start: loc.start + index,
+                    start: i32::try_from(index).expect("int cast"),
                 },
                 len: i32::try_from(op.len()).expect("int cast"),
             };

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2774,9 +2774,7 @@ impl Source {
         let text = &self.contents[0..loc.i()];
         if let Some(index) = bun_core::strings::last_index_of(text, op) {
             return Range {
-                loc: Loc {
-                    start: i32::try_from(index).expect("int cast"),
-                },
+                loc: usize2loc(index),
                 len: i32::try_from(op.len()).expect("int cast"),
             };
         }

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1185,13 +1185,6 @@ pub fn concat_buf_t<'a, T: Copy>(out: &'a mut [T], strs: &[&[T]]) -> Result<&'a 
     Ok(&mut out[0..off])
 }
 
-pub fn index(self_: &[u8], str: &[u8]) -> i32 {
-    match index_of(self_, str) {
-        Some(i) => i32::try_from(i).expect("int cast"),
-        None => -1,
-    }
-}
-
 /// Returns a substring starting at `start` up to the end of the string.
 /// If `start` is greater than the string's length, returns an empty string.
 pub fn substring(self_: &[u8], start: Option<usize>, stop: Option<usize>) -> &[u8] {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3062,6 +3062,35 @@ console.log(resolve.length)
       expectParseError("for ([...a, b] of c) {}", 'Unexpected "," after rest pattern');
     });
 
+    it("binding pattern error locations point at the operator", () => {
+      const parseErrorAt = code => {
+        try {
+          parsed(code, false, false);
+        } catch (er) {
+          const err = er instanceof AggregateError ? er.errors[0] : er;
+          return { message: err.message, offset: err.position?.offset };
+        }
+        throw new Error("Expected parse error for code\n\t" + code);
+      };
+
+      expect(parseErrorAt("((...a = 1) => {})")).toEqual({
+        message: "A rest argument cannot have a default initializer",
+        offset: "((...a ".length,
+      });
+      expect(parseErrorAt("x = 1; ([...a = 1]) => {}")).toEqual({
+        message: "A rest argument cannot have a default initializer",
+        offset: "x = 1; ([...a ".length,
+      });
+      expect(parseErrorAt("a;b;(([]) = []) => {}")).toEqual({
+        message: "Unexpected parentheses in binding pattern",
+        offset: "a;b;(".length,
+      });
+      expect(parseErrorAt("a;b;(({}) = {}) => {}")).toEqual({
+        message: "Unexpected parentheses in binding pattern",
+        offset: "a;b;(".length,
+      });
+    });
+
     it("for-in and for-of loop initializers", () => {
       // Annex B: a plain identifier "var" binding may keep its initializer in a sloppy-mode for-in
       expectPrintedNoTrim("for (var x = 1 in y) ;", "x = 1;\nfor (x in y)\n  ;\nvar x;\n");


### PR DESCRIPTION
## Problem

Parser diagnostics that use `Source::range_of_operator_before` pointed at the wrong column.

```
$ bun build -e '((...a = 1) => {})'
1 | ((...a = 1) => {})
                    ^
error: A rest argument cannot have a default initializer
    at <stdin>:1:17
```

The caret should point at the `=` (column 8). esbuild reports column 7 (0-indexed) for the same input.

With a preceding `=` it gets worse, since the first match in the file is used rather than the last one before the initializer:

```
$ bun build -e 'a;b;(([]) = []) => {}'
1 | a;b;(([]) = []) => {}
              ^
error: Unexpected parentheses in binding pattern
    at <stdin>:1:11
```

The caret should point at the inner `(` (column 6).

## Cause

`Source::range_of_operator_before` in `src/ast/lib.rs` diverged from esbuild's [`RangeOfOperatorBefore`](https://github.com/evanw/esbuild/blob/main/internal/logger/logger.go) in two ways:

1. It called `strings::index` (first match) instead of a last-index search, so it found the first occurrence of the operator in the file rather than the one immediately preceding the target location.
2. The search slice is `&self.contents[0..loc.i()]`, so the returned index is already absolute; adding `loc.start` to it doubled the offset.

## Fix

Use `bun_core::strings::last_index_of` and return the index directly as the absolute location (via the existing `usize2loc` helper), matching esbuild.

This was the last caller of `bun_core::strings::index` (the `i32`/`-1`-sentinel wrapper over `index_of`), so that helper is removed as well.

After:

```
1 | ((...a = 1) => {})
           ^
error: A rest argument cannot have a default initializer
    at <stdin>:1:8

1 | a;b;(([]) = []) => {}
         ^
error: Unexpected parentheses in binding pattern
    at <stdin>:1:6
```

## Tests

Added position assertions in `test/bundler/transpiler/transpiler.test.js` covering all three call sites (`=` before rest initializer, `(` before parenthesized array binding, `(` before parenthesized object binding).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (74ceb90f6)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [7.57ms]
(pass) Bun.Transpiler > normalizes \r\n [6.06ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.04ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.68ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.16ms]
(pass) Bun.Transpiler > property access inlining > works [3.31ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.61ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [20.38ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.93ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.39ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [8.50ms]
(pass) Bun.Transpiler > TypeScript > contextual
... (truncated)

release without fix: 15 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.14ms]
(pass) Bun.Transpiler > normalizes \r\n [0.22ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.24ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.05ms]
(pass) Bun.Transpiler > property access inlining > works [0.04ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.04ms]
141 |     });
142 |     it("bails out on optional-chain index into enum", () => {
143 |       const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
144 |       const lastLine = out => out.trimEnd().split("\n").at(-1);
145 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo["A"];', false))).toBe("export let y = 0 /* A */;");
146 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo?.["A"];', false))).toBe('export let y = Foo?.["A"];');
                                                                                   ^
error: expect(received).toBe(expected)

Expected: "export let y = F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (74ceb90f6)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [10.98ms]
(pass) Bun.Transpiler > normalizes \r\n [12.56ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [7.86ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [16.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.98ms]
(pass) Bun.Transpiler > property access inlining > works [2.79ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.84ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [24.25ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [5.04ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [4.14ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [13.62ms]
(pass) Bun.Transpiler > TypeScript > contex
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1117ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/lib.rs                             |  7 ++-----
 src/bun_core/string/immutable.rs           |  7 -------
 test/bundler/transpiler/transpiler.test.js | 29 +++++++++++++++++++++++++++++
 3 files changed, 31 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/ast/lib.rs                                  2      2      0
src/bun_core/string/immutable.rs                2      2      0
test/bundler/transpiler/transpiler.test.js      4      3      0
```

</details>

**root cause** · written by the author bot

`Source::range_of_operator_before` computed the wrong location because it searched for the first occurrence of the operator instead of the last and then added `loc.start` to an index that was already absolute, effectively doubling the offset. This caused parser diagnostics such as "A rest argument cannot have a default initializer" to point at the wrong column or the wrong operator entirely. The fix switches to a last-index search and uses the returned offset directly, matching esbuild's `RangeOfOperatorBefore` semantics.

<!-- robobun:evidence:end -->