### PR TITLE
FileSink: return the chunk's byte count when write() triggers a buffer drain

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -843,11 +843,9 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.try_write_newly_buffered_data(buf_len)
     }
 
-    /// `chunk_len` is the caller's chunk (already appended to `outgoing`).
-    /// `Wrote`/`Done` report bytes of *that chunk*, not bytes drained from the
-    /// buffer (which includes older chunks the buffer path already reported).
-    /// `Pending` keeps the drained count — its caller-facing value is
-    /// re-derived from `buffered_len()` (see `FileSink::bytes_accepted`).
+    /// `chunk_len` is the caller's chunk, already appended to `outgoing`.
+    /// `Wrote`/`Done` report bytes of *that chunk*; `Pending` reports bytes
+    /// drained (callers re-derive the chunk count from `buffered_len()`).
     fn try_write_newly_buffered_data(&mut self, chunk_len: usize) -> WriteResult {
         debug_assert!(!self.is_done);
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -840,10 +840,15 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
             return WriteResult::Wrote(buf_len);
         }
 
-        self.try_write_newly_buffered_data()
+        self.try_write_newly_buffered_data(buf_len)
     }
 
-    fn try_write_newly_buffered_data(&mut self) -> WriteResult {
+    /// `chunk_len` is the caller's chunk (already appended to `outgoing`).
+    /// `Wrote`/`Done` report bytes of *that chunk*, not bytes drained from the
+    /// buffer (which includes older chunks the buffer path already reported).
+    /// `Pending` keeps the drained count — its caller-facing value is
+    /// re-derived from `buffered_len()` (see `FileSink::bytes_accepted`).
+    fn try_write_newly_buffered_data(&mut self, chunk_len: usize) -> WriteResult {
         debug_assert!(!self.is_done);
 
         // Borrow `self.outgoing` only for the syscall. `try_write` takes `&self`
@@ -856,19 +861,21 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
 
         match rc {
             WriteResult::Wrote(amt) => {
-                if amt == self.outgoing.size() {
-                    self.outgoing.reset();
-                    self.parent_on_write(amt, WriteStatus::Drained);
-                } else {
+                if amt < self.outgoing.size() {
                     self.outgoing.wrote(amt);
                     self.parent_on_write(amt, WriteStatus::Pending);
                     Self::register_poll(self);
                     return WriteResult::Pending(amt);
                 }
+                self.outgoing.reset();
+                self.parent_on_write(amt, WriteStatus::Drained);
+                return WriteResult::Wrote(chunk_len);
             }
             WriteResult::Done(amt) => {
+                let old_buffered = self.outgoing.size().saturating_sub(chunk_len);
                 self.outgoing.reset();
                 self.parent_on_write(amt, WriteStatus::EndOfFile);
+                return WriteResult::Done(amt.saturating_sub(old_buffered));
             }
             WriteResult::Pending(amt) => {
                 self.outgoing.wrote(amt);
@@ -910,7 +917,7 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 return WriteResult::Err(sys::Error::oom());
             }
 
-            return self.try_write_newly_buffered_data();
+            return self.try_write_newly_buffered_data(buf.len());
         }
 
         let rc = self.try_write(self.force_sync, buf);

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -872,7 +872,8 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 return WriteResult::Wrote(chunk_len);
             }
             WriteResult::Done(amt) => {
-                let old_buffered = self.outgoing.size().saturating_sub(chunk_len);
+                debug_assert!(self.outgoing.size() >= chunk_len);
+                let old_buffered = self.outgoing.size() - chunk_len;
                 self.outgoing.reset();
                 self.parent_on_write(amt, WriteStatus::EndOfFile);
                 return WriteResult::Done(amt.saturating_sub(old_buffered));

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,6 +1,6 @@
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 
@@ -205,6 +205,48 @@ it("write result is not cumulative", async () => {
   expect(await writer.write("world!")).toBe(6);
   await writer.end();
   await util.promisify(fs.close)(fd);
+});
+
+// https://github.com/oven-sh/bun/issues/12194
+//
+// A chunk that pushes the sink's internal buffer past its auto-flush threshold
+// must still report its own byte count. Previously the write() that triggered
+// the drain returned the whole drained total (older buffered chunks included),
+// so a `total += sink.write(chunk)` loop double-counted.
+//
+// Writes are issued without `await` in between so the auto-flush microtask
+// cannot drain the buffer first. Skipped on Windows: there every write to a
+// file-backed sink returns a (shared) promise, which the backpressured-write
+// tests below already cover.
+it.skipIf(!isPosix)("write result is not cumulative when the chunk flushes buffered bytes", async () => {
+  using dir = tempDir("filesink-cumulative", {});
+  const filename = path.join(String(dir), "test.bin");
+  const writer = Bun.file(filename).writer();
+
+  const ascii = Buffer.alloc(505, "a").toString();
+  const bytes = Buffer.alloc(64 * 1024, "c");
+  const latin1 = Buffer.alloc(40_000, "é").toString();
+  const utf16 = Buffer.alloc(20_000, "😀").toString();
+
+  const results = [
+    writer.write(ascii), // buffered
+    writer.write(bytes), // flushes `ascii` + itself
+    writer.write(Buffer.alloc(10, "d")), // buffered
+    writer.write(latin1), // flushes the 10 bytes + itself (latin1 path)
+    writer.write("e"), // buffered
+    writer.write(utf16), // flushes the 1 byte + itself (utf16 path)
+  ];
+  await writer.end();
+
+  expect(results).toEqual([
+    Buffer.byteLength(ascii),
+    bytes.byteLength,
+    10,
+    Buffer.byteLength(latin1),
+    1,
+    Buffer.byteLength(utf16),
+  ]);
+  expect(results.reduce((sum, n) => sum + n, 0)).toBe(fs.statSync(filename).size);
 });
 
 // A backpressured write buffers everything `write(2)` would not take, so the

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -225,7 +225,10 @@ it.skipIf(!isPosix)("write result is not cumulative when the chunk flushes buffe
 
   const ascii = Buffer.alloc(505, "a").toString();
   const bytes = Buffer.alloc(64 * 1024, "c");
-  const latin1 = Buffer.alloc(40_000, "é").toString();
+  // Decoding as "latin1" keeps the JSString 8-bit so writer.write() reaches
+  // write_latin1's non-ASCII branch; decoding via utf8 would yield a 16-bit
+  // string that routes to write_utf16 instead.
+  const latin1 = Buffer.alloc(40_000, 0xe9).toString("latin1");
   const utf16 = Buffer.alloc(20_000, "😀").toString();
 
   const results = [


### PR DESCRIPTION
Fixes #12194.

## What

On POSIX, `Bun.file(...).writer().write(chunk)` normally returns the byte length of `chunk`. When the sink's internal buffer crosses the auto-flush threshold (4096 bytes, 16384 on Apple Silicon) it instead returned the total bytes drained, which includes every previously-buffered chunk. A caller that sums the returns to track bytes written double-counts everything buffered so far.

## Repro

```js
import fs from "node:fs";
const fd = fs.openSync("/tmp/x", "w");
const sink = Bun.file(fd).writer();
let total = 0;
for (let i = 0; i < 60; i++) {
  const r = sink.write(Buffer.alloc(81, "x").toString());
  total += r;
  if (r !== 81) console.log(`i=${i}: rc=${r}`);   // i=50: rc=4131
}
await sink.end();
console.log(total, fs.statSync("/tmp/x").size);    // 8910 4860
```

Every call writes 81 bytes. The 51st call (buffer crosses 4096) returns 4131 = 51 * 81 instead of 81, so the summed total is almost twice the file size. The bytes on disk are correct; only the return value is wrong.

## Cause

`PosixStreamingWriter::write` takes two paths. When the combined size stays under `CHUNK_SIZE` it appends and returns `WriteResult::Wrote(chunk_len)`. When it crosses the threshold with data already buffered it appends, then `try_write_newly_buffered_data` drains the whole buffer and returned `WriteResult::Wrote(total_drained)`. `FileSink::to_result` maps `Wrote(n)` straight to the JS return value, so the caller sees the total.

This is the synchronous counterpart of #33538, which fixed the async (`Pending`) arm via `FileSink::bytes_accepted`. #33532 had this fix but was closed as superseded by #33538; that PR did not touch the `Wrote`/`Done` arms, so the synchronous path was still wrong.

## Fix

`try_write_newly_buffered_data` now takes the caller's `chunk_len` and returns it on the fully-drained `Wrote` arm. The `Done` arm returns the chunk-relative portion that reached the fd before EOF. `parent_on_write` still receives the total drained (unchanged), and `Pending` is unchanged: its caller-facing value is already re-derived from `buffered_len()` in `FileSink::bytes_accepted`. The three callers (`write`, `write_latin1`/`write_utf16` via `maybe_write_newly_buffered_data`) pass the encoded chunk length they already have.

Windows is unaffected: `WindowsStreamingWriter::write` returns `Pending(0)` for async file writes and routes through `bytes_accepted`.

## Verification

New test in `filesink.test.ts` writes a small ASCII string, a large `Uint8Array`, a Latin-1 string and a UTF-16 string in a pattern that triggers three buffer-drain boundaries, and asserts each return equals `Buffer.byteLength(chunk)` and the sum matches the final file size.

- `USE_SYSTEM_BUN=1 bun test` fails with `66041/40010/20001` instead of `65536/40000/20000`
- `bun bd test filesink.test.ts`: 51 pass
- `bun bd test spawn-streaming-stdin.test.ts`, `fs-promises-writeFile-async-iterator.test.ts`, `process-stdio.test.ts`: pass
- `bun run rust:check-all`: 10 ok, 0 failed

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesink.test.ts

<!-- robobun:evidence:end -->