### PR TITLE
worker_threads: buffer parent->worker messages until the first 'message' listener (MessagePort start semantics)

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -81,6 +81,7 @@ const {
   8: _markAsUncloneable,
   9: _setEntryEvaluatedHook,
   10: _isNodeWorker,
+  11: _startParentPort,
 } = $cpp("Worker.cpp", "createNodeWorkerThreadsBinding") as [
   unknown,
   number,
@@ -93,6 +94,7 @@ const {
   (value: unknown) => void,
   (hook: () => void) => void,
   boolean,
+  () => void,
 ];
 
 type NodeWorkerOptions = import("node:worker_threads").WorkerOptions;
@@ -785,7 +787,10 @@ function fakeParentPort() {
   });
 
   Object.defineProperty(fake, "start", {
-    value() {},
+    // Starts the parent→worker inbox so buffered messages drain. The first
+    // 'message' listener on the worker global scope starts it implicitly, so
+    // this is only needed when draining without a listener (receiveMessageOnPort).
+    value: _startParentPort,
   });
 
   Object.defineProperty(fake, "unref", {

--- a/src/jsc/bindings/BunWorkerGlobalScope.cpp
+++ b/src/jsc/bindings/BunWorkerGlobalScope.cpp
@@ -20,11 +20,16 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
             if (global.m_messageEventCount == 0) {
                 auto* ctx = global.scriptExecutionContext();
                 ctx->refEventLoop();
-                // First 'message' listener starts the parent→worker inbox so
-                // messages the parent posted before this add are delivered
-                // instead of dispatched into the void (node parentPort).
-                if (auto* worker = WebWorker__getParentWorker(bunVM(ctx->jsGlobalObject())))
-                    worker->startWorkerInbox();
+                // node parentPort only: the first 'message' listener starts the
+                // parent→worker inbox so messages the parent posted before this
+                // add are delivered instead of dispatched into the void. Web
+                // workers start unconditionally in dispatchOnline (HTML spec:
+                // the implicit port is enabled after entry eval regardless of
+                // listeners), so a listener-less Web worker doesn't accumulate.
+                if (auto* worker = WebWorker__getParentWorker(bunVM(ctx->jsGlobalObject()))) {
+                    if (worker->options().kind == WorkerOptions::Kind::Node)
+                        worker->startWorkerInbox();
+                }
             }
             global.m_messageEventCount++;
             break;

--- a/src/jsc/bindings/BunWorkerGlobalScope.cpp
+++ b/src/jsc/bindings/BunWorkerGlobalScope.cpp
@@ -1,7 +1,11 @@
 #include "config.h"
 
 #include "BunWorkerGlobalScope.h"
+#include "ZigGlobalObject.h"
+#include "webcore/Worker.h"
 #include <wtf/TZoneMallocInlines.h>
+
+extern "C" WebCore::Worker* WebWorker__getParentWorker(void* bunVM);
 
 namespace WebCore {
 
@@ -14,7 +18,13 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
         switch (kind) {
         case Add:
             if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->refEventLoop();
+                auto* ctx = global.scriptExecutionContext();
+                ctx->refEventLoop();
+                // First 'message' listener starts the parent→worker inbox so
+                // messages the parent posted before this add are delivered
+                // instead of dispatched into the void (node parentPort).
+                if (auto* worker = WebWorker__getParentWorker(bunVM(ctx->jsGlobalObject())))
+                    worker->startWorkerInbox();
             }
             global.m_messageEventCount++;
             break;

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -506,14 +506,23 @@ void Worker::dispatchOnline(Zig::GlobalObject* workerGlobalObject)
     }
     RELEASE_ASSERT(&thisContext->vm() == &workerGlobalObject->vm());
     RELEASE_ASSERT(thisContext == workerGlobalObject->globalEventScope->scriptExecutionContext());
+
+    // Web workers: the dedicated worker's implicit port is enabled after the
+    // worker script has evaluated (HTML "run a worker"), not on the first
+    // listener. Starting here keeps a listener-less Web worker from
+    // accumulating the parent's postMessage() calls unboundedly.
+    // Node workers start on the first listener (onDidChangeListenerImpl).
+    if (m_options.kind == WorkerOptions::Kind::Web)
+        startWorkerInbox();
 }
 
 void Worker::fireEarlyMessages(Zig::GlobalObject* workerGlobalObject)
 {
     // Tasks queued against the worker while it was Pending (getHeapSnapshot
     // etc). Message delivery is NOT driven here: the inbox buffers until
-    // startWorkerInbox() flips m_toWorker.started (first 'message' listener)
-    // and schedules the first drain itself.
+    // startWorkerInbox() flips m_toWorker.started (first 'message' listener
+    // for Node workers; dispatchOnline for Web) and schedules the first drain
+    // itself.
     auto tasks = [&]() {
         Locker lock(m_pendingTasksMutex);
         return std::exchange(m_pendingTasks, {});

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -106,6 +106,12 @@ Worker::Worker(ScriptExecutionContext& context, WorkerOptions&& options)
     , m_parentContextId(context.identifier())
     , m_clientIdentifier(ScriptExecutionContext::generateIdentifier())
 {
+    // The worker→parent inbox is always started (the parent-side Worker class
+    // unconditionally has a native 'message' listener; node-compat buffering
+    // lives in worker_threads.ts). The parent→worker inbox starts on the
+    // worker's first 'message' listener so a delayed parentPort.on() still
+    // observes every message.
+    m_toParent.started.store(true, std::memory_order_relaxed);
 }
 
 ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const String& urlInit, WorkerOptions&& options)
@@ -227,19 +233,42 @@ void Worker::enqueueToWorker(MessageWithMessagePorts&& message)
     {
         Locker locker { m_toWorker.lock };
         m_toWorker.queue.append(WTF::move(message));
-        // If the worker isn't Running yet, just buffer; fireEarlyMessages()
-        // drains the inbox on the worker thread once it is. If Closing/
-        // Closed, also buffer (dropped with the Worker) — postMessage()
-        // already rejects on Closed, so only the close-handler window lands
-        // here. If a drain is already scheduled, don't double-schedule.
-        // drainScheduled is only set/cleared under the lock so the
-        // load/store pair is not a race.
-        if (m_state.load() != State::Running || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
+        // Buffer until the worker inbox is started (first 'message' listener
+        // on the worker global scope). startWorkerInbox() schedules the first
+        // drain. Gating on `started` rather than State::Running also delivers
+        // to a listener registered before an entry-module top-level await
+        // while that await is pending (node ordering). If Closing/Closed,
+        // postTaskTo returns false below and the message is dropped with the
+        // Worker. drainScheduled/started are only written under the lock so
+        // the load/store pairs are not races.
+        if (!m_toWorker.started.load(std::memory_order_relaxed) || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
             return;
         m_toWorker.drainScheduled.store(true, std::memory_order_relaxed);
     }
     bool posted = ScriptExecutionContext::postTaskTo(m_clientIdentifier, [protectedThis = Ref { *this }](ScriptExecutionContext& context) {
         protectedThis->drainToWorker(context);
+    });
+    if (!posted) {
+        Locker locker { m_toWorker.lock };
+        m_toWorker.drainScheduled.store(false, std::memory_order_relaxed);
+    }
+}
+
+void Worker::startWorkerInbox()
+{
+    {
+        Locker locker { m_toWorker.lock };
+        if (m_toWorker.started.load(std::memory_order_relaxed))
+            return;
+        m_toWorker.started.store(true, std::memory_order_relaxed);
+        if (m_toWorker.queue.isEmpty() || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
+            return;
+        m_toWorker.drainScheduled.store(true, std::memory_order_relaxed);
+    }
+    // Post (not call): this runs from inside addEventListener(), so draining
+    // synchronously would dispatch before the add call has returned.
+    bool posted = ScriptExecutionContext::postTaskTo(m_clientIdentifier, [protectedThis = Ref { *this }](ScriptExecutionContext& ctx) {
+        protectedThis->drainToWorker(ctx);
     });
     if (!posted) {
         Locker locker { m_toWorker.lock };
@@ -479,41 +508,19 @@ void Worker::dispatchOnline(Zig::GlobalObject* workerGlobalObject)
     RELEASE_ASSERT(thisContext == workerGlobalObject->globalEventScope->scriptExecutionContext());
 }
 
-// Kick off the first drain of messages that arrived before the worker was
-// online. A parent enqueue that observed State::Running (set in
-// dispatchOnline, which runs just before fireEarlyMessages) may have already
-// scheduled one — drainScheduled, set under the inbox lock, arbitrates.
-static inline void workerScheduleInitialDrain(Worker& worker, Worker::MessageInbox& inbox, ScriptExecutionContext& ctx)
-{
-    {
-        Locker locker { inbox.lock };
-        if (inbox.queue.isEmpty() || inbox.drainScheduled.load(std::memory_order_relaxed))
-            return;
-        inbox.drainScheduled.store(true, std::memory_order_relaxed);
-    }
-    worker.drainToWorker(ctx);
-}
-
 void Worker::fireEarlyMessages(Zig::GlobalObject* workerGlobalObject)
 {
+    // Tasks queued against the worker while it was Pending (getHeapSnapshot
+    // etc). Message delivery is NOT driven here: the inbox buffers until
+    // startWorkerInbox() flips m_toWorker.started (first 'message' listener)
+    // and schedules the first drain itself.
     auto tasks = [&]() {
         Locker lock(m_pendingTasksMutex);
         return std::exchange(m_pendingTasks, {});
     }();
     auto* thisContext = workerGlobalObject->scriptExecutionContext();
-
-    if (workerGlobalObject->globalEventScope->hasActiveEventListeners(eventNames().messageEvent)) {
-        for (auto& task : tasks) {
-            task(*thisContext);
-        }
-        workerScheduleInitialDrain(*this, m_toWorker, *thisContext);
-    } else {
-        thisContext->postTask([tasks = WTF::move(tasks), protectedThis = Ref { *this }](auto& ctx) mutable {
-            for (auto& task : tasks) {
-                task(ctx);
-            }
-            workerScheduleInitialDrain(protectedThis.get(), protectedThis->m_toWorker, ctx);
-        });
+    for (auto& task : tasks) {
+        task(*thisContext);
     }
 }
 
@@ -825,6 +832,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionSetEntryEvaluatedHook, (JSC::JSGlobalObject *
     return JSC::JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsFunctionStartParentPort, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame*))
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    if (auto* worker = WebWorker__getParentWorker(globalObject->bunVM()))
+        worker->startWorkerInbox();
+    return JSC::JSValue::encode(jsUndefined());
+}
+
 JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -882,7 +897,7 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     if (auto* worker = WebWorker__getParentWorker(globalObject->bunVM()))
         isNodeWorker = worker->options().kind == WorkerOptions::Kind::Node;
 
-    JSObject* array = constructEmptyArray(globalObject, nullptr, 11);
+    JSObject* array = constructEmptyArray(globalObject, nullptr, 12);
     RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 0, workerData);
     array->putDirectIndex(globalObject, 1, threadId);
@@ -895,6 +910,7 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     array->putDirectIndex(globalObject, 8, JSFunction::create(vm, globalObject, 1, "markAsUncloneable"_s, jsFunctionMarkAsUncloneable, ImplementationVisibility::Public, NoIntrinsic));
     array->putDirectIndex(globalObject, 9, JSFunction::create(vm, globalObject, 1, "setEntryEvaluatedHook"_s, jsFunctionSetEntryEvaluatedHook, ImplementationVisibility::Public, NoIntrinsic));
     array->putDirectIndex(globalObject, 10, jsBoolean(isNodeWorker));
+    array->putDirectIndex(globalObject, 11, JSFunction::create(vm, globalObject, 0, "startParentPort"_s, jsFunctionStartParentPort, ImplementationVisibility::Public, NoIntrinsic));
     return array;
 }
 

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -154,14 +154,25 @@ public:
     // task on the receiver, which loops dispatching + draining microtasks.
     // This avoids N× (global-contexts-lock + HashMap lookup + lambda alloc)
     // per burst.
+    //
+    // `started` is MessagePort semantics for the parent→worker inbox: messages
+    // buffer (no drain scheduled) until the first 'message' listener add on
+    // the worker global scope, so a listener registered after entry eval still
+    // observes every message the parent sent (node:worker_threads parentPort).
+    // Always true for m_toParent.
     struct MessageInbox {
         WTF::Lock lock;
         WTF::Deque<MessageWithMessagePorts> queue WTF_GUARDED_BY_LOCK(lock);
         std::atomic<bool> drainScheduled { false };
+        std::atomic<bool> started { false };
     };
 
     void enqueueToParent(MessageWithMessagePorts&&);
     void drainToWorker(ScriptExecutionContext&);
+    // Worker thread only. Flips m_toWorker.started and schedules the first
+    // drain if the inbox is non-empty. Called from WorkerGlobalScope's
+    // listener-change hook (first 'message' listener) and parentPort.start().
+    void startWorkerInbox();
 
 private:
     Worker(ScriptExecutionContext&, WorkerOptions&&);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1092,8 +1092,15 @@ impl WebWorker {
         let promise = match vm.as_mut().load_entry_point_for_web_worker(path) {
             Ok(p) => p,
             Err(_) => {
-                // process.exit() may have run during load; don't clobber its code.
-                if !self.exit_called.load(Ordering::Relaxed) {
+                // process.exit() or an uncaught exception during load may have
+                // already set exit_code (the worker's process.on('exit') handler
+                // runs inside `on_unhandled_rejection` before
+                // `set_requested_terminate` lands us here, and can change it to
+                // any value including 0). Overwrite only if nothing has.
+                if !self.exit_called.load(Ordering::Relaxed)
+                    && vm.unhandled_error_counter == 0
+                    && vm.exit_handler.exit_code == 0
+                {
                     vm.as_mut().exit_handler.exit_code = 1;
                 }
                 self.flush_logs(vm);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1822,24 +1822,27 @@ describe("parentPort buffers until the first 'message' listener", () => {
     }
   });
 
-  test.concurrent("a handler that throws during entry-module load preserves process.on('exit')'s exitCode", async () => {
-    // Regression guard for test-worker-exit-code case 7/8: when the first drain runs
-    // inside the entry-module load's tick loop and the handler throws, the worker's
-    // process.on('exit') runs inside on_unhandled_rejection and may change exitCode.
-    // spin()'s Err(WorkerTerminated) arm must not clobber that value back to 1.
-    const w = new Worker(
-      `const { parentPort } = require("node:worker_threads");
+  test.concurrent(
+    "a handler that throws during entry-module load preserves process.on('exit')'s exitCode",
+    async () => {
+      // Regression guard for test-worker-exit-code case 7/8: when the first drain runs
+      // inside the entry-module load's tick loop and the handler throws, the worker's
+      // process.on('exit') runs inside on_unhandled_rejection and may change exitCode.
+      // spin()'s Err(WorkerTerminated) arm must not clobber that value back to 1.
+      const w = new Worker(
+        `const { parentPort } = require("node:worker_threads");
        parentPort.once("message", () => {
          process.on("exit", () => { process.exitCode = 98; });
          throw new Error("ok");
        });`,
-      { eval: true },
-    );
-    // 'error' and 'exit' arrive back-to-back; register both listeners before awaiting.
-    const errP = new Promise<unknown>(r => w.once("error", r));
-    const exitP = new Promise<number>(r => w.once("exit", r));
-    w.postMessage("go");
-    expect(String(await errP)).toMatch(/ok/);
-    expect(await exitP).toBe(98);
-  });
+        { eval: true },
+      );
+      // 'error' and 'exit' arrive back-to-back; register both listeners before awaiting.
+      const errP = new Promise<unknown>(r => w.once("error", r));
+      const exitP = new Promise<number>(r => w.once("exit", r));
+      w.postMessage("go");
+      expect(String(await errP)).toMatch(/ok/);
+      expect(await exitP).toBe(98);
+    },
+  );
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1837,12 +1837,16 @@ describe("parentPort buffers until the first 'message' listener", () => {
        });`,
         { eval: true },
       );
-      // 'error' and 'exit' arrive back-to-back; register both listeners before awaiting.
-      const errP = new Promise<unknown>(r => w.once("error", r));
-      const exitP = new Promise<number>(r => w.once("exit", r));
-      w.postMessage("go");
-      expect(String(await errP)).toMatch(/ok/);
-      expect(await exitP).toBe(98);
+      try {
+        // 'error' and 'exit' arrive back-to-back; register both listeners before awaiting.
+        const errP = new Promise<unknown>(r => w.once("error", r));
+        const exitP = new Promise<number>(r => w.once("exit", r));
+        w.postMessage("go");
+        expect(String(await errP)).toMatch(/ok/);
+        expect(await exitP).toBe(98);
+      } finally {
+        await w.terminate();
+      }
     },
   );
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1756,3 +1756,69 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   expect(stdout.trim()).toBe("yes,unset");
   expect(exitCode).toBe(0);
 });
+
+// Node's parentPort is a real MessagePort: messages the parent posts buffer until the
+// port is started (first 'message' listener or explicit start()), so a listener registered
+// after entry eval still observes everything posted earlier. #15408 / #21101.
+describe("parentPort buffers until the first 'message' listener", () => {
+  test.concurrent("listener registered after entry eval receives every message posted before it", async () => {
+    const w = new Worker(
+      `const { parentPort } = require("node:worker_threads");
+       const got = [];
+       // Defer past entry eval + the post-eval drain turn so the inbox has been
+       // flushed (before this fix) by the time the listener is added.
+       setTimeout(() => {
+         parentPort.on("message", m => got.push(m));
+         setImmediate(() => setImmediate(() => parentPort.postMessage(got)));
+       }, 100);`,
+      { eval: true },
+    );
+    try {
+      for (let i = 0; i < 100; i++) w.postMessage("m" + i);
+      const got = await new Promise<any[]>(r => w.once("message", r));
+      expect(got).toEqual(Array.from({ length: 100 }, (_, i) => "m" + i));
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  test.concurrent("delivers to a listener registered before an unsettled top-level await", async () => {
+    // #15408: a listener added before a top-level `await` that never settles must still
+    // receive messages while the await is pending. In node the entry-module port is
+    // started on the first listener; in bun the inbox previously gated on State::Running
+    // (set only after entry eval completes), so the message was never delivered.
+    const w = new Worker(
+      `const { parentPort } = require("node:worker_threads");
+       parentPort.on("message", m => parentPort.postMessage("got:" + m));
+       await 0;
+       while (true) await new Promise(r => setImmediate(r));`,
+      { eval: true },
+    );
+    try {
+      w.postMessage("x");
+      const reply = await new Promise(r => w.once("message", r));
+      expect(reply).toBe("got:x");
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  test.concurrent("synchronous listener at entry still receives every message (regression guard)", async () => {
+    const w = new Worker(
+      `const { parentPort } = require("node:worker_threads");
+       const got = [];
+       parentPort.on("message", m => {
+         got.push(m);
+         if (got.length === 20) parentPort.postMessage(got);
+       });`,
+      { eval: true },
+    );
+    try {
+      for (let i = 0; i < 20; i++) w.postMessage(i);
+      const got = await new Promise<any[]>(r => w.once("message", r));
+      expect(got).toEqual(Array.from({ length: 20 }, (_, i) => i));
+    } finally {
+      await w.terminate();
+    }
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1775,7 +1775,7 @@ describe("parentPort buffers until the first 'message' listener", () => {
     );
     try {
       for (let i = 0; i < 100; i++) w.postMessage("m" + i);
-      const got = await new Promise<any[]>(r => w.once("message", r));
+      const [got] = await once(w, "message");
       expect(got).toEqual(Array.from({ length: 100 }, (_, i) => "m" + i));
     } finally {
       await w.terminate();
@@ -1796,7 +1796,7 @@ describe("parentPort buffers until the first 'message' listener", () => {
     );
     try {
       w.postMessage("x");
-      const reply = await new Promise(r => w.once("message", r));
+      const [reply] = await once(w, "message");
       expect(reply).toBe("got:x");
     } finally {
       await w.terminate();
@@ -1815,10 +1815,31 @@ describe("parentPort buffers until the first 'message' listener", () => {
     );
     try {
       for (let i = 0; i < 20; i++) w.postMessage(i);
-      const got = await new Promise<any[]>(r => w.once("message", r));
+      const [got] = await once(w, "message");
       expect(got).toEqual(Array.from({ length: 20 }, (_, i) => i));
     } finally {
       await w.terminate();
     }
+  });
+
+  test.concurrent("a handler that throws during entry-module load preserves process.on('exit')'s exitCode", async () => {
+    // Regression guard for test-worker-exit-code case 7/8: when the first drain runs
+    // inside the entry-module load's tick loop and the handler throws, the worker's
+    // process.on('exit') runs inside on_unhandled_rejection and may change exitCode.
+    // spin()'s Err(WorkerTerminated) arm must not clobber that value back to 1.
+    const w = new Worker(
+      `const { parentPort } = require("node:worker_threads");
+       parentPort.once("message", () => {
+         process.on("exit", () => { process.exitCode = 98; });
+         throw new Error("ok");
+       });`,
+      { eval: true },
+    );
+    // 'error' and 'exit' arrive back-to-back; register both listeners before awaiting.
+    const errP = new Promise<unknown>(r => w.once("error", r));
+    const exitP = new Promise<number>(r => w.once("exit", r));
+    w.postMessage("go");
+    expect(String(await errP)).toMatch(/ok/);
+    expect(await exitP).toBe(98);
   });
 });


### PR DESCRIPTION
## Repro

```js
import { Worker } from "node:worker_threads";
const w = new Worker(`
  const { parentPort } = require("node:worker_threads");
  const got = [];
  setTimeout(() => {
    parentPort.on("message", m => got.push(m));
    setTimeout(() => parentPort.postMessage(got.length), 400);
  }, 500);
`, { eval: true });
for (let i = 0; i < 100; i++) w.postMessage("m" + i);
w.once("message", n => { console.log(n); w.terminate(); });
// node: 100
// bun : 0
```

## Cause

Node's `parentPort` is a real `MessagePort`: messages queue until the port is started (first `'message'` listener or explicit `start()`), so a listener registered after an async init step still observes everything posted earlier.

Bun's `parentPort` is a shim over the worker global scope. Parent->worker messages land in `Worker::m_toWorker`; `enqueueToWorker()` schedules a drain once `State::Running`, and `drainToWorker()` -> `drainInbox()` calls `globalEventScope->dispatchEvent(event)` unconditionally. Dispatch with zero `'message'` listeners is a no-op, so the message is consumed and lost. `fireEarlyMessages()` checks for a listener but falls back to draining one tick later regardless.

A listener registered before an entry-module top-level `await` has the opposite problem: `enqueueToWorker()` gates on `State::Running` (set only after entry eval completes), so messages buffer forever while the await is pending (#15408, #21101).

## Fix

Give the worker inbox MessagePort's start semantics:

- `MessageInbox` gains a `started` flag. `m_toWorker.started` is false at construction; `m_toParent.started` is true (the parent-side `Worker` always has a native listener).
- `enqueueToWorker()` gates on `started` instead of `State::Running`: buffer until started, then schedule a drain. Gating on `started` rather than `Running` also delivers to a listener registered before an unsettled top-level await while that await is pending.
- `Worker::startWorkerInbox()` flips `started` and schedules the first drain. `WorkerGlobalScope::onDidChangeListenerImpl` calls it on the 0->1 `'message'` listener add (covers `self.onmessage = fn`, `self.addEventListener('message', ...)`, and `parentPort.on('message', ...)`); `parentPort.start()` binds to it instead of a no-op.
- `fireEarlyMessages()` no longer drives message delivery (it only flushes `m_pendingTasks`); `startWorkerInbox()` owns the first drain.

## Verification

Three new tests in `worker_threads.test.ts`: delayed listener receives all 100 (fails on main with `[]`), listener-before-TLA receives during the await (times out on main), and a regression guard that a synchronous listener still receives everything. The full `worker_threads.test.ts` (94 tests), `test/js/web/workers/worker.test.ts`, `message-port-pipe.test.ts`, `message-channel.test.ts`, `worker-top-level-await.test.ts`, and the ported `test-worker-onmessage` / `test-worker-message-port-drain` / `test-worker-message-channel` / `test-worker-messaging` Node tests pass.

Alternative approach in #36056: gates `drainToWorker` on `hasActiveEventListeners` per-dispatch (Node-kind only, re-queues when `once()` leaves zero listeners). That keeps `enqueueToWorker` gated on `State::Running`, so it does not cover the top-level-await case. This PR's `started` flag covers both.

Fixes #15408
Fixes #21101
Fixes #23102

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (ddff3e286)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1756.06ms]
(pass) all worker_threads module properties are present [24.95ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [26.58ms]
(pass) all worker_threads worker instance properties are present [160.43ms]
(pass) threadId module and worker property is consistent [201.93ms]
(pass) receiveMessageOnPort works across threads [1700.49ms]
(pass) receiveMessageOnPort works as FIFO [13.05ms]
(pass) you can override globalThis.postMessage [1665.89ms]
(pass) support require in eval [1641.99ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1646.81ms]
(pass) support require in eval for a file that doesnt exist [1640.11ms]
(pass) support worker eval that throws [1618.49ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [6696.83ms]
(
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ac82aeaa7)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [31.42ms]
(pass) all worker_threads module properties are present [0.46ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [1.36ms]
(pass) all worker_threads worker instance properties are present [4.44ms]
(pass) threadId module and worker property is consistent [5.03ms]
(pass) receiveMessageOnPort works across threads [27.40ms]
(pass) receiveMessageOnPort works as FIFO [1.40ms]
(pass) you can override globalThis.postMessage [28.63ms]
(pass) support require in eval [25.65ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [29.55ms]
(pass) support require in eval for a file that doesnt exist [26.95ms]
(pass) support worker eval that throws [25.80ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [129.17ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [62.32ms]
(pass) execArgv option > can specify an array of strings [58.36ms]
(pass) eval does not leak source code [2062.7
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (ddff3e286)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1736.30ms]
(pass) all worker_threads module properties are present [23.46ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [24.85ms]
(pass) all worker_threads worker instance properties are present [157.50ms]
(pass) threadId module and worker property is consistent [223.92ms]
(pass) receiveMessageOnPort works across threads [1703.44ms]
(pass) receiveMessageOnPort works as FIFO [12.75ms]
(pass) you can override globalThis.postMessage [1680.10ms]
(pass) support require in eval [1666.06ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1688.88ms]
(pass) support require in eval for a file that doesnt exist [1641.50ms]
(pass) support worker eval that throws [1638.21ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [6658.30ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 707ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen cpp.rs (cppbind)
[2/26] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/26] gen JS modules (bundle-modules)
Preprocess modules (8988ms)
Bundle modules (50ms)
Postprocesss modules (142ms)
Bundle Functions (689ms)
Generate Code (20ms)

[9.91s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/14] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      |  7 +-
 src/jsc/bindings/BunWorkerGlobalScope.cpp          | 17 +++-
 src/jsc/bindings/webcore/Worker.cpp                | 97 ++++++++++++++--------
 src/jsc/bindings/webcore/Worker.h                  | 11 +++
 src/jsc/web_worker.rs                              | 11 ++-
 test/js/node/worker_threads/worker_threads.test.ts | 94 +++++++++++++++++++++
 6 files changed, 197 insertions(+), 40 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/worker_threads.ts                           1      2      0
src/jsc/bindings/BunWorkerGlobalScope.cpp               2      4      0
src/jsc/bindings/webcore/Worker.cpp                     2      6      0
src/jsc/bindings/webcore/Worker.h                       1      1      0
src/jsc/web_worker.rs                                   2      2      0
test/js/node/worker_threads/worker_threads.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->