### PR TITLE
bundler(html): rewrite prefetch/modulepreload/preload link hrefs

### DIFF
--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -70,8 +70,8 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
-        /// Came from an HTML `<link rel=prefetch|modulepreload|preload as=script>`.
-        /// Fetch-only: emit as a raw asset, tolerate unresolved hrefs.
+        /// Came from an HTML `<link rel=prefetch|modulepreload|preload>` hint.
+        /// Unresolved hrefs pass through untouched.
         const WAS_HTML_RESOURCE_HINT = 1 << 7;
 
         /// If true, this was originally written as a bare "import 'file'" statement

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -70,6 +70,13 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
+        /// This record came from an HTML resource hint (`<link rel="prefetch">`,
+        /// `<link rel="modulepreload">`, `<link rel="preload" as="script">`).
+        /// Hints are fetch-only: the referenced file must be emitted as a raw
+        /// asset (never bundled/executed) and an unresolved href must not fail
+        /// the build.
+        const WAS_HTML_RESOURCE_HINT = 1 << 7;
+
         /// If true, this was originally written as a bare "import 'file'" statement
         const WAS_ORIGINALLY_BARE_IMPORT = 1 << 8;
 

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -70,11 +70,8 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
-        /// This record came from an HTML resource hint (`<link rel="prefetch">`,
-        /// `<link rel="modulepreload">`, `<link rel="preload" as="script">`).
-        /// Hints are fetch-only: the referenced file must be emitted as a raw
-        /// asset (never bundled/executed) and an unresolved href must not fail
-        /// the build.
+        /// Came from an HTML `<link rel=prefetch|modulepreload|preload as=script>`.
+        /// Fetch-only: emit as a raw asset, tolerate unresolved hrefs.
         const WAS_HTML_RESOURCE_HINT = 1 << 7;
 
         /// If true, this was originally written as a bare "import 'file'" statement

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -110,12 +110,7 @@ impl<'a> HTMLScanner<'a> {
             .add_error(Some(self.source), Loc::EMPTY, message.to_vec());
     }
 
