### PR TITLE
s3: stop reifying Blob.prototype members onto S3File.prototype

### DIFF
--- a/src/jsc/bindings/JSS3File.cpp
+++ b/src/jsc/bindings/JSS3File.cpp
@@ -51,9 +51,9 @@ static const HashTableValue JSS3FilePrototypeTableValues[] = {
     { "stat"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, functionS3File_stat, 1 } },
     { "bucket"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor | PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, getterS3File_bucket, 0 } },
 };
-class JSS3FilePrototype final : public WebCore::JSBlobPrototype {
+class JSS3FilePrototype final : public JSC::JSNonFinalObject {
 public:
-    using Base = WebCore::JSBlobPrototype;
+    using Base = JSC::JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static JSS3FilePrototype* create(
@@ -61,8 +61,8 @@ public:
         JSC::JSGlobalObject* globalObject,
         JSC::Structure* structure)
     {
-        JSS3FilePrototype* prototype = new (NotNull, JSC::allocateCell<JSS3FilePrototype>(vm)) JSS3FilePrototype(vm, globalObject, structure);
-        prototype->finishCreation(vm, globalObject);
+        JSS3FilePrototype* prototype = new (NotNull, JSC::allocateCell<JSS3FilePrototype>(vm)) JSS3FilePrototype(vm, structure);
+        prototype->finishCreation(vm);
         return prototype;
     }
 
@@ -86,14 +86,14 @@ public:
     }
 
 protected:
-    JSS3FilePrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
-        : Base(vm, globalObject, structure)
+    JSS3FilePrototype(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
     {
     }
 
-    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    void finishCreation(JSC::VM& vm)
     {
-        Base::finishCreation(vm, globalObject);
+        Base::finishCreation(vm);
         ASSERT(inherits(info()));
         reifyStaticProperties(vm, JSS3File::info(), JSS3FilePrototypeTableValues, *this);
 

--- a/test/js/bun/s3/s3-prototype.test.ts
+++ b/test/js/bun/s3/s3-prototype.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+describe("S3File prototype", () => {
+  const client = new Bun.S3Client({
+    accessKeyId: "a",
+    secretAccessKey: "s",
+    bucket: "b",
+    endpoint: "http://127.0.0.1:9",
+  });
+  const s3file = client.file("k.txt");
+  const S3FileProto = Object.getPrototypeOf(s3file);
+
+  test("inherits from Blob.prototype via the prototype chain", () => {
+    expect(S3FileProto).not.toBe(Blob.prototype);
+    expect(Object.getPrototypeOf(S3FileProto)).toBe(Blob.prototype);
+    expect(s3file).toBeInstanceOf(Blob);
+  });
+
+  test("does not redeclare Blob.prototype members as own properties", () => {
+    // These live on Blob.prototype; S3File.prototype must inherit them, not
+    // shadow them with duplicate own properties. A shadowing copy would be a
+    // separate function object that brand-checks at the Blob level, so
+    // S3File.prototype.text.call(new Blob([...])) would run instead of throwing.
+    for (const name of [
+      "text",
+      "json",
+      "arrayBuffer",
+      "bytes",
+      "formData",
+      "stream",
+      "slice",
+      "exists",
+      "image",
+      "write",
+      "writer",
+      "unlink",
+      "delete",
+      "size",
+      "type",
+      "lastModified",
+      "name",
+    ]) {
+      expect(
+        Object.getOwnPropertyDescriptor(S3FileProto, name),
+        `S3File.prototype should not have own property '${name}'`,
+      ).toBeUndefined();
+      expect(name in s3file, `'${name}' should be reachable on an S3File instance`).toBe(true);
+    }
+  });
+
+  test("own members brand-check for S3File", () => {
+    // S3File.prototype only defines S3-specific members as own properties.
+    const own = new Set(Object.getOwnPropertyNames(S3FileProto));
+    expect(own.has("presign")).toBe(true);
+    expect(own.has("stat")).toBe(true);
+    expect(own.has("bucket")).toBe(true);
+
+    const mem = new Blob(["mem-bytes"]);
+    for (const name of Object.getOwnPropertyNames(S3FileProto)) {
+      const desc = Object.getOwnPropertyDescriptor(S3FileProto, name)!;
+      const fn = desc.value ?? desc.get;
+      if (typeof fn !== "function") continue;
+      expect(() => fn.call(mem), `S3File.prototype.${name} should reject a plain Blob receiver`).toThrow(TypeError);
+      expect(() => fn.call({}), `S3File.prototype.${name} should reject a plain-object receiver`).toThrow(TypeError);
+    }
+  });
+
+  test("Symbol.toStringTag", () => {
+    expect(S3FileProto[Symbol.toStringTag]).toBe("S3File");
+    expect(Object.prototype.toString.call(s3file)).toBe("[object S3File]");
+  });
+});


### PR DESCRIPTION
## Repro

```js
const c = new Bun.S3Client({ accessKeyId: "a", secretAccessKey: "s", bucket: "b", endpoint: "http://127.0.0.1:9" });
const P = Object.getPrototypeOf(c.file("k.txt"));   // S3File.prototype
Object.getOwnPropertyDescriptor(P, "text");          // { value: [Function: text], ... }  (should be undefined)
P.text === Blob.prototype.text;                      // false  (should be true via prototype chain)
await P.text.call(new Blob(["mem-bytes"]));          // "mem-bytes"  (Blob-level brand check on an S3File-own member)
```

## Cause

`JSS3FilePrototype` subclassed the generated `JSBlobPrototype` in C++, so its `Base::finishCreation()` call ran `JSBlobPrototype::finishCreation`, which reifies every `Blob` prototype entry onto `*this`. That left `S3File.prototype` with its own `text`/`arrayBuffer`/`bytes`/`exists`/`slice`/`json`/`formData`/`image`/`size`/`type`/`name`/`lastModified`/`write`/`writer`/`unlink`/`delete`/`stream` properties shadowing the ones already reachable via `Object.getPrototypeOf(S3File.prototype) === Blob.prototype`. The shadowing copies are Blob-level callbacks, so every one of those own members accepted a plain in-memory `Blob` as `this`, which a mechanical brand-check sweep over native class prototypes flagged as "brand check is JSBlob-level, not S3File".

## Fix

Make `JSS3FilePrototype` a plain `JSC::JSNonFinalObject` so `finishCreation` only reifies the S3-specific entries (`presign`, `stat`, `bucket`) plus `Symbol.toStringTag`. The prototype chain is already wired via `createStructure(..., JSBlobPrototype())`, so `Blob` members are inherited rather than duplicated. All S3-own members (`presign`, `stat`, `bucket`) already `dynamicDowncast<JSS3File>` and throw `ERR_INVALID_THIS` on a non-S3File receiver.

## Verification

```
$ bun bd test test/js/bun/s3/s3-prototype.test.ts
 4 pass, 0 fail
$ USE_SYSTEM_BUN=1 bun test test/js/bun/s3/s3-prototype.test.ts
 2 pass, 2 fail (own-property + brand-check tests fail before the fix)
```