### PR TITLE
worker_threads: queue parentPort messages until a 'message' listener is attached

### DIFF
--- a/src/jsc/bindings/BunWorkerGlobalScope.cpp
+++ b/src/jsc/bindings/BunWorkerGlobalScope.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include "BunWorkerGlobalScope.h"
+#include "webcore/Worker.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -15,6 +16,11 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
         case Add:
             if (global.m_messageEventCount == 0) {
                 global.scriptExecutionContext()->refEventLoop();
+                // node:worker_threads parentPort: messages the parent posted while
+                // there was no listener are held in the Worker's m_toWorker inbox
+                // (drainToWorker leaves them there). First listener arriving
+                // schedules the flush. No-op on the main thread and for Web Workers.
+                scheduleParentPortDrainIfNode(global.scriptExecutionContext());
             }
             global.m_messageEventCount++;
             break;

--- a/src/jsc/bindings/BunWorkerGlobalScope.cpp
+++ b/src/jsc/bindings/BunWorkerGlobalScope.cpp
@@ -16,10 +16,8 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
         case Add:
             if (global.m_messageEventCount == 0) {
                 global.scriptExecutionContext()->refEventLoop();
-                // node:worker_threads parentPort: messages the parent posted while
-                // there was no listener are held in the Worker's m_toWorker inbox
-                // (drainToWorker leaves them there). First listener arriving
-                // schedules the flush. No-op on the main thread and for Web Workers.
+                // Node parentPort: flush anything the parent posted while there
+                // was no listener. No-op on main thread / Web Workers.
                 scheduleParentPortDrainIfNode(global.scriptExecutionContext());
             }
             global.m_messageEventCount++;

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -378,9 +378,13 @@ void Worker::drainToWorker(ScriptExecutionContext& context)
 
 void Worker::scheduleDrainToWorker()
 {
+    // Not gated on drainScheduled: enqueueToWorker (parent thread) can leave it
+    // transiently true with no task posted (postTaskTo failed, clear not yet
+    // run), and this path (worker thread, 0→1 listener) is rare enough that a
+    // redundant drain is cheaper than a lost wakeup.
     {
         Locker locker { m_toWorker.lock };
-        if (m_toWorker.queue.isEmpty() || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
+        if (m_toWorker.queue.isEmpty())
             return;
         m_toWorker.drainScheduled.store(true, std::memory_order_relaxed);
     }

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -238,14 +238,10 @@ void Worker::enqueueToWorker(MessageWithMessagePorts&& message)
         auto state = m_state.load();
         if (state >= State::Closing || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
             return;
-        // Web Workers: messages dispatch only after script execution (HTML
-        // "run a worker" step 26), so buffer until fireEarlyMessages().
-        // Node workers: parentPort starts draining once it has a listener,
-        // independent of entry-eval completion (an awaited import / top-level
-        // await may keep the entry promise pending indefinitely), so try to
-        // schedule now — drainToWorker bails if no listener is attached yet,
-        // and postTaskTo returns false if the worker context isn't
-        // registered yet.
+        // Web Workers buffer until fireEarlyMessages() (HTML "run a worker"
+        // step 26). Node workers drain as soon as parentPort has a listener,
+        // so a worker blocked in top-level await can still receive messages;
+        // drainToWorker is the listener gate, postTaskTo the context gate.
         if (state == State::Pending && m_options.kind != WorkerOptions::Kind::Node)
             return;
         m_toWorker.drainScheduled.store(true, std::memory_order_relaxed);
@@ -291,11 +287,8 @@ void Worker::enqueueToParent(MessageWithMessagePorts&& message)
 // sender. A sustained producer (e.g. a tight postMessage loop) would otherwise
 // make every per-message pop a contended acquire.
 //
-// shouldContinue() is checked before each dispatch; returning false prepends
-// the undelivered tail back to the inbox and clears drainScheduled so a later
-// trigger (scheduleDrainToWorker) can re-run the drain. drainToWorker uses this
-// for Node workers to suspend dispatch while parentPort has zero 'message'
-// listeners.
+// shouldContinue() returning false prepends the undelivered tail back to the
+// inbox and clears drainScheduled so a later trigger can re-run the drain.
 template<typename Dispatch, typename ShouldContinue>
 static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* globalObject, ScriptExecutionContext& context, Dispatch&& dispatch, ShouldContinue&& shouldContinue)
 {
@@ -364,11 +357,8 @@ void Worker::drainToWorker(ScriptExecutionContext& context)
         return;
     }
     auto& scope = globalObject->globalEventScope;
-    // Node's parentPort is a MessagePort that stays stopped until it has a
-    // 'message' listener: messages queue until one is added, and re-queue if
-    // the last listener is removed mid-drain (parentPort.once). Web Worker
-    // semantics (the implicit port is auto-started after script execution)
-    // are unchanged.
+    // Node parentPort queues while it has no 'message' listener and re-queues
+    // if once() leaves zero mid-drain; Web Workers dispatch regardless.
     const bool gateOnListeners = m_options.kind == WorkerOptions::Kind::Node;
     if (gateOnListeners && !scope->hasActiveEventListeners(eventNames().messageEvent)) {
         Locker locker { m_toWorker.lock };

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -230,14 +230,23 @@ void Worker::enqueueToWorker(MessageWithMessagePorts&& message)
     {
         Locker locker { m_toWorker.lock };
         m_toWorker.queue.append(WTF::move(message));
-        // If the worker isn't Running yet, just buffer; fireEarlyMessages()
-        // drains the inbox on the worker thread once it is. If Closing/
-        // Closed, also buffer (dropped with the Worker) — postMessage()
+        // Closing/Closed: buffer (dropped with the Worker) — postMessage()
         // already rejects on Closed, so only the close-handler window lands
         // here. If a drain is already scheduled, don't double-schedule.
         // drainScheduled is only set/cleared under the lock so the
         // load/store pair is not a race.
-        if (m_state.load() != State::Running || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
+        auto state = m_state.load();
+        if (state >= State::Closing || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
+            return;
+        // Web Workers: messages dispatch only after script execution (HTML
+        // "run a worker" step 26), so buffer until fireEarlyMessages().
+        // Node workers: parentPort starts draining once it has a listener,
+        // independent of entry-eval completion (an awaited import / top-level
+        // await may keep the entry promise pending indefinitely), so try to
+        // schedule now — drainToWorker bails if no listener is attached yet,
+        // and postTaskTo returns false if the worker context isn't
+        // registered yet.
+        if (state == State::Pending && m_options.kind != WorkerOptions::Kind::Node)
             return;
         m_toWorker.drainScheduled.store(true, std::memory_order_relaxed);
     }

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -96,6 +96,9 @@ void WebWorker__releaseParentPollRef(void* worker);
 // Free the native WebWorker struct. Called from ~Worker.
 void WebWorker__destroy(void* worker);
 
+// The owning Worker* for this VM (null on the main thread / non-worker).
+WebCore::Worker* WebWorker__getParentWorker(void* bunVM);
+
 } // extern "C"
 // -------------------------------------------------------------------------------------------------
 
@@ -278,8 +281,14 @@ void Worker::enqueueToParent(MessageWithMessagePorts&& message)
 // into a local deque under the lock and dispatch without contending with the
 // sender. A sustained producer (e.g. a tight postMessage loop) would otherwise
 // make every per-message pop a contended acquire.
-template<typename Dispatch>
-static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* globalObject, ScriptExecutionContext& context, Dispatch&& dispatch)
+//
+// shouldContinue() is checked before each dispatch; returning false prepends
+// the undelivered tail back to the inbox and clears drainScheduled so a later
+// trigger (scheduleDrainToWorker) can re-run the drain. drainToWorker uses this
+// for Node workers to suspend dispatch while parentPort has zero 'message'
+// listeners.
+template<typename Dispatch, typename ShouldContinue>
+static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* globalObject, ScriptExecutionContext& context, Dispatch&& dispatch, ShouldContinue&& shouldContinue)
 {
     size_t limit;
     Deque<MessageWithMessagePorts> batch;
@@ -295,6 +304,13 @@ static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* gl
 
     while (true) {
         while (!batch.isEmpty()) {
+            if (!shouldContinue()) {
+                Locker locker { inbox.lock };
+                while (!batch.isEmpty())
+                    inbox.queue.prepend(batch.takeLast());
+                inbox.drainScheduled.store(false, std::memory_order_relaxed);
+                return false;
+            }
             if (limit-- == 0) {
                 // Yield to the rest of the event loop. Return the undrained
                 // tail to the front of the inbox so it stays ahead of
@@ -338,14 +354,57 @@ void Worker::drainToWorker(ScriptExecutionContext& context)
         m_toWorker.drainScheduled.store(false, std::memory_order_relaxed);
         return;
     }
-    bool reschedule = drainInbox(m_toWorker, globalObject, context, [&](Event& event) {
-        globalObject->globalEventScope->dispatchEvent(event);
-    });
+    auto& scope = globalObject->globalEventScope;
+    // Node's parentPort is a MessagePort that stays stopped until it has a
+    // 'message' listener: messages queue until one is added, and re-queue if
+    // the last listener is removed mid-drain (parentPort.once). Web Worker
+    // semantics (the implicit port is auto-started after script execution)
+    // are unchanged.
+    const bool gateOnListeners = m_options.kind == WorkerOptions::Kind::Node;
+    if (gateOnListeners && !scope->hasActiveEventListeners(eventNames().messageEvent)) {
+        Locker locker { m_toWorker.lock };
+        m_toWorker.drainScheduled.store(false, std::memory_order_relaxed);
+        return;
+    }
+    bool reschedule = drainInbox(
+        m_toWorker, globalObject, context,
+        [&](Event& event) { scope->dispatchEvent(event); },
+        [&] { return !gateOnListeners || scope->hasActiveEventListeners(eventNames().messageEvent); });
     if (reschedule) {
         ScriptExecutionContext::postTaskTo(m_clientIdentifier, [protectedThis = Ref { *this }](ScriptExecutionContext& ctx) {
             protectedThis->drainToWorker(ctx);
         });
     }
+}
+
+void Worker::scheduleDrainToWorker()
+{
+    {
+        Locker locker { m_toWorker.lock };
+        if (m_toWorker.queue.isEmpty() || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
+            return;
+        m_toWorker.drainScheduled.store(true, std::memory_order_relaxed);
+    }
+    bool posted = ScriptExecutionContext::postTaskTo(m_clientIdentifier, [protectedThis = Ref { *this }](ScriptExecutionContext& ctx) {
+        protectedThis->drainToWorker(ctx);
+    });
+    if (!posted) {
+        Locker locker { m_toWorker.lock };
+        m_toWorker.drainScheduled.store(false, std::memory_order_relaxed);
+    }
+}
+
+void scheduleParentPortDrainIfNode(ScriptExecutionContext* context)
+{
+    if (!context)
+        return;
+    auto* globalObject = defaultGlobalObject(context->jsGlobalObject());
+    if (!globalObject)
+        return;
+    auto* worker = WebWorker__getParentWorker(globalObject->bunVM());
+    if (!worker || worker->options().kind != WorkerOptions::Kind::Node)
+        return;
+    worker->scheduleDrainToWorker();
 }
 
 void Worker::drainToParent(ScriptExecutionContext& context)
@@ -356,9 +415,10 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         m_toParent.drainScheduled.store(false, std::memory_order_relaxed);
         return;
     }
-    bool reschedule = drainInbox(m_toParent, globalObject, context, [&](Event& event) {
-        dispatchEvent(event);
-    });
+    bool reschedule = drainInbox(
+        m_toParent, globalObject, context,
+        [&](Event& event) { dispatchEvent(event); },
+        [] { return true; });
     if (reschedule) {
         postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext& c) {
             protectedThis->drainToParent(c);
@@ -746,8 +806,6 @@ extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker
         return;
     }
 }
-
-extern "C" WebCore::Worker* WebWorker__getParentWorker(void* bunVM);
 
 JSC_DEFINE_HOST_FUNCTION(jsReceiveMessageOnPort, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -162,6 +162,10 @@ public:
 
     void enqueueToParent(MessageWithMessagePorts&&);
     void drainToWorker(ScriptExecutionContext&);
+    // Post a drainToWorker task if the inbox is non-empty and no drain is in
+    // flight. Called on the worker thread when the globalEventScope's
+    // 'message' listener count goes 0→1 (Node-kind workers only).
+    void scheduleDrainToWorker();
 
 private:
     Worker(ScriptExecutionContext&, WorkerOptions&&);
@@ -209,6 +213,12 @@ private:
 };
 
 JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject);
+
+// If this context belongs to a node:worker_threads worker, schedule a drain of
+// its parent→worker inbox. Called from WorkerGlobalScope's listener-change hook
+// so messages queued while parentPort had no 'message' listener are delivered
+// once one is attached.
+void scheduleParentPortDrainIfNode(ScriptExecutionContext*);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionPostMessage);
 

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -162,9 +162,8 @@ public:
 
     void enqueueToParent(MessageWithMessagePorts&&);
     void drainToWorker(ScriptExecutionContext&);
-    // Post a drainToWorker task if the inbox is non-empty and no drain is in
-    // flight. Called on the worker thread when the globalEventScope's
-    // 'message' listener count goes 0→1 (Node-kind workers only).
+    // Post a drainToWorker task if the inbox is non-empty and none is in
+    // flight. Called on the worker thread when parentPort gains a listener.
     void scheduleDrainToWorker();
 
 private:
@@ -214,10 +213,8 @@ private:
 
 JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject);
 
