### PR TITLE
io(posix): do not re-arm the fd poll after a re-entrant process.stdin.pause()

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -389,10 +389,7 @@ impl PosixBufferedReader {
     /// embedding `self` (the shell `PipeReader` does exactly that), so the
     /// caller must not touch `self` again after a `false` return.
     pub fn register_poll(&mut self) -> bool {
-        // `on_read_chunk` re-enters JS, which can call pause() and unregister
-        // the poll before control returns to the read loop that invoked it.
-        // The loop's own re-arm must not undo that pause; unpause() + read()
-        // will re-register when JS resumes.
+        // on_read_chunk may re-enter JS -> pause(); do not re-arm over it.
         if self.flags.contains(PosixFlags::IS_PAUSED) {
             return true;
         }

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -389,6 +389,13 @@ impl PosixBufferedReader {
     /// embedding `self` (the shell `PipeReader` does exactly that), so the
     /// caller must not touch `self` again after a `false` return.
     pub fn register_poll(&mut self) -> bool {
+        // `on_read_chunk` re-enters JS, which can call pause() and unregister
+        // the poll before control returns to the read loop that invoked it.
+        // The loop's own re-arm must not undo that pause; unpause() + read()
+        // will re-register when JS resumes.
+        if self.flags.contains(PosixFlags::IS_PAUSED) {
+            return true;
+        }
         // Hoist vtable-derived scalars and
         // normalize self.handle to Poll before taking the single &mut borrow,
         // so no raw-pointer escape is needed.

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -794,8 +794,7 @@ impl FileReader {
             unsafe { (*parent).increment_count() };
             self.pending.with_mut(|p| p.run());
             close_if_needed!();
-            // Re-entrant cancel closed the reader, or re-entrant setFlowing(false)
-            // paused it; either way tell the io caller to stop.
+            // Re-entrant cancel or setFlowing(false): tell the io caller to stop.
             let ret = if self.done.get() || !self.flowing.get() {
                 false
             } else {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -794,8 +794,13 @@ impl FileReader {
             unsafe { (*parent).increment_count() };
             self.pending.with_mut(|p| p.run());
             close_if_needed!();
-            // Re-entrant cancel closed the reader; tell the io caller to stop.
-            let ret = if self.done.get() { false } else { ret };
+            // Re-entrant cancel closed the reader, or re-entrant setFlowing(false)
+            // paused it; either way tell the io caller to stop.
+            let ret = if self.done.get() || !self.flowing.get() {
+                false
+            } else {
+                ret
+            };
             // SAFETY: see `parent()`; the pin keeps the count >= 1, so this
             // never frees. `self` is not accessed after.
             let _ = unsafe { Source::decrement_count(parent) };

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -442,8 +442,8 @@ test.concurrent("process.stdin.pause() from inside a 'data' handler applies kern
       ], { stdio: ["pipe", "pipe", "inherit"] });
       const line = Buffer.alloc(1000, 120);
       const total = 10000;
-      let written = 0;
-      child.stdin.on("error", () => {});
+      let written = 0, stopping = false;
+      child.stdin.on("error", err => { if (!stopping) throw err; });
       (function pump() {
         while (written < total) {
           written++;
@@ -467,6 +467,7 @@ test.concurrent("process.stdin.pause() from inside a 'data' handler applies kern
           if (written === total || (written === last && ++stable >= 3)) {
             clearInterval(iv);
             console.log(JSON.stringify({ writtenWhilePaused: written, total }));
+            stopping = true;
             child.kill();
           } else if (written !== last) { last = written; stable = 0; }
         }, 100);

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -418,3 +418,64 @@ test.concurrent("pause() and resume() churn while data is in flight never destro
   expect(stdout.trim()).toBe(`TOTAL ${20 * 1024}`);
   expect(exitCode).toBe(0);
 });
+
+test.concurrent("process.stdin.pause() from inside a 'data' handler applies kernel backpressure", async () => {
+  // Before the fix, pause() from inside the 'data' path unregistered the fd
+  // poll but the in-progress read loop re-armed it on return, so the native
+  // reader kept draining the pipe into FileReader.buffered. A drain-throttled
+  // writer could push the whole input through while the consumer was paused,
+  // defeating the events.on 1024-line highWaterMark that
+  // `for await (line of readline)` over piped stdin relies on.
+  //
+  // The inner child pauses stdin on the first chunk and never resumes; the
+  // inner parent pumps 10 MB with drain-based backpressure and reports how
+  // far it got before the pipe stopped accepting writes.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { spawn } = require("node:child_process");
+      const child = spawn(process.execPath, ["-e",
+        'process.stdin.once("data", () => process.stdin.pause()); setTimeout(() => {}, 1e9);'
+      ], { stdio: ["pipe", "ignore", "inherit"] });
+      const line = Buffer.alloc(1000, 120);
+      const total = 10000;
+      let written = 0;
+      child.stdin.on("error", () => {});
+      (function pump() {
+        while (written < total) {
+          written++;
+          if (!child.stdin.write(line)) return child.stdin.once("drain", pump);
+        }
+      })();
+      // The writer is blocked once 'drain' stops firing; a bounded pipe
+      // buffer makes three idle ticks after a stall conclusive. Without the
+      // fix the writer never stalls and reaches 'total'.
+      let last = -1, stable = 0;
+      const iv = setInterval(() => {
+        if (written === total || (written === last && ++stable >= 3)) {
+          clearInterval(iv);
+          console.log(JSON.stringify({ writtenWhilePaused: written, total }));
+          child.kill();
+        } else if (written !== last) { last = written; stable = 0; }
+      }, 100);
+      child.on("exit", () => process.exit(0));
+      `,
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+
+  // Before the fix the parent drained all 10000 lines through the pipe while
+  // the child was paused. With kernel backpressure only the pipe buffer plus
+  // one in-flight chunk fit (a few hundred KB). Node lands at ~300 here.
+  expect(result.writtenWhilePaused).toBeLessThan(2000);
+  expect(result.writtenWhilePaused).toBeLessThan(result.total);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -437,8 +437,9 @@ test.concurrent("process.stdin.pause() from inside a 'data' handler applies kern
       `
       const { spawn } = require("node:child_process");
       const child = spawn(process.execPath, ["-e",
-        'process.stdin.once("data", () => process.stdin.pause()); setTimeout(() => {}, 1e9);'
-      ], { stdio: ["pipe", "ignore", "inherit"] });
+        'process.stdin.once("data", () => { process.stdin.pause(); console.log("PAUSED"); });' +
+        'setTimeout(() => {}, 1e9);'
+      ], { stdio: ["pipe", "pipe", "inherit"] });
       const line = Buffer.alloc(1000, 120);
       const total = 10000;
       let written = 0;
@@ -449,17 +450,27 @@ test.concurrent("process.stdin.pause() from inside a 'data' handler applies kern
           if (!child.stdin.write(line)) return child.stdin.once("drain", pump);
         }
       })();
-      // The writer is blocked once 'drain' stops firing; a bounded pipe
-      // buffer makes three idle ticks after a stall conclusive. Without the
-      // fix the writer never stalls and reaches 'total'.
-      let last = -1, stable = 0;
-      const iv = setInterval(() => {
-        if (written === total || (written === last && ++stable >= 3)) {
-          clearInterval(iv);
-          console.log(JSON.stringify({ writtenWhilePaused: written, total }));
-          child.kill();
-        } else if (written !== last) { last = written; stable = 0; }
-      }, 100);
+      // Stall detection begins only once the child has received the first
+      // chunk and paused, so a slow-starting child does not look like
+      // backpressure.
+      child.stdout.setEncoding("utf8");
+      let out = "";
+      child.stdout.on("data", c => {
+        out += c;
+        if (!out.includes("PAUSED")) return;
+        child.stdout.removeAllListeners("data");
+        // The writer is blocked once 'drain' stops firing; a bounded pipe
+        // buffer makes three idle ticks after a stall conclusive. Without the
+        // fix the writer never stalls and reaches 'total'.
+        let last = -1, stable = 0;
+        const iv = setInterval(() => {
+          if (written === total || (written === last && ++stable >= 3)) {
+            clearInterval(iv);
+            console.log(JSON.stringify({ writtenWhilePaused: written, total }));
+            child.kill();
+          } else if (written !== last) { last = written; stable = 0; }
+        }, 100);
+      });
       child.on("exit", () => process.exit(0));
       `,
     ],

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -438,7 +438,7 @@ test.concurrent("process.stdin.pause() from inside a 'data' handler applies kern
       const { spawn } = require("node:child_process");
       const child = spawn(process.execPath, ["-e",
         'process.stdin.once("data", () => { process.stdin.pause(); console.log("PAUSED"); });' +
-        'setTimeout(() => {}, 1e9);'
+        'setTimeout(() => process.exit(1), 30_000);'
       ], { stdio: ["pipe", "pipe", "inherit"] });
       const line = Buffer.alloc(1000, 120);
       const total = 10000;


### PR DESCRIPTION
## Problem

`for await (const line of readline.createInterface({input: process.stdin}))` applies no backpressure on Bun: the whole piped input is buffered in native memory. With a 100 MB input and any per-line async work, Node pauses stdin ~95 times and stays flat at ~85 MB RSS; Bun pauses ~3 times and buffers everything (peak RSS ~2.5x input, scaling linearly, so big pipes OOM).

```js
// child: for await (line of readline) { await setTimeout(0); }
// parent pumps 100 MB via drain-throttled child.stdin
node  -> {"lines":100000,"stdinPauses":96,"peakRssMB":83}
bun   -> {"lines":100000,"stdinPauses":3, "peakRssMB":381}
```

More directly, a child that calls `process.stdin.pause()` from inside its first `'data'` handler does not block the writer:

```
node  : parent wrote  309 lines (pipe full, child paused)
bun   : parent wrote 50000 lines (entire 50 MB input) while child RSS sits at 181 MB
```

`fs.createReadStream(file)` is bounded; this is stdin-specific.

## Cause

`FileReader::on_read_chunk` resolves the pending JS read, which drains microtasks and runs the `'data'` handler synchronously. When that handler calls `process.stdin.pause()`, the nextTick `disown()` path reaches `FileReader::set_flowing(false)` which calls `PosixBufferedReader::pause()`: `IS_PAUSED` is set and the `FilePoll` is unregistered.

Control then returns to `PosixBufferedReader::read_with_fn` / `read_blocking_pipe`, whose EAGAIN path calls `register_poll()` unconditionally. The poll is re-armed, undoing the pause. The next readable event fires, `on_read_chunk` finds no pending promise and appends to `FileReader.buffered` (returning "keep reading" for pollable fds), and the cycle repeats until EOF, buffering the entire input natively.

Windows is not affected: `on_file_read` already checks `IS_PAUSED` before re-arming and the pipe/tty path relies on `uv_read_stop()`.

## Fix

- `PosixBufferedReader::register_poll()` returns early when `IS_PAUSED` is set, so a read loop's own re-arm cannot undo a re-entrant `pause()`. `unpause()` followed by `read()` re-registers when JS resumes.
- `FileReader::on_read_chunk` reports "stop" after `p.run()` when re-entrant JS cleared `flowing`, so the inner read loop exits promptly instead of continuing until EAGAIN.

## Verification

```
$ bun bd /tmp/repro.mjs
{"runtime":"bun","lines":100000,"stdinPauses":95,"peakRssMB":...}   # was stdinPauses:3

$ bun bd test test/js/node/process/process-stdin.test.ts -t "applies kernel backpressure"
(pass) process.stdin.pause() from inside a 'data' handler applies kernel backpressure
```

The new test pumps 10 MB via drain-throttled `child.stdin` into a child that pauses stdin on the first chunk, then asserts the writer was blocked (`writtenWhilePaused < 2000`). On main the writer drains all 10000 lines.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/process-stdin.test.ts
bun test v1.4.0 (a3373d3fe)

test/js/node/process/process-stdin.test.ts:
(pass) pipe does the right thing [1275.85ms]
(pass) file does the right thing [1386.42ms]
(pass) paused mode read(n) returns the buffered remainder at EOF [1516.09ms]
(pass) stdin with 'readable' event handler should receive data when paused [2242.57ms]
(pass) stdin with 'data' event handler should NOT receive data when paused [2314.27ms]
(pass) a read() that throws does not keep the process alive [1196.51ms]
(pass) explicit read(n) with no 'readable' listener still pulls from stdin [1542.53ms]
(pass) touching stdin again after 'end' does not keep the process alive [1578.95ms]
(pass) 'end' is not emitted when the buffer is never drained, and the process still exits [1380.36ms]
(pass) stdin should not allow process to exit when not paused [1076.97ms]
(pass) stdin should allow process to exit when paused [1415.13ms]
(pass) a throw from a 'data' listener is an uncaughtException, and stdin keeps reading [1626.90ms]
(pass) a t
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (0276aedc2)

test/js/node/process/process-stdin.test.ts:
(pass) pipe does the right thing [34.72ms]
(pass) a read() that throws does not keep the process alive [26.59ms]
(pass) 'end' is not emitted when the buffer is never drained, and the process still exits [25.31ms]
(pass) touching stdin again after 'end' does not keep the process alive [32.96ms]
(pass) a throw from a 'readable' listener is an uncaughtException, including the EOF emission [30.93ms]
(pass) stdin should allow process to exit when paused [34.20ms]
(pass) paused mode read(n) returns the buffered remainder at EOF [39.63ms]
(pass) file does the right thing [46.42ms]
(pass) a throw from a 'data' listener is an uncaughtException, and stdin keeps reading [46.68ms]
(pass) explicit read(n) with no 'readable' listener still pulls from stdin [52.40ms]
485 |   const result = JSON.parse(stdout.trim());
486 | 
487 |   // Before the fix the parent drained all 10000 lines through the pipe while
488 |   // the child was paused. With kernel backpressure only the pipe buffer plus
489 |   // one in-flight chunk fit (a few hundred KB). Node lands at ~300 here.
490 |   expect(result.writtenWhile
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/process-stdin.test.ts
bun test v1.4.0 (a3373d3fe)

test/js/node/process/process-stdin.test.ts:
(pass) pipe does the right thing [1238.59ms]
(pass) paused mode read(n) returns the buffered remainder at EOF [1540.67ms]
(pass) file does the right thing [1634.42ms]
(pass) stdin with 'data' event handler should NOT receive data when paused [2361.64ms]
(pass) stdin with 'readable' event handler should receive data when paused [2580.19ms]
(pass) explicit read(n) with no 'readable' listener still pulls from stdin [1447.70ms]
(pass) a read() that throws does not keep the process alive [1283.05ms]
(pass) touching stdin again after 'end' does not keep the process alive [1664.37ms]
(pass) stdin should not allow process to exit when not paused [1054.02ms]
(pass) 'end' is not emitted when the buffer is never drained, and the process still exits [1572.54ms]
(pass) stdin should allow process to exit when paused [1661.82ms]
(pass) a throw from a 'data' listener is an uncaughtException, and stdin keeps reading [1871.18ms]
(pass) a t
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 791ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/io/PipeReader.rs                       |  4 ++
 src/runtime/webcore/FileReader.rs          |  8 +++-
 test/js/node/process/process-stdin.test.ts | 73 ++++++++++++++++++++++++++++++
 3 files changed, 83 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 3 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/io/PipeReader.rs                           11      6      0
src/runtime/webcore/FileReader.rs               9      4      0
test/js/node/process/process-stdin.test.ts      5     15      0
```

</details>

<!-- robobun:evidence:end -->