### PR TITLE
fs: back createWriteStream(path) with a FileSink that adopts the fd

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2471,6 +2471,11 @@ declare module "bun" {
 
     write(chunk: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer): number;
     /**
+     * Write multiple chunks of data in order.
+     * @returns Number of bytes written
+     */
+    writev(chunks: (ArrayBufferView | ArrayBuffer | SharedArrayBuffer)[]): number;
+    /**
      * Flush the internal buffer.
      *
      * - If {@link ArrayBufferSink.start} was passed a `stream` option, this returns an `ArrayBuffer`.

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -15,6 +15,15 @@ declare module "bun" {
      */
     write(chunk: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer): number | Promise<number>;
     /**
+     * Write multiple chunks of data to the file in order.
+     *
+     * If the file descriptor is not writable yet, the data is buffered.
+     *
+     * @param chunks The data to write
+     * @returns Number of bytes written or, if the write is pending, a Promise resolving to the number of bytes
+     */
+    writev(chunks: (ArrayBufferView | ArrayBuffer | SharedArrayBuffer)[]): number | Promise<number>;
+    /**
      * Flush the internal buffer, committing the data to disk or the pipe.
      *
      * @returns Number of bytes flushed or a Promise resolving to the number of bytes

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -1123,7 +1123,7 @@ pub use ${rustPath} as ${name};
 
 `;
 
-    const hostFns = ["construct", "write", "end", "flush", "start"] as const;
+    const hostFns = ["construct", "write", "writev", "end", "flush", "start"] as const;
     for (const fn of hostFns) {
       const sym = `${name}__${fn}`;
       symbols.push(sym);
@@ -1244,6 +1244,7 @@ function lutInput() {
     end        ${`${name}__end`.padEnd(padding + 8)} ReadOnly|DontDelete|Function 0
     start      ${`${name}__start`.padEnd(padding + 8)} ReadOnly|DontDelete|Function 1
     write      ${`${name}__write`.padEnd(padding + 8)} ReadOnly|DontDelete|Function 1
+    writev     ${`${name}__writev`.padEnd(padding + 8)} ReadOnly|DontDelete|Function 1
     ref        ${`${name}__ref`.padEnd(padding + 8)} ReadOnly|DontDelete|Function 0
     unref      ${`${name}__unref`.padEnd(padding + 8)} ReadOnly|DontDelete|Function 0
     _getFd      ${`${name}__getFd`.padEnd(padding + 8)} ReadOnly|DontDelete|Function 0
@@ -1258,6 +1259,7 @@ function lutInput() {
     end          ${`${controller}__end`.padEnd(protopad + 4)}  ReadOnly|DontDelete|Function 0
     start        ${`${name}__start`.padEnd(protopad + 4)}  ReadOnly|DontDelete|Function 1
     write        ${`${name}__write`.padEnd(protopad + 4)}  ReadOnly|DontDelete|Function 1
+    writev       ${`${name}__writev`.padEnd(protopad + 4)}  ReadOnly|DontDelete|Function 1
 @end
 */
 `;

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -67,15 +67,12 @@ pub trait PosixPipeWriter {
     fn try_write(&self, force_sync: bool, buf: &[u8]) -> WriteResult {
         // PERF: try_write_with_write_fn is not monomorphized per FileType —
         // profile if hot.
-        let ft = if !force_sync {
-            self.get_file_type()
-        } else {
-            FileType::File
-        };
-        match ft {
-            FileType::NonblockingPipe | FileType::File => {
-                self.try_write_with_write_fn(buf, sys::write)
-            }
+        if force_sync {
+            return self.try_write_with_write_fn(buf, sys::write);
+        }
+        match self.get_file_type() {
+            FileType::NonblockingPipe => self.try_write_with_write_fn(buf, sys::write),
+            FileType::File => self.try_write_with_write_fn(buf, sys::write_nonblocking),
             FileType::Pipe => self.try_write_with_write_fn(buf, write_to_blocking_pipe),
             FileType::Socket => self.try_write_with_write_fn(buf, sys::send_non_block),
         }
@@ -96,7 +93,8 @@ pub trait PosixPipeWriter {
         while offset < buf.len() {
             match write_fn(fd, &buf[offset..]) {
                 sys::Result::Err(err) => {
-                    if err.is_retry() {
+                    // After a short write, credit it; the retry reports the error.
+                    if err.is_retry() || offset > 0 {
                         return WriteResult::Pending(offset);
                     }
 
@@ -594,6 +592,7 @@ pub struct PosixStreamingWriter<Parent: PosixStreamingWriterParent> {
     pub force_sync: bool,
     /// Last reported `WriteStatus == Pending` (i.e. write(2) returned EAGAIN).
     backed_up: core::cell::Cell<bool>,
+    pub close_fd: bool,
 }
 
 impl<Parent: PosixStreamingWriterParent> Default for PosixStreamingWriter<Parent> {
@@ -606,6 +605,7 @@ impl<Parent: PosixStreamingWriterParent> Default for PosixStreamingWriter<Parent
             closed_without_reporting: false,
             force_sync: false,
             backed_up: core::cell::Cell::new(false),
+            close_fd: true,
         }
     }
 }
@@ -764,7 +764,8 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         if self.get_fd() != Fd::INVALID {
             debug_assert!(!self.closed_without_reporting);
             self.closed_without_reporting = true;
-            self.handle.close(None, None::<fn(*mut c_void)>);
+            self.handle
+                .close_impl(None, None::<fn(*mut c_void)>, self.close_fd);
         }
     }
 
@@ -832,7 +833,8 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         debug_assert!(!self.is_done);
 
         if self.should_buffer(0) {
-            self.parent_on_write(buf_len, WriteStatus::Drained);
+            // Buffered only: report 0 so the parent can schedule its auto-flush.
+            self.parent_on_write(0, WriteStatus::Drained);
             Self::register_poll(self);
 
             return WriteResult::Wrote(buf_len);
@@ -892,9 +894,8 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 return WriteResult::Err(sys::Error::oom());
             }
 
-            // noop, but need this to have a chance
-            // to register deferred tasks (onAutoFlush)
-            self.parent_on_write(buf.len(), WriteStatus::Drained);
+            // Buffered only: report 0 so the parent can schedule its auto-flush.
+            self.parent_on_write(0, WriteStatus::Drained);
             Self::register_poll(self);
 
             // it's buffered, but should be reported as written to
@@ -942,6 +943,126 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         }
 
         rc
+    }
+
+    fn writev_buffered(&mut self, bufs: &[&[u8]], total: usize) -> WriteResult {
+        if self.outgoing.ensure_unused_capacity(total).is_err() {
+            return WriteResult::Err(sys::Error::oom());
+        }
+        for b in bufs {
+            self.outgoing.write_assume_capacity(b);
+        }
+        self.maybe_write_newly_buffered_data(total)
+    }
+
+    #[cfg(unix)]
+    fn buffer_tail(&mut self, bufs: &[&[u8]], mut skip: usize, remaining: usize) -> Result<(), ()> {
+        if self.outgoing.ensure_unused_capacity(remaining).is_err() {
+            return Err(());
+        }
+        for b in bufs {
+            if skip >= b.len() {
+                skip -= b.len();
+                continue;
+            }
+            self.outgoing.write_assume_capacity(&b[skip..]);
+            skip = 0;
+        }
+        Ok(())
+    }
+
+    pub fn writev(&mut self, bufs: &[&[u8]]) -> WriteResult {
+        if self.is_done || self.closed_without_reporting {
+            return WriteResult::Done(0);
+        }
+        let mut total: usize = 0;
+        for b in bufs {
+            total += b.len();
+        }
+        if total == 0 {
+            return WriteResult::Wrote(0);
+        }
+        #[cfg(not(unix))]
+        {
+            self.writev_buffered(bufs, total)
+        }
+        #[cfg(unix)]
+        {
+            const IOV_MAX: usize = 1024;
+            if self.outgoing.size() > 0 || self.should_buffer(total) || bufs.len() > IOV_MAX {
+                return self.writev_buffered(bufs, total);
+            }
+
+            let fd = self.get_fd();
+            if fd == Fd::INVALID {
+                return WriteResult::Done(0);
+            }
+            let file_type = if self.force_sync {
+                FileType::File
+            } else {
+                self.get_file_type()
+            };
+            if matches!(file_type, FileType::Pipe) {
+                return self.writev_buffered(bufs, total);
+            }
+
+            let mut iov: Vec<libc::iovec> = Vec::with_capacity(bufs.len());
+            for b in bufs {
+                if b.is_empty() {
+                    continue;
+                }
+                iov.push(libc::iovec {
+                    iov_base: b.as_ptr().cast_mut().cast::<core::ffi::c_void>(),
+                    iov_len: b.len(),
+                });
+            }
+
+            let mut offset: usize = 0;
+            let mut start: usize = 0;
+            loop {
+                let rc = if matches!(file_type, FileType::File) && !self.force_sync {
+                    sys::writev_nonblocking(fd, &iov[start..])
+                } else {
+                    sys::writev(fd, &iov[start..])
+                };
+                let wrote = match rc {
+                    sys::Result::Err(err) => {
+                        // Same short-write rule as `try_write_with_write_fn`.
+                        if err.is_retry() || offset > 0 {
+                            if self.buffer_tail(bufs, offset, total - offset).is_err() {
+                                return WriteResult::Err(sys::Error::oom());
+                            }
+                            self.parent_on_write(offset, WriteStatus::Pending);
+                            Self::register_poll(self);
+                            return WriteResult::Pending(offset);
+                        }
+                        return WriteResult::Err(err);
+                    }
+                    sys::Result::Ok(n) => n,
+                };
+                offset += wrote;
+                if wrote == 0 {
+                    self.parent_on_write(offset, WriteStatus::EndOfFile);
+                    return WriteResult::Done(offset);
+                }
+                if offset == total {
+                    self.parent_on_write(offset, WriteStatus::Drained);
+                    return WriteResult::Wrote(offset);
+                }
+                let mut consumed = wrote;
+                while start < iov.len() && consumed >= iov[start].iov_len {
+                    consumed -= iov[start].iov_len;
+                    start += 1;
+                }
+                if start < iov.len() && consumed > 0 {
+                    // SAFETY: `consumed < iov[start].iov_len`, so the advanced
+                    // base stays within the original live buffer.
+                    iov[start].iov_base =
+                        unsafe { iov[start].iov_base.cast::<u8>().add(consumed) }.cast();
+                    iov[start].iov_len -= consumed;
+                }
+            }
+        }
     }
 
     pub fn flush(&mut self) -> WriteResult {
@@ -1026,10 +1147,11 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         }
 
         let parent = self.parent;
-        self.handle.close(
+        self.handle.close_impl(
             Some(parent.cast()),
             // SAFETY: parent was set via set_parent with a *mut Parent.
             Some(|ctx: *mut c_void| unsafe { Parent::on_close(ctx.cast::<Parent>()) }),
+            self.close_fd,
         );
     }
 
@@ -2481,6 +2603,62 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         self.write_internal_u8(buffer, WriteKind::Bytes)
     }
 
+    pub fn writev(&mut self, bufs: &[&[u8]]) -> WriteResult {
+        if self.is_done {
+            return WriteResult::Done(0);
+        }
+        let mut total: usize = 0;
+        for b in bufs {
+            total += b.len();
+        }
+        if total == 0 {
+            return WriteResult::Wrote(0);
+        }
+        let had_buffered_data = self.outgoing.is_not_empty();
+        if self.outgoing.ensure_unused_capacity(total).is_err() {
+            return WriteResult::Err(sys::Error::oom());
+        }
+        for b in bufs {
+            self.outgoing.write_assume_capacity(b);
+        }
+
+        if matches!(self.source, Some(Source::SyncFile(_))) {
+            let result = (|| {
+                let remain = self.outgoing.slice();
+                let initial_len = remain.len();
+                let mut remain = remain;
+                let fd = Fd::from_uv(match &self.source {
+                    Some(Source::SyncFile(f)) => f.file,
+                    _ => unreachable!(),
+                });
+                while remain.len() > 0 {
+                    match sys::write(fd, remain) {
+                        sys::Result::Err(err) => return WriteResult::Err(err),
+                        sys::Result::Ok(wrote) => {
+                            remain = &remain[wrote..];
+                            if wrote == 0 {
+                                break;
+                            }
+                        }
+                    }
+                }
+                let wrote = initial_len - remain.len();
+                if wrote == 0 {
+                    return WriteResult::Done(wrote);
+                }
+                WriteResult::Wrote(wrote)
+            })();
+            self.outgoing.reset();
+            return result;
+        }
+
+        if had_buffered_data {
+            return WriteResult::Pending(0);
+        }
+        self.process_send();
+        self.last_write_result.clone()
+    }
+
     pub fn flush(&mut self) -> WriteResult {
         if self.is_done {
             return WriteResult::Done(0);
@@ -2502,7 +2680,8 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         self.is_done = true;
 
         if !self.has_pending_data() {
-            if !self.owns_fd {
+            if !self.owns_fd && !matches!(self.source, Some(Source::File(_) | Source::SyncFile(_)))
+            {
                 return;
             }
             self.close();

--- a/src/io/openForWriting.rs
+++ b/src/io/openForWriting.rs
@@ -14,6 +14,9 @@ pub trait OpenForWritingInput {
         is_nonblocking: &mut bool,
         openat: &dyn Fn(Fd, &ZStr, i32, Mode) -> bun_sys::Result<Fd>,
     ) -> bun_sys::Result<Fd>;
+    fn borrowed_fd(&self) -> Option<Fd> {
+        None
+    }
 }
 
 impl OpenForWritingInput for crate::PathOrFileDescriptor<'_> {
@@ -31,7 +34,13 @@ impl OpenForWritingInput for crate::PathOrFileDescriptor<'_> {
                 *is_nonblocking = true;
                 bun_sys::openat_a(dir, path, input_flags, mode)
             }
-            Fd(fd_) => bun_sys::dup_with_flags(*fd_, 0),
+            Fd(fd) => bun_sys::Result::Ok(*fd),
+        }
+    }
+    fn borrowed_fd(&self) -> Option<Fd> {
+        match self {
+            crate::PathOrFileDescriptor::Fd(fd) => Some(*fd),
+            crate::PathOrFileDescriptor::Path(_) => None,
         }
     }
 }
@@ -112,15 +121,30 @@ where
     #[cfg(unix)]
     let mut isatty = false;
     let mut is_nonblocking = false;
-    let result =
-        input_path.open_for_writing_result(dir, input_flags, mode, &mut is_nonblocking, &openat);
-    let fd = result?;
+    let borrowed = input_path.borrowed_fd();
+    let fd = match borrowed {
+        Some(fd) => fd,
+        None => input_path.open_for_writing_result(
+            dir,
+            input_flags,
+            mode,
+            &mut is_nonblocking,
+            &openat,
+        )?,
+    };
+    #[cfg(windows)]
+    let _ = borrowed;
 
     #[cfg(unix)]
     {
+        let close_on_err = |fd: Fd| {
+            if borrowed.is_none() {
+                fd.close();
+            }
+        };
         match bun_sys::fstat(fd) {
             Err(err) => {
-                fd.close();
+                close_on_err(fd);
                 return Err(err);
             }
             Ok(stat) => {
@@ -151,7 +175,7 @@ where
                     let flags = match bun_sys::get_fcntl_flags(fd) {
                         Ok(flags) => flags,
                         Err(err) => {
-                            fd.close();
+                            close_on_err(fd);
                             return Err(err);
                         }
                     };

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -37,6 +37,12 @@ const { validateInteger, validateInt32, validateFunction } = require("internal/v
 
 const kIsPerformingIO = Symbol("kIsPerformingIO");
 const kIoDone = Symbol("kIoDone");
+const kFileSink = Symbol("kFileSink");
+const fileSinkBytesWritten: (sink: FileSink) => number | undefined = $newRustFunction(
+  "runtime/webcore/FileSink.rs",
+  "jsBytesWritten",
+  1,
+);
 // Bun supports a fast path for `createWriteStream("path.txt")` where instead of
 // using `node:fs`, `Bun.file(...).writer()` is used instead.
 const kWriteStreamFastPath = Symbol("kWriteStreamFastPath");
@@ -256,6 +262,15 @@ function streamConstruct(this: FSStream, callback: (e?: any) => void) {
         callback(err);
       } else {
         this.fd = fd;
+        if (this[kFileSink] === true && fs.write === write) {
+          try {
+            this[kFileSink] = Bun.file(fd).writer();
+            this._write = fileSinkWrite;
+            this._writev = fileSinkWritev;
+          } catch {
+            this[kFileSink] = undefined;
+          }
+        }
         callback();
         this.emit("open", this.fd);
         this.emit("ready");
@@ -350,6 +365,24 @@ function close(stream, err, cb) {
     return;
   }
 
+  const sink = stream[kFileSink];
+  if (sink && sink !== true) {
+    stream[kFileSink] = undefined;
+    let rc;
+    try {
+      rc = sink.end(err);
+    } catch (sinkErr) {
+      return close(stream, err || sinkErr, cb);
+    }
+    if ($isPromise(rc)) {
+      rc.then(
+        () => close(stream, err, cb),
+        sinkErr => close(stream, err || sinkErr, cb),
+      );
+      return;
+    }
+  }
+
   if (!stream.fd) {
     cb(err);
   } else if (stream.flush) {
@@ -433,6 +466,7 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
     if (!write) this._write = null;
     if (!writev) this._writev = null;
   } else {
+    if (!fastPath && fd == null && start === undefined && autoClose !== false) this[kFileSink] = true;
     this._writev = undefined;
     $assert(this[kFs].write, "assuming user does not delete fs.write!");
   }
@@ -553,6 +587,84 @@ function writevAll(chunks, size, pos, cb, retries = 0) {
       cb();
     }
   });
+}
+
+function fileSinkWrite(data, encoding, cb) {
+  if (this.destroyed) return cb($ERR_STREAM_DESTROYED("write"));
+  const sink = this[kFileSink];
+  let rc;
+  try {
+    rc = sink.write(data);
+    // `true` means the sink is already done and dropped the chunk.
+    if (rc === true) throw $ERR_STREAM_DESTROYED("write");
+    // flush(true) waits for bytes libuv still has in flight (Windows).
+    if (!$isPromise(rc)) rc = sink.flush(true);
+  } catch (e) {
+    return afterFileSinkWriteSettled(this, cb, e, 0);
+  }
+  if ($isPromise(rc)) {
+    this[kIsPerformingIO] = true;
+    rc.then(
+      () => afterFileSinkWriteSettled(this, cb, null, data.length),
+      err => afterFileSinkWriteSettled(this, cb, err, 0),
+    );
+  } else {
+    this.bytesWritten += data.length;
+    process.nextTick(afterFileSinkWrite, this, cb);
+  }
+}
+
+function fileSinkWritev(data, cb) {
+  if (this.destroyed) return cb($ERR_STREAM_DESTROYED("write"));
+  const len = data.length;
+  let size = 0;
+  const chunks = new Array(len);
+  for (let i = 0; i < len; i++) {
+    const chunk = data[i].chunk;
+    chunks[i] = chunk;
+    size += chunk.length;
+  }
+  const sink = this[kFileSink];
+  let rc;
+  try {
+    rc = sink.writev(chunks);
+    if (rc === true) throw $ERR_STREAM_DESTROYED("write");
+    if (!$isPromise(rc)) rc = sink.flush(true);
+  } catch (e) {
+    return afterFileSinkWriteSettled(this, cb, e, 0);
+  }
+  if ($isPromise(rc)) {
+    this[kIsPerformingIO] = true;
+    rc.then(
+      () => afterFileSinkWriteSettled(this, cb, null, size),
+      err => afterFileSinkWriteSettled(this, cb, err, 0),
+    );
+  } else {
+    this.bytesWritten += size;
+    process.nextTick(afterFileSinkWrite, this, cb);
+  }
+}
+
+function afterFileSinkWriteSettled(stream, cb, err, bytes) {
+  stream[kIsPerformingIO] = false;
+  if (stream.destroyed) {
+    cb(err || $ERR_STREAM_DESTROYED("write"));
+    return stream.emit(kIoDone, err);
+  }
+  if (err) {
+    // The rejection does not say how much of the chunk landed; the sink does.
+    const sink = stream[kFileSink];
+    const written = sink && sink !== true ? fileSinkBytesWritten(sink) : undefined;
+    if (written !== undefined) stream.bytesWritten = written;
+    return cb(err);
+  }
+  stream.bytesWritten += bytes;
+  cb(null);
+}
+
+function afterFileSinkWrite(stream, cb) {
+  if (stream.destroyed) return cb($ERR_STREAM_DESTROYED("write"));
+  cb(null);
 }
 
 function _write(data, encoding, cb) {

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -445,6 +445,7 @@ BUN_DECLARE_HOST_FUNCTION(ArrayBufferSink__flush);
 BUN_DECLARE_HOST_FUNCTION(ArrayBufferSink__start);
 ZIG_DECL void ArrayBufferSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(ArrayBufferSink__write);
+BUN_DECLARE_HOST_FUNCTION(ArrayBufferSink__writev);
 
 #endif
 CPP_DECL JSC::EncodedJSValue HTTPSResponseSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
@@ -460,6 +461,7 @@ BUN_DECLARE_HOST_FUNCTION(HTTPSResponseSink__flush);
 BUN_DECLARE_HOST_FUNCTION(HTTPSResponseSink__start);
 ZIG_DECL void HTTPSResponseSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(HTTPSResponseSink__write);
+BUN_DECLARE_HOST_FUNCTION(HTTPSResponseSink__writev);
 
 #endif
 CPP_DECL JSC::EncodedJSValue HTTPResponseSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
@@ -475,6 +477,7 @@ BUN_DECLARE_HOST_FUNCTION(HTTPResponseSink__flush);
 BUN_DECLARE_HOST_FUNCTION(HTTPResponseSink__start);
 ZIG_DECL void HTTPResponseSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(HTTPResponseSink__write);
+BUN_DECLARE_HOST_FUNCTION(HTTPResponseSink__writev);
 
 #endif
 CPP_DECL JSC::EncodedJSValue FileSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
@@ -490,6 +493,7 @@ BUN_DECLARE_HOST_FUNCTION(FileSink__flush);
 BUN_DECLARE_HOST_FUNCTION(FileSink__start);
 ZIG_DECL void FileSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(FileSink__write);
+BUN_DECLARE_HOST_FUNCTION(FileSink__writev);
 
 #endif
 
@@ -506,6 +510,7 @@ BUN_DECLARE_HOST_FUNCTION(FileSink__flush);
 BUN_DECLARE_HOST_FUNCTION(FileSink__start);
 ZIG_DECL void FileSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(FileSink__write);
+BUN_DECLARE_HOST_FUNCTION(FileSink__writev);
 
 #endif
 CPP_DECL JSC::EncodedJSValue NetworkSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
@@ -522,6 +527,7 @@ BUN_DECLARE_HOST_FUNCTION(NetworkSink__flush);
 BUN_DECLARE_HOST_FUNCTION(NetworkSink__start);
 ZIG_DECL void NetworkSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(NetworkSink__write);
+BUN_DECLARE_HOST_FUNCTION(NetworkSink__writev);
 #endif
 
 CPP_DECL JSC::EncodedJSValue FetchRequestBodySink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
@@ -538,6 +544,7 @@ BUN_DECLARE_HOST_FUNCTION(FetchRequestBodySink__flush);
 BUN_DECLARE_HOST_FUNCTION(FetchRequestBodySink__start);
 ZIG_DECL void FetchRequestBodySink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(FetchRequestBodySink__write);
+BUN_DECLARE_HOST_FUNCTION(FetchRequestBodySink__writev);
 #endif
 
 CPP_DECL JSC::EncodedJSValue HTMLRewriterSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
@@ -554,6 +561,7 @@ BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__flush);
 BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__start);
 ZIG_DECL void HTMLRewriterSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__write);
+BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__writev);
 #endif
 
 #ifdef __cplusplus

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1806,6 +1806,18 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
     fn write_bytes(&mut self, data: &StreamResult) -> Writable {
         RewriterPipe::write(self, data)
     }
+    // Handler JS runs inside `write` and may detach a later chunk: copy first.
+    fn writev_bytes(&mut self, bufs: &[&[u8]]) -> Writable {
+        let total = bufs.iter().map(|b| b.len()).sum();
+        let mut buf: Vec<u8> = Vec::new();
+        if buf.try_reserve_exact(total).is_err() {
+            return Writable::Err(SysError::oom());
+        }
+        for b in bufs {
+            buf.extend_from_slice(b);
+        }
+        RewriterPipe::write(self, &StreamResult::Temporary(RawSlice::new(&buf)))
+    }
     fn write_utf16(&mut self, data: &StreamResult) -> Writable {
         let mut buf = Vec::new();
         let _ = buf.write_utf16(data.slice16());

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1758,6 +1758,7 @@ impl BlobExt for Blob {
         #[cfg(windows)]
         {
             use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
+            use bun_sys::FdExt as _;
 
             let pathlike = &store.data.as_file().pathlike;
             // SAFETY: bun_vm() never returns null for a Bun-owned global.
@@ -1799,6 +1800,30 @@ impl BlobExt for Blob {
                 )
             };
 
+            let borrowed = matches!(pathlike, PathOrFileDescriptor::Fd(_));
+            // uv_pipe_open adopts the handle; dup so the caller keeps their fd.
+            let (writer_fd, owns_fd) = if borrowed
+                && !is_stdout_or_stderr
+                && matches!(
+                    bun_sys::windows::libuv::uv_guess_handle(fd.uv()),
+                    bun_sys::windows::libuv::HandleType::NamedPipe
+                        | bun_sys::windows::libuv::HandleType::Tty
+                ) {
+                match bun_sys::dup(fd).and_then(|d| {
+                    d.make_lib_uv_owned_for_syscall(
+                        bun_sys::Tag::dup,
+                        bun_sys::ErrorCase::CloseOnFail,
+                    )
+                }) {
+                    bun_sys::Result::Ok(dup) => (dup, true),
+                    bun_sys::Result::Err(err) => {
+                        return Err(global_this.throw_value(err.to_js(global_this)));
+                    }
+                }
+            } else {
+                (fd, !borrowed)
+            };
+
             let sink = webcore::FileSink::init(
                 fd,
                 jsc::EventLoopHandle::init(
@@ -1810,17 +1835,19 @@ impl BlobExt for Blob {
                 ),
             );
             // `to_js` takes its own per-wrapper +1; init's ref drops at scope end.
-            sink.writer
-                .with_mut(|w| w.owns_fd = !matches!(pathlike, PathOrFileDescriptor::Fd(_)));
+            sink.writer.with_mut(|w| w.owns_fd = owns_fd);
 
             let start_result = sink.writer.with_mut(|w| {
                 if is_stdout_or_stderr {
-                    w.start_sync(fd, false)
+                    w.start_sync(writer_fd, false)
                 } else {
-                    w.start(fd, true)
+                    w.start(writer_fd, true)
                 }
             });
             if let bun_sys::Result::Err(err) = start_result {
+                if owns_fd {
+                    writer_fd.close();
+                }
                 return Err(global_this.throw_value(err.to_js(global_this)));
             }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -6,7 +6,9 @@ use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use bun_io::{self, WriteResult, WriteStatus};
 use bun_jsc::JsCell;
 use bun_ptr::RefPtr;
-use bun_sys::{self as sys, Fd, FdExt as _};
+#[cfg(windows)]
+use bun_sys::FdExt as _;
+use bun_sys::{self as sys, Fd};
 
 use crate::api::bun::process::Status as SpawnStatus;
 use crate::webcore::jsc::{CallFrame, EventLoopHandle, JSGlobalObject, JSValue, JsResult};
@@ -94,6 +96,17 @@ pub mod testing_apis {
 // `generated_js2native.rs` snake-cases `TestingAPIs` as `testing_ap_is`
 // (acronym splitter treats `AP|Is` as two words); alias so both resolve.
 pub use testing_apis as testing_ap_is;
+
+/// Bytes the sink has pushed to its fd so far (`fs.WriteStream`, after a failed write).
+pub(crate) fn js_bytes_written(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let Some(sink) = crate::webcore::sink::JSSink::<FileSink>::from_js(frame.argument(0)) else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    // SAFETY: `from_js` returns the live wrapper's `*mut JSSink<FileSink>`.
+    Ok(JSValue::js_number(
+        unsafe { (*sink).sink.written.get() } as f64
+    ))
+}
 
 /// `bun_sys` does not yet export
 /// an isPollable helper, so re-derive it locally from `S_IFMT`. Windows always
@@ -686,6 +699,37 @@ impl FileSink {
             sys::Result::Ok(fd) => fd,
         };
 
+        let borrowed = matches!(&options.input_path, PathOrFileDescriptor::Fd(_));
+        #[allow(unused_mut)]
+        let mut owns_fd = !borrowed;
+        self.fd.set(fd);
+        // Pollable fds need a per-sink epoll entry; dup those, adopt the rest.
+        #[cfg(unix)]
+        let fd = if borrowed && self.pollable.get() {
+            let dup = bun_sys::dup_with_flags(fd, 0)?;
+            owns_fd = true;
+            dup
+        } else {
+            fd
+        };
+        // uv_pipe_open adopts the handle; dup so the caller keeps their fd.
+        #[cfg(windows)]
+        let fd = if borrowed
+            && !self.force_sync.get()
+            && matches!(
+                uv::uv_guess_handle(fd.uv()),
+                uv::HandleType::NamedPipe | uv::HandleType::Tty
+            ) {
+            use bun_sys::FdExt as _;
+            let dup = bun_sys::dup(fd)?.make_lib_uv_owned_for_syscall(
+                bun_sys::Tag::dup,
+                bun_sys::ErrorCase::CloseOnFail,
+            )?;
+            owns_fd = true;
+            dup
+        } else {
+            fd
+        };
         #[cfg(windows)]
         {
             if self.force_sync.get() {
@@ -695,10 +739,13 @@ impl FileSink {
                     .with_mut(|w| w.start_sync(fd, self.pollable.get()))
                 {
                     sys::Result::Err(err) => {
-                        fd.close();
+                        if owns_fd {
+                            fd.close();
+                        }
                         return sys::Result::Err(err);
                     }
                     sys::Result::Ok(()) => {
+                        self.writer.with_mut(|w| w.owns_fd = owns_fd);
                         self.writer
                             .with_mut(|w| w.update_ref(self.io_evtloop(), false));
                     }
@@ -710,10 +757,21 @@ impl FileSink {
         // SAFETY(JsCell): `start` is pure I/O setup; no JS.
         match self.writer.with_mut(|w| w.start(fd, self.pollable.get())) {
             sys::Result::Err(err) => {
-                fd.close();
+                // POSIX start() may have set handle; let Drop own the close.
+                #[cfg(unix)]
+                self.writer.with_mut(|w| w.close_fd = owns_fd);
+                // Windows start() leaves source = None on failure; close here.
+                #[cfg(windows)]
+                if owns_fd {
+                    fd.close();
+                }
                 return sys::Result::Err(err);
             }
             sys::Result::Ok(()) => {
+                #[cfg(unix)]
+                self.writer.with_mut(|w| w.close_fd = owns_fd);
+                #[cfg(windows)]
+                self.writer.with_mut(|w| w.owns_fd = owns_fd);
                 // Only keep the event loop ref'd while there's a pending write in progress.
                 // If there's no pending write, no need to keep the event loop ref'd.
                 self.writer
@@ -847,7 +905,7 @@ impl FileSink {
     pub(crate) unsafe fn on_auto_flush(this: *mut FileSink) -> bool {
         // SAFETY: caller contract — `this` is live with write+dealloc provenance.
         unsafe {
-            if (*this).done.get() || !(*this).writer.get().has_pending_data() {
+            if !(*this).writer.get().has_pending_data() {
                 (*this).update_ref(false);
                 (*this).auto_flusher.with_mut(|a| a.registered.set(false));
                 return false;
@@ -855,11 +913,14 @@ impl FileSink {
 
             let _guard = RefPtr::init_ref(this);
 
+            let done = (*this).done.get();
             let amount_buffered = (*this).writer.get().outgoing.size();
 
             // SAFETY(JsCell): `IOWriter::flush` is pure I/O; the `on_write`
             // callback it may trigger goes via the stored `*mut FileSink` backref.
-            match (*this).writer.with_mut(|w| w.flush()) {
+            let flush_result = (*this).writer.with_mut(|w| w.flush());
+            (*this).count_flushed(&flush_result);
+            match flush_result {
                 WriteResult::Err(err) => {
                     (*this).update_ref(false);
                     // `flush()` returns a write error without routing through the
@@ -882,11 +943,17 @@ impl FileSink {
                 }
                 WriteResult::Done(_) => {
                     (*this).update_ref(false);
+                    if done {
+                        (*this).writer.with_mut(|w| w.end());
+                    }
                     (*this).run_pending_later();
                 }
                 WriteResult::Wrote(amount_drained) => {
                     if amount_drained == amount_buffered {
                         (*this).update_ref(false);
+                        if done {
+                            (*this).writer.with_mut(|w| w.end());
+                        }
                         (*this).run_pending_later();
                         // `flush()`'s drain bypasses `on_write(Drained)`; resume the parked ByteStream here.
                         if (*this).source_pending_pull.replace(false) {
@@ -912,13 +979,12 @@ impl FileSink {
         sys::Result::Ok(())
     }
 
+    /// `wait`: bytes still in flight (Windows `uv_fs_write`) yield a promise, not a count.
     pub(crate) fn flush_from_js(
         &self,
         global_this: &JSGlobalObject,
         wait: bool,
     ) -> sys::Result<JSValue> {
-        let _ = wait;
-
         if self.pending.get().state == streams::PendingState::Pending {
             if let streams::WritableFuture::Promise { strong, .. } = &self.pending.get().future {
                 return sys::Result::Ok(strong.value());
@@ -941,17 +1007,34 @@ impl FileSink {
         if had_buffered_data && !self.writer.get().has_pending_data() {
             self.update_ref(false);
         }
+        self.count_flushed(&rc);
         let flushed = match rc {
             WriteResult::Done(written)
             | WriteResult::Pending(written)
-            | WriteResult::Wrote(written) => {
-                self.written.set(self.written.get() + written as usize); // @truncate
-                written as u64 // @truncate
-            }
+            | WriteResult::Wrote(written) => written as u64, // @truncate
             WriteResult::Err(err) => {
                 return sys::Result::Err(err);
             }
         };
+        if wait
+            && matches!(rc, WriteResult::Pending(_))
+            && !self.writer.get().is_backed_up()
+            && self.writer.get().has_pending_data()
+        {
+            if !self.must_be_kept_alive_until_eof.get() {
+                self.must_be_kept_alive_until_eof.set(true);
+                self.ref_();
+            }
+            self.pending.with_mut(|p| {
+                p.consumed += flushed;
+                p.result = streams::Writable::Owned(p.consumed);
+            });
+            // SAFETY: JsCell — `WritablePending::promise` allocates a JSPromise
+            // (may GC) but invokes no FileSink host-fn.
+            let promise = unsafe { self.pending.get_mut() }.promise(global_this);
+            // SAFETY: `WritablePending::promise()` never returns null.
+            return sys::Result::Ok(unsafe { (*promise).to_js() });
+        }
         // A flush takes no new chunk from the caller; a pending one reports the
         // bytes it pushed out. It only reaches here when no write is pending.
         match self.to_result(rc, flushed) {
@@ -1055,6 +1138,13 @@ impl FileSink {
         self.to_result(rc, accepted)
     }
 
+    /// `flush()` drains without `on_write`; record what it pushed to the fd.
+    fn count_flushed(&self, rc: &WriteResult) {
+        if let WriteResult::Done(n) | WriteResult::Wrote(n) | WriteResult::Pending(n) = rc {
+            self.written.set(self.written.get() + n);
+        }
+    }
+
     fn count_stream_bytes(&self, rc: &WriteResult, encoded_len: usize) {
         let counted = self.stream_bytes.get().unwrap_or(0);
         match rc {
@@ -1075,6 +1165,21 @@ impl FileSink {
         if self.stream_error.get().is_none() {
             self.stream_error.set(Some(err));
         }
+    }
+
+    pub fn writev_bytes(&self, bufs: &[&[u8]]) -> streams::Writable {
+        if self.done.get() {
+            return streams::Writable::Done;
+        }
+        let buffered_before = self.writer.get().buffered_len();
+        // SAFETY(JsCell): `IOWriter::writev` buffers/writes to fd; does not call JS.
+        let rc = self.writer.with_mut(|w| w.writev(bufs));
+        if self.counting_stream_bytes() {
+            let total: usize = bufs.iter().map(|b| b.len()).sum();
+            self.count_stream_bytes(&rc, total);
+        }
+        let accepted = self.bytes_accepted(buffered_before, &rc);
+        self.to_result(rc, accepted)
     }
 
     pub(crate) fn write_latin1(&self, data: &streams::Result) -> streams::Writable {
@@ -1166,9 +1271,10 @@ impl FileSink {
 
         // SAFETY(JsCell): `IOWriter::flush` is pure I/O; any callback re-entry
         // goes via the stored `*mut FileSink` backref, not this borrow.
-        match self.writer.with_mut(|w| w.flush()) {
-            WriteResult::Done(written) | WriteResult::Wrote(written) => {
-                self.written.set(self.written.get() + written as usize); // @truncate
+        let flush_result = self.writer.with_mut(|w| w.flush());
+        self.count_flushed(&flush_result);
+        match flush_result {
+            WriteResult::Done(_) | WriteResult::Wrote(_) => {
                 if has_pending {
                     // `to_result` already seeded `Owned(consumed)`; just deliver it.
                     self.run_pending_later();
@@ -1189,8 +1295,7 @@ impl FileSink {
                 self.end_writer();
                 sys::Result::Err(e)
             }
-            WriteResult::Pending(written) => {
-                self.written.set(self.written.get() + written as usize); // @truncate
+            WriteResult::Pending(_) => {
                 if !self.must_be_kept_alive_until_eof.get() {
                     self.must_be_kept_alive_until_eof.set(true);
                     self.ref_();
@@ -1233,6 +1338,7 @@ impl FileSink {
 
         // SAFETY(JsCell): `IOWriter::flush` is pure I/O; no JS while held.
         let flush_result = self.writer.with_mut(|w| w.flush());
+        self.count_flushed(&flush_result);
 
         // `writer.end()` only re-enters `on_close`, which never touches
         // `self.pending`; every arm that tears the writer down here with a
@@ -1286,8 +1392,6 @@ impl FileSink {
                 sys::Result::Err(err)
             }
             WriteResult::Pending(pending_written) => {
-                self.written
-                    .set(self.written.get() + pending_written as usize); // @truncate
                 if !self.must_be_kept_alive_until_eof.get() {
                     self.must_be_kept_alive_until_eof.set(true);
                     self.ref_();
@@ -1364,6 +1468,9 @@ impl crate::webcore::sink::JsSinkType for FileSink {
         // `Self::construct()` allocates with `ref_count=1`; that +1 belongs to
         // the C++ `JSFileSink` wrapper `js_construct` is about to create.
         this.write(Self::construct());
+    }
+    fn writev_bytes(&mut self, bufs: &[&[u8]]) -> streams::result::Writable {
+        Self::writev_bytes(self, bufs)
     }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue> {
         Self::end_from_js(self, global)

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -309,6 +309,39 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     fn write_bytes(&mut self, data: &streams::Result) -> streams::result::Writable;
     fn write_utf16(&mut self, data: &streams::Result) -> streams::result::Writable;
     fn write_latin1(&mut self, data: &streams::Result) -> streams::result::Writable;
+    /// `bufs` borrow JS buffers; a sink whose `write_bytes` runs JS must copy them first.
+    fn writev_bytes(&mut self, bufs: &[&[u8]]) -> streams::result::Writable {
+        use streams::result::Writable;
+        let mut total: u64 = 0;
+        let mut backpressure = false;
+        // A sink that parks every write still takes the next chunk.
+        let mut pending = None;
+        for b in bufs {
+            if b.is_empty() {
+                continue;
+            }
+            let data = bun_ptr::RawSlice::new(b);
+            match self.write_bytes(&streams::Result::Temporary(data)) {
+                Writable::Owned(n) | Writable::Temporary(n) => total += n,
+                Writable::Backpressure(n) => {
+                    total += n;
+                    backpressure = true;
+                }
+                Writable::OwnedAndDone(n) => return Writable::OwnedAndDone(total + n),
+                Writable::Done => return Writable::OwnedAndDone(total),
+                slot @ Writable::Pending(_) => pending = Some(slot),
+                err @ Writable::Err(_) => return err,
+            }
+        }
+        if let Some(slot) = pending {
+            return slot;
+        }
+        if backpressure {
+            Writable::Backpressure(total)
+        } else {
+            Writable::Owned(total)
+        }
+    }
     fn end(&mut self, err: Option<SysError>) -> sys::Result<()>;
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue>;
     fn flush(&mut self) -> sys::Result<()>;
@@ -504,6 +537,67 @@ impl<T: JsSinkType> JSSink<T> {
             .sink
             .write_latin1(&streams::Result::Temporary(data))
             .to_js(global))
+    }
+
+    /// `${abi_name}__writev` host-fn body.
+    pub fn js_writev(
+        global: &crate::webcore::jsc::JSGlobalObject,
+        frame: &crate::webcore::jsc::CallFrame,
+    ) -> crate::webcore::jsc::JsResult<crate::webcore::jsc::JSValue> {
+        use crate::webcore::jsc::JSValue;
+        bun_core::mark_binding!();
+
+        let arg = frame.argument(0);
+        arg.ensure_still_alive();
+        let _keep = bun_jsc::EnsureStillAlive(arg);
+        if !arg.is_array() {
+            return Err(global.throw_value(global.to_type_error(
+                bun_jsc::ErrorCode::INVALID_ARG_TYPE,
+                format_args!("writev() expects an array of ArrayBufferView"),
+            )));
+        }
+
+        let len = arg.get_length(global)? as usize;
+        if len == 0 {
+            return Ok(JSValue::js_number(0.0));
+        }
+        const MAX_CHUNKS: usize = 1 << 20;
+        if len > MAX_CHUNKS {
+            return Err(global.throw_value(global.to_type_error(
+                bun_jsc::ErrorCode::OUT_OF_RANGE,
+                format_args!("writev() chunk count {} exceeds {}", len, MAX_CHUNKS),
+            )));
+        }
+
+        bun_jsc::MarkedArgumentBuffer::new(|roots| {
+            let mut items: Vec<JSValue> = Vec::with_capacity(len);
+            for i in 0..len {
+                let item = arg.get_index(global, i as u32)?;
+                roots.append(item);
+                items.push(item);
+            }
+            let mut slices: Vec<&[u8]> = Vec::with_capacity(len);
+            for item in &items {
+                let Some(buffer) = item.as_array_buffer(global) else {
+                    return Err(global.throw_value(global.to_type_error(
+                        bun_jsc::ErrorCode::INVALID_ARG_TYPE,
+                        format_args!("writev() expects an array of ArrayBufferView"),
+                    )));
+                };
+                let slice = buffer.slice();
+                // SAFETY: `roots` keeps every cell GC-live. No JS runs before
+                // `writev_bytes`, and a sink whose write runs JS (RewriterPipe)
+                // copies every chunk before its first write, so no slice is
+                // read after a detach could happen.
+                slices.push(unsafe { core::slice::from_raw_parts(slice.as_ptr(), slice.len()) });
+            }
+            // Acquire `&mut sink` only after all accessor JS has run.
+            let this = Self::get_this(global, frame)?;
+            if let Some(err) = this.sink.get_pending_error() {
+                return Err(global.throw_value(err));
+            }
+            Ok(this.sink.writev_bytes(&slices).to_js(global))
+        })
     }
 
     /// `${abi_name}__flush` host-fn body.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7329,6 +7329,36 @@ pub fn read_nonblocking(fd: Fd, buf: &mut [u8]) -> Maybe<usize> {
     }
     read(fd, buf)
 }
+/// Linux: `pwritev2(iov, -1, RWF_NOWAIT)`; else plain `writev`.
+pub fn writev_nonblocking(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    while linux::RWFFlagSupport::is_maybe_supported() {
+        // SAFETY: fd valid; vecs is a live slice of iovec.
+        let rc = unsafe {
+            sys_pwritev2(
+                fd.native(),
+                vecs.as_ptr(),
+                vecs.len() as c_int,
+                -1,
+                RWF_NOWAIT,
+            )
+        };
+        if rc < 0 {
+            let e = last_errno();
+            match e {
+                libc::EOPNOTSUPP | libc::ENOSYS | libc::EPERM | libc::EACCES => {
+                    linux::RWFFlagSupport::disable();
+                    break;
+                }
+                libc::EINTR => continue,
+                _ => return Err(Error::from_code_int(e, Tag::writev).with_fd(fd)),
+            }
+        }
+        return Ok(rc as usize);
+    }
+    writev(fd, vecs)
+}
+
 /// Linux: `pwritev2(.., RWF_NOWAIT)`; else plain `write`.
 pub fn write_nonblocking(fd: Fd, buf: &[u8]) -> Maybe<usize> {
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -165,9 +165,65 @@ describe("FileSink", () => {
       });
     });
   }
+
+  it("writev writes each chunk in order", async () => {
+    const path = join(tmpdirSync(), "writev.txt");
+    const sink = Bun.file(path).writer();
+    const rc = sink.writev([
+      Buffer.from("one "),
+      new Uint8Array([0x74, 0x77, 0x6f, 0x20]),
+      new TextEncoder().encode("three"),
+    ]);
+    expect(typeof rc === "number" || rc instanceof Promise).toBe(true);
+    await sink.end();
+    expect(await Bun.file(path).text()).toBe("one two three");
+  });
+
+  it("writev rejects non-ArrayBufferView entries", async () => {
+    const path = join(tmpdirSync(), "writev-bad.txt");
+    const sink = Bun.file(path).writer();
+    try {
+      expect(() => sink.writev(["string" as any])).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+      expect(() => (sink as any).writev("not an array")).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    } finally {
+      await sink.end();
+    }
+  });
+
+  it("writev does not dereference a buffer detached by an accessor getter", async () => {
+    const path = join(tmpdirSync(), "writev-detach.txt");
+    const sink = Bun.file(path).writer();
+    const ab = new ArrayBuffer(64);
+    const u8 = new Uint8Array(ab);
+    const arr: any[] = [u8, null];
+    Object.defineProperty(arr, 1, {
+      get() {
+        (ab as any).transfer();
+        return new Uint8Array([0x6f, 0x6b]);
+      },
+    });
+    // The first element is validated after all getters have run, so it is
+    // seen as detached (byteLength 0) and contributes no bytes; the second
+    // element's two bytes are written.
+    sink.writev(arr);
+    await sink.end();
+    expect(await Bun.file(path).text()).toBe("ok");
+  });
+
+  it("writev on ArrayBufferSink falls through to write()", () => {
+    const s = new Bun.ArrayBufferSink();
+    s.start();
+    s.writev([Buffer.from("hello"), Buffer.from(" "), Buffer.from("world")]);
+    const out = s.end();
+    expect(new TextDecoder().decode(out)).toBe("hello world");
+  });
 });
 
+import { once } from "node:events";
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import util from "node:util";
 
@@ -399,6 +455,36 @@ it.skipIf(!isLinux)(
   },
 );
 
+// write(2) accepts the bytes up to RLIMIT_FSIZE and fails the rest with
+// EFBIG. The short write is credited before the error is reported, so end()
+// accounts for every byte that reached the fd.
+it.skipIf(!isLinux)("a write that fails after a short write still credits the bytes written", async () => {
+  const out = join(tmpdirSync(), "efbig.bin");
+  const script = `
+    const fd = require("node:fs").openSync(${JSON.stringify(out)}, "w");
+    const sink = Bun.file(fd).writer();
+    const rc = sink.write(Buffer.alloc(4 << 20, 0x61));
+    const code = await Promise.resolve(rc).then(() => "ok", e => e.code);
+    const ended = await sink.end();
+    console.log(JSON.stringify({ code, ended, size: require("node:fs").fstatSync(fd).size }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: ["sh", "-c", `ulimit -f 2048; exec "${bunExe()}" -e '${script.replace(/'/g, "'\\''")}'`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result.size).toBeWithin(1, 4 << 20);
+  expect({ code: result.code, ended: result.ended, exitCode }).toEqual({
+    code: "EFBIG",
+    ended: result.size,
+    exitCode: 0,
+  });
+});
+
 // The deferred auto-flush microtask runs at the first microtask checkpoint
 // after write() backpressures. If its flush() hit EPIPE, it discarded the
 // error and then let `run_pending_later()` resolve the pending write() promise
@@ -460,6 +546,61 @@ if (isWindows) {
         syscall: "open",
       }),
     );
