### PR TITLE
stdin: apply highwater backpressure to the pipe FileReader source

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -389,6 +389,13 @@ impl PosixBufferedReader {
     /// embedding `self` (the shell `PipeReader` does exactly that), so the
     /// caller must not touch `self` again after a `false` return.
     pub fn register_poll(&mut self) -> bool {
+        // A pause issued from inside the JS re-entry of the read loop
+        // (on_read_chunk → microtasks → setFlowing(false) → pause()) lands
+        // while the loop's own `register_poll()` is still ahead on the stack;
+        // re-arming here would undo it. `unpause()` + `read()` re-arm.
+        if self.flags.contains(PosixFlags::IS_PAUSED) {
+            return true;
+        }
         // Hoist vtable-derived scalars and
         // normalize self.handle to Poll before taking the single &mut borrow,
         // so no raw-pointer escape is needed.
@@ -503,6 +510,9 @@ impl PosixBufferedReader {
     }
 
     pub fn on_poll(parent: &mut PosixBufferedReader, size_hint: isize, received_hup: bool) {
+        if parent.flags.contains(PosixFlags::IS_PAUSED) {
+            return;
+        }
         let fd = parent.get_fd();
         bun_sys::syslog!("onPoll({}) = {}", fd, size_hint);
 
@@ -662,14 +672,18 @@ impl PosixBufferedReader {
 
                         if streaming {
                             // Stream this chunk and register for next cycle
-                            let _ = parent.vtable.on_read_chunk(
+                            if !parent.vtable.on_read_chunk(
                                 &stack_buffer[..bytes_read],
                                 if received_hup && bytes_read < stack_buffer.len() {
                                     ReadState::Eof
                                 } else {
                                     ReadState::Progress
                                 },
-                            );
+                            ) && !received_hup
+                                && !over_budget
+                            {
+                                return;
+                            }
                         } else {
                             parent
                                 ._buffer

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -389,10 +389,8 @@ impl PosixBufferedReader {
     /// embedding `self` (the shell `PipeReader` does exactly that), so the
     /// caller must not touch `self` again after a `false` return.
     pub fn register_poll(&mut self) -> bool {
-        // A pause issued from inside the JS re-entry of the read loop
-        // (on_read_chunk → microtasks → setFlowing(false) → pause()) lands
-        // while the loop's own `register_poll()` is still ahead on the stack;
-        // re-arming here would undo it. `unpause()` + `read()` re-arm.
+        // pause() may land from inside on_read_chunk's JS re-entry while the
+        // loop's own re-arm is still ahead on the stack.
         if self.flags.contains(PosixFlags::IS_PAUSED) {
             return true;
         }
@@ -417,8 +415,6 @@ impl PosixBufferedReader {
             return true;
         };
         if poll.is_watching() {
-            // Already armed kernel-side; a redundant `register_with_fd`
-            // issues an idempotent `epoll_ctl(CTL_MOD)` / `kevent64`.
             return true;
         }
         poll.set_owner(Owner::new(PollTag::BufferedReader, owner_ptr.cast()));

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -416,6 +416,11 @@ impl PosixBufferedReader {
         let Some(poll) = self.handle.get_poll_mut() else {
             return true;
         };
+        if poll.is_watching() {
+            // Already armed kernel-side; a redundant `register_with_fd`
+            // issues an idempotent `epoll_ctl(CTL_MOD)` / `kevent64`.
+            return true;
+        }
         poll.set_owner(Owner::new(PollTag::BufferedReader, owner_ptr.cast()));
 
         if !poll.has_flag(FilePollFlag::WasEverRegistered)

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -414,9 +414,6 @@ impl PosixBufferedReader {
         let Some(poll) = self.handle.get_poll_mut() else {
             return true;
         };
-        if poll.is_watching() {
-            return true;
-        }
         poll.set_owner(Owner::new(PollTag::BufferedReader, owner_ptr.cast()));
 
         if !poll.has_flag(FilePollFlag::WasEverRegistered)
@@ -465,7 +462,9 @@ impl PosixBufferedReader {
     }
 
     pub fn watch(&mut self) {
-        if self.flags.contains(PosixFlags::POLLABLE) {
+        if self.flags.contains(PosixFlags::POLLABLE)
+            && !matches!(&self.handle, PollOrFd::Poll(poll) if poll.is_watching())
+        {
             self.register_poll();
         }
     }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -563,22 +563,6 @@ impl FileReader {
         true
     }
 
-    #[inline]
-    fn reader_is_pollable(&self) -> bool {
-        #[cfg(unix)]
-        {
-            self.reader()
-                .flags
-                .contains(bun_io::pipe_reader::PosixFlags::POLLABLE)
-        }
-        #[cfg(windows)]
-        {
-            self.reader()
-                .flags
-                .contains(bun_io::pipe_reader::WindowsFlags::POLLABLE)
-        }
-    }
-
     pub fn on_read_chunk(&self, init_buf: &[u8], state: ReadState) -> bool {
         let mut buf = init_buf;
         bun_core::scoped_log!(
@@ -809,14 +793,19 @@ impl FileReader {
             }
         }
 
-        // For pipes, we have to keep pulling or the other process will block.
+        // No JS read is waiting; the chunk was appended to `self.buffered`.
+        // Stop the read loop once the buffered bytes reach the highwater mark
+        // or the consumer paused (`setFlowing(false)`). A full kernel pipe
+        // buffer blocking the writer is the backpressure signal. `onPull` /
+        // `setFlowing(true)` re-derive demand and restart the reader.
         // SAFETY: see `reader_buffer` decl.
         let reader_buffer_len = unsafe { (*reader_buffer).len() };
-        let ret = !matches!(
-            self.read_inside_on_pull.get(),
-            ReadDuringJSOnPullResult::Temporary(_)
-        ) && !(self.buffered.get().len() + reader_buffer_len >= self.highwater_mark
-            && !self.reader_is_pollable());
+        let ret = self.flowing.get()
+            && !matches!(
+                self.read_inside_on_pull.get(),
+                ReadDuringJSOnPullResult::Temporary(_)
+            )
+            && self.buffered.get().len() + reader_buffer_len < self.highwater_mark;
         close_if_needed!();
         ret
     }
@@ -964,6 +953,16 @@ impl FileReader {
         let global = self.parent_global();
         self.pending_value.with_mut(|p| p.set(&global, array));
         self.pending_view.set(buffer);
+
+        // The read loop returns without re-arming the one-shot poll when
+        // `on_read_chunk` reports the highwater backstop, and pause() skips
+        // the unregister while the poll is already disarmed, so
+        // `has_pending_read()` (which tracks the registration flag, not the
+        // kernel arm state) can be true with no wakeup scheduled. The
+        // consumer is asking for data here, so make sure the poll is armed.
+        if self.flowing.get() {
+            self.reader().watch();
+        }
 
         bun_core::scoped_log!(FileReader, "onPull({}) = pending", buffer_len);
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -793,11 +793,7 @@ impl FileReader {
             }
         }
 
-        // No JS read is waiting; the chunk was appended to `self.buffered`.
-        // Stop the read loop once the buffered bytes reach the highwater mark
-        // or the consumer paused (`setFlowing(false)`). A full kernel pipe
-        // buffer blocking the writer is the backpressure signal. `onPull` /
-        // `setFlowing(true)` re-derive demand and restart the reader.
+        // No JS read is waiting; stop at the highwater mark. onPull restarts.
         // SAFETY: see `reader_buffer` decl.
         let reader_buffer_len = unsafe { (*reader_buffer).len() };
         let ret = self.flowing.get()
@@ -954,12 +950,8 @@ impl FileReader {
         self.pending_value.with_mut(|p| p.set(&global, array));
         self.pending_view.set(buffer);
 
-        // The read loop returns without re-arming the one-shot poll when
-        // `on_read_chunk` reports the highwater backstop, and pause() skips
-        // the unregister while the poll is already disarmed, so
-        // `has_pending_read()` (which tracks the registration flag, not the
-        // kernel arm state) can be true with no wakeup scheduled. The
-        // consumer is asking for data here, so make sure the poll is armed.
+        // `has_pending_read()` tracks the registration flag, not the kernel
+        // arm state: the highwater backstop leaves the one-shot poll disarmed.
         if self.flowing.get() {
             self.reader().watch();
         }

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows } from "harness";
 
 test.concurrent("pipe does the right thing", async () => {
   // Note: Bun.spawnSync uses memfd_create on Linux for pipe, which means we see
@@ -417,4 +417,115 @@ test.concurrent("pause() and resume() churn while data is in flight never destro
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect(stdout.trim()).toBe(`TOTAL ${20 * 1024}`);
   expect(exitCode).toBe(0);
+});
+
+// The native FileReader source over a pollable pipe used to drain the fd to
+// EAGAIN regardless of JS demand, so an idle consumer still ingested the whole
+// pipe into an internal buffer. The kernel pipe buffer filling up is the
+// backpressure signal; these tests feed far more than that and check the
+// child's resident set does not grow to match.
+describe.skipIf(isWindows)("pipe backpressure", () => {
+  const feedMB = 40;
+  // With no backpressure the child buffers the whole feed (Vec growth roughly
+  // doubles that in RSS). With backpressure only the highwater mark plus the
+  // kernel pipe buffer are resident in the child.
+  const maxDeltaMB = isASAN || isDebug ? 24 : 16;
+
+  async function run(consumer: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", consumer],
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    // The child exits under backpressure having accepted only a few KB, so
+    // the queued writes here fail with EPIPE; that is the expected outcome.
+    const chunk = Buffer.alloc(1024 * 1024, 0x78);
+    const ignoreEpipe = (e: any) => {
+      if (e?.code !== "EPIPE") throw e;
+    };
+    for (let i = 0; i < feedMB; i++) {
+      const r = proc.stdin.write(chunk);
+      if (r && typeof (r as any).then === "function") (r as Promise<number>).catch(ignoreEpipe);
+    }
+    Promise.resolve(proc.stdin.flush()).catch(ignoreEpipe);
+    Promise.resolve(proc.stdin.end()).catch(ignoreEpipe);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect(exitCode).toBe(0);
+    return result;
+  }
+
+  test.concurrent("Bun.stdin.stream(): a single read does not ingest the whole pipe", async () => {
+    const { first, deltaMB } = await run(`
+      const rd = Bun.stdin.stream().getReader();
+      const c = await rd.read();
+      const base = process.memoryUsage().rss;
+      // Give the event loop time to (incorrectly) drain the pipe. The loop is
+      // native (no JS on the no-pending path), so debug/ASAN overhead is small.
+      await new Promise(r => setTimeout(r, 1500));
+      const deltaMB = Math.round((process.memoryUsage().rss - base) / 1048576);
+      process.stdout.write(JSON.stringify({ first: c.value?.length ?? 0, deltaMB }));
+      process.exit(0);
+    `);
+    expect(first).toBeGreaterThan(0);
+    expect(deltaMB).toBeLessThan(maxDeltaMB);
+  });
+
+  test.concurrent("process.stdin.pause() stops the fd from being read", async () => {
+    const { bytesAfter, deltaMB } = await run(`
+      let bytes = 0, pausedAt = 0;
+      process.stdin.on("data", chunk => {
+        bytes += chunk.length;
+        if (!pausedAt && bytes >= 1 << 20) {
+          pausedAt = bytes;
+          process.stdin.pause();
+          const base = process.memoryUsage().rss;
+          setTimeout(() => {
+            const deltaMB = Math.round((process.memoryUsage().rss - base) / 1048576);
+            process.stdout.write(JSON.stringify({ bytesAtPause: pausedAt, bytesAfter: bytes, deltaMB }));
+            process.exit(0);
+          }, 1500);
+        }
+      });
+    `);
+    expect(bytesAfter).toBeLessThan(feedMB * 1024 * 1024);
+    expect(deltaMB).toBeLessThan(maxDeltaMB);
+  });
+
+  test.concurrent("reading resumes after the highwater backstop", async () => {
+    // Stop reading long enough for the backstop to engage, then drain to EOF
+    // and make sure every byte written by the parent is delivered.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const rd = Bun.stdin.stream().getReader();
+        await rd.read().then(c => { globalThis.total = c.value?.length ?? 0; });
+        await new Promise(r => setTimeout(r, 200));
+        while (true) {
+          const { value, done } = await rd.read();
+          if (value) total += value.length;
+          if (done) break;
+        }
+        process.stdout.write(String(total));
+        `,
+      ],
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const chunk = Buffer.alloc(64 * 1024, 0x79);
+    const n = 64;
+    for (let i = 0; i < n; i++) proc.stdin.write(chunk);
+    await proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(String(n * chunk.length));
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Reproduction

```js
const rd = Bun.stdin.stream().getReader();
await rd.read();                       // one read
const base = process.memoryUsage().rss;
await new Promise(r => setTimeout(r, 1500));  // idle, zero demand
console.log(Math.round((process.memoryUsage().rss - base) / 1048576));
```

With 40 MB piped in: RSS grows by ~100 MB while the consumer is idle. The `process.stdin.pause()` variant is the same: `'data'` delivery stops but the fd keeps being ingested into an internal buffer. Node stays flat at the kernel pipe buffer.

## Cause

`FileReader.on_read_chunk` tells the read loop whether to keep reading. When no JS read is pending the chunk is appended to `self.buffered` and the continue decision was

```rust
!(buffered_len >= highwater_mark && !reader_is_pollable())
```

so for a pollable fd the highwater backstop was exempted and the loop always continued. The posix pipe read loop drains the fd until EAGAIN, and the blocking-pipe path (`read_blocking_pipe`, which stdin-from-a-pipe uses because fd 0 is not O_NONBLOCK) additionally discarded the return value of `on_read_chunk` and re-armed the poll unconditionally.

`pause()` set `IS_PAUSED` and unregistered the poll, but the in-flight read loop's own `register_poll()` did not check the flag (so a pause issued from inside the loop's JS re-entry was immediately undone), and `on_poll` did not check it either.

## Fix

- `FileReader.on_read_chunk`: drop the pollable exemption and fold `!flowing` into the continue decision. A full kernel pipe buffer blocking the writer is backpressure.
- `PosixBufferedReader::register_poll` / `on_poll`: early-return when `IS_PAUSED`.
- `read_blocking_pipe` stack-buffer streaming arm: honor the `on_read_chunk` return value the way the with-buffer arm and `read_with_fn` already do.
- `FileReader.on_pull`: when returning `Pending`, re-arm the poll. After the backstop returns without re-arming, the one-shot poll is disarmed kernel-side while `has_pending_read()` (which checks the sticky `PollReadable` flag, not the arm state) still reports true, so the next pull would otherwise wait on a poll that will never fire.

`onPull` and `setFlowing(true)` already restart the reader on demand.

Only `FileReader` ever returned `false` with `received_hup == false` from `on_read_chunk`, so the `read_blocking_pipe` change does not affect shell/subprocess/Terminal readers.

## Verification

`test/js/node/process/process-stdin.test.ts` adds three cases: a single `Bun.stdin.stream()` read with a 40 MB feed stays within a few MB of the baseline, `process.stdin.pause()` after 1 MB stops fd ingestion, and reading to EOF after the backstop engaged delivers every byte. Without the source change the first two fail with ~100 MB RSS growth under `bun bd`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process-stdin.test.ts

<!-- robobun:evidence:end -->