### PR TITLE
node:dns: keep the c-ares timeout timer armed for queries past the 32-slot pending cache

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4155,6 +4155,18 @@ impl Resolver {
             pending_addr_cache_cares,
             pending_nameinfo_cache_cares
         );
+        // The pending caches above are fixed-size (32 slots each); any
+        // query issued past that is dispatched to c-ares untracked
+        // (`LookupCacheHit::Disabled`). Ask c-ares directly so the timeout
+        // timer stays armed for those too. Safe from inside a c-ares callback:
+        // the channel lock is recursive on every platform (PTHREAD_MUTEX_RECURSIVE
+        // on posix, CRITICAL_SECTION on Windows).
+        if let Some(channel) = self.channel.get() {
+            // SAFETY: `channel` is the live c-ares channel owned by `self`.
+            if c_ares::ares_queue_active_queries(unsafe { &*channel }) != 0 {
+                return true;
+            }
+        }
         false
     }
 
@@ -4778,13 +4790,19 @@ impl Resolver {
                 // an error occurred. just pretend that the socket is both readable and writable.
                 // https://github.com/nodejs/node/blob/8a41d9b636be86350cd32847c3f89d327c4f6ff7/src/cares_wrap.cc#L93
                 (*channel).process((*poll).socket, true, true);
-                return;
+            } else {
+                (*channel).process(
+                    (*poll).socket,
+                    events & libuv::UV_READABLE != 0,
+                    events & libuv::UV_WRITABLE != 0,
+                );
             }
-            (*channel).process(
-                (*poll).socket,
-                events & libuv::UV_READABLE != 0,
-                events & libuv::UV_WRITABLE != 0,
-            );
+
+            // See `on_dns_poll` — re-check after `ares_process_fd` has
+            // detached any just-completed queries.
+            if !(*parent).any_requests_pending() {
+                (*parent).remove_timer();
+            }
         }
     }
 
@@ -4828,6 +4846,14 @@ impl Resolver {
         // UnsafeCell-backed).
         unsafe {
             (*channel).process(poll.fd.native(), poll.is_readable(), poll.is_writable());
+        }
+
+        // c-ares detaches a query from its queue only *after* the callback
+        // returns, so `request_completed` (inside the callback) may have seen
+        // the just-finished query still counted and left the timeout timer
+        // armed. Re-check now that `ares_process_fd` has returned.
+        if !self.any_requests_pending() {
+            self.remove_timer();
         }
     }
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4155,12 +4155,9 @@ impl Resolver {
             pending_addr_cache_cares,
             pending_nameinfo_cache_cares
         );
