### PR TITLE
Bun.serve: apply TCP backpressure to a request body the handler reads slowly

### DIFF
--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -58,6 +58,12 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         /* We are done with this request */
         this->state &= ~HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
 
+        /* Release any request-body backpressure pause: onAborted is gone so
+         * the holder can no longer safely resume, and a keep-alive socket
+         * left paused never reads the next request. us_socket_resume is a
+         * no-op when not paused. */
+        ((AsyncSocket<SSL> *) uwsRes)->resume();
+
         HttpResponseData<SSL> *httpResponseData = uwsRes->getHttpResponseData();
         httpResponseData->isIdle = true;
     }

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -58,15 +58,6 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         /* We are done with this request */
         this->state &= ~HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
 
-        /* Release any request-body backpressure pause: onAborted is gone so
-         * the holder can no longer safely resume, and a keep-alive socket
-         * left paused never reads the next request. Skip when the node:http
-         * pipeline-flood guard owns the pause (HTTP_NODE_READS_PAUSED): that
-         * path has its own gated release points. */
-        if (!(this->state & HttpResponseData<SSL>::HTTP_NODE_READS_PAUSED)) {
-            ((AsyncSocket<SSL> *) uwsRes)->resume();
-        }
-
         HttpResponseData<SSL> *httpResponseData = uwsRes->getHttpResponseData();
         httpResponseData->isIdle = true;
     }

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -60,9 +60,12 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
 
         /* Release any request-body backpressure pause: onAborted is gone so
          * the holder can no longer safely resume, and a keep-alive socket
-         * left paused never reads the next request. us_socket_resume is a
-         * no-op when not paused. */
-        ((AsyncSocket<SSL> *) uwsRes)->resume();
+         * left paused never reads the next request. Skip when the node:http
+         * pipeline-flood guard owns the pause (HTTP_NODE_READS_PAUSED): that
+         * path has its own gated release points. */
+        if (!(this->state & HttpResponseData<SSL>::HTTP_NODE_READS_PAUSED)) {
+            ((AsyncSocket<SSL> *) uwsRes)->resume();
+        }
 
         HttpResponseData<SSL> *httpResponseData = uwsRes->getHttpResponseData();
         httpResponseData->isIdle = true;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4141,6 +4141,15 @@ where
             if (*this).resp.is_none() || (*flags).aborted() {
                 return;
             }
