### PR TITLE
node:vm: only convert a termination this evaluation raised

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -98,9 +98,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             nodeVmGlobalObject->drainOwnMicrotasks();
             if (watchdog)
                 watchdog->disarm();
-            // The drain may legitimately leave the termination exception
-            // pending; observe it so the exception-check validator is
-            // satisfied before the TOP scope inside checkForTermination.
+            // Satisfy the exception-check validator before checkForTermination's TOP scope.
             std::ignore = scope.exception();
             if (checkForTermination(vm, globalObject, scope, this, watchdog ? &*watchdog : nullptr))
                 return {};
@@ -225,16 +223,11 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     if (watchdog)
         watchdog->disarm();
 
-    // Evaluation (or the afterEvaluate drain) may leave an exception pending;
-    // observe it so the exception-check validator is satisfied before the TOP
-    // scope inside checkForTermination.
+    // Satisfy the exception-check validator before checkForTermination's TOP scope.
     std::ignore = scope.exception();
     if (checkForTermination(vm, globalObject, scope, this, watchdog ? &*watchdog : nullptr)) {
-        // A foreign termination leaves the uncatchable TerminationException
-        // pending. Do not record that singleton as this module's evaluation
-        // error: re-throwing it later from the Status::Errored branch is
-        // uncatchable and trips VM::setException's isTerminationException
-        // assert when no termination request is armed.
+        // Never store the TerminationException singleton as m_evaluationException;
+        // re-throwing it later is uncatchable and asserts in VM::setException.
         if (vm.hasPendingTerminationException())
             return {};
     } else {

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -8,8 +8,7 @@
 #include "JavaScriptCore/Exception.h"
 #include "JavaScriptCore/JSModuleRecord.h"
 #include "JavaScriptCore/JSPromise.h"
-#include "JavaScriptCore/Watchdog.h"
-
+#include "../vm/NodeVMWatchdogScope.h"
 #include "../vm/SigintWatcher.h"
 
 namespace Bun {
@@ -50,7 +49,7 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
     return array;
 }
 
-void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout);
+bool checkForTermination(JSC::VM&, JSC::JSGlobalObject*, JSC::ThrowScope&, SigintReceiver*, NodeVMWatchdogScope*);
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
@@ -93,29 +92,19 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         NodeVMGlobalObject* nodeVmGlobalObject = NodeVM::getGlobalObjectFromContext(globalObject, m_context.get(), false);
         RETURN_IF_EXCEPTION(scope, {});
         if (nodeVmGlobalObject && nodeVmGlobalObject->hasOwnMicrotaskQueue()) {
-            std::optional<double> oldLimit;
+            std::optional<NodeVMWatchdogScope> watchdog;
             if (timeout != 0)
-                setupWatchdog(vm, timeout, &oldLimit.emplace(), nullptr);
+                watchdog.emplace(vm, timeout);
             nodeVmGlobalObject->drainOwnMicrotasks();
-            if (timeout != 0)
-                vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
+            if (watchdog)
+                watchdog->disarm();
             // The drain may legitimately leave the termination exception
-            // pending (watchdog fired mid-checkpoint); observe it so the
-            // exception-check validator is satisfied before the TOP scope
-            // below, then convert it to ERR_SCRIPT_EXECUTION_*.
+            // pending; observe it so the exception-check validator is
+            // satisfied before the TOP scope inside checkForTermination.
             std::ignore = scope.exception();
-            if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-                vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-                DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-                vm.clearHasTerminationRequest();
-                if (getSigintReceived()) {
-                    setSigintReceived(false);
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-                } else {
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-                }
+            if (checkForTermination(vm, globalObject, scope, this, watchdog ? &*watchdog : nullptr))
                 return {};
-            }
+            RETURN_IF_EXCEPTION(scope, {});
         }
         return m_evaluationResult.get();
     }
@@ -220,11 +209,9 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
 
     setSigintReceived(false);
 
-    std::optional<double> oldLimit, newLimit;
-
-    if (timeout != 0) {
-        setupWatchdog(vm, timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
+    std::optional<NodeVMWatchdogScope> watchdog;
+    if (timeout != 0)
+        watchdog.emplace(vm, timeout);
 
     if (breakOnSigint) {
         auto holder = SigintWatcher::hold(nodeVmGlobalObject, this);
@@ -235,30 +222,15 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         drainAfterEvaluate();
     }
 
-    if (timeout != 0) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
-    }
+    if (watchdog)
+        watchdog->disarm();
 
-    // Evaluation (or the afterEvaluate drain) may leave an exception pending
-    // — a regular one is rethrown by VM_RETURN_IF_EXCEPTION below, a
-    // termination one is converted to ERR_SCRIPT_EXECUTION_* here. Observe it
-    // so the exception-check validator is satisfied before the TOP scope.
+    // Evaluation (or the afterEvaluate drain) may leave an exception pending;
+    // observe it so the exception-check validator is satisfied before the TOP
+    // scope inside checkForTermination.
     std::ignore = scope.exception();
-    if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-        vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (getSigintReceived()) {
-            setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout != 0) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
-        }
-    } else {
+    if (!checkForTermination(vm, globalObject, scope, this, watchdog ? &*watchdog : nullptr))
         setSigintReceived(false);
-    }
 
     VM_RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -49,8 +49,6 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
     return array;
 }
 
