### PR TITLE
sql: brand-check Query prototype methods via private fields

### DIFF
--- a/src/js/internal/sql/query.ts
+++ b/src/js/internal/sql/query.ts
@@ -91,7 +91,6 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
     this[_reject] = reject_!;
     this[_handle] = null;
     this[_handler] = handler;
-    this.#queryStatus = SQLQueryStatus.none;
     this[_strings] = strings;
     this[_values] = values;
     this.#flags = flags;

--- a/src/js/internal/sql/query.ts
+++ b/src/js/internal/sql/query.ts
@@ -29,9 +29,7 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
 
   public readonly [_adapter]: DatabaseAdapter<any, any, Handle>;
 
-  // Private fields so every prototype member that touches status/flags
-  // brand-checks its receiver (TypeError on a non-Query `this`) instead of
-  // reading `undefined` or stamping a Symbol property onto a foreign object.
+  // Private (not Symbol-keyed) so prototype methods brand-check their receiver.
   #queryStatus: SQLQueryStatus = SQLQueryStatus.none;
   #flags: SQLQueryFlags = SQLQueryFlags.none;
 

--- a/src/js/internal/sql/query.ts
+++ b/src/js/internal/sql/query.ts
@@ -3,11 +3,9 @@ import type { DatabaseAdapter } from "./shared.ts";
 const _resolve = Symbol("resolve");
 const _reject = Symbol("reject");
 const _handle = Symbol("handle");
-const _queryStatus = Symbol("status");
 const _handler = Symbol("handler");
 const _strings = Symbol("strings");
 const _values = Symbol("values");
-const _flags = Symbol("flags");
 const _results = Symbol("results");
 const _adapter = Symbol("adapter");
 
@@ -26,15 +24,19 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   public [_reject]: (reason?: Error) => void;
   public [_handle]: Handle | null;
   public [_handler]: (query: Query<T, Handle>, handle: Handle) => T;
-  public [_queryStatus]: SQLQueryStatus;
   public [_strings]: string | TemplateStringsArray;
   public [_values]: any[];
-  public [_flags]: SQLQueryFlags;
 
   public readonly [_adapter]: DatabaseAdapter<any, any, Handle>;
 
