### PR TITLE
Bun.serve: refuse a handler-returned 101 Switching Protocols

### DIFF
--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -169,7 +169,8 @@ impl FileRoute {
                 let status_code = response.status_code();
                 if status_code == 101 {
                     return Err(global.throw_invalid_arguments(format_args!(
-                        "Cannot use a Response with status 101 (Switching Protocols) as a static route: Bun.serve has no way to hand the connection over after the protocol switch. Use server.upgrade() for WebSocket upgrades.",
+                        "{}",
+                        HTTPStatusText::ROUTE_101_REFUSED
                     )));
                 }
 

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -166,6 +166,13 @@ impl FileRoute {
                     ));
                 }
 
+                let status_code = response.status_code();
+                if status_code == 101 {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "Cannot use a Response with status 101 (Switching Protocols) as a static route: Bun.serve has no way to hand the connection over after the protocol switch. Use server.upgrade() for WebSocket upgrades.",
+                    )));
+                }
+
                 let blob = body_value.use_();
 
                 blob.global_this.set(std::ptr::from_ref(global));
@@ -175,7 +182,6 @@ impl FileRoute {
                 );
                 *body_value = BodyValue::Blob(blob.dupe());
                 let headers = headers_from(response.get_init_headers(), &blob);
-                let status_code = response.status_code();
 
                 return Ok(Some(bun_core::heap::into_raw(Box::new(FileRoute {
                     ref_count: Cell::new(1),

--- a/src/runtime/server/HTTPStatusText.rs
+++ b/src/runtime/server/HTTPStatusText.rs
@@ -11,6 +11,13 @@ pub const fn is_sendable(code: u16) -> bool {
     matches!(code, 100..=999)
 }
 
+/// A status Bun.serve can write from a handler-returned Response. 101 is
+/// refused: the fetch handler has no socket-handoff API, so the advertised
+/// protocol switch is unfulfillable. `server.upgrade()` writes its own 101.
+pub const fn is_handler_writable(code: u16) -> bool {
+    is_sendable(code) && code != 101
+}
+
 pub fn get(code: u16) -> Option<&'static [u8]> {
     match code {
         100 => Some(b"100 Continue"),

--- a/src/runtime/server/HTTPStatusText.rs
+++ b/src/runtime/server/HTTPStatusText.rs
@@ -14,7 +14,7 @@ pub const fn is_sendable(code: u16) -> bool {
 pub fn get(code: u16) -> Option<&'static [u8]> {
     match code {
         100 => Some(b"100 Continue"),
-        101 => Some(b"101 Switching protocols"),
+        101 => Some(b"101 Switching Protocols"),
         102 => Some(b"102 Processing"),
         103 => Some(b"103 Early Hints"),
         200 => Some(b"200 OK"),

--- a/src/runtime/server/HTTPStatusText.rs
+++ b/src/runtime/server/HTTPStatusText.rs
@@ -18,6 +18,8 @@ pub const fn is_handler_writable(code: u16) -> bool {
     is_sendable(code) && code != 101
 }
 
+pub const ROUTE_101_REFUSED: &str = "Cannot use a Response with status 101 (Switching Protocols) as a static route: Bun.serve has no way to hand the connection over after the protocol switch. Use server.upgrade() for WebSocket upgrades.";
+
 pub fn get(code: u16) -> Option<&'static [u8]> {
     match code {
         100 => Some(b"100 Continue"),

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3394,10 +3394,16 @@ where
     /// has no HTTP status line, so the Response can never reach the client:
     /// report it like a thrown error rather than writing an unparseable one.
     ///
+    /// A 101 is also refused: the fetch handler has no way to take over the
+    /// connection after a protocol switch, so a 101 on the wire would be an
+    /// unfulfilled promise (the connection keeps parsing HTTP/1.1 and the
+    /// client's post-switch bytes come back as 400). `server.upgrade()` is the
+    /// only supported upgrade path today and it writes its own 101.
+    ///
     /// Takes the status, not the Response: `run_error_handler` below runs user
     /// JS, which may write through the cell pointer the caller holds.
     fn reject_unsendable_response(&mut self, status: u16) -> bool {
-        if HTTPStatusText::is_sendable(status) {
+        if HTTPStatusText::is_sendable(status) && status != 101 {
             return false;
         }
         let Some(server) = self.server else {
@@ -3406,9 +3412,15 @@ where
         };
         // SAFETY: BACKREF
         let global_this = (*server).global_this();
-        let err = global_this.create_error_instance(format_args!(
-            "Cannot send a Response with status {status}. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
-        ));
+        let err = if status == 101 {
+            global_this.create_error_instance(format_args!(
+                "Bun.serve cannot send a Response with status 101 (Switching Protocols): the fetch handler has no way to take over the connection after the protocol switch. Use server.upgrade() for WebSocket upgrades.",
+            ))
+        } else {
+            global_this.create_error_instance(format_args!(
+                "Cannot send a Response with status {status}. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
+            ))
+        };
         self.run_error_handler(err);
         true
     }
@@ -3502,7 +3514,8 @@ where
                         // An unsendable Response from the error handler itself
                         // falls through to the default error page below.
                         // SAFETY: `response` is the live, rooted cell pointer.
-                        if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                        let status = unsafe { (*response).status_code() };
+                        if HTTPStatusText::is_sendable(status) && status != 101 {
                             // SAFETY: as above.
                             unsafe { self.render(response) };
                             return;
@@ -3556,7 +3569,8 @@ where
                 };
 
                 // SAFETY: `response` is the live, rooted cell pointer.
-                if !HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                let fulfilled_status = unsafe { (*response).status_code() };
+                if !HTTPStatusText::is_sendable(fulfilled_status) || fulfilled_status == 101 {
                     ctx.finish_running_error_handler(value, status);
                     return;
                 }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3391,14 +3391,9 @@ where
     }
 
     /// `false` when the Response can be written. A status outside `100..=999`
-    /// has no HTTP status line, so the Response can never reach the client:
-    /// report it like a thrown error rather than writing an unparseable one.
-    ///
-    /// A 101 is also refused: the fetch handler has no way to take over the
-    /// connection after a protocol switch, so a 101 on the wire would be an
-    /// unfulfilled promise (the connection keeps parsing HTTP/1.1 and the
-    /// client's post-switch bytes come back as 400). `server.upgrade()` is the
-    /// only supported upgrade path today and it writes its own 101.
+    /// has no HTTP status line, and a 101 is unfulfillable (the fetch handler
+    /// has no socket-handoff; `server.upgrade()` writes its own 101): report
+    /// either like a thrown error.
     ///
     /// Takes the status, not the Response: `run_error_handler` below runs user
     /// JS, which may write through the cell pointer the caller holds.

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3391,9 +3391,8 @@ where
     }
 
     /// `false` when the Response can be written. A status outside `100..=999`
-    /// has no HTTP status line, and a 101 is unfulfillable (the fetch handler
-    /// has no socket-handoff; `server.upgrade()` writes its own 101): report
-    /// either like a thrown error.
+    /// has no HTTP status line, so the Response can never reach the client:
+    /// report it like a thrown error rather than writing an unparseable one.
     ///
     /// Takes the status, not the Response: `run_error_handler` below runs user
     /// JS, which may write through the cell pointer the caller holds.

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3397,7 +3397,7 @@ where
     /// Takes the status, not the Response: `run_error_handler` below runs user
     /// JS, which may write through the cell pointer the caller holds.
     fn reject_unsendable_response(&mut self, status: u16) -> bool {
-        if HTTPStatusText::is_sendable(status) && status != 101 {
+        if HTTPStatusText::is_handler_writable(status) {
             return false;
         }
         let Some(server) = self.server else {
@@ -3508,8 +3508,8 @@ where
                         // An unsendable Response from the error handler itself
                         // falls through to the default error page below.
                         // SAFETY: `response` is the live, rooted cell pointer.
-                        let status = unsafe { (*response).status_code() };
-                        if HTTPStatusText::is_sendable(status) && status != 101 {
+                        if HTTPStatusText::is_handler_writable(unsafe { (*response).status_code() })
+                        {
                             // SAFETY: as above.
                             unsafe { self.render(response) };
                             return;
@@ -3563,8 +3563,7 @@ where
                 };
 
                 // SAFETY: `response` is the live, rooted cell pointer.
-                let fulfilled_status = unsafe { (*response).status_code() };
-                if !HTTPStatusText::is_sendable(fulfilled_status) || fulfilled_status == 101 {
+                if !HTTPStatusText::is_handler_writable(unsafe { (*response).status_code() }) {
                     ctx.finish_running_error_handler(value, status);
                     return;
                 }

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -157,10 +157,15 @@ impl StaticRoute {
         // unsafe in `JSValue`); every `Response` accessor used below takes
         // `&self` (interior mutability for `body`), so no `&mut` is needed.
         if let Some(response) = argument.as_class_ref::<Response>() {
-            if !HTTPStatusText::is_sendable(response.status_code()) {
+            let status = response.status_code();
+            if !HTTPStatusText::is_sendable(status) {
                 return Err(global_this.throw_invalid_arguments(format_args!(
-                    "Cannot use a Response with status {} as a static route. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
-                    response.status_code(),
+                    "Cannot use a Response with status {status} as a static route. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
+                )));
+            }
+            if status == 101 {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "Cannot use a Response with status 101 (Switching Protocols) as a static route: Bun.serve has no way to hand the connection over after the protocol switch. Use server.upgrade() for WebSocket upgrades.",
                 )));
             }
 

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -164,8 +164,10 @@ impl StaticRoute {
                 )));
             }
             if status == 101 {
-                return Err(global_this
-                    .throw_invalid_arguments(format_args!("{}", HTTPStatusText::ROUTE_101_REFUSED)));
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "{}",
+                    HTTPStatusText::ROUTE_101_REFUSED
+                )));
             }
 
             // The user may want to pass in the same Response object multiple endpoints

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -164,9 +164,8 @@ impl StaticRoute {
                 )));
             }
             if status == 101 {
-                return Err(global_this.throw_invalid_arguments(format_args!(
-                    "Cannot use a Response with status 101 (Switching Protocols) as a static route: Bun.serve has no way to hand the connection over after the protocol switch. Use server.upgrade() for WebSocket upgrades.",
-                )));
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("{}", HTTPStatusText::ROUTE_101_REFUSED)));
             }
 
             // The user may want to pass in the same Response object multiple endpoints

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1581,6 +1581,8 @@ describe("Response with status 101", () => {
         const servers = [
           Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: switching }),
           Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: switching, error: switching }),
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: switching, error: () => Promise.resolve(switching()) }),
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: switching, error: async () => switching() }),
         ];
         for (const server of servers) {
           const response = await fetch(server.url);
@@ -1592,9 +1594,12 @@ describe("Response with status 101", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("500 Something went wrong!\n500 Something went wrong!\n");
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("500 Something went wrong!\n".repeat(4));
     expect(stderr).toContain(refused);
+    // The child reports each refusal as an unhandled error, so it exits 1 by
+    // design; a crash after the last print would read as a signal exit instead.
+    expect(exitCode).toBe(1);
   });
 
   it.each([

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1520,8 +1520,7 @@ describe("Response with status 101", () => {
   const refused =
     "Bun.serve cannot send a Response with status 101 (Switching Protocols): the fetch handler has no way to take over the connection after the protocol switch. Use server.upgrade() for WebSocket upgrades.";
 
-  const switching = () =>
-    new Response(null, { status: 101, headers: { Upgrade: "my-proto", Connection: "Upgrade" } });
+  const switching = () => new Response(null, { status: 101, headers: { Upgrade: "my-proto", Connection: "Upgrade" } });
 
   // Send a request offering a protocol upgrade and return the server's raw
   // reply once the status line is available. The connection is torn down by

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1512,6 +1512,108 @@ describe("Response.error()", () => {
   });
 });
 
+// Bun.serve has no non-WebSocket socket-handoff API, so a 101 Switching
+// Protocols returned from the fetch handler is unfulfillable: the connection
+// would keep parsing HTTP/1.1 and answer the client's post-switch bytes with
+// 400 Bad Request. It must be refused before it reaches the wire.
+describe("Response with status 101", () => {
+  const refused =
+    "Bun.serve cannot send a Response with status 101 (Switching Protocols): the fetch handler has no way to take over the connection after the protocol switch. Use server.upgrade() for WebSocket upgrades.";
+
+  const switching = () =>
+    new Response(null, { status: 101, headers: { Upgrade: "my-proto", Connection: "Upgrade" } });
+
+  // Send a request offering a protocol upgrade and return the server's raw
+  // reply once the status line is available. The connection is torn down by
+  // `await using`; we do not rely on the server closing it.
+  async function rawUpgradeExchange(port: number): Promise<string> {
+    const received: Buffer[] = [];
+    const gotStatus = Promise.withResolvers<void>();
+    await using connection = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data(_socket, data) {
+          received.push(Buffer.from(data));
+          if (Buffer.concat(received).includes("\r\n")) gotStatus.resolve();
+        },
+        close() {
+          gotStatus.resolve();
+        },
+        error(_socket, error) {
+          gotStatus.reject(error);
+        },
+      },
+    });
+    connection.write("GET / HTTP/1.1\r\nHost: h\r\nConnection: Upgrade\r\nUpgrade: my-proto\r\n\r\n");
+    connection.flush();
+    await gotStatus.promise;
+    return Buffer.concat(received).toString();
+  }
+
+  it.each([
+    ["sync", switching],
+    ["async", async () => switching()],
+  ])("a %s fetch handler returning it reaches error() and never writes 101", async (_label, fetchImpl) => {
+    const errors: Error[] = [];
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      development: false,
+      fetch: fetchImpl,
+      error(error) {
+        errors.push(error);
+        return new Response("handled", { status: 502 });
+      },
+    });
+
+    const raw = await rawUpgradeExchange(server.port);
+    // The unfulfillable 101 must never reach the wire.
+    expect(raw).toStartWith("HTTP/1.1 502 Bad Gateway\r\n");
+    expect(errors.map(error => error.message)).toEqual([refused]);
+  });
+
+  it("responds 500 with no error() handler, and when error() returns it too", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const switching = () => new Response(null, { status: 101, headers: { Upgrade: "my-proto", Connection: "Upgrade" } });
+        const servers = [
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: switching }),
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: switching, error: switching }),
+        ];
+        for (const server of servers) {
+          const response = await fetch(server.url);
+          console.log(response.status, await response.text());
+          server.stop(true);
+        }`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("500 Something went wrong!\n500 Something went wrong!\n");
+    expect(stderr).toContain(refused);
+  });
+
+  it.each([
+    ["in-memory body", () => switching()],
+    ["Bun.file body", () => new Response(Bun.file(import.meta.path), { status: 101 })],
+  ])("is rejected when registered as a static route (%s)", (_label, makeResponse) => {
+    expect(() =>
+      Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        routes: { "/": makeResponse() },
+      }),
+    ).toThrow(
+      "Cannot use a Response with status 101 (Switching Protocols) as a static route: Bun.serve has no way to hand the connection over after the protocol switch. Use server.upgrade() for WebSocket upgrades.",
+    );
+  });
+});
+
 describe("response framing", () => {
   type RawResponse = { statusLine: string; headerNames: string[]; headers: Record<string, string>; body: string };
   // Read the raw response so that `Content-Length: 0` and an absent
@@ -1559,10 +1661,11 @@ describe("response framing", () => {
 
   // https://github.com/oven-sh/bun/issues/20676
   // RFC 9110 8.6: a server MUST NOT send a Content-Length header field in any
-  // response with a status code of 1xx or 204. The Response constructor only
-  // accepts 101 out of the 1xx range, so that is the 1xx witness.
+  // response with a status code of 1xx or 204. There is no 1xx witness left:
+  // the Response constructor only accepts 101 out of the 1xx range, and
+  // Bun.serve refuses to write 101 (it has no socket-handoff API).
   describe.each(["GET", "HEAD"])("%s", method => {
-    it.each([101, 204])("a %i response carries no Content-Length header", async status => {
+    it.each([204])("a %i response carries no Content-Length header", async status => {
       using server = Bun.serve({
         port: 0,
         hostname: "127.0.0.1",
@@ -1593,8 +1696,6 @@ describe("response framing", () => {
   // it on the `fetch` path; the static `routes:` path must too.
   describe.each(["routes", "fetch"] as const)("%s: a Response body on a null-body status is dropped", kind => {
     const cases: [status: number, method: string, contentLength: string | null][] = [
-      [101, "GET", null],
-      [101, "HEAD", null],
       [204, "GET", null],
       [204, "HEAD", null],
       [205, "GET", "0"],
@@ -1625,18 +1726,18 @@ describe("response framing", () => {
 
   // `FileRoute` ships its body via sendfile / `HttpResponse::write()`, neither
   // of which goes through `internalEnd`, so it needs its own null-body-status
-  // drop. 101 is the one null-body status its bodiless list was missing.
+  // drop (the 101 that originally motivated this is now refused at config time).
   it.each(["GET", "HEAD"])("a Bun.file route on a null-body status serves no body bytes (%s)", async method => {
     using dir = tempDir("framing-file-route", { "f.bin": "data" });
     using server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
-      routes: { "/": new Response(Bun.file(join(String(dir), "f.bin")), { status: 101 }) },
+      routes: { "/": new Response(Bun.file(join(String(dir), "f.bin")), { status: 204 }) },
       fetch: () => new Response("unreachable", { status: 500 }),
     });
     const { statusLine, headers, body } = await rawRequest(server.port, method);
     expect({ statusLine: statusLine.slice(0, 12), contentLength: headers["content-length"] ?? null, body }).toEqual({
-      statusLine: "HTTP/1.1 101",
+      statusLine: "HTTP/1.1 204",
       contentLength: null,
       body: "",
     });


### PR DESCRIPTION
## What

Bun.serve has no socket-handoff API outside of `server.upgrade()` (WebSocket only), so a `101 Switching Protocols` returned from the fetch handler is unfulfillable. Refuse it before it reaches the wire.

## Reproduction

```js
import net from "node:net";
const s = Bun.serve({
  port: 0, hostname: "127.0.0.1",
  fetch() { return new Response(null, { status: 101, headers: { Upgrade: "my-proto", Connection: "Upgrade" } }); },
});
const c = net.connect(s.port, "127.0.0.1", () => {
  c.write("GET / HTTP/1.1\r\nHost: h\r\nConnection: Upgrade\r\nUpgrade: my-proto\r\n\r\n");
  setTimeout(() => c.write("RAWPROTOBYTES\r\n\r\n"), 200);
});
let buf = ""; c.on("data", d => buf += d);
setTimeout(() => { c.destroy(); s.stop(true); console.log(JSON.stringify(buf)); }, 900);
```

Before:
```
"HTTP/1.1 101 Switching protocols\r\nUpgrade: my-proto\r\nConnection: Upgrade\r\nDate: ...\r\n\r\nHTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n"
```

The 101 is written (with the non-canonical lowercase `protocols`), the connection stays in the HTTP/1.1 parser, and the client's post-switch bytes come back as `400 Bad Request`.

## Cause

`reject_unsendable_response` only guards status codes outside `100..=999`. A 101 Response passes that check, flows through `render` as a null-body status, and `try_end(b"", close=false)` leaves the connection open for the next HTTP request. There is no path that hands the socket to the application, so the advertised protocol switch can never happen.

## Fix

* `RequestContext::reject_unsendable_response` now also refuses 101 and routes it to the `error()` handler with a message pointing at `server.upgrade()`. The error-handler result paths apply the same guard so an `error()` that itself returns 101 falls through to the default error page instead of emitting it.
* `StaticRoute::from_js` and `FileRoute::from_js` reject a 101 Response at config time with the same message, since a route has the same problem.
* `HTTPStatusText::get(101)` now returns the canonical `Switching Protocols` (still used by `NodeHTTPResponse` and the fetch client's `statusText`).

`server.upgrade()` is unaffected; it writes its own 101 on a path that does hand the socket over.

## Verification

```
bun bd test test/js/bun/http/serve.test.ts -t "Response with status 101"
 5 pass, 0 fail
```

The fail-before output shows the exact bug on the wire:
```
Expected to start with: "HTTP/1.1 502 Bad Gateway\r\n"
Received: "HTTP/1.1 101 Switching protocols\r\nUpgrade: my-proto\r\nConnection: Upgrade\r\n..."
```

(WHATWG Fetch says `new Response(_, {status: 101})` should throw `RangeError` in the constructor; that is tracked separately as #924. This change covers the server side regardless of how the Response was obtained.)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->