### PR TITLE
util.parseArgs: match Node error code for `--no-<flag>=<value>` under allowNegative

### DIFF
--- a/src/runtime/node/util/parse_args.rs
+++ b/src/runtime/node/util/parse_args.rs
@@ -254,9 +254,26 @@ fn check_option_usage(
     global: &JSGlobalObject,
     options: &[OptionDefinition],
     allow_positionals: bool,
+    allow_negative: bool,
     token: &OptionToken,
 ) -> JsResult<()> {
-    if let Some(option_idx) = token.option_idx {
+    let mut option_idx = token.option_idx;
+    let mut option_name = token.name;
+
+    if option_idx.is_none() && allow_negative && !token.negative {
+        let name = token.name.as_bun_string(global)?;
+        if name.has_prefix_comptime(b"no-") {
+            let stripped = name.substring(3);
+            if let Some(idx) = find_option_by_long_name(stripped, options) {
+                if options[idx].r#type == OptionValueType::Boolean {
+                    option_idx = Some(idx);
+                    option_name = ValueRef::Bunstr(stripped);
+                }
+            }
+        }
+    }
+
+    if let Some(option_idx) = option_idx {
         let option = &options[option_idx];
         match option.r#type {
             OptionValueType::String => {
@@ -289,7 +306,7 @@ fn check_option_usage(
                             } else {
                                 ""
                             },
-                            token.name.as_bun_string(global)?,
+                            option_name.as_bun_string(global)?,
                         ),
                     );
                     return Err(global.throw_value(err));
@@ -312,7 +329,7 @@ fn check_option_usage(
                             } else {
                                 ""
                             },
-                            token.name.as_bun_string(global)?,
+                            option_name.as_bun_string(global)?,
                         ),
                     );
                     return Err(global.throw_value(err));
@@ -790,7 +807,13 @@ impl<'a> ParseArgsState<'a> {
         match &token_generic {
             Token::Option(token) => {
                 if self.strict {
-                    check_option_usage(global, self.option_defs, self.allow_positionals, token)?;
+                    check_option_usage(
+                        global,
+                        self.option_defs,
+                        self.allow_positionals,
+                        self.allow_negative,
+                        token,
+                    )?;
                     check_option_like_value(global, token)?;
                 }
                 store_option(

--- a/test/js/node/util/parse_args/parse-args-allow-negative.test.ts
+++ b/test/js/node/util/parse_args/parse-args-allow-negative.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { parseArgs } from "node:util";
+
+describe("parseArgs allowNegative with inline value", () => {
+  test("negated boolean option with inline value throws ERR_PARSE_ARGS_INVALID_OPTION_VALUE", () => {
+    const options = { foo: { type: "boolean" } } as const;
+    expect(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true })).toThrow(
+      expect.objectContaining({
+        code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
+        message: "Option '--foo' does not take an argument",
+      }),
+    );
+  });
+
+  test("negated boolean option with short alias includes the short in the message", () => {
+    const options = { foo: { type: "boolean", short: "f" } } as const;
+    expect(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true })).toThrow(
+      expect.objectContaining({
+        code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
+        message: "Option '-f, --foo' does not take an argument",
+      }),
+    );
+  });
+
+  test("negated string option with inline value stays ERR_PARSE_ARGS_UNKNOWN_OPTION", () => {
+    const options = { foo: { type: "string" } } as const;
+    expect(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true })).toThrow(
+      expect.objectContaining({ code: "ERR_PARSE_ARGS_UNKNOWN_OPTION" }),
+    );
+  });
+
+  test("without allowNegative, negated boolean with inline value stays ERR_PARSE_ARGS_UNKNOWN_OPTION", () => {
+    const options = { foo: { type: "boolean" } } as const;
+    expect(() => parseArgs({ args: ["--no-foo=bar"], options })).toThrow(
+      expect.objectContaining({ code: "ERR_PARSE_ARGS_UNKNOWN_OPTION" }),
+    );
+  });
+
+  test("strict:false emits token with unstripped name and stores value under no-foo", () => {
+    const options = { foo: { type: "boolean" } } as const;
+    const result = parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true, strict: false, tokens: true });
+    expect(result.values).toEqual({ __proto__: null, "no-foo": "bar" } as any);
+    expect(result.tokens).toEqual([
+      { kind: "option", name: "no-foo", rawName: "--no-foo", index: 0, value: "bar", inlineValue: true },
+    ]);
+  });
+});

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -423,29 +423,6 @@ describe("parseArgs", () => {
     );
   });
 
