### PR TITLE
ServerWebSocket: send Blob bytes instead of "[object Blob]"

### DIFF
--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -96,6 +96,7 @@ Bun.serve({
       ws.send("Hello world"); // string
       ws.send(response.arrayBuffer()); // ArrayBuffer
       ws.send(new Uint8Array([1, 2, 3])); // TypedArray | DataView
+      ws.send(new Blob(["binary"])); // Blob
     },
   },
 });
@@ -384,7 +385,7 @@ type Compressor =
 
 interface Server {
   pendingWebSockets: number;
-  publish(topic: string, data: string | ArrayBufferView | ArrayBuffer, compress?: boolean): number;
+  publish(topic: string, data: string | ArrayBufferView | ArrayBuffer | Blob, compress?: boolean): number;
   upgrade(
     req: Request,
     options?: {
@@ -399,11 +400,11 @@ interface ServerWebSocket {
   readonly readyState: number;
   readonly remoteAddress: string;
   readonly subscriptions: string[];
-  send(message: string | ArrayBuffer | Uint8Array, compress?: boolean): number;
+  send(message: string | ArrayBuffer | Uint8Array | Blob, compress?: boolean): number;
   close(code?: number, reason?: string): void;
   subscribe(topic: string): boolean;
   unsubscribe(topic: string): boolean;
-  publish(topic: string, message: string | ArrayBuffer | Uint8Array): void;
+  publish(topic: string, message: string | ArrayBuffer | Uint8Array | Blob): void;
   isSubscribed(topic: string): boolean;
   cork(cb: (ws: ServerWebSocket) => void): void;
 }

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -76,7 +76,7 @@ declare module "bun" {
      * ws.send(new Uint8Array([1, 2, 3, 4]));
      * ```
      */
-    send(data: string | BufferSource, compress?: boolean): ServerWebSocketSendStatus;
+    send(data: string | BufferSource | Blob, compress?: boolean): ServerWebSocketSendStatus;
 
     /**
      * Sends a text message to the client.
@@ -102,7 +102,7 @@ declare module "bun" {
      * ws.send(new Uint8Array([1, 2, 3, 4]), true);
      * ```
      */
-    sendBinary(data: BufferSource, compress?: boolean): ServerWebSocketSendStatus;
+    sendBinary(data: BufferSource | Blob, compress?: boolean): ServerWebSocketSendStatus;
 
     /**
      * Closes the connection.
@@ -134,14 +134,14 @@ declare module "bun" {
      *
      * @param data The data to send
      */
-    ping(data?: string | BufferSource): ServerWebSocketSendStatus;
+    ping(data?: string | BufferSource | Blob): ServerWebSocketSendStatus;
 
     /**
      * Sends a pong.
      *
      * @param data The data to send
      */
-    pong(data?: string | BufferSource): ServerWebSocketSendStatus;
+    pong(data?: string | BufferSource | Blob): ServerWebSocketSendStatus;
 
     /**
      * Sends a message to subscribers of the topic.
@@ -156,7 +156,7 @@ declare module "bun" {
      * ws.publish("chat", new Uint8Array([1, 2, 3, 4]));
      * ```
      */
-    publish(topic: string, data: string | BufferSource, compress?: boolean): ServerWebSocketSendStatus;
+    publish(topic: string, data: string | BufferSource | Blob, compress?: boolean): ServerWebSocketSendStatus;
 
     /**
      * Sends a text message to subscribers of the topic.
@@ -184,7 +184,7 @@ declare module "bun" {
      * ws.publish("chat", new Uint8Array([1, 2, 3, 4]), true);
      * ```
      */
-    publishBinary(topic: string, data: BufferSource, compress?: boolean): ServerWebSocketSendStatus;
+    publishBinary(topic: string, data: BufferSource | Blob, compress?: boolean): ServerWebSocketSendStatus;
 
     /**
      * Subscribes a client to the topic.
@@ -1029,7 +1029,7 @@ declare module "bun" {
      */
     publish(
       topic: string,
-      data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer,
+      data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer | Blob,
       compress?: boolean,
     ): ServerWebSocketSendStatus;
 

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -1297,8 +1297,10 @@ impl ServerWebSocket {
                         "bytes",
                     ));
                 } else {
-                    return Err(global_this
-                        .throw(format_args!("{} requires a string or BufferSource", name)));
+                    return Err(global_this.throw(format_args!(
+                        "{} requires a string, Blob, or BufferSource",
+                        name
+                    )));
                 }
             }
         }

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -207,7 +207,7 @@ pub(super) fn blob_payload<'a>(
     };
     if blob.needs_to_read_file() || blob.is_s3() {
         return Err(global_this.throw(format_args!(
-            "{fn_name} cannot send a file-backed Blob synchronously; await blob.bytes() first"
+            "{fn_name} cannot send a file- or S3-backed Blob synchronously; await blob.bytes() first"
         )));
     }
     Ok(Some(blob.shared_view()))

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -196,10 +196,8 @@ pub(super) fn send_status_to_js(
     }
 }
 
