### PR TITLE
Bun.write: deliver the whole payload to a FIFO instead of a torn prefix

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5461,8 +5461,9 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
     // A FIFO/socket/chardev opened O_NONBLOCK will EAGAIN once the pipe
     // buffer fills. Closing mid-payload would deliver a torn prefix and EOF
     // to the reader, so hand the open fd to the async WriteFile path instead
-    // and let it drive POLLOUT. Regular files never EAGAIN; keep the fast path.
-    if NEEDS_OPEN {
+    // and let it drive POLLOUT. Regular files never EAGAIN; keep the fast
+    // path. A 0-byte write cannot EAGAIN either, so stay on the fast path.
+    if NEEDS_OPEN && !str.is_empty() {
         if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
             if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
                 *needs_async = true;
@@ -5529,7 +5530,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     global_this: &JSGlobalObject,
     pathlike: &PathOrFileDescriptor,
     bytes: &[u8],
-    _needs_async: &mut bool,
+    needs_async: &mut bool,
     handoff_fd: &mut Option<Fd>,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
@@ -5550,7 +5551,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
             bun_sys::Result::Err(err) => {
                 #[cfg(not(windows))]
                 if err.get_errno() == bun_sys::E::ENOENT {
-                    *_needs_async = true;
+                    *needs_async = true;
                     return JSValue::ZERO;
                 }
                 return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
@@ -5564,10 +5565,10 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     // See write_string_to_file_fast: route non-regular files to the async
     // path with the fd we just opened, so a FIFO write never closes+reopens
     // mid-payload.
-    if NEEDS_OPEN {
+    if NEEDS_OPEN && !bytes.is_empty() {
         if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
             if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
-                *_needs_async = true;
+                *needs_async = true;
                 *handoff_fd = Some(fd);
                 return JSValue::ZERO;
             }
@@ -5593,7 +5594,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
             bun_sys::Result::Err(err) => {
                 #[cfg(not(windows))]
                 if err.get_errno() == bun_sys::E::EAGAIN {
-                    *_needs_async = true;
+                    *needs_async = true;
                     return JSValue::ZERO;
                 }
                 let err_js = if !NEEDS_OPEN {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1354,6 +1354,7 @@ impl BlobExt for Blob {
                 mkdirp_if_not_exists,
                 extra_options: options,
                 mode: None,
+                handoff_fd: None,
             },
         )
     }
@@ -4456,6 +4457,10 @@ pub struct WriteFileOptions {
     pub mkdirp_if_not_exists: Option<bool>,
     pub extra_options: Option<JSValue>,
     pub mode: Option<bun_sys::Mode>,
+    /// An fd the sync fast path already opened for the destination. When set,
+    /// the async `WriteFile` adopts it instead of reopening the path so a
+    /// FIFO's reader never sees an intermediate EOF.
+    pub handoff_fd: Option<Fd>,
 }
 
 /// Write an empty string to a file by truncating it.
@@ -4674,6 +4679,16 @@ pub fn write_file_with_source_destination(
     destination_blob: &mut Blob,
     options: &WriteFileOptions,
 ) -> JsResult<JSValue> {
+    // The fast path may have opened the destination and handed the fd over.
+    // Only the posix File←Bytes branch adopts it; any other branch (or an
+    // early error) must not leak it.
+    let handoff_fd = core::cell::Cell::new(options.handoff_fd);
+    let _close_handoff_fd = scopeguard::guard((), |()| {
+        if let Some(fd) = handoff_fd.get() {
+            let _ = bun_sys::close(fd);
+        }
+    });
+
     let destination_store = destination_blob
         .store
         .get()
@@ -4734,6 +4749,10 @@ pub fn write_file_with_source_destination(
                 options.mkdirp_if_not_exists.unwrap_or(true),
             )
             .expect("unreachable");
+            if let Some(fd) = handoff_fd.take() {
+                // SAFETY: file_copier was just produced by heap::into_raw; sole owner.
+                unsafe { (*file_copier).opened_fd = fd };
+            }
             let task = write_file_mod::WriteFileTask::create_on_js_thread(ctx, file_copier);
             // Defer promise creation until we're just about to schedule the task.
             // `JSPromiseStrong.strong` is private in `bun_jsc`, so use `init` (which
@@ -5040,6 +5059,18 @@ pub fn write_file_internal(
         }
     }
 
+    #[cfg(not(windows))]
+    let handoff_fd = core::cell::Cell::new(None::<Fd>);
+    // If the fast path opened an fd and handed it off, make sure it closes on
+    // any early-return between here and `write_file_with_source_destination`
+    // consuming it.
+    #[cfg(not(windows))]
+    let _close_handoff_fd = scopeguard::guard((), |()| {
+        if let Some(fd) = handoff_fd.get() {
+            let _ = bun_sys::close(fd);
+        }
+    });
+
     // If you're doing Bun.write(), try to go fast by writing short input on the main thread.
     // This is a heuristic, but it's a good one.
     //
@@ -5047,6 +5078,7 @@ pub fn write_file_internal(
     #[cfg(not(windows))]
     {
         let mut needs_async = false;
+        let mut fast_path_fd: Option<Fd> = None;
         let fast_path_ok = matches!(*path_or_blob, PathOrBlob::Path(_))
             || (matches!(*path_or_blob, PathOrBlob::Blob(ref b)
                 if b.offset.get() == 0 && !b.is_s3()
@@ -5075,6 +5107,7 @@ pub fn write_file_internal(
                             &pathlike,
                             str.get(),
                             &mut needs_async,
+                            &mut fast_path_fd,
                         )
                     } else {
                         write_string_to_file_fast::<false>(
@@ -5082,6 +5115,7 @@ pub fn write_file_internal(
                             &pathlike,
                             str.get(),
                             &mut needs_async,
+                            &mut fast_path_fd,
                         )
                     };
                     if !needs_async {
@@ -5106,6 +5140,7 @@ pub fn write_file_internal(
                             &pathlike,
                             buffer_view.byte_slice(),
                             &mut needs_async,
+                            &mut fast_path_fd,
                         )
                     } else {
                         write_bytes_to_file_fast::<false>(
@@ -5113,6 +5148,7 @@ pub fn write_file_internal(
                             &pathlike,
                             buffer_view.byte_slice(),
                             &mut needs_async,
+                            &mut fast_path_fd,
                         )
                     };
                     if !needs_async {
@@ -5121,6 +5157,7 @@ pub fn write_file_internal(
                 }
             }
         }
+        handoff_fd.set(fast_path_fd);
     }
 
     // if path_or_blob is a path, convert it into a file blob
@@ -5285,6 +5322,12 @@ pub fn write_file_internal(
     // StoreRef clone+drop keeps the destination store alive across the call.
     let _dest_hold = destination_store;
 
+    #[cfg(not(windows))]
+    let options = WriteFileOptions {
+        handoff_fd: handoff_fd.take(),
+        ..options
+    };
+
     write_file_with_source_destination(
         global_this,
         &mut *source_blob,
@@ -5375,6 +5418,7 @@ pub fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
             mkdirp_if_not_exists,
             extra_options: options,
             mode,
+            handoff_fd: None,
         },
     )
 }
@@ -5387,6 +5431,7 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
     pathlike: &PathOrFileDescriptor,
     str: BunString,
     needs_async: &mut bool,
+    handoff_fd: &mut Option<Fd>,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
         pathlike.fd()
@@ -5412,6 +5457,20 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
             }
         }
     };
+
+    // A FIFO/socket/chardev opened O_NONBLOCK will EAGAIN once the pipe
+    // buffer fills. Closing mid-payload would deliver a torn prefix and EOF
+    // to the reader, so hand the open fd to the async WriteFile path instead
+    // and let it drive POLLOUT. Regular files never EAGAIN; keep the fast path.
+    if NEEDS_OPEN {
+        if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
+            if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
+                *needs_async = true;
+                *handoff_fd = Some(fd);
+                return JSValue::ZERO;
+            }
+        }
+    }
 
     // Declared before the truncate guard so it drops *after* it (close runs last).
     let _close = NEEDS_OPEN.then(|| bun_sys::CloseOnDrop::new(fd));
@@ -5471,6 +5530,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     pathlike: &PathOrFileDescriptor,
     bytes: &[u8],
     _needs_async: &mut bool,
+    handoff_fd: &mut Option<Fd>,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
         pathlike.fd()
@@ -5500,6 +5560,19 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
             }
         }
     };