-bool checkForTermination(JSC::VM&, JSC::JSGlobalObject*, JSC::ThrowScope&, SigintReceiver*, NodeVMWatchdogScope*);
-
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
     if (m_status != Status::Evaluating)
@@ -100,7 +98,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
                 watchdog->disarm();
             // Satisfy the exception-check validator before checkForTermination's TOP scope.
             std::ignore = scope.exception();
-            if (checkForTermination(vm, globalObject, scope, this, watchdog ? &*watchdog : nullptr))
+            if (checkForTermination(vm, nodeVmGlobalObject, scope, this, watchdog ? &*watchdog : nullptr))
                 return {};
             RETURN_IF_EXCEPTION(scope, {});
         }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -229,8 +229,17 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // observe it so the exception-check validator is satisfied before the TOP
     // scope inside checkForTermination.
     std::ignore = scope.exception();
-    if (!checkForTermination(vm, globalObject, scope, this, watchdog ? &*watchdog : nullptr))
+    if (checkForTermination(vm, globalObject, scope, this, watchdog ? &*watchdog : nullptr)) {
+        // A foreign termination leaves the uncatchable TerminationException
+        // pending. Do not record that singleton as this module's evaluation
+        // error: re-throwing it later from the Status::Errored branch is
+        // uncatchable and trips VM::setException's isTerminationException
+        // assert when no termination request is armed.
+        if (vm.hasPendingTerminationException())
+            return {};
+    } else {
         setSigintReceived(false);
+    }
 
     VM_RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -98,7 +98,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
                 watchdog->disarm();
             // Satisfy the exception-check validator before checkForTermination's TOP scope.
             std::ignore = scope.exception();
-            if (checkForTermination(vm, nodeVmGlobalObject, scope, this, watchdog ? &*watchdog : nullptr))
+            if (checkForTermination(vm, globalObject, nodeVmGlobalObject, scope, this, watchdog ? &*watchdog : nullptr))
                 return {};
             RETURN_IF_EXCEPTION(scope, {});
         }
@@ -223,7 +223,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
 
     // Satisfy the exception-check validator before checkForTermination's TOP scope.
     std::ignore = scope.exception();
-    if (checkForTermination(vm, globalObject, scope, this, watchdog ? &*watchdog : nullptr)) {
+    if (checkForTermination(vm, globalObject, nodeVmGlobalObject, scope, this, watchdog ? &*watchdog : nullptr)) {
         // Never store the TerminationException singleton as m_evaluationException;
         // re-throwing it later is uncatchable and asserts in VM::setException.
         if (vm.hasPendingTerminationException())

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -309,7 +309,7 @@ void NodeVMScript::destroy(JSCell* cell)
 
 thread_local NodeVMWatchdogScope* NodeVMWatchdogScope::s_innermost { nullptr };
 
-bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, SigintReceiver* receiver, NodeVMWatchdogScope* watchdog)
+bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSGlobalObject* evaluationGlobalObject, JSC::ThrowScope& scope, SigintReceiver* receiver, NodeVMWatchdogScope* watchdog)
 {
     if (!vm.hasTerminationRequest())
         return false;
@@ -323,7 +323,8 @@ bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Th
         return true;
     }
 
-    vm.drainMicrotasksForGlobalObject(globalObject);
+    // clearForGlobalObject(nullptr) is a no-op.
+    vm.drainMicrotasksForGlobalObject(evaluationGlobalObject);
     if (vm.hasPendingTerminationException())
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
     vm.clearHasTerminationRequest();
@@ -388,7 +389,7 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
     if (watchdog)
         watchdog->disarm();
 
