### PR TITLE
resolver: fall back to the literal path when a specifier's ?-stripped prefix does not resolve

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -445,8 +445,14 @@ pub fn normalize_specifier<'a>(
 
     if let Some(i) = strings::index_of_char(slice, b'?') {
         let i = i as usize;
-        query = &slice[i..];
-        slice = &slice[..i];
+        let stripped = &slice[..i];
+        // A resolved module key's path component is a file on disk. If the
+        // stripped prefix is not, the `?` is part of the filesystem path
+        // (POSIX allows it in filenames), not a query separator.
+        if !bun_paths::is_absolute(stripped) || bun_sys::exists_as_file(stripped) {
+            query = &slice[i..];
+            slice = stripped;
+        }
     }
 
     (slice, specifier, query)

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -446,9 +446,7 @@ pub fn normalize_specifier<'a>(
     if let Some(i) = strings::index_of_char(slice, b'?') {
         let i = i as usize;
         let stripped = &slice[..i];
-        // A resolved module key's path component is a file on disk. If the
-        // stripped prefix is not, the `?` is part of the filesystem path
-        // (POSIX allows it in filenames), not a query separator.
+        // `?` starts a query only when the stripped prefix is itself a file.
         if !bun_paths::is_absolute(stripped) || bun_sys::exists_as_file(stripped) {
             query = &slice[i..];
             slice = stripped;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -446,8 +446,9 @@ pub fn normalize_specifier<'a>(
     if let Some(i) = strings::index_of_char(slice, b'?') {
         let i = i as usize;
         let stripped = &slice[..i];
-        // `?` starts a query only when the stripped prefix is itself a file.
-        if !bun_paths::is_absolute(stripped) || bun_sys::exists_as_file(stripped) {
+        // `?` starts a query only when the stripped prefix is itself a file;
+        // `?` is not a valid NTFS filename character, so always split on Windows.
+        if cfg!(windows) || !bun_paths::is_absolute(stripped) || bun_sys::exists_as_file(stripped) {
             query = &slice[i..];
             slice = stripped;
         }

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -60,10 +60,11 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
     }
   }
 
-  // A resolved id may carry a `?query` suffix (part of the module cache key);
-  // match the native-addon extension against the path portion only.
+  // A resolved id is `path` or `path?query`. When the id itself ends in
+  // `.node` there is no query suffix, so any `?` is part of the filesystem
+  // path (POSIX allows it in filenames).
   const queryIndex = id.indexOf("?");
-  if (queryIndex === -1 ? id.endsWith(".node") : id.endsWith(".node", queryIndex)) {
+  if (id.endsWith(".node") || (queryIndex !== -1 && id.endsWith(".node", queryIndex))) {
     return $internalRequire(id, this);
   }
 
@@ -162,9 +163,9 @@ $visibility = "Private";
 export function internalRequire(id: string, parent: JSCommonJSModule) {
   $assert($requireMap.$get(id) === undefined, "Module " + JSON.stringify(id) + " should not be in the map");
   // `id` keys the module cache and may carry a `?query` suffix;
-  // `process.dlopen` needs the on-disk path.
-  const queryIndex = id.indexOf("?");
-  const filename = queryIndex === -1 ? id : id.substring(0, queryIndex);
+  // `process.dlopen` needs the on-disk path. When the id itself ends in
+  // `.node` there is no query suffix, so any `?` is part of the path.
+  const filename = id.endsWith(".node") ? id : id.substring(0, id.indexOf("?"));
   $assert(filename.endsWith(".node"));
 
   const module = $createCommonJSModule(id, {}, true, parent);

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -60,9 +60,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
     }
   }
 
-  // A resolved id is `path` or `path?query`. When the id itself ends in
-  // `.node` there is no query suffix, so any `?` is part of the filesystem
-  // path (POSIX allows it in filenames).
+  // An id ending in ".node" has no query suffix; any `?` is part of the path.
   const queryIndex = id.indexOf("?");
   if (id.endsWith(".node") || (queryIndex !== -1 && id.endsWith(".node", queryIndex))) {
     return $internalRequire(id, this);
@@ -162,9 +160,7 @@ export function requireResolve(
 $visibility = "Private";
 export function internalRequire(id: string, parent: JSCommonJSModule) {
   $assert($requireMap.$get(id) === undefined, "Module " + JSON.stringify(id) + " should not be in the map");
-  // `id` keys the module cache and may carry a `?query` suffix;
-  // `process.dlopen` needs the on-disk path. When the id itself ends in
-  // `.node` there is no query suffix, so any `?` is part of the path.
+  // Strip a `?query` suffix for dlopen; an id ending in `.node` has none.
   const filename = id.endsWith(".node") ? id : id.substring(0, id.indexOf("?"));
   $assert(filename.endsWith(".node"));
 

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -60,9 +60,10 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
     }
   }
 
-  // An id ending in ".node" has no query suffix; any `?` is part of the path.
+  // A resolved id may carry a `?query` suffix (part of the module cache key);
+  // match the native-addon extension against the path portion only.
   const queryIndex = id.indexOf("?");
-  if (id.endsWith(".node") || (queryIndex !== -1 && id.endsWith(".node", queryIndex))) {
+  if (queryIndex === -1 ? id.endsWith(".node") : id.endsWith(".node", queryIndex)) {
     return $internalRequire(id, this);
   }
 
@@ -160,8 +161,10 @@ export function requireResolve(
 $visibility = "Private";
 export function internalRequire(id: string, parent: JSCommonJSModule) {
   $assert($requireMap.$get(id) === undefined, "Module " + JSON.stringify(id) + " should not be in the map");
-  // Strip a `?query` suffix for dlopen; an id ending in `.node` has none.
-  const filename = id.endsWith(".node") ? id : id.substring(0, id.indexOf("?"));
+  // `id` keys the module cache and may carry a `?query` suffix;
+  // `process.dlopen` needs the on-disk path.
+  const queryIndex = id.indexOf("?");
+  const filename = queryIndex === -1 ? id : id.substring(0, queryIndex);
   $assert(filename.endsWith(".node"));
 
   const module = $createCommonJSModule(id, {}, true, parent);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4053,7 +4053,7 @@ impl VirtualMachine {
         let mut normalized_specifier =
             normalize_specifier_for_resolution(specifier, &mut query_string);
         // POSIX filenames may contain a literal `?`.
-        let mut retry_with_literal_question_mark = !query_string.is_empty();
+        let mut retry_with_literal_question_mark = !cfg!(windows) && !query_string.is_empty();
         let top_level_dir = self.top_level_dir();
         let source_to_use: &[u8] = if !is_special_source {
             if is_a_file_path {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4052,8 +4052,7 @@ impl VirtualMachine {
         let mut query_string: &[u8] = b"";
         let mut normalized_specifier =
             normalize_specifier_for_resolution(specifier, &mut query_string);
-        // POSIX filenames may contain a literal `?`; if the stripped specifier
-        // does not resolve, retry once with the `?` treated as part of the path.
+        // POSIX filenames may contain a literal `?`.
         let mut retry_with_literal_question_mark = !query_string.is_empty();
         let top_level_dir = self.top_level_dir();
         let source_to_use: &[u8] = if !is_special_source {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4050,7 +4050,11 @@ impl VirtualMachine {
 
         let is_special_source = source == MAIN_FILE_NAME || Macro::is_macro_path(source);
         let mut query_string: &[u8] = b"";
-        let normalized_specifier = normalize_specifier_for_resolution(specifier, &mut query_string);
+        let mut normalized_specifier =
+            normalize_specifier_for_resolution(specifier, &mut query_string);
+        // POSIX filenames may contain a literal `?`; if the stripped specifier
+        // does not resolve, retry once with the `?` treated as part of the path.
+        let mut retry_with_literal_question_mark = !query_string.is_empty();
         let top_level_dir = self.top_level_dir();
         let source_to_use: &[u8] = if !is_special_source {
             if is_a_file_path {
@@ -4075,7 +4079,7 @@ impl VirtualMachine {
         // returning the resolver result; `retry_on_not_found` is consumed on
         // the first miss.
         let mut retry_on_not_found = bun_paths::is_absolute(source_to_use);
-        let result: bun_resolver::Result = loop {
+        let result: bun_resolver::Result = 'resolve: loop {
             let import_kind = if is_esm {
                 bun_ast::ImportKind::Stmt
             } else {
@@ -4091,55 +4095,66 @@ impl VirtualMachine {
                 ResultUnion::Success(r) => break r,
                 ResultUnion::Failure(e) => return Err(e.into()),
                 ResultUnion::Pending(_) | ResultUnion::NotFound => {
-                    if !retry_on_not_found {
-                        return Err(crate::CrateError::ModuleNotFound);
-                    }
-                    retry_on_not_found = false;
+                    'not_found: {
+                        if !retry_on_not_found {
+                            break 'not_found;
+                        }
+                        retry_on_not_found = false;
 
-                    // SAFETY: thread-local heap allocation; sole `&mut` on the JS
-                    // thread for the duration of the bust below.
-                    let buf = unsafe { &mut *specifier_cache_resolver_buf() }.as_mut_slice();
-                    let buster_name: &[u8] = if bun_paths::is_absolute(normalized_specifier) {
-                        if let Some(dir) = bun_paths::dirname(normalized_specifier) {
-                            if dir.len() > buf.len() {
-                                return Err(crate::CrateError::ModuleNotFound);
+                        // SAFETY: thread-local heap allocation; sole `&mut` on the JS
+                        // thread for the duration of the bust below.
+                        let buf = unsafe { &mut *specifier_cache_resolver_buf() }.as_mut_slice();
+                        let buster_name: &[u8] = if bun_paths::is_absolute(normalized_specifier) {
+                            if let Some(dir) = bun_paths::dirname(normalized_specifier) {
+                                if dir.len() > buf.len() {
+                                    break 'not_found;
+                                }
+                                // Normalized without trailing slash.
+                                bun_paths::string_paths::normalize_slashes_only(
+                                    buf,
+                                    dir,
+                                    bun_paths::SEP,
+                                )
+                            } else {
+                                // Absolute but root — fall through to join.
+                                &b""[..]
                             }
-                            // Normalized without trailing slash.
-                            bun_paths::string_paths::normalize_slashes_only(
-                                buf,
-                                dir,
-                                bun_paths::SEP,
-                            )
                         } else {
-                            // Absolute but root — fall through to join.
                             &b""[..]
-                        }
-                    } else {
-                        &b""[..]
-                    };
-                    let buster_name: &[u8] = if !buster_name.is_empty() {
-                        buster_name
-                    } else {
-                        // If the specifier is too long to join, it can't name
-                        // a real directory — skip the cache bust and fail.
-                        if source_to_use.len() + normalized_specifier.len() + 4 >= buf.len() {
-                            return Err(crate::CrateError::ModuleNotFound);
-                        }
-                        let parts: [&[u8]; 3] = [
-                            source_to_use,
-                            normalized_specifier,
-                            bun_paths::path_literal!("..").as_bytes(),
-                        ];
-                        bun_paths::resolve_path::join_abs_string_buf_z::<
-                            bun_paths::resolve_path::platform::Auto,
-                        >(top_level_dir, buf, &parts)
-                        .as_bytes()
-                    };
+                        };
+                        let buster_name: &[u8] = if !buster_name.is_empty() {
+                            buster_name
+                        } else {
+                            // If the specifier is too long to join, it can't name
+                            // a real directory — skip the cache bust and fail.
+                            if source_to_use.len() + normalized_specifier.len() + 4 >= buf.len() {
+                                break 'not_found;
+                            }
+                            let parts: [&[u8]; 3] = [
+                                source_to_use,
+                                normalized_specifier,
+                                bun_paths::path_literal!("..").as_bytes(),
+                            ];
+                            bun_paths::resolve_path::join_abs_string_buf_z::<
+                                bun_paths::resolve_path::platform::Auto,
+                            >(top_level_dir, buf, &parts)
+                            .as_bytes()
+                        };
 
-                    // Only re-query if we previously had something cached.
-                    if self.transpiler.resolver.bust_dir_cache(
-                        bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
-                    ) {
+                        // Only re-query if we previously had something cached.
+                        if self.transpiler.resolver.bust_dir_cache(
+                            bun_paths::string_paths::without_trailing_slash_windows_path(
+                                buster_name,
+                            ),
+                        ) {
+                            continue 'resolve;
+                        }
+                    }
+                    if retry_with_literal_question_mark {
+                        retry_with_literal_question_mark = false;
+                        normalized_specifier = specifier;
+                        query_string = b"";
+                        retry_on_not_found = bun_paths::is_absolute(source_to_use);
                         continue;
                     }
                     return Err(crate::CrateError::ModuleNotFound);

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -177,10 +177,7 @@ ImportMetaObject* ImportMetaObject::createFromSpecifier(JSC::JSGlobalObject* glo
         StringView view = specifier;
         StringView stripped = view.substring(0, index);
 #if !OS(WINDOWS)
-        // A module key is `path?query`, except when `?` is part of the
-        // filesystem path (POSIX allows it in filenames): then the path
-        // component is the whole key and there is no query. `?` is not a
-        // valid filename character on Windows, so this check is POSIX-only.
+        // `?` starts a query only when the stripped prefix is itself a file.
         if (stripped.startsWith('/')) {
             WTF::CString utf8 = stripped.utf8();
             if (!Bun__existsAsFile(utf8.data(), utf8.length())) {

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -165,13 +165,30 @@ ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JS
     return ImportMetaObject::createFromSpecifier(globalObject, specifier);
 }
 
+#if !OS(WINDOWS)
+extern "C" bool Bun__existsAsFile(const char* ptr, size_t len);
+#endif
+
 ImportMetaObject* ImportMetaObject::createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier)
 {
     auto index = specifier.find('?');
     URL url;
     if (index != notFound) {
         StringView view = specifier;
-        url = URL::fileURLWithFileSystemPath(view.substring(0, index));
+        StringView stripped = view.substring(0, index);
+#if !OS(WINDOWS)
+        // A module key is `path?query`, except when `?` is part of the
+        // filesystem path (POSIX allows it in filenames): then the path
+        // component is the whole key and there is no query. `?` is not a
+        // valid filename character on Windows, so this check is POSIX-only.
+        if (stripped.startsWith('/')) {
+            WTF::CString utf8 = stripped.utf8();
+            if (!Bun__existsAsFile(utf8.data(), utf8.length())) {
+                return create(globalObject, URL::fileURLWithFileSystemPath(specifier).string());
+            }
+        }
+#endif
+        url = URL::fileURLWithFileSystemPath(stripped);
         url.setQuery(view.substring(index + 1));
     } else {
         url = URL::fileURLWithFileSystemPath(specifier);

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -40,13 +40,14 @@ public:
     /// The rules for this function's input is a bit weird. `specifier` is an import path specifier aka a file path.
     ///
     /// - Should be an absolute path or name of a plugin module
-    /// - A '?' is handled not as a literal '?' in a file, but rather as the query string
+    /// - On POSIX, a '?' is treated as the query separator only when the prefix before it
+    ///   names a file on disk; otherwise the '?' is part of the literal filesystem path and
+    ///   is percent-encoded into the URL path. On Windows '?' is always the query separator
+    ///   since it cannot appear in NTFS filenames.
     /// - The string is not URL encoded, despite having a query string.
     ///
-    /// caveat: It is impossible to have a module with a `?` in it's file name.
-    ///
-    /// Fixing this means adjusting a lot of how the module resolver works to operate and handle URL
-    /// escaping, see https://github.com/oven-sh/bun/issues/8640 for more details.
+    /// Fixing this properly means adjusting a lot of how the module resolver works to operate and
+    /// handle URL escaping, see https://github.com/oven-sh/bun/issues/8640 for more details.
     ///
     /// The above rules get a best estimate bandage to solve the problems
     /// stated in https://github.com/oven-sh/bun/pull/9399

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3908,8 +3908,9 @@ unsafe fn normalize_specifier_for_loader<'a>(
     if let Some(i) = bun_core::strings::index_of_char_usize(slice, b'?') {
         let i = i as usize;
         let stripped = &slice[..i];
-        // `?` starts a query only when the stripped prefix is itself a file.
-        if !bun_paths::is_absolute(stripped) || bun_sys::exists_as_file(stripped) {
+        // `?` starts a query only when the stripped prefix is itself a file;
+        // `?` is not a valid NTFS filename character, so always split on Windows.
+        if cfg!(windows) || !bun_paths::is_absolute(stripped) || bun_sys::exists_as_file(stripped) {
             query = &slice[i..];
             slice = stripped;
         }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4948,7 +4948,7 @@ unsafe fn _resolve<'a>(
     let mut query_string: &[u8] = b"";
     let mut normalized_specifier = normalize_specifier_for_resolution(specifier, &mut query_string);
     // POSIX filenames may contain a literal `?`.
-    let mut retry_with_literal_question_mark = !query_string.is_empty();
+    let mut retry_with_literal_question_mark = !cfg!(windows) && !query_string.is_empty();
     // `Fs.PathName.init(source).dirWithTrailingSlash()` slices
     // `source` in place, so the `'a` lifetime is preserved.
     let top_level_dir: &'a [u8] = Fs::FileSystem::get().top_level_dir;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3908,9 +3908,7 @@ unsafe fn normalize_specifier_for_loader<'a>(
     if let Some(i) = bun_core::strings::index_of_char_usize(slice, b'?') {
         let i = i as usize;
         let stripped = &slice[..i];
-        // A resolved module key's path component is a file on disk. If the
-        // stripped prefix is not, the `?` is part of the filesystem path
-        // (POSIX allows it in filenames), not a query separator.
+        // `?` starts a query only when the stripped prefix is itself a file.
         if !bun_paths::is_absolute(stripped) || bun_sys::exists_as_file(stripped) {
             query = &slice[i..];
             slice = stripped;
@@ -4948,8 +4946,7 @@ unsafe fn _resolve<'a>(
     let is_special_source = source == MAIN_FILE_NAME || bun_js_parser::Macro::is_macro_path(source);
     let mut query_string: &[u8] = b"";
     let mut normalized_specifier = normalize_specifier_for_resolution(specifier, &mut query_string);
-    // POSIX filenames may contain a literal `?`; if the stripped specifier
-    // does not resolve, retry once with the `?` treated as part of the path.
+    // POSIX filenames may contain a literal `?`.
     let mut retry_with_literal_question_mark = !query_string.is_empty();
     // `Fs.PathName.init(source).dirWithTrailingSlash()` slices
     // `source` in place, so the `'a` lifetime is preserved.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3907,8 +3907,14 @@ unsafe fn normalize_specifier_for_loader<'a>(
     let mut query: &[u8] = b"";
     if let Some(i) = bun_core::strings::index_of_char_usize(slice, b'?') {
         let i = i as usize;
-        query = &slice[i..];
-        slice = &slice[..i];
+        let stripped = &slice[..i];
+        // A resolved module key's path component is a file on disk. If the
+        // stripped prefix is not, the `?` is part of the filesystem path
+        // (POSIX allows it in filenames), not a query separator.
+        if !bun_paths::is_absolute(stripped) || bun_sys::exists_as_file(stripped) {
+            query = &slice[i..];
+            slice = stripped;
+        }
     }
     (slice, specifier, query)
 }
@@ -4941,7 +4947,10 @@ unsafe fn _resolve<'a>(
     // ── Filesystem resolver ──────────────────────────────────────────────
     let is_special_source = source == MAIN_FILE_NAME || bun_js_parser::Macro::is_macro_path(source);
     let mut query_string: &[u8] = b"";
-    let normalized_specifier = normalize_specifier_for_resolution(specifier, &mut query_string);
+    let mut normalized_specifier = normalize_specifier_for_resolution(specifier, &mut query_string);
+    // POSIX filenames may contain a literal `?`; if the stripped specifier
+    // does not resolve, retry once with the `?` treated as part of the path.
+    let mut retry_with_literal_question_mark = !query_string.is_empty();
     // `Fs.PathName.init(source).dirWithTrailingSlash()` slices
     // `source` in place, so the `'a` lifetime is preserved.
     let top_level_dir: &'a [u8] = Fs::FileSystem::get().top_level_dir;
@@ -4967,7 +4976,7 @@ unsafe fn _resolve<'a>(
     // This cache-bust is disabled when the filesystem is not being used to
     // resolve.
     let mut retry_on_not_found = bun_paths::is_absolute(source_to_use);
-    let result: bun_resolver::Result = loop {
+    let result: bun_resolver::Result = 'resolve: loop {
         // SAFETY: `vm.transpiler.resolver` is the unique per-VM resolver; this
         // is the only `&mut` borrow live for this call (the JS thread is
         // single-entry here).
@@ -4982,49 +4991,60 @@ unsafe fn _resolve<'a>(
             ResolveResultUnion::Success(r) => break r,
             ResolveResultUnion::Failure(e) => return Err(e.into()),
             ResolveResultUnion::Pending(_) | ResolveResultUnion::NotFound => {
-                if !retry_on_not_found {
-                    return Err(crate::Error::ModuleNotFound);
-                }
-                retry_on_not_found = false;
+                'not_found: {
+                    if !retry_on_not_found {
+                        break 'not_found;
+                    }
+                    retry_on_not_found = false;
 
-                // Bust the dir cache for the candidate
-                // parent directory and retry once.
-                let mut buf = bun_paths::path_buffer_pool::get();
-                let buster_name: &[u8] = 'name: {
-                    if bun_paths::is_absolute(normalized_specifier) {
-                        if let Some(dir) = bun_core::dirname(normalized_specifier) {
-                            if dir.len() > buf.len() {
-                                return Err(crate::Error::ModuleNotFound);
+                    // Bust the dir cache for the candidate
+                    // parent directory and retry once.
+                    let mut buf = bun_paths::path_buffer_pool::get();
+                    let buster_name: &[u8] = 'name: {
+                        if bun_paths::is_absolute(normalized_specifier) {
+                            if let Some(dir) = bun_core::dirname(normalized_specifier) {
+                                if dir.len() > buf.len() {
+                                    break 'not_found;
+                                }
+                                // Normalized without trailing slash.
+                                break 'name bun_paths::string_paths::normalize_slashes_only(
+                                    &mut buf[..],
+                                    dir,
+                                    bun_paths::SEP,
+                                );
                             }
-                            // Normalized without trailing slash.
-                            break 'name bun_paths::string_paths::normalize_slashes_only(
-                                &mut buf[..],
-                                dir,
-                                bun_paths::SEP,
-                            );
                         }
+
+                        // If the specifier is too long to join, it can't name a
+                        // real directory — skip the cache bust and fail.
+                        if source_to_use.len() + normalized_specifier.len() + 4 >= buf.len() {
+                            break 'not_found;
+                        }
+
+                        let parts: [&[u8]; 3] = [source_to_use, normalized_specifier, b".."];
+                        break 'name bun_paths::resolve_path::join_abs_string_buf_z::<
+                            bun_paths::platform::Auto,
+                        >(top_level_dir, &mut buf[..], &parts)
+                        .as_bytes();
+                    };
+
+                    // Only re-query if we previously had something cached.
+                    // SAFETY: see above.
+                    if unsafe {
+                        (*vm).transpiler.resolver.bust_dir_cache(
+                            bun_paths::string_paths::without_trailing_slash_windows_path(
+                                buster_name,
+                            ),
+                        )
+                    } {
+                        continue 'resolve;
                     }
-
-                    // If the specifier is too long to join, it can't name a
-                    // real directory — skip the cache bust and fail.
-                    if source_to_use.len() + normalized_specifier.len() + 4 >= buf.len() {
-                        return Err(crate::Error::ModuleNotFound);
-                    }
-
-                    let parts: [&[u8]; 3] = [source_to_use, normalized_specifier, b".."];
-                    break 'name bun_paths::resolve_path::join_abs_string_buf_z::<
-                        bun_paths::platform::Auto,
-                    >(top_level_dir, &mut buf[..], &parts)
-                    .as_bytes();
-                };
-
-                // Only re-query if we previously had something cached.
-                // SAFETY: see above.
-                if unsafe {
-                    (*vm).transpiler.resolver.bust_dir_cache(
-                        bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
-                    )
-                } {
+                }
+                if retry_with_literal_question_mark {
+                    retry_with_literal_question_mark = false;
+                    normalized_specifier = specifier;
+                    query_string = b"";
+                    retry_on_not_found = bun_paths::is_absolute(source_to_use);
                     continue;
                 }
                 return Err(crate::Error::ModuleNotFound);

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9085,6 +9085,15 @@ pub fn exists_as_file(path: &[u8]) -> bool {
     let z = ZStr::from_buf(&buf.0[..], path.len());
     matches!(exists_at_type(Fd::cwd(), z), Ok(ExistsAtType::File))
 }
+/// Exported for `ImportMetaObject.cpp` — see [`exists_as_file`].
+///
+/// # Safety
+/// `ptr[0..len]` must be a valid UTF-8 path slice for the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Bun__existsAsFile(ptr: *const u8, len: usize) -> bool {
+    // SAFETY: per fn contract.
+    exists_as_file(unsafe { core::slice::from_raw_parts(ptr, len) })
+}
 /// `moveFileZ`. Routes through
 /// [`renameat_concurrently_without_fallback`] (renameat2 NOREPLACE → EXCHANGE →
 /// delete-tree + rename); on EISDIR removes the dest dir and

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9072,6 +9072,19 @@ pub fn exists(path: &[u8]) -> bool {
     let z = ZStr::from_buf(&buf.0[..], path.len());
     exists_z(z)
 }
+/// [`exists`] restricted to non-directories. `false` for directories,
+/// ENOENT, and any other stat error.
+pub fn exists_as_file(path: &[u8]) -> bool {
+    let mut buf = bun_paths::path_buffer_pool::get();
+    if path.len() >= buf.0.len() {
+        return false;
+    }
+    buf.0[..path.len()].copy_from_slice(path);
+    buf.0[path.len()] = 0;
+    // SAFETY: NUL-terminated above.
+    let z = ZStr::from_buf(&buf.0[..], path.len());
+    matches!(exists_at_type(Fd::cwd(), z), Ok(ExistsAtType::File))
+}
 /// `moveFileZ`. Routes through
 /// [`renameat_concurrently_without_fallback`] (renameat2 NOREPLACE → EXCHANGE →
 /// delete-tree + rename); on EISDIR removes the dest dir and

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 globalThis.importQueryFixtureOrder = [];
 const resolvedPath = require.resolve("./import-query-fixture.ts");
 const resolvedURL = Bun.pathToFileURL(resolvedPath).href;
@@ -233,4 +233,63 @@ test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
   const resolved = JSON.parse(stdout.trim());
   expect(resolved).toEndWith("target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");
   expect(exitCode).toBe(0);
+});
+
+// `?` is not a valid filename character on Windows/NTFS.
+describe.skipIf(isWindows).concurrent("filename containing a literal ?", () => {
+  async function run(cmd: string[], cwd: string) {
+    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("runs as the CLI entry point", async () => {
+    using dir = tempDir("qmark-cli", {
+      "weird?name.mjs": `console.log("qfile-ran");\n`,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "./weird?name.mjs"], String(dir));
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "qfile-ran\n", stderr: "", exitCode: 0 });
+  });
+
+  test("runs as the CLI entry point when the ? is the first character", async () => {
+    using dir = tempDir("qmark-cli-leading", {
+      "?leading.js": `console.log("leading-ran");\n`,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "./?leading.js"], String(dir));
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "leading-ran\n", stderr: "", exitCode: 0 });
+  });
+
+  test("is reachable via dynamic import and require", async () => {
+    using dir = tempDir("qmark-import", {
+      "weird?name.mjs": `export const v = "qfile"; globalThis.ran = (globalThis.ran || 0) + 1;\n`,
+      "entry.mjs": `
+        const dyn = await import("./weird?name.mjs");
+        const req = require("./weird?name.mjs");
+        console.log(JSON.stringify({ dyn: dyn.v, req: req.v, ran: globalThis.ran }));
+      `,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "entry.mjs"], String(dir));
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ dyn: "qfile", req: "qfile", ran: 1 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("is reachable via static import", async () => {
+    using dir = tempDir("qmark-static", {
+      "weird?name.mjs": `export const v = "qfile";\n`,
+      "entry.mjs": `import { v } from "./weird?name.mjs"; console.log(v);\n`,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "entry.mjs"], String(dir));
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "qfile\n", stderr: "", exitCode: 0 });
+  });
+
+  test("?query still resolves to the stripped path when that file exists", async () => {
+    using dir = tempDir("qmark-precedence", {
+      "pref.mjs": `export const which = "stripped";\n`,
+      "pref.mjs?x": `export const which = "literal";\n`,
+      "entry.mjs": `console.log((await import("./pref.mjs?x")).which);\n`,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "entry.mjs"], String(dir));
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "stripped\n", stderr: "", exitCode: 0 });
+  });
 });

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -283,6 +283,28 @@ describe.skipIf(isWindows).concurrent("filename containing a literal ?", () => {
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "qfile\n", stderr: "", exitCode: 0 });
   });
 
+  test("import.meta inside the file reflects the literal path", async () => {
+    using dir = tempDir("qmark-meta", {
+      "weird?name.mjs": `console.log(JSON.stringify({
+        path: import.meta.path,
+        dir: import.meta.dir,
+        file: import.meta.file,
+        url: import.meta.url,
+      }));\n`,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "./weird?name.mjs"], String(dir));
+    expect(stderr).toBe("");
+    const meta = JSON.parse(stdout.trim());
+    expect(meta).toEqual({
+      path: `${dir}/weird?name.mjs`,
+      dir: String(dir),
+      file: "weird?name.mjs",
+      url: Bun.pathToFileURL(`${dir}/weird?name.mjs`).href,
+    });
+    expect(meta.url).toContain("weird%3Fname.mjs");
+    expect(exitCode).toBe(0);
+  });
+
   test("?query still resolves to the stripped path when that file exists", async () => {
     using dir = tempDir("qmark-precedence", {
       "pref.mjs": `export const which = "stripped";\n`,

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -235,6 +235,16 @@ test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
   expect(exitCode).toBe(0);
 });
 
+test("require of a non-.node file with a query string that ends in .node is not routed to dlopen", async () => {
+  using dir = tempDir("query-endswith-node", {
+    "config.js": `module.exports = { ok: 1 };\n`,
+    "entry.cjs": `console.log(require("./config.js?from=addon.node").ok);\n`,
+  });
+  await using proc = Bun.spawn({ cmd: [bunExe(), "entry.cjs"], env: bunEnv, cwd: String(dir), stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "1\n", stderr: "", exitCode: 0 });
+});
+
 // `?` is not a valid filename character on Windows/NTFS.
 describe.skipIf(isWindows).concurrent("filename containing a literal ?", () => {
   async function run(cmd: string[], cwd: string) {


### PR DESCRIPTION
## Repro

```sh
printf 'export const v = "qfile";\nconsole.log("qfile-ran");\n' > 'weird?name.mjs'
bun './weird?name.mjs'
# error: Module not found '/abs/weird?name.mjs'
node './weird?name.mjs'
# qfile-ran
```

Every import spelling (`import("./weird?name.mjs")`, `require("./weird?name.mjs")`) failed the same way. A legal ext4 filename containing `?` was unreachable in Bun by any means.

## Cause

`_resolve` unconditionally splits the specifier at the first `?` via `normalize_specifier_for_resolution` and hands only the prefix to the filesystem resolver. For the CLI entry point the absolute path is wrapped in the synthetic `import * as start from "<path>"` inside `bun:main`, so it goes through the same split and `'/abs/weird'` is what the resolver sees. At load time `normalize_specifier_for_loader` (and its `options.rs` twin) re-splits the module key the same way, and `ImportMetaObject::createFromSpecifier` assumes the first `?` always starts a query.

## Fix

Resolve side (`VirtualMachine::_resolve` and the `jsc_hooks.rs` twin): when the `?`-stripped specifier does not resolve, retry once with the original un-split specifier. On success the query string is cleared so nothing is re-appended to the module key.

Load side (`normalize_specifier_for_loader` / `options::normalize_specifier` / `ImportMetaObject::createFromSpecifier`): only treat the first `?` as a query separator when the stripped prefix names a file on disk, via the new `bun_sys::exists_as_file` helper (and its `Bun__existsAsFile` FFI wrapper for C++). When it does not, the `?` is part of the filesystem path and the full module key is used. The check is taken once per module load and only when the specifier contains a `?`; the C++ side is gated `#if !OS(WINDOWS)` since `?` is not a valid NTFS filename character.

Cache-bust semantics are unchanged: `./x.js?v=1` still resolves `./x.js` first; the literal-path retry only fires after that fails. `import.meta.url` inside a cache-busted module still carries the query as a URL query; inside a `?`-named file the `?` is percent-encoded into the URL path (matching Node's `file:///abs/weird%3Fname.mjs`).

### Out of scope

`require("./my?dir/addon.node")` (a `.node` addon under a `?`-named directory) was already broken on main with ModuleNotFound and remains broken, now with "use require() instead of import" from the napi loader arm since resolution now succeeds. The `.node` route in `CommonJS.ts` cannot disambiguate a `?` in the path from a `?query` suffix without the same `exists_as_file` check, which would need a new builtin binding; left for a follow-up.

## Verification

```console
$ USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/import-query.test.ts -t "literal"
(fail) filename containing a literal ? > runs as the CLI entry point
(fail) filename containing a literal ? > runs as the CLI entry point when the ? is the first character
(fail) filename containing a literal ? > is reachable via dynamic import and require
(fail) filename containing a literal ? > is reachable via static import
(fail) filename containing a literal ? > import.meta inside the file reflects the literal path
(pass) filename containing a literal ? > ?query still resolves to the stripped path when that file exists
 1 pass  5 fail
$ bun bd test test/js/bun/resolve/import-query.test.ts test/js/bun/resolve/import-meta.test.js
 54 pass  0 fail
```

The new `filename containing a literal ?` tests are POSIX-only (`describe.skipIf(isWindows)`): `?` is not a valid NTFS filename character.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/import-query.test.ts

<!-- robobun:evidence:end -->