### PR TITLE
bundler(html): preserve ?query/#fragment when rewriting asset URLs

### DIFF
--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -106,6 +106,22 @@ fn set_attribute(element: &mut Element<'_, '_>, name: &[u8], value: &[u8]) {
     }
 }
 
+fn set_attribute_with_suffix(
+    element: &mut Element<'_, '_>,
+    name: &[u8],
+    value: &[u8],
+    suffix: &[u8],
+) {
+    if suffix.is_empty() {
+        set_attribute(element, name, value);
+    } else {
+        let mut buf = Vec::with_capacity(value.len() + suffix.len());
+        buf.extend_from_slice(value);
+        buf.extend_from_slice(suffix);
+        set_attribute(element, name, &buf);
+    }
+}
+
 impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     fn on_write_html(&mut self, bytes: &[u8]) {
         self.output.extend_from_slice(bytes);
@@ -121,9 +137,9 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     fn on_tag(
         &mut self,
         element: &mut Element<'_, '_>,
-        _path: &[u8],
+        path: &[u8],
         url_attribute: &[u8],
-        _kind: ImportKind,
+        kind: ImportKind,
     ) {
         if self.current_import_record_index as usize >= self.import_records.len() {
             bun_core::Output::panic(format_args!(
@@ -151,6 +167,19 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             Loader::File
         };
 
+        // The resolver strips a `?query`/`#fragment` to find the file on disk
+        // (e.g. `sprite.svg#home`, `clip.mp4#t=10,20`); carry it across to the
+        // rewritten reference so the fragment still addresses the SVG symbol /
+        // media range. Matches CSS's `url()` handling (see `css::Printer`).
+        let suffix: &[u8] = if kind == ImportKind::Url {
+            match strings::index_of_any(path, b"?#") {
+                Some(i) => &path[i..],
+                None => b"",
+            }
+        } else {
+            b""
+        };
+
         if import_record
             .flags
             .contains(ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS)
@@ -164,14 +193,19 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
 
         if self.linker.dev_server.is_some() {
             if !unique_key_for_additional_files.is_empty() {
-                set_attribute(element, url_attribute, unique_key_for_additional_files);
+                set_attribute_with_suffix(
+                    element,
+                    url_attribute,
+                    unique_key_for_additional_files,
+                    suffix,
+                );
             } else if import_record.path.is_disabled
                 || loader.is_javascript_like()
                 || loader.is_css()
             {
                 element.remove();
             } else {
-                set_attribute(element, url_attribute, import_record.path.pretty);
+                set_attribute_with_suffix(element, url_attribute, import_record.path.pretty, suffix);
             }
             return;
         }
@@ -195,14 +229,25 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             let url_for_css =
                 parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
             if !url_for_css.is_empty() {
-                set_attribute(element, url_attribute, url_for_css);
+                // A `?query` appended to a data: URI lands in the base64 body
+                // and breaks decoding; keep only the `#fragment`.
+                let fragment: &[u8] = match strings::index_of_char(suffix, b'#') {
+                    Some(i) => &suffix[i as usize..],
+                    None => b"",
+                };
+                set_attribute_with_suffix(element, url_attribute, url_for_css, fragment);
                 return;
             }
         }
 
         if !unique_key_for_additional_files.is_empty() {
             // Replace the external href/src with the unique key so that we later will rewrite it to the final URL or pathname
-            set_attribute(element, url_attribute, unique_key_for_additional_files);
+            set_attribute_with_suffix(
+                element,
+                url_attribute,
+                unique_key_for_additional_files,
+                suffix,
+            );
             return;
         }
     }

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -205,7 +205,12 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             {
                 element.remove();
             } else {
-                set_attribute_with_suffix(element, url_attribute, import_record.path.pretty, suffix);
+                set_attribute_with_suffix(
+                    element,
+                    url_attribute,
+                    import_record.path.pretty,
+                    suffix,
+                );
             }
             return;
         }

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -167,8 +167,7 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             Loader::File
         };
 
