### PR TITLE
event_loop: don't debug-panic on late main-VM enqueue_task_concurrent during process.exit

### DIFF
--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -997,11 +997,7 @@ impl EventLoop {
     pub fn enqueue_task_concurrent(&self, task: core::ptr::NonNull<ConcurrentTaskItem>) {
         if cfg!(debug_assertions) {
             let vm = self.vm_ref();
-            // The main-thread VM box is process-static (never `dealloc`'d), so a
-            // late cross-thread push after `global_exit` → `destroy()` just
-            // lands in a queue that is never drained again. The assert exists
-            // to catch the worker case, where `has_terminated` precedes a raw
-            // `dealloc` and a push is UAF-adjacent.
+            // Main-thread VM box is never dealloc'd; only a worker push is UAF-adjacent.
             if vm.has_terminated && !vm.is_main_thread() {
                 panic!("EventLoop.enqueueTaskConcurrent: VM has terminated");
             }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -996,7 +996,13 @@ impl EventLoop {
     /// freshly-allocated or struct-embedded task — never null.
     pub fn enqueue_task_concurrent(&self, task: core::ptr::NonNull<ConcurrentTaskItem>) {
         if cfg!(debug_assertions) {
-            if self.vm_ref().has_terminated {
+            let vm = self.vm_ref();
+            // The main-thread VM box is process-static (never `dealloc`'d), so a
+            // late cross-thread push after `global_exit` → `destroy()` just
+            // lands in a queue that is never drained again. The assert exists
+            // to catch the worker case, where `has_terminated` precedes a raw
+            // `dealloc` and a push is UAF-adjacent.
+            if vm.has_terminated && !vm.is_main_thread() {
                 panic!("EventLoop.enqueueTaskConcurrent: VM has terminated");
             }
         }

--- a/test/js/node/fs/fs-write-exit-race.test.ts
+++ b/test/js/node/fs/fs-write-exit-race.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+
+// A thread-pool `fs.write` that is still blocked in the kernel when
+// `process.exit()` runs must not crash the process when it later completes.
+// `BUN_DESTRUCT_VM_ON_EXIT=1` (set by the CI runner) makes `global_exit`
+// call `VirtualMachine::destroy()` on the main-thread VM before `libc::exit`;
+// a work-pool completion that lands after that posts to the event loop of a
+// VM whose `has_terminated` is already true. The main-thread VM box is never
+// freed, so the push is harmless and the debug assert was a false positive.
+//
+// Deterministically reproducing the race requires something to unblock the
+// kernel write *after* `destroy()` has returned. The child registers a libc
+// atexit handler (via bun:ffi's tinycc) that closes the FIFO reader and
+// then sleeps, so the blocked `write()` returns EPIPE while the main thread
+// is still inside the atexit chain.
+//
+// Linux-only: relies on mkfifo, blocking-pipe write semantics, and glibc's
+// `__cxa_atexit`.
+test.skipIf(!isLinux)(
+  "process.exit with a thread-pool fs.write still blocked in the kernel exits cleanly",
+  async () => {
+    using dir = tempDir("fs-write-exit-race", {
+      "helper.c": `
+        #include <unistd.h>
+        extern int __cxa_atexit(void (*)(void *), void *, void *);
+        static int g_fd = -1;
+        static void do_close_and_sleep(void *unused) {
+          (void)unused;
+          if (g_fd >= 0) close(g_fd);
+          usleep(300000);
+        }
+        void schedule_close_at_exit(int fd) {
+          g_fd = fd;
+          __cxa_atexit(do_close_and_sleep, 0, 0);
+        }
+      `,
+      "child.js": `
+        const fs = require("node:fs");
+        const path = require("node:path");
+        const cp = require("node:child_process");
+        const { cc, FFIType } = require("bun:ffi");
+
+        const fifo = path.join(__dirname, "pipe");
+        cp.spawnSync("mkfifo", [fifo]);
+
+        const rd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+        const wd = fs.openSync(fifo, fs.constants.O_WRONLY);
+
+        const { symbols } = cc({
+          source: path.join(__dirname, "helper.c"),
+          symbols: {
+            schedule_close_at_exit: { args: [FFIType.i32], returns: FFIType.void },
+          },
+        });
+        symbols.schedule_close_at_exit(rd);
+
+        // Larger than any pipe capacity so write() blocks in the kernel until
+        // the reader fd closes.
+        fs.write(wd, Buffer.alloc(1 << 21, 0x41), () => {});
+
+        setTimeout(() => {
+          process.stdout.write("alive\\n");
+          process.exit(0);
+        }, 50);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "child.js"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "alive\n", stderr: "", exitCode: 0 });
+  },
+  // On an unfixed debug build the panic hook symbolizes the backtrace through
+  // llvm-symbolizer (~5s) before the process terminates.
+  15_000,
+);

--- a/test/js/node/fs/fs-write-exit-race.test.ts
+++ b/test/js/node/fs/fs-write-exit-race.test.ts
@@ -66,9 +66,14 @@ test.skipIf(!isLinux || !isASAN)(
         // Consuming one byte does not unblock the 2 MiB writer.
         const buf = Buffer.alloc(1);
         const deadline = Date.now() + 5000;
+        let sawBytes = false;
         while (Date.now() < deadline) {
-          try { if (fs.readSync(rd, buf) > 0) break; } catch (e) { if (e.code !== "EAGAIN") throw e; }
+          try { if (fs.readSync(rd, buf) > 0) { sawBytes = true; break; } } catch (e) { if (e.code !== "EAGAIN") throw e; }
           Bun.sleepSync(1);
+        }
+        if (!sawBytes) {
+          process.stderr.write("writer never entered kernel within 5s\\n");
+          process.exit(1);
         }
 
         process.stdout.write("alive\\n");

--- a/test/js/node/fs/fs-write-exit-race.test.ts
+++ b/test/js/node/fs/fs-write-exit-race.test.ts
@@ -24,7 +24,8 @@ test.skipIf(!isLinux || !isASAN)(
   async () => {
     using dir = tempDir("fs-write-exit-race", {
       "helper.c": `
-        #include <unistd.h>
+        extern int close(int);
+        extern int usleep(unsigned int);
         extern int __cxa_atexit(void (*)(void *), void *, void *);
         static int g_fd = -1;
         static void do_close_and_sleep(void *unused) {

--- a/test/js/node/fs/fs-write-exit-race.test.ts
+++ b/test/js/node/fs/fs-write-exit-race.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, tempDir } from "harness";
 
 // A thread-pool `fs.write` that is still blocked in the kernel when
 // `process.exit()` runs must not crash the process when it later completes.
@@ -15,9 +15,11 @@ import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 // then sleeps, so the blocked `write()` returns EPIPE while the main thread
 // is still inside the atexit chain.
 //
-// Linux-only: relies on mkfifo, blocking-pipe write semantics, and glibc's
-// `__cxa_atexit`.
-test.skipIf(!isLinux)(
+// Linux + ASAN only: relies on mkfifo and blocking-pipe write semantics, and
+// on `Global::exit` taking the `libc_exit()` branch so `__cxa_atexit` handlers
+// run (non-ASAN Linux uses `quick_exit()`, which skips them). The guard being
+// tested is `cfg!(debug_assertions)`-only, which ASAN builds enable.
+test.skipIf(!isLinux || !isASAN)(
   "process.exit with a thread-pool fs.write still blocked in the kernel exits cleanly",
   async () => {
     using dir = tempDir("fs-write-exit-race", {
@@ -59,10 +61,18 @@ test.skipIf(!isLinux)(
         // the reader fd closes.
         fs.write(wd, Buffer.alloc(1 << 21, 0x41), () => {});
 
-        setTimeout(() => {
-          process.stdout.write("alive\\n");
-          process.exit(0);
-        }, 50);
+        // Wait until the work-pool thread has entered the kernel write(): rd is
+        // O_NONBLOCK, so readSync returns >0 once bytes have landed in the pipe.
+        // Consuming one byte does not unblock the 2 MiB writer.
+        const buf = Buffer.alloc(1);
+        const deadline = Date.now() + 5000;
+        while (Date.now() < deadline) {
+          try { if (fs.readSync(rd, buf) > 0) break; } catch (e) { if (e.code !== "EAGAIN") throw e; }
+          Bun.sleepSync(1);
+        }
+
+        process.stdout.write("alive\\n");
+        process.exit(0);
       `,
     });
 


### PR DESCRIPTION
## What

Under `BUN_DESTRUCT_VM_ON_EXIT=1` (set by the CI runner), `process.exit()` on the main thread runs `VirtualMachine::destroy()` (which sets `has_terminated = true`) before `libc::exit()`. If a thread-pool `fs.write` that was blocked in the kernel returns during the atexit chain, its work-pool completion calls `enqueue_task_concurrent` against a VM whose `has_terminated` is already set, and the `debug_assertions`-gated guard panics:

```
panic: EventLoop.enqueueTaskConcurrent: VM has terminated
  ...
  <bun_jsc::event_loop::EventLoop>::enqueue_task_concurrent     src/jsc/event_loop.rs:1000
  AsyncFSTask<Write>::work_pool_callback                        src/runtime/node/node_fs.rs:1314
  <bun_threading::thread_pool::Thread>::run
```

Seen on linux-x64-asan in [build 82810](https://buildkite.com/bun/bun/builds/82810#019f9ff3-0831-4b83-bbea-fead4017a9bf) via `test/js/node/fs/fs.test.ts` (a `createWriteStream` to a FIFO whose reader is held by the parent process).

## Why this is correct

The main-thread `VirtualMachine` box is process-static (`global_exit()` never `dealloc`s it). `destroy()` leaves both the `concurrent_tasks` MPSC queue and the uws loop intact, so the late `push` + `wakeup` are sound; the task just lands in a queue that is never drained again. Release builds already behave that way since the guard is compiled out. The assert exists to catch producers that enqueue into a *worker* VM after `destroy()`, where the box is about to be raw-`dealloc`'d in `WebWorker::shutdown()`, so the guard is kept for that case.

## Fix

Gate the debug panic on `!vm.is_main_thread()`.

## Test

`test/js/node/fs/fs-write-exit-race.test.ts` reproduces the race deterministically on Linux: the child opens a FIFO, dispatches a blocking `fs.write` to the thread pool, and registers a libc atexit handler (via `bun:ffi` `cc()`) that closes the only reader fd and then `usleep()`s. The handler runs after `destroy()` has returned, so the blocked `write()` gets `EPIPE` and posts its completion while `has_terminated` is already set.

On an unfixed debug/ASAN build the child emits the panic + backtrace (assertion fails); with the fix it exits with `{stdout: "alive\n", stderr: "", exitCode: 0}`.

Related: #34154 tackles the worker-VM side of this class (the UAF) and leaves the guard for workers in place; this change only stops the main-VM false positive.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs-write-exit-race.test.ts

<!-- robobun:evidence:end -->