### PR TITLE
http: send RFC 7617 Proxy-Authorization when either proxy URL username or password is empty

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -108,7 +108,7 @@ fn http_thread_timer_read() -> u64 {
     crate::http_thread().timer.elapsed().as_nanos() as u64
 }
 
-/// Build the `Proxy-Authorization: Basic <b64(user[:pass])>` header value.
+/// Build the `Proxy-Authorization: Basic <b64(user:pass)>` header value.
 /// Returns `None` (and logs) if percent-decoding fails.
 pub(crate) fn build_proxy_authorization(proxy: &URL<'_>) -> Option<Vec<u8>> {
     if proxy.username.is_empty() {
@@ -123,24 +123,19 @@ pub(crate) fn build_proxy_authorization(proxy: &URL<'_>) -> Option<Vec<u8>> {
         }
     };
 
-    let auth: Vec<u8> = if !proxy.password.is_empty() {
-        let password = match PercentEncoding::decode_alloc(proxy.password) {
-            Ok(p) => p,
-            Err(err) => {
-                bun_core::scoped_log!(AsyncHTTP, "failed to decode proxy password: {:?}", err);
-                return None;
-            }
-        };
-        // concat user and password
-        let mut auth: Vec<u8> = Vec::with_capacity(username.len() + 1 + password.len());
-        auth.extend_from_slice(&username);
-        auth.push(b':');
-        auth.extend_from_slice(&password);
-        auth
-    } else {
-        // only use user
-        username.into_vec()
+    let password = match PercentEncoding::decode_alloc(proxy.password) {
+        Ok(p) => p,
+        Err(err) => {
+            bun_core::scoped_log!(AsyncHTTP, "failed to decode proxy password: {:?}", err);
+            return None;
+        }
     };
+    // RFC 7617: credentials are `user-id ":" password` even when password is
+    // empty, so always emit the colon (matches curl).
+    let mut auth: Vec<u8> = Vec::with_capacity(username.len() + 1 + password.len());
+    auth.extend_from_slice(&username);
+    auth.push(b':');
+    auth.extend_from_slice(&password);
 
     let size = bun_base64::encode_len_from_size(auth.len());
     let mut buf = vec![0u8; size + b"Basic ".len()];

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -111,7 +111,7 @@ fn http_thread_timer_read() -> u64 {
 /// Build the `Proxy-Authorization: Basic <b64(user:pass)>` header value.
 /// Returns `None` (and logs) if percent-decoding fails.
 pub(crate) fn build_proxy_authorization(proxy: &URL<'_>) -> Option<Vec<u8>> {
-    if proxy.username.is_empty() {
+    if proxy.username.is_empty() && proxy.password.is_empty() {
         return None;
     }
 

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -130,8 +130,6 @@ pub(crate) fn build_proxy_authorization(proxy: &URL<'_>) -> Option<Vec<u8>> {
             return None;
         }
     };
-    // RFC 7617: credentials are `user-id ":" password` even when password is
-    // empty, so always emit the colon (matches curl).
     let mut auth: Vec<u8> = Vec::with_capacity(username.len() + 1 + password.len());
     auth.extend_from_slice(&username);
     auth.push(b':');

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -536,7 +536,11 @@ describe.each([
     const proxy = await createAuthCapturingProxy();
     try {
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", `process.exitCode = (await fetch(${JSON.stringify(String(httpServer.url))})).status === 200 ? 0 : 1;`],
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.exitCode = (await fetch(${JSON.stringify(String(httpServer.url))})).status === 200 ? 0 : 1;`,
+        ],
         env: {
           ...bunEnv,
           NO_PROXY: "",

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -519,15 +519,16 @@ test("proxy with long password (> 4096 chars) works correctly after redirect", a
 });
 
 // RFC 7617: the Basic credential is always `user-id ":" password`, so a proxy
-// URL with an empty password (`user:@host`) must send base64("user:"), not
-// base64("user"). curl does this; bun previously dropped the colon, which
-// strict proxies reject.
+// URL with an empty password (`user:@host`) or an empty username (`:pass@host`)
+// must still send the colon. bun previously dropped the colon for empty
+// password and sent no header at all for empty username.
 //
 // Exercised via http_proxy in a subprocess (rather than the `{proxy}` option)
 // so the raw env string reaches bun_url::URL::parse without WHATWG
 // normalization first dropping the `:` and tripping the userinfo heuristic.
 describe.each([
   { userinfo: "squidadmin:", decoded: "squidadmin:" },
+  { userinfo: ":hunter2", decoded: ":hunter2" },
   { userinfo: "squidadmin:hunter2", decoded: "squidadmin:hunter2" },
 ])("proxy Basic auth keeps the colon for userinfo $userinfo", ({ userinfo, decoded }) => {
   const expected = `Basic ${Buffer.from(decoded).toString("base64")}`;

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -518,6 +518,84 @@ test("proxy with long password (> 4096 chars) works correctly after redirect", a
   }
 });
 
+// RFC 7617: the Basic credential is always `user-id ":" password`, so a proxy
+// URL with an empty password (`user:@host`) must send base64("user:"), not
+// base64("user"). curl does this; bun previously dropped the colon, which
+// strict proxies reject.
+//
+// Exercised via HTTP_PROXY in a subprocess (rather than the `{proxy}` option)
+// so the raw env string reaches bun_url::URL::parse without WHATWG
+// normalization first dropping the `:` and tripping the userinfo heuristic.
+describe.each([
+  { userinfo: "squidadmin:", decoded: "squidadmin:" },
+  { userinfo: "squidadmin:hunter2", decoded: "squidadmin:hunter2" },
+])("proxy Basic auth keeps the colon for userinfo $userinfo", ({ userinfo, decoded }) => {
+  const expected = `Basic ${Buffer.from(decoded).toString("base64")}`;
+
+  test.concurrent("http target (absolute-form)", async () => {
+    const proxy = await createAuthCapturingProxy();
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `process.exitCode = (await fetch(${JSON.stringify(String(httpServer.url))})).status === 200 ? 0 : 1;`],
+        env: {
+          ...bunEnv,
+          NO_PROXY: "",
+          no_proxy: "",
+          HTTP_PROXY: `http://${userinfo}@127.0.0.1:${proxy.port}`,
+        },
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(proxy.capturedAuths).toEqual([expected]);
+      expect(exitCode).toBe(0);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test.concurrent("https target (CONNECT)", async () => {
+    const capturedAuths: string[] = [];
+    const server = net.createServer(socket => {
+      socket.once("data", data => {
+        const request = data.toString();
+        for (const line of request.split("\r\n")) {
+          if (line.toLowerCase().startsWith("proxy-authorization:")) {
+            capturedAuths.push(line.substring("proxy-authorization:".length).trim());
+          }
+        }
+        // Reject the tunnel so we don't need a real TLS origin.
+        socket.end("HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\n\r\n");
+      });
+      socket.on("error", () => {});
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `console.log((await fetch("https://example.invalid/")).status);`],
+        env: {
+          ...bunEnv,
+          NO_PROXY: "",
+          no_proxy: "",
+          HTTPS_PROXY: `http://${userinfo}@127.0.0.1:${port}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("407");
+      expect(capturedAuths).toEqual([expected]);
+      expect(exitCode).toBe(0);
+    } finally {
+      server.close();
+      await once(server, "close");
+    }
+  });
+});
+
 // Regression test for https://github.com/oven-sh/bun/issues/31780
 //
 // The Proxy-Authorization: Basic <...> credential must be encoded with the

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -523,7 +523,7 @@ test("proxy with long password (> 4096 chars) works correctly after redirect", a
 // base64("user"). curl does this; bun previously dropped the colon, which
 // strict proxies reject.
 //
-// Exercised via HTTP_PROXY in a subprocess (rather than the `{proxy}` option)
+// Exercised via http_proxy in a subprocess (rather than the `{proxy}` option)
 // so the raw env string reaches bun_url::URL::parse without WHATWG
 // normalization first dropping the `:` and tripping the userinfo heuristic.
 describe.each([
@@ -531,6 +531,10 @@ describe.each([
   { userinfo: "squidadmin:hunter2", decoded: "squidadmin:hunter2" },
 ])("proxy Basic auth keeps the colon for userinfo $userinfo", ({ userinfo, decoded }) => {
   const expected = `Basic ${Buffer.from(decoded).toString("base64")}`;
+  // bunEnv snapshots process.env before beforeAll clears these, and lowercase
+  // is resolved before uppercase, so override every variant explicitly.
+  const noProxyEnv = { ...bunEnv };
+  for (const k of PROXY_ENV_KEYS) noProxyEnv[k] = "";
 
   test.concurrent("http target (absolute-form)", async () => {
     const proxy = await createAuthCapturingProxy();
@@ -541,12 +545,7 @@ describe.each([
           "-e",
           `process.exitCode = (await fetch(${JSON.stringify(String(httpServer.url))})).status === 200 ? 0 : 1;`,
         ],
-        env: {
-          ...bunEnv,
-          NO_PROXY: "",
-          no_proxy: "",
-          HTTP_PROXY: `http://${userinfo}@127.0.0.1:${proxy.port}`,
-        },
+        env: { ...noProxyEnv, http_proxy: `http://${userinfo}@127.0.0.1:${proxy.port}` },
         stderr: "pipe",
       });
       const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
@@ -579,12 +578,7 @@ describe.each([
     try {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", `console.log((await fetch("https://example.invalid/")).status);`],
-        env: {
-          ...bunEnv,
-          NO_PROXY: "",
-          no_proxy: "",
-          HTTPS_PROXY: `http://${userinfo}@127.0.0.1:${port}`,
-        },
+        env: { ...noProxyEnv, https_proxy: `http://${userinfo}@127.0.0.1:${port}` },
         stdout: "pipe",
         stderr: "pipe",
       });

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -531,10 +531,11 @@ describe.each([
   { userinfo: "squidadmin:hunter2", decoded: "squidadmin:hunter2" },
 ])("proxy Basic auth keeps the colon for userinfo $userinfo", ({ userinfo, decoded }) => {
   const expected = `Basic ${Buffer.from(decoded).toString("base64")}`;
-  // bunEnv snapshots process.env before beforeAll clears these, and lowercase
-  // is resolved before uppercase, so override every variant explicitly.
+  // Delete (not blank) every case variant: on Windows the child env is
+  // case-insensitive, so an `HTTP_PROXY: ""` alongside `http_proxy: <url>`
+  // collapses to "" and the proxy is bypassed.
   const noProxyEnv = { ...bunEnv };
-  for (const k of PROXY_ENV_KEYS) noProxyEnv[k] = "";
+  for (const k of PROXY_ENV_KEYS) delete noProxyEnv[k];
 
   test.concurrent("http target (absolute-form)", async () => {
     const proxy = await createAuthCapturingProxy();


### PR DESCRIPTION
## Reproduction

```sh
# empty password
HTTP_PROXY=http://user:@127.0.0.1:<proxy-port> bun -e 'await fetch("http://origin/")'
# empty username
HTTP_PROXY=http://:secret@127.0.0.1:<proxy-port> bun -e 'await fetch("http://origin/")'
```

Proxy receives, respectively:

```
Proxy-Authorization: Basic dXNlcg==      # base64("user"), missing colon
(no Proxy-Authorization header at all)
```

curl 8.17 and RFC 7617 expect:

```
Proxy-Authorization: Basic dXNlcjo=      # base64("user:")
Proxy-Authorization: Basic OnNlY3JldA==  # base64(":secret")
```

Strict proxies reject the colon-less form, and the empty-username case goes entirely unauthenticated.

## Cause

`build_proxy_authorization` in `src/http/AsyncHTTP.rs` returned `None` when `proxy.username` was empty (dropping password-only credentials), and when `proxy.password` was empty it base64-encoded only the username. RFC 7617 defines the credential as `user-id ":" password` unconditionally. Bun's own `node:http` proxy path (`src/js/internal/http.ts`) already gates on `username || password` and always emits the colon; the WebSocket path in `WebSocket.cpp` already emits the colon for the empty-password case.

## Fix

Skip only when both components are empty, and always assemble `username + ":" + password` before base64.

## Verification

`describe.each` in `test/js/bun/http/proxy.test.ts` covers `user:`, `:pass`, and `user:pass` over both absolute-form (http target) and CONNECT (https target), asserting the exact `Proxy-Authorization` value captured at the proxy. On 1.4.0-canary the `user:` cases fail with `Basic c3F1aWRhZG1pbg==` and the `:pass` cases fail with `[]` (no header sent); with this change all six pass. The test drives fetch via `http_proxy`/`https_proxy` in a subprocess so the raw proxy URL reaches `URL::parse` without WHATWG normalization first dropping the colon (that interaction with the `{proxy}` option is #33616). Verified on linux-x64 and windows-x64.

The two pre-existing failures in `test/js/bun/http/proxy.test.js` (`proxy non-TLS auth can fail`, `simultaneous proxy auth failures should not hang`) fail identically on main without this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/proxy.test.ts
bun test v1.4.0 (e9418c2e2)

test/js/bun/http/proxy.test.ts:
(pass) GET non-TLS proxy -> non-TLS body type undefined [789.13ms]
(pass) POST non-TLS proxy -> non-TLS body type string [771.64ms]
(pass) GET TLS proxy -> non-TLS body type undefined [925.04ms]
(pass) GET non-TLS proxy -> TLS body type undefined [1037.62ms]
(pass) POST non-TLS proxy -> TLS body type string [1057.43ms]
(pass) POST TLS proxy -> non-TLS body type string [426.53ms]
(pass) GET TLS proxy -> TLS body type undefined [659.54ms]
(pass) POST TLS proxy -> TLS body type string [624.51ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [821.52ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [989.42ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [1169.98ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [1080.13ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007 [1503.04ms]
(pass) proxy can handle re
... (truncated)

release without fix: 2 failed, 1 skipped
bun test v1.4.0-canary.1 (38b872605)

test/js/bun/http/proxy.test.ts:
(pass) POST non-TLS proxy -> non-TLS body type string [54.04ms]
(pass) GET non-TLS proxy -> non-TLS body type undefined [56.43ms]
(pass) POST non-TLS proxy -> TLS body type string [81.26ms]
(pass) GET non-TLS proxy -> TLS body type undefined [81.40ms]
(pass) GET TLS proxy -> non-TLS body type undefined [84.79ms]
(pass) POST TLS proxy -> non-TLS body type string [84.77ms]
(pass) POST TLS proxy -> TLS body type string [84.71ms]
(pass) GET TLS proxy -> TLS body type undefined [84.75ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [94.88ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [100.74ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [108.53ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [110.62ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007 [684.68ms]
(pass) proxy can handle redirects with TLS server > with chunked body #12007 [687.49ms]
(pass) non-TLS origin redirect through HTTPS proxy forwards every hop through the proxy [9.37ms]
(pass) uns
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/proxy.test.ts
bun test v1.4.0 (e9418c2e2)

test/js/bun/http/proxy.test.ts:
(pass) GET non-TLS proxy -> non-TLS body type undefined [785.69ms]
(pass) POST non-TLS proxy -> non-TLS body type string [769.54ms]
(pass) GET TLS proxy -> non-TLS body type undefined [914.54ms]
(pass) GET non-TLS proxy -> TLS body type undefined [1031.28ms]
(pass) POST non-TLS proxy -> TLS body type string [1052.22ms]
(pass) POST TLS proxy -> non-TLS body type string [421.44ms]
(pass) GET TLS proxy -> TLS body type undefined [633.85ms]
(pass) POST TLS proxy -> TLS body type string [603.30ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [803.49ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [955.24ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [1111.96ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [1035.56ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007 [1521.45ms]
(pass) proxy can handle re
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 772ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/AsyncHTTP.rs          | 31 +++++++----------
 test/js/bun/http/proxy.test.ts | 78 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 90 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/http/AsyncHTTP.rs               5      5      0
test/js/bun/http/proxy.test.ts      8      9      0
```

</details>

<!-- robobun:evidence:end -->