### PR TITLE
shell: add ShellYesTask dispatch arm in run_task_cold

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -88,6 +88,7 @@ use crate::shell::builtins::{
     mv::{ShellMvBatchedTask, ShellMvCheckTargetTask},
     rm::ShellRmTask,
     touch::ShellTouchTask,
+    yes::YesTask,
 };
 use crate::shell::dispatch_tasks::{
     AsyncDeinitReader as ShellIOReaderAsyncDeinit, AsyncDeinitWriter as ShellIOWriterAsyncDeinit,
@@ -566,6 +567,12 @@ fn run_task_cold(task: Task) {
             ShellRmDirTask::run_from_main_thread(t);
         }
         task_tag::ShellGlobTask => shell_dispatch!(ShellGlobTask),
+        task_tag::ShellYesTask => {
+            let t = cast_ptr!(YesTask);
+            // SAFETY: §Dispatch — tag identifies pointee; live YesTask inside
+            // `Box<Yes>` in the interpreter arena.
+            unsafe { YesTask::run_from_main_thread(&*t) };
+        }
 
         // ── bake dev-server ──────────────────────────────────────────────
         task_tag::BakeHotReloadEvent => {
@@ -576,7 +583,7 @@ fn run_task_cold(task: Task) {
             unsafe { BakeHotReloadEvent::run(cast_ptr!(BakeHotReloadEvent)) };
         }
 
-        // ShellYesTask + any tag the hot path mis-routed: producer bug.
+        // Any tag the hot path mis-routed: producer bug.
         _ => panic!("Unexpected Task tag: {}", task.tag.0),
     }
 }

--- a/test/js/bun/shell/commands/yes.test.ts
+++ b/test/js/bun/shell/commands/yes.test.ts
@@ -44,11 +44,7 @@ describe("yes", async () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("ok\n");
     expect(exitCode).toBe(0);

--- a/test/js/bun/shell/commands/yes.test.ts
+++ b/test/js/bun/shell/commands/yes.test.ts
@@ -1,5 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 $.throws(false);
 
@@ -20,5 +21,36 @@ describe("yes", async () => {
     const buffer = Buffer.alloc(17);
     await $`yes ab cd ef > ${buffer}`;
     expect(buffer.toString()).toEqual("ab cd ef\nab cd ef");
+  });
+
+  // When stdout is an in-memory sink, `yes` writes 4 × 8 KiB then re-enqueues
+  // itself via ShellYesTask to yield the event loop. A buffer larger than
+  // 32 KiB forces that re-enqueue; the dispatch table needs an arm for the
+  // tag or the process aborts with "Unexpected Task tag". Isolated in a
+  // subprocess so the abort is observable as an assertion failure.
+  test("fills a buffer larger than one no-IO burst", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { $ } from "bun";
+         $.throws(false);
+         const buf = Buffer.alloc(40000);
+         await $\`yes > \${buf}\`.quiet();
+         if (!buf.equals(Buffer.alloc(40000, "y\\n"))) throw new Error("buffer mismatch");
+         console.log("ok");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

`panic: Unexpected Task tag: 12` aborts the process whenever the shell `yes` builtin writes to an in-memory sink: `.text()`, `.quiet()`, `.json()`, `.lines()`, or a `> ${Buffer}` redirect larger than 32 KiB.

```js
import { $ } from "bun";
const buf = Buffer.alloc(40000);
await $`yes > ${buf}`;   // panic: Unexpected Task tag: 12
```

## Cause

`run_task` forwards all 16 `Shell*` tags (including `ShellYesTask`) to `run_task_cold` via one or-pattern, but `run_task_cold`'s match only carries 15 of them. `ShellYesTask` falls through to the wildcard `panic!`.

`Yes::start` branches on `stdout.needs_io()`: an fd sink (pipe, file, inherited stdout) stays on the `IOWriter` chunk queue and is fine; an in-memory sink takes `write_no_io_loop`, which writes 4 × 8 KiB then `YesTask::enqueue`s itself so it does not hog the main thread. On the next drain `run_task_cold` receives tag 12 and panics.

The pipe / file / small-buffer cases never reach the enqueue, which is why the existing `yes` tests pass.

## Fix

Add the missing arm. `YesTask` does not implement `ShellTaskCtx` (it has no embedded `ShellTask` / keep-alive ref), so it is dispatched directly via `YesTask::run_from_main_thread` rather than `shell_dispatch!`, mirroring the `ShellRmDirTask` / `ShellIOWriter` pattern.

All 97 `task_tag` variants were cross-checked against `run_task`: `ShellYesTask` was the only tag present in the shell or-pattern but absent from the cold match.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/yes.test.ts`: 3 pass, **1 fail** (subprocess aborts with `Unexpected Task tag: 12`)
- `bun bd test test/js/bun/shell/commands/yes.test.ts`: **4 pass**, 0 fail