### PR TITLE
node:inspector: emit inspectorNotification for every Session notification

### DIFF
--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -430,6 +430,12 @@ class Session extends EventEmitter {
     this.#connected = true;
   }
 
+  #notify(method: string, params: object) {
+    const message = { method, params };
+    this.emit(method, message);
+    this.emit("inspectorNotification", message);
+  }
+
   connectToMainThread() {
     if (Bun.isMainThread) {
       throw $ERR_INSPECTOR_NOT_WORKER();
@@ -657,9 +663,7 @@ class Session extends EventEmitter {
         const title = `[worker ${wt.threadId}] ${wt.threadName}`;
         const workerInfo = { workerId: String(wt.threadId), type: "worker", title };
         queueMicrotask(() => {
-          this.emit("NodeWorker.attachedToWorker", {
-            params: { sessionId: `worker:${wt.threadId}`, workerInfo },
-          });
+          this.#notify("NodeWorker.attachedToWorker", { sessionId: `worker:${wt.threadId}`, workerInfo });
         });
         return {};
       }
@@ -700,15 +704,9 @@ class Session extends EventEmitter {
         // (trace events, then metadata) before signalling completion. Emit
         // synchronously: listeners observe everything before the post()
         // callback (queued as a microtask above) runs.
-        this.emit("NodeTracing.dataCollected", {
-          method: "NodeTracing.dataCollected",
-          params: { value: collected },
-        });
-        this.emit("NodeTracing.dataCollected", {
-          method: "NodeTracing.dataCollected",
-          params: { value: metadata },
-        });
-        this.emit("NodeTracing.tracingComplete", { method: "NodeTracing.tracingComplete", params: {} });
+        this.#notify("NodeTracing.dataCollected", { value: collected });
+        this.#notify("NodeTracing.dataCollected", { value: metadata });
+        this.#notify("NodeTracing.tracingComplete", {});
         return {};
       }
 

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -668,9 +668,7 @@ test("NodeTracing notifications also arrive on inspectorNotification", async () 
     session.on("NodeTracing.tracingComplete", m => specific.push(m));
     session.on("inspectorNotification", m => generic.push(m));
     const post = (method: string, params?: object) =>
-      new Promise<void>((resolve, reject) =>
-        session.post(method, params, err => (err ? reject(err) : resolve())),
-      );
+      new Promise<void>((resolve, reject) => session.post(method, params, err => (err ? reject(err) : resolve())));
     await post("NodeTracing.start", { traceConfig: { includedCategories: ["node.perf"] } });
     performance.mark("inspectorNotification-probe");
     await post("NodeTracing.stop");

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -655,6 +655,76 @@ test("the method-specific event fires before inspectorNotification, like Node", 
   }
 });
 
+// Node's Session#[onMessageSymbol] emits every server notification under both
+// its method name and the generic "inspectorNotification" firehose. Bun only
+// emitted the method-named event for NodeTracing.*.
+test("NodeTracing notifications also arrive on inspectorNotification", async () => {
+  const session = new inspector.Session();
+  session.connect();
+  try {
+    const specific: any[] = [];
+    const generic: any[] = [];
+    session.on("NodeTracing.dataCollected", m => specific.push(m));
+    session.on("NodeTracing.tracingComplete", m => specific.push(m));
+    session.on("inspectorNotification", m => generic.push(m));
+    const post = (method: string, params?: object) =>
+      new Promise<void>((resolve, reject) =>
+        session.post(method, params, err => (err ? reject(err) : resolve())),
+      );
+    await post("NodeTracing.start", { traceConfig: { includedCategories: ["node.perf"] } });
+    performance.mark("inspectorNotification-probe");
+    await post("NodeTracing.stop");
+    expect(specific.map(m => m.method)).toEqual([
+      "NodeTracing.dataCollected",
+      "NodeTracing.dataCollected",
+      "NodeTracing.tracingComplete",
+    ]);
+    // Both listeners must receive the identical {method, params} payloads.
+    expect(generic).toEqual(specific);
+    expect(generic.at(-1)).toEqual({ method: "NodeTracing.tracingComplete", params: {} });
+  } finally {
+    session.disconnect();
+  }
+});
+
+// NodeWorker.enable only emits from inside a worker, so run the session there
+// and send both captured messages back to the parent for assertion.
+test("NodeWorker.attachedToWorker also arrives on inspectorNotification with a method field", async () => {
+  using dir = tempDir("inspector-nodeworker", {
+    "entry.mjs": `
+      import { Worker } from "node:worker_threads";
+      const w = new Worker(new URL("./worker.mjs", import.meta.url));
+      w.on("message", seen => { console.log(JSON.stringify(seen)); process.exit(0); });
+      w.on("error", err => { console.error(err); process.exit(1); });
+    `,
+    "worker.mjs": `
+      import { Session } from "node:inspector";
+      import { parentPort } from "node:worker_threads";
+      const s = new Session();
+      s.connectToMainThread();
+      const seen = { specific: null, generic: null };
+      s.on("NodeWorker.attachedToWorker", m => (seen.specific = m));
+      s.on("inspectorNotification", m => { if (m.method === "NodeWorker.attachedToWorker") seen.generic = m; });
+      s.post("NodeWorker.enable", () => queueMicrotask(() => parentPort.postMessage(seen)));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+  const seen = JSON.parse(stdout.trim());
+  const expected = {
+    method: "NodeWorker.attachedToWorker",
+    params: { sessionId: expect.any(String), workerInfo: expect.any(Object) },
+  };
+  expect(seen.specific).toEqual(expected);
+  expect(seen.generic).toEqual(seen.specific);
+});
+
 test("a consoleAPICalled listener that logs does not recurse", () => {
   const session = new inspector.Session();
   session.connect();


### PR DESCRIPTION
An in-process `node:inspector` `Session` never fired the documented generic `'inspectorNotification'` event for `NodeTracing.*` or `NodeWorker.attachedToWorker`. Notifications arrived only under their method-specific names, so listeners on the firehose event (the one trace collectors subscribe to) saw nothing. Node emits both.

## Repro

```js
import inspector from "node:inspector";
const s = new inspector.Session(); s.connect();
let generic = 0, specific = 0;
s.on("inspectorNotification", () => generic++);
s.on("NodeTracing.dataCollected", () => specific++);
s.on("NodeTracing.tracingComplete", () => specific++);
await new Promise(r => s.post("NodeTracing.start", { traceConfig: { includedCategories: ["node.perf"] } }, () => r()));
performance.mark("m1");
await new Promise(r => s.post("NodeTracing.stop", () => r()));
console.log(`specific=${specific} inspectorNotification=${generic}`);
s.disconnect();
```

Before: `specific=3 inspectorNotification=0`
Node / after: `specific=3 inspectorNotification=3`

## Cause

`Runtime.consoleAPICalled` already emitted both events (and has a test for it), but the `NodeTracing.stop` and `NodeWorker.enable` handlers in `src/js/node/inspector.ts` called `this.emit(method, ...)` directly without the paired `this.emit("inspectorNotification", ...)`.

## Fix

Add a `#notify(method, params)` helper on `Session` that builds `{method, params}` and emits it under both names (method first, then `inspectorNotification`, matching Node's `Session#[onMessageSymbol]`). Route `NodeTracing.dataCollected`, `NodeTracing.tracingComplete`, and `NodeWorker.attachedToWorker` through it. This also adds the previously-missing `method` field to the `NodeWorker.attachedToWorker` payload.

## Verification

New test in `test/js/node/inspector/inspector.test.ts` asserts the `inspectorNotification` listener receives the same three `NodeTracing` messages as the method-named listeners. Fails on `main` (empty array), passes with the fix. Full `inspector.test.ts`, `inspector-profiler.test.ts`, `test-trace-events-dynamic-enable.js`, and `test-worker-name.js` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (0cd6452cc)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [9.50ms]
(pass) inspector.console [11.64ms]
(pass) inspector.close() is a no-op when the inspector is not open [6.18ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [6.52ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [4599.56ms]
(pass) inspector.close() followed by inspector.open() starts a new server [1796.44ms]
(pass) inspector.open() can be retried after a failed start [1919.24ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [1770.66ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [2124.34ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [2119.03ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [67.03ms]
-0 NaN Infinity -Infinity 1
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (0cd6452cc)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [1.09ms]
(pass) inspector.console [0.06ms]
(pass) inspector.close() is a no-op when the inspector is not open [0.05ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [0.08ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [77.06ms]
(pass) inspector.close() followed by inspector.open() starts a new server [35.88ms]
(pass) inspector.open() can be retried after a failed start [41.71ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [37.83ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [44.03ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [42.34ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [1.43ms]
-0 NaN Infinity -Infinity 1n
(pass) Runtime.consoleAPICalled encodes -0/NaN/Infinity/bigint as unserializableValue like Node [0.22ms]
(pass) Session errors carry Node's ERR_INSPECTOR_* codes and post() vali
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (0cd6452cc)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [8.57ms]
(pass) inspector.console [14.58ms]
(pass) inspector.close() is a no-op when the inspector is not open [4.64ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [5.68ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [4239.80ms]
(pass) inspector.close() followed by inspector.open() starts a new server [1748.49ms]
(pass) inspector.open() can be retried after a failed start [1826.87ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [1748.72ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [2090.81ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [2041.75ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [67.49ms]
-0 NaN Infinity -Infinity 1
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 703ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8934ms)
Bundle modules (51ms)
Postprocesss modules (25ms)
Bundle Functions (739ms)
Generate Code (19ms)

[9.79s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (0cd6452cc)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [0.48ms]
(pass) inspector.console [0.05ms]
(pass) inspector.close() is a no-op when the inspector is not open [0.07ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [0.09ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [77.29ms]
(pass) inspector.close() followed by inspector.open() starts a new server [38.79ms]
(pass) inspector.open() can be retried after a failed start [39.40ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [32.03ms]
(pass) inspector.waitForDebugger() bl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/inspector.ts                 | 22 +++++------
 test/js/node/inspector/inspector.test.ts | 68 ++++++++++++++++++++++++++++++++
 2 files changed, 78 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/node/inspector.ts                      1      5      0
test/js/node/inspector/inspector.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->