### PR TITLE
node:inspector: reference-count the shared CPU sampling profiler across --cpu-prof and sessions

### DIFF
--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -415,11 +415,8 @@ function collectCoverageScripts(): any[] | Error {
 class Session extends EventEmitter {
   #connected = false;
   #profilerEnabled = false;
-  // JSC has one SamplingProfiler per VM, reference-counted across --cpu-prof
-  // and every Session. This holds the timestamp startCPUProfiler() returned for
-  // this session's Profiler.start, so disconnect()/Profiler.disable only
-  // release this session's hold (not --cpu-prof's or another session's) and
-  // Profiler.stop excludes samples taken before this session's start.
+  // startCPUProfiler()'s returned timestamp for this session's Profiler.start;
+  // the shared sampling profiler is refcounted (see BunCPUProfiler.h).
   #cpuProfileStartTime: number | undefined;
   #preciseCoverageEnabled = false;
   #preciseCoverageCallCount = false;

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -18,7 +18,7 @@ const kProtocolError = Symbol("kProtocolError");
 
 // Native profiler functions exposed via $newCppFunction
 const startCPUProfiler = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_startCPUProfiler", 0);
-const stopCPUProfiler = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_stopCPUProfiler", 0);
+const stopCPUProfiler = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_stopCPUProfiler", 1);
 const setCPUSamplingInterval = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_setCPUSamplingInterval", 1);
 const isCPUProfilerRunning = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_isCPUProfilerRunning", 0);
 const startPreciseCoverage = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_startPreciseCoverage", 0);
@@ -415,6 +415,12 @@ function collectCoverageScripts(): any[] | Error {
 class Session extends EventEmitter {
   #connected = false;
   #profilerEnabled = false;
+  // JSC has one SamplingProfiler per VM, reference-counted across --cpu-prof
+  // and every Session. This holds the timestamp startCPUProfiler() returned for
+  // this session's Profiler.start, so disconnect()/Profiler.disable only
+  // release this session's hold (not --cpu-prof's or another session's) and
+  // Profiler.stop excludes samples taken before this session's start.
+  #cpuProfileStartTime: number | undefined;
   #preciseCoverageEnabled = false;
   #preciseCoverageCallCount = false;
   #preciseCoverageDetailed = false;
@@ -439,7 +445,10 @@ class Session extends EventEmitter {
 
   disconnect() {
     if (!this.#connected) return;
-    if (isCPUProfilerRunning()) stopCPUProfiler();
+    if (this.#cpuProfileStartTime !== undefined) {
+      stopCPUProfiler(this.#cpuProfileStartTime);
+      this.#cpuProfileStartTime = undefined;
+    }
     if (this.#preciseCoverageEnabled) {
       stopPreciseCoverage();
       this.#preciseCoverageEnabled = false;
@@ -528,8 +537,9 @@ class Session extends EventEmitter {
         return {};
 
       case "Profiler.disable":
-        if (isCPUProfilerRunning()) {
-          stopCPUProfiler();
+        if (this.#cpuProfileStartTime !== undefined) {
+          stopCPUProfiler(this.#cpuProfileStartTime);
+          this.#cpuProfileStartTime = undefined;
         }
         // V8's Profiler agent stops precise coverage on disable; without this
         // the control-flow profiler keeps instrumenting newly-compiled code.
@@ -542,16 +552,19 @@ class Session extends EventEmitter {
 
       case "Profiler.start":
         if (!this.#profilerEnabled) return $ERR_INSPECTOR_COMMAND("-32000: Profiler is not enabled");
-        if (!isCPUProfilerRunning()) startCPUProfiler();
+        if (this.#cpuProfileStartTime === undefined) this.#cpuProfileStartTime = startCPUProfiler();
         return {};
 
-      case "Profiler.stop":
-        if (!isCPUProfilerRunning()) return $ERR_INSPECTOR_COMMAND("-32000: Profiler is not started");
+      case "Profiler.stop": {
+        if (this.#cpuProfileStartTime === undefined) return $ERR_INSPECTOR_COMMAND("-32000: Profiler is not started");
+        const since = this.#cpuProfileStartTime;
+        this.#cpuProfileStartTime = undefined;
         try {
-          return { profile: JSON.parse(stopCPUProfiler()) };
+          return { profile: JSON.parse(stopCPUProfiler(since)) };
         } catch (e) {
           return $ERR_INSPECTOR_COMMAND(`-32000: Failed to parse profile JSON: ${e}`);
         }
+      }
 
       case "Profiler.setSamplingInterval": {
         if (isCPUProfilerRunning())

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -33,7 +33,40 @@ namespace Bun {
 static thread_local double s_profilingStartTime = 0.0;
 // Set sampling interval to 1ms (1000 microseconds) to match Node.js
 static thread_local int s_samplingInterval = 1000;
-static thread_local bool s_isProfilerRunning = false;
+// JSC has one SamplingProfiler per VM. --cpu-prof, node:inspector sessions, and
+// Worker.{start,stop}CpuProfile all share it, so the underlying profiler is
+// started once on the first consumer and only paused/cleared when the last one
+// releases it.
+static thread_local int s_profilerRefCount = 0;
+
+// A sample drained from JSC's SamplingProfiler. releaseStackTraces() also
+// clears m_liveCellPointers, so the raw ExecutableBase*/JSObject* in a
+// StackTrace are only valid under DeferGC; converting to owned strings/ints
+// here lets samples outlive the DeferGC scope so a later consumer can still
+// see samples a prior consumer's stop() released.
+struct RetainedFrame {
+    WTF::String functionName;
+    WTF::String url;
+    int scriptId { 0 };
+    int functionDefLine { -1 };
+    int functionDefColumn { -1 };
+    int sampleLine { 0 };
+    bool isAsync { false };
+};
+
+struct RetainedSample {
+    double timestampUs { 0 };
+    WTF::Vector<RetainedFrame> frames;
+};
+
+static thread_local WTF::Vector<RetainedSample>* s_retainedSamples = nullptr;
+
+static WTF::Vector<RetainedSample>& retainedSamples()
+{
+    if (!s_retainedSamples)
+        s_retainedSamples = new WTF::Vector<RetainedSample>();
+    return *s_retainedSamples;
+}
 
 void setSamplingInterval(int intervalMicroseconds)
 {
@@ -42,24 +75,26 @@ void setSamplingInterval(int intervalMicroseconds)
 
 bool isCPUProfilerRunning()
 {
-    return s_isProfilerRunning;
+    return s_profilerRefCount > 0;
 }
 
-void startCPUProfiler(JSC::VM& vm)
+double startCPUProfiler(JSC::VM& vm)
 {
-    // Capture the wall clock time when profiling starts (before creating stopwatch)
-    // This will be used as the profile's startTime
-    s_profilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
+    double now = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
 
-    // Create a stopwatch and start it
-    auto stopwatch = WTF::Stopwatch::create();
-    stopwatch->start();
+    if (s_profilerRefCount++ == 0) {
+        s_profilingStartTime = now;
 
-    JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
-    samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
-    samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();
-    samplingProfiler.start();
-    s_isProfilerRunning = true;
+        auto stopwatch = WTF::Stopwatch::create();
+        stopwatch->start();
+
+        JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
+        samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
+        samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();
+        samplingProfiler.start();
+    }
+
+    return now;
 }
 
 struct ProfileNode {
@@ -101,21 +136,11 @@ struct FunctionStats {
 // Helper to format a function name properly
 // - Empty names become "(anonymous)"
 // - Async functions get "async " prefix
-static WTF::String formatFunctionName(const WTF::String& name, const JSC::SamplingProfiler::StackFrame& frame)
+static WTF::String formatFunctionName(const WTF::String& name, bool isAsync)
 {
     WTF::String displayName = name.isEmpty() ? "(anonymous)"_s : name;
-
-    // Check if this is an async function and add prefix if needed
-    if (frame.frameType == JSC::SamplingProfiler::FrameType::Executable && frame.executable) {
-        if (auto* functionExecutable = dynamicDowncast<JSC::FunctionExecutable>(frame.executable)) {
-            if (JSC::isAsyncFunctionParseMode(functionExecutable->parseMode())) {
-                if (!displayName.startsWith("async "_s)) {
-                    return makeString("async "_s, displayName);
-                }
-            }
-        }
-    }
-
+    if (isAsync && !displayName.startsWith("async "_s))
+        return makeString("async "_s, displayName);
     return displayName;
 }
 
@@ -269,14 +294,134 @@ static WTF::String formatCodeSpan(const WTF::String& str)
     return sb.toString();
 }
 
-// Helper to generate a minimal valid cpuprofile JSON with no samples
-static WTF::String generateEmptyProfileJSON()
+// Absolute file path → `file://` URL. Chrome DevTools expects `callFrame.url`
+// to be a proper URL; leaving the raw path breaks source-view resolution.
+static void normalizeURL(WTF::String& u)
 {
-    // Return a minimal valid Chrome DevTools CPU profile format
-    // Use s_profilingStartTime if available, otherwise fall back to current time
+    if (u.isEmpty())
+        return;
+    bool isAbsolutePath = false;
+    if (u[0] == '/') {
+        isAbsolutePath = true;
+    } else if (u.length() >= 2 && u[1] == ':') {
+        char firstChar = u[0];
+        if ((firstChar >= 'A' && firstChar <= 'Z') || (firstChar >= 'a' && firstChar <= 'z'))
+            isAbsolutePath = true;
+    } else if (u.length() >= 2 && u[0] == '\\' && u[1] == '\\') {
+        isAbsolutePath = true;
+    }
+    if (isAbsolutePath)
+        u = WTF::URL::fileURLWithFileSystemPath(u).string();
+}
+
+// Extract GC-safe frame info from a StackFrame. Must be called under DeferGC
+// since frame.executable is a raw heap pointer.
+static RetainedFrame extractFrame(JSC::VM& vm, JSC::SamplingProfiler::StackFrame& frame)
+{
+    RetainedFrame out;
+    out.functionName = frame.displayName(vm);
+
+    if (frame.frameType == JSC::SamplingProfiler::FrameType::Executable && frame.executable) {
+        if (auto* functionExecutable = dynamicDowncast<JSC::FunctionExecutable>(frame.executable))
+            out.isAsync = JSC::isAsyncFunctionParseMode(functionExecutable->parseMode());
+        auto sourceProviderAndID = frame.sourceProviderAndID();
+        auto* provider = std::get<0>(sourceProviderAndID);
+        if (provider) {
+            out.url = provider->sourceURL();
+            out.scriptId = static_cast<int>(provider->asID());
+        }
+
+        // Function definition location. JSC returns these 1-based; Chrome
+        // DevTools emits them 0-based. Remapped through the sourcemap callback
+        // so callFrame.url and callFrame.line/column agree on the function's
+        // source. The callback (see FormatStackTraceForJS.cpp) unconditionally
+        // rewrites its out-param back to the raw provider URL when no sourcemap
+        // is found, so normalizeURL runs AFTER it (see #29240).
+        int rawFunctionStartLine = frame.functionStartLine();
+        unsigned rawFunctionStartColumn = frame.functionStartColumn();
+        if (rawFunctionStartLine > 0 && rawFunctionStartColumn != std::numeric_limits<unsigned>::max()) {
+            JSC::LineColumn functionStartLineColumn {
+                static_cast<unsigned>(rawFunctionStartLine),
+                rawFunctionStartColumn,
+            };
+            if (provider) {
+#if USE(BUN_JSC_ADDITIONS)
+                auto& fn = vm.computeLineColumnWithSourcemap();
+                if (fn)
+                    fn(vm, provider, functionStartLineColumn, out.url);
+#endif
+            }
+            out.functionDefLine = functionStartLineColumn.line > 0
+                ? static_cast<int>(functionStartLineColumn.line) - 1
+                : 0;
+            out.functionDefColumn = functionStartLineColumn.column > 0
+                ? static_cast<int>(functionStartLineColumn.column) - 1
+                : 0;
+        }
+
+        normalizeURL(out.url);
+
+        if (frame.hasExpressionInfo()) {
+            // Sample position for positionTicks. Use a throwaway out-param so
+            // the sample remap can't clobber `url` with a different file than
+            // the function definition, and drop the sample line entirely if it
+            // maps to a different original source file (cross-module inlining
+            // in bundled code would otherwise mislocate the tick).
+            JSC::LineColumn sourceMappedLineColumn = frame.semanticLocation.lineColumn;
+            // Seed with the raw provider URL so that when the sourcemap
+            // callback is a no-op, the `sampleURL == url` guard below still
+            // passes for plain .js files. Seeding empty would silently suppress
+            // positionTicks for every non-sourcemapped script.
+            WTF::String sampleURL = provider ? WTF::String(provider->sourceURL()) : WTF::String();
+            if (provider) {
+#if USE(BUN_JSC_ADDITIONS)
+                auto& fn = vm.computeLineColumnWithSourcemap();
+                if (fn)
+                    fn(vm, provider, sourceMappedLineColumn, sampleURL);
+#endif
+            }
+            normalizeURL(sampleURL);
+            if (sourceMappedLineColumn.line > 0 && sampleURL == out.url)
+                out.sampleLine = static_cast<int>(sourceMappedLineColumn.line);
+        }
+    }
+
+    return out;
+}
+
+// Move everything the sampling profiler has accumulated into s_retainedSamples.
+// releaseStackTraces() clears m_liveCellPointers, so the raw heap pointers in
+// the returned traces are only valid inside the DeferGC scope here.
+static void drainSamplesFromProfiler(JSC::VM& vm, JSC::SamplingProfiler& profiler)
+{
+    JSC::JSLockHolder locker(vm);
+    JSC::DeferGC deferGC(vm);
+
+    auto& lock = profiler.getLock();
+    WTF::Locker profilerLocker { lock };
+
+    auto stackTraces = profiler.releaseStackTraces();
+    if (stackTraces.isEmpty())
+        return;
+
+    auto& retained = retainedSamples();
+    retained.reserveCapacity(retained.size() + stackTraces.size());
+    for (auto& stackTrace : stackTraces) {
+        RetainedSample sample;
+        sample.timestampUs = stackTrace.timestamp.approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
+        sample.frames.reserveInitialCapacity(stackTrace.frames.size());
+        for (auto& frame : stackTrace.frames)
+            sample.frames.append(extractFrame(vm, frame));
+        retained.append(WTF::move(sample));
+    }
+}
+
+// Helper to generate a minimal valid cpuprofile JSON with no samples
+static WTF::String generateEmptyProfileJSON(double startTimeUs)
+{
     long long timestamp;
-    if (s_profilingStartTime > 0)
-        timestamp = static_cast<long long>(s_profilingStartTime);
+    if (startTimeUs > 0)
+        timestamp = static_cast<long long>(startTimeUs);
     else
         timestamp = static_cast<long long>(WTF::WallTime::now().secondsSinceEpoch().value() * 1000000.0);
 
@@ -289,52 +434,72 @@ static WTF::String generateEmptyProfileJSON()
     return sb.toString();
 }
 
-// Unified function that stops the profiler and generates requested output formats
-void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
+// Release one consumer's hold on the profiler and generate its profile in the
+// requested formats. sinceTimestampUs is the value startCPUProfiler() returned
+// for this consumer; samples taken before it are excluded so concurrent
+// consumers (e.g. --cpu-prof and a node:inspector session) each see only their
+// own window. 0 means "since the first consumer's start".
+void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText, double sinceTimestampUs)
 {
-    s_isProfilerRunning = false;
+    if (s_profilerRefCount > 0)
+        s_profilerRefCount--;
+    bool isLastConsumer = s_profilerRefCount == 0;
 
     JSC::SamplingProfiler* profiler = vm.samplingProfiler();
     if (!profiler) {
         if (outJSON) *outJSON = WTF::String();
         if (outText) *outText = WTF::String();
+        if (isLastConsumer && s_retainedSamples) {
+            s_retainedSamples->clear();
+            s_profilingStartTime = 0.0;
+        }
         return;
     }
 
-    // JSLock is re-entrant, so always acquiring it handles both JS and shutdown contexts
-    JSC::JSLockHolder locker(vm);
+    drainSamplesFromProfiler(vm, *profiler);
 
-    // Defer GC while we're working with stack traces
-    JSC::DeferGC deferGC(vm);
+    if (isLastConsumer) {
+        auto& lock = profiler->getLock();
+        WTF::Locker profilerLocker { lock };
+        profiler->pause();
+        profiler->clearData();
+    }
 
-    // Pause the profiler while holding the lock
-    auto& lock = profiler->getLock();
-    WTF::Locker profilerLocker { lock };
-    profiler->pause();
+    double startTime = sinceTimestampUs > 0 ? sinceTimestampUs : s_profilingStartTime;
 
-    // releaseStackTraces() calls processUnverifiedStackTraces() internally
-    auto stackTraces = profiler->releaseStackTraces();
-    profiler->clearData();
+    auto cleanup = [&]() {
+        if (isLastConsumer) {
+            if (s_retainedSamples)
+                s_retainedSamples->clear();
+            s_profilingStartTime = 0.0;
+        }
+    };
 
-    // If neither output is requested, we're done
-    if (!outJSON && !outText)
-        return;
-
-    if (stackTraces.isEmpty()) {
-        if (outJSON) *outJSON = generateEmptyProfileJSON();
-        if (outText) *outText = "No samples collected.\n"_s;
+    if (!outJSON && !outText) {
+        cleanup();
         return;
     }
 
-    // Sort traces by timestamp once for both formats
+    auto& retained = retainedSamples();
+
+    // Samples for this consumer, sorted by timestamp. Samples are drained in
+    // batches so the retained vector is not globally sorted.
     WTF::Vector<size_t> sortedIndices;
-    sortedIndices.reserveInitialCapacity(stackTraces.size());
-    for (size_t i = 0; i < stackTraces.size(); i++) {
-        sortedIndices.append(i);
+    sortedIndices.reserveInitialCapacity(retained.size());
+    for (size_t i = 0; i < retained.size(); i++) {
+        if (retained[i].timestampUs >= startTime)
+            sortedIndices.append(i);
     }
-    std::sort(sortedIndices.begin(), sortedIndices.end(), [&stackTraces](size_t a, size_t b) {
-        return stackTraces[a].timestamp < stackTraces[b].timestamp;
+    std::sort(sortedIndices.begin(), sortedIndices.end(), [&retained](size_t a, size_t b) {
+        return retained[a].timestampUs < retained[b].timestampUs;
     });
+
+    if (sortedIndices.isEmpty()) {
+        if (outJSON) *outJSON = generateEmptyProfileJSON(startTime);
+        if (outText) *outText = "No samples collected.\n"_s;
+        cleanup();
+        return;
+    }
 
     // Generate JSON format if requested
     if (outJSON) {
@@ -357,14 +522,14 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         WTF::Vector<int> samples;
         WTF::Vector<long long> timeDeltas;
 
-        double startTime = s_profilingStartTime;
-        double lastTime = s_profilingStartTime;
+        double lastTime = startTime;
 
         for (size_t idx : sortedIndices) {
-            auto& stackTrace = stackTraces[idx];
-            if (stackTrace.frames.isEmpty()) {
+            auto& sample = retained[idx];
+            double currentTime = sample.timestampUs;
+
+            if (sample.frames.isEmpty()) {
                 samples.append(1);
-                double currentTime = stackTrace.timestamp.approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
                 double delta = std::max(0.0, currentTime - lastTime);
                 timeDeltas.append(static_cast<long long>(delta));
                 lastTime = currentTime;
@@ -373,134 +538,23 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
             int currentParentId = 1;
 
-            for (int i = stackTrace.frames.size() - 1; i >= 0; i--) {
-                auto& frame = stackTrace.frames[i];
-
-                WTF::String functionName = frame.displayName(vm);
-                WTF::String url;
-                int scriptId = 0;
-                // Function-definition line/column (0-indexed) for callFrame.
-                int functionDefLine = -1;
-                int functionDefColumn = -1;
-                // Current-sample line (1-indexed) for positionTicks.
-                int sampleLine = 0;
-
-                if (frame.frameType == JSC::SamplingProfiler::FrameType::Executable && frame.executable) {
-                    auto sourceProviderAndID = frame.sourceProviderAndID();
-                    auto* provider = std::get<0>(sourceProviderAndID);
-                    if (provider) {
-                        url = provider->sourceURL();
-                        scriptId = static_cast<int>(provider->asID());
-                    }
-
-                    // Absolute file path → `file://` URL. Chrome DevTools
-                    // expects `callFrame.url` to be a proper URL; leaving
-                    // the raw path breaks source-view resolution. We run
-                    // this AFTER the sourcemap callbacks below because the
-                    // callback (see FormatStackTraceForJS.cpp) unconditionally
-                    // rewrites its out-param back to the raw provider URL when
-                    // no sourcemap is found, which would undo an earlier
-                    // normalization. See #29240.
-                    auto normalizeURL = [](WTF::String& u) {
-                        if (u.isEmpty())
-                            return;
-                        bool isAbsolutePath = false;
-                        if (u[0] == '/') {
-                            isAbsolutePath = true;
-                        } else if (u.length() >= 2 && u[1] == ':') {
-                            char firstChar = u[0];
-                            if ((firstChar >= 'A' && firstChar <= 'Z') || (firstChar >= 'a' && firstChar <= 'z'))
-                                isAbsolutePath = true;
-                        } else if (u.length() >= 2 && u[0] == '\\' && u[1] == '\\') {
-                            isAbsolutePath = true;
-                        }
-                        if (isAbsolutePath)
-                            u = WTF::URL::fileURLWithFileSystemPath(u).string();
-                    };
-
-                    // Function definition location. JSC returns these 1-based;
-                    // Node/Deno/Chrome DevTools emit them 0-based in the JSON.
-                    // The definition (not the sample position) is remapped
-                    // through the sourcemap callback so callFrame.url and
-                    // callFrame.line/column agree on the function's source.
-                    int rawFunctionStartLine = frame.functionStartLine();
-                    unsigned rawFunctionStartColumn = frame.functionStartColumn();
-                    if (rawFunctionStartLine > 0 && rawFunctionStartColumn != std::numeric_limits<unsigned>::max()) {
-                        JSC::LineColumn functionStartLineColumn {
-                            static_cast<unsigned>(rawFunctionStartLine),
-                            rawFunctionStartColumn,
-                        };
-                        if (provider) {
-#if USE(BUN_JSC_ADDITIONS)
-                            auto& fn = vm.computeLineColumnWithSourcemap();
-                            if (fn) {
-                                // `url` is the out-param — on a successful
-                                // remap it becomes the original-source URL.
-                                fn(vm, provider, functionStartLineColumn, url);
-                            }
-#endif
-                        }
-                        functionDefLine = functionStartLineColumn.line > 0
-                            ? static_cast<int>(functionStartLineColumn.line) - 1
-                            : 0;
-                        functionDefColumn = functionStartLineColumn.column > 0
-                            ? static_cast<int>(functionStartLineColumn.column) - 1
-                            : 0;
-                    }
-
-                    // Normalize `url` to a `file://` URL now that any
-                    // sourcemap rewriting is done.
-                    normalizeURL(url);
-
-                    if (frame.hasExpressionInfo()) {
-                        // Sample position for positionTicks. Use a throwaway
-                        // out-param so the sample remap can't clobber `url`
-                        // with a different file than the function definition.
-                        // We also drop the sample line entirely if the sample
-                        // maps back to a DIFFERENT original source file than
-                        // the definition (cross-module inlining in bundled
-                        // code) — attaching a line number from one file to a
-                        // ProfileNode whose callFrame.url is a different file
-                        // would mislocate the tick in Chrome DevTools.
-                        JSC::LineColumn sourceMappedLineColumn = frame.semanticLocation.lineColumn;
-                        // Seed with the raw provider URL (NOT empty). If the
-                        // sourcemap callback is a no-op — BUN_JSC_ADDITIONS
-                        // off, fn null, or the provider has no sourcemap —
-                        // sampleURL stays at this seed, and normalizeURL()
-                        // below converts it to the same `file://` form as
-                        // `url`, letting the `sampleURL == url` guard pass
-                        // for plain .js files. Seeding empty would silently
-                        // suppress positionTicks for every non-sourcemapped
-                        // script.
-                        WTF::String sampleURL = provider ? WTF::String(provider->sourceURL()) : WTF::String();
-                        if (provider) {
-#if USE(BUN_JSC_ADDITIONS)
-                            auto& fn = vm.computeLineColumnWithSourcemap();
-                            if (fn) {
-                                fn(vm, provider, sourceMappedLineColumn, sampleURL);
-                            }
-#endif
-                        }
-                        normalizeURL(sampleURL);
-                        if (sourceMappedLineColumn.line > 0 && sampleURL == url)
-                            sampleLine = static_cast<int>(sourceMappedLineColumn.line);
-                    }
-                }
+            for (int i = sample.frames.size() - 1; i >= 0; i--) {
+                const auto& frame = sample.frames[i];
 
                 // line/column here identify the function's DEFINITION, so all
                 // samples of the same function under the same parent collapse.
                 WTF::StringBuilder keyBuilder;
                 keyBuilder.append(currentParentId);
                 keyBuilder.append(':');
-                keyBuilder.append(functionName);
+                keyBuilder.append(frame.functionName);
                 keyBuilder.append(':');
-                keyBuilder.append(url);
+                keyBuilder.append(frame.url);
                 keyBuilder.append(':');
-                keyBuilder.append(scriptId);
+                keyBuilder.append(frame.scriptId);
                 keyBuilder.append(':');
-                keyBuilder.append(functionDefLine);
+                keyBuilder.append(frame.functionDefLine);
                 keyBuilder.append(':');
-                keyBuilder.append(functionDefColumn);
+                keyBuilder.append(frame.functionDefColumn);
 
                 WTF::String key = keyBuilder.toString();
 
@@ -512,11 +566,11 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
                     ProfileNode node;
                     node.id = nodeId;
-                    node.functionName = functionName;
-                    node.url = url;
-                    node.scriptId = scriptId;
-                    node.lineNumber = functionDefLine;
-                    node.columnNumber = functionDefColumn;
+                    node.functionName = frame.functionName;
+                    node.url = frame.url;
+                    node.scriptId = frame.scriptId;
+                    node.lineNumber = frame.functionDefLine;
+                    node.columnNumber = frame.functionDefColumn;
                     node.hitCount = 0;
 
                     nodes.append(WTF::move(node));
@@ -531,14 +585,13 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
                 if (i == 0) {
                     nodes[nodeId - 1].hitCount++;
-                    if (sampleLine > 0)
-                        nodes[nodeId - 1].positionTicks.add(sampleLine, 0).iterator->value++;
+                    if (frame.sampleLine > 0)
+                        nodes[nodeId - 1].positionTicks.add(frame.sampleLine, 0).iterator->value++;
                 }
             }
 
             samples.append(currentParentId);
 
-            double currentTime = stackTrace.timestamp.approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
             double delta = std::max(0.0, currentTime - lastTime);
             timeDeltas.append(static_cast<long long>(delta));
             lastTime = currentTime;
@@ -617,73 +670,34 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
     // Generate text format if requested
     if (outText) {
-        double startTime = s_profilingStartTime;
-        double lastTime = s_profilingStartTime;
+        double lastTime = startTime;
         double endTime = startTime;
 
         WTF::HashMap<WTF::String, FunctionStats> functionStatsMap;
 
         long long totalTimeUs = 0;
-        int totalSamples = static_cast<int>(stackTraces.size());
+        int totalSamples = static_cast<int>(sortedIndices.size());
 
         for (size_t idx : sortedIndices) {
-            auto& stackTrace = stackTraces[idx];
+            auto& sample = retained[idx];
 
-            double currentTime = stackTrace.timestamp.approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
+            double currentTime = sample.timestampUs;
             long long deltaUs = static_cast<long long>(std::max(0.0, currentTime - lastTime));
             totalTimeUs += deltaUs;
             lastTime = currentTime;
             endTime = currentTime;
 
-            if (stackTrace.frames.isEmpty())
+            if (sample.frames.isEmpty())
                 continue;
 
             WTF::String previousKey;
 
-            for (int i = stackTrace.frames.size() - 1; i >= 0; i--) {
-                auto& frame = stackTrace.frames[i];
+            for (int i = sample.frames.size() - 1; i >= 0; i--) {
+                const auto& frame = sample.frames[i];
 
-                WTF::String rawFunctionName = frame.displayName(vm);
-                WTF::String functionName = formatFunctionName(rawFunctionName, frame);
-                WTF::String url;
-                int lineNumber = -1;
-
-                if (frame.frameType == JSC::SamplingProfiler::FrameType::Executable && frame.executable) {
-                    auto sourceProviderAndID = frame.sourceProviderAndID();
-                    auto* provider = std::get<0>(sourceProviderAndID);
-                    if (provider) {
-                        url = provider->sourceURL();
-
-                        bool isAbsolutePath = false;
-                        if (!url.isEmpty()) {
-                            if (url[0] == '/')
-                                isAbsolutePath = true;
-                            else if (url.length() >= 2 && url[1] == ':') {
-                                char firstChar = url[0];
-                                if ((firstChar >= 'A' && firstChar <= 'Z') || (firstChar >= 'a' && firstChar <= 'z'))
-                                    isAbsolutePath = true;
-                            } else if (url.length() >= 2 && url[0] == '\\' && url[1] == '\\')
-                                isAbsolutePath = true;
-                        }
-                        if (isAbsolutePath)
-                            url = WTF::URL::fileURLWithFileSystemPath(url).string();
-                    }
-
-                    if (frame.hasExpressionInfo()) {
-                        JSC::LineColumn sourceMappedLineColumn = frame.semanticLocation.lineColumn;
-                        if (provider) {
-#if USE(BUN_JSC_ADDITIONS)
-                            auto& fn = vm.computeLineColumnWithSourcemap();
-                            if (fn)
-                                fn(vm, provider, sourceMappedLineColumn, url);
-#endif
-                        }
-                        lineNumber = static_cast<int>(sourceMappedLineColumn.line);
-                    }
-                }
-
-                WTF::String location = formatLocation(url, lineNumber);
-                // Key uses zero-width space separator internally (not shown in output)
+                WTF::String functionName = formatFunctionName(frame.functionName, frame.isAsync);
+                int lineNumber = frame.sampleLine > 0 ? frame.sampleLine : -1;
+                WTF::String location = formatLocation(frame.url, lineNumber);
                 WTF::StringBuilder keyBuilder;
                 keyBuilder.append(functionName);
                 keyBuilder.append(kKeySeparator);
@@ -926,6 +940,8 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
         *outText = output.toString();
     }
+
+    cleanup();
 }
 
 } // namespace Bun
@@ -939,7 +955,7 @@ extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString*
 {
     WTF::String jsonResult;
     WTF::String textResult;
-    Bun::stopCPUProfiler(*vm, outJSON ? &jsonResult : nullptr, outText ? &textResult : nullptr);
+    Bun::stopCPUProfiler(*vm, outJSON ? &jsonResult : nullptr, outText ? &textResult : nullptr, 0.0);
     if (outJSON)
         *outJSON = Bun::toStringRef(jsonResult);
     if (outText)

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -17,6 +17,7 @@
 #include <wtf/URL.h>
 #include <algorithm>
 #include <limits>
+#include <memory>
 
 extern "C" void Bun__startCPUProfiler(JSC::VM* vm);
 extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText);

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -33,17 +33,11 @@ namespace Bun {
 static thread_local double s_profilingStartTime = 0.0;
 // Set sampling interval to 1ms (1000 microseconds) to match Node.js
 static thread_local int s_samplingInterval = 1000;
-// JSC has one SamplingProfiler per VM. --cpu-prof, node:inspector sessions, and
-// Worker.{start,stop}CpuProfile all share it, so the underlying profiler is
-// started once on the first consumer and only paused/cleared when the last one
-// releases it.
 static thread_local int s_profilerRefCount = 0;
 
-// A sample drained from JSC's SamplingProfiler. releaseStackTraces() also
-// clears m_liveCellPointers, so the raw ExecutableBase*/JSObject* in a
-// StackTrace are only valid under DeferGC; converting to owned strings/ints
-// here lets samples outlive the DeferGC scope so a later consumer can still
-// see samples a prior consumer's stop() released.
+// GC-safe copy of a SamplingProfiler::StackFrame: releaseStackTraces() clears
+// m_liveCellPointers, so the raw ExecutableBase* in a StackTrace is only valid
+// under DeferGC; owned strings/ints here survive across consumers.
 struct RetainedFrame {
     WTF::String functionName;
     WTF::String url;
@@ -389,9 +383,6 @@ static RetainedFrame extractFrame(JSC::VM& vm, JSC::SamplingProfiler::StackFrame
     return out;
 }
 
-// Move everything the sampling profiler has accumulated into s_retainedSamples.
-// releaseStackTraces() clears m_liveCellPointers, so the raw heap pointers in
-// the returned traces are only valid inside the DeferGC scope here.
 static void drainSamplesFromProfiler(JSC::VM& vm, JSC::SamplingProfiler& profiler)
 {
     JSC::JSLockHolder locker(vm);
@@ -434,11 +425,6 @@ static WTF::String generateEmptyProfileJSON(double startTimeUs)
     return sb.toString();
 }
 
-// Release one consumer's hold on the profiler and generate its profile in the
-// requested formats. sinceTimestampUs is the value startCPUProfiler() returned
-// for this consumer; samples taken before it are excluded so concurrent
-// consumers (e.g. --cpu-prof and a node:inspector session) each see only their
-// own window. 0 means "since the first consumer's start".
 void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText, double sinceTimestampUs)
 {
     if (s_profilerRefCount > 0)

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -53,12 +53,12 @@ struct RetainedSample {
     WTF::Vector<RetainedFrame> frames;
 };
 
-static thread_local WTF::Vector<RetainedSample>* s_retainedSamples = nullptr;
+static thread_local std::unique_ptr<WTF::Vector<RetainedSample>> s_retainedSamples;
 
 static WTF::Vector<RetainedSample>& retainedSamples()
 {
     if (!s_retainedSamples)
-        s_retainedSamples = new WTF::Vector<RetainedSample>();
+        s_retainedSamples = std::make_unique<WTF::Vector<RetainedSample>>();
     return *s_retainedSamples;
 }
 

--- a/src/jsc/bindings/BunCPUProfiler.h
+++ b/src/jsc/bindings/BunCPUProfiler.h
@@ -13,17 +13,14 @@ namespace Bun {
 void setSamplingInterval(int intervalMicroseconds);
 bool isCPUProfilerRunning();
 
-// Register a consumer of the per-VM sampling profiler and return that
-// consumer's start timestamp (microseconds since epoch). The underlying
-// JSC::SamplingProfiler is started on the first consumer and shared by the
-// rest; the returned timestamp is passed back to stopCPUProfiler() so each
-// consumer's profile is scoped to its own window.
+// The per-VM JSC::SamplingProfiler is shared by --cpu-prof, node:inspector
+// sessions, and Worker.{start,stop}CpuProfile, so startCPUProfiler()/
+// stopCPUProfiler() refcount it: the sampler starts on the first consumer and
+// is paused/cleared on the last. startCPUProfiler() returns this consumer's
+// start timestamp (microseconds since epoch), which is passed back as
+// sinceTimestampUs so each consumer's profile is scoped to its own window
+// (0 = since the first consumer).
 double startCPUProfiler(JSC::VM& vm);
-
-// Release a consumer and emit its profile. Samples before sinceTimestampUs (as
-// returned by startCPUProfiler) are excluded; 0 means "since the first
-// consumer". The underlying profiler is paused and the retained sample buffer
-// cleared only when the last consumer releases.
 void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText, double sinceTimestampUs = 0.0);
 
 } // namespace Bun

--- a/src/jsc/bindings/BunCPUProfiler.h
+++ b/src/jsc/bindings/BunCPUProfiler.h
@@ -13,11 +13,17 @@ namespace Bun {
 void setSamplingInterval(int intervalMicroseconds);
 bool isCPUProfilerRunning();
 
-// Start the CPU profiler
-void startCPUProfiler(JSC::VM& vm);
+// Register a consumer of the per-VM sampling profiler and return that
+// consumer's start timestamp (microseconds since epoch). The underlying
+// JSC::SamplingProfiler is started on the first consumer and shared by the
+// rest; the returned timestamp is passed back to stopCPUProfiler() so each
+// consumer's profile is scoped to its own window.
+double startCPUProfiler(JSC::VM& vm);
 
-// Stop the CPU profiler and get profile data in requested formats.
-// Pass non-null pointers for the formats you want. Null pointers are skipped.
-void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText);
+// Release a consumer and emit its profile. Samples before sinceTimestampUs (as
+// returned by startCPUProfiler) are excluded; 0 means "since the first
+// consumer". The underlying profiler is paused and the retained sample buffer
+// cleared only when the last consumer releases.
+void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText, double sinceTimestampUs = 0.0);
 
 } // namespace Bun

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -19,16 +19,21 @@ using namespace JSC;
 JSC_DECLARE_HOST_FUNCTION(jsFunction_startCPUProfiler);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_startCPUProfiler, (JSGlobalObject * globalObject, CallFrame*))
 {
-    Bun::startCPUProfiler(globalObject->vm());
-    return JSValue::encode(jsUndefined());
+    return JSValue::encode(jsNumber(Bun::startCPUProfiler(globalObject->vm())));
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsFunction_stopCPUProfiler);
-JSC_DEFINE_HOST_FUNCTION(jsFunction_stopCPUProfiler, (JSGlobalObject * globalObject, CallFrame*))
+JSC_DEFINE_HOST_FUNCTION(jsFunction_stopCPUProfiler, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = globalObject->vm();
+    double since = 0.0;
+    if (callFrame->argumentCount() > 0) {
+        JSValue arg = callFrame->uncheckedArgument(0);
+        if (arg.isNumber())
+            since = arg.asNumber();
+    }
     WTF::String result;
-    Bun::stopCPUProfiler(vm, &result, nullptr);
+    Bun::stopCPUProfiler(vm, &result, nullptr, since);
     return JSValue::encode(jsString(vm, result));
 }
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -815,8 +815,13 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_startCpuProfileInter
     uint64_t reqId = worker.registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     bool accepted = worker.postTaskToWorkerGlobalScope([reqId, parentId, protectedWorker = Ref { worker }](ScriptExecutionContext& workerCtx) mutable {
-        if (!Bun::isCPUProfilerRunning())
-            Bun::startCPUProfiler(workerCtx.vm());
+        // The worker thread's sampling profiler is reference-counted across
+        // this API and any in-worker node:inspector Session, so take a ref
+        // rather than guarding on isCPUProfilerRunning(). Tasks posted here run
+        // serially on the worker thread, so the load/store is not racy, and a
+        // second startCpuProfile() before stop stays idempotent.
+        if (protectedWorker->cpuProfileStartTime() == 0.0)
+            protectedWorker->setCpuProfileStartTime(Bun::startCPUProfiler(workerCtx.vm()));
         ScriptExecutionContext::postTaskTo(parentId, [reqId, protectedWorker = WTF::move(protectedWorker)](ScriptExecutionContext& parentCtx) {
             resolveCrossVMRequest(protectedWorker.get(), reqId, parentCtx, jsUndefined());
         });
@@ -840,8 +845,11 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_stopCpuProfileIntern
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     bool accepted = worker.postTaskToWorkerGlobalScope([reqId, parentId, protectedWorker = Ref { worker }](ScriptExecutionContext& workerCtx) mutable {
         WTF::String result;
-        if (Bun::isCPUProfilerRunning())
-            Bun::stopCPUProfiler(workerCtx.vm(), &result, nullptr);
+        double since = protectedWorker->cpuProfileStartTime();
+        if (since != 0.0) {
+            protectedWorker->setCpuProfileStartTime(0.0);
+            Bun::stopCPUProfiler(workerCtx.vm(), &result, nullptr, since);
+        }
         if (result.isEmpty())
             result = kEmptyCpuProfileJSON;
         ScriptExecutionContext::postTaskTo(parentId, [reqId, protectedWorker = WTF::move(protectedWorker), result = result.isolatedCopy()](ScriptExecutionContext& parentCtx) {

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -815,11 +815,6 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_startCpuProfileInter
     uint64_t reqId = worker.registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     bool accepted = worker.postTaskToWorkerGlobalScope([reqId, parentId, protectedWorker = Ref { worker }](ScriptExecutionContext& workerCtx) mutable {
-        // The worker thread's sampling profiler is reference-counted across
-        // this API and any in-worker node:inspector Session, so take a ref
-        // rather than guarding on isCPUProfilerRunning(). Tasks posted here run
-        // serially on the worker thread, so the load/store is not racy, and a
-        // second startCpuProfile() before stop stays idempotent.
         if (protectedWorker->cpuProfileStartTime() == 0.0)
             protectedWorker->setCpuProfileStartTime(Bun::startCPUProfiler(workerCtx.vm()));
         ScriptExecutionContext::postTaskTo(parentId, [reqId, protectedWorker = WTF::move(protectedWorker)](ScriptExecutionContext& parentCtx) {

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -163,10 +163,8 @@ public:
     void enqueueToParent(MessageWithMessagePorts&&);
     void drainToWorker(ScriptExecutionContext&);
 
-    // Worker.{start,stop}CpuProfile's hold on the worker thread's shared
-    // sampling profiler: the timestamp startCPUProfiler() returned, or 0 if no
-    // profile is held. Read and written only from the worker thread's task
-    // queue (serial), so atomicity is for cross-thread destruction visibility.
+    // startCPUProfiler()'s returned timestamp for Worker.startCpuProfile's hold
+    // on the refcounted sampler, 0 if none. Touched only on the worker thread.
     double cpuProfileStartTime() const { return m_cpuProfileStartTime.load(); }
     void setCpuProfileStartTime(double ts) { m_cpuProfileStartTime.store(ts); }
 

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -163,6 +163,13 @@ public:
     void enqueueToParent(MessageWithMessagePorts&&);
     void drainToWorker(ScriptExecutionContext&);
 
+    // Worker.{start,stop}CpuProfile's hold on the worker thread's shared
+    // sampling profiler: the timestamp startCPUProfiler() returned, or 0 if no
+    // profile is held. Read and written only from the worker thread's task
+    // queue (serial), so atomicity is for cross-thread destruction visibility.
+    double cpuProfileStartTime() const { return m_cpuProfileStartTime.load(); }
+    void setCpuProfileStartTime(double ts) { m_cpuProfileStartTime.store(ts); }
+
 private:
     Worker(ScriptExecutionContext&, WorkerOptions&&);
 
@@ -193,6 +200,7 @@ private:
 
     std::atomic<State> m_state { State::Pending };
     std::atomic<bool> m_terminateRequested { false };
+    std::atomic<double> m_cpuProfileStartTime { 0.0 };
 
     // Stable for the process lifetime; used with ScriptExecutionContext::
     // postTaskTo() so the worker thread never dereferences the parent context

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -538,11 +538,9 @@ phase2();
         expect(names).toContain("phase2");
       });
 
-      test.concurrent(
-        "worker.startCpuProfile()'s stop does not tear down an in-worker Session's profile",
-        async () => {
-          using dir = tempDir("inspector-worker-cpuprofile", {
-            "fixture.mjs": `
+      test.concurrent("worker.startCpuProfile()'s stop does not tear down an in-worker Session's profile", async () => {
+        using dir = tempDir("inspector-worker-cpuprofile", {
+          "fixture.mjs": `
 import { Worker } from "node:worker_threads";
 import { once } from "node:events";
 const worker = new Worker(\`
@@ -569,27 +567,26 @@ const [result] = await once(worker, "message");
 await worker.terminate();
 console.log(JSON.stringify(result));
 `,
-          });
-          await using proc = Bun.spawn({
-            cmd: [bunExe(), "fixture.mjs"],
-            env: bunEnv,
-            cwd: String(dir),
-            stderr: "pipe",
-          });
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
-            stderrIfFailed: "",
-            exitCode: 0,
-          });
-          const result = JSON.parse(stdout.trim());
-          // With the old isCPUProfilerRunning() guards in JSWorker.cpp, the
-          // parent's handle.stop() decremented the ref the Session took, so the
-          // Session's own Profiler.stop found the sampler paused and the buffer
-          // cleared.
-          expect(result.samples).toBeGreaterThan(0);
-          expect(result.names).toContain("inWorker");
-        },
-      );
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "fixture.mjs"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+          stderrIfFailed: "",
+          exitCode: 0,
+        });
+        const result = JSON.parse(stdout.trim());
+        // With the old isCPUProfilerRunning() guards in JSWorker.cpp, the
+        // parent's handle.stop() decremented the ref the Session took, so the
+        // Session's own Profiler.stop found the sampler paused and the buffer
+        // cleared.
+        expect(result.samples).toBeGreaterThan(0);
+        expect(result.names).toContain("inWorker");
+      });
     });
   });
 

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync, readFileSync } from "node:fs";
 import inspector from "node:inspector";
 import inspectorPromises from "node:inspector/promises";
+import { join } from "node:path";
 
 // Mirrors how vitest's @vitest/coverage-v8 provider drives the inspector: a
 // promise Session, Profiler.enable, startPreciseCoverage, evaluating modules
@@ -383,6 +385,158 @@ describe("node:inspector", () => {
       const result = session2.post("Profiler.setSamplingInterval", { interval: 500 });
       expect(result).toEqual({});
       session2.disconnect();
+    });
+
+    // The VM has one JSC::SamplingProfiler shared by --cpu-prof and every
+    // Session. A session that never posted Profiler.* must not touch that
+    // shared profiler, and one session's Profiler.stop/disable/disconnect must
+    // not tear down another session's profile.
+    describe("shared sampling profiler ownership", () => {
+      test("a session's disconnect()/Profiler.disable only stops a profile it started", () => {
+        const a = new inspector.Session();
+        a.connect();
+        a.post("Profiler.enable");
+        a.post("Profiler.start");
+
+        const b = new inspector.Session();
+        b.connect();
+        // B never posted Profiler.*: disconnect() must not touch A's profile.
+        b.disconnect();
+
+        const c = new inspector.Session();
+        c.connect();
+        c.post("Profiler.enable");
+        // C enabled but never started: disable must not touch A's profile.
+        c.post("Profiler.disable");
+        c.disconnect();
+
+        const { profile } = a.post("Profiler.stop");
+        expect(profile).toHaveProperty("nodes");
+        a.disconnect();
+      });
+
+      test("one session's Profiler.stop does not stop another session's profile", () => {
+        const a = new inspector.Session();
+        a.connect();
+        a.post("Profiler.enable");
+        a.post("Profiler.start");
+
+        const b = new inspector.Session();
+        b.connect();
+        b.post("Profiler.enable");
+        b.post("Profiler.start");
+        const { profile: profileB } = b.post("Profiler.stop");
+        b.disconnect();
+
+        // A's profile must still be running.
+        const { profile: profileA } = a.post("Profiler.stop");
+        a.disconnect();
+
+        expect(profileB).toHaveProperty("nodes");
+        expect(profileA).toHaveProperty("nodes");
+      });
+
+      // --cpu-prof starts the profiler before any user code runs, so a
+      // Profiler.start issued later must not adopt those earlier samples.
+      test.concurrent("Profiler.stop excludes samples taken before Profiler.start under --cpu-prof", async () => {
+        using dir = tempDir("inspector-profile-window", {
+          "fixture.mjs": `
+import { Session } from "node:inspector";
+function before() { const t = performance.now(); let x = 0; while (performance.now() - t < 200) x += Math.sqrt(x + 1); }
+function after()  { const t = performance.now(); let x = 0; while (performance.now() - t < 200) x += Math.sqrt(x + 1); }
+before();
+const s = new Session();
+s.connect();
+s.post("Profiler.enable");
+s.post("Profiler.start");
+after();
+const { profile } = s.post("Profiler.stop");
+s.disconnect();
+const names = profile.nodes.map(n => n.callFrame.functionName);
+console.log(JSON.stringify({
+  startLEend: profile.startTime <= profile.endTime,
+  hasBefore: names.includes("before"),
+  hasAfter: names.includes("after"),
+}));
+`,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--cpu-prof", "--cpu-prof-dir", String(dir), "fixture.mjs"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+        expect(JSON.parse(stdout.trim())).toEqual({ startLEend: true, hasBefore: false, hasAfter: true });
+      });
+
+      test.concurrent("connect()+disconnect() with no Profiler.* does not empty --cpu-prof", async () => {
+        using dir = tempDir("inspector-cpuprof-disconnect", {
+          "fixture.mjs": `
+import { Session } from "node:inspector";
+function work() { const t = performance.now(); let x = 0; while (performance.now() - t < 200) x += Math.sqrt(x + 1); }
+work();
+const s = new Session();
+s.connect();
+s.disconnect();
+work();
+`,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--cpu-prof", "--cpu-prof-dir", String(dir), "fixture.mjs"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+
+        const file = readdirSync(String(dir)).find(f => f.endsWith(".cpuprofile"));
+        expect(file).toBeDefined();
+        const profile = JSON.parse(readFileSync(join(String(dir), file!), "utf-8"));
+        // Before the fix, the disconnect() released --cpu-prof's hold on the
+        // profiler and the file had a single (root) node with zero samples.
+        expect(profile.samples.length).toBeGreaterThan(0);
+        expect(profile.nodes.length).toBeGreaterThan(1);
+        expect(profile.endTime).toBeGreaterThan(profile.startTime);
+      });
+
+      test.concurrent("a session's Profiler.stop leaves --cpu-prof's samples intact", async () => {
+        using dir = tempDir("inspector-cpuprof-session-stop", {
+          "fixture.mjs": `
+import { Session } from "node:inspector";
+function phase1() { const t = performance.now(); let x = 0; while (performance.now() - t < 200) x += Math.sqrt(x + 1); }
+function phase2() { const t = performance.now(); let x = 0; while (performance.now() - t < 200) x += Math.sqrt(x + 1); }
+phase1();
+const s = new Session();
+s.connect();
+s.post("Profiler.enable");
+s.post("Profiler.start");
+s.post("Profiler.stop");
+s.disconnect();
+phase2();
+`,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--cpu-prof", "--cpu-prof-dir", String(dir), "fixture.mjs"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+
+        const file = readdirSync(String(dir)).find(f => f.endsWith(".cpuprofile"));
+        expect(file).toBeDefined();
+        const profile = JSON.parse(readFileSync(join(String(dir), file!), "utf-8"));
+        const names: string[] = profile.nodes.map((n: any) => n.callFrame.functionName);
+        // --cpu-prof spans the whole run, so both phases must be present. Before
+        // the fix, Profiler.stop consumed the shared buffer and then released
+        // --cpu-prof's hold, so neither phase appeared.
+        expect(names).toContain("phase1");
+        expect(names).toContain("phase2");
+      });
     });
   });
 

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -537,6 +537,59 @@ phase2();
         expect(names).toContain("phase1");
         expect(names).toContain("phase2");
       });
+
+      test.concurrent(
+        "worker.startCpuProfile()'s stop does not tear down an in-worker Session's profile",
+        async () => {
+          using dir = tempDir("inspector-worker-cpuprofile", {
+            "fixture.mjs": `
+import { Worker } from "node:worker_threads";
+import { once } from "node:events";
+const worker = new Worker(\`
+  const { parentPort } = require("node:worker_threads");
+  const { Session } = require("node:inspector");
+  function inWorker() { const t = performance.now(); let x = 0; while (performance.now() - t < 200) x += Math.sqrt(x + 1); }
+  const s = new Session();
+  s.connect();
+  s.post("Profiler.enable");
+  s.post("Profiler.start");
+  parentPort.postMessage("started");
+  parentPort.once("message", () => {
+    inWorker();
+    const { profile } = s.post("Profiler.stop");
+    s.disconnect();
+    parentPort.postMessage({ samples: profile.samples.length, names: profile.nodes.map(n => n.callFrame.functionName) });
+  });
+\`, { eval: true });
+await once(worker, "message");
+const handle = await worker.startCpuProfile();
+JSON.parse(await handle.stop());
+worker.postMessage("go");
+const [result] = await once(worker, "message");
+await worker.terminate();
+console.log(JSON.stringify(result));
+`,
+          });
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "fixture.mjs"],
+            env: bunEnv,
+            cwd: String(dir),
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+            stderrIfFailed: "",
+            exitCode: 0,
+          });
+          const result = JSON.parse(stdout.trim());
+          // With the old isCPUProfilerRunning() guards in JSWorker.cpp, the
+          // parent's handle.stop() decremented the ref the Session took, so the
+          // Session's own Profiler.stop found the sampler paused and the buffer
+          // cleared.
+          expect(result.samples).toBeGreaterThan(0);
+          expect(result.names).toContain("inWorker");
+        },
+      );
     });
   });
 


### PR DESCRIPTION
### Problem

JSC exposes one `SamplingProfiler` per VM. `--cpu-prof` and every `node:inspector` `Session` drove it through a single thread-local `s_isProfilerRunning` flag with no ownership:

```js
// bun --cpu-prof repro.mjs
import { Session } from 'node:inspector';
const work = ms => { const t = performance.now(); let x = 0; while (performance.now() - t < ms) x += Math.sqrt(x + 1); };
work(250);
const s = new Session(); s.connect();
s.disconnect();                 // never posted Profiler.*
work(250);
```

```
bytes=228 nodes=1 samples=0 duration_us=0
```

Node writes a full profile (~300 samples, ~550ms) for the same script.

`Session.disconnect()` ran `if (isCPUProfilerRunning()) stopCPUProfiler()`, `Profiler.disable` did the same, and `Profiler.stop` called `stopCPUProfiler()` on the shared profiler regardless of who started it. So a bare `connect()`+`disconnect()` emptied `--cpu-prof`, one session's `Profiler.stop` made another session's `Profiler.stop` error "Profiler is not started" (its samples gone), and a session whose `Profiler.start` found the profiler already running adopted samples taken before its own start.

### Fix

Reference-count the profiler per consumer and scope each consumer's profile to its own window.

`BunCPUProfiler.cpp`: `startCPUProfiler()` returns the caller's start timestamp and only starts JSC's sampler on the first consumer. `stopCPUProfiler()` takes that timestamp back, drains JSC's accumulated samples into a GC-safe retained buffer (`releaseStackTraces()` also clears `m_liveCellPointers`, so the raw `ExecutableBase*`/`JSObject*` in a `StackTrace` are only valid under `DeferGC`; converting to owned strings/ints lets samples outlive the release so a later consumer still sees what a prior consumer's stop released), builds this consumer's profile from the retained samples filtered by its start timestamp, and only pauses/clears on the last consumer. The frame-extraction logic that was duplicated between the JSON and markdown builders now runs once per sample into a `RetainedFrame`. The markdown builder therefore adopts the JSON builder semantics: the Location column uses the function-definition-remapped URL and drops the sample line when it maps to a different original source file (the old text path let the sample-position callback clobber the URL before normalization, the #29240-class ordering the JSON path already guarded against).

`inspector.ts`: each `Session` records the timestamp its own `Profiler.start` returned in `#cpuProfileStartTime`. `disconnect()`, `Profiler.disable` and `Profiler.stop` release only that session's hold and pass the timestamp through so the returned profile is scoped to the session's own window.

The `--cpu-prof` path (`Bun__startCPUProfiler` / `Bun__stopCPUProfiler`) is unchanged at the ABI: it passes 0 as the since-timestamp and so gets every sample since the first consumer, which is itself since it starts before user code.

### Verification

Repro above now writes `nodes=162 samples=1454 duration_us=1861499`.

```
USE_SYSTEM_BUN=1 bun test test/js/node/inspector/inspector-profiler.test.ts -t 'shared sampling profiler ownership'   # 5 fail
bun bd test test/js/node/inspector/inspector-profiler.test.ts test/cli/run/cpu-prof.test.ts test/regression/issue/29240.test.ts   # 60 pass
bun bd test/js/node/test/parallel/test-worker-cpu-profile.js   # exit 0
```

#33172 (clear stale samples on start) and #32270 (per-VM state) touch the same file for orthogonal bugs; neither addresses the shared-ownership problem here, and the timestamp filter in this PR subsumes #33172's clear-on-start for the inspector path.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (5683406d0)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [12.13ms]
(pass) node:inspector > Session > Session extends EventEmitter [2.53ms]
(pass) node:inspector > Session > connect() establishes connection [5.41ms]
(pass) node:inspector > Session > connect() throws if already connected [4.30ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [4.70ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [2.58ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.33ms]
(pass) node:inspector > Session > post() throws if not connected [7.82ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [8.61ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [23.32ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [2.30ms]
(pass) node:inspecto
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (794ee8c66)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [0.18ms]
(pass) node:inspector > Session > Session extends EventEmitter [0.03ms]
(pass) node:inspector > Session > connect() establishes connection [0.09ms]
(pass) node:inspector > Session > connect() throws if already connected [0.06ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [0.06ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [0.03ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [0.02ms]
(pass) node:inspector > Session > post() throws if not connected [0.12ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [0.14ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [0.33ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [0.03ms]
(pass) node:inspector > Profiler > Profiler.start without enable throws [0.03ms]
(pass) node:inspector > Profiler > Profiler.start after enable succeeds [0.20ms]
(pass) node:inspector > Profiler >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (5683406d0)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [12.13ms]
(pass) node:inspector > Session > Session extends EventEmitter [2.54ms]
(pass) node:inspector > Session > connect() establishes connection [5.22ms]
(pass) node:inspector > Session > connect() throws if already connected [3.96ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [4.57ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [2.55ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.34ms]
(pass) node:inspector > Session > post() throws if not connected [7.56ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [8.30ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [18.82ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [2.45ms]
(pass) node:inspecto
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 664ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] gen cpp.rs (cppbind)
[2/25] gen JS modules (bundle-modules)
Preprocess modules (8882ms)
Bundle modules (56ms)
Postprocesss modules (44ms)
Bundle Functions (682ms)
Generate Code (15ms)

[9.69s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/15] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sy
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/inspector.ts                          |  26 +-
 src/jsc/bindings/BunCPUProfiler.cpp               | 487 +++++++++++-----------
 src/jsc/bindings/BunCPUProfiler.h                 |  15 +-
 src/jsc/bindings/JSInspectorProfiler.cpp          |  13 +-
 src/jsc/bindings/webcore/JSWorker.cpp             |  11 +-
 src/jsc/bindings/webcore/Worker.h                 |   6 +
 test/js/node/inspector/inspector-profiler.test.ts | 204 +++++++++
 7 files changed, 498 insertions(+), 264 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/js/node/inspector.ts                               2      4      0
src/jsc/bindings/BunCPUProfiler.cpp                    9     15      0
src/jsc/bindings/BunCPUProfiler.h                      2      3      0
src/jsc/bindings/JSInspectorProfiler.cpp               1      1      0
src/jsc/bindings/webcore/JSWorker.cpp                  2      4      0
src/jsc/bindings/webcore/Worker.h                      1      3      0
test/js/node/inspector/inspector-profiler.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->

### Out of scope

`bun:jsc`'s `profile()` and `startSamplingProfiler()` (`BunJSCModule.h`) drive `vm.samplingProfiler()` directly and `profile()` still `pause()`+`clearData()`s it unconditionally, so combining them with `--cpu-prof` wipes the `.cpuprofile` the same way. That behaviour is pre-existing and `bun:jsc` emits JSC-native output (`reportTopFunctions`/`stackTracesAsJSON`), not the cpuprofile pipeline here, so routing it through the refcount is a follow-up rather than a mechanical sibling edit.

