### PR TITLE
FileSink: wire highWaterMark into the write(2) batch threshold

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -604,6 +604,12 @@ pub struct PosixStreamingWriter<Parent: PosixStreamingWriterParent> {
     pub is_done: bool,
     pub closed_without_reporting: bool,
     pub force_sync: bool,
+    /// Flush threshold for [`should_buffer`]. Writes accumulate in `outgoing`
+    /// until the buffered size reaches this value, then a single `write(2)`
+    /// drains the batch. Defaults to the page-size [`CHUNK_SIZE`]; `FileSink`
+    /// overwrites this with the user's `highWaterMark` so
+    /// `Bun.file().writer({ highWaterMark })` actually batches to that size.
+    pub chunk_size: usize,
 }
 
 impl<Parent: PosixStreamingWriterParent> Default for PosixStreamingWriter<Parent> {
@@ -615,6 +621,7 @@ impl<Parent: PosixStreamingWriterParent> Default for PosixStreamingWriter<Parent
             is_done: false,
             closed_without_reporting: false,
             force_sync: false,
+            chunk_size: Self::CHUNK_SIZE,
         }
     }
 }
@@ -653,8 +660,10 @@ unsafe impl<Parent: PosixStreamingWriterParent> bun_ptr::LaunderedSelf
 }
 
 impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