-    pub(crate) fn on_tag(
-        &mut self,
-        _element: &mut Element<'_, '_>,
-        path: &[u8],
-        tag: TagHandler,
-    ) {
+    pub(crate) fn on_tag(&mut self, _element: &mut Element<'_, '_>, path: &[u8], tag: TagHandler) {
         let _ = self.create_import_record(path, tag.kind, tag.is_resource_hint);
     }
 

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -31,7 +31,12 @@ impl<'a> HTMLScanner<'a> {
 }
 
 impl<'a> HTMLScanner<'a> {
-    fn create_import_record(&mut self, input_path: &[u8], kind: ImportKind) -> Result<(), Error> {
+    fn create_import_record(
+        &mut self,
+        input_path: &[u8],
+        kind: ImportKind,
+        is_resource_hint: bool,
+    ) -> Result<(), Error> {
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
         let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
@@ -69,6 +74,15 @@ impl<'a> HTMLScanner<'a> {
 
         let owned: &'static [u8] =
             Box::leak(AstAlloc::vec_from_slice(path_to_use).into_boxed_slice());
+        let mut flags = ImportRecordFlags::default();
+        if is_resource_hint {
+            // `<link rel="prefetch">` / `rel="modulepreload"` / `rel="preload"
+            // as="script"` are browser fetch-only hints. An unresolved href
+            // (e.g. a navigation route) must not fail the build, and the
+            // bundler must not execute the target.
+            flags.insert(ImportRecordFlags::WAS_HTML_RESOURCE_HINT);
+            flags.insert(ImportRecordFlags::HANDLES_IMPORT_ERRORS);
+        }
         let record = ImportRecord {
             path: FsPath::init(owned),
             kind,
@@ -77,7 +91,7 @@ impl<'a> HTMLScanner<'a> {
             loader: None,
             source_index: AstIndex::default(),
             original_path: b"",
-            flags: ImportRecordFlags::default(),
+            flags,
         };
 
         self.import_records.push(record);
@@ -100,11 +114,9 @@ impl<'a> HTMLScanner<'a> {
         &mut self,
         _element: &mut Element<'_, '_>,
         path: &[u8],
-        url_attribute: &[u8],
-        kind: ImportKind,
+        tag: TagHandler,
     ) {
-        let _ = url_attribute;
-        let _ = self.create_import_record(path, kind);
+        let _ = self.create_import_record(path, tag.kind, tag.is_resource_hint);
     }
 
     pub(crate) fn scan(&mut self, input: &[u8]) -> Result<(), Error> {
@@ -120,13 +132,7 @@ type Processor<'a> = HTMLProcessor<HTMLScanner<'a>, false>;
 
 /// Trait capturing the methods `HTMLProcessor` calls on `T`.
 pub(crate) trait HTMLProcessorHandler {
-    fn on_tag(
-        &mut self,
-        element: &mut Element<'_, '_>,
-        path: &[u8],
-        url_attribute: &[u8],
-        kind: ImportKind,
-    );
+    fn on_tag(&mut self, element: &mut Element<'_, '_>, path: &[u8], tag: TagHandler);
     fn on_write_html(&mut self, bytes: &[u8]);
     fn on_html_parse_error(&mut self, message: &[u8]);
 
@@ -145,14 +151,8 @@ pub(crate) trait HTMLProcessorHandler {
 }
 
 impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
-    fn on_tag(
-        &mut self,
-        element: &mut Element<'_, '_>,
-        path: &[u8],
-        url_attribute: &[u8],
-        kind: ImportKind,
-    ) {
-        HTMLScanner::on_tag(self, element, path, url_attribute, kind)
+    fn on_tag(&mut self, element: &mut Element<'_, '_>, path: &[u8], tag: TagHandler) {
+        HTMLScanner::on_tag(self, element, path, tag)
     }
     fn on_write_html(&mut self, bytes: &[u8]) {
         HTMLScanner::on_write_html(self, bytes)
@@ -172,6 +172,10 @@ pub struct TagHandler {
     pub url_attribute: &'static str,
     /// The kind of import to create
     pub kind: ImportKind,
+    /// The element is a browser fetch-only hint (prefetch / modulepreload /
+    /// preload as=script). The referenced file is emitted as a raw asset
+    /// rather than bundled, and an unresolved href is tolerated.
+    pub is_resource_hint: bool,
 }
 
 impl TagHandler {
@@ -180,6 +184,16 @@ impl TagHandler {
             selector,
             url_attribute,
             kind,
+            is_resource_hint: false,
+        }
+    }
+
+    const fn hint(selector: &'static str, url_attribute: &'static str, kind: ImportKind) -> Self {
+        Self {
+            selector,
+            url_attribute,
+            kind,
+            is_resource_hint: true,
         }
     }
 }
@@ -207,18 +221,12 @@ pub(crate) const TAG_HANDLERS: [TagHandler; 20] = [
     ),
     // Web Workers
     TagHandler::new("link[as='worker'][href]", "href", ImportKind::Stmt),
-    // Preloaded scripts (<link rel="preload" as="script">)
-    TagHandler::new("link[as='script'][href]", "href", ImportKind::Stmt),
-    // Module preloads (<link rel="modulepreload">)
-    TagHandler::new("link[rel='modulepreload'][href]", "href", ImportKind::Stmt),
     // Generic preload/prefetch targets (fetch/track/document/embed/object)
     TagHandler::new(
         "link[as='fetch'][href], link[as='track'][href], link[as='document'][href], link[as='embed'][href], link[as='object'][href]",
         "href",
         ImportKind::Url,
     ),
-    // Prefetch hints (<link rel="prefetch">)
-    TagHandler::new("link[rel='prefetch'][href]", "href", ImportKind::Url),
     // Manifest files
     TagHandler::new("link[rel='manifest'][href]", "href", ImportKind::Url),
     // Icons
@@ -227,6 +235,12 @@ pub(crate) const TAG_HANDLERS: [TagHandler; 20] = [
         "href",
         ImportKind::Url,
     ),
+    // Preloaded scripts (<link rel="preload" as="script">)
+    TagHandler::hint("link[as='script'][href]", "href", ImportKind::Url),
+    // Module preloads (<link rel="modulepreload">)
+    TagHandler::hint("link[rel='modulepreload'][href]", "href", ImportKind::Url),
+    // Prefetch hints (<link rel="prefetch">)
+    TagHandler::hint("link[rel='prefetch'][href]", "href", ImportKind::Url),
     // Images with src
     TagHandler::new("img[src]", "src", ImportKind::Url),
     // Images with srcset
@@ -301,12 +315,7 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
                             // which is not reborrowed while the rewriter — the only
                             // holder of these closures — is alive.
                             unsafe {
-                                (*this_ptr).on_tag(
-                                    element,
-                                    value.as_bytes(),
-                                    tag_info.url_attribute.as_bytes(),
-                                    tag_info.kind,
-                                );
+                                (*this_ptr).on_tag(element, value.as_bytes(), tag_info);
                             }
                         }
                     }

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -184,7 +184,7 @@ impl TagHandler {
     }
 }
 
-pub(crate) const TAG_HANDLERS: [TagHandler; 16] = [
+pub(crate) const TAG_HANDLERS: [TagHandler; 20] = [
     // Module scripts with src
     TagHandler::new("script[src]", "src", ImportKind::Stmt),
     // CSS Stylesheets
@@ -207,6 +207,18 @@ pub(crate) const TAG_HANDLERS: [TagHandler; 16] = [
     ),
     // Web Workers
     TagHandler::new("link[as='worker'][href]", "href", ImportKind::Stmt),
+    // Preloaded scripts (<link rel="preload" as="script">)
+    TagHandler::new("link[as='script'][href]", "href", ImportKind::Stmt),
+    // Module preloads (<link rel="modulepreload">)
+    TagHandler::new("link[rel='modulepreload'][href]", "href", ImportKind::Stmt),
+    // Generic preload/prefetch targets (fetch/track/document/embed/object)
+    TagHandler::new(
+        "link[as='fetch'][href], link[as='track'][href], link[as='document'][href], link[as='embed'][href], link[as='object'][href]",
+        "href",
+        ImportKind::Url,
+    ),
+    // Prefetch hints (<link rel="prefetch">)
+    TagHandler::new("link[rel='prefetch'][href]", "href", ImportKind::Url),
     // Manifest files
     TagHandler::new("link[rel='manifest'][href]", "href", ImportKind::Url),
     // Icons

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -76,10 +76,6 @@ impl<'a> HTMLScanner<'a> {
             Box::leak(AstAlloc::vec_from_slice(path_to_use).into_boxed_slice());
         let mut flags = ImportRecordFlags::default();
         if is_resource_hint {
-            // `<link rel="prefetch">` / `rel="modulepreload"` / `rel="preload"
-            // as="script"` are browser fetch-only hints. An unresolved href
-            // (e.g. a navigation route) must not fail the build, and the
-            // bundler must not execute the target.
             flags.insert(ImportRecordFlags::WAS_HTML_RESOURCE_HINT);
             flags.insert(ImportRecordFlags::HANDLES_IMPORT_ERRORS);
         }
@@ -167,9 +163,7 @@ pub struct TagHandler {
     pub url_attribute: &'static str,
     /// The kind of import to create
     pub kind: ImportKind,
-    /// The element is a browser fetch-only hint (prefetch / modulepreload /
-    /// preload as=script). The referenced file is emitted as a raw asset
-    /// rather than bundled, and an unresolved href is tolerated.
+    /// Sets `ImportRecordFlags::WAS_HTML_RESOURCE_HINT` on the record.
     pub is_resource_hint: bool,
 }
 
@@ -216,17 +210,17 @@ pub(crate) const TAG_HANDLERS: [TagHandler; 20] = [
     ),
     // Web Workers
     TagHandler::new("link[as='worker'][href]", "href", ImportKind::Stmt),
-    // Generic preload/prefetch targets (fetch/track/document/embed/object)
-    TagHandler::new(
-        "link[as='fetch'][href], link[as='track'][href], link[as='document'][href], link[as='embed'][href], link[as='object'][href]",
-        "href",
-        ImportKind::Url,
-    ),
     // Manifest files
     TagHandler::new("link[rel='manifest'][href]", "href", ImportKind::Url),
     // Icons
     TagHandler::new(
         "link[rel='icon'][href], link[rel='apple-touch-icon'][href]",
+        "href",
+        ImportKind::Url,
+    ),
+    // Generic preload targets (fetch/track/document/embed/object)
+    TagHandler::hint(
+        "link[as='fetch'][href], link[as='track'][href], link[as='document'][href], link[as='embed'][href], link[as='object'][href]",
         "href",
         ImportKind::Url,
     ),

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -106,10 +106,8 @@ pub struct ParseTask {
     pub stage: ParseTaskStage,
 
     pub tree_shaking: bool,
-    /// Set while the only import record that has enqueued this path is an
-    /// HTML resource hint (prefetch/modulepreload/preload-as-script). If a
-    /// non-hint record for the same path is seen later, it restores the
-    /// path's native loader and clears this flag.
+    /// Only HTML resource-hint records have enqueued this path so far. A later
+    /// non-hint record restores the native `loader` and clears this.
     pub is_html_resource_hint: bool,
     pub known_target: options::Target,
     pub module_type: options::ModuleType,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -106,9 +106,6 @@ pub struct ParseTask {
     pub stage: ParseTaskStage,
 
     pub tree_shaking: bool,
-    /// Only HTML resource-hint records have enqueued this path so far. A later
-    /// non-hint record restores the native `loader` and clears this.
-    pub is_html_resource_hint: bool,
     pub known_target: options::Target,
     pub module_type: options::ModuleType,
     pub emit_decorator_metadata: bool,
@@ -284,7 +281,6 @@ impl ParseTask {
             },
             stage: ParseTaskStage::NeedsSourceCode,
             tree_shaking: false,
-            is_html_resource_hint: false,
             is_entry_point: false,
         }
     }
@@ -319,7 +315,6 @@ impl Default for ParseTask {
             },
             stage: ParseTaskStage::NeedsSourceCode,
             tree_shaking: false,
-            is_html_resource_hint: false,
             known_target: options::Target::default(),
             module_type: options::ModuleType::Unknown,
             emit_decorator_metadata: false,
@@ -558,7 +553,6 @@ pub mod parse_worker {
             },
             stage: ParseTaskStage::NeedsSourceCode,
             tree_shaking: false,
-            is_html_resource_hint: false,
             module_type: options::ModuleType::Unknown,
             emit_decorator_metadata: false,
             experimental_decorators: false,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -106,6 +106,11 @@ pub struct ParseTask {
     pub stage: ParseTaskStage,
 
     pub tree_shaking: bool,
+    /// Set while the only import record that has enqueued this path is an
+    /// HTML resource hint (prefetch/modulepreload/preload-as-script). If a
+    /// non-hint record for the same path is seen later, it restores the
+    /// path's native loader and clears this flag.
+    pub is_html_resource_hint: bool,
     pub known_target: options::Target,
     pub module_type: options::ModuleType,
     pub emit_decorator_metadata: bool,
@@ -281,6 +286,7 @@ impl ParseTask {
             },
             stage: ParseTaskStage::NeedsSourceCode,
             tree_shaking: false,
+            is_html_resource_hint: false,
             is_entry_point: false,
         }
     }
@@ -315,6 +321,7 @@ impl Default for ParseTask {
             },
             stage: ParseTaskStage::NeedsSourceCode,
             tree_shaking: false,
+            is_html_resource_hint: false,
             known_target: options::Target::default(),
             module_type: options::ModuleType::Unknown,
             emit_decorator_metadata: false,
@@ -553,6 +560,7 @@ pub mod parse_worker {
             },
             stage: ParseTaskStage::NeedsSourceCode,
             tree_shaking: false,
+            is_html_resource_hint: false,
             module_type: options::ModuleType::Unknown,
             emit_decorator_metadata: false,
             experimental_decorators: false,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6384,7 +6384,15 @@ pub mod bv2_impl {
                     && self.dev_server.is_none();
 
                 if let Some(id) = self.path_to_source_index_map(target).get(path.text) {
-                    if self.dev_server.is_some() && loader != Loader::Html {
+                    if import_record
+                        .flags
+                        .contains(bun_ast::ImportRecordFlags::WAS_HTML_RESOURCE_HINT)
+                        && self.graph.input_files.items_loader()[id as usize] == Loader::Html
+                    {
+                        // A hint pointing at another HTML entry point must not
+                        // add a reachability edge: leave the href untouched.
+                        import_record.path.is_disabled = true;
+                    } else if self.dev_server.is_some() && loader != Loader::Html {
                         import_record.path =
                             self.graph.input_files.items_source()[id as usize].path;
                     } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6368,7 +6368,10 @@ pub mod bv2_impl {
                         && !resolved_loader.should_copy_for_bundling()
                         && !resolved_loader.is_javascript_like()
                         && !resolved_loader.is_css()
-                        && resolved_loader != Loader::Html
+                        && (resolved_loader != Loader::Html
+                            || import_record
+                                .flags
+                                .contains(bun_ast::ImportRecordFlags::WAS_HTML_RESOURCE_HINT))
                     {
                         break 'brk Loader::File;
                     }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6352,13 +6352,9 @@ pub mod bv2_impl {
                         path.loader(&transpiler.options.loaders)
                             .unwrap_or(Loader::File)
                     });
-                    // HTML resource hints (<link rel="prefetch">, rel="modulepreload",
-                    // rel="preload" as="script") are fetch-only: the referenced file
-                    // must be emitted as a raw asset and never bundled/executed.
-                    // Force the file loader regardless of extension. If a non-hint
-                    // record for the same path is seen later in this batch, the
-                    // `resolve_queue.found_existing` branch below restores the
-                    // native loader.
+                    // HTML resource hints are fetch-only: emit as a raw asset,
+                    // never bundle/execute. A later non-hint record for the same
+                    // path restores the native loader at `found_existing` below.
                     if is_html_resource_hint && !resolved_loader.should_copy_for_bundling() {
                         break 'brk Loader::File;
                     }
@@ -6402,10 +6398,6 @@ pub mod bv2_impl {
                 if resolve_entry.found_existing {
                     // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
                     let existing = unsafe { &mut **resolve_entry.value_ptr };
-                    // If the only earlier record for this path was an HTML
-                    // resource hint (which forced Loader::File above), a
-                    // later non-hint record restores the native loader so the
-                    // file is bundled normally.
                     if existing.is_html_resource_hint && !is_html_resource_hint {
                         existing.is_html_resource_hint = false;
                         existing.loader = Some(import_record_loader);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6344,20 +6344,11 @@ pub mod bv2_impl {
                     }
                 }
 
-                let is_html_resource_hint = import_record
-                    .flags
-                    .contains(bun_ast::ImportRecordFlags::WAS_HTML_RESOURCE_HINT);
                 let import_record_loader = 'brk: {
                     let resolved_loader = import_record.loader.unwrap_or_else(|| {
                         path.loader(&transpiler.options.loaders)
                             .unwrap_or(Loader::File)
                     });
-                    // HTML resource hints are fetch-only: emit as a raw asset,
-                    // never bundle/execute. A later non-hint record for the same
-                    // path restores the native loader at `found_existing` below.
-                    if is_html_resource_hint && !resolved_loader.should_copy_for_bundling() {
-                        break 'brk Loader::File;
-                    }
                     // When an HTML file references a URL asset (e.g. <link rel="manifest" href="./manifest.json" />),
                     // the file must be copied to the output directory as-is. If the resolved loader would
                     // parse/transform the file (e.g. .json, .toml) rather than copy it, force the .file loader
@@ -6397,12 +6388,8 @@ pub mod bv2_impl {
                 let resolve_entry = resolve_queue.get_or_put(path.text).expect("oom");
                 if resolve_entry.found_existing {
                     // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
-                    let existing = unsafe { &mut **resolve_entry.value_ptr };
-                    if existing.is_html_resource_hint && !is_html_resource_hint {
-                        existing.is_html_resource_hint = false;
-                        existing.loader = Some(import_record_loader);
-                    }
-                    import_record.path = path_as_static(&existing.path);
+                    import_record.path =
+                        path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
                     continue;
                 }
 
@@ -6433,7 +6420,6 @@ pub mod bv2_impl {
                 };
 
                 resolve_task.loader = Some(import_record_loader);
-                resolve_task.is_html_resource_hint = is_html_resource_hint;
                 resolve_task.tree_shaking = transpiler.options.tree_shaking;
                 *resolve_entry.value_ptr = resolve_task;
                 if let Some(secondary) = &resolve_result.path_pair.secondary {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6665,6 +6665,9 @@ pub mod bv2_impl {
             // so borrowck sees it as disjoint from `self.graph.input_files` above.
             let path_to_source_index_map = &mut self.graph.build_graphs[ctx.target];
             for (i, record) in import_records.as_mut_slice().iter_mut().enumerate() {
+                if record.path.is_disabled {
+                    continue;
+                }
                 if let Some(source_index) = path_to_source_index_map.get_path(&record.path) {
                     if save_import_record_source_index
                         || input_file_loaders[source_index as usize].is_css()

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6273,6 +6273,15 @@ pub mod bv2_impl {
                             && (import_record.loader.is_none()
                                 || import_record.loader.unwrap() == Loader::Html)
                         {
+                            if import_record
+                                .flags
+                                .contains(bun_ast::ImportRecordFlags::WAS_HTML_RESOURCE_HINT)
+                            {
+                                // <link rel="prefetch" href="./page2.html"> and similar
+                                // hints are fetch-only; leave the href untouched.
+                                import_record.path.is_disabled = true;
+                                continue 'outer;
+                            }
                             // This use case is currently not supported. This error
                             // blocks an assertion failure because the DevServer
                             // reserves the HTML file's spot in IncrementalGraph for the

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6344,11 +6344,24 @@ pub mod bv2_impl {
                     }
                 }
 
+                let is_html_resource_hint = import_record
+                    .flags
+                    .contains(bun_ast::ImportRecordFlags::WAS_HTML_RESOURCE_HINT);
                 let import_record_loader = 'brk: {
                     let resolved_loader = import_record.loader.unwrap_or_else(|| {
                         path.loader(&transpiler.options.loaders)
                             .unwrap_or(Loader::File)
                     });
+                    // HTML resource hints (<link rel="prefetch">, rel="modulepreload",
+                    // rel="preload" as="script") are fetch-only: the referenced file
+                    // must be emitted as a raw asset and never bundled/executed.
+                    // Force the file loader regardless of extension. If a non-hint
+                    // record for the same path is seen later in this batch, the
+                    // `resolve_queue.found_existing` branch below restores the
+                    // native loader.
+                    if is_html_resource_hint && !resolved_loader.should_copy_for_bundling() {
+                        break 'brk Loader::File;
+                    }
                     // When an HTML file references a URL asset (e.g. <link rel="manifest" href="./manifest.json" />),
                     // the file must be copied to the output directory as-is. If the resolved loader would
                     // parse/transform the file (e.g. .json, .toml) rather than copy it, force the .file loader
@@ -6388,8 +6401,16 @@ pub mod bv2_impl {
                 let resolve_entry = resolve_queue.get_or_put(path.text).expect("oom");
                 if resolve_entry.found_existing {
                     // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
-                    import_record.path =
-                        path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
+                    let existing = unsafe { &mut **resolve_entry.value_ptr };
+                    // If the only earlier record for this path was an HTML
+                    // resource hint (which forced Loader::File above), a
+                    // later non-hint record restores the native loader so the
+                    // file is bundled normally.
+                    if existing.is_html_resource_hint && !is_html_resource_hint {
+                        existing.is_html_resource_hint = false;
+                        existing.loader = Some(import_record_loader);
+                    }
+                    import_record.path = path_as_static(&existing.path);
                     continue;
                 }
 
@@ -6420,6 +6441,7 @@ pub mod bv2_impl {
                 };
 
                 resolve_task.loader = Some(import_record_loader);
+                resolve_task.is_html_resource_hint = is_html_resource_hint;
                 resolve_task.tree_shaking = transpiler.options.tree_shaking;
                 *resolve_entry.value_ptr = resolve_task;
                 if let Some(secondary) = &resolve_result.path_pair.secondary {

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -3,13 +3,13 @@ use crate::mal_prelude::*;
 use bstr::BStr;
 
 use bun_ast::Log;
-use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags};
+use bun_ast::{ImportRecord, ImportRecordFlags};
 use bun_core::strings;
 use bun_threading::thread_pool::Task as ThreadPoolLibTask;
 use lol_html::HandlerResult;
 use lol_html::html_content::{ContentType, Element, EndTag};
 
-use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler};
+use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler, TagHandler};
 use crate::linker_context_mod::{GenerateChunkCtx, LinkerContext, debug};
 use crate::options::Loader;
 use crate::{Chunk, CompileResult};
@@ -118,13 +118,8 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
         ));
     }
 
-    fn on_tag(
-        &mut self,
-        element: &mut Element<'_, '_>,
-        _path: &[u8],
-        url_attribute: &[u8],
-        _kind: ImportKind,
-    ) {
+    fn on_tag(&mut self, element: &mut Element<'_, '_>, _path: &[u8], tag: TagHandler) {
+        let url_attribute = tag.url_attribute.as_bytes();
         if self.current_import_record_index as usize >= self.import_records.len() {
             bun_core::Output::panic(format_args!(
                 "Assertion failure in HTMLLoader.onTag: current_import_record_index ({}) >= import_records.len ({})",
@@ -162,9 +157,16 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             return;
         }
 
+        let is_resource_hint = import_record
+            .flags
+            .contains(ImportRecordFlags::WAS_HTML_RESOURCE_HINT);
+
         if self.linker.dev_server.is_some() {
             if !unique_key_for_additional_files.is_empty() {
                 set_attribute(element, url_attribute, unique_key_for_additional_files);
+            } else if is_resource_hint && import_record.path.is_disabled {
+                // An unresolved prefetch/modulepreload href (e.g. a navigation
+                // route) passes through untouched.
             } else if import_record.path.is_disabled
                 || loader.is_javascript_like()
                 || loader.is_css()

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -165,8 +165,7 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             if !unique_key_for_additional_files.is_empty() {
                 set_attribute(element, url_attribute, unique_key_for_additional_files);
             } else if is_resource_hint && import_record.path.is_disabled {
-                // An unresolved prefetch/modulepreload href (e.g. a navigation
-                // route) passes through untouched.
+                // Unresolved hint href: pass through untouched.
             } else if import_record.path.is_disabled
                 || loader.is_javascript_like()
                 || loader.is_css()

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -370,3 +370,29 @@ devTest("error report endpoint blanks stray non-text bytes in reported frames", 
     await dev.fetch("/").expect.toInclude("<h1>Frame Bytes</h1>");
   },
 });
+
+devTest("resource-hint links pass through in dev server", {
+  htmlFiles: ["index.html"],
+  files: {
+    "index.html": `
+      <!DOCTYPE html><html><head>
+      <link rel="prefetch" href="./page2.html">
+      <link rel="prefetch" href="/some-route">
+      <link rel="modulepreload" href="/cdn/lib.js">
+      </head><body><h1>Hints</h1></body></html>
+    `,
+    "page2.html": "<!doctype html><h1>Page 2</h1>",
+  },
+  async test(dev) {
+    // Before the WAS_HTML_RESOURCE_HINT carve-out in bundle_v2.rs, the local
+    // ./page2.html hint hit the "Browser builds cannot import HTML files"
+    // dev-server guard and failed the build.
+    const html = await (await dev.fetch("/")).text();
+    expect(html).toInclude("<h1>Hints</h1>");
+    // Unresolved hint hrefs pass through untouched rather than being dropped.
+    expect(html).toInclude('<link rel="prefetch" href="/some-route">');
+    expect(html).toInclude('<link rel="modulepreload" href="/cdn/lib.js">');
+    expect(html).toInclude('rel="prefetch"');
+    expect(html).not.toInclude("Browser builds cannot import HTML files");
+  },
+});

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -389,10 +389,10 @@ devTest("resource-hint links pass through in dev server", {
     // dev-server guard and failed the build.
     const html = await (await dev.fetch("/")).text();
     expect(html).toInclude("<h1>Hints</h1>");
+    expect(html).toInclude('<link rel="prefetch" href="./page2.html">');
     // Unresolved hint hrefs pass through untouched rather than being dropped.
     expect(html).toInclude('<link rel="prefetch" href="/some-route">');
     expect(html).toInclude('<link rel="modulepreload" href="/cdn/lib.js">');
-    expect(html).toInclude('rel="prefetch"');
     expect(html).not.toInclude("Browser builds cannot import HTML files");
   },
 });

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1113,7 +1113,8 @@ body {
 
       // page2.html's <script> must not leak into index.html's entry chunk.
       const js = html.match(/src="(?:\.\/|\/)?(index-[a-z0-9]+\.js)"/);
-      if (js) expect(api.readFile("out/" + js[1])).not.toContain("PAGE2_SCRIPT");
+      expect(js).not.toBeNull();
+      expect(api.readFile("out/" + js![1])).not.toContain("PAGE2_SCRIPT");
 
       const page2 = html.match(/href="(?:\.\/|\/)?(page2-[a-z0-9]+\.html)"/);
       expect(page2).not.toBeNull();

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1101,8 +1101,9 @@ body {
     },
   });
 
-  // Resource-hint hrefs that do not resolve to a local file (navigation routes)
-  // pass through untouched instead of failing the build.
+  // Resource-hint hrefs that do not resolve to a local file (navigation routes,
+  // API endpoints, external URLs) pass through untouched instead of failing the
+  // build.
   itBundled("html/link-hint-unresolved", {
     outdir: "out/",
     files: {
@@ -1111,6 +1112,8 @@ body {
 <html>
   <head>
     <link rel="prefetch" href="/dashboard">
+    <link rel="preload" as="fetch" href="/api/user" crossorigin>
+    <link rel="preload" as="document" href="/settings">
     <link rel="modulepreload" href="https://cdn.example.com/lib.js">
   </head>
   <body></body>
@@ -1120,6 +1123,8 @@ body {
     onAfterBundle(api) {
       const html = api.readFile("out/index.html");
       expect(html).toContain('<link rel="prefetch" href="/dashboard">');
+      expect(html).toContain('<link rel="preload" as="fetch" href="/api/user" crossorigin>');
+      expect(html).toContain('<link rel="preload" as="document" href="/settings">');
       expect(html).toContain('<link rel="modulepreload" href="https://cdn.example.com/lib.js">');
     },
   });

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1130,14 +1130,19 @@ body {
       "/index.html": `
 <!DOCTYPE html>
 <html>
-  <head><link rel="prefetch" href="./page2.html"></head>
+  <head>
+    <link rel="prefetch" href="./page2.html">
+    <link rel="prefetch" href="/page3.html">
+  </head>
   <body><script src="./index-script.js"></script></body>
 </html>`,
       "/page2.html": `<!doctype html><script src="./page2-script.js"></script><h1>Page 2</h1>`,
+      "/page3.html": `<!doctype html><script src="./page3-script.js"></script><h1>Page 3</h1>`,
       "/index-script.js": `console.log("INDEX_SCRIPT");`,
       "/page2-script.js": `console.log("PAGE2_SCRIPT");`,
+      "/page3-script.js": `console.log("PAGE3_SCRIPT");`,
     },
-    entryPoints: ["/index.html", "/page2.html"],
+    entryPoints: ["/index.html", "/page2.html", "/page3.html"],
     onAfterBundle(api) {
       const html = api.readFile("out/index.html");
       const js = html.match(/src="(?:\.\/|\/)?(index-[a-z0-9]+\.js)"/);
@@ -1145,9 +1150,11 @@ body {
       const jsContent = api.readFile("out/" + js![1]);
       expect(jsContent).toContain("INDEX_SCRIPT");
       expect(jsContent).not.toContain("PAGE2_SCRIPT");
-      // page2.html is emitted under its own entry-point name, so the original
-      // href is already a valid output path.
+      expect(jsContent).not.toContain("PAGE3_SCRIPT");
+      // page2.html/page3.html are emitted under their own entry-point names,
+      // so the original hrefs are already valid output paths.
       expect(html).toContain('<link rel="prefetch" href="./page2.html">');
+      expect(html).toContain('<link rel="prefetch" href="/page3.html">');
     },
   });
 

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1014,9 +1014,8 @@ body {
 
   // <link rel="prefetch">, <link rel="modulepreload"> and <link rel="preload"> with
   // as={script,fetch,track,document,embed,object} must not ship dangling source-path
-  // hrefs. Hints are fetch-only: targets are emitted as raw hashed assets (never
-  // bundled/executed), and when the target was already bundled via <script>/<link
-  // rel=stylesheet> the hint is dropped.
+  // hrefs. Non-code targets are emitted + hashed; JS/CSS targets are bundled and
+  // the hint tag is dropped (nothing separate to preload once bundled).
   itBundled("html/link-preload-prefetch", {
     outdir: "out/",
     files: {
@@ -1025,20 +1024,19 @@ body {
 <html>
   <head>
     <link rel="prefetch" href="./hero.png">
-    <link rel="modulepreload" href="./mod.js">
+    <link rel="modulepreload" href="./dep.js">
     <link rel="preload" as="script" href="./preloaded.js">
     <link rel="preload" as="fetch" href="./data.json" crossorigin>
     <link rel="preload" as="track" href="./captions.vtt">
-    <link rel="prefetch" href="./lazy.js">
   </head>
   <body>
     <img src="./hero.png">
-    <script type="module" src="./mod.js"></script>
+    <script type="module" src="./main.js"></script>
   </body>
 </html>`,
-      "/mod.js": `console.log("mod");`,
-      "/preloaded.js": `globalThis.PRELOADED_RAN = true;`,
-      "/lazy.js": `globalThis.LAZY_RAN = true;`,
+      "/main.js": `import { x } from "./dep.js"; console.log("main", x);`,
+      "/dep.js": `export const x = 42; console.log("dep");`,
+      "/preloaded.js": `console.log("preloaded");`,
       "/hero.png": "PNG",
       "/data.json": `{"k":1}`,
       "/captions.vtt": "WEBVTT",
@@ -1050,54 +1048,39 @@ body {
       // No raw source paths should survive in the output; every one of these
       // would have been a guaranteed 404 before.
       expect(html).not.toContain('href="./hero.png"');
-      expect(html).not.toContain('href="./mod.js"');
+      expect(html).not.toContain('href="./dep.js"');
       expect(html).not.toContain('href="./preloaded.js"');
       expect(html).not.toContain('href="./data.json"');
       expect(html).not.toContain('href="./captions.vtt"');
-      expect(html).not.toContain('href="./lazy.js"');
 
-      // prefetch: asset is copied + hashed and the href is rewritten.
+      // prefetch / preload of non-code assets: copied + hashed and href rewritten.
       expect(html).toMatch(/<link rel="prefetch" href="[^"]*hero-[a-z0-9]+\.png">/);
-
-      // preload as=fetch / as=track: assets are copied + hashed and the href is rewritten.
       expect(html).toMatch(/<link rel="preload" as="fetch" href="[^"]*data-[a-z0-9]+\.json" crossorigin>/);
       expect(html).toMatch(/<link rel="preload" as="track" href="[^"]*captions-[a-z0-9]+\.vtt">/);
 
-      // modulepreload of ./mod.js: the module is also pulled in via <script src>, so
-      // it is bundled and the hint is dropped (there is no separate file to preload).
+      // JS hints are bundled and the hint tag is dropped.
       expect(html).not.toMatch(/rel="modulepreload"/);
+      expect(html).not.toMatch(/as="script"/);
 
-      // preload as=script / prefetch of JS not otherwise referenced: emitted as a
-      // separate hashed file and the href is rewritten. The browser fetches but
-      // never executes, matching the source-page semantics.
-      expect(html).toMatch(/<link rel="preload" as="script" href="[^"]*preloaded-[a-z0-9]+\.js">/);
-      expect(html).toMatch(/<link rel="prefetch" href="[^"]*lazy-[a-z0-9]+\.js">/);
-
-      // The emitted files exist and carry the original bytes.
       const hero = html.match(/href="(?:\.\/|\/)?(hero-[a-z0-9]+\.png)"/);
       const data = html.match(/href="(?:\.\/|\/)?(data-[a-z0-9]+\.json)"/);
       const vtt = html.match(/href="(?:\.\/|\/)?(captions-[a-z0-9]+\.vtt)"/);
-      const preloaded = html.match(/href="(?:\.\/|\/)?(preloaded-[a-z0-9]+\.js)"/);
-      const lazy = html.match(/href="(?:\.\/|\/)?(lazy-[a-z0-9]+\.js)"/);
       expect(hero).not.toBeNull();
       expect(data).not.toBeNull();
       expect(vtt).not.toBeNull();
-      expect(preloaded).not.toBeNull();
-      expect(lazy).not.toBeNull();
       api.expectFile("out/" + hero![1]).toBe("PNG");
       api.expectFile("out/" + data![1]).toBe(`{"k":1}`);
       api.expectFile("out/" + vtt![1]).toBe("WEBVTT");
-      api.expectFile("out/" + preloaded![1]).toBe(`globalThis.PRELOADED_RAN = true;`);
-      api.expectFile("out/" + lazy![1]).toBe(`globalThis.LAZY_RAN = true;`);
 
-      // The entry JS chunk contains only mod.js. Resource-hint JS is never
-      // bundled/executed: PRELOADED_RAN / LAZY_RAN must not be in the chunk.
+      // modulepreload of a transitive dep: dep.js is reached via both the hint
+      // and main.js's import. It must be bundled as JS (not pinned to a file
+      // loader), so `import { x } from "./dep.js"` resolves.
       const js = html.match(/src="(?:\.\/|\/)?(index-[a-z0-9]+\.js)"/);
       expect(js).not.toBeNull();
       const jsContent = api.readFile("out/" + js![1]);
-      expect(jsContent).toContain('"mod"');
-      expect(jsContent).not.toContain("PRELOADED_RAN");
-      expect(jsContent).not.toContain("LAZY_RAN");
+      expect(jsContent).toContain('"main"');
+      expect(jsContent).toContain('"dep"');
+      expect(jsContent).toContain('"preloaded"');
     },
   });
 

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1014,7 +1014,9 @@ body {
 
   // <link rel="prefetch">, <link rel="modulepreload"> and <link rel="preload"> with
   // as={script,fetch,track,document,embed,object} must not ship dangling source-path
-  // hrefs. Assets are emitted + hashed; JS preloads are folded into the entry chunk.
+  // hrefs. Hints are fetch-only: targets are emitted as raw hashed assets (never
+  // bundled/executed), and when the target was already bundled via <script>/<link
+  // rel=stylesheet> the hint is dropped.
   itBundled("html/link-preload-prefetch", {
     outdir: "out/",
     files: {
@@ -1027,6 +1029,7 @@ body {
     <link rel="preload" as="script" href="./preloaded.js">
     <link rel="preload" as="fetch" href="./data.json" crossorigin>
     <link rel="preload" as="track" href="./captions.vtt">
+    <link rel="prefetch" href="./lazy.js">
   </head>
   <body>
     <img src="./hero.png">
@@ -1034,7 +1037,8 @@ body {
   </body>
 </html>`,
       "/mod.js": `console.log("mod");`,
-      "/preloaded.js": `console.log("preloaded");`,
+      "/preloaded.js": `globalThis.PRELOADED_RAN = true;`,
+      "/lazy.js": `globalThis.LAZY_RAN = true;`,
       "/hero.png": "PNG",
       "/data.json": `{"k":1}`,
       "/captions.vtt": "WEBVTT",
@@ -1050,6 +1054,7 @@ body {
       expect(html).not.toContain('href="./preloaded.js"');
       expect(html).not.toContain('href="./data.json"');
       expect(html).not.toContain('href="./captions.vtt"');
+      expect(html).not.toContain('href="./lazy.js"');
 
       // prefetch: asset is copied + hashed and the href is rewritten.
       expect(html).toMatch(/<link rel="prefetch" href="[^"]*hero-[a-z0-9]+\.png">/);
@@ -1058,28 +1063,64 @@ body {
       expect(html).toMatch(/<link rel="preload" as="fetch" href="[^"]*data-[a-z0-9]+\.json" crossorigin>/);
       expect(html).toMatch(/<link rel="preload" as="track" href="[^"]*captions-[a-z0-9]+\.vtt">/);
 
-      // modulepreload / preload as=script: the referenced module is bundled into the
-      // entry chunk, so the hint tag is dropped (there is no separate file to preload).
+      // modulepreload of ./mod.js: the module is also pulled in via <script src>, so
+      // it is bundled and the hint is dropped (there is no separate file to preload).
       expect(html).not.toMatch(/rel="modulepreload"/);
-      expect(html).not.toMatch(/as="script"/);
+
+      // preload as=script / prefetch of JS not otherwise referenced: emitted as a
+      // separate hashed file and the href is rewritten. The browser fetches but
+      // never executes, matching the source-page semantics.
+      expect(html).toMatch(/<link rel="preload" as="script" href="[^"]*preloaded-[a-z0-9]+\.js">/);
+      expect(html).toMatch(/<link rel="prefetch" href="[^"]*lazy-[a-z0-9]+\.js">/);
 
       // The emitted files exist and carry the original bytes.
       const hero = html.match(/href="(?:\.\/|\/)?(hero-[a-z0-9]+\.png)"/);
       const data = html.match(/href="(?:\.\/|\/)?(data-[a-z0-9]+\.json)"/);
       const vtt = html.match(/href="(?:\.\/|\/)?(captions-[a-z0-9]+\.vtt)"/);
+      const preloaded = html.match(/href="(?:\.\/|\/)?(preloaded-[a-z0-9]+\.js)"/);
+      const lazy = html.match(/href="(?:\.\/|\/)?(lazy-[a-z0-9]+\.js)"/);
       expect(hero).not.toBeNull();
       expect(data).not.toBeNull();
       expect(vtt).not.toBeNull();
+      expect(preloaded).not.toBeNull();
+      expect(lazy).not.toBeNull();
       api.expectFile("out/" + hero![1]).toBe("PNG");
       api.expectFile("out/" + data![1]).toBe(`{"k":1}`);
       api.expectFile("out/" + vtt![1]).toBe("WEBVTT");
+      api.expectFile("out/" + preloaded![1]).toBe(`globalThis.PRELOADED_RAN = true;`);
+      api.expectFile("out/" + lazy![1]).toBe(`globalThis.LAZY_RAN = true;`);
 
-      // Both preloaded scripts end up in the single entry JS chunk.
+      // The entry JS chunk contains only mod.js. Resource-hint JS is never
+      // bundled/executed: PRELOADED_RAN / LAZY_RAN must not be in the chunk.
       const js = html.match(/src="(?:\.\/|\/)?(index-[a-z0-9]+\.js)"/);
       expect(js).not.toBeNull();
       const jsContent = api.readFile("out/" + js![1]);
       expect(jsContent).toContain('"mod"');
-      expect(jsContent).toContain('"preloaded"');
+      expect(jsContent).not.toContain("PRELOADED_RAN");
+      expect(jsContent).not.toContain("LAZY_RAN");
+    },
+  });
+
+  // Resource-hint hrefs that do not resolve to a local file (navigation routes)
+  // pass through untouched instead of failing the build.
+  itBundled("html/link-hint-unresolved", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="prefetch" href="/dashboard">
+    <link rel="modulepreload" href="https://cdn.example.com/lib.js">
+  </head>
+  <body></body>
+</html>`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      expect(html).toContain('<link rel="prefetch" href="/dashboard">');
+      expect(html).toContain('<link rel="modulepreload" href="https://cdn.example.com/lib.js">');
     },
   });
 });

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1011,4 +1011,75 @@ body {
       expect(htmlContent).toMatch(/href=".*\.webmanifest"/);
     },
   });
+
+  // <link rel="prefetch">, <link rel="modulepreload"> and <link rel="preload"> with
+  // as={script,fetch,track,document,embed,object} must not ship dangling source-path
+  // hrefs. Assets are emitted + hashed; JS preloads are folded into the entry chunk.
+  itBundled("html/link-preload-prefetch", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="prefetch" href="./hero.png">
+    <link rel="modulepreload" href="./mod.js">
+    <link rel="preload" as="script" href="./preloaded.js">
+    <link rel="preload" as="fetch" href="./data.json" crossorigin>
+    <link rel="preload" as="track" href="./captions.vtt">
+  </head>
+  <body>
+    <img src="./hero.png">
+    <script type="module" src="./mod.js"></script>
+  </body>
+</html>`,
+      "/mod.js": `console.log("mod");`,
+      "/preloaded.js": `console.log("preloaded");`,
+      "/hero.png": "PNG",
+      "/data.json": `{"k":1}`,
+      "/captions.vtt": "WEBVTT",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+
+      // No raw source paths should survive in the output; every one of these
+      // would have been a guaranteed 404 before.
+      expect(html).not.toContain('href="./hero.png"');
+      expect(html).not.toContain('href="./mod.js"');
+      expect(html).not.toContain('href="./preloaded.js"');
+      expect(html).not.toContain('href="./data.json"');
+      expect(html).not.toContain('href="./captions.vtt"');
+
+      // prefetch: asset is copied + hashed and the href is rewritten.
+      expect(html).toMatch(/<link rel="prefetch" href="[^"]*hero-[a-z0-9]+\.png">/);
+
+      // preload as=fetch / as=track: assets are copied + hashed and the href is rewritten.
+      expect(html).toMatch(/<link rel="preload" as="fetch" href="[^"]*data-[a-z0-9]+\.json" crossorigin>/);
+      expect(html).toMatch(/<link rel="preload" as="track" href="[^"]*captions-[a-z0-9]+\.vtt">/);
+
+      // modulepreload / preload as=script: the referenced module is bundled into the
+      // entry chunk, so the hint tag is dropped (there is no separate file to preload).
+      expect(html).not.toMatch(/rel="modulepreload"/);
+      expect(html).not.toMatch(/as="script"/);
+
+      // The emitted files exist and carry the original bytes.
+      const hero = html.match(/href="(?:\.\/|\/)?(hero-[a-z0-9]+\.png)"/);
+      const data = html.match(/href="(?:\.\/|\/)?(data-[a-z0-9]+\.json)"/);
+      const vtt = html.match(/href="(?:\.\/|\/)?(captions-[a-z0-9]+\.vtt)"/);
+      expect(hero).not.toBeNull();
+      expect(data).not.toBeNull();
+      expect(vtt).not.toBeNull();
+      api.expectFile("out/" + hero![1]).toBe("PNG");
+      api.expectFile("out/" + data![1]).toBe(`{"k":1}`);
+      api.expectFile("out/" + vtt![1]).toBe("WEBVTT");
+
+      // Both preloaded scripts end up in the single entry JS chunk.
+      const js = html.match(/src="(?:\.\/|\/)?(index-[a-z0-9]+\.js)"/);
+      expect(js).not.toBeNull();
+      const jsContent = api.readFile("out/" + js![1]);
+      expect(jsContent).toContain('"mod"');
+      expect(jsContent).toContain('"preloaded"');
+    },
+  });
 });

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1084,6 +1084,43 @@ body {
     },
   });
 
+  // A resource hint targeting a local .html file must be emitted as a raw asset,
+  // not parsed as a nested HTML entry (which would pull its scripts into the
+  // entry chunk).
+  itBundled("html/link-hint-local-html", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="prefetch" href="./page2.html">
+    <link rel="preload" as="document" href="./frame.html">
+  </head>
+  <body><h1>Index</h1></body>
+</html>`,
+      "/page2.html": `<!doctype html><script src="./page2-script.js"></script><h1>Page 2</h1>`,
+      "/frame.html": `<!doctype html><h1>Frame</h1>`,
+      "/page2-script.js": `console.log("PAGE2_SCRIPT");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      expect(html).not.toContain('href="./page2.html"');
+      expect(html).not.toContain('href="./frame.html"');
+      expect(html).toMatch(/<link rel="prefetch" href="[^"]*page2-[a-z0-9]+\.html">/);
+      expect(html).toMatch(/<link rel="preload" as="document" href="[^"]*frame-[a-z0-9]+\.html">/);
+
+      // page2.html's <script> must not leak into index.html's entry chunk.
+      const js = html.match(/src="(?:\.\/|\/)?(index-[a-z0-9]+\.js)"/);
+      if (js) expect(api.readFile("out/" + js[1])).not.toContain("PAGE2_SCRIPT");
+
+      const page2 = html.match(/href="(?:\.\/|\/)?(page2-[a-z0-9]+\.html)"/);
+      expect(page2).not.toBeNull();
+      api.expectFile("out/" + page2![1]).toContain("<h1>Page 2</h1>");
+    },
+  });
+
   // Resource-hint hrefs that do not resolve to a local file (navigation routes,
   // API endpoints, external URLs) pass through untouched instead of failing the
   // build.

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1122,6 +1122,35 @@ body {
     },
   });
 
+  // A resource hint targeting a sibling HTML entry point must not add a
+  // reachability edge that pulls the sibling's scripts into this entry's chunk.
+  itBundled("html/link-hint-sibling-entry", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head><link rel="prefetch" href="./page2.html"></head>
+  <body><script src="./index-script.js"></script></body>
+</html>`,
+      "/page2.html": `<!doctype html><script src="./page2-script.js"></script><h1>Page 2</h1>`,
+      "/index-script.js": `console.log("INDEX_SCRIPT");`,
+      "/page2-script.js": `console.log("PAGE2_SCRIPT");`,
+    },
+    entryPoints: ["/index.html", "/page2.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const js = html.match(/src="(?:\.\/|\/)?(index-[a-z0-9]+\.js)"/);
+      expect(js).not.toBeNull();
+      const jsContent = api.readFile("out/" + js![1]);
+      expect(jsContent).toContain("INDEX_SCRIPT");
+      expect(jsContent).not.toContain("PAGE2_SCRIPT");
+      // page2.html is emitted under its own entry-point name, so the original
+      // href is already a valid output path.
+      expect(html).toContain('<link rel="prefetch" href="./page2.html">');
+    },
+  });
+
   // Resource-hint hrefs that do not resolve to a local file (navigation routes,
   // API endpoints, external URLs) pass through untouched instead of failing the
   // build.


### PR DESCRIPTION
## Problem

`bun build ./index.html` only rewrites `<link href>` for a fixed allowlist of `rel`/`as` values. Any `<link>` outside that list keeps its original source path in the output, which is a guaranteed 404 because the target was either emitted under a hashed name or bundled into the entry chunk.

```sh
$ cat index.html
<link rel="prefetch" href="./i.png">
<link rel="modulepreload" href="./a.js">
<link rel="preload" as="script" href="./b.js">
<link rel="preload" as="fetch" href="./data.json" crossorigin>
<img src="./i.png"><script type="module" src="./a.js"></script>

$ bun build ./index.html --outdir=out && grep -oE '(src|href)="[^"]*"' out/index.html
href="./i.png"        # 404 (file emitted as i-<hash>.png)
href="./a.js"         # 404 (bundled into index-<hash>.js)
href="./b.js"         # 404 (never emitted)
href="./data.json"    # 404 (never emitted)
src="./i-53dyeqnw.png"
src="./index-fjf1hdtz.js"
```

This contradicts `docs/bundler/html-static`: "Any `<link>` tag with an `href` attribute pointing to a local file is rewritten to the new path, and hashed".

## Fix

Add four resource-hint entries to `TAG_HANDLERS` in `src/bundler/HTMLScanner.rs` covering `rel=prefetch`, `rel=modulepreload`, `as=script`, and `as=fetch|track|document|embed|object`. These use a new `TagHandler::hint` constructor that sets `ImportRecordFlags::WAS_HTML_RESOURCE_HINT` and `HANDLES_IMPORT_ERRORS` on the record.

Behaviour per target type:

- **Non-code assets** (images, JSON, VTT, etc.): the existing `ImportKind::Url` path emits the file with a content hash and the `href` is rewritten to the output path.
- **JS/CSS targets**: bundled into the entry chunk with the native loader and the hint tag is dropped. This keeps the canonical modulepreload pattern working: `<link rel=modulepreload href=./dep.js>` + `<script src=./main.js>` where `main.js` imports `dep.js` bundles `dep.js` as JS (covered by `html/link-preload-prefetch`).
- **`.html` targets**: emitted as raw hashed assets (the existing `Url`->`File` override now also fires for `Loader::Html` when `WAS_HTML_RESOURCE_HINT` is set), so `<link rel=prefetch href=./page2.html>` is copied verbatim with a rewritten href instead of being parsed as a nested HTML entry (`html/link-hint-local-html`). In dev-server mode these records skip the "Browser builds cannot import HTML files" guard and pass through untouched (`test/bake/dev/html.test.ts`).
- **Sibling HTML entry points**: a hint record whose `path_to_source_index_map` lookup hits an `Html`-loaded slot is marked disabled so the reachability walk does not follow it, and the href passes through (the sibling is emitted under its own entry-point name, so the original href is already a valid output path; `html/link-hint-sibling-entry`).
- **Unresolvable hrefs** (navigation routes like `/dashboard`, API endpoints like `/api/user`, external URLs, protocol-relative URLs): `HANDLES_IMPORT_ERRORS` lets these pass through untouched instead of failing the build (`html/link-hint-unresolved`).

Output for the repro above:

```html
<link rel="prefetch" href="./i-53dyeqnw.png">
<link rel="preload" as="fetch" href="./data-jq8ssgva.json" crossorigin>
<img src="./i-53dyeqnw.png">
<script type="module" crossorigin src="./index-t1rzg9pe.js"></script>
```

(`modulepreload` and `as=script` tags are dropped because their targets are in the entry chunk.)

## Trade-offs

Both stem from the resolve pipeline's first-wins loader pinning; fixing them requires deferring hint-only `ParseTask`s until the module graph is complete, which is a larger change than this 404 fix warrants.

- A hint whose JS target is not otherwise referenced (`<link rel="preload" as="script" href="./unused.js">` with no `<script src>` and no transitive import) is bundled into the entry chunk, matching the existing `link[as=worker]` handler.
- A hint whose `.json`/`.toml`/text target is also statically imported from JS (`<link rel=preload as=fetch href=./data.json>` + `import data from './data.json'`) pins the file to `Loader::File` via the pre-existing `Url`->`File` override, so the JS import sees the emitted path string instead of the parsed object. The `as=fetch` hint is for `fetch()` calls; a static import is bundled and needs no preload hint.

## Verification

New `html/link-preload-prefetch`, `html/link-hint-local-html`, `html/link-hint-sibling-entry`, and `html/link-hint-unresolved` cases in `test/bundler/bundler_html.test.ts`, plus a dev-server pass-through case in `test/bake/dev/html.test.ts`. All 22 existing `bundler_html` cases still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/html.test.ts test/bundler/bundler_html.test.ts
bun test v1.4.0 (378ad584b)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [610.23ms]
(pass) bundler > html/implicit-relative-paths [109.39ms]
(pass) bundler > html/multiple-assets [129.45ms]
(pass) bundler > html/image-hashing [135.24ms]
(pass) bundler > html/external-assets [116.69ms]
(pass) bundler > html/mixed-assets [124.96ms]
(pass) bundler > html/js-imports [120.52ms]
(pass) bundler > html/css-imports [141.88ms]
(pass) bundler > html/multiple-entries [156.31ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [159.92ms]
(pass) bundler > html/shared-chunks [159.40ms]
(pass) bundler > html/js-importing-html [110.57ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [110.80ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [200.04ms]
(pass) bundler > html/circular-js-html [116.57ms]
(pass) bundler > html/css-
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (2d2add3db)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [35.25ms]
(pass) bundler > html/implicit-relative-paths [5.79ms]
(pass) bundler > html/multiple-assets [5.03ms]
(pass) bundler > html/image-hashing [4.85ms]
(pass) bundler > html/external-assets [3.82ms]
(pass) bundler > html/mixed-assets [10.45ms]
(pass) bundler > html/js-imports [5.30ms]
(pass) bundler > html/css-imports [4.41ms]
(pass) bundler > html/multiple-entries [4.94ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [7.05ms]
(pass) bundler > html/shared-chunks [6.20ms]
(pass) bundler > html/js-importing-html [3.64ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [3.90ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [3.60ms]
(pass) bundler > html/circular-js-html [3.40ms]
(pass) bundler > html/css-only [5.92ms]
(pass) bundler > html/absolute-paths [4.28ms]
(pass) bundler > html/no-sourcemap-comments [4.55ms]
(pass) bundler > html/no-sourcemap-comments-inline [3.47ms]
(pass) bundler > html/SharedCSSProductio
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/html.test.ts test/bundler/bundler_html.test.ts
bun test v1.4.0 (378ad584b)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [553.80ms]
(pass) bundler > html/implicit-relative-paths [111.26ms]
(pass) bundler > html/multiple-assets [113.24ms]
(pass) bundler > html/image-hashing [101.57ms]
(pass) bundler > html/external-assets [101.68ms]
(pass) bundler > html/mixed-assets [119.04ms]
(pass) bundler > html/js-imports [136.87ms]
(pass) bundler > html/css-imports [132.35ms]
(pass) bundler > html/multiple-entries [178.61ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [168.13ms]
(pass) bundler > html/shared-chunks [153.73ms]
(pass) bundler > html/js-importing-html [116.47ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [124.70ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [144.09ms]
(pass) bundler > html/circular-js-html [113.38ms]
(pass) bundler > html/css-
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 716ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/import_record.rs                           |   4 +
 src/bundler/HTMLScanner.rs                         |  76 +++++----
 src/bundler/bundle_v2.rs                           |  27 +++-
 .../generateCompileResultForHtmlChunk.rs           |  19 +--
 test/bake/dev/html.test.ts                         |  26 +++
 test/bundler/bundler_html.test.ts                  | 174 +++++++++++++++++++++
 6 files changed, 282 insertions(+), 44 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/ast/import_record.rs                                      3      4      0
src/bundler/HTMLScanner.rs                                    4     11      0
src/bundler/bundle_v2.rs                                     14     12      0
…ler/linker_context/generateCompileResultForHtmlChunk.rs      2      4      0
test/bake/dev/html.test.ts                                    2      3      0
test/bundler/bundler_html.test.ts                             5     10      0
```

</details>

<!-- robobun:evidence:end -->