### PR TITLE
dotenv: warn and continue when a default .env fails to open with ELOOP

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -856,7 +856,9 @@ impl Loader {
         match read_env_file_contents(&file) {
             ReadEnvFile::Empty => {}
             ReadEnvFile::ReadErr(err) => {
-                if !self.quiet {
+                // EISDIR is the expected "directory named .env" case; everything
+                // else (EIO, ESTALE, ENOMEM, …) is always surfaced.
+                if err.get_errno() != bun_sys::E::EISDIR {
                     bun_core::pretty_errorln!(
                         "<r><red>{}<r> error loading {} file",
                         bstr::BStr::new(err.name()),
@@ -903,7 +905,7 @@ impl Loader {
         match read_env_file_contents(&file) {
             ReadEnvFile::Empty => {}
             ReadEnvFile::ReadErr(err) => {
-                if !self.quiet {
+                if err.get_errno() != bun_sys::E::EISDIR {
                     bun_core::pretty_errorln!(
                         "<r><red>{}<r> error loading {} file",
                         bstr::BStr::new(err.name()),
@@ -928,7 +930,7 @@ impl Loader {
 /// `load_env_file_dynamic`; callers handle open and slot bookkeeping.
 enum ReadEnvFile {
     Empty,
-    /// Caller prints (unless `quiet`) and skips. Never fatal.
+    /// Caller prints (unless EISDIR) and skips. Never fatal.
     ReadErr(bun_sys::Error),
     Bytes(Vec<u8>),
 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -826,39 +826,40 @@ impl Loader {
             return Ok(());
         }
 
-        // `bun_sys` is errno-based; the match arms below group the recoverable
-        // errnos. Any errno not listed propagates.
+        // Default .env files are loaded optimistically: an open failure is never
+        // fatal. Propagating the error here reaches callers that print `vm.log`
+        // (which this path never writes to) and then `exit(1)`, i.e. a silent
+        // hard failure for every bun command in that cwd.
+        //
+        // ENOENT/EISDIR are expected and stay silent. EACCES/EBUSY respect
+        // `self.quiet` (some environments deliberately make .env unreadable).
+        // Anything else (ELOOP, ENAMETOOLONG, …) is a broken setup the user
+        // should fix and is printed regardless of `quiet`.
         let file =
             match bun_sys::File::openat(dir, base, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0) {
                 Ok(file) => file,
                 Err(err) => {
                     use bun_sys::E;
-                    match err.get_errno() {
-                        E::EISDIR | E::ENOENT => {
-                            // prevent retrying
-                            *self.default_file_slot(base) =
-                                Some(bun_ast::Source::init_path_string(base, b""));
-                            return Ok(());
-                        }
-                        E::EBUSY | E::EACCES => {
-                            if !self.quiet {
-                                bun_core::pretty_errorln!(
-                                    "<r><red>{}<r> error loading {} file",
-                                    bstr::BStr::new(err.name()),
-                                    bstr::BStr::new(base)
-                                );
-                            }
-                            // prevent retrying
-                            *self.default_file_slot(base) =
-                                Some(bun_ast::Source::init_path_string(base, b""));
-                            return Ok(());
-                        }
-                        _ => return Err(err.into()),
+                    let print = match err.get_errno() {
+                        E::EISDIR | E::ENOENT => false,
+                        E::EBUSY | E::EACCES => !self.quiet,
+                        _ => true,
+                    };
+                    if print {
+                        bun_core::pretty_errorln!(
+                            "<r><red>{}<r> error loading {} file",
+                            bstr::BStr::new(err.name()),
+                            bstr::BStr::new(base)
+                        );
                     }
+                    // prevent retrying
+                    *self.default_file_slot(base) =
+                        Some(bun_ast::Source::init_path_string(base, b""));
+                    return Ok(());
                 }
             };
 
-        match read_env_file_contents(&file)? {
+        match read_env_file_contents(&file) {
             ReadEnvFile::Empty => {}
             ReadEnvFile::ReadErr(err) => {
                 if !self.quiet {
@@ -905,7 +906,7 @@ impl Loader {
             }
         };
 
-        match read_env_file_contents(&file)? {
+        match read_env_file_contents(&file) {
             ReadEnvFile::Empty => {}
             ReadEnvFile::ReadErr(err) => {
                 if !self.quiet {
@@ -930,31 +931,24 @@ impl Loader {
 }
 
 /// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`:
-/// `File::read_to_end` (fstat-presized) with the recoverable-errno filter.
-/// The two callers differ in their open path, open-error handling, and the
-/// memo slot they write — those stay in the callers. Only the shared read
-/// tail is factored here.
+/// `File::read_to_end` (fstat-presized). The two callers differ in their open
+/// path, open-error handling, and the memo slot they write — those stay in
+/// the callers. Only the shared read tail is factored here.
 enum ReadEnvFile {
     /// Zero-length — caller marks the slot and returns.
     Empty,
-    /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — caller prints
-    /// (unless `quiet`), marks the slot, and returns.
+    /// Read errno — caller prints (unless `quiet`), marks the slot, and
+    /// returns. Never fatal: `.env` loads are optimistic.
     ReadErr(bun_sys::Error),
     /// File contents; `buf.len()` is the amount read.
     Bytes(Vec<u8>),
 }
 
-fn read_env_file_contents(file: &bun_sys::File) -> crate::Result<ReadEnvFile> {
+fn read_env_file_contents(file: &bun_sys::File) -> ReadEnvFile {
     match file.read_to_end() {
-        Ok(buf) if buf.is_empty() => Ok(ReadEnvFile::Empty),
-        Ok(buf) => Ok(ReadEnvFile::Bytes(buf)),
-        Err(err) => {
-            use bun_sys::E;
-            match err.get_errno() {
-                E::ENOMEM | E::EPIPE | E::EACCES | E::EISDIR => Ok(ReadEnvFile::ReadErr(err)),
-                _ => Err(err.into()),
-            }
-        }
+        Ok(buf) if buf.is_empty() => ReadEnvFile::Empty,
+        Ok(buf) => ReadEnvFile::Bytes(buf),
+        Err(err) => ReadEnvFile::ReadErr(err),
     }
 }
 

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -856,8 +856,7 @@ impl Loader {
         match read_env_file_contents(&file) {
             ReadEnvFile::Empty => {}
             ReadEnvFile::ReadErr(err) => {
-                // EISDIR is the expected "directory named .env" case; everything
-                // else (EIO, ESTALE, ENOMEM, …) is always surfaced.
+                // EISDIR = "directory named .env"; every other read errno is surfaced.
                 if err.get_errno() != bun_sys::E::EISDIR {
                     bun_core::pretty_errorln!(
                         "<r><red>{}<r> error loading {} file",

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -826,15 +826,9 @@ impl Loader {
             return Ok(());
         }
 
-        // Default .env files are loaded optimistically: an open failure is never
-        // fatal. Propagating the error here reaches callers that print `vm.log`
-        // (which this path never writes to) and then `exit(1)`, i.e. a silent
-        // hard failure for every bun command in that cwd.
-        //
-        // ENOENT/EISDIR are expected and stay silent. EACCES/EBUSY respect
-        // `self.quiet` (some environments deliberately make .env unreadable).
-        // Anything else (ELOOP, ENAMETOOLONG, …) is a broken setup the user
-        // should fix and is printed regardless of `quiet`.
+        // Default .env loads are optimistic: an open failure is never fatal.
+        // ENOENT/EISDIR stay silent; EACCES/EBUSY respect `quiet`; anything
+        // else (ELOOP, …) is always printed so the user can fix it.
         let file =
             match bun_sys::File::openat(dir, base, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0) {
                 Ok(file) => file,
@@ -930,17 +924,12 @@ impl Loader {
     }
 }
 
-/// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`:
-/// `File::read_to_end` (fstat-presized). The two callers differ in their open
-/// path, open-error handling, and the memo slot they write — those stay in
-/// the callers. Only the shared read tail is factored here.
+/// Shared post-open `File::read_to_end` tail for `load_env_file` and
+/// `load_env_file_dynamic`; callers handle open and slot bookkeeping.
 enum ReadEnvFile {
-    /// Zero-length — caller marks the slot and returns.
     Empty,
-    /// Read errno — caller prints (unless `quiet`), marks the slot, and
-    /// returns. Never fatal: `.env` loads are optimistic.
+    /// Caller prints (unless `quiet`) and skips. Never fatal.
     ReadErr(bun_sys::Error),
-    /// File contents; `buf.len()` is the amount read.
     Bytes(Vec<u8>),
 }
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -193,7 +193,9 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
         }
         MacroOptions::Unspecified => {}
     }
-    if vm.transpiler.configure_defines().is_err() {
+    if let Err(err) = vm.transpiler.configure_defines() {
+        // `fail_with_build_error` only dumps `vm.log`, which this path may not have written to.
+        Output::err(err, "Failed to load environment variables and defines", ());
         fail_with_build_error(vm);
     }
     // `vm.log` was set from `ctx.log` above (non-null, process-lifetime);

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -124,7 +124,8 @@ impl ReplCommand {
         b.options.env.behavior = EnvBehavior::LoadAllWithoutInlining;
         b.options.dead_code_elimination = false; // REPL needs all code
 
-        if b.configure_defines().is_err() {
+        if let Err(err) = b.configure_defines() {
+            Output::err(err, "Failed to load environment variables and defines", ());
             Self::dump_build_error(VirtualMachine::get());
             Global::exit(1);
         }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1038,13 +1038,16 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // reshaped for borrowck — `b` borrows `vm.transpiler`
         // exclusively; `fail_with_build_error(vm)` needs the whole `vm`, so
         // capture the defines result, drop `b`, then branch.
-        let defines_ok = {
+        let defines_result = {
             let b = &mut vm.transpiler;
             Self::wire_transpiler_from_ctx(b, ctx);
             b.options.env.behavior = api::DotEnvBehavior::LoadAllWithoutInlining;
-            b.configure_defines().is_ok()
+            b.configure_defines()
         };
-        if !defines_ok {
+        if let Err(err) = defines_result {
+            // `fail_with_build_error` only dumps `vm.log`; not every error on this
+            // path writes to it, so name the error explicitly.
+            Output::err(err, "Failed to load environment variables and defines", ());
             crate::run_main::fail_with_build_error(vm);
         }
 
@@ -1190,7 +1193,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // reshaped for borrowck — `b` borrows `vm.transpiler`
         // exclusively; `fail_with_build_error(vm)` needs the whole `vm`, so
         // capture the defines result, drop `b`, then branch.
-        let defines_ok = {
+        let defines_result = {
             let b = &mut vm.transpiler;
             Self::wire_transpiler_from_ctx(b, ctx);
 
@@ -1200,9 +1203,12 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
             crate::run_main::apply_standalone_runtime_flags(b, graph);
 
-            b.configure_defines().is_ok()
+            b.configure_defines()
         };
-        if !defines_ok {
+        if let Err(err) = defines_result {
+            // `fail_with_build_error` only dumps `vm.log`; not every error on this
+            // path writes to it, so name the error explicitly.
+            Output::err(err, "Failed to load environment variables and defines", ());
             crate::run_main::fail_with_build_error(vm);
         }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1045,8 +1045,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             b.configure_defines()
         };
         if let Err(err) = defines_result {
-            // `fail_with_build_error` only dumps `vm.log`; not every error on this
-            // path writes to it, so name the error explicitly.
+            // `fail_with_build_error` only dumps `vm.log`, which this path may not have written to.
             Output::err(err, "Failed to load environment variables and defines", ());
             crate::run_main::fail_with_build_error(vm);
         }
@@ -1206,8 +1205,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             b.configure_defines()
         };
         if let Err(err) = defines_result {
-            // `fail_with_build_error` only dumps `vm.log`; not every error on this
-            // path writes to it, so name the error explicitly.
+            // `fail_with_build_error` only dumps `vm.log`, which this path may not have written to.
             Output::err(err, "Failed to load environment variables and defines", ());
             crate::run_main::fail_with_build_error(vm);
         }

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1068,3 +1068,31 @@ test.skipIf(!isASAN || isWindows)(".env with a huge lying st_size does not abort
   // 1099511627792 bytes failed", SIGABRT) without ever reaching app.js.
   expect({ stdout, exitCode }).toEqual({ stdout: "reached user code\n", exitCode: 0 });
 });
+
+// A `.env` that is a symlink loop (`.env -> .env`) fails openat(2) with ELOOP.
+// Previously the unhandled errno propagated up to `fail_with_build_error`, which
+// printed an empty log and called exit(1): every bun command in that cwd died
+// with rc=1 and not one byte of output. Default .env loads are optimistic; an
+// unreadable .env must warn and continue, matching EACCES/EBUSY.
+test("a .env that is a symlink loop (ELOOP) warns and continues instead of exiting silently", async () => {
+  const dir = tempDirWithFiles("dotenv-eloop", {
+    "index.ts": `console.log("ran");`,
+  });
+  fs.symlinkSync(".env", path.join(dir, ".env"), "file");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The diagnostic must name both the errno and the file so the user can act
+  // on it. Unfixed: stderr was empty and exitCode was 1.
+  expect(stderr).toContain("ELOOP");
+  expect(stderr).toContain(".env");
+  expect(stdout).toBe("ran\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1073,10 +1073,12 @@ test.skipIf(!isASAN || isWindows)(".env with a huge lying st_size does not abort
 // Previously the unhandled errno propagated up to `fail_with_build_error`, which
 // printed an empty log and called exit(1): every bun command in that cwd died
 // with rc=1 and not one byte of output. Default .env loads are optimistic; an
-// unreadable .env must warn and continue, matching EACCES/EBUSY.
+// unreadable .env must warn and continue (other .env.* files still load),
+// matching EACCES/EBUSY.
 test("a .env that is a symlink loop (ELOOP) warns and continues instead of exiting silently", async () => {
   const dir = tempDirWithFiles("dotenv-eloop", {
-    "index.ts": `console.log("ran");`,
+    ".env.local": "FROMLOCAL=okl\n",
+    "index.ts": `console.log("ran:" + process.env.FROMLOCAL);`,
   });
   fs.symlinkSync(".env", path.join(dir, ".env"), "file");
 
@@ -1090,9 +1092,9 @@ test("a .env that is a symlink loop (ELOOP) warns and continues instead of exiti
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // The diagnostic must name both the errno and the file so the user can act
-  // on it. Unfixed: stderr was empty and exitCode was 1.
+  // on it. Unfixed: stderr was empty, stdout was empty, and exitCode was 1.
   expect(stderr).toContain("ELOOP");
   expect(stderr).toContain(".env");
-  expect(stdout).toBe("ran\n");
+  expect(stdout).toBe("ran:okl\n");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Reproduction

```sh
d=$(mktemp -d); cd "$d"
ln -s .env .env                          # .env -> .env (symlink loop)
bun -e 'console.log("ran")'; echo "rc=$?"
# before: rc=1, not one byte of stdout or stderr
# after:  rc=0, stderr "ELOOP error loading .env file", stdout "ran"
```

A `.env` (or `.env.local`, etc.) that is a symlink loop made every `bun -e`, `bun <file>`, and `bun run` in that directory exit 1 with zero output. `bun --no-env-file` worked; `bun install` printed `error: An internal error occurred (ELOOP)` but exited 0. By contrast a dangling `.env` symlink, a directory named `.env`, or an `EACCES` `.env` were all already skipped with rc=0.

## Cause

`Loader::load_env_file` matched the recoverable open errnos explicitly:

```rust
E::EISDIR | E::ENOENT => { /* silent skip */ }
E::EBUSY  | E::EACCES => { /* print (if !quiet) + skip */ }
_ => return Err(err.into()),
```

`ELOOP` fell into the `_` arm and propagated through `load` / `run_env_loader` / `configure_defines` to `run_command.rs`, where `configure_defines().is_ok()` became false and `fail_with_build_error(vm)` printed `vm.log` (empty, because nothing on this path ever wrote to it) and called `exit(1)`. The same structure existed in the post-open read tail.

## Fix

Default `.env` files are loaded optimistically; an open failure should never be fatal. The open-error arm now always skips the file, printing a diagnostic for anything that is not `ENOENT`/`EISDIR`. `EACCES`/`EBUSY` keep respecting `loader.quiet` (some environments deliberately make `.env` unreadable); any other errno (`ELOOP`, `ENAMETOOLONG`, ...) is a broken setup and is printed unconditionally. `read_env_file_contents` is simplified the same way: every read errno is reported and skipped rather than propagated.

`bun install` now prints `ELOOP error loading .env file` instead of the generic internal-error line.

## Verification

```
$ bun bd test test/cli/run/env.test.ts -t "symlink loop"
(pass) a .env that is a symlink loop (ELOOP) warns and continues instead of exiting silently

$ USE_SYSTEM_BUN=1 bun test test/cli/run/env.test.ts -t "symlink loop"
(fail) ... Expected to contain: "ELOOP"  Received: ""
```

Full `test/cli/run/env.test.ts`: 92 pass / 0 fail.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->