-// If this context belongs to a node:worker_threads worker, schedule a drain of
-// its parent→worker inbox. Called from WorkerGlobalScope's listener-change hook
-// so messages queued while parentPort had no 'message' listener are delivered
-// once one is attached.
+// Called from WorkerGlobalScope's listener-change hook: schedules a
+// parent→worker inbox drain if this context belongs to a Node worker.
 void scheduleParentPortDrainIfNode(ScriptExecutionContext*);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionPostMessage);

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -162,8 +162,8 @@ public:
 
     void enqueueToParent(MessageWithMessagePorts&&);
     void drainToWorker(ScriptExecutionContext&);
-    // Post a drainToWorker task if the inbox is non-empty and none is in
-    // flight. Called on the worker thread when parentPort gains a listener.
+    // Post a drainToWorker task if the inbox is non-empty. Called on the
+    // worker thread when parentPort gains a listener.
     void scheduleDrainToWorker();
 
 private:

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1092,8 +1092,14 @@ impl WebWorker {
         let promise = match vm.as_mut().load_entry_point_for_web_worker(path) {
             Ok(p) => p,
             Err(_) => {
-                // process.exit() may have run during load; don't clobber its code.
-                if !self.exit_called.load(Ordering::Relaxed) {
+                // process.exit() may have run during load; don't clobber its
+                // code. Likewise, an uncaught exception from a task processed
+                // inside wait_for_promise_with_termination (a timer, or a Node
+                // worker's parentPort message handler) has already been
+                // through on_unhandled_rejection, which set exit_code=1 and
+                // ran the worker's process.on('exit') handlers — those may
+                // have changed it, so don't clobber that either.
+                if !self.exit_called.load(Ordering::Relaxed) && vm.unhandled_error_counter == 0 {
                     vm.as_mut().exit_handler.exit_code = 1;
                 }
                 self.flush_logs(vm);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1520,6 +1520,11 @@ fn on_unhandled_rejection(
 
     let mut array: Vec<u8> = Vec::new();
 
+    // uncaught_exception's non-test path set exit_code=1 already; the Promise-
+    // rejection and isBunTest paths did not. Set it before worker_ref's shared
+    // borrow so process.on('exit') below sees code=1 and can override it.
+    vm.exit_handler.exit_code = 1;
+
     // `worker_ref()` is the safe BACKREF accessor — `vm.worker` points at the
     // heap `WebWorker` owned by C++ that outlives `vm`. `&WebWorker` (not
     // `&mut`) — see worker-thread `&self` note.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1092,13 +1092,9 @@ impl WebWorker {
         let promise = match vm.as_mut().load_entry_point_for_web_worker(path) {
             Ok(p) => p,
             Err(_) => {
-                // process.exit() may have run during load; don't clobber its
-                // code. Likewise, an uncaught exception from a task processed
-                // inside wait_for_promise_with_termination (a timer, or a Node
-                // worker's parentPort message handler) has already been
-                // through on_unhandled_rejection, which set exit_code=1 and
-                // ran the worker's process.on('exit') handlers — those may
-                // have changed it, so don't clobber that either.
+                // Don't clobber a code set during load: process.exit(), or an
+                // uncaught exception in a task (timer / parentPort handler)
+                // that already ran on_unhandled_rejection + process.on('exit').
                 if !self.exit_called.load(Ordering::Relaxed) && vm.unhandled_error_counter == 0 {
                     vm.as_mut().exit_handler.exit_code = 1;
                 }

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1756,3 +1756,111 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   expect(stdout.trim()).toBe("yes,unset");
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/5460
+// Node's parentPort is a MessagePort that stays stopped until it has a 'message'
+// listener: messages the parent posts before the worker attaches one are queued
+// and delivered in order once it does. Bun previously dispatched them into the
+// listener-less globalEventScope and silently dropped them.
+describe("parentPort buffers parent→worker messages while there is no 'message' listener", () => {
+  // The shape that bites real code: the parent posts right after `new Worker()`
+  // and the worker only wires up parentPort after an async init step.
+  test.concurrent("listener attached after async init receives everything posted at construction", async () => {
+    const src = `
+      const { parentPort } = require('node:worker_threads');
+      const got = [];
+      setTimeout(() => {
+        parentPort.on('message', m => got.push(m));
+        setTimeout(() => parentPort.postMessage(got), 200);
+      }, 100);`;
+    const w = new Worker(src, { eval: true });
+    try {
+      for (let i = 1; i <= 5; i++) w.postMessage("m" + i);
+      const got = await new Promise(r => w.once("message", r));
+      expect(got).toEqual(["m1", "m2", "m3", "m4", "m5"]);
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  test.concurrent("listener attached after 'online' receives everything posted then", async () => {
+    const src = `
+      const { parentPort } = require('node:worker_threads');
+      const got = [];
+      setTimeout(() => {
+        parentPort.on('message', m => got.push(m));
+        setTimeout(() => parentPort.postMessage(got), 200);
+      }, 100);`;
+    const w = new Worker(src, { eval: true });
+    try {
+      await once(w, "online");
+      for (let i = 1; i <= 5; i++) w.postMessage("a" + i);
+      const got = await new Promise(r => w.once("message", r));
+      expect(got).toEqual(["a1", "a2", "a3", "a4", "a5"]);
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  test.concurrent("once('message') consumes one; the rest re-queue for the next listener", async () => {
+    const src = `
+      const { parentPort } = require('node:worker_threads');
+      setTimeout(() => {
+        let first;
+        parentPort.once('message', m => { first = m; });
+        setTimeout(() => {
+          const rest = [];
+          parentPort.on('message', m => rest.push(m));
+          setTimeout(() => parentPort.postMessage({ first, rest }), 200);
+        }, 100);
+      }, 100);`;
+    const w = new Worker(src, { eval: true });
+    try {
+      for (let i = 1; i <= 5; i++) w.postMessage("m" + i);
+      const result = await new Promise(r => w.once("message", r));
+      expect(result).toEqual({ first: "m1", rest: ["m2", "m3", "m4", "m5"] });
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  // Delivery is scheduled, not synchronous inside on(): matches Node's
+  // port.start() semantics.
+  test.concurrent("buffered delivery is async (fires after the code that added the listener)", async () => {
+    const src = `
+      const { parentPort } = require('node:worker_threads');
+      const log = [];
+      setTimeout(() => {
+        parentPort.on('message', m => log.push('got:' + m));
+        log.push('after-on');
+        setTimeout(() => parentPort.postMessage(log), 200);
+      }, 100);`;
+    const w = new Worker(src, { eval: true });
+    try {
+      for (let i = 1; i <= 3; i++) w.postMessage("m" + i);
+      const log = await new Promise(r => w.once("message", r));
+      expect(log).toEqual(["after-on", "got:m1", "got:m2", "got:m3"]);
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  test.concurrent("Web Worker semantics are unchanged: no buffering without a listener", async () => {
+    const src = `
+      const got = [];
+      setTimeout(() => {
+        self.addEventListener('message', e => got.push(e.data));
+        setTimeout(() => self.postMessage(got), 200);
+      }, 100);`;
+    const url = URL.createObjectURL(new Blob([src], { type: "application/javascript" }));
+    const w = new globalThis.Worker(url);
+    try {
+      for (let i = 1; i <= 3; i++) w.postMessage("m" + i);
+      const got = await new Promise(r => (w.onmessage = e => r(e.data)));
+      expect(got).toEqual([]);
+    } finally {
+      w.terminate();
+      URL.revokeObjectURL(url);
+    }
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -1763,21 +1763,27 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
 // and delivered in order once it does. Bun previously dispatched them into the
 // listener-less globalEventScope and silently dropped them.
 describe("parentPort buffers parent→worker messages while there is no 'message' listener", () => {
+  const nextMessage = async (w: Worker) => {
+    const [msg] = await once(w, "message");
+    return msg;
+  };
+
   // The shape that bites real code: the parent posts right after `new Worker()`
   // and the worker only wires up parentPort after an async init step.
   test.concurrent("listener attached after async init receives everything posted at construction", async () => {
+    // The outer setImmediate defers listener attachment past fireEarlyMessages();
+    // the worker reports once the known-count batch has fully arrived.
     const src = `
       const { parentPort } = require('node:worker_threads');
       const got = [];
-      setTimeout(() => {
-        parentPort.on('message', m => got.push(m));
-        setTimeout(() => parentPort.postMessage(got), 200);
-      }, 100);`;
+      setImmediate(() => parentPort.on('message', m => {
+        got.push(m);
+        if (got.length === 5) parentPort.postMessage(got);
+      }));`;
     const w = new Worker(src, { eval: true });
     try {
       for (let i = 1; i <= 5; i++) w.postMessage("m" + i);
-      const got = await new Promise(r => w.once("message", r));
-      expect(got).toEqual(["m1", "m2", "m3", "m4", "m5"]);
+      expect(await nextMessage(w)).toEqual(["m1", "m2", "m3", "m4", "m5"]);
     } finally {
       await w.terminate();
     }
@@ -1787,16 +1793,15 @@ describe("parentPort buffers parent→worker messages while there is no 'message
     const src = `
       const { parentPort } = require('node:worker_threads');
       const got = [];
-      setTimeout(() => {
-        parentPort.on('message', m => got.push(m));
-        setTimeout(() => parentPort.postMessage(got), 200);
-      }, 100);`;
+      setImmediate(() => parentPort.on('message', m => {
+        got.push(m);
+        if (got.length === 5) parentPort.postMessage(got);
+      }));`;
     const w = new Worker(src, { eval: true });
     try {
       await once(w, "online");
       for (let i = 1; i <= 5; i++) w.postMessage("a" + i);
-      const got = await new Promise(r => w.once("message", r));
-      expect(got).toEqual(["a1", "a2", "a3", "a4", "a5"]);
+      expect(await nextMessage(w)).toEqual(["a1", "a2", "a3", "a4", "a5"]);
     } finally {
       await w.terminate();
     }
@@ -1805,20 +1810,21 @@ describe("parentPort buffers parent→worker messages while there is no 'message
   test.concurrent("once('message') consumes one; the rest re-queue for the next listener", async () => {
     const src = `
       const { parentPort } = require('node:worker_threads');
-      setTimeout(() => {
+      setImmediate(() => {
         let first;
         parentPort.once('message', m => { first = m; });
-        setTimeout(() => {
+        setImmediate(() => {
           const rest = [];
-          parentPort.on('message', m => rest.push(m));
-          setTimeout(() => parentPort.postMessage({ first, rest }), 200);
-        }, 100);
-      }, 100);`;
+          parentPort.on('message', m => {
+            rest.push(m);
+            if (rest.length === 4) parentPort.postMessage({ first, rest });
+          });
+        });
+      });`;
     const w = new Worker(src, { eval: true });
     try {
       for (let i = 1; i <= 5; i++) w.postMessage("m" + i);
-      const result = await new Promise(r => w.once("message", r));
-      expect(result).toEqual({ first: "m1", rest: ["m2", "m3", "m4", "m5"] });
+      expect(await nextMessage(w)).toEqual({ first: "m1", rest: ["m2", "m3", "m4", "m5"] });
     } finally {
       await w.terminate();
     }
@@ -1830,22 +1836,50 @@ describe("parentPort buffers parent→worker messages while there is no 'message
     const src = `
       const { parentPort } = require('node:worker_threads');
       const log = [];
-      setTimeout(() => {
-        parentPort.on('message', m => log.push('got:' + m));
+      setImmediate(() => {
+        parentPort.on('message', m => {
+          log.push('got:' + m);
+          if (log.length === 4) parentPort.postMessage(log);
+        });
         log.push('after-on');
-        setTimeout(() => parentPort.postMessage(log), 200);
-      }, 100);`;
+      });`;
     const w = new Worker(src, { eval: true });
     try {
       for (let i = 1; i <= 3; i++) w.postMessage("m" + i);
-      const log = await new Promise(r => w.once("message", r));
-      expect(log).toEqual(["after-on", "got:m1", "got:m2", "got:m3"]);
+      expect(await nextMessage(w)).toEqual(["after-on", "got:m1", "got:m2", "got:m3"]);
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  // https://github.com/oven-sh/bun/issues/15408
+  // https://github.com/oven-sh/bun/issues/21101
+  // A worker whose entry module never settles (top-level await on a pending
+  // promise, or an infinite await-setImmediate loop) never reaches
+  // fireEarlyMessages(). parentPort must still drain once a listener is
+  // attached, and keep draining for messages the parent posts afterwards.
+  test.concurrent("listener attached before an unsettled top-level await receives messages", async () => {
+    using dir = tempDir("parentport-tla", {
+      "worker.mjs": `
+        import { parentPort } from "node:worker_threads";
+        parentPort.on("message", m => parentPort.postMessage("echo:" + m));
+        await new Promise(() => {});
+      `,
+    });
+    const w = new Worker(join(String(dir), "worker.mjs"));
+    try {
+      w.postMessage("m1");
+      expect(await nextMessage(w)).toBe("echo:m1");
+      w.postMessage("m2");
+      expect(await nextMessage(w)).toBe("echo:m2");
     } finally {
       await w.terminate();
     }
   });
 
   test.concurrent("Web Worker semantics are unchanged: no buffering without a listener", async () => {
+    // Asserting "nothing arrived" has no observable completion signal; a short
+    // bounded window is the assertion.
     const src = `
       const got = [];
       setTimeout(() => {
@@ -1856,7 +1890,10 @@ describe("parentPort buffers parent→worker messages while there is no 'message
     const w = new globalThis.Worker(url);
     try {
       for (let i = 1; i <= 3; i++) w.postMessage("m" + i);
-      const got = await new Promise(r => (w.onmessage = e => r(e.data)));
+      const got = await new Promise((resolve, reject) => {
+        w.onmessage = e => resolve(e.data);
+        w.onerror = e => reject(e.error ?? e.message);
+      });
       expect(got).toEqual([]);
     } finally {
       w.terminate();

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1901,3 +1901,50 @@ describe("parentPort buffers parent→worker messages while there is no 'message
     }
   });
 });
+
+// Pins on_unhandled_rejection's exit_code=1 write: an unhandled promise
+// rejection while the entry module is blocked in top-level await must fire
+// process.on('exit') with code=1 and exit 1 by default, and the exit handler
+// must be able to override it. Subprocess so the isBunTest branch (which skips
+// the non-test exit_code=1 write in uncaught_exception) is the path exercised.
+describe("worker exit code after an unhandled rejection during unsettled top-level await", () => {
+  const runWorkerFrom = async (body: string) => {
+    using dir = tempDir("worker-reject-tla", { "w.mjs": body });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(${JSON.stringify(join(String(dir), "w.mjs"))});
+         w.on("error", () => {});
+         w.on("exit", c => console.log("exit:" + c));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+  };
+
+  test.concurrent("exits 1 and the 'exit' handler observes code=1", async () => {
+    const { stdout, stderr, exitCode } = await runWorkerFrom(`
+      process.on("exit", code => process.stderr.write("handler-code:" + code));
+      setImmediate(() => Promise.reject(new Error("boom")));
+      await new Promise(() => {});
+    `);
+    expect(stderr).toBe("handler-code:1");
+    expect(stdout).toBe("exit:1");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an 'exit' handler that sets process.exitCode overrides the default", async () => {
+    const { stdout, stderr, exitCode } = await runWorkerFrom(`
+      process.on("exit", code => { process.stderr.write("handler-code:" + code); process.exitCode = 7; });
+      setImmediate(() => Promise.reject(new Error("boom")));
+      await new Promise(() => {});
+    `);
+    expect(stderr).toBe("handler-code:1");
+    expect(stdout).toBe("exit:7");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #5460
Fixes #15408
Fixes #21101

## Repro

```js
import { Worker } from "node:worker_threads";
const src = `const {parentPort}=require('node:worker_threads'); const got=[];
setTimeout(()=>{ parentPort.on('message', m=>got.push(m));
  setTimeout(()=>parentPort.postMessage(got), 500); }, 300);`;
const w = new Worker(src, { eval: true });
for (let i = 1; i <= 5; i++) w.postMessage("m" + i);
console.log(await new Promise(r => w.once("message", r)));
await w.terminate();
// node: [ 'm1', 'm2', 'm3', 'm4', 'm5' ]
// bun : []
```

The parent posts right after `new Worker(...)` and the worker attaches `parentPort.on('message', ...)` after an async init step. In Node every message is delivered; in Bun every message is silently discarded.

## Cause

Node's `parentPort` is a real `MessagePort` that stays stopped until it has a `'message'` listener (`setupPortReferencing` wires `newListener`/`removeListener` to `start()`/`stop()`), so messages queue natively and start draining as soon as a listener is added, independent of whether the entry module's top-level await has settled.

Bun's `parentPort` is a shim over the worker's `globalEventScope` (a plain `EventTarget`). Parent→worker messages land in the C++ `Worker::m_toWorker` inbox and `Worker::drainToWorker` dispatches each one straight into `globalEventScope->dispatchEvent(event)` without checking for listeners. `enqueueToWorker` only schedules a drain once the worker reaches `State::Running`, and `fireEarlyMessages` (called after entry eval completes) drains whether or not anything is listening. So a listener attached after async init sees nothing, and a worker whose entry module never settles (TLA on a pending promise, #15408/#21101) never drains at all.

## Fix

For `WorkerOptions::Kind::Node` workers only:

* `drainToWorker` returns early (inbox intact, `drainScheduled` cleared) when `globalEventScope` has no active `'message'` listener.
* `drainInbox` gains a `shouldContinue` predicate checked before each dispatch; when a `once()` listener leaves zero listeners mid-batch, the undelivered tail is prepended back to the inbox instead of being dispatched into the void.
* `WorkerGlobalScope::onDidChangeListenerImpl` calls the new `scheduleParentPortDrainIfNode` on the 0→1 listener transition, posting a `drainToWorker` task so buffered messages redeliver on the next tick (matching Node's async `port.start()` delivery).
* `enqueueToWorker` schedules the drain during `State::Pending` for Node workers (so a worker blocked in top-level await still receives messages); `drainToWorker` is the listener gate and `postTaskTo` returns false until the worker context is registered.

Web Worker semantics are unchanged: the gate is keyed on the worker kind, and `drainToParent` passes an always-true predicate. A test pins the existing Web Worker behavior (messages posted before a listener are dropped).

### Exit-code clobber in `spin()`

Delivering messages during `State::Pending` means a throwing message handler can run inside `wait_for_promise_with_termination`, which arms termination and makes `load_entry_point_for_web_worker` return `Err`. `spin()`'s `Err` arm was writing `exit_code = 1` unconditionally (guarded only by `exit_called`), clobbering any `process.exitCode` the worker's `process.on('exit')` handler had set after the uncaught exception. This was already observable on main via `setImmediate(() => { throw ... })` in a TLA worker (Node exits with the handler's code; Bun exited 1). The `Err` arm now also skips the write when `unhandled_error_counter > 0`, so `test/js/node/test/parallel/test-worker-exit-code.js` stays green.

## Not fixed here

* #23102 uses the Web `Worker` constructor, where the spec auto-starts the implicit port after script execution; this PR deliberately leaves Web Worker semantics alone.
* #28643 is the `w.unref()` keep-alive bug (#28645), not a parentPort buffering bug.
* #27002 is `child_process` fork IPC (`process.on('message')`), not `worker_threads`.

## Verification

New `describe("parentPort buffers parent→worker messages ...")` block in `worker_threads.test.ts` with five Node-compat cases (posted-at-construction, posted-after-online, `once()` re-queue, async delivery order, unsettled-TLA echo) that all fail on main and pass with the fix, plus the Web Worker invariant test. The full `worker_threads.test.ts` (97 tests), `test/js/web/workers/worker.test.ts`, `message-port-pipe.test.ts`, and the ported `test-worker-exit-code` / `test-worker-onmessage*` / `test-worker-message-port-drain` / `test-worker-message-channel` Node tests pass.

Related: #35556 fixes the opposite direction (worker→parent `Worker` object buffering).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (d9aca937c)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1796.08ms]
(pass) all worker_threads module properties are present [24.00ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [25.01ms]
(pass) all worker_threads worker instance properties are present [162.82ms]
(pass) threadId module and worker property is consistent [203.74ms]
(pass) receiveMessageOnPort works across threads [1733.52ms]
(pass) receiveMessageOnPort works as FIFO [13.32ms]
(pass) you can override globalThis.postMessage [1702.30ms]
(pass) support require in eval [1665.76ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1695.01ms]
(pass) support require in eval for a file that doesnt exist [1701.99ms]
(pass) support worker eval that throws [1687.27ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [6652.18ms]
(
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bff0340be)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [36.97ms]
(pass) all worker_threads module properties are present [0.33ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.41ms]
(pass) all worker_threads worker instance properties are present [2.84ms]
(pass) threadId module and worker property is consistent [3.90ms]
(pass) receiveMessageOnPort works across threads [32.09ms]
(pass) receiveMessageOnPort works as FIFO [0.32ms]
(pass) you can override globalThis.postMessage [30.15ms]
(pass) support require in eval [28.55ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [28.72ms]
(pass) support require in eval for a file that doesnt exist [28.02ms]
(pass) support worker eval that throws [27.33ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [128.68ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [61.38ms]
(pass) execArgv option > can specify an array of strings [58.73ms]
(pass) eval does not leak source code [2118.7
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (d9aca937c)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1753.78ms]
(pass) all worker_threads module properties are present [22.84ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.26ms]
(pass) all worker_threads worker instance properties are present [156.24ms]
(pass) threadId module and worker property is consistent [202.22ms]
(pass) receiveMessageOnPort works across threads [1708.55ms]
(pass) receiveMessageOnPort works as FIFO [12.86ms]
(pass) you can override globalThis.postMessage [1689.99ms]
(pass) support require in eval [1689.32ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1647.43ms]
(pass) support require in eval for a file that doesnt exist [1702.80ms]
(pass) support worker eval that throws [1679.81ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [6696.94ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 666ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[3/13] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[4/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[5/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[6/13] gen cpp.rs (cppbind)
[7/13] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[7/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunWorkerGlobalScope.cpp          |   4 +
 src/jsc/bindings/webcore/Worker.cpp                |  89 ++++++++--
 src/jsc/bindings/webcore/Worker.h                  |   7 +
 src/jsc/web_worker.rs                              |  11 +-
 test/js/node/worker_threads/worker_threads.test.ts | 194 ++++++++++++++++++++-
 5 files changed, 288 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 3 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/BunWorkerGlobalScope.cpp               2      3      0
src/jsc/bindings/webcore/Worker.cpp                     7      9      0
src/jsc/bindings/webcore/Worker.h                       4      5      0
src/jsc/web_worker.rs                                   3     10      0
test/js/node/worker_threads/worker_threads.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->