+  });
+
+  // A regular-file write on Windows is an async uv_fs_write; write() reports
+  // it accepted, flush(true) hands back the promise for its completion.
+  it("flush(true) waits for the in-flight uv_fs_write", async () => {
+    const path = join(tmpdirSync(), "flush-wait.bin");
+    const fd = fs.openSync(path, "w");
+    try {
+      const sink = Bun.file(fd).writer();
+      const data = Buffer.alloc(64 * 1024, 0x62);
+      sink.write(data);
+      const flushed = sink.flush(true);
+      expect(flushed).toBeInstanceOf(Promise);
+      await flushed;
+      expect(fs.fstatSync(fd).size).toBe(data.length);
+      await sink.end();
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  it("Bun.file(fd).writer() on a named pipe dups so end() releases the sink", async () => {
+    const pipePath = `\\\\.\\pipe\\bun-filesink-${process.pid}-${Date.now()}`;
+    const { promise: gotData, resolve: onData, reject: onErr } = Promise.withResolvers<string>();
+    const server = net.createServer(c => {
+      c.once("data", d => onData(String(d)));
+      c.once("error", onErr);
+    });
+    server.once("error", onErr);
+    server.listen(pipePath);
+    await once(server, "listening");
+
+    let fd = -1;
+    try {
+      fd = fs.openSync(pipePath, "w");
+      const baseline = fileSinkInternals.liveCount();
+      const sink = Bun.file(fd).writer();
+      const rc = sink.write(Buffer.from("hello"));
+      if (rc instanceof Promise) await rc;
+      await sink.end();
+
+      // end() must not close the caller's fd: fstat still works.
+      expect(() => fs.fstatSync(fd)).not.toThrow();
+      expect(await gotData).toBe("hello");
+
+      for (let i = 0; i < 50; i++) {
+        Bun.gc(true);
+        if (fileSinkInternals.liveCount() <= baseline) break;
+        await Bun.sleep(10);
+      }
+      expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline);
+    } finally {
+      if (fd !== -1) fs.closeSync(fd);
+      await new Promise<void>(r => server.close(() => r()));
+    }
   });
 }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -15,6 +15,7 @@ import {
   tempDirWithFiles,
   tmpdirSync,
 } from "harness";
+import { once } from "node:events";
 import fs, {
   closeSync,
   constants,
@@ -4475,6 +4476,196 @@ describe("createWriteStream", () => {
         done();
       }
     });
+  });
+
+  async function writeLines(ws: fs.WriteStream, n: number, line: string | Buffer) {
+    for (let i = 0; i < n; i++) {
+      if (!ws.write(line)) await once(ws, "drain");
+    }
+    await new Promise<void>((resolve, reject) => ws.end(err => (err ? reject(err) : resolve())));
+    await once(ws, "close");
+  }
+
+  it.skipIf(!isLinux)("coalesces many small writes instead of dispatching one syscall per chunk", async () => {
+    const syscw = () => +readFileSync("/proc/self/io", "utf8").match(/syscw: (\d+)/)![1];
+    const N = 5000;
+    const line = Buffer.alloc(81, "x");
+    using dir = tempDir("ws-coalesce", {});
+    const streamPath = join(String(dir), "out.txt");
+
+    const ws = createWriteStream(streamPath);
+    await once(ws, "ready");
+    const fd = ws.fd as number;
+    expect(fd).toBeGreaterThan(0);
+
+    const before = syscw();
+    await writeLines(ws, N, line);
+    const writeSyscalls = syscw() - before;
+
+    expect({
+      size: statSync(streamPath).size,
+      bytesWritten: ws.bytesWritten,
+      fdClosed: (() => {
+        try {
+          fstatSync(fd);
+          return false;
+        } catch {
+          return true;
+        }
+      })(),
+    }).toEqual({ size: N * line.length, bytesWritten: N * line.length, fdClosed: true });
+
+    // Without coalescing each chunk is a separate thread-pool dispatch (one
+    // write(2) to the file plus one 8-byte eventfd wake), so 5000 chunks is
+    // ~10000 write syscalls. Coalescing brings it well under N/4.
+    expect(writeSyscalls).toBeLessThan(N / 4);
+  });
+
+  it.skipIf(!isLinux)("holds a single fd for the stream's lifetime", async () => {
+    using dir = tempDir("ws-fd-count", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const fs = require("node:fs");
+         const { once } = require("node:events");
+         const countFds = () => fs.readdirSync("/proc/self/fd").length;
+         const before = countFds();
+         const ws = fs.createWriteStream(process.argv[1]);
+         await once(ws, "ready");
+         const open = countFds() - before;
+         ws.write("x");
+         await new Promise((res, rej) => ws.end(e => (e ? rej(e) : res())));
+         await once(ws, "close");
+         console.log(JSON.stringify({ open, closed: countFds() - before }));`,
+        join(String(dir), "out.txt"),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ open: 1, closed: 0 });
+    expect(exitCode).toBe(0);
+  });
+
+  it("many small writes produce byte-exact output and bytesWritten", async () => {
+    const N = isDebug ? 2000 : 10000;
+    const chunk = "\u00e9#"; // 2-byte UTF-8 char + 1 ASCII byte => 3 bytes/chunk
+    const byteLen = Buffer.byteLength(chunk);
+    using dir = tempDir("ws-bytes", {});
+    const streamPath = join(String(dir), "out.txt");
+
+    const ws = createWriteStream(streamPath);
+    await writeLines(ws, N, chunk);
+
+    expect({
+      size: statSync(streamPath).size,
+      bytesWritten: ws.bytesWritten,
+      head: readFileSync(streamPath, "utf8").slice(0, chunk.length * 3),
+    }).toEqual({ size: N * byteLen, bytesWritten: N * byteLen, head: chunk + chunk + chunk });
+  });
+
+  it.skipIf(!isLinux)("surfaces a synchronous write(2) failure via the stream's 'error' event", async () => {
+    const ws = createWriteStream("/dev/full");
+    await once(ws, "ready");
+    let unhandled = 0;
+    const onUnhandled = () => unhandled++;
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const errorPromise = once(ws, "error");
+      ws.write(Buffer.alloc(8192));
+      const [err] = (await errorPromise) as [NodeJS.ErrnoException];
+      await new Promise(r => setImmediate(r));
+      expect({ code: err.code, bytesWritten: ws.bytesWritten, unhandled }).toEqual({
+        code: "ENOSPC",
+        bytesWritten: 0,
+        unhandled: 0,
+      });
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  it("write callback fires only after the bytes are on disk", async () => {
+    using dir = tempDir("ws-cb-on-disk", {});
+    const streamPath = join(String(dir), "out.bin");
+    const ws = createWriteStream(streamPath);
+    await once(ws, "ready");
+    const data = Buffer.alloc(256 * 1024, 0x63);
+    const { promise, resolve, reject } = Promise.withResolvers<number>();
+    ws.write(data, err => (err ? reject(err) : resolve(fstatSync(ws.fd as number).size)));
+    expect(await promise).toBe(data.length);
+    await new Promise<void>((res, rej) => ws.end(e => (e ? rej(e) : res())));
+  });
+
+  // A chunk under the sink's 4 KB threshold is buffered first and only hits
+  // the fd on flush. When that flush fails, nothing landed.
+  it.skipIf(!isLinux)("bytesWritten stays 0 when a small buffered write fails", async () => {
+    const ws = createWriteStream("/dev/full");
+    await once(ws, "ready");
+    const errorPromise = once(ws, "error");
+    ws.write(Buffer.alloc(100));
+    const [err] = (await errorPromise) as [NodeJS.ErrnoException];
+    expect({ code: err.code, bytesWritten: ws.bytesWritten }).toEqual({ code: "ENOSPC", bytesWritten: 0 });
+  });
+
+  it.skipIf(!isLinux)("bytesWritten matches the file size when a write fails after many small writes", async () => {
+    using dir = tempDir("cws-efbig-small", {});
+    const out = join(String(dir), "out.bin");
+    const script = `
+      const fs = require("node:fs");
+      const { once } = require("node:events");
+      const s = fs.createWriteStream(${JSON.stringify(out)});
+      const ev = [];
+      s.on("error", e => ev.push("error:" + e.code));
+      s.on("close", () => {
+        console.log(JSON.stringify({ ev, bytesWritten: s.bytesWritten, size: fs.statSync(${JSON.stringify(out)}).size }));
+      });
+      const chunk = Buffer.alloc(512, 0x41);
+      for (let i = 0; i < 8192 && !s.destroyed; i++) {
+        if (!s.write(chunk)) await once(s, "drain").catch(() => {});
+      }
+      s.end();
+    `;
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `ulimit -f 2048; exec "${bunExe()}" -e '${script.replace(/'/g, "'\\''")}'`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect(result.size).toBeWithin(1, 8192 * 512);
+    expect({ ev: result.ev, bytesWritten: result.bytesWritten, exitCode }).toEqual({
+      ev: ["error:EFBIG"],
+      bytesWritten: result.size,
+      exitCode: 0,
+    });
+  });
+
+  it("routes writes through fs.write so a monkey-patch is honoured", async () => {
+    using dir = tempDir("ws-patch", {});
+    const streamPath = join(String(dir), "out.txt");
+    const ws = createWriteStream(streamPath);
+    const original = fs.write;
+    let calls = 0;
+    // @ts-ignore
+    fs.write = function () {
+      calls++;
+      return original.apply(fs, arguments);
+    };
+    try {
+      ws.write("hello");
+      ws.write(" world");
+      await new Promise<void>((resolve, reject) => ws.end(err => (err ? reject(err) : resolve())));
+      await once(ws, "close");
+    } finally {
+      fs.write = original;
+    }
+    expect({ calls, contents: readFileSync(streamPath, "utf8") }).toEqual({ calls: 2, contents: "hello world" });
   });
 });
 

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2726,6 +2726,28 @@ describe("fetch should allow duplex", () => {
     expect(exitCode).toBe(0);
   });
 
