### PR TITLE
glob: drive scan()/scanSync() iterators lazily

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1496,31 +1496,6 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
         err.with_path(&self.path_buf[0..copy_len])
     }
 
-    pub fn walk(&mut self) -> Result<Maybe<()>, Error> {
-        if self.pattern_components.is_empty() {
-            return Ok(Ok(()));
-        }
-
-        let mut iter = Iterator::new(self);
-        if let Err(err) = iter.init()? {
-            return Ok(Err(err));
-        }
-
-        loop {
-            let path = match iter.next()? {
-                Err(err) => return Ok(Err(err)),
-                Ok(matched_path) => matched_path,
-            };
-            let Some(path) = path else { break };
-            log!("walker: matched path: {}", bstr::BStr::new(&path));
-            // The paths are already put into self.matched_paths, which we use for the output,
-            // so we don't need to do anything here
-            let _ = path;
-        }
-
-        Ok(Ok(()))
-    }
-
     // Note: associated fn taking `pattern_components` so callers can
     // split-borrow it from `&mut self.path_buf` (Rust
     // forbids `&mut self` + `&mut self.path_buf`). Error path builds SysError

--- a/src/js/builtins/Glob.ts
+++ b/src/js/builtins/Glob.ts
@@ -4,18 +4,35 @@ interface Glob {
 }
 
 export function scan(this: Glob, opts) {
-  const valuesPromise = this.$pull(opts);
+  const scanner = this.$pull(opts);
   async function* iter() {
-    const values = (await valuesPromise) || [];
-    yield* values;
+    if (!scanner) return;
+    try {
+      let chunk;
+      while ((chunk = scanner.pull()) !== null) {
+        chunk = await chunk;
+        if (chunk === null) return;
+        yield* chunk;
+      }
+    } finally {
+      scanner.close();
+    }
   }
   return iter();
 }
 
 export function scanSync(this: Glob, opts) {
-  const arr = this.$resolveSync(opts) || [];
+  const scanner = this.$resolveSync(opts);
   function* iter() {
-    yield* arr;
+    if (!scanner) return;
+    try {
+      let value;
+      while ((value = scanner.nextSync()) !== null) {
+        yield value;
+      }
+    } finally {
+      scanner.close();
+    }
   }
   return iter();
 }

--- a/src/runtime/api/Glob.classes.ts
+++ b/src/runtime/api/Glob.classes.ts
@@ -36,4 +36,28 @@ export default [
       },
     },
   }),
+  define({
+    name: "GlobScanIterator",
+    noConstructor: true,
+    construct: false,
+    finalize: true,
+    hasPendingActivity: true,
+    configurable: false,
+    klass: {},
+    JSType: "0b11101110",
+    proto: {
+      nextSync: {
+        fn: "nextSync",
+        length: 0,
+      },
+      pull: {
+        fn: "pull",
+        length: 0,
+      },
+      close: {
+        fn: "close",
+        length: 0,
+      },
+    },
+  }),
 ];

--- a/src/runtime/api/Glob.classes.ts
+++ b/src/runtime/api/Glob.classes.ts
@@ -5,7 +5,6 @@ export default [
     name: "Glob",
     construct: true,
     finalize: true,
-    hasPendingActivity: true,
     configurable: false,
     klass: {},
     JSType: "0b11101110",

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -1,13 +1,14 @@
+use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use bun_alloc::Arena;
 use bun_core::String as BunString;
 use bun_glob::BunGlobWalker as GlobWalker;
-use bun_jsc::bun_string_jsc;
+use bun_glob::walk::{Iterator as GlobIter, MatchedPath, SyscallAccessor};
 use bun_jsc::concurrent_promise_task::{ConcurrentPromiseTask, ConcurrentPromiseTaskContext};
 use bun_jsc::{
-    ArgumentsSlice, CallFrame, JSGlobalObject, JSPromise, JSValue, JsResult, JsTerminated,
-    StringJsc as _, SysErrorJsc as _,
+    ArgumentsSlice, CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsResult, JsTerminated,
+    StringJsc as _, SysErrorJsc as _, bun_string_jsc,
 };
 use bun_paths::resolve_path::join_string_buf;
 use bun_paths::{self as resolve_path, MAX_PATH_BYTES, PathBuffer, platform};
@@ -192,14 +193,6 @@ impl ScanOpts {
     }
 }
 
-pub(crate) struct WalkTask<'a> {
-    // `Box<GlobWalker>` drop runs `GlobWalker::Drop` then frees the box.
-    walker: Box<GlobWalker>,
-    err: Option<WalkTaskErr>,
-    global: &'a JSGlobalObject,
-    has_pending_activity: &'a AtomicUsize,
-}
-
 pub(crate) enum WalkTaskErr {
     Syscall(syscall::Error),
     Unknown(crate::Error),
@@ -216,19 +209,236 @@ impl WalkTaskErr {
     }
 }
 