-/// If `value` is a `Blob`, returns its in-memory bytes as `Ok(Some(slice))`.
-/// File-/S3-backed blobs throw (the send/publish APIs are synchronous and
-/// return a byte count, so async I/O cannot happen here). Non-blobs return
-/// `Ok(None)` so callers fall through to their next type check.
+/// File-/S3-backed blobs throw: these send paths return a synchronous byte
+/// count, so there is no way to do the I/O here.
 #[inline]
 pub(super) fn blob_payload<'a>(
     global_this: &JSGlobalObject,

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -196,8 +196,6 @@ pub(super) fn send_status_to_js(
     }
 }
 
-/// File-/S3-backed blobs throw: these send paths return a synchronous byte
-/// count, so there is no way to do the I/O here.
 #[inline]
 pub(super) fn blob_payload<'a>(
     global_this: &JSGlobalObject,

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -14,6 +14,7 @@ use crate::server::jsc::{
     JSType, JSValue, JsError, JsRef, JsResult, ZigStringSlice,
 };
 use crate::server::web_socket_server_context::HandlerFlags;
+use crate::webcore::Blob;
 
 bun_output::declare_scope!(WebSocketServer, visible);
 
@@ -193,6 +194,27 @@ pub(super) fn send_status_to_js(
             JSValue::js_number(0.0)
         }
     }
+}
+
+/// If `value` is a `Blob`, returns its in-memory bytes as `Ok(Some(slice))`.
+/// File-/S3-backed blobs throw (the send/publish APIs are synchronous and
+/// return a byte count, so async I/O cannot happen here). Non-blobs return
+/// `Ok(None)` so callers fall through to their next type check.
+#[inline]
+pub(super) fn blob_payload<'a>(
+    global_this: &JSGlobalObject,
+    fn_name: &'static str,
+    value: JSValue,
+) -> JsResult<Option<&'a [u8]>> {
+    let Some(blob) = value.as_class_ref::<Blob>() else {
+        return Ok(None);
+    };
+    if blob.needs_to_read_file() || blob.is_s3() {
+        return Err(global_this.throw(format_args!(
+            "{fn_name} cannot send a file-backed Blob synchronously; await blob.bytes() first"
+        )));
+    }
+    Ok(Some(blob.shared_view()))
 }
 
 impl ServerWebSocket {
@@ -854,6 +876,20 @@ impl ServerWebSocket {
             ));
         }
 
+        if let Some(slice) = blob_payload(global_this, "publish", message_value)? {
+            let ret = self.do_publish(
+                ssl,
+                app,
+                publish_to_self,
+                topic_slice.slice(),
+                slice,
+                Opcode::Binary,
+                compress,
+            );
+            message_value.ensure_still_alive();
+            return Ok(ret);
+        }
+
         {
             let js_string = message_value.to_js_string(global_this)?;
             let view = js_string.view(global_this);
@@ -969,19 +1005,33 @@ impl ServerWebSocket {
             );
         }
 
-        let Some(array_buffer) = message_value.as_array_buffer(global_this) else {
-            return Err(global_this.throw(format_args!("publishBinary expects an ArrayBufferView")));
-        };
+        if let Some(array_buffer) = message_value.as_array_buffer(global_this) {
+            return Ok(self.do_publish(
+                ssl,
+                app,
+                publish_to_self,
+                topic_slice.slice(),
+                array_buffer.slice(),
+                Opcode::Binary,
+                compress,
+            ));
+        }
 
