### PR TITLE
Exit 13 on unsettled top-level await in the main entry instead of spinning

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2445,11 +2445,7 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            // Drain-aware wait (same shape as the worker path's
-            // `wait_for_promise_with_termination`): return with the promise
-            // still Pending once nothing in the loop can settle it, so the
-            // caller can report an unsettled top-level await (warn + exit 13)
-            // instead of spinning a no-op `tick_without_idle()` forever.
+            // Returns (promise still Pending) once the loop has nothing to settle it.
             while crate::JSPromise::status_ptr(promise) == crate::js_promise::Status::Pending {
                 self.event_loop_mut().tick();
                 if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2445,7 +2445,21 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            self.wait_for_promise(jsc::AnyPromise::Internal(promise));
+            // Drain-aware wait (same shape as the worker path's
+            // `wait_for_promise_with_termination`): return with the promise
+            // still Pending once nothing in the loop can settle it, so the
+            // caller can report an unsettled top-level await (warn + exit 13)
+            // instead of spinning a no-op `tick_without_idle()` forever.
+            while crate::JSPromise::status_ptr(promise) == crate::js_promise::Status::Pending {
+                self.event_loop_mut().tick();
+                if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending {
+                    break;
+                }
+                if !self.is_event_loop_alive() {
+                    break;
+                }
+                self.auto_tick();
+            }
         }
 
         Ok(self.pending_internal_promise.unwrap_or(promise))

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1493,8 +1493,13 @@ impl Run {
             }
         }
 