-        // The pending caches above are fixed-size (32 slots each); any
-        // query issued past that is dispatched to c-ares untracked
-        // (`LookupCacheHit::Disabled`). Ask c-ares directly so the timeout
-        // timer stays armed for those too. Safe from inside a c-ares callback:
-        // the channel lock is recursive on every platform (PTHREAD_MUTEX_RECURSIVE
-        // on posix, CRITICAL_SECTION on Windows).
+        // The 32-slot caches overflow to `LookupCacheHit::Disabled`; c-ares' own
+        // queue length covers those too. Its channel lock is recursive, so this
+        // is safe from inside a completion callback.
         if let Some(channel) = self.channel.get() {
             // SAFETY: `channel` is the live c-ares channel owned by `self`.
             if c_ares::ares_queue_active_queries(unsafe { &*channel }) != 0 {
@@ -4220,12 +4217,11 @@ impl Resolver {
         // Normally checkTimeouts does this, so we have to be sure to do it ourself if we cancel the timer
         let this = self.as_ctx_ptr();
         scopeguard::defer! {
-            // SAFETY: `this` is the heap allocation from `init`. This releases the
-            // ref taken by `add_timer`. Callers via `request_completed` hold an
-            // `IntrusiveRc<Resolver>`; the `close_channel_for_terminate` caller is
-            // the global resolver, which carries a permanent +1 pin from
-            // `global_resolver()`. Either way the timer ref is never the last and
-            // this `deref` cannot reach 0 while `&self` is live.
+            // SAFETY: `this` is the heap allocation from `init`. This releases
+            // the ref taken by `add_timer`. Every caller holds at least one
+            // other ref for the duration of this call (an `IntrusiveRc`, a
+            // `ref_scope` guard, or the global-resolver permanent pin), so this
+            // `deref` cannot reach 0 while `&self` is live.
             unsafe {
                 let uws_loop = (*this).vm().uws_loop();
                 let state = crate::jsc_hooks::runtime_state();
@@ -4798,8 +4794,7 @@ impl Resolver {
                 );
             }
 
-            // See `on_dns_poll` — re-check after `ares_process_fd` has
-            // detached any just-completed queries.
+            // See `on_dns_poll` for why this re-check follows `ares_process_fd`.
             if !(*parent).any_requests_pending() {
                 (*parent).remove_timer();
             }
@@ -4848,10 +4843,8 @@ impl Resolver {
             (*channel).process(poll.fd.native(), poll.is_readable(), poll.is_writable());
         }
 
-        // c-ares detaches a query from its queue only *after* the callback
-        // returns, so `request_completed` (inside the callback) may have seen
-        // the just-finished query still counted and left the timeout timer
-        // armed. Re-check now that `ares_process_fd` has returned.
+        // c-ares detaches a query only *after* its callback returns, so
+        // `request_completed` may have seen it still counted; re-check now.
         if !self.any_requests_pending() {
             self.remove_timer();
         }

--- a/test/js/node/dns/dns-resolver-concurrent-timeout-fixture.ts
+++ b/test/js/node/dns/dns-resolver-concurrent-timeout-fixture.ts
@@ -30,13 +30,13 @@ srv.bind(0, "127.0.0.1", () => {
   R.setServers([`127.0.0.1:${port}`]);
 
   let ok = 0;
-  let err = 0;
+  const errCodes: string[] = [];
   const ps: Promise<void>[] = [];
   for (let i = 0; i < 32; i++) {
     ps.push(
       R.resolve4(`ok.a${i}.test`).then(
         () => void ok++,
-        () => void err++,
+        e => void errCodes.push(e.code),
       ),
     );
   }
@@ -44,13 +44,13 @@ srv.bind(0, "127.0.0.1", () => {
     ps.push(
       R.resolve4(`silent.a${i}.test`).then(
         () => void ok++,
-        () => void err++,
+        e => void errCodes.push(e.code),
       ),
     );
   }
 
   Promise.allSettled(ps).then(() => {
-    console.log(JSON.stringify({ ok, err }));
+    console.log(JSON.stringify({ ok, errCodes: errCodes.sort() }));
     srv.close();
     R.cancel();
   });

--- a/test/js/node/dns/dns-resolver-concurrent-timeout-fixture.ts
+++ b/test/js/node/dns/dns-resolver-concurrent-timeout-fixture.ts
@@ -1,0 +1,57 @@
+// Exercises the c-ares timeout timer with more concurrent queries than the
+// resolver's 32-slot pending cache: 32 queries get an instant answer (filling
+// every tracked slot) and 8 more are never answered and must ETIMEOUT via the
+// poll timer. Before the fix, the 8 overflow queries were invisible to
+// `any_requests_pending()`, the timer was disarmed once the 32 tracked queries
+// completed, and the 8 promises stayed pending forever (process never exits).
+import dns from "node:dns";
+import dgram from "node:dgram";
+
+const srv = dgram.createSocket("udp4");
+srv.on("message", (msg, rinfo) => {
+  // qname: first label starts at offset 12, length at byte 12
+  const first = msg.subarray(13, 13 + msg[12]).toString();
+  if (first === "silent") return; // never answer these
+
+  let off = 12;
+  while (msg[off] !== 0) off += msg[off] + 1;
+  const question = msg.subarray(12, off + 5);
+  const reply = Buffer.concat([
+    Buffer.from([msg[0], msg[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]),
+    question,
+    Buffer.from([0xc0, 12, 0, 1, 0, 1, 0, 0, 0, 60, 0, 4, 127, 0, 0, 7]),
+  ]);
+  srv.send(reply, rinfo.port, rinfo.address);
+});
+
+srv.bind(0, "127.0.0.1", () => {
+  const port = srv.address().port;
+  const R = new dns.promises.Resolver({ timeout: 1000, tries: 1 });
+  R.setServers([`127.0.0.1:${port}`]);
+
+  let ok = 0;
+  let err = 0;
+  const ps: Promise<void>[] = [];
+  for (let i = 0; i < 32; i++) {
+    ps.push(
+      R.resolve4(`ok.a${i}.test`).then(
+        () => void ok++,
+        () => void err++,
+      ),
+    );
+  }
+  for (let i = 0; i < 8; i++) {
+    ps.push(
+      R.resolve4(`silent.a${i}.test`).then(
+        () => void ok++,
+        () => void err++,
+      ),
+    );
+  }
+
+  Promise.allSettled(ps).then(() => {
+    console.log(JSON.stringify({ ok, err }));
+    srv.close();
+    R.cancel();
+  });
+});

--- a/test/js/node/dns/dns-resolver-concurrent-timeout.test.ts
+++ b/test/js/node/dns/dns-resolver-concurrent-timeout.test.ts
@@ -19,6 +19,6 @@ test("dns.Resolver: unanswered queries past 32 concurrent still time out", async
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr.trim()).toBe("");
-  expect(JSON.parse(stdout.trim())).toEqual({ ok: 32, err: 8 });
+  expect(JSON.parse(stdout.trim())).toEqual({ ok: 32, errCodes: Array(8).fill("ETIMEOUT") });
   expect(exitCode).toBe(0);
 }, 20_000);

--- a/test/js/node/dns/dns-resolver-concurrent-timeout.test.ts
+++ b/test/js/node/dns/dns-resolver-concurrent-timeout.test.ts
@@ -8,21 +8,17 @@ import { join } from "node:path";
 // looked only at the cache bitsets, so once the 32 tracked queries completed
 // the timer was disarmed and any still-pending untracked query never saw its
 // ETIMEOUT: its promise stayed pending forever and the process never exited.
-test(
-  "dns.Resolver: unanswered queries past 32 concurrent still time out",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "dns-resolver-concurrent-timeout-fixture.ts")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+test("dns.Resolver: unanswered queries past 32 concurrent still time out", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "dns-resolver-concurrent-timeout-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr.trim()).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual({ ok: 32, err: 8 });
-    expect(exitCode).toBe(0);
-  },
-  20_000,
-);
+  expect(stderr.trim()).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ ok: 32, err: 8 });
+  expect(exitCode).toBe(0);
+}, 20_000);

--- a/test/js/node/dns/dns-resolver-concurrent-timeout.test.ts
+++ b/test/js/node/dns/dns-resolver-concurrent-timeout.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// The resolver's per-type pending cache is a fixed 32-slot HiveArray; any query
+// issued past that is dispatched to c-ares without a cache slot. Before the
+// fix, `any_requests_pending()` (which gates the 1s c-ares timeout poll timer)
+// looked only at the cache bitsets, so once the 32 tracked queries completed
+// the timer was disarmed and any still-pending untracked query never saw its
+// ETIMEOUT: its promise stayed pending forever and the process never exited.
+test(
+  "dns.Resolver: unanswered queries past 32 concurrent still time out",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "dns-resolver-concurrent-timeout-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ ok: 32, err: 8 });
+    expect(exitCode).toBe(0);
+  },
+  20_000,
+);