-    if (checkForTermination(vm, globalObject, scope, script, watchdog ? &*watchdog : nullptr)) {
+    if (checkForTermination(vm, globalObject, globalObject, scope, script, watchdog ? &*watchdog : nullptr)) {
         return {};
     }
 
@@ -452,7 +453,7 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
     if (watchdog)
         watchdog->disarm();
 
-    if (checkForTermination(vm, globalObject, scope, script, watchdog ? &*watchdog : nullptr)) {
+    if (checkForTermination(vm, globalObject, nullptr, scope, script, watchdog ? &*watchdog : nullptr)) {
         return {};
     }
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -11,6 +11,7 @@
 #include "JavaScriptCore/SourceCodeKey.h"
 
 #include "NodeVMScriptFetcher.h"
+#include "../vm/NodeVMWatchdogScope.h"
 #include "../vm/SigintWatcher.h"
 
 #include <bit>
@@ -306,51 +307,38 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
-static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
+thread_local NodeVMWatchdogScope* NodeVMWatchdogScope::s_innermost { nullptr };
+
+bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, SigintReceiver* receiver, NodeVMWatchdogScope* watchdog)
 {
-    if (vm.hasTerminationRequest()) {
-        vm.drainMicrotasksForGlobalObject(globalObject);
-        // The termination may have fired inside an afterEvaluate microtask
-        // checkpoint, leaving the termination exception pending; clear it so
-        // the ERR_SCRIPT_EXECUTION_* error below replaces it.
-        if (vm.hasPendingTerminationException())
-            DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (script->getSigintReceived()) {
-            script->setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
-        }
+    if (!vm.hasTerminationRequest())
+        return false;
+
+    bool sigint = receiver->getSigintReceived();
+    bool timedOut = watchdog && watchdog->timedOut();
+    if (!sigint && !timedOut) {
+        // A foreign termination (worker.terminate(), process.exit() inside the
+        // worker, or an enclosing evaluation's watchdog/SIGINT). Leave the
+        // request set and propagate the uncatchable TerminationException so
+        // whoever raised it handles the unwind.
+        scope.throwException(globalObject, vm.ensureTerminationException());
         return true;
     }
 
-    return false;
-}
-
-void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout)
-{
-    JSC::JSLockHolder locker(vm);
-    JSC::Watchdog& dog = vm.ensureWatchdog();
-    dog.enteredVM();
-
-    Seconds oldLimit = dog.getTimeLimit();
-
-    if (oldTimeout) {
-        *oldTimeout = oldLimit.milliseconds();
-    }
-
-    if (oldLimit.isInfinity() || timeout < oldLimit.milliseconds()) {
-        dog.setTimeLimit(WTF::Seconds::fromMilliseconds(timeout));
+    vm.drainMicrotasksForGlobalObject(globalObject);
+    // The termination may have fired inside an afterEvaluate microtask
+    // checkpoint, leaving the termination exception pending; clear it so
+    // the ERR_SCRIPT_EXECUTION_* error below replaces it.
+    if (vm.hasPendingTerminationException())
+        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+    vm.clearHasTerminationRequest();
+    if (sigint) {
+        receiver->setSigintReceived(false);
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
     } else {
-        timeout = oldLimit.milliseconds();
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, watchdog->milliseconds(), "ms"_s));
     }
-
-    if (newTimeout) {
-        *newTimeout = timeout;
-    }
+    return true;
 }
 
 static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVMScript* script, JSObject* contextifiedObject, JSValue optionsArg, bool allowStringInPlaceOfOptions = false)
@@ -379,11 +367,9 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         result = JSC::evaluate(globalObject, script->source(), globalObject, exception);
     };
 
-    std::optional<double> oldLimit, newLimit;
-
-    if (options.timeout) {
-        setupWatchdog(vm, *options.timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
+    std::optional<NodeVMWatchdogScope> watchdog;
+    if (options.timeout)
+        watchdog.emplace(vm, *options.timeout);
 
     script->setSigintReceived(false);
 
@@ -404,11 +390,10 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         drainAfterEvaluate();
     }
 
-    if (options.timeout) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
-    }
+    if (watchdog)
+        watchdog->disarm();
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, scope, script, watchdog ? &*watchdog : nullptr)) {
         return {};
     }
 
@@ -455,11 +440,9 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         result = JSC::evaluate(globalObject, script->source(), globalObject, exception);
     };
 
-    std::optional<double> oldLimit, newLimit;
-
-    if (options.timeout) {
-        setupWatchdog(vm, *options.timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
+    std::optional<NodeVMWatchdogScope> watchdog;
+    if (options.timeout)
+        watchdog.emplace(vm, *options.timeout);
 
     script->setSigintReceived(false);
 
@@ -471,11 +454,10 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         run();
     }
 
-    if (options.timeout) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
-    }
+    if (watchdog)
+        watchdog->disarm();
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, scope, script, watchdog ? &*watchdog : nullptr)) {
         return {};
     }
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -309,6 +309,8 @@ void NodeVMScript::destroy(JSCell* cell)
 
 thread_local NodeVMWatchdogScope* NodeVMWatchdogScope::s_innermost { nullptr };
 
