### PR TITLE
refactor: drop Zig-shadowing underscore affixes from Rust fn names

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2282,7 +2282,7 @@ pub struct Yield {
 }
 
 pub struct If {
-    pub test_: ExprNodeIndex,
+    pub test: ExprNodeIndex,
     pub yes: ExprNodeIndex,
     pub no: ExprNodeIndex,
 }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2146,7 +2146,7 @@ impl Data {
             }
             Data::EIf(el) => {
                 let item = bump.alloc(E::If {
-                    test_: el.test_.deep_clone_no_detach(bump)?,
+                    test: el.test.deep_clone_no_detach(bump)?,
                     yes: el.yes.deep_clone_no_detach(bump)?,
                     no: el.no.deep_clone_no_detach(bump)?,
                 });

--- a/src/ast/s.rs
+++ b/src/ast/s.rs
@@ -126,7 +126,7 @@ pub struct Class {
 }
 
 pub struct If {
-    pub test_: ExprNodeIndex,
+    pub test: ExprNodeIndex,
     pub yes: StmtNodeIndex,
     pub no: Option<StmtNodeIndex>,
 }
@@ -134,7 +134,7 @@ pub struct If {
 pub struct For {
     /// May be a SConst, SLet, SVar, or SExpr
     pub init: Option<StmtNodeIndex>, // = None
-    pub test_: Option<ExprNodeIndex>,  // = None
+    pub test: Option<ExprNodeIndex>,  // = None
     pub update: Option<ExprNodeIndex>, // = None
     pub body: StmtNodeIndex,
 }
@@ -156,11 +156,11 @@ pub struct ForOf {
 
 pub struct DoWhile {
     pub body: StmtNodeIndex,
-    pub test_: ExprNodeIndex,
+    pub test: ExprNodeIndex,
 }
 
 pub struct While {
-    pub test_: ExprNodeIndex,
+    pub test: ExprNodeIndex,
     pub body: StmtNodeIndex,
 }
 
@@ -174,12 +174,12 @@ pub struct Try {
     pub body_loc: crate::Loc,
     pub body: StmtNodeList,
 
-    pub catch_: Option<Catch>,    // = None
+    pub catch: Option<Catch>,    // = None
     pub finally: Option<Finally>, // = None
 }
 
 pub struct Switch {
-    pub test_: ExprNodeIndex,
+    pub test: ExprNodeIndex,
     pub body_loc: crate::Loc,
     pub cases: StoreSlice<Case>, // arena-owned
 }

--- a/src/ast/s.rs
+++ b/src/ast/s.rs
@@ -134,7 +134,7 @@ pub struct If {
 pub struct For {
     /// May be a SConst, SLet, SVar, or SExpr
     pub init: Option<StmtNodeIndex>, // = None
-    pub test: Option<ExprNodeIndex>,  // = None
+    pub test: Option<ExprNodeIndex>,   // = None
     pub update: Option<ExprNodeIndex>, // = None
     pub body: StmtNodeIndex,
 }
@@ -174,7 +174,7 @@ pub struct Try {
     pub body_loc: crate::Loc,
     pub body: StmtNodeList,
 
-    pub catch: Option<Catch>,    // = None
+    pub catch: Option<Catch>,     // = None
     pub finally: Option<Finally>, // = None
 }
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -411,34 +411,34 @@ impl<'a> Parser<'a> {
         }
 
         if cmd == CommandTag::TestCommand {
-            if let Some(test_) = json.get(b"test") {
-                if let Some(root) = test_.get(b"root") {
+            if let Some(test) = json.get(b"test") {
+                if let Some(root) = test.get(b"root") {
                     self.ctx.debug.test_directory = root.as_string(self.bump).unwrap_or(b"").into();
                 }
 
-                if let Some(expr) = test_.get(b"preload") {
+                if let Some(expr) = test.get(b"preload") {
                     self.load_preload(&expr)?;
                 }
 
-                if let Some(expr) = test_.get(b"smol") {
+                if let Some(expr) = test.get(b"smol") {
                     self.expect(&expr, ExprTag::EBoolean)?;
                     self.ctx.runtime_options.smol =
                         expr.as_bool().expect("infallible: type checked");
                 }
 
-                if let Some(expr) = test_.get(b"coverage") {
+                if let Some(expr) = test.get(b"coverage") {
                     self.expect(&expr, ExprTag::EBoolean)?;
                     self.ctx.test_options.coverage.enabled =
                         expr.as_bool().expect("infallible: type checked");
                 }
 
-                if let Some(expr) = test_.get(b"onlyFailures") {
+                if let Some(expr) = test.get(b"onlyFailures") {
                     self.expect(&expr, ExprTag::EBoolean)?;
                     self.ctx.test_options.reporters.only_failures =
                         expr.as_bool().expect("infallible: type checked");
                 }
 
-                if let Some(expr) = test_.get(b"reporter") {
+                if let Some(expr) = test.get(b"reporter") {
                     self.expect(&expr, ExprTag::EObject)?;
                     if let Some(junit_expr) = expr.get(b"junit") {
                         self.expect_string(&junit_expr)?;
@@ -457,7 +457,7 @@ impl<'a> Parser<'a> {
                     }
                 }
 
-                if let Some(expr) = test_.get(b"coverageReporter") {
+                if let Some(expr) = test.get(b"coverageReporter") {
                     'brk: {
                         self.ctx.test_options.coverage.reporters = CoverageReporters {
                             text: false,
@@ -478,7 +478,7 @@ impl<'a> Parser<'a> {
                     }
                 }
 
-                if let Some(expr) = test_.get(b"coverageDir") {
+                if let Some(expr) = test.get(b"coverageDir") {
                     self.expect_string(&expr)?;
                     self.ctx.test_options.coverage.reports_directory = estring_to_owned(
                         expr.data
@@ -489,7 +489,7 @@ impl<'a> Parser<'a> {
                     );
                 }
 
-                if let Some(expr) = test_.get(b"coverageThreshold") {
+                if let Some(expr) = test.get(b"coverageThreshold") {
                     'outer: {
                         if let ExprData::ENumber(n) = expr.data {
                             let v = n.value();
@@ -523,13 +523,13 @@ impl<'a> Parser<'a> {
                 }
 
                 // This mostly exists for debugging.
-                if let Some(expr) = test_.get(b"coverageIgnoreSourcemaps") {
+                if let Some(expr) = test.get(b"coverageIgnoreSourcemaps") {
                     self.expect(&expr, ExprTag::EBoolean)?;
                     self.ctx.test_options.coverage.ignore_sourcemap =
                         expr.as_bool().expect("infallible: type checked");
                 }
 
-                if let Some(expr) = test_.get(b"coverageSkipTestFiles") {
+                if let Some(expr) = test.get(b"coverageSkipTestFiles") {
                     self.expect(&expr, ExprTag::EBoolean)?;
                     self.ctx.test_options.coverage.skip_test_files =
                         expr.as_bool().expect("infallible: type checked");
@@ -537,14 +537,14 @@ impl<'a> Parser<'a> {
 
                 let mut randomize_from_config: Option<bool> = None;
 
-                if let Some(expr) = test_.get(b"randomize") {
+                if let Some(expr) = test.get(b"randomize") {
                     self.expect(&expr, ExprTag::EBoolean)?;
                     randomize_from_config = expr.as_bool();
                     self.ctx.test_options.randomize =
                         expr.as_bool().expect("infallible: type checked");
                 }
 
-                if let Some(expr) = test_.get(b"seed") {
+                if let Some(expr) = test.get(b"seed") {
                     self.expect(&expr, ExprTag::ENumber)?;
                     let seed_value =
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
@@ -562,7 +562,7 @@ impl<'a> Parser<'a> {
                     self.ctx.test_options.seed = Some(seed_value);
                 }
 
-                if let Some(expr) = test_.get(b"rerunEach") {
+                if let Some(expr) = test.get(b"rerunEach") {
                     self.expect(&expr, ExprTag::ENumber)?;
                     if self.ctx.test_options.retry != 0 {
                         self.add_error(expr.loc, b"\"rerunEach\" cannot be used with \"retry\"")?;
@@ -572,7 +572,7 @@ impl<'a> Parser<'a> {
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }
 
-                if let Some(expr) = test_.get(b"retry") {
+                if let Some(expr) = test.get(b"retry") {
                     self.expect(&expr, ExprTag::ENumber)?;
                     if self.ctx.test_options.repeat_count != 0 {
                         self.add_error(expr.loc, b"\"retry\" cannot be used with \"rerunEach\"")?;
@@ -582,7 +582,7 @@ impl<'a> Parser<'a> {
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }
 
-                if let Some(expr) = test_.get(b"concurrentTestGlob") {
+                if let Some(expr) = test.get(b"concurrentTestGlob") {
                     match &expr.data {
                         ExprData::EString(s) => {
                             if s.len() == 0 {
@@ -634,7 +634,7 @@ impl<'a> Parser<'a> {
                     }
                 }
 
-                if let Some(expr) = test_.get(b"coveragePathIgnorePatterns") {
+                if let Some(expr) = test.get(b"coveragePathIgnorePatterns") {
                     'brk: {
                         match &expr.data {
                             ExprData::EString(s) => {
@@ -670,7 +670,7 @@ impl<'a> Parser<'a> {
                     }
                 }
 
-                if let Some(expr) = test_.get(b"pathIgnorePatterns") {
+                if let Some(expr) = test.get(b"pathIgnorePatterns") {
                     'brk: {
                         // Only skip if --path-ignore-patterns was explicitly passed via CLI
                         if self.ctx.test_options.path_ignore_patterns_from_cli {

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -256,12 +256,12 @@ impl VendorPrefix {
     /// Returns VendorPrefix::None if empty.
     #[inline]
     pub fn or_none(self) -> VendorPrefix {
-        self.or_(VendorPrefix::NONE)
+        self.or(VendorPrefix::NONE)
     }
 
     /// **WARNING**: NOT THE SAME as bitwise-or!!
     #[inline]
-    pub fn or_(self, other: VendorPrefix) -> VendorPrefix {
+    pub fn or(self, other: VendorPrefix) -> VendorPrefix {
         if self.is_empty() { other } else { self }
     }
 

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -2584,7 +2584,7 @@ impl NthSelectorData {
         })
     }
 
-    pub fn is_function(&self) -> bool {
+    pub fn is_function_(&self) -> bool {
         self.a != 0 || self.b != 1
     }
 

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -2584,7 +2584,7 @@ impl NthSelectorData {
         })
     }
 
-    pub fn is_function_(&self) -> bool {
+    pub fn is_function(&self) -> bool {
         self.a != 0 || self.b != 1
     }
 

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1613,8 +1613,8 @@ pub mod tocss_servo {
                 }
             }
             Component::Nth(nth_data) => {
-                nth_data.write_start(dest, nth_data.is_function())?;
-                if nth_data.is_function() {
+                nth_data.write_start(dest, nth_data.is_function_())?;
+                if nth_data.is_function_() {
                     nth_data.write_affine(dest)?;
                     dest.write_char(b')')?;
                 }

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -895,7 +895,7 @@ pub mod serialize {
                         dest.write_str(b":not(")?;
                     }
                     Component::Any { vendor_prefix, .. } => {
-                        let vp = dest.vendor_prefix.or_(*vendor_prefix);
+                        let vp = dest.vendor_prefix.or(*vendor_prefix);
                         if vp.contains(VendorPrefix::WEBKIT) || vp.contains(VendorPrefix::MOZ) {
                             dest.write_char(b':')?;
                             vp.to_css(dest)?;
@@ -1613,8 +1613,8 @@ pub mod tocss_servo {
                 }
             }
             Component::Nth(nth_data) => {
-                nth_data.write_start(dest, nth_data.is_function_())?;
-                if nth_data.is_function_() {
+                nth_data.write_start(dest, nth_data.is_function())?;
+                if nth_data.is_function() {
                     nth_data.write_affine(dest)?;
                     dest.write_char(b')')?;
                 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1207,7 +1207,7 @@ impl<'a> Parser<'a> {
         Ok(Some(self.value_buffer.as_slice()))
     }
 
-    fn _parse<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
+    fn parse<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
         &mut self,
         map: &mut Map,
     ) -> Result<(), AllocError> {
@@ -1236,7 +1236,7 @@ impl<'a> Parser<'a> {
         if !IS_PROCESS && EXPAND {
             // borrowck — index-based iteration: clone the value bytes, run
             // expansion against an immutable `&Map`, then write back via
-            // `values_mut()`. Values are dupe'd by `_parse` above, so length
+            // `values_mut()`. Values are dupe'd by `parse` above, so length
             // is bounded by file size.
             let total = map.map.count();
             let mut idx = count;
@@ -1272,7 +1272,7 @@ impl<'a> Parser<'a> {
             src: strings::without_utf8_bom(src),
             value_buffer,
         };
-        parser._parse::<OVERRIDE, IS_PROCESS, EXPAND>(map)
+        parser.parse::<OVERRIDE, IS_PROCESS, EXPAND>(map)
     }
 }
 

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -71,7 +71,7 @@ pub struct MiniEventLoop {
     // Raw pointer because the loop is C-owned
     // (created by `uws_get_loop`/`us_create_loop`) and outlives this struct.
     pub loop_: *mut UwsLoop,
-    pub file_polls_: Option<Box<FilePollStore>>,
+    pub file_polls: Option<Box<FilePollStore>>,
     /// Mutable; callers (shell spawn,
     /// `createNullDelimitedEnvMap`) write through it. Stored as `NonNull`
     /// (BACKREF) so [`EventLoopHandle::env`] can hand out a `*mut` with
@@ -239,14 +239,14 @@ impl MiniEventLoop {
     ///
     /// # Safety
     /// `this` must point to a live `MiniEventLoop`. Caller must not hold a
-    /// live `&mut` to `file_polls_` itself across this call. (Not eligible for
+    /// live `&mut` to `file_polls` itself across this call. (Not eligible for
     /// `unsafe-fn-narrow`: every unsafe op below derefs the caller-supplied
     /// `this`; the body cannot discharge that precondition.)
     pub unsafe fn file_polls_raw(this: *mut Self) -> *mut FilePollStore {
         // SAFETY: caller guarantees `this` points to a live `MiniEventLoop` (see fn `# Safety`);
-        // `addr_of_mut!` projects to `file_polls_` without forming `&mut Self`.
+        // `addr_of_mut!` projects to `file_polls` without forming `&mut Self`.
         unsafe {
-            let slot = core::ptr::addr_of_mut!((*this).file_polls_);
+            let slot = core::ptr::addr_of_mut!((*this).file_polls);
             if (*slot).is_none() {
                 slot.write(Some(Box::new(FilePollStore::init())));
             }
@@ -264,7 +264,7 @@ impl MiniEventLoop {
             tasks: Queue::init(),
             concurrent_tasks: ConcurrentTaskQueue::default(),
             loop_: UwsLoop::get(),
-            file_polls_: None,
+            file_polls: None,
             env: None,
             top_level_dir: Box::default(),
             after_event_loop_callback_ctx: None,

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -298,7 +298,7 @@ bun_output::declare_scope!(PackageManager, hidden);
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct PackageManager {
-    pub cache_directory_: Option<bun_sys::Dir>,
+    pub cache_directory: Option<bun_sys::Dir>,
     pub cache_directory_path: ZBox, // owned; process lifetime via the leaked singleton
     pub root_dir: &'static mut fs::DirEntry,
     // allocator dropped per §Allocators (was `bun.default_allocator`). For the
@@ -1855,7 +1855,7 @@ pub fn init(
             (*p).preallocated_resolve_tasks
         ));
 
-        wr!(cache_directory_, None);
+        wr!(cache_directory, None);
         wr!(cache_directory_path, ZBox::from_bytes(b""));
         wr!(options, options);
         wr!(
@@ -2281,7 +2281,7 @@ pub(crate) fn init_with_runtime_once(
             (*p).preallocated_resolve_tasks
         ));
 
-        wr!(cache_directory_, None);
+        wr!(cache_directory, None);
         wr!(cache_directory_path, ZBox::from_bytes(b""));
         wr!(
             options,

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -28,7 +28,7 @@ use super::{Command, Options, PackageManager, ProgressStrings, Subcommand};
 
 impl PackageManager {
     /// Borrowed view of the cached cache-directory fd. Returns `Fd` (not `Dir`)
-    /// because the descriptor is owned by `self.cache_directory_` — handing out
+    /// because the descriptor is owned by `self.cache_directory` — handing out
     /// an owning `Dir` would close the cached fd when the caller drops it.
     /// Callers that need `Dir` methods should use `Dir::borrow(&fd)`.
     #[inline]
@@ -68,7 +68,7 @@ impl PackageManager {
 // ───────────────────────────── cache directory ────────────────────────────────
 
 /// Returns a borrowed view (`Fd`) of the lazily-opened cache directory. The
-/// descriptor is owned by `PackageManager::cache_directory_` (closed only if
+/// descriptor is owned by `PackageManager::cache_directory` (closed only if
 /// the singleton is ever dropped). Callers must not close the returned `Fd`;
 /// use `Dir::borrow(&fd)` to call `&self` `Dir` methods on it.
 #[inline]
@@ -81,7 +81,7 @@ pub fn get_cache_directory(this: &mut PackageManager) -> Fd {
 /// Raw-pointer entry for callers that hold a disjoint `&mut this.manifests`
 /// borrow (see `PackageManifestMap::by_name_hash_allow_expired`). Never
 /// materializes a `&mut PackageManager` covering the whole struct — only the
-/// disjoint `cache_directory_`, `cache_directory_path`, `options.enable`, and
+/// disjoint `cache_directory`, `cache_directory_path`, `options.enable`, and
 /// `env` fields are projected, so an outstanding `&mut manifests` derived
 /// from the same provenance root stays valid under Stacked Borrows.
 ///
@@ -90,9 +90,9 @@ pub fn get_cache_directory(this: &mut PackageManager) -> Fd {
 /// caller must hold no live borrow that overlaps the fields listed above.
 #[inline]
 pub unsafe fn get_cache_directory_raw(this: *mut PackageManager) -> Fd {
-    // SAFETY: caller contract — `cache_directory_` is disjoint from any
+    // SAFETY: caller contract — `cache_directory` is disjoint from any
     // borrow the caller holds.
-    if let Some(d) = unsafe { (*this).cache_directory_.as_ref() } {
+    if let Some(d) = unsafe { (*this).cache_directory.as_ref() } {
         return d.fd();
     }
     // SAFETY: caller contract — `this` is valid and no live borrow overlaps
@@ -100,7 +100,7 @@ pub unsafe fn get_cache_directory_raw(this: *mut PackageManager) -> Fd {
     let d = unsafe { ensure_cache_directory(this) };
     let fd = d.fd();
     // SAFETY: as above; single writer.
-    unsafe { (*this).cache_directory_ = Some(d) };
+    unsafe { (*this).cache_directory = Some(d) };
     fd
 }
 

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -314,7 +314,7 @@ impl<'a> Task<'a> {
                         manifest.name.slice(),
                         loaded_manifest,
                         // SAFETY: see `manager` decl — short-lived `&mut` at call
-                        // boundary only (callee touches `cache_directory_` /
+                        // boundary only (callee touches `cache_directory` /
                         // `temporary_directory` lazily).
                         unsafe { &mut *manager },
                         is_extended_manifest,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2516,7 +2516,7 @@ impl<'a> StringBuilder<'a> {
         if SemverString::can_inline(slice) {
             return;
         }
-        self._count_with_hash(slice, SemverStringBuilder::string_hash(slice));
+        self.count_with_hash(slice, SemverStringBuilder::string_hash(slice));
     }
 
     #[inline]
@@ -2531,7 +2531,7 @@ impl<'a> StringBuilder<'a> {
     }
 
     #[inline]
-    fn _count_with_hash(&mut self, slice: &[u8], hash: u64) {
+    fn count_with_hash(&mut self, slice: &[u8], hash: u64) {
         self.assert_not_allocated();
 
         if !self.string_pool.contains(hash) {

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1275,7 +1275,7 @@ impl WindowsBufferedReader {
         MaxBuf::on_read_bytes(maxbuf, bytes_read as u64)
     }
 
-    fn _on_read_chunk(&mut self, buf: &[u8], has_more: ReadState) -> bool {
+    fn on_read_chunk(&mut self, buf: &[u8], has_more: ReadState) -> bool {
         if has_more == ReadState::Eof {
             self.flags.insert(WindowsFlags::RECEIVED_EOF);
         }
@@ -1902,7 +1902,7 @@ impl WindowsBufferedReader {
 
         let over_budget = self.charge_max_buffer(amount_result);
 
-        let should_continue = self._on_read_chunk(slice, has_more);
+        let should_continue = self.on_read_chunk(slice, has_more);
 
         // Streaming parents (shell IOReader, subprocess) cannot re-derive
         // `&mut Self` from inside the vtable callback to restart the pipe

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -833,7 +833,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn maybe_defined_helper(&mut self, identifier_expr: Expr) -> Result<Expr, crate::Error> {
         let p = self;
-        let test_ = Self::check_if_defined_helper(p, identifier_expr)?;
+        let test = Self::check_if_defined_helper(p, identifier_expr)?;
         let object_ref = p
             .find_symbol(bun_ast::Loc::EMPTY, b"Object")
             .expect("unreachable")
@@ -841,7 +841,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let yes = p.new_expr(E::Identifier::init(object_ref), bun_ast::Loc::EMPTY);
         Ok(p.new_expr(
             E::If {
-                test_,
+                test,
                 yes,
                 no: identifier_expr,
             },

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -466,7 +466,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::ExprData::ESpread(e) => self.rewrite_expr(&mut e.value, kind),
             js_ast::ExprData::EUnary(e) => self.rewrite_expr(&mut e.value, kind),
             js_ast::ExprData::EIf(e) => {
-                self.rewrite_expr(&mut e.test_, kind);
+                self.rewrite_expr(&mut e.test, kind);
                 self.rewrite_expr(&mut e.yes, kind);
                 self.rewrite_expr(&mut e.no, kind);
             }
@@ -541,9 +541,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 js_ast::StmtData::SThrow(data) => self.rewrite_expr(&mut data.value, kind),
                 js_ast::StmtData::SIf(data) => {
-                    let mut t = data.test_;
+                    let mut t = data.test;
                     self.rewrite_expr(&mut t, kind);
-                    data.test_ = t;
+                    data.test = t;
                     let mut yes = data.yes;
                     self.rewrite_stmts(core::slice::from_mut(&mut yes), kind);
                     data.yes = yes;
@@ -559,7 +559,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if let Some(fi) = &mut data.init {
                         self.rewrite_stmts(core::slice::from_mut(fi), kind);
                     }
-                    if let Some(t) = &mut data.test_ {
+                    if let Some(t) = &mut data.test {
                         self.rewrite_expr(t, kind);
                     }
                     if let Some(u) = &mut data.update {
@@ -586,25 +586,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     data.body = body;
                 }
                 js_ast::StmtData::SWhile(data) => {
-                    let mut t = data.test_;
+                    let mut t = data.test;
                     self.rewrite_expr(&mut t, kind);
-                    data.test_ = t;
+                    data.test = t;
                     let mut body = data.body;
                     self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
                     data.body = body;
                 }
                 js_ast::StmtData::SDoWhile(data) => {
-                    let mut t = data.test_;
+                    let mut t = data.test;
                     self.rewrite_expr(&mut t, kind);
-                    data.test_ = t;
+                    data.test = t;
                     let mut body = data.body;
                     self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
                     data.body = body;
                 }
                 js_ast::StmtData::SSwitch(data) => {
-                    let mut t = data.test_;
+                    let mut t = data.test;
                     self.rewrite_expr(&mut t, kind);
-                    data.test_ = t;
+                    data.test = t;
                     let cases = data.cases.slice_mut();
                     for case in cases.iter_mut() {
                         if let Some(v) = &mut case.value {
@@ -617,7 +617,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 js_ast::StmtData::STry(data) => {
                     let body = data.body.slice_mut();
                     self.rewrite_stmts(body, kind);
-                    if let Some(c) = &mut data.catch_ {
+                    if let Some(c) = &mut data.catch {
                         let cb = c.body.slice_mut();
                         self.rewrite_stmts(cb, kind);
                     }
@@ -819,9 +819,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.rewrite_private_accesses_in_expr(&mut e.value, map)
             }
             js_ast::ExprData::EIf(e) => {
-                let mut t = e.test_;
+                let mut t = e.test;
                 self.rewrite_private_accesses_in_expr(&mut t, map);
-                e.test_ = t;
+                e.test = t;
                 let mut y = e.yes;
                 self.rewrite_private_accesses_in_expr(&mut y, map);
                 e.yes = y;
@@ -959,9 +959,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
                 js_ast::StmtData::SIf(data) => {
-                    let mut t = data.test_;
+                    let mut t = data.test;
                     self.rewrite_private_accesses_in_expr(&mut t, map);
-                    data.test_ = t;
+                    data.test = t;
                     let mut yes = data.yes;
                     self.rewrite_private_accesses_in_stmts(core::slice::from_mut(&mut yes), map);
                     data.yes = yes;
@@ -977,7 +977,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if let Some(fi) = &mut data.init {
                         self.rewrite_private_accesses_in_stmts(core::slice::from_mut(fi), map);
                     }
-                    if let Some(t) = &mut data.test_ {
+                    if let Some(t) = &mut data.test {
                         self.rewrite_private_accesses_in_expr(t, map);
                     }
                     if let Some(u) = &mut data.update {
@@ -1004,25 +1004,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     data.body = body;
                 }
                 js_ast::StmtData::SWhile(data) => {
-                    let mut t = data.test_;
+                    let mut t = data.test;
                     self.rewrite_private_accesses_in_expr(&mut t, map);
-                    data.test_ = t;
+                    data.test = t;
                     let mut body = data.body;
                     self.rewrite_private_accesses_in_stmts(core::slice::from_mut(&mut body), map);
                     data.body = body;
                 }
                 js_ast::StmtData::SDoWhile(data) => {
-                    let mut t = data.test_;
+                    let mut t = data.test;
                     self.rewrite_private_accesses_in_expr(&mut t, map);
-                    data.test_ = t;
+                    data.test = t;
                     let mut body = data.body;
                     self.rewrite_private_accesses_in_stmts(core::slice::from_mut(&mut body), map);
                     data.body = body;
                 }
                 js_ast::StmtData::SSwitch(data) => {
-                    let mut t = data.test_;
+                    let mut t = data.test;
                     self.rewrite_private_accesses_in_expr(&mut t, map);
-                    data.test_ = t;
+                    data.test = t;
                     let cases = data.cases.slice_mut();
                     for case in cases.iter_mut() {
                         if let Some(v) = &mut case.value {
@@ -1035,7 +1035,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 js_ast::StmtData::STry(data) => {
                     let body = data.body.slice_mut();
                     self.rewrite_private_accesses_in_stmts(body, map);
-                    if let Some(c) = &mut data.catch_ {
+                    if let Some(c) = &mut data.catch {
                         let cb = c.body.slice_mut();
                         self.rewrite_private_accesses_in_stmts(cb, map);
                     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -896,7 +896,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 E::If {
                     yes: self.maybe_transpose_if_import(ex.yes, state),
                     no: self.maybe_transpose_if_import(ex.no, state),
-                    test_: ex.test_,
+                    test: ex.test,
                 },
                 arg.loc,
             ),
@@ -910,7 +910,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 E::If {
                     yes: self.maybe_transpose_if_require(ex.yes, state),
                     no: self.maybe_transpose_if_require(ex.no, state),
-                    test_: ex.test_,
+                    test: ex.test,
                 },
                 arg.loc,
             ),
@@ -927,7 +927,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             E::If {
                 yes: self.maybe_transpose_if_require(ex.yes, state),
                 no: self.maybe_transpose_if_require(ex.no, state),
-                test_: ex.test_,
+                test: ex.test,
             },
             arg.loc,
         )
@@ -939,7 +939,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 E::If {
                     yes: self.maybe_transpose_if_require_resolve(ex.yes, state),
                     no: self.maybe_transpose_if_require_resolve(ex.no, state),
-                    test_: ex.test_,
+                    test: ex.test,
                 },
                 arg.loc,
             ),
@@ -956,7 +956,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             E::If {
                 yes: self.maybe_transpose_if_require_resolve(ex.yes, state),
                 no: self.maybe_transpose_if_require_resolve(ex.no, state),
-                test_: ex.test_,
+                test: ex.test,
             },
             arg.loc,
         )
@@ -2077,10 +2077,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
                 js_ast::StmtData::SIf(mut if_stmt) => {
-                    break 'brk js_ast::StoreRef::from_bump(&mut if_stmt.test_);
+                    break 'brk js_ast::StoreRef::from_bump(&mut if_stmt.test);
                 }
                 js_ast::StmtData::SSwitch(mut switch_stmt) => {
-                    break 'brk js_ast::StoreRef::from_bump(&mut switch_stmt.test_);
+                    break 'brk js_ast::StoreRef::from_bump(&mut switch_stmt.test);
                 }
                 js_ast::StmtData::SLocal(mut local) => {
                     if local.decls.len_u32() > 0 {
@@ -2408,18 +2408,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 js_ast::ExprData::EIf(mut e) => {
                     match self.substitute_single_use_symbol_in_expr(
-                        e.test_,
+                        e.test,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
                         Substitution::Continue(_) => {}
                         Substitution::Success(result) => {
-                            e.test_ = result;
+                            e.test = result;
                             return Substitution::Success(expr);
                         }
                         Substitution::Failure(result) => {
-                            e.test_ = result;
+                            e.test = result;
                             return Substitution::Failure(expr);
                         }
                     }
@@ -5516,10 +5516,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 return true;
             }
             js_ast::ExprData::EIf(ex) => {
-                return self.expr_can_be_removed_if_unused_without_dce_check(&ex.test_)
-                    && (self.is_side_effect_free_unbound_identifier_ref(ex.yes, ex.test_, true)
+                return self.expr_can_be_removed_if_unused_without_dce_check(&ex.test)
+                    && (self.is_side_effect_free_unbound_identifier_ref(ex.yes, ex.test, true)
                         || self.expr_can_be_removed_if_unused_without_dce_check(&ex.yes))
-                    && (self.is_side_effect_free_unbound_identifier_ref(ex.no, ex.test_, false)
+                    && (self.is_side_effect_free_unbound_identifier_ref(ex.no, ex.test, false)
                         || self.expr_can_be_removed_if_unused_without_dce_check(&ex.no));
             }
             js_ast::ExprData::EArray(ex) => {
@@ -7186,7 +7186,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     E::If {
                         yes,
                         no: dots,
-                        test_: maybe_defined_dots,
+                        test: maybe_defined_dots,
                     },
                     bun_ast::Loc::EMPTY,
                 );
@@ -9207,7 +9207,7 @@ impl LowerUsingDeclarationsContext {
             S::Try {
                 body: non_exported_statements,
                 body_loc: loc,
-                catch_: Some(js_ast::Catch {
+                catch: Some(js_ast::Catch {
                     binding: Some(catch_binding),
                     body: catch_body,
                     body_loc: loc,

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -209,7 +209,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loop {
             p.lexer.next()?;
             p.lexer.expect(T::TOpenParen)?;
-            let test_ = p.parse_expr(Level::Lowest)?;
+            let test = p.parse_expr(Level::Lowest)?;
             p.lexer.expect(T::TCloseParen)?;
             let mut stmt_opts = ParseStatementOptions {
                 lexical_decl: LexicalDecl::AllowFnInsideIf,
@@ -220,7 +220,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Create the if node
             let if_stmt = p.s(
                 S::If {
-                    test_,
+                    test,
                     yes,
                     no: None,
                 },
@@ -277,7 +277,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let body = p.parse_stmt(&mut stmt_opts)?;
         p.lexer.expect(T::TWhile)?;
         p.lexer.expect(T::TOpenParen)?;
-        let test_ = p.parse_expr(Level::Lowest)?;
+        let test = p.parse_expr(Level::Lowest)?;
         p.lexer.expect(T::TCloseParen)?;
 
         // This is a weird corner case where automatic semicolon insertion applies
@@ -285,7 +285,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if p.lexer.token == T::TSemicolon {
             p.lexer.next()?;
         }
-        Ok(p.s(S::DoWhile { body, test_ }, loc))
+        Ok(p.s(S::DoWhile { body, test }, loc))
     }
 
     #[inline(never)]
@@ -293,13 +293,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.lexer.next()?;
 
         p.lexer.expect(T::TOpenParen)?;
-        let test_ = p.parse_expr(Level::Lowest)?;
+        let test = p.parse_expr(Level::Lowest)?;
         p.lexer.expect(T::TCloseParen)?;
 
         let mut stmt_opts = ParseStatementOptions::default();
         let body = p.parse_stmt(&mut stmt_opts)?;
 
-        Ok(p.s(S::While { body, test_ }, loc))
+        Ok(p.s(S::While { body, test }, loc))
     }
 
     #[cold]
@@ -307,7 +307,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn t_with(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
         p.lexer.next()?;
         p.lexer.expect(T::TOpenParen)?;
-        let test_ = p.parse_expr(Level::Lowest)?;
+        let test = p.parse_expr(Level::Lowest)?;
         let body_loc = p.lexer.loc();
         p.lexer.expect(T::TCloseParen)?;
 
@@ -323,7 +323,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             S::With {
                 body,
                 body_loc,
-                value: test_,
+                value: test,
             },
             loc,
         ))
@@ -334,7 +334,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.lexer.next()?;
 
         p.lexer.expect(T::TOpenParen)?;
-        let test_ = p.parse_expr(Level::Lowest)?;
+        let test = p.parse_expr(Level::Lowest)?;
         p.lexer.expect(T::TCloseParen)?;
 
         let body_loc = p.lexer.loc();
@@ -392,7 +392,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.expect(T::TCloseBrace)?;
             Ok(p.s(
                 S::Switch {
-                    test_,
+                    test,
                     body_loc,
                     cases: bun_ast::StoreSlice::from_bump(cases),
                 },
@@ -414,7 +414,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.pop_scope();
         p.lexer.next()?;
 
-        let mut catch_: Option<js_ast::Catch> = None;
+        let mut catch: Option<js_ast::Catch> = None;
         let mut finally: Option<js_ast::Finally> = None;
 
         if p.lexer.token == T::TCatch {
@@ -452,7 +452,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let stmts = p.parse_stmts_up_to(T::TCloseBrace, &mut stmt_opts)?;
             p.pop_scope();
             p.lexer.next()?;
-            catch_ = Some(js_ast::Catch {
+            catch = Some(js_ast::Catch {
                 loc: catch_loc,
                 binding,
                 body: bun_ast::StoreSlice::from_bump(stmts),
@@ -461,7 +461,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.pop_scope();
         }
 
-        if p.lexer.token == T::TFinally || catch_.is_none() {
+        if p.lexer.token == T::TFinally || catch.is_none() {
             let finally_loc = p.lexer.loc();
             let _ = p.push_scope_for_parse_pass(js_ast::scope::Kind::Block, finally_loc)?;
             p.lexer.expect(T::TFinally)?;
@@ -479,7 +479,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             S::Try {
                 body_loc,
                 body: bun_ast::StoreSlice::from_bump(body),
-                catch_,
+                catch,
                 finally,
             },
             loc,
@@ -519,7 +519,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.expect(T::TOpenParen)?;
 
             let mut init_: Option<Stmt> = None;
-            let mut test_: Option<Expr> = None;
+            let mut test: Option<Expr> = None;
             let mut update: Option<Expr> = None;
 
             // "in" expressions aren't allowed here
@@ -701,7 +701,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             p.lexer.expect(T::TSemicolon)?;
             if p.lexer.token != T::TSemicolon {
-                test_ = Some(p.parse_expr(Level::Lowest)?);
+                test = Some(p.parse_expr(Level::Lowest)?);
             }
 
             p.lexer.expect(T::TSemicolon)?;
@@ -716,7 +716,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             Ok(p.s(
                 S::For {
                     init: init_,
-                    test_,
+                    test,
                     update,
                     body,
                 },

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -432,7 +432,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // boxed arena slot: allocate first, then fill via DerefMut on StoreRef.
         let ternary = p.new_expr(
             E::If {
-                test_: prev,
+                test: prev,
                 yes: Expr::EMPTY,
                 no: Expr::EMPTY,
             },

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -188,14 +188,14 @@ impl SideEffects {
 
                 // "foo() ? 1 : 2" => "foo()"
                 if ternary.yes.is_empty() && ternary.no.is_empty() {
-                    return Self::simplify_unused_expr(p, ternary.test_);
+                    return Self::simplify_unused_expr(p, ternary.test);
                 }
 
                 // "foo() ? 1 : bar()" => "foo() || bar()"
                 if ternary.yes.is_empty() {
                     return Some(Expr::join_with_left_associative_op(
                         Op::Code::BinLogicalOr,
-                        ternary.test_,
+                        ternary.test,
                         ternary.no,
                     ));
                 }
@@ -204,7 +204,7 @@ impl SideEffects {
                 if ternary.no.is_empty() {
                     return Some(Expr::join_with_left_associative_op(
                         Op::Code::BinLogicalAnd,
-                        ternary.test_,
+                        ternary.test,
                         ternary.yes,
                     ));
                 }
@@ -666,7 +666,7 @@ impl SideEffects {
                 if Self::should_keep_stmts_in_dead_control_flow(try_stmt.body, bump) {
                     return true;
                 }
-                if let Some(catch_stmt) = &try_stmt.catch_ {
+                if let Some(catch_stmt) = &try_stmt.catch {
                     if Self::should_keep_stmts_in_dead_control_flow(catch_stmt.body, bump) {
                         return true;
                     }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1775,8 +1775,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let prev_stmt = output[prev_idx];
                         if let StmtData::SExpr(prev_expr) = prev_stmt.data {
                             if !prev_stmt.is_super_call() {
-                                s_switch.test_ =
-                                    Expr::join_with_comma(prev_expr.value, s_switch.test_);
+                                s_switch.test =
+                                    Expr::join_with_comma(prev_expr.value, s_switch.test);
                                 output.truncate(prev_idx);
                             }
                         }
@@ -1790,7 +1790,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let prev_stmt = output[prev_idx];
                         if let StmtData::SExpr(prev_expr) = prev_stmt.data {
                             if !prev_stmt.is_super_call() {
-                                s_if.test_ = Expr::join_with_comma(prev_expr.value, s_if.test_);
+                                s_if.test = Expr::join_with_comma(prev_expr.value, s_if.test);
                                 output.truncate(prev_idx);
                             }
                         }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1464,12 +1464,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let prev_in_branch = p.in_branch_condition;
         p.in_branch_condition = true;
-        p.visit_expr(&mut e_.test_);
+        p.visit_expr(&mut e_.test);
         p.in_branch_condition = prev_in_branch;
 
-        e_.test_ = SideEffects::simplify_boolean(p, e_.test_);
+        e_.test = SideEffects::simplify_boolean(p, e_.test);
 
-        let side_effects = SideEffects::to_boolean(p, &e_.test_.data);
+        let side_effects = SideEffects::to_boolean(p, &e_.test.data);
 
         if !side_effects.ok {
             p.visit_expr(&mut e_.yes);
@@ -1485,8 +1485,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.is_control_flow_dead = old;
 
                 if side_effects.side_effects == SideEffects::CouldHaveSideEffects {
-                    *e = SideEffects::simplify_unused_expr(p, e_.test_)
-                        .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test_.loc))
+                    *e = SideEffects::simplify_unused_expr(p, e_.test)
+                        .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test.loc))
                         .join_with_comma(e_.yes);
                     return;
                 }
@@ -1496,7 +1496,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
                 if is_call_target && e_.yes.has_value_for_this_in_call() {
                     *e = p
-                        .new_expr(E::Number::new(0.0), e_.test_.loc)
+                        .new_expr(E::Number::new(0.0), e_.test.loc)
                         .join_with_comma(e_.yes);
                     return;
                 }
@@ -1513,8 +1513,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 // "(a, false) ? b : c" => "a, c"
                 if side_effects.side_effects == SideEffects::CouldHaveSideEffects {
-                    *e = SideEffects::simplify_unused_expr(p, e_.test_)
-                        .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test_.loc))
+                    *e = SideEffects::simplify_unused_expr(p, e_.test)
+                        .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test.loc))
                         .join_with_comma(e_.no);
                     return;
                 }
@@ -1524,7 +1524,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
                 if is_call_target && e_.no.has_value_for_this_in_call() {
                     *e = p
-                        .new_expr(E::Number::new(0.0), e_.test_.loc)
+                        .new_expr(E::Number::new(0.0), e_.test.loc)
                         .join_with_comma(e_.no);
                     return;
                 }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1649,17 +1649,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::While,
     ) -> Result<(), Error> {
-        p.visit_expr(&mut data.test_);
+        p.visit_expr(&mut data.test);
         data.body = p.visit_loop_body(data.body);
 
-        data.test_ = SideEffects::simplify_boolean(p, data.test_);
-        let result = SideEffects::to_boolean(p, &data.test_.data);
+        data.test = SideEffects::simplify_boolean(p, data.test);
+        let result = SideEffects::to_boolean(p, &data.test.data);
         if result.ok && result.side_effects == SideEffects::NoSideEffects {
-            data.test_ = p.new_expr(
+            data.test = p.new_expr(
                 E::Boolean {
                     value: result.value,
                 },
-                data.test_.loc,
+                data.test.loc,
             );
         }
 
@@ -1674,9 +1674,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data: &mut S::DoWhile,
     ) -> Result<(), Error> {
         data.body = p.visit_loop_body(data.body);
-        p.visit_expr(&mut data.test_);
+        p.visit_expr(&mut data.test);
 
-        data.test_ = SideEffects::simplify_boolean(p, data.test_);
+        data.test = SideEffects::simplify_boolean(p, data.test);
         stmts.push(*stmt);
         Ok(())
     }
@@ -1689,14 +1689,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<(), Error> {
         let prev_in_branch = p.in_branch_condition;
         p.in_branch_condition = true;
-        p.visit_expr(&mut data.test_);
+        p.visit_expr(&mut data.test);
         p.in_branch_condition = prev_in_branch;
 
         if p.options.features.minify_syntax {
-            data.test_ = SideEffects::simplify_boolean(p, data.test_);
+            data.test = SideEffects::simplify_boolean(p, data.test);
         }
 
-        let effects = SideEffects::to_boolean(p, &data.test_.data);
+        let effects = SideEffects::to_boolean(p, &data.test.data);
         if effects.ok && !effects.value {
             let old = p.is_control_flow_dead;
             p.is_control_flow_dead = true;
@@ -1749,13 +1749,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     {
                         if effects.side_effects == SideEffects::CouldHaveSideEffects {
                             // Keep the condition if it could have side effects (but is still known to be truthy)
-                            if let Some(test_) = SideEffects::simplify_unused_expr(p, data.test_) {
+                            if let Some(test) = SideEffects::simplify_unused_expr(p, data.test) {
                                 stmts.push(p.s(
                                     S::SExpr {
-                                        value: test_,
+                                        value: test,
                                         ..Default::default()
                                     },
-                                    test_.loc,
+                                    test.loc,
                                 ));
                             }
                         }
@@ -1769,13 +1769,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if !SideEffects::should_keep_stmt_in_dead_control_flow(data.yes, p.arena) {
                         if effects.side_effects == SideEffects::CouldHaveSideEffects {
                             // Keep the condition if it could have side effects (but is still known to be truthy)
-                            if let Some(test_) = SideEffects::simplify_unused_expr(p, data.test_) {
+                            if let Some(test) = SideEffects::simplify_unused_expr(p, data.test) {
                                 stmts.push(p.s(
                                     S::SExpr {
-                                        value: test_,
+                                        value: test,
                                         ..Default::default()
                                     },
-                                    test_.loc,
+                                    test.loc,
                                 ));
                             }
                         }
@@ -1790,7 +1790,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             // TODO: more if statement syntax minification
-            let can_remove_test = p.expr_can_be_removed_if_unused(&data.test_);
+            let can_remove_test = p.expr_can_be_removed_if_unused(&data.test);
             match data.yes.data {
                 StmtData::SExpr(yes_expr) => {
                     if yes_expr.value.is_missing() {
@@ -1833,13 +1833,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             data.init = Some(p.visit_for_loop_init(initst, false));
         }
 
-        if let Some(mut test_) = data.test_ {
-            p.visit_expr(&mut test_);
-            data.test_ = Some(SideEffects::simplify_boolean(p, test_));
+        if let Some(mut test) = data.test {
+            p.visit_expr(&mut test);
+            data.test = Some(SideEffects::simplify_boolean(p, test));
 
-            let result = SideEffects::to_boolean(p, &data.test_.unwrap().data);
+            let result = SideEffects::to_boolean(p, &data.test.unwrap().data);
             if result.ok && result.value && result.side_effects == SideEffects::NoSideEffects {
-                data.test_ = None;
+                data.test = None;
             }
         }
 
@@ -2043,20 +2043,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         p.pop_scope();
 
-        if let Some(catch_) = &mut data.catch_ {
-            p.push_scope_for_visit_pass(js_ast::scope::Kind::CatchBinding, catch_.loc)
+        if let Some(catch) = &mut data.catch {
+            p.push_scope_for_visit_pass(js_ast::scope::Kind::CatchBinding, catch.loc)
                 .expect("unreachable");
             {
-                if let Some(catch_binding) = catch_.binding {
+                if let Some(catch_binding) = catch.binding {
                     p.visit_binding(catch_binding, None);
                 }
-                let mut _stmts = stmts_to_list(p.arena, catch_.body);
-                p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, catch_.body_loc)
+                let mut _stmts = stmts_to_list(p.arena, catch.body);
+                p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, catch.body_loc)
                     .expect("unreachable");
                 p.visit_stmts(&mut _stmts, StmtsKind::None)
                     .expect("unreachable");
                 p.pop_scope();
-                catch_.body = list_to_stmts(_stmts);
+                catch.body = list_to_stmts(_stmts);
             }
             p.pop_scope();
         }
@@ -2083,7 +2083,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::Switch,
     ) -> Result<(), Error> {
-        p.visit_expr(&mut data.test_);
+        p.visit_expr(&mut data.test);
         let mut lowered_using = false;
         {
             p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, data.body_loc)

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3458,7 +3458,7 @@ pub mod __gated_printer {
                         self.print(b"(");
                         flags.remove(ExprFlag::ForbidIn);
                     }
-                    self.print_expr(e.test_, Level::Conditional, flags);
+                    self.print_expr(e.test, Level::Conditional, flags);
                     self.print_space();
                     self.print(b"?");
                     self.print_space();
@@ -5561,7 +5561,7 @@ pub mod __gated_printer {
                     self.print(b"while");
                     self.print_space();
                     self.print(b"(");
-                    self.print_expr(s.test_, Level::Lowest, ExprFlag::none());
+                    self.print_expr(s.test, Level::Lowest, ExprFlag::none());
                     self.print(b")");
                     self.print_semicolon_after_statement();
                 }
@@ -5608,7 +5608,7 @@ pub mod __gated_printer {
                     self.print(b"while");
                     self.print_space();
                     self.print(b"(");
-                    self.print_expr(s.test_, Level::Lowest, ExprFlag::none());
+                    self.print_expr(s.test, Level::Lowest, ExprFlag::none());
                     self.print(b")");
                     self.print_body(s.body, tlmtlo.sub_var());
                 }
@@ -5642,18 +5642,18 @@ pub mod __gated_printer {
                     let sub_var_try = tlmtlo.sub_var();
                     self.print_block(s.body_loc, slice_of(s.body), None, sub_var_try);
 
-                    if let Some(catch_) = &s.catch_ {
+                    if let Some(catch) = &s.catch {
                         self.print_space();
-                        self.add_source_mapping(catch_.loc);
+                        self.add_source_mapping(catch.loc);
                         self.print(b"catch");
-                        if let Some(binding) = &catch_.binding {
+                        if let Some(binding) = &catch.binding {
                             self.print_space();
                             self.print(b"(");
                             self.print_binding(*binding, TopLevelAndIsExport::default());
                             self.print(b")");
                         }
                         self.print_space();
-                        self.print_block(catch_.body_loc, slice_of(catch_.body), None, sub_var_try);
+                        self.print_block(catch.body_loc, slice_of(catch.body), None, sub_var_try);
                     }
 
                     if let Some(finally) = &s.finally {
@@ -5679,8 +5679,8 @@ pub mod __gated_printer {
 
                     self.print(b";");
 
-                    if let Some(test_) = &s.test_ {
-                        self.print_expr(*test_, Level::Lowest, ExprFlag::none());
+                    if let Some(test) = &s.test {
+                        self.print_expr(*test, Level::Lowest, ExprFlag::none());
                     }
 
                     self.print(b";");
@@ -5700,7 +5700,7 @@ pub mod __gated_printer {
                     self.print(b"switch");
                     self.print_space();
                     self.print(b"(");
-                    self.print_expr(s.test_, Level::Lowest, ExprFlag::none());
+                    self.print_expr(s.test, Level::Lowest, ExprFlag::none());
                     self.print(b")");
                     self.print_space();
                     self.print(b"{");
@@ -6281,7 +6281,7 @@ pub mod __gated_printer {
             self.print(b"if");
             self.print_space();
             self.print(b"(");
-            self.print_expr(s.test_, Level::Lowest, ExprFlag::none());
+            self.print_expr(s.test, Level::Lowest, ExprFlag::none());
             self.print(b")");
 
             match &s.yes.data {

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -115,7 +115,7 @@ fn find_path_inner(
     errorable.unwrap().ok()
 }
 
-pub fn _stat(path: &[u8]) -> i32 {
+pub fn stat(path: &[u8]) -> i32 {
     // PERF: `exists_at_type`
     // takes a `&ZStr`, so we copy into a NUL-terminated heap buffer here.
     let zpath = bun_core::ZBox::from_bytes(path);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1842,7 +1842,7 @@ bun_io::link_impl_EventLoopCtx! {
         platform_event_loop_ptr() => vm_from_owner(this.cast()).uws_loop(),
         file_polls_ptr() => {
             let rare = vm_from_owner(this.cast()).rare_data();
-            &raw mut **rare.file_polls_.get_or_insert_with(|| Box::new(bun_io::Store::init()))
+            &raw mut **rare.file_polls.get_or_insert_with(|| Box::new(bun_io::Store::init()))
         },
         // CROSS-THREAD: reached via `KeepAlive::unref_on_next_tick_concurrently`.
         // Do NOT route through `vm_from_owner()` — that mints `&mut VM`, which

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1306,7 +1306,7 @@ bun_event_loop::link_impl_JsEventLoop! {
                 .vm_ref()
                 .as_mut()
                 .rare_data()
-                .file_polls_
+                .file_polls
                 .get_or_insert_with(|| Box::new(Async::file_poll::Store::init()))
                 .as_mut(),
         ),
@@ -1319,7 +1319,7 @@ bun_event_loop::link_impl_JsEventLoop! {
                     .vm_ref()
                     .as_mut()
                     .rare_data()
-                    .file_polls_
+                    .file_polls
                     .get_or_insert_with(|| Box::new(Async::file_poll::Store::init()))
                     .as_mut(),
             );

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -779,7 +779,7 @@ pub struct WindowsWrite {
 #[cfg(windows)]
 impl WindowsWrite {
     pub fn destroy(this: *mut WindowsWrite) {
-        // SAFETY: `this` was produced by heap::alloc in SendQueue::_write;
+        // SAFETY: `this` was produced by heap::alloc in SendQueue::write;
         // libuv guarantees the write callback fires exactly once.
         let _ = unsafe { bun_core::heap::take(this) };
         // write_slice freed by Box<[u8]> Drop.
@@ -791,8 +791,8 @@ impl WindowsWrite {
 pub struct WindowsState {
     pub is_server: bool,
     /// Non-owning raw pointer. The allocation
-    /// is `heap::alloc`'d in `_write` and freed exactly once by
-    /// `_windows_on_write_complete` via `WindowsWrite::destroy`. Nulling this
+    /// is `heap::alloc`'d in `write` and freed exactly once by
+    /// `windows_on_write_complete` via `WindowsWrite::destroy`. Nulling this
     /// field never frees.
     pub windows_write: Option<*mut WindowsWrite>,
     pub try_close_after_write: bool,
@@ -959,7 +959,7 @@ impl SendQueue {
                         self.windows.try_close_after_write = true;
                     } else {
                         log!("SendQueue#closeSocket -> close now");
-                        self._windows_close();
+                        self.windows_close();
                     }
                 }
                 #[cfg(not(windows))]
@@ -968,24 +968,24 @@ impl SendQueue {
                         CloseReason::Normal => bun_uws::CloseCode::Normal,
                         CloseReason::Failure => bun_uws::CloseCode::Failure,
                     });
-                    self._socket_closed();
+                    self.socket_closed();
                 }
             }
             _ => {
-                self._socket_closed();
+                self.socket_closed();
             }
         }
         let _ = reason; // suppress unused on windows
     }
 
-    fn _socket_closed(&mut self) {
+    fn socket_closed(&mut self) {
         log!("SendQueue#_socketClosed");
         #[cfg(windows)]
         {
             if let Some(windows_write) = self.windows.windows_write {
                 // SAFETY: `windows_write` was leaked via `heap::alloc` in
-                // `_write`; libuv still holds it and will free it in
-                // `_windows_on_write_complete`. We only clear the backref so
+                // `write`; libuv still holds it and will free it in
+                // `windows_on_write_complete`. We only clear the backref so
                 // the callback doesn't touch a dead `SendQueue`.
                 unsafe { (*windows_write).owner = None };
             }
@@ -1003,7 +1003,7 @@ impl SendQueue {
             // Note: `bun_event_loop::JsResult` erases the error to `*mut ()`;
             // adapt the jsc-crate `JsResult` via a non-capturing closure (coerces to fn ptr).
             let task = ManagedTask::new(std::ptr::from_mut::<SendQueue>(self), |p| {
-                let _ = Self::_on_after_ipc_closed(p);
+                let _ = Self::on_after_ipc_closed(p);
                 Ok(())
             });
             self.after_close_task = Some(task);
@@ -1021,7 +1021,7 @@ impl SendQueue {
     }
 
     #[cfg(windows)]
-    fn _windows_close(&mut self) {
+    fn windows_close(&mut self) {
         log!("SendQueue#_windowsClose");
         let SocketUnion::Open(pipe) = self.socket else {
             return;
@@ -1029,15 +1029,13 @@ impl SendQueue {
         // SAFETY: pipe is live until the close cb fires.
         unsafe {
             (*pipe).data = pipe.cast();
-            (*pipe).close(Self::_windows_on_closed);
+            (*pipe).close(Self::windows_on_closed);
         }
-        self._socket_closed();
+        self.socket_closed();
     }
-    #[cfg(not(windows))]
-    fn _windows_close(&mut self) {}
 
     #[cfg(windows)]
-    extern "C" fn _windows_on_closed(windows: *mut uv::Pipe) {
+    extern "C" fn windows_on_closed(windows: *mut uv::Pipe) {
         log!("SendQueue#_windowsOnClosed");
         // SAFETY: pipe was heap-allocated in windowsConfigureClient / created by caller.
         let _ = unsafe { bun_core::heap::take(windows) };
@@ -1056,9 +1054,9 @@ impl SendQueue {
             self.close_socket(CloseReason::Normal, CloseFrom::User);
             return;
         }
-        // Note: see `_socket_closed` — adapt `bun_event_loop::JsResult` via closure.
+        // Note: see `socket_closed` — adapt `bun_event_loop::JsResult` via closure.
         let task = ManagedTask::new(std::ptr::from_mut::<SendQueue>(self), |p| {
-            let _ = Self::_close_socket_task(p);
+            let _ = Self::close_socket_task(p);
             Ok(())
         });
         self.close_next_tick = Some(task);
@@ -1069,7 +1067,7 @@ impl SendQueue {
             .enqueue_task(self.close_next_tick.unwrap());
     }
 
-    fn _close_socket_task(this: *mut SendQueue) -> JsResult<()> {
+    fn close_socket_task(this: *mut SendQueue) -> JsResult<()> {
         // SAFETY: `this` was the live `*mut SendQueue` passed to ManagedTask::new;
         // the task is cancelled in Drop before the storage is freed.
         let this = unsafe { &mut *this };
@@ -1080,8 +1078,8 @@ impl SendQueue {
         Ok(())
     }
 
-    fn _on_after_ipc_closed(this: *mut SendQueue) -> JsResult<()> {
-        // SAFETY: see _close_socket_task.
+    fn on_after_ipc_closed(this: *mut SendQueue) -> JsResult<()> {
+        // SAFETY: see close_socket_task.
         let this = unsafe { &mut *this };
         log!("SendQueue#_onAfterIPCClosed");
         this.after_close_task = None;
@@ -1275,14 +1273,14 @@ impl SendQueue {
         debug_assert!(!self.write_in_progress);
         self.write_in_progress = true;
         let fd = self.queue[0].handle.as_ref().map(|h| h.fd);
-        // `_write` re-slices `self.queue[0]` internally so we never hand a
+        // `write` re-slices `self.queue[0]` internally so we never hand a
         // borrow of `self` into a `&mut self` method (PORTING.md aliased-&mut).
-        self._write(fd);
+        self.write(fd);
         // the write is queued. this._onWriteComplete() will be called when the write completes.
         self.update_ref(global);
     }
 
-    fn _on_write_complete(&mut self, n: i32) {
+    fn on_write_complete(&mut self, n: i32) {
         log!("SendQueue#_onWriteComplete {}", n);
         self.debug_log_message_queue();
         if !self.write_in_progress || self.queue.is_empty() {
@@ -1421,9 +1419,9 @@ impl SendQueue {
     /// The outbound bytes are read from `self.queue[0]` *inside* this method so
     /// the caller never passes a slice that borrows `self` into a `&mut self`
     /// receiver (which would violate Stacked Borrows).
-    fn _write(&mut self, fd: Option<Fd>) {
+    fn write(&mut self, fd: Option<Fd>) {
         if self.get_socket().is_none() {
-            self._on_write_complete(-1);
+            self.on_write_complete(-1);
             return;
         }
         #[cfg(windows)]
@@ -1440,7 +1438,7 @@ impl SendQueue {
             let write_req_slice: Box<[u8]> = {
                 let first = &self.queue[0];
                 let data = &first.data.list[first.data.cursor..];
-                log!("SendQueue#_write len {}", data.len());
+                log!("SendQueue#write len {}", data.len());
                 let write_len = data.len().min(i32::MAX as usize);
                 Box::from(&data[0..write_len])
             };
@@ -1454,7 +1452,7 @@ impl SendQueue {
             });
             write_req.write_buffer = uv::uv_buf_t::init(&write_req.write_slice);
             // Hand ownership to libuv; reclaimed exactly once by
-            // `_windows_on_write_complete` via `WindowsWrite::destroy`.
+            // `windows_on_write_complete` via `WindowsWrite::destroy`.
             let write_req: *mut WindowsWrite = bun_core::heap::into_raw(write_req);
             debug_assert!(self.windows.windows_write.is_none());
             self.windows.windows_write = Some(write_req);
@@ -1471,28 +1469,28 @@ impl SendQueue {
                     // `write()` stores a *Rust* fn pointer (`fn(*mut T, ReturnCode)`)
                     // and thunks it through libuv. The callback receives the
                     // raw `*mut WindowsWrite` (NOT `&mut`) because
-                    // `_windows_on_write_complete` deallocates the request via
+                    // `windows_on_write_complete` deallocates the request via
                     // `WindowsWrite::destroy`; holding a live `&mut WindowsWrite`
                     // across that free would dangle the reference (UB) and the
                     // `Box::from_raw` would carry the `&mut`-reborrow tag instead
                     // of the original allocation root.
-                    |req: *mut WindowsWrite, rc| SendQueue::_windows_on_write_complete(req, rc),
+                    |req: *mut WindowsWrite, rc| SendQueue::windows_on_write_complete(req, rc),
                 )
             };
             if result.to_error(bun_sys::Tag::write).is_some() {
-                // Synchronous-error path: do NOT call `_windows_on_write_complete`
+                // Synchronous-error path: do NOT call `windows_on_write_complete`
                 // here — that helper rebuilds `&mut SendQueue` from the raw
                 // `write_req.owner` backref, which would alias the `&mut self`
                 // already live in this frame (and in `continue_send` above it).
                 // Inline the same cleanup through `self` instead. The async
-                // libuv-callback path still uses `_windows_on_write_complete`
+                // libuv-callback path still uses `windows_on_write_complete`
                 // (sound there: no `&mut self` is live when libuv fires it).
                 WindowsWrite::destroy(write_req);
                 self.windows.windows_write = None;
                 // SAFETY: pipe is live (socket == .open); pairs with the
                 // `(*pipe).ref_()` above.
                 unsafe { (*pipe).unref() };
-                self._on_write_complete(-1);
+                self.on_write_complete(-1);
                 if self.windows.try_close_after_write {
                     self.close_socket(CloseReason::Normal, CloseFrom::User);
                 }
@@ -1504,24 +1502,24 @@ impl SendQueue {
         {
             let socket = *self.get_socket().unwrap();
             // Compute the write result while only holding a *shared* borrow of
-            // `self.queue[0]`; `_on_write_complete` (which may pop the queue)
+            // `self.queue[0]`; `on_write_complete` (which may pop the queue)
             // runs after that borrow has ended.
             let n: i32 = {
                 let first = &self.queue[0];
                 let data = &first.data.list[first.data.cursor..];
-                log!("SendQueue#_write len {}", data.len());
+                log!("SendQueue#write len {}", data.len());
                 if let Some(fd_unwrapped) = fd {
                     socket.write_fd(data, fd_unwrapped.native())
                 } else {
                     socket.write(data)
                 }
             };
-            self._on_write_complete(n);
+            self.on_write_complete(n);
         }
     }
 
     #[cfg(windows)]
-    fn _windows_on_write_complete(write_req: *mut WindowsWrite, status: uv::ReturnCode) {
+    fn windows_on_write_complete(write_req: *mut WindowsWrite, status: uv::ReturnCode) {
         log!("SendQueue#_windowsOnWriteComplete");
         // SAFETY: write_req was passed to uv_write as the data ptr; libuv hands it back here.
         // Explicit `&` so the slice `.len()` autoref doesn't trigger
@@ -1535,7 +1533,7 @@ impl SendQueue {
                 None => return, // orelse case if disconnected before the write completes
             }
         };
-        // SAFETY: owner is a BACKREF into the live SendQueue (cleared in _socket_closed if not).
+        // SAFETY: owner is a BACKREF into the live SendQueue (cleared in socket_closed if not).
         let this: &mut SendQueue = unsafe { &mut *this };
 
         let vm = VirtualMachine::get();
@@ -1546,13 +1544,13 @@ impl SendQueue {
         this.windows.windows_write = None;
         if let Some(socket) = this.get_socket() {
             // SAFETY: `get_socket()` -> `&*mut uv::Pipe`; double-deref reaches the
-            // live `uv_pipe_t` place (matches the `(*pipe).ref_()` site in `_write`).
+            // live `uv_pipe_t` place (matches the `(*pipe).ref_()` site in `write`).
             unsafe { (**socket).unref() }; // write complete; unref
         }
         if status.to_error(bun_sys::Tag::write).is_some() {
-            this._on_write_complete(-1);
+            this.on_write_complete(-1);
         } else {
-            this._on_write_complete(i32::try_from(write_len).expect("int cast"));
+            this.on_write_complete(i32::try_from(write_len).expect("int cast"));
         }
 
         if this.windows.try_close_after_write {
@@ -2058,7 +2056,7 @@ pub mod IPCHandlers {
         pub fn on_close(send_queue: &mut SendQueue, _: Socket, _: c_int, _: Option<*mut c_void>) {
             // uSockets has already freed the underlying socket
             log!("NewSocketIPCHandler#onClose\n");
-            send_queue._socket_closed();
+            send_queue.socket_closed();
         }
 
         pub fn on_data(send_queue: &mut SendQueue, _: Socket, all_data: &[u8]) {
@@ -2270,7 +2268,7 @@ pub mod IPCHandlers {
             // wired into readStart), but route through `_socketClosed` so any
             // future wiring tracks the `_onAfterIPCClosed` task for `deinit`
             // to cancel, matching every other close path.
-            send_queue._socket_closed();
+            send_queue.socket_closed();
         }
     }
 }

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -220,7 +220,7 @@ pub struct RareData {
     // This does not handle ShadowRealm correctly!
     pub cleanup_hooks: Vec<CleanupHook>,
 
-    pub file_polls_: Option<Box<FilePollStore>>,
+    pub file_polls: Option<Box<FilePollStore>>,
 
     /// Embedded socket groups for kinds that aren't tied to a Listener / server.
     /// Lazily linked into the loop on first socket; never separately allocated.
@@ -308,7 +308,7 @@ impl Default for RareData {
             hot_map: None,
             cron_jobs: Vec::new(),
             cleanup_hooks: Vec::new(),
-            file_polls_: None,
+            file_polls: None,
             spawn_ipc_group: SocketGroup::default(),
             test_parallel_ipc_group: SocketGroup::default(),
             bun_connect_group_tcp: SocketGroup::default(),

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -636,9 +636,9 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         };
 
         let mut this = Self::init();
-        // top_level_dir is &[u8]; `_buf_append_input` routes it through
+        // top_level_dir is &[u8]; `buf_append_input` routes it through
         // `append_other` (transcoding) when U == u16.
-        this._buf_append_input(trimmed, false);
+        this.buf_append_input(trimmed, false);
         this
     }
 
@@ -659,10 +659,10 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
 
         #[cfg(windows)]
         {
-            this._buf_append_input(crate::windows::long_path_prefix_for::<U>(), false);
+            this.buf_append_input(crate::windows::long_path_prefix_for::<U>(), false);
         }
 
-        this._buf_append_input(trimmed, false);
+        this.buf_append_input(trimmed, false);
 
         this
     }
@@ -777,10 +777,10 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         let mut this = Self::init();
         #[cfg(windows)]
         {
-            this._buf_append_input(crate::windows::long_path_prefix_for::<U>(), false);
+            this.buf_append_input(crate::windows::long_path_prefix_for::<U>(), false);
         }
 
-        this._buf_append_input(trimmed, false);
+        this.buf_append_input(trimmed, false);
         Ok(this)
     }
 
@@ -811,7 +811,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         }
 
         let mut this = Self::init();
-        this._buf_append_input(trimmed, false);
+        this.buf_append_input(trimmed, false);
         Ok(this)
     }
 
@@ -962,7 +962,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
                     }
                 }
 
-                self._buf_append_input(trimmed, needs_sep);
+                self.buf_append_input(trimmed, needs_sep);
             }
             Kind::Rel => {
                 debug_assert!(!is_input_absolute(input));
@@ -979,7 +979,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
                     }
                 }
 
-                self._buf_append_input(trimmed, needs_sep);
+                self.buf_append_input(trimmed, needs_sep);
             }
             Kind::Any => {
                 let input_is_absolute = is_input_absolute(input);
@@ -1014,7 +1014,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
                     }
                 }
 
-                self._buf_append_input(trimmed, needs_sep);
+                self.buf_append_input(trimmed, needs_sep);
             }
         }
         Ok(())
@@ -1241,7 +1241,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
 
     /// Dispatch `Buf::append` / `Buf::append_other` based on whether the input
     /// element type matches `U`.
-    fn _buf_append_input<C: PathUnit>(&mut self, characters: &[C], add_separator: bool) {
+    fn buf_append_input<C: PathUnit>(&mut self, characters: &[C], add_separator: bool) {
         use core::any::TypeId;
         // Route via concrete `u8`/`u16` using the safe trait-dispatched
         // identity casts (`id_u8`/`id_from_u8` etc.) — each is the literal

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1665,11 +1665,11 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
     _parts: &[&[u8]],
 ) -> &'a [u8] {
     if P::P == Platform::Windows || (cfg!(windows) && P::P == Platform::Loose) {
-        return _join_abs_string_buf_windows::<IS_SENTINEL>(_cwd, buf, _parts);
+        return join_abs_string_buf_windows::<IS_SENTINEL>(_cwd, buf, _parts);
     }
 
     if P::P == Platform::Nt {
-        let end_path = _join_abs_string_buf_windows::<IS_SENTINEL>(_cwd, &mut buf[4..], _parts);
+        let end_path = join_abs_string_buf_windows::<IS_SENTINEL>(_cwd, &mut buf[4..], _parts);
         let end_len = end_path.len();
         buf[0..4].copy_from_slice(b"\\\\?\\");
         if IS_SENTINEL {
@@ -1778,7 +1778,7 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
     &buf[0..result_len + leading_len]
 }
 
-fn _join_abs_string_buf_windows<'a, const IS_SENTINEL: bool>(
+fn join_abs_string_buf_windows<'a, const IS_SENTINEL: bool>(
     cwd: &'a [u8],
     buf: &'a mut [u8],
     parts: &[&[u8]],

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -334,7 +334,7 @@ pub fn codegen_function(
             );
             let instrument_call = Stmt::alloc(
                 S::If {
-                    test_: if_test,
+                    test: if_test,
                     yes: expr_stmt(call, Loc::EMPTY),
                     no: None,
                 },
@@ -829,7 +829,7 @@ fn codegen_reactive_scope(
 
     let memo_stmt = Stmt::alloc(
         S::If {
-            test_: test_condition,
+            test: test_condition,
             yes,
             no,
         },
@@ -852,7 +852,7 @@ fn codegen_reactive_scope(
         let name_expr = Expr::init_identifier(cx.ref_for_id(early_return.value)?, loc);
         statements.push(Stmt::alloc(
             S::If {
-                test_: Expr::init(
+                test: Expr::init(
                     E::Binary {
                         op: OpCode::BinStrictNe,
                         left: name_expr,
@@ -963,7 +963,7 @@ fn codegen_terminal(
             };
             Ok(Some(Stmt::alloc(
                 S::If {
-                    test_: test_expr,
+                    test: test_expr,
                     yes: body_stmt(consequent_block, stmt_loc),
                     no: alternate_stmt,
                 },
@@ -1000,7 +1000,7 @@ fn codegen_terminal(
             }
             Ok(Some(Stmt::alloc(
                 S::Switch {
-                    test_: test_expr,
+                    test: test_expr,
                     body_loc: stmt_loc,
                     cases: StoreSlice::new_mut(switch_cases.leak()),
                 },
@@ -1019,7 +1019,7 @@ fn codegen_terminal(
             Ok(Some(Stmt::alloc(
                 S::DoWhile {
                     body: body_stmt(body, stmt_loc),
-                    test_: test_expr,
+                    test: test_expr,
                 },
                 stmt_loc,
             )))
@@ -1035,7 +1035,7 @@ fn codegen_terminal(
             let body = codegen_block(cx, loop_block)?;
             Ok(Some(Stmt::alloc(
                 S::While {
-                    test_: test_expr,
+                    test: test_expr,
                     body: body_stmt(body, stmt_loc),
                 },
                 stmt_loc,
@@ -1060,7 +1060,7 @@ fn codegen_terminal(
             Ok(Some(Stmt::alloc(
                 S::For {
                     init: init_val,
-                    test_: Some(test_expr),
+                    test: Some(test_expr),
                     update: update_expr,
                     body: body_stmt(body, stmt_loc),
                 },
@@ -1107,7 +1107,7 @@ fn codegen_terminal(
                 S::Try {
                     body_loc: stmt_loc,
                     body: leak_stmts(try_block),
-                    catch_: Some(Catch {
+                    catch: Some(Catch {
                         loc: stmt_loc,
                         binding: catch_param,
                         body: leak_stmts(handler_block),
@@ -1722,7 +1722,7 @@ fn codegen_instruction_value(
             let alt_expr = codegen_instruction_value_to_expression(cx, alternate)?;
             Ok(Expr::init(
                 E::If {
-                    test_: test_expr,
+                    test: test_expr,
                     yes: cons_expr,
                     no: alt_expr,
                 },
@@ -3494,7 +3494,7 @@ fn wrap_hook_call_with_guard(guard_ref: Ref, call_expr: Expr, before: u32, after
                     loc,
                 ),
             ]),
-            catch_: None,
+            catch: None,
             finally: Some(Finally {
                 loc,
                 stmts: leak_stmts(vec![guard_call(after)]),
@@ -3554,7 +3554,7 @@ fn create_function_body_hook_guard(
         S::Try {
             body_loc: loc,
             body: leak_stmts(try_body),
-            catch_: None,
+            catch: None,
             finally: Some(Finally {
                 loc,
                 stmts: leak_stmts(vec![guard_call(after)]),

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -584,7 +584,7 @@ fn lower_conditional(
         test_block,
     );
 
-    let test_place = lower_expression_to_temporary(builder, &cond.test_)?;
+    let test_place = lower_expression_to_temporary(builder, &cond.test)?;
     builder.terminate_with_continuation(
         Terminal::Branch {
             test: test_place,
@@ -1346,7 +1346,7 @@ fn is_reorderable_expression(
             _ => false,
         },
         Data::EIf(cond) => {
-            is_reorderable_expression(builder, &cond.test_, allow_local_identifiers)
+            is_reorderable_expression(builder, &cond.test, allow_local_identifiers)
                 && is_reorderable_expression(builder, &cond.yes, allow_local_identifiers)
                 && is_reorderable_expression(builder, &cond.no, allow_local_identifiers)
         }

--- a/src/react_compiler/lowering/build_hir/mod.rs
+++ b/src/react_compiler/lowering/build_hir/mod.rs
@@ -589,7 +589,7 @@ impl<'h> CaptureWalker<'h> {
             }
             StmtData::SThrow(t) => self.walk_expr(&t.value),
             StmtData::SIf(i) => {
-                self.walk_expr(&i.test_);
+                self.walk_expr(&i.test);
                 self.walk_stmt(&i.yes);
                 if let Some(no) = &i.no {
                     self.walk_stmt(no);
@@ -600,7 +600,7 @@ impl<'h> CaptureWalker<'h> {
                 if let Some(init) = &f.init {
                     self.walk_stmt(init);
                 }
-                if let Some(test) = &f.test_ {
+                if let Some(test) = &f.test {
                     self.walk_expr(test);
                 }
                 if let Some(update) = &f.update {
@@ -624,15 +624,15 @@ impl<'h> CaptureWalker<'h> {
                 self.pop_scope();
             }
             StmtData::SWhile(w) => {
-                self.walk_expr(&w.test_);
+                self.walk_expr(&w.test);
                 self.walk_stmt(&w.body);
             }
             StmtData::SDoWhile(d) => {
                 self.walk_stmt(&d.body);
-                self.walk_expr(&d.test_);
+                self.walk_expr(&d.test);
             }
             StmtData::SSwitch(s) => {
-                self.walk_expr(&s.test_);
+                self.walk_expr(&s.test);
                 self.push_scope(s.body_loc);
                 for case in s.cases.slice() {
                     if let Some(v) = &case.value {
@@ -646,7 +646,7 @@ impl<'h> CaptureWalker<'h> {
                 self.push_scope(stmt_loc);
                 self.walk_stmts(t.body.slice());
                 self.pop_scope();
-                if let Some(catch) = &t.catch_ {
+                if let Some(catch) = &t.catch {
                     self.push_scope(catch.loc);
                     if let Some(binding) = &catch.binding {
                         self.walk_binding_decl(binding);
@@ -729,7 +729,7 @@ impl<'h> CaptureWalker<'h> {
             }
             ExprData::ESpread(s) => self.walk_expr(&s.value),
             ExprData::EIf(c) => {
-                self.walk_expr(&c.test_);
+                self.walk_expr(&c.test);
                 self.walk_expr(&c.yes);
                 self.walk_expr(&c.no);
             }

--- a/src/react_compiler/lowering/build_hir/stmt.rs
+++ b/src/react_compiler/lowering/build_hir/stmt.rs
@@ -235,7 +235,7 @@ fn ref_in_nested_fn_stmt(builder: &HirBuilder, target: Ref, stmt: &Stmt, depth: 
             .is_some_and(|v| ref_in_nested_fn_expr(builder, target, v, depth)),
         Data::SThrow(t) => ref_in_nested_fn_expr(builder, target, &t.value, depth),
         Data::SIf(i) => {
-            ref_in_nested_fn_expr(builder, target, &i.test_, depth)
+            ref_in_nested_fn_expr(builder, target, &i.test, depth)
                 || ref_in_nested_fn_stmt(builder, target, &i.yes, depth)
                 || i.no
                     .as_ref()
@@ -245,7 +245,7 @@ fn ref_in_nested_fn_stmt(builder: &HirBuilder, target: Ref, stmt: &Stmt, depth: 
             f.init
                 .as_ref()
                 .is_some_and(|s| ref_in_nested_fn_stmt(builder, target, s, depth))
-                || f.test_
+                || f.test
                     .as_ref()
                     .is_some_and(|e| ref_in_nested_fn_expr(builder, target, e, depth))
                 || f.update
@@ -264,15 +264,15 @@ fn ref_in_nested_fn_stmt(builder: &HirBuilder, target: Ref, stmt: &Stmt, depth: 
                 || ref_in_nested_fn_stmt(builder, target, &f.body, depth)
         }
         Data::SWhile(w) => {
-            ref_in_nested_fn_expr(builder, target, &w.test_, depth)
+            ref_in_nested_fn_expr(builder, target, &w.test, depth)
                 || ref_in_nested_fn_stmt(builder, target, &w.body, depth)
         }
         Data::SDoWhile(d) => {
             ref_in_nested_fn_stmt(builder, target, &d.body, depth)
-                || ref_in_nested_fn_expr(builder, target, &d.test_, depth)
+                || ref_in_nested_fn_expr(builder, target, &d.test, depth)
         }
         Data::SSwitch(sw) => {
-            ref_in_nested_fn_expr(builder, target, &sw.test_, depth)
+            ref_in_nested_fn_expr(builder, target, &sw.test, depth)
                 || sw.cases.slice().iter().any(|c| {
                     c.value
                         .as_ref()
@@ -288,7 +288,7 @@ fn ref_in_nested_fn_stmt(builder: &HirBuilder, target: Ref, stmt: &Stmt, depth: 
                 .slice()
                 .iter()
                 .any(|s| ref_in_nested_fn_stmt(builder, target, s, depth))
-                || t.catch_.as_ref().is_some_and(|c| {
+                || t.catch.as_ref().is_some_and(|c| {
                     c.body
                         .slice()
                         .iter()
@@ -427,7 +427,7 @@ fn ref_in_nested_fn_expr(builder: &HirBuilder, target: Ref, e: &Expr, depth: u32
         }),
         ExprData::ESpread(s) => ref_in_nested_fn_expr(builder, target, &s.value, depth),
         ExprData::EIf(c) => {
-            ref_in_nested_fn_expr(builder, target, &c.test_, depth)
+            ref_in_nested_fn_expr(builder, target, &c.test, depth)
                 || ref_in_nested_fn_expr(builder, target, &c.yes, depth)
                 || ref_in_nested_fn_expr(builder, target, &c.no, depth)
         }
@@ -740,7 +740,7 @@ pub(crate) fn lower_statement(
                 continuation_id
             };
 
-            let test = lower_expression_to_temporary(builder, &if_stmt.test_)?;
+            let test = lower_expression_to_temporary(builder, &if_stmt.test)?;
             builder.terminate_with_continuation(
                 Terminal::If {
                     test,
@@ -855,7 +855,7 @@ pub(crate) fn lower_statement(
             );
 
             // Fill in the test block
-            if let Some(test_expr) = &for_stmt.test_ {
+            if let Some(test_expr) = &for_stmt.test {
                 let test = lower_expression_to_temporary(builder, test_expr)?;
                 builder.terminate_with_continuation(
                     Terminal::Branch {
@@ -933,7 +933,7 @@ pub(crate) fn lower_statement(
             );
 
             // Fill in the conditional block: lower test, branch
-            let test = lower_expression_to_temporary(builder, &while_stmt.test_)?;
+            let test = lower_expression_to_temporary(builder, &while_stmt.test)?;
             builder.terminate_with_continuation(
                 Terminal::Branch {
                     test,
@@ -982,7 +982,7 @@ pub(crate) fn lower_statement(
             );
 
             // Fill in the conditional block: lower test, branch
-            let test = lower_expression_to_temporary(builder, &do_while_stmt.test_)?;
+            let test = lower_expression_to_temporary(builder, &do_while_stmt.test)?;
             builder.terminate_with_continuation(
                 Terminal::Branch {
                     test,
@@ -1241,7 +1241,7 @@ pub(crate) fn lower_statement(
             }
 
             builder.pop_scope();
-            let test = lower_expression_to_temporary(builder, &switch_stmt.test_)?;
+            let test = lower_expression_to_temporary(builder, &switch_stmt.test)?;
             builder.terminate_with_continuation(
                 Terminal::Switch {
                     test,
@@ -1258,7 +1258,7 @@ pub(crate) fn lower_statement(
             let continuation_block = builder.reserve(BlockKind::Block);
             let continuation_id = continuation_block.id;
 
-            let handler_clause = match &try_stmt.catch_ {
+            let handler_clause = match &try_stmt.catch {
                 Some(h) => h,
                 None => {
                     builder.record_error(CompilerErrorDetail {

--- a/src/react_compiler/lowering/find_context_identifiers.rs
+++ b/src/react_compiler/lowering/find_context_identifiers.rs
@@ -253,7 +253,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
             }
             StmtData::SThrow(t) => self.walk_expr(&t.value),
             StmtData::SIf(i) => {
-                self.walk_expr(&i.test_);
+                self.walk_expr(&i.test);
                 self.walk_stmt(&i.yes);
                 if let Some(no) = &i.no {
                     self.walk_stmt(no);
@@ -264,7 +264,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
                 if let Some(init) = &f.init {
                     self.walk_stmt(init);
                 }
-                if let Some(test) = &f.test_ {
+                if let Some(test) = &f.test {
                     self.walk_expr(test);
                 }
                 if let Some(update) = &f.update {
@@ -288,15 +288,15 @@ impl<'a> ContextIdentifierVisitor<'a> {
                 self.pop_scope();
             }
             StmtData::SWhile(w) => {
-                self.walk_expr(&w.test_);
+                self.walk_expr(&w.test);
                 self.walk_stmt(&w.body);
             }
             StmtData::SDoWhile(d) => {
                 self.walk_stmt(&d.body);
-                self.walk_expr(&d.test_);
+                self.walk_expr(&d.test);
             }
             StmtData::SSwitch(s) => {
-                self.walk_expr(&s.test_);
+                self.walk_expr(&s.test);
                 self.push_scope(s.body_loc);
                 for case in s.cases.slice() {
                     if let Some(v) = &case.value {
@@ -310,7 +310,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
                 self.push_scope(stmt_loc);
                 self.walk_stmts(t.body.slice());
                 self.pop_scope();
-                if let Some(catch) = &t.catch_ {
+                if let Some(catch) = &t.catch {
                     self.push_scope(catch.loc);
                     if let Some(binding) = &catch.binding {
                         self.walk_binding_decl(binding);
@@ -452,7 +452,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
             }
             Data::ESpread(s) => self.walk_expr(&s.value),
             Data::EIf(c) => {
-                self.walk_expr(&c.test_);
+                self.walk_expr(&c.test);
                 self.walk_expr(&c.yes);
                 self.walk_expr(&c.no);
             }

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -730,7 +730,7 @@ fn returns_non_node_in_stmt(stmt: &Stmt, result: &mut bool) {
             for s in try_stmt.body.slice() {
                 returns_non_node_in_stmt(s, result);
             }
-            if let Some(handler) = &try_stmt.catch_ {
+            if let Some(handler) = &try_stmt.catch {
                 for s in handler.body.slice() {
                     returns_non_node_in_stmt(s, result);
                 }
@@ -768,7 +768,7 @@ fn calls_hooks_or_creates_jsx_in_stmt(host: &dyn Host, stmt: &Stmt) -> bool {
         }),
         StmtData::SBlock(b) => calls_hooks_or_creates_jsx_in_stmts(host, b.stmts.slice()),
         StmtData::SIf(i) => {
-            calls_hooks_or_creates_jsx_in_expr(host, &i.test_)
+            calls_hooks_or_creates_jsx_in_expr(host, &i.test)
                 || calls_hooks_or_creates_jsx_in_stmt(host, &i.yes)
                 || i.no
                     .as_ref()
@@ -778,7 +778,7 @@ fn calls_hooks_or_creates_jsx_in_stmt(host: &dyn Host, stmt: &Stmt) -> bool {
             f.init
                 .as_ref()
                 .is_some_and(|s| calls_hooks_or_creates_jsx_in_stmt(host, s))
-                || f.test_
+                || f.test
                     .as_ref()
                     .is_some_and(|e| calls_hooks_or_creates_jsx_in_expr(host, e))
                 || f.update
@@ -787,12 +787,12 @@ fn calls_hooks_or_creates_jsx_in_stmt(host: &dyn Host, stmt: &Stmt) -> bool {
                 || calls_hooks_or_creates_jsx_in_stmt(host, &f.body)
         }
         StmtData::SWhile(w) => {
-            calls_hooks_or_creates_jsx_in_expr(host, &w.test_)
+            calls_hooks_or_creates_jsx_in_expr(host, &w.test)
                 || calls_hooks_or_creates_jsx_in_stmt(host, &w.body)
         }
         StmtData::SDoWhile(d) => {
             calls_hooks_or_creates_jsx_in_stmt(host, &d.body)
-                || calls_hooks_or_creates_jsx_in_expr(host, &d.test_)
+                || calls_hooks_or_creates_jsx_in_expr(host, &d.test)
         }
         StmtData::SForIn(f) => {
             calls_hooks_or_creates_jsx_in_expr(host, &f.value)
@@ -803,7 +803,7 @@ fn calls_hooks_or_creates_jsx_in_stmt(host: &dyn Host, stmt: &Stmt) -> bool {
                 || calls_hooks_or_creates_jsx_in_stmt(host, &f.body)
         }
         StmtData::SSwitch(s) => {
-            if calls_hooks_or_creates_jsx_in_expr(host, &s.test_) {
+            if calls_hooks_or_creates_jsx_in_expr(host, &s.test) {
                 return true;
             }
             for case in s.cases.slice() {
@@ -823,7 +823,7 @@ fn calls_hooks_or_creates_jsx_in_stmt(host: &dyn Host, stmt: &Stmt) -> bool {
         StmtData::SThrow(t) => calls_hooks_or_creates_jsx_in_expr(host, &t.value),
         StmtData::STry(t) => {
             calls_hooks_or_creates_jsx_in_stmts(host, t.body.slice())
-                || t.catch_
+                || t.catch
                     .as_ref()
                     .is_some_and(|c| calls_hooks_or_creates_jsx_in_stmts(host, c.body.slice()))
                 || t.finally
@@ -867,7 +867,7 @@ fn calls_hooks_or_creates_jsx_in_expr(host: &dyn Host, expr: &Expr) -> bool {
                 || calls_hooks_or_creates_jsx_in_expr(host, &b.right)
         }
         ExprData::EIf(c) => {
-            calls_hooks_or_creates_jsx_in_expr(host, &c.test_)
+            calls_hooks_or_creates_jsx_in_expr(host, &c.test)
                 || calls_hooks_or_creates_jsx_in_expr(host, &c.yes)
                 || calls_hooks_or_creates_jsx_in_expr(host, &c.no)
         }

--- a/src/resolver/data_url.rs
+++ b/src/resolver/data_url.rs
@@ -84,10 +84,10 @@ impl PercentEncoding {
 
     /// Replaces percent encoded entities within `path` without throwing an error if other URL unsafe characters are present
     pub(crate) fn decode_unstrict(path: &[u8]) -> Result<Option<Vec<u8>>, EncodeError> {
-        Self::_decode(path, false)
+        Self::decode(path, false)
     }
 
-    fn _decode(path: &[u8], strict: bool) -> Result<Option<Vec<u8>>, EncodeError> {
+    fn decode(path: &[u8], strict: bool) -> Result<Option<Vec<u8>>, EncodeError> {
         let mut ret: Option<Vec<u8>> = None;
         // errdefer: `ret` is a Vec — drops automatically on `?` error path
         let mut ret_index: usize = 0;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2837,7 +2837,7 @@ impl H2FrameParser {
         CORK_OFFSET.with(|c| c.set(0));
     }
 
-    pub(crate) fn _generic_flush<S: NativeSocketWrite>(&self, mut socket: S) -> usize {
+    pub(crate) fn generic_flush<S: NativeSocketWrite>(&self, mut socket: S) -> usize {
         let buffer_len = self.write_buffer.get().slice()[self.write_buffer_offset.get()..].len();
         if buffer_len > 0 {
             let result: i32 = socket.write_maybe_corked(
@@ -2875,7 +2875,7 @@ impl H2FrameParser {
         buffer_len
     }
 
-    pub(crate) fn _generic_write<S: NativeSocketWrite>(&self, mut socket: S, bytes: &[u8]) -> bool {
+    pub(crate) fn generic_write<S: NativeSocketWrite>(&self, mut socket: S, bytes: &[u8]) -> bool {
         bun_output::scoped_log!(H2FrameParser, "_genericWrite {}", bytes.len());
 
         let global = self.global();
@@ -3002,10 +3002,10 @@ impl H2FrameParser {
         let mut written = self.uncork();
         written += match self.native_socket.get() {
             BunSocket::TlsWriteonly(socket) | BunSocket::Tls(socket) => {
-                self._generic_flush(socket.get())
+                self.generic_flush(socket.get())
             }
             BunSocket::TcpWriteonly(socket) | BunSocket::Tcp(socket) => {
-                self._generic_flush(socket.get())
+                self.generic_flush(socket.get())
             }
             BunSocket::None => {
                 // consider that backpressure is gone and flush data queue
@@ -3054,10 +3054,10 @@ impl H2FrameParser {
         let _keepalive = self.keepalive();
         match self.native_socket.get() {
             BunSocket::TlsWriteonly(socket) | BunSocket::Tls(socket) => {
-                self._generic_write(socket.get(), bytes)
+                self.generic_write(socket.get(), bytes)
             }
             BunSocket::TcpWriteonly(socket) | BunSocket::Tcp(socket) => {
-                self._generic_write(socket.get(), bytes)
+                self.generic_write(socket.get(), bytes)
             }
             BunSocket::None => {
                 let global = self.global();
@@ -3186,7 +3186,7 @@ impl H2FrameParser {
         self.deref();
     }
 
-    /// A `write_maybe_corked` in `_generic_write`/`_generic_flush` returned a fatal
+    /// A `write_maybe_corked` in `generic_write`/`generic_flush` returned a fatal
     /// errno (< -1: the kernel rejected the send - peer gone). No retry can succeed,
     /// and when the failure is only visible on the write side (a peer reset the read
     /// path has not observed yet - routine on Windows, where the RST completes the
@@ -3509,7 +3509,7 @@ impl Payload {
     }
 }
 
-/// Trait to abstract over TLSSocket / TCPSocket for `_generic_flush`/`_generic_write`.
+/// Trait to abstract over TLSSocket / TCPSocket for `generic_flush`/`generic_write`.
 pub(crate) trait NativeSocketWrite {
     fn write_maybe_corked(&mut self, buf: &[u8]) -> i32;
 }

--- a/src/runtime/api/bun/subprocess/ResourceUsage.rs
+++ b/src/runtime/api/bun/subprocess/ResourceUsage.rs
@@ -39,42 +39,42 @@ impl ResourceUsage {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_max_rss(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.maxrss_())
+        JSValue::js_number(this.rusage.maxrss())
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_shared_memory_size(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.ixrss_())
+        JSValue::js_number(this.rusage.ixrss())
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_swap_count(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.nswap_())
+        JSValue::js_number(this.rusage.nswap())
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_ops(this: &Self, global: &JSGlobalObject) -> JSValue {
         let ops = JSValue::create_empty_object_with_null_prototype(global);
-        ops.put(global, b"in", JSValue::js_number(this.rusage.inblock_()));
-        ops.put(global, b"out", JSValue::js_number(this.rusage.oublock_()));
+        ops.put(global, b"in", JSValue::js_number(this.rusage.inblock()));
+        ops.put(global, b"out", JSValue::js_number(this.rusage.oublock()));
         ops
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_messages(this: &Self, global: &JSGlobalObject) -> JSValue {
         let msgs = JSValue::create_empty_object_with_null_prototype(global);
-        msgs.put(global, b"sent", JSValue::js_number(this.rusage.msgsnd_()));
+        msgs.put(global, b"sent", JSValue::js_number(this.rusage.msgsnd()));
         msgs.put(
             global,
             b"received",
-            JSValue::js_number(this.rusage.msgrcv_()),
+            JSValue::js_number(this.rusage.msgrcv()),
         );
         msgs
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_signal_count(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.nsignals_())
+        JSValue::js_number(this.rusage.nsignals())
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -83,12 +83,12 @@ impl ResourceUsage {
         ctx.put(
             global,
             b"voluntary",
-            JSValue::js_number(this.rusage.nvcsw_()),
+            JSValue::js_number(this.rusage.nvcsw()),
         );
         ctx.put(
             global,
             b"involuntary",
-            JSValue::js_number(this.rusage.nivcsw_()),
+            JSValue::js_number(this.rusage.nivcsw()),
         );
         ctx
     }

--- a/src/runtime/api/standalone_graph_jsc.rs
+++ b/src/runtime/api/standalone_graph_jsc.rs
@@ -75,7 +75,7 @@ impl FileJsc for File {
             // The real name goes here:
             // SAFETY: see above; `data` is `Bytes` by construction.
             if let Data::Bytes(bytes) = unsafe { &mut (*store_ptr).data } {
-                // `Bytes::Drop` and `jsdom_file_construct_` both require
+                // `Bytes::Drop` and `jsdom_file_construct` both require
                 // `stored_name` to be heap-owned (or empty); a borrowed
                 // `'static` slice would be invalid-freed there.
                 bytes.stored_name = self.name.to_vec().into_boxed_slice();

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1741,8 +1741,8 @@ fn print_unhandled_version_note(vm: &mut VirtualMachine) {
 }
 
 impl RunCommand {
-    /// `_bootAndHandleError` — duplicate `path` to a process-lifetime buffer,
-    /// boot the VM, and on failure print the formatted error + `exit(1)`.
+    /// Duplicate `path` to a process-lifetime buffer, boot the VM, and on
+    /// failure print the formatted error + `exit(1)`.
     fn boot_and_handle_error(ctx: &mut ContextData, path: &[u8], loader: Option<Loader>) -> bool {
         if matches!(
             loader.or_else(|| Self::default_loader_for(path)),

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1743,7 +1743,7 @@ fn print_unhandled_version_note(vm: &mut VirtualMachine) {
 impl RunCommand {
     /// `_bootAndHandleError` — duplicate `path` to a process-lifetime buffer,
     /// boot the VM, and on failure print the formatted error + `exit(1)`.
-    fn _boot_and_handle_error(ctx: &mut ContextData, path: &[u8], loader: Option<Loader>) -> bool {
+    fn boot_and_handle_error(ctx: &mut ContextData, path: &[u8], loader: Option<Loader>) -> bool {
         if matches!(
             loader.or_else(|| Self::default_loader_for(path)),
             Some(Loader::Md)
@@ -2607,10 +2607,10 @@ impl RunCommand {
                     .unwrap_or(Loader::Tsx);
                 if loader.can_be_run_by_bun() || loader == Loader::Html || loader == Loader::Md {
                     bun_core::scoped_log!(RUN_LOG, "Resolved to: `{}`", bstr::BStr::new(path.text));
-                    // borrowck — `_boot_and_handle_error` takes
+                    // borrowck — `boot_and_handle_error` takes
                     // `&mut ctx`; copy `path.text` out of the resolver borrow.
                     let text: Box<[u8]> = path.text.to_vec().into_boxed_slice();
-                    return Ok(Self::_boot_and_handle_error(ctx, &text, Some(loader)));
+                    return Ok(Self::boot_and_handle_error(ctx, &text, Some(loader)));
                 } else {
                     bun_core::scoped_log!(
                         RUN_LOG,
@@ -2627,7 +2627,7 @@ impl RunCommand {
                 if strings::has_suffix_comptime(target_name, b".html")
                     && strings::contains_char(target_name, b'*')
                 {
-                    return Ok(Self::_boot_and_handle_error(
+                    return Ok(Self::boot_and_handle_error(
                         ctx,
                         target_name,
                         Some(Loader::Html),
@@ -2884,7 +2884,7 @@ impl RunCommand {
         };
         let _ = bun_sys::close(fd);
 
-        Self::_boot_and_handle_error(ctx, &absolute_script_path, None)
+        Self::boot_and_handle_error(ctx, &absolute_script_path, None)
     }
 
     /// `bun run -` — read script from stdin into `ctx.runtime_options.eval`
@@ -2924,7 +2924,7 @@ impl RunCommand {
         passthrough_list.append(&mut ctx.passthrough);
         ctx.passthrough = passthrough_list;
 
-        // NOT routed through `_boot_and_handle_error` — the
+        // NOT routed through `boot_and_handle_error` — the
         // stdin path skips the
         // `configure_allocator(long_running=true)` / `.md` checks and prints
         // `basename(target_name)` (= "-"), not `basename(entry_path)`
@@ -3024,7 +3024,7 @@ impl RunCommand {
             Self::exec_as_if_node_missing_script();
         }
 
-        // borrowck — `_boot_and_handle_error` takes `&mut ctx`, so
+        // borrowck — `boot_and_handle_error` takes `&mut ctx`, so
         // dupe the positional out before the call.
         let filename: Box<[u8]> = ctx.positionals[0].clone();
 
@@ -3049,7 +3049,7 @@ impl RunCommand {
         };
 
         // This arm calls `Run::boot`
-        // directly — NOT `_boot_and_handle_error` — so it (a) does not call
+        // directly — NOT `boot_and_handle_error` — so it (a) does not call
         // `Global::configure_allocator` and (b) uses the
         // `Output.err(err, "Failed to run script \"...\"")` form.
         let basename: Box<[u8]> = paths::basename(&normalized).to_vec().into_boxed_slice();

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -340,10 +340,10 @@ impl<'a> Coordinator<'a> {
         match kind {
             frame::Kind::Ready => self.assign_work_or_retry(w),
             frame::Kind::FileStart => {
-                let _ = rd.u32_();
+                let _ = rd.u32();
             }
             frame::Kind::TestDone => {
-                let idx = rd.u32_();
+                let idx = rd.u32();
                 let formatted = rd.str();
                 if w.inflight != Some(idx) {
                     return;
@@ -366,7 +366,7 @@ impl<'a> Coordinator<'a> {
             frame::Kind::FileDone => {
                 let mut nums = [0u32; 9];
                 for n in nums.iter_mut() {
-                    *n = rd.u32_();
+                    *n = rd.u32();
                 }
                 let [
                     idx,

--- a/src/runtime/cli/test/parallel/Frame.rs
+++ b/src/runtime/cli/test/parallel/Frame.rs
@@ -70,7 +70,7 @@ impl Frame {
         self.buf.push(kind as u8);
     }
 
-    pub(crate) fn u32_(&mut self, v: u32) {
+    pub(crate) fn u32(&mut self, v: u32) {
         self.buf.extend_from_slice(&v.to_le_bytes());
     }
 
@@ -88,7 +88,7 @@ impl Frame {
             0
         };
         if s.len() <= room {
-            self.u32_(u32::try_from(s.len()).unwrap());
+            self.u32(u32::try_from(s.len()).unwrap());
             self.buf.extend_from_slice(s);
             return;
         }
@@ -97,7 +97,7 @@ impl Frame {
         } else {
             0
         };
-        self.u32_(u32::try_from(keep + TRUNC.len()).unwrap());
+        self.u32(u32::try_from(keep + TRUNC.len()).unwrap());
         self.buf.extend_from_slice(&s[0..keep]);
         self.buf.extend_from_slice(TRUNC);
     }
@@ -120,7 +120,7 @@ pub struct Reader<'a> {
 }
 
 impl<'a> Reader<'a> {
-    pub(crate) fn u32_(&mut self) -> u32 {
+    pub(crate) fn u32(&mut self) -> u32 {
         if self.p.len() < 4 {
             return 0;
         }
@@ -130,7 +130,7 @@ impl<'a> Reader<'a> {
     }
 
     pub(crate) fn str(&mut self) -> &'a [u8] {
-        let n = self.u32_() as usize;
+        let n = self.u32() as usize;
         if self.p.len() < n {
             return b"";
         }

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -361,7 +361,7 @@ impl Worker {
         // SAFETY: coord backref valid; frame mutation — see `coord` field doc (provenance caveats).
         let f = unsafe { &mut (*self.coord.cast_mut()).frame };
         f.begin(frame::Kind::Run);
-        f.u32_(file_idx);
+        f.u32(file_idx);
         f.str(file);
         self.ipc.send(f.finish());
         self.inflight = Some(file_idx);

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -536,7 +536,7 @@ impl ChannelOwner for WorkerCommands {
     fn on_channel_frame(&mut self, kind: frame::Kind, rd: &mut frame::Reader<'_>) {
         match kind {
             frame::Kind::Run => {
-                self.pending_idx = Some(rd.u32_());
+                self.pending_idx = Some(rd.u32());
                 self.pending_path.clear();
                 self.pending_path.extend_from_slice(rd.str());
             }
@@ -591,7 +591,7 @@ impl<'a> WorkerLoop<'a> {
 
             self.reporter.worker_ipc_file_idx = Some(idx);
             wf.begin(frame::Kind::FileStart);
-            wf.u32_(idx);
+            wf.u32(idx);
             self.cmds.send(wf.finish());
 
             let before = *self.reporter.summary();
@@ -631,7 +631,7 @@ impl<'a> WorkerLoop<'a> {
                 after.files - before.files,
                 self.reporter.jest.unhandled_errors_between_tests - before_unhandled,
             ] {
-                wf.u32_(v);
+                wf.u32(v);
             }
             self.cmds.send(wf.finish());
         }
@@ -816,7 +816,7 @@ pub fn worker_emit_test_done(file_idx: u32, formatted_line: &[u8]) {
     // SAFETY: single-threaded worker; WORKER_FRAME is a process-global scratch buffer.
     let wf = unsafe { &mut *WORKER_FRAME.get() };
     wf.begin(frame::Kind::TestDone);
-    wf.u32_(file_idx);
+    wf.u32(file_idx);
     wf.str(formatted_line);
     cmds.send(wf.finish());
 }

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -351,7 +351,7 @@ pub(crate) unsafe extern "C" fn bindgen_NodeModuleModule_dispatch_stat1(
     // valid out-param.
     let s = unsafe { (*arg_str).to_utf8() };
     // SAFETY: `out` is a valid C++ stack out-param.
-    unsafe { *out = bun_jsc::node_module_module::_stat(s.slice()) };
+    unsafe { *out = bun_jsc::node_module_module::stat(s.slice()) };
     true
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4804,7 +4804,7 @@ unsafe fn resolve_embedded_node_file_hook(
 
 // ════════════════════════════════════════════════════════════════════════════
 // LoaderHooks::resolve — `VirtualMachine.resolveMaybeNeedsTrailingSlash`
-// + `_resolve`.
+// + `resolve`.
 //
 // This is the resolution path behind `Bun__resolveSync`,
 // `Zig__GlobalObject__resolve`, `import.meta.resolve`, and
@@ -4815,7 +4815,7 @@ unsafe fn resolve_embedded_node_file_hook(
 // ════════════════════════════════════════════════════════════════════════════
 
 /// Path-separator-adjusted literal suffixes. Only the two
-/// `_resolve` callers need them (the `[eval]` / `[stdin]` suffix checks), so
+/// `resolve` callers need them (the `[eval]` / `[stdin]` suffix checks), so
 /// inline the per-platform constants.
 #[cfg(windows)]
 const EVAL_SUFFIX: &[u8] = b"\\[eval]";
@@ -4847,7 +4847,7 @@ fn normalize_source(source: &[u8]) -> &[u8] {
     source.strip_prefix(b"file://".as_slice()).unwrap_or(source)
 }
 
-/// `VirtualMachine._resolve`.
+/// `VirtualMachine.resolve`.
 ///
 /// Writes the resolved path/query into `*ret_path` / `*ret_query`. A full
 /// `Resolver::Result` would be unused by the
@@ -4860,7 +4860,7 @@ fn normalize_source(source: &[u8]) -> &[u8] {
 /// `vm` is the live per-thread VM. `specifier` / `source` borrow the caller's
 /// `to_utf8()` buffers and must outlive the returned slices (which the caller
 /// immediately `cloneUTF8`s).
-unsafe fn _resolve<'a>(
+unsafe fn resolve<'a>(
     vm: *mut VirtualMachine,
     specifier: &'a [u8],
     source: &'a [u8],
@@ -5198,7 +5198,7 @@ unsafe fn resolve_hook(
         // SAFETY: `vm` is the live per-thread VM; restoring the log pointers
         // swapped just above so early-return paths don't leave a dangling
         // stack pointer. The PM may have been lazily created inside
-        // `_resolve` with `pm.log = resolver.log` (our stack `log`), so
+        // `resolve` with `pm.log = resolver.log` (our stack `log`), so
         // restore it even if it was `None` at swap time.
         unsafe {
             (*vm).log = Some(old_log);
@@ -5215,7 +5215,7 @@ unsafe fn resolve_hook(
     // SAFETY: `vm` is the live per-thread VM; the slices borrow
     // `specifier_utf8`/`source_utf8` which outlive this call.
     if let Err(err) = unsafe {
-        _resolve(
+        resolve(
             vm,
             specifier_utf8.slice(),
             normalize_source(source_utf8.slice()),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4804,7 +4804,7 @@ unsafe fn resolve_embedded_node_file_hook(
 
 // ════════════════════════════════════════════════════════════════════════════
 // LoaderHooks::resolve — `VirtualMachine.resolveMaybeNeedsTrailingSlash`
-// + `resolve`.
+// + `_resolve`.
 //
 // This is the resolution path behind `Bun__resolveSync`,
 // `Zig__GlobalObject__resolve`, `import.meta.resolve`, and
@@ -4847,7 +4847,7 @@ fn normalize_source(source: &[u8]) -> &[u8] {
     source.strip_prefix(b"file://".as_slice()).unwrap_or(source)
 }
 
-/// `VirtualMachine.resolve`.
+/// `VirtualMachine._resolve`.
 ///
 /// Writes the resolved path/query into `*ret_path` / `*ret_query`. A full
 /// `Resolver::Result` would be unused by the

--- a/src/runtime/node/fs_events.rs
+++ b/src/runtime/node/fs_events.rs
@@ -524,7 +524,7 @@ impl FSEventsLoop {
     // Runs in CF thread, when there're events in FSEventStream. Body discharges
     // its own preconditions; safe `extern "C" fn` coerces to the
     // `FSEventStreamCallback` pointer type.
-    extern "C" fn _events_cb(
+    extern "C" fn events_cb(
         _: FSEventStreamRef,
         info: *mut c_void,
         num_events: usize,
@@ -535,7 +535,7 @@ impl FSEventsLoop {
         let paths_ptr = event_paths as *const *const c_char;
         // SAFETY: event_paths is a `char **` of length num_events per FSEvents API
         let paths = unsafe { bun_core::ffi::slice(paths_ptr, num_events) };
-        // SAFETY: `info` is the leaked `&'static FSEventsLoop` set as `ctx.info` in `_schedule()`.
+        // SAFETY: `info` is the leaked `&'static FSEventsLoop` set as `ctx.info` in `schedule()`.
         let loop_: &FSEventsLoop = unsafe { &*info.cast::<FSEventsLoop>() };
         // SAFETY: event_flags is an array of length num_events per FSEvents API
         let event_flags = unsafe { bun_core::ffi::slice(event_flags.cast_const(), num_events) };
@@ -620,7 +620,7 @@ impl FSEventsLoop {
     }
 
     // Runs on CF Thread
-    fn _schedule(&self) {
+    fn schedule(&self) {
         let _guard = self.mutex.lock_guard();
         // SAFETY: holding `mutex` — see `FSEventsLoop::state`.
         let state = unsafe { self.state() };
@@ -717,7 +717,7 @@ impl FSEventsLoop {
             //
             let r#ref = (cs.fs_event_stream_create)(
                 ptr::null_mut(),
-                Self::_events_cb,
+                Self::events_cb,
                 &raw mut ctx,
                 cf_paths,
                 cs.k_fs_event_stream_event_id_since_now,
@@ -783,7 +783,7 @@ impl FSEventsLoop {
         } else {
             return;
         }
-        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::_schedule));
+        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::schedule));
     }
 
     fn unregister_watcher(&'static self, watcher: *mut FSEventsWatcher) {
@@ -808,18 +808,18 @@ impl FSEventsLoop {
         // Rebuild the FSEventStream on the CF thread so it stops firing for
         // the path we just removed. Without this the stream keeps delivering
         // events for freed paths until another register happens to
-        // reschedule. `_events_cb` tolerates the interim (it sees `null` and
+        // reschedule. `events_cb` tolerates the interim (it sees `null` and
         // skips) because both sides hold `this.mutex`.
         if !state.has_scheduled_watchers {
             state.has_scheduled_watchers = true;
         } else {
             return;
         }
-        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::_schedule));
+        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::schedule));
     }
 
     // Runs on CF loop to close the loop
-    fn _stop(&self) {
+    fn stop(&self) {
         let cf = CoreFoundation::get();
         // SAFETY: runs on the CF thread — this is our own run loop.
         unsafe { (cf.run_loop_stop)(self.loop_.load(Ordering::Relaxed)) };
@@ -832,7 +832,7 @@ impl FSEventsLoop {
             return; // already shut down
         };
         // signal close and wait
-        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::_stop));
+        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::stop));
         let _ = thread.join();
 
         let cf = CoreFoundation::get();
@@ -866,7 +866,7 @@ pub struct FSEventsWatcher {
     /// Borrowed from the owning `PathWatcher`. The
     /// PathWatcher heap-allocates this watcher and only frees it after `Drop`
     /// (→ `unregister_watcher`) has run, so the bytes outlive every read in
-    /// `_events_cb` / `_schedule` — `RawSlice` invariant. The backing buffer is
+    /// `events_cb` / `schedule` — `RawSlice` invariant. The backing buffer is
     /// a `ZBox`, so `path.slice().as_ptr()` is NUL-terminated (required by
     /// `CFStringCreateWithFileSystemRepresentation`).
     pub path: bun_ptr::RawSlice<u8>,

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -181,7 +181,7 @@ impl BlockList {
             validators::validate_string(global, family_js, format_args!("family"))?;
             SocketAddress::init_from_addr_family(global, end_js, family_js)?._addr
         };
-        if let Some(ord) = _compare(&start, &end) {
+        if let Some(ord) = compare(&start, &end) {
             if ord == Ordering::Greater {
                 return Err(global.throw_invalid_argument_value_custom(
                     b"start",
@@ -280,7 +280,7 @@ impl BlockList {
         for item in self.da_rules.get().iter() {
             match item {
                 Rule::Addr(a) => {
-                    let Some(order) = _compare(address, a) else {
+                    let Some(order) = compare(address, a) else {
                         continue;
                     };
                     if order.is_eq() {
@@ -288,10 +288,10 @@ impl BlockList {
                     }
                 }
                 Rule::Range { start, end } => {
-                    let Some(os) = _compare(address, start) else {
+                    let Some(os) = compare(address, start) else {
                         continue;
                     };
-                    let Some(oe) = _compare(address, end) else {
+                    let Some(oe) = compare(address, end) else {
                         continue;
                     };
                     if os.is_ge() && oe.is_le() {
@@ -510,19 +510,19 @@ pub(crate) enum Rule {
     Subnet { network: sockaddr, prefix: u8 },
 }
 
-fn _compare(l: &sockaddr, r: &sockaddr) -> Option<Ordering> {
+fn compare(l: &sockaddr, r: &sockaddr) -> Option<Ordering> {
     if let Some(l_4) = l.as_v4() {
         if let Some(r_4) = r.as_v4() {
             return Some(l_4.swap_bytes().cmp(&r_4.swap_bytes()));
         }
     }
     if let (Some(l6), Some(r6)) = (l.as_sin6(), r.as_sin6()) {
-        return Some(_compare_ipv6(l6, r6));
+        return Some(compare_ipv6(l6, r6));
     }
     None
 }
 
-fn _compare_ipv6(l: &inet::sockaddr_in6, r: &inet::sockaddr_in6) -> Ordering {
+fn compare_ipv6(l: &inet::sockaddr_in6, r: &inet::sockaddr_in6) -> Ordering {
     let l128 = u128::from_ne_bytes(l.addr).swap_bytes();
     let r128 = u128::from_ne_bytes(r.addr).swap_bytes();
     l128.cmp(&r128)

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1802,7 +1802,7 @@ mod _async_tasks {
         }
 
         /// Directory scanning + clonefile will block this thread, then each individual file copy (what the sync version
-        /// calls "_copySingleFileSync") will be dispatched as a separate task.
+        /// calls "copy_single_file_sync") will be dispatched as a separate task.
         pub fn cp_async(nodefs: &mut NodeFS, this: *mut Self) {
             // The directory-scan task holds one reference in `subtask_count`
             // (initialized to 1 in create*). Drop it on return. `runFromJSThread`
@@ -9122,7 +9122,7 @@ impl NodeFS {
     /// `dest` copied into `sync_error_buf`.
     #[cfg_attr(windows, allow(dead_code))]
     fn cp_open_dest_with_mkdir(&mut self, dest: &ZStr, flags: i32, mode: Mode) -> Maybe<FD> {
-        // PORT: extracted from the mac/linux/freebsd arms of `_copySingleFileSync`
+        // PORT: extracted from the mac/linux/freebsd arms of `copy_single_file_sync`
         // only — there `OSPathSliceZ == ZStr`. Taking `&ZStr` keeps the body
         // monomorphic (and lets it type-check on Windows where it's dead code).
         match Syscall::open(dest, flags, mode) {
@@ -9152,27 +9152,6 @@ impl NodeFS {
                 Err(err.with_path(&self.sync_error_buf[..dest.len()]))
             }
         }
-    }
-
-    // returns boolean `should_continue`
-    fn _cp_async_directory(
-        &mut self,
-        args: args::CpFlags,
-        task: *mut AsyncCpTask,
-        src_buf: &mut OSPathBuffer,
-        src_dir_len: PathInt,
-        dest_buf: &mut OSPathBuffer,
-        dest_dir_len: PathInt,
-    ) -> bool {
-        AsyncCpTask::cp_async_directory(
-            self,
-            args,
-            task,
-            src_buf,
-            src_dir_len,
-            dest_buf,
-            dest_dir_len,
-        )
     }
 
     /// Const-generic dispatch from `NodeFSFunctionEnum` to the matching

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1498,7 +1498,7 @@ mod _async_tasks {
             let mut node_fs = NodeFS::default();
 
             let args = &parent.args;
-            let result = node_fs._copy_single_file_sync(
+            let result = node_fs.copy_single_file_sync(
                 self.src(),
                 self.dest(),
                 constants::Copyfile::from_raw(if args.flags.error_on_exist || !args.flags.force {
@@ -1812,7 +1812,7 @@ mod _async_tasks {
             // once every reference (including this one) has been dropped.
             let _done = scopeguard::guard(this, Self::on_subtask_done);
             // SAFETY: same pointer as above; valid for the duration of this fn.
-            // Shared borrow only — once `_cp_async_directory` spawns `CpSingleTask`s,
+            // Shared borrow only — once `cp_async_directory` spawns `CpSingleTask`s,
             // other workpool threads concurrently hold `&Self` to this same allocation.
             let this = unsafe { &**_done };
 
@@ -1856,13 +1856,13 @@ mod _async_tasks {
                 let file_or_symlink = (attributes & bun_sys::c::FILE_ATTRIBUTE_DIRECTORY) == 0
                     || (attributes & bun_sys::c::FILE_ATTRIBUTE_REPARSE_POINT) != 0;
                 if file_or_symlink {
-                    let r = nodefs._copy_single_file_sync(
+                    let r = nodefs.copy_single_file_sync(
                         src,
                         dest,
                         if IS_SHELL {
                             // Shell always forces copy (overwrite allowed).
                             // `Copyfile::force` is `COPYFILE_FICLONE_FORCE`, and
-                            // `_copy_single_file_sync` has an ENOSYS guard for
+                            // `copy_single_file_sync` has an ENOSYS guard for
                             // `is_force_clone()` on Windows (see the comment at
                             // the top of that branch), so passing `FORCE` would
                             // make every shell `cp file dest` fail with ENOSYS.
@@ -1908,7 +1908,7 @@ mod _async_tasks {
 
                 if !sys::S::ISDIR(stat_.st_mode as _) {
                     // This is the only file, there is no point in dispatching subtasks
-                    let r = nodefs._copy_single_file_sync(
+                    let r = nodefs.copy_single_file_sync(
                         src,
                         dest,
                         constants::Copyfile::from_raw(
@@ -1947,7 +1947,7 @@ mod _async_tasks {
             // are slices into `src_buf`/`dest_buf` and must end their borrow first.
             let src_len = PathInt::try_from(src.len()).expect("int cast");
             let dest_len = PathInt::try_from(dest.len()).expect("int cast");
-            let _ = Self::_cp_async_directory(
+            let _ = Self::cp_async_directory(
                 nodefs,
                 args.flags,
                 // Pass the raw `*mut Self` (Box::leak provenance) so spawned
@@ -1962,7 +1962,7 @@ mod _async_tasks {
         }
 
         // returns boolean `should_continue`
-        pub(super) fn _cp_async_directory(
+        pub(super) fn cp_async_directory(
             nodefs: &mut NodeFS,
             args: args::CpFlags,
             this: *mut Self,
@@ -2106,7 +2106,7 @@ mod _async_tasks {
                         dest_buf[dd] = paths::SEP as OSPathChar;
                         dest_buf[dd + 1 + cname.len()] = 0;
 
-                        let should_continue = Self::_cp_async_directory(
+                        let should_continue = Self::cp_async_directory(
                             nodefs,
                             args,
                             this,
@@ -8252,7 +8252,7 @@ impl NodeFS {
             if attributes & sys::c::FILE_ATTRIBUTE_DIRECTORY == 0
                 || attributes & sys::c::FILE_ATTRIBUTE_REPARSE_POINT != 0
             {
-                let r = self._copy_single_file_sync(
+                let r = self.copy_single_file_sync(
                     src,
                     dest,
                     constants::Copyfile::from_raw(if cp_flags.error_on_exist || !cp_flags.force {
@@ -8281,7 +8281,7 @@ impl NodeFS {
                 }
             };
             if !sys::S::ISDIR(stat_.st_mode as _) {
-                let r = self._copy_single_file_sync(
+                let r = self.copy_single_file_sync(
                     src,
                     dest,
                     constants::Copyfile::from_raw(if cp_flags.error_on_exist || !cp_flags.force {
@@ -8407,7 +8407,7 @@ impl NodeFS {
                     // NUL written at [len] above; `from_buf` debug-asserts it.
                     let src_z = OSPathSliceZ::from_buf(&src_buf[..], sd + 1 + name_slice.len());
                     let dest_z = OSPathSliceZ::from_buf(&dest_buf[..], dd + 1 + name_slice.len());
-                    let r = self._copy_single_file_sync(
+                    let r = self.copy_single_file_sync(
                         src_z,
                         dest_z,
                         constants::Copyfile::from_raw(
@@ -8466,7 +8466,8 @@ impl NodeFS {
         result
     }
 
-    fn _cp_symlink(&mut self, src: &ZStr, dest: &ZStr) -> Maybe<ret::CopyFile> {
+    #[cfg_attr(any(windows, target_os = "macos"), allow(dead_code))]
+    fn cp_symlink(&mut self, src: &ZStr, dest: &ZStr) -> Maybe<ret::CopyFile> {
         let mut target_buf = PathBuffer::uninit();
         // `bun_sys::readlink` returns the byte length on every
         // platform (the `Syscall` alias = `sys_uv` on Windows would return the
@@ -8516,7 +8517,7 @@ impl NodeFS {
     }
 
     /// This is `copyFile`, but it copies symlinks as-is
-    pub fn _copy_single_file_sync(
+    pub fn copy_single_file_sync(
         &mut self,
         src: &OSPathSliceZ,
         dest: &OSPathSliceZ,
@@ -8609,7 +8610,7 @@ impl NodeFS {
                 }
 
                 let dest_fd =
-                    Self::_cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
+                    Self::cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
                 let _close_dest =
                     scopeguard::guard((dest_fd, stat_.st_mode, &wrote), |(fd, m, wrote)| {
                         let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
@@ -8676,7 +8677,7 @@ impl NodeFS {
                     if err.get_errno() == E::ELOOP {
                         // ELOOP is returned when you open a symlink with NOFOLLOW.
                         // as in, it does not actually let you open it.
-                        return self._cp_symlink(src, dest);
+                        return self.cp_symlink(src, dest);
                     }
                     return Err(err);
                 }
@@ -8702,7 +8703,7 @@ impl NodeFS {
                 flags |= sys::O::EXCL;
             }
 
-            let dest_fd = Self::_cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
+            let dest_fd = Self::cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
 
             let mut size: usize = stat_.st_size.max(0) as usize;
 
@@ -8848,7 +8849,7 @@ impl NodeFS {
                     // open(2) returns EMLINK for this case, though POSIX
                     // specifies ELOOP; accept either.
                     if matches!(err.get_errno(), E::EMLINK | E::ELOOP) {
-                        return self._cp_symlink(src, dest);
+                        return self.cp_symlink(src, dest);
                     }
                     return Err(err);
                 }
@@ -8874,7 +8875,7 @@ impl NodeFS {
             }
 
             let dest_fd =
-                match Self::_cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode) {
+                match Self::cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode) {
                     Ok(fd) => fd,
                     Err(e) => return Err(e),
                 };
@@ -9115,11 +9116,12 @@ impl NodeFS {
     }
 
     /// Shared `dest_fd:` block from the mac/linux/freebsd branches of
-    /// `_copy_single_file_sync`.
+    /// `copy_single_file_sync`.
     /// Tries `open(dest, flags, mode)`; on ENOENT creates the
     /// parent directory and retries once. Any other error is annotated with
     /// `dest` copied into `sync_error_buf`.
-    fn _cp_open_dest_with_mkdir(&mut self, dest: &ZStr, flags: i32, mode: Mode) -> Maybe<FD> {
+    #[cfg_attr(windows, allow(dead_code))]
+    fn cp_open_dest_with_mkdir(&mut self, dest: &ZStr, flags: i32, mode: Mode) -> Maybe<FD> {
         // PORT: extracted from the mac/linux/freebsd arms of `_copySingleFileSync`
         // only — there `OSPathSliceZ == ZStr`. Taking `&ZStr` keeps the body
         // monomorphic (and lets it type-check on Windows where it's dead code).
@@ -9162,7 +9164,7 @@ impl NodeFS {
         dest_buf: &mut OSPathBuffer,
         dest_dir_len: PathInt,
     ) -> bool {
-        AsyncCpTask::_cp_async_directory(
+        AsyncCpTask::cp_async_directory(
             self,
             args,
             task,

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -1057,7 +1057,7 @@ pub(crate) fn extname(
 
 /// Based on Node v21.6.1 private helper _format:
 /// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L145
-fn _format_t<'a, T: PathCharCwd>(
+fn format_t<'a, T: PathCharCwd>(
     path_object: &PathParsed<'a, T>,
     sep: T,
     buf: &'a mut [T],
@@ -1159,7 +1159,7 @@ pub(crate) fn format_posix_js_t<T: PathCharCwd>(
 ) -> JsResult<JSValue> {
     create_js_string_t::<T>(
         global_object,
-        _format_t(path_object, T::from_u8(CHAR_FORWARD_SLASH), buf),
+        format_t(path_object, T::from_u8(CHAR_FORWARD_SLASH), buf),
     )
 }
 
@@ -1170,7 +1170,7 @@ pub(crate) fn format_windows_js_t<T: PathCharCwd>(
 ) -> JsResult<JSValue> {
     create_js_string_t::<T>(
         global_object,
-        _format_t(path_object, T::from_u8(CHAR_BACKWARD_SLASH), buf),
+        format_t(path_object, T::from_u8(CHAR_BACKWARD_SLASH), buf),
     )
 }
 

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -223,7 +223,7 @@ pub(crate) struct ChangeEvent {
     #[cfg(not(windows))]
     hash: u64,
     #[cfg(not(windows))]
-    event_type_: WatchEventKind,
+    event_type: WatchEventKind,
     #[cfg(not(windows))]
     timestamp: i64,
 }
@@ -234,11 +234,11 @@ impl ChangeEvent {
         let time_diff = timestamp - self.timestamp;
         if self.timestamp == 0
             || time_diff > 1
-            || self.event_type_ != event_type
+            || self.event_type != event_type
             || self.hash != hash
         {
             self.timestamp = timestamp;
-            self.event_type_ = event_type;
+            self.event_type = event_type;
             self.hash = hash;
             return true;
         }
@@ -323,9 +323,9 @@ impl PathWatcher {
     ///
     /// On macOS the FSEvents unregister happens *after* releasing `manager.mutex`:
     /// `FSEventsWatcher.deinit()` takes the FSEvents loop mutex, and the CF thread's
-    /// `_events_cb` holds that mutex while calling into `onFSEvent` (which takes
+    /// `events_cb` holds that mutex while calling into `onFSEvent` (which takes
     /// `manager.mutex`). Holding both here would be AB/BA with the CF thread. Once
-    /// `fse.deinit()` returns, `_events_cb` has released the loop mutex and nulled our
+    /// `fse.deinit()` returns, `events_cb` has released the loop mutex and nulled our
     /// slot, so no further callbacks will fire and `destroy()` is safe.
     ///
     /// # Safety
@@ -1207,7 +1207,7 @@ impl Darwin {
 
     /// Caller does NOT hold `manager.mutex` (same lock-order reasoning as `addWatch`).
     /// `FSEventsWatcher.deinit()` → `unregisterWatcher()` blocks on the FSEvents loop
-    /// mutex, which `_events_cb` holds for the whole dispatch; once this returns no
+    /// mutex, which `events_cb` holds for the whole dispatch; once this returns no
     /// further `onFSEvent` calls will arrive for `watcher`.
     ///
     /// Takes a raw `*mut PathWatcher`: while we block on the FSEvents loop mutex
@@ -1226,14 +1226,14 @@ impl Darwin {
         }
     }
 
-    /// Called from the CFRunLoop thread (`fs_events.rs`'s `_events_cb`) with the
+    /// Called from the CFRunLoop thread (`fs_events.rs`'s `events_cb`) with the
     /// FSEvents loop mutex held. Take `manager.mutex` so iterating `handlers` can't
     /// race with `watch()`/`detach()` mutating it. The JS thread never holds
     /// `manager.mutex` across a call into FSEvents, so this is deadlock-free.
     ///
     /// `watcher` itself is kept alive by the FSEvents loop mutex: `detach()` →
     /// `removeWatch()` → `fse.deinit()` → `unregisterWatcher()` blocks until
-    /// `_events_cb` releases it, so `destroy()` cannot run under us. The
+    /// `events_cb` releases it, so `destroy()` cannot run under us. The
     /// `watcher.manager == null` check catches the window where detach has already
     /// unlinked us but hasn't yet called `fse.deinit()`.
     fn on_fs_event(ctx: *mut c_void, event: Event, is_file: bool) {

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -25,7 +25,7 @@ pub struct Context {
     pub flush: Op,
 
     pub last_result: LastResult,
-    pub error_: c::BrotliDecoderErrorCode2,
+    pub error: c::BrotliDecoderErrorCode2,
 
     /// Owned copy of the dictionary bytes. The prepared dictionary (encode) and
     /// the decoder (decode) borrow this buffer, so it must outlive both; it is
@@ -47,7 +47,7 @@ impl Default for Context {
             flush: Op::process,
             // SAFETY: all-zero is a valid LastResult (c_int 0 / enum 0).
             last_result: unsafe { bun_core::ffi::zeroed_unchecked() },
-            error_: c::BrotliDecoderErrorCode2::NO_ERROR,
+            error: c::BrotliDecoderErrorCode2::NO_ERROR,
             dictionary: Vec::new(),
             prepared_dictionary: None,
         }
@@ -602,7 +602,7 @@ mod _impl {
                     };
                     // SAFETY: d was just written by the line above.
                     if unsafe { self.last_result.d } == c::BrotliDecoderResult::err {
-                        self.error_ = c::BrotliDecoderGetErrorCode(self.decoder_mut());
+                        self.error = c::BrotliDecoderGetErrorCode(self.decoder_mut());
                     }
                 }
                 _ => unreachable!(),
@@ -628,11 +628,11 @@ mod _impl {
                     Error::ok()
                 }
                 bun_zlib::NodeMode::BROTLI_DECODE => {
-                    if self.error_ != c::BrotliDecoderErrorCode2::NO_ERROR {
+                    if self.error != c::BrotliDecoderErrorCode2::NO_ERROR {
                         return Error::init(
                             c"Decompression failed".as_ptr(),
-                            self.error_ as i32,
-                            code_for_error(self.error_),
+                            self.error as i32,
+                            code_for_error(self.error),
                         );
                     } else if self.flush == Op::finish
                     // SAFETY: d is the active field after a decode do_work().

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -492,7 +492,7 @@ impl NodeHTTPResponse {
         {
             return;
         }
-        raw.resume_();
+        raw.resume();
     }
 
     pub(crate) fn upgrade(

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -293,11 +293,11 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     pub user_routes: Vec<UserRoute<SSL, DEBUG>>,
 
     /// Raw shadow of the wrapper's `m_onClientError` WriteBarrier slot.
-    /// `JSValue::ZERO` when unset; written by `server_set_on_client_error_`.
+    /// `JSValue::ZERO` when unset; written by `server_set_on_client_error`.
     pub on_clienterror: JSValue,
 
     /// Raw shadow of the wrapper's `m_onConnection` WriteBarrier slot.
-    /// `JSValue::ZERO` when unset; written by `server_set_on_connection_`.
+    /// `JSValue::ZERO` when unset; written by `server_set_on_connection`.
     pub on_connection: JSValue,
 
     pub inspector_server_id: jsc::DebuggerId,

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3941,10 +3941,7 @@ extern "C" fn server_set_on_client_error_shim(
     server: JSValue,
     callback: JSValue,
 ) -> JSValue {
-    host_fn::to_js_host_fn_result(
-        global,
-        server_set_on_client_error(global, server, callback),
-    )
+    host_fn::to_js_host_fn_result(global, server_set_on_client_error(global, server, callback))
 }
 
 #[unsafe(export_name = "Server__setOnConnection")]

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3641,7 +3641,7 @@ pub(super) extern "C" fn Server__setIdleTimeout(
     seconds: JSValue,
     global: &JSGlobalObject,
 ) {
-    match server_set_idle_timeout_(server, seconds, global) {
+    match server_set_idle_timeout(server, seconds, global) {
         Ok(()) => {}
         Err(JsError::Thrown) => {}
         Err(JsError::OutOfMemory) => {
@@ -3651,7 +3651,7 @@ pub(super) extern "C" fn Server__setIdleTimeout(
     }
 }
 
-pub(super) fn server_set_idle_timeout_(
+pub(super) fn server_set_idle_timeout(
     server: JSValue,
     seconds: JSValue,
     global: &JSGlobalObject,
@@ -3688,7 +3688,7 @@ pub(super) fn server_set_idle_timeout_(
     Ok(())
 }
 
-pub(super) fn server_set_on_client_error_(
+pub(super) fn server_set_on_client_error(
     global: &JSGlobalObject,
     server: JSValue,
     callback: JSValue,
@@ -3756,7 +3756,7 @@ pub(super) fn server_set_on_client_error_(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn server_set_on_connection_(
+pub(super) fn server_set_on_connection(
     global: &JSGlobalObject,
     server: JSValue,
     callback: JSValue,
@@ -3818,7 +3818,7 @@ pub(super) fn server_set_on_connection_(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn server_set_app_flags_(
+pub(super) fn server_set_app_flags(
     global: &JSGlobalObject,
     server: JSValue,
     require_host_header: bool,
@@ -3872,7 +3872,7 @@ pub(super) fn server_set_app_flags_(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn server_set_max_http_header_size_(
+pub(super) fn server_set_max_http_header_size(
     global: &JSGlobalObject,
     server: JSValue,
     max_header_size: u64,
@@ -3924,7 +3924,7 @@ extern "C" fn server_set_app_flags_shim(
 ) -> JSValue {
     host_fn::to_js_host_fn_result(
         global,
-        server_set_app_flags_(
+        server_set_app_flags(
             global,
             server,
             require_host_header,
@@ -3943,7 +3943,7 @@ extern "C" fn server_set_on_client_error_shim(
 ) -> JSValue {
     host_fn::to_js_host_fn_result(
         global,
-        server_set_on_client_error_(global, server, callback),
+        server_set_on_client_error(global, server, callback),
     )
 }
 
@@ -3953,7 +3953,7 @@ extern "C" fn server_set_on_connection_shim(
     server: JSValue,
     callback: JSValue,
 ) -> JSValue {
-    host_fn::to_js_host_fn_result(global, server_set_on_connection_(global, server, callback))
+    host_fn::to_js_host_fn_result(global, server_set_on_connection(global, server, callback))
 }
 
 #[unsafe(export_name = "Server__setMaxHTTPHeaderSize")]
@@ -3964,7 +3964,7 @@ extern "C" fn server_set_max_http_header_size_shim(
 ) -> JSValue {
     host_fn::to_js_host_fn_result(
         global,
-        server_set_max_http_header_size_(global, server, max_header_size),
+        server_set_max_http_header_size(global, server, max_header_size),
     )
 }
 

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -969,8 +969,8 @@ impl BunTest {
                     min_timeout = min_timeout.min_ignore_epoch(timeout);
                 }
                 StepResult::Complete => {
-                    // SAFETY: short-lived reborrow; `_advance` does not re-enter `.get()`.
-                    if unsafe { (*this)._advance(global_this)? } == Advance::Exit {
+                    // SAFETY: short-lived reborrow; `advance` does not re-enter `.get()`.
+                    if unsafe { (*this).advance(global_this)? } == Advance::Exit {
                         return Ok(());
                     }
                     // SAFETY: `UnsafeCell`-derived `*mut`; sole `&mut` for this enqueue.
@@ -1017,7 +1017,7 @@ impl BunTest {
         }
     }
 
-    fn _advance(&mut self, _global_this: &JSGlobalObject) -> JsResult<Advance> {
+    fn advance(&mut self, _global_this: &JSGlobalObject) -> JsResult<Advance> {
         let _g = group_begin!();
         bun_core::scoped_log!(bun_test_group, "advance from {}", <&'static str>::from(self.phase));
         // capture `self.phase` by raw ptr so the deferred log doesn't

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -759,9 +759,8 @@ impl Expect {
         Err(global_this.throw(format_args!("expect() cannot be called with new")))
     }
 
-    // pass here has a leading underscore to avoid name collision with the pass variable in other functions
     #[bun_jsc::host_fn(method)]
-    pub fn _pass(
+    pub fn pass(
         &self,
         global_this: &JSGlobalObject,
         call_frame: &CallFrame,

--- a/src/runtime/test_runner/jest.classes.ts
+++ b/src/runtime/test_runner/jest.classes.ts
@@ -286,7 +286,7 @@ export default [
     },
     proto: {
       pass: {
-        fn: "_pass",
+        fn: "pass",
         length: 1,
       },
       fail: {

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1928,7 +1928,6 @@ impl<const SSL: bool> SocketHandler<SSL> {
         )
     }
 
-    // `pub const onHandshake = if (ssl) onHandshake_ else null;`
     pub const ON_HANDSHAKE: Option<
         fn(
             &JSValkeyClient,

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1776,7 +1776,7 @@ pub struct SocketHandler<const SSL: bool>;
 type SocketType<const SSL: bool> = uws::NewSocketHandler<SSL>;
 
 impl<const SSL: bool> SocketHandler<SSL> {
-    fn _socket(s: SocketType<SSL>) -> Socket {
+    fn socket(s: SocketType<SSL>) -> Socket {
         // `NewSocketHandler<SSL>` only differs by const generic; the
         // `socket` field is identical. Re-wrap the inner `InternalSocket` into
         // the right `AnySocket` variant.
@@ -1788,11 +1788,11 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub fn on_open(this: &JSValkeyClient, socket: SocketType<SSL>) -> JsTerminatedResult<()> {
-        this.client_mut().socket = Self::_socket(socket);
-        narrow_terminated(this.client_mut().on_open(Self::_socket(socket)))
+        this.client_mut().socket = Self::socket(socket);
+        narrow_terminated(this.client_mut().on_open(Self::socket(socket)))
     }
 
-    pub fn on_handshake_(
+    pub fn on_handshake(
         this: &JSValkeyClient,
         _socket: SocketType<SSL>,
         success: i32,
@@ -1936,7 +1936,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
             i32,
             uws::us_bun_verify_error_t,
         ) -> JsTerminatedResult<()>,
-    > = if SSL { Some(Self::on_handshake_) } else { None };
+    > = if SSL { Some(Self::on_handshake) } else { None };
 
     pub fn on_close(
         this: &JSValkeyClient,
@@ -1984,13 +1984,13 @@ impl<const SSL: bool> SocketHandler<SSL> {
     pub fn on_timeout(this: &JSValkeyClient, socket: SocketType<SSL>) {
         debug!("Socket timed out.");
 
-        this.client_mut().socket = Self::_socket(socket);
+        this.client_mut().socket = Self::socket(socket);
         // Handle socket timeout
     }
 
     pub fn on_data(this: &JSValkeyClient, socket: SocketType<SSL>, data: &[u8]) {
         // Ensure the socket pointer is updated.
-        this.client_mut().socket = Self::_socket(socket);
+        this.client_mut().socket = Self::socket(socket);
 
         let _guard = this.ref_scope();
         let _ = this.client_mut().on_data(data); // TODO: properly propagate exception upwards
@@ -1998,7 +1998,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub fn on_writable(this: &JSValkeyClient, socket: SocketType<SSL>) {
-        this.client_mut().socket = Self::_socket(socket);
+        this.client_mut().socket = Self::socket(socket);
         let _guard = this.ref_scope();
         this.client_mut().on_writable();
         this.update_poll_ref();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -821,7 +821,7 @@ impl BlobExt for Blob {
         let mut buffer_stream =
             bun_io::FixedBufferStream::new(unsafe { bun_core::ffi::slice(*cursor, total_length) });
 
-        let result = match _on_structured_clone_deserialize(global_this, &mut buffer_stream) {
+        let result = match on_structured_clone_deserialize(global_this, &mut buffer_stream) {
             Ok(v) => v,
             Err(e) if e.name() == "OutOfMemory" => {
                 return Err(global_this.throw_out_of_memory());
@@ -4118,7 +4118,7 @@ fn read_slice<B: AsRef<[u8]>>(
     Ok(slice)
 }
 
-fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
+fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
     global_this: &JSGlobalObject,
     reader: &mut bun_io::FixedBufferStream<B>,
 ) -> crate::Result<JSValue> {
@@ -5560,8 +5560,8 @@ bun_jsc::jsc_host_abi! {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> Option<NonNull<Blob>> {
-        match jsdom_file_construct_(global_this, callframe) {
-            Ok(b) => Some(NonNull::new(b).expect("jsdom_file_construct_ returns Blob::new (heap::alloc)")),
+        match jsdom_file_construct(global_this, callframe) {
+            Ok(b) => Some(NonNull::new(b).expect("jsdom_file_construct returns Blob::new (heap::alloc)")),
             Err(jsc::JsError::Thrown) => None,
             Err(jsc::JsError::OutOfMemory) => {
                 let _ = global_this.throw_out_of_memory();
@@ -5572,7 +5572,7 @@ bun_jsc::jsc_host_abi! {
     }
 }
 
-pub fn jsdom_file_construct_(
+pub fn jsdom_file_construct(
     global_this: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<*mut Blob> {

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1452,7 +1452,7 @@ pub struct WindowsSpawnResult {
     // ref-counted via `bun_ptr::ThreadSafeRefCount` and recovered via
     // `uv_process_t.data` in the libuv callbacks; allocation is `heap::alloc`
     // and destruction is `heap::take` (see `ThreadSafeRefCounted::destructor`).
-    pub process_: Option<*mut Process>,
+    pub process: Option<*mut Process>,
     pub stdin: WindowsStdioResult,
     pub stdout: WindowsStdioResult,
     pub stderr: WindowsStdioResult,
@@ -1465,7 +1465,7 @@ pub struct WindowsSpawnResult {
 impl Default for WindowsSpawnResult {
     fn default() -> Self {
         Self {
-            process_: None,
+            process: None,
             stdin: WindowsStdioResult::Unavailable,
             stdout: WindowsStdioResult::Unavailable,
             stderr: WindowsStdioResult::Unavailable,
@@ -1536,7 +1536,7 @@ impl Drop for WindowsSpawnResult {
 #[cfg(windows)]
 impl WindowsSpawnResult {
     pub fn to_process(&mut self, _event_loop: impl Sized, sync_: bool) -> *mut Process {
-        let process = self.process_.take().unwrap();
+        let process = self.process.take().unwrap();
         // SAFETY: caller has unique ownership at this point (just spawned)
         unsafe {
             (*process).sync = sync_;
@@ -1545,7 +1545,7 @@ impl WindowsSpawnResult {
     }
 
     pub fn close(&mut self) {
-        if let Some(proc) = self.process_.take() {
+        if let Some(proc) = self.process.take() {
             // SAFETY: proc is a live intrusive-refcounted Process
             unsafe {
                 (*proc).close();
@@ -2173,7 +2173,7 @@ mod spawn_process_body {
         // temporary default — E0509. Spell the defaults out instead.
         let mut result = WindowsSpawnResult {
             // Intrusive raw pointer; refcount lives inside `Process` (see field comment).
-            process_: Some(process),
+            process: Some(process),
             stdin: WindowsStdioResult::Unavailable,
             stdout: WindowsStdioResult::Unavailable,
             stderr: WindowsStdioResult::Unavailable,

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -162,16 +162,16 @@ pub trait RusageFields {
     fn utime_usec(&self) -> i64;
     fn stime_sec(&self) -> i64;
     fn stime_usec(&self) -> i64;
-    fn maxrss_(&self) -> f64;
-    fn ixrss_(&self) -> f64;
-    fn nswap_(&self) -> f64;
-    fn inblock_(&self) -> f64;
-    fn oublock_(&self) -> f64;
-    fn msgsnd_(&self) -> f64;
-    fn msgrcv_(&self) -> f64;
-    fn nsignals_(&self) -> f64;
-    fn nvcsw_(&self) -> f64;
-    fn nivcsw_(&self) -> f64;
+    fn maxrss(&self) -> f64;
+    fn ixrss(&self) -> f64;
+    fn nswap(&self) -> f64;
+    fn inblock(&self) -> f64;
+    fn oublock(&self) -> f64;
+    fn msgsnd(&self) -> f64;
+    fn msgrcv(&self) -> f64;
+    fn nsignals(&self) -> f64;
+    fn nvcsw(&self) -> f64;
+    fn nivcsw(&self) -> f64;
 }
 
 #[cfg(unix)]
@@ -195,43 +195,43 @@ impl RusageFields for libc::rusage {
         self.ru_stime.tv_usec as i64
     }
     #[inline]
-    fn maxrss_(&self) -> f64 {
+    fn maxrss(&self) -> f64 {
         self.ru_maxrss as f64
     }
     #[inline]
-    fn ixrss_(&self) -> f64 {
+    fn ixrss(&self) -> f64 {
         self.ru_ixrss as f64
     }
     #[inline]
-    fn nswap_(&self) -> f64 {
+    fn nswap(&self) -> f64 {
         self.ru_nswap as f64
     }
     #[inline]
-    fn inblock_(&self) -> f64 {
+    fn inblock(&self) -> f64 {
         self.ru_inblock as f64
     }
     #[inline]
-    fn oublock_(&self) -> f64 {
+    fn oublock(&self) -> f64 {
         self.ru_oublock as f64
     }
     #[inline]
-    fn msgsnd_(&self) -> f64 {
+    fn msgsnd(&self) -> f64 {
         self.ru_msgsnd as f64
     }
     #[inline]
-    fn msgrcv_(&self) -> f64 {
+    fn msgrcv(&self) -> f64 {
         self.ru_msgrcv as f64
     }
     #[inline]
-    fn nsignals_(&self) -> f64 {
+    fn nsignals(&self) -> f64 {
         self.ru_nsignals as f64
     }
     #[inline]
-    fn nvcsw_(&self) -> f64 {
+    fn nvcsw(&self) -> f64 {
         self.ru_nvcsw as f64
     }
     #[inline]
-    fn nivcsw_(&self) -> f64 {
+    fn nivcsw(&self) -> f64 {
         self.ru_nivcsw as f64
     }
 }
@@ -254,44 +254,44 @@ impl RusageFields for WinRusage {
         self.stime.usec
     }
     #[inline]
-    fn maxrss_(&self) -> f64 {
+    fn maxrss(&self) -> f64 {
         self.maxrss as f64
     }
     // These counters do not exist on Windows — always zero.
     #[inline]
-    fn ixrss_(&self) -> f64 {
+    fn ixrss(&self) -> f64 {
         0.0
     }
     #[inline]
-    fn nswap_(&self) -> f64 {
+    fn nswap(&self) -> f64 {
         0.0
     }
     #[inline]
-    fn inblock_(&self) -> f64 {
+    fn inblock(&self) -> f64 {
         self.inblock as f64
     }
     #[inline]
-    fn oublock_(&self) -> f64 {
+    fn oublock(&self) -> f64 {
         self.oublock as f64
     }
     #[inline]
-    fn msgsnd_(&self) -> f64 {
+    fn msgsnd(&self) -> f64 {
         0.0
     }
     #[inline]
-    fn msgrcv_(&self) -> f64 {
+    fn msgrcv(&self) -> f64 {
         0.0
     }
     #[inline]
-    fn nsignals_(&self) -> f64 {
+    fn nsignals(&self) -> f64 {
         0.0
     }
     #[inline]
-    fn nvcsw_(&self) -> f64 {
+    fn nvcsw(&self) -> f64 {
         0.0
     }
     #[inline]
-    fn nivcsw_(&self) -> f64 {
+    fn nivcsw(&self) -> f64 {
         0.0
     }
 }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -948,7 +948,7 @@ pub struct SocketHandler<const SSL: bool>;
 // (`feature(inherent_associated_types)`), so spell out
 // `NewSocketHandler<SSL>` at every use site instead.
 impl<const SSL: bool> SocketHandler<SSL> {
-    fn _socket(s: NewSocketHandler<SSL>) -> AnySocket {
+    fn socket(s: NewSocketHandler<SSL>) -> AnySocket {
         if SSL {
             AnySocket::SocketTls(s.assume_ssl())
         } else {
@@ -957,7 +957,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub fn on_open(this: &JSMySQLConnection, s: NewSocketHandler<SSL>) {
-        let socket = Self::_socket(s);
+        let socket = Self::socket(s);
         let is_tcp = matches!(socket, AnySocket::SocketTcp(_));
         this.connection_mut().set_socket(socket);
 
@@ -973,7 +973,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.update_reference_type();
     }
 
-    fn on_handshake_(
+    fn on_handshake(
         this: &JSMySQLConnection,
         _: NewSocketHandler<SSL>,
         success: i32,
@@ -997,7 +997,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     // pub const onHandshake = if (ssl) onHandshake_ else null;
     pub const ON_HANDSHAKE: Option<
         fn(&JSMySQLConnection, NewSocketHandler<SSL>, i32, uws::us_bun_verify_error_t),
-    > = if SSL { Some(Self::on_handshake_) } else { None };
+    > = if SSL { Some(Self::on_handshake) } else { None };
 
     pub fn on_close(
         this: &JSMySQLConnection,

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -994,7 +994,6 @@ impl<const SSL: bool> SocketHandler<SSL> {
         }
     }
 
-    // pub const onHandshake = if (ssl) onHandshake_ else null;
     pub const ON_HANDSHAKE: Option<
         fn(&JSMySQLConnection, NewSocketHandler<SSL>, i32, uws::us_bun_verify_error_t),
     > = if SSL { Some(Self::on_handshake) } else { None };

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
@@ -244,7 +244,7 @@ pub fn decode_binary_value<Context: ReaderContext>(
             if column_length == 1 {
                 let data = reader.encode_len_string()?;
                 let slice = data.slice();
-                Ok(SQLDataCell::bool_(!slice.is_empty() && slice[0] == 1))
+                Ok(SQLDataCell::bool(!slice.is_empty() && slice[0] == 1))
             } else {
                 let data = reader.encode_len_string()?;
                 Ok(SQLDataCell::raw(Some(&data)))

--- a/src/sql_jsc/mysql/protocol/ResultSet.rs
+++ b/src/sql_jsc/mysql/protocol/ResultSet.rs
@@ -169,7 +169,7 @@ impl<'a> Row<'a> {
                 // BIT(1) is a special case, it's a boolean
                 if column.column_length == 1 {
                     let slice = value.slice();
-                    *cell = SQLDataCell::bool_(!slice.is_empty() && slice[0] == 1);
+                    *cell = SQLDataCell::bool(!slice.is_empty() && slice[0] == 1);
                 } else {
                     *cell = SQLDataCell::raw(value);
                 }

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -362,13 +362,13 @@ fn parse_array(
                                     return Err(AnyPostgresError::UnsupportedArrayFormat);
                                 }
                                 if &slice[0..5] == b"false" {
-                                    array.push(SQLDataCell::bool_(false));
+                                    array.push(SQLDataCell::bool(false));
                                     slice = try_slice(slice, 5);
                                     continue;
                                 }
                                 return Err(AnyPostgresError::UnsupportedArrayFormat);
                             } else {
-                                array.push(SQLDataCell::bool_(false));
+                                array.push(SQLDataCell::bool(false));
                                 slice = try_slice(slice, 1);
                                 continue;
                             }
@@ -380,13 +380,13 @@ fn parse_array(
                                     return Err(AnyPostgresError::UnsupportedArrayFormat);
                                 }
                                 if &slice[0..4] == b"true" {
-                                    array.push(SQLDataCell::bool_(true));
+                                    array.push(SQLDataCell::bool(true));
                                     slice = try_slice(slice, 4);
                                     continue;
                                 }
                                 return Err(AnyPostgresError::UnsupportedArrayFormat);
                             } else {
-                                array.push(SQLDataCell::bool_(true));
+                                array.push(SQLDataCell::bool(true));
                                 slice = try_slice(slice, 1);
                                 continue;
                             }
@@ -809,9 +809,9 @@ pub(crate) fn from_bytes(
         T::jsonb | T::json => Ok(SQLDataCell::json(bytes)),
         T::bool => {
             if binary {
-                Ok(SQLDataCell::bool_(!bytes.is_empty() && bytes[0] == 1))
+                Ok(SQLDataCell::bool(!bytes.is_empty() && bytes[0] == 1))
             } else {
-                Ok(SQLDataCell::bool_(!bytes.is_empty() && bytes[0] == b't'))
+                Ok(SQLDataCell::bool(!bytes.is_empty() && bytes[0] == b't'))
             }
         }
         tag @ (T::date | T::timestamp | T::timestamptz) => {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1329,7 +1329,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         Self::guarded(this, |t| t.on_open(Self::socket(socket)));
     }
 
-    fn on_handshake_(
+    fn on_handshake(
         this: &PostgresSQLConnection,
         _: SocketType<SSL>,
         success: i32,
@@ -1338,10 +1338,9 @@ impl<const SSL: bool> SocketHandler<SSL> {
         Self::guarded(this, |t| t.on_handshake(success, ssl_error));
     }
 
-    // pub const onHandshake = if (ssl) onHandshake_ else null;
     pub const ON_HANDSHAKE: Option<
         fn(&PostgresSQLConnection, SocketType<SSL>, i32, uws::us_bun_verify_error_t),
-    > = if SSL { Some(Self::on_handshake_) } else { None };
+    > = if SSL { Some(Self::on_handshake) } else { None };
 
     pub fn on_close(
         this: &PostgresSQLConnection,

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1302,7 +1302,7 @@ pub struct SocketHandler<const SSL: bool>;
 pub type SocketType<const SSL: bool> = uws::NewSocketHandler<SSL>;
 
 impl<const SSL: bool> SocketHandler<SSL> {
-    fn _socket(s: SocketType<SSL>) -> Socket {
+    fn socket(s: SocketType<SSL>) -> Socket {
         // `NewSocketHandler<SSL>` has identical layout for any `SSL`; rebuild the
         // monomorphic variant from the inner `InternalSocket`.
         if SSL {
@@ -1326,7 +1326,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub fn on_open(this: &PostgresSQLConnection, socket: SocketType<SSL>) {
-        Self::guarded(this, |t| t.on_open(Self::_socket(socket)));
+        Self::guarded(this, |t| t.on_open(Self::socket(socket)));
     }
 
     fn on_handshake_(

--- a/src/sql_jsc/shared/SQLDataCell.rs
+++ b/src/sql_jsc/shared/SQLDataCell.rs
@@ -310,7 +310,7 @@ impl SQLDataCell {
     }
 
     #[inline]
-    pub fn bool_(value: bool) -> SQLDataCell {
+    pub fn bool(value: bool) -> SQLDataCell {
         SQLDataCell {
             tag: Tag::Bool,
             value: Value { bool_: value as u8 },

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -171,7 +171,7 @@ impl<const SSL: bool> Response<SSL> {
         c::uws_res_pause(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn resume_(&mut self) {
+    pub fn resume(&mut self) {
         c::uws_res_resume(Self::ssl_flag(), self.as_raw())
     }
 
@@ -826,8 +826,8 @@ impl AnyResponse {
         any_dispatch!(self, |r| r.pause())
     }
 
-    pub fn resume_(self) {
-        any_dispatch!(self, |r| r.resume_())
+    pub fn resume(self) {
+        any_dispatch!(self, |r| r.resume())
     }
 
     pub fn write_header_int(self, key: &[u8], value: u64) {

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -157,7 +157,7 @@ impl Response {
     pub fn pause(&mut self) {
         c::uws_h3_res_pause(self)
     }
-    pub fn resume_(&mut self) {
+    pub fn resume(&mut self) {
         c::uws_h3_res_resume(self)
     }
     pub fn timeout(&mut self, seconds: u8) {


### PR DESCRIPTION
## What

Renames ~60 functions and ~12 struct fields across 75 files to drop leading/trailing underscores that were carried over from the Zig codebase as shadowing workarounds and are not needed in Rust.

Example: `resume_` is named that way because `resume` is a Zig keyword. It is not a Rust keyword, so `Response::resume()` is fine.

Example: `Expect::_pass` was named that way because other functions in the file had a local `pass` variable, which Zig refuses to shadow. Rust doesn't care, so it's now `Expect::pass` (jest.classes.ts updated to match).

Example: AST node fields `test_`/`catch_` exist because `test` and `catch` are Zig keywords. Neither is a Rust keyword.

## Functions renamed

**Trailing underscore dropped** (was a Zig keyword or shadowed a local):
- `resume_` (uws Response/h3)
- `or_` (VendorPrefix; `or` is a Zig keyword, not Rust)
- `jsdom_file_construct_`
- `on_handshake_` (valkey, mysql, postgres SocketHandler)
- `server_set_{idle_timeout,on_client_error,on_connection,app_flags,max_http_header_size}_`
- `RusageFields::{maxrss,ixrss,nswap,inblock,oublock,msgsnd,msgrcv,nsignals,nvcsw,nivcsw}_`
- `SQLDataCell::bool_`, `Frame::u32_`, `Reader::u32_`

**Leading underscore dropped** (Zig private-impl convention):
- `Expect::_pass` (+ jest.classes.ts)
- `_advance` `_parse` (dotenv) `_resolve` (jsc_hooks) `_boot_and_handle_error` `_stat` `_socket` `_decode` `_format_t` `_count_with_hash` `_buf_append_input` `_join_abs_string_buf_windows` `_on_read_chunk` `_on_structured_clone_deserialize` `_compare` `_compare_ipv6` `_generic_flush` `_generic_write` `_events_cb` `_schedule` `_stop`
- node_fs: `_cp_async_directory` `_cp_symlink` `_cp_open_dest_with_mkdir` `_copy_single_file_sync`
- ipc: `_socket_closed` `_write` `_on_write_complete` `_on_after_ipc_closed` `_close_socket_task` `_windows_close` `_windows_on_closed` `_windows_on_write_complete`

For `cp_symlink`/`cp_open_dest_with_mkdir` (only called on some platforms) the dead-code suppression moves from the `_` prefix to an explicit `#[cfg_attr(..., allow(dead_code))]`. The unused `#[cfg(not(windows))]` `_windows_close` stub in ipc.rs and the dead `NodeFS::_cp_async_directory` wrapper are removed.

## Struct fields renamed

- `test_` -> `test` (AST `If`/`For`/`DoWhile`/`While`/`Switch`, `e::If`; ~105 access sites)
- `catch_` -> `catch` (AST `Try`)
- `cache_directory_` (PackageManager), `error_` (NativeBrotli Context), `event_type_` (ChangeEvent), `file_polls_` (RareData, MiniEventLoop), `process_` (WindowsSpawnResult)

## Not renamed

- **Rust keywords/reserved**: `ref_` `loop_` `type_` `final_` `mut_` `do_` `typeof_` `static_` `match_` `as_` `use_` `impl_` `for_` `fn_` `in_` `self_` `move_` `macro_`. These still need the suffix.
- **Real C symbol names**: `deflateInit_` `inflateInit2_` `gzgetc_` `_dyld_*` `_lwp_self` `_strnicmp` `_umask` etc.
- **repr(C) fields matching the C struct**: libuv `sys_errno_`/`unused_`, libwebp `private_`, `ExternSocketConfig::unix_` (C macro collision), `SQLDataCell::Value::bool_`.
- **Same-scope wrapper/impl pairs**: html_rewriter `on_`/`get_attribute_`/..., CryptoHasher `hash_`/`digest_`, FetchHeaders `get_`/`cast_`/`fast_*_`, `NthSelectorData::is_function_`, `start_`/`next_`/`ptr_`/`generate_js_renamer_`/`_parse` (js_parser)/`_exec`/`_resolve` (VM)/etc. In each case the clean name already exists on the same type as a field, arg-decode wrapper, or public entrypoint, so the `_` variant still needs disambiguation. Happy to follow up with an `_impl` suffix convention if preferred.
- **Field+accessor pairs** (clean name is the getter): `Entry::base_`, `PackedMap::vlq_`, `RareData::{mysql,valkey,ws_*}_group_`, `spawn_sync_event_loop_`, c-ares `AddrInfo::name_`.
- **Intentional Rust `#[doc(hidden)]`/macro helpers**: `_atomic_*` `_dispatch_*` `_ws_minify*` `_wired` `_needs_nl` `_scoped_use_ansi`.
- `deref_`: kept for symmetry with `ref_`.

## Verification

`bun run rust:check-all` passes (linux/macos/windows, x64/aarch64). Smoke-tested `expect.test.js`, `html-rewriter.test`, `fs/cp.test.ts`, `blocklist-gc.test.ts`, `transpiler.test`, `bundler/esbuild/default.test.ts`.
