### PR TITLE
runtime: share one parsed value between import and require() of a JSON/TOML file

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -1208,13 +1208,6 @@ static JSValue fetchESMSourceCode(
             RELEASE_AND_RETURN(scope, reject(JSC::createSyntaxError(globalObject, "Failed to parse Object"_s)));
         }
 
-        value = reconcileDataModuleWithRequireCache(globalObject, specifierJS, value);
-        if (scope.exception()) [[unlikely]] {
-            auto* exception = scope.exception();
-            (void)scope.tryClearException();
-            RELEASE_AND_RETURN(scope, reject(exception));
-        }
-
         // JSON can become strings, null, numbers, booleans so we must handle "export default 123"
         auto function = generateJSValueExportDefaultObjectSourceCode(
             globalObject,

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -919,6 +919,37 @@ template JSValue fetchCommonJSModuleNonBuiltin<false>(
 
 extern "C" bool isBunTest;
 
+// JSON/TOML/text-like modules are pure data: the ESM default export and the
+// CommonJS `module.exports` are the same parsed value. Share that value with
+// require.cache so `import default from "./x.json"` and `require("./x.json")`
+// observe one object (Node.js guarantees this identity for JSON).
+static JSC::JSValue reconcileDataModuleWithRequireCache(
+    Zig::GlobalObject* globalObject,
+    JSC::JSString* specifierJS,
+    JSC::JSValue value)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue entry = globalObject->requireMap()->get(globalObject, specifierJS);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* mod = entry ? dynamicDowncast<Bun::JSCommonJSModule>(entry) : nullptr) {
+        if (mod->hasEvaluated) {
+            JSValue existing = mod->exportsObject();
+            RETURN_IF_EXCEPTION(scope, {});
+            if (existing)
+                return existing;
+        }
+        mod->setExportsObject(value);
+        mod->hasEvaluated = true;
+        return value;
+    }
+    auto* mod = Bun::JSCommonJSModule::create(globalObject, specifierJS, value, true, jsUndefined());
+    RETURN_IF_EXCEPTION(scope, {});
+    globalObject->requireMap()->set(globalObject, specifierJS, mod);
+    RETURN_IF_EXCEPTION(scope, {});
+    return value;
+}
+
 template<bool allowPromise>
 static JSValue fetchESMSourceCode(
     Zig::GlobalObject* globalObject,
@@ -1134,6 +1165,13 @@ static JSValue fetchESMSourceCode(
             RELEASE_AND_RETURN(scope, reject(exception));
         }
 
+        value = reconcileDataModuleWithRequireCache(globalObject, specifierJS, value);
+        if (scope.exception()) [[unlikely]] {
+            auto* exception = scope.exception();
+            (void)scope.tryClearException();
+            RELEASE_AND_RETURN(scope, reject(exception));
+        }
+
         // JSON can become strings, null, numbers, booleans so we must handle "export default 123"
         auto function = generateJSValueModuleSourceCode(
             globalObject,
@@ -1151,6 +1189,13 @@ static JSValue fetchESMSourceCode(
             RELEASE_AND_RETURN(scope, reject(JSC::createSyntaxError(globalObject, "Failed to parse Object"_s)));
         }
 
+        value = reconcileDataModuleWithRequireCache(globalObject, specifierJS, value);
+        if (scope.exception()) [[unlikely]] {
+            auto* exception = scope.exception();
+            (void)scope.tryClearException();
+            RELEASE_AND_RETURN(scope, reject(exception));
+        }
+
         // JSON can become strings, null, numbers, booleans so we must handle "export default 123"
         auto function = generateJSValueModuleSourceCode(
             globalObject,
@@ -1164,6 +1209,13 @@ static JSValue fetchESMSourceCode(
         JSC::JSValue value = JSC::JSValue::decode(res->result.value.jsvalue_for_export);
         if (!value) {
             RELEASE_AND_RETURN(scope, reject(JSC::createSyntaxError(globalObject, "Failed to parse Object"_s)));
+        }
+
+        value = reconcileDataModuleWithRequireCache(globalObject, specifierJS, value);
+        if (scope.exception()) [[unlikely]] {
+            auto* exception = scope.exception();
+            (void)scope.tryClearException();
+            RELEASE_AND_RETURN(scope, reject(exception));
         }
 
         // JSON can become strings, null, numbers, booleans so we must handle "export default 123"

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -930,15 +930,9 @@ static JSC::JSValue reconcileDataModuleWithRequireCache(
     JSValue entry = globalObject->requireMap()->get(globalObject, specifierJS);
     RETURN_IF_EXCEPTION(scope, {});
     if (auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(entry)) {
-        if (mod->hasEvaluated) {
-            JSValue existing = mod->exportsObject();
-            RETURN_IF_EXCEPTION(scope, {});
-            if (existing)
-                return existing;
-        }
-        mod->setExportsObject(value);
-        mod->hasEvaluated = true;
-        return value;
+        JSValue existing = mod->exportsObject();
+        RETURN_IF_EXCEPTION(scope, {});
+        return existing ? existing : value;
     }
     if (!entry.isUndefined())
         return value; // user-installed require.cache entry; don't clobber it

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -919,10 +919,8 @@ template JSValue fetchCommonJSModuleNonBuiltin<false>(
 
 extern "C" bool isBunTest;
 
-// JSON/TOML/text-like modules are pure data: the ESM default export and the
-// CommonJS `module.exports` are the same parsed value. Share that value with
-// require.cache so `import default from "./x.json"` and `require("./x.json")`
-// observe one object (Node.js guarantees this identity for JSON).
+// Node.js returns one object for `import default` and `require()` of a JSON
+// file; without this, a later require() would hand back the ESM namespace.
 static JSC::JSValue reconcileDataModuleWithRequireCache(
     Zig::GlobalObject* globalObject,
     JSC::JSString* specifierJS,

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -929,7 +929,7 @@ static JSC::JSValue reconcileDataModuleWithRequireCache(
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue entry = globalObject->requireMap()->get(globalObject, specifierJS);
     RETURN_IF_EXCEPTION(scope, {});
-    if (auto* mod = entry ? dynamicDowncast<Bun::JSCommonJSModule>(entry) : nullptr) {
+    if (auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(entry)) {
         if (mod->hasEvaluated) {
             JSValue existing = mod->exportsObject();
             RETURN_IF_EXCEPTION(scope, {});
@@ -940,6 +940,9 @@ static JSC::JSValue reconcileDataModuleWithRequireCache(
         mod->hasEvaluated = true;
         return value;
     }
+    if (!entry.isUndefined())
+        return value; // user-installed require.cache entry; don't clobber it
+
     auto* mod = Bun::JSCommonJSModule::create(globalObject, specifierJS, value, true, jsUndefined());
     RETURN_IF_EXCEPTION(scope, {});
     globalObject->requireMap()->set(globalObject, specifierJS, mod);

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -919,8 +919,7 @@ template JSValue fetchCommonJSModuleNonBuiltin<false>(
 
 extern "C" bool isBunTest;
 
-// Node.js returns one object for `import default` and `require()` of a JSON
-// file; without this, a later require() would hand back the ESM namespace.
+// Node.js: `import default` and `require()` of a JSON file return one object.
 static JSC::JSValue reconcileDataModuleWithRequireCache(
     Zig::GlobalObject* globalObject,
     JSC::JSString* specifierJS,

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -932,7 +932,7 @@ static JSC::JSValue reconcileDataModuleWithRequireCache(
     if (auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(entry)) {
         JSValue existing = mod->exportsObject();
         RETURN_IF_EXCEPTION(scope, {});
-        return existing ? existing : value;
+        return existing;
     }
     if (!entry.isUndefined())
         return value; // user-installed require.cache entry; don't clobber it

--- a/test/js/bun/resolve/json-require-import-identity.test.ts
+++ b/test/js/bun/resolve/json-require-import-identity.test.ts
@@ -157,6 +157,35 @@ test.concurrent("require() of a .json alone (no prior import) still returns the 
   expect(exitCode).toBe(0);
 });
 
+test.concurrent(
+  "a require.extensions['.json'] override is not clobbered by a later ESM import of the same file",
+  async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "cfg.json": `{"a":1}`,
+        "index.cjs": `
+          const fs = require("fs");
+          require.extensions[".json"] = (m, f) => { m.exports = { overridden: true }; };
+          const r1 = require("./cfg.json");
+          (async () => {
+            await import("./cfg.json", { with: { type: "json" } });
+            const r2 = require("./cfg.json");
+            console.log("r1:", JSON.stringify(r1));
+            console.log("r1 === r2:", r1 === r2);
+          })();
+        `,
+      },
+      "index.cjs",
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
+      "r1: {"overridden":true}
+      r1 === r2: true"
+    `);
+    expect(exitCode).toBe(0);
+  },
+);
+
 test.concurrent("a plain-object require.cache entry for a .json is not clobbered by a later ESM import", async () => {
   const { stdout, stderr, exitCode } = await run(
     {

--- a/test/js/bun/resolve/json-require-import-identity.test.ts
+++ b/test/js/bun/resolve/json-require-import-identity.test.ts
@@ -20,10 +20,12 @@ async function run(files: Record<string, string>, entry = "index.mjs") {
   return { stdout: normalizeBunSnapshot(stdout, dir), stderr, exitCode };
 }
 
-test.concurrent("require() of a .json already imported via ESM returns the parsed data (no spurious default key)", async () => {
-  const { stdout, stderr, exitCode } = await run({
-    "cfg.json": `{"a":1,"b":{"c":[1,2]}}`,
-    "index.mjs": `
+test.concurrent(
+  "require() of a .json already imported via ESM returns the parsed data (no spurious default key)",
+  async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "cfg.json": `{"a":1,"b":{"c":[1,2]}}`,
+      "index.mjs": `
       import def from "./cfg.json" with { type: "json" };
       import { createRequire } from "node:module";
       const req = createRequire(import.meta.url)("./cfg.json");
@@ -31,20 +33,23 @@ test.concurrent("require() of a .json already imported via ESM returns the parse
       console.log("same:", req === def);
       console.log("own keys:", Object.getOwnPropertyNames(req).sort().join(","));
     `,
-  });
-  expect(stderr).toBe("");
-  expect(stdout).toMatchInlineSnapshot(`
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
     "{"a":1,"b":{"c":[1,2]}}
     same: true
     own keys: a,b"
   `);
-  expect(exitCode).toBe(0);
-});
+    expect(exitCode).toBe(0);
+  },
+);
 
-test.concurrent("require() of a .json array already imported via ESM returns the array, not a namespace wrapper", async () => {
-  const { stdout, stderr, exitCode } = await run({
-    "arr.json": `[1,2,3]`,
-    "index.mjs": `
+test.concurrent(
+  "require() of a .json array already imported via ESM returns the array, not a namespace wrapper",
+  async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "arr.json": `[1,2,3]`,
+      "index.mjs": `
       import def from "./arr.json" with { type: "json" };
       import { createRequire } from "node:module";
       const req = createRequire(import.meta.url)("./arr.json");
@@ -52,15 +57,16 @@ test.concurrent("require() of a .json array already imported via ESM returns the
       console.log("isArray:", Array.isArray(req));
       console.log("same:", req === def);
     `,
-  });
-  expect(stderr).toBe("");
-  expect(stdout).toMatchInlineSnapshot(`
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
     "[1,2,3]
     isArray: true
     same: true"
   `);
-  expect(exitCode).toBe(0);
-});
+    expect(exitCode).toBe(0);
+  },
+);
 
 test.concurrent("import default of a .json already require()d returns the same object", async () => {
   const { stdout, stderr, exitCode } = await run(
@@ -113,7 +119,7 @@ test.concurrent("require.cache[path].exports is the parsed JSON value after an E
 
 test.concurrent("require() and import default of a .toml file share one object", async () => {
   const { stdout, stderr, exitCode } = await run({
-    "cfg.toml": "a = 1\nb = \"hello\"\n",
+    "cfg.toml": 'a = 1\nb = "hello"\n',
     "index.mjs": `
       import def from "./cfg.toml";
       import { createRequire } from "node:module";
@@ -165,10 +171,12 @@ test.concurrent("import * as ns from a .json has no extra synthetic export names
   expect(exitCode).toBe(0);
 });
 
-test.concurrent("delete require.cache[path] after ESM import lets a subsequent require() re-read from disk", async () => {
-  const { stdout, stderr, exitCode } = await run({
-    "cfg.json": `{"a":1}`,
-    "index.mjs": `
+test.concurrent(
+  "delete require.cache[path] after ESM import lets a subsequent require() re-read from disk",
+  async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "cfg.json": `{"a":1}`,
+      "index.mjs": `
       import def from "./cfg.json" with { type: "json" };
       import { createRequire } from "node:module";
       import { writeFileSync } from "node:fs";
@@ -182,12 +190,13 @@ test.concurrent("delete require.cache[path] after ESM import lets a subsequent r
       console.log("second.a:", second.a);
       console.log("second === first:", second === first);
     `,
-  });
-  expect(stderr).toBe("");
-  expect(stdout).toMatchInlineSnapshot(`
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
     "first === default: true
     second.a: 2
     second === first: false"
   `);
-  expect(exitCode).toBe(0);
-});
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/resolve/json-require-import-identity.test.ts
+++ b/test/js/bun/resolve/json-require-import-identity.test.ts
@@ -157,6 +157,32 @@ test.concurrent("require() of a .json alone (no prior import) still returns the 
   expect(exitCode).toBe(0);
 });
 
+test.concurrent("a plain-object require.cache entry for a .json is not clobbered by a later ESM import", async () => {
+  const { stdout, stderr, exitCode } = await run(
+    {
+      "cfg.json": `{"a":1}`,
+      "index.cjs": `
+        const key = require.resolve("./cfg.json");
+        require.cache[key] = { exports: { mocked: true } };
+        (async () => {
+          const def = (await import("./cfg.json", { with: { type: "json" } })).default;
+          console.log("def:", JSON.stringify(def));
+          console.log("entry survived:", require.cache[key].exports.mocked === true);
+          console.log("require:", JSON.stringify(require("./cfg.json")));
+        })();
+      `,
+    },
+    "index.cjs",
+  );
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`
+    "def: {"a":1}
+    entry survived: true
+    require: {"mocked":true}"
+  `);
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("import * as ns from a .json has no extra synthetic export names", async () => {
   // the fix inserts into require.cache; it must not change the ESM namespace shape.
   const { stdout, stderr, exitCode } = await run({

--- a/test/js/bun/resolve/json-require-import-identity.test.ts
+++ b/test/js/bun/resolve/json-require-import-identity.test.ts
@@ -164,7 +164,6 @@ test.concurrent(
       {
         "cfg.json": `{"a":1}`,
         "index.cjs": `
-          const fs = require("fs");
           require.extensions[".json"] = (m, f) => { m.exports = { overridden: true }; };
           const r1 = require("./cfg.json");
           (async () => {

--- a/test/js/bun/resolve/json-require-import-identity.test.ts
+++ b/test/js/bun/resolve/json-require-import-identity.test.ts
@@ -1,0 +1,193 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+// A .json file that is both `import`ed (ESM) and `require`d in the same
+// process must yield one shared object. Before this was fixed, the ESM loader
+// built a synthetic namespace and a later require() handed that namespace back
+// (with a self-referencing `default` key and no identity with the ESM default),
+// while require() alone returned the plain data.
+
+async function run(files: Record<string, string>, entry = "index.mjs") {
+  using dir = tempDir("json-require-import", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: normalizeBunSnapshot(stdout, dir), stderr, exitCode };
+}
+
+test.concurrent("require() of a .json already imported via ESM returns the parsed data (no spurious default key)", async () => {
+  const { stdout, stderr, exitCode } = await run({
+    "cfg.json": `{"a":1,"b":{"c":[1,2]}}`,
+    "index.mjs": `
+      import def from "./cfg.json" with { type: "json" };
+      import { createRequire } from "node:module";
+      const req = createRequire(import.meta.url)("./cfg.json");
+      console.log(JSON.stringify(req));
+      console.log("same:", req === def);
+      console.log("own keys:", Object.getOwnPropertyNames(req).sort().join(","));
+    `,
+  });
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`
+    "{"a":1,"b":{"c":[1,2]}}
+    same: true
+    own keys: a,b"
+  `);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("require() of a .json array already imported via ESM returns the array, not a namespace wrapper", async () => {
+  const { stdout, stderr, exitCode } = await run({
+    "arr.json": `[1,2,3]`,
+    "index.mjs": `
+      import def from "./arr.json" with { type: "json" };
+      import { createRequire } from "node:module";
+      const req = createRequire(import.meta.url)("./arr.json");
+      console.log(JSON.stringify(req));
+      console.log("isArray:", Array.isArray(req));
+      console.log("same:", req === def);
+    `,
+  });
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`
+    "[1,2,3]
+    isArray: true
+    same: true"
+  `);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("import default of a .json already require()d returns the same object", async () => {
+  const { stdout, stderr, exitCode } = await run(
+    {
+      "cfg.json": `{"a":1}`,
+      "index.cjs": `
+        const req = require("./cfg.json");
+        req.mutated = 42;
+        (async () => {
+          const def = (await import("./cfg.json", { with: { type: "json" } })).default;
+          console.log("same:", req === def);
+          console.log("mutation:", def.mutated);
+          console.log(JSON.stringify(def));
+        })();
+      `,
+    },
+    "index.cjs",
+  );
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`
+    "same: true
+    mutation: 42
+    {"a":1,"mutated":42}"
+  `);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("require.cache[path].exports is the parsed JSON value after an ESM import", async () => {
+  const { stdout, stderr, exitCode } = await run({
+    "cfg.json": `{"a":1}`,
+    "index.mjs": `
+      import def from "./cfg.json" with { type: "json" };
+      import { createRequire } from "node:module";
+      const require = createRequire(import.meta.url);
+      const key = require.resolve("./cfg.json");
+      const entry = require.cache[key];
+      console.log("exports === default:", entry.exports === def);
+      console.log("loaded:", entry.loaded);
+      console.log(JSON.stringify(entry.exports));
+    `,
+  });
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`
+    "exports === default: true
+    loaded: true
+    {"a":1}"
+  `);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("require() and import default of a .toml file share one object", async () => {
+  const { stdout, stderr, exitCode } = await run({
+    "cfg.toml": "a = 1\nb = \"hello\"\n",
+    "index.mjs": `
+      import def from "./cfg.toml";
+      import { createRequire } from "node:module";
+      const req = createRequire(import.meta.url)("./cfg.toml");
+      console.log(JSON.stringify(req));
+      console.log("same:", req === def);
+    `,
+  });
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`
+    "{"a":1,"b":"hello"}
+    same: true"
+  `);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("require() of a .json alone (no prior import) still returns the plain data", async () => {
+  // regression guard: the CJS-only path was already correct.
+  const { stdout, stderr, exitCode } = await run(
+    {
+      "cfg.json": `{"a":1,"b":{"c":[1,2]}}`,
+      "index.cjs": `
+        const req = require("./cfg.json");
+        console.log(JSON.stringify(req));
+        console.log("own keys:", Object.getOwnPropertyNames(req).sort().join(","));
+      `,
+    },
+    "index.cjs",
+  );
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`
+    "{"a":1,"b":{"c":[1,2]}}
+    own keys: a,b"
+  `);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("import * as ns from a .json has no extra synthetic export names", async () => {
+  // the fix inserts into require.cache; it must not change the ESM namespace shape.
+  const { stdout, stderr, exitCode } = await run({
+    "cfg.json": `{"a":1,"b":2}`,
+    "index.mjs": `
+      import * as ns from "./cfg.json" with { type: "json" };
+      console.log(Object.getOwnPropertyNames(ns).sort().join(","));
+    `,
+  });
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`"a,b,default"`);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("delete require.cache[path] after ESM import lets a subsequent require() re-read from disk", async () => {
+  const { stdout, stderr, exitCode } = await run({
+    "cfg.json": `{"a":1}`,
+    "index.mjs": `
+      import def from "./cfg.json" with { type: "json" };
+      import { createRequire } from "node:module";
+      import { writeFileSync } from "node:fs";
+      const require = createRequire(import.meta.url);
+      const key = require.resolve("./cfg.json");
+      const first = require("./cfg.json");
+      console.log("first === default:", first === def);
+      delete require.cache[key];
+      writeFileSync(key, JSON.stringify({ a: 2 }));
+      const second = require("./cfg.json");
+      console.log("second.a:", second.a);
+      console.log("second === first:", second === first);
+    `,
+  });
+  expect(stderr).toBe("");
+  expect(stdout).toMatchInlineSnapshot(`
+    "first === default: true
+    second.a: 2
+    second === first: false"
+  `);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
A `.json` file that is both `import`ed and `require()`d in one process returned two different objects in Bun, and when the ESM import happened first the `require()` result was the module namespace rather than the plain data.

## Reproduction

```js
// cfg.json: {"a":1,"b":{"c":[1,2]}}
import def from './cfg.json' with { type: 'json' };
import { createRequire } from 'node:module';
const req = createRequire(import.meta.url)('./cfg.json');
JSON.stringify(req);
// node: {"a":1,"b":{"c":[1,2]}}
// bun:  {"a":1,"b":{"c":[1,2]},"default":{"a":1,"b":{"c":[1,2]}}}
req === def;            // node: true   bun: false
```

For a JSON array it was worse: `Array.isArray(require('./arr.json'))` was `false` after an ESM import of the same file, because the namespace object (not the array) came back. The reverse order (`require` first, then `import`) was clean on shape but still produced two distinct objects. Node.js guarantees identity for JSON in both orders.

## Cause

`fetchESMSourceCode` handles JSON/TOML/JSONC/YAML by parsing the value and wrapping it in a synthetic module record (`generateJSValueModuleSourceCode` in `ObjectModule.cpp`). It never touches `require.cache`. A later `require()` reaches `fetchCommonJSModule`, sees the specifier already in the ESM registry, returns `-1`, and `overridableRequire` falls back to `namespace["module.exports"] ?? namespace`, which for these records is the namespace itself.

A `require()` without a prior import takes a different branch (`fetchCommonJSModuleNonBuiltin` → `target.exports = JSON.parse(src)`) and is unaffected, but that parse result is private to `require.cache` and never reused by a later `import`.

## Fix

`reconcileDataModuleWithRequireCache` is called from the two data-module branches of `fetchESMSourceCode` (`JSONForObjectLoader` for `.json`, `ExportsObject` for TOML/JSONC/YAML). It seeds `require.cache[specifier]` with a `JSCommonJSModule` whose `exports` is the parsed value, or reuses the `exports` an earlier `require()` already put there. Both loaders now hand back the same object, and `require()` returns the plain data because it finds the entry in `$requireMap` before the ESM-registry short-circuit.

The `ExportDefaultObject` branch (HTML bundles, CSS stubs, the file loader) is intentionally left alone: seeding `require.cache` there made the inspector report `.html` dev-server routes as CJS modules.

The ESM namespace shape is unchanged (no extra export names), and `delete require.cache[key]` still forces a re-read.

## Verification

`USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/json-require-import-identity.test.ts`: 2 pass (regression guards) / 6 fail.

`bun bd test test/js/bun/resolve/json-require-import-identity.test.ts`: 8 pass / 0 fail (also under `BUN_JSC_validateExceptionChecks=1`).

Also green on the debug build: `jsonc.test.ts`, `import-meta.test.js`, `esModule.test.ts`, `esModule-annotation.test.js`, `resolve.test.ts`, `import-query.test.ts`, `import-attributes.test.ts`, `toml/toml.test.js`, `require-and-import-trailing.test.ts`, `node-module-module.test.js`, `require-extensions.test.ts`, `BunFrontendDevServer.test.ts`.

## Related

#35914 is about a `.json` imported with and without `with { type: 'json' }` producing two ESM records; this PR is about the ESM record and the CJS cache not sharing a value. The two are independent.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/json-require-import-identity.test.ts
bun test v1.4.0 (081bbdd93)

test/js/bun/resolve/json-require-import-identity.test.ts:
33 |       console.log("same:", req === def);
34 |       console.log("own keys:", Object.getOwnPropertyNames(req).sort().join(","));
35 |     `,
36 |     });
37 |     expect(stderr).toBe("");
38 |     expect(stdout).toMatchInlineSnapshot(`
                        ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "{"a":1,"b":{"c":[1,2]}}
- same: true
- own keys: a,b"
- 
+ "{"a":1,"b":{"c":[1,2]},"default":{"a":1,"b":{"c":[1,2]}}}
+ same: false
+ own keys: a,b,default"
+ 

- Expected  - 4
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/bun/resolve/json-require-import-identity.test.ts:38:20)
(fail) require() of a .json already imported via ESM returns the parsed data (no spurious default key) [411.17ms]
57 |       console.log("isArray:", Array.isArray(req));
58 |       console.log("same:", req === def);
59 |     `,
60 |     });
61 |     expect(stderr).toBe("");
62 |    
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3b85d5854)

test/js/bun/resolve/json-require-import-identity.test.ts:
(pass) require() of a .json already imported via ESM returns the parsed data (no spurious default key) [53.00ms]
(pass) import default of a .json already require()d returns the same object [38.04ms]
(pass) require() of a .json array already imported via ESM returns the array, not a namespace wrapper [43.22ms]
(pass) require.cache[path].exports is the parsed JSON value after an ESM import [37.04ms]
(pass) a plain-object require.cache entry for a .json is not clobbered by a later ESM import [35.77ms]
(pass) require() of a .json alone (no prior import) still returns the plain data [37.68ms]
(pass) require() and import default of a .toml file share one object [38.80ms]
(pass) import * as ns from a .json has no extra synthetic export names [34.61ms]
(pass) a require.extensions['.json'] override is not clobbered by a later ESM import of the same file [37.78ms]
(pass) delete require.cache[path] after ESM import lets a subsequent require() re-read from disk [53.44ms]

 10 pass
 0 fail
 10 snapshots, 30 expect() calls
Ran 10 tests across 1 file. [275.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/json-require-import-identity.test.ts
bun test v1.4.0 (081bbdd93)

test/js/bun/resolve/json-require-import-identity.test.ts:
(pass) require() of a .json already imported via ESM returns the parsed data (no spurious default key) [390.65ms]
(pass) require() of a .json array already imported via ESM returns the array, not a namespace wrapper [385.45ms]
(pass) import default of a .json already require()d returns the same object [416.70ms]
(pass) require.cache[path].exports is the parsed JSON value after an ESM import [420.85ms]
(pass) require() and import default of a .toml file share one object [474.99ms]
(pass) require() of a .json alone (no prior import) still returns the plain data [298.86ms]
(pass) a require.extensions['.json'] override is not clobbered by a later ESM import of the same file [397.49ms]
(pass) a plain-object require.cache entry for a .json is not clobbered by a later ESM import [360.46ms]
(pass) import * as ns from a .json has no extra synthetic export names [535.06ms]
(pass) delete require.cache[pat
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 957ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ModuleLoader.cpp                  |  39 ++++
 .../resolve/json-require-import-identity.test.ts   | 256 +++++++++++++++++++++
 2 files changed, 295 insertions(+)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/ModuleLoader.cpp                            11     10      0
test/js/bun/resolve/json-require-import-identity.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->