### PR TITLE
Bun.Glob: walk the filesystem lazily in scan()/scanSync()

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -502,7 +502,9 @@ void ${proto}::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
     ${
-      Object.keys(protoFields).length > 0
+      Object.keys(protoFields).some(
+        n => !("privateSymbol" in protoFields[n] || "internal" in protoFields[n] || "value" in protoFields[n] || n.startsWith("@@")),
+      )
         ? `reifyStaticProperties(vm, ${className(typeName)}::info(), ${proto}TableValues, *this);`
         : ""
     }${specialSymbols}${staticPrototypeValues}

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -503,7 +503,13 @@ void ${proto}::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
     Base::finishCreation(vm);
     ${
       Object.keys(protoFields).some(
-        n => !("privateSymbol" in protoFields[n] || "internal" in protoFields[n] || "value" in protoFields[n] || n.startsWith("@@")),
+        n =>
+          !(
+            "privateSymbol" in protoFields[n] ||
+            "internal" in protoFields[n] ||
+            "value" in protoFields[n] ||
+            n.startsWith("@@")
+          ),
       )
         ? `reifyStaticProperties(vm, ${className(typeName)}::info(), ${proto}TableValues, *this);`
         : ""

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -349,8 +349,11 @@ impl<A: Accessor> Directory<A> {
 // Iterator
 // ─────────────────────────────────────────────────────────────────────────────
 
-pub struct Iterator<'a, A: Accessor, const SENTINEL: bool> {
-    pub walker: &'a mut GlobWalker<A, SENTINEL>,
+pub struct Iterator<W, A: Accessor, const SENTINEL: bool>
+where
+    W: core::ops::DerefMut<Target = GlobWalker<A, SENTINEL>>,
+{
+    pub walker: W,
     pub iter_state: IterState<A>,
     pub cwd_fd: A::Handle,
     /// This is to make sure in debug/tests that we are closing file descriptors
@@ -363,13 +366,21 @@ pub struct Iterator<'a, A: Accessor, const SENTINEL: bool> {
     pub nt_filter_buf: [u16; 256],
 }
 
+/// Iterator that borrows the walker. Kept for callers that drive the walk
+/// and still want to read `walker.matched_paths` afterwards.
+pub type IteratorRef<'a, A, const SENTINEL: bool> =
+    Iterator<&'a mut GlobWalker<A, SENTINEL>, A, SENTINEL>;
+
 #[inline]
 fn count_fds<A: Accessor>() -> bool {
     A::COUNT_FDS && cfg!(debug_assertions)
 }
 
-impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
-    pub fn new(walker: &'a mut GlobWalker<A, SENTINEL>) -> Self {
+impl<W, A: Accessor, const SENTINEL: bool> Iterator<W, A, SENTINEL>
+where
+    W: core::ops::DerefMut<Target = GlobWalker<A, SENTINEL>>,
+{
+    pub fn new(walker: W) -> Self {
         Self {
             walker,
             iter_state: IterState::GetNext,
@@ -448,7 +459,11 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                         Ok(fd) => fd,
                     };
                     let _ = A::close(fd);
-                    self.iter_state = IterState::Matched(path);
+                    self.iter_state = if self.walker.only_files {
+                        IterState::GetNext
+                    } else {
+                        IterState::Matched(path)
+                    };
                     return Ok(Ok(()));
                 }
 
@@ -1213,7 +1228,10 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
     }
 }
 
-impl<'a, A: Accessor, const SENTINEL: bool> Drop for Iterator<'a, A, SENTINEL> {
+impl<W, A: Accessor, const SENTINEL: bool> Drop for Iterator<W, A, SENTINEL>
+where
+    W: core::ops::DerefMut<Target = GlobWalker<A, SENTINEL>>,
+{
     fn drop(&mut self) {
         self.close_cwd_fd();
         if let IterState::Directory(dir) = &self.iter_state {

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -85,6 +85,7 @@ pub trait Accessor {
 
     fn open(path: &ZStr) -> Result<Maybe<Self::Handle>, Error>;
     fn openat(handle: Self::Handle, path: &ZStr) -> Result<Maybe<Self::Handle>, Error>;
+    fn stat(path: &ZStr) -> Maybe<Stat>;
     fn statat(handle: Self::Handle, path: &ZStr) -> Maybe<Stat>;
     /// Like statat but does not follow symlinks.
     fn lstatat(handle: Self::Handle, path: &ZStr) -> Maybe<Stat>;
@@ -174,6 +175,10 @@ impl Accessor for SyscallAccessor {
 
     fn open(path: &ZStr) -> Result<Maybe<SyscallHandle>, Error> {
         Ok(Syscall::open(path, O::DIRECTORY | O::RDONLY, 0).map(|fd| SyscallHandle { value: fd }))
+    }
+
+    fn stat(path: &ZStr) -> Maybe<Stat> {
+        Syscall::stat(path)
     }
 
     fn statat(handle: SyscallHandle, path: &ZStr) -> Maybe<Stat> {
@@ -436,33 +441,30 @@ where
                 //
                 // In that case we don't need to do any walking and can just open up the FS entry
                 if starting_component_idx as usize >= self.walker.pattern_components.len() {
-                    // Matched-path payload must respect SENTINEL. The open()
-                    // probe always needs a NUL — use a separate dupeZ for it so
+                    // Matched-path payload must respect SENTINEL. The stat()
+                    // probe always needs a NUL; use a separate dupeZ for it so
                     // SENTINEL=false matched paths don't carry a spurious 0x00.
                     let path = dupe_matched::<SENTINEL>(path_without_special_syntax);
                     let pathz_owned = dupe_z(path_without_special_syntax);
                     // SAFETY: dupe_z appends NUL at len()-1; ZStr len excludes it.
                     let pathz = ZStr::from_slice_with_nul(&pathz_owned[..]);
-                    let fd = match A::open(pathz)? {
+                    let mode = match A::stat(pathz) {
                         Err(e) => {
-                            if e.get_errno() == E::ENOTDIR {
-                                self.iter_state = IterState::Matched(path);
-                                return Ok(Ok(()));
-                            }
-                            // Doesn't exist
-                            if e.get_errno() == E::ENOENT {
+                            if matches!(e.get_errno(), E::ENOENT | E::ENOTDIR) {
                                 self.iter_state = IterState::GetNext;
                                 return Ok(Ok(()));
                             }
                             return Ok(Err(e.with_path(matched_as_slice::<SENTINEL>(&path))));
                         }
-                        Ok(fd) => fd,
+                        Ok(st) => st.st_mode as u32,
                     };
-                    let _ = A::close(fd);
-                    self.iter_state = if self.walker.only_files {
-                        IterState::GetNext
-                    } else {
+                    let matches = (S::ISDIR(mode) && !self.walker.only_files)
+                        || S::ISREG(mode)
+                        || !self.walker.only_files;
+                    self.iter_state = if matches {
                         IterState::Matched(path)
+                    } else {
+                        IterState::GetNext
                     };
                     return Ok(Ok(()));
                 }

--- a/src/glob/lib.rs
+++ b/src/glob/lib.rs
@@ -13,6 +13,7 @@ pub use walk::GlobWalker;
 // parameter (const-generic fn ptrs are unstable).
 pub type BunGlobWalker = walk::GlobWalker<walk::SyscallAccessor, false>;
 pub type BunGlobWalkerZ = walk::GlobWalker<walk::SyscallAccessor, true>;
+pub type BunGlobIterator = walk::Iterator<Box<BunGlobWalker>, walk::SyscallAccessor, false>;
 
 /// Returns true if the given string contains glob syntax,
 /// excluding those escaped with backslashes

--- a/src/js/builtins/Glob.ts
+++ b/src/js/builtins/Glob.ts
@@ -1,21 +1,42 @@
+interface GlobScanHandle {
+  $pull(): Promise<string[] | null>;
+  $resolveSync(): string[] | null;
+  $close(): void;
+}
+
 interface Glob {
-  $pull(opts);
-  $resolveSync(opts);
+  $pull(opts): GlobScanHandle | undefined;
+  $resolveSync(opts): GlobScanHandle | undefined;
 }
 
 export function scan(this: Glob, opts) {
-  const valuesPromise = this.$pull(opts);
+  const handle = this.$pull(opts);
   async function* iter() {
-    const values = (await valuesPromise) || [];
-    yield* values;
+    if (!handle) return;
+    try {
+      let batch: string[] | null;
+      while ((batch = await handle.$pull())) {
+        yield* batch;
+      }
+    } finally {
+      handle.$close();
+    }
   }
   return iter();
 }
 
 export function scanSync(this: Glob, opts) {
-  const arr = this.$resolveSync(opts) || [];
+  const handle = this.$resolveSync(opts);
   function* iter() {
-    yield* arr;
+    if (!handle) return;
+    try {
+      let batch: string[] | null;
+      while ((batch = handle.$resolveSync())) {
+        yield* batch;
+      }
+    } finally {
+      handle.$close();
+    }
   }
   return iter();
 }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1928,6 +1928,10 @@ pub mod dir_entry_accessor {
         type Handle = DirEntryHandle;
         type DirIter = DirEntryDirIter;
 
+        fn stat(path: &ZStr) -> Maybe<Stat> {
+            Syscall::stat(path)
+        }
+
         fn statat(handle: DirEntryHandle, path_: &ZStr) -> Maybe<Stat> {
             let mut buf = PathBuffer::uninit();
             let path: &ZStr = if !Platform::AUTO.is_absolute(path_.as_bytes()) {

--- a/src/runtime/api/Glob.classes.ts
+++ b/src/runtime/api/Glob.classes.ts
@@ -5,7 +5,6 @@ export default [
     name: "Glob",
     construct: true,
     finalize: true,
-    hasPendingActivity: true,
     configurable: false,
     klass: {},
     JSType: "0b11101110",
@@ -33,6 +32,32 @@ export default [
       match: {
         fn: "match",
         length: 1,
+      },
+    },
+  }),
+  define({
+    name: "GlobScanHandle",
+    construct: false,
+    noConstructor: true,
+    finalize: true,
+    hasPendingActivity: true,
+    configurable: false,
+    klass: {},
+    proto: {
+      __batch: {
+        fn: "__batch",
+        length: 0,
+        privateSymbol: "pull",
+      },
+      __batchSync: {
+        fn: "__batchSync",
+        length: 0,
+        privateSymbol: "resolveSync",
+      },
+      __close: {
+        fn: "__close",
+        length: 0,
+        privateSymbol: "close",
       },
     },
   }),

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -2,23 +2,25 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 use bun_alloc::Arena;
 use bun_core::String as BunString;
+use bun_glob::BunGlobIterator as GlobIterator;
 use bun_glob::BunGlobWalker as GlobWalker;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::concurrent_promise_task::{ConcurrentPromiseTask, ConcurrentPromiseTaskContext};
 use bun_jsc::{
-    ArgumentsSlice, CallFrame, JSGlobalObject, JSPromise, JSValue, JsResult, JsTerminated,
+    ArgumentsSlice, CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsResult, JsTerminated,
     StringJsc as _, SysErrorJsc as _,
 };
 use bun_paths::resolve_path::join_string_buf;
 use bun_paths::{self as resolve_path, MAX_PATH_BYTES, PathBuffer, platform};
 use bun_sys as syscall;
 
+const BATCH_SIZE: usize = 256;
+
 // Codegen hooks (JSGlob): toJS / fromJS / fromJSDirect are provided by the
 // generated C++ wrapper. See PORTING.md §JSC ".classes.ts-backed types".
 #[bun_jsc::JsClass]
 pub struct Glob {
     pattern: Box<[u8]>,
-    has_pending_activity: AtomicUsize,
 }
 
 struct ScanOpts {
@@ -192,14 +194,6 @@ impl ScanOpts {
     }
 }
 
-pub(crate) struct WalkTask<'a> {
-    // `Box<GlobWalker>` drop runs `GlobWalker::Drop` then frees the box.
-    walker: Box<GlobWalker>,
-    err: Option<WalkTaskErr>,
-    global: &'a JSGlobalObject,
-    has_pending_activity: &'a AtomicUsize,
-}
-
 pub(crate) enum WalkTaskErr {
     Syscall(syscall::Error),
     Unknown(crate::Error),
@@ -216,78 +210,179 @@ impl WalkTaskErr {
     }
 }
 
-pub(crate) type AsyncGlobWalkTask<'a> = ConcurrentPromiseTask<'a, WalkTask<'a>>;
+/// Drive `iter` for up to [`BATCH_SIZE`] matches, initializing it on the
+/// first call. Returns `Ok(false)` once the iterator is exhausted so the
+/// caller can drop it and short-circuit the next batch call.
+fn drive_batch(
+    iter: &mut GlobIterator,
+    inited: &mut bool,
+    batch: &mut Vec<Box<[u8]>>,
+) -> Result<bool, WalkTaskErr> {
+    if !*inited {
+        *inited = true;
+        match iter.init() {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => return Err(WalkTaskErr::Syscall(err)),
+            Err(err) => return Err(WalkTaskErr::Unknown(err.into())),
+        }
+    }
+    while batch.len() < BATCH_SIZE {
+        match iter.next() {
+            Ok(Ok(Some(path))) => batch.push(path),
+            Ok(Ok(None)) => return Ok(false),
+            Ok(Err(err)) => return Err(WalkTaskErr::Syscall(err)),
+            Err(err) => return Err(WalkTaskErr::Unknown(err.into())),
+        }
+    }
+    Ok(true)
+}
 
-impl<'a> WalkTask<'a> {
-    pub(crate) fn create(
-        global_this: &'a JSGlobalObject,
-        glob_walker: Box<GlobWalker>,
-        has_pending_activity: &'a AtomicUsize,
-    ) -> Box<AsyncGlobWalkTask<'a>> {
-        let walk_task = Box::new(WalkTask {
-            walker: glob_walker,
-            global: global_this,
-            err: None,
-            has_pending_activity,
+fn batch_to_js(batch: &[Box<[u8]>], global_this: &JSGlobalObject) -> JsResult<JSValue> {
+    if batch.is_empty() {
+        return Ok(JSValue::NULL);
+    }
+    JSValue::create_array_from_iter(global_this, batch.iter(), |path| {
+        bun_string_jsc::create_utf8_for_js(global_this, path)
+    })
+}
+
+/// Incremental scan state behind `Glob.scan`/`scanSync`. Owns the walker via
+/// an owning `Iterator<Box<GlobWalker>, ..>`; dropping the iterator closes any
+/// open directory fds and drains the work stack.
+#[bun_jsc::JsClass(no_construct, no_constructor)]
+pub struct GlobScanHandle {
+    iter: JsCell<Option<Box<GlobIterator>>>,
+    inited: JsCell<bool>,
+    has_pending_activity: AtomicUsize,
+}
+
+impl GlobScanHandle {
+    fn open(walker: Box<GlobWalker>, global_this: &JSGlobalObject) -> JSValue {
+        let handle = Box::new(GlobScanHandle {
+            iter: JsCell::new(Some(Box::new(GlobIterator::new(walker)))),
+            inited: JsCell::new(false),
+            has_pending_activity: AtomicUsize::new(0),
         });
-        AsyncGlobWalkTask::create_on_js_thread(global_this, walk_task)
+        GlobScanHandle::to_js_boxed(handle, global_this)
+    }
+
+    pub fn has_pending_activity(&self) -> bool {
+        self.has_pending_activity.load(Ordering::SeqCst) > 0
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn __batch(
+        &self,
+        global_this: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let Some(iter) = self.iter.replace(None) else {
+            return Ok(JSValue::NULL);
+        };
+
+        self.has_pending_activity.fetch_add(1, Ordering::SeqCst);
+        let ctx = Box::new(WalkTask {
+            iter: Some(iter),
+            inited: self.inited.replace(true),
+            batch: Vec::new(),
+            err: None,
+            global: global_this,
+            handle: core::ptr::from_ref(self).cast_mut(),
+        });
+        let mut task = AsyncGlobWalkTask::create_on_js_thread(global_this, ctx);
+        let promise = task.promise.value();
+        task.schedule();
+        // WalkTask<'_> borrows `global_this` and holds a raw pointer to `self`.
+        // Both referents outlive the task: `GlobScanHandle` is GC-rooted via
+        // `hasPendingActivity()`, and `JSGlobalObject` lives until VM teardown.
+        let _ = bun_core::heap::into_raw(task);
+        Ok(promise)
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn __batch_sync(
+        &self,
+        global_this: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let Some(mut iter) = self.iter.replace(None) else {
+            return Ok(JSValue::NULL);
+        };
+
+        let mut batch: Vec<Box<[u8]>> = Vec::new();
+        let mut inited = self.inited.replace(true);
+        match drive_batch(&mut iter, &mut inited, &mut batch) {
+            Ok(more) => {
+                if more {
+                    self.iter.set(Some(iter));
+                }
+                batch_to_js(&batch, global_this)
+            }
+            Err(err) => Err(global_this.throw_value(err.to_js(global_this)?)),
+        }
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn __close(
+        &self,
+        _global_this: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        self.iter.set(None);
+        Ok(JSValue::UNDEFINED)
     }
 }
 
+pub(crate) struct WalkTask<'a> {
+    iter: Option<Box<GlobIterator>>,
+    inited: bool,
+    batch: Vec<Box<[u8]>>,
+    err: Option<WalkTaskErr>,
+    global: &'a JSGlobalObject,
+    /// The GC-owned handle this batch was taken from. The handle is kept alive
+    /// while the task is in flight via `has_pending_activity`.
+    handle: *mut GlobScanHandle,
+}
+
+pub(crate) type AsyncGlobWalkTask<'a> = ConcurrentPromiseTask<'a, WalkTask<'a>>;
+
 impl<'a> ConcurrentPromiseTaskContext for WalkTask<'a> {
     const TASK_TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::AsyncGlobWalkTask;
+
     fn run(&mut self) {
-        let guard = scopeguard::guard(self.has_pending_activity, |hpa| {
-            decr_pending_activity_flag(hpa);
-        });
-        let result = match self.walker.walk() {
-            Ok(r) => r,
+        let iter = self.iter.as_deref_mut().expect("iter taken before run");
+        match drive_batch(iter, &mut self.inited, &mut self.batch) {
+            Ok(more) => {
+                if !more {
+                    self.iter = None;
+                }
+            }
             Err(err) => {
-                self.err = Some(WalkTaskErr::Unknown(err.into()));
-                drop(guard);
-                return;
+                self.iter = None;
+                self.err = Some(err);
             }
-        };
-        match result {
-            bun_sys::Result::Err(err) => {
-                self.err = Some(WalkTaskErr::Syscall(err));
-            }
-            bun_sys::Result::Ok(()) => {}
         }
-        drop(guard);
     }
 
     fn then(&mut self, promise: &mut JSPromise) -> Result<(), JsTerminated> {
-        // Ownership of `Box<WalkTask>` is held by `ConcurrentPromiseTask.ctx`; the wrapper is
-        // freed via `ConcurrentPromiseTask::destroy` on the `.manual_deinit` path
-        // after `run_from_js` returns, which drops `ctx` (and thus `walker`).
+        // SAFETY: `handle` points at the live `m_ctx` payload of a JS wrapper
+        // kept reachable by `has_pending_activity > 0` for the duration of
+        // this task; `then` runs on the JS thread so no concurrent access.
+        let handle = unsafe { &*self.handle };
+        handle.iter.set(self.iter.take());
+        handle.has_pending_activity.fetch_sub(1, Ordering::SeqCst);
 
         if let Some(err) = &self.err {
             promise.reject_with_async_stack(self.global, err.to_js(self.global))?;
             return Ok(());
         }
 
-        let js_strings = match glob_walk_result_to_js(&mut self.walker, self.global) {
+        let js = match batch_to_js(&self.batch, self.global) {
             Ok(v) => v,
-            // `reject()` pulls the pending exception off the VM.
             Err(e) => return promise.reject(self.global, Err(e)),
         };
-        promise.resolve(self.global, js_strings)
+        promise.resolve(self.global, js)
     }
-}
-
-fn glob_walk_result_to_js(
-    glob_walk: &mut GlobWalker,
-    global_this: &JSGlobalObject,
-) -> JsResult<JSValue> {
-    let keys = glob_walk.matched_paths.keys();
-    if keys.is_empty() {
-        return JSValue::create_empty_array(global_this, 0);
-    }
-
-    JSValue::create_array_from_iter(global_this, keys.iter(), |key| {
-        bun_string_jsc::create_utf8_for_js(global_this, key)
-    })
 }
 
 impl Glob {
@@ -378,46 +473,26 @@ impl Glob {
             .into_vec()
             .into_boxed_slice();
 
-        Ok(Box::new(Glob {
-            pattern: pat_str,
-            has_pending_activity: AtomicUsize::new(0),
-        }))
+        Ok(Box::new(Glob { pattern: pat_str }))
     }
-
-    /// Called on the GC thread concurrently with the mutator. Reads only the
-    /// atomic counter; never allocates, locks, or touches JS. The codegen shim
-    /// (`Glob__hasPendingActivity`) handles the `callconv(.c)` ABI and passes
-    /// `&*this`.
-    pub fn has_pending_activity(&self) -> bool {
-        self.has_pending_activity.load(Ordering::SeqCst) > 0
-    }
-}
-
-fn incr_pending_activity_flag(has_pending_activity: &AtomicUsize) {
-    let _ = has_pending_activity.fetch_add(1, Ordering::SeqCst);
-}
-
-fn decr_pending_activity_flag(has_pending_activity: &AtomicUsize) {
-    let _ = has_pending_activity.fetch_sub(1, Ordering::SeqCst);
 }
 
 impl Glob {
     // R-2 (host-fn re-entrancy): all JS-exposed methods take `&self`. `Glob`'s
-    // fields are read-only after construction (`pattern`) or already atomic
-    // (`has_pending_activity`), so no `Cell`/`JsCell` wrapping is needed — the
-    // `&mut self` receivers were vestigial. The codegen shim still emits
-    // `this: &mut Glob`; `&mut T` auto-derefs to `&T`.
-    #[bun_jsc::host_fn(method)]
-    pub fn __scan(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+    // only field (`pattern`) is read-only after construction, so no
+    // `Cell`/`JsCell` wrapping is needed.
+    fn open_scan_handle(
+        &self,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+        fn_name: &'static str,
+    ) -> JsResult<JSValue> {
         // SAFETY: bun_vm() returns a non-null *mut to the live VirtualMachine for this global.
         let mut arguments = ArgumentsSlice::init(global_this.bun_vm(), callframe.arguments());
-        // `arguments` drops at scope exit.
 
         let mut arena = Arena::new();
-        // GlobWalker::init/init_with_cwd own their allocations (Box); the
-        // arena here is vestigial.
         let glob_walker =
-            match self.make_glob_walker(global_this, &mut arguments, "scan", &mut arena) {
+            match self.make_glob_walker(global_this, &mut arguments, fn_name, &mut arena) {
                 Err(err) => {
                     drop(arena);
                     return Err(err);
@@ -429,18 +504,12 @@ impl Glob {
                 Ok(Some(gw)) => gw,
             };
 
-        incr_pending_activity_flag(&self.has_pending_activity);
-        let mut task = WalkTask::create(global_this, glob_walker, &self.has_pending_activity);
-        let promise = task.promise.value();
-        task.schedule();
-        // Ownership passes to the work pool / event loop; freed via
-        // `ConcurrentPromiseTask::destroy` on the `.manual_deinit` path.
-        // WalkTask<'_> borrows `&self.has_pending_activity`
-        // and `global_this`. Both referents outlive the task: `Glob` is GC-rooted
-        // via `hasPendingActivity()`, and `JSGlobalObject` lives until VM teardown.
-        // `into_raw` erases the stack-tied `'_` once the heap allocation escapes.
-        let _ = bun_core::heap::into_raw(task);
-        Ok(promise)
+        Ok(GlobScanHandle::open(glob_walker, global_this))
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn __scan(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        self.open_scan_handle(global_this, callframe, "scan")
     }
 
     #[bun_jsc::host_fn(method)]
@@ -449,32 +518,7 @@ impl Glob {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: bun_vm() returns a non-null *mut to the live VirtualMachine for this global.
-        let mut arguments = ArgumentsSlice::init(global_this.bun_vm(), callframe.arguments());
-
-        let mut arena = Arena::new();
-        let mut glob_walker =
-            match self.make_glob_walker(global_this, &mut arguments, "scanSync", &mut arena) {
-                Err(err) => {
-                    drop(arena);
-                    return Err(err);
-                }
-                Ok(None) => {
-                    drop(arena);
-                    return Ok(JSValue::UNDEFINED);
-                }
-                Ok(Some(gw)) => gw,
-            };
-        // Box<GlobWalker> drops at scope exit.
-
-        match glob_walker.walk().map_err(crate::Error::from)? {
-            bun_sys::Result::Err(err) => {
-                return Err(global_this.throw_value(err.to_js(global_this)));
-            }
-            bun_sys::Result::Ok(()) => {}
-        }
-
-        glob_walk_result_to_js(&mut glob_walker, global_this)
+        self.open_scan_handle(global_this, callframe, "scanSync")
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -220,6 +220,9 @@ fn drive_batch(
 ) -> Result<bool, WalkTaskErr> {
     if !*inited {
         *inited = true;
+        if iter.walker.pattern_components.is_empty() {
+            return Ok(false);
+        }
         match iter.init() {
             Ok(Ok(())) => {}
             Ok(Err(err)) => return Err(WalkTaskErr::Syscall(err)),

--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -39,7 +39,7 @@ type GlobWalker = glob::GlobWalker<bun_resolver::DirEntryAccessor, false>;
 // heap-allocated (`*mut GlobWalker` from `Box::into_raw`) so its address is stable even if
 // the `PackageFilterIterator` itself moves; the borrow is erased to `'static` because the
 // allocation lives until `deinit_walker` drops the iterator first, then frees the walker.
-type GlobWalkerIterator = glob::walk::Iterator<'static, bun_resolver::DirEntryAccessor, false>;
+type GlobWalkerIterator = glob::walk::IteratorRef<'static, bun_resolver::DirEntryAccessor, false>;
 
 pub(crate) fn get_candidate_package_patterns<'a>(
     log: &mut Log,

--- a/test/js/bun/glob/leak.test.ts
+++ b/test/js/bun/glob/leak.test.ts
@@ -38,6 +38,9 @@ describe("leaks", () => {
     timeout,
   );
 
+  // scan() allocates a scan handle per call and drives the walk in batches, so
+  // debug builds see more per-iteration overhead than scanSync; fewer
+  // iterations here still saturate ASAN's quarantine and catch any real leak.
   test.concurrent(
     "scan",
     async () => {
@@ -49,7 +52,7 @@ describe("leaks", () => {
         for (let i = 0; i < 1000; i++) await Array.fromAsync(glob.scan());
         Bun.gc(true);
         const before = process.memoryUsage.rss();
-        for (let i = 0; i < 100000; i++) await Array.fromAsync(glob.scan());
+        for (let i = 0; i < 30000; i++) await Array.fromAsync(glob.scan());
         Bun.gc(true);
         const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
         if (growthMB > ${thresholdMB}) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
@@ -91,7 +94,7 @@ describe("leaks", () => {
         for (let i = 0; i < 1000; i++) await Array.fromAsync(glob.scan());
         Bun.gc(true);
         const before = process.memoryUsage.rss();
-        for (let i = 0; i < 100000; i++) await Array.fromAsync(glob.scan());
+        for (let i = 0; i < 30000; i++) await Array.fromAsync(glob.scan());
         Bun.gc(true);
         const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
         if (growthMB > ${thresholdMB}) throw new Error("leaked " + growthMB.toFixed(2) + "MB");

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -24,7 +24,7 @@ import { Glob, GlobScanOptions } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execSync } from "child_process";
 import fg from "fast-glob";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import * as fs from "node:fs";
 import * as path from "path";
 import { createTempDirectoryWithBrokenSymlinks, prepareEntries, tempFixturesDir } from "./util";
@@ -563,33 +563,38 @@ describe("scan/scanSync iterate the filesystem lazily", () => {
     expect(norm(await Array.fromAsync(it))).toEqual(["a/x.txt", "b/x.txt"]);
   });
 
-  test("early break stops the walk and releases directory handles", () => {
+  // More matches than the native batch size so the iterator is parked in the
+  // scan handle across yields and return()/finally has real cleanup to do.
+  test.skipIf(isWindows)("scanSync early break releases directory handles", () => {
     const files: Record<string, string> = {};
-    for (let i = 0; i < 20; i++) for (let j = 0; j < 10; j++) files[`d${i}/f${j}.txt`] = "x";
+    for (let i = 0; i < 30; i++) for (let j = 0; j < 10; j++) files[`d${i}/f${j}.txt`] = "x";
     using dir = tempDir("glob-scan-lazy-break", files);
     const cwd = String(dir);
 
+    using _ = fileDescriptorLeakChecker();
     for (let k = 0; k < 64; k++) {
       const it = new Glob("**/*.txt").scanSync({ cwd });
       expect(it.next().value).toBeString();
       it.return?.(undefined);
     }
-    // Full scan after repeated early breaks still finds everything.
-    expect([...new Glob("**/*.txt").scanSync({ cwd })]).toHaveLength(200);
+    Bun.gc(true);
+    expect([...new Glob("**/*.txt").scanSync({ cwd })]).toHaveLength(300);
   });
 
-  test("scan releases directory handles on early break", async () => {
+  test.skipIf(isWindows)("scan early break releases directory handles", async () => {
     const files: Record<string, string> = {};
-    for (let i = 0; i < 20; i++) for (let j = 0; j < 10; j++) files[`d${i}/f${j}.txt`] = "x";
+    for (let i = 0; i < 30; i++) for (let j = 0; j < 10; j++) files[`d${i}/f${j}.txt`] = "x";
     using dir = tempDir("glob-scan-lazy-break-async", files);
     const cwd = String(dir);
 
+    using _ = fileDescriptorLeakChecker();
     for (let k = 0; k < 64; k++) {
       const it = new Glob("**/*.txt").scan({ cwd });
       expect((await it.next()).value).toBeString();
       await it.return?.(undefined);
     }
-    expect(await Array.fromAsync(new Glob("**/*.txt").scan({ cwd }))).toHaveLength(200);
+    Bun.gc(true);
+    expect(await Array.fromAsync(new Glob("**/*.txt").scan({ cwd }))).toHaveLength(300);
   });
 
   test("partial iteration yields a bounded prefix of a large tree", () => {
@@ -606,6 +611,29 @@ describe("scan/scanSync iterate the filesystem lazily", () => {
     }
     expect(taken).toHaveLength(50);
     expect([...new Glob("**/*.txt").scanSync({ cwd })]).toHaveLength(400);
+  });
+});
+
+describe("absolute literal pattern honours onlyFiles", () => {
+  test("matches a regular file, skips a directory by default", () => {
+    using dir = tempDir("glob-abs-literal", { "file.txt": "x", "subdir/keep": "x" });
+    const file = path.join(String(dir), "file.txt");
+    const subdir = path.join(String(dir), "subdir");
+
+    expect([...new Glob(file).scanSync()]).toEqual([file]);
+    expect([...new Glob(subdir).scanSync()]).toEqual([]);
+    expect([...new Glob(subdir).scanSync({ onlyFiles: false })]).toEqual([subdir]);
+    expect([...new Glob(path.join(String(dir), "missing")).scanSync()]).toEqual([]);
+  });
+
+  test("async matches a regular file, skips a directory by default", async () => {
+    using dir = tempDir("glob-abs-literal-async", { "file.txt": "x", "subdir/keep": "x" });
+    const file = path.join(String(dir), "file.txt");
+    const subdir = path.join(String(dir), "subdir");
+
+    expect(await Array.fromAsync(new Glob(file).scan())).toEqual([file]);
+    expect(await Array.fromAsync(new Glob(subdir).scan())).toEqual([]);
+    expect(await Array.fromAsync(new Glob(subdir).scan({ onlyFiles: false }))).toEqual([subdir]);
   });
 });
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -533,6 +533,82 @@ test.skipIf(process.platform == "win32")("error broken symlinks", async () => {
   expect(err).toBeDefined();
 });
 
+describe("scan/scanSync iterate the filesystem lazily", () => {
+  const norm = (a: string[]) => a.map(p => p.replaceAll("\\", "/")).sort();
+
+  test("scanSync does not read the directory until iterated", () => {
+    using dir = tempDir("glob-scan-lazy-sync", {
+      "a/x.txt": "a",
+    });
+    const cwd = String(dir);
+    const it = new Glob("**/*.txt").scanSync({ cwd });
+    // Walk has not started yet: files created before the first next() are seen.
+    fs.mkdirSync(path.join(cwd, "b"));
+    fs.writeFileSync(path.join(cwd, "b", "x.txt"), "b");
+    expect(norm([...it])).toEqual(["a/x.txt", "b/x.txt"]);
+  });
+
+  test("scan does not start the walk until the iterator is consumed", async () => {
+    using dir = tempDir("glob-scan-lazy-async", {
+      "a/x.txt": "a",
+    });
+    const cwd = String(dir);
+    const it = new Glob("**/*.txt").scan({ cwd });
+    // Drain one full glob walk through the work pool so that any walk
+    // scheduled eagerly by `scan()` above has also completed.
+    expect(norm(await Array.fromAsync(new Glob("**/*.txt").scan({ cwd })))).toEqual(["a/x.txt"]);
+    expect(norm(await Array.fromAsync(new Glob("**/*.txt").scan({ cwd })))).toEqual(["a/x.txt"]);
+    fs.mkdirSync(path.join(cwd, "b"));
+    fs.writeFileSync(path.join(cwd, "b", "x.txt"), "b");
+    expect(norm(await Array.fromAsync(it))).toEqual(["a/x.txt", "b/x.txt"]);
+  });
+
+  test("early break stops the walk and releases directory handles", () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 20; i++) for (let j = 0; j < 10; j++) files[`d${i}/f${j}.txt`] = "x";
+    using dir = tempDir("glob-scan-lazy-break", files);
+    const cwd = String(dir);
+
+    for (let k = 0; k < 64; k++) {
+      const it = new Glob("**/*.txt").scanSync({ cwd });
+      expect(it.next().value).toBeString();
+      it.return?.(undefined);
+    }
+    // Full scan after repeated early breaks still finds everything.
+    expect([...new Glob("**/*.txt").scanSync({ cwd })]).toHaveLength(200);
+  });
+
+  test("scan releases directory handles on early break", async () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 20; i++) for (let j = 0; j < 10; j++) files[`d${i}/f${j}.txt`] = "x";
+    using dir = tempDir("glob-scan-lazy-break-async", files);
+    const cwd = String(dir);
+
+    for (let k = 0; k < 64; k++) {
+      const it = new Glob("**/*.txt").scan({ cwd });
+      expect((await it.next()).value).toBeString();
+      await it.return?.(undefined);
+    }
+    expect(await Array.fromAsync(new Glob("**/*.txt").scan({ cwd }))).toHaveLength(200);
+  });
+
+  test("partial iteration yields a bounded prefix of a large tree", () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 20; i++) for (let j = 0; j < 20; j++) files[`d${i}/f${j}.txt`] = "x";
+    using dir = tempDir("glob-scan-lazy-partial", files);
+    const cwd = String(dir);
+
+    const it = new Glob("**/*.txt").scanSync({ cwd });
+    const taken: string[] = [];
+    for (const p of it) {
+      taken.push(p);
+      if (taken.length === 50) break;
+    }
+    expect(taken).toHaveLength(50);
+    expect([...new Glob("**/*.txt").scanSync({ cwd })]).toHaveLength(400);
+  });
+});
+
 test("error non-existent cwd", async () => {
   const glob = new Glob("**/*");
   let err: Error | undefined = undefined;


### PR DESCRIPTION
`Glob.scan()` and `Glob.scanSync()` previously drained the entire walk before yielding anything: the JS builtin called the native `$pull`/`$resolveSync` which ran `GlobWalker::walk()` to completion and handed back one array. On a large tree this read every directory and materialized every matched path even when the caller only wanted the first few results, and breaking out of the iterator early recovered nothing.

`GlobWalker::Iterator` is already an incremental generator (`next()` returns one matched path per call with at most two directory fds open); only the binding drained it eagerly.

### Change

* `walk::Iterator` is now generic over its walker storage so it can own a `Box<GlobWalker>` as well as borrow `&mut GlobWalker`. Existing borrow-based callers are unchanged via an `IteratorRef<'a, ..>` alias.
* A new private `GlobScanHandle` JS class owns an owning `Iterator<Box<GlobWalker>, ..>` and exposes private `$pull`/`$resolveSync`/`$close` methods.
* `Glob.$pull`/`$resolveSync` now return that handle (pattern parsing only, no filesystem access) and the `scan`/`scanSync` builtins pull batches of up to 256 paths on demand, closing the iterator from the generator's `finally` block so `break`/`return()` releases directory handles immediately.
* The existing `AsyncGlobWalkTask` is repurposed as the per-batch work-pool task, so no new event-loop wiring is needed.

### Drive-by fixes

* `Iterator::init()`'s absolute-literal-path fast path probed with `open(O_DIRECTORY)` and treated `Ok` as a directory and `ENOTDIR` as a file. That match was then discarded by `walk()` because it read `matched_paths` (which the fast path never inserted into), so this code path always returned `[]`. The batch path surfaces what `next()` returns, so the fast path now `stat()`s the path and applies the same `(ISDIR && !only_files) || ISREG || !only_files` rule as the literal-tail stat path, which makes `new Glob("/etc/hosts").scanSync()` return `["/etc/hosts"]` and `new Glob("/tmp").scanSync()` honour `onlyFiles` on every platform.
* `generate-classes.ts` no longer emits a `reifyStaticProperties(.., ${T}PrototypeTableValues, ..)` call when every proto entry is private-only (the hash table isn't emitted in that case).

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/glob/scan.test.ts -t "lazily|absolute literal"
(fail) scanSync does not read the directory until iterated
(fail) scan does not start the walk until the iterator is consumed
(fail) absolute literal pattern honours onlyFiles > matches a regular file, ...
(fail) absolute literal pattern honours onlyFiles > async matches a regular file, ...

$ bun bd test test/js/bun/glob/scan.test.ts -t "lazily|absolute literal"
7 pass
```

Full `test/js/bun/glob/` and `test/js/node/fs/glob.test.ts` pass on Linux and Windows. `rust:check-all` passes on all ten targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/glob/scan.test.ts

<!-- robobun:evidence:end -->