### PR TITLE
node:path: don't wrap the argument count to 16 bits at the native boundary

### DIFF
--- a/src/jsc/bindings/Path.cpp
+++ b/src/jsc/bindings/Path.cpp
@@ -28,7 +28,7 @@ namespace JSCastingHelpers = JSC::JSCastingHelpers;
 
 using namespace JSC;
 
-using PathFunction = JSC::EncodedJSValue (*SYSV_ABI)(JSGlobalObject*, bool, EncodedJSValue*, uint16_t len);
+using PathFunction = JSC::EncodedJSValue (*SYSV_ABI)(JSGlobalObject*, bool, EncodedJSValue*, size_t len);
 
 template<bool isWindows, PathFunction Function>
 static inline JSC::EncodedJSValue createZigFunction(JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
@@ -38,6 +38,10 @@ static inline JSC::EncodedJSValue createZigFunction(JSGlobalObject* globalObject
     MarkedArgumentBufferWithSize<8> args = MarkedArgumentBufferWithSize<8>();
     for (unsigned i = 0, size = callFrame->argumentCount(); i < size; ++i) {
         args.append(callFrame->argument(i));
+    }
+    if (args.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return {};
     }
     const auto result = Function(globalObject, isWindows, args.data(), args.size());
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -448,17 +448,17 @@ ZIG_DECL void Zig__GlobalObject__resolve(ErrorableString* arg0, JSC::JSGlobalObj
 
 #ifdef __cplusplus
 
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__basename(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__dirname(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__extname(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__format(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__isAbsolute(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__join(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__normalize(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__parse(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__relative(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__resolve(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
-extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__toNamespacedPath(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, uint16_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__basename(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__dirname(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__extname(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__format(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__isAbsolute(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__join(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__normalize(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__parse(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__relative(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__resolve(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
+extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__toNamespacedPath(JSC::JSGlobalObject* arg0, bool arg1, JSC::EncodedJSValue* arg2, size_t arg3);
 
 #endif
 

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3615,14 +3615,14 @@ macro_rules! export_path_host_fn {
                 global: &JSGlobalObject,
                 is_windows: bool,
                 args_ptr: *const JSValue,
-                args_len: u16,
+                args_len: usize,
             ) -> JSValue {
                 // SAFETY: `args_ptr` points to `args_len` JSValues from the C++
                 // CallFrame (NodePath.cpp). Borrowed for the synchronous call.
                 // (Body kept in sync with the non-Windows arm below — bughunt
                 // changed the target signature to take a slice but only updated
                 // one cfg arm.)
-                let args = unsafe { bun_core::ffi::slice(args_ptr, args_len as usize) };
+                let args = unsafe { bun_core::ffi::slice(args_ptr, args_len) };
                 crate::jsc::host_fn::to_js_host_call(
                     global,
                     || $target(global, is_windows, args),
@@ -3634,12 +3634,12 @@ macro_rules! export_path_host_fn {
                 global: &JSGlobalObject,
                 is_windows: bool,
                 args_ptr: *const JSValue,
-                args_len: u16,
+                args_len: usize,
             ) -> JSValue {
                 // SAFETY: `args_ptr` points to `args_len` JSValues from the C++
                 // CallFrame (the caller is `Bun__Path__*` in NodePath.cpp). The
                 // slice is borrowed for the synchronous host-call only.
-                let args = unsafe { bun_core::ffi::slice(args_ptr, args_len as usize) };
+                let args = unsafe { bun_core::ffi::slice(args_ptr, args_len) };
                 crate::jsc::host_fn::to_js_host_call(
                     global,
                     || $target(global, is_windows, args),

--- a/test/js/node/path/join.test.js
+++ b/test/js/node/path/join.test.js
@@ -145,4 +145,23 @@ describe("path.join", () => {
 
     assert.strictEqual(failures.length, 0, failures.join(""));
   });
+
+  test("more than 65535 arguments", () => {
+    // The argument count used to cross the C++/native boundary as a uint16_t,
+    // so path.join(...70000 args) silently joined only (70000 & 0xffff) = 4464
+    // of them and path.join(...65536 args) saw 0 args and returned ".".
+    const n = 70000;
+    const args = new Array(n).fill("a");
+    const expectedLen = n * 2 - 1;
+
+    const posix = path.posix.join(...args);
+    assert.strictEqual(posix.length, expectedLen);
+    assert.strictEqual(posix.slice(0, 3), "a/a");
+    assert.strictEqual(posix.slice(-3), "a/a");
+
+    const win32 = path.win32.join(...args);
+    assert.strictEqual(win32.length, expectedLen);
+    assert.strictEqual(win32.slice(0, 3), "a\\a");
+    assert.strictEqual(win32.slice(-3), "a\\a");
+  });
 });

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -179,4 +179,20 @@ describe("path.resolve", () => {
     const expectedEnding = isWindows ? "\\c" : "/c";
     assert.ok(result.endsWith(expectedEnding));
   });
+
+  test("more than 65535 arguments", () => {
+    // Same uint16_t argument-count wrap as path.join (see join.test.js).
+    const n = 70000;
+    const args = new Array(n).fill("a");
+
+    const posix = path.posix.resolve("/", ...args);
+    assert.strictEqual(posix.length, 1 + n * 2 - 1);
+    assert.strictEqual(posix.slice(0, 4), "/a/a");
+    assert.strictEqual(posix.slice(-3), "a/a");
+
+    const win32 = path.win32.resolve("C:\\", ...args);
+    assert.strictEqual(win32.length, 3 + n * 2 - 1);
+    assert.strictEqual(win32.slice(0, 6), "C:\\a\\a");
+    assert.strictEqual(win32.slice(-3), "a\\a");
+  });
 });


### PR DESCRIPTION
## What

`path.join` / `path.resolve` (posix and win32) silently drop arguments when called with more than 65535 of them. The argument count crosses the C++ to native boundary as a `uint16_t`, so it wraps:

```js
import path from "node:path";
path.posix.join(...new Array(65536).fill("a"));   // "."         (wrapped to 0 args)
path.posix.join(...new Array(70000).fill("a"));   // "a/a/.../a"  (4464 segments, not 70000)
```

Node.js joins all the arguments; its only ceiling is the spread call's stack `RangeError`, which throws rather than returning a plausible wrong path.

## Cause

`src/jsc/bindings/Path.cpp` declares the native thunk type as:

```cpp
using PathFunction = JSC::EncodedJSValue (*SYSV_ABI)(JSGlobalObject*, bool, EncodedJSValue*, uint16_t len);
```

and passes `args.size()` (a `size_t`) through that `uint16_t`. The matching `extern "C"` declarations in `headers.h` and the Rust `extern` thunks in `src/runtime/node/path.rs` agree on `uint16_t` / `u16`, so the narrowing is silent on both sides. Every `node:path` native receives a wrapped count; only the two variadic ones (`join`, `resolve`) can observe it.

## Fix

Widen the length parameter to `size_t` / `usize` in all three places (the `PathFunction` typedef, the 11 `Bun__Path__*` extern declarations, and both `cfg` arms of the Rust export macro). Also check `hasOverflowed()` on the `MarkedArgumentBuffer` copy and throw `OutOfMemoryError` instead of proceeding with a short buffer now that large counts actually reach it.

## Verification

New test in `test/js/node/path/join.test.js` calls `path.posix.join` and `path.win32.join` with 70000 segments and asserts the full result length.

```
before: AssertionError: 8927 !== 139999
after:  (pass) path.join > more than 65535 arguments
```

All 123 `test/js/node/path/` tests pass. `rust:check-all` clean across targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/path/resolve.test.js

<!-- robobun:evidence:end -->