### PR TITLE
bun:jsc: profile() preserves --cpu-prof's samples when the sampler is shared

### DIFF
--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -169,14 +169,14 @@ declare module "bun:jsc" {
     bytecodes: string;
 
     /**
-     * Stack traces of the top functions.
+     * Sampled stack traces in JSC's native `stackTracesAsJSON()` format.
      *
      * `null` when another CPU profiler consumer (`--cpu-prof`,
      * `node:inspector`'s `Profiler.start`, `Worker.startCpuProfile`) already
      * owns the VM's single sampling profiler: JSC's stack-trace dump is
      * destructive, so it is skipped to preserve the other consumer's samples.
      */
-    stackTraces: string[] | null;
+    stackTraces: { interval: number; traces: unknown[]; sources: unknown[] } | null;
   }
 
   /**

--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -169,9 +169,14 @@ declare module "bun:jsc" {
     bytecodes: string;
 
     /**
-     * Stack traces of the top functions
+     * Stack traces of the top functions.
+     *
+     * `null` when another CPU profiler consumer (`--cpu-prof`,
+     * `node:inspector`'s `Profiler.start`, `Worker.startCpuProfile`) already
+     * owns the VM's single sampling profiler: JSC's stack-trace dump is
+     * destructive, so it is skipped to preserve the other consumer's samples.
      */