-        Ok(self.do_publish(
-            ssl,
-            app,
-            publish_to_self,
-            topic_slice.slice(),
-            array_buffer.slice(),
-            Opcode::Binary,
-            compress,
-        ))
+        if let Some(slice) = blob_payload(global_this, "publishBinary", message_value)? {
+            let ret = self.do_publish(
+                ssl,
+                app,
+                publish_to_self,
+                topic_slice.slice(),
+                slice,
+                Opcode::Binary,
+                compress,
+            );
+            message_value.ensure_still_alive();
+            return Ok(ret);
+        }
+
+        Err(global_this.throw(format_args!("publishBinary expects a Blob or BufferSource")))
     }
 
     // `passThis: true` in server.classes.ts — wrapper is emitted by
@@ -1062,6 +1112,17 @@ impl ServerWebSocket {
                 "send",
                 "bytes",
             ));
+        }
+
+        if let Some(slice) = blob_payload(global_this, "send", message_value)? {
+            let ret = send_status_to_js(
+                self.websocket().send(slice, Opcode::Binary, compress, true),
+                slice.len(),
+                "send",
+                "bytes",
+            );
+            message_value.ensure_still_alive();
+            return Ok(ret);
         }
 
         {
@@ -1150,17 +1211,28 @@ impl ServerWebSocket {
             callframe.arguments_count() as usize,
         )?;
 
-        let Some(buffer) = message_value.as_array_buffer(global_this) else {
-            return Err(global_this.throw(format_args!("sendBinary requires an ArrayBufferView")));
-        };
+        if let Some(buffer) = message_value.as_array_buffer(global_this) {
+            let slice = buffer.slice();
+            return Ok(send_status_to_js(
+                self.websocket().send(slice, Opcode::Binary, compress, true),
+                slice.len(),
+                "sendBinary",
+                "bytes",
+            ));
+        }
 
-        let slice = buffer.slice();
-        Ok(send_status_to_js(
-            self.websocket().send(slice, Opcode::Binary, compress, true),
-            slice.len(),
-            "sendBinary",
-            "bytes",
-        ))
+        if let Some(slice) = blob_payload(global_this, "sendBinary", message_value)? {
+            let ret = send_status_to_js(
+                self.websocket().send(slice, Opcode::Binary, compress, true),
+                slice.len(),
+                "sendBinary",
+                "bytes",
+            );
+            message_value.ensure_still_alive();
+            return Ok(ret);
+        }
+
+        Err(global_this.throw(format_args!("sendBinary requires a Blob or BufferSource")))
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1199,6 +1271,18 @@ impl ServerWebSocket {
                         name,
                         "bytes",
                     ));
+                } else if let Some(buffer) = blob_payload(global_this, name, value)? {
+                    if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
+                        return Err(throw_control_frame_too_large(global_this, buffer.len()));
+                    }
+                    let ret = send_status_to_js(
+                        self.websocket().send(buffer, opcode, false, true),
+                        buffer.len(),
+                        name,
+                        "bytes",
+                    );
+                    value.ensure_still_alive();
+                    return Ok(ret);
                 } else if value.is_string() {
                     // SAFETY: to_js_string returns a non-null *mut JSString on the Ok path.
                     let string_value = value.to_js_string(global_this)?.to_slice(global_this);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1661,6 +1661,27 @@ where
             ));
         }
 
