### PR TITLE
shell: dispatch ShellYesTask so captured-stdout yes does not abort

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -88,6 +88,7 @@ use crate::shell::builtins::{
     mv::{ShellMvBatchedTask, ShellMvCheckTargetTask},
     rm::ShellRmTask,
     touch::ShellTouchTask,
+    yes::YesTask as ShellYesTask,
 };
 use crate::shell::dispatch_tasks::{
     AsyncDeinitReader as ShellIOReaderAsyncDeinit, AsyncDeinitWriter as ShellIOWriterAsyncDeinit,
@@ -566,6 +567,12 @@ fn run_task_cold(task: Task) {
             ShellRmDirTask::run_from_main_thread(t);
         }
         task_tag::ShellGlobTask => shell_dispatch!(ShellGlobTask),
+        task_tag::ShellYesTask => {
+            // SAFETY: §Dispatch — tag identifies pointee; enqueued by
+            // `YesTask::enqueue`, storage lives inside `Box<Yes>` in the
+            // interpreter arena and is stable until the builtin deinits.
+            ShellYesTask::run_from_main_thread(unsafe { &*cast_ptr!(ShellYesTask) });
+        }
 
         // ── bake dev-server ──────────────────────────────────────────────
         task_tag::BakeHotReloadEvent => {
@@ -576,7 +583,7 @@ fn run_task_cold(task: Task) {
             unsafe { BakeHotReloadEvent::run(cast_ptr!(BakeHotReloadEvent)) };
         }
 
-        // ShellYesTask + any tag the hot path mis-routed: producer bug.
+        // Any tag the hot path mis-routed: producer bug.
         _ => panic!("Unexpected Task tag: {}", task.tag.0),
     }
 }

--- a/test/js/bun/shell/commands/yes.test.ts
+++ b/test/js/bun/shell/commands/yes.test.ts
@@ -1,5 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 $.throws(false);
 
@@ -20,5 +21,44 @@ describe("yes", async () => {
     const buffer = Buffer.alloc(17);
     await $`yes ab cd ef > ${buffer}`;
     expect(buffer.toString()).toEqual("ab cd ef\nab cd ef");
+  });
+
+  test("fills a buffer larger than one no-IO burst", async () => {
+    // One no-IO burst writes ~4*BUFSIZ before `yes` re-schedules itself on
+    // the event loop; a buffer larger than that forces the re-schedule path
+    // at least once before the target fills and returns ENOSPC. Run in a
+    // subprocess so a regression surfaces as a test failure rather than
+    // aborting the runner.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { $ } from "bun";
+         const buffer = Buffer.alloc(128 * 1024);
+         const { exitCode, stderr } = await $\`yes hi > \${buffer}\`.nothrow().quiet();
+         console.log(JSON.stringify({
+           exitCode,
+           stderr: stderr.toString(),
+           head: buffer.subarray(0, 12).toString(),
+           filled: buffer.indexOf(0) === -1,
+         }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      exitCode: 1,
+      stderr: "yes: ENOSPC\n",
+      head: "hi\nhi\nhi\nhi\n",
+      filled: true,
+    });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/shell/commands/yes.test.ts
+++ b/test/js/bun/shell/commands/yes.test.ts
@@ -47,11 +47,7 @@ describe("yes", async () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({
       exitCode: 1,


### PR DESCRIPTION
## Repro

```js
import { $ } from "bun";
await $`yes hi`.text();
```

```
panic: Unexpected Task tag: 12
```

Aborts the process in ~15 ms on any captured-output form (`.text()`, `.quiet()`, `.lines()`, `.json()`). Piped (`yes | head`), redirected (`yes > file`), and inherited stdout are fine.

## Cause

When `yes` writes to a non-fd target, `Yes::write_no_io_loop` emits four chunks then bounces back onto the event loop via `YesTask::enqueue` (tag `task_tag::ShellYesTask`) so it does not hog the main thread. `run_task` routes `ShellYesTask` into `run_task_cold`, but `run_task_cold` had no arm for it; the enqueued task fell into the producer-bug wildcard at `src/runtime/dispatch.rs:580` and panicked. The fd path (`enqueue_chunk`) never enqueues this task, so only captured/array-buffer output was affected.

## Fix

Add the `ShellYesTask` arm to `run_task_cold`, wired to `YesTask::run_from_main_thread` (same shape as the other shell builtin tasks).

## Verification

New test in `test/js/bun/shell/commands/yes.test.ts` redirects `yes` into a 128 KB `Buffer`. One no-IO burst is ~4*BUFSIZ, so a 128 KB target forces several bounces through `ShellYesTask` dispatch before the buffer fills and `write_no_io_to` returns `ENOSPC`, giving a deterministic terminating path through the previously-panicking code.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/yes.test.ts   # 1 fail (subprocess aborts with the panic)
bun bd test test/js/bun/shell/commands/yes.test.ts                 # 4 pass
bun bd test test/js/bun/shell/bunshell.test.ts                     # 414 pass, 0 fail
```

The same dispatch arm is also part of #31906 (as a side fix for its sandbox limit tests); this PR lands it standalone so the crash is fixed independently of that feature.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/yes.test.ts
bun test v1.4.0 (1330fe690)

test/js/bun/shell/commands/yes.test.ts:
yes: ENOSPC
(pass) yes > can pipe to a buffer [46.11ms]
yes: ENOSPC
(pass) yes > can be overwritten by the first argument [9.49ms]
yes: ENOSPC
(pass) yes > ignores other arguments [8.56ms]
killed 1 dangling process
(fail) yes > fills a buffer larger than one no-IO burst [5005.94ms]
  ^ this test timed out after 5000ms.

 3 pass
 1 fail
 3 expect() calls
Ran 4 tests across 1 file. [7.12s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (8776da67a)

test/js/bun/shell/commands/yes.test.ts:
yes: ENOSPC
(pass) yes > can pipe to a buffer [0.96ms]
yes: ENOSPC
(pass) yes > can be overwritten by the first argument [0.20ms]
yes: ENOSPC
(pass) yes > ignores other arguments [0.19ms]
(pass) yes > fills a buffer larger than one no-IO burst [8.77ms]

 4 pass
 0 fail
 6 expect() calls
Ran 4 tests across 1 file. [268.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/yes.test.ts
bun test v1.4.0 (1330fe690)

test/js/bun/shell/commands/yes.test.ts:
yes: ENOSPC
(pass) yes > can pipe to a buffer [44.39ms]
yes: ENOSPC
(pass) yes > can be overwritten by the first argument [9.07ms]
yes: ENOSPC
(pass) yes > ignores other arguments [8.32ms]
(pass) yes > fills a buffer larger than one no-IO burst [390.30ms]

 4 pass
 0 fail
 6 expect() calls
Ran 4 tests across 1 file. [2.42s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 759ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/dispatch.rs                |  9 ++++++++-
 test/js/bun/shell/commands/yes.test.ts | 36 ++++++++++++++++++++++++++++++++++
 2 files changed, 44 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/dispatch.rs                     1      3      0
test/js/bun/shell/commands/yes.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->