+
+    // See write_string_to_file_fast: route non-regular files to the async
+    // path with the fd we just opened, so a FIFO write never closes+reopens
+    // mid-payload.
+    if NEEDS_OPEN {
+        if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
+            if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
+                *_needs_async = true;
+                *handoff_fd = Some(fd);
+                return JSValue::ZERO;
+            }
+        }
+    }
 
     // TODO: on windows this is always synchronous
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5453,13 +5453,15 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
         }
     };
 
-    // Non-regular files (FIFO/socket/chardev) can EAGAIN; hand the open fd
-    // to the async WriteFile path so it can wait for POLLOUT.
-    if NEEDS_OPEN && !str.is_empty() {
+    // Non-regular files (FIFO/socket/chardev) can EAGAIN; route them to the
+    // async WriteFile path before any bytes go out so it can wait for POLLOUT.
+    if !str.is_empty() {
         if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
             if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
                 *needs_async = true;
-                *handoff_fd = Some(fd);
+                if NEEDS_OPEN {
+                    *handoff_fd = Some(fd);
+                }
                 return JSValue::ZERO;
             }
         }
@@ -5554,13 +5556,15 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
         }
     };
 
-    // Non-regular files (FIFO/socket/chardev) can EAGAIN; hand the open fd
-    // to the async WriteFile path so it can wait for POLLOUT.
-    if NEEDS_OPEN && !bytes.is_empty() {
+    // Non-regular files (FIFO/socket/chardev) can EAGAIN; route them to the
+    // async WriteFile path before any bytes go out so it can wait for POLLOUT.
+    if !bytes.is_empty() {
         if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
             if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
                 *needs_async = true;
-                *handoff_fd = Some(fd);
+                if NEEDS_OPEN {
+                    *handoff_fd = Some(fd);
+                }
                 return JSValue::ZERO;
             }
         }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4457,9 +4457,8 @@ pub struct WriteFileOptions {
     pub mkdirp_if_not_exists: Option<bool>,
     pub extra_options: Option<JSValue>,
     pub mode: Option<bun_sys::Mode>,
-    /// An fd the sync fast path already opened for the destination. When set,
-    /// the async `WriteFile` adopts it instead of reopening the path so a
-    /// FIFO's reader never sees an intermediate EOF.
+    /// Destination fd already opened by the sync fast path, for `WriteFile`
+    /// to adopt instead of reopening.
     pub handoff_fd: Option<Fd>,
 }
 
