### PR TITLE
bundler(html): fix asset-URL classification and emit contract

### DIFF
--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -34,38 +34,41 @@ impl<'a> HTMLScanner<'a> {
     fn create_import_record(&mut self, input_path: &[u8], kind: ImportKind) -> Result<(), Error> {
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
-        let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
-            resolve_path::join_abs_string::<platform::Auto>(
-                fs::FileSystem::instance().top_level_dir,
-                &[&input_path[1..]],
-            )
-        }
-        // Check if imports to (e.g) "App.tsx" are actually relative imoprts w/o the "./"
-        else if input_path.len() > 2 && input_path[0] != b'.' && input_path[1] != b'/' {
-            'blk: {
-                let Some(index_of_dot) = input_path.iter().rposition(|&b| b == b'.') else {
-                    break 'blk input_path;
-                };
-                let ext = &input_path[index_of_dot..];
-                if ext.len() > 4 {
-                    break 'blk input_path;
-                }
-                // /foo/bar/index.html -> /foo/bar
-                let dirname = resolve_path::dirname::<platform::Auto>(self.source.path.text());
-                if dirname.is_empty() {
-                    break 'blk input_path;
-                }
-                let resolved =
-                    resolve_path::join_abs_string_z::<platform::Auto>(dirname, &[input_path]);
-                if sys::exists_z(resolved) {
-                    resolved.as_bytes()
-                } else {
-                    input_path
-                }
+        // A leading `//` is a protocol-relative URL, not a rooted path; leave it for the
+        // resolver's own `starts_with("//")` external rule.
+        let path_to_use: &[u8] =
+            if input_path.len() > 1 && input_path[0] == b'/' && input_path[1] != b'/' {
+                resolve_path::join_abs_string::<platform::Auto>(
+                    fs::FileSystem::instance().top_level_dir,
+                    &[&input_path[1..]],
+                )
             }
-        } else {
-            input_path
-        };
+            // Check if imports to (e.g) "App.tsx" are actually relative imoprts w/o the "./"
+            else if input_path.len() > 2 && input_path[0] != b'.' && input_path[1] != b'/' {
+                'blk: {
+                    let Some(index_of_dot) = input_path.iter().rposition(|&b| b == b'.') else {
+                        break 'blk input_path;
+                    };
+                    let ext = &input_path[index_of_dot..];
+                    if ext.len() > 4 {
+                        break 'blk input_path;
+                    }
+                    // /foo/bar/index.html -> /foo/bar
+                    let dirname = resolve_path::dirname::<platform::Auto>(self.source.path.text());
+                    if dirname.is_empty() {
+                        break 'blk input_path;
+                    }
+                    let resolved =
+                        resolve_path::join_abs_string_z::<platform::Auto>(dirname, &[input_path]);
+                    if sys::exists_z(resolved) {
+                        resolved.as_bytes()
+                    } else {
+                        input_path
+                    }
+                }
+            } else {
+                input_path
+            };
 
         let owned: &'static [u8] =
             Box::leak(AstAlloc::vec_from_slice(path_to_use).into_boxed_slice());
@@ -103,7 +106,12 @@ impl<'a> HTMLScanner<'a> {
         url_attribute: &[u8],
         kind: ImportKind,
     ) {
-        let _ = url_attribute;
+        if url_attribute == b"srcset" {
+            for (url, _) in SrcSetIter::new(path) {
+                let _ = self.create_import_record(url, kind);
+            }
+            return;
+        }
         let _ = self.create_import_record(path, kind);
     }
 
@@ -163,6 +171,77 @@ impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
 }
 
 pub(crate) struct HTMLProcessor<T, const VISIT_DOCUMENT_TAGS: bool>(PhantomData<T>);