+extern "C" int Bun__VM__scriptExecutionStatus(void*);
+
 bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSGlobalObject* evaluationGlobalObject, JSC::ThrowScope& scope, SigintReceiver* receiver, NodeVMWatchdogScope* watchdog)
 {
     if (!vm.hasTerminationRequest())
@@ -316,7 +318,11 @@ bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JS
 
     bool sigint = receiver->getSigintReceived();
     bool timedOut = watchdog && watchdog->timedOut();
-    if (!sigint && !timedOut) {
+    // requested_terminate is stored (Release) before notifyNeedTermination, so
+    // a terminate() that raced this scope's own watchdog fire is visible here
+    // even though timedOut is also true.
+    bool stopping = Bun__VM__scriptExecutionStatus(WebCore::clientData(vm)->bunVM) != 0;
+    if (stopping || (!sigint && !timedOut)) {
         // Not ours: leave the request set and propagate the uncatchable
         // TerminationException to whoever raised it.
         scope.throwException(globalObject, vm.ensureTerminationException());

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -317,18 +317,13 @@ bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Th
     bool sigint = receiver->getSigintReceived();
     bool timedOut = watchdog && watchdog->timedOut();
     if (!sigint && !timedOut) {
-        // A foreign termination (worker.terminate(), process.exit() inside the
-        // worker, or an enclosing evaluation's watchdog/SIGINT). Leave the
-        // request set and propagate the uncatchable TerminationException so
-        // whoever raised it handles the unwind.
+        // Not ours: leave the request set and propagate the uncatchable
+        // TerminationException to whoever raised it.
         scope.throwException(globalObject, vm.ensureTerminationException());
         return true;
     }
 
     vm.drainMicrotasksForGlobalObject(globalObject);
-    // The termination may have fired inside an afterEvaluate microtask
-    // checkpoint, leaving the termination exception pending; clear it so
-    // the ERR_SCRIPT_EXECUTION_* error below replaces it.
     if (vm.hasPendingTerminationException())
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
     vm.clearHasTerminationRequest();

--- a/src/jsc/bindings/vm/NodeVMWatchdogScope.h
+++ b/src/jsc/bindings/vm/NodeVMWatchdogScope.h
@@ -6,15 +6,10 @@
 
 namespace Bun {
 
-// RAII wrapper around the JSC Watchdog for a single node:vm `{timeout}`
-// evaluation. Installs a ShouldTerminateCallback that records whether the
-// watchdog itself raised the termination, so the post-evaluation check can
-// tell its own timeout apart from a foreign termination (worker.terminate(),
-// process.exit() inside the worker, or an enclosing evaluation's watchdog).
-//
-// Scopes nest strictly, tracked through a thread_local innermost pointer so
-// disarm() can re-install the enclosing scope's callback when restoring the
-// previous limit.
+// Arms the JSC Watchdog for one node:vm `{timeout}` evaluation and records,
+// via ShouldTerminateCallback, whether the watchdog itself fired. Lets
+// checkForTermination tell its own timeout apart from a foreign termination
+// (worker.terminate(), process.exit(), an enclosing evaluation's watchdog).
 class NodeVMWatchdogScope {
     WTF_MAKE_NONCOPYABLE(NodeVMWatchdogScope);
     WTF_MAKE_NONMOVABLE(NodeVMWatchdogScope);

--- a/src/jsc/bindings/vm/NodeVMWatchdogScope.h
+++ b/src/jsc/bindings/vm/NodeVMWatchdogScope.h
@@ -6,6 +6,8 @@
 
 namespace Bun {
 
+class SigintReceiver;
+
 // Arms the JSC Watchdog for one node:vm `{timeout}` evaluation and records,
 // via ShouldTerminateCallback, whether the watchdog itself fired. Lets
 // checkForTermination tell its own timeout apart from a foreign termination
@@ -24,10 +26,15 @@ public:
         dog.enteredVM();
         m_previousLimit = dog.getTimeLimit();
         WTF::Seconds limit = WTF::Seconds::fromMilliseconds(milliseconds);
-        if (!m_previousLimit.isInfinity() && m_previousLimit < limit)
+        // When the enclosing scope's limit is at least as tight, a fire at
+        // that limit belongs to the enclosing scope: leave its callback armed
+        // so the fire sets m_enclosing->m_timedOut, not ours.
+        m_installed = m_previousLimit.isInfinity() || limit < m_previousLimit;
+        if (m_installed)
+            dog.setTimeLimit(limit, &didFire, this, nullptr);
+        else
             limit = m_previousLimit;
         m_milliseconds = limit.milliseconds();
-        dog.setTimeLimit(limit, &didFire, this, nullptr);
         s_innermost = this;
     }
 
@@ -38,7 +45,8 @@ public:
         if (std::exchange(m_disarmed, true))
             return;
         s_innermost = m_enclosing;
-        m_vm.watchdog()->setTimeLimit(m_previousLimit, m_enclosing ? &didFire : nullptr, m_enclosing, nullptr);
+        if (m_installed)
+            m_vm.watchdog()->setTimeLimit(m_previousLimit, m_enclosing ? &didFire : nullptr, m_enclosing, nullptr);
     }
 
     bool timedOut() const { return m_timedOut; }
@@ -58,7 +66,10 @@ private:
     WTF::Seconds m_previousLimit { WTF::Seconds::infinity() };
     double m_milliseconds { 0 };
     bool m_timedOut { false };
+    bool m_installed { false };
     bool m_disarmed { false };
 };
+
+bool checkForTermination(JSC::VM&, JSC::JSGlobalObject*, JSC::ThrowScope&, SigintReceiver*, NodeVMWatchdogScope*);
 
 } // namespace Bun

--- a/src/jsc/bindings/vm/NodeVMWatchdogScope.h
+++ b/src/jsc/bindings/vm/NodeVMWatchdogScope.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "root.h"
+
+#include "JavaScriptCore/Watchdog.h"
+
+namespace Bun {
+
+// RAII wrapper around the JSC Watchdog for a single node:vm `{timeout}`
+// evaluation. Installs a ShouldTerminateCallback that records whether the
+// watchdog itself raised the termination, so the post-evaluation check can
+// tell its own timeout apart from a foreign termination (worker.terminate(),
+// process.exit() inside the worker, or an enclosing evaluation's watchdog).
+//
+// Scopes nest strictly, tracked through a thread_local innermost pointer so
+// disarm() can re-install the enclosing scope's callback when restoring the
+// previous limit.
+class NodeVMWatchdogScope {
+    WTF_MAKE_NONCOPYABLE(NodeVMWatchdogScope);
+    WTF_MAKE_NONMOVABLE(NodeVMWatchdogScope);
+
+public:
+    NodeVMWatchdogScope(JSC::VM& vm, double milliseconds)
+        : m_vm(vm)
+        , m_enclosing(s_innermost)
+    {
+        JSC::JSLockHolder locker(vm);
+        JSC::Watchdog& dog = vm.ensureWatchdog();
+        dog.enteredVM();
+        m_previousLimit = dog.getTimeLimit();
+        WTF::Seconds limit = WTF::Seconds::fromMilliseconds(milliseconds);
+        if (!m_previousLimit.isInfinity() && m_previousLimit < limit)
+            limit = m_previousLimit;
+        m_milliseconds = limit.milliseconds();
+        dog.setTimeLimit(limit, &didFire, this, nullptr);
+        s_innermost = this;
+    }
+
+    ~NodeVMWatchdogScope() { disarm(); }
+
+    void disarm()
+    {
+        if (std::exchange(m_disarmed, true))
+            return;
+        s_innermost = m_enclosing;
+        m_vm.watchdog()->setTimeLimit(m_previousLimit, m_enclosing ? &didFire : nullptr, m_enclosing, nullptr);
+    }
+
+    bool timedOut() const { return m_timedOut; }
+    double milliseconds() const { return m_milliseconds; }
+
+private:
+    static bool didFire(JSC::JSGlobalObject*, void* self, void*)
+    {
+        static_cast<NodeVMWatchdogScope*>(self)->m_timedOut = true;
+        return true;
+    }
+
+    static thread_local NodeVMWatchdogScope* s_innermost;
+
+    JSC::VM& m_vm;
+    NodeVMWatchdogScope* m_enclosing;
+    WTF::Seconds m_previousLimit { WTF::Seconds::infinity() };
+    double m_milliseconds { 0 };
+    bool m_timedOut { false };
+    bool m_disarmed { false };
+};
+
+} // namespace Bun

--- a/src/jsc/bindings/vm/NodeVMWatchdogScope.h
+++ b/src/jsc/bindings/vm/NodeVMWatchdogScope.h
@@ -70,6 +70,10 @@ private:
     bool m_disarmed { false };
 };
 
-bool checkForTermination(JSC::VM&, JSC::JSGlobalObject*, JSC::ThrowScope&, SigintReceiver*, NodeVMWatchdogScope*);
+// `globalObject` is the realm the ERR_SCRIPT_EXECUTION_* error is created in.
+// `evaluationGlobalObject` is the vm context whose still-queued microtasks are
+// discarded on an owned termination; pass null when the evaluation ran in the
+// caller's own global so unrelated caller microtasks are not dropped.
+bool checkForTermination(JSC::VM&, JSC::JSGlobalObject* globalObject, JSC::JSGlobalObject* evaluationGlobalObject, JSC::ThrowScope&, SigintReceiver*, NodeVMWatchdogScope*);
 
 } // namespace Bun

