### PR TITLE
bundler(html): parse srcset into per-candidate imports

### DIFF
--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -102,9 +102,10 @@ impl<'a> HTMLScanner<'a> {
         path: &[u8],
         url_attribute: &[u8],
         kind: ImportKind,
-    ) {
+    ) -> TagAction {
         let _ = url_attribute;
         let _ = self.create_import_record(path, kind);
+        TagAction::Keep
     }
 
     pub(crate) fn scan(&mut self, input: &[u8]) -> Result<(), Error> {
@@ -118,6 +119,96 @@ type Processor<'a> = HTMLProcessor<HTMLScanner<'a>, false>;
 // HTMLProcessor — generic over visitor `T` and `VISIT_DOCUMENT_TAGS`
 // ───────────────────────────────────────────────────────────────────────────
 
+/// What `HTMLProcessor::run` should do with the URL that triggered an
+/// `on_tag` call. The handler returns the action; `run` applies it (so that
+/// `srcset`'s N candidates can be rewritten into one attribute value).
+pub(crate) enum TagAction {
+    /// Leave the URL as-is in the attribute.
+    Keep,
+    /// Replace the URL with this value.
+    Replace(Vec<u8>),
+    /// Remove the whole element (bundled `<script>` / `<link>`).
+    Remove,
+}
+
+/// HTML "ASCII whitespace" per <https://infra.spec.whatwg.org/#ascii-whitespace>:
+/// TAB, LF, FF, CR, SPACE. Not Rust's `is_ascii_whitespace` (which also matches VT).
+#[inline]
+fn is_html_whitespace(b: u8) -> bool {
+    matches!(b, b'\t' | b'\n' | b'\x0C' | b'\r' | b' ')
+}
+
+pub(crate) struct SrcsetCandidate<'a> {
+    pub url: &'a [u8],
+    /// Raw descriptor text (e.g. `1x`, `480w`), whitespace-trimmed, not validated.
+    pub descriptor: &'a [u8],
+}
+
+/// Split a `srcset` attribute into `(url, descriptor)` candidates following
+/// <https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute>.
+/// Descriptor text is kept verbatim (trimmed), not validated.
+pub(crate) fn parse_srcset(input: &[u8]) -> Vec<SrcsetCandidate<'_>> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    loop {
+        while pos < input.len() && (is_html_whitespace(input[pos]) || input[pos] == b',') {
+            pos += 1;
+        }
+        if pos >= input.len() {
+            return out;
+        }
+        let url_start = pos;
+        while pos < input.len() && !is_html_whitespace(input[pos]) {
+            pos += 1;
+        }
+        let mut url_end = pos;
+        // Trailing commas on the URL terminate this candidate with no descriptor.
+        if url_end > url_start && input[url_end - 1] == b',' {
+            while url_end > url_start && input[url_end - 1] == b',' {
+                url_end -= 1;
+            }
+            if url_end > url_start {
+                out.push(SrcsetCandidate {
+                    url: &input[url_start..url_end],
+                    descriptor: b"",
+                });
+            }
+            continue;
+        }
+        // Descriptor tokenizer: collect to the next top-level comma, treating
+        // commas inside `(...)` as descriptor text.
+        while pos < input.len() && is_html_whitespace(input[pos]) {
+            pos += 1;
+        }
+        let desc_start = pos;
+        let mut in_parens = false;
+        while pos < input.len() {
+            let c = input[pos];
+            if in_parens {
+                if c == b')' {
+                    in_parens = false;
+                }
+            } else if c == b'(' {
+                in_parens = true;
+            } else if c == b',' {
+                break;
+            }
+            pos += 1;
+        }
+        let mut desc_end = pos;
+        while desc_end > desc_start && is_html_whitespace(input[desc_end - 1]) {
+            desc_end -= 1;
+        }
+        out.push(SrcsetCandidate {
+            url: &input[url_start..url_end],
+            descriptor: &input[desc_start..desc_end],
+        });
+        if pos < input.len() && input[pos] == b',' {
+            pos += 1;
+        }
+    }
+}
+
 /// Trait capturing the methods `HTMLProcessor` calls on `T`.
 pub(crate) trait HTMLProcessorHandler {
     fn on_tag(
@@ -126,7 +217,7 @@ pub(crate) trait HTMLProcessorHandler {
         path: &[u8],
         url_attribute: &[u8],
         kind: ImportKind,
-    );
+    ) -> TagAction;
     fn on_write_html(&mut self, bytes: &[u8]);
     fn on_html_parse_error(&mut self, message: &[u8]);
 
@@ -151,7 +242,7 @@ impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
         path: &[u8],
         url_attribute: &[u8],
         kind: ImportKind,
-    ) {
+    ) -> TagAction {
         HTMLScanner::on_tag(self, element, path, url_attribute, kind)
     }
     fn on_write_html(&mut self, bytes: &[u8]) {
@@ -263,6 +354,69 @@ fn element_entry<'h>(
     ))
 }
 
