### PR TITLE
node:vm: propagate foreign termination instead of asserting or converting

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -51,6 +51,7 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
 }
 
 void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout);
+bool isForeignTermination(JSC::VM&, bool sigintReceived, bool hasTimeout);
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
@@ -105,6 +106,10 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // below, then convert it to ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+                if (isForeignTermination(vm, getSigintReceived(), timeout != 0)) {
+                    scope.throwException(globalObject, vm.ensureTerminationException());
+                    return {};
+                }
                 vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
                 DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
                 vm.clearHasTerminationRequest();
@@ -245,16 +250,20 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+        if (isForeignTermination(vm, getSigintReceived(), timeout != 0)) {
+            status(Status::Errored);
+            m_evaluationException.set(vm, this, JSC::Exception::create(vm, jsNull()));
+            scope.throwException(globalObject, vm.ensureTerminationException());
+            return {};
+        }
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();
         if (getSigintReceived()) {
             setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout != 0) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         }
     } else {
         setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -253,7 +253,10 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         if (isForeignTermination(vm, getSigintReceived(), timeout != 0)) {
             status(Status::Errored);
             JSC::Exception* termination = vm.ensureTerminationException();
-            m_evaluationException.set(vm, this, termination);
+            // Store a fresh Exception wrapping TerminatedExecutionError, not the
+            // VM singleton: the errored fast path re-throws m_evaluationException,
+            // and re-throwing the singleton is uncatchable by pointer identity.
+            m_evaluationException.set(vm, this, JSC::Exception::create(vm, termination->value()));
             scope.throwException(globalObject, termination);
             return {};
         }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -252,8 +252,9 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
         if (isForeignTermination(vm, getSigintReceived(), timeout != 0)) {
             status(Status::Errored);
-            m_evaluationException.set(vm, this, JSC::Exception::create(vm, jsNull()));
-            scope.throwException(globalObject, vm.ensureTerminationException());
+            JSC::Exception* termination = vm.ensureTerminationException();
+            m_evaluationException.set(vm, this, termination);
+            scope.throwException(globalObject, termination);
             return {};
         }
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -308,15 +308,10 @@ void NodeVMScript::destroy(JSCell* cell)
 
 extern "C" int Bun__VM__scriptExecutionStatus(void*);
 
-// A termination request belongs to this evaluation only if this evaluation
-// armed the watchdog ({timeout}) or was the SIGINT watcher's target
-// ({breakOnSigint}). Any other source is foreign: the execution context is
-// being stopped permanently (process.exit() inside a worker, worker.terminate()
-// from the parent, VM shutdown), or an enclosing evaluation's watchdog/SIGINT
-// fired while this untimed inner one was running. Converting a foreign
-// termination to a catchable ERR_SCRIPT_EXECUTION_* lets the caller's
-// try/catch swallow a kill request; propagate it as the uncatchable
-// TerminationException instead so it unwinds to whoever armed it.
+// A termination not raised by this evaluation's own {timeout}/{breakOnSigint}
+// (worker process.exit()/terminate(), VM shutdown, or an enclosing eval's
+// watchdog) must stay uncatchable; converting it to ERR_SCRIPT_EXECUTION_*
+// would let the caller's try/catch swallow a kill request.
 bool isForeignTermination(JSC::VM& vm, bool sigintReceived, bool hasTimeout)
 {
     if (Bun__VM__scriptExecutionStatus(Bun::vm(vm)) != 0)

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -306,28 +306,48 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
+extern "C" int Bun__VM__scriptExecutionStatus(void*);
+
+// A termination request belongs to this evaluation only if this evaluation
+// armed the watchdog ({timeout}) or was the SIGINT watcher's target
+// ({breakOnSigint}). Any other source is foreign: the execution context is
+// being stopped permanently (process.exit() inside a worker, worker.terminate()
+// from the parent, VM shutdown), or an enclosing evaluation's watchdog/SIGINT
+// fired while this untimed inner one was running. Converting a foreign
+// termination to a catchable ERR_SCRIPT_EXECUTION_* lets the caller's
+// try/catch swallow a kill request; propagate it as the uncatchable
+// TerminationException instead so it unwinds to whoever armed it.
+bool isForeignTermination(JSC::VM& vm, bool sigintReceived, bool hasTimeout)
+{
+    if (Bun__VM__scriptExecutionStatus(Bun::vm(vm)) != 0)
+        return true;
+    return !sigintReceived && !hasTimeout;
+}
+
 static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
-    if (vm.hasTerminationRequest()) {
-        vm.drainMicrotasksForGlobalObject(globalObject);
-        // The termination may have fired inside an afterEvaluate microtask
-        // checkpoint, leaving the termination exception pending; clear it so
-        // the ERR_SCRIPT_EXECUTION_* error below replaces it.
-        if (vm.hasPendingTerminationException())
-            DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (script->getSigintReceived()) {
-            script->setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
-        }
+    if (!vm.hasTerminationRequest())
+        return false;
+
+    if (isForeignTermination(vm, script->getSigintReceived(), timeout.has_value())) {
+        scope.throwException(globalObject, vm.ensureTerminationException());
         return true;
     }
 
-    return false;
+    vm.drainMicrotasksForGlobalObject(globalObject);
+    // The termination may have fired inside an afterEvaluate microtask
+    // checkpoint, leaving the termination exception pending; clear it so
+    // the ERR_SCRIPT_EXECUTION_* error below replaces it.
+    if (vm.hasPendingTerminationException())
+        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+    vm.clearHasTerminationRequest();
+    if (script->getSigintReceived()) {
+        script->setSigintReceived(false);
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
+    } else {
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
+    }
+    return true;
 }
 
 void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout)

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1383,3 +1383,32 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// An outer {timeout} watchdog firing while an option-less inner evaluation is
+// on the stack must propagate through the inner eval (which armed nothing) to
+// the outer one, which converts it to ERR_SCRIPT_EXECUTION_TIMEOUT. This pins
+// the !sigintReceived && !hasTimeout clause of isForeignTermination on a VM
+// that is not permanently stopping (main thread, no worker).
+test("node:vm outer timeout propagates through an untimed inner runInNewContext", async () => {
+  const src = `
+    const vm = require("node:vm");
+    const inner = () => vm.runInNewContext("for(;;){}", {});
+    try {
+      vm.runInNewContext("inner()", { inner }, { timeout: 100 });
+    } catch (e) { console.log("CODE=" + (e && e.code)); }
+    console.log("alive");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "CODE=ERR_SCRIPT_EXECUTION_TIMEOUT\nalive",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1735,17 +1735,10 @@ describe.concurrent("process.exit() inside a worker's node:vm evaluation", () =>
   test("untimed runInNewContext: worker exits, parent survives", async () => {
     const fixture = `
       const { Worker } = require("node:worker_threads");
-      let beats = 0;
-      const hb = setInterval(() => beats++, 20);
       const src = "require('node:vm').runInNewContext('process.exit(0)', { process });";
       const w = new Worker(src, { eval: true });
       w.on("error", e => { console.error("worker-error:" + (e && e.message)); process.exit(1); });
-      w.on("exit", code => {
-        setTimeout(() => {
-          console.log("PARENT-ALIVE worker-exit=" + code + " beats>0=" + (beats > 0));
-          clearInterval(hb);
-        }, 200);
-      });
+      w.on("exit", code => { console.log("PARENT-ALIVE worker-exit=" + code); });
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
@@ -1755,7 +1748,7 @@ describe.concurrent("process.exit() inside a worker's node:vm evaluation", () =>
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "PARENT-ALIVE worker-exit=0 beats>0=true",
+      stdout: "PARENT-ALIVE worker-exit=0",
       stderr: "",
       exitCode: 0,
       signalCode: null,
@@ -1811,6 +1804,39 @@ describe.concurrent("process.exit() inside a worker's node:vm evaluation", () =>
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
       stdout: "worker-exit=3",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test("SourceTextModule.evaluate(): worker exits, parent survives", async () => {
+    const body = [
+      `const vm = require("node:vm");`,
+      `const fs = require("fs");`,
+      `(async () => {`,
+      `  const ctx = vm.createContext({ process });`,
+      `  const mod = new vm.SourceTextModule("process.exit(5)", { context: ctx });`,
+      `  await mod.link(() => {});`,
+      `  try { await mod.evaluate(); } catch (e) { fs.writeSync(2, "CAUGHT:" + (e && e.code) + "\\n"); }`,
+      `  fs.writeSync(2, "AFTER-BODY\\n");`,
+      `})();`,
+    ].join("\n");
+    const fixture = `
+      const { Worker } = require("node:worker_threads");
+      const w = new Worker(${JSON.stringify(body)}, { eval: true });
+      w.on("error", e => { console.error("worker-error:" + (e && e.message)); process.exit(1); });
+      w.on("exit", code => { console.log("worker-exit=" + code); });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--experimental-vm-modules", "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "worker-exit=5",
       stderr: "",
       exitCode: 0,
       signalCode: null,

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1723,6 +1723,101 @@ test("process.debugPort defaults to 9229 on the main thread", async () => {
   expect(exitCode).toBe(0);
 });
 
+// process.exit() inside a worker arms NeedTermination on the worker's own VM.
+// If that fires while the worker is inside a node:vm evaluation,
+// checkForTermination must propagate the uncatchable TerminationException to
+// the worker run loop rather than attribute it to this evaluation's own
+// {timeout}/{breakOnSigint}. Attributing it to an untimed eval hits
+// RELEASE_ASSERT_NOT_REACHED (whole-process SIGABRT); attributing it to a
+// timed eval converts the kill into a catchable ERR_SCRIPT_EXECUTION_TIMEOUT
+// so the worker's try/catch swallows its own exit request and keeps running.
+describe.concurrent("process.exit() inside a worker's node:vm evaluation", () => {
+  test("untimed runInNewContext: worker exits, parent survives", async () => {
+    const fixture = `
+      const { Worker } = require("node:worker_threads");
+      let beats = 0;
+      const hb = setInterval(() => beats++, 20);
+      const src = "require('node:vm').runInNewContext('process.exit(0)', { process });";
+      const w = new Worker(src, { eval: true });
+      w.on("error", e => { console.error("worker-error:" + (e && e.message)); process.exit(1); });
+      w.on("exit", code => {
+        setTimeout(() => {
+          console.log("PARENT-ALIVE worker-exit=" + code + " beats>0=" + (beats > 0));
+          clearInterval(hb);
+        }, 200);
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "PARENT-ALIVE worker-exit=0 beats>0=true",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test("timed runInNewContext: exit is not converted to ERR_SCRIPT_EXECUTION_TIMEOUT", async () => {
+    const body = [
+      `const vm = require("node:vm");`,
+      `const fs = require("fs");`,
+      `try {`,
+      `  vm.runInNewContext("process.exit(7)", { process }, { timeout: 60000 });`,
+      `} catch (e) { fs.writeSync(2, "CAUGHT:" + (e && e.code) + "\\n"); }`,
+      `fs.writeSync(2, "AFTER-BODY\\n");`,
+    ].join("\n");
+    const fixture = `
+      const { Worker } = require("node:worker_threads");
+      const w = new Worker(${JSON.stringify(body)}, { eval: true });
+      w.on("error", e => { console.error("worker-error:" + (e && e.message)); process.exit(1); });
+      w.on("exit", code => { console.log("worker-exit=" + code); });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The worker's try/catch must not observe ERR_SCRIPT_EXECUTION_TIMEOUT and
+    // nothing after the vm call may run; the termination unwinds straight out.
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "worker-exit=7",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test("runInThisContext: worker exits, parent survives", async () => {
+    const fixture = `
+      const { Worker } = require("node:worker_threads");
+      const src = "new (require('node:vm').Script)('process.exit(3)').runInThisContext();";
+      const w = new Worker(src, { eval: true });
+      w.on("error", e => { console.error("worker-error:" + (e && e.message)); process.exit(1); });
+      w.on("exit", code => { console.log("worker-exit=" + code); });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "worker-exit=3",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});
+
 // Founding a SHARE_ENV tree replaces the founding thread's process.env object. If the
 // replacement were orphaned, the founder's later writes would go nowhere. child_process
 // enumerates the JS process.env (a var deleted from the map is invisible to the child),


### PR DESCRIPTION
### Repro

```js
const { Worker } = require('node:worker_threads');
const src = "require('node:vm').runInNewContext('process.exit(0)', {process});";
const w = new Worker(src, { eval: true });
w.on('exit', c => console.log('PARENT-ALIVE worker-exit=' + c));
```

Node v26.3.0: `PARENT-ALIVE worker-exit=0`, parent exits 0.
Bun main (release): whole-process SIGABRT rc 134, `PARENT-ALIVE` never prints.
Bun main (debug/ASAN): `ASSERTION FAILED: vm.Script terminated due neither to SIGINT nor to timeout` at `NodeVMScript.cpp:325`.

With `{timeout: 60000}` instead of an untimed eval, the guest's own `process.exit(7)` is converted to a catchable `ERR_SCRIPT_EXECUTION_TIMEOUT` within a few ms; the worker's `try/catch` swallows it and the worker runs arbitrary JS after its own exit request before ending naturally (Node: exits immediately with code 7).

### Cause

`checkForTermination` in `NodeVMScript.cpp` (and the two equivalent blocks in `NodeVMModule::evaluate`) attributes every `vm.hasTerminationRequest()` to this evaluation's own `{timeout}`/`{breakOnSigint}`: it clears the pending termination exception, calls `vm.clearHasTerminationRequest()`, and either throws a catchable `ERR_SCRIPT_EXECUTION_*` or, with neither option set, hits `RELEASE_ASSERT_NOT_REACHED`. `process.exit()` inside a worker calls `WebWorker::exit`, which sets `requested_terminate` and arms `notifyNeedTermination` on the worker's own VM, so that request is foreign to the evaluation. The same assert/conversion path is hit by `worker.terminate()` from the parent and by an enclosing evaluation's watchdog/SIGINT firing while an untimed inner one is running.

### Fix

Attribute before clearing. `isForeignTermination` returns true when `Bun__VM__scriptExecutionStatus` reports the execution context stopping (reads `is_shutting_down` / `worker.requested_terminate` on the Rust `VirtualMachine`, set only for a permanent stop, never by node:vm's own watchdog or SIGINT watcher), or when this evaluation armed neither a timeout nor `breakOnSigint`. In that case leave `hasTerminationRequest` set and rethrow the uncatchable `TerminationException` so it unwinds to whoever armed it (the worker run loop, or the enclosing evaluation that converts it). The `RELEASE_ASSERT_NOT_REACHED` paths are gone. Applied to `checkForTermination` and both termination checks in `NodeVMModule::evaluate`.

### Verification

New tests in `test/js/node/worker_threads/worker_threads.test.ts` cover `process.exit()` inside a worker's untimed `runInNewContext`, timed `runInNewContext`, and untimed `runInThisContext`. All three fail on an unpatched `bun bd` (two SIGABRT at the assert, one `CAUGHT:ERR_SCRIPT_EXECUTION_TIMEOUT` + `AFTER-BODY` leak) and pass with the fix, matching Node. `test/js/node/vm/vm.test.ts` (212 pass), the full `worker_threads.test.ts` (94 pass), and the `test-vm-timeout*`/`test-vm-sigint*` node-parallel tests are unchanged.

Supersedes #35976 (parent `worker.terminate()`) and #33762 (nested-eval under outer timeout): the permanent-stop check covers the former including its timed variant, the neither-option check covers the latter, and the `process.exit()` variants here are covered by neither of those on its own.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (ef7c2d34b)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.54ms]
(pass) vm > runInContext() > can return a value [15.31ms]
(pass) vm > runInContext() > can return a complex value [15.10ms]
(pass) vm > runInContext() > can return the last value [14.63ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.82ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.99ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.36ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.84ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.37ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [14.72ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.63ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [1
... (truncated)

release without fix: 62 skipped
bun test v1.4.0-canary.1 (8434152af)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [2.54ms]
(pass) vm > runInContext() > can return a value [0.80ms]
(pass) vm > runInContext() > can return a complex value [0.26ms]
(pass) vm > runInContext() > can return the last value [0.19ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (ef7c2d34b)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.09ms]
(pass) vm > runInContext() > can return a value [14.46ms]
(pass) vm > runInContext() > can return a complex value [15.43ms]
(pass) vm > runInContext() > can return the last value [14.98ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.94ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.10ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [14.62ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.05ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [14.83ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [14.74ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.37ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [1
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVMModule.cpp                  |  19 +++-
 src/jsc/bindings/NodeVMScript.cpp                  |  49 ++++++---
 test/js/node/vm/vm.test.ts                         |  29 +++++
 test/js/node/worker_threads/worker_threads.test.ts | 121 +++++++++++++++++++++
 4 files changed, 198 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/NodeVMModule.cpp                       4      6      0
src/jsc/bindings/NodeVMScript.cpp                       3      2      0
test/js/node/vm/vm.test.ts                              1      1      0
test/js/node/worker_threads/worker_threads.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->