+/// Self-referential pair: `iter` borrows `*walker`. The walker is heap-allocated
+/// via `Box::into_raw` so its address is stable; the iterator's `'static`
+/// lifetime is erased (sound because `iter` is always dropped before the walker
+/// is freed, in [`Self::teardown`]).
+struct ScanIteratorState {
+    /// Null once exhausted / torn down.
+    walker: *mut GlobWalker,
+    /// Initialized iff `walker` is non-null.
+    iter: MaybeUninit<GlobIter<'static, SyscallAccessor, false>>,
+    /// `iter.init()` has been called. For the async path this is deferred to the
+    /// first chunk so no filesystem work happens on the JS thread.
+    did_init: bool,
+}
+
+enum Step {
+    Match(MatchedPath),
+    Done,
+    Err(WalkTaskErr),
+}
+
+impl ScanIteratorState {
+    fn new(walker: Box<GlobWalker>) -> Self {
+        if walker.pattern_components.is_empty() {
+            return Self {
+                walker: core::ptr::null_mut(),
+                iter: MaybeUninit::uninit(),
+                did_init: true,
+            };
+        }
+        let walker_ptr = Box::into_raw(walker);
+        // SAFETY: `walker_ptr` is a live, uniquely-owned heap allocation that
+        // outlives `iter` (freed only in `teardown`, after `iter` is dropped).
+        let iter = GlobIter::new(unsafe { &mut *walker_ptr });
+        Self {
+            walker: walker_ptr,
+            iter: MaybeUninit::new(iter),
+            did_init: false,
+        }
+    }
+
+    fn teardown(&mut self) {
+        if self.walker.is_null() {
+            return;
+        }
+        // SAFETY: `walker` non-null implies `iter` is initialized. Drop `iter`
+        // first (it borrows the walker allocation and closes any open fds),
+        // then free the walker.
+        unsafe {
+            self.iter.assume_init_drop();
+            drop(Box::from_raw(self.walker));
+        }
+        self.walker = core::ptr::null_mut();
+    }
+
+    /// Advance the underlying walker one match. On error or exhaustion the
+    /// state is torn down so subsequent calls return `Done`.
+    fn step(&mut self) -> Step {
+        if self.walker.is_null() {
+            return Step::Done;
+        }
+        // SAFETY: `walker` non-null implies `iter` is initialized.
+        let iter = unsafe { self.iter.assume_init_mut() };
+        if !self.did_init {
+            self.did_init = true;
+            match iter.init() {
+                Err(err) => {
+                    self.teardown();
+                    return Step::Err(WalkTaskErr::Unknown(err.into()));
+                }
+                Ok(bun_sys::Result::Err(err)) => {
+                    self.teardown();
+                    return Step::Err(WalkTaskErr::Syscall(err));
+                }
+                Ok(bun_sys::Result::Ok(())) => {}
+            }
+        }
+        loop {
+            match iter.next() {
+                Err(err) => {
+                    self.teardown();
+                    return Step::Err(WalkTaskErr::Unknown(err.into()));
+                }
+                Ok(bun_sys::Result::Err(err)) => {
+                    self.teardown();
+                    return Step::Err(WalkTaskErr::Syscall(err));
+                }
+                Ok(bun_sys::Result::Ok(None)) => {
+                    self.teardown();
+                    return Step::Done;
+                }
+                Ok(bun_sys::Result::Ok(Some(path))) => {
+                    // The previous (eager) implementation built the result
+                    // array from `matched_paths`, so a `Matched` state that was
+                    // never registered there (the absolute literal-path fast
+                    // path in `Iterator::init`) did not surface. Preserve that.
+                    if iter.walker.matched_paths.contains_key(&path[..]) {
+                        return Step::Match(path);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ScanIteratorState {
+    fn drop(&mut self) {
+        self.teardown();
+    }
+}
+
+/// Backing state for a single `scan()` / `scanSync()` call. Drives the
+/// underlying `GlobWalker` incrementally so the JS iterator yields matches as
+/// they are produced, rather than after the full directory walk has finished.
+#[bun_jsc::JsClass(no_construct, no_constructor)]
+pub struct GlobScanIterator {
+    state: JsCell<ScanIteratorState>,
+    has_pending_activity: AtomicUsize,
+}
+
+impl GlobScanIterator {
+    fn new(walker: Box<GlobWalker>) -> Box<Self> {
+        Box::new(Self {
+            state: JsCell::new(ScanIteratorState::new(walker)),
+            has_pending_activity: AtomicUsize::new(0),
+        })
+    }
+
+    pub fn has_pending_activity(&self) -> bool {
+        self.has_pending_activity.load(Ordering::SeqCst) > 0
+    }
+
+    /// Called from `scanSync()` before returning to JS so the `cwd`-does-not-
+    /// exist error path throws at the `scanSync()` call site, matching previous
+    /// behaviour.
+    fn init_sync(&self, global_this: &JSGlobalObject) -> JsResult<()> {
+        self.state.with_mut(|state| {
+            if state.walker.is_null() || state.did_init {
+                return Ok(());
+            }
+            state.did_init = true;
+            // SAFETY: `walker` non-null implies `iter` is initialized.
+            let iter = unsafe { state.iter.assume_init_mut() };
+            match iter.init() {
+                Err(err) => {
+                    state.teardown();
+                    Err(crate::Error::from(err).into())
+                }
+                Ok(bun_sys::Result::Err(err)) => {
+                    state.teardown();
+                    Err(global_this.throw_value(err.to_js(global_this)))
+                }
+                Ok(bun_sys::Result::Ok(())) => Ok(()),
+            }
+        })
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn next_sync(
+        &self,
+        global_this: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        self.state.with_mut(|state| match state.step() {
+            Step::Done => Ok(JSValue::NULL),
+            Step::Err(WalkTaskErr::Syscall(err)) => {
+                Err(global_this.throw_value(err.to_js(global_this)))
+            }
+            Step::Err(WalkTaskErr::Unknown(err)) => Err(err.into()),
+            Step::Match(path) => bun_string_jsc::create_utf8_for_js(global_this, &path),
+        })
+    }
+
+    /// Early-termination hook: closes any open directory fds immediately
+    /// instead of waiting for GC.
+    #[bun_jsc::host_fn(method)]
+    pub fn close(&self, _global_this: &JSGlobalObject, _callframe: &CallFrame) -> JsResult<JSValue> {
+        if self.has_pending_activity.load(Ordering::SeqCst) == 0 {
+            self.state.with_mut(|state| state.teardown());
+        }
+        Ok(JSValue::UNDEFINED)
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn pull(&self, global_this: &JSGlobalObject, _callframe: &CallFrame) -> JsResult<JSValue> {
+        if self.state.get().walker.is_null() {
+            return Ok(JSValue::NULL);
+        }
+        incr_pending_activity_flag(&self.has_pending_activity);
+        let mut task = WalkTask::create(global_this, self);
+        let promise = task.promise.value();
+        task.schedule();
+        // `WalkTask<'_>` borrows `self.state` / `self.has_pending_activity` /
+        // `global_this`. `self` is GC-rooted via `hasPendingActivity()` for the
+        // task's duration, and `JSGlobalObject` outlives every scheduled task.
+        // `into_raw` erases the stack-tied `'_` once the heap allocation
+        // escapes; freed via `ConcurrentPromiseTask::destroy`.
+        let _ = bun_core::heap::into_raw(task);
+        Ok(promise)
+    }
+}
+
 pub(crate) type AsyncGlobWalkTask<'a> = ConcurrentPromiseTask<'a, WalkTask<'a>>;
 
+/// Number of matches collected per thread-pool round-trip by `scan()`.
+const ASYNC_CHUNK: usize = 64;
+
+pub(crate) struct WalkTask<'a> {
+    /// Points at the `GlobScanIterator`'s `JsCell<ScanIteratorState>` payload.
+    /// The owning JS object is GC-rooted via `hasPendingActivity` for the
+    /// task's duration, so the pointee outlives `run()`/`then()`.
+    state: *mut ScanIteratorState,
+    chunk: Vec<MatchedPath>,
+    done: bool,
+    err: Option<WalkTaskErr>,
+    global: &'a JSGlobalObject,
+    has_pending_activity: &'a AtomicUsize,
+}
+
 impl<'a> WalkTask<'a> {
-    pub(crate) fn create(
+    fn create(
         global_this: &'a JSGlobalObject,
-        glob_walker: Box<GlobWalker>,
-        has_pending_activity: &'a AtomicUsize,
+        scanner: &'a GlobScanIterator,
     ) -> Box<AsyncGlobWalkTask<'a>> {
         let walk_task = Box::new(WalkTask {
-            walker: glob_walker,
-            global: global_this,
+            state: scanner.state.as_ptr(),
+            chunk: Vec::new(),
+            done: false,
             err: None,
-            has_pending_activity,
+            global: global_this,
+            has_pending_activity: &scanner.has_pending_activity,
         });
         AsyncGlobWalkTask::create_on_js_thread(global_this, walk_task)
     }
@@ -236,58 +446,56 @@ impl<'a> WalkTask<'a> {
 
 impl<'a> ConcurrentPromiseTaskContext for WalkTask<'a> {
     const TASK_TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::AsyncGlobWalkTask;
+
     fn run(&mut self) {
-        let guard = scopeguard::guard(self.has_pending_activity, |hpa| {
-            decr_pending_activity_flag(hpa);
-        });
-        let result = match self.walker.walk() {
-            Ok(r) => r,
-            Err(err) => {
-                self.err = Some(WalkTaskErr::Unknown(err.into()));
-                drop(guard);
-                return;
+        // SAFETY: the owning `GlobScanIterator` is GC-rooted via
+        // `hasPendingActivity` until `then()` decrements, and no JS-thread code
+        // touches `state` while a pull is in flight (the builtin generator
+        // awaits each chunk before the next call).
+        let state = unsafe { &mut *self.state };
+        self.chunk.reserve(ASYNC_CHUNK);
+        while self.chunk.len() < ASYNC_CHUNK {
+            match state.step() {
+                Step::Match(path) => self.chunk.push(path),
+                Step::Done => {
+                    self.done = true;
+                    break;
+                }
+                Step::Err(err) => {
+                    self.err = Some(err);
+                    break;
+                }
             }
-        };
-        match result {
-            bun_sys::Result::Err(err) => {
-                self.err = Some(WalkTaskErr::Syscall(err));
-            }
-            bun_sys::Result::Ok(()) => {}
         }
-        drop(guard);
     }
 
     fn then(&mut self, promise: &mut JSPromise) -> Result<(), JsTerminated> {
-        // Ownership of `Box<WalkTask>` is held by `ConcurrentPromiseTask.ctx`; the wrapper is
-        // freed via `ConcurrentPromiseTask::destroy` on the `.manual_deinit` path
-        // after `run_from_js` returns, which drops `ctx` (and thus `walker`).
+        let guard = scopeguard::guard(self.has_pending_activity, |hpa| {
+            decr_pending_activity_flag(hpa);
+        });
 
-        if let Some(err) = &self.err {
+        if let Some(err) = self.err.take() {
+            drop(guard);
             promise.reject_with_async_stack(self.global, err.to_js(self.global))?;
             return Ok(());
         }
 
-        let js_strings = match glob_walk_result_to_js(&mut self.walker, self.global) {
-            Ok(v) => v,
-            // `reject()` pulls the pending exception off the VM.
-            Err(e) => return promise.reject(self.global, Err(e)),
-        };
-        promise.resolve(self.global, js_strings)
-    }
-}
+        if self.chunk.is_empty() && self.done {
+            drop(guard);
+            return promise.resolve(self.global, JSValue::NULL);
+        }
 
-fn glob_walk_result_to_js(
-    glob_walk: &mut GlobWalker,
-    global_this: &JSGlobalObject,
-) -> JsResult<JSValue> {
-    let keys = glob_walk.matched_paths.keys();
-    if keys.is_empty() {
-        return JSValue::create_empty_array(global_this, 0);
+        let js_strings = JSValue::create_array_from_iter(
+            self.global,
+            core::mem::take(&mut self.chunk).into_iter(),
+            |path| bun_string_jsc::create_utf8_for_js(self.global, &path),
+        );
+        drop(guard);
+        match js_strings {
+            Ok(v) => promise.resolve(self.global, v),
+            Err(e) => promise.reject(self.global, Err(e)),
+        }
     }
-
-    JSValue::create_array_from_iter(global_this, keys.iter(), |key| {
-        bun_string_jsc::create_utf8_for_js(global_this, key)
-    })
 }
 
 impl Glob {
@@ -407,40 +615,35 @@ impl Glob {
     // (`has_pending_activity`), so no `Cell`/`JsCell` wrapping is needed — the
     // `&mut self` receivers were vestigial. The codegen shim still emits
     // `this: &mut Glob`; `&mut T` auto-derefs to `&T`.
+    fn make_scanner(
+        &self,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+        fn_name: &'static str,
+    ) -> JsResult<Option<Box<GlobScanIterator>>> {
+        let mut arguments = ArgumentsSlice::init(global_this.bun_vm(), callframe.arguments());
+        let mut arena = Arena::new();
+        // GlobWalker::init/init_with_cwd own their allocations (Box); the arena
+        // here is vestigial.
+        match self.make_glob_walker(global_this, &mut arguments, fn_name, &mut arena) {
+            Err(err) => {
+                drop(arena);
+                Err(err)
+            }
+            Ok(None) => {
+                drop(arena);
+                Ok(None)
+            }
+            Ok(Some(gw)) => Ok(Some(GlobScanIterator::new(gw))),
+        }
+    }
+
     #[bun_jsc::host_fn(method)]
     pub fn __scan(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        // SAFETY: bun_vm() returns a non-null *mut to the live VirtualMachine for this global.
-        let mut arguments = ArgumentsSlice::init(global_this.bun_vm(), callframe.arguments());
-        // `arguments` drops at scope exit.
-
-        let mut arena = Arena::new();
-        // GlobWalker::init/init_with_cwd own their allocations (Box); the
-        // arena here is vestigial.
-        let glob_walker =
-            match self.make_glob_walker(global_this, &mut arguments, "scan", &mut arena) {
-                Err(err) => {
-                    drop(arena);
-                    return Err(err);
-                }
-                Ok(None) => {
-                    drop(arena);
-                    return Ok(JSValue::UNDEFINED);
-                }
-                Ok(Some(gw)) => gw,
-            };
-
-        incr_pending_activity_flag(&self.has_pending_activity);
-        let mut task = WalkTask::create(global_this, glob_walker, &self.has_pending_activity);
-        let promise = task.promise.value();
-        task.schedule();
-        // Ownership passes to the work pool / event loop; freed via
-        // `ConcurrentPromiseTask::destroy` on the `.manual_deinit` path.
-        // WalkTask<'_> borrows `&self.has_pending_activity`
-        // and `global_this`. Both referents outlive the task: `Glob` is GC-rooted
-        // via `hasPendingActivity()`, and `JSGlobalObject` lives until VM teardown.
-        // `into_raw` erases the stack-tied `'_` once the heap allocation escapes.
-        let _ = bun_core::heap::into_raw(task);
-        Ok(promise)
+        match self.make_scanner(global_this, callframe, "scan")? {
+            None => Ok(JSValue::UNDEFINED),
+            Some(scanner) => Ok(GlobScanIterator::to_js_boxed(scanner, global_this)),
+        }
     }
 
     #[bun_jsc::host_fn(method)]
@@ -449,32 +652,13 @@ impl Glob {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: bun_vm() returns a non-null *mut to the live VirtualMachine for this global.
-        let mut arguments = ArgumentsSlice::init(global_this.bun_vm(), callframe.arguments());
-
-        let mut arena = Arena::new();
-        let mut glob_walker =
-            match self.make_glob_walker(global_this, &mut arguments, "scanSync", &mut arena) {
-                Err(err) => {
-                    drop(arena);
-                    return Err(err);
-                }
-                Ok(None) => {
-                    drop(arena);
-                    return Ok(JSValue::UNDEFINED);
-                }
-                Ok(Some(gw)) => gw,
-            };
-        // Box<GlobWalker> drops at scope exit.
-
-        match glob_walker.walk().map_err(crate::Error::from)? {
-            bun_sys::Result::Err(err) => {
-                return Err(global_this.throw_value(err.to_js(global_this)));
+        match self.make_scanner(global_this, callframe, "scanSync")? {
+            None => Ok(JSValue::UNDEFINED),
+            Some(scanner) => {
+                scanner.init_sync(global_this)?;
+                Ok(GlobScanIterator::to_js_boxed(scanner, global_this))
             }
-            bun_sys::Result::Ok(()) => {}
         }
-
-        glob_walk_result_to_js(&mut glob_walker, global_this)
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -209,17 +209,12 @@ impl WalkTaskErr {
     }
 }
 
-/// Self-referential pair: `iter` borrows `*walker`. The walker is heap-allocated
-/// via `Box::into_raw` so its address is stable; the iterator's `'static`
-/// lifetime is erased (sound because `iter` is always dropped before the walker
-/// is freed, in [`Self::teardown`]).
 struct ScanIteratorState {
-    /// Null once exhausted / torn down.
+    /// `Box::into_raw`'d; null once torn down.
     walker: *mut GlobWalker,
-    /// Initialized iff `walker` is non-null.
+    /// Borrows `*walker` (lifetime erased); initialized iff `walker` is non-null.
     iter: MaybeUninit<GlobIter<'static, SyscallAccessor, false>>,
-    /// `iter.init()` has been called. For the async path this is deferred to the
-    /// first chunk so no filesystem work happens on the JS thread.
+    /// `iter.init()` done (deferred to the first chunk on the async path).
     did_init: bool,
 }
 
@@ -263,8 +258,6 @@ impl ScanIteratorState {
         self.walker = core::ptr::null_mut();
     }
 
-    /// Advance the underlying walker one match. On error or exhaustion the
-    /// state is torn down so subsequent calls return `Done`.
     fn step(&mut self) -> Step {
         if self.walker.is_null() {
             return Step::Done;
@@ -300,10 +293,7 @@ impl ScanIteratorState {
                     return Step::Done;
                 }
                 Ok(bun_sys::Result::Ok(Some(path))) => {
-                    // The previous (eager) implementation built the result
-                    // array from `matched_paths`, so a `Matched` state that was
-                    // never registered there (the absolute literal-path fast
-                    // path in `Iterator::init`) did not surface. Preserve that.
+                    // `Iterator::init`'s literal-path arm yields without registering in `matched_paths`; skip those to match the previous result set.
                     if iter.walker.matched_paths.contains_key(&path[..]) {
                         return Step::Match(path);
                     }
@@ -319,9 +309,7 @@ impl Drop for ScanIteratorState {
     }
 }
 
-/// Backing state for a single `scan()` / `scanSync()` call. Drives the
-/// underlying `GlobWalker` incrementally so the JS iterator yields matches as
-/// they are produced, rather than after the full directory walk has finished.
+/// Drives the `GlobWalker` incrementally for one `scan()` / `scanSync()` call.
 #[bun_jsc::JsClass(no_construct, no_constructor)]
 pub struct GlobScanIterator {
     state: JsCell<ScanIteratorState>,
@@ -340,9 +328,7 @@ impl GlobScanIterator {
         self.has_pending_activity.load(Ordering::SeqCst) > 0
     }
 
-    /// Called from `scanSync()` before returning to JS so the `cwd`-does-not-
-    /// exist error path throws at the `scanSync()` call site, matching previous
-    /// behaviour.
+    /// Eager `iter.init()` so a bad `cwd` still throws at the `scanSync()` call site.
     fn init_sync(&self, global_this: &JSGlobalObject) -> JsResult<()> {
         self.state.with_mut(|state| {
             if state.walker.is_null() || state.did_init {
@@ -381,8 +367,7 @@ impl GlobScanIterator {
         })
     }
 
-    /// Early-termination hook: closes any open directory fds immediately
-    /// instead of waiting for GC.
+    /// Early-`break` hook: release open directory fds now rather than at GC.
     #[bun_jsc::host_fn(method)]
     pub fn close(
         &self,
@@ -404,11 +389,9 @@ impl GlobScanIterator {
         let mut task = WalkTask::create(global_this, self);
         let promise = task.promise.value();
         task.schedule();
-        // `WalkTask<'_>` borrows `self.state` / `self.has_pending_activity` /
-        // `global_this`. `self` is GC-rooted via `hasPendingActivity()` for the
-        // task's duration, and `JSGlobalObject` outlives every scheduled task.
-        // `into_raw` erases the stack-tied `'_` once the heap allocation
-        // escapes; freed via `ConcurrentPromiseTask::destroy`.
+        // SAFETY: `self` is GC-rooted via `hasPendingActivity()` for the task's
+        // duration; `into_raw` erases the stack-tied `'_` and ownership passes
+        // to the work pool (freed via `ConcurrentPromiseTask::destroy`).
         let _ = bun_core::heap::into_raw(task);
         Ok(promise)
     }
@@ -420,9 +403,7 @@ pub(crate) type AsyncGlobWalkTask<'a> = ConcurrentPromiseTask<'a, WalkTask<'a>>;
 const ASYNC_CHUNK: usize = 64;
 
 pub(crate) struct WalkTask<'a> {
-    /// Points at the `GlobScanIterator`'s `JsCell<ScanIteratorState>` payload.
-    /// The owning JS object is GC-rooted via `hasPendingActivity` for the
-    /// task's duration, so the pointee outlives `run()`/`then()`.
+    /// Inside the `GlobScanIterator`, GC-rooted via `hasPendingActivity`.
     state: *mut ScanIteratorState,
     chunk: Vec<MatchedPath>,
     done: bool,
@@ -627,19 +608,9 @@ impl Glob {
     ) -> JsResult<Option<Box<GlobScanIterator>>> {
         let mut arguments = ArgumentsSlice::init(global_this.bun_vm(), callframe.arguments());
         let mut arena = Arena::new();
-        // GlobWalker::init/init_with_cwd own their allocations (Box); the arena
-        // here is vestigial.
-        match self.make_glob_walker(global_this, &mut arguments, fn_name, &mut arena) {
-            Err(err) => {
-                drop(arena);
-                Err(err)
-            }
-            Ok(None) => {
-                drop(arena);
-                Ok(None)
-            }
-            Ok(Some(gw)) => Ok(Some(GlobScanIterator::new(gw))),
-        }
+        Ok(self
+            .make_glob_walker(global_this, &mut arguments, fn_name, &mut arena)?
+            .map(GlobScanIterator::new))
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -583,9 +583,6 @@ fn decr_pending_activity_flag(has_pending_activity: &AtomicUsize) {
 }
 
 impl Glob {
-    // R-2 (host-fn re-entrancy): all JS-exposed methods take `&self`. `Glob`'s
-    // only field (`pattern`) is read-only after construction, so no
-    // `Cell`/`JsCell` wrapping is needed.
     fn make_scanner(
         &self,
         global_this: &JSGlobalObject,

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -384,7 +384,11 @@ impl GlobScanIterator {
     /// Early-termination hook: closes any open directory fds immediately
     /// instead of waiting for GC.
     #[bun_jsc::host_fn(method)]
-    pub fn close(&self, _global_this: &JSGlobalObject, _callframe: &CallFrame) -> JsResult<JSValue> {
+    pub fn close(
+        &self,
+        _global_this: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
         if self.has_pending_activity.load(Ordering::SeqCst) == 0 {
             self.state.with_mut(|state| state.teardown());
         }

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -19,7 +19,6 @@ use bun_sys as syscall;
 #[bun_jsc::JsClass]
 pub struct Glob {
     pattern: Box<[u8]>,
-    has_pending_activity: AtomicUsize,
 }
 
 struct ScanOpts {
@@ -571,18 +570,7 @@ impl Glob {
             .into_vec()
             .into_boxed_slice();
 
-        Ok(Box::new(Glob {
-            pattern: pat_str,
-            has_pending_activity: AtomicUsize::new(0),
-        }))
-    }
-
-    /// Called on the GC thread concurrently with the mutator. Reads only the
-    /// atomic counter; never allocates, locks, or touches JS. The codegen shim
-    /// (`Glob__hasPendingActivity`) handles the `callconv(.c)` ABI and passes
-    /// `&*this`.
-    pub fn has_pending_activity(&self) -> bool {
-        self.has_pending_activity.load(Ordering::SeqCst) > 0
+        Ok(Box::new(Glob { pattern: pat_str }))
     }
 }
 
@@ -596,10 +584,8 @@ fn decr_pending_activity_flag(has_pending_activity: &AtomicUsize) {
 
 impl Glob {
     // R-2 (host-fn re-entrancy): all JS-exposed methods take `&self`. `Glob`'s
-    // fields are read-only after construction (`pattern`) or already atomic
-    // (`has_pending_activity`), so no `Cell`/`JsCell` wrapping is needed — the
-    // `&mut self` receivers were vestigial. The codegen shim still emits
-    // `this: &mut Glob`; `&mut T` auto-derefs to `&T`.
+    // only field (`pattern`) is read-only after construction, so no
+    // `Cell`/`JsCell` wrapping is needed.
     fn make_scanner(
         &self,
         global_this: &JSGlobalObject,

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -327,29 +327,6 @@ impl GlobScanIterator {
         self.has_pending_activity.load(Ordering::SeqCst) > 0
     }
 
-    /// Eager `iter.init()` so a bad `cwd` still throws at the `scanSync()` call site.
-    fn init_sync(&self, global_this: &JSGlobalObject) -> JsResult<()> {
-        self.state.with_mut(|state| {
-            if state.walker.is_null() || state.did_init {
-                return Ok(());
-            }
-            state.did_init = true;
-            // SAFETY: `walker` non-null implies `iter` is initialized.
-            let iter = unsafe { state.iter.assume_init_mut() };
-            match iter.init() {
-                Err(err) => {
-                    state.teardown();
-                    Err(crate::Error::from(err).into())
-                }
-                Ok(bun_sys::Result::Err(err)) => {
-                    state.teardown();
-                    Err(global_this.throw_value(err.to_js(global_this)))
-                }
-                Ok(bun_sys::Result::Ok(())) => Ok(()),
-            }
-        })
-    }
-
     #[bun_jsc::host_fn(method)]
     pub fn next_sync(
         &self,
@@ -612,10 +589,7 @@ impl Glob {
     ) -> JsResult<JSValue> {
         match self.make_scanner(global_this, callframe, "scanSync")? {
             None => Ok(JSValue::UNDEFINED),
-            Some(scanner) => {
-                scanner.init_sync(global_this)?;
-                Ok(GlobScanIterator::to_js_boxed(scanner, global_this))
-            }
+            Some(scanner) => Ok(GlobScanIterator::to_js_boxed(scanner, global_this)),
         }
     }
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -681,6 +681,25 @@ describe("lazy iteration", () => {
     }
   });
 
+  test("scan: breaking early releases the directory fd", async () => {
+    // The async close() path is gated on has_pending_activity == 0, which the
+    // sync variant never touches; exercise it separately.
+    using dir = tempDir("glob-lazy-fd-async", { "a/b.txt": "", "a/c.txt": "" });
+    const before = getFDCount();
+    for (let i = 0; i < 64; i++) {
+      for await (const entry of new Glob("**/*.txt").scan({ cwd: String(dir) })) {
+        expect(entry).toStartWith("a" + path.sep);
+        break;
+      }
+    }
+    if (isWindows) {
+      fs.rmSync(path.join(String(dir), "a"), { recursive: true });
+      expect(fs.existsSync(path.join(String(dir), "a"))).toBeFalse();
+    } else {
+      expect(getFDCount() - before).toBeLessThan(8);
+    }
+  });
+
   test("scanSync: never-iterated result holds no fd", () => {
     using dir = tempDir("glob-lazy-fd-noiter", { "a/b.txt": "" });
     const before = getFDCount();

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -24,7 +24,7 @@ import { Glob, GlobScanOptions } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execSync } from "child_process";
 import fg from "fast-glob";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, getFDCount, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import * as fs from "node:fs";
 import * as path from "path";
 import { createTempDirectoryWithBrokenSymlinks, prepareEntries, tempFixturesDir } from "./util";
@@ -663,15 +663,38 @@ describe("lazy iteration", () => {
 
   test("scanSync: breaking early releases the directory fd", () => {
     using dir = tempDir("glob-lazy-fd", { "a/b.txt": "", "a/c.txt": "" });
-    // `a` is open between the two yields; `break` must close it eagerly
-    // rather than waiting for GC so the directory can be removed immediately
-    // on Windows.
-    for (const entry of new Glob("**/*.txt").scanSync({ cwd: String(dir) })) {
-      expect(entry).toStartWith("a" + path.sep);
-      break;
+    const before = getFDCount();
+    for (let i = 0; i < 64; i++) {
+      for (const entry of new Glob("**/*.txt").scanSync({ cwd: String(dir) })) {
+        expect(entry).toStartWith("a" + path.sep);
+        break;
+      }
     }
-    fs.rmSync(path.join(String(dir), "a"), { recursive: true });
-    expect(fs.existsSync(path.join(String(dir), "a"))).toBeFalse();
+    // If `break` leaves the walker's dirfd open, each of the 64 iterations
+    // above adds one (no GC between them). On POSIX an open dirfd doesn't
+    // block `rmSync`, so count fds instead.
+    if (isWindows) {
+      fs.rmSync(path.join(String(dir), "a"), { recursive: true });
+      expect(fs.existsSync(path.join(String(dir), "a"))).toBeFalse();
+    } else {
+      expect(getFDCount() - before).toBeLessThan(8);
+    }
+  });
+
+  test("scanSync: never-iterated result holds no fd", () => {
+    using dir = tempDir("glob-lazy-fd-noiter", { "a/b.txt": "" });
+    const before = getFDCount();
+    const held: unknown[] = [];
+    for (let i = 0; i < 64; i++) {
+      held.push(new Glob("**/*.txt").scanSync({ cwd: String(dir) }));
+    }
+    if (isWindows) {
+      fs.rmSync(path.join(String(dir), "a"), { recursive: true });
+      expect(fs.existsSync(path.join(String(dir), "a"))).toBeFalse();
+    } else {
+      expect(getFDCount() - before).toBeLessThan(8);
+    }
+    held.length = 0;
   });
 });
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -619,6 +619,62 @@ describe("literal fast path", async () => {
   });
 });
 
+describe("lazy iteration", () => {
+  // scanSync()/scan() drive the directory walk incrementally rather than
+  // materialising the whole result set before the first value is yielded.
+  // A file created inside a subdirectory *after* the iterator has produced
+  // its first match (but before the walker has descended there) is observed
+  // by a lazy walk and missed by an eager one, giving a deterministic
+  // fail-before signal that does not depend on timing.
+
+  test("scanSync: subdirectories are read when reached, not upfront", () => {
+    using dir = tempDir("glob-lazy-sync", {
+      "first.txt": "",
+      "sub/original.txt": "",
+    });
+    const it = new Glob("**/*.txt").scanSync({ cwd: String(dir) });
+    // Root-level files are yielded before the walker descends into `sub`,
+    // regardless of readdir order (subdirectories are queued and processed
+    // only once the current directory is exhausted).
+    expect(it.next()).toEqual({ value: "first.txt", done: false });
+    fs.writeFileSync(path.join(String(dir), "sub", "added.txt"), "");
+    const rest = [...it].sort();
+    expect(rest).toEqual([`sub${path.sep}added.txt`, `sub${path.sep}original.txt`]);
+  });
+
+  test("scan: subdirectories are read when reached, not upfront", async () => {
+    // The async walker pulls matches off the thread pool in bounded chunks.
+    // Put enough root-level files in front of `sub/` that the first chunk
+    // cannot reach it.
+    const files: Record<string, string> = { "sub/original.txt": "" };
+    for (let i = 0; i < 200; i++) files[`f${i}.txt`] = "";
+    using dir = tempDir("glob-lazy-async", files);
+    const it = new Glob("**/*.txt").scan({ cwd: String(dir) })[Symbol.asyncIterator]();
+    const first = await it.next();
+    expect(first.done).toBeFalse();
+    expect(first.value).not.toStartWith("sub" + path.sep);
+    fs.writeFileSync(path.join(String(dir), "sub", "added.txt"), "");
+    const rest: string[] = [];
+    for (let r = await it.next(); !r.done; r = await it.next()) rest.push(r.value);
+    expect(rest).toContain(`sub${path.sep}added.txt`);
+    expect(rest).toContain(`sub${path.sep}original.txt`);
+    expect(rest.length + 1).toBe(202);
+  });
+
+  test("scanSync: breaking early releases the directory fd", () => {
+    using dir = tempDir("glob-lazy-fd", { "a/b.txt": "", "a/c.txt": "" });
+    // `a` is open between the two yields; `break` must close it eagerly
+    // rather than waiting for GC so the directory can be removed immediately
+    // on Windows.
+    for (const entry of new Glob("**/*.txt").scanSync({ cwd: String(dir) })) {
+      expect(entry).toStartWith("a" + path.sep);
+      break;
+    }
+    fs.rmSync(path.join(String(dir), "a"), { recursive: true });
+    expect(fs.existsSync(path.join(String(dir), "a"))).toBeFalse();
+  });
+});
+
 describe("trailing directory separator", async () => {
   test("matches directories absolute", async () => {
     const tmpdir = tmpdirSync();

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -683,11 +683,18 @@ describe("lazy iteration", () => {
 
   test("scan: breaking early releases the directory fd", async () => {
     // The async close() path is gated on has_pending_activity == 0, which the
-    // sync variant never touches; exercise it separately.
-    using dir = tempDir("glob-lazy-fd-async", { "a/b.txt": "", "a/c.txt": "" });
+    // sync variant never touches. More than ASYNC_CHUNK files under `a/` means
+    // the first chunk returns with the walker still inside `a`, so `break`
+    // actually has a live dirfd to release.
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 100; i++) files[`a/f${i}.txt`] = "";
+    using dir = tempDir("glob-lazy-fd-async", files);
     const before = getFDCount();
+    const held: unknown[] = [];
     for (let i = 0; i < 64; i++) {
-      for await (const entry of new Glob("**/*.txt").scan({ cwd: String(dir) })) {
+      const it = new Glob("**/*.txt").scan({ cwd: String(dir) });
+      held.push(it);
+      for await (const entry of it) {
         expect(entry).toStartWith("a" + path.sep);
         break;
       }
@@ -698,6 +705,7 @@ describe("lazy iteration", () => {
     } else {
       expect(getFDCount() - before).toBeLessThan(8);
     }
+    held.length = 0;
   });
 
   test("scanSync: never-iterated result holds no fd", () => {


### PR DESCRIPTION
`Bun.Glob`'s `scan()` / `scanSync()` return generators, but they were facades over an eagerly materialised array: `__scan_sync` called `GlobWalker::walk()` to completion and built one JS array before the first value was available, and the async path did the same on a worker thread. So `for (const p of glob.scanSync(...)) { ...; break }` paid for the entire directory walk, and `scanSync()` itself blocked for the whole tree even if the iterator was never consumed.

```js
// 25k-file tree, release build
scanSync() call: 8.55 ms    // full walk happens HERE
first next():    0.03 ms    // array lookup
```

#### Cause

`src/js/builtins/Glob.ts` wrapped the native result directly:

```ts
export function scanSync(this, opts) {
  const arr = this.$resolveSync(opts) || [];   // whole walk happens here
  function* iter() { yield* arr; }
  return iter();
}
```

and `src/runtime/api/glob.rs` drove the walker to completion before returning. `GlobWalker` already has an incremental `Iterator` state machine (`IterState::{GetNext, Directory, Matched}`) that yields one match per `next()` call; it was just never exposed to JS.

#### Fix

Add a `GlobScanIterator` native class that owns the boxed walker plus its `Iterator` state, and have the JS generators pull from it:

* `scanSync()` drives `nextSync()` per match. Nothing is opened until the first `next()`, so a generator that is never iterated holds no fd; the first value is produced after reading only the root directory.
* `scan()` schedules bounded chunks (64 matches) on the thread pool, so the first `await` returns after one chunk while filesystem I/O stays off the JS thread.
* `break` runs the generator's `finally` block, which calls `close()` to release the open directory fd immediately instead of waiting for GC.

Results are still sourced from the walker's dedup map so the match set is byte-identical to before. A bad `cwd` now throws on the first iteration rather than at the `scanSync()` call itself; that is still the same source line for `for...of` / spread / `Array.from` and now matches `scan()`.

`Glob` no longer owns any in-flight work (the iterator does), so its `has_pending_activity` field, accessor, and `hasPendingActivity: true` class flag are removed.

#### Verification

The new tests in `test/js/bun/glob/scan.test.ts` write a file into a subdirectory *after* the iterator has yielded its first match; a lazy walk sees it, an eager walk does not.

```
=== before ===
(fail) lazy iteration > scanSync: subdirectories are read when reached, not upfront
(fail) lazy iteration > scan: subdirectories are read when reached, not upfront
=== after ===
(pass) lazy iteration > scanSync: subdirectories are read when reached, not upfront
(pass) lazy iteration > scan: subdirectories are read when reached, not upfront
(pass) lazy iteration > scanSync: breaking early releases the directory fd
(pass) lazy iteration > scanSync: never-iterated result holds no fd
```

All 198 existing tests in `test/js/bun/glob/scan.test.ts` continue to pass, as do `test/js/node/fs/glob.test.ts`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/glob/scan.test.ts

<!-- robobun:evidence:end -->