### PR DESCRIPTION
## Problem

The per-record pending caches on `Resolver` (`pending_a_cache_cares` etc.) are fixed 32-slot `HiveArray`s used to coalesce duplicate in-flight lookups. When more than 32 distinct queries of one type are in flight at once, the overflow queries are still dispatched to c-ares but get `LookupCacheHit::Disabled` and occupy no cache slot.

`any_requests_pending()` is the only gate that keeps the resolver's 1s poll timer armed (and it is what decides `request_completed()` → `remove_timer()`). It scanned only the cache bitsets, so once the 32 tracked queries completed it returned `false`, the timer was removed, and nothing ever called `ares_process_fd(ARES_SOCKET_BAD, ARES_SOCKET_BAD)` again. Any untracked query that had not been answered by then never saw its c-ares timeout: its promise stayed pending forever and the process never exited.

### Repro

```js
import dns from "node:dns"; import dgram from "node:dgram";
const srv = dgram.createSocket("udp4");
srv.on("message", (msg, r) => {
  if (msg.slice(13, 13 + msg[12]).toString() === "silent") return;
  let o = 12; while (msg[o] !== 0) o += msg[o] + 1;
  srv.send(Buffer.concat([Buffer.from([msg[0], msg[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]), msg.slice(12, o + 5),
    Buffer.from([0xc0, 12, 0, 1, 0, 1, 0, 0, 0, 60, 0, 4, 127, 0, 0, 7])]), r.port, r.address);
});
srv.bind(0, "127.0.0.1", () => {
  const R = new dns.promises.Resolver({ timeout: 1000, tries: 1 });
  R.setServers([`127.0.0.1:${srv.address().port}`]);
  const ps = [];
  for (let i = 0; i < 32; i++) ps.push(R.resolve4(`ok.a${i}.t`).catch(() => {}));     // fill the 32 tracked slots
  for (let i = 0; i < 8; i++) ps.push(R.resolve4(`silent.a${i}.t`).catch(() => {}));  // untracked, never answered
  Promise.allSettled(ps).then(() => { console.log("settled"); srv.close(); });
});
```

