### PR TITLE
Bun.write: deliver the full payload to a FIFO named by path

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4672,6 +4672,7 @@ pub fn write_file_with_source_destination(
     ctx: &JSGlobalObject,
     source_blob: &mut Blob,
     destination_blob: &mut Blob,
+    dest_opened_fd: Fd,
     options: &WriteFileOptions,
 ) -> JsResult<JSValue> {
     let destination_store = destination_blob
@@ -4688,9 +4689,18 @@ pub fn write_file_with_source_destination(
     );
 
     let Some(source_store) = source_blob.store.get().clone() else {
+        debug_assert!(dest_opened_fd == Fd::INVALID);
         return write_file_with_empty_source_to_destination(ctx, destination_blob, options);
     };
     let source_type = source_store.data.tag();
+
+    // Only the fast path in `write_file_internal` supplies a pre-opened fd, and
+    // it only runs for string/ArrayBuffer (→ Bytes) sources into a path-backed
+    // File destination, so the fd is consumed on the File+Bytes arm below.
+    debug_assert!(
+        dest_opened_fd == Fd::INVALID
+            || (destination_type == store::DataTag::File && source_type == store::DataTag::Bytes)
+    );
 
     if destination_type == store::DataTag::File && source_type == store::DataTag::Bytes {
         let write_file_promise = bun_core::heap::into_raw(Box::new(WriteFilePromise {
@@ -4702,6 +4712,8 @@ pub fn write_file_with_source_destination(
         // `WriteFile::create` takes its own ref.
         #[cfg(windows)]
         {
+            debug_assert!(dest_opened_fd == Fd::INVALID);
+            let _ = dest_opened_fd;
             let promise = JSPromise::create(ctx);
             let promise_value = promise.as_value(ctx);
             promise_value.ensure_still_alive();
@@ -4729,6 +4741,7 @@ pub fn write_file_with_source_destination(
             let file_copier = write_file_mod::WriteFile::create(
                 destination_blob.borrowed_view(),
                 source_blob.borrowed_view(),
+                dest_opened_fd,
                 write_file_promise,
                 WriteFilePromise::run,
                 options.mkdirp_if_not_exists.unwrap_or(true),
@@ -5044,6 +5057,8 @@ pub fn write_file_internal(
     // This is a heuristic, but it's a good one.
     //
     // except if you're on Windows. Windows I/O is slower. Let's not even try.
+    #[cfg_attr(windows, allow(unused_mut))]
+    let mut dest_opened_fd = Fd::INVALID;
     #[cfg(not(windows))]
     {
         let mut needs_async = false;
@@ -5075,6 +5090,7 @@ pub fn write_file_internal(
                             &pathlike,
                             str.get(),
                             &mut needs_async,
+                            &mut dest_opened_fd,
                         )
                     } else {
                         write_string_to_file_fast::<false>(
@@ -5082,6 +5098,7 @@ pub fn write_file_internal(
                             &pathlike,
                             str.get(),
                             &mut needs_async,
+                            &mut dest_opened_fd,
                         )
                     };
                     if !needs_async {
@@ -5106,6 +5123,7 @@ pub fn write_file_internal(
                             &pathlike,
                             buffer_view.byte_slice(),
                             &mut needs_async,
+                            &mut dest_opened_fd,
                         )
                     } else {
                         write_bytes_to_file_fast::<false>(
@@ -5113,6 +5131,7 @@ pub fn write_file_internal(
                             &pathlike,
                             buffer_view.byte_slice(),
                             &mut needs_async,
+                            &mut dest_opened_fd,
                         )
                     };
                     if !needs_async {
@@ -5122,6 +5141,14 @@ pub fn write_file_internal(
             }
         }
     }
+
+    // If the fast path handed us an open fd and anything below throws before
+    // `WriteFile` adopts it, close it instead of leaking.
+    let dest_opened_fd = scopeguard::guard(dest_opened_fd, |fd| {
+        if fd != Fd::INVALID {
+            let _ = bun_sys::close(fd);
+        }
+    });
 
     // if path_or_blob is a path, convert it into a file blob
     let mut destination_blob: Blob = match path_or_blob {
@@ -5289,6 +5316,7 @@ pub fn write_file_internal(
         global_this,
         &mut *source_blob,
         &mut destination_blob,
+        scopeguard::ScopeGuard::into_inner(dest_opened_fd),
         &options,
     )
 }
@@ -5387,6 +5415,7 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
     pathlike: &PathOrFileDescriptor,
     str: BunString,
     needs_async: &mut bool,
+    handoff_fd: &mut Fd,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
         pathlike.fd()
@@ -5412,6 +5441,20 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
             }
         }
     };
+
+    // A FIFO/socket/chardev opened O_NONBLOCK will EAGAIN once the pipe buffer
+    // fills. Closing after a partial write delivers EOF to the reader and the
+    // async fallback's reopen then fails ENXIO, so hand the open fd to the
+    // async `WriteFile` (which owns the POLLOUT drain) instead of writing here.
+    if NEEDS_OPEN && !str.is_empty() {
+        if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
+            if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
+                *handoff_fd = fd;
+                *needs_async = true;
+                return JSValue::ZERO;
+            }
+        }
+    }
 
     // Declared before the truncate guard so it drops *after* it (close runs last).
     let _close = NEEDS_OPEN.then(|| bun_sys::CloseOnDrop::new(fd));
@@ -5471,6 +5514,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     pathlike: &PathOrFileDescriptor,
     bytes: &[u8],
     _needs_async: &mut bool,
+    handoff_fd: &mut Fd,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
         pathlike.fd()
@@ -5500,6 +5544,18 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
             }
         }
     };
+
+    // See `write_string_to_file_fast`: hand a non-regular destination's open
+    // fd to the async `WriteFile` instead of risking a torn partial write.
+    if NEEDS_OPEN && !bytes.is_empty() {
+        if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
+            if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
+                *handoff_fd = fd;
+                *_needs_async = true;
+                return JSValue::ZERO;
+            }
+        }
+    }
 
     // TODO: on windows this is always synchronous
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4694,12 +4694,10 @@ pub fn write_file_with_source_destination(
     };
     let source_type = source_store.data.tag();
 
-    // Only the fast path in `write_file_internal` supplies a pre-opened fd, and
-    // it only runs for string/ArrayBuffer (→ Bytes) sources into a path-backed
-    // File destination, so the fd is consumed on the File+Bytes arm below.
     debug_assert!(
         dest_opened_fd == Fd::INVALID
-            || (destination_type == store::DataTag::File && source_type == store::DataTag::Bytes)
+            || (destination_type == store::DataTag::File && source_type == store::DataTag::Bytes),
+        "fast path only pre-opens for Bytes->File; other arms would leak the fd",
     );
 
     if destination_type == store::DataTag::File && source_type == store::DataTag::Bytes {
@@ -5142,8 +5140,7 @@ pub fn write_file_internal(
         }
     }
 
-    // If the fast path handed us an open fd and anything below throws before
-    // `WriteFile` adopts it, close it instead of leaking.
+    // Close the fast path's fd if anything below throws before `WriteFile` adopts it.
     let dest_opened_fd = scopeguard::guard(dest_opened_fd, |fd| {
         if fd != Fd::INVALID {
             let _ = bun_sys::close(fd);
@@ -5442,10 +5439,8 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
         }
     };
 
-    // A FIFO/socket/chardev opened O_NONBLOCK will EAGAIN once the pipe buffer
-    // fills. Closing after a partial write delivers EOF to the reader and the
-    // async fallback's reopen then fails ENXIO, so hand the open fd to the
-    // async `WriteFile` (which owns the POLLOUT drain) instead of writing here.
+    // Hand a FIFO/socket/chardev fd to the async WriteFile: closing here after a
+    // partial write would EOF the reader and make the async reopen fail ENXIO.
     if NEEDS_OPEN && !str.is_empty() {
         if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
             if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {
@@ -5545,8 +5540,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
         }
     };
 
-    // See `write_string_to_file_fast`: hand a non-regular destination's open
-    // fd to the async `WriteFile` instead of risking a torn partial write.
+    // See `write_string_to_file_fast`: hand a non-regular fd to the async WriteFile.
     if NEEDS_OPEN && !bytes.is_empty() {
         if let bun_sys::Result::Ok(st) = bun_sys::fstat(fd) {
             if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) {

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -349,9 +349,7 @@ impl WriteFile {
             }
             bun_sys::Result::Err(err) => {
                 if err.get_errno() == io::RETRY {
-                    // write(2) on a regular file never returns EAGAIN, so reaching
-                    // this arm means the fd is pollable regardless of what the
-                    // open-time classification guessed.
+                    // Regular-file write(2) never EAGAINs, so the fd is pollable.
                     self.could_block = true;
                     self.wait_for_writable();
                 } else {
@@ -457,9 +455,7 @@ impl WriteFile {
                             }
                         }
                         PathOrFileDescriptor::Path(_) => {
-                            // We just opened the path with O_NONBLOCK. For a FIFO/socket/
-                            // character device that open succeeds and every write can
-                            // EAGAIN, so classify from fstat instead of assuming regular.
+                            // Opened O_NONBLOCK; the path may be a FIFO/socket/chardev.
                             if let bun_sys::Result::Ok(st) = sys::fstat(fd) {
                                 break 'brk !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode);
                             }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -276,6 +276,7 @@ impl WriteFile {
     pub fn create_with_ctx(
         file_blob: Blob,
         bytes_blob: Blob,
+        opened_fd: Fd,
         on_write_file_context: *mut c_void,
         on_complete_callback: WriteFileOnWriteFileCallback,
         mkdirp_if_not_exists: bool,
@@ -283,7 +284,7 @@ impl WriteFile {
         let write_file = bun_core::heap::into_raw(Box::new(WriteFile {
             file_blob,
             bytes_blob,
-            opened_fd: Fd::INVALID,
+            opened_fd,
             system_error: None,
             errno: None,
             task: WorkPoolTask {
@@ -311,6 +312,7 @@ impl WriteFile {
     pub fn create<C>(
         file_blob: Blob,
         bytes_blob: Blob,
+        opened_fd: Fd,
         context: *mut C,
         callback: WriteFileOnWriteFileCallback,
         mkdirp_if_not_exists: bool,
@@ -321,6 +323,7 @@ impl WriteFile {
         WriteFile::create_with_ctx(
             file_blob,
             bytes_blob,
+            opened_fd,
             context.cast::<c_void>(),
             callback,
             mkdirp_if_not_exists,
@@ -338,35 +341,26 @@ impl WriteFile {
         //
         // On macOS, it is an error to use pwrite() on a
         // non-seekable file.
-        let result: bun_sys::Result<usize> =
-            sys::write(fd, &self.bytes_blob.shared_view()[off..off + len]);
-
-        loop {
-            match &result {
-                bun_sys::Result::Ok(res) => {
-                    *wrote = *res;
-                    self.total_written += *res;
-                }
-                bun_sys::Result::Err(err) => {
-                    if err.get_errno() == io::RETRY {
-                        if !self.could_block {
-                            // regular files cannot use epoll.
-                            // this is fine on kqueue, but not on epoll.
-                            continue;
-                        }
-                        self.wait_for_writable();
-                        return false;
-                    } else {
-                        self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-                        self.system_error = Some(err.to_system_error().into());
-                        return false;
-                    }
-                }
+        match sys::write(fd, &self.bytes_blob.shared_view()[off..off + len]) {
+            bun_sys::Result::Ok(res) => {
+                *wrote = res;
+                self.total_written += res;
+                true
             }
-            break;
+            bun_sys::Result::Err(err) => {
+                if err.get_errno() == io::RETRY {
+                    // write(2) on a regular file never returns EAGAIN, so reaching
+                    // this arm means the fd is pollable regardless of what the
+                    // open-time classification guessed.
+                    self.could_block = true;
+                    self.wait_for_writable();
+                } else {
+                    self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                    self.system_error = Some(err.to_system_error().into());
+                }
+                false
+            }
         }
-
-        true
     }
 
     pub fn then(mut this: Box<WriteFile>, _global: &JSGlobalObject) -> Result<(), JsTerminated> {
@@ -453,21 +447,26 @@ impl WriteFile {
         self.could_block = 'brk: {
             if let Some(store) = self.file_blob.store.get().as_ref() {
                 if let blob::store::Data::File(file) = &store.data {
-                    if file.pathlike.is_fd() {
-                        // If seekable was set, then so was mode
-                        if file.seekable.is_some() {
-                            // This is mostly to handle pipes which were passsed to the process somehow
-                            // such as stderr, stdout. Bun.stdin and Bun.stderr will automatically set `mode` for us.
-                            break 'brk !bun_sys::is_regular_file(file.mode);
+                    match file.pathlike {
+                        PathOrFileDescriptor::Fd(_) => {
+                            // If seekable was set, then so was mode
+                            if file.seekable.is_some() {
+                                // This is mostly to handle pipes which were passsed to the process somehow
+                                // such as stderr, stdout. Bun.stdin and Bun.stderr will automatically set `mode` for us.
+                                break 'brk !bun_sys::is_regular_file(file.mode);
+                            }
+                        }
+                        PathOrFileDescriptor::Path(_) => {
+                            // We just opened the path with O_NONBLOCK. For a FIFO/socket/
+                            // character device that open succeeds and every write can
+                            // EAGAIN, so classify from fstat instead of assuming regular.
+                            if let bun_sys::Result::Ok(st) = sys::fstat(fd) {
+                                break 'brk !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode);
+                            }
                         }
                     }
                 }
             }
-
-            // We opened the file descriptor with O_NONBLOCK, so we
-            // shouldn't have to worry about blocking reads/writes
-            //
-            // We do not call fstat() because that is very expensive.
             false
         };
 
@@ -1381,6 +1380,7 @@ impl WriteFileWaitFromLockedValueTask {
                     global_this,
                     &mut blob,
                     &mut file_blob,
+                    Fd::INVALID,
                     &blob::WriteFileOptions {
                         mkdirp_if_not_exists: Some(this_ref.mkdirp_if_not_exists),
                         ..Default::default()

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -728,3 +728,64 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     expect(f.name).toBe(filePath);
   });
 });
+
+// Bun.write(path, ...) on a FIFO used to either (a) tear the payload at the
+// pipe-buffer boundary because the sync fast path closed the fd on EAGAIN and
+// the async fallback's reopen got ENXIO after the reader saw EOF, or (b) never
+// settle because the thread-pool WriteFile kept re-matching a cached EAGAIN
+// without ever calling write() again. Run outside describe.concurrent so an
+// unfixed build's spin doesn't starve neighbours into their default timeout.
+describe.skipIf(isWindows)("Bun.write to a FIFO by path", () => {
+  // 200 KiB exercises the <256 KiB sync fast path; 1 MiB exercises the
+  // thread-pool WriteFile path (string/ArrayBuffer) and the Blob path.
+  it.each([
+    ["200 KiB string", "string", 200 * 1024],
+    ["1 MiB string", "string", 1 << 20],
+    ["1 MiB Uint8Array", "u8", 1 << 20],
+    ["1 MiB Blob", "blob", 1 << 20],
+  ])("delivers a %s in full", async (_label, kind, size) => {
+    using dir = tempDir("bun-write-fifo", {});
+    const script = `
+      const fs = require("fs");
+      const { FIFO, KIND, SIZE } = process.env;
+      const size = Number(SIZE);
+      require("child_process").execFileSync("mkfifo", [FIFO]);
+      // Open the read end synchronously so Bun.write's O_WRONLY|O_NONBLOCK
+      // open has a reader and doesn't ENXIO; hand it to a child to drain so
+      // the write side actually back-pressures.
+      const readFd = fs.openSync(FIFO, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+      const reader = Bun.spawn({
+        cmd: [process.execPath, "-e",
+          "let n=0; for await (const c of Bun.stdin.stream()) n+=c.length; process.stdout.write(String(n))"],
+        stdin: readFd,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      fs.closeSync(readFd);
+      const body = Buffer.alloc(size, 0x61);
+      const src =
+        KIND === "string" ? body.toString()
+        : KIND === "u8" ? new Uint8Array(body)
+        : new Blob([body]);
+      const wrote = await Bun.write(FIFO, src);
+      const got = Number(await reader.stdout.text());
+      await reader.exited;
+      console.log(JSON.stringify({ wrote, got, size }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, FIFO: join(String(dir), "fifo"), KIND: kind, SIZE: String(size) },
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+      stderr: "",
+      stdout: JSON.stringify({ wrote: size, got: size, size }),
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 30_000);
+});

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -743,9 +743,11 @@ describe.skipIf(isWindows)("Bun.write to a FIFO by path", () => {
     ["1 MiB string", "string", 1 << 20],
     ["1 MiB Uint8Array", "u8", 1 << 20],
     ["1 MiB Blob", "blob", 1 << 20],
-  ])("delivers a %s in full", async (_label, kind, size) => {
-    using dir = tempDir("bun-write-fifo", {});
-    const script = `
+  ])(
+    "delivers a %s in full",
+    async (_label, kind, size) => {
+      using dir = tempDir("bun-write-fifo", {});
+      const script = `
       const fs = require("fs");
       const { FIFO, KIND, SIZE } = process.env;
       const size = Number(SIZE);
@@ -772,20 +774,22 @@ describe.skipIf(isWindows)("Bun.write to a FIFO by path", () => {
       await reader.exited;
       console.log(JSON.stringify({ wrote, got, size }));
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: { ...bunEnv, FIFO: join(String(dir), "fifo"), KIND: kind, SIZE: String(size) },
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 20_000,
-      killSignal: "SIGKILL",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
-      stderr: "",
-      stdout: JSON.stringify({ wrote: size, got: size, size }),
-      exitCode: 0,
-      signalCode: null,
-    });
-  }, 30_000);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, FIFO: join(String(dir), "fifo"), KIND: kind, SIZE: String(size) },
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 20_000,
+        killSignal: "SIGKILL",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+        stderr: "",
+        stdout: JSON.stringify({ wrote: size, got: size, size }),
+        exitCode: 0,
+        signalCode: null,
+      });
+    },
+    30_000,
+  );
 });


### PR DESCRIPTION
### Repro

```sh
mkfifo /tmp/f
(cat /tmp/f > /tmp/o &)
bun -e 'await Bun.write("/tmp/f", "x".repeat(1<<20))'  # never settles
# or with 200 KiB: rejects ENXIO, /tmp/o has only the pipe-buffer prefix
```

### Cause

Two independent faults in the path-destination write paths:

1. **Torn write then ENXIO** (string/TypedArray < 256 KiB). `write_{string,bytes}_to_file_fast::<true>` opens the FIFO `O_WRONLY|O_NONBLOCK`, loops `write()`, and on `EAGAIN` sets `needs_async` and returns. Its `CloseOnDrop` guard closes the fd, which removes the FIFO's only writer, so the reader's blocked `read()` returns 0 and exits with only the pipe-buffer-sized prefix. The async fallback reopens `O_WRONLY|O_CREAT|O_TRUNC|O_NONBLOCK` with no reader present and the promise rejects `ENXIO`.

2. **Never settles** (Blob/Response or any source >= 256 KiB). `WriteFile::run_with_fd` left `could_block=false` for every path-opened destination, and `do_write` computed `sys::write(...)` once outside a `loop { match &result { ... } }`; the `EAGAIN && !could_block => continue` arm re-matched the same stale error forever without re-issuing the syscall or registering for `POLLOUT`, so a pool worker spins at 100% with zero syscalls while the reader sits in `pipe_r`.

`Bun.file(fifo).writer()` already works: its open path fstats and marks pipes pollable, and its streaming writer resumes at the saved offset on `POLLOUT` on the same fd.

### Fix

`src/runtime/webcore/Blob.rs`, `write_{string,bytes}_to_file_fast`: after opening a path, `fstat` the fd; when not a regular file, hand the already-open fd to the async `WriteFile` via a new `opened_fd` parameter instead of writing here, so the FIFO is never closed and reopened mid-payload. Regular-file writes keep the existing synchronous loop.

`src/runtime/webcore/blob/write_file.rs`:

- `do_write`: drop the stale-result loop. `write(2)` on a regular file never returns `EAGAIN`, so reaching that arm means the fd is pollable; set `could_block = true` and `wait_for_writable()`.
- `run_with_fd`: `fstat` a path-opened fd to derive `could_block` so pipes use the `POLLOUT` wait from the start and skip `preallocate_file`.
- `create`/`create_with_ctx`: accept a pre-opened fd. `FileOpener::get_fd` already short-circuits when `opened_fd` is set, and `is_allowed_to_close()` (path-backed) closes it on finish.

`write_file_with_source_destination` threads the fd through; a `scopeguard` closes it if construction of the source/destination blobs throws before `WriteFile` adopts it.

### Verification

New `describe.skipIf(isWindows)` block in `test/js/bun/io/bun-write.test.js` with four cases (200 KiB string via the fast path; 1 MiB string/Uint8Array/Blob via the thread-pool path). Each spawns a child that `mkfifo`s, opens the read end synchronously (`O_RDONLY|O_NONBLOCK`) so the write-side open has a reader, hands that fd to a draining grandchild, and asserts `Bun.write` resolves with the full byte count and the reader receives every byte. Without the fix the 200 KiB case rejects `ENXIO` with a short delivery and the 1 MiB cases are killed by the 20 s spawn timeout with a pool worker spinning.

Related: #35953 fixes the same `do_write` spin for `Bun.stdout` pipes and dups caller-supplied fds for epoll; this PR covers the FIFO-by-path entry and the fast-path fd handoff. The `do_write` hunk is the same shape and will merge cleanly with whichever lands second.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->