+            // A sink that already ended the response reached `markDone()` (which
+            // resumed the socket and dropped `onAborted`); `resp` may since be
+            // freed — see `end_already_responded_stream`. Just clear the flag.
+            if let Some(sink) = (*this).sink {
+                if (*sink.as_ptr()).sink.ended_response {
+                    (*flags).set_request_body_paused(false);
+                    return;
+                }
+            }
             (*flags).set_request_body_paused(false);
             if let Some(resp) = (*this).resp {
                 resp.resume_();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4486,9 +4486,9 @@ pub struct SendfileContext {
     pub total: BlobSizeType,
 }
 
-// All flags are bool (with two debug-conditional ones), so `bitflags!` over u16
-// works. We keep all bits in every build and just gate the
-// `is_web_browser_navigation` / `has_finalized` accessors on the const params.
+// All flags are bool (with two debug-conditional ones). We keep all bits in
+// every build and just gate the `is_web_browser_navigation` / `has_finalized`
+// accessors on the const params.
 bitflags::bitflags! {
     #[derive(Default, Clone, Copy)]
     pub struct FlagsBits: u32 {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1186,7 +1186,7 @@ where
     pub fn end_already_responded_stream(&mut self) {
         ctx_log!("endAlreadyRespondedStream");
         debug_assert!(!HTTP3);
-        // `resp` may be freed (see above); uWS `markDone()` resumed the socket while it was live.
+        // `resp` may be freed (see above); the sink resumed it at `ended_response = true`.
         self.flags.set_request_body_paused(false);
         if self.resp.take().is_some() {
             self.flags.set_is_waiting_for_request_body(false);
@@ -2862,6 +2862,13 @@ where
             req.flags.set_aborted(aborted);
             wrote_anything = wrapper.sink.wrote > 0;
             ended_response = wrapper.sink.ended_response;
+            if ended_response {
+                // `resp` may be freed; the sink already resumed it. Clear these
+                // before `detach()` below re-enters JS so any drain callback /
+                // `on_start_buffering` reached from there early-returns.
+                req.flags.set_request_body_paused(false);
+                req.clear_request_body_stream_drain_handler(req.server().global_this());
+            }
 
             wrapper.sink.finalize();
             let sink_global = wrapper
@@ -2946,6 +2953,11 @@ where
         if let Some(wrapper) = req.sink_mut() {
             let wrapper_ptr = req.sink.take().expect("infallible: sink_mut returned Some");
             ended_response = wrapper.sink.ended_response;
+            if ended_response {
+                // `resp` may be freed; the sink already resumed it. Clear before JS below.
+                req.flags.set_request_body_paused(false);
+                req.clear_request_body_stream_drain_handler(global_this);
+            }
             if let Some(prom) = wrapper.sink.pending_flush.take() {
                 // The promise value was protected when pending_flush was
                 // assigned (flushFromJS / endFromJS). Drop that root before
@@ -4107,9 +4119,24 @@ where
         }
         ctx_log!("resumeRequestBodySocket");
         self.flags.set_request_body_paused(false);
+        if self.resp_may_be_freed() {
+            return;
+        }
         if let Some(resp) = self.resp {
             resp.resume_();
         }
+    }
+
+    /// After a streaming-response sink has set `ended_response`, `markDone()`
+    /// dropped `onAborted` and `resp` may point at a freed `us_socket_t` (see
+    /// `end_already_responded_stream`). The sink already resumed the socket.
+    #[inline]
+    fn resp_may_be_freed(&self) -> bool {
+        if let Some(sink) = self.sink {
+            // SAFETY: `sink` is owned by this context and freed in `handle_resolve_stream`/`deinit`.
+            return unsafe { (*sink.as_ptr()).sink.ended_response };
+        }
+        false
     }
 
     /// Detach the body ByteStream's `drain_handler` (the stream can outlive this ctx in JS).
@@ -4138,19 +4165,10 @@ where
             if !(*flags).request_body_paused() {
                 return;
             }
-            if (*this).resp.is_none() || (*flags).aborted() {
+            (*flags).set_request_body_paused(false);
+            if (*this).resp.is_none() || (*flags).aborted() || (*this).resp_may_be_freed() {
                 return;
             }
-            // A sink that already ended the response reached `markDone()` (which
-            // resumed the socket and dropped `onAborted`); `resp` may since be
-            // freed — see `end_already_responded_stream`. Just clear the flag.
-            if let Some(sink) = (*this).sink {
-                if (*sink.as_ptr()).sink.ended_response {
-                    (*flags).set_request_body_paused(false);
-                    return;
-                }
-            }
-            (*flags).set_request_body_paused(false);
             if let Some(resp) = (*this).resp {
                 resp.resume_();
             }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1186,6 +1186,9 @@ where
     pub fn end_already_responded_stream(&mut self) {
         ctx_log!("endAlreadyRespondedStream");
         debug_assert!(!HTTP3);
+        // Resume before `take()`: READABLE was disabled while paused, so the
+        // socket cannot have been recycled onto a next request in the interim.
+        self.resume_request_body_socket();
         if self.resp.take().is_some() {
             self.flags.set_is_waiting_for_request_body(false);
             self.flags.set_has_abort_handler(false);
@@ -3963,7 +3966,10 @@ where
 
                 // What `on_data` buffered; `on_stream_drained` resumes once it empties.
                 let buffered = bytes.buffer.get().len().saturating_sub(bytes.offset.get());
-                if buffered >= REQUEST_BODY_HIGH_WATER_MARK {
+                if bytes.buffer_action.get().is_some() || bytes.pipe.get().ctx.is_some() {
+                    // `.text()`-after-`.body` / native pipe want it all; no `on_pull` will fire.
+                    this.resume_request_body_socket();
+                } else if buffered >= REQUEST_BODY_HIGH_WATER_MARK {
                     this.pause_request_body_socket();
                 }
             } else {
@@ -4124,13 +4130,23 @@ where
     /// `on_stream_drained` context.
     pub(crate) fn on_request_body_stream_drained_callback(ctx: Option<*mut c_void>) {
         let Some(ctx) = ctx else { return };
-        // SAFETY: caller upholds the fn-level contract — `ctx` is the
-        // `*mut RequestContext` registered as the body callback context.
-        let this = unsafe { bun_ptr::callback_ctx::<Self>(ctx) };
-        if this.is_aborted_or_ended() {
-            return;
+        let this = ctx.cast::<Self>();
+        // SAFETY: `ctx` is the registered `*mut RequestContext`. `ByteStream::
+        // on_data` can re-enter here while `on_buffered_body_chunk` already
+        // holds `&mut Self` (borrow = ptr), so dispatch via the raw pointer.
+        unsafe {
+            let flags = &raw mut (*this).flags;
+            if !(*flags).request_body_paused() {
+                return;
+            }
+            if (*this).resp.is_none() || (*flags).aborted() {
+                return;
+            }
+            (*flags).set_request_body_paused(false);
+            if let Some(resp) = (*this).resp {
+                resp.resume_();
+            }
         }
-        this.resume_request_body_socket();
     }
 
     pub fn on_start_streaming_request_body(&mut self) -> WebCore::DrainResult {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3961,8 +3961,7 @@ where
                 // TODO: properly propagate exception upwards
                 let _ = bytes.on_data(WebCore::streams::Result::Temporary(borrowed));
 
-                // Whatever `on_data` did not hand to a waiting reader is now in
-                // `bytes.buffer`; `on_stream_drained` resumes once it empties.
+                // What `on_data` buffered; `on_stream_drained` resumes once it empties.
                 let buffered = bytes.buffer.get().len().saturating_sub(bytes.offset.get());
                 if buffered >= REQUEST_BODY_HIGH_WATER_MARK {
                     this.pause_request_body_socket();
@@ -4076,8 +4075,7 @@ where
             }
             this.request_body_buf.extend_from_slice(chunk);
 
-            // Pre-stream backpressure; resumed by `on_stream_drained` once the
-            // handler reads, or by `on_start_buffering` for `.text()` etc.
+            // Pre-stream backpressure; resumed by `on_stream_drained` / `on_start_buffering`.
             if !this.flags.request_body_buffer_all()
                 && this.request_body_buf.len() >= REQUEST_BODY_HIGH_WATER_MARK
             {
@@ -4109,8 +4107,7 @@ where
         }
     }
 
-    /// Detach the body ByteStream's `drain_handler` before this context is
-    /// released: the stream can outlive it in JS.
+    /// Detach the body ByteStream's `drain_handler` (the stream can outlive this ctx in JS).
     fn clear_request_body_stream_drain_handler(&self, global_this: &JSGlobalObject) {
         let Some(readable) = self.request_body_readable_stream_ref.get(global_this) else {
             return;
@@ -4264,8 +4261,7 @@ where
 
 const MAX_REQUEST_BODY_PREALLOCATE_LENGTH: usize = 1024 * 256;
 
-/// Pause socket reads once the request-body buffer holds this many unconsumed
-/// bytes: two `LIBUS_RECV_BUFFER_LENGTH` (512 KB) recv buffers.
+/// Pause socket reads at this many unconsumed request-body bytes (two 512 KB uWS recv buffers).
 const REQUEST_BODY_HIGH_WATER_MARK: usize = 1024 * 1024;
 
 // Trap host fn for the `(false, _, true)` arms of `exported_host_fns`. Those

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1186,8 +1186,8 @@ where
     pub fn end_already_responded_stream(&mut self) {
         ctx_log!("endAlreadyRespondedStream");
         debug_assert!(!HTTP3);
-        // Resume before `take()`: READABLE was disabled while paused, so the socket has not been recycled.
-        self.resume_request_body_socket();
+        // `resp` may be freed (see above); the sink resumed the socket at `res.end()` while live.
+        self.flags.set_request_body_paused(false);
         if self.resp.take().is_some() {
             self.flags.set_is_waiting_for_request_body(false);
             self.flags.set_has_abort_handler(false);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4166,7 +4166,10 @@ where
                 return;
             }
             (*flags).set_request_body_paused(false);
-            if (*this).resp.is_none() || (*flags).aborted() {
+            if (*this).resp.is_none()
+                || (*flags).aborted()
+                || (*this).server.is_none_or(|s| s.terminated())
+            {
                 return;
             }
             // Inline `resp_may_be_freed()` via raw ptr (borrow = ptr; see above).

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4166,8 +4166,14 @@ where
                 return;
             }
             (*flags).set_request_body_paused(false);
-            if (*this).resp.is_none() || (*flags).aborted() || (*this).resp_may_be_freed() {
+            if (*this).resp.is_none() || (*flags).aborted() {
                 return;
+            }
+            // Inline `resp_may_be_freed()` via raw ptr (borrow = ptr; see above).
+            if let Some(sink) = (*this).sink {
+                if (*sink.as_ptr()).sink.ended_response {
+                    return;
+                }
             }
             if let Some(resp) = (*this).resp {
                 resp.resume_();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1506,6 +1506,7 @@ where
         }
         self.response_weakref.deref();
 
+        self.clear_request_body_stream_drain_handler(global_this);
         self.request_body_readable_stream_ref.deinit();
 
         // Releases the ref taken in `set_cookies` (via `CookieMapRef::drop`).
@@ -2374,6 +2375,10 @@ where
         self.request_body_buf = Vec::new();
 
         if let Some(resp) = self.resp.take() {
+            if self.flags.request_body_paused() {
+                self.flags.set_request_body_paused(false);
+                resp.resume_();
+            }
             if self.flags.is_waiting_for_request_body() {
                 self.flags.set_is_waiting_for_request_body(false);
                 resp.clear_on_data();
@@ -3901,6 +3906,7 @@ where
             if this.request_body_streamed_len > server.config().max_request_body_size {
                 this.resp.expect("infallible: resp bound").clear_on_data();
                 this.flags.set_is_waiting_for_request_body(false);
+                this.resume_request_body_socket();
 
                 let _exit = vm.enter_event_loop_scope();
 
@@ -3911,6 +3917,9 @@ where
 
                 readable.value.ensure_still_alive();
                 if let Some(bytes) = readable.ptr.bytes() {
+                    let source = bytes.parent_const();
+                    source.drain_handler.set(None);
+                    source.drain_ctx.set(None);
                     let mut err = Body::ValueError::Message(BunString::static_(
                         "Request body exceeded maxRequestBodySize",
                     ));
@@ -3951,7 +3960,17 @@ where
                 );
                 // TODO: properly propagate exception upwards
                 let _ = bytes.on_data(WebCore::streams::Result::Temporary(borrowed));
+
+                // Backpressure: if the reader did not consume this chunk
+                // synchronously, `on_data` parked it in the ByteStream's
+                // internal buffer. Stop reading from the socket until the JS
+                // side drains it (signalled via `on_stream_drained`).
+                let buffered = bytes.buffer.get().len().saturating_sub(bytes.offset.get());
+                if buffered >= REQUEST_BODY_HIGH_WATER_MARK {
+                    this.pause_request_body_socket();
+                }
             } else {
+                this.resume_request_body_socket();
                 // Moved out so the Strong (and its underlying GC handle) is
                 // released at scope exit via `Drop` on `strong::Optional`.
                 let _strong = core::mem::take(&mut this.request_body_readable_stream_ref);
@@ -3966,6 +3985,9 @@ where
                 let bytes = bun_ptr::BackRef::from(
                     NonNull::new(bytes_ptr).expect("Source::Bytes payload is non-null"),
                 );
+                let source = bytes.parent_const();
+                source.drain_handler.set(None);
+                source.drain_ctx.set(None);
                 // TODO: properly propagate exception upwards
                 let _ = bytes.on_data(WebCore::streams::Result::TemporaryAndDone(borrowed));
             }
@@ -4055,7 +4077,69 @@ where
                 );
             }
             this.request_body_buf.extend_from_slice(chunk);
+
+            // Backpressure for bodies that have not been touched yet: cap the
+            // pre-stream buffer so a handler that delays reading does not have
+            // the whole body queued in memory. Resumed when the handler starts
+            // streaming (first `read()` drains the ByteStream and fires
+            // `on_stream_drained`) or opts into whole-body buffering.
+            if !this.flags.request_body_buffer_all()
+                && this.request_body_buf.len() >= REQUEST_BODY_HIGH_WATER_MARK
+            {
+                this.pause_request_body_socket();
+            }
         }
+    }
+
+    fn pause_request_body_socket(&mut self) {
+        if self.flags.request_body_paused() {
+            return;
+        }
+        let Some(resp) = self.resp else {
+            return;
+        };
+        ctx_log!("pauseRequestBodySocket");
+        self.flags.set_request_body_paused(true);
+        resp.pause();
+    }
+
+    fn resume_request_body_socket(&mut self) {
+        if !self.flags.request_body_paused() {
+            return;
+        }
+        ctx_log!("resumeRequestBodySocket");
+        self.flags.set_request_body_paused(false);
+        if let Some(resp) = self.resp {
+            resp.resume_();
+        }
+    }
+
+    /// Detach `on_request_body_stream_drained_callback` from the body's
+    /// ByteStream source before this context is released (the stream can
+    /// outlive it in JS).
+    fn clear_request_body_stream_drain_handler(&self, global_this: &JSGlobalObject) {
+        let Some(readable) = self.request_body_readable_stream_ref.get(global_this) else {
+            return;
+        };
+        if let Some(bytes) = readable.ptr.bytes() {
+            let source = bytes.parent_const();
+            source.drain_handler.set(None);
+            source.drain_ctx.set(None);
+        }
+    }
+
+    /// # Safety
+    /// `ctx` must be a `*mut RequestContext` previously registered as the body
+    /// `on_stream_drained` context.
+    pub(crate) fn on_request_body_stream_drained_callback(ctx: Option<*mut c_void>) {
+        let Some(ctx) = ctx else { return };
+        // SAFETY: caller upholds the fn-level contract — `ctx` is the
+        // `*mut RequestContext` registered as the body callback context.
+        let this = unsafe { bun_ptr::callback_ctx::<Self>(ctx) };
+        if this.is_aborted_or_ended() {
+            return;
+        }
+        this.resume_request_body_socket();
     }
 
     pub fn on_start_streaming_request_body(&mut self) -> WebCore::DrainResult {
@@ -4089,6 +4173,10 @@ where
     pub fn on_start_buffering(&mut self) {
         if let Some(server) = self.server {
             ctx_log!("onStartBuffering");
+            // `.text()`/`.json()` etc. want the whole body: release any
+            // pre-stream backpressure and stop re-applying it.
+            self.flags.set_request_body_buffer_all(true);
+            self.resume_request_body_socket();
             // TODO: check if is someone calling onStartBuffering other than onStartBufferingCallback
             // if is not, this should be removed and only keep protect + setAbortHandler
             // HTTP/3 (RFC 9114): Content-Length is optional; the body is
@@ -4182,6 +4270,12 @@ where
 }
 
 const MAX_REQUEST_BODY_PREALLOCATE_LENGTH: usize = 1024 * 256;
+
+/// Pause the socket when the request-body ByteStream (or the pre-stream
+/// `request_body_buf`) holds more than this many unconsumed bytes. Two uWS recv
+/// buffers' worth (`LIBUS_RECV_BUFFER_LENGTH` = 512 KB) keeps loopback
+/// throughput high while bounding memory to O(1) per request.
+const REQUEST_BODY_HIGH_WATER_MARK: usize = 1024 * 1024;
 
 // Trap host fn for the `(false, _, true)` arms of `exported_host_fns`. Those
 // `RequestContext` monomorphs (plain-HTTP/3) are type-reachable via the
@@ -4395,7 +4489,7 @@ pub struct SendfileContext {
 // `is_web_browser_navigation` / `has_finalized` accessors on the const params.
 bitflags::bitflags! {
     #[derive(Default, Clone, Copy)]
-    pub struct FlagsBits: u16 {
+    pub struct FlagsBits: u32 {
         const HAS_MARKED_COMPLETE         = 1 << 0;
         const HAS_MARKED_PENDING          = 1 << 1;
         const HAS_ABORT_HANDLER           = 1 << 2;
@@ -4416,6 +4510,13 @@ bitflags::bitflags! {
         const ABORTED                     = 1 << 13;
         const HAS_FINALIZED               = 1 << 14;
         const IS_ERROR_PROMISE_PENDING    = 1 << 15;
+        /// Socket reads are paused because the request-body ByteStream (or the
+        /// pre-stream `request_body_buf`) is over its high-water mark.
+        const REQUEST_BODY_PAUSED         = 1 << 16;
+        /// The handler has asked for the whole body via `.text()`/`.json()`
+        /// etc. (`on_start_buffering` fired). Skip backpressure on the
+        /// pre-stream buffer: the consumer wants everything.
+        const REQUEST_BODY_BUFFER_ALL     = 1 << 17;
     }
 }
 
@@ -4494,6 +4595,16 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
         is_error_promise_pending,
         set_is_error_promise_pending,
         IS_ERROR_PROMISE_PENDING
+    );
+    flag_accessor!(
+        request_body_paused,
+        set_request_body_paused,
+        REQUEST_BODY_PAUSED
+    );
+    flag_accessor!(
+        request_body_buffer_all,
+        set_request_body_buffer_all,
+        REQUEST_BODY_BUFFER_ALL
     );
 
     #[inline]

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3961,10 +3961,8 @@ where
                 // TODO: properly propagate exception upwards
                 let _ = bytes.on_data(WebCore::streams::Result::Temporary(borrowed));
 
-                // Backpressure: if the reader did not consume this chunk
-                // synchronously, `on_data` parked it in the ByteStream's
-                // internal buffer. Stop reading from the socket until the JS
-                // side drains it (signalled via `on_stream_drained`).
+                // Whatever `on_data` did not hand to a waiting reader is now in
+                // `bytes.buffer`; `on_stream_drained` resumes once it empties.
                 let buffered = bytes.buffer.get().len().saturating_sub(bytes.offset.get());
                 if buffered >= REQUEST_BODY_HIGH_WATER_MARK {
                     this.pause_request_body_socket();
@@ -4078,11 +4076,8 @@ where
             }
             this.request_body_buf.extend_from_slice(chunk);
 
-            // Backpressure for bodies that have not been touched yet: cap the
-            // pre-stream buffer so a handler that delays reading does not have
-            // the whole body queued in memory. Resumed when the handler starts
-            // streaming (first `read()` drains the ByteStream and fires
-            // `on_stream_drained`) or opts into whole-body buffering.
+            // Pre-stream backpressure; resumed by `on_stream_drained` once the
+            // handler reads, or by `on_start_buffering` for `.text()` etc.
             if !this.flags.request_body_buffer_all()
                 && this.request_body_buf.len() >= REQUEST_BODY_HIGH_WATER_MARK
             {
@@ -4114,9 +4109,8 @@ where
         }
     }
 
-    /// Detach `on_request_body_stream_drained_callback` from the body's
-    /// ByteStream source before this context is released (the stream can
-    /// outlive it in JS).
+    /// Detach the body ByteStream's `drain_handler` before this context is
+    /// released: the stream can outlive it in JS.
     fn clear_request_body_stream_drain_handler(&self, global_this: &JSGlobalObject) {
         let Some(readable) = self.request_body_readable_stream_ref.get(global_this) else {
             return;
@@ -4173,8 +4167,7 @@ where
     pub fn on_start_buffering(&mut self) {
         if let Some(server) = self.server {
             ctx_log!("onStartBuffering");
-            // `.text()`/`.json()` etc. want the whole body: release any
-            // pre-stream backpressure and stop re-applying it.
+            // `.text()`/`.json()` want the whole body; disable pre-stream backpressure.
             self.flags.set_request_body_buffer_all(true);
             self.resume_request_body_socket();
             // TODO: check if is someone calling onStartBuffering other than onStartBufferingCallback
@@ -4271,10 +4264,8 @@ where
 
 const MAX_REQUEST_BODY_PREALLOCATE_LENGTH: usize = 1024 * 256;
 
-/// Pause the socket when the request-body ByteStream (or the pre-stream
-/// `request_body_buf`) holds more than this many unconsumed bytes. Two uWS recv
-/// buffers' worth (`LIBUS_RECV_BUFFER_LENGTH` = 512 KB) keeps loopback
-/// throughput high while bounding memory to O(1) per request.
+/// Pause socket reads once the request-body buffer holds this many unconsumed
+/// bytes: two `LIBUS_RECV_BUFFER_LENGTH` (512 KB) recv buffers.
 const REQUEST_BODY_HIGH_WATER_MARK: usize = 1024 * 1024;
 
 // Trap host fn for the `(false, _, true)` arms of `exported_host_fns`. Those
@@ -4510,12 +4501,9 @@ bitflags::bitflags! {
         const ABORTED                     = 1 << 13;
         const HAS_FINALIZED               = 1 << 14;
         const IS_ERROR_PROMISE_PENDING    = 1 << 15;
-        /// Socket reads are paused because the request-body ByteStream (or the
-        /// pre-stream `request_body_buf`) is over its high-water mark.
+        /// Socket reads are paused because the request-body buffer is over its high-water mark.
         const REQUEST_BODY_PAUSED         = 1 << 16;
-        /// The handler has asked for the whole body via `.text()`/`.json()`
-        /// etc. (`on_start_buffering` fired). Skip backpressure on the
-        /// pre-stream buffer: the consumer wants everything.
+        /// `on_start_buffering` fired (`.text()` etc.); skip pre-stream backpressure.
         const REQUEST_BODY_BUFFER_ALL     = 1 << 17;
     }
 }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1186,8 +1186,7 @@ where
     pub fn end_already_responded_stream(&mut self) {
         ctx_log!("endAlreadyRespondedStream");
         debug_assert!(!HTTP3);
-        // Resume before `take()`: READABLE was disabled while paused, so the
-        // socket cannot have been recycled onto a next request in the interim.
+        // Resume before `take()`: READABLE was disabled while paused, so the socket has not been recycled.
         self.resume_request_body_socket();
         if self.resp.take().is_some() {
             self.flags.set_is_waiting_for_request_body(false);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1186,7 +1186,7 @@ where
     pub fn end_already_responded_stream(&mut self) {
         ctx_log!("endAlreadyRespondedStream");
         debug_assert!(!HTTP3);
-        // `resp` may be freed (see above); the sink resumed the socket at `res.end()` while live.
+        // `resp` may be freed (see above); uWS `markDone()` resumed the socket while it was live.
         self.flags.set_request_body_paused(false);
         if self.resp.take().is_some() {
             self.flags.set_is_waiting_for_request_body(false);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -818,6 +818,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             on_readable_stream_available: Some(
                                 ServerRequestContext::<SSL, DEBUG>::on_request_body_readable_stream_available,
                             ),
+                            on_stream_drained: Some(
+                                ServerRequestContext::<SSL, DEBUG>::on_request_body_stream_drained_callback,
+                            ),
                             ..Default::default()
                         });
                 }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -136,6 +136,7 @@ pub(super) trait RequestCtxOps: RequestCtx {
         global_this: &JSGlobalObject,
         readable: WebCore::ReadableStream,
     );
+    fn on_request_body_stream_drained_callback(this: Option<*mut c_void>);
 }
 
 impl<ThisServer, const SSL: bool, const DBG: bool, const H3: bool> RequestCtxOps
@@ -274,6 +275,10 @@ where
         readable: WebCore::ReadableStream,
     ) {
         Self::on_request_body_readable_stream_available(this, global_this, readable)
+    }
+    #[inline]
+    fn on_request_body_stream_drained_callback(this: Option<*mut c_void>) {
+        Self::on_request_body_stream_drained_callback(this)
     }
 }
 
@@ -3187,6 +3192,7 @@ where
                         on_readable_stream_available: Some(
                             Ctx::on_request_body_readable_stream_available,
                         ),
+                        on_stream_drained: Some(Ctx::on_request_body_stream_drained_callback),
                         ..Default::default()
                     });
                 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5244,6 +5244,11 @@ pub fn write_file_internal(
                         let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
                             unreachable!()
                         };
+                        if let (Some(on_start_buffering), Some(orig_task)) =
+                            (locked.on_start_buffering.take(), locked.task)
+                        {
+                            on_start_buffering(orig_task);
+                        }
                         locked.task = Some(task.cast::<c_void>());
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
                         // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1760,9 +1760,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         self.requested_end = true;
-        // Release any request-body backpressure pause before `markDone()` drops
-        // `onAborted`, after which the RequestContext's stale `resp` must not
-        // be dereferenced (see `end_already_responded_stream`).
+        // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
         if let Some(res) = self.any_res() {
             res.resume_();
         }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1760,10 +1760,6 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         self.requested_end = true;
-        // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
-        if let Some(res) = self.any_res() {
-            res.resume_();
-        }
         let readable_len = self.readable_slice().len();
         self.end_len = readable_len;
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1404,6 +1404,8 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             if self.requested_end {
                 if let Some(res) = self.any_res() {
                     res.clear_on_writable();
+                    // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
+                    res.resume_();
                 }
                 // `send_readable` drained the parked `try_end`, so uWS has
                 // `markDone()`d the response and dropped its `onAborted`.
@@ -1778,6 +1780,10 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             }
         }
 
+        if let Some(res) = self.any_res() {
+            // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
+            res.resume_();
+        }
         // Both branches above fully ended the response through uWS, which
         // `markDone()`s it and drops its `onAborted`.
         self.ended_response = true;

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1865,6 +1865,20 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return true;
         }
         self.auto_flusher.registered.set(false);
+
+        if self.requested_end {
+            if let Some(res) = self.any_res() {
+                res.clear_on_writable();
+                // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
+                res.resume_();
+            }
+            // `send_readable` drained the parked `try_end`/`end`, so uWS has
+            // `markDone()`d the response and dropped its `onAborted`.
+            self.ended_response = true;
+            self.signal.close(None);
+            let _ = self.flush_promise();
+            self.finalize();
+        }
         false
     }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1760,6 +1760,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         self.requested_end = true;
+        // Release any request-body backpressure pause before `markDone()` drops
+        // `onAborted`, after which the RequestContext's stale `resp` must not
+        // be dereferenced (see `end_already_responded_stream`).
+        if let Some(res) = self.any_res() {
+            res.resume_();
+        }
         let readable_len = self.readable_slice().len();
         self.end_len = readable_len;
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3330,6 +3330,9 @@ describe("request body backpressure", () => {
       port: 0,
       idleTimeout: 0,
       maxRequestBodySize: TOTAL + 1,
+      error(e) {
+        serverDone.reject(e);
+      },
       async fetch(req) {
         const reader = req.body!.getReader();
         const first = await reader.read();
@@ -3386,6 +3389,9 @@ describe("request body backpressure", () => {
       port: 0,
       idleTimeout: 0,
       maxRequestBodySize: TOTAL + 1,
+      error(e) {
+        serverDone.reject(e);
+      },
       async fetch(req) {
         await gate.promise;
         for await (const c of req.body!) {
@@ -3413,36 +3419,45 @@ describe("request body backpressure", () => {
     }
   });
 
-  it("resumes a paused request body when the handler calls .arrayBuffer()", async () => {
-    // .arrayBuffer() wants the whole body, so the pre-stream pause must release
-    // once it is called instead of leaving the socket wedged.
-    const TOTAL = 32 * 1024 * 1024;
-    const gate = Promise.withResolvers<void>();
-    const serverDone = Promise.withResolvers<number>();
+  for (const touchBodyFirst of [false, true]) {
+    it(`resumes a paused request body when the handler calls .arrayBuffer()${touchBodyFirst ? " after touching req.body" : ""}`, async () => {
+      // .arrayBuffer() wants the whole body, so the pre-stream pause must
+      // release once it is called instead of leaving the socket wedged. The
+      // second variant materializes `req.body` first so `.arrayBuffer()` goes
+      // through the ByteStream buffer_action fastpath instead of
+      // on_start_buffering.
+      const TOTAL = 32 * 1024 * 1024;
+      const gate = Promise.withResolvers<void>();
+      const serverDone = Promise.withResolvers<number>();
 
-    using server = serve({
-      port: 0,
-      idleTimeout: 0,
-      maxRequestBodySize: TOTAL + 1,
-      async fetch(req) {
-        await gate.promise;
-        const buf = await req.arrayBuffer();
-        serverDone.resolve(buf.byteLength);
-        return new Response("ok");
-      },
+      using server = serve({
+        port: 0,
+        idleTimeout: 0,
+        maxRequestBodySize: TOTAL + 1,
+        error(e) {
+          serverDone.reject(e);
+        },
+        async fetch(req) {
+          if (touchBodyFirst) void req.body;
+          await gate.promise;
+          const buf = await req.arrayBuffer();
+          serverDone.resolve(buf.byteLength);
+          return new Response("ok");
+        },
+      });
+
+      const { sock, sentBeforeGate } = await pumpUploadUntilPlateau(server.port, TOTAL, 5);
+      try {
+        expect(sentBeforeGate).toBeLessThan(TOTAL);
+
+        gate.resolve();
+        const bytes = await serverDone.promise;
+        expect(bytes).toBe(TOTAL);
+      } finally {
+        sock.destroy();
+      }
     });
-
-    const { sock, sentBeforeGate } = await pumpUploadUntilPlateau(server.port, TOTAL, 5);
-    try {
-      expect(sentBeforeGate).toBeLessThan(TOTAL);
-
-      gate.resolve();
-      const bytes = await serverDone.promise;
-      expect(bytes).toBe(TOTAL);
-    } finally {
-      sock.destroy();
-    }
-  });
+  }
 });
 
 // https://github.com/oven-sh/bun/issues/32469

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3419,6 +3419,43 @@ describe("request body backpressure", () => {
     }
   });
 
+  it("resumes a paused request body when the handler calls Bun.write(file, req)", async () => {
+    // Bun.write on a Locked body installs on_receive_value without creating a
+    // ByteStream; the pre-stream pause must release via on_start_buffering.
+    const TOTAL = 32 * 1024 * 1024;
+    const gate = Promise.withResolvers<void>();
+    const serverDone = Promise.withResolvers<number>();
+
+    using dir = tempDir("serve-request-body-bunwrite", {});
+    const out = join(String(dir), "body");
+
+    using server = serve({
+      port: 0,
+      idleTimeout: 0,
+      maxRequestBodySize: TOTAL + 1,
+      error(e) {
+        serverDone.reject(e);
+      },
+      async fetch(req) {
+        await gate.promise;
+        const n = await Bun.write(out, req);
+        serverDone.resolve(n);
+        return new Response("ok");
+      },
+    });
+
+    const { sock, sentBeforeGate } = await pumpUploadUntilPlateau(server.port, TOTAL, 3);
+    try {
+      expect(sentBeforeGate).toBeLessThan(TOTAL);
+
+      gate.resolve();
+      const bytes = await serverDone.promise;
+      expect(bytes).toBe(TOTAL);
+    } finally {
+      sock.destroy();
+    }
+  });
+
   for (const touchBodyFirst of [false, true]) {
     it(`resumes a paused request body when the handler calls .arrayBuffer()${touchBodyFirst ? " after touching req.body" : ""}`, async () => {
       // .arrayBuffer() wants the whole body, so the pre-stream pause must

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3268,235 +3268,181 @@ it("resumes a backpressured Response(ReadableStream) once the client drains and 
   }
 });
 
-// https://github.com/oven-sh/bun/issues/4970
-it("applies backpressure to a streamed request body when the handler reads slowly", async () => {
-  // The server reads one chunk then stalls on a gate. Without backpressure the
-  // client can push the whole body into the ByteStream's internal buffer in
-  // that window (one ~TOTAL-sized mega-chunk once the gate opens). With it the
-  // socket is paused once ~1 MiB is buffered, so the client's write loop parks
-  // on `drain` well short of TOTAL and every delivered chunk stays bounded.
-  const TOTAL = 32 * 1024 * 1024;
-  const BLOCK = Buffer.alloc(256 * 1024, 7);
+describe("request body backpressure", () => {
+  // Raw-socket PUT client: connect, send the request head, then pump `total`
+  // bytes of `fill`, pausing on `drain`. Resolves once the client's `sent`
+  // counter has plateaued for 12×25 ms (backpressure engaged) or it finished
+  // the whole body (the bug).
+  async function pumpUploadUntilPlateau(port: number, total: number, fill: number) {
+    const block = Buffer.alloc(256 * 1024, fill);
+    const sock = net.connect(port, "127.0.0.1");
+    await new Promise<void>((resolve, reject) => {
+      sock.once("connect", () => resolve());
+      sock.once("error", reject);
+    });
+    sock.on("error", () => {});
+    sock.on("data", () => {});
+    sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${total}\r\nConnection: close\r\n\r\n`);
 
-  const gate = Promise.withResolvers<void>();
-  const gotFirstChunk = Promise.withResolvers<void>();
-  let serverBytes = 0;
-  let maxChunk = 0;
-  let contentOk = true;
-  const serverDone = Promise.withResolvers<void>();
-
-  using server = serve({
-    port: 0,
-    idleTimeout: 0,
-    maxRequestBodySize: TOTAL + 1,
-    async fetch(req) {
-      const reader = req.body!.getReader();
-      const first = await reader.read();
-      if (first.value) {
-        serverBytes += first.value.length;
-        maxChunk = Math.max(maxChunk, first.value.length);
-        if (first.value[0] !== 7 || first.value.at(-1) !== 7) contentOk = false;
+    let sent = 0;
+    let drainWaiters = 0;
+    const writeMore = () => {
+      while (sent < total) {
+        const n = Math.min(block.length, total - sent);
+        const ok = sock.write(n === block.length ? block : block.subarray(0, n));
+        sent += n;
+        if (!ok) {
+          drainWaiters++;
+          sock.once("drain", writeMore);
+          return;
+        }
       }
-      gotFirstChunk.resolve();
-      await gate.promise;
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        serverBytes += value.length;
-        maxChunk = Math.max(maxChunk, value.length);
-        if (value[0] !== 7 || value.at(-1) !== 7) contentOk = false;
-      }
-      serverDone.resolve();
-      return new Response("ok");
-    },
-  });
+    };
+    writeMore();
 
-  const sock = net.connect(server.port, "127.0.0.1");
-  await new Promise<void>((resolve, reject) => {
-    sock.once("connect", () => resolve());
-    sock.once("error", reject);
-  });
-  sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${TOTAL}\r\nConnection: close\r\n\r\n`);
-
-  let sent = 0;
-  let drainWaiters = 0;
-  const writeMore = () => {
-    while (sent < TOTAL) {
-      const n = Math.min(BLOCK.length, TOTAL - sent);
-      const ok = sock.write(n === BLOCK.length ? BLOCK : BLOCK.subarray(0, n));
-      sent += n;
-      if (!ok) {
-        drainWaiters++;
-        sock.once("drain", writeMore);
-        return;
+    let last = -1;
+    let stable = 0;
+    while (sent < total && stable < 12) {
+      await Bun.sleep(25);
+      if (sent === last) stable++;
+      else {
+        stable = 0;
+        last = sent;
       }
     }
-  };
-  writeMore();
-  await gotFirstChunk.promise;
-
-  // Poll until the client's progress plateaus (backpressure engaged) or it
-  // manages to send the whole body (the bug).
-  let last = -1;
-  let stable = 0;
-  while (sent < TOTAL && stable < 12) {
-    await Bun.sleep(25);
-    if (sent === last) stable++;
-    else {
-      stable = 0;
-      last = sent;
-    }
+    return { sock, sentBeforeGate: sent, drainWaiters };
   }
-  const sentBeforeGate = sent;
 
-  gate.resolve();
-  sock.on("data", () => {});
-  await serverDone.promise;
-  sock.destroy();
+  it("applies backpressure to a streamed request body when the handler reads slowly", async () => {
+    // The server reads one chunk then stalls on a gate. Without backpressure the
+    // client can push the whole body into the ByteStream's internal buffer in
+    // that window (one ~TOTAL-sized mega-chunk once the gate opens). With it the
+    // socket is paused once ~1 MiB is buffered, so the client's write loop parks
+    // on `drain` well short of TOTAL and every delivered chunk stays bounded.
+    const TOTAL = 32 * 1024 * 1024;
+    const gate = Promise.withResolvers<void>();
+    let serverBytes = 0;
+    let maxChunk = 0;
+    let contentOk = true;
+    const serverDone = Promise.withResolvers<void>();
 
-  // With backpressure the client stalls after ~HWM + kernel socket buffers.
-  // Without it, the client finishes the whole body before the gate opens.
-  expect(sentBeforeGate).toBeGreaterThan(0);
-  expect(sentBeforeGate).toBeLessThan(TOTAL);
-  expect(drainWaiters).toBeGreaterThan(0);
-  // The ByteStream buffer is capped at ~1 MiB, so the largest chunk the
-  // handler ever sees is that plus at most one recv buffer. Without
-  // backpressure the second read would deliver ~TOTAL bytes in one chunk.
-  expect(maxChunk).toBeLessThan(4 * 1024 * 1024);
-  expect(serverBytes).toBe(TOTAL);
-  expect(contentOk).toBe(true);
-});
+    using server = serve({
+      port: 0,
+      idleTimeout: 0,
+      maxRequestBodySize: TOTAL + 1,
+      async fetch(req) {
+        const reader = req.body!.getReader();
+        const first = await reader.read();
+        if (first.value) {
+          serverBytes += first.value.length;
+          maxChunk = Math.max(maxChunk, first.value.length);
+          if (first.value[0] !== 7 || first.value.at(-1) !== 7) contentOk = false;
+        }
+        await gate.promise;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          serverBytes += value.length;
+          maxChunk = Math.max(maxChunk, value.length);
+          if (value[0] !== 7 || value.at(-1) !== 7) contentOk = false;
+        }
+        serverDone.resolve();
+        return new Response("ok");
+      },
+    });
 
-it("applies backpressure to a request body that the handler has not touched yet", async () => {
-  // Same shape as above but the handler does not touch req.body until after the
-  // client has plateaued, covering the pre-stream request_body_buf path.
-  const TOTAL = 32 * 1024 * 1024;
-  const BLOCK = Buffer.alloc(256 * 1024, 9);
+    const { sock, sentBeforeGate, drainWaiters } = await pumpUploadUntilPlateau(server.port, TOTAL, 7);
+    try {
+      gate.resolve();
+      await serverDone.promise;
 
-  const gate = Promise.withResolvers<void>();
-  let serverBytes = 0;
-  let maxChunk = 0;
-  const serverDone = Promise.withResolvers<void>();
-
-  using server = serve({
-    port: 0,
-    idleTimeout: 0,
-    maxRequestBodySize: TOTAL + 1,
-    async fetch(req) {
-      await gate.promise;
-      for await (const c of req.body!) {
-        serverBytes += c.length;
-        maxChunk = Math.max(maxChunk, c.length);
-      }
-      serverDone.resolve();
-      return new Response("ok");
-    },
+      // With backpressure the client stalls after ~HWM + kernel socket buffers.
+      // Without it, the client finishes the whole body before the gate opens.
+      expect(sentBeforeGate).toBeGreaterThan(0);
+      expect(sentBeforeGate).toBeLessThan(TOTAL);
+      expect(drainWaiters).toBeGreaterThan(0);
+      // The ByteStream buffer is capped at ~1 MiB, so the largest chunk the
+      // handler ever sees is that plus at most one recv buffer. Without
+      // backpressure the second read would deliver ~TOTAL bytes in one chunk.
+      expect(maxChunk).toBeLessThan(4 * 1024 * 1024);
+      expect(serverBytes).toBe(TOTAL);
+      expect(contentOk).toBe(true);
+    } finally {
+      sock.destroy();
+    }
   });
 
-  const sock = net.connect(server.port, "127.0.0.1");
-  await new Promise<void>((resolve, reject) => {
-    sock.once("connect", () => resolve());
-    sock.once("error", reject);
-  });
-  sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${TOTAL}\r\nConnection: close\r\n\r\n`);
+  it("applies backpressure to a request body that the handler has not touched yet", async () => {
+    // Same shape as above but the handler does not touch req.body until after the
+    // client has plateaued, covering the pre-stream request_body_buf path.
+    const TOTAL = 32 * 1024 * 1024;
+    const gate = Promise.withResolvers<void>();
+    let serverBytes = 0;
+    let maxChunk = 0;
+    let contentOk = true;
+    const serverDone = Promise.withResolvers<void>();
 
-  let sent = 0;
-  const writeMore = () => {
-    while (sent < TOTAL) {
-      const n = Math.min(BLOCK.length, TOTAL - sent);
-      const ok = sock.write(n === BLOCK.length ? BLOCK : BLOCK.subarray(0, n));
-      sent += n;
-      if (!ok) {
-        sock.once("drain", writeMore);
-        return;
-      }
+    using server = serve({
+      port: 0,
+      idleTimeout: 0,
+      maxRequestBodySize: TOTAL + 1,
+      async fetch(req) {
+        await gate.promise;
+        for await (const c of req.body!) {
+          serverBytes += c.length;
+          maxChunk = Math.max(maxChunk, c.length);
+          if (c[0] !== 9 || c.at(-1) !== 9) contentOk = false;
+        }
+        serverDone.resolve();
+        return new Response("ok");
+      },
+    });
+
+    const { sock, sentBeforeGate } = await pumpUploadUntilPlateau(server.port, TOTAL, 9);
+    try {
+      gate.resolve();
+      await serverDone.promise;
+
+      expect(sentBeforeGate).toBeGreaterThan(0);
+      expect(sentBeforeGate).toBeLessThan(TOTAL);
+      expect(maxChunk).toBeLessThan(4 * 1024 * 1024);
+      expect(serverBytes).toBe(TOTAL);
+      expect(contentOk).toBe(true);
+    } finally {
+      sock.destroy();
     }
-  };
-  writeMore();
-
-  let last = -1;
-  let stable = 0;
-  while (sent < TOTAL && stable < 12) {
-    await Bun.sleep(25);
-    if (sent === last) stable++;
-    else {
-      stable = 0;
-      last = sent;
-    }
-  }
-  const sentBeforeGate = sent;
-
-  gate.resolve();
-  sock.on("data", () => {});
-  await serverDone.promise;
-  sock.destroy();
-
-  expect(sentBeforeGate).toBeGreaterThan(0);
-  expect(sentBeforeGate).toBeLessThan(TOTAL);
-  expect(maxChunk).toBeLessThan(4 * 1024 * 1024);
-  expect(serverBytes).toBe(TOTAL);
-});
-
-it("resumes a paused request body when the handler calls .arrayBuffer()", async () => {
-  // .arrayBuffer() wants the whole body, so the pre-stream pause must release
-  // once it is called instead of leaving the socket wedged.
-  const TOTAL = 8 * 1024 * 1024;
-  const BLOCK = Buffer.alloc(256 * 1024, 5);
-
-  const gate = Promise.withResolvers<void>();
-  const serverDone = Promise.withResolvers<number>();
-
-  using server = serve({
-    port: 0,
-    idleTimeout: 0,
-    maxRequestBodySize: TOTAL + 1,
-    async fetch(req) {
-      await gate.promise;
-      const buf = await req.arrayBuffer();
-      serverDone.resolve(buf.byteLength);
-      return new Response("ok");
-    },
   });
 
-  const sock = net.connect(server.port, "127.0.0.1");
-  await new Promise<void>((resolve, reject) => {
-    sock.once("connect", () => resolve());
-    sock.once("error", reject);
+  it("resumes a paused request body when the handler calls .arrayBuffer()", async () => {
+    // .arrayBuffer() wants the whole body, so the pre-stream pause must release
+    // once it is called instead of leaving the socket wedged.
+    const TOTAL = 32 * 1024 * 1024;
+    const gate = Promise.withResolvers<void>();
+    const serverDone = Promise.withResolvers<number>();
+
+    using server = serve({
+      port: 0,
+      idleTimeout: 0,
+      maxRequestBodySize: TOTAL + 1,
+      async fetch(req) {
+        await gate.promise;
+        const buf = await req.arrayBuffer();
+        serverDone.resolve(buf.byteLength);
+        return new Response("ok");
+      },
+    });
+
+    const { sock, sentBeforeGate } = await pumpUploadUntilPlateau(server.port, TOTAL, 5);
+    try {
+      expect(sentBeforeGate).toBeLessThan(TOTAL);
+
+      gate.resolve();
+      const bytes = await serverDone.promise;
+      expect(bytes).toBe(TOTAL);
+    } finally {
+      sock.destroy();
+    }
   });
-  sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${TOTAL}\r\nConnection: close\r\n\r\n`);
-
-  let sent = 0;
-  const writeMore = () => {
-    while (sent < TOTAL) {
-      const n = Math.min(BLOCK.length, TOTAL - sent);
-      const ok = sock.write(n === BLOCK.length ? BLOCK : BLOCK.subarray(0, n));
-      sent += n;
-      if (!ok) {
-        sock.once("drain", writeMore);
-        return;
-      }
-    }
-  };
-  writeMore();
-
-  let last = -1;
-  let stable = 0;
-  while (sent < TOTAL && stable < 12) {
-    await Bun.sleep(25);
-    if (sent === last) stable++;
-    else {
-      stable = 0;
-      last = sent;
-    }
-  }
-  expect(sent).toBeLessThan(TOTAL);
-
-  gate.resolve();
-  sock.on("data", () => {});
-  const bytes = await serverDone.promise;
-  sock.destroy();
-
-  expect(bytes).toBe(TOTAL);
 });
 
 // https://github.com/oven-sh/bun/issues/32469

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3451,6 +3451,8 @@ describe("request body backpressure", () => {
       gate.resolve();
       const bytes = await serverDone.promise;
       expect(bytes).toBe(TOTAL);
+      const written = await Bun.file(out).bytes();
+      expect([written.length, written[0], written.at(-1)]).toEqual([TOTAL, 3, 3]);
     } finally {
       sock.destroy();
     }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3268,6 +3268,237 @@ it("resumes a backpressured Response(ReadableStream) once the client drains and 
   }
 });
 
+// https://github.com/oven-sh/bun/issues/4970
+it("applies backpressure to a streamed request body when the handler reads slowly", async () => {
+  // The server reads one chunk then stalls on a gate. Without backpressure the
+  // client can push the whole body into the ByteStream's internal buffer in
+  // that window (one ~TOTAL-sized mega-chunk once the gate opens). With it the
+  // socket is paused once ~1 MiB is buffered, so the client's write loop parks
+  // on `drain` well short of TOTAL and every delivered chunk stays bounded.
+  const TOTAL = 32 * 1024 * 1024;
+  const BLOCK = Buffer.alloc(256 * 1024, 7);
+
+  const gate = Promise.withResolvers<void>();
+  const gotFirstChunk = Promise.withResolvers<void>();
+  let serverBytes = 0;
+  let maxChunk = 0;
+  let contentOk = true;
+  const serverDone = Promise.withResolvers<void>();
+
+  using server = serve({
+    port: 0,
+    idleTimeout: 0,
+    maxRequestBodySize: TOTAL + 1,
+    async fetch(req) {
+      const reader = req.body!.getReader();
+      const first = await reader.read();
+      if (first.value) {
+        serverBytes += first.value.length;
+        maxChunk = Math.max(maxChunk, first.value.length);
+        if (first.value[0] !== 7 || first.value.at(-1) !== 7) contentOk = false;
+      }
+      gotFirstChunk.resolve();
+      await gate.promise;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        serverBytes += value.length;
+        maxChunk = Math.max(maxChunk, value.length);
+        if (value[0] !== 7 || value.at(-1) !== 7) contentOk = false;
+      }
+      serverDone.resolve();
+      return new Response("ok");
+    },
+  });
+
+  const sock = net.connect(server.port, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    sock.once("connect", () => resolve());
+    sock.once("error", reject);
+  });
+  sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${TOTAL}\r\nConnection: close\r\n\r\n`);
+
+  let sent = 0;
+  let drainWaiters = 0;
+  const writeMore = () => {
+    while (sent < TOTAL) {
+      const n = Math.min(BLOCK.length, TOTAL - sent);
+      const ok = sock.write(n === BLOCK.length ? BLOCK : BLOCK.subarray(0, n));
+      sent += n;
+      if (!ok) {
+        drainWaiters++;
+        sock.once("drain", writeMore);
+        return;
+      }
+    }
+  };
+  writeMore();
+  await gotFirstChunk.promise;
+
+  // Poll until the client's progress plateaus (backpressure engaged) or it
+  // manages to send the whole body (the bug).
+  let last = -1;
+  let stable = 0;
+  while (sent < TOTAL && stable < 12) {
+    await Bun.sleep(25);
+    if (sent === last) stable++;
+    else {
+      stable = 0;
+      last = sent;
+    }
+  }
+  const sentBeforeGate = sent;
+
+  gate.resolve();
+  sock.on("data", () => {});
+  await serverDone.promise;
+  sock.destroy();
+
+  // With backpressure the client stalls after ~HWM + kernel socket buffers.
+  // Without it, the client finishes the whole body before the gate opens.
+  expect(sentBeforeGate).toBeGreaterThan(0);
+  expect(sentBeforeGate).toBeLessThan(TOTAL);
+  expect(drainWaiters).toBeGreaterThan(0);
+  // The ByteStream buffer is capped at ~1 MiB, so the largest chunk the
+  // handler ever sees is that plus at most one recv buffer. Without
+  // backpressure the second read would deliver ~TOTAL bytes in one chunk.
+  expect(maxChunk).toBeLessThan(4 * 1024 * 1024);
+  expect(serverBytes).toBe(TOTAL);
+  expect(contentOk).toBe(true);
+});
+
+it("applies backpressure to a request body that the handler has not touched yet", async () => {
+  // Same shape as above but the handler does not touch req.body until after the
+  // client has plateaued, covering the pre-stream request_body_buf path.
+  const TOTAL = 32 * 1024 * 1024;
+  const BLOCK = Buffer.alloc(256 * 1024, 9);
+
+  const gate = Promise.withResolvers<void>();
+  let serverBytes = 0;
+  let maxChunk = 0;
+  const serverDone = Promise.withResolvers<void>();
+
+  using server = serve({
+    port: 0,
+    idleTimeout: 0,
+    maxRequestBodySize: TOTAL + 1,
+    async fetch(req) {
+      await gate.promise;
+      for await (const c of req.body!) {
+        serverBytes += c.length;
+        maxChunk = Math.max(maxChunk, c.length);
+      }
+      serverDone.resolve();
+      return new Response("ok");
+    },
+  });
+
+  const sock = net.connect(server.port, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    sock.once("connect", () => resolve());
+    sock.once("error", reject);
+  });
+  sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${TOTAL}\r\nConnection: close\r\n\r\n`);
+
+  let sent = 0;
+  const writeMore = () => {
+    while (sent < TOTAL) {
+      const n = Math.min(BLOCK.length, TOTAL - sent);
+      const ok = sock.write(n === BLOCK.length ? BLOCK : BLOCK.subarray(0, n));
+      sent += n;
+      if (!ok) {
+        sock.once("drain", writeMore);
+        return;
+      }
+    }
+  };
+  writeMore();
+
+  let last = -1;
+  let stable = 0;
+  while (sent < TOTAL && stable < 12) {
+    await Bun.sleep(25);
+    if (sent === last) stable++;
+    else {
+      stable = 0;
+      last = sent;
+    }
+  }
+  const sentBeforeGate = sent;
+
+  gate.resolve();
+  sock.on("data", () => {});
+  await serverDone.promise;
+  sock.destroy();
+
+  expect(sentBeforeGate).toBeGreaterThan(0);
+  expect(sentBeforeGate).toBeLessThan(TOTAL);
+  expect(maxChunk).toBeLessThan(4 * 1024 * 1024);
+  expect(serverBytes).toBe(TOTAL);
+});
+
+it("resumes a paused request body when the handler calls .arrayBuffer()", async () => {
+  // .arrayBuffer() wants the whole body, so the pre-stream pause must release
+  // once it is called instead of leaving the socket wedged.
+  const TOTAL = 8 * 1024 * 1024;
+  const BLOCK = Buffer.alloc(256 * 1024, 5);
+
+  const gate = Promise.withResolvers<void>();
+  const serverDone = Promise.withResolvers<number>();
+
+  using server = serve({
+    port: 0,
+    idleTimeout: 0,
+    maxRequestBodySize: TOTAL + 1,
+    async fetch(req) {
+      await gate.promise;
+      const buf = await req.arrayBuffer();
+      serverDone.resolve(buf.byteLength);
+      return new Response("ok");
+    },
+  });
+
+  const sock = net.connect(server.port, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    sock.once("connect", () => resolve());
+    sock.once("error", reject);
+  });
+  sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${TOTAL}\r\nConnection: close\r\n\r\n`);
+
+  let sent = 0;
+  const writeMore = () => {
+    while (sent < TOTAL) {
+      const n = Math.min(BLOCK.length, TOTAL - sent);
+      const ok = sock.write(n === BLOCK.length ? BLOCK : BLOCK.subarray(0, n));
+      sent += n;
+      if (!ok) {
+        sock.once("drain", writeMore);
+        return;
+      }
+    }
+  };
+  writeMore();
+
+  let last = -1;
+  let stable = 0;
+  while (sent < TOTAL && stable < 12) {
+    await Bun.sleep(25);
+    if (sent === last) stable++;
+    else {
+      stable = 0;
+      last = sent;
+    }
+  }
+  expect(sent).toBeLessThan(TOTAL);
+
+  gate.resolve();
+  sock.on("data", () => {});
+  const bytes = await serverDone.promise;
+  sock.destroy();
+
+  expect(bytes).toBe(TOTAL);
+});
+
 // https://github.com/oven-sh/bun/issues/32469
 it("type: direct stream awaiting flush(true) under backpressure does not re-enter pull", async () => {
   const CHUNK = Buffer.alloc(256 * 1024, 67);


### PR DESCRIPTION
## Repro

A `Bun.serve` handler that reads `req.body` slower than the client sends gets no TCP backpressure: the client is never throttled and the whole remaining body is buffered in server memory.

```js
const s = Bun.serve({
  port: 0,
  maxRequestBodySize: 2 ** 33,
  async fetch(req) {
    let n = 0, mx = 0;
    for await (const c of req.body) {
      n += c.length; mx = Math.max(mx, c.length);
      await Bun.sleep(n / 5e6 * 1000 - performance.now()); // ~5 MB/s sink
    }
    return Response.json({ bytes: n, maxChunkMB: Math.round(mx / 1e6) });
  },
});
// raw-socket client PUTs 60 MB at loopback speed
```

Before: `{"clientWriteMs":116}` / server `{"bytes":60000000,"maxChunkMB":55,"peakRssMB":204}` (client dumps 60 MB in 116 ms; one 55 MB chunk).
After: `{"clientWriteMs":10586}` / server `{"maxChunkMB":1}` (client throttled to the sink rate; every chunk ≤ ~1.4 MB).

The same shape held for `pipeTo(slowWritable)`, for `getReader()` + one `read()` then idle, and for a handler that did not touch `req.body` at all while the body arrived. Bun's own `node:http` server already applied backpressure on the same uWS socket (`NodeHTTPResponse::pause_socket`), so the primitive was in place; the `Bun.serve` `req.body` path just never used it.

## Cause

`RequestContext::on_buffered_body_chunk` forwards every uWS `onData` chunk into `ByteStream::on_data`. When no JS reader is waiting, `on_data` appends to the ByteStream's internal `buffer: Vec<u8>` and returns; nothing observed that buffer's size and nothing called `resp.pause()`. For a body that has not been touched yet the chunk is appended to `request_body_buf` with the same unbounded growth.

## Fix

**Pause.** `on_buffered_body_chunk` pauses the socket once the ByteStream's unconsumed buffer (or the pre-stream `request_body_buf`) crosses a 1 MiB high-water mark. The ByteStream's existing `signal_drained` (fired from `on_pull` when the buffer empties) is wired to resume via `on_stream_drained` on the request's `PendingValue`.

**Whole-body consumers.** A consumer that wants the whole body never drives `on_pull`, so pausing would wedge it:
- `.text()`/`.json()`/`.arrayBuffer()` on an untouched body fire `on_start_buffering`, which resumes and sets `REQUEST_BODY_BUFFER_ALL` to suppress further pre-stream pausing.
- `.text()` after `req.body` has been touched goes through the ByteStream's `buffer_action`; `on_buffered_body_chunk` skips the pause when `buffer_action` or a native `pipe` is set.
- `Bun.write(file, req)` registered `on_receive_value` without calling `on_start_buffering`; it now does, mirroring `BodyValueBufferer`.

**Stale-`resp` window.** Once a streaming-response sink calls `res.end()`, uWS `markDone()` drops `onAborted` and (for `Connection: close`) the socket may be freed on the next loop tick while the `RequestContext` still holds `resp`. The sink resumes the socket at both points it sets `ended_response = true` (same frame as `res.end()`, so the socket is at worst closed, never freed). Every Rust-side resume path consults `resp_may_be_freed()` (i.e. `sink.ended_response`) and clears the flag without dereferencing `resp` once the sink has ended. `handle_resolve_stream`/`handle_reject_stream` clear `REQUEST_BODY_PAUSED` and the ByteStream `drain_handler` immediately after reading `ended_response`, before `detach()`/`run_error_handler` can re-enter JS. `end_already_responded_stream` and `detach_response` clear the flag without dereferencing. uWS itself is unchanged, so node:http's own pause owners (`pausePipelineReads`, `IncomingMessage` pause, the C++ pipeline-flood guard) are unaffected.

Two `FlagsBits` are added (widening the set to `u32`): `REQUEST_BODY_PAUSED` and `REQUEST_BODY_BUFFER_ALL`.

## Verification

`bun bd test test/js/bun/http/serve.test.ts -t "request body backpressure"`

Five tests next to the existing response-side backpressure tests: a stalled streaming reader, a handler that defers touching `req.body`, `Bun.write(file, req)` after the pre-stream pause, and `.arrayBuffer()` with and without `req.body` touched first. Each writes a 32 MiB body from a raw socket, polls the client's `sent` counter until it plateaus, and asserts the plateau is well short of the total and the largest chunk the handler sees is under 4 MiB. All five fail on `main` and pass with this change; bytes are delivered intact.

The stale-`resp` paths (reader.read and req.text inside a direct-stream `pull()` after `c.end()` across a loop tick) were verified under ASAN. `node-http.test.ts` "pipelined responses buffered past the high water mark pause reads on the connection" passes.

## Binary size

The +~530 KB flagged by the size check is measured against main build 79916, the last passing canary. Twelve commits landed on main between that baseline and this PR's parent, including `node:quic` (#32602), the full `node:repl` (#31827), and `node:inspector` (#31823), none of which has produced a passing canary yet.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->