+  // Private fields so every prototype member that touches status/flags
+  // brand-checks its receiver (TypeError on a non-Query `this`) instead of
+  // reading `undefined` or stamping a Symbol property onto a foreign object.
+  #queryStatus: SQLQueryStatus = SQLQueryStatus.none;
+  #flags: SQLQueryFlags = SQLQueryFlags.none;
+
   [Symbol.for("nodejs.util.inspect.custom")](): `Query { ${string} }` {
-    const status = this[_queryStatus];
+    const status = this.#queryStatus;
 
     let query = "";
     if ((status & SQLQueryStatus.active) != 0) query += "active ";
@@ -51,9 +53,9 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
     if (!handle) {
       try {
         const [sql, values] = this[_adapter].normalizeQuery(this[_strings], this[_values]);
-        this[_handle] = handle = this[_adapter].createQueryHandle(sql, values, this[_flags]);
+        this[_handle] = handle = this[_adapter].createQueryHandle(sql, values, this.#flags);
       } catch (err) {
-        this[_queryStatus] |= SQLQueryStatus.error | SQLQueryStatus.invalidHandle;
+        this.#queryStatus |= SQLQueryStatus.error | SQLQueryStatus.invalidHandle;
         this.reject(err as Error);
       }
     }
@@ -89,16 +91,17 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
     this[_reject] = reject_!;
     this[_handle] = null;
     this[_handler] = handler;
-    this[_queryStatus] = SQLQueryStatus.none;
+    this.#queryStatus = SQLQueryStatus.none;
     this[_strings] = strings;
     this[_values] = values;
-    this[_flags] = flags;
+    this.#flags = flags;
 
     this[_results] = null;
   }
 
   #run() {
-    const { [_handler]: handler, [_queryStatus]: status } = this;
+    const handler = this[_handler];
+    const status = this.#queryStatus;
 
     if (
       status &
@@ -107,12 +110,12 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
       return;
     }
 
-    if (this[_flags] & SQLQueryFlags.notTagged) {
+    if (this.#flags & SQLQueryFlags.notTagged) {
       this.reject(this[_adapter].notTaggedCallError());
       return;
     }
 
-    this[_queryStatus] |= SQLQueryStatus.executed;
+    this.#queryStatus |= SQLQueryStatus.executed;
     const handle = this.#getQueryHandle();
 
     if (!handle) {
@@ -122,13 +125,14 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
     try {
       return handler(this, handle);
     } catch (err) {
-      this[_queryStatus] |= SQLQueryStatus.error;
+      this.#queryStatus |= SQLQueryStatus.error;
       this.reject(err as Error);
     }
   }
 
   async #runAsync() {
-    const { [_handler]: handler, [_queryStatus]: status } = this;
+    const handler = this[_handler];
+    const status = this.#queryStatus;
 
     if (
       status &
@@ -137,12 +141,12 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
       return;
     }
 
-    if (this[_flags] & SQLQueryFlags.notTagged) {
+    if (this.#flags & SQLQueryFlags.notTagged) {
       this.reject(this[_adapter].notTaggedCallError());
       return;
     }
 
-    this[_queryStatus] |= SQLQueryStatus.executed;
+    this.#queryStatus |= SQLQueryStatus.executed;
     const handle = this.#getQueryHandle();
 
     if (!handle) {
@@ -154,34 +158,34 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
     try {
       return handler(this, handle);
     } catch (err) {
-      this[_queryStatus] |= SQLQueryStatus.error;
+      this.#queryStatus |= SQLQueryStatus.error;
       this.reject(err as Error);
     }
   }
 
   get active() {
-    return (this[_queryStatus] & SQLQueryStatus.active) != 0;
+    return (this.#queryStatus & SQLQueryStatus.active) != 0;
   }
 
   set active(value) {
-    const status = this[_queryStatus];
+    const status = this.#queryStatus;
     if (status & (SQLQueryStatus.cancelled | SQLQueryStatus.error)) {
       return;
     }
 
     if (value) {
-      this[_queryStatus] |= SQLQueryStatus.active;
+      this.#queryStatus |= SQLQueryStatus.active;
     } else {
-      this[_queryStatus] &= ~SQLQueryStatus.active;
+      this.#queryStatus &= ~SQLQueryStatus.active;
     }
   }
 
   get cancelled() {
-    return (this[_queryStatus] & SQLQueryStatus.cancelled) !== 0;
+    return (this.#queryStatus & SQLQueryStatus.cancelled) !== 0;
   }
 
   resolve(x: T) {
-    this[_queryStatus] &= ~SQLQueryStatus.active;
+    this.#queryStatus &= ~SQLQueryStatus.active;
     const handle = this.#getQueryHandle();
 
     if (!handle) {
@@ -194,10 +198,10 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   }
 
   reject(x: Error) {
-    this[_queryStatus] &= ~SQLQueryStatus.active;
-    this[_queryStatus] |= SQLQueryStatus.error;
+    this.#queryStatus &= ~SQLQueryStatus.active;
+    this.#queryStatus |= SQLQueryStatus.error;
 
-    if (!(this[_queryStatus] & SQLQueryStatus.invalidHandle)) {
+    if (!(this.#queryStatus & SQLQueryStatus.invalidHandle)) {
       const handle = this.#getQueryHandle();
 
       if (!handle) {
@@ -211,12 +215,12 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   }
 
   cancel() {
-    const status = this[_queryStatus];
+    const status = this.#queryStatus;
     if (status & SQLQueryStatus.cancelled) {
       return this;
     }
 
-    this[_queryStatus] |= SQLQueryStatus.cancelled;
+    this.#queryStatus |= SQLQueryStatus.cancelled;
 
     if (status & SQLQueryStatus.executed) {
       const handle = this.#getQueryHandle();
@@ -235,7 +239,7 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   }
 
   async run() {
-    if (this[_flags] & SQLQueryFlags.notTagged) {
+    if (this.#flags & SQLQueryFlags.notTagged) {
       throw this[_adapter].notTaggedCallError();
     }
 
@@ -255,7 +259,7 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   }
 
   simple() {
-    this[_flags] |= SQLQueryFlags.simple;
+    this.#flags |= SQLQueryFlags.simple;
     return this;
   }
 
@@ -296,7 +300,7 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   }
 
   catch() {
-    if (this[_flags] & SQLQueryFlags.notTagged) {
+    if (this.#flags & SQLQueryFlags.notTagged) {
       throw this[_adapter].notTaggedCallError();
     }
 
@@ -309,7 +313,7 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   }
 
   finally(_onfinally?: (() => void) | undefined | null) {
-    if (this[_flags] & SQLQueryFlags.notTagged) {
+    if (this.#flags & SQLQueryFlags.notTagged) {
       throw this[_adapter].notTaggedCallError();
     }
 
@@ -356,11 +360,9 @@ export default {
     _resolve,
     _reject,
     _handle,
-    _queryStatus,
     _handler,
     _strings,
     _values,
-    _flags,
     _results,
   },
 };

--- a/test/js/sql/sql-query-receiver-check.test.ts
+++ b/test/js/sql/sql-query-receiver-check.test.ts
@@ -1,0 +1,55 @@
+// Query prototype members must brand-check their receiver. Previously
+// cancel()/simple()/active/cancelled used Symbol-keyed storage with no guard,
+// so calling them on a foreign `this` would return that object (and write a
+// Symbol(status)/Symbol(flags) property onto it) instead of throwing. The
+// other members already threw via private-method access; after the fix every
+// member rejects a non-Query receiver with TypeError and leaves it untouched.
+// No live database is needed: the URL points at a closed port that is never
+// dialed because the brand check (or cancel) runs before any I/O.
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.SQL Query prototype rejects foreign receivers", () => {
+  const sql = new SQL("postgres://u:p@127.0.0.1:1/db", { max: 1 });
+  const q = sql`select 1`;
+  q.cancel();
+  q.catch(() => {});
+  const proto = Object.getPrototypeOf(q);
+
+  const methods = ["cancel", "simple", "resolve", "reject", "execute", "raw", "values"];
+  test.each(methods)("%s() throws TypeError and does not mutate the receiver", name => {
+    const stranger: Record<PropertyKey, unknown> = { hello: "world" };
+    expect(() => proto[name].call(stranger)).toThrow(TypeError);
+    expect(Object.getOwnPropertySymbols(stranger)).toEqual([]);
+    expect(Object.keys(stranger)).toEqual(["hello"]);
+  });
+
+  for (const name of ["active", "cancelled"]) {
+    test(`${name} getter throws TypeError`, () => {
+      const { get } = Object.getOwnPropertyDescriptor(proto, name)!;
+      expect(() => get!.call({})).toThrow(TypeError);
+    });
+  }
+
+  test("active setter throws TypeError and does not mutate the receiver", () => {
+    const { set } = Object.getOwnPropertyDescriptor(proto, "active")!;
+    const stranger = {};
+    expect(() => set!.call(stranger, true)).toThrow(TypeError);
+    expect(Object.getOwnPropertySymbols(stranger)).toEqual([]);
+  });
+
+  test("inspect custom throws TypeError", () => {
+    const inspect = proto[Symbol.for("nodejs.util.inspect.custom")];
+    expect(() => inspect.call({})).toThrow(TypeError);
+  });
+
+  test("methods still work on a real Query", () => {
+    const real = sql`select 1`;
+    expect(real.active).toBe(false);
+    expect(real.cancelled).toBe(false);
+    expect(real.simple()).toBe(real);
+    expect(real.cancel()).toBe(real);
+    expect(real.cancelled).toBe(true);
+    real.catch(() => {});
+  });
+});


### PR DESCRIPTION
## Problem

Several `Bun.SQL` Query prototype members accept any receiver instead of throwing when `this` is not a Query. `cancel()` and `simple()` return the foreign object and write `Symbol(status)` / `Symbol(flags)` onto it; the `active`/`cancelled` accessors read `undefined & N` and report `false`; `resolve()`/`reject()` throw only after stamping `Symbol(status)` onto the receiver. The remaining members already throw `TypeError` because their first access is a `#private` method.

```js
const sql = new Bun.SQL("postgres://u:p@127.0.0.1:9/db");
const q = sql`select 1`; q.catch(() => {});
const P = Object.getPrototypeOf(q);
const stranger = { hello: "world" };
P.cancel.call(stranger) === stranger;            // true, expected TypeError
Object.getOwnPropertySymbols(stranger);          // [ Symbol(status) ]
Object.getOwnPropertyDescriptor(P, "active").get.call({});  // false, expected TypeError
```

## Cause

`_queryStatus` and `_flags` were plain `Symbol()`-keyed own properties. `this[_queryStatus]` on a non-Query `this` reads `undefined` (no error), and `this[_queryStatus] |= x` creates the property on the foreign object.

## Fix

Store status and flags in `#queryStatus` / `#flags` private fields. Private field access is a built-in brand check, so every member that touches them now throws `TypeError` on a foreign receiver before any read or write, matching the members that were already guarded by `#private` method calls. The two symbols were exported from `internal/sql/query` but nothing in the tree imported them, so they are dropped.

## Verification

`test/js/sql/sql-query-receiver-check.test.ts` asserts that `cancel`, `simple`, `resolve`, `reject`, `execute`, `raw`, `values`, the `active`/`cancelled` accessors, and the inspect hook all throw `TypeError` on a foreign receiver without mutating it, and that the same members still work on a real Query. 8 of the 12 cases fail on the released binary and all 12 pass with this change. `sql-helpers-validation`, `sqlite-url-parsing`, and `adapter-override` continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-query-receiver-check.test.ts
bun test v1.4.0 (4044ca36d)

test/js/sql/sql-query-receiver-check.test.ts:
17 |   const proto = Object.getPrototypeOf(q);
18 | 
19 |   const methods = ["cancel", "simple", "resolve", "reject", "execute", "raw", "values"];
20 |   test.each(methods)("%s() throws TypeError and does not mutate the receiver", name => {
21 |     const stranger: Record<PropertyKey, unknown> = { hello: "world" };
22 |     expect(() => proto[name].call(stranger)).toThrow(TypeError);
                                                  ^
error: expect(received).toThrow(expected)

Expected constructor: TypeError

Received function did not throw
Received value: {
  hello: "world",
  [Symbol(status)]: 4,
}

      at <anonymous> (/workspace/bun/test/js/sql/sql-query-receiver-check.test.ts:22:46)
(fail) Bun.SQL Query prototype rejects foreign receivers > cancel() throws TypeError and does not mutate the receiver [6.62ms]
17 |   const proto = Object.getPrototypeOf(q);
18 | 
19 |   const methods = ["cancel", "simple", "resolve"
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (82c2218ac)

test/js/sql/sql-query-receiver-check.test.ts:
(pass) Bun.SQL Query prototype rejects foreign receivers > cancel() throws TypeError and does not mutate the receiver [0.11ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > simple() throws TypeError and does not mutate the receiver [0.02ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > resolve() throws TypeError and does not mutate the receiver [0.04ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > reject() throws TypeError and does not mutate the receiver [0.03ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > execute() throws TypeError and does not mutate the receiver [0.02ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > raw() throws TypeError and does not mutate the receiver [0.02ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > values() throws TypeError and does not mutate the receiver [0.01ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > active getter throws TypeError [0.05ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > cancelled getter throws TypeError [0.02ms]
(pass) Bun.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-query-receiver-check.test.ts
bun test v1.4.0 (4044ca36d)

test/js/sql/sql-query-receiver-check.test.ts:
(pass) Bun.SQL Query prototype rejects foreign receivers > cancel() throws TypeError and does not mutate the receiver [15.67ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > simple() throws TypeError and does not mutate the receiver [6.06ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > resolve() throws TypeError and does not mutate the receiver [6.04ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > reject() throws TypeError and does not mutate the receiver [6.44ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > execute() throws TypeError and does not mutate the receiver [4.83ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > raw() throws TypeError and does not mutate the receiver [7.33ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > values() throws TypeError and does not mutate the receiver [4.60ms]
(pass) Bun.SQL Query prototype rejects for
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1324ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (24115ms)
Bundle modules (207ms)
Postprocesss modules (28ms)
Bundle Functions (941ms)
Generate Code (25ms)

[25.34s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (82c2218ac)

test/js/sql/sql-query-receiver-check.test.ts:
(pass) Bun.SQL Query prototype rejects foreign receivers > cancel() throws TypeError and does not mutate the receiver [0.12ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > simple() throws TypeError and does not mutate the receiver [0.02ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > resolve() throws TypeError and does not mutate the receiver [0.04ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > reject() throws TypeError and does not mutate the receiver [0.03ms]
(pass) Bun.SQL Query prototype rejects foreign receivers > execute() throws TypeError and does not mutate the rece
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/query.ts                 | 67 ++++++++++++++--------------
 test/js/sql/sql-query-receiver-check.test.ts | 55 +++++++++++++++++++++++
 2 files changed, 88 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/js/internal/sql/query.ts                      4     17      0
test/js/sql/sql-query-receiver-check.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->