-    stackTraces: string[];
+    stackTraces: string[] | null;
   }
 
   /**

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -704,9 +704,13 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
         }
     }
 
-    const auto report = [hasOtherConsumer](JSC::VM& vm,
+    const auto report = [](JSC::VM& vm,
                             JSC::JSGlobalObject* globalObject) -> JSC::JSValue {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
+        // Re-read at report time: on the promise path a node:inspector
+        // Profiler.start inside the awaited callback can begin owning the
+        // sampler between profile() entry and here.
+        const bool hasOtherConsumer = Bun::isCPUProfilerRunning();
 
         auto& samplingProfiler = *vm.samplingProfiler();
         StringPrintStream topFunctions;
@@ -742,8 +746,8 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
 
         return result;
     };
-    const auto reportFailure = [hasOtherConsumer](JSC::VM& vm) -> JSC::JSValue {
-        if (!hasOtherConsumer) {
+    const auto reportFailure = [](JSC::VM& vm) -> JSC::JSValue {
+        if (!Bun::isCPUProfilerRunning()) {
             if (auto* samplingProfiler = vm.samplingProfiler()) {
                 auto& lock = samplingProfiler->getLock();
                 WTF::Locker locker { lock };

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -663,13 +663,6 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeZone, (JSGlobalObject * globalObject, Ca
 JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
-    // --cpu-prof / node:inspector / Worker.{start,stop}CpuProfile share the
-    // VM's single JSC::SamplingProfiler via Bun::startCPUProfiler. When one of
-    // those already owns it, profile() must not pause, clearData, change the
-    // timing interval, or call stackTracesAsJSON() (which itself ends with
-    // clearData()); doing so wipes their samples and leaves the sampler paused
-    // so the resulting .cpuprofile is empty.
-    const bool hasOtherConsumer = Bun::isCPUProfilerRunning();
     JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::Stopwatch::create());
 
     JSC::JSValue callbackValue = callFrame->argument(0);
@@ -693,7 +686,9 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
 
     JSC::JSFunction* function = uncheckedDowncast<JSC::JSFunction>(callbackValue);
 
-    if (!hasOtherConsumer) {
+    // --cpu-prof / node:inspector share this VM's single SamplingProfiler via
+    // Bun::startCPUProfiler; when one of those owns it, don't stomp its state.
+    if (!Bun::isCPUProfilerRunning()) {
         if (sampleValue.isNumber()) {
             unsigned sampleInterval = sampleValue.toUInt32(globalObject);
             samplingProfiler.setTimingInterval(Seconds::fromMicroseconds(sampleInterval));
@@ -707,10 +702,6 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
     const auto report = [](JSC::VM& vm,
                             JSC::JSGlobalObject* globalObject) -> JSC::JSValue {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
-        // Re-read at report time: on the promise path a node:inspector
-        // Profiler.start inside the awaited callback can begin owning the
-        // sampler between profile() entry and here.
-        const bool hasOtherConsumer = Bun::isCPUProfilerRunning();
 
         auto& samplingProfiler = *vm.samplingProfiler();
         StringPrintStream topFunctions;
@@ -720,10 +711,11 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
         samplingProfiler.reportTopBytecodes(byteCodes);
 
         JSValue stackTraces;
-        if (hasOtherConsumer) {
-            // stackTracesAsJSON() calls clearData() internally; skip it so the
-            // other consumer's samples survive. reportTopFunctions /
-            // reportTopBytecodes above are read-only.
+        // Re-read (not captured): a Profiler.start inside the callback can
+        // flip this after entry. stackTracesAsJSON() ends with clearData(), so
+        // skip it (and pause/clearData below) when another consumer owns the
+        // sampler; the two report* calls above are read-only.
+        if (Bun::isCPUProfilerRunning()) {
             stackTraces = jsNull();
         } else {
             stackTraces = JSONParse(globalObject, samplingProfiler.stackTracesAsJSON()->toJSONString());

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -37,6 +37,7 @@
 #include <wtf/MemoryFootprint.h>
 #include <wtf/text/WTFString.h>
 
+#include "BunCPUProfiler.h"
 #include "BunProcess.h"
 #include <JavaScriptCore/SourceProviderCache.h>
 #if ENABLE(REMOTE_INSPECTOR)
@@ -662,6 +663,13 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeZone, (JSGlobalObject * globalObject, Ca
 JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
+    // --cpu-prof / node:inspector / Worker.{start,stop}CpuProfile share the
+    // VM's single JSC::SamplingProfiler via Bun::startCPUProfiler. When one of
+    // those already owns it, profile() must not pause, clearData, change the
+    // timing interval, or call stackTracesAsJSON() (which itself ends with
+    // clearData()); doing so wipes their samples and leaves the sampler paused
+    // so the resulting .cpuprofile is empty.
+    const bool hasOtherConsumer = Bun::isCPUProfilerRunning();
     JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::Stopwatch::create());
 
     JSC::JSValue callbackValue = callFrame->argument(0);
@@ -685,16 +693,18 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
 
     JSC::JSFunction* function = uncheckedDowncast<JSC::JSFunction>(callbackValue);
 
-    if (sampleValue.isNumber()) {
-        unsigned sampleInterval = sampleValue.toUInt32(globalObject);
-        samplingProfiler.setTimingInterval(Seconds::fromMicroseconds(sampleInterval));
-    } else {
-        // Reset to default interval (1000 microseconds) to ensure each profile()
-        // call is independent of previous calls
-        samplingProfiler.setTimingInterval(Seconds::fromMicroseconds(1000));
+    if (!hasOtherConsumer) {
+        if (sampleValue.isNumber()) {
+            unsigned sampleInterval = sampleValue.toUInt32(globalObject);
+            samplingProfiler.setTimingInterval(Seconds::fromMicroseconds(sampleInterval));
+        } else {
+            // Reset to default interval (1000 microseconds) to ensure each profile()
+            // call is independent of previous calls
+            samplingProfiler.setTimingInterval(Seconds::fromMicroseconds(1000));
+        }
     }
 
-    const auto report = [](JSC::VM& vm,
+    const auto report = [hasOtherConsumer](JSC::VM& vm,
                             JSC::JSGlobalObject* globalObject) -> JSC::JSValue {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
 
@@ -705,15 +715,23 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
         StringPrintStream byteCodes;
         samplingProfiler.reportTopBytecodes(byteCodes);
 
-        JSValue stackTraces = JSONParse(globalObject, samplingProfiler.stackTracesAsJSON()->toJSONString());
+        JSValue stackTraces;
+        if (hasOtherConsumer) {
+            // stackTracesAsJSON() calls clearData() internally; skip it so the
+            // other consumer's samples survive. reportTopFunctions /
+            // reportTopBytecodes above are read-only.
+            stackTraces = jsNull();
+        } else {
+            stackTraces = JSONParse(globalObject, samplingProfiler.stackTracesAsJSON()->toJSONString());
 
-        // Use pause() instead of shutdown() to allow the profiler to be restarted
-        // shutdown() sets m_isShutDown=true which is never reset, making the profiler unusable
-        {
-            auto& lock = samplingProfiler.getLock();
-            WTF::Locker locker { lock };
-            samplingProfiler.pause();
-            samplingProfiler.clearData();
+            // Use pause() instead of shutdown() to allow the profiler to be restarted
+            // shutdown() sets m_isShutDown=true which is never reset, making the profiler unusable
+            {
+                auto& lock = samplingProfiler.getLock();
+                WTF::Locker locker { lock };
+                samplingProfiler.pause();
+                samplingProfiler.clearData();
+            }
         }
         RETURN_IF_EXCEPTION(throwScope, {});
 
@@ -724,12 +742,14 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
 
         return result;
     };
-    const auto reportFailure = [](JSC::VM& vm) -> JSC::JSValue {
-        if (auto* samplingProfiler = vm.samplingProfiler()) {
-            auto& lock = samplingProfiler->getLock();
-            WTF::Locker locker { lock };
-            samplingProfiler->pause();
-            samplingProfiler->clearData();
+    const auto reportFailure = [hasOtherConsumer](JSC::VM& vm) -> JSC::JSValue {
+        if (!hasOtherConsumer) {
+            if (auto* samplingProfiler = vm.samplingProfiler()) {
+                auto& lock = samplingProfiler->getLock();
+                WTF::Locker locker { lock };
+                samplingProfiler->pause();
+                samplingProfiler->clearData();
+            }
         }
 
         return {};

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -422,18 +422,17 @@ import { profile } from "bun:jsc";
 function phase1() { const t = performance.now(); while (performance.now() - t < 100); }
 function phase2() { const t = performance.now(); while (performance.now() - t < 100); }
 phase1();
-const r = profile(() => { const t = performance.now(); while (performance.now() - t < 10); });
+const r = profile(() => { const t = performance.now(); while (performance.now() - t < 10); }, 50);
 phase2();
 console.log(JSON.stringify({
-  functions: typeof r.functions,
-  bytecodes: typeof r.bytecodes,
   stackTraces: r.stackTraces,
+  rate: r.functions.match(/Sampling rate: [0-9.]+/)?.[0] ?? "",
 }));
 `,
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "--cpu-prof", "--cpu-prof-dir", String(dir), "test.mjs"],
+      cmd: [bunExe(), "--cpu-prof", "--cpu-prof-interval", "5000", "--cpu-prof-dir", String(dir), "test.mjs"],
       env: bunEnv,
       cwd: String(dir),
       stderr: "pipe",
@@ -452,10 +451,14 @@ console.log(JSON.stringify({
     expect(names).toContain("phase1");
     expect(names).toContain("phase2");
 
-    // profile() still returns its read-only reports; stackTraces is null because
+    // profile()'s own stackTraces is null because
     // JSC::SamplingProfiler::stackTracesAsJSON() is destructive (it ends with
-    // clearData()) and is skipped when --cpu-prof owns the sampler.
-    expect(JSON.parse(stdout.trim())).toEqual({ functions: "string", bytecodes: "string", stackTraces: null });
+    // clearData()) and is skipped when --cpu-prof owns the sampler. The
+    // sampling rate reported by reportTopFunctions (which prints
+    // m_timingInterval directly) must still be --cpu-prof-interval's 5000us,
+    // not profile()'s sampleInterval argument (50) or its 1000us default:
+    // profile() must not setTimingInterval() when it doesn't own the sampler.
+    expect(JSON.parse(stdout.trim())).toEqual({ stackTraces: null, rate: "Sampling rate: 5000.000000" });
     expect(exitCode).toBe(0);
   });
 
@@ -479,9 +482,8 @@ phase2();
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
 
     const file = readdirSync(String(dir)).find(f => f.endsWith(".cpuprofile"));
     expect(file).toBeDefined();
@@ -490,5 +492,50 @@ phase2();
     expect(prof.samples.length).toBeGreaterThan(0);
     expect(names).toContain("phase1");
     expect(names).toContain("phase2");
+    expect(exitCode).toBe(0);
+  });
+
+  // The ownership check must be re-evaluated at report time, not captured at
+  // profile() entry: a node:inspector Profiler.start issued inside the callback
+  // flips Bun::isCPUProfilerRunning() after entry. No --cpu-prof here; the
+  // inspector session is the other consumer.
+  test("bun:jsc profile() does not wipe a node:inspector profile started inside its callback", async () => {
+    using dir = tempDir("cpu-prof-bunjsc-profile-inspector", {
+      "test.mjs": `
+import { profile } from "bun:jsc";
+import { Session } from "node:inspector/promises";
+const s = new Session();
+s.connect();
+await s.post("Profiler.enable");
+function duringProfile() { const t = performance.now(); while (performance.now() - t < 100); }
+profile(() => {
+  s.post("Profiler.start");
+  duringProfile();
+});
+const { profile: p } = await s.post("Profiler.stop");
+s.disconnect();
+console.log(JSON.stringify({
+  samples: p.samples.length,
+  names: p.nodes.map(n => n.callFrame.functionName),
+}));
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    // Before the fix, profile()'s report path ran
+    // stackTracesAsJSON()+pause()+clearData() on return because no consumer was
+    // active at entry, so the inspector session's Profiler.stop got an empty
+    // profile.
+    expect(out.samples).toBeGreaterThan(0);
+    expect(out.names).toContain("duringProfile");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -410,4 +410,85 @@ describe.concurrent("--cpu-prof", () => {
     const mdContent = readFileSync(join(String(dir), mdFiles[0]), "utf-8");
     expect(mdContent).toContain("# CPU Profile");
   });
+
+  // bun:jsc's profile() drives the same per-VM JSC::SamplingProfiler that
+  // --cpu-prof uses. It used to unconditionally pause()+clearData() (and
+  // stackTracesAsJSON() itself clears), which wiped --cpu-prof's accumulated
+  // samples and left the sampler paused, so the written .cpuprofile was empty.
+  test("bun:jsc profile() does not wipe --cpu-prof's samples", async () => {
+    using dir = tempDir("cpu-prof-bunjsc-profile", {
+      "test.mjs": `
+import { profile } from "bun:jsc";
+function phase1() { const t = performance.now(); while (performance.now() - t < 100); }
+function phase2() { const t = performance.now(); while (performance.now() - t < 100); }
+phase1();
+const r = profile(() => { const t = performance.now(); while (performance.now() - t < 10); });
+phase2();
+console.log(JSON.stringify({
+  functions: typeof r.functions,
+  bytecodes: typeof r.bytecodes,
+  stackTraces: r.stackTraces,
+}));
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--cpu-prof", "--cpu-prof-dir", String(dir), "test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+
+    const file = readdirSync(String(dir)).find(f => f.endsWith(".cpuprofile"));
+    expect(file).toBeDefined();
+    const prof = JSON.parse(readFileSync(join(String(dir), file!), "utf8"));
+    const names: string[] = prof.nodes.map((n: any) => n.callFrame.functionName);
+    // --cpu-prof spans the whole run, so both phases must be present. Before
+    // the fix, profile() paused+cleared the shared SamplingProfiler and the
+    // file had a single (root) node with zero samples.
+    expect(prof.samples.length).toBeGreaterThan(0);
+    expect(names).toContain("phase1");
+    expect(names).toContain("phase2");
+
+    // profile() still returns its read-only reports; stackTraces is null because
+    // JSC::SamplingProfiler::stackTracesAsJSON() is destructive (it ends with
+    // clearData()) and is skipped when --cpu-prof owns the sampler.
+    expect(JSON.parse(stdout.trim())).toEqual({ functions: "string", bytecodes: "string", stackTraces: null });
+    expect(exitCode).toBe(0);
+  });
+
+  // Same ownership hazard on the failure path: when the callback throws,
+  // profile()'s catch path paused+cleared the shared profiler too.
+  test("bun:jsc profile() with a throwing callback does not wipe --cpu-prof's samples", async () => {
+    using dir = tempDir("cpu-prof-bunjsc-profile-throw", {
+      "test.mjs": `
+import { profile } from "bun:jsc";
+function phase1() { const t = performance.now(); while (performance.now() - t < 100); }
+function phase2() { const t = performance.now(); while (performance.now() - t < 100); }
+phase1();
+try { profile(() => { throw new Error("boom"); }); } catch {}
+phase2();
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--cpu-prof", "--cpu-prof-dir", String(dir), "test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const file = readdirSync(String(dir)).find(f => f.endsWith(".cpuprofile"));
+    expect(file).toBeDefined();
+    const prof = JSON.parse(readFileSync(join(String(dir), file!), "utf8"));
+    const names: string[] = prof.nodes.map((n: any) => n.callFrame.functionName);
+    expect(prof.samples.length).toBeGreaterThan(0);
+    expect(names).toContain("phase1");
+    expect(names).toContain("phase2");
+  });
 });


### PR DESCRIPTION
### Repro

```js
// bun --cpu-prof repro.mjs
import { profile } from "bun:jsc";
const work = ms => { const t = performance.now(); while (performance.now() - t < ms); };
work(200);
profile(() => work(10));
work(200);
```

The written `.cpuprofile` has zero samples (a single `(root)` node). Without the `profile()` call the same script produces ~350 samples.

### Cause

JSC exposes one `SamplingProfiler` per VM. `--cpu-prof`, `node:inspector`'s `Profiler.start`/`stop`, and `Worker.{start,stop}CpuProfile` drive it through `Bun::startCPUProfiler`/`stopCPUProfiler` (`BunCPUProfiler.cpp`). `bun:jsc`'s `profile()` (`functionRunProfiler` in `src/jsc/modules/BunJSCModule.h`) drives `vm.samplingProfiler()` directly: after the callback returns (or throws) it unconditionally takes the profiler lock and calls `pause()` + `clearData()`, and its `stackTracesAsJSON()` call ends with `clearData()` internally too. So every sample `--cpu-prof` has accumulated is discarded and the sampler stays paused for the rest of the run.

### Fix

Guard `profile()`'s destructive calls on `Bun::isCPUProfilerRunning()`, read at each decision point rather than captured at entry (a `node:inspector` `Profiler.start` issued inside the callback, sync or on the promise path, flips the flag after entry). When another consumer owns the sampler:

- `setTimingInterval()` is skipped so `--cpu-prof-interval` is preserved.
- `stackTracesAsJSON()` is skipped (it is inherently destructive; JSC has no non-destructive accessor) and `stackTraces` is `null`. `reportTopFunctions`/`reportTopBytecodes` still run since both iterate `m_stackTraces` without clearing.
- `pause()`/`clearData()` are skipped on both the success and failure paths.

When no other consumer is active `profile()`'s behaviour is unchanged. `SamplingProfile.stackTraces` is widened to `string[] | null` in `packages/bun-types/jsc.d.ts` and the JSDoc notes when it is `null`.

#36017 reference-counts the shared profiler for `--cpu-prof` / `node:inspector` / Worker and explicitly leaves `bun:jsc` out of scope; this PR is the minimal guard so `profile()` stops destroying their state. `bun:jsc`'s `startSamplingProfiler()` / `samplingProfilerStackTraces()` are intentionally left alone: they are the explicit low-level start/drain pair and a caller reaching for them is knowingly taking over the sampler, whereas `profile()` is a convenience wrapper where the profiler is an implementation detail. Routing `profile()` through #36017's retained-sample pipeline (so `stackTraces` can be scoped to the callback window non-destructively) is a follow-up once that infrastructure is on main.

### Verification

New tests in `test/cli/run/cpu-prof.test.ts` cover the success path (with a non-default `--cpu-prof-interval` asserted via `reportTopFunctions`' sampling-rate line), the throwing-callback path, and a `node:inspector` `Profiler.start` issued inside `profile()`'s callback:

```
$ USE_SYSTEM_BUN=1 bun test test/cli/run/cpu-prof.test.ts -t "bun:jsc profile"
  3 fail  (Expected: > 0, Received: 0)

$ bun bd test test/cli/run/cpu-prof.test.ts test/js/bun/jsc/bun-jsc.test.ts test/js/node/inspector/inspector-profiler.test.ts
  92 pass  0 fail

$ bun test test/integration/bun-types/bun-types.test.ts
  14 pass  0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/cpu-prof.test.ts
bun test v1.4.0 (18bfc9695)

test/cli/run/cpu-prof.test.ts:
(pass) --cpu-prof > --cpu-prof-dir sets custom directory [451.86ms]
(pass) --cpu-prof > --cpu-prof-name sets custom filename [496.25ms]
(pass) --cpu-prof > profile captures function names [511.37ms]
(pass) --cpu-prof > --cpu-prof-md with custom name [455.98ms]
(pass) --cpu-prof > generates CPU profile with default name [1050.05ms]
(pass) --cpu-prof > --cpu-prof-md shows function details with relationships [569.05ms]
(pass) --cpu-prof > --cpu-prof-md works standalone without --cpu-prof [569.37ms]
(pass) --cpu-prof > --cpu-prof and --cpu-prof-md together creates both files [552.99ms]
(pass) --cpu-prof > --cpu-prof-md generates markdown format profile [1493.18ms]
487 | 
488 |     const file = readdirSync(String(dir)).find(f => f.endsWith(".cpuprofile"));
489 |     expect(file).toBeDefined();
490 |     const prof = JSON.parse(readFileSync(join(String(dir), file!), "utf8"));
491 |     const names: string[] = prof.nodes.map((n: any) => n.callFrame.funct
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8c8a7cacc)

test/cli/run/cpu-prof.test.ts:
(pass) --cpu-prof > profile captures function names [108.63ms]
(pass) --cpu-prof > --cpu-prof-md with custom name [107.61ms]
(pass) --cpu-prof > --cpu-prof-name sets custom filename [110.38ms]
(pass) --cpu-prof > --cpu-prof-dir sets custom directory [110.43ms]
(pass) --cpu-prof > --cpu-prof-md works standalone without --cpu-prof [107.52ms]
(pass) --cpu-prof > --cpu-prof-md shows function details with relationships [108.44ms]
(pass) --cpu-prof > generates CPU profile with default name [113.51ms]
(pass) --cpu-prof > --cpu-prof and --cpu-prof-md together creates both files [110.61ms]
(pass) --cpu-prof > --cpu-prof-md generates markdown format profile [113.44ms]
(pass) --cpu-prof > bun:jsc profile() does not wipe a node:inspector profile started inside its callback [129.52ms]
(pass) --cpu-prof > bun:jsc profile() with a throwing callback does not wipe --cpu-prof's samples [213.11ms]
(pass) --cpu-prof > bun:jsc profile() does not wipe --cpu-prof's samples [218.74ms]

 12 pass
 0 fail
 327 expect() calls
Ran 12 tests across 1 file. [405.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/cpu-prof.test.ts
bun test v1.4.0 (18bfc9695)

test/cli/run/cpu-prof.test.ts:
(pass) --cpu-prof > --cpu-prof-name sets custom filename [492.09ms]
(pass) --cpu-prof > profile captures function names [485.97ms]
(pass) --cpu-prof > --cpu-prof-dir sets custom directory [529.18ms]
(pass) --cpu-prof > generates CPU profile with default name [975.70ms]
(pass) --cpu-prof > --cpu-prof-md with custom name [464.02ms]
(pass) --cpu-prof > --cpu-prof-md works standalone without --cpu-prof [481.63ms]
(pass) --cpu-prof > --cpu-prof-md shows function details with relationships [545.65ms]
(pass) --cpu-prof > --cpu-prof-md generates markdown format profile [1205.19ms]
(pass) --cpu-prof > --cpu-prof and --cpu-prof-md together creates both files [620.14ms]
(pass) --cpu-prof > bun:jsc profile() does not wipe --cpu-prof's samples [613.51ms]
(pass) --cpu-prof > bun:jsc profile() with a throwing callback does not wipe --cpu-prof's samples [689.92ms]
(pass) --cpu-prof > bun:jsc profile() does not wipe a node:inspector profile started inside its call
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 659ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/jsc.d.ts    |   9 ++-
 src/jsc/modules/BunJSCModule.h |  58 ++++++++++++-------
 test/cli/run/cpu-prof.test.ts  | 128 +++++++++++++++++++++++++++++++++++++++++
 3 files changed, 172 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
packages/bun-types/jsc.d.ts         2      3      0
src/jsc/modules/BunJSCModule.h      3      8      0
test/cli/run/cpu-prof.test.ts       4      7      0
```

</details>

<!-- robobun:evidence:end -->