### PR TITLE
Bun.spawn: throw AbortError for an already-aborted signal instead of spawning

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7004,8 +7004,12 @@ declare module "bun" {
        * Use this to abort the subprocess when another part of the program is
        * aborted, such as a `fetch`.
        *
-       * If the signal is aborted, the process is killed with the signal
-       * specified by `killSignal` (defaults to SIGTERM).
+       * If the signal is already aborted when `spawn` is called, no process is
+       * created and an `AbortError` (with `cause` set to `signal.reason`) is
+       * thrown synchronously.
+       *
+       * If the signal is aborted after the process starts, the process is
+       * killed with the signal specified by `killSignal` (defaults to SIGTERM).
        *
        * @example
        * ```ts

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -539,7 +539,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                     // `from_js` returns a live FFI handle owned by JS.
                     // `AbortSignal` is an `opaque_ffi!` ZST handle; `opaque_ref`
                     // is the centralised non-null deref proof.
-                    **abort_signal = Some(WebCore::AbortSignal::opaque_ref(signal).ref_());
+                    let sig = WebCore::AbortSignal::opaque_ref(signal);
+                    if let Some(abort_error) = sig.node_abort_error_if_aborted(global_this) {
+                        return Err(global_this.throw_value(abort_error));
+                    }
+                    **abort_signal = Some(sig.ref_());
                 } else {
                     return Err(global_this.throw_invalid_argument_type_value(
                         b"signal",

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -20,23 +20,77 @@ test("spawn AbortSignal works after spawning", async () => {
   expect(end - start).toBeLessThan(100);
 });
 
-test("spawn AbortSignal works if already aborted", async () => {
+test("spawn AbortSignal throws if already aborted", () => {
   const controller = new AbortController();
-  const { signal } = controller;
-  const start = performance.now();
-  const subprocess = Bun.spawn({
-    cmd: [bunExe(), "--eval", "await Bun.sleep(100000)"],
-    env: bunEnv,
-    stdout: "inherit",
-    stderr: "inherit",
-    stdin: "inherit",
-    signal,
-  });
-  await Bun.sleep(1);
   controller.abort();
-  expect(await subprocess.exited).not.toBe(0);
-  const end = performance.now();
-  expect(end - start).toBeLessThan(100);
+  expect(() =>
+    Bun.spawn({
+      cmd: [bunExe(), "--eval", "await Bun.sleep(100000)"],
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "inherit",
+      signal: controller.signal,
+    }),
+  ).toThrow(
+    expect.objectContaining({
+      name: "AbortError",
+      code: "ABORT_ERR",
+    }),
+  );
+});
+
+test("spawn AbortSignal already aborted carries signal.reason as cause", () => {
+  const controller = new AbortController();
+  const reason = new Error("USER_REASON");
+  controller.abort(reason);
+  let thrown: any;
+  try {
+    Bun.spawn({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+      signal: controller.signal,
+    });
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toEqual(
+    expect.objectContaining({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      cause: reason,
+    }),
+  );
+  expect(thrown.cause).toBe(reason);
+});
+
+test("spawn AbortSignal.abort() throws synchronously", () => {
+  expect(() =>
+    Bun.spawn({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+      signal: AbortSignal.abort(),
+    }),
+  ).toThrow(expect.objectContaining({ name: "AbortError", code: "ABORT_ERR" }));
+});
+
+test("spawnSync AbortSignal throws if already aborted", () => {
+  const controller = new AbortController();
+  const reason = new Error("USER_REASON");
+  controller.abort(reason);
+  expect(() =>
+    Bun.spawnSync({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+      signal: controller.signal,
+    }),
+  ).toThrow(
+    expect.objectContaining({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      cause: reason,
+    }),
+  );
 });
 
 test("spawn AbortSignal args validation", async () => {

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -20,19 +20,29 @@ test("spawn AbortSignal works after spawning", async () => {
   expect(end - start).toBeLessThan(100);
 });
 
-test("spawn AbortSignal throws if already aborted", () => {
+test("spawn AbortSignal throws if already aborted", async () => {
   const controller = new AbortController();
   controller.abort();
-  expect(() =>
-    Bun.spawn({
+  let proc: Bun.Subprocess | undefined;
+  let thrown: any;
+  try {
+    proc = Bun.spawn({
       cmd: [bunExe(), "--eval", "await Bun.sleep(100000)"],
       env: bunEnv,
       stdout: "inherit",
       stderr: "inherit",
       stdin: "inherit",
       signal: controller.signal,
-    }),
-  ).toThrow(
+    });
+  } catch (e) {
+    thrown = e;
+  }
+  if (proc) {
+    proc.kill(9);
+    await proc.exited;
+  }
+  expect(proc).toBeUndefined();
+  expect(thrown).toEqual(
     expect.objectContaining({
       name: "AbortError",
       code: "ABORT_ERR",
@@ -64,10 +74,12 @@ test("spawn AbortSignal already aborted carries signal.reason as cause", () => {
   expect(thrown.cause).toBe(reason);
 });
 
-test("spawn AbortSignal.abort() throws synchronously", () => {
+test("spawn AbortSignal already aborted throws before resolving the executable", () => {
+  // If Bun.spawn reached PATH resolution or posix_spawn before checking the
+  // signal, this would throw ENOENT for the missing executable instead.
   expect(() =>
     Bun.spawn({
-      cmd: [bunExe(), "-e", ""],
+      cmd: ["bun-spawn-nonexistent-executable-for-abort-test"],
       env: bunEnv,
       signal: AbortSignal.abort(),
     }),


### PR DESCRIPTION
## Problem

`Bun.spawn({signal})` with a signal that is already aborted still forks and execs the child, then races a SIGTERM at it after `posix_spawn` returns. The child can run its first instructions (observed via `strace`: `execve` followed by `kill(SIGTERM)`), and nothing abort-shaped is surfaced to the caller: no throw, no rejection, just `proc.exited` resolving to 143 and `signalCode === "SIGTERM"`, which is indistinguishable from an external kill.

`Bun.spawnSync` is worse: the pre-aborted signal is effectively ignored and the call blocks for the child's full lifetime.

```js
const ac = new AbortController();
ac.abort(new Error("USER_REASON")); // aborted BEFORE spawn
const proc = Bun.spawn(["/bin/sh", "-c", "echo started > marker; sleep 30"], { signal: ac.signal });
console.log(typeof proc.pid);    // "number" - a process WAS created
console.log(await proc.exited);  // 143 - no throw, no AbortError anywhere
```

Every other `{signal}` consumer (fetch, fs/promises, timers/promises, streams, events.once) refuses to start work for a known-cancelled operation and surfaces `signal.reason`.

## Cause

The abort listener is attached only after `posix_spawn` completes (`js_bun_spawn_bindings.rs` around `add_listener`), so for an already-aborted signal "cancel" becomes a post-spawn kill rather than a refusal to start.

## Fix

Check `signal.aborted` when the `signal` option is parsed, before any process is created. If already aborted, throw an `AbortError` (`name: "AbortError"`, `code: "ABORT_ERR"`) with `cause` set to `signal.reason`, matching the Node.js convention used by `fs/promises` and `timers/promises`.

`node:child_process` is unaffected: it handles the signal at the JS level and does not forward `signal` to `Bun.spawn`.

## Verification

```
=== before (stock bun) ===
(fail) spawn AbortSignal throws if already aborted
(fail) spawn AbortSignal already aborted carries signal.reason as cause
(fail) spawn AbortSignal.abort() throws synchronously
(fail) spawnSync AbortSignal throws if already aborted

=== after (this PR) ===
12 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-signal.test.ts
bun test v1.4.0 (d864ffe41)

test/js/bun/spawn/spawn-signal.test.ts:
(pass) spawn AbortSignal works after spawning [17.37ms]
39 |   }
40 |   if (proc) {
41 |     proc.kill(9);
42 |     await proc.exited;
43 |   }
44 |   expect(proc).toBeUndefined();
                    ^
