### PR TITLE
module loader: wait on EvaluatingAsync deps in dynamic-import cycles; exit 13 on unsettled TLA

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1165,6 +1165,14 @@ impl JSGlobalObject {
         });
     }
 
+    pub fn has_pending_rejected_promises(&self) -> bool {
+        unsafe extern "C" {
+            fn Bun__hasPendingRejectedPromises(global: *const JSGlobalObject) -> bool;
+        }
+        // SAFETY: `self` is a live JSC global object.
+        unsafe { Bun__hasPendingRejectedPromises(self) }
+    }
+
     pub fn readable_stream_to_array_buffer(&self, value: JSValue) -> JSValue {
         ZigGlobalObject__readableStreamToArrayBuffer(self, value)
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1048,6 +1048,25 @@ impl VirtualMachine {
             || !el.next_immediate_tasks.is_empty()
     }
 
+    /// Whether anything in the loop could still settle a pending module
+    /// promise. Unlike [`is_event_loop_alive`](Self::is_event_loop_alive),
+    /// ignores `unhandled_error_counter` (an unhandled rejection doesn't mean
+    /// nothing can settle the await) and counts queued concurrent tasks.
+    pub fn has_pending_loop_work(&self) -> bool {
+        let el = self.event_loop_shared();
+        let active = self
+            .platform_loop_opt()
+            .map(|h| h.is_active())
+            .unwrap_or(false);
+        active
+            || self.active_tasks > 0
+            || el.tasks.readable_length() > 0
+            || el.has_pending_refs()
+            || !el.concurrent_tasks.is_empty()
+            || !el.immediate_tasks.is_empty()
+            || !el.next_immediate_tasks.is_empty()
+    }
+
     pub fn wakeup(&mut self) {
         self.event_loop_mut().wakeup();
     }
@@ -2468,7 +2487,7 @@ impl VirtualMachine {
             if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending {
                 return;
             }
-            if !self.is_event_loop_alive() {
+            if !self.has_pending_loop_work() {
                 return;
             }
             self.auto_tick();
@@ -4654,7 +4673,7 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            self.wait_for_promise(jsc::AnyPromise::Internal(promise));
+            self.wait_for_module_promise(promise);
         }
 
         self.auto_tick();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3400,6 +3400,7 @@ impl VirtualMachine {
         match self.unhandled_rejections_mode() {
             Mode::Bun => {
                 if handle_unhandled() {
+                    drain(self);
                     return;
                 }
                 // continue to default handler

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2485,6 +2485,15 @@ impl VirtualMachine {
                 return;
             }
             if !self.has_pending_loop_work() {
+                // tick()'s trailing handle_rejected_promises can leave a JSC
+                // microtask undrained (the Mode::Bun handled-by-listener arm).
+                // Drain once and re-check before concluding the TLA is stalled.
+                let _ = self.event_loop_mut().drain_microtasks();
+                if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending
+                    || self.has_pending_loop_work()
+                {
+                    continue;
+                }
                 return;
             }
             self.auto_tick();
@@ -3400,7 +3409,6 @@ impl VirtualMachine {
         match self.unhandled_rejections_mode() {
             Mode::Bun => {
                 if handle_unhandled() {
-                    drain(self);
                     return;
                 }
                 // continue to default handler

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2464,9 +2464,6 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            // Returns with the promise still Pending if the loop drains with
-            // nothing left to settle it, so the caller can detect an unsettled
-            // top-level await instead of spinning forever.
             self.wait_for_module_promise(promise);
         }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2486,9 +2486,20 @@ impl VirtualMachine {
             }
             if !self.has_pending_loop_work() {
                 // tick()'s trailing handle_rejected_promises can leave a JSC
-                // microtask undrained (the Mode::Bun handled-by-listener arm).
-                // Drain once and re-check before concluding the TLA is stalled.
-                let _ = self.event_loop_mut().drain_microtasks();
+                // microtask undrained (the Mode::Bun handled-by-listener arm);
+                // that continuation can itself queue a rejection. Run drain +
+                // handle_rejected_promises to fixpoint before concluding the
+                // TLA is stalled.
+                let global = self.global;
+                loop {
+                    let _ = self.event_loop_mut().drain_microtasks();
+                    // SAFETY: `global` is the live per-thread global object.
+                    if !unsafe { &*global }.has_pending_rejected_promises() {
+                        break;
+                    }
+                    // SAFETY: see above.
+                    unsafe { &*global }.handle_rejected_promises();
+                }
                 if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending
                     || self.has_pending_loop_work()
                 {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2445,10 +2445,73 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            self.wait_for_promise(jsc::AnyPromise::Internal(promise));
+            // Returns with the promise still Pending if the loop drains with
+            // nothing left to settle it, so the caller can detect an unsettled
+            // top-level await instead of spinning forever.
+            self.wait_for_module_promise(promise);
         }
 
         Ok(self.pending_internal_promise.unwrap_or(promise))
+    }
+
+    /// Like [`wait_for_promise`](Self::wait_for_promise) but returns (with the
+    /// promise possibly still `Pending`) once nothing in the loop could settle
+    /// it, instead of spinning on an unsettled top-level await.
+    pub fn wait_for_module_promise(&mut self, promise: *mut JSInternalPromise) {
+        let jsc_vm = self.jsc_vm;
+        while crate::JSPromise::status_ptr(promise) == crate::js_promise::Status::Pending {
+            // SAFETY: `jsc_vm` is the live per-thread JSC VM (set in `init`).
+            if unsafe { &*jsc_vm }.execution_forbidden() {
+                return;
+            }
+            self.event_loop_mut().tick();
+            if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending {
+                return;
+            }
+            if !self.is_event_loop_alive() {
+                return;
+            }
+            self.auto_tick();
+        }
+    }
+
+    /// True when the entry module's evaluation promise is still pending after
+    /// the loop has drained, i.e. an unsettled top-level await.
+    pub fn entry_module_promise_is_pending(&self) -> bool {
+        self.pending_internal_promise
+            .is_some_and(|p| crate::JSPromise::status_ptr(p) == crate::js_promise::Status::Pending)
+    }
+
+    /// Print Node's "Detected unsettled top-level await" warning to stderr,
+    /// naming the stalled module(s) from the JSC module registry.
+    pub fn report_unsettled_top_level_await(&self) {
+        unsafe extern "C" {
+            fn Bun__findStalledTopLevelAwait(global: *mut JSGlobalObject) -> bun_core::String;
+        }
+        // SAFETY: `self.global` is the live per-thread global object.
+        let stalled = unsafe { Bun__findStalledTopLevelAwait(self.global) };
+        let stalled_utf8 = stalled.to_utf8();
+        let slice = stalled_utf8.slice();
+        let warn = |module: &[u8]| {
+            bun_core::pretty_errorln!(
+                "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await at <b>{}<r>",
+                bstr::BStr::new(module),
+            );
+        };
+        if !slice.is_empty() {
+            for module in slice.split(|&b| b == b'\0') {
+                warn(module);
+            }
+        } else if !self.main().is_empty() {
+            warn(self.main());
+        } else {
+            bun_core::pretty_errorln!(
+                "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await"
+            );
+        }
+        bun_core::Output::flush();
+        drop(stalled_utf8);
+        stalled.deref();
     }
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -38,6 +38,7 @@
 #include "JavaScriptCore/JSModuleLoader.h"
 #include "JavaScriptCore/CyclicModuleRecord.h"
 #include "JavaScriptCore/ModuleRegistryEntry.h"
+#include <wtf/text/StringBuilder.h>
 #include "JavaScriptCore/JSModuleNamespaceObject.h"
 #include "JavaScriptCore/JSModuleNamespaceObjectInlines.h"
 #include "JavaScriptCore/JSModuleRecord.h"
@@ -731,6 +732,34 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
         return cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluated && !cyclic->evaluationError();
     // SyntheticModuleRecord is "evaluated" once linked (it has an environment).
     return record->moduleEnvironmentMayBeNull() != nullptr;
+}
+
+// Module specifiers suspended on their own top-level await (EvaluatingAsync,
+// syntactic TLA, no pending async dependency), NUL-joined, for the
+// unsettled-TLA warning. Empty when nothing is stalled.
+extern "C" BunString Bun__findStalledTopLevelAwait(JSC::JSGlobalObject* globalObject)
+{
+    WTF::StringBuilder builder;
+    for (auto& [key, entry] : globalObject->moduleLoader()->moduleMap()) {
+        if (!key.first || !entry)
+            continue;
+        auto* record = entry->record();
+        if (!record || !record->hasTLA())
+            continue;
+        auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record);
+        if (!cyclic || cyclic->status() != JSC::CyclicModuleRecord::Status::EvaluatingAsync)
+            continue;
+        // EvaluatingAsync because it awaits an unfinished dependency: that
+        // dependency is the real culprit, skip this one.
+        if (auto pending = record->pendingAsyncDependencies(); pending && *pending > 0)
+            continue;
+        if (!builder.isEmpty())
+            builder.append('\0');
+        builder.append(String { key.first });
+    }
+    if (builder.isEmpty())
+        return BunStringEmpty;
+    return Bun::toStringRef(builder.toString());
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionEsmNamespaceForCjs, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -3678,16 +3707,10 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
 
     auto sourceURL = sourceOrigin.url();
     String sourceOriginStringHolder;
-    int64_t referrerAsyncOrder = -1;
     if (sourceURL.isEmpty()) {
         sourceOriginStringHolder = String("."_s);
     } else if (sourceURL.protocolIsFile()) {
         sourceOriginStringHolder = sourceURL.fileSystemPath();
-        auto query = sourceURL.queryWithLeadingQuestionMark();
-        auto referrerKey = query.isEmpty()
-            ? JSC::Identifier::fromString(vm, sourceOriginStringHolder)
-            : JSC::Identifier::fromString(vm, makeString(sourceOriginStringHolder, query));
-        referrerAsyncOrder = globalObject->moduleLoader()->asyncEvaluationOrderForKey(referrerKey);
     } else if (sourceURL.protocol() == "builtin"_s) {
         ASSERT(sourceURL.string().startsWith("builtin://"_s));
         sourceOriginStringHolder = sourceURL.string().substringSharingImpl(10 /* builtin:// */);
@@ -3699,7 +3722,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(moduleName, sourceURL.protocolIsFile() ? sourceOriginStringHolder : String())) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());
 
-            auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, /* deferred */ false, referrerAsyncOrder);
+            auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, /* deferred */ false);
             if (scope.exception()) [[unlikely]] {
                 return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
             }
@@ -3759,7 +3782,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     // ScriptFetchParameters before calling this hook, so `parameters` is
     // already the parsed RefPtr (or null). Just forward it.
     auto result = JSC::importModule(globalObject, resolvedIdentifier,
-        JSC::Identifier(), WTF::move(parameters), nullptr, /* deferred */ false, referrerAsyncOrder);
+        JSC::Identifier(), WTF::move(parameters), nullptr, /* deferred */ false);
     if (scope.exception()) [[unlikely]] {
         return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
     }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -734,6 +734,11 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
     return record->moduleEnvironmentMayBeNull() != nullptr;
 }
 
+extern "C" bool Bun__hasPendingRejectedPromises(JSC::JSGlobalObject* globalObject)
+{
+    return uncheckedDowncast<Zig::GlobalObject>(globalObject)->hasPendingRejectedPromises();
+}
+
 // Module specifiers suspended on their own top-level await (EvaluatingAsync,
 // syntactic TLA, no pending async dependency), NUL-joined, for the
 // unsettled-TLA warning. Empty when nothing is stalled.

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -345,6 +345,7 @@ public:
     uint8_t drainMicrotasks();
 
     void handleRejectedPromises();
+    bool hasPendingRejectedPromises() const { return !m_aboutToBeNotifiedRejectedPromises.isEmpty(); }
     ALWAYS_INLINE void initGeneratedLazyClasses();
 
     template<typename Visitor>

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1571,6 +1571,18 @@ impl Run {
                 vm.auto_tick_active();
             }
 
+            // The entry module's evaluation promise is still pending after the
+            // loop drained: an unsettled top-level await (e.g. a TLA dynamic
+            // import() whose target statically imports the awaiter back, which
+            // per spec waits on an EvaluatingAsync dependency and deadlocks).
+            // Node prints a warning and exits 13; match that here.
+            if vm.entry_module_promise_is_pending() {
+                vm.report_unsettled_top_level_await();
+                if vm.exit_handler.exit_code == 0 {
+                    vm.exit_handler.exit_code = 13;
+                }
+            }
+
             if ctx.runtime_options.eval.eval_and_print {
                 let to_print: JSValue = 'brk: {
                     let result = vm

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1571,13 +1571,9 @@ impl Run {
                 vm.auto_tick_active();
             }
 
-            // The entry module's evaluation promise is still pending after the
-            // loop drained: an unsettled top-level await (e.g. a TLA dynamic
-            // import() whose target statically imports the awaiter back, which
-            // per spec waits on an EvaluatingAsync dependency and deadlocks).
-            // Node prints a warning and exits 13; match that here. Skip when an
-            // unhandled rejection already stopped the loop: that's why it's
-            // pending, not a stalled TLA.
+            // Entry module's evaluation promise still pending after the loop
+            // drained (and no unhandled rejection caused the drain): unsettled
+            // top-level await. Node warns and exits 13.
             if vm.unhandled_error_counter == 0 && vm.entry_module_promise_is_pending() {
                 vm.report_unsettled_top_level_await();
                 if vm.exit_handler.exit_code == 0 {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1571,16 +1571,6 @@ impl Run {
                 vm.auto_tick_active();
             }
 
-            // Entry module's evaluation promise still pending after the loop
-            // drained (and no unhandled rejection caused the drain): unsettled
-            // top-level await. Node warns and exits 13.
-            if vm.unhandled_error_counter == 0 && vm.entry_module_promise_is_pending() {
-                vm.report_unsettled_top_level_await();
-                if vm.exit_handler.exit_code == 0 {
-                    vm.exit_handler.exit_code = 13;
-                }
-            }
-
             if ctx.runtime_options.eval.eval_and_print {
                 let to_print: JSValue = 'brk: {
                     let result = vm
@@ -1629,6 +1619,31 @@ impl Run {
             }
 
             vm.on_before_exit();
+
+            // A beforeExit handler can resolve the entry's await; the reaction
+            // is a microtask is_event_loop_alive() doesn't count. Drain it and
+            // re-run the loop if the resumed body schedules more work.
+            while vm.unhandled_error_counter == 0 && vm.entry_module_promise_is_pending() {
+                vm.tick();
+                if !vm.is_event_loop_alive() {
+                    break;
+                }
+                while vm.is_event_loop_alive() {
+                    vm.tick();
+                    vm.auto_tick_active();
+                }
+                vm.on_before_exit();
+            }
+
+            // Entry module's evaluation promise still pending after the loop
+            // and beforeExit re-drained, with no unhandled rejection: unsettled
+            // top-level await. Node warns and exits 13.
+            if vm.unhandled_error_counter == 0 && vm.entry_module_promise_is_pending() {
+                vm.report_unsettled_top_level_await();
+                if vm.exit_handler.exit_code == 0 {
+                    vm.exit_handler.exit_code = 13;
+                }
+            }
         }
 
         if log_has_msgs(vm) {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1638,10 +1638,35 @@ impl Run {
             // Entry module's evaluation promise still pending after the loop
             // and beforeExit re-drained, with no unhandled rejection: unsettled
             // top-level await. Node warns and exits 13.
-            if vm.unhandled_error_counter == 0 && vm.entry_module_promise_is_pending() {
-                vm.report_unsettled_top_level_await();
-                if vm.exit_handler.exit_code == 0 {
-                    vm.exit_handler.exit_code = 13;
+            if vm.unhandled_error_counter == 0 {
+                match vm
+                    .pending_internal_promise
+                    .map(bun_jsc::JSPromise::status_ptr)
+                {
+                    Some(PromiseStatus::Pending) => {
+                        vm.report_unsettled_top_level_await();
+                        if vm.exit_handler.exit_code == 0 {
+                            vm.exit_handler.exit_code = 13;
+                        }
+                    }
+                    Some(PromiseStatus::Rejected)
+                        if vm.pending_internal_promise_reported_at != vm.hot_reload_counter =>
+                    {
+                        // The re-drain transitioned the entry to Rejected (a
+                        // beforeExit handler rejected the await, or the resumed
+                        // body threw). JSInternalPromise is filtered out of
+                        // promiseRejectionTracker, so report it here.
+                        let p = vm.pending_internal_promise.unwrap();
+                        // SAFETY: `p` is a live JSC heap cell; `vm.jsc_vm` set in `init`.
+                        let result = unsafe { &mut *p }.result(unsafe { &mut *vm.jsc_vm });
+                        let global = vm.global;
+                        // SAFETY: `global` valid for VM lifetime.
+                        let _ = vm.uncaught_exception(unsafe { &*global }, result, true);
+                        // SAFETY: `p` is a live JSC heap cell.
+                        unsafe { &mut *p }.set_handled();
+                        vm.pending_internal_promise_reported_at = vm.hot_reload_counter;
+                    }
+                    _ => {}
                 }
             }
         }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1575,8 +1575,10 @@ impl Run {
             // loop drained: an unsettled top-level await (e.g. a TLA dynamic
             // import() whose target statically imports the awaiter back, which
             // per spec waits on an EvaluatingAsync dependency and deadlocks).
-            // Node prints a warning and exits 13; match that here.
-            if vm.entry_module_promise_is_pending() {
+            // Node prints a warning and exits 13; match that here. Skip when an
+            // unhandled rejection already stopped the loop: that's why it's
+            // pending, not a stalled TLA.
+            if vm.unhandled_error_counter == 0 && vm.entry_module_promise_is_pending() {
                 vm.report_unsettled_top_level_await();
                 if vm.exit_handler.exit_code == 0 {
                     vm.exit_handler.exit_code = 13;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3295,7 +3295,14 @@ impl TestCommand {
                     // wait_for_module_promise returned with nothing left to
                     // settle the entry's TLA: a stalled top-level await. Treat
                     // as a load failure so we don't run a truncated test set.
-                    vm.report_unsettled_top_level_await();
+                    // Name this file directly: the module map is shared across
+                    // files without --isolate, so the walk would re-name every
+                    // previously-stalled file.
+                    bun_core::pretty_errorln!(
+                        "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await at <b>{}<r>",
+                        bstr::BStr::new(file_path),
+                    );
+                    bun_core::Output::flush();
                     true
                 }
                 jsc::js_promise::Status::Rejected => {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3291,6 +3291,14 @@ impl TestCommand {
 
             // S012: `JSInternalPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
             match jsc::JSInternalPromise::opaque_mut(promise).status() {
+                jsc::js_promise::Status::Pending => {
+                    // wait_for_module_promise returned with nothing left to
+                    // settle the entry's TLA: a stalled top-level await. Treat
+                    // as a load failure so we don't run a truncated test set.
+                    vm.report_unsettled_top_level_await();
+                    reporter.summary().fail += 1;
+                    return Ok(());
+                }
                 jsc::js_promise::Status::Rejected => {
                     // `vm.global()` returns `&'static`, decoupled from `vm`'s borrow so
                     // `unhandled_rejection(&mut self, ...)` can reborrow.

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3295,14 +3295,21 @@ impl TestCommand {
                     // wait_for_module_promise returned with nothing left to
                     // settle the entry's TLA: a stalled top-level await. Treat
                     // as a load failure so we don't run a truncated test set.
-                    // Name this file directly: the module map is shared across
-                    // files without --isolate, so the walk would re-name every
-                    // previously-stalled file.
-                    bun_core::pretty_errorln!(
-                        "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await at <b>{}<r>",
-                        bstr::BStr::new(file_path),
-                    );
-                    bun_core::Output::flush();
+                    if vm.pending_internal_promise_is_protected {
+                        // load_preloads returned the stalled preload promise;
+                        // this test file was never loaded. Walk the module
+                        // map to name the preload.
+                        vm.report_unsettled_top_level_await();
+                    } else {
+                        // Name this file directly: the module map is shared
+                        // across files without --isolate, so the walk would
+                        // re-name every previously-stalled file.
+                        bun_core::pretty_errorln!(
+                            "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await at <b>{}<r>",
+                            bstr::BStr::new(file_path),
+                        );
+                        bun_core::Output::flush();
+                    }
                     true
                 }
                 jsc::js_promise::Status::Rejected => {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3290,14 +3290,13 @@ impl TestCommand {
             }
 
             // S012: `JSInternalPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
-            match jsc::JSInternalPromise::opaque_mut(promise).status() {
+            let load_failed = match jsc::JSInternalPromise::opaque_mut(promise).status() {
                 jsc::js_promise::Status::Pending => {
                     // wait_for_module_promise returned with nothing left to
                     // settle the entry's TLA: a stalled top-level await. Treat
                     // as a load failure so we don't run a truncated test set.
                     vm.report_unsettled_top_level_await();
-                    reporter.summary().fail += 1;
-                    return Ok(());
+                    true
                 }
                 jsc::js_promise::Status::Rejected => {
                     // `vm.global()` returns `&'static`, decoupled from `vm`'s borrow so
@@ -3306,40 +3305,43 @@ impl TestCommand {
                     let p = jsc::JSInternalPromise::opaque_mut(promise);
                     let (result, promise_js) = (p.result(global.vm()), p.to_js());
                     vm.unhandled_rejection(global, result, promise_js);
-                    reporter.summary().fail += 1;
-
-                    if reporter.jest.bail == reporter.summary().fail {
-                        reporter.print_summary();
-                        pretty_error!(
-                            "\nBailed out after {} failure{}<r>\n",
-                            reporter.jest.bail,
-                            if reporter.jest.bail == 1 { "" } else { "s" }
-                        );
-                        reporter.write_junit_report_if_needed();
-
-                        vm.exit_handler.exit_code = 1;
-                        vm.is_shutting_down = true;
-                        // `global_exit()` diverges, so the `exit_file()` defer
-                        // above never fires. Release the active file's
-                        // `Strong`s and the preload-hook scope here so
-                        // `destructOnExit()`'s `collectNow()` can reclaim them,
-                        // then clear `RUNNER` so finalizers can't observe a
-                        // partially-torn-down `TestRunner`.
-                        // SAFETY: single-threaded; raw-ptr reborrow mirrors the
-                        // defer's escape.
-                        unsafe {
-                            (*bun_test_root_ptr).deinit_for_exit();
-                            jest::Jest::RUNNER.write(None);
-                        }
-                        let vm_ptr = std::ptr::from_mut::<VirtualMachine>(vm);
-                        // SAFETY: global_exit diverges; `vm_ptr` is a fresh
-                        // raw-ptr reborrow of the exclusive `vm` borrow.
-                        unsafe { (*vm_ptr).run_with_api_lock(|| (&mut *vm_ptr).global_exit()) };
-                    }
-
-                    return Ok(());
+                    true
                 }
-                _ => {}
+                jsc::js_promise::Status::Fulfilled => false,
+            };
+            if load_failed {
+                reporter.summary().fail += 1;
+
+                if reporter.jest.bail == reporter.summary().fail {
+                    reporter.print_summary();
+                    pretty_error!(
+                        "\nBailed out after {} failure{}<r>\n",
+                        reporter.jest.bail,
+                        if reporter.jest.bail == 1 { "" } else { "s" }
+                    );
+                    reporter.write_junit_report_if_needed();
+
+                    vm.exit_handler.exit_code = 1;
+                    vm.is_shutting_down = true;
+                    // `global_exit()` diverges, so the `exit_file()` defer
+                    // above never fires. Release the active file's
+                    // `Strong`s and the preload-hook scope here so
+                    // `destructOnExit()`'s `collectNow()` can reclaim them,
+                    // then clear `RUNNER` so finalizers can't observe a
+                    // partially-torn-down `TestRunner`.
+                    // SAFETY: single-threaded; raw-ptr reborrow mirrors the
+                    // defer's escape.
+                    unsafe {
+                        (*bun_test_root_ptr).deinit_for_exit();
+                        jest::Jest::RUNNER.write(None);
+                    }
+                    let vm_ptr = std::ptr::from_mut::<VirtualMachine>(vm);
+                    // SAFETY: global_exit diverges; `vm_ptr` is a fresh
+                    // raw-ptr reborrow of the exclusive `vm` borrow.
+                    unsafe { (*vm_ptr).run_with_api_lock(|| (&mut *vm_ptr).global_exit()) };
+                }
+
+                return Ok(());
             }
 
             vm.event_loop_ref().tick();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -35,8 +35,8 @@ use bun_jsc::virtual_machine::{
     InitOptions, RuntimeHooks, RuntimeState as OpaqueRuntimeState, VirtualMachine,
 };
 use bun_jsc::{
-    AnyPromise, ErrorCode, ErrorableResolvedSource, ErrorableString, JSGlobalObject,
-    JSInternalPromise, JSModuleLoader, JSValue, JsResult, ResolvedSource,
+    ErrorCode, ErrorableResolvedSource, ErrorableString, JSGlobalObject, JSInternalPromise,
+    JSModuleLoader, JSValue, JsResult, ResolvedSource,
 };
 
 use bun_ast::ImportKind;
@@ -833,7 +833,7 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
                 unsafe { (*(*vm).event_loop()).perform_gc() };
                 // SAFETY: per fn contract — short-lived `&mut *vm`; `promise` is a
                 // live protected JSC heap cell.
-                unsafe { (*vm).wait_for_promise(AnyPromise::Internal(promise)) };
+                unsafe { (*vm).wait_for_module_promise(promise) };
             }
         }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -796,7 +796,7 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
 
         // ── wait ────────────────────────────────────────────────────────
         // HMR `pending_internal_promise` swap loop; non-watcher path uses
-        // `wait_for_promise` directly.
+        // `wait_for_module_promise`.
         {
             // SAFETY: per fn contract.
             if unsafe { &*vm }.is_watcher_enabled() {
@@ -838,8 +838,16 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
         }
 
         // SAFETY: `promise` is a live (still-protected) JSC heap cell.
-        if unsafe { &*promise }.status() == PromiseStatus::Rejected {
-            return Ok(promise);
+        match unsafe { &*promise }.status() {
+            PromiseStatus::Rejected => return Ok(promise),
+            PromiseStatus::Pending => {
+                // wait_for_module_promise returned with nothing left to settle
+                // the preload's TLA. Return the pending promise so the caller's
+                // `!p.is_null()` early-return keeps it in
+                // `pending_internal_promise` for the run_command warn/exit-13.
+                return Ok(promise);
+            }
+            PromiseStatus::Fulfilled => {}
         }
         // `_protected` drops here → unprotect.
     }

--- a/test/js/bun/http/js-sink-sourmap-fixture/index.mjs
+++ b/test/js/bun/http/js-sink-sourmap-fixture/index.mjs
@@ -5596,8 +5596,19 @@ try {
   });
   console.log(`Listening on http://localhost:${server.port}...`);
 
-  const result = await fetch(`${server.url}/stream`).then(res => res.text());
-  process.exit(result == "nitroisawesome" ? 0 : 2);
+  // The /stream route handler lazy-imports ./chunks/stream.mjs, which
+  // statically imports this module back. Per ECMA-262 that chunk waits on us
+  // while we're EvaluatingAsync, so a top-level `await fetch` here deadlocks
+  // (Node does too). Defer the self-test so this module finishes evaluating
+  // first and the chunk's back-edge sees an Evaluated dependency.
+  setImmediate(() =>
+    fetch(`${server.url}/stream`)
+      .then(res => res.text())
+      .then(
+        result => process.exit(result == "nitroisawesome" ? 0 : 2),
+        () => process.exit(1),
+      ),
+  );
 } catch {
   process.exit(1);
 }

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -140,12 +140,12 @@ test("mutual top-level await import() cycle is an unsettled TLA (exit 13)", asyn
   expect(exitCode).toBe(13);
 });
 
-// The deadlock-avoidance above must NOT fire for sibling static imports in the
-// same Evaluate() pass. Here `entry` first imports `a` (in an SCC {a,c} with
-// an async dep), popping the SCC to EvaluatingAsync, then imports `b` which
-// reads a binding from `c`. `b` must wait for the SCC; previously the
-// EvaluatingAsync check made it skip the wait and run with `c`'s bindings
-// still in TDZ. Node and pre-rewrite Bun both wait.
+// Sibling static imports in the same Evaluate() pass must wait on an
+// EvaluatingAsync SCC (step 12.b.v). Here `entry` first imports `a` (in an SCC
+// {a,c} with an async dep), popping the SCC to EvaluatingAsync, then imports
+// `b` which reads a binding from `c`. `b` must wait for the SCC. Regression
+// guard for a prior loader version that skipped the wait and ran `b` with
+// `c`'s bindings in TDZ; Node waits here.
 test("static sibling import waits for an async-pending SCC from the same Evaluate()", async () => {
   using dir = tempDir("static-sibling-async-scc", {
     "entry.mjs": `
@@ -189,13 +189,10 @@ test("static sibling import waits for an async-pending SCC from the same Evaluat
   expect(exitCode).toBe(0);
 });
 
-// #30259: same narrowing as above, but the TLA dep has NO async deps of its own
-// (pendingAsyncDependencies == 0) and is re-imported by a sibling subtree in the
-// same Evaluate(). Previously the discriminator was only "body has been entered"
-// which is also true here — `await.ts` is suspended at its first await — so the
-// sibling skipped the wait and ran with `foo` still in TDZ. The discriminator
-// must additionally check the dep entered EvaluatingAsync in a *prior*
-// Evaluate(); within the same DFS the spec wait is required.
+// #30259: a TLA dep (pendingAsyncDependencies == 0) suspended earlier in the
+// same Evaluate() is re-imported by a sibling. The sibling must wait on it per
+// step 12.b.v. Regression guard for a prior loader version that skipped the
+// wait and ran `child` with `foo` still in TDZ.
 test("static sibling import waits for a TLA dep that suspended earlier in the same Evaluate()", async () => {
   using dir = tempDir("static-sibling-tla", {
     "root.ts": `
@@ -229,8 +226,7 @@ test("static sibling import waits for a TLA dep that suspended earlier in the sa
 });
 
 // Same as above but the TLA dep is reached indirectly through different parents
-// (so neither parent is on the DFS stack when the second one visits it). Guards
-// against discriminating by "is an asyncParentModule on the stack".
+// (so neither parent is on the DFS stack when the second one visits it).
 test("static sibling import waits for an indirectly-shared TLA dep in the same Evaluate()", async () => {
   using dir = tempDir("static-sibling-tla-indirect", {
     "root.ts": `

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -2,12 +2,13 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // A top-level-awaited dynamic import whose target statically imports the
-// awaiting module back. The spec's innerModuleEvaluation 11.c.v would have the
-// chunk wait on the entry's async-evaluation order, but the entry can only
-// finish once the chunk's evaluate() promise settles — a self-deadlock. Bun
-// matches the pre-rewrite loader and lets the chunk evaluate immediately
-// against the entry's already-initialised bindings.
-test("dynamic import inside TLA whose target imports the awaiter back does not deadlock", async () => {
+// awaiting module back. Per ECMA-262 InnerModuleEvaluation step 12.b.v, the
+// chunk waits on the entry (an EvaluatingAsync dependency); the entry is
+// itself waiting on the chunk via the dynamic import, so the graph deadlocks.
+// Node detects the unsettled top-level await and exits 13. Previously Bun
+// skipped the wait and let the chunk observe the entry's half-initialised
+// bindings (TDZ for post-await `const`, `undefined` for post-await `var`).
+test("dynamic import inside TLA whose target imports the awaiter back is an unsettled TLA (exit 13)", async () => {
   using dir = tempDir("dyn-tla-cycle", {
     "index.mjs": `
       import fs from "node:fs";
@@ -32,17 +33,17 @@ test("dynamic import inside TLA whose target imports the awaiter back does not d
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("chunk loaded: 43");
-  expect(exitCode).toBe(0);
+  // The chunk never evaluates: it is waiting on index.mjs, which is waiting on it.
+  expect(stdout).toBe("");
+  expect(stderr).toContain("Detected unsettled top-level await");
+  expect(stderr).toContain("index.mjs");
+  expect(exitCode).toBe(13);
 });
 
-// Same self-deadlock pattern, but the awaiting module is not the Evaluate()
-// entry — it's a static dependency of the entry. The cycle root re-entered by
-// the chunk has no TopLevelCapability of its own, so the discriminator must
-// be "has its body started" (pendingAsyncDependencies == 0), not "is it the
-// Evaluate() entry".
-test("dynamic import inside TLA of a non-entry module whose target imports it back does not deadlock", async () => {
+// Same pattern with the awaiting module reached via a static import. The
+// chunk statically imports `mid.mjs` while it is EvaluatingAsync, so it waits;
+// `mid.mjs` is awaiting the chunk's evaluate() promise. Deadlock, exit 13.
+test("dynamic import inside TLA of a non-entry module whose target imports it back is an unsettled TLA (exit 13)", async () => {
   using dir = tempDir("dyn-tla-cycle-nonentry", {
     "entry.mjs": `
       import { result } from "./mid.mjs";
@@ -69,9 +70,74 @@ test("dynamic import inside TLA of a non-entry module whose target imports it ba
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("result: 43");
-  expect(exitCode).toBe(0);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("Detected unsettled top-level await");
+  expect(stderr).toContain("mid.mjs");
+  expect(exitCode).toBe(13);
+});
+
+// The observable failure mode of the old deadlock-skip: `b` runs while `a` is
+// suspended mid-TLA and reads `a`'s post-await bindings in TDZ / as undefined.
+// Per spec `b` must wait on `a` (deadlock); it must never observe partial state.
+test("dynamic-import cycle does not let the importee observe the awaiter's half-initialised bindings", async () => {
+  using dir = tempDir("dyn-tla-cycle-partial", {
+    "entry.mjs": `import "./a.mjs"; console.log("entry:done");`,
+    "a.mjs": `
+      export const PRE = "pre";
+      const b = await import("./b.mjs");
+      console.log("a got:", b.report);
+      export const POST = "post";
+      export var V = "v";
+    `,
+    "b.mjs": `
+      import { PRE, POST, V } from "./a.mjs";
+      const r = f => { try { return String(f()) } catch (e) { return "threw:" + e.constructor.name } };
+      export const report = \`PRE=\${r(()=>PRE)} POST=\${r(()=>POST)} V=\${r(()=>V)}\`;
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // b never runs (it is waiting on a), so a's `await` never resolves and entry
+  // never completes. No partial-state observation leaks to stdout.
+  expect(stdout).not.toContain("threw:ReferenceError");
+  expect(stdout).not.toContain("V=undefined");
+  expect(stdout).toBe("");
+  expect(stderr).toContain("Detected unsettled top-level await");
+  expect(stderr).toContain("a.mjs");
+  expect(exitCode).toBe(13);
+});
+
+// Mutual `await import()` at top level: both suspend on each other. Per spec
+// this deadlocks; both Node and Bun exit 13. Distinct from the one-sided case
+// above (only one side is a dynamic import).
+test("mutual top-level await import() cycle is an unsettled TLA (exit 13)", async () => {
+  using dir = tempDir("dyn-tla-mutual", {
+    "a.mjs": `console.log("a:start"); await import("./b.mjs"); console.log("a:done");`,
+    "b.mjs": `console.log("b:start"); await import("./a.mjs"); console.log("b:done");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "a.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("a:start\nb:start\n");
+  expect(stderr).toContain("Detected unsettled top-level await");
+  expect(exitCode).toBe(13);
 });
 
 // The deadlock-avoidance above must NOT fire for sibling static imports in the

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -11,6 +11,7 @@ import {
   isPosix,
   isWindows,
   shellExe,
+  tempDir,
   tmpdirSync,
   withoutAggressiveGC,
 } from "harness";
@@ -806,6 +807,9 @@ describe("unref() + .exited with nothing else ref'd (Windows)", () => {
   // Windows: with only an unref'd uv_process_t left, uv_run() used to skip its
   // body and never dequeue the IOCP exit packet, so these children busy-spun
   // forever. us_loop_pump now forces one non-blocking iteration (POSIX parity).
+  // Driven via bun:test so the keep-going predicate comes from the runner's
+  // own drive loop (which does not ref the uv loop) rather than a ref'd handle;
+  // a top-level await on an unref'd handle alone is an unsettled TLA.
   for (const [name, body] of [
     ["unref() then await .exited", `const p = Bun.spawn(opts); p.unref(); await p.exited;`],
     [".exited then unref() then await", `const p = Bun.spawn(opts); const done = p.exited; p.unref(); await done;`],
@@ -816,31 +820,27 @@ describe("unref() + .exited with nothing else ref'd (Windows)", () => {
     ],
   ] as const) {
     it(name, async () => {
+      using dir = tempDir("spawn-unref-exited", {
+        "t.test.ts": `
+          import { it } from "bun:test";
+          const opts = { cmd: [${JSON.stringify(bunExe())}, "-e", ""], stdio: ["ignore", "ignore", "ignore"] };
+          it("awaits", async () => {
+            ${body}
+            console.log("resolved");
+          });
+        `,
+      });
       await using child = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          // A top-level await on an unref'd handle alone is an unsettled TLA
-          // (Node exits 13 too). Keep one ref'd timer so the loop stays alive
-          // long enough to observe the unref'd child's exit, which is what
-          // this test is about: the IOCP packet must be dequeued.
-          `const opts = { cmd: [${JSON.stringify(bunExe())}, "-e", ""], stdio: ["ignore", "ignore", "ignore"] };
-           const keepAlive = setTimeout(() => {}, 60_000);
-           ${body}
-           clearTimeout(keepAlive);
-           console.log("resolved");`,
-        ],
+        cmd: [bunExe(), "test", "t.test.ts"],
         env: bunEnv,
+        cwd: String(dir),
         stdout: "pipe",
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
-      expect({ stdout, stderr, exitCode, signalCode: child.signalCode }).toEqual({
-        stdout: "resolved\n",
-        stderr: "",
-        exitCode: 0,
-        signalCode: null,
-      });
+      expect(stderr).toContain("1 pass");
+      expect(stdout).toContain("resolved\n");
+      expect({ exitCode, signalCode: child.signalCode }).toEqual({ exitCode: 0, signalCode: null });
     });
   }
 });

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -820,8 +820,14 @@ describe("unref() + .exited with nothing else ref'd (Windows)", () => {
         cmd: [
           bunExe(),
           "-e",
+          // A top-level await on an unref'd handle alone is an unsettled TLA
+          // (Node exits 13 too). Keep one ref'd timer so the loop stays alive
+          // long enough to observe the unref'd child's exit, which is what
+          // this test is about: the IOCP packet must be dequeued.
           `const opts = { cmd: [${JSON.stringify(bunExe())}, "-e", ""], stdio: ["ignore", "ignore", "ignore"] };
+           const keepAlive = setTimeout(() => {}, 60_000);
            ${body}
+           clearTimeout(keepAlive);
            console.log("resolved");`,
         ],
         env: bunEnv,


### PR DESCRIPTION
## What

A top-level `await import("./b")` where `b` *statically* imports the awaiter back was running `b` immediately against the awaiter's half-initialised bindings: post-await `const` reads hit TDZ, post-await `var` reads returned `undefined`, and the program exited 0.

```js
// a.mjs
export const PRE = "pre";
const b = await import("./b.mjs");
console.log("a got:", b.report);
export const POST = "post"; export var V = "v";

// b.mjs
import { PRE, POST, V } from "./a.mjs";
const r = f => { try { return String(f()) } catch (e) { return "threw:" + e.constructor.name } };
export const report = `PRE=${r(()=>PRE)} POST=${r(()=>POST)} V=${r(()=>V)}`;

// entry.mjs
import "./a.mjs"; console.log("entry:done");
```

Before: `a got: PRE=pre POST=threw:ReferenceError V=undefined` / `entry:done`, exit 0.
Node:   `Warning: Detected unsettled top-level await at .../a.mjs:2`, exit 13.
After:  `Warning: Detected unsettled top-level await at .../a.mjs`, exit 13.

## Why

ECMA-262 `InnerModuleEvaluation` step 12.b.v: when a dependency is `EVALUATING-ASYNC`, the importer increments `PendingAsyncDependencies` and waits. Here `a` is `EVALUATING-ASYNC` (suspended at its `await`), so `b` must wait for `a`; `a` is waiting on `b` via the dynamic `import()` promise. The graph deadlocks by spec.

`moduleLoaderImportModule` was passing the referrer's `asyncEvaluationOrder` through to `innerModuleEvaluation`, which used it to skip the step-12.b.v wait when the `EvaluatingAsync` dep *is* the referrer (the `referrerAsyncOrder` check added in #32437). That avoided the deadlock at the cost of breaking the ESM guarantee that a module's static dependencies finish evaluating before its body runs. Node does not take that shortcut on this graph and exits 13.

## Fix

- `moduleLoaderImportModule` no longer captures or forwards `referrerAsyncOrder`. The WebKit-side skip is keyed off that value being a valid order, so passing the default (`-1`) makes it never fire and step 12.b.v applies as specified. (The `asyncEvaluationOrderForKey` plumbing in oven-sh/WebKit is now dead and can be dropped in a follow-up there.)
- `load_entry_point` / `load_entry_point_for_test_runner` use a new `wait_for_module_promise` that returns once `!has_pending_loop_work()` with the entry promise still pending, instead of spinning forever. `has_pending_loop_work()` ignores `unhandled_error_counter` so a prior unhandled rejection does not read as a stalled TLA.
- After the main run loop drains with no unhandled error, if the entry module's evaluation promise is still pending, print Node's `Detected unsettled top-level await` warning (naming the stalled module(s) via a walk of the JSC module map) and set exit code 13.

Intentionally left on the existing unconditional wait (each would busy-spin on a TLA-cycle graph, which previously evaluated with partial state; all are exotic triggers):
- `--watch` / `--hot`: the file-watcher handle keeps `has_pending_loop_work()` true, so a mechanical swap does not help. A stalled TLA parks on the watcher fd. The stalled-TLA discriminator for this path belongs with #33286 and siblings.
- `bun build --app` loading `bun.app.ts` (`production.rs:355`, `:1248`): the callers do `Unwrapped::Pending => unreachable!()`, so a swap needs an explicit Pending arm. bake is experimental.
- `with { type: 'macro' }` entry modules (`_load_macro_entry_point`, VirtualMachine.rs).

## Tests

- `test/js/bun/resolve/dynamic-import-tla-cycle.test.ts`: the two self-cycle tests now assert exit 13 (matching Node) instead of exit 0; added the partial-state-observation repro and a mutual `await import()` cycle. The four #30259 / #30634 sibling-wait tests still pass.
- `test/js/bun/http/js-sink-sourmap-fixture/index.mjs`: the nitro-style fixture's self-test `await fetch` was a TLA whose handler lazy-imports a chunk that statically imports the fixture back. That graph deadlocks per spec (Node deadlocks on it too). Moved the self-test into `setImmediate` so the module finishes evaluating first and the chunk sees an `Evaluated` dependency.
- `test/js/bun/spawn/spawn.test.ts` "unref'd .exited": a top-level `await` on an unref'd handle alone is an unsettled TLA in Node as well (exit 13). The tests now drive the await from a spawned `bun test` file so the keep-going predicate is the runner's own drive loop (which does not ref the uv loop), preserving coverage of the `us_loop_pump` IOCP fix.

Fixes #14708
Addresses the core of #33283; the broader handling (beforeExit re-drain, `--print` ordering, `--watch`) is in #33286 and siblings.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->