+fn apply_tag_action(element: &mut Element<'_, '_>, attr: &str, action: TagAction) {
+    match action {
+        TagAction::Keep => {}
+        TagAction::Replace(value) => match core::str::from_utf8(&value) {
+            Ok(value) => {
+                if element.set_attribute(attr, value).is_err() {
+                    bun_core::Output::panic(format_args!(
+                        "unexpected error from Element.setAttribute"
+                    ));
+                }
+            }
+            Err(_) => bun_core::Output::panic(format_args!(
+                "unexpected error from Element.setAttribute"
+            )),
+        },
+        TagAction::Remove => element.remove(),
+    }
+}
+
+/// Call `on_tag` once per `srcset` candidate URL and, if any candidate was
+/// rewritten, rebuild the attribute with descriptors preserved.
+fn process_srcset<T: HTMLProcessorHandler>(
+    this: &mut T,
+    element: &mut Element<'_, '_>,
+    value: &[u8],
+    kind: ImportKind,
+) {
+    let candidates = parse_srcset(value);
+    if candidates.is_empty() {
+        return;
+    }
+    let mut rebuilt = Vec::<u8>::new();
+    let mut any_replaced = false;
+    let mut remove = false;
+    for (i, cand) in candidates.iter().enumerate() {
+        let action = this.on_tag(element, cand.url, b"srcset", kind);
+        let url: &[u8] = match &action {
+            TagAction::Keep => cand.url,
+            TagAction::Replace(v) => {
+                any_replaced = true;
+                v.as_slice()
+            }
+            TagAction::Remove => {
+                remove = true;
+                cand.url
+            }
+        };
+        if i > 0 {
+            rebuilt.extend_from_slice(b", ");
+        }
+        rebuilt.extend_from_slice(url);
+        if !cand.descriptor.is_empty() {
+            rebuilt.push(b' ');
+            rebuilt.extend_from_slice(cand.descriptor);
+        }
+    }
+    if remove {
+        element.remove();
+    } else if any_replaced {
+        apply_tag_action(element, "srcset", TagAction::Replace(rebuilt));
+    }
+}
+
 impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
     HTMLProcessor<T, VISIT_DOCUMENT_TAGS>
 {
@@ -288,13 +442,18 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
                             // SAFETY: `this_ptr` was derived from `run`'s `&mut T`,
                             // which is not reborrowed while the rewriter — the only
                             // holder of these closures — is alive.
-                            unsafe {
-                                (*this_ptr).on_tag(
+                            let this = unsafe { &mut *this_ptr };
+                            let attr = tag_info.url_attribute;
+                            if attr == "srcset" {
+                                process_srcset(this, element, value.as_bytes(), tag_info.kind);
+                            } else {
+                                let action = this.on_tag(
                                     element,
                                     value.as_bytes(),
-                                    tag_info.url_attribute.as_bytes(),
+                                    attr.as_bytes(),
                                     tag_info.kind,
                                 );
+                                apply_tag_action(element, attr, action);
                             }
                         }
                     }

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -126,12 +126,6 @@ pub(crate) enum TagAction {
     Remove,
 }
 
-/// Infra "ASCII whitespace" (no VT, unlike `u8::is_ascii_whitespace`).
-#[inline]
-fn is_html_whitespace(b: u8) -> bool {
-    matches!(b, b'\t' | b'\n' | b'\x0C' | b'\r' | b' ')
-}
-
 pub(crate) struct SrcsetCandidate<'a> {
     pub url: &'a [u8],
     pub descriptor: &'a [u8],
@@ -142,14 +136,14 @@ pub(crate) fn parse_srcset(input: &[u8]) -> Vec<SrcsetCandidate<'_>> {
     let mut out = Vec::new();
     let mut pos = 0usize;
     loop {
-        while pos < input.len() && (is_html_whitespace(input[pos]) || input[pos] == b',') {
+        while pos < input.len() && (input[pos].is_ascii_whitespace() || input[pos] == b',') {
             pos += 1;
         }
         if pos >= input.len() {
             return out;
         }
         let url_start = pos;
-        while pos < input.len() && !is_html_whitespace(input[pos]) {
+        while pos < input.len() && !input[pos].is_ascii_whitespace() {
             pos += 1;
         }
         let mut url_end = pos;
@@ -165,7 +159,7 @@ pub(crate) fn parse_srcset(input: &[u8]) -> Vec<SrcsetCandidate<'_>> {
             }
             continue;
         }
-        while pos < input.len() && is_html_whitespace(input[pos]) {
+        while pos < input.len() && input[pos].is_ascii_whitespace() {
             pos += 1;
         }
         let desc_start = pos;
@@ -184,7 +178,7 @@ pub(crate) fn parse_srcset(input: &[u8]) -> Vec<SrcsetCandidate<'_>> {
             pos += 1;
         }
         let mut desc_end = pos;
-        while desc_end > desc_start && is_html_whitespace(input[desc_end - 1]) {
+        while desc_end > desc_start && input[desc_end - 1].is_ascii_whitespace() {
             desc_end -= 1;
         }
         out.push(SrcsetCandidate {

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -119,20 +119,14 @@ type Processor<'a> = HTMLProcessor<HTMLScanner<'a>, false>;
 // HTMLProcessor — generic over visitor `T` and `VISIT_DOCUMENT_TAGS`
 // ───────────────────────────────────────────────────────────────────────────
 
-/// What `HTMLProcessor::run` should do with the URL that triggered an
-/// `on_tag` call. The handler returns the action; `run` applies it (so that
-/// `srcset`'s N candidates can be rewritten into one attribute value).
+/// Returned by `on_tag`; `HTMLProcessor::run` applies it to the element.
 pub(crate) enum TagAction {
-    /// Leave the URL as-is in the attribute.
     Keep,
-    /// Replace the URL with this value.
     Replace(Vec<u8>),
-    /// Remove the whole element (bundled `<script>` / `<link>`).
     Remove,
 }
 
-/// HTML "ASCII whitespace" per <https://infra.spec.whatwg.org/#ascii-whitespace>:
-/// TAB, LF, FF, CR, SPACE. Not Rust's `is_ascii_whitespace` (which also matches VT).
+/// Infra "ASCII whitespace" (no VT, unlike `u8::is_ascii_whitespace`).
 #[inline]
 fn is_html_whitespace(b: u8) -> bool {
     matches!(b, b'\t' | b'\n' | b'\x0C' | b'\r' | b' ')
@@ -140,13 +134,10 @@ fn is_html_whitespace(b: u8) -> bool {
 
 pub(crate) struct SrcsetCandidate<'a> {
     pub url: &'a [u8],
-    /// Raw descriptor text (e.g. `1x`, `480w`), whitespace-trimmed, not validated.
     pub descriptor: &'a [u8],
 }
 
-/// Split a `srcset` attribute into `(url, descriptor)` candidates following
-/// <https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute>.
-/// Descriptor text is kept verbatim (trimmed), not validated.
+/// <https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute>
 pub(crate) fn parse_srcset(input: &[u8]) -> Vec<SrcsetCandidate<'_>> {
     let mut out = Vec::new();
     let mut pos = 0usize;
@@ -162,7 +153,6 @@ pub(crate) fn parse_srcset(input: &[u8]) -> Vec<SrcsetCandidate<'_>> {
             pos += 1;
         }
         let mut url_end = pos;
-        // Trailing commas on the URL terminate this candidate with no descriptor.
         if url_end > url_start && input[url_end - 1] == b',' {
             while url_end > url_start && input[url_end - 1] == b',' {
                 url_end -= 1;
@@ -175,8 +165,6 @@ pub(crate) fn parse_srcset(input: &[u8]) -> Vec<SrcsetCandidate<'_>> {
             }
             continue;
         }
-        // Descriptor tokenizer: collect to the next top-level comma, treating
-        // commas inside `(...)` as descriptor text.
         while pos < input.len() && is_html_whitespace(input[pos]) {
             pos += 1;
         }
@@ -373,8 +361,6 @@ fn apply_tag_action(element: &mut Element<'_, '_>, attr: &str, action: TagAction
     }
 }
 
-/// Call `on_tag` once per `srcset` candidate URL and, if any candidate was
-/// rewritten, rebuild the attribute with descriptors preserved.
 fn process_srcset<T: HTMLProcessorHandler>(
     this: &mut T,
     element: &mut Element<'_, '_>,

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -365,9 +365,9 @@ fn apply_tag_action(element: &mut Element<'_, '_>, attr: &str, action: TagAction
                     ));
                 }
             }
-            Err(_) => bun_core::Output::panic(format_args!(
-                "unexpected error from Element.setAttribute"
-            )),
+            Err(_) => {
+                bun_core::Output::panic(format_args!("unexpected error from Element.setAttribute"))
+            }
         },
         TagAction::Remove => element.remove(),
     }

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -366,33 +366,34 @@ fn process_srcset<T: HTMLProcessorHandler>(
         return;
     }
     let mut rebuilt = Vec::<u8>::new();