-        // Re-append the original `?query`/`#fragment` (e.g. `sprite.svg#home`)
-        // that the resolver stripped to locate the file. Matches `css::Printer`.
+        // `?query`/`#fragment` the resolver stripped to locate the file (e.g. `sprite.svg#home`).
         let suffix: &[u8] = if kind == ImportKind::Url {
             match strings::index_of_any(path, b"?#") {
                 Some(i) => &path[i..],

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -167,10 +167,8 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             Loader::File
         };
 
-        // The resolver strips a `?query`/`#fragment` to find the file on disk
-        // (e.g. `sprite.svg#home`, `clip.mp4#t=10,20`); carry it across to the
-        // rewritten reference so the fragment still addresses the SVG symbol /
-        // media range. Matches CSS's `url()` handling (see `css::Printer`).
+        // Re-append the original `?query`/`#fragment` (e.g. `sprite.svg#home`)
+        // that the resolver stripped to locate the file. Matches `css::Printer`.
         let suffix: &[u8] = if kind == ImportKind::Url {
             match strings::index_of_any(path, b"?#") {
                 Some(i) => &path[i..],
@@ -234,8 +232,7 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             let url_for_css =
                 parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
             if !url_for_css.is_empty() {
-                // A `?query` appended to a data: URI lands in the base64 body
-                // and breaks decoding; keep only the `#fragment`.
+                // data: URIs have no `?query` component; keep only `#fragment`.
                 let fragment: &[u8] = match strings::index_of_char(suffix, b'#') {
                     Some(i) => &suffix[i as usize..],
                     None => b"",

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -154,9 +154,7 @@ describe("bundler", () => {
       expect(attrs).toContain("https://example.com/sprite.svg#ext");
 
       // Both references to clip.png point at the same emitted asset.
-      const clipHashes = new Set(
-        attrs.map(a => a.match(/clip-([a-z0-9]+)\.png/)?.[1]).filter(Boolean),
-      );
+      const clipHashes = new Set(attrs.map(a => a.match(/clip-([a-z0-9]+)\.png/)?.[1]).filter(Boolean));
       expect(clipHashes.size).toBe(1);
     },
   });

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -122,6 +122,45 @@ describe("bundler", () => {
     },
   });
 
+  // #fragment / ?query on an asset URL must survive the rewrite (SVG sprite
+  // symbol selectors, media-fragment ranges, cache-bust queries).
+  itBundled("html/asset-url-fragment-query", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <img src="./sprite.svg#home">
+    <video src="./clip.png#t=10,20"></video>
+    <img src="./clip.png?v=3">
+    <img src="./sprite.svg?q=1#icon">
+    <img src="https://example.com/sprite.svg#ext">
+  </body>
+</html>`,
+      "/sprite.svg": `<svg xmlns="http://www.w3.org/2000/svg"><symbol id="home"/></svg>`,
+      "/clip.png": "fake image content",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const attrs = [...html.matchAll(/(?:src|href)="([^"]*)"/g)].map(m => m[1]);
+
+      expect(attrs.filter(a => /sprite-[a-z0-9]+\.svg#home$/.test(a))).toHaveLength(1);
+      expect(attrs.filter(a => /clip-[a-z0-9]+\.png#t=10,20$/.test(a))).toHaveLength(1);
+      expect(attrs.filter(a => /clip-[a-z0-9]+\.png\?v=3$/.test(a))).toHaveLength(1);
+      expect(attrs.filter(a => /sprite-[a-z0-9]+\.svg\?q=1#icon$/.test(a))).toHaveLength(1);
+      // External reference is left untouched.
+      expect(attrs).toContain("https://example.com/sprite.svg#ext");
+
+      // Both references to clip.png point at the same emitted asset.
+      const clipHashes = new Set(
+        attrs.map(a => a.match(/clip-([a-z0-9]+)\.png/)?.[1]).filter(Boolean),
+      );
+      expect(clipHashes.size).toBe(1);
+    },
+  });
+
   // Test external assets preservation
   itBundled("html/external-assets", {
     outdir: "out/",


### PR DESCRIPTION
## What does this PR do?

`bun build ./index.html` rewrites an `<img>` / `<video>` / `<link>` `src`/`href` to point at the emitted (hashed) asset, but drops the `?query` / `#fragment` from the original reference. The file is resolved and copied correctly; only the rewritten URL loses the suffix.

That quietly breaks:

- SVG sprite symbol selectors: `<img src="./sprite.svg#home">` becomes `<img src="./sprite-<hash>.svg">`, so the whole sprite renders instead of the one symbol.
- Media fragments: `<video src="./clip.mp4#t=10,20">` loses its start/end range.
- Cache-bust queries: `<img src="./i.png?v=3">` loses `?v=3`.

### Repro

```sh
d=$(mktemp -d); cd "$d"
printf '<svg xmlns="http://www.w3.org/2000/svg"><symbol id="home"/></svg>' > sprite.svg
printf '\x89PNG' > i.png
cat > index.html <<'HTML'
<!doctype html>
<img src="./sprite.svg#home">
<video src="./i.png#t=10,20"></video>
<img src="./i.png?v=3">
HTML
bun build ./index.html --outdir=./out && grep -oE 'src="[^"]*"' out/index.html
```

Before:

```
src="./sprite-vws8wck6.svg"
src="./i-53dyeqnw.png"
src="./i-53dyeqnw.png"
```

After:

```
src="./sprite-vws8wck6.svg#home"
src="./i-53dyeqnw.png#t=10,20"
src="./i-53dyeqnw.png?v=3"
```

### Fix

`HTMLLoader::on_tag` now lifts the `?`/`#` suffix from the original attribute value (the `path` it already receives) and appends it to the rewritten reference. For inlined `data:` URIs it keeps only the `#fragment` (a `?query` would land inside the base64 body). This mirrors what `css::Printer::get_import_record_url` already does for `url()` tokens.

## How did you verify your code works?

New `html/asset-url-fragment-query` case in `test/bundler/bundler_html.test.ts`: fails on a build without the `src/` change, passes with it. Full `bundler_html.test.ts` and `bundler_html_server.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.0 (fd1ccecef)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [837.11ms]
(pass) bundler > html/implicit-relative-paths [154.04ms]
(pass) bundler > html/multiple-assets [153.11ms]
(pass) bundler > html/image-hashing [122.63ms]
144 |     entryPoints: ["/index.html"],
145 |     onAfterBundle(api) {
146 |       const html = api.readFile("out/index.html");
147 |       const attrs = [...html.matchAll(/(?:src|href)="([^"]*)"/g)].map(m => m[1]);
148 | 
149 |       expect(attrs.filter(a => /sprite-[a-z0-9]+\.svg#home$/.test(a))).toHaveLength(1);
                                                                             ^
error: expect(received).toHaveLength(expected)

Expected length: 1
Received length: 0

      at onAfterBundle (/workspace/bun/test/bundler/bundler_html.test.ts:149:72)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) bundler > html/asset-url-fragment-query [149.81ms]
(pass) bundler > html/external-assets [121.29ms]
(pass) bundler 
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [15.48ms]
(pass) bundler > html/implicit-relative-paths [5.37ms]
(pass) bundler > html/multiple-assets [5.39ms]
(pass) bundler > html/image-hashing [4.73ms]
144 |     entryPoints: ["/index.html"],
145 |     onAfterBundle(api) {
146 |       const html = api.readFile("out/index.html");
147 |       const attrs = [...html.matchAll(/(?:src|href)="([^"]*)"/g)].map(m => m[1]);
148 | 
149 |       expect(attrs.filter(a => /sprite-[a-z0-9]+\.svg#home$/.test(a))).toHaveLength(1);
                                                                             ^
error: expect(received).toHaveLength(expected)

Expected length: 1
Received length: 0

      at onAfterBundle (/workspace/bun/test/bundler/bundler_html.test.ts:149:72)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) bundler > html/asset-url-fragment-query [4.82ms]
(pass) bundler > html/external-assets [4.36ms]
(pass) bundler > html/mixed-assets [5.56ms]
(pass) bundler > html/js-imports [4.20ms]
(pass) bundler > html/css-imports [4.69ms]
(pass) bundler > html/multiple-entries [4.95ms]
448 |  
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.0 (fd1ccecef)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [580.06ms]
(pass) bundler > html/implicit-relative-paths [138.63ms]
(pass) bundler > html/multiple-assets [157.69ms]
(pass) bundler > html/image-hashing [126.51ms]
(pass) bundler > html/asset-url-fragment-query [176.17ms]
(pass) bundler > html/external-assets [109.49ms]
(pass) bundler > html/mixed-assets [127.81ms]
(pass) bundler > html/js-imports [140.81ms]
(pass) bundler > html/css-imports [145.76ms]
(pass) bundler > html/multiple-entries [195.79ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [186.99ms]
(pass) bundler > html/shared-chunks [218.48ms]
(pass) bundler > html/js-importing-html [165.16ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [163.32ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [178.25ms]
(pass) bundler > html/circular-js-html [172.5
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fd1ccecef4
  features     baseline

22 deps, 108 codegen, 1171 objects in 2376ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [15.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1234] fetch zlib
[zlib] up to date
[4/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1234] gen bindgenv2
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [15.00ms]
[7/1234] gen ErrorCode+*.h
[8/1234] fetch picohttpparser
[picohttpparser] up to date
[9/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1234] fetch tinycc
[tinycc] up to date
[11/1234] gen .bind.ts → Genera
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../generateCompileResultForHtmlChunk.rs           | 58 +++++++++++++++++++---
 test/bundler/bundler_html.test.ts                  | 37 ++++++++++++++
 2 files changed, 89 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…ler/linker_context/generateCompileResultForHtmlChunk.rs      2      5      0
test/bundler/bundler_html.test.ts                             1      1      0
```

</details>

<!-- robobun:evidence:end -->