--- a/src/jsc/bindings/vm/NodeVMWatchdogScope.h
+++ b/src/jsc/bindings/vm/NodeVMWatchdogScope.h
@@ -45,8 +45,14 @@ public:
         if (std::exchange(m_disarmed, true))
             return;
         s_innermost = m_enclosing;
-        if (m_installed)
-            m_vm.watchdog()->setTimeLimit(m_previousLimit, m_enclosing ? &didFire : nullptr, m_enclosing, nullptr);
+        if (!m_installed)
+            return;
+        // Restore to the nearest ancestor that actually armed the Watchdog;
+        // a non-installed ancestor never owned the callback.
+        NodeVMWatchdogScope* owner = m_enclosing;
+        while (owner && !owner->m_installed)
+            owner = owner->m_enclosing;
+        m_vm.watchdog()->setTimeLimit(m_previousLimit, owner ? &didFire : nullptr, owner, nullptr);
     }
 
     bool timedOut() const { return m_timedOut; }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1430,4 +1430,32 @@ describe.concurrent("node:vm nested evaluation propagates an enclosing terminati
       `),
     ).toEqual({ stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive", stderr: "", exitCode: 0, signalCode: null });
   });
+
+  test("outer timeout fires inside a SourceTextModule evaluation: re-evaluate stays catchable", async () => {
+    // The inner module's post-evaluation check propagates the foreign
+    // termination but must not record the VM's TerminationException singleton
+    // as the module's evaluation error: re-throwing that singleton from the
+    // errored-module branch is uncatchable (and asserts under debug JSC).
+    expect(
+      await run(`
+        const vm = require("node:vm");
+        (async () => {
+          const ctx = vm.createContext({ t0: Date.now(), Date });
+          const mod = new vm.SourceTextModule("while (Date.now() - t0 < 10000);", { context: ctx });
+          await mod.link(() => {});
+          try { vm.runInNewContext("m.evaluate()", { m: mod }, { timeout: 70 }); }
+          catch (e) { console.log("outer:" + (e && e.code)); }
+          console.log("status=" + mod.status);
+          try { await mod.evaluate(); console.log("re-eval:resolved"); }
+          catch { console.log("re-eval:rejected"); }
+          console.log("alive");
+        })();
+      `),
+    ).toEqual({
+      stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nstatus=errored\nre-eval:rejected\nalive",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1446,6 +1446,35 @@ describe.concurrent("node:vm nested evaluation propagates an enclosing terminati
     ).toEqual({ stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive", stderr: "", exitCode: 0, signalCode: null });
   });
 
+  test("a context-less SourceTextModule's own timeout does not discard the caller's pending microtasks", async () => {
+    // vm.drainMicrotasksForGlobalObject discards (not runs) queued microtasks
+    // for the given global. For a module with no {context}, passing the
+    // caller's global there would drop the unrelated `await` continuations
+    // that were already queued before the spinning evaluate() grabbed the
+    // thread, so they never resume.
+    const { stdout, stderr, exitCode, signalCode } = await run(`
+      const vm = require("node:vm");
+      (async () => {
+        const m = new vm.SourceTextModule("globalThis.__hit = true;");
+        await m.link(() => {});
+        await m.evaluate();
+        console.log("sibling:done hit=" + globalThis.__hit);
+      })();
+      (async () => {
+        const m = new vm.SourceTextModule("while (true) {}");
+        await m.link(() => {});
+        try { await m.evaluate({ timeout: 200 }); console.log("timed:UNEXPECTED"); }
+        catch (e) { console.log("timed:" + (e && e.code)); }
+      })();
+    `);
+    expect({ lines: stdout.split("\n").sort(), stderr, exitCode, signalCode }).toEqual({
+      lines: ["sibling:done hit=true", "timed:ERR_SCRIPT_EXECUTION_TIMEOUT"],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
   test("outer timeout fires inside a SourceTextModule evaluation: re-evaluate stays catchable", async () => {
     // The inner module's post-evaluation check propagates the foreign
     // termination but must not record the VM's TerminationException singleton

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1430,6 +1430,25 @@ describe.concurrent("node:vm nested evaluation propagates an enclosing terminati
     ).toEqual({ stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive", stderr: "", exitCode: 0, signalCode: null });
   });
 
+  test("three-level nesting: outer's fire after a tighter inner disarms is attributed to outer", async () => {
+    // outer{100ms} / middle{60000ms, clamped so not installed} / inner{50ms}.
+    // inner disarms back to the nearest *installed* ancestor (outer), not to
+    // middle, so the 100ms fire sets outer's flag and middle propagates.
+    expect(
+      await run(`
+        const vm = require("node:vm");
+        const inner = () => vm.runInNewContext("1", {}, { timeout: 50 });
+        const middle = () => {
+          try { return vm.runInNewContext("inner(); while(true){}", { inner }, { timeout: 60000 }); }
+          catch (e) { return "middle-threw:" + (e && e.code); }
+        };
+        try { console.log("outer:" + vm.runInNewContext("middle()", { middle }, { timeout: 100 })); }
+        catch (e) { console.log("outer:" + (e && e.code)); }
+        console.log("alive");
+      `),
+    ).toEqual({ stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive", stderr: "", exitCode: 0, signalCode: null });
+  });
+
   test("outer timeout fires inside an inner untimed runInThisContext", async () => {
     expect(
       await run(`

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1383,3 +1383,51 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// An outer evaluation's watchdog can fire while an inner vm evaluation with no
+// {timeout} of its own is on the stack. The inner post-evaluation check must
+// not claim that termination: the uncatchable exception should unwind past the
+// inner try/catch to the outer evaluation, which owns it.
+describe.concurrent("node:vm nested evaluation propagates an enclosing termination", () => {
+  async function run(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  test("outer timeout fires inside an inner untimed runInNewContext", async () => {
+    expect(
+      await run(`
+        const vm = require("node:vm");
+        const inner = () => {
+          try { return vm.runInNewContext("const t0=Date.now(); while(Date.now()-t0<10000); 'done'", {}); }
+          catch (e) { return "inner-threw:" + (e && e.code); }
+        };
+        try { console.log("outer:" + vm.runInNewContext("inner()", { inner }, { timeout: 70 })); }
+        catch (e) { console.log("outer:" + (e && e.code)); }
+        console.log("alive");
+      `),
+    ).toEqual({ stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive", stderr: "", exitCode: 0, signalCode: null });
+  });
+
+  test("outer timeout fires inside an inner untimed runInThisContext", async () => {
+    expect(
+      await run(`
+        const vm = require("node:vm");
+        globalThis.__inner = () => {
+          try { return new vm.Script("const t0=Date.now(); while(Date.now()-t0<10000); 'done'").runInThisContext(); }
+          catch (e) { return "inner-threw:" + (e && e.code); }
+        };
+        try { console.log("outer:" + new vm.Script("__inner()").runInThisContext({ timeout: 70 })); }
+        catch (e) { console.log("outer:" + (e && e.code)); }
+        delete globalThis.__inner;
+        console.log("alive");
+      `),
+    ).toEqual({ stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive", stderr: "", exitCode: 0, signalCode: null });
+  });
+});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1415,6 +1415,21 @@ describe.concurrent("node:vm nested evaluation propagates an enclosing terminati
     ).toEqual({ stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive", stderr: "", exitCode: 0, signalCode: null });
   });
 
+  test("outer timeout fires inside an inner runInNewContext with a longer timeout", async () => {
+    expect(
+      await run(`
+        const vm = require("node:vm");
+        const inner = () => {
+          try { return vm.runInNewContext("while(true){}", {}, { timeout: 60000 }); }
+          catch (e) { return "inner-threw:" + (e && e.code); }
+        };
+        try { console.log("outer:" + vm.runInNewContext("inner()", { inner }, { timeout: 70 })); }
+        catch (e) { console.log("outer:" + (e && e.code)); }
+        console.log("alive");
+      `),
+    ).toEqual({ stdout: "outer:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive", stderr: "", exitCode: 0, signalCode: null });
+  });
+
   test("outer timeout fires inside an inner untimed runInThisContext", async () => {
     expect(
       await run(`

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1723,6 +1723,118 @@ test("process.debugPort defaults to 9229 on the main thread", async () => {
   expect(exitCode).toBe(0);
 });
 
+// node:vm's post-evaluation termination check must not claim a termination it
+// did not raise. If it converts a foreign termination into a catchable
+// ERR_SCRIPT_EXECUTION_* (or RELEASE_ASSERTs because it can't classify it),
+// worker.terminate() either aborts the whole process or is swallowed by the
+// guest's try/catch and the worker keeps running for as long as the guest
+// chooses.
+describe.concurrent("worker.terminate() / process.exit() landing inside a node:vm evaluation", () => {
+  const terminateFixture = (evalExpr: string) => `
+    const { Worker } = require("node:worker_threads");
+    const fs = require("fs");
+    const spin = new Int32Array(new SharedArrayBuffer(4));
+    const body = \`
+      const { workerData } = require("node:worker_threads");
+      const vm = require("node:vm");
+      const fs = require("fs");
+      try { ${evalExpr}; }
+      catch (e) { fs.writeSync(2, "caught:" + (e && e.code)); }
+      fs.writeSync(2, "after-body");
+    \`;
+    const w = new Worker(body, { eval: true, workerData: { spin } });
+    w.on("error", e => { fs.writeSync(2, "worker-error:" + e); process.exit(1); });
+    (async () => {
+      while (Atomics.load(spin, 0) === 0) await new Promise(r => setImmediate(r));
+      const code = await w.terminate();
+      console.log("terminated code=" + code);
+      process.exit(0);
+    })();
+  `;
+
+  async function run(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  test("untimed vm.runInNewContext: terminate() propagates instead of aborting", async () => {
+    expect(
+      await run(
+        terminateFixture(
+          `vm.runInNewContext("while(true){ Atomics.store(spin,0,1) }", { spin: workerData.spin, Atomics })`,
+        ),
+      ),
+    ).toEqual({ stdout: "terminated code=1", stderr: "", exitCode: 0, signalCode: null });
+  });
+
+  test("timed vm.runInNewContext: terminate() is not converted to ERR_SCRIPT_EXECUTION_TIMEOUT", async () => {
+    expect(
+      await run(
+        terminateFixture(
+          `vm.runInNewContext("while(true){ Atomics.store(spin,0,1) }", { spin: workerData.spin, Atomics }, { timeout: 60000 })`,
+        ),
+      ),
+    ).toEqual({ stdout: "terminated code=1", stderr: "", exitCode: 0, signalCode: null });
+  });
+
+  test("untimed Script#runInThisContext: terminate() propagates", async () => {
+    expect(
+      await run(
+        terminateFixture(
+          `globalThis.__spin = workerData.spin; new vm.Script("while(true){ Atomics.store(__spin,0,1) }").runInThisContext()`,
+        ),
+      ),
+    ).toEqual({ stdout: "terminated code=1", stderr: "", exitCode: 0, signalCode: null });
+  });
+
+  test("retry loop of timed evals: terminate() is not deferred to the guest's schedule", async () => {
+    // Before the fix each inner eval cleared the termination request and threw
+    // a catchable ERR_SCRIPT_EXECUTION_TIMEOUT, so the guest's outer while kept
+    // re-entering vm.runInNewContext until its own wall-clock budget ran out.
+    expect(
+      await run(
+        terminateFixture(
+          `(() => {
+             const t0 = Date.now();
+             while (Date.now() - t0 < 8000) {
+               try {
+                 vm.runInNewContext("while(true){ Atomics.store(spin,0,1) }",
+                                    { spin: workerData.spin, Atomics },
+                                    { timeout: 200 });
+               } catch {}
+             }
+           })()`,
+        ),
+      ),
+    ).toEqual({ stdout: "terminated code=1", stderr: "", exitCode: 0, signalCode: null });
+  });
+
+  test("process.exit() inside the eval stops the worker with that code", async () => {
+    expect(
+      await run(`
+        const { Worker } = require("node:worker_threads");
+        const fs = require("fs");
+        const body = \`
+          const vm = require("node:vm");
+          const fs = require("fs");
+          try { vm.runInNewContext("exit(7); while(true){}", { exit: process.exit.bind(process) }); }
+          catch (e) { fs.writeSync(2, "caught:" + (e && e.code)); }
+          fs.writeSync(2, "after-body");
+        \`;
+        const w = new Worker(body, { eval: true });
+        w.on("error", e => { fs.writeSync(2, "worker-error:" + e); process.exit(1); });
+        w.on("exit", code => { console.log("exit code=" + code); process.exit(0); });
+      `),
+    ).toEqual({ stdout: "exit code=7", stderr: "", exitCode: 0, signalCode: null });
+  });
+});
+
 // Founding a SHARE_ENV tree replaces the founding thread's process.env object. If the
 // replacement were orphaned, the founder's later writes would go nowhere. child_process
 // enumerates the JS process.env (a var deleted from the map is invisible to the child),


### PR DESCRIPTION
### Repro

Untimed eval in a worker + `terminate()` aborts the whole process:

```js
import { Worker } from "node:worker_threads";
const w = new Worker(`require("vm").runInNewContext("while(true){}", {})`, { eval: true });
setTimeout(() => w.terminate().then(c => console.log("TERMINATED code=" + c)), 150);
```

```
ASSERTION FAILED: vm.Script terminated due neither to SIGINT nor to timeout
.../NodeVMScript.cpp(325) : bool Bun::checkForTermination(...)
Aborted (core dumped)
```

Timed eval + `terminate()` lets the guest swallow the kill request:

```js
import { Worker } from "node:worker_threads";
const w = new Worker(`
  const vm = require("vm");
  const t0 = Date.now();
  while (Date.now() - t0 < 8000) {
    try { vm.runInNewContext("while(true){}", {}, { timeout: 400 }); } catch {}
  }
`, { eval: true });
setTimeout(() => { const t = Date.now(); w.terminate().then(() => console.log(Date.now() - t + "ms")); }, 150);
```

Node: `~5ms`. Bun main: `~8000ms` (the guest's own budget; unbounded with `while(true)`). `process.exit()` called from inside an eval hits the same `RELEASE_ASSERT`, as does an outer timed `runInNewContext` whose watchdog fires while a nested untimed eval is on the stack.

### Cause

`checkForTermination` in `NodeVMScript.cpp` (and the two equivalent blocks in `NodeVMModule::evaluate`) assumed every `vm.hasTerminationRequest()` observed after an evaluation was raised by that evaluation's own `{timeout}` watchdog or `{breakOnSigint}` watcher. It unconditionally cleared the request and either threw a catchable `ERR_SCRIPT_EXECUTION_*` (when a timeout was requested) or hit `RELEASE_ASSERT_NOT_REACHED` (when one was not).

Bun has four other `notifyNeedTermination()` producers that can fire during a `node:vm` eval: `worker.terminate()` from the parent, `process.exit()` inside the worker, `terminate_all_and_wait` at main-thread exit (behind `BUN_DESTRUCT_VM_ON_EXIT`), and an enclosing `node:vm` evaluation's watchdog.

### Fix

Arm the JSC Watchdog through a `NodeVMWatchdogScope` RAII type whose `ShouldTerminateCallback` records whether the watchdog itself fired. `checkForTermination` now clears the request and converts to `ERR_SCRIPT_EXECUTION_*` only when that flag or this evaluation's SIGINT watcher is set. Any other termination is left pending and the uncatchable `TerminationException` is rethrown so it unwinds to whoever owns it (the worker run loop for `terminate()`/`process.exit()`, or the enclosing evaluation for a nested watchdog). Both `RELEASE_ASSERT` branches are deleted. The scope replaces the free `setupWatchdog` helper and restores the enclosing scope's callback when nested timed evals unwind.

### Verification

New tests in `test/js/node/worker_threads/worker_threads.test.ts` and `test/js/node/vm/vm.test.ts` cover: untimed eval + `terminate()`, timed eval + `terminate()`, retry-loop of timed evals + `terminate()`, `process.exit()` inside an eval, `runInThisContext` + `terminate()`, and outer-timed/inner-untimed nesting. All seven fail on main (SIGABRT or `caught:ERR_SCRIPT_EXECUTION_TIMEOUT`/`after-body` on stderr) and pass with this change. `test/js/node/vm/vm.test.ts` (214 pass), `test/js/node/worker_threads/worker_threads.test.ts` (96 pass), and the `test-vm-timeout*` / `test-vm-sigint*` node-parallel tests pass unchanged, including under `BUN_JSC_validateExceptionChecks=1`.

Supersedes #35976 (checks `scriptExecutionStatus`, misses the nested-eval abort) and #33762 (checks `!timeout`, misses timed-eval + `terminate()`). #32773 replaces the Watchdog outright; this change composes with it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (b7916571e)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [20.49ms]
(pass) vm > runInContext() > can return a value [14.39ms]
(pass) vm > runInContext() > can return a complex value [15.26ms]
(pass) vm > runInContext() > can return the last value [13.93ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.58ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.06ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [14.93ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.47ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [14.45ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.95ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.08ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [1
... (truncated)

release without fix: 62 skipped
bun test v1.4.0-canary.1 (b7916571e)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.72ms]
(pass) vm > runInContext() > can return a value [0.22ms]
(pass) vm > runInContext() > can return a complex value [0.21ms]
(pass) vm > runInContext() > can return the last value [0.16ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (b7916571e)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.03ms]
(pass) vm > runInContext() > can return a value [14.82ms]
(pass) vm > runInContext() > can return a complex value [15.55ms]
(pass) vm > runInContext() > can return the last value [14.48ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.21ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.49ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.11ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.48ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.53ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [14.68ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.45ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [1
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 750ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+b7916571e
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (b7916571e)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.34ms]
(pass) vm > runInContext() > can return a value [0.20ms]
(pass) vm > runInContext() > can return a complex value [0.22ms]
(pass) vm > runInContext() > can return the last value [0.17ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runI
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVMModule.cpp                  |  66 +++-------
 src/jsc/bindings/NodeVMScript.cpp                  |  96 ++++++--------
 src/jsc/bindings/vm/NodeVMWatchdogScope.h          |  85 +++++++++++++
 test/js/node/vm/vm.test.ts                         | 139 +++++++++++++++++++++
 test/js/node/worker_threads/worker_threads.test.ts | 112 +++++++++++++++++
 5 files changed, 395 insertions(+), 103 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/NodeVMModule.cpp                       6     13      0
src/jsc/bindings/NodeVMScript.cpp                       7     11      0
src/jsc/bindings/vm/NodeVMWatchdogScope.h               1      5      0
test/js/node/vm/vm.test.ts                              3      7      0
test/js/node/worker_threads/worker_threads.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->