### PR TITLE
process.env.TZ: drop the 32-char length cap on the runtime setter

### DIFF
--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -487,7 +487,7 @@ static constexpr ASCIILiteral kProxyEnvVarNames[] = {
 // side-effecting var need only be added in one place.
 static void applyTZFromString(JSGlobalObject* globalObject, const String& value)
 {
-    if (value.length() < 32 && WTF::setTimeZoneOverride(value)) {
+    if (WTF::setTimeZoneOverride(value)) {
         WTF::timeZoneDidChange();
         JSC::getVM(globalObject).dateCache.clearForTimeZoneChange();
     }

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -270,6 +270,25 @@ it("process.env.TZ", () => {
   expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe(realOrigTimezone);
 });
 
+it("process.env.TZ accepts zone ids >= 32 chars", () => {
+  const origTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  try {
+    process.env.TZ = "Asia/Tokyo";
+    expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe("Asia/Tokyo");
+
+    // "America/Argentina/ComodRivadavia" is exactly 32 chars and a valid IANA
+    // link zone. The runtime setter used to gate on length < 32, silently
+    // dropping it while the launch-time TZ path had no such cap.
+    const long = "America/Argentina/ComodRivadavia";
+    expect(long.length).toBe(32);
+    process.env.TZ = long;
+    expect(Intl.DateTimeFormat().resolvedOptions().timeZone).not.toBe("Asia/Tokyo");
+    expect(new Date("2026-07-27T15:00Z").getTimezoneOffset()).toBe(180);
+  } finally {
+    process.env.TZ = origTimezone;
+  }
+});
+
 it("process.version starts with v", () => {
   expect(process.version.startsWith("v")).toBeTruthy();
 });


### PR DESCRIPTION
## Repro

```js
process.env.TZ = "Asia/Tokyo";
console.log(Intl.DateTimeFormat().resolvedOptions().timeZone); // Asia/Tokyo
process.env.TZ = "America/Argentina/ComodRivadavia"; // 32 chars, valid IANA link zone
console.log(Intl.DateTimeFormat().resolvedOptions().timeZone,
  new Date("2026-07-27T15:00Z").getTimezoneOffset());
// before: "Asia/Tokyo -540"  (assignment silently dropped)
// after:  "America/Argentina/Catamarca 180"
// node:   "America/Catamarca 180"
```

Launch-time `TZ=America/Argentina/ComodRivadavia bun -e ...` already worked; only the mid-process setter was affected.

## Cause

`applyTZFromString` in `src/jsc/bindings/JSEnvironmentVariableMap.cpp` gated on `value.length() < 32 && WTF::setTimeZoneOverride(value)`. The strict `< 32` dropped every value of 32+ characters before ICU ever saw it. The launch-time path (`JSGlobalObject__setTimeZone`) and `bun:jsc`'s `setTimeZone` have no such cap.

`WTF::setTimeZoneOverride` already validates through ICU's `ucal_getCanonicalTimeZoneID` and returns `false` for anything it rejects, so the length pre-filter is redundant and only serves to reject valid long zone ids (and tzfile paths).

## Fix

Remove the `value.length() < 32 &&` guard.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/process/process.test.js -t "process.env.TZ"
(pass) process.env.TZ
(fail) process.env.TZ accepts zone ids >= 32 chars
  error: expect(received).not.toBe(expected)
  Expected: not "Asia/Tokyo"

$ bun bd test test/js/node/process/process.test.js -t "process.env.TZ"
(pass) process.env.TZ
(pass) process.env.TZ accepts zone ids >= 32 chars
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->