-  test("allowNegative: negated boolean option used with inline value", () => {
-    const options = { foo: { type: "boolean" } };
-    expectToThrowErrorMatching(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }), {
-      code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
-      message: "Option '--foo' does not take an argument",
-    });
-  });
-
-  test("allowNegative: negated boolean option with short used with inline value", () => {
-    const options = { foo: { type: "boolean", short: "f" } };
-    expectToThrowErrorMatching(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }), {
-      code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
-      message: "Option '-f, --foo' does not take an argument",
-    });
-  });
-
-  test("allowNegative: negated string option with inline value stays unknown", () => {
-    const options = { foo: { type: "string" } };
-    expectToThrowErrorMatching(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }), {
-      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
-    });
-  });
-
   test("invalid short option length", () => {
     const args = [];
     const options = { foo: { short: "fo", type: "boolean" } };

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -425,34 +425,25 @@ describe("parseArgs", () => {
 
   test("allowNegative: negated boolean option used with inline value", () => {
     const options = { foo: { type: "boolean" } };
-    expectToThrowErrorMatching(
-      () => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }),
-      {
-        code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
-        message: "Option '--foo' does not take an argument",
-      },
-    );
+    expectToThrowErrorMatching(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }), {
+      code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
+      message: "Option '--foo' does not take an argument",
+    });
   });
 
   test("allowNegative: negated boolean option with short used with inline value", () => {
     const options = { foo: { type: "boolean", short: "f" } };
-    expectToThrowErrorMatching(
-      () => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }),
-      {
-        code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
-        message: "Option '-f, --foo' does not take an argument",
-      },
-    );
+    expectToThrowErrorMatching(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }), {
+      code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
+      message: "Option '-f, --foo' does not take an argument",
+    });
   });
 
   test("allowNegative: negated string option with inline value stays unknown", () => {
     const options = { foo: { type: "string" } };
-    expectToThrowErrorMatching(
-      () => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }),
-      {
-        code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
-      },
-    );
+    expectToThrowErrorMatching(() => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }), {
+      code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+    });
   });
 
   test("invalid short option length", () => {

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -423,6 +423,38 @@ describe("parseArgs", () => {
     );
   });
 
+  test("allowNegative: negated boolean option used with inline value", () => {
+    const options = { foo: { type: "boolean" } };
+    expectToThrowErrorMatching(
+      () => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }),
+      {
+        code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
+        message: "Option '--foo' does not take an argument",
+      },
+    );
+  });
+
+  test("allowNegative: negated boolean option with short used with inline value", () => {
+    const options = { foo: { type: "boolean", short: "f" } };
+    expectToThrowErrorMatching(
+      () => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }),
+      {
+        code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE",
+        message: "Option '-f, --foo' does not take an argument",
+      },
+    );
+  });
+
+  test("allowNegative: negated string option with inline value stays unknown", () => {
+    const options = { foo: { type: "string" } };
+    expectToThrowErrorMatching(
+      () => parseArgs({ args: ["--no-foo=bar"], options, allowNegative: true }),
+      {
+        code: "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      },
+    );
+  });
+
   test("invalid short option length", () => {
     const args = [];
     const options = { foo: { short: "fo", type: "boolean" } };


### PR DESCRIPTION
With `allowNegative: true`, passing an inline value to a negated boolean option throws a different error than Node.

## Repro

```js
import { parseArgs } from "node:util";
try {
  parseArgs({ args: ["--no-c=x"], options: { c: { type: "boolean" } }, allowNegative: true });
} catch (e) {
  console.log(e.code, e.message);
}
```

Node v26.3.0:
```
ERR_PARSE_ARGS_INVALID_OPTION_VALUE Option '--c' does not take an argument
```

Bun before this change:
```
ERR_PARSE_ARGS_UNKNOWN_OPTION Unknown option '--no-c'
```

The plain `--no-c` form (no inline value) already matched Node (`{c: false}`).

## Cause

Node's `checkOptionUsage` resolves negation as a fallback: if the token name is not a known option but `allowNegative` is on and the name starts with `no-`, it strips the prefix and retries against the declared options; if the stripped name is a declared boolean, validation continues against that option and rejects the inline value with `ERR_PARSE_ARGS_INVALID_OPTION_VALUE`.

Bun's `check_option_usage` only looked at the pre-computed `option_idx`. For `--no-c=x` (the `LongOptionAndValue` path) that lookup is done on the literal `no-c`, so `option_idx` was `None` and the function went straight to `ERR_PARSE_ARGS_UNKNOWN_OPTION`.

## Fix

Mirror Node's fallback in `check_option_usage`: when `option_idx` is `None`, `allow_negative` is set, and the token name has a `no-` prefix (and negation was not already applied by the tokenizer), look up the stripped name. If it resolves to a declared boolean option, validate against that option so the inline value is rejected with the correct code and message (including the short alias, e.g. `Option '-C, --c' does not take an argument`).

## Verification

New tests in `test/js/node/util/parse_args/parse-args-allow-negative.test.ts` fail on the released binary and pass with this change. Also verified against Node v26.3.0 across adjacent cases (string-typed option stays `UNKNOWN_OPTION`, `allowNegative: false` unchanged, `strict: false` token output unchanged, `--no-no-c` stays `UNKNOWN_OPTION`, declared `no-*` options unaffected).
