### PR TITLE
console/worker_threads: keep fd 1/2 blocking across worker start; poll on EAGAIN in the console writer

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -446,11 +446,8 @@ function makePortWritable(port) {
 
 function setupWorkerStdio(stdio) {
   const { stdin, stdout, stderr } = stdio;
-  // Plain assignment, not Object.defineProperty: process.stdout/stderr/stdin
-  // are static PropertyCallback slots, and JSC's defineOwnProperty reifies the
-  // lazy value first (running the fd-backed constructor on the shared fd 1/2)
-  // before replacing it. put() replaces the slot without reifying and yields
-  // the same {writable,enumerable,configurable}=true descriptor.
+  // Plain assignment: defineProperty would reify the lazy fd-backed stdio
+  // (JSC reifies a static PropertyCallback before defining over it).
   if (stdout) {
     process.stdout = makePortWritable(stdout);
   }

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -446,37 +446,27 @@ function makePortWritable(port) {
 
 function setupWorkerStdio(stdio) {
   const { stdin, stdout, stderr } = stdio;
+  // Plain assignment, not Object.defineProperty: process.stdout/stderr/stdin
+  // are static PropertyCallback slots, and JSC's defineOwnProperty reifies the
+  // lazy value first (running the fd-backed constructor on the shared fd 1/2)
+  // before replacing it. put() replaces the slot without reifying and yields
+  // the same {writable,enumerable,configurable}=true descriptor.
   if (stdout) {
-    Object.defineProperty(process, "stdout", {
-      value: makePortWritable(stdout),
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    });
+    process.stdout = makePortWritable(stdout);
   }
   if (stderr) {
-    Object.defineProperty(process, "stderr", {
-      value: makePortWritable(stderr),
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    });
+    process.stderr = makePortWritable(stderr);
   }
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },
   // otherwise an immediately-EOF'd stream — never the process-wide fd 0, which
   // would race the main thread (and hang on a TTY).
-  Object.defineProperty(process, "stdin", {
-    value: stdin
-      ? makePortReadable(stdin, true)
-      : new Readable({
-          read() {
-            this.push(null);
-          },
-        }),
-    writable: true,
-    configurable: true,
-    enumerable: true,
-  });
+  process.stdin = stdin
+    ? makePortReadable(stdin, true)
+    : new Readable({
+        read() {
+          this.push(null);
+        },
+      });
   // node routes console.log through process.stdout/stderr; Bun's global console
   // writes the fd directly, so rebind it to the captured streams when present.
   if (stdout || stderr) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -446,8 +446,7 @@ function makePortWritable(port) {
 
 function setupWorkerStdio(stdio) {
   const { stdin, stdout, stderr } = stdio;
-  // Plain assignment: defineProperty would reify the lazy fd-backed stdio
-  // (JSC reifies a static PropertyCallback before defining over it).
+  // Not defineProperty: that reifies the lazy fd-backed stdio before replacing it.
   if (stdout) {
     process.stdout = makePortWritable(stdout);
   }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -643,9 +643,6 @@ impl FileSink {
             }
             sys::Result::Ok(fd) => fd,
         };
-        // Record the dup'd/opened fd so `get_fd()` and the process.stdout
-        // force-sync hook (which clears O_NONBLOCK on it) see a real fd.
-        self.fd.set(fd);
 
         #[cfg(windows)]
         {
@@ -660,6 +657,7 @@ impl FileSink {
                         return sys::Result::Err(err);
                     }
                     sys::Result::Ok(()) => {
+                        self.fd.set(fd);
                         self.writer
                             .with_mut(|w| w.update_ref(self.io_evtloop(), false));
                     }
@@ -675,6 +673,9 @@ impl FileSink {
                 return sys::Result::Err(err);
             }
             sys::Result::Ok(()) => {
+                // Record the dup'd/opened fd so `get_fd()` and the process.stdout
+                // force-sync hook (which clears O_NONBLOCK on it) see a real fd.
+                self.fd.set(fd);
                 // Only keep the event loop ref'd while there's a pending write in progress.
                 // If there's no pending write, no need to keep the event loop ref'd.
                 self.writer

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -643,6 +643,9 @@ impl FileSink {
             }
             sys::Result::Ok(fd) => fd,
         };
+        // Record the dup'd/opened fd so `get_fd()` and the process.stdout
+        // force-sync hook (which clears O_NONBLOCK on it) see a real fd.
+        self.fd.set(fd);
 
         #[cfg(windows)]
         {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -673,8 +673,7 @@ impl FileSink {
                 return sys::Result::Err(err);
             }
             sys::Result::Ok(()) => {
-                // Record the dup'd/opened fd so `get_fd()` and the process.stdout
-                // force-sync hook (which clears O_NONBLOCK on it) see a real fd.
+                // `get_fd()` and the stdio force-sync O_NONBLOCK undo read this.
                 self.fd.set(fd);
                 // Only keep the event loop ref'd while there's a pending write in progress.
                 // If there's no pending write, no need to keep the event loop ref'd.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9411,6 +9411,9 @@ fn fd_write_all_quiet(fd: Fd, mut bytes: &[u8]) -> bool {
         match write(fd, bytes) {
             Ok(0) => return false, // short write → give up
             Ok(n) => bytes = &bytes[n..],
+            // Darwin's write$NOCANCEL is single-shot (no EINTR retry in `write()`).
+            #[cfg(unix)]
+            Err(e) if e.get_errno() == E::EINTR => continue,
             #[cfg(unix)]
             Err(e) if e.is_retry() => {
                 let mut pfd = [posix::PollFd {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9405,11 +9405,26 @@ fn qw_set_fd(qw: &mut bun_core::output::QuietWriter, fd: Fd) {
 
 /// Best-effort write-all loop. Returns `false` on I/O error / zero-write so
 /// `ScopedLogger::log` can disable the scope; "quiet" callers discard the bool.
+/// EAGAIN is not an error: the open file description backing a stdio fd can be
+/// flipped to O_NONBLOCK by any co-process or thread sharing it (workers,
+/// parent shells, libuv), so block on writability and retry instead of
+/// discarding the unwritten tail.
 fn fd_write_all_quiet(fd: Fd, mut bytes: &[u8]) -> bool {
     while !bytes.is_empty() {
         match write(fd, bytes) {
             Ok(0) => return false, // short write → give up
             Ok(n) => bytes = &bytes[n..],
+            #[cfg(unix)]
+            Err(e) if e.is_retry() => {
+                let mut pfd = [posix::PollFd {
+                    fd: fd.native(),
+                    events: posix::POLL_OUT,
+                    revents: 0,
+                }];
+                if posix::poll(&mut pfd, -1).is_err() {
+                    return false;
+                }
+            }
             Err(_) => return false,
         }
     }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9405,10 +9405,7 @@ fn qw_set_fd(qw: &mut bun_core::output::QuietWriter, fd: Fd) {
 
 /// Best-effort write-all loop. Returns `false` on I/O error / zero-write so
 /// `ScopedLogger::log` can disable the scope; "quiet" callers discard the bool.
-/// EAGAIN is not an error: the open file description backing a stdio fd can be
-/// flipped to O_NONBLOCK by any co-process or thread sharing it (workers,
-/// parent shells, libuv), so block on writability and retry instead of
-/// discarding the unwritten tail.
+/// EAGAIN polls: anything sharing the open file description can flip O_NONBLOCK.
 fn fd_write_all_quiet(fd: Fd, mut bytes: &[u8]) -> bool {
     while !bytes.is_empty() {
         match write(fd, bytes) {

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync } from "bun";
-import { cc, ptr } from "bun:ffi";
+import { dlopen, ptr } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMacOS, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, libcPathForDlopen, tempDirWithFiles } from "harness";
 import { closeSync, readSync } from "node:fs";
 import path from "path";
 import { isatty } from "tty";
@@ -172,10 +172,8 @@ describe.concurrent("process-stdio", () => {
     const dir = tempDirWithFiles("stdio-nonblock", {
       "fdutil.c": `
 #include <fcntl.h>
-#include <unistd.h>
 int fd_is_nonblock(int fd) { int fl = fcntl(fd, F_GETFL); return fl >= 0 && (fl & O_NONBLOCK) != 0; }
 int fd_set_nonblock(int fd) { int fl = fcntl(fd, F_GETFL); return fl < 0 ? fl : fcntl(fd, F_SETFL, fl | O_NONBLOCK); }
-int fd_pipe(int* fds) { return pipe(fds); }
 `,
     });
     const fdutil = path.join(dir, "fdutil.c");
@@ -252,12 +250,12 @@ w.on("online", () => {
       // read end only this test drains: the child fills it to EAGAIN, signals
       // the byte count on stderr, then console.log()s the markers into the
       // still-full pipe; the parent starts draining only after the signal.
-      const { fd_pipe } = cc({
-        source: fdutil,
-        symbols: { fd_pipe: { args: ["ptr"], returns: "int" } },
+      // pipe(2) is not variadic, so a dlopen binding is ABI-correct everywhere.
+      const { pipe } = dlopen(libcPathForDlopen(), {
+        pipe: { args: ["ptr"], returns: "int" },
       }).symbols;
       const fds = new Int32Array(2);
-      expect(fd_pipe(ptr(fds))).toBe(0);
+      expect(pipe(ptr(fds))).toBe(0);
       const [r, w] = fds;
       let wClosed = false;
       try {

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,8 @@
 import { spawn, spawnSync } from "bun";
+import { dlopen, FFIType, ptr } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isPosix, libcPathForDlopen } from "harness";
+import { closeSync, readSync } from "node:fs";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -157,5 +159,148 @@ describe.concurrent("process-stdio", () => {
     expect(stdout?.toString()).toBe(
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
+  });
+
+  // O_NONBLOCK is an open-file-description flag: any co-process or thread
+  // sharing the description (worker threads, a parent shell, libuv) can flip it
+  // on the process-wide fd 1/2. Bun must (a) not flip it from the worker stdio
+  // path and (b) not drop output when something else has.
+  describe.skipIf(!isPosix)("stdout/stderr vs O_NONBLOCK on a pipe", () => {
+    // F_GETFL/F_SETFL are 3/4 on Linux and Darwin; O_NONBLOCK differs (2048 vs 4).
+    // describe.skipIf still evaluates this body on Windows, so guard the libc
+    // lookup (which throws there); the skipped tests never read the value.
+    const libc = isPosix ? libcPathForDlopen() : "";
+    const fcntlPrelude = `
+const { dlopen, FFIType } = require("bun:ffi");
+const { O_NONBLOCK } = require("node:constants");
+const { fcntl } = dlopen(${JSON.stringify(libc)}, {
+  fcntl: { args: [FFIType.int, FFIType.int, FFIType.int], returns: FFIType.int },
+}).symbols;
+const nonblock = fd => (fcntl(fd, 3, 0) & O_NONBLOCK) !== 0;
+`;
+
+    test("reading process.stdout / process.stderr leaves fd 1/2 blocking", async () => {
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          fcntlPrelude +
+            `
+const before = [nonblock(1), nonblock(2)];
+void process.stdout;
+void process.stderr;
+const after = [nonblock(1), nonblock(2)];
+process.stderr.write(JSON.stringify({ before, after }));
+`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("");
+      expect(JSON.parse(stderr)).toEqual({ before: [false, false], after: [false, false] });
+      expect(exitCode).toBe(0);
+    });
+
+    test("starting a node:worker_threads Worker leaves fd 1/2 blocking", async () => {
+      // The worker's stdio rebind must not reify the fd-backed stream
+      // (JSC defineOwnProperty on a lazy PropertyCallback would run it).
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          fcntlPrelude +
+            `
+const { Worker } = require("node:worker_threads");
+const before = [nonblock(1), nonblock(2)];
+const w = new Worker("setTimeout(() => {}, 0)", { eval: true });
+w.on("online", () => {
+  const after = [nonblock(1), nonblock(2)];
+  process.stderr.write(JSON.stringify({ before, after }));
+  w.on("exit", () => {});
+});
+`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("");
+      expect(JSON.parse(stderr)).toEqual({ before: [false, false], after: [false, false] });
+      expect(exitCode).toBe(0);
+    });
+
+    test("console.log delivers every byte when fd 1 is O_NONBLOCK and the pipe is full", async () => {
+      // The open file description can be flipped by anything sharing it; the
+      // native console writer must poll for writability on EAGAIN, not discard
+      // the unwritten tail.
+      // stdout: "pipe" pre-drains into the parent, so use a raw pipe(2) whose
+      // read end only this test drains: the child fills it to EAGAIN, signals
+      // the byte count on stderr, then console.log()s the markers into the
+      // still-full pipe; the parent starts draining only after the signal.
+      const { pipe } = dlopen(libc, {
+        pipe: { args: [FFIType.ptr], returns: FFIType.int },
+      }).symbols;
+      const fds = new Int32Array(2);
+      expect(pipe(ptr(fds))).toBe(0);
+      const [r, w] = fds;
+      try {
+        await using proc = spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            fcntlPrelude +
+              `
+const fs = require("node:fs");
+fcntl(1, 4, fcntl(1, 3, 0) | O_NONBLOCK);
+const fill = Buffer.alloc(4096, 120);
+let filled = 0;
+for (let i = 0; i < 1000; i++) {
+  try { filled += fs.writeSync(1, fill); } catch { break; }
+}
+fs.writeSync(2, String(filled) + "\\n");
+for (let i = 0; i < 10; i++) console.log("marker " + i);
+`,
+          ],
+          env: bunEnv,
+          stdio: ["ignore", w, "pipe"],
+        });
+        closeSync(w);
+        const reader = proc.stderr.getReader();
+        const first = await reader.read();
+        const filled = Number(Buffer.from(first.value).toString().trim());
+        expect(filled).toBeGreaterThan(0);
+        const buf = Buffer.alloc(65536);
+        let total = Buffer.alloc(0);
+        for (;;) {
+          const n = readSync(r, buf);
+          if (n === 0) break;
+          total = Buffer.concat([total, buf.subarray(0, n)]);
+        }
+        let stderrRest = "";
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          stderrRest += Buffer.from(value).toString();
+        }
+        const exitCode = await proc.exited;
+        expect({
+          stderrRest,
+          filledOK: total.subarray(0, filled).equals(Buffer.alloc(filled, 120)),
+          payload: total.subarray(filled).toString(),
+        }).toEqual({
+          stderrRest: "",
+          filledOK: true,
+          payload: Array.from({ length: 10 }, (_, i) => `marker ${i}\n`).join(""),
+        });
+        expect(exitCode).toBe(0);
+      } finally {
+        try {
+          closeSync(r);
+        } catch {}
+      }
+    });
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync } from "bun";
-import { dlopen, FFIType, ptr } from "bun:ffi";
+import { cc, ptr } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, libcPathForDlopen } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, tempDirWithFiles } from "harness";
 import { closeSync, readSync } from "node:fs";
 import path from "path";
 import { isatty } from "tty";
@@ -165,18 +165,30 @@ describe.concurrent("process-stdio", () => {
   // sharing the description (worker threads, a parent shell, libuv) can flip it
   // on the process-wide fd 1/2. Bun must (a) not flip it from the worker stdio
   // path and (b) not drop output when something else has.
-  describe.skipIf(!isPosix)("stdout/stderr vs O_NONBLOCK on a pipe", () => {
-    // F_GETFL/F_SETFL are 3/4 on Linux and Darwin; O_NONBLOCK differs (2048 vs 4).
-    // describe.skipIf still evaluates this body on Windows, so guard the libc
-    // lookup (which throws there); the skipped tests never read the value.
-    const libc = isPosix ? libcPathForDlopen() : "";
-    const fcntlPrelude = `
-const { dlopen, FFIType } = require("bun:ffi");
-const { O_NONBLOCK } = require("node:constants");
-const { fcntl } = dlopen(${JSON.stringify(libc)}, {
-  fcntl: { args: [FFIType.int, FFIType.int, FFIType.int], returns: FFIType.int },
+  describe.skipIf(!(isLinux || isMacOS))("stdout/stderr vs O_NONBLOCK on a pipe", () => {
+    // fcntl is variadic; Apple's arm64 ABI puts variadic args on the stack, so a
+    // fixed-arg dlopen binding gets F_SETFL wrong there. Compile non-variadic
+    // wrappers instead (fdutil.c is shared with the spawned children).
+    const dir = tempDirWithFiles("stdio-nonblock", {
+      "fdutil.c": `
+#include <fcntl.h>
+#include <unistd.h>
+int fd_is_nonblock(int fd) { int fl = fcntl(fd, F_GETFL); return fl >= 0 && (fl & O_NONBLOCK) != 0; }
+int fd_set_nonblock(int fd) { int fl = fcntl(fd, F_GETFL); return fl < 0 ? fl : fcntl(fd, F_SETFL, fl | O_NONBLOCK); }
+int fd_pipe(int* fds) { return pipe(fds); }
+`,
+    });
+    const fdutil = path.join(dir, "fdutil.c");
+    const prelude = `
+const { cc } = require("bun:ffi");
+const { fd_is_nonblock, fd_set_nonblock } = cc({
+  source: ${JSON.stringify(fdutil)},
+  symbols: {
+    fd_is_nonblock: { args: ["int"], returns: "int" },
+    fd_set_nonblock: { args: ["int"], returns: "int" },
+  },
 }).symbols;
-const nonblock = fd => (fcntl(fd, 3, 0) & O_NONBLOCK) !== 0;
+const nonblock = fd => fd_is_nonblock(fd) !== 0;
 `;
 
     test("reading process.stdout / process.stderr leaves fd 1/2 blocking", async () => {
@@ -184,7 +196,7 @@ const nonblock = fd => (fcntl(fd, 3, 0) & O_NONBLOCK) !== 0;
         cmd: [
           bunExe(),
           "-e",
-          fcntlPrelude +
+          prelude +
             `
 const before = [nonblock(1), nonblock(2)];
 void process.stdout;
@@ -210,7 +222,7 @@ process.stderr.write(JSON.stringify({ before, after }));
         cmd: [
           bunExe(),
           "-e",
-          fcntlPrelude +
+          prelude +
             `
 const { Worker } = require("node:worker_threads");
 const before = [nonblock(1), nonblock(2)];
@@ -240,21 +252,23 @@ w.on("online", () => {
       // read end only this test drains: the child fills it to EAGAIN, signals
       // the byte count on stderr, then console.log()s the markers into the
       // still-full pipe; the parent starts draining only after the signal.
-      const { pipe } = dlopen(libc, {
-        pipe: { args: [FFIType.ptr], returns: FFIType.int },
+      const { fd_pipe } = cc({
+        source: fdutil,
+        symbols: { fd_pipe: { args: ["ptr"], returns: "int" } },
       }).symbols;
       const fds = new Int32Array(2);
-      expect(pipe(ptr(fds))).toBe(0);
+      expect(fd_pipe(ptr(fds))).toBe(0);
       const [r, w] = fds;
+      let wClosed = false;
       try {
         await using proc = spawn({
           cmd: [
             bunExe(),
             "-e",
-            fcntlPrelude +
+            prelude +
               `
 const fs = require("node:fs");
-fcntl(1, 4, fcntl(1, 3, 0) | O_NONBLOCK);
+fd_set_nonblock(1);
 const fill = Buffer.alloc(4096, 120);
 let filled = 0;
 for (let i = 0; i < 1000; i++) {
@@ -268,9 +282,17 @@ for (let i = 0; i < 10; i++) console.log("marker " + i);
           stdio: ["ignore", w, "pipe"],
         });
         closeSync(w);
+        wClosed = true;
         const reader = proc.stderr.getReader();
-        const first = await reader.read();
-        const filled = Number(Buffer.from(first.value).toString().trim());
+        let header = "";
+        while (!header.includes("\n")) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          header += Buffer.from(value).toString();
+        }
+        const nl = header.indexOf("\n");
+        const filled = Number(header.slice(0, nl >= 0 ? nl : header.length));
+        let stderrRest = nl >= 0 ? header.slice(nl + 1) : "";
         expect(filled).toBeGreaterThan(0);
         const buf = Buffer.alloc(65536);
         let total = Buffer.alloc(0);
@@ -279,7 +301,6 @@ for (let i = 0; i < 10; i++) console.log("marker " + i);
           if (n === 0) break;
           total = Buffer.concat([total, buf.subarray(0, n)]);
         }
-        let stderrRest = "";
         for (;;) {
           const { value, done } = await reader.read();
           if (done) break;
@@ -297,6 +318,11 @@ for (let i = 0; i < 10; i++) console.log("marker " + i);
         });
         expect(exitCode).toBe(0);
       } finally {
+        if (!wClosed) {
+          try {
+            closeSync(w);
+          } catch {}
+        }
         try {
           closeSync(r);
         } catch {}


### PR DESCRIPTION
## Repro

```js
// bun r.mjs 2>/dev/null | { sleep 1; cat; } | wc -l
//   bun  -> ~700  (of 20000; exit 0, torn line at the 64 KiB pipe boundary)
//   node -> 20000
import { Worker } from "node:worker_threads";
const w = new Worker('setTimeout(() => {}, 2500)', { eval: true }); // worker logs NOTHING
await new Promise(r => w.on("online", r));
for (let i = 0; i < 20000; i++) console.log("line", String(i).padStart(6, "0"), "p".repeat(80));
await new Promise(r => w.on("exit", r));
```

The worker never writes a byte. Its mere creation flips the process-wide fd 1 to `O_NONBLOCK`, after which the main thread's native `console.log` silently drops on `EAGAIN` when piped to a slow reader (`| tee`, `| grep`, CI log collectors behind any worker pool such as piscina/tinypool).

strace signature from the worker's JS thread, before any user eval runs:

```
fcntl(1, F_DUPFD_CLOEXEC, 0) = 11
fcntl(11, F_GETFL)           = O_WRONLY
fcntl(11, F_SETFL, O_WRONLY|O_NONBLOCK) = 0
```

No thread ever issues a restoring `F_SETFL`.

## Cause

`O_NONBLOCK` is an open-file-**description** flag, not an fd flag. `dup()` makes a new fd number pointing at the same description, and worker threads share the fd table, so an `F_SETFL` on the worker's dup is a mode change of the parent's fd 1.

The flip is reached because the worker's stdio rebind (`setupWorkerStdio`) uses `Object.defineProperty(process, "stdout"/"stderr", {...})`. `process.stdout`/`stderr` are static `PropertyCallback` slots, and JSC's `defineOwnProperty` reifies a lazy static property before defining over it. Reification runs `constructStdout` → `getStdioWriteStream` → `Bun.file(1).writer()` → `FileSink::setup()` → `open_for_writing`, which dups fd 1 and calls `set_nonblocking` on the dup. The worker immediately discards that fd-backed stream (the port-backed writable replaces it), but the `O_NONBLOCK` on the shared description is the residue.

The intended undo lives in `Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio`, which is gated on `self.fd != INVALID`. `FileSink::setup()` never wrote `self.fd` (the fd went only to `self.writer`), so that branch is dead code. `void process.stdout` on a pipe therefore leaves fd 1 nonblocking even on the main thread with no worker involved.

The drop is `fd_write_all_quiet` (the native console / output writer) treating any `Err(_)`, including `EAGAIN`, as terminal and discarding the unwritten tail.

## Fix

Three small changes, each closing one seam:

- **`src/js/node/worker_threads.ts`**: rebind worker stdio with plain assignment (`process.stdout = ...`) instead of `Object.defineProperty`. `put()` replaces a `PropertyCallback` slot without reifying it and yields the same `{writable,enumerable,configurable}=true` descriptor, so the fd-backed constructor is never run in a worker and fd 1/2 are never touched.

- **`src/sys/lib.rs`**: `fd_write_all_quiet` polls `POLLOUT` and retries on `EAGAIN` instead of giving up. Anything sharing the open file description (a worker, a parent shell, libuv in a co-process, node itself) can flip the flag at any time; blocking on writability is what makes this class safe in Node.

- **`src/runtime/webcore/FileSink.rs`**: `setup()` records the dup'd/opened fd in `self.fd`, so the process-stdio force-sync hook's `update_nonblocking(self.fd, false)` actually runs, and `_getFd()` returns the real fd on the `Bun.file(fd).writer()` path.

## Verification

New tests in `test/js/node/process/process-stdio.test.ts` (POSIX):

- `reading process.stdout / process.stderr leaves fd 1/2 blocking`: fcntl(F_GETFL) on fd 1/2 before/after the lazy getter fires.
- `starting a node:worker_threads Worker leaves fd 1/2 blocking`: same, across an idle worker coming online.
- `console.log delivers every byte when fd 1 is O_NONBLOCK and the pipe is full`: a raw `pipe(2)` under the test's control; the child fills it to `EAGAIN`, signals on stderr, then `console.log`s markers into the still-full pipe. Without the fix the markers are dropped (payload `""`, 5/5); with the fix the writer polls until the parent drains and all markers arrive (5/5).

All three fail on `main` and pass with this change. The original 20000-line worker repro delivers 20000/20000.

## Related

- #35956 also records `self.fd` in `FileSink::setup()` (and fixes a separate `Bun.write` EAGAIN spin); the one-line overlap here will drop out on rebase if that lands first.
- #33560 is the same `fd_write_all_quiet` EAGAIN poll; this PR adds the worker trigger and a deterministic pipe-full test alongside it.
- #31216 introduced the worker-side `defineProperty` that reaches the existing `setup()`/writer seams.

Fixes #21516.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process-stdio.test.ts

<!-- robobun:evidence:end -->