+        if let Some(slice) =
+            super::server_web_socket::blob_payload(global, "publish", message_value)?
+        {
+            let status = AnyWebSocket::publish_with_options(
+                SSL,
+                app,
+                topic_slice.slice(),
+                slice,
+                uws_sys::Opcode::Binary,
+                compress,
+            );
+            let result = super::server_web_socket::send_status_to_js(
+                status,
+                slice.len(),
+                "publish",
+                "bytes",
+            );
+            message_value.ensure_still_alive();
+            return Ok(result);
+        }
+
         {
             let js_string = message_value.to_js_string(global)?;
             let view = js_string.view(global);

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -802,6 +802,7 @@ describe("ServerWebSocket", () => {
         fetch: (req, s) => (s.upgrade(req) ? undefined : new Response()),
         websocket: { publishToSelf: true, open: ws => opened.resolve(ws), message() {} },
       });
+      servers.push(server);
       const c = new WebSocket(`ws://${server.hostname}:${server.port}/`);
       c.binaryType = "arraybuffer";
       c.onmessage = e => {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -802,7 +802,6 @@ describe("ServerWebSocket", () => {
         fetch: (req, s) => (s.upgrade(req) ? undefined : new Response()),
         websocket: { publishToSelf: true, open: ws => opened.resolve(ws), message() {} },
       });
-      servers.push(server);
       const c = new WebSocket(`ws://${server.hostname}:${server.port}/`);
       c.binaryType = "arraybuffer";
       c.onmessage = e => {
@@ -814,7 +813,15 @@ describe("ServerWebSocket", () => {
         opened.reject(err);
         flushed.reject(err);
       };
-      const ws = await opened.promise;
+      let ws: ServerWebSocket<unknown>;
+      try {
+        ws = await opened.promise;
+      } catch (e) {
+        c.onclose = c.onerror = null;
+        c.close();
+        server.stop(true);
+        throw e;
+      }
       return {
         server,
         ws,

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -892,18 +892,20 @@ describe("ServerWebSocket", () => {
       });
     });
 
-    it.concurrent("throws on file-backed Blob", async () => {
+    it.concurrent("throws on file- or S3-backed Blob", async () => {
       using h = await openOne();
       h.ws.subscribe("t");
       using dir = tempDir("ws-blob-file", { "a.bin": "abcd" });
       const file = Bun.file(path.join(String(dir), "a.bin"));
-      expect(() => h.ws.send(file)).toThrow("send cannot send a file-backed Blob synchronously");
-      expect(() => h.ws.sendBinary(file)).toThrow("sendBinary cannot send a file-backed Blob synchronously");
-      expect(() => h.ws.publish("t", file)).toThrow("publish cannot send a file-backed Blob synchronously");
-      expect(() => h.ws.publishBinary("t", file)).toThrow("publishBinary cannot send a file-backed Blob synchronously");
-      expect(() => h.ws.ping(file)).toThrow("ping cannot send a file-backed Blob synchronously");
-      expect(() => h.ws.pong(file)).toThrow("pong cannot send a file-backed Blob synchronously");
-      expect(() => h.server.publish("t", file)).toThrow("publish cannot send a file-backed Blob synchronously");
+      const msg = (fn: string) =>
+        `${fn} cannot send a file- or S3-backed Blob synchronously; await blob.bytes() first`;
+      expect(() => h.ws.send(file)).toThrow(msg("send"));
+      expect(() => h.ws.sendBinary(file)).toThrow(msg("sendBinary"));
+      expect(() => h.ws.publish("t", file)).toThrow(msg("publish"));
+      expect(() => h.ws.publishBinary("t", file)).toThrow(msg("publishBinary"));
+      expect(() => h.ws.ping(file)).toThrow(msg("ping"));
+      expect(() => h.ws.pong(file)).toThrow(msg("pong"));
+      expect(() => h.server.publish("t", file)).toThrow(msg("publish"));
     });
   });
   describe("sendBinary()", () => {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -897,8 +897,7 @@ describe("ServerWebSocket", () => {
       h.ws.subscribe("t");
       using dir = tempDir("ws-blob-file", { "a.bin": "abcd" });
       const file = Bun.file(path.join(String(dir), "a.bin"));
-      const msg = (fn: string) =>
-        `${fn} cannot send a file- or S3-backed Blob synchronously; await blob.bytes() first`;
+      const msg = (fn: string) => `${fn} cannot send a file- or S3-backed Blob synchronously; await blob.bytes() first`;
       expect(() => h.ws.send(file)).toThrow(msg("send"));
       expect(() => h.ws.sendBinary(file)).toThrow(msg("sendBinary"));
       expect(() => h.ws.publish("t", file)).toThrow(msg("publish"));

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1,7 +1,7 @@
 import type { Server, ServerWebSocket, Subprocess, WebSocketHandler } from "bun";
 import { serve, spawn } from "bun";
 import { afterEach, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, forceGuardMalloc, isWindows } from "harness";
+import { bunEnv, bunExe, forceGuardMalloc, isWindows, tempDir } from "harness";
 import net, { isIP } from "node:net";
 import path from "node:path";
 
@@ -791,6 +791,114 @@ describe("ServerWebSocket", () => {
       done();
     },
   }));
+  // https://github.com/oven-sh/bun/issues/5271
+  describe("Blob", () => {
+    async function openOne() {
+      const opened = Promise.withResolvers<ServerWebSocket<unknown>>();
+      const flushed = Promise.withResolvers<void>();
+      const received: unknown[] = [];
+      const server = serve({
+        port: 0,
+        fetch: (req, s) => (s.upgrade(req) ? undefined : new Response()),
+        websocket: { publishToSelf: true, open: ws => opened.resolve(ws), message() {} },
+      });
+      const c = new WebSocket(`ws://${server.hostname}:${server.port}/`);
+      c.binaryType = "arraybuffer";
+      c.onmessage = e => {
+        if (e.data === "done") return flushed.resolve();
+        received.push(typeof e.data === "string" ? e.data : Buffer.from(e.data));
+      };
+      c.onerror = c.onclose = ev => {
+        const err = new Error(`client ${ev.type}`);
+        opened.reject(err);
+        flushed.reject(err);
+      };
+      const ws = await opened.promise;
+      return {
+        server,
+        ws,
+        received,
+        flush: () => (ws.send("done"), flushed.promise),
+        [Symbol.dispose]() {
+          c.onclose = c.onerror = null;
+          c.close();
+          server.stop(true);
+        },
+      };
+    }
+
+    it.concurrent("send/sendBinary/ping/pong send the blob's bytes, not '[object Blob]'", async () => {
+      using h = await openOne();
+      const blobs = [
+        ["Blob", new Blob([new Uint8Array([1, 2, 3, 4])]), [1, 2, 3, 4]],
+        ["Blob.slice", new Blob([new Uint8Array([9, 9, 1, 2, 3, 4, 9, 9])]).slice(2, 6), [1, 2, 3, 4]],
+        ["File", new File([new Uint8Array([5, 6, 7, 8])], "name.bin"), [5, 6, 7, 8]],
+      ] as const;
+      const rcs: Record<string, unknown> = {};
+      for (const [label, blob] of blobs) {
+        rcs[`send ${label}`] = h.ws.send(blob);
+        rcs[`sendBinary ${label}`] = h.ws.sendBinary(blob);
+        rcs[`ping ${label}`] = h.ws.ping(blob);
+        rcs[`pong ${label}`] = h.ws.pong(blob);
+      }
+      rcs["send empty"] = h.ws.send(new Blob([]));
+      rcs["sendBinary empty"] = h.ws.sendBinary(new Blob([]));
+      await h.flush();
+      expect({ rcs, received: h.received }).toEqual({
+        rcs: {
+          "send Blob": 4,
+          "sendBinary Blob": 4,
+          "ping Blob": 4,
+          "pong Blob": 4,
+          "send Blob.slice": 4,
+          "sendBinary Blob.slice": 4,
+          "ping Blob.slice": 4,
+          "pong Blob.slice": 4,
+          "send File": 4,
+          "sendBinary File": 4,
+          "ping File": 4,
+          "pong File": 4,
+          "send empty": 0,
+          "sendBinary empty": 0,
+        },
+        received: [
+          ...blobs.flatMap(([, , bytes]) => [Buffer.from(bytes), Buffer.from(bytes)]),
+          Buffer.alloc(0),
+          Buffer.alloc(0),
+        ],
+      });
+    });
+
+    it.concurrent("publish/publishBinary/server.publish send the blob's bytes", async () => {
+      using h = await openOne();
+      h.ws.subscribe("t");
+      const blob = new Blob([new Uint8Array([1, 2, 3, 4])]);
+      const rcs = {
+        "ws.publish": h.ws.publish("t", blob),
+        "ws.publishBinary": h.ws.publishBinary("t", blob),
+        "server.publish": h.server.publish("t", blob),
+      };
+      await h.flush();
+      expect({ rcs, received: h.received }).toEqual({
+        rcs: { "ws.publish": 4, "ws.publishBinary": 4, "server.publish": 4 },
+        received: [Buffer.from([1, 2, 3, 4]), Buffer.from([1, 2, 3, 4]), Buffer.from([1, 2, 3, 4])],
+      });
+    });
+
+    it.concurrent("throws on file-backed Blob", async () => {
+      using h = await openOne();
+      h.ws.subscribe("t");
+      using dir = tempDir("ws-blob-file", { "a.bin": "abcd" });
+      const file = Bun.file(path.join(String(dir), "a.bin"));
+      expect(() => h.ws.send(file)).toThrow("send cannot send a file-backed Blob synchronously");
+      expect(() => h.ws.sendBinary(file)).toThrow("sendBinary cannot send a file-backed Blob synchronously");
+      expect(() => h.ws.publish("t", file)).toThrow("publish cannot send a file-backed Blob synchronously");
+      expect(() => h.ws.publishBinary("t", file)).toThrow("publishBinary cannot send a file-backed Blob synchronously");
+      expect(() => h.ws.ping(file)).toThrow("ping cannot send a file-backed Blob synchronously");
+      expect(() => h.ws.pong(file)).toThrow("pong cannot send a file-backed Blob synchronously");
+      expect(() => h.server.publish("t", file)).toThrow("publish cannot send a file-backed Blob synchronously");
+    });
+  });
   describe("sendBinary()", () => {
     for (const { label, message, bytes } of buffers) {
       test(label, done => ({

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -791,7 +791,6 @@ describe("ServerWebSocket", () => {
       done();
     },
   }));
-  // https://github.com/oven-sh/bun/issues/5271
   describe("Blob", () => {
     async function openOne() {
       const opened = Promise.withResolvers<ServerWebSocket<unknown>>();


### PR DESCRIPTION
## What

`ServerWebSocket.send(blob)`, `ws.publish(topic, blob)`, `ws.sendBinary(blob)`, `ws.publishBinary(topic, blob)`, `ws.ping(blob)`, `ws.pong(blob)`, and `server.publish(topic, blob)` now send the Blob's bytes as a **binary** frame, matching the client-side `WebSocket.send(blob)` and npm `ws`.

Previously:
- `send` / `publish` fell through to `ToString` and shipped the literal text `"[object Blob]"` (return code 13), silently corrupting data.
- `sendBinary` / `publishBinary` / `ping` / `pong` rejected Blobs with a TypeError.

So passing the same Blob to the client `WebSocket.send`, the server `ws.send`, and `ws.sendBinary` produced three different results.

## Repro

```js
const server = Bun.serve({
  port: 0,
  fetch: (req, s) => (s.upgrade(req) ? undefined : new Response("no")),
  websocket: { open(ws) { globalThis.sws = ws; ws.subscribe("t"); }, message() {} },
});
const c = new WebSocket(`ws://127.0.0.1:${server.port}/`);
c.binaryType = "arraybuffer";
c.onmessage = e =>
  console.log("client got:", typeof e.data === "string" ? JSON.stringify(e.data) : new Uint8Array(e.data));
c.onopen = () => {
  const blob = new Blob([new Uint8Array([1, 2, 3, 4])]);
  console.log("ws.send(blob) rc =", sws.send(blob));           // before: 13, after: 4
  console.log("server.publish rc =", server.publish("t", blob)); // before: 13, after: 4
};
// before: client got: "[object Blob]"  "[object Blob]"
// after:  client got: Uint8Array [1,2,3,4]  Uint8Array [1,2,3,4]
```

## Cause

`send()` / `publish()` check `message_value.as_array_buffer()` and on miss fall straight through to `message_value.to_js_string()`, which is the JS `ToString` coercion. Blobs (and every other object) become `"[object Blob]"`.

## Fix

Insert a `value.as_class_ref::<Blob>()` check between the ArrayBuffer check and the string coercion at all seven sites, sending `blob.shared_view()` as `Opcode::Binary`. A shared `blob_payload()` helper does the detection and rejects file/S3-backed blobs (`Bun.file()`, `Bun.s3()`) with a TypeError that points at `await blob.bytes()`, since these send paths are synchronous and return a byte count so async I/O cannot happen there.

`sendBinary` / `publishBinary` error messages now say "Blob or BufferSource" instead of "an ArrayBufferView".

Type definitions and the websockets doc page are updated to include `Blob` in the unions.

## Notes

Non-Blob objects passed to `send` / `publish` still coerce via `ToString` (e.g. `ws.send(42)` sends `"42"`). Tightening that to a TypeError the way npm `ws` does would be a separate behavior change.



<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->
