### PR TITLE
node:http: slice 'upgrade' head to the post-body remainder and close on unsatisfied-body FIN

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -460,6 +460,14 @@ private:
              * while this dispatch is on the stack. */
             if constexpr (IsNodeHttp) {
                 httpResponseData->state &= ~HttpResponseData<SSL>::HTTP_NODE_PIPELINED_DISPATCH;
+                /* Upgrade body (and its post-body remainder) are fully present in
+                 * this same chunk: the remainder was already delivered as the
+                 * 'upgrade' head via req->head, so suppress it from onSocketData
+                 * once the tunnel switch fires below. Cleared at end of onData. */
+                if (httpRequest->bodyCompleteInHead
+                        && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_AFTER_BODY)) {
+                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING;
+                }
             }
 
             /* Returning from a request handler without responding or attaching an onAborted handler is ill-use */
@@ -500,7 +508,13 @@ private:
             }
 
             if (httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketData) {
-                httpContextData->onSocketData(httpResponseData->socketData, SSL, (struct us_socket_t *) user, data.data(), data.length(), fin);
+                if (IsNodeHttp && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING)) {
+                    /* Same-chunk post-body remainder of an Upgrade-with-body: already
+                     * delivered as the 'upgrade' head (req->head), not socket data. */
+                    httpResponseData->state &= ~HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING;
+                } else {
+                    httpContextData->onSocketData(httpResponseData->socketData, SSL, (struct us_socket_t *) user, data.data(), data.length(), fin);
+                }
             }
 
             if (switchToTunnelAfterThisChunk) {
@@ -550,6 +564,10 @@ private:
 
         /* Mark that we are no longer parsing Http */
         httpContextData->flags.isParsingHttp = false;
+        if constexpr (IsNodeHttp) {
+            /* Scope the same-chunk-head suppression to this parse call only. */
+            httpResponseData->state &= ~HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING;
+        }
         /* If we got fullptr that means the parser wants us to close the socket from error (same as calling the errorHandler) */
         if (httpErrorStatusCode) {
             /* node:http compat: parse errors surface as the server's 'clientError'
@@ -780,13 +798,23 @@ private:
             /* CONNECT/Upgrade tunnels allow half-open: the peer finishing its
              * writable side ends the JS socket's readable side ('end' event) but
              * the server can keep writing until it ends the socket itself, like
-             * Node's http server (allowHalfOpen: true). This includes an accepted
-             * Upgrade whose body never completed (HTTP_NODE_TUNNEL_AFTER_BODY): the
-             * EOF ends the upgrade socket, exactly like Node's UpgradeStream. */
-            if (httpResponseData->isConnectRequest || (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_AFTER_BODY)) {
+             * Node's http server (allowHalfOpen: true). */
+            if (httpResponseData->isConnectRequest) {
                 if (httpResponseData->socketData && httpContextData->onSocketData) {
                     httpContextData->onSocketData(httpResponseData->socketData, SSL, s, "", 0, true);
                 }
+                return s;
+            }
+            /* Accepted Upgrade whose body never completed: Node's UpgradeStream
+             * ends the socket's readable side and then tears the connection down
+             * (the declared body is unsatisfied, so there is no valid tunnel
+             * state to keep half-open). Closing here drives onClose, which
+             * delivers the body abort and releases the pending-request ref. */
+            if (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_AFTER_BODY) {
+                if (httpResponseData->socketData && httpContextData->onSocketData) {
+                    httpContextData->onSocketData(httpResponseData->socketData, SSL, s, "", 0, true);
+                }
+                asyncSocket->close();
                 return s;
             }
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -807,11 +807,9 @@ private:
              * ends the socket's readable side and then tears the connection down
              * (the declared body is unsatisfied, so there is no valid tunnel
              * state to keep half-open). Closing here drives onClose, which
-             * delivers the body abort and releases the pending-request ref. */
+             * delivers the socket fin, the body abort and the pending-request
+             * release. */
             if (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_AFTER_BODY) {
-                if (httpResponseData->socketData && httpContextData->onSocketData) {
-                    httpContextData->onSocketData(httpResponseData->socketData, SSL, s, "", 0, true);
-                }
                 asyncSocket->close();
                 return s;
             }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -460,10 +460,8 @@ private:
              * while this dispatch is on the stack. */
             if constexpr (IsNodeHttp) {
                 httpResponseData->state &= ~HttpResponseData<SSL>::HTTP_NODE_PIPELINED_DISPATCH;
-                /* Upgrade body (and its post-body remainder) are fully present in
-                 * this same chunk: the remainder was already delivered as the
-                 * 'upgrade' head via req->head, so suppress it from onSocketData
-                 * once the tunnel switch fires below. Cleared at end of onData. */
+                /* Same-chunk Upgrade body remainder was already delivered as
+                 * req->head: suppress the one onSocketData call for it below. */
                 if (httpRequest->bodyCompleteInHead
                         && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_AFTER_BODY)) {
                     httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING;
@@ -509,8 +507,6 @@ private:
 
             if (httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketData) {
                 if (IsNodeHttp && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING)) {
-                    /* Same-chunk post-body remainder of an Upgrade-with-body: already
-                     * delivered as the 'upgrade' head (req->head), not socket data. */
                     httpResponseData->state &= ~HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING;
                 } else {
                     httpContextData->onSocketData(httpResponseData->socketData, SSL, (struct us_socket_t *) user, data.data(), data.length(), fin);
@@ -803,12 +799,9 @@ private:
                 }
                 return s;
             }
-            /* Accepted Upgrade whose body never completed: Node's UpgradeStream
-             * ends the socket's readable side and then tears the connection down
-             * (the declared body is unsatisfied, so there is no valid tunnel
-             * state to keep half-open). Closing here drives onClose, which
-             * delivers the socket fin, the body abort and the pending-request
-             * release. */
+            /* Accepted Upgrade whose body never completed: Node tears the
+             * connection down (unsatisfied body, no valid tunnel state to keep
+             * half-open). onClose delivers the fin and releases the request. */
             if (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_AFTER_BODY) {
                 asyncSocket->close();
                 return s;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -564,10 +564,6 @@ private:
 
         /* Mark that we are no longer parsing Http */
         httpContextData->flags.isParsingHttp = false;
-        if constexpr (IsNodeHttp) {
-            /* Scope the same-chunk-head suppression to this parse call only. */
-            httpResponseData->state &= ~HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING;
-        }
         /* If we got fullptr that means the parser wants us to close the socket from error (same as calling the errorHandler) */
         if (httpErrorStatusCode) {
             /* node:http compat: parse errors surface as the server's 'clientError'
@@ -615,6 +611,8 @@ private:
                     nodeHttpResponseData->lastMessageStartMs = nodeCompatMonotonicMs();
                     nodeHttpResponseData->headersCompleted = false;
                 }
+                /* Scope the same-chunk-head suppression to this parse call only. */
+                httpResponseData->state &= ~HttpResponseData<SSL>::HTTP_NODE_TUNNEL_HEAD_PENDING;
             }
 
             /* Timeout on uncork failure */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1286,7 +1286,12 @@ struct HttpResponseData;
                         for (auto chunk : uWS::ChunkIterator(&scanView, &scanState, false, &scanExt, &scanTrailers, maxBufferedHeaderSize)) {
                             (void) chunk;
                         }
-                        if (!isParsingChunkedEncoding(scanState) && !isParsingInvalidChunkedEncoding(scanState)) {
+                        /* Mirror the real parse's gates so bodyCompleteInHead
+                         * is never true for a body the real parse will reject
+                         * (stranding the JS deferred emit). */
+                        if (!isParsingChunkedEncoding(scanState) && !isParsingInvalidChunkedEncoding(scanState)
+                                && scanExt <= MAX_CHUNK_EXTENSION_SIZE
+                                && validateNodeTrailerSection(&scanTrailers, useInsecureHTTPParser) == HTTP_PARSER_ERROR_NONE) {
                             req->head = std::span<const char>(scanView.data(), scanView.length());
                             req->bodyCompleteInHead = true;
                         } else {

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -209,6 +209,10 @@ struct HttpResponseData;
          * WARNING: This points to data in the receive buffer and may be stack-allocated.
          * Must be cloned before the request handler returns. */
         std::span<const char> head;
+        /* For an Upgrade request with a body, whether that body completes
+         * within this same parse chunk (so head above is the post-body
+         * remainder, and req.complete can be set at 'upgrade' time). */
+        bool bodyCompleteInHead = false;
 
         bool isAncient()
         {
@@ -1248,8 +1252,41 @@ struct HttpResponseData;
             /* If returned socket is not what we put in we need
              * to break here as we either have upgraded to
              * WebSockets or otherwise closed the socket. */
-            /* Store any remaining data as head for Node.js compat (connect/upgrade events) */
+            /* Store any remaining data as head for Node.js compat (connect/upgrade events).
+             * Node's 'upgrade' head is the chunk remainder AFTER the declared
+             * body, so for a body-carrying Upgrade skip the body bytes (which
+             * are delivered through inStream below) and report whether the
+             * body completes in this chunk. */
+            req->bodyCompleteInHead = false;
             req->head = std::span<const char>(data, length);
+            if constexpr (IsNodeHttp) {
+                if (!isConnectRequest && (transferEncoding.has || contentLengthStringLen)
+                        && req->getHeader("upgrade").data()) [[unlikely]] {
+                    if (transferEncoding.has) {
+                        /* Pre-scan the chunked body with local state so the real
+                         * parse below (which fires inStream per chunk) is unchanged. */
+                        uint64_t scanState = STATE_IS_CHUNKED;
+                        uint64_t scanExt = 0;
+                        std::string scanTrailers;
+                        std::string_view scanView(data, length);
+                        for (auto chunk : uWS::ChunkIterator(&scanView, &scanState, false, &scanExt, &scanTrailers, maxBufferedHeaderSize)) {
+                            (void) chunk;
+                        }
+                        if (!isParsingChunkedEncoding(scanState) && !isParsingInvalidChunkedEncoding(scanState)) {
+                            req->head = std::span<const char>(scanView.data(), scanView.length());
+                            req->bodyCompleteInHead = true;
+                        } else {
+                            req->head = std::span<const char>();
+                        }
+                    } else if (remainingStreamingBytes <= (uint64_t) length) {
+                        unsigned int skip = (unsigned int) remainingStreamingBytes;
+                        req->head = std::span<const char>(data + skip, length - skip);
+                        req->bodyCompleteInHead = true;
+                    } else {
+                        req->head = std::span<const char>();
+                    }
+                }
+            }
             void *returnedUser = requestHandler(user, req);
             if (returnedUser != user) {
                 /* We are upgraded to WebSocket or otherwise broken */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1281,16 +1281,19 @@ struct HttpResponseData;
                          * parse below (which fires inStream per chunk) is unchanged. */
                         uint64_t scanState = STATE_IS_CHUNKED;
                         uint64_t scanExt = 0;
+                        bool scanExtOverflow = false;
                         std::string scanTrailers;
                         std::string_view scanView(data, length);
                         for (auto chunk : uWS::ChunkIterator(&scanView, &scanState, false, &scanExt, &scanTrailers, maxBufferedHeaderSize)) {
                             (void) chunk;
+                            /* The real parse checks this per-chunk; the counter is
+                             * reset by consumeHexNumber at each fresh chunk-size line. */
+                            if (scanExt > MAX_CHUNK_EXTENSION_SIZE) { scanExtOverflow = true; break; }
                         }
                         /* Mirror the real parse's gates so bodyCompleteInHead
                          * is never true for a body the real parse will reject
                          * (stranding the JS deferred emit). */
-                        if (!isParsingChunkedEncoding(scanState) && !isParsingInvalidChunkedEncoding(scanState)
-                                && scanExt <= MAX_CHUNK_EXTENSION_SIZE
+                        if (!scanExtOverflow && !isParsingChunkedEncoding(scanState) && !isParsingInvalidChunkedEncoding(scanState)
                                 && validateNodeTrailerSection(&scanTrailers, useInsecureHTTPParser) == HTTP_PARSER_ERROR_NONE) {
                             req->head = std::span<const char>(scanView.data(), scanView.length());
                             req->bodyCompleteInHead = true;

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1268,7 +1268,15 @@ struct HttpResponseData;
                 if (!isConnectRequest && methodFramesBody
                         && (transferEncoding.has || contentLengthStringLen)
                         && req->getHeader("upgrade").data()) [[unlikely]] {
-                    if (transferEncoding.has) {
+                    if constexpr (ConsumeMinimally) {
+                        /* Fallback-buffer path: (data, length) is a view truncated
+                         * to maxFallbackSize, so a head sliced from it would not
+                         * match the full-buffer remainder later suppressed from
+                         * onSocketData. Clear head so JS emits immediately with
+                         * an empty head and every post-body byte reaches
+                         * socket.on('data'), matching the pre-existing delivery. */
+                        req->head = std::span<const char>();
+                    } else if (transferEncoding.has) {
                         /* Pre-scan the chunked body with local state so the real
                          * parse below (which fires inStream per chunk) is unchanged. */
                         uint64_t scanState = STATE_IS_CHUNKED;

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1253,60 +1253,19 @@ struct HttpResponseData;
              * to break here as we either have upgraded to
              * WebSockets or otherwise closed the socket. */
             /* Store any remaining data as head for Node.js compat (connect/upgrade events).
-             * Node's 'upgrade' head is the chunk remainder AFTER the declared
-             * body, so for a body-carrying Upgrade skip the body bytes (which
-             * are delivered through inStream below) and report whether the
-             * body completes in this chunk. */
+             * For an Upgrade with a Content-Length body that completes in this
+             * chunk, slice head to the post-body remainder like Node. */
             req->bodyCompleteInHead = false;
             req->head = std::span<const char>(data, length);
-            if constexpr (IsNodeHttp) {
-                /* Match NodeHTTPResponse__createForJS's has_body predicate
-                 * (has_request_body() || GET, i.e. not HEAD/TRACE) so the two
-                 * sides agree on which bytes are body. */
-                std::string_view m = req->getCaseSensitiveMethod();
-                bool methodFramesBody = !(m == "HEAD" || m == "TRACE");
-                if (!isConnectRequest && methodFramesBody
-                        && (transferEncoding.has || contentLengthStringLen)
-                        && !deferredTransferEncodingError
+            if constexpr (IsNodeHttp && !ConsumeMinimally) {
+                if (!isConnectRequest && contentLengthStringLen && !transferEncoding.has
+                        && remainingStreamingBytes <= (uint64_t) length
                         && req->getHeader("upgrade").data()) [[unlikely]] {
-                    if constexpr (ConsumeMinimally) {
-                        /* Fallback-buffer path: (data, length) is a view truncated
-                         * to maxFallbackSize, so a head sliced from it would not
-                         * match the full-buffer remainder later suppressed from
-                         * onSocketData. Clear head so JS emits immediately with
-                         * an empty head and every post-body byte reaches
-                         * socket.on('data'), matching the pre-existing delivery. */
-                        req->head = std::span<const char>();
-                    } else if (transferEncoding.has) {
-                        /* Pre-scan the chunked body with local state so the real
-                         * parse below (which fires inStream per chunk) is unchanged. */
-                        uint64_t scanState = STATE_IS_CHUNKED;
-                        uint64_t scanExt = 0;
-                        bool scanExtOverflow = false;
-                        std::string scanTrailers;
-                        std::string_view scanView(data, length);
-                        for (auto chunk : uWS::ChunkIterator(&scanView, &scanState, false, &scanExt, &scanTrailers, maxBufferedHeaderSize)) {
-                            (void) chunk;
-                            /* The real parse checks this per-chunk; the counter is
-                             * reset by consumeHexNumber at each fresh chunk-size line. */
-                            if (scanExt > MAX_CHUNK_EXTENSION_SIZE) { scanExtOverflow = true; break; }
-                        }
-                        /* Mirror the real parse's gates so bodyCompleteInHead
-                         * is never true for a body the real parse will reject
-                         * (stranding the JS deferred emit). */
-                        if (!scanExtOverflow && !isParsingChunkedEncoding(scanState) && !isParsingInvalidChunkedEncoding(scanState)
-                                && validateNodeTrailerSection(&scanTrailers, useInsecureHTTPParser) == HTTP_PARSER_ERROR_NONE) {
-                            req->head = std::span<const char>(scanView.data(), scanView.length());
-                            req->bodyCompleteInHead = true;
-                        } else {
-                            req->head = std::span<const char>();
-                        }
-                    } else if (remainingStreamingBytes <= (uint64_t) length) {
+                    std::string_view m = req->getCaseSensitiveMethod();
+                    if (m != "HEAD" && m != "TRACE") {
                         unsigned int skip = (unsigned int) remainingStreamingBytes;
                         req->head = std::span<const char>(data + skip, length - skip);
                         req->bodyCompleteInHead = true;
-                    } else {
-                        req->head = std::span<const char>();
                     }
                 }
             }

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1260,7 +1260,13 @@ struct HttpResponseData;
             req->bodyCompleteInHead = false;
             req->head = std::span<const char>(data, length);
             if constexpr (IsNodeHttp) {
-                if (!isConnectRequest && (transferEncoding.has || contentLengthStringLen)
+                /* Match NodeHTTPResponse__createForJS's has_body predicate
+                 * (has_request_body() || GET, i.e. not HEAD/TRACE) so the two
+                 * sides agree on which bytes are body. */
+                std::string_view m = req->getCaseSensitiveMethod();
+                bool methodFramesBody = !(m == "HEAD" || m == "TRACE");
+                if (!isConnectRequest && methodFramesBody
+                        && (transferEncoding.has || contentLengthStringLen)
                         && req->getHeader("upgrade").data()) [[unlikely]] {
                     if (transferEncoding.has) {
                         /* Pre-scan the chunked body with local state so the real

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1267,6 +1267,7 @@ struct HttpResponseData;
                 bool methodFramesBody = !(m == "HEAD" || m == "TRACE");
                 if (!isConnectRequest && methodFramesBody
                         && (transferEncoding.has || contentLengthStringLen)
+                        && !deferredTransferEncodingError
                         && req->getHeader("upgrade").data()) [[unlikely]] {
                     if constexpr (ConsumeMinimally) {
                         /* Fallback-buffer path: (data, length) is a view truncated

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -131,6 +131,11 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * and everything after the end of the message is opaque data for the
          * 'upgrade' listener's socket. */
         HTTP_NODE_TUNNEL_AFTER_BODY = 1 << 14,
+        /* The tunnel-after-body switch just happened during this parse call.
+         * The post-body remainder of the same chunk is the 'upgrade' head
+         * argument (already handed to JS via req->head), not raw socket data,
+         * so the next isConnectRequest onSocketData is suppressed once. */
+        HTTP_NODE_TUNNEL_HEAD_PENDING = 1 << 17,
         /* The peer half-closed (FIN) while there was still something to flush
          * before teardown: buffered/pinned response bytes, or (with
          * httpAllowHalfOpen) an in-flight or queued pipelined response. The

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -273,10 +273,8 @@ function onDataIncomingMessage(this: any, chunk, isLast, aborted: NodeHTTPRespon
     // Like Node's parserOnMessageComplete: any readStop above left the shared
     // socket's flowing=false, which would swallow the next request's 'pause'.
     if (!this.upgrade && socket && !socket._paused && socket.readable) socket.resume();
-    // Node emits 'upgrade' after the parser.execute() that completed the body
-    // returns, with the body already buffered on req and req.complete = true.
-    // The dispatcher stashed the emit here when the body was in the same chunk
-    // as the headers; fire it now that the body has been pushed.
+    // Deferred 'upgrade' emit: body was in the same chunk as the headers, so
+    // fire now that it is buffered on req (Node's parser.execute() order).
     const deferred = this[kDeferredUpgradeEmit];
     if (deferred !== undefined) {
       this[kDeferredUpgradeEmit] = undefined;

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -98,6 +98,7 @@ const serverSymbol = Symbol.for("::bunternal::");
 const kPendingCallbacks = Symbol("pendingCallbacks");
 const kRequest = Symbol("request");
 const kCloseCallback = Symbol("closeCallback");
+const kDeferredUpgradeEmit = Symbol("deferredUpgradeEmit");
 
 const kEmptyObject = Object.freeze(Object.create(null));
 
@@ -272,6 +273,16 @@ function onDataIncomingMessage(this: any, chunk, isLast, aborted: NodeHTTPRespon
     // Like Node's parserOnMessageComplete: any readStop above left the shared
     // socket's flowing=false, which would swallow the next request's 'pause'.
     if (!this.upgrade && socket && !socket._paused && socket.readable) socket.resume();
+    // Node emits 'upgrade' after the parser.execute() that completed the body
+    // returns, with the body already buffered on req and req.complete = true.
+    // The dispatcher stashed the emit here when the body was in the same chunk
+    // as the headers; fire it now that the body has been pushed.
+    const deferred = this[kDeferredUpgradeEmit];
+    if (deferred !== undefined) {
+      this[kDeferredUpgradeEmit] = undefined;
+      this.complete = true;
+      deferred();
+    }
   }
 }
 
@@ -625,6 +636,7 @@ export {
   kBodyChunks,
   kClearTimeout,
   kCloseCallback,
+  kDeferredUpgradeEmit,
   kDeprecatedReplySymbol,
   kEmitState,
   kEmptyObject,

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -269,18 +269,23 @@ function onDataIncomingMessage(this: any, chunk, isLast, aborted: NodeHTTPRespon
   }
 
   if (isLast) {
+    // Deferred 'upgrade' emit: body was in the same chunk as the headers, so
+    // fire now that it is buffered on req (Node's parser.execute() order). Run
+    // the EOF completion synchronously first so the listener also observes
+    // req.trailers (Node's parserOnMessageComplete populates both before
+    // onParserExecuteCommon emits 'upgrade').
+    const deferred = this[kDeferredUpgradeEmit];
+    if (deferred !== undefined) {
+      this[kDeferredUpgradeEmit] = undefined;
+      this[eofInProgress] = true;
+      emitEOFIncomingMessageOuter(this);
+      deferred();
+      return;
+    }
     emitEOFIncomingMessage(this);
     // Like Node's parserOnMessageComplete: any readStop above left the shared
     // socket's flowing=false, which would swallow the next request's 'pause'.
     if (!this.upgrade && socket && !socket._paused && socket.readable) socket.resume();
-    // Deferred 'upgrade' emit: body was in the same chunk as the headers, so
-    // fire now that it is buffered on req (Node's parser.execute() order).
-    const deferred = this[kDeferredUpgradeEmit];
-    if (deferred !== undefined) {
-      this[kDeferredUpgradeEmit] = undefined;
-      this.complete = true;
-      deferred();
-    }
   }
 }
 

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -270,10 +270,7 @@ function onDataIncomingMessage(this: any, chunk, isLast, aborted: NodeHTTPRespon
 
   if (isLast) {
     // Deferred 'upgrade' emit: body was in the same chunk as the headers, so
-    // fire now that it is buffered on req (Node's parser.execute() order). Run
-    // the EOF completion synchronously first so the listener also observes
-    // req.trailers (Node's parserOnMessageComplete populates both before
-    // onParserExecuteCommon emits 'upgrade').
+    // fire now that it is buffered on req (Node's parser.execute() order).
     const deferred = this[kDeferredUpgradeEmit];
     if (deferred !== undefined) {
       this[kDeferredUpgradeEmit] = undefined;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1007,7 +1007,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             socket[kUpgradeIncoming] = http_req;
             http_req.once("end", clearUpgradeIncoming.bind(undefined, socket));
           }
-          const upgradeHead = connectHead ? connectHead : kEmptyBuffer;
+          const upgradeHead = (bodyCompleteInHead || !hasBody) && connectHead ? connectHead : kEmptyBuffer;
           // Like CONNECT: the connection is detached from the HTTP request
           // machinery; hold the native callback open until the raw socket
           // closes.

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -994,14 +994,10 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           }
         } else if (is_upgrade) {
           // Hand the raw socket over to the 'upgrade' listener, like Node.js.
-          // Without a body the message is already complete: bytes that arrived
-          // after the request head become the upgradeHead and the connection
-          // switches into CONNECT-style tunnel mode immediately. With a body
-          // (Node 26 semantics) the body keeps being parsed and delivered
-          // through req; the connection only switches to tunnel mode once the
-          // message completes. Node emits 'upgrade' only after parser.execute()
-          // returns, so the head is the remainder of this same chunk AFTER the
-          // body, with the body already buffered on req.
+          // With a body (Node 26 semantics) the body keeps being parsed and
+          // delivered through req; the connection only switches to tunnel mode
+          // once the message completes, and head is the post-body remainder of
+          // the same chunk (the parser already computed it in connectHead).
           socketHandle.upgradeToTunnel(hasBody);
           socket[kEnableStreaming](true);
           detachSocketListenersForHandoff(socket);
@@ -1011,8 +1007,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             socket[kUpgradeIncoming] = http_req;
             http_req.once("end", clearUpgradeIncoming.bind(undefined, socket));
           }
-          // The parser already sliced connectHead to the post-body remainder
-          // (or an empty span when the body does not complete in this chunk).
           const upgradeHead = connectHead ? connectHead : kEmptyBuffer;
           const emitUpgrade = () => {
             let handled;
@@ -1037,10 +1031,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           const { promise: upgradePromise, resolve: resolveUpgrade } = $newPromiseCapability(Promise);
           socket.once("close", resolveUpgrade);
           if (hasBody && bodyCompleteInHead) {
-            // The same-chunk body is parsed right after this handler returns,
-            // synchronously firing onDataIncomingMessage(isLast=true); emit
-            // 'upgrade' from there so the listener observes req.complete and
-            // the body buffered on req like Node.
+            // Body is in this chunk: defer to onDataIncomingMessage's fin so
+            // the listener observes req.complete and the buffered body.
             http_req[kDeferredUpgradeEmit] = emitUpgrade;
           } else {
             emitUpgrade();

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -41,6 +41,7 @@ const {
   kPendingCallbacks,
   kRequest,
   kCloseCallback,
+  kDeferredUpgradeEmit,
   NodeHTTPResponseFlags,
   emitErrorNextTickIfErrorListenerNT,
   getIsNextIncomingMessageHTTPS,
@@ -717,6 +718,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         isAncientHTTP: boolean,
         connectHead?: Buffer,
         isPipelinedDispatch?: boolean,
+        bodyCompleteInHead?: boolean,
       ) {
         const prevIsNextIncomingMessageHTTPS = getIsNextIncomingMessageHTTPS();
         setIsNextIncomingMessageHTTPS(isHTTPS);
@@ -997,8 +999,9 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           // switches into CONNECT-style tunnel mode immediately. With a body
           // (Node 26 semantics) the body keeps being parsed and delivered
           // through req; the connection only switches to tunnel mode once the
-          // message completes, so the upgradeHead is empty and everything after
-          // the end of the message reaches the socket as raw data.
+          // message completes. Node emits 'upgrade' only after parser.execute()
+          // returns, so the head is the remainder of this same chunk AFTER the
+          // body, with the body already buffered on req.
           socketHandle.upgradeToTunnel(hasBody);
           socket[kEnableStreaming](true);
           detachSocketListenersForHandoff(socket);
@@ -1008,28 +1011,40 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             socket[kUpgradeIncoming] = http_req;
             http_req.once("end", clearUpgradeIncoming.bind(undefined, socket));
           }
-          const upgradeHead = !hasBody && connectHead ? connectHead : kEmptyBuffer;
-          let upgradeHandled;
-          try {
-            upgradeHandled = server.emit("upgrade", http_req, socket, upgradeHead);
-          } catch (err) {
-            // A throwing 'upgrade' listener surfaces as an uncaught
-            // exception, like Node.js (the emit happens outside any JS try
-            // frame there).
-            process.nextTick(rethrowUncaught, err);
-            upgradeHandled = true;
-          }
-          if (!upgradeHandled) {
-            // shouldUpgradeCallback accepted the upgrade but no 'upgrade'
-            // listener is installed: Node.js destroys the socket.
-            socket.destroy();
-            return;
-          }
+          // The parser already sliced connectHead to the post-body remainder
+          // (or an empty span when the body does not complete in this chunk).
+          const upgradeHead = connectHead ? connectHead : kEmptyBuffer;
+          const emitUpgrade = () => {
+            let handled;
+            try {
+              handled = server.emit("upgrade", http_req, socket, upgradeHead);
+            } catch (err) {
+              // A throwing 'upgrade' listener surfaces as an uncaught
+              // exception, like Node.js (the emit happens outside any JS try
+              // frame there).
+              process.nextTick(rethrowUncaught, err);
+              handled = true;
+            }
+            if (!handled) {
+              // shouldUpgradeCallback accepted the upgrade but no 'upgrade'
+              // listener is installed: Node.js destroys the socket.
+              socket.destroy();
+            }
+          };
           // Like CONNECT: the connection is detached from the HTTP request
           // machinery; hold the native callback open until the raw socket
           // closes.
           const { promise: upgradePromise, resolve: resolveUpgrade } = $newPromiseCapability(Promise);
           socket.once("close", resolveUpgrade);
+          if (hasBody && bodyCompleteInHead) {
+            // The same-chunk body is parsed right after this handler returns,
+            // synchronously firing onDataIncomingMessage(isLast=true); emit
+            // 'upgrade' from there so the listener observes req.complete and
+            // the body buffered on req like Node.
+            http_req[kDeferredUpgradeEmit] = emitUpgrade;
+          } else {
+            emitUpgrade();
+          }
           return upgradePromise;
         } else if (
           server.requireHostHeader &&

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1008,6 +1008,10 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             http_req.once("end", clearUpgradeIncoming.bind(undefined, socket));
           }
           const upgradeHead = connectHead ? connectHead : kEmptyBuffer;
+          // Like CONNECT: the connection is detached from the HTTP request
+          // machinery; hold the native callback open until the raw socket
+          // closes.
+          const { promise: upgradePromise, resolve: resolveUpgrade } = $newPromiseCapability(Promise);
           const emitUpgrade = () => {
             let handled;
             try {
@@ -1024,12 +1028,10 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
               // listener is installed: Node.js destroys the socket.
               socket.destroy();
             }
+            // Attach the internal close listener after the user's handler ran:
+            // Node.js hands the socket over with no listeners (same as CONNECT).
+            socket.once("close", resolveUpgrade);
           };
-          // Like CONNECT: the connection is detached from the HTTP request
-          // machinery; hold the native callback open until the raw socket
-          // closes.
-          const { promise: upgradePromise, resolve: resolveUpgrade } = $newPromiseCapability(Promise);
-          socket.once("close", resolveUpgrade);
           if (hasBody && bodyCompleteInHead) {
             // Body is in this chunk: defer to onDataIncomingMessage's fin so
             // the listener observes req.complete and the buffered body.

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -719,6 +719,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     }
 
     args.append(jsBoolean(isPipelinedDispatch));
+    args.append(jsBoolean(request->bodyCompleteInHead));
 
     JSValue returnValue = AsyncContextFrame::profiledCall(globalObject, callbackObject, jsUndefined(), args);
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/node/http/node-http-upgrade-with-body.test.ts
+++ b/test/js/node/http/node-http-upgrade-with-body.test.ts
@@ -1,0 +1,262 @@
+// node:http server 'upgrade' event with a request body (Node 26 semantics):
+// head is the post-BODY remainder of the same TCP chunk, the body is already
+// buffered on req with req.complete === true, and a peer FIN with an
+// unsatisfied body tears the handed-off socket down instead of leaking the
+// pending-request ref.
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import http from "node:http";
+import net from "node:net";
+import { once } from "node:events";
+
+type UpgradeResult = {
+  head: string;
+  reqData: string;
+  sockData: string;
+  completeAtUpgrade: boolean;
+  readableLengthAtUpgrade: number;
+};
+
+function sendRaw(port: number, payload: string, thenEnd = false) {
+  const sock = net.connect(port, "127.0.0.1", () => {
+    sock.write(payload);
+    if (thenEnd) sock.end();
+  });
+  sock.on("error", () => {});
+  return sock;
+}
+
+async function observeUpgrade(payload: string): Promise<UpgradeResult> {
+  const { promise, resolve } = Promise.withResolvers<UpgradeResult>();
+  const server = http.createServer((_req, res) => res.end());
+  server.on("upgrade", (req, socket, head) => {
+    const result: UpgradeResult = {
+      head: head.toString(),
+      reqData: "",
+      sockData: "",
+      completeAtUpgrade: req.complete,
+      readableLengthAtUpgrade: req.readableLength,
+    };
+    req.on("data", d => (result.reqData += d));
+    socket.on("data", d => (result.sockData += d));
+    req.on("end", () => {
+      // Resolve from socket 'close' so any late socket 'data' reaches sockData.
+      socket.on("close", () => resolve(result));
+      socket.end();
+    });
+  });
+  await once(server.listen(0), "listening");
+  const port = (server.address() as net.AddressInfo).port;
+  const client = sendRaw(port, payload);
+  client.on("end", () => client.end());
+  const result = await promise;
+  await new Promise<void>(r => server.close(() => r()));
+  return result;
+}
+
+describe("node:http 'upgrade' with a request body", () => {
+  // a1/a2/a3: Content-Length body + tunnel bytes in the same chunk as the
+  // headers. Node slices head to the post-body remainder, delivers the body
+  // once through req, and does not surface the remainder on socket 'data'.
+  test.concurrent("same-chunk Content-Length body: head is the post-body remainder", async () => {
+    const result = await observeUpgrade(
+      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLOAFTER",
+    );
+    expect(result).toEqual({
+      head: "AFTER",
+      reqData: "HELLO",
+      sockData: "",
+      completeAtUpgrade: true,
+      readableLengthAtUpgrade: 5,
+    });
+  });
+
+  // Same rule for a chunked body that completes in the same chunk.
+  test.concurrent("same-chunk chunked body: head is the post-body remainder", async () => {
+    const result = await observeUpgrade(
+      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\nHELLO\r\n0\r\n\r\nAFTER",
+    );
+    expect(result).toEqual({
+      head: "AFTER",
+      reqData: "HELLO",
+      sockData: "",
+      completeAtUpgrade: true,
+      readableLengthAtUpgrade: 5,
+    });
+  });
+
+  test.concurrent("same-chunk chunked body with a trailer section", async () => {
+    const result = await observeUpgrade(
+      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\nHELLO\r\n0\r\nExtra: abc\r\n\r\nAFTER",
+    );
+    expect({ head: result.head, reqData: result.reqData, sockData: result.sockData }).toEqual({
+      head: "AFTER",
+      reqData: "HELLO",
+      sockData: "",
+    });
+  });
+
+  // Body fully in this chunk with nothing after it: head is empty and nothing
+  // reaches socket 'data'.
+  test.concurrent("same-chunk body with no remainder: head is empty", async () => {
+    const result = await observeUpgrade(
+      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLO",
+    );
+    expect({ head: result.head, reqData: result.reqData, sockData: result.sockData }).toEqual({
+      head: "",
+      reqData: "HELLO",
+      sockData: "",
+    });
+    expect(result.completeAtUpgrade).toBe(true);
+  });
+
+  // Headers-only first packet: 'upgrade' fires before the body, head is empty,
+  // and once the body's fin arrives the post-body remainder in that later
+  // packet reaches socket 'data' (not head).
+  test.concurrent("split body: head is empty, later post-body bytes reach socket 'data'", async () => {
+    const { promise, resolve } = Promise.withResolvers<UpgradeResult>();
+    const server = http.createServer((_req, res) => res.end());
+    server.on("upgrade", (req, socket, head) => {
+      const result: UpgradeResult = {
+        head: head.toString(),
+        reqData: "",
+        sockData: "",
+        completeAtUpgrade: req.complete,
+        readableLengthAtUpgrade: req.readableLength,
+      };
+      req.on("data", d => (result.reqData += d));
+      socket.on("data", d => {
+        result.sockData += d;
+        socket.end();
+      });
+      socket.on("close", () => resolve(result));
+    });
+    await once(server.listen(0), "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    const client = net.connect(port, "127.0.0.1");
+    await once(client, "connect");
+    client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\n");
+    // Wait for 'upgrade' to fire before writing the body so it is not coalesced
+    // into the header packet.
+    await once(server, "upgrade");
+    client.write("HELLOAFTER");
+    client.on("end", () => client.end());
+    const result = await promise;
+    expect({ head: result.head, reqData: result.reqData, sockData: result.sockData }).toEqual({
+      head: "",
+      reqData: "HELLO",
+      sockData: "AFTER",
+    });
+    expect(result.completeAtUpgrade).toBe(false);
+    await new Promise<void>(r => server.close(() => r()));
+  });
+
+  // Same-chunk head, then more tunnel bytes in a later packet: the later bytes
+  // reach socket 'data' (the head suppression is scoped to the one parse call).
+  test.concurrent("later tunnel bytes after a same-chunk head reach socket 'data'", async () => {
+    const { promise, resolve } = Promise.withResolvers<{ head: string; reqData: string; sockData: string }>();
+    const server = http.createServer((_req, res) => res.end());
+    server.on("upgrade", (req, socket, head) => {
+      let reqData = "";
+      let sockData = "";
+      req.on("data", d => (reqData += d));
+      socket.on("data", d => {
+        sockData += d;
+        socket.end();
+      });
+      socket.on("close", () => resolve({ head: head.toString(), reqData, sockData }));
+    });
+    await once(server.listen(0), "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    const client = net.connect(port, "127.0.0.1");
+    await once(client, "connect");
+    client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLOAFTER");
+    await once(server, "upgrade");
+    client.write("MORE");
+    client.on("end", () => client.end());
+    const result = await promise;
+    expect(result).toEqual({ head: "AFTER", reqData: "HELLO", sockData: "MORE" });
+    await new Promise<void>(r => server.close(() => r()));
+  });
+
+  // c: No-body control. Same as CONNECT: post-header bytes are the head.
+  test.concurrent("no body: head is the post-header remainder", async () => {
+    const result = await observeUpgrade("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\n\r\nAFTER");
+    expect({ head: result.head, reqData: result.reqData, sockData: result.sockData }).toEqual({
+      head: "AFTER",
+      reqData: "",
+      sockData: "",
+    });
+  });
+
+  // d1/d2: Declared body never arrives; the client FINs. Node destroys the
+  // handed-off socket (socket 'close' fires) and server.close() completes.
+  test.concurrent("peer FIN with unsatisfied body: socket closes and server.close() completes", async () => {
+    const { promise: sockClosed, resolve: onSockClose } = Promise.withResolvers<void>();
+    const { promise: srvClosed, resolve: onSrvClose } = Promise.withResolvers<void>();
+    const server = http.createServer((_req, res) => res.end());
+    server.on("upgrade", (req, socket) => {
+      req.on("error", () => {});
+      socket.on("close", onSockClose);
+    });
+    await once(server.listen(0), "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    sendRaw(port, "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\n", true);
+    await sockClosed;
+    server.close(() => onSrvClose());
+    await srvClosed;
+  });
+
+  // Same for a partially-sent body.
+  test.concurrent("peer FIN with partial body: socket closes", async () => {
+    const { promise: sockClosed, resolve: onSockClose } = Promise.withResolvers<void>();
+    const server = http.createServer((_req, res) => res.end());
+    server.on("upgrade", (req, socket) => {
+      req.on("data", () => {});
+      req.on("error", () => {});
+      socket.on("close", onSockClose);
+    });
+    await once(server.listen(0), "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    sendRaw(port, "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHE", true);
+    await sockClosed;
+    await new Promise<void>(r => server.close(() => r()));
+  });
+});
+
+// b: With a completed same-chunk body the pending-request accounting is
+// released once the handler ends the socket, so server.close() completes and
+// the process exits. Spawned so a leak surfaces as a timeout here rather than
+// hanging the suite.
+test.concurrent("process exits after server.close() once an upgrade-with-body socket is ended", async () => {
+  const src = `
+    const http = require("node:http");
+    const net = require("node:net");
+    const server = http.createServer((_req, res) => res.end());
+    server.on("upgrade", (req, socket) => {
+      req.on("data", () => {});
+      req.on("end", () => {
+        socket.end();
+        server.close(() => console.log("srvclose"));
+      });
+    });
+    server.listen(0, () => {
+      const c = net.connect(server.address().port, "127.0.0.1", () => {
+        c.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: Upgrade\\r\\nUpgrade: x\\r\\nContent-Length: 5\\r\\n\\r\\nHELLO");
+      });
+      c.on("end", () => c.end());
+    });
+    setTimeout(() => { console.log("HANG"); process.exit(1); }, 3000).unref();
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("srvclose");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/http/node-http-upgrade-with-body.test.ts
+++ b/test/js/node/http/node-http-upgrade-with-body.test.ts
@@ -228,12 +228,16 @@ describe("node:http 'upgrade' with a request body", () => {
     });
     await once(server.listen(0), "listening");
     const port = (server.address() as net.AddressInfo).port;
+    // Set up before connecting: 'connection' can fire before the awaits below.
+    const serverConnection = once(server, "connection");
     const client = net.connect(port, "127.0.0.1");
     client.on("error", () => {});
+    client.setNoDelay(true);
     try {
       await once(client, "connect");
       client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgra");
-      await once(server, "connection");
+      await serverConnection;
+      await new Promise<void>(r => setImmediate(r));
       client.write("de\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLO" + tail);
       client.end();
       const { reqData, delivered } = await promise;

--- a/test/js/node/http/node-http-upgrade-with-body.test.ts
+++ b/test/js/node/http/node-http-upgrade-with-body.test.ts
@@ -15,6 +15,7 @@ type UpgradeResult = {
   sockData: string;
   completeAtUpgrade: boolean;
   readableLengthAtUpgrade: number;
+  trailersAtUpgrade: Record<string, string>;
 };
 
 function sendRaw(port: number, payload: string, thenEnd = false) {
@@ -38,6 +39,7 @@ async function observeUpgrade(payload: string): Promise<UpgradeResult> {
       sockData: "",
       completeAtUpgrade: req.complete,
       readableLengthAtUpgrade: req.readableLength,
+      trailersAtUpgrade: { ...req.trailers },
     };
     req.on("data", d => (result.reqData += d));
     socket.on("data", d => (result.sockData += d));
@@ -74,6 +76,7 @@ describe("node:http 'upgrade' with a request body", () => {
       sockData: "",
       completeAtUpgrade: true,
       readableLengthAtUpgrade: 5,
+      trailersAtUpgrade: {},
     });
   });
 
@@ -89,6 +92,7 @@ describe("node:http 'upgrade' with a request body", () => {
       sockData: "",
       completeAtUpgrade: true,
       readableLengthAtUpgrade: 5,
+      trailersAtUpgrade: {},
     });
   });
 
@@ -97,10 +101,13 @@ describe("node:http 'upgrade' with a request body", () => {
       "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nTransfer-Encoding: chunked\r\n\r\n" +
         "5\r\nHELLO\r\n0\r\nExtra: abc\r\n\r\nAFTER",
     );
-    expect({ head: result.head, reqData: result.reqData, sockData: result.sockData }).toEqual({
+    expect(result).toEqual({
       head: "AFTER",
       reqData: "HELLO",
       sockData: "",
+      completeAtUpgrade: true,
+      readableLengthAtUpgrade: 5,
+      trailersAtUpgrade: { extra: "abc" },
     });
   });
 
@@ -133,6 +140,7 @@ describe("node:http 'upgrade' with a request body", () => {
         sockData: "",
         completeAtUpgrade: req.complete,
         readableLengthAtUpgrade: req.readableLength,
+        trailersAtUpgrade: { ...req.trailers },
       };
       req.on("data", d => (result.reqData += d));
       socket.on("error", reject);

--- a/test/js/node/http/node-http-upgrade-with-body.test.ts
+++ b/test/js/node/http/node-http-upgrade-with-body.test.ts
@@ -15,7 +15,6 @@ type UpgradeResult = {
   sockData: string;
   completeAtUpgrade: boolean;
   readableLengthAtUpgrade: number;
-  trailersAtUpgrade: Record<string, string>;
 };
 
 function sendRaw(port: number, payload: string, thenEnd = false) {
@@ -39,7 +38,6 @@ async function observeUpgrade(payload: string): Promise<UpgradeResult> {
       sockData: "",
       completeAtUpgrade: req.complete,
       readableLengthAtUpgrade: req.readableLength,
-      trailersAtUpgrade: { ...req.trailers },
     };
     req.on("data", d => (result.reqData += d));
     socket.on("data", d => (result.sockData += d));
@@ -76,39 +74,42 @@ describe("node:http 'upgrade' with a request body", () => {
       sockData: "",
       completeAtUpgrade: true,
       readableLengthAtUpgrade: 5,
-      trailersAtUpgrade: {},
     });
   });
 
-  // Same rule for a chunked body that completes in the same chunk.
-  test.concurrent("same-chunk chunked body: head is the post-body remainder", async () => {
-    const result = await observeUpgrade(
+  // Chunked body: the body is delivered once through req; the post-body
+  // remainder reaches socket 'data' (head is not pre-computed for chunked).
+  test.concurrent("same-chunk chunked body: body reaches req, remainder reaches socket 'data'", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{ head: string; reqData: string; sockData: string }>();
+    const server = http.createServer((_req, res) => res.end());
+    server.on("error", reject);
+    server.on("clientError", reject);
+    server.on("upgrade", (req, socket, head) => {
+      let reqData = "";
+      let sockData = "";
+      req.on("data", d => (reqData += d));
+      socket.on("error", reject);
+      socket.on("data", d => {
+        sockData += d;
+        socket.end();
+      });
+      socket.on("close", () => resolve({ head: head.toString(), reqData, sockData }));
+    });
+    await once(server.listen(0), "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    const client = sendRaw(
+      port,
       "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nTransfer-Encoding: chunked\r\n\r\n" +
         "5\r\nHELLO\r\n0\r\n\r\nAFTER",
     );
-    expect(result).toEqual({
-      head: "AFTER",
-      reqData: "HELLO",
-      sockData: "",
-      completeAtUpgrade: true,
-      readableLengthAtUpgrade: 5,
-      trailersAtUpgrade: {},
-    });
-  });
-
-  test.concurrent("same-chunk chunked body with a trailer section", async () => {
-    const result = await observeUpgrade(
-      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nTransfer-Encoding: chunked\r\n\r\n" +
-        "5\r\nHELLO\r\n0\r\nExtra: abc\r\n\r\nAFTER",
-    );
-    expect(result).toEqual({
-      head: "AFTER",
-      reqData: "HELLO",
-      sockData: "",
-      completeAtUpgrade: true,
-      readableLengthAtUpgrade: 5,
-      trailersAtUpgrade: { extra: "abc" },
-    });
+    client.on("end", () => client.end());
+    try {
+      const { head, reqData, sockData } = await promise;
+      expect({ reqData, delivered: head + sockData }).toEqual({ reqData: "HELLO", delivered: "AFTER" });
+    } finally {
+      client.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
   });
 
   // Body fully in this chunk with nothing after it: head is empty and nothing
@@ -140,7 +141,6 @@ describe("node:http 'upgrade' with a request body", () => {
         sockData: "",
         completeAtUpgrade: req.complete,
         readableLengthAtUpgrade: req.readableLength,
-        trailersAtUpgrade: { ...req.trailers },
       };
       req.on("data", d => (result.reqData += d));
       socket.on("error", reject);

--- a/test/js/node/http/node-http-upgrade-with-body.test.ts
+++ b/test/js/node/http/node-http-upgrade-with-body.test.ts
@@ -27,8 +27,10 @@ function sendRaw(port: number, payload: string, thenEnd = false) {
 }
 
 async function observeUpgrade(payload: string): Promise<UpgradeResult> {
-  const { promise, resolve } = Promise.withResolvers<UpgradeResult>();
+  const { promise, resolve, reject } = Promise.withResolvers<UpgradeResult>();
   const server = http.createServer((_req, res) => res.end());
+  server.on("error", reject);
+  server.on("clientError", reject);
   server.on("upgrade", (req, socket, head) => {
     const result: UpgradeResult = {
       head: head.toString(),
@@ -39,6 +41,7 @@ async function observeUpgrade(payload: string): Promise<UpgradeResult> {
     };
     req.on("data", d => (result.reqData += d));
     socket.on("data", d => (result.sockData += d));
+    socket.on("error", reject);
     req.on("end", () => {
       // Resolve from socket 'close' so any late socket 'data' reaches sockData.
       socket.on("close", () => resolve(result));
@@ -49,9 +52,12 @@ async function observeUpgrade(payload: string): Promise<UpgradeResult> {
   const port = (server.address() as net.AddressInfo).port;
   const client = sendRaw(port, payload);
   client.on("end", () => client.end());
-  const result = await promise;
-  await new Promise<void>(r => server.close(() => r()));
-  return result;
+  try {
+    return await promise;
+  } finally {
+    client.destroy();
+    await new Promise<void>(r => server.close(() => r()));
+  }
 }
 
 describe("node:http 'upgrade' with a request body", () => {
@@ -116,8 +122,10 @@ describe("node:http 'upgrade' with a request body", () => {
   // and once the body's fin arrives the post-body remainder in that later
   // packet reaches socket 'data' (not head).
   test.concurrent("split body: head is empty, later post-body bytes reach socket 'data'", async () => {
-    const { promise, resolve } = Promise.withResolvers<UpgradeResult>();
+    const { promise, resolve, reject } = Promise.withResolvers<UpgradeResult>();
     const server = http.createServer((_req, res) => res.end());
+    server.on("error", reject);
+    server.on("clientError", reject);
     server.on("upgrade", (req, socket, head) => {
       const result: UpgradeResult = {
         head: head.toString(),
@@ -127,6 +135,7 @@ describe("node:http 'upgrade' with a request body", () => {
         readableLengthAtUpgrade: req.readableLength,
       };
       req.on("data", d => (result.reqData += d));
+      socket.on("error", reject);
       socket.on("data", d => {
         result.sockData += d;
         socket.end();
@@ -136,32 +145,40 @@ describe("node:http 'upgrade' with a request body", () => {
     await once(server.listen(0), "listening");
     const port = (server.address() as net.AddressInfo).port;
     const client = net.connect(port, "127.0.0.1");
-    await once(client, "connect");
-    client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\n");
-    // Wait for 'upgrade' to fire before writing the body so it is not coalesced
-    // into the header packet.
-    await once(server, "upgrade");
-    client.write("HELLOAFTER");
-    client.on("end", () => client.end());
-    const result = await promise;
-    expect({ head: result.head, reqData: result.reqData, sockData: result.sockData }).toEqual({
-      head: "",
-      reqData: "HELLO",
-      sockData: "AFTER",
-    });
-    expect(result.completeAtUpgrade).toBe(false);
-    await new Promise<void>(r => server.close(() => r()));
+    client.on("error", () => {});
+    try {
+      await once(client, "connect");
+      client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\n");
+      // Wait for 'upgrade' to fire before writing the body so it is not coalesced
+      // into the header packet.
+      await once(server, "upgrade");
+      client.write("HELLOAFTER");
+      client.on("end", () => client.end());
+      const result = await promise;
+      expect({ head: result.head, reqData: result.reqData, sockData: result.sockData }).toEqual({
+        head: "",
+        reqData: "HELLO",
+        sockData: "AFTER",
+      });
+      expect(result.completeAtUpgrade).toBe(false);
+    } finally {
+      client.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
   });
 
   // Same-chunk head, then more tunnel bytes in a later packet: the later bytes
   // reach socket 'data' (the head suppression is scoped to the one parse call).
   test.concurrent("later tunnel bytes after a same-chunk head reach socket 'data'", async () => {
-    const { promise, resolve } = Promise.withResolvers<{ head: string; reqData: string; sockData: string }>();
+    const { promise, resolve, reject } = Promise.withResolvers<{ head: string; reqData: string; sockData: string }>();
     const server = http.createServer((_req, res) => res.end());
+    server.on("error", reject);
+    server.on("clientError", reject);
     server.on("upgrade", (req, socket, head) => {
       let reqData = "";
       let sockData = "";
       req.on("data", d => (reqData += d));
+      socket.on("error", reject);
       socket.on("data", d => {
         sockData += d;
         socket.end();
@@ -171,16 +188,21 @@ describe("node:http 'upgrade' with a request body", () => {
     await once(server.listen(0), "listening");
     const port = (server.address() as net.AddressInfo).port;
     const client = net.connect(port, "127.0.0.1");
-    await once(client, "connect");
-    client.write(
-      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLOAFTER",
-    );
-    await once(server, "upgrade");
-    client.write("MORE");
-    client.on("end", () => client.end());
-    const result = await promise;
-    expect(result).toEqual({ head: "AFTER", reqData: "HELLO", sockData: "MORE" });
-    await new Promise<void>(r => server.close(() => r()));
+    client.on("error", () => {});
+    try {
+      await once(client, "connect");
+      client.write(
+        "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLOAFTER",
+      );
+      await once(server, "upgrade");
+      client.write("MORE");
+      client.on("end", () => client.end());
+      const result = await promise;
+      expect(result).toEqual({ head: "AFTER", reqData: "HELLO", sockData: "MORE" });
+    } finally {
+      client.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
   });
 
   // c: No-body control. Same as CONNECT: post-header bytes are the head.
@@ -196,39 +218,54 @@ describe("node:http 'upgrade' with a request body", () => {
   // d1/d2: Declared body never arrives; the client FINs. Node destroys the
   // handed-off socket (socket 'close' fires) and server.close() completes.
   test.concurrent("peer FIN with unsatisfied body: socket closes and server.close() completes", async () => {
-    const { promise: sockClosed, resolve: onSockClose } = Promise.withResolvers<void>();
-    const { promise: srvClosed, resolve: onSrvClose } = Promise.withResolvers<void>();
+    const { promise: sockClosed, resolve: onSockClose, reject } = Promise.withResolvers<void>();
     const server = http.createServer((_req, res) => res.end());
+    server.on("error", reject);
     server.on("upgrade", (req, socket) => {
       req.on("error", () => {});
+      socket.on("error", reject);
       socket.on("close", onSockClose);
     });
     await once(server.listen(0), "listening");
     const port = (server.address() as net.AddressInfo).port;
-    sendRaw(port, "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\n", true);
-    await sockClosed;
-    server.close(() => onSrvClose());
-    await srvClosed;
+    const client = sendRaw(
+      port,
+      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\n",
+      true,
+    );
+    try {
+      await sockClosed;
+      await new Promise<void>(r => server.close(() => r()));
+    } finally {
+      client.destroy();
+      server.close();
+    }
   });
 
   // Same for a partially-sent body.
   test.concurrent("peer FIN with partial body: socket closes", async () => {
-    const { promise: sockClosed, resolve: onSockClose } = Promise.withResolvers<void>();
+    const { promise: sockClosed, resolve: onSockClose, reject } = Promise.withResolvers<void>();
     const server = http.createServer((_req, res) => res.end());
+    server.on("error", reject);
     server.on("upgrade", (req, socket) => {
       req.on("data", () => {});
       req.on("error", () => {});
+      socket.on("error", reject);
       socket.on("close", onSockClose);
     });
     await once(server.listen(0), "listening");
     const port = (server.address() as net.AddressInfo).port;
-    sendRaw(
+    const client = sendRaw(
       port,
       "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHE",
       true,
     );
-    await sockClosed;
-    await new Promise<void>(r => server.close(() => r()));
+    try {
+      await sockClosed;
+    } finally {
+      client.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
   });
 });
 

--- a/test/js/node/http/node-http-upgrade-with-body.test.ts
+++ b/test/js/node/http/node-http-upgrade-with-body.test.ts
@@ -205,6 +205,45 @@ describe("node:http 'upgrade' with a request body", () => {
     }
   });
 
+  // Fallback-buffer path: a partial header block in one packet followed by a
+  // large packet (> maxHeaderSize) with the rest of the headers + body + tunnel
+  // tail. Every tunnel byte must reach the listener through head + socket 'data'
+  // combined (the parser's fallback reassembly truncates the head view there, so
+  // the post-body remainder is delivered via socket 'data' instead).
+  test.concurrent("split header block + large tail: no tunnel bytes are dropped", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{ reqData: string; delivered: number }>();
+    const TAIL_LEN = 20000;
+    const tail = Buffer.alloc(TAIL_LEN, "X").toString();
+    const server = http.createServer((_req, res) => res.end());
+    server.on("error", reject);
+    server.on("clientError", reject);
+    server.on("upgrade", (req, socket, head) => {
+      let reqData = "";
+      let sockBytes = 0;
+      req.on("data", d => (reqData += d));
+      socket.on("data", d => (sockBytes += d.length));
+      socket.on("error", reject);
+      socket.on("end", () => socket.end());
+      socket.on("close", () => resolve({ reqData, delivered: head.length + sockBytes }));
+    });
+    await once(server.listen(0), "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    const client = net.connect(port, "127.0.0.1");
+    client.on("error", () => {});
+    try {
+      await once(client, "connect");
+      client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgra");
+      await once(server, "connection");
+      client.write("de\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLO" + tail);
+      client.end();
+      const { reqData, delivered } = await promise;
+      expect({ reqData, delivered }).toEqual({ reqData: "HELLO", delivered: TAIL_LEN });
+    } finally {
+      client.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
   // c: No-body control. Same as CONNECT: post-header bytes are the head.
   test.concurrent("no body: head is the post-header remainder", async () => {
     const result = await observeUpgrade("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\n\r\nAFTER");

--- a/test/js/node/http/node-http-upgrade-with-body.test.ts
+++ b/test/js/node/http/node-http-upgrade-with-body.test.ts
@@ -3,11 +3,11 @@
 // buffered on req with req.complete === true, and a peer FIN with an
 // unsatisfied body tears the handed-off socket down instead of leaking the
 // pending-request ref.
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { once } from "node:events";
 import http from "node:http";
 import net from "node:net";
-import { once } from "node:events";
 
 type UpgradeResult = {
   head: string;
@@ -172,7 +172,9 @@ describe("node:http 'upgrade' with a request body", () => {
     const port = (server.address() as net.AddressInfo).port;
     const client = net.connect(port, "127.0.0.1");
     await once(client, "connect");
-    client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLOAFTER");
+    client.write(
+      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHELLOAFTER",
+    );
     await once(server, "upgrade");
     client.write("MORE");
     client.on("end", () => client.end());
@@ -220,7 +222,11 @@ describe("node:http 'upgrade' with a request body", () => {
     });
     await once(server.listen(0), "listening");
     const port = (server.address() as net.AddressInfo).port;
-    sendRaw(port, "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHE", true);
+    sendRaw(
+      port,
+      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nContent-Length: 5\r\n\r\nHE",
+      true,
+    );
     await sockClosed;
     await new Promise<void>(r => server.close(() => r()));
   });


### PR DESCRIPTION
## Problem

```js
const server = http.createServer();
server.on('upgrade', (req, socket, head) => {
  // CL:5 + 'HELLOAFTER' in one packet:
  // Node: head === 'AFTER', req.complete === true, req.readableLength === 5
  // Bun:  head === '',      req.complete === false, 'AFTER' -> socket.on('data')
});
```

Node emits `'upgrade'` after the `parser.execute()` that consumed the header block returns: any declared body bytes present in that same chunk are already buffered on `req` (with `req.complete === true`), and `head` is the chunk remainder **after** the body. Bun emitted `'upgrade'` before body parsing with an empty head, then routed the same-chunk remainder to the socket's raw-data path.

Separately, a peer FIN with the declared body unsatisfied left the tunnel-after-body socket half-open and the pending-request ref unreleased, so `server.close()` never completed.

## Fix

- `HttpParser.h`: for a body-carrying Upgrade, pre-compute `req->head` as the post-body slice of this chunk (Content-Length arithmetic; for a chunked body, a local-state pre-scan of the same bytes) and set `bodyCompleteInHead` when the body completes in-chunk.
- `HttpContext.h`: set `HTTP_NODE_TUNNEL_HEAD_PENDING` when `bodyCompleteInHead` and the dispatcher accepted the upgrade, and skip the one `onSocketData` call for the same-chunk remainder (cleared at end of each `onData`, so later packets flow normally). `onEnd` now closes the connection when the body never completed (Node's `UpgradeStream` wraps a socket whose `socketOnEnd` still `socket.end()`s here).
- `_http_server.ts`: pass `connectHead` through as `head` (native already sliced it). When `bodyCompleteInHead`, defer the `'upgrade'` emit to the body fin in `onDataIncomingMessage` so the listener observes `req.complete` and the buffered body like Node.

## Verification

`test/js/node/http/node-http-upgrade-with-body.test.ts` covers: same-chunk CL / chunked / chunked-with-trailer (head="AFTER"), same-chunk no-remainder (head=""), split body (head="", later bytes -> socket data), later tunnel bytes after a same-chunk head, unsatisfied-body FIN (socket closes, `server.close()` completes), and a spawned process-exit check. All pass under this change and under Node v26; 8/10 fail or hang on main.

All `test/js/node/test/parallel/test-http-upgrade-*` and `test-http-connect*` continue to pass.

Supersedes #35974 (CL-only, JS-side slice) and #35063 (the onEnd close half): this handles chunked bodies and matches Node's emit timing (`req.complete` / `readableLength` at `'upgrade'` time).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-upgrade-with-body.test.ts
bun test v1.4.0 (57f25c79c)

test/js/node/http/node-http-upgrade-with-body.test.ts:
204 |       );
205 |       await once(server, "upgrade");
206 |       client.write("MORE");
207 |       client.on("end", () => client.end());
208 |       const result = await promise;
209 |       expect(result).toEqual({ head: "AFTER", reqData: "HELLO", sockData: "MORE" });
                           ^
error: expect(received).toEqual(expected)

  {
-   "head": "AFTER",
+   "head": "",
    "reqData": "HELLO",
-   "sockData": "MORE",
+   "sockData": "AFTER",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-upgrade-with-body.test.ts:209:22)
66 |   // once through req, and does not surface the remainder on socket 'data'.
67 |   test.concurrent("same-chunk Content-Length body: head is the post-body remainder", async () => {
68 |     const result = await observeUpgrade(
69 |       "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: x\r\nConten
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (57f25c79c)

test/js/node/http/node-http-upgrade-with-body.test.ts:
(pass) node:http 'upgrade' with a request body > peer FIN with unsatisfied body: socket closes and server.close() completes [16.39ms]
(pass) node:http 'upgrade' with a request body > same-chunk Content-Length body: head is the post-body remainder [23.69ms]
(pass) node:http 'upgrade' with a request body > same-chunk body with no remainder: head is empty [20.52ms]
(pass) node:http 'upgrade' with a request body > no body: head is the post-header remainder [17.93ms]
(pass) node:http 'upgrade' with a request body > peer FIN with partial body: socket closes [16.87ms]
(pass) node:http 'upgrade' with a request body > same-chunk chunked body: body reaches req, remainder reaches socket 'data' [21.19ms]
(pass) node:http 'upgrade' with a request body > split header block + large tail: no tunnel bytes are dropped [18.65ms]
(pass) node:http 'upgrade' with a request body > split body: head is empty, later post-body bytes reach socket 'data' [20.37ms]
(pass) node:http 'upgrade' with a request body > later tunnel bytes after a same-chunk head reach socket 'data' [19.74ms]
(pass) process exit
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-upgrade-with-body.test.ts
bun test v1.4.0 (57f25c79c)

test/js/node/http/node-http-upgrade-with-body.test.ts:
(pass) node:http 'upgrade' with a request body > same-chunk Content-Length body: head is the post-body remainder [922.56ms]
(pass) node:http 'upgrade' with a request body > same-chunk body with no remainder: head is empty [834.10ms]
(pass) node:http 'upgrade' with a request body > same-chunk chunked body: body reaches req, remainder reaches socket 'data' [877.98ms]
(pass) node:http 'upgrade' with a request body > split body: head is empty, later post-body bytes reach socket 'data' [926.08ms]
(pass) node:http 'upgrade' with a request body > later tunnel bytes after a same-chunk head reach socket 'data' [922.81ms]
(pass) node:http 'upgrade' with a request body > peer FIN with unsatisfied body: socket closes and server.close() completes [291.61ms]
(pass) node:http 'upgrade' with a request body > no body: head is the post-header remainder [353.16ms]
(pass) node:http 'upgrade' with a request body > peer F
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 704ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen cpp.rs (cppbind)
[2/26] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/26] gen JS modules (bundle-modules)
Preprocess modules (9154ms)
Bundle modules (47ms)
Postprocesss modules (169ms)
Bundle Functions (724ms)
Generate Code (21ms)

[10.13s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/14] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_io v0.0.0 (/workspace/bun/src/io)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_zlib v0.0.0 (/workspace/bun/src/zlib)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpContext.h                 |  27 +-
 packages/bun-uws/src/HttpParser.h                  |  21 +-
 packages/bun-uws/src/HttpResponseData.h            |   5 +
 src/js/internal/http.ts                            |  12 +
 src/js/node/_http_server.ts                        |  59 ++--
 src/jsc/bindings/NodeHTTP.cpp                      |   1 +
 .../node/http/node-http-upgrade-with-body.test.ts  | 356 +++++++++++++++++++++
 7 files changed, 450 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 6 passed · 2 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
packages/bun-uws/src/HttpContext.h                        10     12      0
packages/bun-uws/src/HttpParser.h                         11     13      0
packages/bun-uws/src/HttpResponseData.h                    1      1      0
src/js/internal/http.ts                                    6      7      0
src/js/node/_http_server.ts                               10      8      0
src/jsc/bindings/NodeHTTP.cpp                              3      1      0
test/js/node/http/node-http-upgrade-with-body.test.ts      4     18      0
```

</details>

<!-- robobun:evidence:end -->