@@ -4679,9 +4678,7 @@ pub fn write_file_with_source_destination(
     destination_blob: &mut Blob,
     options: &WriteFileOptions,
 ) -> JsResult<JSValue> {
-    // The fast path may have opened the destination and handed the fd over.
-    // Only the posix File←Bytes branch adopts it; any other branch (or an
-    // early error) must not leak it.
+    // Close the handoff fd on any branch that doesn't adopt it.
     let handoff_fd = core::cell::Cell::new(options.handoff_fd);
     let _close_handoff_fd = scopeguard::guard((), |()| {
         if let Some(fd) = handoff_fd.get() {
@@ -5061,9 +5058,7 @@ pub fn write_file_internal(
 
     #[cfg(not(windows))]
     let handoff_fd = core::cell::Cell::new(None::<Fd>);
-    // If the fast path opened an fd and handed it off, make sure it closes on
-    // any early-return between here and `write_file_with_source_destination`
-    // consuming it.
+    // Close the fast-path fd on any early return before WriteFile adopts it.
     #[cfg(not(windows))]
     let _close_handoff_fd = scopeguard::guard((), |()| {
         if let Some(fd) = handoff_fd.get() {
@@ -5458,11 +5453,8 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
         }
     };
 
-    // A FIFO/socket/chardev opened O_NONBLOCK will EAGAIN once the pipe
-    // buffer fills. Closing mid-payload would deliver a torn prefix and EOF
-    // to the reader, so hand the open fd to the async WriteFile path instead
-    // and let it drive POLLOUT. Regular files never EAGAIN; keep the fast
-    // path. A 0-byte write cannot EAGAIN either, so stay on the fast path.
+    // Non-regular files (FIFO/socket/chardev) can EAGAIN; hand the open fd
+    // to the async WriteFile path so it can wait for POLLOUT.
     if NEEDS_OPEN && !str.is_empty() {
         if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
             if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
@@ -5562,9 +5554,8 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
         }
     };
 
-    // See write_string_to_file_fast: route non-regular files to the async
-    // path with the fd we just opened, so a FIFO write never closes+reopens
-    // mid-payload.
+    // Non-regular files (FIFO/socket/chardev) can EAGAIN; hand the open fd
+    // to the async WriteFile path so it can wait for POLLOUT.
     if NEEDS_OPEN && !bytes.is_empty() {
         if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
             if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -594,6 +594,7 @@ impl S3Client {
                 mkdirp_if_not_exists: Some(false),
                 extra_options: options,
                 mode: None,
+                handoff_fd: None,
             },
         )
     }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -333,15 +333,15 @@ impl WriteFile {
         let fd = self.opened_fd;
         debug_assert!(fd != Fd::INVALID);
 
-        // We do not use pwrite() because the file may not be
-        // seekable (such as stdout)
-        //
-        // On macOS, it is an error to use pwrite() on a
-        // non-seekable file.
-        let result: bun_sys::Result<usize> =
-            sys::write(fd, &self.bytes_blob.shared_view()[off..off + len]);
-
         loop {
+            // We do not use pwrite() because the file may not be
+            // seekable (such as stdout)
+            //
+            // On macOS, it is an error to use pwrite() on a
+            // non-seekable file.
+            let result: bun_sys::Result<usize> =
+                sys::write(fd, &self.bytes_blob.shared_view()[off..off + len]);
+
             match &result {
                 bun_sys::Result::Ok(res) => {
                     *wrote = *res;
@@ -464,10 +464,13 @@ impl WriteFile {
                 }
             }
 
-            // We opened the file descriptor with O_NONBLOCK, so we
-            // shouldn't have to worry about blocking reads/writes
-            //
-            // We do not call fstat() because that is very expensive.
+            // We opened with O_NONBLOCK. For a regular file that flag is a
+            // no-op, but for a FIFO/socket/chardev write() can return EAGAIN
+            // and we must wait for POLLOUT rather than spin. One fstat on the
+            // just-opened fd is cheap and tells us which we have.
+            if let bun_sys::Result::Ok(st) = sys::fstat(fd) {
+                break 'brk !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode);
+            }
             false
         };
 

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -464,10 +464,8 @@ impl WriteFile {
                 }
             }
 
-            // We opened with O_NONBLOCK. For a regular file that flag is a
-            // no-op, but for a FIFO/socket/chardev write() can return EAGAIN
-            // and we must wait for POLLOUT rather than spin. One fstat on the
-            // just-opened fd is cheap and tells us which we have.
+            // Path-opened fds have no cached mode; fstat so a FIFO/socket
+            // reaches wait_for_writable() on EAGAIN.
             if let bun_sys::Result::Ok(st) = sys::fstat(fd) {
                 break 'brk !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode);
             }

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -750,46 +750,32 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       const N = 200003;
       const payload = Buffer.alloc(N - 3, "x").toString() + "END";
 
-      // Reader: a node:fs read stream opens O_RDONLY in the thread pool
-      // (blocks there until our write side opens) and drains to EOF.
-      const { promise: opened, resolve: onOpen, reject: onOpenErr } = Promise.withResolvers();
-      const { promise: drained, resolve: onEnd, reject: onReadErr } = Promise.withResolvers();
-      const chunks = [];
-      const reader = fs
-        .createReadStream(fifo)
-        .once("open", onOpen)
-        .on("data", c => chunks.push(c))
-        .once("end", () => onEnd(Buffer.concat(chunks)))
-        .once("error", e => {
-          onOpenErr(e);
-          onReadErr(e);
-        });
+      // Open the read side synchronously with O_NONBLOCK so it returns
+      // immediately (no writer required) and the writer's O_WRONLY|O_NONBLOCK
+      // open cannot observe ENXIO. Reading through Bun.file(fd).stream() polls
+      // on EAGAIN instead of parking a thread-pool worker, which matters under
+      // describe.concurrent.
+      const readFd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+      const drained = (async () => {
+        const chunks = [];
+        for await (const chunk of Bun.file(readFd).stream()) chunks.push(chunk);
+        return Buffer.concat(chunks);
+      })();
 
+      let got;
+      let written;
       try {
-        // Our O_WRONLY|O_NONBLOCK open returns ENXIO until the reader's open
-        // has started. Retry the write until the reader is attached instead
-        // of sleeping for a guess.
-        let written;
-        while (true) {
-          try {
-            written = await Bun.write(fifo, toSource(payload));
-            break;
-          } catch (e) {
-            if (e?.code !== "ENXIO") throw e;
-            await Bun.sleep(0);
-          }
-        }
-        await opened;
-
-        const got = await drained;
-        expect({ bytes: got.length, tail: got.subarray(-3).toString(), written }).toEqual({
-          bytes: N,
-          tail: "END",
-          written: N,
-        });
+        written = await Bun.write(fifo, toSource(payload));
+        got = await drained;
       } finally {
-        reader.destroy();
+        fs.closeSync(readFd);
       }
+
+      expect({ bytes: got.length, tail: got.subarray(-3).toString(), written }).toEqual({
+        bytes: N,
+        tail: "END",
+        written: N,
+      });
     });
   });
 });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import fs, { mkdirSync } from "fs";
 import { bunEnv, bunExe, exampleHtml, exampleSite, gcTick, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import { mkfifo } from "mkfifo";
 import path, { join } from "path";
 
 let i = 0;
@@ -726,5 +727,69 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     Bun.gc(true);
 
     expect(f.name).toBe(filePath);
+  });
+
+  // Writing more than the kernel pipe buffer to a FIFO used to deliver only the
+  // first partial write to the reader and then either reject ENXIO (fast path
+  // closed and reopened the fifo) or never settle (async path spun on EAGAIN
+  // with could_block=false). Both must now deliver the full payload.
+  describe.skipIf(isWindows).each([
+    ["string", payload => payload],
+    ["Uint8Array", payload => new TextEncoder().encode(payload)],
+    ["Blob", payload => new Blob([payload])],
+    ["Response", payload => new Response(payload)],
+  ])("Bun.write(fifo, %s) larger than the pipe buffer", (label, toSource) => {
+    it("delivers every byte to the reader", async () => {
+      using dir = tempDir(`bun-write-fifo-${label}`, {});
+      const fifo = join(String(dir), "f.fifo");
+      mkfifo(fifo);
+
+      // 200003 bytes: well over the 64 KiB Linux pipe buffer (and the 8 KiB
+      // minimum some CI kernels use), with a distinct tail so a torn prefix
+      // is visible.
+      const N = 200003;
+      const payload = Buffer.alloc(N - 3, "x").toString() + "END";
+
+      // Reader: a node:fs read stream opens O_RDONLY in the thread pool
+      // (blocks there until our write side opens) and drains to EOF.
+      const { promise: opened, resolve: onOpen, reject: onOpenErr } = Promise.withResolvers();
+      const { promise: drained, resolve: onEnd, reject: onReadErr } = Promise.withResolvers();
+      const chunks = [];
+      const reader = fs
+        .createReadStream(fifo)
+        .once("open", onOpen)
+        .on("data", c => chunks.push(c))
+        .once("end", () => onEnd(Buffer.concat(chunks)))
+        .once("error", e => {
+          onOpenErr(e);
+          onReadErr(e);
+        });
+
+      try {
+        // Our O_WRONLY|O_NONBLOCK open returns ENXIO until the reader's open
+        // has started. Retry the write until the reader is attached instead
+        // of sleeping for a guess.
+        let written;
+        while (true) {
+          try {
+            written = await Bun.write(fifo, toSource(payload));
+            break;
+          } catch (e) {
+            if (e?.code !== "ENXIO") throw e;
+            await Bun.sleep(0);
+          }
+        }
+        await opened;
+
+        const got = await drained;
+        expect({ bytes: got.length, tail: got.subarray(-3).toString(), written }).toEqual({
+          bytes: N,
+          tail: "END",
+          written: N,
+        });
+      } finally {
+        reader.destroy();
+      }
+    });
   });
 });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -739,16 +739,16 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     ["Blob", payload => new Blob([payload])],
     ["Response", payload => new Response(payload)],
   ])("Bun.write(fifo, %s) larger than the pipe buffer", (label, toSource) => {
-    it("delivers every byte to the reader", async () => {
-      using dir = tempDir(`bun-write-fifo-${label}`, {});
+    // 200003 bytes: well over the 64 KiB Linux pipe buffer (and the 8 KiB
+    // minimum some CI kernels use), with a distinct tail so a torn prefix
+    // is visible.
+    const N = 200003;
+    const payload = Buffer.alloc(N - 3, "x").toString() + "END";
+
+    async function exercise(suffix, writeTo) {
+      using dir = tempDir(`bun-write-fifo-${label}-${suffix}`, {});
       const fifo = join(String(dir), "f.fifo");
       mkfifo(fifo);
-
-      // 200003 bytes: well over the 64 KiB Linux pipe buffer (and the 8 KiB
-      // minimum some CI kernels use), with a distinct tail so a torn prefix
-      // is visible.
-      const N = 200003;
-      const payload = Buffer.alloc(N - 3, "x").toString() + "END";
 
       // Open the read side synchronously with O_NONBLOCK so it returns
       // immediately (no writer required) and the writer's O_WRONLY|O_NONBLOCK
@@ -761,14 +761,16 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         for await (const chunk of Bun.file(readFd).stream()) chunks.push(chunk);
         return Buffer.concat(chunks);
       })();
+      drained.catch(() => {});
 
       let got;
       let written;
       try {
-        written = await Bun.write(fifo, toSource(payload));
+        written = await writeTo(fifo, toSource(payload));
         got = await drained;
       } finally {
         fs.closeSync(readFd);
+        await drained.catch(() => {});
       }
 
       expect({ bytes: got.length, tail: got.subarray(-3).toString(), written }).toEqual({
@@ -776,6 +778,18 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         tail: "END",
         written: N,
       });
-    });
+    }
+
+    it("delivers every byte to the reader (path dest)", () => exercise("path", (fifo, src) => Bun.write(fifo, src)));
+
+    it("delivers every byte to the reader (O_NONBLOCK fd dest)", () =>
+      exercise("fd", async (fifo, src) => {
+        const wfd = fs.openSync(fifo, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+        try {
+          return await Bun.write(Bun.file(wfd), src);
+        } finally {
+          fs.closeSync(wfd);
+        }
+      }));
   });
 });


