### PR TITLE
DecompressionStream("zstd"): decode concatenated frames instead of rejecting as trailing junk

### DIFF
--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -200,10 +200,8 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._maxOutputLength = maxOutputLength;
 
   this._rejectGarbageAfterEnd = opts?.rejectGarbageAfterEnd === true;
-  // A zstd stream is one or more concatenated frames (RFC 8878 §3.1).
-  // DecompressionStream("zstd") opts in via rejectGarbageAfterEnd and must
-  // decode every frame; the plain node:zlib zstd stream keeps stopping at
-  // the first frame to match Node.js. See processCallback.
+  // zstd streams are one or more concatenated frames (RFC 8878 §3.1); only
+  // DecompressionStream opts in so plain createZstdDecompress matches Node.js.
   this._continueOnFrameEnd = this._rejectGarbageAfterEnd && mode === ZSTD_DECOMPRESS;
 }
 $toClass(ZlibBase, "ZlibBase", Transform);
@@ -461,10 +459,7 @@ function processCallback() {
     return;
   }
 
-  // Zstd: a frame boundary with input remaining is the start of the next
-  // frame, not trailing junk. Re-enter the write loop so the native decoder
-  // starts that frame; actual garbage surfaces as ZSTD_error_prefix_unknown
-  // on that call. Only DecompressionStream opts in (see _continueOnFrameEnd).
+  // zstd: input remaining after a frame is the next frame, not trailing junk.
   const continueNextFrame = availInAfter > 0 && self._continueOnFrameEnd;
 
   // Exhausted the output buffer, or used all the input create a new one.

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -200,8 +200,6 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._maxOutputLength = maxOutputLength;
 
   this._rejectGarbageAfterEnd = opts?.rejectGarbageAfterEnd === true;
-  // zstd is multi-frame (RFC 8878 §3.1); scoped so createZstdDecompress stays Node-compatible.
-  this._continueOnFrameEnd = this._rejectGarbageAfterEnd && mode === ZSTD_DECOMPRESS;
 }
 $toClass(ZlibBase, "ZlibBase", Transform);
 
@@ -458,19 +456,16 @@ function processCallback() {
     return;
   }
 
-  // zstd: input remaining after a frame is the next frame, not trailing junk.
-  const continueNextFrame = availInAfter > 0 && self._continueOnFrameEnd;
-
   // Exhausted the output buffer, or used all the input create a new one.
   let chunkSize;
