### PR TITLE
process.versions.tz: report the bundled IANA tzdata version

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -92,6 +92,7 @@ typedef int mode_t;
 #include "JSNextTickQueue.h"
 #include "ProcessBindingUV.h"
 #include "ProcessBindingNatives.h"
+#include <unicode/ucal.h>
 
 #if OS(LINUX)
 #include <features.h>
@@ -256,6 +257,12 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
 
     object->putDirect(vm, JSC::Identifier::fromString(vm, "icu"_s), JSValue(JSC::jsOwnedString(vm, String(ASCIILiteral::fromLiteralUnsafe(U_ICU_VERSION)))), 0);
     object->putDirect(vm, JSC::Identifier::fromString(vm, "unicode"_s), JSValue(JSC::jsOwnedString(vm, String(ASCIILiteral::fromLiteralUnsafe(U_UNICODE_VERSION)))), 0);
+    {
+        UErrorCode status = U_ZERO_ERROR;
+        const char* tz = ucal_getTZDataVersion(&status);
+        if (U_SUCCESS(status) && tz != nullptr)
+            object->putDirect(vm, JSC::Identifier::fromString(vm, "tz"_s), JSValue(JSC::jsString(vm, String::fromLatin1(tz))), 0);
+    }
     object->putDirect(vm, JSC::Identifier::fromString(vm, "sqlite"_s), JSValue(JSC::jsOwnedString(vm, String(ASCIILiteral::fromLiteralUnsafe(Bun__sqlite3_version())))), 0);
 
 #define STRINGIFY_IMPL(x) #x

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -92,7 +92,14 @@ typedef int mode_t;
 #include "JSNextTickQueue.h"
 #include "ProcessBindingUV.h"
 #include "ProcessBindingNatives.h"
+#include <unicode/utypes.h>
+#if __has_include(<unicode/ucal.h>)
 #include <unicode/ucal.h>
+#else
+// Apple's macOS SDK ships only a subset of ICU headers (no ucal.h), but
+// libicucore exports the symbol.
+U_CAPI const char* U_EXPORT2 ucal_getTZDataVersion(UErrorCode* status);
+#endif
 
 #if OS(LINUX)
 #include <features.h>

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -93,13 +93,7 @@ typedef int mode_t;
 #include "ProcessBindingUV.h"
 #include "ProcessBindingNatives.h"
 #include <unicode/utypes.h>
-#if __has_include(<unicode/ucal.h>)
-#include <unicode/ucal.h>
-#else
-// Apple's macOS SDK ships only a subset of ICU headers (no ucal.h), but
-// libicucore exports the symbol.
 U_CAPI const char* U_EXPORT2 ucal_getTZDataVersion(UErrorCode* status);
-#endif
 
 #if OS(LINUX)
 #include <features.h>

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -248,6 +248,10 @@ it("ICU version does not regress", () => {
   expect(parseFloat(process.versions.icu, 10) || 0).toBeGreaterThanOrEqual(parseFloat(min, 10));
 });
 
+it("process.versions.tz reports the bundled IANA tzdata version", () => {
+  expect(process.versions.tz).toMatch(/^20\d{2}[a-z]$/);
+});
+
 it("process.env.TZ", () => {
   var origTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 


### PR DESCRIPTION
## Problem

Bun statically links ICU 75.1, which bundles IANA tzdata **2024a**. IANA has published several releases since, and there is no way to tell from inside Bun that the bundled data is stale: `process.versions.tz` is `undefined` (Node populates it).

The stale data is user-visible. Paraguay abolished DST in October 2024 (tzdata 2024b), so real Paraguay has been permanent UTC-3 for nearly two years, but Bun still runs the old cycle:

```js
new Intl.DateTimeFormat("en-US", { timeZone: "America/Asuncion", timeZoneName: "longOffset" })
  .formatToParts(new Date("2026-07-27T15:00:00Z"))
  .find(p => p.type === "timeZoneName").value
// bun:  "GMT-04:00"
// node: "GMT-03:00"  (tz 2026b)
// date: "-0300"      (host tzdata)
```

`America/Coyhaique` (new in tzdata 2025b) throws `RangeError: invalid time zone`.

## This PR

Populate `process.versions.tz` from `ucal_getTZDataVersion()`, the same way Node does. This reads the version string out of ICU's `zoneinfo64.res` at runtime, so it reports whatever tzdata the linked `libicudata` actually contains (currently `"2024a"` on Linux/Windows; on macOS it reflects Apple's system `libicucore`).

## The data refresh

The tzdata itself is baked into the prebuilt WebKit artifact. oven-sh/WebKit#358 vendors the four ICU tzdata resource bundles at 2026c and injects them into the ICU data package with `icupkg -a` during the WebKit build. That has been verified end-to-end by repacking `libicudata.a` locally and relinking a debug Bun:

```
process.versions.tz                                       -> "2026c"
America/Asuncion @ 2025-07, 2026-03, 2026-07, 2027-01     -> GMT-03:00 (all four)
TZ=America/Asuncion getTimezoneOffset()                   -> 180
Intl.DateTimeFormat("en", { timeZone: "America/Coyhaique" }) -> ok
test/js/web/intl/intl.test.ts                             -> 31/31 pass
```

Once oven-sh/WebKit#358 merges and its autobuild publishes, a follow-up here will bump `WEBKIT_VERSION` and add the `America/Asuncion` / `America/Coyhaique` regression test plus a tzdata floor check alongside the existing ICU-version floor.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->