### PR TITLE
util.parseArgs: include leading '-' in unknown-option error for grouped short options

### DIFF
--- a/src/runtime/node/util/parse_args.rs
+++ b/src/runtime/node/util/parse_args.rs
@@ -117,7 +117,7 @@ impl fmt::Display for RawNameFormatter {
         let raw = self.raw;
         if let Some(optgroup_idx) = token.optgroup_idx {
             let i = optgroup_idx as usize;
-            raw.substring_with_len(i, i + 1).fmt(f)
+            write!(f, "-{}", raw.substring_with_len(i, i + 1))
         } else {
             match token.parse_type {
                 OptionParseType::LoneShortOption | OptionParseType::LoneLongOption => raw.fmt(f),

--- a/test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts
+++ b/test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { parseArgs } from "node:util";
+
+// The ERR_PARSE_ARGS_UNKNOWN_OPTION message for a short option that was reached via a
+// short-option group must include the leading '-', matching Node.js. Previously Bun emitted
+// "Unknown option 'x'" instead of "Unknown option '-x'".
+
+test("unknown short option inside a group: error message includes leading '-'", () => {
+  const args = ["-axb"];
+  const options = {
+    alpha: { type: "boolean", short: "a" },
+    beta: { type: "boolean", short: "b" },
+  } as const;
+
+  expect(() => parseArgs({ args, options })).toThrow(
+    expect.objectContaining({
+      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      message: "Unknown option '-x'",
+    }),
+  );
+
+  expect(() => parseArgs({ args, options, allowPositionals: true })).toThrow(
+    expect.objectContaining({
+      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      message:
+        "Unknown option '-x'. To specify a positional argument starting with a '-', " +
+        `place it at the end of the command after '--', as in '-- "-x"`,
+    }),
+  );
+});
+
+test("unknown short option from '-x=5' group path: error message includes leading '-'", () => {
+  const args = ["-x=5"];
+  const options = { xx: { type: "boolean", short: "x" } } as const;
+
+  expect(() => parseArgs({ args, options })).toThrow(
+    expect.objectContaining({
+      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      message: "Unknown option '-='",
+    }),
+  );
+});
+
+test("unknown lone short option: error message already includes leading '-' (baseline)", () => {
+  expect(() => parseArgs({ args: ["-w"], options: {} })).toThrow(
+    expect.objectContaining({
+      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      message: "Unknown option '-w'",
+    }),
+  );
+});

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -350,30 +350,6 @@ describe("parseArgs", () => {
     );
   });
 
-  test("unknown short option in group: error message includes leading '-'", () => {
-    const args = ["-axb"];
-    const options = { alpha: { type: "boolean", short: "a" }, beta: { type: "boolean", short: "b" } };
-    expectToThrowErrorMatching(() => parseArgs({ args, options }), {
-      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
-      message: "Unknown option '-x'",
-    });
-    expectToThrowErrorMatching(() => parseArgs({ args, options, allowPositionals: true }), {
-      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
-      message:
-        "Unknown option '-x'. To specify a positional argument starting with a '-', " +
-        `place it at the end of the command after '--', as in '-- "-x"`,
-    });
-  });
-
-  test("unknown short option from '-x=5': error message includes leading '-'", () => {
-    const args = ["-x=5"];
-    const options = { xx: { type: "boolean", short: "x" } };
-    expectToThrowErrorMatching(() => parseArgs({ args, options }), {
-      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
-      message: "Unknown option '-='",
-    });
-  });
-
   test("unknown option with explicit value", () => {
     const args = ["--foo", "--bar=baz"];
     const options = { foo: { type: "boolean" } };
@@ -1142,7 +1118,7 @@ describe("parseArgs extra tests", () => {
         Bun.gc();
       }
       expect(Object.keys(result.values)).toHaveLength(93);
-    }, 60_000);
+    });
   });
 
   test("undefined or null options", () => {

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -350,6 +350,30 @@ describe("parseArgs", () => {
     );
   });
 
+  test("unknown short option in group: error message includes leading '-'", () => {
+    const args = ["-axb"];
+    const options = { alpha: { type: "boolean", short: "a" }, beta: { type: "boolean", short: "b" } };
+    expectToThrowErrorMatching(() => parseArgs({ args, options }), {
+      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      message: "Unknown option '-x'",
+    });
+    expectToThrowErrorMatching(() => parseArgs({ args, options, allowPositionals: true }), {
+      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      message:
+        "Unknown option '-x'. To specify a positional argument starting with a '-', " +
+        `place it at the end of the command after '--', as in '-- "-x"`,
+    });
+  });
+
+  test("unknown short option from '-x=5': error message includes leading '-'", () => {
+    const args = ["-x=5"];
+    const options = { xx: { type: "boolean", short: "x" } };
+    expectToThrowErrorMatching(() => parseArgs({ args, options }), {
+      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      message: "Unknown option '-='",
+    });
+  });
+
   test("unknown option with explicit value", () => {
     const args = ["--foo", "--bar=baz"];
     const options = { foo: { type: "boolean" } };
@@ -1118,7 +1142,7 @@ describe("parseArgs extra tests", () => {
         Bun.gc();
       }
       expect(Object.keys(result.values)).toHaveLength(93);
-    });
+    }, 60_000);
   });
 
   test("undefined or null options", () => {


### PR DESCRIPTION
## What

For an unknown short option encountered inside a short-option group (or the `-x=val` group path), Bun's `ERR_PARSE_ARGS_UNKNOWN_OPTION` message dropped the leading `-`:

```js
import { parseArgs } from "node:util";
parseArgs({ args: ["-axb"], options: { alpha: { type: "boolean", short: "a" }, beta: { type: "boolean", short: "b" } } });
// node: Unknown option '-x'
// bun:  Unknown option 'x'

parseArgs({ args: ["-x=5"], options: { xx: { type: "boolean", short: "x" } } });
// node: Unknown option '-='
// bun:  Unknown option '='
```

The error class (`TypeError`) and code (`ERR_PARSE_ARGS_UNKNOWN_OPTION`) already matched; only the message text differed.

## Why

`RawNameFormatter::fmt` handled the `optgroup_idx` case by emitting just `raw[i..i+1]`, without the `-` prefix. The sibling `make_raw_name_js_value` (used for the `tokens` array) already did `"-" + raw[i..i+1]`; the error-message formatter was simply missing the same prefix.

## Fix

Prepend `-` in the `optgroup_idx` arm of `RawNameFormatter::fmt`.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts
1 pass, 2 fail  (Unknown option 'x' / '=')

$ bun bd test test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts
3 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts
bun test v1.4.0 (dc009f662)

test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts:
10 |   const options = {
11 |     alpha: { type: "boolean", short: "a" },
12 |     beta: { type: "boolean", short: "b" },
13 |   } as const;
14 | 
15 |   expect(() => parseArgs({ args, options })).toThrow(
                                                  ^
error: expect(received).toThrow(expected)

Expected value: ObjectContaining {
  code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
  message: "Unknown option '-x'",
}
Received value: 10 |   const options = {
11 |     alpha: { type: "boolean", short: "a" },
12 |     beta: { type: "boolean", short: "b" },
13 |   } as const;
14 | 
15 |   expect(() => parseArgs({ args, options })).toThrow(
                                                  ^
TypeError: Unknown option 'x'
 code: "ERR_PARSE_ARGS_UNKNOWN_OPTION"

      at <anonymous> (/workspace/bun/test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts:15:46)


     
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (dc009f662)

test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts:
10 |   const options = {
11 |     alpha: { type: "boolean", short: "a" },
12 |     beta: { type: "boolean", short: "b" },
13 |   } as const;
14 | 
15 |   expect(() => parseArgs({ args, options })).toThrow(
                                                  ^
error: expect(received).toThrow(expected)

Expected value: ObjectContaining {
  code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
  message: "Unknown option '-x'",
}
Received value: 10 |   const options = {
11 |     alpha: { type: "boolean", short: "a" },
12 |     beta: { type: "boolean", short: "b" },
13 |   } as const;
14 | 
15 |   expect(() => parseArgs({ args, options })).toThrow(
                                                  ^
TypeError: Unknown option 'x'
 code: "ERR_PARSE_ARGS_UNKNOWN_OPTION"

      at <anonymous> (/workspace/bun/test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts:15:46)


      at <anonymous> (/workspace/bun/test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts:15:46)
(fail) unknown short option inside a group: error message includes leading '-' [1.27m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts
bun test v1.4.0 (dc009f662)

test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts:
(pass) unknown short option inside a group: error message includes leading '-' [18.33ms]
(pass) unknown short option from '-x=5' group path: error message includes leading '-' [4.48ms]
(pass) unknown lone short option: error message already includes leading '-' (baseline) [3.09ms]

 3 pass
 0 fail
 4 expect() calls
Ran 3 tests across 1 file. [2.32s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 696ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 10s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+dc009f662
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (dc009f662)

test/js/node/util/parse_args/parse-args-unknown-option-message.test.ts:
(pass) unknown short option inside a group: error message includes leading '-' [0.75ms]
(pass) unknown short option from '-x=5' group path: error message includes leading '-' [0.06ms]
(pa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/util/parse_args.rs                |  2 +-
 .../parse-args-unknown-option-message.test.ts      | 51 ++++++++++++++++++++++
 2 files changed, 52 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/node/util/parse_args.rs                           1      1      0
…il/parse_args/parse-args-unknown-option-message.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->