+        let _entry_promise_protected;
         match vm.load_entry_point(entry) {
             Ok(promise) => {
+                // `pending_internal_promise` is a raw, unvisited pointer on this
+                // path; root it so the post-`on_before_exit` status read below
+                // survives the intervening GC and user JS.
+                _entry_promise_protected = JSValue::from_cell(promise).protected();
                 // SAFETY: `promise` is a live GC cell returned by the module loader.
                 let promise = unsafe { &mut *promise };
                 if promise.status() == PromiseStatus::Rejected {
@@ -1620,8 +1625,11 @@ impl Run {
 
             vm.on_before_exit();
 
-            if let Some(p) = vm.pending_internal_promise {
-                // SAFETY: `p` is a live JSC heap cell tracked by the VM.
+            if vm.unhandled_error_counter == 0
+                && let Some(p) = vm.pending_internal_promise
+            {
+                // SAFETY: `p` is a live JSC heap cell rooted by
+                // `_entry_promise_protected` above.
                 let p = unsafe { &mut *p };
                 match p.status() {
                     PromiseStatus::Pending => {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1622,15 +1622,33 @@ impl Run {
 
             if let Some(p) = vm.pending_internal_promise {
                 // SAFETY: `p` is a live JSC heap cell tracked by the VM.
-                if unsafe { &*p }.status() == PromiseStatus::Pending {
-                    pretty_errorln!(
-                        "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await at {}",
-                        bstr::BStr::new(vm.main()),
-                    );
-                    Output::flush();
-                    if vm.exit_handler.exit_code == 0 {
-                        vm.exit_handler.exit_code = 13;
+                let p = unsafe { &mut *p };
+                match p.status() {
+                    PromiseStatus::Pending => {
+                        pretty_errorln!(
+                            "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await at {}",
+                            bstr::BStr::new(vm.main()),
+                        );
+                        Output::flush();
+                        if vm.exit_handler.exit_code == 0 {
+                            vm.exit_handler.exit_code = 13;
+                        }
                     }
+                    PromiseStatus::Rejected
+                        if vm.pending_internal_promise_reported_at != vm.hot_reload_counter =>
+                    {
+                        vm.pending_internal_promise_reported_at = vm.hot_reload_counter;
+                        // SAFETY: `vm.jsc_vm` set in `init`; FFI takes `*mut`.
+                        let result = p.result(unsafe { &mut *vm.jsc_vm });
+                        let global = vm.global;
+                        // SAFETY: `global` valid for VM lifetime.
+                        let handled = vm.uncaught_exception(unsafe { &*global }, result, true);
+                        p.set_handled();
+                        if !handled {
+                            exit_with_unhandled_note(vm);
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1619,6 +1619,23 @@ impl Run {
             }
 
             vm.on_before_exit();
+
+            // Unsettled top-level await: the loop (and beforeExit) drained but
+            // the entry module's evaluation promise is still pending. Node
+            // prints a warning and exits 13 unless the user set an exit code.
+            if let Some(p) = vm.pending_internal_promise {
+                // SAFETY: `p` is a live JSC heap cell tracked by the VM.
+                if unsafe { &*p }.status() == PromiseStatus::Pending {
+                    pretty_errorln!(
+                        "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await at {}",
+                        bstr::BStr::new(vm.main()),
+                    );
+                    Output::flush();
+                    if vm.exit_handler.exit_code == 0 {
+                        vm.exit_handler.exit_code = 13;
+                    }
+                }
+            }
         }
 
         if log_has_msgs(vm) {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1620,9 +1620,6 @@ impl Run {
 
             vm.on_before_exit();
 
-            // Unsettled top-level await: the loop (and beforeExit) drained but
-            // the entry module's evaluation promise is still pending. Node
-            // prints a warning and exits 13 unless the user set an exit code.
             if let Some(p) = vm.pending_internal_promise {
                 // SAFETY: `p` is a live JSC heap cell tracked by the VM.
                 if unsafe { &*p }.status() == PromiseStatus::Pending {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1496,9 +1496,7 @@ impl Run {
         let _entry_promise_protected;
         match vm.load_entry_point(entry) {
             Ok(promise) => {
-                // `pending_internal_promise` is a raw, unvisited pointer on this
-                // path; root it so the post-`on_before_exit` status read below
-                // survives the intervening GC and user JS.
+                // Root it (the stored raw ptr is not GC-visited on this path).
                 _entry_promise_protected = JSValue::from_cell(promise).protected();
                 // SAFETY: `promise` is a live GC cell returned by the module loader.
                 let promise = unsafe { &mut *promise };

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -802,10 +802,11 @@ describe("should not hang", () => {
   }
 });
 
-describe("unref() + .exited with nothing else ref'd (Windows)", () => {
-  // Windows: with only an unref'd uv_process_t left, uv_run() used to skip its
-  // body and never dequeue the IOCP exit packet, so these children busy-spun
-  // forever. us_loop_pump now forces one non-blocking iteration (POSIX parity).
+describe("top-level await on an unref'd subprocess exits 13 (Node parity)", () => {
+  // These used to only resolve because the entry loader busy-spun the uws loop.
+  // Node exits 13 (unsettled TLA) in all three shapes; Bun now does too. The
+  // original Windows IOCP-unref'd-handle concern (#34478) is still covered by
+  // the "should not hang" block above (non-TLA context).
   for (const [name, body] of [
     ["unref() then await .exited", `const p = Bun.spawn(opts); p.unref(); await p.exited;`],
     [".exited then unref() then await", `const p = Bun.spawn(opts); const done = p.exited; p.unref(); await done;`],
@@ -827,12 +828,13 @@ describe("unref() + .exited with nothing else ref'd (Windows)", () => {
         env: bunEnv,
         stdout: "pipe",
         stderr: "pipe",
+        timeout: 5_000,
       });
       const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
-      expect({ stdout, stderr, exitCode, signalCode: child.signalCode }).toEqual({
-        stdout: "resolved\n",
-        stderr: "",
-        exitCode: 0,
+      expect(stderr).toContain("Detected unsettled top-level await");
+      expect({ stdout, exitCode, signalCode: child.signalCode }).toEqual({
+        stdout: "",
+        exitCode: 13,
         signalCode: null,
       });
     });

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -91,6 +91,16 @@ test.concurrent("bun -e with a never-settling top-level await exits 13", async (
   expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
 });
 
+test.concurrent("uncaught exception during top-level await does not print a spurious TLA warning", async () => {
+  using dir = tempDir("tla-uncaught", {
+    "a.mjs": `setImmediate(() => { throw new Error("boom"); });\nawait new Promise(r => setTimeout(r, 100));\n`,
+  });
+  const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
+  expect(stderr).toContain("boom");
+  expect(stderr).not.toContain("Detected unsettled top-level await");
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 1 });
+});
+
 test.concurrent("top-level await rejected during beforeExit is reported (exit 1, not swallowed)", async () => {
   using dir = tempDir("tla-reject-beforeexit", {
     "a.mjs":

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -74,8 +74,7 @@ test.concurrent("unsettled top-level await preserves a user-set process.exitCode
 
 test.concurrent("beforeExit fires with 0 before the unsettled-TLA warning", async () => {
   using dir = tempDir("tla-beforeexit", {
-    "a.mjs":
-      `process.on("beforeExit", c => console.error("beforeExit", c));\n` + `await new Promise(() => {});\n`,
+    "a.mjs": `process.on("beforeExit", c => console.error("beforeExit", c));\n` + `await new Promise(() => {});\n`,
   });
   const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
   expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// When the entry module's top-level await never settles and nothing else refs
+// the event loop, Bun used to spin `wait_for_promise` forever (100% CPU, no
+// epoll park). Node prints a warning and exits 13. Issue #33283.
+
+// Watchdog below the per-test timeout so a regression surfaces as a clean
+// SIGTERM assertion instead of a suite-level timeout. The fixed path exits in
+// well under a second.
+const watchdog = 3_000;
+
+async function run(cmd: string[], cwd?: string) {
+  await using proc = Bun.spawn({
+    cmd,
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: watchdog,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+test.concurrent("never-settling top-level await exits 13 with a warning", async () => {
+  using dir = tempDir("tla-unsettled", {
+    "a.mjs": `await new Promise(() => {});\n`,
+  });
+  const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
+  expect(stderr).toContain("Detected unsettled top-level await at");
+  expect(stderr).toContain("a.mjs");
+});
+
+test.concurrent("never-settling top-level await in a dependency exits 13", async () => {
+  using dir = tempDir("tla-unsettled-dep", {
+    "entry.mjs": `import { ready } from "./dep.mjs";\nawait ready;\n`,
+    "dep.mjs": `export const ready = new Promise(() => {});\n`,
+  });
+  const { stderr, exitCode, signalCode } = await run([bunExe(), "entry.mjs"], String(dir));
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
+  expect(stderr).toContain("Detected unsettled top-level await");
+});
+
+test.concurrent("top-level await resolved by a ref'd timer exits 0", async () => {
+  using dir = tempDir("tla-timer", {
+    "a.mjs": `await new Promise(r => setTimeout(r, 50));\nconsole.log("done");\n`,
+  });
+  const { stdout, stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
+  expect(stdout).toBe("done\n");
+  expect(stderr).not.toContain("Detected unsettled top-level await");
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 0 });
+});
+
+test.concurrent("top-level await resolved by a microtask exits 0", async () => {
+  using dir = tempDir("tla-micro", {
+    "a.mjs": `await new Promise(r => queueMicrotask(r));\nconsole.log("done");\n`,
+  });
+  const { stdout, stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
+  expect(stdout).toBe("done\n");
+  expect(stderr).not.toContain("Detected unsettled top-level await");
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 0 });
+});
+
+test.concurrent("unsettled top-level await preserves a user-set process.exitCode", async () => {
+  using dir = tempDir("tla-exitcode", {
+    "a.mjs": `process.exitCode = 7;\nawait new Promise(() => {});\n`,
+  });
+  const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 7 });
+  expect(stderr).toContain("Detected unsettled top-level await");
+});
+
+test.concurrent("beforeExit fires with 0 before the unsettled-TLA warning", async () => {
+  using dir = tempDir("tla-beforeexit", {
+    "a.mjs":
+      `process.on("beforeExit", c => console.error("beforeExit", c));\n` + `await new Promise(() => {});\n`,
+  });
+  const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
+  const before = stderr.indexOf("beforeExit 0");
+  const warn = stderr.indexOf("Detected unsettled top-level await");
+  expect(before).toBeGreaterThanOrEqual(0);
+  expect(warn).toBeGreaterThan(before);
+});
+
+test.concurrent("bun -e with a never-settling top-level await exits 13", async () => {
+  const { stderr, exitCode, signalCode } = await run([bunExe(), "-e", "await new Promise(() => {})"]);
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
+  expect(stderr).toContain("Detected unsettled top-level await");
+});

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -90,3 +90,16 @@ test.concurrent("bun -e with a never-settling top-level await exits 13", async (
   expect(stderr).toContain("Detected unsettled top-level await");
   expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
 });
+
+test.concurrent("top-level await rejected during beforeExit is reported (exit 1, not swallowed)", async () => {
+  using dir = tempDir("tla-reject-beforeexit", {
+    "a.mjs":
+      `const { promise, reject } = Promise.withResolvers();\n` +
+      `process.once("beforeExit", () => setImmediate(() => reject(new Error("db never connected"))));\n` +
+      `await promise;\n`,
+  });
+  const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
+  expect(stderr).toContain("db never connected");
+  expect(stderr).not.toContain("Detected unsettled top-level await");
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 1 });
+});

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -28,9 +28,9 @@ test.concurrent("never-settling top-level await exits 13 with a warning", async 
     "a.mjs": `await new Promise(() => {});\n`,
   });
   const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
-  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
   expect(stderr).toContain("Detected unsettled top-level await at");
   expect(stderr).toContain("a.mjs");
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
 });
 
 test.concurrent("never-settling top-level await in a dependency exits 13", async () => {
@@ -39,8 +39,9 @@ test.concurrent("never-settling top-level await in a dependency exits 13", async
     "dep.mjs": `export const ready = new Promise(() => {});\n`,
   });
   const { stderr, exitCode, signalCode } = await run([bunExe(), "entry.mjs"], String(dir));
-  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
   expect(stderr).toContain("Detected unsettled top-level await");
+  expect(stderr).toContain("entry.mjs");
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
 });
 
 test.concurrent("top-level await resolved by a ref'd timer exits 0", async () => {
@@ -68,8 +69,8 @@ test.concurrent("unsettled top-level await preserves a user-set process.exitCode
     "a.mjs": `process.exitCode = 7;\nawait new Promise(() => {});\n`,
   });
   const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
-  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 7 });
   expect(stderr).toContain("Detected unsettled top-level await");
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 7 });
 });
 
 test.concurrent("beforeExit fires with 0 before the unsettled-TLA warning", async () => {
@@ -77,15 +78,15 @@ test.concurrent("beforeExit fires with 0 before the unsettled-TLA warning", asyn
     "a.mjs": `process.on("beforeExit", c => console.error("beforeExit", c));\n` + `await new Promise(() => {});\n`,
   });
   const { stderr, exitCode, signalCode } = await run([bunExe(), "a.mjs"], String(dir));
-  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
   const before = stderr.indexOf("beforeExit 0");
   const warn = stderr.indexOf("Detected unsettled top-level await");
   expect(before).toBeGreaterThanOrEqual(0);
   expect(warn).toBeGreaterThan(before);
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
 });
 
 test.concurrent("bun -e with a never-settling top-level await exits 13", async () => {
   const { stderr, exitCode, signalCode } = await run([bunExe(), "-e", "await new Promise(() => {})"]);
-  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
   expect(stderr).toContain("Detected unsettled top-level await");
+  expect({ signalCode, exitCode }).toEqual({ signalCode: null, exitCode: 13 });
 });


### PR DESCRIPTION
## Repro

```sh
$ printf 'await new Promise(() => {});\n' > a.mjs
$ bun a.mjs                    # before: spins at ~100% CPU, never exits
$ node a.mjs                   # prints warning, exits 13
```

strace confirms the before state is a pure user-space busy re-tick: the main thread is `R`, the startup epoll fd is never waited on, and `auto_tick` → `tick_without_idle()` → `us_loop_run_bun_tick` early-returns on `num_polls == 0` every iteration of `wait_for_promise`.

## Cause

`Run::start` → `VirtualMachine::load_entry_point` (non-watcher arm) calls `wait_for_promise`, which loops `tick()`/`auto_tick()` until the entry promise settles with no liveness check. When the top-level await can never settle and nothing else refs the loop, this spins forever and `load_entry_point` never returns, so the core run-loop and `on_before_exit` are never reached.

The worker entry path already handles this: `wait_for_promise_with_termination` breaks once `!is_event_loop_alive()` with the entry promise still pending, and `web_worker.rs` sets `exit_code = 13`.

## Fix

Give the main entry the same treatment (mirroring the worker path):

- `load_entry_point`'s non-watcher wait now breaks once `!is_event_loop_alive()` with the promise still Pending, so it returns instead of spinning.
- After the core run-loop and `on_before_exit()`, `Run::start` checks `pending_internal_promise`:
  - still Pending → print Node's `Detected unsettled top-level await at <entry path>` warning and set `exit_code = 13` (unless the user already set one);
  - Rejected (transitioned during the drain or a `beforeExit` listener) → route through `uncaught_exception` so the error is reported and exit 1, same as an initial-load rejection. Without this arm a late rejection was swallowed and the process exited 0.

The check sits after `on_before_exit()` so `beforeExit` fires with code 0 first, matching Node's order. The warning names the entry path (JSC does not expose a stalled-module API like V8's, so no `:line` yet). `--watch`/`--hot` are unchanged.

**Behavior change:** top-level `await` on an unref'd subprocess (`p.unref(); await p.exited`) now exits 13 like Node. Previously the busy-spin happened to pick up the exit and resolve. `spawn.test.ts`'s `(Windows)` block is updated accordingly; the underlying IOCP-unref'd-handle fix (#34478) is still covered by the non-TLA "should not hang" block above it.

**Intentionally not in this PR** (same bug class, pre-existing, left for a follow-up so this stays reviewable): `--preload` with an unsettled TLA (`jsc_hooks.rs:836`) and `bun test` on a file with module-level `await new Promise(()=>{})` (`load_entry_point_for_test_runner`, `VirtualMachine.rs:4608`) still call the unbounded `wait_for_promise`. Those callers each need their own Pending-handling (mark the preload/test file as failed and continue); #33286 / #36052 cover that ground.

## Verification

`test/js/node/process/unsettled-top-level-await.test.ts` (8 cases, 3s watchdog):

- `await new Promise(() => {})` → exit 13 + warning
- dependency exporting a never-settling promise → exit 13 naming the entry
- TLA resolved by `setTimeout(50)` (ref'd timer) → exit 0, no warning
- TLA resolved by `queueMicrotask` → exit 0, no warning
- `process.exitCode = 7` then unsettled TLA → exit 7 (user's code preserved)
- `beforeExit` listener fires with `0` before the warning → exit 13
- `bun -e 'await new Promise(()=>{})'` → exit 13
- `beforeExit` handler rejects the awaited promise → error reported, exit 1

All pass with the fix; 6 of them hang (→ SIGTERM at the watchdog) on the released build. `worker-top-level-await.test.ts`, `dynamic-import-tla-cycle.test.ts`, `run-eval.test.ts`, `require-esm-transitive-tla.test.ts`, and the updated `spawn.test.ts` block pass.

Fixes #33283. Minimal subset of #33286 (which also reworks `--print` ordering, adds a `beforeExit`-resolves-TLA drain loop, a C++ stalled-module walk, and covers preload/test-runner); those can follow separately.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->