error: expect(received).toBeUndefined()

Received: Subprocess {
  connected: false,
  disconnect: [Function: disconnect],
  exitCode: null,
  exited: Promise { <resolved> },
  kill: [Function: kill],
  killed: true,
  pid: 50771,
  readable: undefined,
  ref: [Function: ref],
  resourceUsage: [Function: resourceUsage],
  send: [Function: send],
  signalCode: "SIGTERM",
  stderr: undefined,
  stdin: undefined,
  stdio: [ null, null, null ],
  stdout: undefined,
  terminal: undefined,
  unref: [Function: unref],
  writable: undefined,
  [Symbol(Symbol.asyncDispose)]: [Function: asyncDispose],
}

      at <anonymous> (/workspace/bun/test/js/bun/spawn/spawn-signal.test.ts:44:16)
(fail) spawn AbortSignal throws if already aborted [22.8
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/spawn/spawn-signal.test.ts:
(pass) spawn AbortSignal works after spawning [2.33ms]
39 |   }
40 |   if (proc) {
41 |     proc.kill(9);
42 |     await proc.exited;
43 |   }
44 |   expect(proc).toBeUndefined();
                    ^
error: expect(received).toBeUndefined()

Received: Subprocess {
  connected: false,
  disconnect: [Function: disconnect],
  exitCode: null,
  exited: Promise { <resolved> },
  kill: [Function: kill],
  killed: true,
  pid: 50802,
  readable: undefined,
  ref: [Function: ref],
  resourceUsage: [Function: resourceUsage],
  send: [Function: send],
  signalCode: "SIGTERM",
  stderr: undefined,
  stdin: undefined,
  stdio: [ null, null, null ],
  stdout: undefined,
  terminal: undefined,
  unref: [Function: unref],
  writable: undefined,
  [Symbol(Symbol.asyncDispose)]: [Function: asyncDispose],
}

      at <anonymous> (/workspace/bun/test/js/bun/spawn/spawn-signal.test.ts:44:16)