+  // The request-body sink parks every JS-pump write as pending; writev must
+  // still take every chunk instead of stopping after the first.
+  it("sends every chunk of a type:'direct' body's controller.writev()", async () => {
+    using server = serve({
+      port: 0,
+      async fetch(req) {
+        return new Response(await req.text());
+      },
+    });
+    const res = await fetch(server.url, {
+      method: "POST",
+      body: new ReadableStream({
+        type: "direct",
+        async pull(controller: any) {
+          await controller.writev([Buffer.from("a"), Buffer.from("bb"), Buffer.from("ccc")]);
+          await controller.end();
+        },
+      }),
+    });
+    expect(await res.text()).toBe("abbccc");
+  });
+
   // Passing a response body as a request body attaches it to a native sink;
   // the source stream must be marked locked + disturbed so a second consumer
   // errors instead of hanging on data that will never be delivered to it.

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -600,6 +600,47 @@ describe("HTMLRewriter", () => {
       expect(afterFlush).toBe(1);
     });
 
+    // `controller.writev()` hands the sink borrowed views of every chunk. A
+    // handler that runs while the first chunk is fed can detach a later
+    // chunk's ArrayBuffer, so the sink must copy the chunks before feeding.
+    // `Malloc=1` puts JSC on the system allocator so an ASAN build sees the
+    // dangling read as a use-after-free instead of stale bytes.
+    it("a direct pull() writev() survives a handler that detaches a later chunk", async () => {
+      const fixture = `
+        const encoder = new TextEncoder();
+        const tailText = "<span>tail</span>";
+        const tail = new Uint8Array(new ArrayBuffer(1 << 16));
+        tail.set(encoder.encode(tailText));
+        const stream = new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            await controller.writev([encoder.encode("<div>head</div>"), tail.subarray(0, tailText.length)]);
+            await controller.end();
+          },
+        });
+        const res = new HTMLRewriter()
+          .on("div", {
+            element(el) {
+              el.setAttribute("seen", "");
+              tail.buffer.transfer();
+              Bun.gc(true);
+            },
+          })
+          .transform(new Response(stream));
+        console.log(await res.text());
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, Malloc: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('<div seen="">head</div><span>tail</span>\n');
+      expect(exitCode).toBe(0);
+    });
+
     // Two rewriters chained, both suspending: `init()`'s own comment names
     // "another transform()" as a supported consumer of a pending body.
     it("chained suspending transforms", async () => {


### PR DESCRIPTION
Fixes #21252

### Problem
- `fs.createWriteStream(path)` is about 30x slower than node for many small writes. 20000 x 81-byte lines: bun 40001 `write(2)` calls in 309 ms, node 106 calls in 23 ms.
- `WriteStream._write` sends each chunk to the thread pool through `fs.write`: one `write(2)` plus one eventfd wake per chunk. The constructor sets `this._writev = undefined` (#16422), so Writable never coalesces.

### Fix
- `createWriteStream(path)` wraps the fd from `fs.open` in `Bun.file(fd).writer()` and routes `_write` / `_writev` through `sink.write` / the new `sink.writev`, then `flush(true)`. The same run takes 14 ms and about 50 syscalls. `options.fs`, `fd`, `start`, `autoClose: false`, and a patched `fs.write` keep the old path.
- `FileSink` adopts a borrowed fd instead of dup'ing it. Pollable fds (POSIX) and pipe/tty handles (Windows) are still dup'd, so each sink owns its poll registration and `end()` reaches `on_close`.
- `sink.writev(chunks)` is new on every sink. `FileSink` builds an iovec for `pwritev2(RWF_NOWAIT)` on Linux, `writev(2)` elsewhere. The binding roots each chunk in a `MarkedArgumentBuffer` before it takes a slice.
- A write that fails after a short write now credits the short write first, so `bytesWritten` counts the bytes that reached the fd.
- Verified: `test/js/node/fs/fs.test.ts` (`createWriteStream`, 8 new tests), `test/js/bun/util/filesink.test.ts` (7 new tests), `test/js/web/fetch/fetch.test.ts` (1 new test), `test/js/workerd/html-rewriter.test.js` (1 new test). Also the vendored write-stream scripts, `process-stdio`, spawn, and `bun-write` suites, on Linux and Windows.

### Background
- `FileSink` is the native sink behind `Bun.file().writer()`. It buffers up to 4 KB, flushes on a microtask, and returns a Promise when a write cannot finish at once.
- `PosixStreamingWriter` / `WindowsStreamingWriter` do the fd I/O under `FileSink`. `WriteResult::Pending(n)` means `n` bytes reached the fd; the rest waits for a retry.
- A sink whose write returned `Pending` refs itself until `on_close`. If `end()` never reaches `close()`, that ref leaks the sink.
- `RWF_NOWAIT` returns `EOPNOTSUPP` for buffered writes on ext4 and most network filesystems. The probe then disables it and falls back to a blocking `write(2)`, the pre-PR behavior.

<details><summary>Notes</summary>

**Reproduction**

```js
const { createWriteStream } = await import("node:fs");
const N = 20000; const line = "x".repeat(80) + "\n";
const p = `/tmp/wsappend-${process.pid}.out`;
const ws = createWriteStream(p);
let drains = 0; const t0 = performance.now();
for (let i = 0; i < N; i++) { if (!ws.write(line)) await new Promise(r => ws.once("drain", () => { drains++; r(); })); }
await new Promise(r => ws.end(r));
console.log(JSON.stringify({ rt: process.versions.bun ?? "node", N, ms: +(performance.now() - t0).toFixed(0), drains }));
```

| 20000 x 81-byte string lines | wall clock | `write(2)` syscalls |
| --- | --- | --- |
| bun (before) | 309 ms | 40001 |
| bun (this PR) | 14 ms | 50 |
| node | 23 ms | 106 |

100000 x 81-byte: bun 1600 ms -> 59 ms; node 70 ms.

**fd ownership**

`PosixStreamingWriter` gains `close_fd: bool` (mirrors `PosixBufferedWriter` and the Windows writers' `owns_fd`), threaded through `close()` / `close_without_reporting()` into `PollOrFd::close_impl`. `open_for_writing` adopts a borrowed fd and does not close it on an error path. `FileSink::setup()` records the fd on `self.fd` and sets `close_fd` / `owns_fd` after `start()` returns. On a POSIX `start()` failure the writer already holds the fd, so Drop closes it; on Windows `start()` leaves `source = None`, so the error path closes it directly.

Two sinks on the same pipe fd each need their own epoll entry (`EEXIST` otherwise), so a borrowed pollable fd is still dup'd. On Windows `uv_pipe_open` adopts the HANDLE and `uv_close` closes it, so a borrowed pipe/tty is dup'd too; the caller keeps their fd and `end()` reaches `close()`, which releases the keep-alive ref that the old early `return` leaked.

**writev**

`PosixStreamingWriter::writev` buffers when the total is under the chunk size, when bytes are already buffered, when the fd is a blocking pipe (so `try_write`'s `is_writable` gate applies), or when there are more than `IOV_MAX` chunks. Otherwise it writes the iovec directly and advances a cursor on a short write. `WindowsStreamingWriter::writev` appends to `outgoing` and sends once. The default `JsSinkType::writev_bytes` loops `write_bytes` for the other sinks.

The default `writev_bytes` keeps writing past a `Pending` result and returns the last pending slot, because `FetchRequestBodySink` parks every JS-pump write as `Pending` while still taking the next chunk.

`HTMLRewriterSink` overrides `writev_bytes` to copy every chunk into one buffer before the first feed: lol-html handlers run JS inside `write`, and a handler can detach a later chunk's `ArrayBuffer`. The other sinks' `write_bytes` do not run JS.

`js_writev` reads the array twice: first every element into a `MarkedArgumentBuffer`, then the slices. An accessor getter that detaches an earlier buffer is therefore seen as a zero-length view, not a dangling pointer. `get_this` runs after the getters so a getter that closes the sink cannot leave a stale `&mut`.

**Short-write accounting**

`try_write_with_write_fn` used to return `Err` when a later iteration of its loop failed, dropping the offset already written. It now returns `Pending(offset)` in that case; the retry (poll for pipes, `AutoFlusher` for files) reports the error with nothing written.

`FileSink.written` now counts only bytes that reached the fd. Before, the buffer-only arms of `PosixStreamingWriter::write` reported the buffered length through `on_write`, and `flush_from_js` counted the same bytes again when it drained them. The buffer-only arms now report 0 (the callback still schedules the auto-flush), and every `flush()` caller records its drain through `count_flushed`. `fs.WriteStream` reads the counter through an internal `$newRustFunction` after a rejected write. This is what makes `bytesWritten === size` hold under `RLIMIT_FSIZE` (the `EFBIG` test that main added in #36135) and keeps `bytesWritten` at 0 when a small buffered write fails on flush.

**flush(true)**

On Windows a regular-file write is an async `uv_fs_write`; `sink.write()` reports it accepted (`Owned`) so a ReadableStream pump keeps flowing, and a plain `flush()` returns `0` while the write is still in flight. `flush_from_js(wait: true)` now opens the pending slot in that case and returns its promise, settled by the completion callback. `fs.WriteStream` calls `flush(true)`, so its callback waits for the bytes to land and a failed completion rejects to the stream. POSIX is unchanged (a `Pending` flush there already had `backed_up` set).

**on_auto_flush after end()**

`on_auto_flush` used to return early when `done` was set, so bytes buffered by `write()` right before `end()` were never flushed and the pending promise never settled. It now flushes, and ends the writer once the buffer drains so `on_close` fires.

**Rebase onto main (third)**

#40516 made `FileSink::init` return an owning `RefPtr`, so `Blob::get_writer` (Windows) drops the scopeguard and accesses `sink.writer` directly; the `writer_fd` / `owns_fd` logic is unchanged.

**Rebase onto main (086159ab)**

Second rebase: main removed `H3ResponseSink` (#40137), so its `__writev` declaration in `headers.h` goes with it. No other conflicts.

**Rebase onto main (2e7e00c8)**

Conflicts in `Blob.rs` (`get_writer` now uses a scopeguard for init's ref), `FileSink.rs` (`impl_js_sink_forwarders!` replaced the hand-written trait forwarders; `stream_bytes` counting added to `write`, now also in `writev_bytes`), and `PipeWriter.rs` (`backed_up` field). Main also added `FetchRequestBodySink` and `HTMLRewriterSink`, which get `__writev` declarations in `headers.h`.

**Related**

Same motivation as #31764, which keeps the thread-pool `fs.writev` path and batches native `fs.writev` / `fs.readv` past `IOV_MAX`.

**Known limit**

`RWF_NOWAIT` is only honored by a few filesystems for buffered writes (btrfs, tmpfs). On ext4, XFS, overlayfs, FUSE, and NFS the first `pwritev2` returns `EOPNOTSUPP`, `RWFFlagSupport` is disabled for the process, and regular-file writes block the JS thread as they did before this PR. macOS has no `pwritev2`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 12 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js, test/js/web/fetch/fetch.test.ts, test/js/node/fs/fs.test.ts, test/js/bun/util/filesink.test.ts

<!-- robobun:evidence:end -->