-  if (availOutAfter === 0 || continueNextFrame || self._outOffset >= (chunkSize = self._chunkSize)) {
+  if (availOutAfter === 0 || self._outOffset >= (chunkSize = self._chunkSize)) {
     chunkSize ??= self._chunkSize;
     handle.availOutBefore = chunkSize;
     self._outOffset = 0;
     self._outBuffer = Buffer.allocUnsafe(chunkSize);
   }
 
-  if (availOutAfter === 0 || continueNextFrame) {
+  if (availOutAfter === 0) {
     // Not actually done. Need to reprocess.
     // Also, update the availInBefore to the availInAfter value,
     // so that if we have to hit it a third (fourth, etc.) time,

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -200,6 +200,11 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._maxOutputLength = maxOutputLength;
 
   this._rejectGarbageAfterEnd = opts?.rejectGarbageAfterEnd === true;
+  // A zstd stream is one or more concatenated frames (RFC 8878 §3.1).
+  // DecompressionStream("zstd") opts in via rejectGarbageAfterEnd and must
+  // decode every frame; the plain node:zlib zstd stream keeps stopping at
+  // the first frame to match Node.js. See processCallback.
+  this._continueOnFrameEnd = this._rejectGarbageAfterEnd && mode === ZSTD_DECOMPRESS;
 }
 $toClass(ZlibBase, "ZlibBase", Transform);
 
@@ -456,16 +461,22 @@ function processCallback() {
     return;
   }
 
+  // Zstd: a frame boundary with input remaining is the start of the next
+  // frame, not trailing junk. Re-enter the write loop so the native decoder
+  // starts that frame; actual garbage surfaces as ZSTD_error_prefix_unknown
+  // on that call. Only DecompressionStream opts in (see _continueOnFrameEnd).
+  const continueNextFrame = availInAfter > 0 && self._continueOnFrameEnd;
+
   // Exhausted the output buffer, or used all the input create a new one.
   let chunkSize;
-  if (availOutAfter === 0 || self._outOffset >= (chunkSize = self._chunkSize)) {
+  if (availOutAfter === 0 || continueNextFrame || self._outOffset >= (chunkSize = self._chunkSize)) {
     chunkSize ??= self._chunkSize;
     handle.availOutBefore = chunkSize;
     self._outOffset = 0;
     self._outBuffer = Buffer.allocUnsafe(chunkSize);
   }
 
-  if (availOutAfter === 0) {
+  if (availOutAfter === 0 || continueNextFrame) {
     // Not actually done. Need to reprocess.
     // Also, update the availInBefore to the availInAfter value,
     // so that if we have to hit it a third (fourth, etc.) time,

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -200,8 +200,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._maxOutputLength = maxOutputLength;
 
   this._rejectGarbageAfterEnd = opts?.rejectGarbageAfterEnd === true;
-  // zstd streams are one or more concatenated frames (RFC 8878 §3.1); only
-  // DecompressionStream opts in so plain createZstdDecompress matches Node.js.
+  // zstd is multi-frame (RFC 8878 §3.1); scoped so createZstdDecompress stays Node-compatible.
   this._continueOnFrameEnd = this._rejectGarbageAfterEnd && mode === ZSTD_DECOMPRESS;
 }
 $toClass(ZlibBase, "ZlibBase", Transform);

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -570,7 +570,7 @@ mod _impl {
                         };
                     }
                     ret
-                },
+                }
                 _ => unreachable!(),
             } as u64;
         }

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -491,6 +491,42 @@ mod _impl {
             self.flush = flush;
         }
 
+        const ZSTD_MAGICNUMBER: u32 = 0xFD2FB528;
+        const ZSTD_MAGIC_SKIPPABLE_START: u32 = 0x184D2A50;
+        const ZSTD_MAGIC_SKIPPABLE_MASK: u32 = 0xFFFFFFF0;
+
+        /// A zstd stream is one or more concatenated frames (RFC 8878 §3.1).
+        /// After `ZSTD_decompressStream` returns 0 (frame complete) with input
+        /// remaining, decide whether those bytes begin another frame so the
+        /// caller can loop. Bytes that are not a frame/skippable magic (or a
+        /// prefix of one when fewer than 4 remain) are left unconsumed so the
+        /// JS layer can treat them as trailing data.
+        fn next_input_is_frame(&self) -> bool {
+            let avail = self.input.size - self.input.pos;
+            if avail == 0 {
+                return false;
+            }
+            // SAFETY: `input.src[..input.size]` is the caller-kept-alive input
+            // slice installed by `set_buffers`; `input.pos < input.size` here.
+            let rest = unsafe {
+                core::slice::from_raw_parts(
+                    self.input.src.cast::<u8>().add(self.input.pos),
+                    avail.min(4),
+                )
+            };
+            let frame = Self::ZSTD_MAGICNUMBER.to_le_bytes();
+            let skippable = Self::ZSTD_MAGIC_SKIPPABLE_START.to_le_bytes();
+            if rest.len() < 4 {
+                // The low nibble of a skippable magic's first byte varies, so
+                // compare it under the mask.
+                return rest == &frame[..rest.len()]
+                    || (rest[0] & 0xF0 == skippable[0] && rest[1..] == skippable[1..rest.len()]);
+            }
+            let magic = u32::from_le_bytes([rest[0], rest[1], rest[2], rest[3]]);
+            magic == Self::ZSTD_MAGICNUMBER
+                || magic & Self::ZSTD_MAGIC_SKIPPABLE_MASK == Self::ZSTD_MAGIC_SKIPPABLE_START
+        }
+
         pub fn do_work(&mut self) {
             // A handle driven before `init()` has no CCtx/DCtx; zstd
             // dereferences the context pointer unconditionally.
@@ -508,13 +544,32 @@ mod _impl {
                         self.flush as c_uint,
                     )
                 },