### PR DESCRIPTION
## Repro

```js
// linux; mkfifo /tmp/f && (cat /tmp/f > /tmp/got &) then:
await Bun.write("/tmp/f", "x".repeat(200000) + "END");
```

With a live reader attached and a payload larger than the kernel pipe buffer:

| source | before | reader received |
| --- | --- | --- |
| string / Uint8Array | rejects `ENXIO` (\"no reader\") | torn prefix (pipe-buffer bytes) |
| Blob / Response | never settles | torn prefix |
| `Bun.file(fifo).writer()` (control) | ok | full payload |

## Cause

**Sync fast path** (`write_string_to_file_fast` / `write_bytes_to_file_fast`): opened `O_WRONLY|O_NONBLOCK`, wrote until `EAGAIN`, then set `needs_async`, which dropped the `CloseOnDrop` guard and closed the fd. Closing the only writer gave the reader EOF at the partial length; the async fallback then reopened with `O_TRUNC|O_NONBLOCK` and got `ENXIO` because the reader had already gone.

**Async `WriteFile` path**: `could_block` was hardwired `false` for path targets (the fstat was deliberately skipped), and `do_write` matched `EAGAIN` in a `loop` whose `sys::write` sat outside the loop body, so `continue` re-matched the same stale `Err(EAGAIN)` forever without ever reaching `wait_for_writable()`.

## Fix

* `write_file.rs`: `run_with_fd` now fstats the opened fd and sets `could_block = !is_regular_file(mode)`, so a FIFO/socket/chardev registers for POLLOUT on `EAGAIN` exactly like `FileSink` already does. `do_write` issues `sys::write` inside the loop so the non-pollable branch actually retries.
* `Blob.rs`: when the fast path opens a path and fstat shows it is not a regular file, it writes nothing and hands the open fd to the async path via a new `WriteFileOptions.handoff_fd`. `WriteFile` adopts that fd (`get_fd` already short-circuits on a preset `opened_fd`), so the FIFO is opened exactly once and the reader never sees an intermediate EOF. Scope guards close the fd on any early return between the fast path and `WriteFile` adopting it.

Regular-file writes are unchanged apart from one `fstat` on the freshly opened fd.

## Verification

```
$ bun bd test test/js/bun/io/bun-write.test.js -t "larger than the pipe buffer"
(pass) Bun.write(fifo, string) larger than the pipe buffer > delivers every byte to the reader
(pass) Bun.write(fifo, Uint8Array) larger than the pipe buffer > delivers every byte to the reader
(pass) Bun.write(fifo, Blob) larger than the pipe buffer > delivers every byte to the reader
(pass) Bun.write(fifo, Response) larger than the pipe buffer > delivers every byte to the reader
4 pass, 0 fail
```

All four time out on main. `Bun.write(fifo, ...)` with no reader still rejects `ENXIO` immediately, and the existing `filesink.test.ts` suite is unchanged (50 pass).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->