### PR TITLE
dotenv: keep $ literal before a digit

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1109,6 +1109,10 @@ impl<'a> Parser<'a> {
         fn is_ident(b: u8) -> bool {
             matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
         }
+        #[inline]
+        fn is_ident_start(b: u8) -> bool {
+            matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'_')
+        }
 
         let mut pos = 0;
         let mut changed = false;
@@ -1183,7 +1187,7 @@ impl<'a> Parser<'a> {
                 pos = close + 1;
                 continue;
             }
-            if is_ident(next) {
+            if is_ident_start(next) {
                 changed = true;
                 let key_start = pos + 1;
                 let mut k = key_start;

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -396,6 +396,53 @@ test.concurrent(".env escaped dollar sign", async () => {
   expect(stdout).toBe("foo $FOO");
 });
 
+test.concurrent(".env leaves $ literal when not followed by an identifier (issue #4994)", async () => {
+  // https://github.com/oven-sh/bun/issues/4994
+  // Expansion only fires on `$IDENT` (letter or underscore start) or `${...}`.
+  // A `$` followed by a digit, another `$`, `(`, `-`, or the end of the value
+  // stays literal, inside and outside quotes and inside a `:-` default.
+  const expected = {
+    ISSUE: "123$567",
+    P1: "price$5.00",
+    P2: "a$(b)c",
+    P3: "cost$-1",
+    P4: "$1abc",
+    P5: "end$",
+    P6: "pa$$",
+    P7: "$5.00",
+    P8: "hit$5",
+    P9: "hit$5",
+    P10: "$5",
+    P11: "123$567",
+    P12: "123$567",
+  };
+  using dir = tempDir("dotenv-literal-dollar", {
+    ".env": [
+      "ISSUE=123$567",
+      "P1=price$5.00",
+      "P2=a$(b)c",
+      "P3=cost$-1",
+      "P4=$1abc",
+      "P5=end$",
+      "P6=pa$$",
+      "P7=\\$5.00",
+      "SET=hit",
+      "P8=$SET$5",
+      "P9=${SET}$5",
+      "P10=${UNSET:-$5}",
+      'P11="123$567"',
+      "P12='123$567'",
+    ].join("\n"),
+    "index.ts":
+      `const keys = ${JSON.stringify(Object.keys(expected))};` +
+      "const out = {};" +
+      "for (const k of keys) out[k] = process.env[k];" +
+      "console.log(JSON.stringify(out));",
+  });
+  const { stdout } = await bunRun(`${dir}/index.ts`);
+  expect(JSON.parse(stdout)).toEqual(expected);
+});
+
 test.concurrent(".env doesnt crash with 159 bytes", async () => {
   using dir = tempDir("dotenv-159", {
     ".env":


### PR DESCRIPTION
### Problem
- A `.env` value with `$` before a digit loses the `$` and the digits. `someKey=123$567` loads as `123`, `$1abc` as an empty string. This is the repro in #4994.
- The cause is the bare `$` arm in `Parser::expand_into` (`src/dotenv/env_loader.rs:1190`). It enters on any identifier byte, digits included, looks up the key `567` and splices in the empty result.

### Fix
- A bare `$` expands only when `[A-Za-z_]` follows. `$5`, `$1abc` and `${A:-$5}` stay literal. `\$` still becomes `$`. `$(`, `$-`, `$$` and a trailing `$` are literal since #36199.
- This is the dotenv-expand rule, `\$([A-Za-z_][A-Za-z0-9_]*)` in v12 `lib/main.js`. dotenvx uses the same regex. Neither produces `123` for `123$567`.
- A letter-led reference such as `pa$$word` still expands `$word` to the empty string, as documented. Escape it with `\$`, or see #4177 for an opt-out of expansion.
- Verified: `test/cli/run/env.test.ts`, one new test (`issue #4994`). It fails on 1.4.1 and passes with this change. The full file (99 tests) and the `parseEnv` tests in `test/js/node` pass.

### Background
- `Parser::parse` stores every `KEY=VALUE` first, then runs `expand_into` over the new entries against the full map. A value can reference a key defined later in the file.
- `expand_into` is a forward scan. `${...}` finds its matching `}` by depth, and a `:-` default is expanded recursively. #36199 replaced the old backward splice with it.
- Quoting does not affect expansion today. Double, single and backtick quoted values all expand. This PR keeps that. #36927 proposes a quote rule and is the place for that discussion.

<details><summary>Notes</summary>

Rebased onto main on 2026-08-26. The first version of this PR also made `$(`, `$-`, `$$` and a trailing `$` literal and fixed a reversed-slice panic in `${A:-$B}`. #36199 landed both.

The first version also accepted non-ASCII bytes in keys (`üñí=uval`). That change is dropped from this PR. It has no issue behind it, it picks a key grammar that is neither dotenv's `[\w.-]+` nor Node's "everything before `=`", and the `util.parseEnv` half of it belongs to #34006.

Behavior on main (1.4.1) for the probe file below, and with this change:

```
VAR=world
K4994=123$567      main: 123          now: 123$567
P1=price$5.00      main: price.00     now: price$5.00
P5=$1abc           main: (empty)      now: $1abc
P2=pa$$word        main: pa$          now: pa$       ($word is a valid reference)
DQ="123$567"       main: 123          now: 123$567
SQ='123$567'       main: 123          now: 123$567
```

Other suites run: `test/js/node/util/util.test.js -t parseEnv`, `test/js/node/process/process.test.js`, `test/js/node/test/parallel/test-util-parse-env.js`, `test/internal/source-lints/byte-search.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->