### PR TITLE
node:crypto: deliver ERR_CRYPTO_HASH_FINALIZED via stream error path in Hash/Hmac

### DIFF
--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -280,14 +280,7 @@ Object.assign(Hash.prototype, {
     callback();
   },
   _flush: function (callback) {
-    let digest;
-    try {
-      digest = this[kHandle].digest(null, false);
-    } catch (err) {
-      callback(err);
-      return;
-    }
-    this.push(digest);
+    this.push(this[kHandle].digest(null, false));
     callback();
   },
   update: function (data, encoding) {

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -271,11 +271,23 @@ Object.assign(Hash.prototype, {
     return new Hash(this[kHandle], options);
   },
   _transform: function (chunk, encoding, callback) {
-    this[kHandle].update(this, chunk, encoding);
+    try {
+      this[kHandle].update(this, chunk, encoding);
+    } catch (err) {
+      callback(err);
+      return;
+    }
     callback();
   },
   _flush: function (callback) {
-    this.push(this[kHandle].digest(null, false));
+    let digest;
+    try {
+      digest = this[kHandle].digest(null, false);
+    } catch (err) {
+      callback(err);
+      return;
+    }
+    this.push(digest);
     callback();
   },
   update: function (data, encoding) {
@@ -311,7 +323,12 @@ Object.assign(Hmac.prototype, {
     return this[kHandle].digest(outputEncoding);
   },
   _transform: function (chunk, encoding, callback) {
-    this[kHandle].update(this, chunk, encoding);
+    try {
+      this[kHandle].update(this, chunk, encoding);
+    } catch (err) {
+      callback(err);
+      return;
+    }
     callback();
   },
   _flush: function (callback) {

--- a/test/js/node/crypto/crypto-lazyhash.test.ts
+++ b/test/js/node/crypto/crypto-lazyhash.test.ts
@@ -90,21 +90,3 @@ describe.each([
     expect(code).toBe("ERR_CRYPTO_HASH_FINALIZED");
   });
 });
-
-test("Hash end() without input after digest() errors from _flush", async () => {
-  const h = createHash("sha256");
-  h.update("x");
-  h.digest("hex");
-
-  const errorEvent = once(h, "error");
-  let threw: unknown = null;
-  try {
-    h.end();
-  } catch (err) {
-    threw = err;
-  }
-
-  expect(threw).toBeNull();
-  const [emitted] = await errorEvent;
-  expect((emitted as NodeJS.ErrnoException).code).toBe("ERR_CRYPTO_HASH_FINALIZED");
-});

--- a/test/js/node/crypto/crypto-lazyhash.test.ts
+++ b/test/js/node/crypto/crypto-lazyhash.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { Hash, createHash } from "crypto";
-import { Transform } from "stream";
+import { Hash, createHash, createHmac } from "crypto";
+import { Readable, Transform } from "stream";
+import { pipeline } from "stream/promises";
+import { once } from "events";
 
 describe("LazyHash quirks", () => {
   test("hash instanceof Transform", () => {
@@ -9,5 +11,80 @@ describe("LazyHash quirks", () => {
   });
   test("Hash.prototype instanceof Transform", () => {
     expect(Hash.prototype instanceof Transform).toBe(true);
+  });
+});
+
+describe.each([
+  ["Hash", () => createHash("sha256")],
+  ["Hmac", () => createHmac("sha256", "key")],
+])("%s stream after digest()", (_, make) => {
+  test("write() does not throw synchronously; error goes to callback and 'error'", async () => {
+    const h = make();
+    h.update("x");
+    h.digest("hex");
+
+    const errorEvent = once(h, "error");
+    let cbErr: unknown = "not-called";
+    let threw: unknown = null;
+    let ret: unknown;
+    try {
+      ret = h.write("late", (err?: unknown) => {
+        cbErr = err;
+      });
+    } catch (err) {
+      threw = err;
+    }
+
+    expect(threw).toBeNull();
+    expect(ret).toBe(false);
+
+    const [emitted] = await errorEvent;
+    expect((emitted as NodeJS.ErrnoException).code).toBe("ERR_CRYPTO_HASH_FINALIZED");
+    expect((cbErr as NodeJS.ErrnoException)?.code).toBe("ERR_CRYPTO_HASH_FINALIZED");
+  });
+
+  test("end() does not throw synchronously; error goes to 'error'", async () => {
+    const h = make();
+    h.update("x");
+    h.digest("hex");
+
+    const errorEvent = once(h, "error");
+    let threw: unknown = null;
+    try {
+      h.end("late");
+    } catch (err) {
+      threw = err;
+    }
+
+    expect(threw).toBeNull();
+    const [emitted] = await errorEvent;
+    expect((emitted as NodeJS.ErrnoException).code).toBe("ERR_CRYPTO_HASH_FINALIZED");
+  });
+
+  test("pipeline into finalized stream rejects via stream error (no sync throw)", async () => {
+    const h = make();
+    h.update("x");
+    h.digest("hex");
+
+    let err: unknown = null;
+    try {
+      await pipeline(Readable.from([Buffer.from("late")]), h);
+    } catch (e) {
+      err = e;
+    }
+    expect((err as NodeJS.ErrnoException)?.code).toBe("ERR_CRYPTO_HASH_FINALIZED");
+  });
+
+  test("direct update() after digest() still throws synchronously", () => {
+    const h = make();
+    h.update("x");
+    h.digest("hex");
+    let code: unknown = null;
+    try {
+      h.update("late");
+    } catch (e) {
+      code = (e as NodeJS.ErrnoException).code;
+    }
+    expect(code).toBe("ERR_CRYPTO_HASH_FINALIZED");
   });
 });

--- a/test/js/node/crypto/crypto-lazyhash.test.ts
+++ b/test/js/node/crypto/crypto-lazyhash.test.ts
@@ -66,13 +66,15 @@ describe.each([
     h.update("x");
     h.digest("hex");
 
-    let err: unknown = null;
+    let threw: unknown = null;
+    let result: Promise<void> | undefined;
     try {
-      await pipeline(Readable.from([Buffer.from("late")]), h);
-    } catch (e) {
-      err = e;
+      result = pipeline(Readable.from([Buffer.from("late")]), h);
+    } catch (err) {
+      threw = err;
     }
-    expect((err as NodeJS.ErrnoException)?.code).toBe("ERR_CRYPTO_HASH_FINALIZED");
+    expect(threw).toBeNull();
+    await expect(result).rejects.toMatchObject({ code: "ERR_CRYPTO_HASH_FINALIZED" });
   });
 
   test("direct update() after digest() still throws synchronously", () => {
@@ -87,4 +89,22 @@ describe.each([
     }
     expect(code).toBe("ERR_CRYPTO_HASH_FINALIZED");
   });
+});
+
+test("Hash end() without input after digest() errors from _flush", async () => {
+  const h = createHash("sha256");
+  h.update("x");
+  h.digest("hex");
+
+  const errorEvent = once(h, "error");
+  let threw: unknown = null;
+  try {
+    h.end();
+  } catch (err) {
+    threw = err;
+  }
+
+  expect(threw).toBeNull();
+  const [emitted] = await errorEvent;
+  expect((emitted as NodeJS.ErrnoException).code).toBe("ERR_CRYPTO_HASH_FINALIZED");
 });

--- a/test/js/node/crypto/crypto-lazyhash.test.ts
+++ b/test/js/node/crypto/crypto-lazyhash.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { Hash, createHash, createHmac } from "crypto";
+import { once } from "events";
 import { Readable, Transform } from "stream";
 import { pipeline } from "stream/promises";
-import { once } from "events";
 
 describe("LazyHash quirks", () => {
   test("hash instanceof Transform", () => {

--- a/test/js/node/crypto/crypto-lazyhash.test.ts
+++ b/test/js/node/crypto/crypto-lazyhash.test.ts
@@ -61,20 +61,14 @@ describe.each([
     expect((emitted as NodeJS.ErrnoException).code).toBe("ERR_CRYPTO_HASH_FINALIZED");
   });
 
-  test("pipeline into finalized stream rejects via stream error (no sync throw)", async () => {
+  test("pipeline into finalized stream rejects with ERR_CRYPTO_HASH_FINALIZED", async () => {
     const h = make();
     h.update("x");
     h.digest("hex");
 
-    let threw: unknown = null;
-    let result: Promise<void> | undefined;
-    try {
-      result = pipeline(Readable.from([Buffer.from("late")]), h);
-    } catch (err) {
-      threw = err;
-    }
-    expect(threw).toBeNull();
-    await expect(result).rejects.toMatchObject({ code: "ERR_CRYPTO_HASH_FINALIZED" });
+    await expect(pipeline(Readable.from([Buffer.from("late")]), h)).rejects.toMatchObject({
+      code: "ERR_CRYPTO_HASH_FINALIZED",
+    });
   });
 
   test("direct update() after digest() still throws synchronously", () => {


### PR DESCRIPTION
## What

Calling `write()`/`end()`/`pipe` on a `Hash` or `Hmac` stream after `digest()` has already been called on it directly throws `ERR_CRYPTO_HASH_FINALIZED` **synchronously** out of `Writable.write()`:

```js
import crypto from "node:crypto";

const h = crypto.createHash("sha256");
h.update("x");
h.digest("hex");

h.on("error", e => console.log("error:", e.code));
h.write("late"); // bun: sync throw ERR_CRYPTO_HASH_FINALIZED, 'error' listener never fires
                 // node: returns true, late bytes silently dropped
```

The Writable contract delivers transform-time errors via the write callback and the `'error'` event, not as a synchronous throw from `write()`. A caller with an `'error'` listener attached and no `try`/`catch` around `write()` gets an uncaught exception.

## Cause

`Hash.prototype._transform` and `Hmac.prototype._transform` call the native handle's `update` directly. The native layer throws `ERR_CRYPTO_HASH_FINALIZED` when `m_finalized` is set, and that throw propagates synchronously through `Transform._write` → `writeOrBuffer` → `write()`.

Node.js checks a JS-side `kFinalized` flag only in the public `update()`/`digest()` methods; its `_transform` calls the native handle without the check, and OpenSSL's `EVP_DigestUpdate` on a finalized context is a no-op, so Node silently absorbs late writes.

## Fix

Route the native error through `callback(err)` in `_transform` instead of letting it throw. The error is still surfaced (unlike Node's silent absorb), but now arrives on the stream error path:

- `write()` returns, its callback receives the error, `'error'` fires
- `pipeline()` into a finalized hash rejects with `ERR_CRYPTO_HASH_FINALIZED`
- `end(chunk)` surfaces the error via `'error'`

The direct `update()`/`digest()` API is unchanged and still throws synchronously after finalization, matching Node. `_flush` is also unchanged: Writable's `prefinish()` already wraps `stream._final()` in try/catch, which is the only path into `_flush`, so a sync throw from there is already routed to `'error'`.

## Verification

```
bun bd test test/js/node/crypto/crypto-lazyhash.test.ts
```

The `write()` and `end(chunk)` tests fail with `expect(threw).toBeNull()` on the sync throw before this change and pass after.

## Scope

`Cipheriv.prototype._transform` and `Sign.prototype._write`/`Verify.prototype._write` in the same file share this shape but are intentionally left unwrapped: Node.js itself sync-throws from `cipher.write()` after `final()` (`"Trying to add data in unsupported state"`) and from `sign.write()` after `sign()`, so Bun already matches Node at those sites. The Hash/Hmac case was different because Node's native `EVP_DigestUpdate` on a finalized context is a silent no-op, so Bun was throwing where Node does not.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/crypto-lazyhash.test.ts
bun test v1.4.0 (d356ac6f9)

test/js/node/crypto/crypto-lazyhash.test.ts:
(pass) LazyHash quirks > hash instanceof Transform [7.05ms]
(pass) LazyHash quirks > Hash.prototype instanceof Transform [1.59ms]
33 |       });
34 |     } catch (err) {
35 |       threw = err;
36 |     }
37 | 
38 |     expect(threw).toBeNull();
                       ^
error: expect(received).toBeNull()

Received: 215 | @toClass(Hash, "Hash", LazyTransform);
216 | Object.assign(Hash.prototype, {
217 |   copy: function(options) {
218 |     return new Hash(this[kHandle], options);
219 |   },
220 |     this[kHandle].update(this, chunk, encoding);
                       ^
error: Digest already called
 code: "ERR_CRYPTO_HASH_FINALIZED"

      at _transform (node:crypto:220:25)
      at <anonymous> (internal:streams/transform:70:18)
      at writeOrBuffer (internal:streams/writable:385:18)
      at <anonymous> (internal:streams/writable:338:16)
      at <anonymous> (/workspace/bun/test/js/node/crypto/crypto-lazyhash.test.ts:
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9abc522fe)

test/js/node/crypto/crypto-lazyhash.test.ts:
(pass) LazyHash quirks > hash instanceof Transform [0.14ms]
(pass) LazyHash quirks > Hash.prototype instanceof Transform [0.02ms]
(pass) Hash stream after digest() > write() does not throw synchronously; error goes to callback and 'error' [2.58ms]
(pass) Hash stream after digest() > end() does not throw synchronously; error goes to 'error' [0.36ms]
(pass) Hash stream after digest() > pipeline into finalized stream rejects with ERR_CRYPTO_HASH_FINALIZED [4.35ms]
(pass) Hash stream after digest() > direct update() after digest() still throws synchronously [0.05ms]
(pass) Hmac stream after digest() > write() does not throw synchronously; error goes to callback and 'error' [0.24ms]
(pass) Hmac stream after digest() > end() does not throw synchronously; error goes to 'error' [0.12ms]
(pass) Hmac stream after digest() > pipeline into finalized stream rejects with ERR_CRYPTO_HASH_FINALIZED [0.74ms]
(pass) Hmac stream after digest() > direct update() after digest() still throws synchronously [0.02ms]

 10 pass
 0 fail
 18 expect() calls
Ran 10 tests across 1 file. [169.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/crypto-lazyhash.test.ts
bun test v1.4.0 (d356ac6f9)

test/js/node/crypto/crypto-lazyhash.test.ts:
(pass) LazyHash quirks > hash instanceof Transform [5.95ms]
(pass) LazyHash quirks > Hash.prototype instanceof Transform [1.56ms]
(pass) Hash stream after digest() > write() does not throw synchronously; error goes to callback and 'error' [152.09ms]
(pass) Hash stream after digest() > end() does not throw synchronously; error goes to 'error' [18.69ms]
(pass) Hash stream after digest() > pipeline into finalized stream rejects with ERR_CRYPTO_HASH_FINALIZED [232.60ms]
(pass) Hash stream after digest() > direct update() after digest() still throws synchronously [3.43ms]
(pass) Hmac stream after digest() > write() does not throw synchronously; error goes to callback and 'error' [16.27ms]
(pass) Hmac stream after digest() > end() does not throw synchronously; error goes to 'error' [8.57ms]
(pass) Hmac stream after digest() > pipeline into finalized stream rejects with ERR_CRYPTO_HASH_FINALIZED [44.15ms]
(pass) Hmac stream af
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 688ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (9592ms)
Bundle modules (60ms)
Postprocesss modules (52ms)
Bundle Functions (924ms)
Generate Code (20ms)

[10.66s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 37.07s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+d356ac6f9
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (d356ac6f9)

test/js/node/crypto/crypto-lazyhash.test.ts:
(pass) LazyHash quirks > hash instanceof Transform [0.12ms]
(pass) LazyHash quirks > Hash.prototype instanceof Transform [0.02ms]
(pass) Hash stream after digest() > write() does not throw synchronousl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/crypto.ts                       | 14 +++++-
 test/js/node/crypto/crypto-lazyhash.test.ts | 77 ++++++++++++++++++++++++++++-
 2 files changed, 87 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/node/crypto.ts                            2      3      0
test/js/node/crypto/crypto-lazyhash.test.ts      4      7      0
```

</details>

<!-- robobun:evidence:end -->