### PR TITLE
fs: copy directory entries with non-UTF-8 names byte-exact in cp/cpSync

### DIFF
--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -17,6 +17,7 @@ const {
   utimesSync,
 } = require("node:fs");
 const { dirname, isAbsolute, join, parse, resolve, sep } = require("node:path");
+const { Buffer, isUtf8 } = require("node:buffer");
 
 const { EEXIST, EISDIR, EINVAL, ENOTDIR } = $processBindingConstants.os.errno;
 
@@ -39,10 +40,18 @@ const defaultCpOptions = {
 };
 
 function decorateSystemError(err, prefix, context) {
-  const { syscall, code, message: ctxMessage, path, dest, errno } = context;
+  const { syscall, code, message: ctxMessage, errno } = context;
+  const path = pathToString(context.path);
+  const dest = pathToString(context.dest);
   let message = `${prefix}: ${syscall} returned ${code} (${ctxMessage})`;
-  if (path !== undefined) message += ` ${path}`;
-  if (dest !== undefined) message += ` => ${dest}`;
+  if (path !== undefined) {
+    message += ` ${path}`;
+    context.path = path;
+  }
+  if (dest !== undefined) {
+    message += ` => ${dest}`;
+    context.dest = dest;
+  }
   err.message = message;
   err.name = "SystemError";
   err.info = context;
@@ -146,12 +155,48 @@ function areIdentical(srcStat, destStat) {
   return destStat.ino && destStat.dev && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev;
 }
 
+// POSIX names are bytes; Windows names are UTF-16, which strings already hold losslessly.
+const kReaddirBufferOpts =
+  process.platform === "win32" ? { withFileTypes: true } : { withFileTypes: true, encoding: "buffer" };
+const kReadlinkOpts = process.platform === "win32" ? undefined : { encoding: "buffer" };
+
+// latin1 maps each byte to one code unit and back, so node:path can normalize a Buffer path.
+function latin1View(p) {
+  return (Buffer.isBuffer(p) ? p : Buffer.from(p)).toString("latin1");
+}
+
+function joinDirEntry(dir, name) {
+  if (!Buffer.isBuffer(name)) return join(dir, name);
+  if (!Buffer.isBuffer(dir) && isUtf8(name)) return join(dir, name.toString());
+  return Buffer.from(join(latin1View(dir), latin1View(name)), "latin1");
+}
+
+// What the copy of the link at `linkPath` should point at, given what readlink returned for it.
+function copiedLinkTarget(linkPath, target, verbatim) {
+  if (Buffer.isBuffer(target) && isUtf8(target)) target = target.toString();
+  if (verbatim || isAbsolute(Buffer.isBuffer(target) ? latin1View(target) : target)) return target;
+  if (!Buffer.isBuffer(linkPath) && !Buffer.isBuffer(target)) return resolve(dirname(linkPath), target);
+  // resolve() would otherwise fall back to process.cwd(), which is not a latin1 view.
+  return Buffer.from(resolve(latin1View(process.cwd()), dirname(latin1View(linkPath)), latin1View(target)), "latin1");
+}
+
+// filter() and error objects get strings, as in node; bytes that are not UTF-8 show up as U+FFFD.
+function pathToString(p) {
+  return Buffer.isBuffer(p) ? p.toString() : p;
+}
+
 const normalizePathToArray = path =>
   ArrayPrototypeFilter.$call(StringPrototypeSplit.$call(resolve(path), sep), Boolean);
 
 // Return true if dest is a subdir of src, otherwise false.
 // It only checks the path strings.
 function isSrcSubdir(src, dest) {
+  if (Buffer.isBuffer(src) || Buffer.isBuffer(dest)) {
+    // Compare on the latin1 view so that distinct bytes that are not UTF-8 stay distinct.
+    const cwd = latin1View(process.cwd());
+    src = resolve(cwd, latin1View(src));
+    dest = resolve(cwd, latin1View(dest));
+  }
   const srcArr = normalizePathToArray(src);
   const destArr = normalizePathToArray(dest);
   return ArrayPrototypeEvery.$call(srcArr, (cur, i) => destArr[i] === cur);
@@ -159,7 +204,7 @@ function isSrcSubdir(src, dest) {
 
 function checkPathsSync(src, dest, opts) {
   if (opts.filter) {
-    const shouldCopy = opts.filter(src, dest);
+    const shouldCopy = opts.filter(pathToString(src), pathToString(dest));
     if ($isPromise(shouldCopy)) {
       throw $ERR_INVALID_RETURN_VALUE("boolean", "filter", shouldCopy);
     }
@@ -260,14 +305,14 @@ function treeContainsOnlyFilesAndDirsSync(root) {
     const dir = stack.pop();
     let entries;
     try {
-      entries = readdirSync(dir, { withFileTypes: true });
+      entries = readdirSync(dir, kReaddirBufferOpts);
     } catch {
       return false;
     }
     for (let i = 0; i < entries.length; i++) {
       const entry = entries[i];
       if (entry.isDirectory()) {
-        stack.push(join(dir, entry.name));
+        stack.push(joinDirEntry(dir, entry.name));
       } else if (!entry.isFile()) {
         return false;
       }
@@ -442,26 +487,23 @@ function mkDirAndCopy(srcMode, src, dest, opts) {
 }
 
 function copyDir(src, dest, opts) {
-  for (const dirent of readdirSync(src, { withFileTypes: true })) {
+  for (const dirent of readdirSync(src, kReaddirBufferOpts)) {
     const { name } = dirent;
-    const srcItem = join(src, name);
-    const destItem = join(dest, name);
+    const srcItem = joinDirEntry(src, name);
+    const destItem = joinDirEntry(dest, name);
     const { destStat, skipped } = checkPathsSync(srcItem, destItem, opts);
     if (!skipped) getStats(destStat, srcItem, destItem, opts);
   }
 }
 
 function onLink(destStat, src, dest, opts) {
-  let resolvedSrc = readlinkSync(src);
-  if (!opts.verbatimSymlinks && !isAbsolute(resolvedSrc)) {
-    resolvedSrc = resolve(dirname(src), resolvedSrc);
-  }
+  const resolvedSrc = copiedLinkTarget(src, readlinkSync(src, kReadlinkOpts), opts.verbatimSymlinks);
   if (!destStat) {
     return symlinkSync(resolvedSrc, dest);
   }
   let resolvedDest;
   try {
-    resolvedDest = readlinkSync(dest);
+    resolvedDest = readlinkSync(dest, kReadlinkOpts);
   } catch (err: any) {
     // Dest exists and is a regular file or directory,
     // Windows may throw UNKNOWN error. If dest already exists,
@@ -471,9 +513,7 @@ function onLink(destStat, src, dest, opts) {
     }
     throw err;
   }
-  if (!isAbsolute(resolvedDest)) {
-    resolvedDest = resolve(dirname(dest), resolvedDest);
-  }
+  resolvedDest = copiedLinkTarget(dest, resolvedDest, false);
   let srcIsDir = false;
   try {
     srcIsDir = statSync(src).isDirectory();
@@ -511,6 +551,11 @@ export default {
   cpSyncFn,
   validateCpOptions,
   tryNativeFastPathSync,
+  joinDirEntry,
+  pathToString,
+  kReaddirBufferOpts,
+  kReadlinkOpts,
+  copiedLinkTarget,
   errno: { EEXIST, EISDIR, EINVAL, ENOTDIR },
   fsCpDirToNonDirError,
   fsCpEExistError,

--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -12,28 +12,21 @@ const {
   fsEisdirError,
   areIdentical,
   isSrcSubdir,
+  joinDirEntry,
+  pathToString,
+  kReaddirBufferOpts,
+  kReadlinkOpts,
+  copiedLinkTarget,
 } = require("internal/fs/cp-sync");
 
-const {
-  chmod,
-  copyFile,
-  lstat,
-  mkdir,
-  opendir,
-  readdir,
-  readlink,
-  stat,
-  symlink,
-  unlink,
-  utimes,
-} = require("node:fs/promises");
-const { dirname, isAbsolute, join, parse, resolve } = require("node:path");
+const { chmod, copyFile, lstat, mkdir, readdir, readlink, stat, symlink, unlink, utimes } = require("node:fs/promises");
+const { dirname, parse, resolve } = require("node:path");
 
 const PromisePrototypeThen = $Promise.prototype.$then;
 const PromiseReject = Promise.$reject;
 
 async function checkPaths(src, dest, opts) {
-  if (opts.filter && !(await opts.filter(src, dest))) {
+  if (opts.filter && !(await opts.filter(pathToString(src), pathToString(dest)))) {
     return { __proto__: null, skipped: true };
   }
   const { 0: srcStat, 1: destStat } = await getStats(src, dest, opts);
@@ -132,14 +125,14 @@ async function treeContainsOnlyFilesAndDirs(root) {
     const dir = stack.pop();
     let entries;
     try {
-      entries = await readdir(dir, { withFileTypes: true });
+      entries = await readdir(dir, kReaddirBufferOpts);
     } catch {
       return false;
     }
     for (let i = 0; i < entries.length; i++) {
       const entry = entries[i];
       if (entry.isDirectory()) {
-        stack.push(join(dir, entry.name));
+        stack.push(joinDirEntry(dir, entry.name));
       } else if (!entry.isFile()) {
         return false;
       }
@@ -335,27 +328,22 @@ async function mkDirAndCopy(srcMode, src, dest, opts) {
 }
 
 async function copyDir(src, dest, opts) {
-  const dir = await opendir(src);
-
-  for await (const { name } of dir) {
-    const srcItem = join(src, name);
-    const destItem = join(dest, name);
+  for (const { name } of await readdir(src, kReaddirBufferOpts)) {
+    const srcItem = joinDirEntry(src, name);
+    const destItem = joinDirEntry(dest, name);
     const { destStat, skipped } = await checkPaths(srcItem, destItem, opts);
     if (!skipped) await getStatsForCopy(destStat, srcItem, destItem, opts);
   }
 }
 
 async function onLink(destStat, src, dest, opts) {
-  let resolvedSrc = await readlink(src);
-  if (!opts.verbatimSymlinks && !isAbsolute(resolvedSrc)) {
-    resolvedSrc = resolve(dirname(src), resolvedSrc);
-  }
+  const resolvedSrc = copiedLinkTarget(src, await readlink(src, kReadlinkOpts), opts.verbatimSymlinks);
   if (!destStat) {
     return symlink(resolvedSrc, dest);
   }
   let resolvedDest;
   try {
-    resolvedDest = await readlink(dest);
+    resolvedDest = await readlink(dest, kReadlinkOpts);
   } catch (err: any) {
     // Dest exists and is a regular file or directory,
     // Windows may throw UNKNOWN error. If dest already exists,
@@ -365,9 +353,7 @@ async function onLink(destStat, src, dest, opts) {
     }
     throw err;
   }
-  if (!isAbsolute(resolvedDest)) {
-    resolvedDest = resolve(dirname(dest), resolvedDest);
-  }
+  resolvedDest = copiedLinkTarget(dest, resolvedDest, false);
   // stat(src) follows the link; a dangling src symlink throws ENOENT here,
   // same as before (both gated checks below only apply to directories).
   const srcStat = await stat(src);

--- a/src/jsc/bindings/NodeDirent.cpp
+++ b/src/jsc/bindings/NodeDirent.cpp
@@ -12,6 +12,7 @@
 #include "JavaScriptCore/ObjectInitializationScope.h"
 
 #include "JavaScriptCore/ObjectConstructor.h"
+#include "JSBuffer.h"
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/Identifier.h>
@@ -327,7 +328,8 @@ extern "C" JSC::EncodedJSValue Bun__JSDirentObjectConstructor(Zig::GlobalObject*
     return JSValue::encode(globalobject->m_JSDirentClassStructure.constructor(globalobject));
 }
 
-extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject, int type, BunString name, BunString path, JSString** previousPath)
+// Consumes `path`.
+static JSC::EncodedJSValue createDirentObject(Zig::GlobalObject* globalObject, int type, JSValue nameValue, BunString path, JSString** previousPath)
 {
     auto& vm = globalObject->vm();
 
@@ -358,15 +360,32 @@ extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject
         }
     }
 
-    auto nameString = name.transferToWTFString();
-    auto nameValue = jsString(vm, WTF::move(nameString));
-    auto typeValue = jsNumber(type);
     object->putDirectOffset(vm, 0, nameValue);
     object->putDirectOffset(vm, 1, pathValue);
-    object->putDirectOffset(vm, 2, typeValue);
+    object->putDirectOffset(vm, 2, jsNumber(type));
     object->putDirectOffset(vm, 3, pathValue);
 
     return JSValue::encode(object);
+}
+
+extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject, int type, BunString name, BunString path, JSString** previousPath)
+{
+    auto& vm = globalObject->vm();
+    auto nameString = name.transferToWTFString();
+    return createDirentObject(globalObject, type, jsString(vm, WTF::move(nameString)), path, previousPath);
+}
+
+// `name` is a Node Buffer holding the raw entry bytes; `path` is still a string.
+extern "C" JSC::EncodedJSValue Bun__Dirent__toJSWithBufferName(Zig::GlobalObject* globalObject, int type, const uint8_t* nameBytes, size_t nameLen, BunString path, JSString** previousPath)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* nameValue = WebCore::createBuffer(globalObject, nameBytes, nameLen);
+    if (scope.exception()) [[unlikely]] {
+        path.deref();
+        return {};
+    }
+    RELEASE_AND_RETURN(scope, createDirentObject(globalObject, type, nameValue, path, previousPath));
 }
 
 const ClassInfo JSDirentPrototype::s_info = { "Dirent"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDirentPrototype) };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -156,9 +156,9 @@ use bun_jsc::AbortSignalRef;
 use super::stat::Stats;
 use super::time_like::TimeLike;
 use super::types::{
-    ArgumentsSlice, Dirent, Encoding, FdArgExt as _, FileSystemFlags, FileSystemFlagsKind,
-    NameTooLong, PathLike, PathLikeExt as _, PathOrFdExt as _, StringObjects, StringOrBuffer,
-    ThreadIsolated, ThreadIsolatedArg, VectorArrayBuffer,
+    ArgumentsSlice, Dirent, DirentBuffer, Encoding, FdArgExt as _, FileSystemFlags,
+    FileSystemFlagsKind, NameTooLong, PathLike, PathLikeExt as _, PathOrFdExt as _, StringObjects,
+    StringOrBuffer, ThreadIsolated, ThreadIsolatedArg, VectorArrayBuffer,
 };
 // Re-exported publicly: `crate::node::fs::PathOrFileDescriptor` is the
 // canonical path used by `cli/build_command.rs` et al., and `node_fs::Flavor`
@@ -2212,6 +2212,9 @@ mod _async_tasks {
                     ResultListEntryValue::WithFileTypes(v) => {
                         ret::Readdir::WithFileTypes(v.into_boxed_slice())
                     }
+                    ResultListEntryValue::WithFileTypesBuffer(v) => {
+                        ret::Readdir::WithFileTypesBuffer(v.into_boxed_slice())
+                    }
                     ResultListEntryValue::Buffers(v) => ret::Readdir::Buffers(v.into_boxed_slice()),
                     ResultListEntryValue::Files(v) => ret::Readdir::Files(v.into_boxed_slice()),
                 };
@@ -2236,6 +2239,7 @@ mod _async_tasks {
 
     pub enum ResultListEntryValue {
         WithFileTypes(Vec<Dirent>),
+        WithFileTypesBuffer(Vec<DirentBuffer>),
         Buffers(Vec<Buffer>),
         Files(Vec<BunString>),
     }
@@ -2327,6 +2331,9 @@ mod _async_tasks {
             let result_list = match tag {
                 ret::ReaddirTag::Files => ResultListEntryValue::Files(Vec::new()),
                 ret::ReaddirTag::WithFileTypes => ResultListEntryValue::WithFileTypes(Vec::new()),
+                ret::ReaddirTag::WithFileTypesBuffer => {
+                    ResultListEntryValue::WithFileTypesBuffer(Vec::new())
+                }
                 ret::ReaddirTag::Buffers => ResultListEntryValue::Buffers(Vec::new()),
             };
             // Subtasks read the root path after `run` has returned its borrow of the
@@ -2414,6 +2421,9 @@ mod _async_tasks {
             match self.tag {
                 ret::ReaddirTag::Files => impl_tag!(BunString, Files),
                 ret::ReaddirTag::WithFileTypes => impl_tag!(Dirent, WithFileTypes),
+                ret::ReaddirTag::WithFileTypesBuffer => {
+                    impl_tag!(DirentBuffer, WithFileTypesBuffer)
+                }
                 ret::ReaddirTag::Buffers => impl_tag!(Buffer, Buffers),
             }
         }
@@ -2537,6 +2547,11 @@ mod _async_tasks {
             ResultListEntryValue::WithFileTypes(v)
         }
     }
+    impl IntoResultListEntry for DirentBuffer {
+        fn into_variant(v: Vec<Self>) -> ResultListEntryValue {
+            ResultListEntryValue::WithFileTypesBuffer(v)
+        }
+    }
     impl IntoResultListEntry for Buffer {
         fn into_variant(v: Vec<Self>) -> ResultListEntryValue {
             ResultListEntryValue::Buffers(v)
@@ -2555,6 +2570,7 @@ mod _async_tasks {
         fn clear(&mut self) {
             match self {
                 Self::WithFileTypes(v) => v.clear(),
+                Self::WithFileTypesBuffer(v) => v.clear(),
                 Self::Buffers(v) => v.clear(),
                 Self::Files(v) => v.clear(),
             }
@@ -2562,6 +2578,7 @@ mod _async_tasks {
         fn reserve_exact(&mut self, n: usize) {
             match self {
                 Self::WithFileTypes(v) => v.reserve_exact(n),
+                Self::WithFileTypesBuffer(v) => v.reserve_exact(n),
                 Self::Buffers(v) => v.reserve_exact(n),
                 Self::Files(v) => v.reserve_exact(n),
             }
@@ -2569,6 +2586,7 @@ mod _async_tasks {
         fn append_from(&mut self, other: &mut Self) {
             match (self, other) {
                 (Self::WithFileTypes(a), Self::WithFileTypes(b)) => a.append(b),
+                (Self::WithFileTypesBuffer(a), Self::WithFileTypesBuffer(b)) => a.append(b),
                 (Self::Buffers(a), Self::Buffers(b)) => a.append(b),
                 (Self::Files(a), Self::Files(b)) => a.append(b),
                 _ => debug_assert!(false, "ResultListEntryValue tag mismatch"),
@@ -3352,15 +3370,11 @@ pub mod args {
     }
     impl Readdir<'_> {
         pub(crate) fn tag(&self) -> ret::ReaddirTag {
-            match self.encoding {
-                Encoding::Buffer => ret::ReaddirTag::Buffers,
-                _ => {
-                    if self.with_file_types {
-                        ret::ReaddirTag::WithFileTypes
-                    } else {
-                        ret::ReaddirTag::Files
-                    }
-                }
+            match (self.with_file_types, self.encoding) {
+                (true, Encoding::Buffer) => ret::ReaddirTag::WithFileTypesBuffer,
+                (true, _) => ret::ReaddirTag::WithFileTypes,
+                (false, Encoding::Buffer) => ret::ReaddirTag::Buffers,
+                (false, _) => ret::ReaddirTag::Files,
             }
         }
     }
@@ -4311,12 +4325,14 @@ pub mod ret {
     #[derive(Copy, Clone, PartialEq, Eq)]
     pub enum ReaddirTag {
         WithFileTypes,
+        WithFileTypesBuffer,
         Buffers,
         Files,
     }
 
     pub enum Readdir {
         WithFileTypes(Box<[Dirent]>),
+        WithFileTypesBuffer(Box<[DirentBuffer]>),
         Buffers(Box<[Buffer]>),
         Files(Box<[BunString]>),
     }
@@ -4324,6 +4340,15 @@ pub mod ret {
         pub fn to_js(self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
             match self {
                 Readdir::WithFileTypes(items) => {
+                    let array = JSValue::create_empty_array(global_object, items.len())?;
+                    let mut previous_jsstring: *mut bun_jsc::JSString = core::ptr::null_mut();
+                    for (i, item) in items.into_vec().into_iter().enumerate() {
+                        let res = item.into_js(global_object, Some(&mut previous_jsstring))?;
+                        array.put_index(global_object, i as u32, res)?;
+                    }
+                    Ok(array)
+                }
+                Readdir::WithFileTypesBuffer(items) => {
                     let array = JSValue::create_empty_array(global_object, items.len())?;
                     let mut previous_jsstring: *mut bun_jsc::JSString = core::ptr::null_mut();
                     for (i, item) in items.into_vec().into_iter().enumerate() {
@@ -6111,6 +6136,12 @@ impl NodeFS {
                 flavor,
             ),
             ret::ReaddirTag::WithFileTypes => Self::readdir_inner::<Dirent>(
+                &mut self.sync_error_buf,
+                args,
+                args.recursive,
+                flavor,
+            ),
+            ret::ReaddirTag::WithFileTypesBuffer => Self::readdir_inner::<DirentBuffer>(
                 &mut self.sync_error_buf,
                 args,
                 args.recursive,
@@ -9245,6 +9276,52 @@ impl ReaddirEntry for Dirent {
             } else {
                 BunString::clone_utf8(utf8_name)
             },
+            path: dirent_path.clone(),
+            kind,
+        });
+    }
+}
+impl ReaddirEntry for DirentBuffer {
+    const IS_DIRENT: bool = true;
+    const IS_U16: bool = false;
+    fn into_readdir(v: Vec<Self>) -> ret::Readdir {
+        ret::Readdir::WithFileTypesBuffer(v.into_boxed_slice())
+    }
+    fn append_entry(
+        entries: &mut Vec<Self>,
+        utf8_name: &[u8],
+        dirent_path: &BunString,
+        kind: sys::FileKind,
+        _encoding: Encoding,
+    ) {
+        entries.push(DirentBuffer {
+            name: utf8_name.into(),
+            path: dirent_path.clone(),
+            kind,
+        });
+    }
+    fn append_entry_w(
+        _: &mut Vec<Self>,
+        _: &[u16],
+        _: &BunString,
+        _: sys::FileKind,
+        _: Encoding,
+        _: Option<&mut PathBuffer>,
+    ) {
+        // IS_U16 = false, so the u16 iterator arm is never taken.
+        unreachable!()
+    }
+    fn append_entry_recursive(
+        entries: &mut Vec<Self>,
+        utf8_name: &[u8],
+        _name_to_copy: &[u8],
+        dirent_path: &BunString,
+        kind: sys::FileKind,
+        _encoding: Encoding,
+        _apply_encoding: bool,
+    ) {
+        entries.push(DirentBuffer {
+            name: utf8_name.into(),
             path: dirent_path.clone(),
             kind,
         });

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1689,6 +1689,14 @@ unsafe extern "C" {
         path: bun_core::String,
         cached_previous_path_jsvalue: Option<&mut *mut jsc::JSString>,
     ) -> JSValue;
+    fn Bun__Dirent__toJSWithBufferName(
+        global: &JSGlobalObject,
+        kind: i32,
+        name_bytes: *const u8,
+        name_len: usize,
+        path: bun_core::String,
+        cached_previous_path_jsvalue: Option<&mut *mut jsc::JSString>,
+    ) -> JSValue;
 }
 
 impl Dirent {
@@ -1701,21 +1709,7 @@ impl Dirent {
         global_object: &JSGlobalObject,
         cached_previous_path_jsvalue: Option<&mut *mut jsc::JSString>,
     ) -> JsResult<JSValue> {
-        use bun_libuv_sys::{
-            UV_DIRENT_BLOCK, UV_DIRENT_CHAR, UV_DIRENT_DIR, UV_DIRENT_FIFO, UV_DIRENT_FILE,
-            UV_DIRENT_LINK, UV_DIRENT_SOCKET, UV_DIRENT_UNKNOWN,
-        };
-        let kind_int: i32 = match self.kind {
-            DirentKind::File => UV_DIRENT_FILE,
-            DirentKind::BlockDevice => UV_DIRENT_BLOCK,
-            DirentKind::CharacterDevice => UV_DIRENT_CHAR,
-            DirentKind::Directory => UV_DIRENT_DIR,
-            // event_port is deliberate there.
-            DirentKind::EventPort | DirentKind::NamedPipe => UV_DIRENT_FIFO,
-            DirentKind::UnixDomainSocket => UV_DIRENT_SOCKET,
-            DirentKind::SymLink => UV_DIRENT_LINK,
-            DirentKind::Whiteout | DirentKind::Door | DirentKind::Unknown => UV_DIRENT_UNKNOWN,
-        };
+        let kind_int = dirent_kind_to_uv(self.kind);
         bun_jsc::from_js_host_call(global_object, || {
             Bun__Dirent__toJS(
                 global_object,
@@ -1725,6 +1719,56 @@ impl Dirent {
                 cached_previous_path_jsvalue,
             )
         })
+    }
+}
+
+/// [`Dirent`] with raw-byte `name` for `readdir({ withFileTypes, encoding: 'buffer' })`.
+pub struct DirentBuffer {
+    pub name: Box<[u8]>,
+    pub path: bun_core::String,
+    pub(crate) kind: DirentKind,
+}
+
+impl DirentBuffer {
+    pub fn into_js(
+        self,
+        global_object: &JSGlobalObject,
+        cached_previous_path_jsvalue: Option<&mut *mut jsc::JSString>,
+    ) -> JsResult<JSValue> {
+        let kind_int = dirent_kind_to_uv(self.kind);
+        let name = self.name;
+        bun_jsc::from_js_host_call(global_object, || {
+            // SAFETY: `name` is a live `Box<[u8]>` for the whole call; C++ only
+            // reads the range (it copies the bytes into a fresh Buffer).
+            unsafe {
+                Bun__Dirent__toJSWithBufferName(
+                    global_object,
+                    kind_int,
+                    name.as_ptr(),
+                    name.len(),
+                    self.path,
+                    cached_previous_path_jsvalue,
+                )
+            }
+        })
+    }
+}
+
+fn dirent_kind_to_uv(kind: DirentKind) -> i32 {
+    use bun_libuv_sys::{
+        UV_DIRENT_BLOCK, UV_DIRENT_CHAR, UV_DIRENT_DIR, UV_DIRENT_FIFO, UV_DIRENT_FILE,
+        UV_DIRENT_LINK, UV_DIRENT_SOCKET, UV_DIRENT_UNKNOWN,
+    };
+    match kind {
+        DirentKind::File => UV_DIRENT_FILE,
+        DirentKind::BlockDevice => UV_DIRENT_BLOCK,
+        DirentKind::CharacterDevice => UV_DIRENT_CHAR,
+        DirentKind::Directory => UV_DIRENT_DIR,
+        // event_port is deliberate there.
+        DirentKind::EventPort | DirentKind::NamedPipe => UV_DIRENT_FIFO,
+        DirentKind::UnixDomainSocket => UV_DIRENT_SOCKET,
+        DirentKind::SymLink => UV_DIRENT_LINK,
+        DirentKind::Whiteout | DirentKind::Door | DirentKind::Unknown => UV_DIRENT_UNKNOWN,
     }
 }
 

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -312,6 +312,316 @@ for (const [name, copy] of impls) {
       expect(e.code).toBe("ERR_FS_CP_FIFO_PIPE");
     });
 
+    test.skipIf(!isLinux)("recursive - entries with non-UTF-8 names are copied byte-exact", async () => {
+      using root = tempDir("cp-nonutf8", {});
+      const src = join(String(root), "src");
+      fs.mkdirSync(src);
+      const srcBuf = Buffer.from(src + "/");
+      // caf<0xe9> (Latin-1), d<0xe4>r/ (Latin-1 subdir), foo<0xff><0xfe>bar (raw bytes)
+      fs.writeFileSync(Buffer.concat([srcBuf, Buffer.from([0x63, 0x61, 0x66, 0xe9])]), "cafe");
+      fs.writeFileSync(join(src, "ok.txt"), "ok");
+      const sub = Buffer.concat([srcBuf, Buffer.from([0x64, 0xe4, 0x72])]);
+      fs.mkdirSync(sub);
+      fs.writeFileSync(Buffer.concat([sub, Buffer.from("/inner.txt")]), "inner");
+      fs.writeFileSync(Buffer.concat([sub, Buffer.from([0x2f, 0x66, 0x6f, 0x6f, 0xff, 0xfe, 0x62, 0x61, 0x72])]), "w");
+
+      const tree = (d: string) => {
+        const out: Record<string, string> = {};
+        const walk = (cur: Buffer) => {
+          for (const name of fs.readdirSync(cur, { encoding: "buffer" })) {
+            const full = Buffer.concat([cur, Buffer.from("/"), name]);
+            if (fs.lstatSync(full).isDirectory()) walk(full);
+            else out[full.subarray(Buffer.byteLength(d) + 1).toString("hex")] = fs.readFileSync(full, "utf8");
+          }
+        };
+        walk(Buffer.from(d));
+        return out;
+      };
+
+      const cases: [string, Parameters<typeof copy>[2]][] = [
+        ["dest", { recursive: true }],
+        ["dest-filter", { recursive: true, filter: () => true }],
+      ];
+      for (const [destName, opts] of cases) {
+        const dest = join(String(root), destName);
+        await copy(src, dest, opts);
+        expect(tree(dest)).toEqual(tree(src));
+      }
+    });
+
+    test.skipIf(isWindows)(
+      "recursive - valid UTF-8 non-ASCII names reach filter as strings and symlinks resolve",
+      async () => {
+        await using basename = tempDir("cp-utf8-nonascii", {
+          "from/caf\u00e9/sibling.txt": "s",
+          "from/a.txt": "a",
+        });
+        fs.symlinkSync("sibling.txt", join(basename, "from", "caf\u00e9", "link"));
+
+        const seen: string[] = [];
+        await copy(join(basename, "from"), join(basename, "result"), {
+          recursive: true,
+          filter: src => {
+            seen.push(src);
+            return true;
+          },
+        });
+
+        const copiedLink = join(basename, "result", "caf\u00e9", "link");
+        expect({
+          filterSawUtf8: seen.some(s => s.endsWith(join("caf\u00e9", "sibling.txt"))),
+          filterSawMojibake: seen.some(s => s.includes("caf\u00c3\u00a9")),
+          linkTarget: fs.readlinkSync(copiedLink),
+          followed: fs.readFileSync(copiedLink, "utf8"),
+        }).toEqual({
+          filterSawUtf8: true,
+          filterSawMojibake: false,
+          linkTarget: join(basename, "from", "caf\u00e9", "sibling.txt"),
+          followed: "s",
+        });
+      },
+    );
+
+    test.skipIf(!isLinux)("recursive - merge into existing dest with non-UTF-8 entry names", async () => {
+      using root = tempDir("cp-nonutf8-merge", {});
+      const src = join(String(root), "src");
+      const dest = join(String(root), "dest");
+      fs.mkdirSync(src);
+      fs.mkdirSync(dest);
+      const name = Buffer.from([0x63, 0x61, 0x66, 0xe9]);
+      fs.writeFileSync(Buffer.concat([Buffer.from(src + "/"), name]), "hello");
+      fs.writeFileSync(join(dest, "keep.txt"), "keep");
+
+      await copy(src, dest, { recursive: true });
+
+      expect({
+        copied: fs.readFileSync(Buffer.concat([Buffer.from(dest + "/"), name]), "utf8"),
+        kept: fs.readFileSync(join(dest, "keep.txt"), "utf8"),
+        entries: fs
+          .readdirSync(dest, { encoding: "buffer" })
+          .map(b => b.toString("hex"))
+          .sort(),
+      }).toEqual({
+        copied: "hello",
+        kept: "keep",
+        entries: [name.toString("hex"), Buffer.from("keep.txt").toString("hex")].sort(),
+      });
+    });
+
+    test.skipIf(!isLinux)("recursive - non-UTF-8 names survive the filter + preserveTimestamps path", async () => {
+      await using basename = tempDir("cp-nonutf8-slow", { "from/ok.txt": "ascii" });
+      const name = Buffer.from([0x63, 0x61, 0x66, 0xe9]);
+      fs.writeFileSync(Buffer.concat([Buffer.from(basename + "/from/"), name]), "latin1");
+
+      const seen: unknown[] = [];
+      await copy(basename + "/from", basename + "/to", {
+        recursive: true,
+        preserveTimestamps: true,
+        filter: src => {
+          seen.push(src);
+          return true;
+        },
+      });
+
+      expect({
+        filterArgsAreStrings: seen.every(p => typeof p === "string"),
+        filterSawOk: seen.includes(join(basename, "from", "ok.txt")),
+        // The entry whose name is not UTF-8 reaches the filter as a string too
+        // (the byte that is not UTF-8 shows up as U+FFFD); the copy itself
+        // below still uses the exact bytes.
+        filterSawLossyName: seen.includes(join(basename, "from", "caf\ufffd")),
+        entries: fs
+          .readdirSync(basename + "/to", { encoding: "buffer" })
+          .map(b => b.toString("hex"))
+          .sort(),
+        copied: fs.readFileSync(Buffer.concat([Buffer.from(basename + "/to/"), name]), "utf8"),
+      }).toEqual({
+        filterArgsAreStrings: true,
+        filterSawOk: true,
+        filterSawLossyName: true,
+        entries: [name.toString("hex"), Buffer.from("ok.txt").toString("hex")].sort(),
+        copied: "latin1",
+      });
+    });
+
+    test.skipIf(!isLinux)("err.path is a string when a non-UTF-8 entry's type conflicts", async () => {
+      await using basename = tempDir("cp-nonutf8-errpath", { "from/.keep": "", "result/.keep": "" });
+      const dirName = Buffer.from([0x64, 0xe4, 0x72]);
+      const srcDir = Buffer.concat([Buffer.from(basename + "/from/"), dirName]);
+      fs.mkdirSync(srcDir);
+      fs.writeFileSync(Buffer.concat([srcDir, Buffer.from("/x.txt")]), "x");
+      fs.writeFileSync(Buffer.concat([Buffer.from(basename + "/result/"), dirName]), "not a dir");
+
+      const e = await copyShouldThrow(basename + "/from", basename + "/result", { recursive: true });
+      expect({ code: e.code, path: e.path, infoPath: e.info?.path }).toEqual({
+        code: "ERR_FS_CP_DIR_TO_NON_DIR",
+        path: join(basename, "result", "d\ufffdr"),
+        infoPath: join(basename, "result", "d\ufffdr"),
+      });
+    });
+
+    test.skipIf(!isLinux)("recursive - symlink with a non-UTF-8 name is copied", async () => {
+      await using basename = tempDir("cp-nonutf8-linkname", { "from/target.txt": "hello" });
+      const linkName = Buffer.concat([Buffer.from("link"), Buffer.from([0xe9])]);
+      fs.symlinkSync("target.txt", Buffer.concat([Buffer.from(basename + "/from/"), linkName]));
+
+      await copy(basename + "/from", basename + "/to", { recursive: true });
+
+      const copiedLink = Buffer.concat([Buffer.from(basename + "/to/"), linkName]);
+      expect({
+        isSymlink: fs.lstatSync(copiedLink).isSymbolicLink(),
+        followed: fs.readFileSync(copiedLink, "utf8"),
+      }).toEqual({ isSymlink: true, followed: "hello" });
+    });
+
+    test.skipIf(!isLinux)("recursive - symlink whose target is non-UTF-8 is copied byte-exact", async () => {
+      await using basename = tempDir("cp-nonutf8-linktarget", { "from/.keep": "" });
+      const target = Buffer.from([0x63, 0x61, 0x66, 0xe9]);
+      fs.writeFileSync(Buffer.concat([Buffer.from(basename + "/from/"), target]), "hello");
+      fs.symlinkSync(target, basename + "/from/link");
+
+      await copy(basename + "/from", basename + "/to", { recursive: true });
+
+      // The relative target is resolved against the source directory, so the
+      // copied link is absolute and its final component keeps the raw bytes.
+      expect({
+        linkTarget: fs.readlinkSync(basename + "/to/link", { encoding: "buffer" }).toString("hex"),
+        followed: fs.readFileSync(basename + "/to/link", "utf8"),
+      }).toEqual({
+        linkTarget: Buffer.concat([Buffer.from(basename + "/from/"), target]).toString("hex"),
+        followed: "hello",
+      });
+    });
+
+    test.skipIf(!isLinux)("recursive - verbatimSymlinks keeps a non-UTF-8 relative target as-is", async () => {
+      await using basename = tempDir("cp-nonutf8-verbatim", { "from/.keep": "" });
+      const target = Buffer.from([0x63, 0x61, 0x66, 0xe9]);
+      fs.writeFileSync(Buffer.concat([Buffer.from(basename + "/from/"), target]), "hello");
+      fs.symlinkSync(target, basename + "/from/link");
+
+      await copy(basename + "/from", basename + "/to", { recursive: true, verbatimSymlinks: true });
+
+      // The target file is copied alongside the link, so the untouched
+      // relative target resolves inside the destination.
+      expect({
+        linkTarget: fs.readlinkSync(basename + "/to/link", { encoding: "buffer" }).toString("hex"),
+        followed: fs.readFileSync(basename + "/to/link", "utf8"),
+      }).toEqual({
+        linkTarget: target.toString("hex"),
+        followed: "hello",
+      });
+    });
+
+    test.skipIf(!isLinux)(
+      "recursive - replacing a dest link does not confuse distinct non-UTF-8 targets for the same path",
+      async () => {
+        await using basename = tempDir("cp-nonutf8-subdir-check", { "from/.keep": "", "to/.keep": "" });
+        // Both targets decode to "d\ufffd", so a lossy comparison would report
+        // one as a subdirectory of the other and refuse to replace the link.
+        const srcTarget = Buffer.concat([Buffer.from(basename + "/d"), Buffer.from([0xe9])]);
+        const destTarget = Buffer.concat([Buffer.from(basename + "/d"), Buffer.from([0xe4]), Buffer.from("/inner")]);
+        fs.mkdirSync(srcTarget);
+        fs.mkdirSync(destTarget, { recursive: true });
+        fs.symlinkSync(srcTarget, basename + "/from/link");
+        fs.symlinkSync(destTarget, basename + "/to/link");
+
+        await copy(basename + "/from", basename + "/to", { recursive: true });
+
+        expect(fs.readlinkSync(basename + "/to/link", { encoding: "buffer" }).toString("hex")).toBe(
+          srcTarget.toString("hex"),
+        );
+      },
+    );
+
+    test.skipIf(!isLinux)(
+      "recursive - relative symlink inside a non-UTF-8 directory resolves against the source tree",
+      async () => {
+        await using basename = tempDir("cp-nonutf8-linkdir", { "from/.keep": "" });
+        const dirName = Buffer.from([0x64, 0xe4, 0x72]);
+        const dir = Buffer.concat([Buffer.from(basename + "/from/"), dirName]);
+        fs.mkdirSync(dir);
+        fs.writeFileSync(Buffer.concat([dir, Buffer.from("/target.txt")]), "hello");
+        fs.symlinkSync("target.txt", Buffer.concat([dir, Buffer.from("/link")]));
+
+        const prevCwd = process.cwd();
+        process.chdir(String(basename));
+        try {
+          await copy("from", "to", { recursive: true });
+        } finally {
+          process.chdir(prevCwd);
+        }
+
+        const copiedLink = Buffer.concat([Buffer.from(basename + "/to/"), dirName, Buffer.from("/link")]);
+        expect({
+          linkTarget: fs.readlinkSync(copiedLink, { encoding: "buffer" }).toString("hex"),
+          followed: fs.readFileSync(copiedLink, "utf8"),
+        }).toEqual({
+          linkTarget: Buffer.concat([dir, Buffer.from("/target.txt")]).toString("hex"),
+          followed: "hello",
+        });
+      },
+    );
+
+    test.skipIf(isWindows)("filter - trailing slash on src/dest does not double the separator", async () => {
+      await using basename = tempDir("cp-trailing", { "from/a.txt": "a" });
+      const seen: [string, string][] = [];
+      await copy(basename + "/from/", basename + "/result/", {
+        recursive: true,
+        filter: (s, d) => (seen.push([s, d]), true),
+      });
+      expect(seen).toContainEqual([basename + "/from/a.txt", basename + "/result/a.txt"]);
+      expect(seen.some(([s]) => s.includes("//"))).toBe(false);
+    });
+
+    test("filter - nested paths are joined the way node joins them, whatever shape src/dest were given in", async () => {
+      await using basename = tempDir("cp-filter-join", { "from/a.txt": "a", "x/.keep": "" });
+      const shapes: [string, string][] = [
+        ["./from", "to1"],
+        ["from/./", "to2"],
+        ["from//", "to3"],
+        // On Windows, existsSync("x/..") is false and mkdirSync("x/..", { recursive: true })
+        // throws ENOENT, so cp's own parent-directory check fails for a dest under "x/..".
+        ...(isWindows
+          ? []
+          : ([
+              ["from", "x/../to4"],
+              ["from", "to5//"],
+            ] as [string, string][])),
+      ];
+      const prevCwd = process.cwd();
+      process.chdir(String(basename));
+      try {
+        for (const [src, dest] of shapes) {
+          const seen: [string, string][] = [];
+          await copy(src, dest, { recursive: true, filter: (s, d) => (seen.push([s, d]), true) });
+          // The root pair is passed through as given; every nested pair is
+          // join(src, name) / join(dest, name), so "./", "//" and "x/.." are
+          // normalized away exactly as path.join does it.
+          expect({ src, dest, nested: seen.filter(([s]) => s !== src) }).toEqual({
+            src,
+            dest,
+            nested: [[join(src, "a.txt"), join(dest, "a.txt")]],
+          });
+        }
+      } finally {
+        process.chdir(prevCwd);
+      }
+    });
+
+    test("err.path is a string when a nested entry's type conflicts", async () => {
+      await using basename = tempDir("cp-errpath", {
+        "from/sub/x.txt": "x",
+        "result/sub": "not a dir",
+      });
+      const e = await copyShouldThrow(join(basename, "from"), join(basename, "result"), { recursive: true });
+      expect({ code: e.code, pathType: typeof e.path, path: e.path, infoPathType: typeof e.info?.path }).toEqual({
+        code: "ERR_FS_CP_DIR_TO_NON_DIR",
+        pathType: "string",
+        path: join(basename, "result", "sub"),
+        infoPathType: "string",
+      });
+    });
+
     test("filter - works", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1747,6 +1747,79 @@ it("readdir with { encoding: 'buffer' } returns Buffer entries", async () => {
   ).toEqual(expected);
 });
 
+// Node returns Dirent objects (not bare Buffers) when both options are set,
+// with `name` as a Buffer. `parentPath` follows the type of the path argument
+// in node; only the string-argument case (string `parentPath`) is covered here.
+it("readdir with { withFileTypes: true, encoding: 'buffer' } returns Dirent with Buffer names", async () => {
+  using dir = tempDir("readdir-buffer-dirent", { "a.txt": "", "sub/b.txt": "" });
+  const summarize = (entries: any[]) =>
+    entries
+      .map(e => ({
+        ctor: e.constructor.name,
+        nameIsBuffer: Buffer.isBuffer(e.name),
+        name: e.name.toString("utf8"),
+        isFile: e.isFile(),
+        isDirectory: e.isDirectory(),
+        parentPathIsString: typeof e.parentPath === "string",
+      }))
+      .sort((a, b) => (a.name < b.name ? -1 : 1));
+  const expected = [
+    { ctor: "Dirent", nameIsBuffer: true, name: "a.txt", isFile: true, isDirectory: false, parentPathIsString: true },
+    { ctor: "Dirent", nameIsBuffer: true, name: "sub", isFile: false, isDirectory: true, parentPathIsString: true },
+  ];
+  const expectedRecursive = [
+    ...expected,
+    { ctor: "Dirent", nameIsBuffer: true, name: "b.txt", isFile: true, isDirectory: false, parentPathIsString: true },
+  ].sort((a, b) => (a.name < b.name ? -1 : 1));
+
+  expect(summarize(readdirSync(String(dir), { withFileTypes: true, encoding: "buffer" }))).toEqual(expected);
+  expect(summarize(readdirSync(String(dir), { withFileTypes: true, encoding: "buffer", recursive: true }))).toEqual(
+    expectedRecursive,
+  );
+  expect(summarize(await promises.readdir(String(dir), { withFileTypes: true, encoding: "buffer" }))).toEqual(expected);
+  expect(
+    summarize(await promises.readdir(String(dir), { withFileTypes: true, encoding: "buffer", recursive: true })),
+  ).toEqual(expectedRecursive);
+});
+
+it.skipIf(!isLinux)(
+  "readdir with { withFileTypes: true, encoding: 'buffer' } preserves non-UTF-8 name bytes",
+  async () => {
+    using dir = tempDir("readdir-buffer-dirent-bytes", {});
+    const name = Buffer.from([0x63, 0x61, 0x66, 0xe9]);
+    writeFileSync(Buffer.concat([Buffer.from(String(dir) + "/"), name]), "");
+    mkdirSync(join(String(dir), "sub"));
+    writeFileSync(Buffer.concat([Buffer.from(join(String(dir), "sub") + "/"), name]), "");
+
+    const summarize = (entries: any[]) =>
+      entries
+        .map(e => ({
+          nameIsBuffer: Buffer.isBuffer(e.name),
+          nameHex: e.name.toString("hex"),
+          isFile: e.isFile(),
+          parentPath: relative(String(dir), e.parentPath),
+        }))
+        .sort((a, b) => a.parentPath.localeCompare(b.parentPath) || a.nameHex.localeCompare(b.nameHex));
+    const top = { nameIsBuffer: true, nameHex: name.toString("hex"), isFile: true, parentPath: "" };
+    const subDir = { nameIsBuffer: true, nameHex: Buffer.from("sub").toString("hex"), isFile: false, parentPath: "" };
+    const nested = { nameIsBuffer: true, nameHex: name.toString("hex"), isFile: true, parentPath: "sub" };
+
+    const flat = { withFileTypes: true, encoding: "buffer" } as const;
+    const recursive = { ...flat, recursive: true } as const;
+    expect({
+      sync: summarize(readdirSync(String(dir), flat)),
+      async: summarize(await promises.readdir(String(dir), flat)),
+      syncRecursive: summarize(readdirSync(String(dir), recursive)),
+      asyncRecursive: summarize(await promises.readdir(String(dir), recursive)),
+    }).toEqual({
+      sync: [top, subDir],
+      async: [top, subDir],
+      syncRecursive: [top, subDir, nested],
+      asyncRecursive: [top, subDir, nested],
+    });
+  },
+);
+
 // The error cleanup path previously called MarkedArrayBuffer.destroy() on
 // structs stored by-value inside the entries ArrayList, which passed interior
 // ArrayList pointers to the allocator (freeing entries.items.ptr for index 0 and


### PR DESCRIPTION
Fixes #27914. Addresses the `Dirent[]` / Buffer `name` part of #30482 (see "Scope" below).

## Problem

On POSIX, directory entry names are arbitrary byte strings (only NUL and `/` are reserved). Recursive `fs.cpSync` / `fs.promises.cp` / `fs.cp` fail on any tree containing such a name:

```
strace: getdents64() returns d_name="caf\351"
        statx(AT_FDCWD, ".../src/caf\357\277\275", AT_SYMLINK_NOFOLLOW) = -1 ENOENT
```

`\357\277\275` is U+FFFD: the entry name was decoded as UTF-8 into a JS string, then re-encoded as UTF-8 for the next syscall. `readdirSync({ encoding: "buffer" })` and recursive `rmSync` already handle these bytes correctly; only the cp walker round-tripped through a lossy string. Node's cp (and `cp -r`) copy such trees byte-exact. Symlink targets had the same round trip through `readlink()`.

Separately, `readdirSync(p, { withFileTypes: true, encoding: "buffer" })` silently dropped `withFileTypes` and returned bare `Buffer[]`, so `dirent.name` was `undefined` (#27914). Node returns `Dirent[]` with `name` as a `Buffer`.

## Cause

- `copyDir` in `src/js/internal/fs/cp-sync.ts` / `cp.ts` listed entries with `readdirSync(src, { withFileTypes: true })`, so `dirent.name` was always a (possibly lossy) string, and `onLink` read targets with `readlink()` returning a string.
- `args::Readdir::tag()` mapped `encoding: "buffer"` to `ReaddirTag::Buffers` regardless of `withFileTypes`, so a byte-preserving Dirent was not reachable.

## Fix

- `readdir*({ withFileTypes: true, encoding: "buffer" })` now returns `Dirent[]` with a Buffer `name` (sync, async and recursive). A new `DirentBuffer` carries the raw name bytes through the existing readdir paths and `Bun__Dirent__toJSWithBufferName` builds the object with `createBuffer` for the name slot.
- The cp walkers read entries with `{ withFileTypes: true, encoding: "buffer" }` on POSIX. A name that is valid UTF-8 is turned back into a string and joined with `path.join` exactly as before, so for every tree that copied before this change the walker, `filter` arguments and error objects see the same strings as before (and as on Windows, which keeps string names since filenames there are native UTF-16). Only a name that is not UTF-8 makes its path, and the paths below it, a Buffer, which every `lstat` / `mkdir` / `copyFile` / `symlink` then receives byte for byte. `path.join` / `path.resolve` are run on a latin1 view of those bytes (latin1 maps each byte to one code unit and back), so Buffer paths get the same normalization as string paths.
- `readlink` is asked for a Buffer on POSIX and handled the same way: a UTF-8 target becomes a string and is resolved as before; a target that is not UTF-8, or a link that sits under a directory whose name is not UTF-8, is resolved on the latin1 view (with the cwd passed in explicitly, since `path.resolve` would otherwise fall back to `process.cwd()` as a UTF-8 string), so the copied link points at the exact bytes instead of dangling.
- `filter` and `err.path` / `err.dest` receive strings in the Buffer case too (the offending bytes decode to U+FFFD), which is the type node's cp hands out; `isSrcSubdir` decodes both sides the same way.
- The macOS `clonefile()` fast path is unchanged; on Linux the JS walker remains the directory path (the native walker does not preserve directory modes).

## Scope

- `parentPath` on the returned Dirents is a string. In node it follows the type of the `path` argument (a Buffer argument yields a Buffer `parentPath`); bun returns a string for the plain `withFileTypes` case today as well, and this PR does not change that, which is why #30482 (whose repro passes a Buffer) is not marked as fixed here. #30484 implements that rule and stays open for it.
- #36059 was the cp-only version of this change and has been closed; its coverage (symlink with a non-UTF-8 name, non-UTF-8 symlink target, relative symlink under a non-UTF-8 directory, filter + preserveTimestamps) is carried here. An earlier revision of this branch concatenated every POSIX child path as bytes, which silently changed the strings `filter` and error objects receive for unnormalized inputs such as `cpSync("./src", ...)`; the current revision keeps the string path until a name that is not UTF-8 is met, and a test now pins the nested `filter` arguments to `path.join`'s output on every platform.
- Rebased onto current main, where `bun_core::String` owns its WTF ref (#40238): `Dirent` and `DirentBuffer` are consumed by value through `into_js`, `Drop` releases their strings, and the C++ entry points take `BunString` by value. `Bun__Dirent__toJSWithBufferName` checks for a pending exception after `createBuffer` (releasing `path` on that path) and its Rust declaration is an unsafe `fn`, since it carries a raw pointer + length.
- `isSrcSubdir` compares Buffer paths on their latin1 view so that two targets whose bytes differ only in non-UTF-8 positions (both decoding to U+FFFD) are not mistaken for the same directory; a test covers replacing a dest link with such a pair.

## Verification

`test/js/node/fs/cp.test.ts` (each case for both `cpSync` and `promises.cp`): byte-exact tree with latin1 file, latin1 subdir and `\xff\xfe` bytes, with and without `filter`; merge into an existing dest; filter + preserveTimestamps, including the lossy string the non-UTF-8 entry is reported as; `err.path` for a conflicting non-UTF-8 entry; symlink with a non-UTF-8 name; symlink whose target is non-UTF-8; relative symlink inside a non-UTF-8 directory copied from a relative `src`; valid UTF-8 non-ASCII names reaching `filter` as strings; nested `filter` arguments equal to `path.join(src, name)` for `./from`, `from/./` and `from//` on every platform, plus `x/../to` and `to//` on POSIX (on Windows bun's `existsSync("x/..")` is false and `mkdirSync("x/..", { recursive: true })` throws, a pre-existing divergence reported separately); trailing-slash join; string `err.path` for nested conflicts. `test/js/node/fs/fs.test.ts` covers the Dirent shape for sync/async/recursive and the raw-byte round trip.

Without the native change the readdir cases fail with `e.name` undefined and every non-UTF-8 cp case fails with `ENOENT lstat '.../caf\ufffd'`; the two symlink-target cases also failed on the byte-concatenating revision of this branch; and the join-normalization case is what that revision got wrong (`./from/a.txt` where `path.join` gives `from/a.txt`). On this branch `cp.test.ts`, `cp-symlink-target.test.ts`, `dir.test.ts` and `fs.test.ts` pass, as do the `test-fs-cp-*`, `test-fs-readdir*` and `test-fs-opendir*` node tests.

CI on the current head: every lane that exercises this change is green (Linux, Windows, macOS arm64 and x64). The one red shard is `test/js/web/url/url.test.ts` on macOS x64, which fails on main as well and is unrelated to this PR.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts, test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->