### PR TITLE
tls: report a handshake dropped by the peer as ECONNRESET when a write is queued

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -361,10 +361,7 @@ function onConnectEnd() {
   }
 }
 
-// A write queued before the TLS handshake completed can never be sent once the
-// peer has closed. Node's TLSWrap fails these with ECANCELED from
-// InvokeQueued() during wrap destruction; mirror that so the write callback's
-// error does not mask the socket-level ECONNRESET from onConnectEnd.
+// https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc (TLSWrap::InvokeQueued)
 function tlsWriteCanceled() {
   return new ErrnoException(UV_ECANCELED, "write", "Canceled because of SSL destruction");
 }
@@ -1380,11 +1377,8 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     if (pendingWrite) {
       self[kwriteCallback] = null;
       if (self.secureConnecting && !self._hadError) {
-        // 'end' (and so onConnectEnd) is deferred to nextTick; failing the
-        // write here would destroy the stream first and suppress it, leaving
-        // ERR_SOCKET_CLOSED as the socket error. Run the mid-handshake
-        // disconnect logic now so the socket is destroyed with ECONNRESET,
-        // then report the queued write the way Node's TLSWrap does.
+        // onConnectEnd listens on 'end' (nextTick); the write-error destroy
+        // would win that race and surface the wrong code.
         onConnectEnd.$call(self);
         pendingWrite(tlsWriteCanceled());
       } else {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -670,12 +670,7 @@ function SocketEmitEndNT(self, _err?) {
   const pendingWrite = self[kwriteCallback];
   if (pendingWrite && (self.destroyed || _err)) {
     self[kwriteCallback] = null;
-    if (self.secureConnecting && !self._hadError) {
-      onConnectEnd.$call(self);
-      pendingWrite(tlsWriteCanceled());
-    } else {
-      pendingWrite(_err ?? $ERR_SOCKET_CLOSED());
-    }
+    pendingWrite(_err ?? $ERR_SOCKET_CLOSED());
   }
 }
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -361,6 +361,14 @@ function onConnectEnd() {
   }
 }
 
+// A write queued before the TLS handshake completed can never be sent once the
+// peer has closed. Node's TLSWrap fails these with ECANCELED from
+// InvokeQueued() during wrap destruction; mirror that so the write callback's
+// error does not mask the socket-level ECONNRESET from onConnectEnd.
+function tlsWriteCanceled() {
+  return new ErrnoException(UV_ECANCELED, "write", "Canceled because of SSL destruction");
+}
+
 /**
  * Build the Error for a handshake that failed before completing. A fatal SSL
  * protocol error (wrong version number, bad record, ...) carries the OpenSSL
@@ -665,7 +673,12 @@ function SocketEmitEndNT(self, _err?) {
   const pendingWrite = self[kwriteCallback];
   if (pendingWrite && (self.destroyed || _err)) {
     self[kwriteCallback] = null;
-    pendingWrite(_err ?? $ERR_SOCKET_CLOSED());
+    if (self.secureConnecting && !self._hadError) {
+      onConnectEnd.$call(self);
+      pendingWrite(tlsWriteCanceled());
+    } else {
+      pendingWrite(_err ?? $ERR_SOCKET_CLOSED());
+    }
   }
 }
 
@@ -1366,7 +1379,17 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     const pendingWrite = self[kwriteCallback];
     if (pendingWrite) {
       self[kwriteCallback] = null;
-      pendingWrite($ERR_SOCKET_CLOSED());
+      if (self.secureConnecting && !self._hadError) {
+        // 'end' (and so onConnectEnd) is deferred to nextTick; failing the
+        // write here would destroy the stream first and suppress it, leaving
+        // ERR_SOCKET_CLOSED as the socket error. Run the mid-handshake
+        // disconnect logic now so the socket is destroyed with ECONNRESET,
+        // then report the queued write the way Node's TLSWrap does.
+        onConnectEnd.$call(self);
+        pendingWrite(tlsWriteCanceled());
+      } else {
+        pendingWrite($ERR_SOCKET_CLOSED());
+      }
     }
   },
   handshake(socket, success, verifyError) {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1196,3 +1196,61 @@ describe("throwing 'secureConnect' listener", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// A peer that FINs the TCP connection during the TLS handshake (right after
+// ClientHello) is the load-balancer/rate-limiter drop shape. Node reports it as
+// ECONNRESET ("Client network socket disconnected before secure TLS connection
+// was established"), which got/axios retry by default. ERR_SOCKET_CLOSED is
+// Node's code for local use-after-close and would point at the app instead of
+// the peer.
+describe("peer closes during TLS handshake", () => {
+  async function withHandshakeDroppingServer<T>(fn: (port: number) => Promise<T>): Promise<T> {
+    const srv = net.createServer(s => {
+      s.on("error", () => {});
+      s.once("data", () => s.end());
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    try {
+      return await fn((srv.address() as AddressInfo).port);
+    } finally {
+      srv.close();
+    }
+  }
+
+  it("https.request reports ECONNRESET, not ERR_SOCKET_CLOSED", async () => {
+    await withHandshakeDroppingServer(async port => {
+      const { promise, resolve } = Promise.withResolvers<NodeJS.ErrnoException>();
+      const req = https.get({ host: "127.0.0.1", port, path: "/", rejectUnauthorized: false });
+      req.on("error", resolve);
+      const err = await promise;
+      expect({ code: err.code, message: err.message, host: (err as any).host, port: (err as any).port }).toEqual({
+        code: "ECONNRESET",
+        message: "Client network socket disconnected before secure TLS connection was established",
+        host: "127.0.0.1",
+        port,
+      });
+    });
+  });
+
+  it("tls.connect with a queued write reports ECONNRESET and cancels the write with ECANCELED", async () => {
+    await withHandshakeDroppingServer(async port => {
+      const socketErr = Promise.withResolvers<NodeJS.ErrnoException>();
+      const writeErr = Promise.withResolvers<NodeJS.ErrnoException>();
+      const sock = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false });
+      sock.on("error", socketErr.resolve);
+      sock.write("GET / HTTP/1.1\r\n\r\n", err => writeErr.resolve(err as NodeJS.ErrnoException));
+      const [se, we] = await Promise.all([socketErr.promise, writeErr.promise]);
+      expect({
+        socket: { code: se.code, message: se.message },
+        write: { code: we.code, syscall: (we as any).syscall },
+      }).toEqual({
+        socket: {
+          code: "ECONNRESET",
+          message: "Client network socket disconnected before secure TLS connection was established",
+        },
+        write: { code: "ECANCELED", syscall: "write" },
+      });
+    });
+  });
+});

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1197,12 +1197,8 @@ describe("throwing 'secureConnect' listener", () => {
   });
 });
 
-// A peer that FINs the TCP connection during the TLS handshake (right after
-// ClientHello) is the load-balancer/rate-limiter drop shape. Node reports it as
-// ECONNRESET ("Client network socket disconnected before secure TLS connection
-// was established"), which got/axios retry by default. ERR_SOCKET_CLOSED is
-// Node's code for local use-after-close and would point at the app instead of
-// the peer.
+// A peer FIN during the TLS handshake must surface as ECONNRESET like Node,
+// not ERR_SOCKET_CLOSED (Node's code for local use-after-close).
 describe("peer closes during TLS handshake", () => {
   async function withHandshakeDroppingServer<T>(fn: (port: number) => Promise<T>): Promise<T> {
     const srv = net.createServer(s => {


### PR DESCRIPTION
A TLS client whose peer FINs the TCP connection during the handshake (right after ClientHello, the load-balancer/rate-limiter drop shape) reports `ERR_SOCKET_CLOSED` / "Socket is closed" when a write is queued, while Node reports `ECONNRESET` / "Client network socket disconnected before secure TLS connection was established". `ERR_SOCKET_CLOSED` is Node's code for local use-after-close, so the label points at the app instead of the peer, and got's default retry `errorCodes` retry this on Node but not on Bun.

```js
import net from "node:net";
import https from "node:https";
const srv = net.createServer(s => { s.on("error", () => {}); s.once("data", () => s.end()); });
await new Promise(r => srv.listen(0, "127.0.0.1", r));
await new Promise(res => {
  const req = https.get({ host: "127.0.0.1", port: srv.address().port, path: "/", rejectUnauthorized: false });
  req.on("error", e => { console.log(e.code, "|", e.message); res(); });
});
srv.close();
// bun : ERR_SOCKET_CLOSED | Socket is closed
// node: ECONNRESET       | Client network socket disconnected before secure TLS connection was established
```

A bare `tls.connect()` without a write already reports `ECONNRESET` correctly (the `onConnectEnd` listener on `'end'` produces it). The bug only appears when a write is queued before the handshake completes, which is always the case for `https.get`/`https.request`.

### Cause

`SocketHandlers2.close` fails the queued write with `ERR_SOCKET_CLOSED` synchronously. That write-callback error destroys the stream (via Writable's `onwrite` -> `errorOrDestroy`) and sets `kErrored` on the readable side, so the deferred `'end'` event is suppressed and `onConnectEnd` never runs. The first destroy error, `ERR_SOCKET_CLOSED`, becomes the socket error.

### Fix

When the close handler has a pending write and the socket is still `secureConnecting`, run `onConnectEnd`'s mid-handshake disconnect logic inline before failing the write, so the socket is destroyed with `ECONNRESET` and the Node-parity message (including `host`/`port`). The queued write is then failed with `ECANCELED` / `write ECANCELED Canceled because of SSL destruction`, matching Node's `TLSWrap::InvokeQueued(UV_ECANCELED, ...)`. The no-queued-write path is unchanged.

### Tests

Added to `test/js/node/tls/node-tls-connect.test.ts`:

- `https.get` against a server that FINs after ClientHello must emit `ECONNRESET` with Node's message and `host`/`port` populated.
- `tls.connect` with a queued write against the same server must emit `ECONNRESET` on the socket and `ECANCELED` to the write callback.

Both fail on the unfixed build with `ERR_SOCKET_CLOSED` and pass with this change; both assertions were verified to pass under Node.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.0 (34a08e3c9)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.72ms]
(pass) should thow ECONNRESET if FIN is received before handshake [547.15ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [18.79ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [172.79ms]
(pass) should be able to grab the JSStreamSocket constructor [28.20ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [86.55ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [97.02ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port 
... (truncated)

release without fix: 18 skipped
bun test v1.4.0-canary.1 (b7c73b6b2)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.55ms]
(pass) should thow ECONNRESET if FIN is received before handshake [15.50ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.27ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [5.28ms]
(pass) should be able to grab the JSStreamSocket constructor [0.30ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [17.10ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [5.17ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.0 (34a08e3c9)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.61ms]
(pass) should thow ECONNRESET if FIN is received before handshake [436.28ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [30.56ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [182.25ms]
(pass) should be able to grab the JSStreamSocket constructor [28.82ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [84.33ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [107.31ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1012ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (10892ms)
Bundle modules (135ms)
Postprocesss modules (173ms)
Bundle Functions (904ms)
Generate Code (47ms)

[12.17s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                        | 14 +++++++-
 test/js/node/tls/node-tls-connect.test.ts | 54 +++++++++++++++++++++++++++++++
 2 files changed, 67 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/net.ts                            11      6      0
test/js/node/tls/node-tls-connect.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->