-    // The smallest page size the target
-    // supports (16K on Apple Silicon, 4K elsewhere among our targets).
+    // Default flush threshold for `should_buffer`: the smallest page size the
+    // target supports (16K on Apple Silicon, 4K elsewhere among our targets).
+    // Stored per-instance in `self.chunk_size` so callers (FileSink's
+    // `highWaterMark`) can override it.
     const CHUNK_SIZE: usize = if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
         16384
     } else {
@@ -717,7 +726,7 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
     }
 
     pub fn should_buffer(&self, addition: usize) -> bool {
-        !self.force_sync && self.outgoing.size() + addition < Self::CHUNK_SIZE
+        !self.force_sync && self.outgoing.size() + addition < self.chunk_size
     }
 
     pub fn get_buffer(&self) -> &[u8] {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -757,10 +757,18 @@ impl FileSink {
     }
 
     pub fn start(&self, stream_start: &streams::Start) -> sys::Result<()> {
-        match stream_start {
-            streams::Start::FileSink(file)
-                if !matches!(file.input_path, PathOrFileDescriptor::Fd(Fd::INVALID)) =>
-            {
+        if let streams::Start::FileSink(file) = stream_start {
+            // Apply the user's `highWaterMark` as the writer's flush
+            // threshold so small writes batch into one `write(2)` of that
+            // size. Windows uses libuv's own write queue and has no knob.
+            #[cfg(unix)]
+            if file.chunk_size > 0 {
+                // SAFETY(JsCell): single-field write; does not call into JS.
+                self.writer
+                    .with_mut(|w| w.chunk_size = file.chunk_size as usize);
+            }
+
+            if !matches!(file.input_path, PathOrFileDescriptor::Fd(Fd::INVALID)) {
                 match self.setup(file) {
                     sys::Result::Err(err) => {
                         return sys::Result::Err(err);
@@ -768,7 +776,6 @@ impl FileSink {
                     sys::Result::Ok(()) => {}
                 }
             }
-            _ => {}
         }
 
         self.done.set(false);

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -599,6 +599,50 @@ it("Bun.file(fd).writer() write/end under GC pressure does not crash", async () 
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
 });
 
+// The `highWaterMark` option on `Bun.file().writer()` is parsed into the
+// FileSink's `chunk_size`, but the buffered streaming writer compared against
+// a hardcoded page-size constant instead, so the option had no effect: 20 MB
+// of 100-byte writes with highWaterMark:65536 issued ~4.9k write(2) syscalls
+// (4 KiB batches) instead of ~300. With the threshold wired through, the
+// syscall count scales with the requested batch size.
+//
+// Linux-only because it counts write syscalls via /proc/self/io (the bug and
+// fix are POSIX-wide, but macOS has no cheap equivalent counter).
+it.skipIf(!isLinux)("highWaterMark controls the write(2) batch size", async () => {
+  const dir = tmpdirSync();
+  const child = `
+    const fs = require("fs");
+    const out = ${JSON.stringify(join(dir, "hwm.txt"))};
+    function syscw() {
+      return Number(fs.readFileSync("/proc/self/io", "utf8").match(/syscw:\\s*(\\d+)/)[1]);
+    }
+    const N = 10000;
+    const line = Buffer.alloc(100, 0x78);
+    const w = Bun.file(out).writer({ highWaterMark: 64 * 1024 });
+    const before = syscw();
+    for (let i = 0; i < N; i++) w.write(line);
+    await w.end();
+    const after = syscw();
+    const size = fs.statSync(out).size;
+    fs.unlinkSync(out);
+    console.log(JSON.stringify({ syscw: after - before, size }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", child],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { syscw, size } = JSON.parse(stdout);
+  // Before the fix the threshold was locked to 4096 (16384 on Apple Silicon),
+  // so 1 MB in 100-byte chunks produced ~244 write syscalls regardless of
+  // highWaterMark. At 64 KiB the ceiling is 1 MB / 64 KiB = 16, plus a
+  // handful for open/close/eventfd traffic.
+  expect({ size, syscwUnder50: syscw < 50 ? true : syscw }).toEqual({ size: 1_000_000, syscwUnder50: true });
+  expect(exitCode).toBe(0);
+});
+
 it("fs.promises.writeFile with iterables under GC pressure does not crash", async () => {
   const dir = tmpdirSync();
   await using proc = Bun.spawn({


### PR DESCRIPTION
## Summary

`Bun.file(path).writer({ highWaterMark: N })` parsed `N` into `FileSinkOptions.chunk_size` and then nothing read it. The flush decision in `PosixStreamingWriter::should_buffer` compared the buffered size against a compile-time `const CHUNK_SIZE` (4 KiB; 16 KiB on Apple Silicon), so small writes were always batched to the page size regardless of the caller's `highWaterMark`.

## Reproduction

`write(2)` syscalls counted via `/proc/self/io` for 2e5 x 100-byte `.write()` calls (20 MB total):

| highWaterMark | before | after | bytes / syscall (after) |
| ---: | ---: | ---: | ---: |
| 4096 | 4879 | 4879 | ~4.1 KiB |
| 65536 | 4879 | 305 | ~64 KiB |
| 1048576 | 4879 | 20 | ~1 MiB |
| 0 / unset | 4879 | 4879 | page-size default (unchanged) |

Output byte-identical in all rows.

## Cause

`src/runtime/webcore/streams.rs` reads `highWaterMark` into `FileSinkOptions.chunk_size` (default 1024) and hands it to `FileSink::start`, but neither `start` nor `setup` forwarded it to the writer. `PosixStreamingWriter::should_buffer` (src/io/PipeWriter.rs) compared against `Self::CHUNK_SIZE`, a `const`:

```rust
pub fn should_buffer(&self, addition: usize) -> bool {
    !self.force_sync && self.outgoing.size() + addition < Self::CHUNK_SIZE
}
```

so the parsed option never reached the one place that decides when to flush.

## Fix

- `PosixStreamingWriter` gains a `chunk_size: usize` field, defaulting to the existing page-size constant, and `should_buffer` reads the field instead of the constant.
- `FileSink::start` copies `options.chunk_size` into `writer.chunk_size` when nonzero (POSIX only; the Windows writer drains through libuv's write queue and has no equivalent threshold).

Default behaviour is unchanged; callers that never set `highWaterMark`, and the other `StreamingWriter` users (subprocess stdin, named pipes, terminal), keep the page-size threshold via `Default`.

## Verification

New test `highWaterMark controls the write(2) batch size` in `test/js/bun/util/filesink.test.ts` writes 10000 x 100 B with `highWaterMark: 64 * 1024` in a child process and asserts `< 50` syscw via `/proc/self/io`. On stock bun the count is 244; with this change it is ~16. Linux-only because the counter is Linux-only; the changed code path is POSIX-wide.

All 51 existing `filesink.test.ts` tests pass. `bun run rust:check-all` passes across all targets.