### PR TITLE
shell: drop the spurious trailing empty string from ShellPromise.lines()

### DIFF
--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -120,6 +120,10 @@ declare module "bun" {
        * Read from stdout as a string, line by line
        *
        * Automatically calls {@link quiet} to disable echoing to stdout.
+       *
+       * Note: this currently buffers the command's entire stdout in memory and
+       * yields lines once the command exits. If the output ends with a newline,
+       * no trailing empty string is yielded.
        */
       lines(): AsyncIterable<string>;
 

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -208,11 +208,12 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     async *lines() {
       const { stdout } = (await this.#quiet(true)) as ShellOutput;
 
-      if (process.platform === "win32") {
-        yield* stdout.toString().split(/\r?\n/);
-      } else {
-        yield* stdout.toString().split("\n");
-      }
+      const text = stdout.toString();
+      const lines = process.platform === "win32" ? text.split(/\r?\n/) : text.split("\n");
+      // A trailing newline produces a final "" from split(); drop it so callers
+      // get one element per line instead of a spurious empty trailing element.
+      if (lines[lines.length - 1] === "") lines.length--;
+      yield* lines;
     }
 
     async arrayBuffer() {

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -210,8 +210,6 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
 
       const text = stdout.toString();
       const lines = process.platform === "win32" ? text.split(/\r?\n/) : text.split("\n");
-      // A trailing newline produces a final "" from split(); drop it so callers
-      // get one element per line instead of a spurious empty trailing element.
       if (lines[lines.length - 1] === "") lines.length--;
       yield* lines;
     }

--- a/test/js/bun/shell/bunshell-instance.test.ts
+++ b/test/js/bun/shell/bunshell-instance.test.ts
@@ -32,14 +32,30 @@ test("$.json", async () => {
 });
 
 test("$.lines", async () => {
-  expect(await Array.fromAsync(await $`echo hello`.lines())).toEqual(["hello", ""]);
+  expect(await Array.fromAsync($`echo hello`.lines())).toEqual(["hello"]);
 
-  const lines = [];
+  const lines: string[] = [];
   for await (const line of $`echo hello`.lines()) {
     lines.push(line);
   }
 
-  expect(lines).toEqual(["hello", ""]);
+  expect(lines).toEqual(["hello"]);
+});
+
+test("$.lines does not yield a trailing empty string for newline-terminated output", async () => {
+  expect(await Array.fromAsync($`echo -n ${"a\nb\nc\n"}`.lines())).toEqual(["a", "b", "c"]);
+});
+
+test("$.lines keeps interior blank lines", async () => {
+  expect(await Array.fromAsync($`echo -n ${"a\n\nb\n"}`.lines())).toEqual(["a", "", "b"]);
+});
+
+test("$.lines with no trailing newline", async () => {
+  expect(await Array.fromAsync($`echo -n ${"a\nb\nc"}`.lines())).toEqual(["a", "b", "c"]);
+});
+
+test("$.lines with empty output yields nothing", async () => {
+  expect(await Array.fromAsync($`echo -n ${""}`.lines())).toEqual([]);
 });
 
 test("$.arrayBuffer", async () => {


### PR DESCRIPTION
### What does this PR do?

`ShellPromise.lines()` yielded one extra empty string whenever the command's stdout ended with a newline (which is the usual case), and yielded a single `""` for empty output.

```js
import { $ } from "bun";
await Array.fromAsync($`echo hello`.lines());
// before: ["hello", ""]
// after:  ["hello"]
```

The trailing element is the `split("\n")` artifact of a newline-terminated string:

https://github.com/oven-sh/bun/blob/6c12afd8ea/src/js/builtins/shell.ts#L208-L216

This PR drops that trailing empty element so callers get exactly one iteration per line. Interior blank lines are preserved; output with no trailing newline is unchanged.

The `.d.ts` doc for `lines()` now also notes that it currently buffers the command's entire stdout and yields after the command exits. Making `.lines()` stream incrementally requires native changes to the shell interpreter (there is no per-chunk stdout hook exposed to JS today) and is tracked in #8365 / #14693.

### How did you verify your code works?

New tests in `test/js/bun/shell/bunshell-instance.test.ts`:

```
$ bun bd test test/js/bun/shell/bunshell-instance.test.ts
(pass) $.lines
(pass) $.lines does not yield a trailing empty string for newline-terminated output
(pass) $.lines keeps interior blank lines
(pass) $.lines with no trailing newline
(pass) $.lines with empty output yields nothing
 20 pass, 0 fail
```

Fail-before against the released binary:

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/shell/bunshell-instance.test.ts -t lines
(fail) $.lines
(fail) $.lines does not yield a trailing empty string for newline-terminated output
(fail) $.lines keeps interior blank lines
(fail) $.lines with empty output yields nothing
 1 pass, 4 fail
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/bunshell-instance.test.ts
bun test v1.4.0 (c8d01b53c)

test/js/bun/shell/bunshell-instance.test.ts:
bun

bun
bun2
(pass) $$ [60.15ms]
(pass) $.text [14.97ms]
(pass) $.json [12.09ms]
(pass) $.json [7.07ms]
30 | test("$.json", async () => {
31 |   expect(await $`echo '{"hello": 123}'`.json()).toEqual({ hello: 123 });
32 | });
33 | 
34 | test("$.lines", async () => {
35 |   expect(await Array.fromAsync($`echo hello`.lines())).toEqual(["hello"]);
                                                            ^
error: expect(received).toEqual(expected)

  [
    "hello",
+   "",
  ]

- Expected  - 0
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/shell/bunshell-instance.test.ts:35:56)
(fail) $.lines [48.31ms]
41 | 
42 |   expect(lines).toEqual(["hello"]);
43 | });
44 | 
45 | test("$.lines does not yield a trailing empty string for newline-terminated output", async () => {
46 |   expect(await Array.fromAsync($`echo -n ${"a\nb\nc\n"}`.lines())).toEqual(["a", "b", "c"]);
                                         
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (26c3c8a58)

test/js/bun/shell/bunshell-instance.test.ts:
bun

bun
bun2
(pass) $$ [1.54ms]
(pass) $.text [0.34ms]
(pass) $.json [0.29ms]
(pass) $.json [0.21ms]
(pass) $.lines [1.23ms]
(pass) $.lines does not yield a trailing empty string for newline-terminated output [0.23ms]
(pass) $.lines keeps interior blank lines [0.20ms]
(pass) $.lines with no trailing newline [0.24ms]
(pass) $.lines with empty output yields nothing [0.20ms]
(pass) $.arrayBuffer [0.27ms]
(pass) $.bytes [0.23ms]
(pass) $.blob [0.26ms]
(pass) hello world!.repeat(9000) > $(cat < Blob).text() [10.69ms]
(pass) hello world!.repeat(9000) > $(cat hello > Blob).text() fails [0.90ms]
(pass) hello world!.repeat(9000) > $(cat < Buffer).text() [1.70ms]
(pass) hello world!.repeat(9000) > $(cat hello > Buffer).text() passes [2.28ms]
(pass) hello world!.repeat(9000) > $(cat < Uint8Array).text() [1.00ms]
(pass) hello world!.repeat(9000) > $(cat hello > Uint8Array).text() passes [1.56ms]
(pass) hello world!.repeat(9000) > $(cat < Response).text() [1.26ms]
(pass) hello world!.repeat(9000) > $(cat hello > Response).text() fails [0.10ms]

 20 pass
 0 fail
 24 expect() calls
Ran 20 tests acr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/bunshell-instance.test.ts
bun test v1.4.0 (c8d01b53c)

test/js/bun/shell/bunshell-instance.test.ts:
bun

bun
bun2
(pass) $$ [97.07ms]
(pass) $.text [32.52ms]
(pass) $.json [18.22ms]
(pass) $.json [11.59ms]
(pass) $.lines [84.74ms]
(pass) $.lines does not yield a trailing empty string for newline-terminated output [13.93ms]
(pass) $.lines keeps interior blank lines [15.26ms]
(pass) $.lines with no trailing newline [15.83ms]
(pass) $.lines with empty output yields nothing [12.46ms]
(pass) $.arrayBuffer [16.51ms]
(pass) $.bytes [14.65ms]
(pass) $.blob [18.98ms]
(pass) hello world!.repeat(9000) > $(cat < Blob).text() [32.27ms]
(pass) hello world!.repeat(9000) > $(cat hello > Blob).text() fails [28.03ms]
(pass) hello world!.repeat(9000) > $(cat < Buffer).text() [17.58ms]
(pass) hello world!.repeat(9000) > $(cat hello > Buffer).text() passes [34.67ms]
(pass) hello world!.repeat(9000) > $(cat < Uint8Array).text() [25.17ms]
(pass) hello world!.repeat(9000) > $(cat hello > Uint8Array).text() passes [15.85ms]
(pass) hello world
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 795ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (9020ms)
Bundle modules (56ms)
Postprocesss modules (53ms)
Bundle Functions (764ms)
Generate Code (19ms)

[9.93s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/shell.d.ts               |  4 ++++
 src/js/builtins/shell.ts                    |  9 ++++-----
 test/js/bun/shell/bunshell-instance.test.ts | 22 +++++++++++++++++++---
 3 files changed, 27 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
packages/bun-types/shell.d.ts                    2      1      0
src/js/builtins/shell.ts                         3      3      0
test/js/bun/shell/bunshell-instance.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->