+
+/// Walks an HTML `srcset` attribute yielding `(url, descriptor)` per candidate,
+/// per the WHATWG image-candidate-string grammar. The scan and rewrite passes
+/// both drive this so their import-record counts stay 1:1.
+pub(crate) struct SrcSetIter<'a> {
+    rest: &'a [u8],
+}
+
+impl<'a> SrcSetIter<'a> {
+    pub(crate) fn new(value: &'a [u8]) -> Self {
+        Self { rest: value }
+    }
+
+    #[inline]
+    fn is_ascii_ws(b: u8) -> bool {
+        matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0C)
+    }
+}
+
+impl<'a> Iterator for SrcSetIter<'a> {
+    /// `(url, descriptor)`; `descriptor` is `b""` when absent.
+    type Item = (&'a [u8], &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Skip leading whitespace and commas.
+        let mut i = 0;
+        while i < self.rest.len() && (Self::is_ascii_ws(self.rest[i]) || self.rest[i] == b',') {
+            i += 1;
+        }
+        self.rest = &self.rest[i..];
+        if self.rest.is_empty() {
+            return None;
+        }
+        // URL runs until whitespace.
+        let mut url_end = 0;
+        while url_end < self.rest.len() && !Self::is_ascii_ws(self.rest[url_end]) {
+            url_end += 1;
+        }
+        // Per spec, trailing commas terminate the candidate (they are not part of the URL).
+        let mut url_trim = url_end;
+        while url_trim > 0 && self.rest[url_trim - 1] == b',' {
+            url_trim -= 1;
+        }
+        let url = &self.rest[..url_trim];
+        // If the URL itself ended in a comma there is no descriptor.
+        if url_trim < url_end {
+            self.rest = &self.rest[url_end..];
+            return Some((url, b""));
+        }
+        // Descriptor runs until the next comma.
+        let mut desc_start = url_end;
+        while desc_start < self.rest.len() && Self::is_ascii_ws(self.rest[desc_start]) {
+            desc_start += 1;
+        }
+        let mut desc_end = desc_start;
+        while desc_end < self.rest.len() && self.rest[desc_end] != b',' {
+            desc_end += 1;
+        }
+        let mut desc_trim = desc_end;
+        while desc_trim > desc_start && Self::is_ascii_ws(self.rest[desc_trim - 1]) {
+            desc_trim -= 1;
+        }
+        let descriptor = &self.rest[desc_start..desc_trim];
+        self.rest = if desc_end < self.rest.len() {
+            &self.rest[desc_end + 1..]
+        } else {
+            &self.rest[desc_end..]
+        };
+        Some((url, descriptor))
+    }
+}
 
 #[derive(Clone, Copy)]
 pub struct TagHandler {

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -169,80 +169,58 @@ impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
 
 pub(crate) struct HTMLProcessor<T, const VISIT_DOCUMENT_TAGS: bool>(PhantomData<T>);
 
-/// Yields `(url, descriptor)` per `srcset` candidate; scan and rewrite both
-/// use this so their per-candidate import-record counts stay 1:1.
-pub(crate) struct SrcSetIter<'a> {
-    rest: &'a [u8],
-}
+/// `(url, descriptor)` per `srcset` candidate; scan and rewrite both use this so their record counts stay 1:1.
+pub(crate) struct SrcSetIter<'a>(&'a [u8]);
 
 impl<'a> SrcSetIter<'a> {
     pub(crate) fn new(value: &'a [u8]) -> Self {
-        Self { rest: value }
-    }
-
-    #[inline]
-    fn is_ascii_ws(b: u8) -> bool {
-        matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0C)
+        Self(value)
     }
 }
 
 impl<'a> Iterator for SrcSetIter<'a> {
-    /// `(url, descriptor)`; `descriptor` is `b""` when absent.
     type Item = (&'a [u8], &'a [u8]);
-
     fn next(&mut self) -> Option<Self::Item> {
-        // Skip leading whitespace and commas.
-        let mut i = 0;
-        while i < self.rest.len() && (Self::is_ascii_ws(self.rest[i]) || self.rest[i] == b',') {
-            i += 1;
+        let ws = u8::is_ascii_whitespace;
+        let s = &mut self.0;
+        while s.first().is_some_and(|b| ws(b) || *b == b',') {
+            *s = &s[1..];
         }
-        self.rest = &self.rest[i..];
-        if self.rest.is_empty() {
+        if s.is_empty() {
             return None;
         }
-        // URL runs until whitespace.
-        let mut url_end = 0;
-        while url_end < self.rest.len() && !Self::is_ascii_ws(self.rest[url_end]) {
-            url_end += 1;
-        }
-        // Per spec, trailing commas terminate the candidate (they are not part of the URL).
-        let mut url_trim = url_end;
-        while url_trim > 0 && self.rest[url_trim - 1] == b',' {
-            url_trim -= 1;
-        }
-        let url = &self.rest[..url_trim];
-        // If the URL itself ended in a comma there is no descriptor.
+        let url_end = s.iter().position(ws).unwrap_or(s.len());
+        let url_trim = s[..url_end]
+            .iter()
+            .rposition(|&b| b != b',')
+            .map_or(0, |i| i + 1);
+        let url = &s[..url_trim];
         if url_trim < url_end {
-            self.rest = &self.rest[url_end..];
+            *s = &s[url_end..];
             return Some((url, b""));
         }
-        // Descriptor runs until the next top-level comma (a comma inside `(...)` is part of the descriptor).
-        let mut desc_start = url_end;
-        while desc_start < self.rest.len() && Self::is_ascii_ws(self.rest[desc_start]) {
-            desc_start += 1;
+        let mut i = url_end;
+        while s.get(i).is_some_and(ws) {
+            i += 1;
         }
-        let mut desc_end = desc_start;
+        let desc_start = i;
         let mut depth: u32 = 0;
-        while desc_end < self.rest.len() {
-            match self.rest[desc_end] {
+        while let Some(&b) = s.get(i) {
+            match b {
                 b',' if depth == 0 => break,
                 b'(' => depth += 1,
                 b')' => depth = depth.saturating_sub(1),
                 _ => {}
             }
-            desc_end += 1;
+            i += 1;
         }
-        let mut desc_trim = desc_end;
-        while desc_trim > desc_start && Self::is_ascii_ws(self.rest[desc_trim - 1]) {
-            desc_trim -= 1;
-        }
-        let descriptor = &self.rest[desc_start..desc_trim];
-        self.rest = if desc_end < self.rest.len() {
-            &self.rest[desc_end + 1..]
-        } else {
-            &self.rest[desc_end..]
-        };
-        Some((url, descriptor))
+        let desc = &s[desc_start
+            ..s[desc_start..i]
+                .iter()
+                .rposition(|b| !ws(b))
+                .map_or(desc_start, |j| desc_start + j + 1)];
+        *s = s.get(i + 1..).unwrap_or(b"");
+        Some((url, desc))
     }
 }
 

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -32,10 +32,7 @@ impl<'a> HTMLScanner<'a> {
 
 impl<'a> HTMLScanner<'a> {
     fn create_import_record(&mut self, input_path: &[u8], kind: ImportKind) -> Result<(), Error> {
-        // In HTML, sometimes people do /src/index.js
-        // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
-        // A leading `//` is a protocol-relative URL, not a rooted path; leave it for the
-        // resolver's own `starts_with("//")` external rule.
+        // `/src/x.js` is project-root-relative; `//host/x.js` is protocol-relative (external).
         let path_to_use: &[u8] =
             if input_path.len() > 1 && input_path[0] == b'/' && input_path[1] != b'/' {
                 resolve_path::join_abs_string::<platform::Auto>(
@@ -172,9 +169,8 @@ impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
 
 pub(crate) struct HTMLProcessor<T, const VISIT_DOCUMENT_TAGS: bool>(PhantomData<T>);
 
-/// Walks an HTML `srcset` attribute yielding `(url, descriptor)` per candidate,
-/// per the WHATWG image-candidate-string grammar. The scan and rewrite passes
-/// both drive this so their import-record counts stay 1:1.
+/// Yields `(url, descriptor)` per `srcset` candidate; scan and rewrite both
+/// use this so their per-candidate import-record counts stay 1:1.
 pub(crate) struct SrcSetIter<'a> {
     rest: &'a [u8],
 }

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -216,13 +216,20 @@ impl<'a> Iterator for SrcSetIter<'a> {
             self.rest = &self.rest[url_end..];
             return Some((url, b""));
         }
-        // Descriptor runs until the next comma.
+        // Descriptor runs until the next top-level comma (a comma inside `(...)` is part of the descriptor).
         let mut desc_start = url_end;
         while desc_start < self.rest.len() && Self::is_ascii_ws(self.rest[desc_start]) {
             desc_start += 1;
         }
         let mut desc_end = desc_start;
-        while desc_end < self.rest.len() && self.rest[desc_end] != b',' {
+        let mut depth: u32 = 0;
+        while desc_end < self.rest.len() {
+            match self.rest[desc_end] {
+                b',' if depth == 0 => break,
+                b'(' => depth += 1,
+                b')' => depth = depth.saturating_sub(1),
+                _ => {}
+            }
             desc_end += 1;
         }
         let mut desc_trim = desc_end;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4170,67 +4170,21 @@ pub mod bv2_impl {
                 }
 
                 // Distinct-content asset collisions on one output path are a hard error; identical content is benign.
-                {
-                    let mut seen: bun_collections::StringHashMap<(u64, usize)> =
-                        bun_collections::StringHashMap::default();
-                    let mut duplicates: bun_collections::StringArrayHashMap<Vec<usize>> =
-                        bun_collections::StringArrayHashMap::default();
-                    for (i, out) in additional_output_files.iter().enumerate() {
-                        let gop = seen.get_or_put(&out.dest_path)?;
-                        if !gop.found_existing {
-                            *gop.value_ptr = (out.hash, i);
-                            continue;
-                        }
-                        let (prev_hash, prev_i) = *gop.value_ptr;
-                        if prev_hash == out.hash {
-                            continue;
-                        }
-                        let dup = duplicates.get_or_put(&out.dest_path)?;
-                        if !dup.found_existing {
-                            dup.value_ptr.push(prev_i);
-                        }
-                        dup.value_ptr.push(i);
-                    }
-                    if duplicates.count() > 0 {
-                        let mut msg: Vec<u8> = Vec::new();
-                        let _ = writeln!(&mut msg, "Multiple files share the same output path");
-                        for (path, indices) in duplicates.keys().iter().zip(duplicates.values()) {
-                            let _ = writeln!(&mut msg, "  {}:", bstr::BStr::new(path));
-                            for &j in indices {
-                                let pretty: &[u8] = additional_output_files[j]
-                                    .source_index
-                                    .get()
-                                    .map(|i| sources[i.get() as usize].path.pretty)
-                                    .unwrap_or(additional_output_files[j].src_path.text);
-                                let _ = writeln!(
-                                    &mut msg,
-                                    "    from input {}",
-                                    bstr::BStr::new(pretty)
-                                );
-                            }
-                        }
-                        self.transpiler
-                            .log_mut()
-                            .add_error(None, bun_ast::Loc::EMPTY, msg);
-                        let template = &self.transpiler.options.asset_naming;
-                        if !template.is_empty() {
-                            let mut note: Vec<u8> = Vec::new();
-                            let _ = write!(
-                                &mut note,
-                                "asset naming is '{}', consider adding '[hash]' to make filenames unique",
-                                bstr::BStr::new(template),
-                            );
-                            self.transpiler.log_mut().add_msg(bun_ast::Msg {
-                                kind: bun_ast::Kind::Note,
-                                data: bun_ast::Data {
-                                    text: std::borrow::Cow::Owned(note),
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            });
-                        }
+                let mut seen: bun_collections::StringHashMap<u64> = Default::default();
+                for out in &additional_output_files {
+                    let gop = seen.get_or_put(&out.dest_path)?;
+                    if gop.found_existing && *gop.value_ptr != out.hash {
+                        self.transpiler.log_mut().add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!(
+                                "Multiple files share the same output path: {}\nConsider adding \"[hash]\" to --asset-naming",
+                                bstr::BStr::new(&out.dest_path),
+                            ),
+                        );
                         return Err(Error::DuplicateOutputPath);
                     }
+                    *gop.value_ptr = out.hash;
                 }
 
                 self.graph.additional_output_files = additional_output_files;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1794,9 +1794,7 @@ pub mod bv2_impl {
                             let import_record = &self.all_import_records
                                 [import_record_list_id.get() as usize]
                                 .as_slice()[ir_idx];
-                            // A CSS importer will inline the file as a data: URI; any other
-                            // importer (JS, HTML, ...) needs the asset emitted on disk, so
-                            // treat every non-CSS reference as a copy-forcing context.
+                            // CSS inlines as data:; any non-CSS importer (JS, HTML) forces on-disk emission.
                             let is_inlined = import_record.source_index.is_valid()
                                 && !self.all_urls_for_css
                                     [import_record.source_index.get() as usize]
@@ -4172,9 +4170,7 @@ pub mod bv2_impl {
                     }
                 }
 
-                // Distinct-content collisions on the same output path are last-writer-wins on
-                // disk; surface them as the same hard error the chunk pass emits. Identical
-                // content mapping to one path is benign and left alone.
+                // Distinct-content asset collisions on one output path are a hard error; identical content is benign.
                 {
                     let mut seen: bun_collections::StringHashMap<(u64, usize)> =
                         bun_collections::StringHashMap::default();

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1744,7 +1744,6 @@ pub mod bv2_impl {
                     }
                 }
 
-                let is_js = self.all_loaders[source_index.get() as usize].is_javascript_like();
                 let is_css = self.all_loaders[source_index.get() as usize].is_css();
 
                 let import_record_list_id = source_index;
@@ -1795,17 +1794,21 @@ pub mod bv2_impl {
                             let import_record = &self.all_import_records
                                 [import_record_list_id.get() as usize]
                                 .as_slice()[ir_idx];
-                            // Mark if the file is imported by JS and its URL is inlined for CSS
+                            // A CSS importer will inline the file as a data: URI; any other
+                            // importer (JS, HTML, ...) needs the asset emitted on disk, so
+                            // treat every non-CSS reference as a copy-forcing context.
                             let is_inlined = import_record.source_index.is_valid()
                                 && !self.all_urls_for_css
                                     [import_record.source_index.get() as usize]
                                     .is_empty();
-                            if is_js && is_inlined {
-                                self.additional_files_imported_by_js_and_inlined_in_css
-                                    .set(import_record.source_index.get() as usize);
-                            } else if is_css && is_inlined {
-                                self.additional_files_imported_by_css_and_inlined
-                                    .set(import_record.source_index.get() as usize);
+                            if is_inlined {
+                                if is_css {
+                                    self.additional_files_imported_by_css_and_inlined
+                                        .set(import_record.source_index.get() as usize);
+                                } else {
+                                    self.additional_files_imported_by_js_and_inlined_in_css
+                                        .set(import_record.source_index.get() as usize);
+                                }
                             }
 
                             let next_source = import_record.source_index;
@@ -4166,6 +4169,60 @@ pub mod bv2_impl {
                         additional_files[index].push(crate::AdditionalFile::OutputFile(
                             (additional_output_files.len() - 1) as u32,
                         ));
+                    }
+                }
+
+                // Distinct-content collisions on the same output path are last-writer-wins on
+                // disk; surface them as the same hard error the chunk pass emits. Identical
+                // content mapping to one path is benign and left alone.
+                {
+                    let mut seen: bun_collections::StringHashMap<(u64, usize)> =
+                        bun_collections::StringHashMap::default();
+                    let mut had_collision = false;
+                    for (i, out) in additional_output_files.iter().enumerate() {
+                        let gop = seen.get_or_put(&out.dest_path)?;
+                        if !gop.found_existing {
+                            *gop.value_ptr = (out.hash, i);
+                            continue;
+                        }
+                        let (prev_hash, prev_i) = *gop.value_ptr;
+                        if prev_hash == out.hash {
+                            continue;
+                        }
+                        had_collision = true;
+                        let mut msg: Vec<u8> = Vec::new();
+                        let _ = writeln!(&mut msg, "Multiple files share the same output path");
+                        let _ = writeln!(&mut msg, "  {}:", bstr::BStr::new(&out.dest_path));
+                        for j in [prev_i, i] {
+                            let _ = writeln!(
+                                &mut msg,
+                                "    from input {}",
+                                bstr::BStr::new(additional_output_files[j].src_path.text)
+                            );
+                        }
+                        self.transpiler
+                            .log_mut()
+                            .add_error(None, bun_ast::Loc::EMPTY, msg);
+                        let template = &self.transpiler.options.asset_naming;
+                        if !template.is_empty() {
+                            let mut note: Vec<u8> = Vec::new();
+                            let _ = write!(
+                                &mut note,
+                                "asset naming is '{}', consider adding '[hash]' to make filenames unique",
+                                bstr::BStr::new(template),
+                            );
+                            self.transpiler.log_mut().add_msg(bun_ast::Msg {
+                                kind: bun_ast::Kind::Note,
+                                data: bun_ast::Data {
+                                    text: std::borrow::Cow::Owned(note),
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            });
+                        }
+                    }
+                    if had_collision {
+                        return Err(Error::DuplicateOutputPath);
                     }
                 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1643,7 +1643,7 @@ pub mod bv2_impl {
         pub scb_bitset: Option<DynamicBitSetUnmanaged>,
         pub scb_list: server_component_boundary::Slice<'a>,
 
-        /// Files which are imported by JS and inlined in CSS
+        /// Files inlined in CSS and also imported by a non-CSS source (JS, HTML)
         pub additional_files_imported_by_js_and_inlined_in_css: &'a mut DynamicBitSetUnmanaged,
         /// Files which are imported by CSS and inlined in CSS
         pub additional_files_imported_by_css_and_inlined: &'a mut DynamicBitSetUnmanaged,
@@ -1977,8 +1977,7 @@ pub mod bv2_impl {
             let content_hashes: &mut [u64] = input_files_cols.content_hash_for_additional_file;
             for (index, url_for_css) in all_urls_for_css.iter().enumerate() {
                 if !url_for_css.is_empty() {
-                    // We like to inline additional files in CSS if they fit a size threshold
-                    // If we do inline a file in CSS, and it is not imported by JS, then we don't need to copy the additional file into the output directory
+                    // A file inlined in CSS and not imported by any non-CSS source needn't be copied to the output directory.
                     if additional_files_imported_by_css_and_inlined.is_set(index)
                         && !additional_files_imported_by_js_and_inlined_in_css.is_set(index)
                     {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4198,10 +4198,15 @@ pub mod bv2_impl {
                         for (path, indices) in duplicates.keys().iter().zip(duplicates.values()) {
                             let _ = writeln!(&mut msg, "  {}:", bstr::BStr::new(path));
                             for &j in indices {
+                                let pretty: &[u8] = additional_output_files[j]
+                                    .source_index
+                                    .get()
+                                    .map(|i| sources[i.get() as usize].path.pretty)
+                                    .unwrap_or(additional_output_files[j].src_path.text);
                                 let _ = writeln!(
                                     &mut msg,
                                     "    from input {}",
-                                    bstr::BStr::new(additional_output_files[j].src_path.text)
+                                    bstr::BStr::new(pretty)
                                 );
                             }
                         }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4178,7 +4178,8 @@ pub mod bv2_impl {
                 {
                     let mut seen: bun_collections::StringHashMap<(u64, usize)> =
                         bun_collections::StringHashMap::default();
-                    let mut had_collision = false;
+                    let mut duplicates: bun_collections::StringArrayHashMap<Vec<usize>> =
+                        bun_collections::StringArrayHashMap::default();
                     for (i, out) in additional_output_files.iter().enumerate() {
                         let gop = seen.get_or_put(&out.dest_path)?;
                         if !gop.found_existing {
@@ -4189,16 +4190,24 @@ pub mod bv2_impl {
                         if prev_hash == out.hash {
                             continue;
                         }
-                        had_collision = true;
+                        let dup = duplicates.get_or_put(&out.dest_path)?;
+                        if !dup.found_existing {
+                            dup.value_ptr.push(prev_i);
+                        }
+                        dup.value_ptr.push(i);
+                    }
+                    if duplicates.count() > 0 {
                         let mut msg: Vec<u8> = Vec::new();
                         let _ = writeln!(&mut msg, "Multiple files share the same output path");
-                        let _ = writeln!(&mut msg, "  {}:", bstr::BStr::new(&out.dest_path));
-                        for j in [prev_i, i] {
-                            let _ = writeln!(
-                                &mut msg,
-                                "    from input {}",
-                                bstr::BStr::new(additional_output_files[j].src_path.text)
-                            );
+                        for (path, indices) in duplicates.keys().iter().zip(duplicates.values()) {
+                            let _ = writeln!(&mut msg, "  {}:", bstr::BStr::new(path));
+                            for &j in indices {
+                                let _ = writeln!(
+                                    &mut msg,
+                                    "    from input {}",
+                                    bstr::BStr::new(additional_output_files[j].src_path.text)
+                                );
+                            }
                         }
                         self.transpiler
                             .log_mut()
@@ -4220,8 +4229,6 @@ pub mod bv2_impl {
                                 ..Default::default()
                             });
                         }
-                    }
-                    if had_collision {
                         return Err(Error::DuplicateOutputPath);
                     }
                 }

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -126,8 +126,6 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
         _kind: ImportKind,
     ) {
         if url_attribute == b"srcset" {
-            // One import record per candidate URL, same split order as the scan
-            // pass. Rewrites the whole attribute so descriptors are preserved.
             let mut out: Vec<u8> = Vec::with_capacity(path.len());
             let mut remove = false;
             for (url, descriptor) in SrcSetIter::new(path) {
@@ -191,10 +189,8 @@ impl RewrittenUrl {
 }
 
 impl<'a> HTMLLoader<'a> {
-    /// Advances one import record and returns what to write for its attribute
-    /// value. `original` is the URL as it appeared in the source HTML; its
-    /// `?query`/`#fragment` suffix is re-appended to emitted asset references
-    /// (mirroring the CSS printer).
+    /// Advances one import record; re-appends `original`'s `?#` suffix to the
+    /// rewritten reference (mirroring the CSS printer).
     fn rewrite_one_url(&mut self, original: &[u8]) -> RewrittenUrl {
         if self.current_import_record_index as usize >= self.import_records.len() {
             bun_core::Output::panic(format_args!(
@@ -280,9 +276,7 @@ impl<'a> HTMLLoader<'a> {
         let url_for_css =
             parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
 
-        // Standalone HTML mode inlines assets as data: URIs. Otherwise prefer the
-        // emitted file's unique key, falling back to the data: URI when the asset
-        // was CSS-inlined-only, so the raw source path never reaches the output.
+        // Standalone mode inlines; otherwise the data: URI is only a fallback when no file was emitted.
         if !url_for_css.is_empty()
             && (self.compile_to_standalone_html || unique_key_for_additional_files.is_empty())
         {

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -127,11 +127,12 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     ) {
         if url_attribute == b"srcset" {
             let mut out: Vec<u8> = Vec::with_capacity(path.len());
-            let mut remove = false;
             for (url, descriptor) in SrcSetIter::new(path) {
                 let rewritten = self.rewrite_one_url(url);
                 if matches!(rewritten, RewrittenUrl::Remove) {
-                    remove = true;
+                    // Remove means "tag re-emitted elsewhere"; that never applies to an
+                    // <img>/<source>, so drop the one candidate instead of the element.
+                    continue;
                 }
                 if !out.is_empty() {
                     out.extend_from_slice(b", ");
@@ -142,9 +143,7 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
                     out.extend_from_slice(descriptor);
                 }
             }
-            if remove {
-                element.remove();
-            } else if out != path {
+            if out != path {
                 set_attribute(element, url_attribute, &out);
             }
             return;

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -237,6 +237,11 @@ impl<'a> HTMLLoader<'a> {
             Some(i) => &original[i..],
             None => b"",
         };
+        // A `?query` appended to a data: URI lands in the base64 body; keep only `#fragment`.
+        let fragment: &[u8] = match strings::index_of_char(suffix, b'#') {
+            Some(i) => &suffix[i as usize..],
+            None => b"",
+        };
         let with_suffix = |url: &[u8], suffix: &[u8]| -> RewrittenUrl {
             if suffix.is_empty() {
                 return RewrittenUrl::Value(url.to_vec());
@@ -275,28 +280,18 @@ impl<'a> HTMLLoader<'a> {
         let url_for_css =
             parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
 
-        // In standalone HTML mode, inline assets as data: URIs
-        if self.compile_to_standalone_html && !url_for_css.is_empty() {
-            let fragment: &[u8] = match strings::index_of_char(suffix, b'#') {
-                Some(i) => &suffix[i as usize..],
-                None => b"",
-            };
+        // Standalone HTML mode inlines assets as data: URIs. Otherwise prefer the
+        // emitted file's unique key, falling back to the data: URI when the asset
+        // was CSS-inlined-only, so the raw source path never reaches the output.
+        if !url_for_css.is_empty()
+            && (self.compile_to_standalone_html || unique_key_for_additional_files.is_empty())
+        {
             return with_suffix(url_for_css, fragment);
         }
 
         if !unique_key_for_additional_files.is_empty() {
             // Replace the external href/src with the unique key so that we later will rewrite it to the final URL or pathname
             return with_suffix(unique_key_for_additional_files, suffix);
-        }
-
-        // The asset was inlined for CSS and not emitted as a file; reuse its
-        // data: URI here rather than leaving the raw source path in the output.
-        if !url_for_css.is_empty() {
-            let fragment: &[u8] = match strings::index_of_char(suffix, b'#') {
-                Some(i) => &suffix[i as usize..],
-                None => b"",
-            };
-            return with_suffix(url_for_css, fragment);
         }
 
         RewrittenUrl::Unchanged

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -9,7 +9,7 @@ use bun_threading::thread_pool::Task as ThreadPoolLibTask;
 use lol_html::HandlerResult;
 use lol_html::html_content::{ContentType, Element, EndTag};
 
-use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler};
+use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler, SrcSetIter};
 use crate::linker_context_mod::{GenerateChunkCtx, LinkerContext, debug};
 use crate::options::Loader;
 use crate::{Chunk, CompileResult};
@@ -121,10 +121,81 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     fn on_tag(
         &mut self,
         element: &mut Element<'_, '_>,
-        _path: &[u8],
+        path: &[u8],
         url_attribute: &[u8],
         _kind: ImportKind,
     ) {
+        if url_attribute == b"srcset" {
+            // One import record per candidate URL, same split order as the scan
+            // pass. Rewrites the whole attribute so descriptors are preserved.
+            let mut out: Vec<u8> = Vec::with_capacity(path.len());
+            let mut remove = false;
+            for (url, descriptor) in SrcSetIter::new(path) {
+                let rewritten = self.rewrite_one_url(url);
+                if matches!(rewritten, RewrittenUrl::Remove) {
+                    remove = true;
+                }
+                if !out.is_empty() {
+                    out.extend_from_slice(b", ");
+                }
+                out.extend_from_slice(rewritten.as_bytes(url));
+                if !descriptor.is_empty() {
+                    out.push(b' ');
+                    out.extend_from_slice(descriptor);
+                }
+            }
+            if remove {
+                element.remove();
+            } else if out != path {
+                set_attribute(element, url_attribute, &out);
+            }
+            return;
+        }
+
+        match self.rewrite_one_url(path) {
+            RewrittenUrl::Unchanged => {}
+            RewrittenUrl::Remove => element.remove(),
+            RewrittenUrl::Value(v) => set_attribute(element, url_attribute, &v),
+        }
+    }
+
+    fn on_head_tag(&mut self, element: &mut Element<'_, '_>) -> bool {
+        self.register_end_tag_handler(element, Self::end_head_tag_handler)
+    }
+
+    fn on_html_tag(&mut self, element: &mut Element<'_, '_>) -> bool {
+        self.register_end_tag_handler(element, Self::end_html_tag_handler)
+    }
+
+    fn on_body_tag(&mut self, element: &mut Element<'_, '_>) -> bool {
+        self.register_end_tag_handler(element, Self::end_body_tag_handler)
+    }
+}
+
+enum RewrittenUrl {
+    /// Leave the attribute value as-is.
+    Unchanged,
+    /// Remove the element (JS/CSS tags the bundle emits elsewhere).
+    Remove,
+    /// New value to write back.
+    Value(Vec<u8>),
+}
+
+impl RewrittenUrl {
+    fn as_bytes<'a>(&'a self, original: &'a [u8]) -> &'a [u8] {
+        match self {
+            RewrittenUrl::Value(v) => v,
+            _ => original,
+        }
+    }
+}
+
+impl<'a> HTMLLoader<'a> {
+    /// Advances one import record and returns what to write for its attribute
+    /// value. `original` is the URL as it appeared in the source HTML; its
+    /// `?query`/`#fragment` suffix is re-appended to emitted asset references
+    /// (mirroring the CSS printer).
+    fn rewrite_one_url(&mut self, original: &[u8]) -> RewrittenUrl {
         if self.current_import_record_index as usize >= self.import_records.len() {
             bun_core::Output::panic(format_args!(
                 "Assertion failure in HTMLLoader.onTag: current_import_record_index ({}) >= import_records.len ({})",
@@ -159,21 +230,33 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
                 "Leaving external import: {}",
                 BStr::new(import_record.path.text)
             );
-            return;
+            return RewrittenUrl::Unchanged;
         }
+
+        let suffix: &[u8] = match strings::index_of_any(original, b"?#") {
+            Some(i) => &original[i..],
+            None => b"",
+        };
+        let with_suffix = |url: &[u8], suffix: &[u8]| -> RewrittenUrl {
+            if suffix.is_empty() {
+                return RewrittenUrl::Value(url.to_vec());
+            }
+            let mut v = Vec::with_capacity(url.len() + suffix.len());
+            v.extend_from_slice(url);
+            v.extend_from_slice(suffix);
+            RewrittenUrl::Value(v)
+        };
 
         if self.linker.dev_server.is_some() {
             if !unique_key_for_additional_files.is_empty() {
-                set_attribute(element, url_attribute, unique_key_for_additional_files);
+                return with_suffix(unique_key_for_additional_files, suffix);
             } else if import_record.path.is_disabled
                 || loader.is_javascript_like()
                 || loader.is_css()
             {
-                element.remove();
-            } else {
-                set_attribute(element, url_attribute, import_record.path.pretty);
+                return RewrittenUrl::Remove;
             }
-            return;
+            return RewrittenUrl::Value(import_record.path.pretty.to_vec());
         }
 
         if import_record.source_index.is_invalid() {
@@ -181,42 +264,42 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
                 "Leaving import with invalid source index: {}",
                 BStr::new(import_record.path.text)
             );
-            return;
+            return RewrittenUrl::Unchanged;
         }
 
         if loader.is_javascript_like() || loader.is_css() {
             // Remove the original non-external tags
-            element.remove();
-            return;
+            return RewrittenUrl::Remove;
         }
 
-        if self.compile_to_standalone_html && import_record.source_index.is_valid() {
-            // In standalone HTML mode, inline assets as data: URIs
-            let url_for_css =
-                parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
-            if !url_for_css.is_empty() {
-                set_attribute(element, url_attribute, url_for_css);
-                return;
-            }
+        let url_for_css =
+            parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
+
+        // In standalone HTML mode, inline assets as data: URIs
+        if self.compile_to_standalone_html && !url_for_css.is_empty() {
+            let fragment: &[u8] = match strings::index_of_char(suffix, b'#') {
+                Some(i) => &suffix[i as usize..],
+                None => b"",
+            };
+            return with_suffix(url_for_css, fragment);
         }
 
         if !unique_key_for_additional_files.is_empty() {
             // Replace the external href/src with the unique key so that we later will rewrite it to the final URL or pathname
-            set_attribute(element, url_attribute, unique_key_for_additional_files);
-            return;
+            return with_suffix(unique_key_for_additional_files, suffix);
         }
-    }
 
-    fn on_head_tag(&mut self, element: &mut Element<'_, '_>) -> bool {
-        self.register_end_tag_handler(element, Self::end_head_tag_handler)
-    }
+        // The asset was inlined for CSS and not emitted as a file; reuse its
+        // data: URI here rather than leaving the raw source path in the output.
+        if !url_for_css.is_empty() {
+            let fragment: &[u8] = match strings::index_of_char(suffix, b'#') {
+                Some(i) => &suffix[i as usize..],
+                None => b"",
+            };
+            return with_suffix(url_for_css, fragment);
+        }
 
-    fn on_html_tag(&mut self, element: &mut Element<'_, '_>) -> bool {
-        self.register_end_tag_handler(element, Self::end_html_tag_handler)
-    }
-
-    fn on_body_tag(&mut self, element: &mut Element<'_, '_>) -> bool {
-        self.register_end_tag_handler(element, Self::end_body_tag_handler)
+        RewrittenUrl::Unchanged
     }
 }
 

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -10,7 +10,7 @@ use lol_html::HandlerResult;
 use lol_html::html_content::{ContentType, Element, EndTag};
 
 use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler, SrcSetIter};
-use crate::linker_context_mod::{GenerateChunkCtx, LinkerContext, debug};
+use crate::linker_context_mod::{GenerateChunkCtx, LinkerContext};
 use crate::options::Loader;
 use crate::{Chunk, CompileResult};
 
@@ -127,20 +127,18 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     ) {
         if url_attribute == b"srcset" {
             let mut out: Vec<u8> = Vec::with_capacity(path.len());
-            for (url, descriptor) in SrcSetIter::new(path) {
-                let rewritten = self.rewrite_one_url(url);
-                if matches!(rewritten, RewrittenUrl::Remove) {
-                    // Remove means "tag re-emitted elsewhere"; that never applies to an
-                    // <img>/<source>, so drop the one candidate instead of the element.
+            for (url, desc) in SrcSetIter::new(path) {
+                let v = self.next_record_url(url);
+                if matches!(v, Rewrite::Remove) {
                     continue;
                 }
                 if !out.is_empty() {
                     out.extend_from_slice(b", ");
                 }
-                out.extend_from_slice(rewritten.as_bytes(url));
-                if !descriptor.is_empty() {
+                out.extend_from_slice(if let Rewrite::Set(ref s) = v { s } else { url });
+                if !desc.is_empty() {
                     out.push(b' ');
-                    out.extend_from_slice(descriptor);
+                    out.extend_from_slice(desc);
                 }
             }
             if out != path {
@@ -148,11 +146,10 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             }
             return;
         }
-
-        match self.rewrite_one_url(path) {
-            RewrittenUrl::Unchanged => {}
-            RewrittenUrl::Remove => element.remove(),
-            RewrittenUrl::Value(v) => set_attribute(element, url_attribute, &v),
+        match self.next_record_url(path) {
+            Rewrite::Keep => {}
+            Rewrite::Remove => element.remove(),
+            Rewrite::Set(v) => set_attribute(element, url_attribute, &v),
         }
     }
 
@@ -169,125 +166,65 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     }
 }
 
-enum RewrittenUrl {
-    /// Leave the attribute value as-is.
-    Unchanged,
-    /// Remove the element (JS/CSS tags the bundle emits elsewhere).
+enum Rewrite {
+    Keep,
     Remove,
-    /// New value to write back.
-    Value(Vec<u8>),
-}
-
-impl RewrittenUrl {
-    fn as_bytes<'a>(&'a self, original: &'a [u8]) -> &'a [u8] {
-        match self {
-            RewrittenUrl::Value(v) => v,
-            _ => original,
-        }
-    }
+    Set(Vec<u8>),
 }
 
 impl<'a> HTMLLoader<'a> {
-    /// Advances one import record; re-appends `original`'s `?#` suffix to the
-    /// rewritten reference (mirroring the CSS printer).
-    fn rewrite_one_url(&mut self, original: &[u8]) -> RewrittenUrl {
-        if self.current_import_record_index as usize >= self.import_records.len() {
-            bun_core::Output::panic(format_args!(
-                "Assertion failure in HTMLLoader.onTag: current_import_record_index ({}) >= import_records.len ({})",
-                self.current_import_record_index,
-                self.import_records.len()
-            ));
-        }
-
-        let import_record: &ImportRecord =
-            &self.import_records[self.current_import_record_index as usize];
+    /// Advances one import record; returns the rewritten value with `original`'s `?#` suffix re-appended.
+    fn next_record_url(&mut self, original: &[u8]) -> Rewrite {
+        let record: &ImportRecord = &self.import_records[self.current_import_record_index as usize];
         self.current_import_record_index += 1;
 
-        let parse_graph = self.linker.parse_graph();
-        let unique_key_for_additional_files: &[u8] = if import_record.source_index.is_valid() {
-            &parse_graph
-                .input_files
-                .items_unique_key_for_additional_file()[import_record.source_index.get() as usize]
-        } else {
-            b""
-        };
-        let loader: Loader = if import_record.source_index.is_valid() {
-            parse_graph.input_files.items_loader()[import_record.source_index.get() as usize]
-        } else {
-            Loader::File
-        };
-
-        if import_record
+        if record
             .flags
             .contains(ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS)
         {
-            debug!(
-                "Leaving external import: {}",
-                BStr::new(import_record.path.text)
-            );
-            return RewrittenUrl::Unchanged;
+            return Rewrite::Keep;
         }
 
-        let suffix: &[u8] = match strings::index_of_any(original, b"?#") {
-            Some(i) => &original[i..],
-            None => b"",
+        let graph = self.linker.parse_graph();
+        let src = record.source_index;
+        let (unique_key, loader, url_for_css): (&[u8], Loader, &[u8]) = if src.is_valid() {
+            let i = src.get() as usize;
+            (
+                &graph.input_files.items_unique_key_for_additional_file()[i],
+                graph.input_files.items_loader()[i],
+                graph.ast.items_url_for_css()[i],
+            )
+        } else {
+            (b"", Loader::File, b"")
         };
-        // A `?query` appended to a data: URI lands in the base64 body; keep only `#fragment`.
-        let fragment: &[u8] = match strings::index_of_char(suffix, b'#') {
-            Some(i) => &suffix[i as usize..],
-            None => b"",
-        };
-        let with_suffix = |url: &[u8], suffix: &[u8]| -> RewrittenUrl {
-            if suffix.is_empty() {
-                return RewrittenUrl::Value(url.to_vec());
-            }
-            let mut v = Vec::with_capacity(url.len() + suffix.len());
-            v.extend_from_slice(url);
-            v.extend_from_slice(suffix);
-            RewrittenUrl::Value(v)
-        };
+
+        let suffix: &[u8] = strings::index_of_any(original, b"?#").map_or(b"", |i| &original[i..]);
+        let set = |url: &[u8], suffix: &[u8]| Rewrite::Set([url, suffix].concat());
 
         if self.linker.dev_server.is_some() {
-            if !unique_key_for_additional_files.is_empty() {
-                return with_suffix(unique_key_for_additional_files, suffix);
-            } else if import_record.path.is_disabled
-                || loader.is_javascript_like()
-                || loader.is_css()
-            {
-                return RewrittenUrl::Remove;
-            }
-            return with_suffix(import_record.path.pretty, suffix);
+            return if !unique_key.is_empty() {
+                set(unique_key, suffix)
+            } else if record.path.is_disabled || loader.is_javascript_like() || loader.is_css() {
+                Rewrite::Remove
+            } else {
+                set(record.path.pretty, suffix)
+            };
         }
-
-        if import_record.source_index.is_invalid() {
-            debug!(
-                "Leaving import with invalid source index: {}",
-                BStr::new(import_record.path.text)
-            );
-            return RewrittenUrl::Unchanged;
+        if src.is_invalid() {
+            return Rewrite::Keep;
         }
-
         if loader.is_javascript_like() || loader.is_css() {
-            // Remove the original non-external tags
-            return RewrittenUrl::Remove;
+            return Rewrite::Remove;
         }
-
-        let url_for_css =
-            parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
-
-        // Standalone mode inlines; otherwise the data: URI is only a fallback when no file was emitted.
-        if !url_for_css.is_empty()
-            && (self.compile_to_standalone_html || unique_key_for_additional_files.is_empty())
-        {
-            return with_suffix(url_for_css, fragment);
+        if !url_for_css.is_empty() && (self.compile_to_standalone_html || unique_key.is_empty()) {
+            let fragment: &[u8] =
+                strings::index_of_char(suffix, b'#').map_or(b"", |i| &suffix[i as usize..]);
+            return set(url_for_css, fragment);
         }
-
-        if !unique_key_for_additional_files.is_empty() {
-            // Replace the external href/src with the unique key so that we later will rewrite it to the final URL or pathname
-            return with_suffix(unique_key_for_additional_files, suffix);
+        if !unique_key.is_empty() {
+            return set(unique_key, suffix);
         }
-
-        RewrittenUrl::Unchanged
+        Rewrite::Keep
     }
 }
 

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -257,7 +257,7 @@ impl<'a> HTMLLoader<'a> {
             {
                 return RewrittenUrl::Remove;
             }
-            return RewrittenUrl::Value(import_record.path.pretty.to_vec());
+            return with_suffix(import_record.path.pretty, suffix);
         }
 
         if import_record.source_index.is_invalid() {

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1118,15 +1118,9 @@ body {
     onAfterBundle(api) {
       const html = api.readFile("out/index.html");
       // HTML got the emitted asset path, not the raw "./tiny.png"
-      expect(html).not.toContain('src="./tiny.png"');
       const img = html.match(/<img src="([^"]+)">/)![1];
-      // Either the hashed asset path or (as a fallback) the inlined data: URL;
-      // the source path is never left raw.
-      expect(img === "./tiny.png").toBe(false);
-      if (!img.startsWith("data:")) {
-        expect(img).toMatch(/tiny-[a-z0-9]+\.png$/);
-        expect(api.readFile("out/" + img.replace(/^\.\//, ""))).toBe("x");
-      }
+      expect(img).toMatch(/^\.\/tiny-[a-z0-9]+\.png$/);
+      expect(api.readFile("out/" + img.replace(/^\.\//, ""))).toBe("x");
       // CSS kept its data: URL inlining
       const cssHref = html.match(/href="([^"]+\.css)"/)![1];
       expect(api.readFile("out/" + cssHref.replace(/^\.\//, ""))).toContain("data:");

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1011,4 +1011,125 @@ body {
       expect(htmlContent).toMatch(/href=".*\.webmanifest"/);
     },
   });
+
+  // Protocol-relative URLs (`//host/...`) must be treated as external, not
+  // rewritten as a rooted project path.
+  itBundled("html/protocol-relative-url-is-external", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="//cdn.example.com/style.css">
+    <script src="//cdn.example.com/script.js"></script>
+  </head>
+  <body>
+    <img src="//cdn.example.com/logo.png">
+  </body>
+</html>`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      expect(html).toContain('href="//cdn.example.com/style.css"');
+      expect(html).toContain('src="//cdn.example.com/script.js"');
+      expect(html).toContain('src="//cdn.example.com/logo.png"');
+    },
+  });
+
+  // `srcset` is a comma-separated list of `url [descriptor]` candidates; each
+  // local URL should be emitted as an asset and the descriptors preserved.
+  itBundled("html/srcset-candidates", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <img srcset="./a.png 1x, ./b.png 2x">
+    <picture>
+      <source srcset="./a.png 300w, https://cdn.example.com/big.png 600w">
+    </picture>
+  </body>
+</html>`,
+      "/a.png": "A",
+      "/b.png": "B",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const img = html.match(/<img srcset="([^"]+)">/)![1];
+      const [c1, c2] = img.split(/,\s*/);
+      expect(c1).toMatch(/^\.\/a-[a-z0-9]+\.png 1x$/);
+      expect(c2).toMatch(/^\.\/b-[a-z0-9]+\.png 2x$/);
+
+      const source = html.match(/<source srcset="([^"]+)">/)![1];
+      const [s1, s2] = source.split(/,\s*/);
+      expect(s1).toMatch(/^\.\/a-[a-z0-9]+\.png 300w$/);
+      // External candidate stays untouched
+      expect(s2).toBe("https://cdn.example.com/big.png 600w");
+
+      // The asset files themselves were emitted
+      const aName = c1.split(" ")[0].replace(/^\.\//, "");
+      expect(api.readFile("out/" + aName)).toBe("A");
+    },
+  });
+
+  // The `?query`/`#fragment` on an asset reference must survive the rewrite to
+  // the hashed output filename (SVG fragment addressing, cache-busting).
+  itBundled("html/asset-url-preserves-query-and-fragment", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <img src="./sprites.svg#icon">
+    <img src="./logo.png?v=1">
+  </body>
+</html>`,
+      "/sprites.svg": "<svg><symbol id='icon'/></svg>",
+      "/logo.png": "fake png",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      expect(html).toMatch(/src="\.\/sprites-[a-z0-9]+\.svg#icon"/);
+      expect(html).toMatch(/src="\.\/logo-[a-z0-9]+\.png\?v=1"/);
+    },
+  });
+
+  // An asset small enough to be inlined in CSS but also referenced from HTML
+  // must still be emitted on disk so the HTML reference resolves.
+  itBundled("html/asset-shared-css-and-html-emitted", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head><link rel="stylesheet" href="./style.css"></head>
+  <body><img src="./tiny.png"></body>
+</html>`,
+      "/style.css": `body { background: url(./tiny.png); }`,
+      "/tiny.png": "x",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      // HTML got the emitted asset path, not the raw "./tiny.png"
+      expect(html).not.toContain('src="./tiny.png"');
+      const img = html.match(/<img src="([^"]+)">/)![1];
+      // Either the hashed asset path or (as a fallback) the inlined data: URL;
+      // the source path is never left raw.
+      expect(img === "./tiny.png").toBe(false);
+      if (!img.startsWith("data:")) {
+        expect(img).toMatch(/tiny-[a-z0-9]+\.png$/);
+        expect(api.readFile("out/" + img.replace(/^\.\//, ""))).toBe("x");
+      }
+      // CSS kept its data: URL inlining
+      const cssHref = html.match(/href="([^"]+\.css)"/)![1];
+      expect(api.readFile("out/" + cssHref.replace(/^\.\//, ""))).toContain("data:");
+    },
+  });
 });

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1067,7 +1067,10 @@ body {
       expect(c2).toMatch(/^\.\/b-[a-z0-9]+\.png 2x$/);
 
       // Descriptor-less, newline-separated, multi-space, trailing comma.
-      const bare = html.match(/<img id="bare" srcset="([^"]+)">/)![1].split(/,\s*/).filter(Boolean);
+      const bare = html
+        .match(/<img id="bare" srcset="([^"]+)">/)![1]
+        .split(/,\s*/)
+        .filter(Boolean);
       expect(bare).toHaveLength(2);
       expect(bare[0]).toMatch(/^\.\/a-[a-z0-9]+\.png$/);
       expect(bare[1]).toMatch(/^\.\/b-[a-z0-9]+\.png$/);

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1048,6 +1048,8 @@ body {
 <html>
   <body>
     <img srcset="./a.png 1x, ./b.png 2x">
+    <img id="bare" srcset="./a.png,
+      ./b.png  ,">
     <picture>
       <source srcset="./a.png 300w, https://cdn.example.com/big.png 600w">
     </picture>
@@ -1063,6 +1065,12 @@ body {
       const [c1, c2] = img.split(/,\s*/);
       expect(c1).toMatch(/^\.\/a-[a-z0-9]+\.png 1x$/);
       expect(c2).toMatch(/^\.\/b-[a-z0-9]+\.png 2x$/);
+
+      // Descriptor-less, newline-separated, multi-space, trailing comma.
+      const bare = html.match(/<img id="bare" srcset="([^"]+)">/)![1].split(/,\s*/).filter(Boolean);
+      expect(bare).toHaveLength(2);
+      expect(bare[0]).toMatch(/^\.\/a-[a-z0-9]+\.png$/);
+      expect(bare[1]).toMatch(/^\.\/b-[a-z0-9]+\.png$/);
 
       const source = html.match(/<source srcset="([^"]+)">/)![1];
       const [s1, s2] = source.split(/,\s*/);

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -192,7 +192,6 @@ describe("bundler", () => {
     ],
   });
   itBundled("naming/AssetNoOverwrite", {
-    todo: true,
     files: {
       "/src/entry.js": /* js */ `
         import asset1 from "./asset1.file";
@@ -213,7 +212,27 @@ describe("bundler", () => {
       ".file": "file",
     },
     bundleErrors: {
-      "<bun>": ['Multiple files share the same output path: "same-filename.txt"'],
+      "<bun>": [`Multiple files share the same output path`],
+    },
+  });
+  itBundled("naming/AssetNoOverwriteSameContent", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import asset1 from "./a/icon.file";
+        import asset2 from "./b/icon.file";
+        console.log(asset1, asset2);
+      `,
+      "/src/a/icon.file": "same bytes",
+      "/src/b/icon.file": "same bytes",
+    },
+    root: "/src",
+    assetNaming: "icon.txt",
+    entryPointsRaw: ["./src/entry.js"],
+    loader: {
+      ".file": "file",
+    },
+    onAfterBundle(api) {
+      api.expectFile("out/icon.txt").toBe("same bytes");
     },
   });
   itBundled("naming/AssetFileLoaderPath1", {


### PR DESCRIPTION
Five fixes to how HTML entrypoints classify asset URLs and emit them, so the HTML build's asset-URL contract matches the CSS printer's.

## Repro

```sh
# 1. protocol-relative URL treated as rooted path
printf '<script src="//cdn.example.com/x.js"></script>' > index.html
bun build ./index.html --outdir=dist
# error: Could not resolve: "/cdn.example.com/x.js"

# 2. srcset passed whole to the one-URL resolver
printf '<img srcset="./a.png 1x, ./b.png 2x">' > index.html; touch a.png b.png
bun build ./index.html --outdir=dist
# error: Could not resolve: "./a.png 1x, ./b.png 2x"

# 3. ?query/#fragment stripped on rewrite
printf '<img src="./sprites.svg#icon">' > index.html; touch sprites.svg
bun build ./index.html --outdir=dist && grep '#icon' dist/index.html
# (no match; written as <img src="./sprites-HASH.svg">)

# 4. CSS-inlined asset also referenced from HTML left with raw path
printf '<link rel="stylesheet" href="./s.css"><img src="./t.png">' > index.html
printf 'body{background:url(./t.png)}' > s.css; printf x > t.png
bun build ./index.html --outdir=dist && cat dist/index.html; ls dist/
# <img src="./t.png"> but no t.png in dist/

# 5. asset output-path collision is silent last-writer-wins
# (see naming/AssetNoOverwrite: two distinct .file inputs, --asset-naming=fixed.txt)
```

## Cause

- `HTMLScanner::create_import_record` rewrites any leading `/` as a rooted project path, so `//cdn/x.js` never reaches the resolver's own `starts_with("//")` external rule.
- `TAG_HANDLERS` `img[srcset]`/`source[srcset]` push the whole attribute through the single-URL path.
- `HTMLLoader::on_tag` replaces the whole attribute value with the unique key after the resolver already stripped `?#` to find the file. The CSS printer re-appends the suffix from `record.original_path`; HTML didn't.
- `find_reachable_files` counts only JS importers as copy-forcing, so an asset inlined in CSS and referenced only from HTML has its unique key cleared and the HTML rewrite is a silent no-op.
- `process_files_to_copy` pushes each asset `OutputFile` with no output-path uniqueness check; the chunk-side "Multiple files share the same output path" guard only sees chunks.

## Fix

- `HTMLScanner`: skip the rooted-path branch when the second byte is also `/`.
- `HTMLScanner` + `HTMLLoader`: shared `SrcSetIter` walks the WHATWG image-candidate grammar; scan creates one import record per candidate, rewrite rebuilds the attribute with descriptors preserved. Both passes drive the same iterator so record counts stay 1:1.
- `HTMLLoader::rewrite_one_url`: re-append the source URL's `?#` suffix to the emitted reference (fragment only for `data:` URIs), same as `css/printer.rs`.
- `find_reachable_files`: any non-CSS importer forces the asset to be emitted. `HTMLLoader` falls back to the `data:` URI when no unique key exists instead of leaving the raw source path.
- `process_files_to_copy`: map over asset output paths and raise `DuplicateOutputPath` with the existing error/note wording when two distinct content hashes collide; identical-content collisions are benign.

## Verification

```sh
bun bd test test/bundler/bundler_html.test.ts test/bundler/bundler_naming.test.ts \
  -t "protocol-relative|srcset-candidates|preserves-query|shared-css-and-html|AssetNoOverwrite"
```

All five fail on `main` (4 in `bundler_html.test.ts`, `naming/AssetNoOverwrite` was previously `todo: true`) and pass with this change. The full `bundler_html`, `bundler_naming`, `bundler_loader`, `bundler_edgecase`, `bundler_html_server` and `html-import-manifest` suites pass.

Consolidates #36007, #36008, #36012 (the first three fixes) and adds the two emit-contract fixes that had no open PR.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts test/bundler/bundler_naming.test.ts
bun test v1.4.0 (0e4276e15)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [477.20ms]
(pass) bundler > naming/ImplicitOutbase1 [636.19ms]
(pass) bundler > naming/ImplicitOutbase2 [884.71ms]
(pass) bundler > naming/EntryNamingTemplate1 [899.91ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [381.37ms]
(pass) bundler > naming/AssetNamingMkdir [358.06ms]
(pass) bundler > naming/AssetNamingDir [349.03ms]
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
1369 |         } else if (expectedErrors && expectedErrors.length > 0) {
1370 |           throw new Error("Errors were expected while bundling:\n" + expectedErrors.map(formatError).join("\n"));
                           ^
error: Errors were expected while bundling:
<bun>: Multiple files share the same output path
      at <anonymou
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (c0ae41785)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [18.50ms]
(pass) bundler > naming/ImplicitOutbase1 [33.72ms]
(pass) bundler > naming/ImplicitOutbase2 [40.58ms]
(pass) bundler > naming/EntryNamingTemplate1 [42.01ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [16.28ms]
(pass) bundler > naming/AssetNamingMkdir [15.70ms]
(pass) bundler > naming/AssetNamingDir [15.35ms]
(pass) bundler > naming/AssetNoOverwrite [2.67ms]
(pass) bundler > naming/AssetNoOverwriteSameContent [3.08ms]
(pass) bundler > naming/AssetFileLoaderPath1 [2.65ms]
ENOENT opening root directory "/tmp/bun-build-tests/bun-HZLCBM/naming/NonexistantRoot/lib"

(pass) bundler > naming/NonexistantRoot [9.46ms]
(todo) bundler > naming/EntrypointOutsideOfRoot
(pass) bundler > naming/WithPathTraversal [41.00ms]
(pass) bundler > naming/NonAsciiSourceFilenameSymbol [16.65ms]

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [15.11ms]
(pass) bundler > html/implicit-relative-paths [3.76ms]
(pass) bundler > html/multiple-assets [3.00ms]
(pass) bundler > html/image-hashing [2.97ms]
(pass) bundler 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts test/bundler/bundler_naming.test.ts
bun test v1.4.0 (0e4276e15)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [495.90ms]
(pass) bundler > naming/ImplicitOutbase1 [634.96ms]
(pass) bundler > naming/ImplicitOutbase2 [924.12ms]
(pass) bundler > naming/EntryNamingTemplate1 [883.96ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [358.02ms]
(pass) bundler > naming/AssetNamingMkdir [358.22ms]
(pass) bundler > naming/AssetNamingDir [358.91ms]
(pass) bundler > naming/AssetNoOverwrite [81.69ms]
(pass) bundler > naming/AssetNoOverwriteSameContent [87.22ms]
(pass) bundler > naming/AssetFileLoaderPath1 [75.21ms]
ENOENT opening root directory "/tmp/bun-build-tests/bun-AaSlhc/naming/NonexistantRoot/lib"

(pass) bundler > naming/NonexistantRoot [155.21ms]
(todo) bundler > naming/EntrypointOutsideOfRoot
(pass) bundler > naming/WithPathTraversal [901.60ms]
(pass) bundler > naming/NonAsciiSourceFilenameSymbol [367.83ms]

test/bundler/bundler_html.t
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 757ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/HTMLScanner.rs                         | 128 +++++++++++-----
 src/bundler/bundle_v2.rs                           |  40 +++--
 .../generateCompileResultForHtmlChunk.rs           | 164 +++++++++++----------
 test/bundler/bundler_html.test.ts                  | 126 ++++++++++++++++
 test/bundler/bundler_naming.test.ts                |  23 ++-
 5 files changed, 356 insertions(+), 125 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/HTMLScanner.rs                                    6     10      0
src/bundler/bundle_v2.rs                                      9     13      0
…ler/linker_context/generateCompileResultForHtmlChunk.rs      8     12      0
test/bundler/bundler_html.test.ts                             5      3      0
test/bundler/bundler_naming.test.ts                           3      2      0
```

</details>

<!-- robobun:evidence:end -->