### PR TITLE
Headers: add brand checks to getSetCookie()/getAll()/count

### DIFF
--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -25,6 +25,7 @@
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "IDLTypes.h"
+#include "JSDOMAttribute.h"
 #include "JSDOMBinding.h"
 #include "JSDOMConstructor.h"
 #include "JSDOMConvertBase.h"
@@ -184,26 +185,20 @@ template<> void JSFetchHeadersDOMConstructor::initializeProperties(VM& vm, JSDOM
 /**
  * Non standard function.
  **/
-JSC_DEFINE_CUSTOM_GETTER(jsFetchHeadersGetterCount, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+static inline JSC::JSValue jsFetchHeaders_countGetter(JSC::JSGlobalObject&, JSFetchHeaders& thisObject)
 {
-    JSFetchHeaders* castedThis = dynamicDowncast<JSFetchHeaders>(JSValue::decode(thisValue));
-    if (!castedThis) [[unlikely]] {
-        return JSValue::encode(jsUndefined());
-    }
-
-    auto& impl = castedThis->wrapped();
-    auto count = impl.size();
-    return JSValue::encode(jsNumber(count));
+    return jsNumber(thisObject.wrapped().size());
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsFetchHeadersPrototypeFunction_getAll, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+JSC_DEFINE_CUSTOM_GETTER(jsFetchHeadersGetterCount, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName attributeName))
+{
+    return IDLAttribute<JSFetchHeaders>::get<jsFetchHeaders_countGetter>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline JSC::EncodedJSValue jsFetchHeadersPrototypeFunction_getAllBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSFetchHeaders>::ClassParameter castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSFetchHeaders* castedThis = dynamicDowncast<JSFetchHeaders>(callFrame->thisValue());
-    if (!castedThis) [[unlikely]] {
-        return JSValue::encode(jsUndefined());
-    }
 
     if (!callFrame->argumentCount()) [[unlikely]] {
         throwTypeError(lexicalGlobalObject, scope, "Missing argument"_s);
@@ -262,6 +257,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFetchHeadersPrototypeFunction_getAll, (JSGlobalObject
     return JSValue::encode(array);
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsFetchHeadersPrototypeFunction_getAll, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSFetchHeaders>::call<jsFetchHeadersPrototypeFunction_getAllBody>(*lexicalGlobalObject, *callFrame, "getAll");
+}
+
 JSC::EncodedJSValue fetchHeadersGetSetCookie(JSC::JSGlobalObject* lexicalGlobalObject, VM& vm, WebCore::FetchHeaders* impl)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -288,15 +288,15 @@ JSC::EncodedJSValue fetchHeadersGetSetCookie(JSC::JSGlobalObject* lexicalGlobalO
     return JSValue::encode(array);
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsFetchHeadersPrototypeFunction_getSetCookie, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+static inline JSC::EncodedJSValue jsFetchHeadersPrototypeFunction_getSetCookieBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame*, typename IDLOperation<JSFetchHeaders>::ClassParameter castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
-    JSFetchHeaders* castedThis = dynamicDowncast<JSFetchHeaders>(callFrame->thisValue());
-    if (!castedThis) [[unlikely]] {
-        return JSValue::encode(jsUndefined());
-    }
-    auto& impl = castedThis->wrapped();
-    return fetchHeadersGetSetCookie(lexicalGlobalObject, vm, &impl);
+    return fetchHeadersGetSetCookie(lexicalGlobalObject, vm, &castedThis->wrapped());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFetchHeadersPrototypeFunction_getSetCookie, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSFetchHeaders>::call<jsFetchHeadersPrototypeFunction_getSetCookieBody>(*lexicalGlobalObject, *callFrame, "getSetCookie");
 }
 
 /* Hash table for prototype */

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -599,6 +599,34 @@ describe("Headers", () => {
     });
   });
 
+  describe("brand checks", () => {
+    const receivers = [{}, null, undefined, 42, "str", new Response(), new Map([["set-cookie", "a=1"]])];
+
+    test.each(receivers)("getSetCookie() throws TypeError on %p", receiver => {
+      expect(() => Headers.prototype.getSetCookie.call(receiver)).toThrow(TypeError);
+    });
+
+    test.each(receivers)("getAll() throws TypeError on %p", receiver => {
+      // @ts-expect-error
+      expect(() => Headers.prototype.getAll.call(receiver, "set-cookie")).toThrow(TypeError);
+    });
+
+    test.each(receivers)("count getter throws TypeError on %p", receiver => {
+      const desc = Object.getOwnPropertyDescriptor(Headers.prototype, "count");
+      expect(desc?.get).toBeFunction();
+      expect(() => desc!.get!.call(receiver)).toThrow(TypeError);
+    });
+
+    test("getSetCookie(), getAll() and count still work on a real Headers", () => {
+      const h = new Headers([["Set-Cookie", "a=1"]]);
+      expect(Headers.prototype.getSetCookie.call(h)).toEqual(["a=1"]);
+      // @ts-expect-error
+      expect(Headers.prototype.getAll.call(h, "set-cookie")).toEqual(["a=1"]);
+      const desc = Object.getOwnPropertyDescriptor(Headers.prototype, "count")!;
+      expect(desc.get!.call(h)).toBe(1);
+    });
+  });
+
   // Header-name lowercasing on iteration (Object.fromEntries / spread / toJSON /
   // keys()) runs through a SIMD kernel on the 8-bit path. Sweep name lengths
   // across the vector-block boundaries and include every ASCII printable that is


### PR DESCRIPTION
## What does this PR do?

`Headers.prototype.getSetCookie`, `Headers.prototype.getAll` and the non-standard `count` getter silently returned `undefined` when called on a non-`Headers` receiver instead of throwing a `TypeError`. Every other `Headers` member (`get`, `set`, `append`, `has`, `delete`, `keys`, `values`, `entries`, `forEach`, `toJSON`) already throws, and Node/undici, Deno and browsers all throw per WebIDL.

### Repro

```js
const g = Headers.prototype.getSetCookie;
for (const t of [{}, null, 42, "str", new Response("x"), new Map([["set-cookie", "a=1"]])]) {
  let r; try { r = { returned: String(g.call(t)) }; } catch (e) { r = { threw: e.constructor.name }; }
  console.log(Object.prototype.toString.call(t), JSON.stringify(r));
}
const count = Object.getOwnPropertyDescriptor(Headers.prototype, "count");
let r; try { r = { returned: String(count.get.call({})) }; } catch (e) { r = { threw: e.constructor.name }; }
console.log("count getter on {}", JSON.stringify(r));
```

Before: every row prints `{"returned":"undefined"}`.
After: every row prints `{"threw":"TypeError"}` (matches Node).

### Cause

These three were added with a manual `dynamicDowncast<JSFetchHeaders>` that fell through to `return JSValue::encode(jsUndefined())` on failure, rather than going through `IDLOperation<JSFetchHeaders>::call` / `IDLAttribute<JSFetchHeaders>::get` like the rest of the prototype members (which call `throwThisTypeError` when the cast fails).

### Fix

Split each into a `*Body` function and wrap it with `IDLOperation::call` / `IDLAttribute::get`, matching `append`/`get`/`set`/`toJSON` etc. in the same file.

## How did you verify your code works?

Added `describe("brand checks")` to `test/js/web/fetch/headers.test.ts` covering `getSetCookie`, `getAll` and the `count` getter across `{}`, `null`, `undefined`, primitives, a `Response` and a `Map`, plus a sanity check that all three still work on a real `Headers` instance.

- `USE_SYSTEM_BUN=1 bun test test/js/web/fetch/headers.test.ts -t "brand checks"`: 21 fail, 1 pass
- `bun bd test test/js/web/fetch/headers.test.ts`: 121 pass, 0 fail
- `bun bd test test/js/web/fetch/fetch_headers.test.js test/js/web/fetch/headers-case.test.ts test/js/web/fetch/headers.undici.test.ts test/js/web/fetch/cookies.test.ts`: all pass

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 21 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.0 (ba8ce41e0)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [6.33ms]
(pass) Headers > constructor > cannot create headers from null [4.81ms]
(pass) Headers > constructor > can create headers from empty object [3.91ms]
(pass) Headers > constructor > can create headers from object [3.55ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [3.55ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [8.46ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [10.26ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [15.38ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [9.48ms]
(pass) Headers > constructor > const
... (truncated)

release without fix: 23 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [0.10ms]
(pass) Headers > constructor > cannot create headers from null [0.08ms]
(pass) Headers > constructor > can create headers from empty object [0.05ms]
(pass) Headers > constructor > can create headers from object [0.05ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [0.06ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [0.11ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [0.11ms]
88 |           },
89 |         },
90 |         "x-second": "second",
91 |         "x-third": "third",
92 |       };
93 |       expect([...new Headers(record)]).toEqual([
                      ^
TypeError: Cannot convert a symbol to a string
      at <anonymous> (/workspace/bun/test/js/web/fetch/headers.test.ts:93:18)
(fail) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [0.35ms]
109 |             return "first"
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.0 (ba8ce41e0)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [6.18ms]
(pass) Headers > constructor > cannot create headers from null [4.58ms]
(pass) Headers > constructor > can create headers from empty object [4.09ms]
(pass) Headers > constructor > can create headers from object [2.88ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [3.10ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [7.22ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [9.38ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [13.70ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [9.43ms]
(pass) Headers > constructor > constr
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ba8ce41e0d
  features     baseline

22 deps, 108 codegen, 1171 objects in 1314ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] gen bindgenv2
[3/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [38.00ms]
[4/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [16.00ms]
[7/1234] gen .bind.ts → GeneratedBindings.cpp
[8/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSFetchHeaders.cpp | 40 ++++++++++++++---------------
 test/js/web/fetch/headers.test.ts           | 28 ++++++++++++++++++++
 2 files changed, 48 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/webcore/JSFetchHeaders.cpp      3      4      0
test/js/web/fetch/headers.test.ts                2      1      0
```

</details>

**root cause** · written by the author bot

The `getSetCookie` and `getAll` methods and the `count` getter on `Headers.prototype` bypassed the WebIDL receiver check, so when invoked with a non-Headers `this` they quietly returned `undefined` instead of throwing a `TypeError` as the spec requires and as every other Headers member already does. The fix routes these three through the same `IDLOperation` and `IDLAttribute` wrappers used by the rest of the prototype, which validate the receiver and throw on an invalid `this`. Behavior on valid Headers instances is unchanged.

<!-- robobun:evidence:end -->