Node.js prints `settled` and exits after ~1s (32 ok + 8 ETIMEOUT). Bun before this change prints nothing and never exits; change 32→31 answered and everything times out correctly. The same shows up in the real world as a `Promise.all` over many hostnames hanging whenever UDP receive-buffer loss or a slow server leaves a few answers outstanding.

## Fix

`any_requests_pending()` now also consults `ares_queue_active_queries()`, which is c-ares' own count of in-flight queries on the channel and therefore covers every query regardless of whether it got a pending-cache slot. The channel lock is recursive on every platform (`PTHREAD_MUTEX_RECURSIVE` on posix, `CRITICAL_SECTION` on Windows), so calling it from inside a completion callback is safe; it is already used this way from `setServers`.

c-ares detaches a query from `all_queries` only after its callback returns, so `request_completed()` (running inside that callback) would otherwise see the just-finished query still counted and leave the timer armed for one extra tick. `on_dns_poll` / `on_dns_poll_uv` therefore re-check once `ares_process_fd` has returned and disarm then, so a single resolved query still lets the process exit immediately.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/dns/dns-resolver-concurrent-timeout.test.ts  # times out at 20s (hang)
bun bd test test/js/node/dns/dns-resolver-concurrent-timeout.test.ts                # pass, {ok:32, err:8}
```

Exit latency for a single resolved query is unchanged (measured: ~6ms tail before and after on a loopback resolver).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-resolver-concurrent-timeout.test.ts
bun test v1.4.0 (50cf2f802)

test/js/node/dns/dns-resolver-concurrent-timeout.test.ts:
killed 1 dangling process
(fail) dns.Resolver: unanswered queries past 32 concurrent still time out [20005.28ms]
  ^ this test timed out after 20000ms.

 0 pass
 1 fail
Ran 1 test across 1 file. [21.98s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (c21539a7f)

test/js/node/dns/dns-resolver-concurrent-timeout.test.ts:
(pass) dns.Resolver: unanswered queries past 32 concurrent still time out [3020.84ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.18s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-resolver-concurrent-timeout.test.ts
bun test v1.4.0 (50cf2f802)

test/js/node/dns/dns-resolver-concurrent-timeout.test.ts:
(pass) dns.Resolver: unanswered queries past 32 concurrent still time out [3846.13ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [5.82s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 772ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/dns_jsc/dns.rs                         | 43 +++++++++++-----
 .../dns/dns-resolver-concurrent-timeout-fixture.ts | 57 ++++++++++++++++++++++
 .../dns/dns-resolver-concurrent-timeout.test.ts    | 24 +++++++++
 3 files changed, 112 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/dns_jsc/dns.rs                                   11      8      0
…/js/node/dns/dns-resolver-concurrent-timeout-fixture.ts      1      2      0
test/js/node/dns/dns-resolver-concurrent-timeout.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->