### PR TITLE
node:vm: propagate worker.terminate() instead of converting it to ERR_SCRIPT_EXECUTION_TIMEOUT

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -51,6 +51,7 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
 }
 
 void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout);
+bool isContextStoppingPermanently(JSC::VM&);
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
@@ -105,6 +106,10 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // below, then convert it to ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+                if (isContextStoppingPermanently(vm)) {
+                    scope.throwException(globalObject, vm.ensureTerminationException());
+                    return {};
+                }
                 vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
                 DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
                 vm.clearHasTerminationRequest();
@@ -245,6 +250,10 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+        if (isContextStoppingPermanently(vm)) {
+            scope.throwException(globalObject, vm.ensureTerminationException());
+            return {};
+        }
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -51,7 +51,7 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
 }
 
 void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout);
-bool terminationIsExternalWorkerKill(JSC::VM&);
+bool workerHasRequestedTerminate(JSC::VM&);
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
@@ -106,7 +106,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // below, then convert it to ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-                if (terminationIsExternalWorkerKill(vm)) {
+                if (workerHasRequestedTerminate(vm)) {
                     scope.throwException(globalObject, vm.ensureTerminationException());
                     return {};
                 }
@@ -250,7 +250,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-        if (terminationIsExternalWorkerKill(vm)) {
+        if (workerHasRequestedTerminate(vm)) {
             scope.throwException(globalObject, vm.ensureTerminationException());
             return {};
         }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -51,7 +51,7 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
 }
 
 void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout);
-bool isContextStoppingPermanently(JSC::VM&);
+bool terminationIsExternalWorkerKill(JSC::VM&);
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
@@ -106,7 +106,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // below, then convert it to ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-                if (isContextStoppingPermanently(vm)) {
+                if (terminationIsExternalWorkerKill(vm)) {
                     scope.throwException(globalObject, vm.ensureTerminationException());
                     return {};
                 }