(fail) spawn AbortSignal throws if already aborted [0.96ms]
62 |       signal: controller.signal,
63 |     });
64 |   } catch (e) {
65 |     thrown = e;
66 |   }
67 |   expect(thrown).toEqual(
                      ^
err
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-signal.test.ts
bun test v1.4.0 (d864ffe41)

test/js/bun/spawn/spawn-signal.test.ts:
(pass) spawn AbortSignal works after spawning [17.64ms]
(pass) spawn AbortSignal throws if already aborted [10.21ms]
(pass) spawn AbortSignal already aborted carries signal.reason as cause [5.18ms]
(pass) spawn AbortSignal already aborted throws before resolving the executable [4.07ms]
(pass) spawnSync AbortSignal throws if already aborted [4.37ms]
(pass) spawn AbortSignal args validation [3.65ms]
(pass) spawnSync AbortSignal works as timeout [15.42ms]
(pass) Bun.spawn option validation > Bun.spawn > timeout: NaN throws ERR_OUT_OF_RANGE [6.89ms]
(pass) Bun.spawn option validation > Bun.spawn > killSignal: 0 throws ERR_UNKNOWN_SIGNAL [5.01ms]
(pass) Bun.spawn option validation > Bun.spawnSync > timeout: NaN throws ERR_OUT_OF_RANGE [3.65ms]
(pass) Bun.spawn option validation > Bun.spawnSync > killSignal: 0 throws ERR_UNKNOWN_SIGNAL [2.24ms]
(pass) Bun.spawn option validation > proc.kill(0) is still accepted [25.95ms]

 12 pass
 0 f
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 698ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts                  |  8 ++-
 src/runtime/api/bun/js_bun_spawn_bindings.rs |  6 +-
 test/js/bun/spawn/spawn-signal.test.ts       | 96 +++++++++++++++++++++++-----
 3 files changed, 92 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/bun.d.ts                       1      1      0
src/runtime/api/bun/js_bun_spawn_bindings.rs      9      1      0
test/js/bun/spawn/spawn-signal.test.ts            2      7      0
```

</details>

<!-- robobun:evidence:end -->