### PR TITLE
bundler(html): emit link[as='worker'] as its own file, not into the page bundle

### DIFF
--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -4,7 +4,9 @@ use std::borrow::Cow;
 use crate::Error;
 use crate::bun_fs as fs;
 use bun_alloc::AstAlloc;
-use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag, Index as AstIndex};
+use bun_ast::{
+    ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag, Index as AstIndex, Loader,
+};
 use bun_ast::{Loc, Log, Range, Source};
 use bun_paths::fs::Path as FsPath;
 use bun_paths::{platform, resolve_path};
@@ -31,7 +33,12 @@ impl<'a> HTMLScanner<'a> {
 }
 
 impl<'a> HTMLScanner<'a> {
-    fn create_import_record(&mut self, input_path: &[u8], kind: ImportKind) -> Result<(), Error> {
+    fn create_import_record(
+        &mut self,
+        input_path: &[u8],
+        kind: ImportKind,
+        loader: Option<Loader>,
+    ) -> Result<(), Error> {
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
         let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
@@ -74,7 +81,7 @@ impl<'a> HTMLScanner<'a> {
             kind,
             range: Range::NONE,
             tag: ImportRecordTag::default(),
-            loader: None,
+            loader,
             source_index: AstIndex::default(),
             original_path: b"",
             flags: ImportRecordFlags::default(),
@@ -102,9 +109,10 @@ impl<'a> HTMLScanner<'a> {
         path: &[u8],
         url_attribute: &[u8],
         kind: ImportKind,
+        loader: Option<Loader>,
     ) {
         let _ = url_attribute;
-        let _ = self.create_import_record(path, kind);
+        let _ = self.create_import_record(path, kind, loader);
     }
 
     pub(crate) fn scan(&mut self, input: &[u8]) -> Result<(), Error> {
@@ -126,6 +134,7 @@ pub(crate) trait HTMLProcessorHandler {
         path: &[u8],
         url_attribute: &[u8],
         kind: ImportKind,
+        loader: Option<Loader>,
     );
     fn on_write_html(&mut self, bytes: &[u8]);
     fn on_html_parse_error(&mut self, message: &[u8]);
@@ -151,8 +160,9 @@ impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
         path: &[u8],
         url_attribute: &[u8],
         kind: ImportKind,
+        loader: Option<Loader>,
     ) {
-        HTMLScanner::on_tag(self, element, path, url_attribute, kind)
+        HTMLScanner::on_tag(self, element, path, url_attribute, kind, loader)
     }
     fn on_write_html(&mut self, bytes: &[u8]) {
         HTMLScanner::on_write_html(self, bytes)
@@ -172,6 +182,10 @@ pub struct TagHandler {
     pub url_attribute: &'static str,
     /// The kind of import to create
     pub kind: ImportKind,
+    /// Force a specific loader on the import record instead of inferring from
+    /// the extension. Used for `<link as="worker">` to keep worker scripts out
+    /// of the page's JS chunk.
+    pub loader: Option<Loader>,
 }
 
 impl TagHandler {
@@ -180,6 +194,7 @@ impl TagHandler {
             selector,
             url_attribute,
             kind,
+            loader: None,
         }
     }
 }
@@ -205,8 +220,15 @@ pub(crate) const TAG_HANDLERS: [TagHandler; 16] = [
         "href",
         ImportKind::Url,
     ),
-    // Web Workers
-    TagHandler::new("link[as='worker'][href]", "href", ImportKind::Stmt),
+    // Web Workers. The worker script runs in its own global scope, so it must be
+    // emitted as a standalone file (like font/image/manifest preloads) rather than
+    // concatenated into the page's module bundle.
+    TagHandler {
+        selector: "link[as='worker'][href]",
+        url_attribute: "href",
+        kind: ImportKind::Url,
+        loader: Some(Loader::File),
+    },
     // Manifest files
     TagHandler::new("link[rel='manifest'][href]", "href", ImportKind::Url),
     // Icons
@@ -294,6 +316,7 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
                                     value.as_bytes(),
                                     tag_info.url_attribute.as_bytes(),
                                     tag_info.kind,
+                                    tag_info.loader,
                                 );
                             }
                         }

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -124,6 +124,7 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
         _path: &[u8],
         url_attribute: &[u8],
         _kind: ImportKind,
+        _loader: Option<bun_ast::Loader>,
     ) {
         if self.current_import_record_index as usize >= self.import_records.len() {
             bun_core::Output::panic(format_args!(

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1011,4 +1011,50 @@ body {
       expect(htmlContent).toMatch(/href=".*\.webmanifest"/);
     },
   });
+
+  // <link rel="preload" as="worker"> must emit the worker script as its own
+  // file and rewrite the href, not fold the worker's source into the page's
+  // module bundle.
+  itBundled("html/link-preload-worker", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="preload" as="worker" href="./w.js">
+    <script type="module" src="./m.js"></script>
+  </head>
+  <body></body>
+</html>`,
+      "/w.js": `self.onmessage = e => postMessage(e.data * 2);\nconsole.log("WORKER TOP-LEVEL RAN", typeof document);\n`,
+      "/m.js": `console.log("main");\n`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+
+      // The <link as="worker"> tag must survive with a rewritten href.
+      const linkMatch = html.match(/<link[^>]*\bas="worker"[^>]*\bhref="\.\/([^"]+)"/);
+      expect(linkMatch).not.toBeNull();
+      const workerFile = linkMatch![1];
+      expect(workerFile).toMatch(/\.js$/);
+
+      // The emitted worker file is the original source, not the page bundle.
+      const workerContents = api.readFile("out/" + workerFile);
+      expect(workerContents).toContain("self.onmessage");
+      expect(workerContents).not.toContain(`console.log("main")`);
+
+      // The page's module bundle must NOT contain the worker's top-level code.
+      const scriptMatch = html.match(/<script[^>]*\bsrc="\.\/([^"]+)"/);
+      expect(scriptMatch).not.toBeNull();
+      const pageBundle = api.readFile("out/" + scriptMatch![1]);
+      expect(pageBundle).toContain(`console.log("main")`);
+      expect(pageBundle).not.toContain("self.onmessage");
+      expect(pageBundle).not.toContain("WORKER TOP-LEVEL RAN");
+
+      // Worker and page bundle are distinct files.
+      expect(workerFile).not.toBe(scriptMatch![1]);
+    },
+  });
 });


### PR DESCRIPTION
## Repro

```sh
d=$(mktemp -d); cd "$d"
printf 'self.onmessage = e => postMessage(e.data*2);\nconsole.log("WORKER TOP-LEVEL RAN", typeof document);\n' > w.js
printf 'console.log("main");\n' > m.js
cat > index.html <<'HTML'
<!doctype html>
<link rel="preload" as="worker" href="./w.js">
<script type="module" src="./m.js"></script>
HTML
bun build ./index.html --outdir=./out && ls out && cat out/index.html && cat out/*.js
```

Before: one `index-<h>.js` is emitted; the `<link>` tag is deleted; the page bundle begins with
```
// w.js
self.onmessage = (e) => postMessage(e.data * 2); console.log("WORKER TOP-LEVEL RAN", typeof document);
// m.js
console.log("main");
```
so the worker's top-level code runs on the main thread against `window`, and `new Worker("./w.js")` has nothing to load.

## Cause

`TAG_HANDLERS` in `src/bundler/HTMLScanner.rs` registered `link[as='worker'][href]` with `ImportKind::Stmt`, identical to `script[src]`. The worker file therefore joined the HTML entry's module graph and was linearised into the page's JS chunk, and `generateCompileResultForHtmlChunk` stripped the `<link>` element (it removes every tag whose resolved loader is JS/CSS because their content is now in the combined chunk).

## Fix

Treat `link[as='worker']` the same as the other `<link>` preloads (`as='font'`, `as='image'`, `rel='manifest'`): mark its import record `ImportKind::Url` with a forced `Loader::File`. The existing file-loader path then copies the script to the output with a content hash, sets a unique key, and `HTMLLoader::on_tag` rewrites `href` instead of removing the element. `TagHandler` gains an optional `loader` field threaded through `HTMLProcessorHandler::on_tag` so only this selector is affected.

After:
```
  index-zcpber09.js  29 bytes   (entry point)
  index.html         143 bytes  (entry point)
  w-jv3dbprw.js      99 bytes   (asset)
```
```html
<!doctype html>
<link rel="preload" as="worker" href="./w-jv3dbprw.js">
<script type="module" crossorigin src="./index-zcpber09.js"></script>
```

The worker script is copied as-is (no bundling of its own imports); making it a fully bundled separate entry point would be a larger change to chunk computation and is not attempted here.

## Verification

`test/bundler/bundler_html.test.ts` `html/link-preload-worker` asserts the `<link as="worker">` tag survives with a rewritten href, the emitted worker file contains the worker source, and the page bundle does not. Fails on `main` (the tag is stripped), passes with this change. Full `bundler_html.test.ts` and `bundler_html_server.test.ts` suites pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.0 (214a115b1)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [493.64ms]
(pass) bundler > html/implicit-relative-paths [114.95ms]
(pass) bundler > html/multiple-assets [107.59ms]
(pass) bundler > html/image-hashing [85.33ms]
(pass) bundler > html/external-assets [101.95ms]
(pass) bundler > html/mixed-assets [158.63ms]
(pass) bundler > html/js-imports [117.58ms]
(pass) bundler > html/css-imports [102.07ms]
(pass) bundler > html/multiple-entries [137.18ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [136.49ms]
(pass) bundler > html/shared-chunks [141.32ms]
(pass) bundler > html/js-importing-html [94.35ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [113.86ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [101.25ms]
(pass) bundler > html/circular-js-html [101.24ms]
(pass) bundler > html/css-only [136.93ms]
(pass) bundle
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (214a115b1)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [12.92ms]
(pass) bundler > html/implicit-relative-paths [3.41ms]
(pass) bundler > html/multiple-assets [3.67ms]
(pass) bundler > html/image-hashing [3.95ms]
(pass) bundler > html/external-assets [3.76ms]
(pass) bundler > html/mixed-assets [4.04ms]
(pass) bundler > html/js-imports [3.93ms]
(pass) bundler > html/css-imports [4.73ms]
(pass) bundler > html/multiple-entries [4.97ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [5.74ms]
(pass) bundler > html/shared-chunks [5.76ms]
(pass) bundler > html/js-importing-html [4.48ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [4.35ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [3.77ms]
(pass) bundler > html/circular-js-html [4.94ms]
(pass) bundler > html/css-only [5.27ms]
(pass) bundler > html/absolute-paths [5.36ms]
(pass) bundler > html/no-sourcemap-comments [5.32ms]
(pass) bundler > html/no-sourcemap-comments-inline [4.22ms]
(pass) bundler > html/SharedCSSProduction
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.0 (214a115b1)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [481.66ms]
(pass) bundler > html/implicit-relative-paths [110.70ms]
(pass) bundler > html/multiple-assets [102.06ms]
(pass) bundler > html/image-hashing [88.60ms]
(pass) bundler > html/external-assets [87.69ms]
(pass) bundler > html/mixed-assets [97.23ms]
(pass) bundler > html/js-imports [105.11ms]
(pass) bundler > html/css-imports [103.28ms]
(pass) bundler > html/multiple-entries [127.44ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [168.15ms]
(pass) bundler > html/shared-chunks [137.05ms]
(pass) bundler > html/js-importing-html [259.53ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [102.33ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [102.07ms]
(pass) bundler > html/circular-js-html [103.88ms]
(pass) bundler > html/css-only [132.69ms]
(pass) bundler
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 741ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/HTMLScanner.rs                         | 37 +++++++++++++----
 .../generateCompileResultForHtmlChunk.rs           |  1 +
 test/bundler/bundler_html.test.ts                  | 46 ++++++++++++++++++++++
 3 files changed, 77 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/HTMLScanner.rs                                    1      9      0
…ler/linker_context/generateCompileResultForHtmlChunk.rs      1      1      0
test/bundler/bundler_html.test.ts                             2      1      0
```

</details>

<!-- robobun:evidence:end -->