@@ -250,7 +250,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-        if (isContextStoppingPermanently(vm)) {
+        if (terminationIsExternalWorkerKill(vm)) {
             scope.throwException(globalObject, vm.ensureTerminationException());
             return {};
         }

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -308,12 +308,9 @@ void NodeVMScript::destroy(JSCell* cell)
 
 extern "C" bool Bun__VM__hasWorkerRequestedTerminate(void*);
 
-// worker.requested_terminate is set only by worker.terminate(); node:vm's own
-// watchdog/SIGINT never touch it. Not is_shutting_down: that is already true
-// inside a worker's process.on('exit') listeners, where a {timeout} must stay
-// a catchable ERR_SCRIPT_EXECUTION_TIMEOUT.
 bool terminationIsExternalWorkerKill(JSC::VM& vm)
 {
+    // Not is_shutting_down: that is already true inside a worker's process.on('exit') listeners.
     return Bun__VM__hasWorkerRequestedTerminate(Bun::vm(vm));
 }
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -308,27 +308,20 @@ void NodeVMScript::destroy(JSCell* cell)
 
 extern "C" bool Bun__VM__hasWorkerRequestedTerminate(void*);
 
-bool isContextStoppingPermanently(JSC::VM& vm)
+// worker.requested_terminate is set only by worker.terminate(); node:vm's own
+// watchdog/SIGINT never touch it. Not is_shutting_down: that is already true
+// inside a worker's process.on('exit') listeners, where a {timeout} must stay
+// a catchable ERR_SCRIPT_EXECUTION_TIMEOUT.
+bool terminationIsExternalWorkerKill(JSC::VM& vm)
 {
-    // worker.requested_terminate is set only by worker.terminate() / the
-    // process-wide terminate-all sweep, never by node:vm's own watchdog or
-    // SIGINT watcher, so it distinguishes an external kill from a
-    // {timeout}/{breakOnSigint} termination that this evaluation owns.
-    // is_shutting_down is deliberately not consulted: a worker sets that flag
-    // before running process.on('exit') listeners, and a {timeout} firing
-    // inside one of those must stay a catchable ERR_SCRIPT_EXECUTION_TIMEOUT.
     return Bun__VM__hasWorkerRequestedTerminate(Bun::vm(vm));
 }
 
 static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
     if (vm.hasTerminationRequest()) {
-        if (isContextStoppingPermanently(vm)) {
-            // worker.terminate() raised this termination. Converting it to a
-            // catchable error would let the caller's try/catch swallow the
-            // kill request. Leave hasTerminationRequest set and rethrow the
-            // uncatchable TerminationException so it unwinds to the worker
-            // loop.
+        if (terminationIsExternalWorkerKill(vm)) {
+            // Keep worker.terminate() uncatchable: do not convert to ERR_SCRIPT_EXECUTION_*.
             scope.throwException(globalObject, vm.ensureTerminationException());
             return true;
         }

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -306,28 +306,29 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
-extern "C" int Bun__VM__scriptExecutionStatus(void*);
+extern "C" bool Bun__VM__hasWorkerRequestedTerminate(void*);
 
 bool isContextStoppingPermanently(JSC::VM& vm)
 {
-    // scriptExecutionStatus consults the Rust VirtualMachine (is_shutting_down,
-    // worker.requested_terminate). Those are set only for a permanent stop of
-    // the execution context, never by node:vm's own watchdog / SIGINT watcher,
-    // so this distinguishes a worker.terminate() from a {timeout}/{breakOnSigint}
-    // termination that this evaluation owns. Go through clientData rather than
-    // defaultGlobalObject() so the globalObject argument's type does not matter.
-    return Bun__VM__scriptExecutionStatus(Bun::vm(vm)) != 0;
+    // worker.requested_terminate is set only by worker.terminate() / the
+    // process-wide terminate-all sweep, never by node:vm's own watchdog or
+    // SIGINT watcher, so it distinguishes an external kill from a
+    // {timeout}/{breakOnSigint} termination that this evaluation owns.
+    // is_shutting_down is deliberately not consulted: a worker sets that flag
+    // before running process.on('exit') listeners, and a {timeout} firing
+    // inside one of those must stay a catchable ERR_SCRIPT_EXECUTION_TIMEOUT.
+    return Bun__VM__hasWorkerRequestedTerminate(Bun::vm(vm));
 }
 
 static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
     if (vm.hasTerminationRequest()) {
         if (isContextStoppingPermanently(vm)) {
-            // worker.terminate() (or a permanent VM stop) raised this
-            // termination. Converting it to a catchable error would let the
-            // caller's try/catch swallow the kill request. Leave
-            // hasTerminationRequest set and rethrow the uncatchable
-            // TerminationException so it unwinds to the worker loop.
+            // worker.terminate() raised this termination. Converting it to a
+            // catchable error would let the caller's try/catch swallow the
+            // kill request. Leave hasTerminationRequest set and rethrow the
+            // uncatchable TerminationException so it unwinds to the worker
+            // loop.
             scope.throwException(globalObject, vm.ensureTerminationException());
             return true;
         }

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -306,9 +306,31 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
+extern "C" int Bun__VM__scriptExecutionStatus(void*);
+
+bool isContextStoppingPermanently(JSC::VM& vm)
+{
+    // scriptExecutionStatus consults the Rust VirtualMachine (is_shutting_down,
+    // worker.requested_terminate). Those are set only for a permanent stop of
+    // the execution context, never by node:vm's own watchdog / SIGINT watcher,
+    // so this distinguishes a worker.terminate() from a {timeout}/{breakOnSigint}
+    // termination that this evaluation owns. Go through clientData rather than
+    // defaultGlobalObject() so the globalObject argument's type does not matter.
+    return Bun__VM__scriptExecutionStatus(Bun::vm(vm)) != 0;
+}
+
 static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
     if (vm.hasTerminationRequest()) {
+        if (isContextStoppingPermanently(vm)) {
+            // worker.terminate() (or a permanent VM stop) raised this
+            // termination. Converting it to a catchable error would let the
+            // caller's try/catch swallow the kill request. Leave
+            // hasTerminationRequest set and rethrow the uncatchable
+            // TerminationException so it unwinds to the worker loop.
+            scope.throwException(globalObject, vm.ensureTerminationException());
+            return true;
+        }
         vm.drainMicrotasksForGlobalObject(globalObject);
         // The termination may have fired inside an afterEvaluate microtask
         // checkpoint, leaving the termination exception pending; clear it so

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -308,17 +308,17 @@ void NodeVMScript::destroy(JSCell* cell)
 
 extern "C" bool Bun__VM__hasWorkerRequestedTerminate(void*);
 
-bool terminationIsExternalWorkerKill(JSC::VM& vm)
+bool workerHasRequestedTerminate(JSC::VM& vm)
 {
-    // Not is_shutting_down: that is already true inside a worker's process.on('exit') listeners.
+    // Not is_shutting_down: that is already true inside a naturally-exiting worker's process.on('exit') listeners.
     return Bun__VM__hasWorkerRequestedTerminate(Bun::vm(vm));
 }
 
 static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
     if (vm.hasTerminationRequest()) {
-        if (terminationIsExternalWorkerKill(vm)) {
-            // Keep worker.terminate() uncatchable: do not convert to ERR_SCRIPT_EXECUTION_*.
+        if (workerHasRequestedTerminate(vm)) {
+            // Keep worker.terminate()/process.exit() uncatchable: do not convert to ERR_SCRIPT_EXECUTION_*.
             scope.throwException(globalObject, vm.ensureTerminationException());
             return true;
         }

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -31,6 +31,12 @@ pub fn script_execution_status(this: &VirtualMachine) -> i32 {
     this.script_execution_status() as i32
 }
 
+// HOST_EXPORT(Bun__VM__hasWorkerRequestedTerminate, c)
+pub fn has_worker_requested_terminate(this: &VirtualMachine) -> bool {
+    this.worker_ref()
+        .is_some_and(|w| w.has_requested_terminate())
+}
+
 // HOST_EXPORT(Bun__getVM, c)
 pub fn get_vm() -> *mut VirtualMachine {
     VirtualMachine::get_mut_ptr()

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1723,6 +1723,58 @@ test("process.debugPort defaults to 9229 on the main thread", async () => {
   expect(exitCode).toBe(0);
 });
 
+// A worker.terminate() that lands while the worker is inside a
+// vm.runInNewContext({timeout}) must propagate the uncatchable
+// TerminationException. If node:vm converts it to a catchable
+// ERR_SCRIPT_EXECUTION_TIMEOUT instead, the worker's try/catch swallows the
+// kill request and the worker keeps running whatever is on its microtask
+// queue (here: a self-rescheduling guest microtask loop) until the stale
+// Watchdog timer fires, which in debug trips ASSERT(hasTimeLimit()).
+test("worker.terminate() interrupts a worker blocked in a timed vm.runInNewContext", async () => {
+  const body = [
+    `const { workerData } = require("node:worker_threads");`,
+    `const vm = require("node:vm");`,
+    `const fs = require("fs");`,
+    `try {`,
+    `  vm.runInNewContext("(function loop(){ Promise.resolve().then(loop) })(); 1", {}, { timeout: 4000 });`,
+    `} catch (e) { fs.writeSync(2, "caught1:" + (e && e.code)); }`,
+    `try {`,
+    `  vm.runInNewContext("while(true){ Atomics.store(spin, 0, 1); }", { spin: workerData.spin, Atomics }, { timeout: 30000 });`,
+    `} catch (e) { fs.writeSync(2, "caught2:" + (e && e.code)); }`,
+    `fs.writeSync(2, "after-body");`,
+  ].join("\n");
+  const fixture = `
+    const { Worker } = require("node:worker_threads");
+    const fs = require("fs");
+    const spin = new Int32Array(new SharedArrayBuffer(4));
+    const w = new Worker(${JSON.stringify(body)}, { eval: true, workerData: { spin } });
+    w.on("error", e => { fs.writeSync(2, "worker-error:" + e); process.exit(1); });
+    (async () => {
+      while (Atomics.load(spin, 0) === 0) await new Promise(r => setImmediate(r));
+      const code = await w.terminate();
+      console.log("terminated code=" + code);
+      process.exit(0);
+    })();
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // terminate() raises an uncatchable TerminationException: the try/catch
+  // around the second eval must not observe ERR_SCRIPT_EXECUTION_TIMEOUT,
+  // nothing after it may run, and the subprocess must not abort on the
+  // Watchdog ASSERT(hasTimeLimit()).
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "terminated code=1",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
 // Founding a SHARE_ENV tree replaces the founding thread's process.env object. If the
 // replacement were orphaned, the founder's later writes would go nowhere. child_process
 // enumerates the JS process.env (a var deleted from the map is invisible to the child),


### PR DESCRIPTION
### Repro

```js
import { Worker } from "node:worker_threads";
const body = `const {parentPort}=require('node:worker_threads');const vm=require('node:vm');
try { vm.runInNewContext("(function loop(){ Promise.resolve().then(loop) })(); 1", {}, { timeout: 5000 }); } catch (e) {}
parentPort.postMessage('ready');
try { vm.runInNewContext("while(true){}", {}, { timeout: 10000 }); } catch (e) {}`;
const w = new Worker(body, { eval: true });
w.on("message", m => m === "ready" && setTimeout(() => w.terminate().then(() => process.exit(0)), 50));
```

Node v26.3.0: `terminate()` resolves within ~2 ms.
Bun main (release): `terminate()` does not resolve for ~12.5 s.
Bun main (debug/ASAN): `ASSERTION FAILED: hasTimeLimit()` in `JSC::Watchdog::startTimer` (Watchdog.cpp:133), SIGABRT.

The control case (same `while(true)` + `terminate()` without the prior microtask-loop eval) terminates promptly in Bun too; the earlier timed eval is what puts the worker in a state where `terminate()` is ignored.

### Cause

`checkForTermination` in `NodeVMScript.cpp` (and the two equivalent blocks in `NodeVMModule::evaluate`) attributes every `hasTerminationRequest()` to this evaluation's own `{timeout}`/`{breakOnSigint}`: it clears the pending termination exception, calls `vm.clearHasTerminationRequest()`, and throws a catchable `ERR_SCRIPT_EXECUTION_TIMEOUT`. When the termination was raised by `worker.terminate()` (`WebWorker__notifyNeedTermination` fires `NeedTermination`), the caller's `try/catch` swallows the replacement error and the worker keeps running. With a self-rescheduling guest microtask left on the VM queue by the earlier timed eval and the Watchdog's stale `m_cpuDeadline` still armed, the worker spins in its microtask drain until the stale watchdog check fires, which under debug/ASAN reaches `startTimer` with `m_timeLimit == noTimeLimit` and asserts.

### Fix

Before clearing the request, check `Bun__VM__scriptExecutionStatus` (which reads `is_shutting_down` / `worker.requested_terminate` on the Rust `VirtualMachine`, set only for a permanent context stop, never by node:vm's watchdog or SIGINT watcher). If the context is stopping, leave `hasTerminationRequest` set and rethrow the uncatchable `TerminationException` so it unwinds past the caller's `try/catch` to the worker run loop. Applied to `checkForTermination` and both termination checks in `NodeVMModule::evaluate`.

### Verification

New test in `test/js/node/worker_threads/worker_threads.test.ts` spawns a worker that runs the microtask-loop eval, then spins `while(true){ Atomics.store(spin,0,1) }` with `{timeout: 30000}`; the parent polls the shared flag so `terminate()` is guaranteed to land inside the spinning eval. On an unpatched `bun bd` the subprocess prints `caught2:ERR_SCRIPT_EXECUTION_TIMEOUT` / `after-body` and aborts on `ASSERT(hasTimeLimit())`; with this change it prints `terminated code=1` and exits 0. `test/js/node/vm/vm.test.ts` (212 pass) and the `test-vm-timeout*` / `test-vm-sigint*` node-parallel tests are unchanged.

Related: #33762 handles the nested-eval-without-timeout abort in the same function; #32773 replaces the JSC Watchdog for `{timeout}` outright. This change is the targeted fix for `worker.terminate()` being swallowed.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (b234fdf24)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1909.36ms]
(pass) all worker_threads module properties are present [25.75ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [32.39ms]
(pass) all worker_threads worker instance properties are present [190.79ms]
(pass) threadId module and worker property is consistent [241.15ms]
(pass) receiveMessageOnPort works across threads [1879.20ms]
(pass) receiveMessageOnPort works as FIFO [17.98ms]
(pass) you can override globalThis.postMessage [1890.40ms]
(pass) support require in eval [1835.81ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1783.95ms]
(pass) support require in eval for a file that doesnt exist [1759.30ms]
(pass) support worker eval that throws [1685.60ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [7187.50ms]
(
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (0b989beca)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [30.28ms]
(pass) all worker_threads module properties are present [0.35ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.38ms]
(pass) all worker_threads worker instance properties are present [1.66ms]
(pass) threadId module and worker property is consistent [5.72ms]
(pass) receiveMessageOnPort works across threads [27.62ms]
(pass) receiveMessageOnPort works as FIFO [0.24ms]
(pass) you can override globalThis.postMessage [28.10ms]
(pass) support require in eval [28.77ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [27.87ms]
(pass) support require in eval for a file that doesnt exist [26.45ms]
(pass) support worker eval that throws [26.64ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [116.14ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [58.78ms]
(pass) execArgv option > can specify an array of strings [60.56ms]
(pass) eval does not leak source code [2103.9
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (b234fdf24)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1801.83ms]
(pass) all worker_threads module properties are present [24.65ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [26.77ms]
(pass) all worker_threads worker instance properties are present [162.93ms]
(pass) threadId module and worker property is consistent [204.51ms]
(pass) receiveMessageOnPort works across threads [1776.74ms]
(pass) receiveMessageOnPort works as FIFO [13.60ms]
(pass) you can override globalThis.postMessage [1775.48ms]
(pass) support require in eval [1714.75ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1749.91ms]
(pass) support require in eval for a file that doesnt exist [1711.62ms]
(pass) support worker eval that throws [1688.30ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [6845.55ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 754ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen cpp.rs (cppbind)
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 95 exports (host=3, lazy=10, generic=82, rust=0); 240 extern-C blocks audited
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVMModule.cpp                  |  9 ++++
 src/jsc/bindings/NodeVMScript.cpp                  | 13 ++++++
 src/jsc/virtual_machine_exports.rs                 |  6 +++
 test/js/node/worker_threads/worker_threads.test.ts | 52 ++++++++++++++++++++++
 4 files changed, 80 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/NodeVMModule.cpp                       3      7      0
src/jsc/bindings/NodeVMScript.cpp                       7     12      0
src/jsc/virtual_machine_exports.rs                      2      3      0
test/js/node/worker_threads/worker_threads.test.ts      2      7      0
```

</details>

<!-- robobun:evidence:end -->