### PR TITLE
Bun.serve: server.publish() throws on null/undefined message

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1644,6 +1644,10 @@ where
         let compress_js = compress_value.unwrap_or(JSValue::TRUE);
         let compress = compress_js.to_boolean();
 
+        if message_value.is_empty_or_undefined_or_null() {
+            return Err(global.throw(format_args!("publish requires a non-empty message")));
+        }
+
         if let Some(buffer) = message_value.as_array_buffer(global) {
             let status = AnyWebSocket::publish_with_options(
                 SSL,

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1594,6 +1594,51 @@ describe.concurrent("publish() return value reflects subscriber backpressure", (
   });
 });
 
+it.concurrent("server.publish() throws on null/undefined message like ws.send()/ws.publish()", async () => {
+  const opened = Promise.withResolvers<ServerWebSocket<unknown>>();
+  const received: string[] = [];
+  await using server = serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("no", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        ws.subscribe("t");
+        opened.resolve(ws);
+      },
+      message() {},
+    },
+  });
+
+  const client = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+  client.onmessage = e => received.push(String(e.data));
+  client.onerror = e => opened.reject(e);
+  try {
+    const ws = await opened.promise;
+    for (const value of [null, undefined] as const) {
+      // @ts-expect-error
+      expect(() => server.publish("t", value)).toThrow("publish requires a non-empty message");
+      // @ts-expect-error
+      expect(() => ws.publish("t", value)).toThrow("publish requires a non-empty message");
+      // @ts-expect-error
+      expect(() => ws.send(value)).toThrow("send requires a non-empty message");
+    }
+    // Nothing should have been broadcast. Round-trip a sentinel to flush.
+    expect(server.publish("t", "ok")).toBeGreaterThan(0);
+    const gotOk = Promise.withResolvers<void>();
+    client.onmessage = e => {
+      received.push(String(e.data));
+      if (e.data === "ok") gotOk.resolve();
+    };
+    await gotOk.promise;
+    expect(received).toEqual(["ok"]);
+  } finally {
+    client.close();
+  }
+});
+
 // https://github.com/oven-sh/bun/issues/34158
 it.each(["server", "client"] as const)(
   "server.stop() promise resolves after the last websocket closes (%s-initiated close)",

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1596,6 +1596,7 @@ describe.concurrent("publish() return value reflects subscriber backpressure", (
 
 it.concurrent("server.publish() throws on null/undefined message like ws.send()/ws.publish()", async () => {
   const opened = Promise.withResolvers<ServerWebSocket<unknown>>();
+  const gotOk = Promise.withResolvers<void>();
   const received: string[] = [];
   await using server = serve({
     port: 0,
@@ -1613,8 +1614,17 @@ it.concurrent("server.publish() throws on null/undefined message like ws.send()/
   });
 
   const client = new WebSocket(`ws://127.0.0.1:${server.port}/`);
-  client.onmessage = e => received.push(String(e.data));
-  client.onerror = e => opened.reject(e);
+  const fail = (e: Event) => {
+    const err = new Error(`client ${e.type} before ok`);
+    opened.reject(err);
+    gotOk.reject(err);
+  };
+  client.onerror = fail;
+  client.onclose = fail;
+  client.onmessage = e => {
+    received.push(String(e.data));
+    if (e.data === "ok") gotOk.resolve();
+  };
   try {
     const ws = await opened.promise;
     for (const value of [null, undefined] as const) {
@@ -1627,14 +1637,10 @@ it.concurrent("server.publish() throws on null/undefined message like ws.send()/
     }
     // Nothing should have been broadcast. Round-trip a sentinel to flush.
     expect(server.publish("t", "ok")).toBeGreaterThan(0);
-    const gotOk = Promise.withResolvers<void>();
-    client.onmessage = e => {
-      received.push(String(e.data));
-      if (e.data === "ok") gotOk.resolve();
-    };
     await gotOk.promise;
     expect(received).toEqual(["ok"]);
   } finally {
+    client.onerror = client.onclose = null;
     client.close();
   }
 });


### PR DESCRIPTION
## Repro

```js
using server = Bun.serve({
  port: 0,
  fetch: (r, s) => (s.upgrade(r) ? undefined : new Response("x")),
  websocket: {
    open(ws) {
      ws.subscribe("t");
      console.log(server.publish("t", null));       // 4, broadcasts "null"
      console.log(server.publish("t", undefined));  // 9, broadcasts "undefined"
    },
    message() {},
  },
});
```

The sibling APIs `ws.send(null|undefined)` and `ws.publish(t, null|undefined)` throw `"... requires a non-empty message"`; `server.publish` silently broadcasts the literal string and returns a positive byte count (rc 4 / 9).

## Cause

`ServerWebSocket::send` / `ServerWebSocket::publish` guard with `message_value.is_empty_or_undefined_or_null()` before the ToString arm. `NewServer::publish` (`src/runtime/server/server_body.rs`) only checks the topic for null/undefined; a null/undefined message reaches `to_js_string()` and publishes `"null"` / `"undefined"`.

## Fix

Add the same `is_empty_or_undefined_or_null()` guard before the buffer/string switch, matching the two siblings.

## Verification

New test in `test/js/bun/websocket/websocket-server.test.ts` asserts `server.publish(t, null|undefined)` throws `"publish requires a non-empty message"` (and re-asserts the existing behaviour for `ws.publish` / `ws.send`), and that no `"null"` / `"undefined"` frame reaches the subscriber.

```
USE_SYSTEM_BUN=1 bun test websocket-server.test.ts -t 'throws on null/undefined'   # fail: Received function did not throw / Received value: 4
bun bd test websocket-server.test.ts -t 'throws on null/undefined'                 # pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->