-    let mut any_replaced = false;
-    let mut remove = false;
-    for (i, cand) in candidates.iter().enumerate() {
+    let mut changed = false;
+    let mut kept = 0usize;
+    for cand in &candidates {
         let action = this.on_tag(element, cand.url, b"srcset", kind);
         let url: &[u8] = match &action {
             TagAction::Keep => cand.url,
             TagAction::Replace(v) => {
-                any_replaced = true;
+                changed = true;
                 v.as_slice()
             }
             TagAction::Remove => {
-                remove = true;
-                cand.url
+                changed = true;
+                continue;
             }
         };
-        if i > 0 {
+        if kept > 0 {
             rebuilt.extend_from_slice(b", ");
         }
+        kept += 1;
         rebuilt.extend_from_slice(url);
         if !cand.descriptor.is_empty() {
             rebuilt.push(b' ');
             rebuilt.extend_from_slice(cand.descriptor);
         }
     }
-    if remove {
+    if kept == 0 {
         element.remove();
-    } else if any_replaced {
+    } else if changed {
         apply_tag_action(element, "srcset", TagAction::Replace(rebuilt));
     }
 }

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -392,7 +392,7 @@ fn process_srcset<T: HTMLProcessorHandler>(
         }
     }
     if kept == 0 {
-        element.remove();
+        element.remove_attribute("srcset");
     } else if changed {
         apply_tag_action(element, "srcset", TagAction::Replace(rebuilt));
     }

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -9,7 +9,7 @@ use bun_threading::thread_pool::Task as ThreadPoolLibTask;
 use lol_html::HandlerResult;
 use lol_html::html_content::{ContentType, Element, EndTag};
 
-use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler};
+use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler, TagAction};
 use crate::linker_context_mod::{GenerateChunkCtx, LinkerContext, debug};
 use crate::options::Loader;
 use crate::{Chunk, CompileResult};
