### PR TITLE
bundler(html): treat protocol-relative URLs as external

### DIFF
--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -34,7 +34,8 @@ impl<'a> HTMLScanner<'a> {
     fn create_import_record(&mut self, input_path: &[u8], kind: ImportKind) -> Result<(), Error> {
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
-        let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
+        // But "//cdn.example.com/lib.js" is a protocol-relative URL, not a rooted path; let the resolver mark it external.
+        let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' && input_path[1] != b'/' {
             resolve_path::join_abs_string::<platform::Auto>(
                 fs::FileSystem::instance().top_level_dir,
                 &[&input_path[1..]],

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -35,38 +35,39 @@ impl<'a> HTMLScanner<'a> {
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
         // But "//cdn.example.com/lib.js" is a protocol-relative URL, not a rooted path; let the resolver mark it external.
-        let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' && input_path[1] != b'/' {
-            resolve_path::join_abs_string::<platform::Auto>(
-                fs::FileSystem::instance().top_level_dir,
-                &[&input_path[1..]],
-            )
-        }
-        // Check if imports to (e.g) "App.tsx" are actually relative imoprts w/o the "./"
-        else if input_path.len() > 2 && input_path[0] != b'.' && input_path[1] != b'/' {
-            'blk: {
-                let Some(index_of_dot) = input_path.iter().rposition(|&b| b == b'.') else {
-                    break 'blk input_path;
-                };
-                let ext = &input_path[index_of_dot..];
-                if ext.len() > 4 {
-                    break 'blk input_path;
-                }
-                // /foo/bar/index.html -> /foo/bar
-                let dirname = resolve_path::dirname::<platform::Auto>(self.source.path.text());
-                if dirname.is_empty() {
-                    break 'blk input_path;
-                }
-                let resolved =
-                    resolve_path::join_abs_string_z::<platform::Auto>(dirname, &[input_path]);
-                if sys::exists_z(resolved) {
-                    resolved.as_bytes()
-                } else {
-                    input_path
-                }
+        let path_to_use: &[u8] =
+            if input_path.len() > 1 && input_path[0] == b'/' && input_path[1] != b'/' {
+                resolve_path::join_abs_string::<platform::Auto>(
+                    fs::FileSystem::instance().top_level_dir,
+                    &[&input_path[1..]],
+                )
             }
-        } else {
-            input_path
-        };
+            // Check if imports to (e.g) "App.tsx" are actually relative imoprts w/o the "./"
+            else if input_path.len() > 2 && input_path[0] != b'.' && input_path[1] != b'/' {
+                'blk: {
+                    let Some(index_of_dot) = input_path.iter().rposition(|&b| b == b'.') else {
+                        break 'blk input_path;
+                    };
+                    let ext = &input_path[index_of_dot..];
+                    if ext.len() > 4 {
+                        break 'blk input_path;
+                    }
+                    // /foo/bar/index.html -> /foo/bar
+                    let dirname = resolve_path::dirname::<platform::Auto>(self.source.path.text());
+                    if dirname.is_empty() {
+                        break 'blk input_path;
+                    }
+                    let resolved =
+                        resolve_path::join_abs_string_z::<platform::Auto>(dirname, &[input_path]);
+                    if sys::exists_z(resolved) {
+                        resolved.as_bytes()
+                    } else {
+                        input_path
+                    }
+                }
+            } else {
+                input_path
+            };
 
         let owned: &'static [u8] =
             Box::leak(AstAlloc::vec_from_slice(path_to_use).into_boxed_slice());

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -146,6 +146,31 @@ describe("bundler", () => {
     },
   });
 
+  // Test protocol-relative (scheme-relative) external assets
+  itBundled("html/external-assets-protocol-relative", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="//cdn.example.com/style.css">
+    <script src="//cdn.example.com/script.js"></script>
+  </head>
+  <body>
+    <img src="//cdn.example.com/logo.png">
+  </body>
+</html>`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      expect(html).toContain('href="//cdn.example.com/style.css"');
+      expect(html).toContain('src="//cdn.example.com/script.js"');
+      expect(html).toContain('src="//cdn.example.com/logo.png"');
+    },
+  });
+
   // Test mixed local and external assets
   itBundled("html/mixed-assets", {
     outdir: "out/",


### PR DESCRIPTION
## Problem

`bun build ./index.html` fails when any scanned attribute (`script[src]`, `link[href]`, `img[src]`, ...) contains a protocol-relative URL:

```html
<script src="//cdn.example.com/lib.js"></script>
```

```
error: Could not resolve: "/cdn.example.com/lib.js"
    at /tmp/x/index.html
exit=1
```

`https://cdn.example.com/lib.js` in the same slot is correctly preserved as external; only the `//host` form is misclassified.

## Cause

`HTMLScanner::create_import_record` rewrites any attribute value starting with `/` into a project-rooted filesystem path before creating the import record. For `//cdn.example.com/lib.js` this strips one slash and joins `/cdn.example.com/lib.js` against the project root, so the resolver never sees the original `//` prefix it already knows to treat as implicitly external (`src/resolver/resolver.rs`, same block as `http://` / `https://`).

## Fix

Skip the rooted-path rewrite when the second byte is also `/`, so `//host/...` reaches the resolver unchanged and is marked external like the other absolute URL forms.

## Verification

```
$ bun bd test test/bundler/bundler_html.test.ts
 23 pass
 0 fail
```

New `html/external-assets-protocol-relative` test fails on main with `Could not resolve: "/cdn.example.com/style.css"` and passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.0 (9aef8dfce)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [523.26ms]
(pass) bundler > html/implicit-relative-paths [106.10ms]
(pass) bundler > html/multiple-assets [108.47ms]
(pass) bundler > html/image-hashing [100.90ms]
(pass) bundler > html/external-assets [90.31ms]
1363 |             }
1364 | 
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
/index.html:-1:-1: Could not resolve: "/cdn.example.com/style.css"
/index.html:-1:-1: Could not resolve: "/cdn.example.com/script.js"
/index.html:-1:-1: Could not resolve: "/cdn.example.com/logo.png"
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1368:21)
(fail) bundler > html/external-assets-protocol-relative [102.78ms]
(pass) bundler > html/mixed-assets [97.06ms]
(pass) bundler > html/js-imports [105.40ms]
(pass) bundler > html/css-import
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9aef8dfce)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [13.85ms]
(pass) bundler > html/implicit-relative-paths [4.10ms]
(pass) bundler > html/multiple-assets [3.31ms]
(pass) bundler > html/image-hashing [3.89ms]
(pass) bundler > html/external-assets [4.59ms]
(pass) bundler > html/external-assets-protocol-relative [3.39ms]
(pass) bundler > html/mixed-assets [3.91ms]
(pass) bundler > html/js-imports [3.43ms]
(pass) bundler > html/css-imports [3.65ms]
(pass) bundler > html/multiple-entries [5.23ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [5.03ms]
(pass) bundler > html/shared-chunks [4.37ms]
(pass) bundler > html/js-importing-html [3.42ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [3.91ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [7.96ms]
(pass) bundler > html/circular-js-html [3.96ms]
(pass) bundler > html/css-only [4.16ms]
(pass) bundler > html/absolute-paths [4.48ms]
(pass) bundler > html/no-sourcemap-comments [4.11ms]
(pass) bundler > html/no-sourcemap-c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.0 (9aef8dfce)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [540.03ms]
(pass) bundler > html/implicit-relative-paths [107.16ms]
(pass) bundler > html/multiple-assets [97.71ms]
(pass) bundler > html/image-hashing [86.39ms]
(pass) bundler > html/external-assets [84.81ms]
(pass) bundler > html/external-assets-protocol-relative [88.22ms]
(pass) bundler > html/mixed-assets [97.46ms]
(pass) bundler > html/js-imports [102.50ms]
(pass) bundler > html/css-imports [99.69ms]
(pass) bundler > html/multiple-entries [154.78ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [238.32ms]
(pass) bundler > html/shared-chunks [175.77ms]
(pass) bundler > html/js-importing-html [133.28ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [113.53ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [135.47ms]
(pass) bundler > html/circular-js-html [13
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 767ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sy
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/HTMLScanner.rs        | 64 ++++++++++++++++++++-------------------
 test/bundler/bundler_html.test.ts | 25 +++++++++++++++
 2 files changed, 58 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/bundler/HTMLScanner.rs             1      1      0
test/bundler/bundler_html.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->