### PR TITLE
ws: convert text frames to strings in server socket EventTarget API

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -786,6 +786,27 @@ const RUNNING = 0;
 const CLOSING = 1;
 const CLOSED = 2;
 
+// Text frames are converted per binaryType before being emitted, so recover
+// the string the same way `ws`'s event-target shim does (`data.toString()`).
+function textEventData(data) {
+  if (typeof data === "string") return data;
+  if (Buffer.isBuffer(data)) return data.toString();
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString();
+  return data; // Blob has no synchronous string conversion
+}
+
+function createMessageEventWrapper(target, listener) {
+  const wrapper = (data, isBinary) => {
+    listener.$call(target, {
+      type: "message",
+      data: isBinary ? data : textEventData(data),
+      target,
+    });
+  };
+  wrapper.listener = listener;
+  return wrapper;
+}
+
 class BunWebSocketMocked extends EventEmitter {
   #ws;
   #state;
@@ -1078,7 +1099,7 @@ class BunWebSocketMocked extends EventEmitter {
     if (this.#onmessage) {
       this.removeListener("message", this.#onmessage);
     }
-    const l = data => cb({ data });
+    const l = createMessageEventWrapper(this, cb);
     this.on("message", l);
     this.#onmessage = l;
   }
@@ -1100,26 +1121,29 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   get onmessage() {
-    return this.#onmessage;
+    return this.#onmessage?.listener;
   }
 
   get onopen() {
     return this.#onopen;
   }
 
-  // TODO: implement this more proper
-  addEventListener(type, listener, _options) {
-    if (type === "message") {
-      const l = data => listener({ data });
-      l.listener = listener;
+  addEventListener(type, listener, options) {
+    const l = type === "message" ? createMessageEventWrapper(this, listener) : listener;
+    if (options?.once) {
+      this.once(type, l);
+    } else {
       this.on(type, l);
-      return;
     }
-    this.on(type, listener);
   }
 
   removeEventListener(type, listener) {
-    this.off(type, listener);
+    for (const l of this.listeners(type)) {
+      if (l === listener || l.listener === listener) {
+        this.removeListener(type, l);
+        break;
+      }
+    }
   }
 }
 

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -795,7 +795,12 @@ function textEventData(data) {
   return data; // Blob has no synchronous string conversion
 }
 
-function createMessageEventWrapper(target, listener) {
+// Mirrors npm ws's event-target shim: on-event-attribute wrappers are tagged
+// so removeEventListener never removes a handler assigned via `onmessage`.
+const kForOnEventAttribute = Symbol("kForOnEventAttribute");
+const kListener = Symbol("kListener");
+
+function createMessageEventWrapper(target, listener, forOnEventAttribute = false) {
   const wrapper = (data, isBinary) => {
     listener.$call(target, {
       type: "message",
@@ -803,7 +808,8 @@ function createMessageEventWrapper(target, listener) {
       target,
     });
   };
-  wrapper.listener = listener;
+  wrapper[kForOnEventAttribute] = forOnEventAttribute;
+  wrapper[kListener] = listener;
   return wrapper;
 }
 
@@ -1099,7 +1105,7 @@ class BunWebSocketMocked extends EventEmitter {
     if (this.#onmessage) {
       this.removeListener("message", this.#onmessage);
     }
-    const l = createMessageEventWrapper(this, cb);
+    const l = createMessageEventWrapper(this, cb, true);
     this.on("message", l);
     this.#onmessage = l;
   }
@@ -1121,7 +1127,7 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   get onmessage() {
-    return this.#onmessage?.listener;
+    return this.#onmessage?.[kListener];
   }
 
   get onopen() {
@@ -1138,8 +1144,11 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   removeEventListener(type, listener) {
+    // listeners() unwraps once() wrappers, leaving the registered listener or
+    // message wrapper (message wrappers have no .listener, only kListener).
     for (const l of this.listeners(type)) {
-      if (l === listener || l.listener === listener) {
+      if (l[kForOnEventAttribute]) continue;
+      if (l === listener || l[kListener] === listener) {
         this.removeListener(type, l);
         break;
       }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1088,7 +1088,9 @@ class BunWebSocketMocked extends EventEmitter {
   set onmessage(cb) {
     if (this.#onmessage) {
       this.removeListener("message", this.#onmessage);
+      this.#onmessage = undefined;
     }
+    if (!$isCallable(cb)) return;
     const l = createMessageEventWrapper(this, cb, true);
     this.on("message", l);
     this.#onmessage = l;
@@ -1111,7 +1113,7 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   get onmessage() {
-    return this.#onmessage?.[kListener];
+    return this.#onmessage?.[kListener] ?? null;
   }
 
   get onopen() {
@@ -1128,10 +1130,12 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   removeEventListener(type, listener) {
-    // listeners() unwraps once() wrappers but not message wrappers (kListener, not .listener)
+    // listeners() unwraps once() wrappers but not message wrappers (kListener, not .listener).
+    // Message listeners are always wrapped, so matching only kListener there keeps
+    // plain .on("message") subscriptions invisible to removeEventListener, like npm ws.
     for (const l of this.listeners(type)) {
       if (l[kForOnEventAttribute]) continue;
-      if (l === listener || l[kListener] === listener) {
+      if (type === "message" ? l[kListener] === listener : l === listener) {
         this.removeListener(type, l);
         break;
       }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -786,8 +786,7 @@ const RUNNING = 0;
 const CLOSING = 1;
 const CLOSED = 2;
 
-// Text frames are converted per binaryType before being emitted, so recover
-// the string the same way `ws`'s event-target shim does (`data.toString()`).
+// Recovers the text of a frame already converted per binaryType, like npm ws's `data.toString()`.
 function textEventData(data) {
   if (typeof data === "string") return data;
   if (Buffer.isBuffer(data)) return data.toString();
@@ -795,8 +794,7 @@ function textEventData(data) {
   return data; // Blob has no synchronous string conversion
 }
 
-// Mirrors npm ws's event-target shim: on-event-attribute wrappers are tagged
-// so removeEventListener never removes a handler assigned via `onmessage`.
+// Same tags as npm ws's event-target shim; removeEventListener skips `onmessage`-assigned wrappers.
 const kForOnEventAttribute = Symbol("kForOnEventAttribute");
 const kListener = Symbol("kListener");
 
@@ -1144,8 +1142,7 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   removeEventListener(type, listener) {
-    // listeners() unwraps once() wrappers, leaving the registered listener or
-    // message wrapper (message wrappers have no .listener, only kListener).
+    // listeners() unwraps once() wrappers but not message wrappers (kListener, not .listener)
     for (const l of this.listeners(type)) {
       if (l[kForOnEventAttribute]) continue;
       if (l === listener || l[kListener] === listener) {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1130,11 +1130,9 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   removeEventListener(type, listener) {
-    // Non-functions never match a registration, or l[kListener] === undefined would.
+    // a non-function would match any untagged listener via l[kListener] === undefined
     if (!$isCallable(listener)) return;
-    // listeners() unwraps once() wrappers but not message wrappers (kListener, not .listener).
-    // Message listeners are always wrapped, so matching only kListener there keeps
-    // plain .on("message") subscriptions invisible to removeEventListener, like npm ws.
+    // message listeners match only their kListener tag, so plain .on() subscriptions stay untouched like npm ws
     for (const l of this.listeners(type)) {
       if (l[kForOnEventAttribute]) continue;
       if (type === "message" ? l[kListener] === listener : l === listener) {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -786,14 +786,6 @@ const RUNNING = 0;
 const CLOSING = 1;
 const CLOSED = 2;
 
-// Recovers the text of a frame already converted per binaryType, like npm ws's `data.toString()`.
-function textEventData(data) {
-  if (typeof data === "string") return data;
-  if (Buffer.isBuffer(data)) return data.toString();
-  if (data instanceof ArrayBuffer) return Buffer.from(data).toString();
-  return data; // Blob has no synchronous string conversion
-}
-
 // Same tags as npm ws's event-target shim; removeEventListener skips `onmessage`-assigned wrappers.
 const kForOnEventAttribute = Symbol("kForOnEventAttribute");
 const kListener = Symbol("kListener");
@@ -802,7 +794,7 @@ function createMessageEventWrapper(target, listener, forOnEventAttribute = false
   const wrapper = (data, isBinary) => {
     listener.$call(target, {
       type: "message",
-      data: isBinary ? data : textEventData(data),
+      data: isBinary ? data : data.toString(),
       target,
     });
   };
@@ -872,14 +864,8 @@ class BunWebSocketMocked extends EventEmitter {
 
     let isBinary = false;
     if (typeof message === "string") {
-      if (this.#binaryType === "arraybuffer") {
-        message = encoder.encode(message).buffer;
-      } else if (this.#binaryType === "blob") {
-        message = new Blob([message], { type: "text/plain" });
-      } else {
-        // nodebuffer
-        message = Buffer.from(message);
-      }
+      // npm ws emits text frames as Buffer regardless of binaryType
+      message = Buffer.from(message);
     } else {
       //Buffer
       isBinary = true;

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1130,6 +1130,8 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   removeEventListener(type, listener) {
+    // Non-functions never match a registration, or l[kListener] === undefined would.
+    if (!$isCallable(listener)) return;
     // listeners() unwraps once() wrappers but not message wrappers (kListener, not .listener).
     // Message listeners are always wrapped, so matching only kListener there keeps
     // plain .on("message") subscriptions invisible to removeEventListener, like npm ws.

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -357,17 +357,80 @@ it("isBinary", async () => {
 it("onmessage", done => {
   const wss = new WebSocketServer({ port: 0 });
   wss.on("connection", ws => {
-    ws.onmessage = e => {
-      expect(e.data).toEqual(Buffer.from("hello"));
+    const handler = e => {
+      expect(e.data).toBe("hello");
+      expect(ws.onmessage).toBe(handler);
       done();
       wss.close();
     };
+    ws.onmessage = handler;
   });
 
   const ws = new WebSocket("ws://localhost:" + wss.address().port);
   ws.onopen = () => {
     ws.send("hello");
   };
+});
+
+// https://github.com/oven-sh/bun/issues/36060
+it("addEventListener('message') converts text frames to strings", async () => {
+  const wss = new WebSocketServer({ port: 0 });
+  const events: any[] = [];
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  wss.on("connection", ws => {
+    ws.addEventListener("message", event => {
+      events.push(event);
+      if (events.length === 2) resolve();
+    });
+    ws.on("error", reject);
+  });
+
+  const ws = new WebSocket("ws://localhost:" + wss.address().port);
+  ws.on("open", () => {
+    ws.send("hello");
+    ws.send(Buffer.from([1, 2, 3]));
+  });
+
+  await promise;
+  expect(events[0].type).toBe("message");
+  expect(events[0].data).toBe("hello");
+  expect(events[1].type).toBe("message");
+  expect(Buffer.isBuffer(events[1].data)).toBeTrue();
+  expect(events[1].data).toEqual(Buffer.from([1, 2, 3]));
+  wss.close();
+  ws.close();
+});
+
+it("addEventListener supports { once: true } and removeEventListener", async () => {
+  const wss = new WebSocketServer({ port: 0 });
+  let onceCount = 0;
+  let removedCount = 0;
+  const seen: string[] = [];
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  wss.on("connection", ws => {
+    ws.addEventListener("message", () => onceCount++, { once: true });
+    const removed = () => removedCount++;
+    ws.addEventListener("message", removed);
+    ws.removeEventListener("message", removed);
+    ws.addEventListener("message", event => {
+      seen.push(event.data);
+      if (seen.length === 2) resolve();
+    });
+    ws.on("error", reject);
+  });
+
+  const ws = new WebSocket("ws://localhost:" + wss.address().port);
+  ws.on("open", () => {
+    ws.send("first");
+    ws.send("second");
+  });
+
+  await promise;
+  expect(seen).toEqual(["first", "second"]);
+  expect(onceCount).toBe(1);
+  expect(removedCount).toBe(0);
+  wss.close();
+  ws.close();
 });
 
 // https://github.com/oven-sh/bun/issues/7896
@@ -398,7 +461,7 @@ it("close event", async () => {
   const wss = new WebSocketServer({ port: 0 });
   wss.on("connection", ws => {
     ws.onmessage = e => {
-      expect(e.data).toEqual(Buffer.from("hello"));
+      expect(e.data).toBe("hello");
       setTimeout(() => ws.close(), 10);
     };
   });

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -387,6 +387,7 @@ it("addEventListener('message') converts text frames to strings", async () => {
 
   const ws = new WebSocket("ws://localhost:" + wss.address().port);
   try {
+    ws.on("error", reject);
     ws.on("open", () => {
       ws.send("hello");
       ws.send(Buffer.from([1, 2, 3]));
@@ -398,6 +399,43 @@ it("addEventListener('message') converts text frames to strings", async () => {
     expect(events[1].type).toBe("message");
     expect(Buffer.isBuffer(events[1].data)).toBeTrue();
     expect(events[1].data).toEqual(Buffer.from([1, 2, 3]));
+  } finally {
+    wss.close();
+    ws.close();
+  }
+});
+
+it("text frames stay Buffer/string when binaryType is 'blob'", async () => {
+  const wss = new WebSocketServer({ port: 0 });
+  const emitted: [unknown, boolean][] = [];
+  const eventData: unknown[] = [];
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  wss.on("connection", ws => {
+    ws.binaryType = "blob";
+    ws.on("message", (data, isBinary) => emitted.push([data, isBinary]));
+    ws.addEventListener("message", event => {
+      eventData.push(event.data);
+      if (eventData.length === 2) resolve();
+    });
+    ws.on("error", reject);
+  });
+
+  const ws = new WebSocket("ws://localhost:" + wss.address().port);
+  try {
+    ws.on("error", reject);
+    ws.on("open", () => {
+      ws.send("hello");
+      ws.send(Buffer.from([1, 2, 3]));
+    });
+
+    await promise;
+    // binaryType only affects binary frames, like npm ws
+    expect(Buffer.isBuffer(emitted[0][0])).toBeTrue();
+    expect(emitted[0][1]).toBeFalse();
+    expect(eventData[0]).toBe("hello");
+    expect(emitted[1][0]).toBeInstanceOf(Blob);
+    expect(emitted[1][1]).toBeTrue();
+    expect(eventData[1]).toBeInstanceOf(Blob);
   } finally {
     wss.close();
     ws.close();
@@ -431,6 +469,7 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
 
   const ws = new WebSocket("ws://localhost:" + wss.address().port);
   try {
+    ws.on("error", reject);
     ws.on("open", () => {
       ws.send("first");
       ws.send("second");

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -499,10 +499,12 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
     ws.addEventListener("message", shared);
     ws.removeEventListener("message", shared);
     ws.onmessage = () => {};
-    // plain .on() subscriptions are invisible to removeEventListener
+    // plain .on() subscriptions are invisible to removeEventListener,
+    // and non-function listeners must not match anything
     const direct = () => directCount++;
     ws.on("message", direct);
     ws.removeEventListener("message", direct);
+    ws.removeEventListener("message", undefined);
     ws.addEventListener("message", event => {
       seen.push(event.data);
       if (seen.length === 2) resolve();

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -386,25 +386,29 @@ it("addEventListener('message') converts text frames to strings", async () => {
   });
 
   const ws = new WebSocket("ws://localhost:" + wss.address().port);
-  ws.on("open", () => {
-    ws.send("hello");
-    ws.send(Buffer.from([1, 2, 3]));
-  });
+  try {
+    ws.on("open", () => {
+      ws.send("hello");
+      ws.send(Buffer.from([1, 2, 3]));
+    });
 
-  await promise;
-  expect(events[0].type).toBe("message");
-  expect(events[0].data).toBe("hello");
-  expect(events[1].type).toBe("message");
-  expect(Buffer.isBuffer(events[1].data)).toBeTrue();
-  expect(events[1].data).toEqual(Buffer.from([1, 2, 3]));
-  wss.close();
-  ws.close();
+    await promise;
+    expect(events[0].type).toBe("message");
+    expect(events[0].data).toBe("hello");
+    expect(events[1].type).toBe("message");
+    expect(Buffer.isBuffer(events[1].data)).toBeTrue();
+    expect(events[1].data).toEqual(Buffer.from([1, 2, 3]));
+  } finally {
+    wss.close();
+    ws.close();
+  }
 });
 
 it("addEventListener supports { once: true } and removeEventListener", async () => {
   const wss = new WebSocketServer({ port: 0 });
   let onceCount = 0;
   let removedCount = 0;
+  let sharedCount = 0;
   const seen: string[] = [];
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   wss.on("connection", ws => {
@@ -412,6 +416,12 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
     const removed = () => removedCount++;
     ws.addEventListener("message", removed);
     ws.removeEventListener("message", removed);
+    // removeEventListener must skip on-event-attribute handlers, even when the
+    // same function was also registered via addEventListener.
+    const shared = () => sharedCount++;
+    ws.addEventListener("message", shared);
+    ws.onmessage = shared;
+    ws.removeEventListener("message", shared);
     ws.addEventListener("message", event => {
       seen.push(event.data);
       if (seen.length === 2) resolve();
@@ -420,17 +430,22 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
   });
 
   const ws = new WebSocket("ws://localhost:" + wss.address().port);
-  ws.on("open", () => {
-    ws.send("first");
-    ws.send("second");
-  });
+  try {
+    ws.on("open", () => {
+      ws.send("first");
+      ws.send("second");
+    });
 
-  await promise;
-  expect(seen).toEqual(["first", "second"]);
-  expect(onceCount).toBe(1);
-  expect(removedCount).toBe(0);
-  wss.close();
-  ws.close();
+    await promise;
+    expect(seen).toEqual(["first", "second"]);
+    expect(onceCount).toBe(1);
+    expect(removedCount).toBe(0);
+    // only the onmessage registration remains: once per message
+    expect(sharedCount).toBe(2);
+  } finally {
+    wss.close();
+    ws.close();
+  }
 });
 
 // https://github.com/oven-sh/bun/issues/7896

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -455,11 +455,15 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
     ws.addEventListener("message", removed);
     ws.removeEventListener("message", removed);
     // removeEventListener must skip on-event-attribute handlers, even when the
-    // same function was also registered via addEventListener.
+    // same function was also registered via addEventListener. The onmessage
+    // wrapper sits first in the listener list, so a non-skipping implementation
+    // removes it instead; reassigning onmessage afterwards then leaks the
+    // addEventListener wrapper and shared keeps firing.
     const shared = () => sharedCount++;
-    ws.addEventListener("message", shared);
     ws.onmessage = shared;
+    ws.addEventListener("message", shared);
     ws.removeEventListener("message", shared);
+    ws.onmessage = () => {};
     ws.addEventListener("message", event => {
       seen.push(event.data);
       if (seen.length === 2) resolve();
@@ -479,8 +483,9 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
     expect(seen).toEqual(["first", "second"]);
     expect(onceCount).toBe(1);
     expect(removedCount).toBe(0);
-    // only the onmessage registration remains: once per message
-    expect(sharedCount).toBe(2);
+    // removeEventListener took the addEventListener registration and the
+    // onmessage reassignment replaced the rest, so shared never fires
+    expect(sharedCount).toBe(0);
   } finally {
     wss.close();
     ws.close();

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -372,6 +372,34 @@ it("onmessage", done => {
   };
 });
 
+it("assigning a non-function to onmessage clears the handler", async () => {
+  const wss = new WebSocketServer({ port: 0 });
+  let called = 0;
+  const observed: unknown[] = [];
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  wss.on("connection", ws => {
+    observed.push(ws.onmessage);
+    ws.onmessage = () => called++;
+    ws.onmessage = null;
+    observed.push(ws.onmessage);
+    ws.addEventListener("message", () => resolve());
+    ws.on("error", reject);
+  });
+
+  const ws = new WebSocket("ws://localhost:" + wss.address().port);
+  try {
+    ws.on("error", reject);
+    ws.on("open", () => ws.send("hello"));
+
+    await promise;
+    expect(observed).toEqual([null, null]);
+    expect(called).toBe(0);
+  } finally {
+    wss.close();
+    ws.close();
+  }
+});
+
 // https://github.com/oven-sh/bun/issues/36060
 it("addEventListener('message') converts text frames to strings", async () => {
   const wss = new WebSocketServer({ port: 0 });
@@ -408,14 +436,16 @@ it("addEventListener('message') converts text frames to strings", async () => {
 it("text frames stay Buffer/string when binaryType is 'blob'", async () => {
   const wss = new WebSocketServer({ port: 0 });
   const emitted: [unknown, boolean][] = [];
-  const eventData: unknown[] = [];
+  const events: any[] = [];
+  let serverSocket: any;
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   wss.on("connection", ws => {
+    serverSocket = ws;
     ws.binaryType = "blob";
     ws.on("message", (data, isBinary) => emitted.push([data, isBinary]));
     ws.addEventListener("message", event => {
-      eventData.push(event.data);
-      if (eventData.length === 2) resolve();
+      events.push(event);
+      if (events.length === 2) resolve();
     });
     ws.on("error", reject);
   });
@@ -432,10 +462,14 @@ it("text frames stay Buffer/string when binaryType is 'blob'", async () => {
     // binaryType only affects binary frames, like npm ws
     expect(Buffer.isBuffer(emitted[0][0])).toBeTrue();
     expect(emitted[0][1]).toBeFalse();
-    expect(eventData[0]).toBe("hello");
+    expect(events[0].type).toBe("message");
+    expect(events[0].target).toBe(serverSocket);
+    expect(events[0].data).toBe("hello");
     expect(emitted[1][0]).toBeInstanceOf(Blob);
     expect(emitted[1][1]).toBeTrue();
-    expect(eventData[1]).toBeInstanceOf(Blob);
+    expect(events[1].type).toBe("message");
+    expect(events[1].target).toBe(serverSocket);
+    expect(events[1].data).toBeInstanceOf(Blob);
   } finally {
     wss.close();
     ws.close();
@@ -447,6 +481,7 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
   let onceCount = 0;
   let removedCount = 0;
   let sharedCount = 0;
+  let directCount = 0;
   const seen: string[] = [];
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   wss.on("connection", ws => {
@@ -464,6 +499,10 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
     ws.addEventListener("message", shared);
     ws.removeEventListener("message", shared);
     ws.onmessage = () => {};
+    // plain .on() subscriptions are invisible to removeEventListener
+    const direct = () => directCount++;
+    ws.on("message", direct);
+    ws.removeEventListener("message", direct);
     ws.addEventListener("message", event => {
       seen.push(event.data);
       if (seen.length === 2) resolve();
@@ -486,6 +525,7 @@ it("addEventListener supports { once: true } and removeEventListener", async () 
     // removeEventListener took the addEventListener registration and the
     // onmessage reassignment replaced the rest, so shared never fires
     expect(sharedCount).toBe(0);
+    expect(directCount).toBe(2);
   } finally {
     wss.close();
     ws.close();


### PR DESCRIPTION
Fixes #36060

### Repro

```ts
import { WebSocketServer } from "ws";
const server = new WebSocketServer({ port: 0 });
server.on("connection", socket => {
  socket.on("message", (_data, isBinary) => console.log({ isBinary })); // { isBinary: false }
  socket.addEventListener("message", e => console.log(typeof e.data)); // "object" (Buffer), expected "string"
});
```

A text frame received on a server-side socket is correctly reported as `isBinary: false` through the EventEmitter API, but `addEventListener("message")` and the `onmessage` setter exposed `event.data` as a `Buffer`. Node with npm `ws@8.x` gives a string.

### Cause

`BunWebSocketMocked` in `src/js/thirdparty/ws.js` converts incoming text to the socket's `binaryType` representation (a `Buffer` for the default `nodebuffer`) before emitting `message`. The EventTarget-style wrappers (`addEventListener` and the `onmessage` setter) then forwarded only the converted data, dropping the `isBinary` flag that npm `ws`'s event-target shim uses to build the event (`data: isBinary ? data : data.toString()`).

### Fix

The message wrappers now take `(data, isBinary)` and convert non-binary data back to a string, matching npm `ws` (verified against `ws@8.18.0` on Node 26). The event object also carries `type` and `target` like npm `ws`. While in there:

- `addEventListener` now honors `{ once: true }` (previously options were ignored)
- `removeEventListener` matches wrapped listeners the way npm `ws` does, so removing a `{ once }` listener before it fires works
- the `onmessage` getter returns the assigned handler instead of the internal wrapper

Two existing tests asserted the old behavior (`e.data` equal to `Buffer.from("hello")` for a text frame via `onmessage`); they were updated to the npm `ws` behavior.

### Verification

New tests in `test/js/first_party/ws/ws.test.ts` fail on current bun and pass with this change; all 47 tests in the file pass. The 3 failures in `ws-proxy.test.ts` pre-exist on main without this diff.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws.test.ts
bun test v1.4.0 (47a15b898)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:34289/
(pass) WebSocket > url [1814.76ms]
Listening: ws://127.0.0.1:39925/
Received upgrade: {
  host: "127.0.0.1:39925",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "XrrY4vamSw2FQDxR8MWrDw==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [2020.25ms]
Listening: ws://127.0.0.1:39071/
(pass) WebSocket > binaryType > (default) [1768.66ms]
Listening: ws://127.0.0.1:46873/
(pass) WebSocket > binaryType > (invalid) [1772.53ms]
Listening: ws://127.0.0.1:44763/
Received upgrade: {
  host: "127.0.0.1:44763",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "HMzQbX/GRSKKRbPOWk3yBg==",
}
Received connection: 127.0.0.1
Received message: <Buffer
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6e98bbffa)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:34629/
(pass) WebSocket > url [43.12ms]
Listening: ws://127.0.0.1:35259/
Received upgrade: {
  host: "127.0.0.1:35259",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "K/e8DYEoSrCaZEiy4MKCAg==",
}
Received connection: 127.0.0.1
Received close: 1000 
(pass) WebSocket > readyState [47.74ms]
Listening: ws://127.0.0.1:45513/
(pass) WebSocket > binaryType > (default) [31.49ms]
Listening: ws://127.0.0.1:41625/
(pass) WebSocket > binaryType > (invalid) [38.08ms]
Listening: ws://127.0.0.1:35065/
Received upgrade: {
  host: "127.0.0.1:35065",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "+UYmZi75SlObjh5KL0kQNw==",
}
Received connection: 127.0.0.1
Received message: <Buffer 00>
Received ping: <Buffer >
Received pong: <Buffer >
(pass) WebSocket > binaryType > nodebuffer [43.11ms]
Listening: ws://127.0.0.1:38181/
Rec
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws.test.ts
bun test v1.4.0 (47a15b898)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:36973/
(pass) WebSocket > url [1804.80ms]
Listening: ws://127.0.0.1:34165/
Received upgrade: {
  host: "127.0.0.1:34165",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "YHgorM9CQoqtB5HW1K06Sw==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [2030.89ms]
Listening: ws://127.0.0.1:34505/
(pass) WebSocket > binaryType > (default) [1737.75ms]
Listening: ws://127.0.0.1:41013/
(pass) WebSocket > binaryType > (invalid) [1756.17ms]
Listening: ws://127.0.0.1:33729/
Received upgrade: {
  host: "127.0.0.1:33729",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "zNhwX1f9Qvi6nepKPQgmyA==",
}
Received connection: 127.0.0.1
Received message: <Buffer
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 759ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (8916ms)
Bundle modules (91ms)
Postprocesss modules (216ms)
Bundle Functions (744ms)
Generate Code (30ms)

[10.02s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/ws.js           |  56 +++++++++----
 test/js/first_party/ws/ws.test.ts | 170 +++++++++++++++++++++++++++++++++++++-
 2 files changed, 205 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/js/thirdparty/ws.js                7     10      0
test/js/first_party/ws/ws.test.ts      4      9      0
```

</details>

<!-- robobun:evidence:end -->