@@ -94,18 +94,6 @@ struct HTMLLoader<'a> {
     added_body_script: bool,
 }
 
-/// `Element::set_attribute` takes `&str`, so non-UTF-8 `name`/`value` bytes
-/// fail the same way an invalid attribute name does.
-fn set_attribute(element: &mut Element<'_, '_>, name: &[u8], value: &[u8]) {
-    let ok = match (core::str::from_utf8(name), core::str::from_utf8(value)) {
-        (Ok(name), Ok(value)) => element.set_attribute(name, value).is_ok(),
-        _ => false,
-    };
-    if !ok {
-        panic!("unexpected error from Element.setAttribute");
-    }
-}
-
 impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     fn on_write_html(&mut self, bytes: &[u8]) {
         self.output.extend_from_slice(bytes);
@@ -120,11 +108,11 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
 
     fn on_tag(
         &mut self,
-        element: &mut Element<'_, '_>,
+        _element: &mut Element<'_, '_>,
         _path: &[u8],
-        url_attribute: &[u8],
+        _url_attribute: &[u8],
         _kind: ImportKind,
-    ) {
+    ) -> TagAction {
         if self.current_import_record_index as usize >= self.import_records.len() {
             bun_core::Output::panic(format_args!(
                 "Assertion failure in HTMLLoader.onTag: current_import_record_index ({}) >= import_records.len ({})",
@@ -159,21 +147,20 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
                 "Leaving external import: {}",
                 BStr::new(import_record.path.text)
             );
-            return;
+            return TagAction::Keep;
         }
 
         if self.linker.dev_server.is_some() {
             if !unique_key_for_additional_files.is_empty() {
-                set_attribute(element, url_attribute, unique_key_for_additional_files);
+                return TagAction::Replace(unique_key_for_additional_files.to_vec());
             } else if import_record.path.is_disabled
                 || loader.is_javascript_like()
                 || loader.is_css()
             {
-                element.remove();
+                return TagAction::Remove;
             } else {
-                set_attribute(element, url_attribute, import_record.path.pretty);
+                return TagAction::Replace(import_record.path.pretty.to_vec());
             }
-            return;
         }
 
         if import_record.source_index.is_invalid() {
@@ -181,13 +168,12 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
                 "Leaving import with invalid source index: {}",
                 BStr::new(import_record.path.text)
             );
-            return;
+            return TagAction::Keep;
         }
 
         if loader.is_javascript_like() || loader.is_css() {
             // Remove the original non-external tags
-            element.remove();
-            return;
+            return TagAction::Remove;
         }
 
         if self.compile_to_standalone_html && import_record.source_index.is_valid() {
@@ -195,16 +181,16 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             let url_for_css =
                 parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
             if !url_for_css.is_empty() {
-                set_attribute(element, url_attribute, url_for_css);
-                return;
+                return TagAction::Replace(url_for_css.to_vec());
             }
         }
 
         if !unique_key_for_additional_files.is_empty() {
             // Replace the external href/src with the unique key so that we later will rewrite it to the final URL or pathname
-            set_attribute(element, url_attribute, unique_key_for_additional_files);
-            return;
+            return TagAction::Replace(unique_key_for_additional_files.to_vec());
         }
+
+        TagAction::Keep
     }
 
     fn on_head_tag(&mut self, element: &mut Element<'_, '_>) -> bool {

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -122,7 +122,7 @@ describe("bundler", () => {
     },
   });
 
-  // https://github.com/oven-sh/bun/issues/5032
+  // https://github.com/oven-sh/bun/issues/19529
   // srcset is a comma-separated list of "<url> <descriptor>" candidates, not a
   // single URL. Each candidate's URL must be resolved and hashed independently
   // and the descriptor preserved.

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -145,6 +145,9 @@ describe("bundler", () => {
     ">
     <img srcset="./small.png, ./big.png">
     <img srcset="https://example.com/ext.png 1x, ./big.png 2x">
+    <img srcset="./small.png">
+    <img srcset="">
+    <img srcset=" , ">
   </body>
 </html>`,
       "/small.png": "smallsmall",
@@ -154,7 +157,7 @@ describe("bundler", () => {
     onAfterBundle(api) {
       const html = api.readFile("out/index.html");
       const srcsets = [...html.matchAll(/srcset="([^"]*)"/g)].map(m => m[1]);
-      expect(srcsets).toHaveLength(6);
+      expect(srcsets).toHaveLength(9);
 
       // Two local candidates with density descriptors.
       expect(srcsets[0]).toMatch(/^\.\/small-[a-z0-9]+\.png 1x, \.\/big-[a-z0-9]+\.png 2x$/);
@@ -168,6 +171,11 @@ describe("bundler", () => {
       expect(srcsets[4]).toMatch(/^\.\/small-[a-z0-9]+\.png, \.\/big-[a-z0-9]+\.png$/);
       // External candidate is left alone; local one is hashed.
       expect(srcsets[5]).toMatch(/^https:\/\/example\.com\/ext\.png 1x, \.\/big-[a-z0-9]+\.png 2x$/);
+      // Bare single URL with no descriptor.
+      expect(srcsets[6]).toMatch(/^\.\/small-[a-z0-9]+\.png$/);
+      // Empty and delimiter-only values yield no candidates and are left untouched.
+      expect(srcsets[7]).toBe("");
+      expect(srcsets[8]).toBe(" , ");
 
       // The <img src> inside <picture> is hashed too.
       api.expectFile("out/index.html").toMatch(/<img src="\.\/small-[a-z0-9]+\.png" alt="image">/);

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -122,6 +122,63 @@ describe("bundler", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/5032
+  // srcset is a comma-separated list of "<url> <descriptor>" candidates, not a
+  // single URL. Each candidate's URL must be resolved and hashed independently
+  // and the descriptor preserved.
+  itBundled("html/srcset", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <img srcset="./small.png 1x, ./big.png 2x">
+    <picture>
+      <source srcset="./small.png 480w, ./big.png 800w">
+      <img src="./small.png" alt="image">
+    </picture>
+    <img srcset="./small.png 2x">
+    <img srcset="
+      ./small.png 480w,
+      ./big.png   800w
+    ">
+    <img srcset="./small.png, ./big.png">
+    <img srcset="https://example.com/ext.png 1x, ./big.png 2x">
+  </body>
+</html>`,
+      "/small.png": "smallsmall",
+      "/big.png": "bigbigbigbig",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const srcsets = [...html.matchAll(/srcset="([^"]*)"/g)].map(m => m[1]);
+      expect(srcsets).toHaveLength(6);
+
+      // Two local candidates with density descriptors.
+      expect(srcsets[0]).toMatch(/^\.\/small-[a-z0-9]+\.png 1x, \.\/big-[a-z0-9]+\.png 2x$/);
+      // <source> with width descriptors.
+      expect(srcsets[1]).toMatch(/^\.\/small-[a-z0-9]+\.png 480w, \.\/big-[a-z0-9]+\.png 800w$/);
+      // Single candidate with descriptor.
+      expect(srcsets[2]).toMatch(/^\.\/small-[a-z0-9]+\.png 2x$/);
+      // Newlines and extra whitespace between candidates are normalized.
+      expect(srcsets[3]).toMatch(/^\.\/small-[a-z0-9]+\.png 480w, \.\/big-[a-z0-9]+\.png 800w$/);
+      // No descriptors; comma directly follows the URL.
+      expect(srcsets[4]).toMatch(/^\.\/small-[a-z0-9]+\.png, \.\/big-[a-z0-9]+\.png$/);
+      // External candidate is left alone; local one is hashed.
+      expect(srcsets[5]).toMatch(/^https:\/\/example\.com\/ext\.png 1x, \.\/big-[a-z0-9]+\.png 2x$/);
+
+      // The <img src> inside <picture> is hashed too.
+      api.expectFile("out/index.html").toMatch(/<img src="\.\/small-[a-z0-9]+\.png" alt="image">/);
+
+      // The hashed assets referenced from the srcset were actually emitted.
+      const [, small, big] = srcsets[0].match(/^\.\/(small-[a-z0-9]+\.png) 1x, \.\/(big-[a-z0-9]+\.png) 2x$/)!;
+      api.assertFileExists(`out/${small}`);
+      api.assertFileExists(`out/${big}`);
+    },
+  });
+
   // Test external assets preservation
   itBundled("html/external-assets", {
     outdir: "out/",


### PR DESCRIPTION
### What does this PR do?

Fixes #19529.

`bun build ./index.html` failed on any real-world `<img srcset>` / `<source srcset>` because the entire attribute value (comma-separated `url descriptor` candidates) was handed to the resolver as a single path:

```
error: Could not resolve: "./small.png 1x, ./big.png 2x"
```

`HTMLProcessor` now tokenizes `srcset` following the [HTML image-set parsing algorithm](https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute) (ASCII-whitespace URL splitting, trailing-comma candidate terminator, paren-aware descriptor scan), dispatches `on_tag` once per candidate URL, and rebuilds the attribute with descriptors preserved. To make that reassembly possible, `on_tag` now returns a `TagAction` (`Keep` / `Replace(bytes)` / `Remove`) and `HTMLProcessor::run` applies it, instead of each handler mutating the element directly.

**Before:** build fails.
**After:**
```html
<img srcset="./small-6kt9k1q8.png 1x, ./big-6kt9k1q8.png 2x">
<picture><source srcset="./small-6kt9k1q8.png 480w, ./big-6kt9k1q8.png 800w"><img src="./small-6kt9k1q8.png" alt="image"></picture>
```

### How did you verify your code works?

New `html/srcset` bundler test covers density descriptors, width descriptors, `<picture><source>`, single candidate + descriptor, multiline whitespace, no-descriptor comma lists, and mixed external/local candidates. `test/bundler/bundler_html.test.ts`, `bundler_html_server.test.ts`, and `html-import-manifest.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.0 (2842c9449)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [970.84ms]
(pass) bundler > html/implicit-relative-paths [354.93ms]
(pass) bundler > html/multiple-assets [255.82ms]
(pass) bundler > html/image-hashing [272.54ms]
1363 |             }
1364 | 
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
/index.html:-1:-1: Could not resolve: "./small.png 1x, ./big.png 2x"
/index.html:-1:-1: Could not resolve: "./small.png 480w, ./big.png 800w"
/index.html:-1:-1: Could not resolve: "./small.png 2x"
/index.html:-1:-1: Could not resolve: "
      ./small.png 480w,
      ./big.png   800w
    ". Maybe you need to "bun install"?
/index.html:-1:-1: Could not resolve: "./small.png, ./big.png"
/index.html:-1:-1: Could not resolve: " , ". Maybe you need to "bun install"?
      at <anonymous> (/workspace/bun/test/bundl
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3a9e3f418)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [78.16ms]
(pass) bundler > html/implicit-relative-paths [16.46ms]
(pass) bundler > html/multiple-assets [11.58ms]
(pass) bundler > html/image-hashing [6.16ms]
(pass) bundler > html/srcset [6.01ms]
(pass) bundler > html/external-assets [5.10ms]
(pass) bundler > html/mixed-assets [5.30ms]
(pass) bundler > html/js-imports [5.63ms]
(pass) bundler > html/css-imports [5.81ms]
(pass) bundler > html/multiple-entries [6.27ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [15.58ms]
(pass) bundler > html/shared-chunks [6.88ms]
(pass) bundler > html/js-importing-html [5.18ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [5.19ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [5.01ms]
(pass) bundler > html/circular-js-html [5.86ms]
(pass) bundler > html/css-only [7.84ms]
(pass) bundler > html/absolute-paths [6.21ms]
(pass) bundler > html/no-sourcemap-comments [5.93ms]
(pass) bundler > html/no-sourcemap-comments-inline [6.00ms]

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.0 (2842c9449)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [647.89ms]
(pass) bundler > html/implicit-relative-paths [133.55ms]
(pass) bundler > html/multiple-assets [113.73ms]
(pass) bundler > html/image-hashing [110.01ms]
(pass) bundler > html/srcset [214.59ms]
(pass) bundler > html/external-assets [130.68ms]
(pass) bundler > html/mixed-assets [148.35ms]
(pass) bundler > html/js-imports [163.95ms]
(pass) bundler > html/css-imports [215.88ms]
(pass) bundler > html/multiple-entries [232.02ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [282.11ms]
(pass) bundler > html/shared-chunks [251.08ms]
(pass) bundler > html/js-importing-html [208.42ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [219.38ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [154.66ms]
(pass) bundler > html/circular-js-html [144.82ms]
(pass) bundle
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1316ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
ninja: no work to do.
[build] done
bun test v1.4.0-canary.1 (2842c9449)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [16.23ms]
(pass) bundler > html/implicit-relative-paths [5.24ms]
(pass) bundler > html/multiple-assets [4.06ms]
(pass) bundler > html/image-hashing [4.94ms]
(pass) bundler > html/srcset [5.28ms]
(pass) bundler > html/external-assets [4.07ms]
(pass) bundler > html/mixed-assets [5.23ms]
(pass) bundler > html/js-imports [5.37ms]
(pass) bundler > html/css-imports [5.48ms]
(pass) bundler > html/multiple-entries [6.00ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [8.08ms]
(pass) bundler > html/shared-chunks [6.94ms]
(pass) bundler > html/js-importing-html [4.63ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [5.50ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [4.60ms]
(pass) bundler > html/circular-js-html [5.75ms]
(pa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/HTMLScanner.rs                         | 152 ++++++++++++++++++++-
 .../generateCompileResultForHtmlChunk.rs           |  42 ++----
 test/bundler/bundler_html.test.ts                  |  65 +++++++++
 3 files changed, 225 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/HTMLScanner.rs                                    8     14      0
…ler/linker_context/generateCompileResultForHtmlChunk.rs      1      3      0
test/bundler/bundler_html.test.ts                             4      7      0
```

</details>

<!-- robobun:evidence:end -->