### PR TITLE
node:http: chunk-frame the body when both Content-Length and Transfer-Encoding: chunked are set

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2414,6 +2414,17 @@ function renderNativeHeaders(res) {
       // The user removed Content-Length (only): advertise chunked so the native
       // side frames the body instead of auto-writing the removed header back.
       flat.push("Transfer-Encoding", "chunked");
+    } else if (storedTransferEncoding !== undefined && storedContentLength !== undefined) {
+      // Both framing headers set by the user. Node's _storeHeader honours an
+      // explicit Transfer-Encoding: chunked (matchHeader sets chunkedEncoding)
+      // and ships both headers with a chunk-framed body; the native framer's
+      // decision ignores the TE bit once Content-Length is present, so signal
+      // the override through the NUL-named sentinel pair so the Content-Length
+      // state is dropped from the framing decision.
+      const teValue = storedTransferEncoding[1];
+      if (chunkExpression.test($isArray(teValue) ? teValue.join(", ") : String(teValue))) {
+        flat.push("\u0000", "3");
+      }
     }
   } catch (e) {
     // String(value) above can run user toString() that throws; release the

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -981,10 +981,16 @@ static bool NodeHTTPServer__writeHead(
                 // node:http marks framing decisions with a NUL-named sentinel
                 // pair instead of a real header: value "1" = close-delimited
                 // (the user removed the framing headers), value "2" = no body
-                // (HEAD - suppress all body framing like 204/304).
+                // (HEAD - suppress all body framing like 204/304), value "3" =
+                // app-forced chunked (user set both Content-Length and
+                // Transfer-Encoding: chunked; node honours the explicit TE, so
+                // drop the Content-Length bit from the framing decision - both
+                // headers stay on the wire, the body is chunk-framed).
                 if (name.length() == 1 && name[0] == 0) {
                     if (value == "2"_s) {
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_NO_BODY_STATUS;
+                    } else if (value == "3"_s) {
+                        httpResponseData->state &= ~uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
                     } else {
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_CLOSE_DELIMITED;
                     }

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -55,6 +55,90 @@ test(`should not duplicate transfer-encoding header in request`, async () => {
   return promise;
 });
 
+// Node's _storeHeader: an explicit Transfer-Encoding: chunked sets
+// chunkedEncoding=true regardless of Content-Length (matchHeader tests the TE
+// value; the CL branch only records _contentLength). Both headers go on the
+// wire verbatim and the body is chunk-framed. Asserted against Node v26.3.0.
+test("explicit Transfer-Encoding: chunked chunk-frames the body even with Content-Length", async () => {
+  await using server = createServer((req, res) => {
+    res.setHeader("Content-Length", "5");
+    res.setHeader("Transfer-Encoding", "chunked");
+    if (req.url === "/end") {
+      res.end("hello");
+    } else if (req.url === "/write") {
+      res.write("he");
+      res.write("llo");
+      res.end();
+    } else {
+      res.flushHeaders();
+      res.write("hello");
+      res.end();
+    }
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const wire = (path: string) =>
+    new Promise<string>((resolve, reject) => {
+      const s = connect(port, "127.0.0.1");
+      let data = "";
+      s.on("data", c => (data += c));
+      s.on("close", () => resolve(data));
+      s.on("error", reject);
+      s.write(`GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+    });
+
+  for (const path of ["/end", "/write", "/flush"]) {
+    const raw = await wire(path);
+    const [head, ...rest] = raw.split("\r\n\r\n");
+    const body = rest.join("\r\n\r\n");
+    // Both user-set headers ship verbatim, once each.
+    expect(head.match(/^transfer-encoding:/gim)).toHaveLength(1);
+    expect(head.match(/^content-length:/gim)).toHaveLength(1);
+    expect(head).toMatch(/^transfer-encoding: chunked$/im);
+    expect(head).toMatch(/^content-length: 5$/im);
+    // Body is chunk-framed: hex-size line(s), then the terminating 0 chunk.
+    expect(body).toMatch(/^[0-9a-f]+\r\n/i);
+    expect(body).toEndWith("0\r\n\r\n");
+    // Reassembled payload is exactly "hello".
+    const chunks: string[] = [];
+    let s = body;
+    for (;;) {
+      const m = /^([0-9a-f]+)\r\n/i.exec(s);
+      if (!m) break;
+      const n = parseInt(m[1], 16);
+      s = s.slice(m[0].length);
+      if (n === 0) break;
+      chunks.push(s.slice(0, n));
+      s = s.slice(n + 2);
+    }
+    expect(chunks.join("")).toBe("hello");
+  }
+});
+
+test("Content-Length with a non-chunked Transfer-Encoding keeps identity framing", async () => {
+  await using server = createServer((req, res) => {
+    res.setHeader("Content-Length", "5");
+    res.setHeader("Transfer-Encoding", "identity");
+    res.end("hello");
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const raw = await new Promise<string>((resolve, reject) => {
+    const s = connect(port, "127.0.0.1");
+    let data = "";
+    s.on("data", c => (data += c));
+    s.on("close", () => resolve(data));
+    s.on("error", reject);
+    s.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  });
+  const [head, body] = raw.split("\r\n\r\n");
+  expect(head).toMatch(/^transfer-encoding: identity$/im);
+  expect(head).toMatch(/^content-length: 5$/im);
+  expect(body).toBe("hello");
+});
+
 test("should not duplicate transfer-encoding header in response when explicitly set", async () => {
   await using server = createServer((req, res) => {
     res.writeHead(200, { "Transfer-Encoding": "chunked" });


### PR DESCRIPTION
## Problem

A handler that sets both framing headers produces an unparseable response: the `Transfer-Encoding: chunked` header ships verbatim but the body is written identity-framed.

```js
http.createServer((req, res) => {
  res.setHeader('Content-Length', '5');
  res.setHeader('Transfer-Encoding', 'chunked');
  res.end('hello');
});
```

Raw wire, before:
```
HTTP/1.1 200 OK
Content-Length: 5
Transfer-Encoding: chunked
...

hello
```

Node v26.3.0 (and this PR):
```
HTTP/1.1 200 OK
Content-Length: 5
Transfer-Encoding: chunked
...

5
hello
0

```

Bun's own `fetch` hangs reading it; `curl` reports a malformed chunk.

## Cause

The node:http head-assembly pairs loop (`NodeHTTPServer__writeHead`) sets `HTTP_WROTE_CONTENT_LENGTH_HEADER` for the app's Content-Length and `HTTP_WROTE_TRANSFER_ENCODING_HEADER` for the app's Transfer-Encoding. The latter only suppresses uWS's own auto-TE line; every body-framing site derives `chunked = !(state & (WROTE_CL | ANCIENT | CLOSE_DELIMITED))`, which never consults the TE bit. With Content-Length present, `chunked` is false and the body goes out raw under a chunked header.

Node's `_storeHeader` honours an explicit `Transfer-Encoding: chunked` regardless of Content-Length: `matchHeader` sets `chunkedEncoding = true` whenever the TE value matches `chunked`, and `write_`/`end` then chunk-frame the body with both headers shipped verbatim.

## Fix

`renderNativeHeaders` pushes a NUL-named sentinel (value `"3"`) when the app set both headers and the TE value matches `chunked`. The native head writer clears `HTTP_WROTE_CONTENT_LENGTH_HEADER` for that sentinel. With the CL bit cleared and the TE bit still set, every existing framing site (`write`, `end`, `flushHeaders`, `internalEnd`, `tryWriteBody`, `spillBodyTail`) takes the chunked path, no per-site changes needed. Both user-set header lines still ship verbatim; only the framing decision changes.

A non-chunked TE (e.g. `identity`) alongside Content-Length keeps identity framing (regression-guarded).

## Verification

New tests in `test/js/node/http/node-http-transfer-encoding.test.ts` cover the `end()`, `write()`, and `flushHeaders()` paths, assert both headers ship once each, the body is chunk-framed with a terminating `0\r\n\r\n`, and the reassembled payload is intact. Asserted byte-identical against Node v26.3.0.

The `res.statusCode` coercion half of the same investigation is in #35994.

---

Possibly related: #19789 (`ERR_INCOMPLETE_CHUNKED_ENCODING` behind NGINX/Traefik). An identity-framed body under a `Transfer-Encoding: chunked` header is exactly what produces that browser error, though that issue thread also mentions duplicate TE headers and HTTP/1.0 upstreams, so it may have more than one cause.