-                // SAFETY: state is a valid DCtx.
-                NodeMode::ZSTD_DECOMPRESS => unsafe {
-                    c::ZSTD_decompressStream(
-                        self.state_ptr().cast(),
-                        &raw mut self.output,
-                        &raw mut self.input,
-                    )
+                NodeMode::ZSTD_DECOMPRESS => {
+                    // SAFETY: state is a valid DCtx.
+                    let mut ret = unsafe {
+                        c::ZSTD_decompressStream(
+                            self.state_ptr().cast(),
+                            &raw mut self.output,
+                            &raw mut self.input,
+                        )
+                    };
+                    // ret == 0 is frame-complete. Mirrors GUNZIP multi-member
+                    // handling in NativeZlib::do_work_inflate; libzstd resets
+                    // the DCtx to start-of-frame itself so no explicit reset.
+                    while ret == 0
+                        && self.output.pos < self.output.size
+                        && self.next_input_is_frame()
+                    {
+                        // SAFETY: state is a valid DCtx; input/output point to caller-kept-alive buffers.
+                        ret = unsafe {
+                            c::ZSTD_decompressStream(
+                                self.state_ptr().cast(),
+                                &raw mut self.output,
+                                &raw mut self.input,
+                            )
+                        };
+                    }
+                    ret
                 },
                 _ => unreachable!(),
             } as u64;

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -495,9 +495,7 @@ mod _impl {
         const ZSTD_MAGIC_SKIPPABLE_START: u32 = 0x184D2A50;
         const ZSTD_MAGIC_SKIPPABLE_MASK: u32 = 0xFFFFFFF0;
 
-        /// RFC 8878 §3.1: a zstd stream is one or more concatenated frames.
-        /// True when the unconsumed input begins a zstd or skippable frame
-        /// magic (or a prefix of one when fewer than 4 bytes remain).
+        /// True when the unconsumed input begins a zstd/skippable frame magic (or a prefix of one).
         fn next_input_is_frame(&self) -> bool {
             let avail = self.input.size - self.input.pos;
             if avail == 0 {

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -491,32 +491,27 @@ mod _impl {
             self.flush = flush;
         }
 
-        const ZSTD_MAGICNUMBER: u32 = 0xFD2FB528;
-        const ZSTD_MAGIC_SKIPPABLE_START: u32 = 0x184D2A50;
-        const ZSTD_MAGIC_SKIPPABLE_MASK: u32 = 0xFFFFFFF0;
+        const ZSTD_MAGICNUMBER: [u8; 4] = 0xFD2FB528u32.to_le_bytes();
+        const ZSTD_MAGIC_SKIPPABLE: [u8; 4] = 0x184D2A50u32.to_le_bytes();
 
         /// True when the unconsumed input begins a zstd/skippable frame magic (or a prefix of one).
         fn next_input_is_frame(&self) -> bool {
-            let avail = self.input.size - self.input.pos;
-            if avail == 0 {
+            let n = (self.input.size - self.input.pos).min(4);
+            if n == 0 {
                 return false;
             }
-            // SAFETY: input.src[..input.size] is the caller-kept-alive slice from set_buffers; pos < size here.
-            let rest = unsafe {
-                core::slice::from_raw_parts(
+            let mut head = [0u8; 4];
+            // SAFETY: input.src[pos..pos+n] lies within the slice installed by set_buffers.
+            unsafe {
+                ptr::copy_nonoverlapping(
                     self.input.src.cast::<u8>().add(self.input.pos),
-                    avail.min(4),
-                )
-            };
-            let frame = Self::ZSTD_MAGICNUMBER.to_le_bytes();
-            let skippable = Self::ZSTD_MAGIC_SKIPPABLE_START.to_le_bytes();
-            if rest.len() < 4 {
-                return rest == &frame[..rest.len()]
-                    || (rest[0] & 0xF0 == skippable[0] && rest[1..] == skippable[1..rest.len()]);
+                    head.as_mut_ptr(),
+                    n,
+                );
             }
-            let magic = u32::from_le_bytes([rest[0], rest[1], rest[2], rest[3]]);
-            magic == Self::ZSTD_MAGICNUMBER
-                || magic & Self::ZSTD_MAGIC_SKIPPABLE_MASK == Self::ZSTD_MAGIC_SKIPPABLE_START
+            head[..n] == Self::ZSTD_MAGICNUMBER[..n]
+                || (head[0] & 0xF0 == Self::ZSTD_MAGIC_SKIPPABLE[0]
+                    && head[1..n] == Self::ZSTD_MAGIC_SKIPPABLE[1..n])
         }
 
         pub fn do_work(&mut self) {

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -495,19 +495,15 @@ mod _impl {
         const ZSTD_MAGIC_SKIPPABLE_START: u32 = 0x184D2A50;
         const ZSTD_MAGIC_SKIPPABLE_MASK: u32 = 0xFFFFFFF0;
 
-        /// A zstd stream is one or more concatenated frames (RFC 8878 §3.1).
-        /// After `ZSTD_decompressStream` returns 0 (frame complete) with input
-        /// remaining, decide whether those bytes begin another frame so the
-        /// caller can loop. Bytes that are not a frame/skippable magic (or a
-        /// prefix of one when fewer than 4 remain) are left unconsumed so the
-        /// JS layer can treat them as trailing data.
+        /// RFC 8878 §3.1: a zstd stream is one or more concatenated frames.
+        /// True when the unconsumed input begins a zstd or skippable frame
+        /// magic (or a prefix of one when fewer than 4 bytes remain).
         fn next_input_is_frame(&self) -> bool {
             let avail = self.input.size - self.input.pos;
             if avail == 0 {
                 return false;
             }
-            // SAFETY: `input.src[..input.size]` is the caller-kept-alive input
-            // slice installed by `set_buffers`; `input.pos < input.size` here.
+            // SAFETY: input.src[..input.size] is the caller-kept-alive slice from set_buffers; pos < size here.
             let rest = unsafe {
                 core::slice::from_raw_parts(
                     self.input.src.cast::<u8>().add(self.input.pos),
@@ -517,8 +513,6 @@ mod _impl {
             let frame = Self::ZSTD_MAGICNUMBER.to_le_bytes();
             let skippable = Self::ZSTD_MAGIC_SKIPPABLE_START.to_le_bytes();
             if rest.len() < 4 {
-                // The low nibble of a skippable magic's first byte varies, so
-                // compare it under the mask.
                 return rest == &frame[..rest.len()]
                     || (rest[0] & 0xF0 == skippable[0] && rest[1..] == skippable[1..rest.len()]);
             }
@@ -553,9 +547,7 @@ mod _impl {
                             &raw mut self.input,
                         )
                     };
-                    // ret == 0 is frame-complete. Mirrors GUNZIP multi-member
-                    // handling in NativeZlib::do_work_inflate; libzstd resets
-                    // the DCtx to start-of-frame itself so no explicit reset.
+                    // ret == 0 is frame-complete; mirrors NativeZlib::do_work_inflate's GUNZIP loop.
                     while ret == 0
                         && self.output.pos < self.output.size
                         && self.next_input_is_frame()

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -566,6 +566,12 @@ describe("zlib.zstd", () => {
     expect(roundtrip.toString()).toEqual(inputString);
   });
 
+  it("zstdDecompressSync decodes concatenated frames", () => {
+    const f1 = zlib.zstdCompressSync(Buffer.from("first\n"));
+    const f2 = zlib.zstdCompressSync(Buffer.from("second\n"));
+    expect(zlib.zstdDecompressSync(Buffer.concat([f1, f2])).toString()).toBe("first\nsecond\n");
+  });
+
   it("can compress streaming", async () => {
     const encoder = zlib.createZstdCompress();
     for (const chunk of window(inputString, 55)) {

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -263,12 +263,26 @@ describe("CompressionStream and DecompressionStream", () => {
       expect(out.equals(Buffer.alloc(piece.length * 64, "Z"))).toBe(true);
     });
 
+    test("decompresses a zstd stream with a leading skippable frame", async () => {
+      // Skippable frame: magic 0x184D2A50..5F, 4-byte LE size, then size bytes.
+      const skippable = Buffer.concat([
+        Buffer.from([0x55, 0x2a, 0x4d, 0x18]), // magic (variant 5)
+        Buffer.from([0x03, 0x00, 0x00, 0x00]), // size = 3
+        Buffer.from([0xaa, 0xbb, 0xcc]),
+      ]);
+      const frame = zlib.zstdCompressSync(Buffer.from("payload"));
+      const cat = Buffer.concat([skippable, frame, skippable]);
+
+      const out = await new Response(new Blob([cat]).stream().pipeThrough(new DecompressionStream("zstd"))).text();
+      expect(out).toBe("payload");
+    });
+
     test("rejects trailing garbage after a zstd frame", async () => {
       const frame = zlib.zstdCompressSync(Buffer.from("hello"));
       const withJunk = Buffer.concat([frame, Buffer.from([0xde, 0xad, 0xbe, 0xef])]);
 
       const read = new Response(new Blob([withJunk]).stream().pipeThrough(new DecompressionStream("zstd"))).text();
-      await expect(read).rejects.toMatchObject({ code: "ZSTD_error_prefix_unknown" });
+      await expect(read).rejects.toMatchObject({ code: "ERR_TRAILING_JUNK_AFTER_STREAM_END" });
     });
   });
 

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -231,22 +231,30 @@ describe("CompressionStream and DecompressionStream", () => {
       expect(out).toBe("first frame\nsecond frame\n");
     });
 
-    test("decompresses a multi-frame zstd stream split across writes", async () => {
+    // Skippable frame: magic 0x184D2A50..5F, 4-byte LE size, then size bytes.
+    const skippable = Buffer.concat([
+      Buffer.from([0x55, 0x2a, 0x4d, 0x18]), // magic (variant 5)
+      Buffer.from([0x03, 0x00, 0x00, 0x00]), // size = 3
+      Buffer.from([0xaa, 0xbb, 0xcc]),
+    ]);
+
+    test.each([
+      ["zstd frame", zlib.zstdCompressSync(Buffer.from("second frame\n")), "first frame\nsecond frame\n"],
+      ["skippable frame", Buffer.concat([skippable, zlib.zstdCompressSync(Buffer.from("second frame\n"))]), "first frame\nsecond frame\n"],
+    ] as const)("decompresses a multi-frame zstd stream split across writes (next = %s)", async (_, next, expected) => {
       const f1 = zlib.zstdCompressSync(Buffer.from("first frame\n"));
-      const f2 = zlib.zstdCompressSync(Buffer.from("second frame\n"));
-      const cat = Buffer.concat([f1, f2]);
+      const cat = Buffer.concat([f1, next]);
 
-      const ds = new DecompressionStream("zstd");
-      const writer = ds.writable.getWriter();
-      // Split in the middle of the second frame's header so the boundary is
-      // not a frame boundary.
-      const split = f1.length + 2;
-      writer.write(cat.subarray(0, split));
-      writer.write(cat.subarray(split));
-      writer.close();
-
-      const out = await new Response(ds.readable).text();
-      expect(out).toBe("first frame\nsecond frame\n");
+      for (const offset of [1, 2, 3]) {
+        const ds = new DecompressionStream("zstd");
+        const writer = ds.writable.getWriter();
+        const read = new Response(ds.readable).text();
+        const split = f1.length + offset;
+        await writer.write(cat.subarray(0, split));
+        await writer.write(cat.subarray(split));
+        await writer.close();
+        expect(await read).toBe(expected);
+      }
     });
 
     test("decompresses many concatenated zstd frames larger than one output chunk", async () => {
@@ -264,12 +272,6 @@ describe("CompressionStream and DecompressionStream", () => {
     });
 
     test("decompresses a zstd stream with a leading skippable frame", async () => {
-      // Skippable frame: magic 0x184D2A50..5F, 4-byte LE size, then size bytes.
-      const skippable = Buffer.concat([
-        Buffer.from([0x55, 0x2a, 0x4d, 0x18]), // magic (variant 5)
-        Buffer.from([0x03, 0x00, 0x00, 0x00]), // size = 3
-        Buffer.from([0xaa, 0xbb, 0xcc]),
-      ]);
       const frame = zlib.zstdCompressSync(Buffer.from("payload"));
       const cat = Buffer.concat([skippable, frame, skippable]);
 

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -268,7 +268,7 @@ describe("CompressionStream and DecompressionStream", () => {
       const withJunk = Buffer.concat([frame, Buffer.from([0xde, 0xad, 0xbe, 0xef])]);
 
       const read = new Response(new Blob([withJunk]).stream().pipeThrough(new DecompressionStream("zstd"))).text();
-      await expect(read).rejects.toThrow();
+      await expect(read).rejects.toMatchObject({ code: "ZSTD_error_prefix_unknown" });
     });
   });
 

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -227,9 +227,7 @@ describe("CompressionStream and DecompressionStream", () => {
       const f2 = zlib.zstdCompressSync(Buffer.from("second frame\n"));
       const cat = Buffer.concat([f1, f2]);
 
-      const out = await new Response(
-        new Blob([cat]).stream().pipeThrough(new DecompressionStream("zstd")),
-      ).text();
+      const out = await new Response(new Blob([cat]).stream().pipeThrough(new DecompressionStream("zstd"))).text();
       expect(out).toBe("first frame\nsecond frame\n");
     });
 
@@ -259,9 +257,7 @@ describe("CompressionStream and DecompressionStream", () => {
       const cat = Buffer.concat(frames);
 
       const out = Buffer.from(
-        await new Response(
-          new Blob([cat]).stream().pipeThrough(new DecompressionStream("zstd")),
-        ).arrayBuffer(),
+        await new Response(new Blob([cat]).stream().pipeThrough(new DecompressionStream("zstd"))).arrayBuffer(),
       );
       expect(out.length).toBe(piece.length * 64);
       expect(out.equals(Buffer.alloc(piece.length * 64, "Z"))).toBe(true);
@@ -271,9 +267,7 @@ describe("CompressionStream and DecompressionStream", () => {
       const frame = zlib.zstdCompressSync(Buffer.from("hello"));
       const withJunk = Buffer.concat([frame, Buffer.from([0xde, 0xad, 0xbe, 0xef])]);
 
-      const read = new Response(
-        new Blob([withJunk]).stream().pipeThrough(new DecompressionStream("zstd")),
-      ).text();
+      const read = new Response(new Blob([withJunk]).stream().pipeThrough(new DecompressionStream("zstd"))).text();
       await expect(read).rejects.toThrow();
     });
   });

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -240,7 +240,11 @@ describe("CompressionStream and DecompressionStream", () => {
 
     test.each([
       ["zstd frame", zlib.zstdCompressSync(Buffer.from("second frame\n")), "first frame\nsecond frame\n"],
-      ["skippable frame", Buffer.concat([skippable, zlib.zstdCompressSync(Buffer.from("second frame\n"))]), "first frame\nsecond frame\n"],
+      [
+        "skippable frame",
+        Buffer.concat([skippable, zlib.zstdCompressSync(Buffer.from("second frame\n"))]),
+        "first frame\nsecond frame\n",
+      ],
     ] as const)("decompresses a multi-frame zstd stream split across writes (next = %s)", async (_, next, expected) => {
       const f1 = zlib.zstdCompressSync(Buffer.from("first frame\n"));
       const cat = Buffer.concat([f1, next]);

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import zlib from "node:zlib";
 
 describe("CompressionStream and DecompressionStream", () => {
   describe("brotli", () => {
@@ -216,6 +217,64 @@ describe("CompressionStream and DecompressionStream", () => {
         const output = decoder.decode(decompressed);
         expect(output).toBe(input);
       }
+    });
+
+    // RFC 8878 §3.1: a zstd stream is one or more concatenated frames; a
+    // decoder MUST decode each in order. pzstd output is multi-frame by
+    // construction, as is `cat a.zst b.zst`.
+    test("decompresses a multi-frame zstd stream", async () => {
+      const f1 = zlib.zstdCompressSync(Buffer.from("first frame\n"));
+      const f2 = zlib.zstdCompressSync(Buffer.from("second frame\n"));
+      const cat = Buffer.concat([f1, f2]);
+
+      const out = await new Response(
+        new Blob([cat]).stream().pipeThrough(new DecompressionStream("zstd")),
+      ).text();
+      expect(out).toBe("first frame\nsecond frame\n");
+    });
+
+    test("decompresses a multi-frame zstd stream split across writes", async () => {
+      const f1 = zlib.zstdCompressSync(Buffer.from("first frame\n"));
+      const f2 = zlib.zstdCompressSync(Buffer.from("second frame\n"));
+      const cat = Buffer.concat([f1, f2]);
+
+      const ds = new DecompressionStream("zstd");
+      const writer = ds.writable.getWriter();
+      // Split in the middle of the second frame's header so the boundary is
+      // not a frame boundary.
+      const split = f1.length + 2;
+      writer.write(cat.subarray(0, split));
+      writer.write(cat.subarray(split));
+      writer.close();
+
+      const out = await new Response(ds.readable).text();
+      expect(out).toBe("first frame\nsecond frame\n");
+    });
+
+    test("decompresses many concatenated zstd frames larger than one output chunk", async () => {
+      const piece = Buffer.alloc(4096, "Z");
+      const frame = zlib.zstdCompressSync(piece);
+      const frames: Buffer[] = [];
+      for (let i = 0; i < 64; i++) frames.push(frame);
+      const cat = Buffer.concat(frames);
+
+      const out = Buffer.from(
+        await new Response(
+          new Blob([cat]).stream().pipeThrough(new DecompressionStream("zstd")),
+        ).arrayBuffer(),
+      );
+      expect(out.length).toBe(piece.length * 64);
+      expect(out.equals(Buffer.alloc(piece.length * 64, "Z"))).toBe(true);
+    });
+
+    test("rejects trailing garbage after a zstd frame", async () => {
+      const frame = zlib.zstdCompressSync(Buffer.from("hello"));
+      const withJunk = Buffer.concat([frame, Buffer.from([0xde, 0xad, 0xbe, 0xef])]);
+
+      const read = new Response(
+        new Blob([withJunk]).stream().pipeThrough(new DecompressionStream("zstd")),
+      ).text();
+      await expect(read).rejects.toThrow();
     });
   });
 


### PR DESCRIPTION
## Repro

```js
import zlib from "node:zlib";
const f1 = zlib.zstdCompressSync(Buffer.from("first frame\n"));
const f2 = zlib.zstdCompressSync(Buffer.from("second frame\n"));
const cat = Buffer.concat([f1, f2]);            // valid 2-frame stream (cat a.zst b.zst / pzstd)

await new Response(new Blob([cat]).stream()
  .pipeThrough(new DecompressionStream("zstd"))).text();
// TypeError: Trailing junk found after the end of the compressed stream
//   code: "ERR_TRAILING_JUNK_AFTER_STREAM_END"

Bun.zstdDecompressSync(cat);  // "first frame\nsecond frame\n" (correct)
```

A zstd stream is one or more concatenated frames (RFC 8878 section 3.1); `zstd -d`, pzstd output (multi-frame by construction), `Bun.zstdDecompressSync`, and the `fetch()` `Content-Encoding: zstd` decoder all decode every frame. Only `DecompressionStream("zstd")` rejects the second frame as trailing junk, so a real pzstd file is unreadable through it while every other zstd decoder in the process accepts it. A leading skippable frame (magic `0x184D2A50..5F`) is rejected the same way.

## Cause

The native zstd `do_work()` calls `ZSTD_decompressStream` once per write; libzstd stops at every frame boundary (returns 0 with the next frame unconsumed), so `processCallback` sees `availInAfter > 0` with output room and, because `DecompressionStream` passes `rejectGarbageAfterEnd: true`, raises `ERR_TRAILING_JUNK_AFTER_STREAM_END`. `Gunzip` avoids this because `NativeZlib::do_work_inflate` already loops on multi-member input.

## Fix

In `NativeZstd::do_work`, after `ZSTD_decompressStream` returns 0 with input and output room remaining, peek the next four bytes: if they are the frame magic `0xFD2FB528` or a skippable-frame magic `0x184D2A5?` (or a prefix of either when fewer than four remain, so a header split across chunks decodes), call `ZSTD_decompressStream` again. libzstd resets the DCtx to start-of-frame itself, so no explicit reset is needed. Bytes that are not a magic or magic prefix are left unconsumed so the existing `ERR_TRAILING_JUNK_AFTER_STREAM_END` check still fires for genuine garbage, and `createZstdDecompress` still silently ignores trailing non-frame data the way Node.js does.

`src/js/node/zlib.ts` is unchanged.

## Verification

New tests in `test/js/web/streams/compression.test.ts` cover a 2-frame stream written as one chunk, a 2-frame stream split mid-header across two writes, 64 frames totalling more than one output chunk, a stream with leading and trailing skippable frames, and trailing non-frame garbage still rejected with `ERR_TRAILING_JUNK_AFTER_STREAM_END`. The four multi-frame tests fail on `main` with that error and pass with this change; the Node-compat `createZstdDecompress` trailing-data tests in `test/js/node/zlib/zlib.test.js` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib.test.js test/js/web/streams/compression.test.ts
bun test v1.4.0 (f5a1ac96b)

test/js/web/streams/compression.test.ts:
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [302.30ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [113.72ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [341.86ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [35.81ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [58.35ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [223.26ms]
TypeError: Trailing junk found after the end of the compressed stream
 code: "ERR_TRAILING_JUNK_AFTER_STREAM_END"

      at unknown:1:1
      at processCallback (node:zlib:431:37)
(fail) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream [45.46ms]
TypeError: Trailing junk found afte
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (f62fd6a24)

test/js/web/streams/compression.test.ts:
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [5.42ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [2.23ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [6.12ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [2.48ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [1.10ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [4.71ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream [0.51ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = zstd frame) [1.23ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = skippable frame) [2.40ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses many concatenated zstd frames larger than one output 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib.test.js test/js/web/streams/compression.test.ts
bun test v1.4.0 (f5a1ac96b)

test/js/web/streams/compression.test.ts:
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [377.58ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [115.46ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [324.69ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [44.76ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [62.49ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [186.59ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream [22.91ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = zstd frame) [64.47ms]
(pass) CompressionStream and DecompressionStream > zstd > decompress
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 766ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/zlib/NativeZstd.rs     | 56 +++++++++++++++++++++----
 test/js/node/zlib/zlib.test.js          |  6 +++
 test/js/web/streams/compression.test.ts | 73 +++++++++++++++++++++++++++++++++
 3 files changed, 127 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/node/zlib/NativeZstd.rs          6      8      0
test/js/node/zlib/zlib.test.js               2      1      0
test/js/web/streams/compression.test.ts      6      8      0
```

</details>

<!-- robobun:evidence:end -->