### PR TITLE
bundler: error when asset naming yields the same output path for different content

### DIFF
--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -521,6 +521,65 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
             return Err(crate::Error::DuplicateOutputPath);
         }
+
+        // Same check for copy-loader assets; identical-content collisions are allowed.
+        let additional = c.parse_graph().additional_output_files.as_slice();
+        if !additional.is_empty() {
+            #[derive(Default)]
+            struct AssetPathEntry {
+                hash: u64,
+                inputs: Vec<usize>,
+                collides: bool,
+            }
+            let mut asset_paths: StringArrayHashMap<AssetPathEntry> = StringArrayHashMap::default();
+            let mut has_collision = false;
+
+            for (i, out) in additional.iter().enumerate() {
+                let collides_with_chunk = path_names_map.get_or_put(&out.dest_path)?.found_existing;
+                let entry = asset_paths.get_or_put(&out.dest_path)?;
+                if !entry.found_existing {
+                    entry.value_ptr.hash = out.hash.value;
+                    entry.value_ptr.collides = collides_with_chunk;
+                } else if entry.value_ptr.hash != out.hash.value {
+                    entry.value_ptr.collides = true;
+                }
+                entry.value_ptr.inputs.push(i);
+                has_collision |= entry.value_ptr.collides;
+            }
+
+            if has_collision {
+                let sources = c.parse_graph().input_files.items_source();
+                let mut msg: Vec<u8> = Vec::new();
+                writeln!(&mut msg, "Multiple files share the same output path")?;
+                for (key, entry) in asset_paths.keys().iter().zip(asset_paths.values().iter()) {
+                    if !entry.collides {
+                        continue;
+                    }
+                    writeln!(&mut msg, "  {}:", bstr::BStr::new(key))?;
+                    for &i in entry.inputs.iter() {
+                        let pretty: &[u8] = match additional[i].source_index.get() {
+                            Some(idx) if idx.get_usize() < sources.len() => {
+                                sources[idx.get_usize()].path.pretty
+                            }
+                            _ => additional[i].src_path.text,
+                        };
+                        writeln!(&mut msg, "    from input {}", bstr::BStr::new(pretty))?;
+                    }
+                }
+                c.log_disjoint().add_error(None, bun_ast::Loc::EMPTY, msg);
+                c.log_disjoint().add_msg(bun_ast::Msg {
+                    kind: bun_ast::Kind::Note,
+                    data: bun_ast::Data {
+                        text: Cow::Borrowed(
+                            b"consider adding '[hash]' to asset naming to make filenames unique",
+                        ),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+                return Err(crate::Error::DuplicateOutputPath);
+            }
+        }
     }
 
     // After final_rel_path is computed for all chunks, fix up module_info

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -236,8 +236,8 @@ describe("bundler", () => {
       stdout: "./bun/data.file",
     },
   });
+  // https://github.com/oven-sh/bun/issues/5030
   itBundled("naming/AssetNoOverwrite", {
-    todo: true,
     files: {
       "/src/entry.js": /* js */ `
         import asset1 from "./asset1.file";
@@ -258,7 +258,69 @@ describe("bundler", () => {
       ".file": "file",
     },
     bundleErrors: {
-      "<bun>": ['Multiple files share the same output path: "same-filename.txt"'],
+      "<bun>": [`Multiple files share the same output path`],
+    },
+  });
+  itBundled("naming/AssetNoOverwriteNameExt", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import a from "./a/logo.file";
+        import b from "./b/logo.file";
+        console.log(a, b);
+      `,
+      "/src/a/logo.file": `content-A`,
+      "/src/b/logo.file": `content-B`,
+    },
+    root: "/src",
+    assetNaming: "[name].[ext]",
+    entryPointsRaw: ["./src/entry.js"],
+    loader: {
+      ".file": "file",
+    },
+    bundleErrors: {
+      "<bun>": [`Multiple files share the same output path`],
+    },
+  });
+  itBundled("naming/AssetSameContentSamePath", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import a from "./a/logo.file";
+        import b from "./b/logo.file";
+        console.log(a, b);
+      `,
+      "/src/a/logo.file": `same-content`,
+      "/src/b/logo.file": `same-content`,
+    },
+    root: "/src",
+    assetNaming: "[name].[ext]",
+    entryPointsRaw: ["./src/entry.js"],
+    loader: {
+      ".file": "file",
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "./logo.file ./logo.file",
+    },
+    outputPaths: ["/out/entry.js", "/out/logo.file"],
+  });
+  // An asset template that renders to the entry point's own output path must
+  // not replace the entry point on disk.
+  itBundled("naming/AssetCollidesWithEntryPoint", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import a from "./a/logo.file";
+        console.log(a);
+      `,
+      "/src/a/logo.file": `content-A`,
+    },
+    root: "/src",
+    assetNaming: "entry.js",
+    entryPointsRaw: ["./src/entry.js"],
+    loader: {
+      ".file": "file",
+    },
+    bundleErrors: {
+      "<bun>": [`Multiple files share the same output path`],
     },
   });
   itBundled("naming/AssetFileLoaderPath1", {


### PR DESCRIPTION
Fixes #5030.

## Repro

```js
// a/logo.dat = 'content-A', b/logo.dat = 'content-B', c/logo.dat = 'content-A'
await Bun.build({
  entrypoints: ['entry.mjs'],  // imports all three
  outdir: 'out',
  naming: { asset: '[name].[ext]' },
});
// success: true, logs: 0
// outputs: 3 assets at out/logo.dat with hashes 2jfy9j3g / dgdwykdh / 2jfy9j3g
// on disk: one logo.dat = 'content-A'; b's bytes are gone
```

## Cause

The output-path collision check in `generate_chunks_in_parallel` iterates `chunks[]` only. Copy-loader assets go into `parse_graph.additional_output_files` (populated earlier by `process_files_to_copy`) and are written to disk without ever being checked, so whichever asset is processed last wins.

## Fix

After the chunk collision check, iterate `additional_output_files` and map `dest_path -> content_hash`. A repeated path with a different hash, or a path that matches a chunk, produces the same `Multiple files share the same output path` error that entrypoint collisions already emit:

```
error: Multiple files share the same output path
  ./logo.dat:
    from input a/logo.dat
    from input b/logo.dat

note: consider adding '[hash]' to asset naming to make filenames unique
```

Two assets at the same path with identical content are still permitted (they write the same bytes).

## Verification

`test/bundler/bundler_naming.test.ts`: un-todo'd `naming/AssetNoOverwrite`, added `naming/AssetNoOverwriteNameExt` (the `[name].[ext]` case from the issue) and `naming/AssetSameContentSamePath` (identical bytes must still succeed). The first two fail on main and pass with this change.


An asset whose rendered path equals an entry point or chunk path is rejected the same way (`naming/AssetCollidesWithEntryPoint`: `--asset-naming assets.js` over the `assets.js` entry point previously left only the PNG bytes on disk and reported `success: true`).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_naming.test.ts
bun test v1.4.0 (dad83cc9a)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [480.74ms]
(pass) bundler > naming/ImplicitOutbase1 [638.91ms]
(pass) bundler > naming/ImplicitOutbase2 [918.75ms]
(pass) bundler > naming/EntryNamingTemplate1 [928.86ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [357.02ms]
(pass) bundler > naming/AssetNamingMkdir [375.22ms]
(pass) bundler > naming/AssetNamingDir [373.39ms]
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
1369 |         } else if (expectedErrors && expectedErrors.length > 0) {
1370 |           throw new Error("Errors were expected while bundling:\n" + expectedErrors.map(formatError).join("\n"));
                           ^
error: Errors were expected while bundling:
<bun>: Multiple files share the same output path
      at <anonymous> (/workspace/bun/test/bundler/ex
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (32f40d7c5)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [14.52ms]
(pass) bundler > naming/ImplicitOutbase1 [31.49ms]
(pass) bundler > naming/ImplicitOutbase2 [37.21ms]
(pass) bundler > naming/EntryNamingTemplate1 [44.05ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [15.62ms]
(pass) bundler > naming/AssetNamingMkdir [14.74ms]
(pass) bundler > naming/AssetNamingDir [14.86ms]
(pass) bundler > naming/AssetNoOverwrite [3.63ms]
(pass) bundler > naming/AssetNoOverwriteNameExt [3.57ms]
(pass) bundler > naming/AssetSameContentSamePath [15.78ms]
(pass) bundler > naming/AssetFileLoaderPath1 [3.57ms]
ENOENT opening root directory "/tmp/bun-build-tests/bun-PLpny4/naming/NonexistantRoot/lib"

(pass) bundler > naming/NonexistantRoot [2.79ms]
(todo) bundler > naming/EntrypointOutsideOfRoot
(pass) bundler > naming/WithPathTraversal [40.15ms]
(pass) bundler > naming/NonAsciiSourceFilenameSymbol [15.31ms]

 14 pass
 2 todo
 0 fail
 19 expect() calls
Ran 16 tests across 1 file. [428.00ms]
__F:0:S:2
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_naming.test.ts
bun test v1.4.0 (dad83cc9a)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [476.59ms]
(pass) bundler > naming/ImplicitOutbase1 [665.55ms]
(pass) bundler > naming/ImplicitOutbase2 [937.01ms]
(pass) bundler > naming/EntryNamingTemplate1 [916.20ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [349.40ms]
(pass) bundler > naming/AssetNamingMkdir [349.44ms]
(pass) bundler > naming/AssetNamingDir [367.95ms]
(pass) bundler > naming/AssetNoOverwrite [102.49ms]
(pass) bundler > naming/AssetNoOverwriteNameExt [85.64ms]
(pass) bundler > naming/AssetSameContentSamePath [373.16ms]
(pass) bundler > naming/AssetFileLoaderPath1 [88.53ms]
ENOENT opening root directory "/tmp/bun-build-tests/bun-HYNmzJ/naming/NonexistantRoot/lib"

(pass) bundler > naming/NonexistantRoot [159.51ms]
(todo) bundler > naming/EntrypointOutsideOfRoot
(pass) bundler > naming/WithPathTraversal [903.39ms]
(pass) bundler > naming/NonAsciiSourceFilenameSymbol [365.42ms]

 14 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 704ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_output v0.0.0 (/workspace/bun/src/output)
^[[1m^[[92m   Compiling^[[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
^[[1m^[[92m   Compiling^[[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/generateChunksInParallel.rs     | 59 ++++++++++++++++++++++
 test/bundler/bundler_naming.test.ts                | 46 ++++++++++++++++-
 2 files changed, 103 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/bundler/linker_context/generateChunksInParallel.rs      5      4      0
test/bundler/bundler_naming.test.ts                         1      2      0
```

</details>

<!-- robobun:evidence:end -->
