### PR TITLE
glob: open followed-symlink descendants relative to the deepest followed link

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -89,6 +89,11 @@ pub trait Accessor {
     /// Like statat but does not follow symlinks.
     fn lstatat(handle: Self::Handle, path: &ZStr) -> Maybe<Stat>;
     fn close(handle: Self::Handle) -> Option<SysError>;
+    /// Independent handle to the same open directory. Default is a `Copy`
+    /// (correct for accessors whose `close` is a no-op).
+    fn dup(handle: Self::Handle) -> Maybe<Self::Handle> {
+        Ok(handle)
+    }
 }
 
 pub trait AccessorDirIter {
@@ -205,6 +210,10 @@ impl Accessor for SyscallAccessor {
     fn close(handle: SyscallHandle) -> Option<SysError> {
         handle.value.close_allowing_bad_file_descriptor(None)
     }
+
+    fn dup(handle: SyscallHandle) -> Maybe<SyscallHandle> {
+        Syscall::dup(handle.value).map(|fd| SyscallHandle { value: fd })
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -266,6 +275,16 @@ pub struct GlobWalker<A: Accessor, const SENTINEL: bool> {
     pub workbuf: Vec<WorkItem<A>>,
 
     followed_links: Vec<FollowedLink>,
+    /// Parallel to `followed_links`: for each followed symlink on the current
+    /// ancestor chain, an open handle to its target directory together with
+    /// the logical-path byte length the handle anchors. Descendant opens
+    /// resolve the suffix past that length relative to the handle (at most
+    /// one symlink hop) instead of the full accumulated path relative to
+    /// `cwd_fd`, which re-resolves every ancestor link on every open and
+    /// trips the kernel's `MAXSYMLINKS` on acyclic chains deeper than ~40.
+    /// `None` entries arise only for accessors whose `openat` is not a real
+    /// syscall (the resolver cache), where the issue doesn't apply.
+    link_anchors: Vec<LinkAnchor<A::Handle>>,
 
     is_ignored: IgnoreFilterFn,
 
@@ -550,6 +569,46 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
         }
     }
 
+    /// `openat(cwd_fd, full_path)` re-resolves every symlink component in
+    /// `full_path` on every call, so a single open on a path that has
+    /// accumulated more than `MAXSYMLINKS` (40 on Linux, 32 on macOS) followed
+    /// links fails with `ELOOP` even when the chain is acyclic. The deepest
+    /// anchor on [`GlobWalker::link_anchors`] is an already-open handle to the
+    /// most recently followed link's target, so opening the suffix past its
+    /// prefix resolves at most one link: the entry being opened.
+    fn openat_anchored(&self, full_path_z: &ZStr) -> Result<Maybe<A::Handle>, Error> {
+        if let Some(&(anchor_fd, prefix_len)) =
+            self.walker.link_anchors.iter().rev().find_map(Option::as_ref)
+        {
+            let full = full_path_z.as_bytes();
+            let prefix_len = prefix_len as usize;
+            if full.len() > prefix_len {
+                let mut off = prefix_len;
+                if full[off] == b'/' || (IS_WINDOWS && full[off] == b'\\') {
+                    off += 1;
+                }
+                // SAFETY: `full_path_z` is NUL-terminated at `full.len()`, so
+                // `full[off..]` is NUL-terminated at its own length; `off` is
+                // in `1..=full.len()`.
+                let suffix_z =
+                    unsafe { ZStr::from_raw(full.as_ptr().add(off), full.len() - off) };
+                return A::openat(anchor_fd, suffix_z);
+            }
+        }
+        A::openat(self.cwd_fd, full_path_z)
+    }
+
+    /// Restore the followed-link ancestor chain (and its parallel anchor
+    /// chain) to `len`, closing anchor handles that fall off the end.
+    fn truncate_followed_links(&mut self, len: usize) {
+        for anchor in self.walker.link_anchors.drain(len..) {
+            if let Some((fd, _)) = anchor {
+                let _ = A::close(fd);
+            }
+        }
+        self.walker.followed_links.truncate(len);
+    }
+
     fn transition_to_dir_iter_state<const ROOT: bool>(
         &mut self,
         work_item: WorkItem<A>,
@@ -629,7 +688,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
             }
             if ROOT {
                 if had_dot_dot {
-                    break 'fd match A::openat(self.cwd_fd, dir_path)? {
+                    break 'fd match self.openat_anchored(dir_path)? {
                         Err(err) => {
                             return Ok(Err(self.walker.handle_sys_err_with_path(&err, dir_path)));
                         }
@@ -644,7 +703,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                 break 'fd self.cwd_fd;
             }
 
-            match A::openat(self.cwd_fd, dir_path)? {
+            match self.openat_anchored(dir_path)? {
                 Err(err) => {
                     return Ok(Err(self.walker.handle_sys_err_with_path(&err, dir_path)));
                 }
@@ -803,11 +862,10 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                     let mut work_item = self.walker.workbuf.pop().unwrap();
                     // The workbuf is LIFO, so `followed_links_len` restores the
                     // exact followed-link ancestor chain of this work item.
-                    self.walker
-                        .followed_links
-                        .truncate(work_item.followed_links_len);
+                    self.truncate_followed_links(work_item.followed_links_len);
                     if let Some(link) = work_item.followed_link.take() {
                         self.walker.followed_links.push(link);
+                        self.walker.link_anchors.push(work_item.link_anchor.take());
                     }
                     match work_item.kind {
                         WorkItemKind::Directory => {
@@ -823,6 +881,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                             // NUL in `.len()`; drop it (see `work_item_logical_path`) so the
                             // NUL re-written at `[len]` below isn't left embedded in the path.
                             let work_item_path: &[u8] = work_item_logical_path(&work_item.path);
+                            let anchor_prefix_len = work_item_path.len() as u32;
                             if work_item_path.len() >= MAX_PATH_BYTES {
                                 return Ok(Err(SysError::from_code(
                                     E::ENAMETOOLONG,
@@ -889,7 +948,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
 
                             self.iter_state = IterState::GetNext;
                             let maybe_dir_fd: Option<A::Handle> =
-                                match A::openat(self.cwd_fd, symlink_full_path_z)? {
+                                match self.openat_anchored(symlink_full_path_z)? {
                                     Err(err) => 'brk: {
                                         if err.get_errno() == E::ENOTDIR {
                                             break 'brk None;
@@ -963,6 +1022,9 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                     }
                                 };
                             if descend {
+                                let link_anchor = followed_link.is_some().then(|| {
+                                    A::dup(dir_fd).ok().map(|fd| (fd, anchor_prefix_len))
+                                }).flatten();
                                 self.walker.push_work_item(
                                     WorkItem::new_with_fd(
                                         work_item.path,
@@ -971,6 +1033,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                         dir_fd,
                                     ),
                                     followed_link,
+                                    link_anchor,
                                 );
                             } else {
                                 self.close_disallowing_cwd(dir_fd);
@@ -1062,6 +1125,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                             WorkItemKind::Directory,
                                         ),
                                         followed_link,
+                                        None,
                                     );
                                 }
                             }
@@ -1157,6 +1221,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                                 WorkItemKind::Directory,
                                             ),
                                             None,
+                                            None,
                                         );
                                     }
                                     if add_dir && !self.walker.only_files {
@@ -1227,6 +1292,14 @@ impl<'a, A: Accessor, const SENTINEL: bool> Drop for Iterator<'a, A, SENTINEL> {
             if let Some(fd) = work_item.fd {
                 self.close_disallowing_cwd(fd);
             }
+            if let Some((fd, _)) = work_item.link_anchor {
+                let _ = A::close(fd);
+            }
+        }
+        for anchor in self.walker.link_anchors.drain(..) {
+            if let Some((fd, _)) = anchor {
+                let _ = A::close(fd);
+            }
         }
 
         if count_fds::<A>() {
@@ -1268,6 +1341,9 @@ impl FollowedLink {
     }
 }
 
+/// See [`GlobWalker::link_anchors`].
+type LinkAnchor<H> = Option<(H, u32)>;
+
 pub struct WorkItem<A: Accessor> {
     pub path: Box<[u8]>,
     /// Bitmask of active component indices.
@@ -1281,6 +1357,8 @@ pub struct WorkItem<A: Accessor> {
     /// The followed link this item descends into, pushed onto `followed_links`
     /// (after the truncation above) when it is popped.
     followed_link: Option<FollowedLink>,
+    /// Pushed onto [`GlobWalker::link_anchors`] alongside `followed_link`.
+    link_anchor: LinkAnchor<A::Handle>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1299,6 +1377,7 @@ impl<A: Accessor> WorkItem<A> {
             fd: None,
             followed_links_len: 0,
             followed_link: None,
+            link_anchor: None,
         }
     }
 
@@ -1458,6 +1537,7 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
             path_buf: Box::new(PathBuffer::uninit()),
             workbuf: Vec::new(),
             followed_links: Vec::new(),
+            link_anchors: Vec::new(),
             is_ignored: ignore_filter_fn.unwrap_or(dummy_filter_false),
             _accessor: core::marker::PhantomData,
         };
@@ -1984,15 +2064,23 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
         self.push_work_item(
             WorkItem::new_symlink(subdir_entry_name, active, entry_start),
             None,
+            None,
         );
         Ok(())
     }
 
     /// Single push site: snapshots the followed-link ancestor chain (and the
     /// link `item` itself descends into) so the pop site can restore it.
-    fn push_work_item(&mut self, mut item: WorkItem<A>, followed_link: Option<FollowedLink>) {
+    fn push_work_item(
+        &mut self,
+        mut item: WorkItem<A>,
+        followed_link: Option<FollowedLink>,
+        link_anchor: LinkAnchor<A::Handle>,
+    ) {
+        debug_assert_eq!(self.followed_links.len(), self.link_anchors.len());
         item.followed_links_len = self.followed_links.len();
         item.followed_link = followed_link;
+        item.link_anchor = link_anchor;
         self.workbuf.push(item);
     }
 

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -89,8 +89,7 @@ pub trait Accessor {
     /// Like statat but does not follow symlinks.
     fn lstatat(handle: Self::Handle, path: &ZStr) -> Maybe<Stat>;
     fn close(handle: Self::Handle) -> Option<SysError>;
-    /// Independent handle to the same open directory. Default is a `Copy`
-    /// (correct for accessors whose `close` is a no-op).
+    /// Independent handle to the same open directory.
     fn dup(handle: Self::Handle) -> Maybe<Self::Handle> {
         Ok(handle)
     }
@@ -275,15 +274,8 @@ pub struct GlobWalker<A: Accessor, const SENTINEL: bool> {
     pub workbuf: Vec<WorkItem<A>>,
 
     followed_links: Vec<FollowedLink>,
-    /// Parallel to `followed_links`: for each followed symlink on the current
-    /// ancestor chain, an open handle to its target directory together with
-    /// the logical-path byte length the handle anchors. Descendant opens
-    /// resolve the suffix past that length relative to the handle (at most
-    /// one symlink hop) instead of the full accumulated path relative to
-    /// `cwd_fd`, which re-resolves every ancestor link on every open and
-    /// trips the kernel's `MAXSYMLINKS` on acyclic chains deeper than ~40.
-    /// `None` entries arise only for accessors whose `openat` is not a real
-    /// syscall (the resolver cache), where the issue doesn't apply.
+    /// Parallel to `followed_links`: open handle to each followed target and
+    /// the logical-path prefix it covers; see [`Iterator::openat_anchored`].
     link_anchors: Vec<LinkAnchor<A::Handle>>,
 
     is_ignored: IgnoreFilterFn,
@@ -569,13 +561,10 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
         }
     }
 
-    /// `openat(cwd_fd, full_path)` re-resolves every symlink component in
-    /// `full_path` on every call, so a single open on a path that has
-    /// accumulated more than `MAXSYMLINKS` (40 on Linux, 32 on macOS) followed
-    /// links fails with `ELOOP` even when the chain is acyclic. The deepest
-    /// anchor on [`GlobWalker::link_anchors`] is an already-open handle to the
-    /// most recently followed link's target, so opening the suffix past its
-    /// prefix resolves at most one link: the entry being opened.
+    /// Open `full_path` relative to the deepest [`GlobWalker::link_anchors`]
+    /// handle (suffix past its prefix), so each open resolves at most one
+    /// symlink rather than every link accumulated in `full_path` relative to
+    /// `cwd_fd`, which the kernel caps at `MAXSYMLINKS` with `ELOOP`.
     fn openat_anchored(&self, full_path_z: &ZStr) -> Result<Maybe<A::Handle>, Error> {
         if let Some(&(anchor_fd, prefix_len)) = self
             .walker
@@ -601,8 +590,6 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
         A::openat(self.cwd_fd, full_path_z)
     }
 
-    /// Restore the followed-link ancestor chain (and its parallel anchor
-    /// chain) to `len`, closing anchor handles that fall off the end.
     fn truncate_followed_links(&mut self, len: usize) {
         for anchor in self.walker.link_anchors.drain(len..) {
             if let Some((fd, _)) = anchor {

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -369,6 +369,9 @@ pub struct Iterator<'a, A: Accessor, const SENTINEL: bool> {
     /// directory being iterated on.
     #[cfg(debug_assertions)]
     pub fds_open: usize,
+    /// Dup'd [`GlobWalker::link_anchors`] handles currently live.
+    #[cfg(debug_assertions)]
+    anchors_open: usize,
 
     #[cfg(windows)]
     pub nt_filter_buf: [u16; 256],
@@ -387,6 +390,8 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
             cwd_fd: A::Handle::EMPTY,
             #[cfg(debug_assertions)]
             fds_open: 0,
+            #[cfg(debug_assertions)]
+            anchors_open: 0,
             #[cfg(windows)]
             nt_filter_buf: [0; 256],
         }
@@ -590,10 +595,20 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
         A::openat(self.cwd_fd, full_path_z)
     }
 
+    fn close_anchor(&mut self, fd: A::Handle) {
+        let _ = A::close(fd);
+        if count_fds::<A>() {
+            #[cfg(debug_assertions)]
+            {
+                self.anchors_open -= 1;
+            }
+        }
+    }
+
     fn truncate_followed_links(&mut self, len: usize) {
-        for anchor in self.walker.link_anchors.drain(len..) {
-            if let Some((fd, _)) = anchor {
-                let _ = A::close(fd);
+        while self.walker.link_anchors.len() > len {
+            if let Some((fd, _)) = self.walker.link_anchors.pop().flatten() {
+                self.close_anchor(fd);
             }
         }
         self.walker.followed_links.truncate(len);
@@ -1016,6 +1031,12 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                     .is_some()
                                     .then(|| A::dup(dir_fd).ok().map(|fd| (fd, anchor_prefix_len)))
                                     .flatten();
+                                if count_fds::<A>() && link_anchor.is_some() {
+                                    #[cfg(debug_assertions)]
+                                    {
+                                        self.anchors_open += 1;
+                                    }
+                                }
                                 self.walker.push_work_item(
                                     WorkItem::new_with_fd(
                                         work_item.path,
@@ -1284,18 +1305,17 @@ impl<'a, A: Accessor, const SENTINEL: bool> Drop for Iterator<'a, A, SENTINEL> {
                 self.close_disallowing_cwd(fd);
             }
             if let Some((fd, _)) = work_item.link_anchor {
-                let _ = A::close(fd);
+                self.close_anchor(fd);
             }
         }
-        for anchor in self.walker.link_anchors.drain(..) {
-            if let Some((fd, _)) = anchor {
-                let _ = A::close(fd);
-            }
-        }
+        self.truncate_followed_links(0);
 
         if count_fds::<A>() {
             #[cfg(debug_assertions)]
-            debug_assert!(self.fds_open == 0);
+            {
+                debug_assert!(self.fds_open == 0);
+                debug_assert!(self.anchors_open == 0);
+            }
         }
     }
 }

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -577,8 +577,12 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
     /// most recently followed link's target, so opening the suffix past its
     /// prefix resolves at most one link: the entry being opened.
     fn openat_anchored(&self, full_path_z: &ZStr) -> Result<Maybe<A::Handle>, Error> {
-        if let Some(&(anchor_fd, prefix_len)) =
-            self.walker.link_anchors.iter().rev().find_map(Option::as_ref)
+        if let Some(&(anchor_fd, prefix_len)) = self
+            .walker
+            .link_anchors
+            .iter()
+            .rev()
+            .find_map(Option::as_ref)
         {
             let full = full_path_z.as_bytes();
             let prefix_len = prefix_len as usize;
@@ -590,8 +594,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                 // SAFETY: `full_path_z` is NUL-terminated at `full.len()`, so
                 // `full[off..]` is NUL-terminated at its own length; `off` is
                 // in `1..=full.len()`.
-                let suffix_z =
-                    unsafe { ZStr::from_raw(full.as_ptr().add(off), full.len() - off) };
+                let suffix_z = unsafe { ZStr::from_raw(full.as_ptr().add(off), full.len() - off) };
                 return A::openat(anchor_fd, suffix_z);
             }
         }
@@ -947,35 +950,35 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                             };
 
                             self.iter_state = IterState::GetNext;
-                            let maybe_dir_fd: Option<A::Handle> =
-                                match self.openat_anchored(symlink_full_path_z)? {
-                                    Err(err) => 'brk: {
-                                        if err.get_errno() == E::ENOTDIR {
-                                            break 'brk None;
-                                        }
-                                        if self.walker.error_on_broken_symlinks {
-                                            return Ok(Err(self.walker.handle_sys_err_with_path(
-                                                &err,
-                                                symlink_full_path_z,
-                                            )));
-                                        }
-                                        if !self.walker.only_files
-                                            && self.walker.eval_file(&active, entry_name)
-                                        {
-                                            match self.walker.prepare_matched_path_symlink(
-                                                symlink_full_path_z.as_bytes(),
-                                            )? {
-                                                Some(p) => return Ok(Ok(Some(p))),
-                                                None => continue 'outer,
-                                            }
-                                        }
-                                        continue 'outer;
+                            let maybe_dir_fd: Option<A::Handle> = match self
+                                .openat_anchored(symlink_full_path_z)?
+                            {
+                                Err(err) => 'brk: {
+                                    if err.get_errno() == E::ENOTDIR {
+                                        break 'brk None;
                                     }
-                                    Ok(fd) => {
-                                        self.bump_open_fds();
-                                        Some(fd)
+                                    if self.walker.error_on_broken_symlinks {
+                                        return Ok(Err(self
+                                            .walker
+                                            .handle_sys_err_with_path(&err, symlink_full_path_z)));
                                     }
-                                };
+                                    if !self.walker.only_files
+                                        && self.walker.eval_file(&active, entry_name)
+                                    {
+                                        match self.walker.prepare_matched_path_symlink(
+                                            symlink_full_path_z.as_bytes(),
+                                        )? {
+                                            Some(p) => return Ok(Ok(Some(p))),
+                                            None => continue 'outer,
+                                        }
+                                    }
+                                    continue 'outer;
+                                }
+                                Ok(fd) => {
+                                    self.bump_open_fds();
+                                    Some(fd)
+                                }
+                            };
 
                             let Some(dir_fd) = maybe_dir_fd else {
                                 // Symlink target is a file
@@ -1022,9 +1025,10 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                     }
                                 };
                             if descend {
-                                let link_anchor = followed_link.is_some().then(|| {
-                                    A::dup(dir_fd).ok().map(|fd| (fd, anchor_prefix_len))
-                                }).flatten();
+                                let link_anchor = followed_link
+                                    .is_some()
+                                    .then(|| A::dup(dir_fd).ok().map(|fd| (fd, anchor_prefix_len)))
+                                    .flatten();
                                 self.walker.push_work_item(
                                     WorkItem::new_with_fd(
                                         work_item.path,

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1157,9 +1157,7 @@ test.skipIf(isWindows || !canCreateDirSymlink)(
     expect(matched).toContain(path.join(nextPrefix, "real", "sub.txt"));
 
     expect(() =>
-      Array.from(
-        new Glob("**/*.txt").scanSync({ cwd, followSymlinks: true, throwErrorOnBrokenSymlink: true }),
-      ),
+      Array.from(new Glob("**/*.txt").scanSync({ cwd, followSymlinks: true, throwErrorOnBrokenSymlink: true })),
     ).not.toThrow();
   },
 );

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1127,6 +1127,43 @@ describe.skipIf(!canCreateDirSymlink)("literal path segment through a symlinked 
   });
 });
 
+// An acyclic symlink chain (`nK/next -> ../nK+1`) must be followed to any
+// depth. Opening each followed link by its full accumulated path relative to
+// the cwd fd re-resolves every ancestor link on every open, so the kernel's
+// per-resolution MAXSYMLINKS limit (40 on Linux, 32 on macOS) fires on a
+// healthy tree, truncating results and misreporting the cutoff as a broken
+// link. `find -L` walks the same tree unbounded because each open resolves at
+// most one link relative to its parent.
+// Windows symlinks resolve through a different limit (63 reparse points) and
+// relative directory symlinks are not reliably creatable in CI; covered by the
+// POSIX lanes only.
+test.skipIf(isWindows || !canCreateDirSymlink)(
+  "followSymlinks walks an acyclic symlink chain past the kernel's MAXSYMLINKS limit",
+  () => {
+    const chainDepth = 90;
+    const files: Record<string, string> = {};
+    for (let i = 0; i <= chainDepth; i++) files[`n${i}/f${i}.txt`] = "";
+    files[`n50/real/sub.txt`] = "";
+    using dir = tempDir("glob-scan-symlink-chain", files);
+    for (let i = 0; i < chainDepth; i++) {
+      fs.symlinkSync(path.join("..", `n${i + 1}`), path.join(String(dir), `n${i}`, "next"), "dir");
+    }
+    const cwd = path.join(String(dir), "n0");
+
+    const matched = Array.from(new Glob("**/*.txt").scanSync({ cwd, followSymlinks: true }));
+    const filesOnChain = matched.filter(p => /f\d+\.txt$/.test(p));
+    expect(filesOnChain).toHaveLength(chainDepth + 1);
+    const nextPrefix = "next/".repeat(50);
+    expect(matched).toContain(path.join(nextPrefix, "real", "sub.txt"));
+
+    expect(() =>
+      Array.from(
+        new Glob("**/*.txt").scanSync({ cwd, followSymlinks: true, throwErrorOnBrokenSymlink: true }),
+      ),
+    ).not.toThrow();
+  },
+);
+
 // A directory the user can read but not write (RX-only grant) must still be
 // descended by the scanner: directory opens used to request FILE_ADD_FILE and
 // fail ACCESS_DENIED there. Elevated tokens bypass the ACL; the precondition


### PR DESCRIPTION
## What

`Bun.Glob.scan({followSymlinks: true})` silently truncates results when an acyclic symlink chain is deeper than the kernel's per-resolution `MAXSYMLINKS` limit (40 on Linux, 32 on macOS), misclassifying the live directory link at the cutoff as a broken symlink.

## Repro

```js
// n0..n90, each nK holds fK.txt and next -> ../nK+1 (no cycle)
const root = fs.mkdtempSync(path.join(os.tmpdir(), 'eloop-'));
for (let i = 0; i <= 90; i++) {
  fs.mkdirSync(`${root}/n${i}`);
  fs.writeFileSync(`${root}/n${i}/f${i}.txt`, '');
  if (i < 90) fs.symlinkSync(`../n${i + 1}`, `${root}/n${i}/next`);
}
const cwd = `${root}/n0`;
[...new Bun.Glob('**/*.txt').scanSync({ cwd, followSymlinks: true })].length;
// 41  (find -L: 91)
[...new Bun.Glob('**').scanSync({ cwd, followSymlinks: true, throwErrorOnBrokenSymlink: true })];
// throws ELOOP on a healthy tree
```

## Cause

The Symlink work-item arm (and the Directory re-open in `transition_to_dir_iter_state`) open by the full accumulated logical path relative to the cwd fd:

```
openat(cwd_fd, "next/next/.../next", O_DIRECTORY)
```

so the kernel re-resolves every ancestor symlink on every open. Once a single path carries more than `MAXSYMLINKS` link components the open returns `ELOOP`, and the `Err` arm treats any non-`ENOTDIR` failure as a dangling link: results stop, `onlyFiles:false` yields the cutoff link as an entry, and `throwErrorOnBrokenSymlink` surfaces a bogus `ELOOP`. Parent-relative walkers (`find -L`, fts) never accumulate more than one link per open, so chain depth is unbounded.

## Fix

Keep a dup'd handle to each followed link's target directory on the ancestor chain (`link_anchors`, parallel to the existing `followed_links`) together with the logical-path prefix length it covers. `openat_anchored` opens the suffix past the deepest anchor relative to that handle, so each open resolves at most one symlink (the entry itself). Anchors are closed when the chain is truncated on pop and in `Iterator::drop`; the added fd footprint is bounded by the followed-link depth, not tree width.

## Verification

- New test `followSymlinks walks an acyclic symlink chain past the kernel's MAXSYMLINKS limit` builds a 90-deep `next -> ../nK+1` chain and asserts all 91 files are found, a real subdirectory at depth 50 is reachable, and `throwErrorOnBrokenSymlink` does not throw.
  - System bun: `expected 91, received 41`.
  - This build: pass.
- Existing `scan.test.ts` (195 tests), `test/js/node/fs/glob.test.ts`, related regressions and path-length tests all pass.
- 50-iteration fd-count probe with a 60-deep chain (full walk and early-break): delta 0.
- `rust:check-all` green on all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/glob/scan.test.ts

<!-- robobun:evidence:end -->