### PR TITLE
fetch: reject chunked responses truncated inside the trailer section

### DIFF
--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -235,12 +235,15 @@ impl<'a> InternalState<'a> {
     }
 
     /// True when a socket close during `in_progress` completes the body rather
-    /// than failing it: chunked decoder already in the trailers state, or a
-    /// close-delimited response (no Content-Length, no Transfer-Encoding).
+    /// than failing it: only a close-delimited response (no Content-Length, no
+    /// Transfer-Encoding, RFC 9112 section 6.3 rule 7). A chunked body is
+    /// self-delimiting; `phr_decode_chunked` returns >= 0 and sets
+    /// `received_last_chunk` only after the trailer section's terminating CRLF
+    /// (RFC 9112 section 7.1), so FIN while still in the trailer-scan states is
+    /// a truncated message.
     pub fn is_body_complete_on_close(&self) -> bool {
         if self.is_chunked_encoding() {
-            // 4 = CHUNKED_IN_TRAILERS_LINE_HEAD, 5 = CHUNKED_IN_TRAILERS_LINE_MIDDLE
-            return matches!(self.chunked_decoder._state, 4 | 5);
+            return self.flags.received_last_chunk;
         }
         self.content_length.is_none() && self.response_stage == HTTPStage::Body
     }

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -237,10 +237,10 @@ impl<'a> InternalState<'a> {
     /// True when a socket close during `in_progress` completes the body rather
     /// than failing it: only a close-delimited response (no Content-Length, no
     /// Transfer-Encoding, RFC 9112 section 6.3 rule 7). A chunked body is
-    /// self-delimiting; `phr_decode_chunked` returns >= 0 and sets
-    /// `received_last_chunk` only after the trailer section's terminating CRLF
-    /// (RFC 9112 section 7.1), so FIN while still in the trailer-scan states is
-    /// a truncated message.
+    /// self-delimiting; `received_last_chunk` is set by the chunked-body
+    /// handlers once `phr_decode_chunked` returns >= 0, which requires the
+    /// trailer section's terminating CRLF (RFC 9112 section 7.1), so FIN while
+    /// still in the trailer-scan states is a truncated message.
     pub fn is_body_complete_on_close(&self) -> bool {
         if self.is_chunked_encoding() {
             return self.flags.received_last_chunk;

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -235,12 +235,9 @@ impl<'a> InternalState<'a> {
     }
 
     /// True when a socket close during `in_progress` completes the body rather
-    /// than failing it: only a close-delimited response (no Content-Length, no
-    /// Transfer-Encoding, RFC 9112 section 6.3 rule 7). A chunked body is
-    /// self-delimiting; `received_last_chunk` is set by the chunked-body
-    /// handlers once `phr_decode_chunked` returns >= 0, which requires the
-    /// trailer section's terminating CRLF (RFC 9112 section 7.1), so FIN while
-    /// still in the trailer-scan states is a truncated message.
+    /// than failing it: a close-delimited response (no Content-Length, no
+    /// Transfer-Encoding). A chunked body is self-delimiting (RFC 9112 7.1);
+    /// FIN before the trailer section's terminating CRLF is truncation.
     pub fn is_body_complete_on_close(&self) -> bool {
         if self.is_chunked_encoding() {
             return self.flags.received_last_chunk;

--- a/test/js/web/fetch/chunked-trailing.test.js
+++ b/test/js/web/fetch/chunked-trailing.test.js
@@ -22,12 +22,12 @@ it("handles trailing headers split across packets", async () => {
         }, 10);
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello, world");
 });
@@ -48,12 +48,12 @@ it("handles trailing headers in a single packet", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -73,12 +73,12 @@ it("handles trailing headers with empty body", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("");
 });
@@ -101,12 +101,12 @@ it("handles multiple trailing headers", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -130,12 +130,12 @@ it("handles trailing headers with very long delay", async () => {
         }, 100);
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -170,12 +170,12 @@ it("handles trailing headers with byte-by-byte transmission", async () => {
         setTimeout(writeNextByte, 10);
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -198,13 +198,13 @@ it("rejects when the trailer section is missing its final CRLF", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
   try {
-    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    await fetch(`http://127.0.0.1:${address.port}`).then(res => res.text());
     expect.unreachable();
   } catch (e) {
     expect(e?.code).toBe("ECONNRESET");
@@ -228,12 +228,12 @@ it("handles trailing headers with extremely large values", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -254,13 +254,13 @@ it("rejects when the connection closes inside the trailer section", async () => 
         socket.end(); // Close connection abruptly
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
   try {
-    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    await fetch(`http://127.0.0.1:${address.port}`).then(res => res.text());
     expect.unreachable();
   } catch (e) {
     expect(e?.code).toBe("ECONNRESET");
@@ -277,13 +277,13 @@ it("rejects when the connection closes after 0\\r\\n with no terminating CRLF", 
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
   try {
-    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    await fetch(`http://127.0.0.1:${address.port}`).then(res => res.text());
     expect.unreachable();
   } catch (e) {
     expect(e?.code).toBe("ECONNRESET");
@@ -300,13 +300,13 @@ it("rejects when the connection closes mid-trailer-line", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
   try {
-    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    await fetch(`http://127.0.0.1:${address.port}`).then(res => res.text());
     expect.unreachable();
   } catch (e) {
     expect(e?.code).toBe("ECONNRESET");
@@ -331,12 +331,12 @@ it("handles trailing headers with multiple header lines", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -357,12 +357,12 @@ it("handles trailing headers with empty values", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -387,12 +387,12 @@ it("handles delayed trailing headers", async () => {
         }, 100);
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -420,12 +420,12 @@ it("handles trailing headers after the final chunk only", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("HelloWorld");
 });
@@ -447,12 +447,12 @@ it("handles chunked extensions with empty extension", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -474,12 +474,12 @@ it("handles chunked extensions with simple key", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -501,12 +501,12 @@ it("handles chunked extensions with key-value pair", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -528,12 +528,12 @@ it("handles chunked extensions with quoted value", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -560,12 +560,12 @@ it("handles chunked extensions on multiple chunks", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("HelloWorld");
 });
@@ -591,12 +591,12 @@ it("handles chunked extensions with trailing headers", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("HelloWorld");
 });
@@ -618,12 +618,12 @@ it("handles chunked extensions with special characters", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
+  const res = await fetch(`http://127.0.0.1:${address.port}`);
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("Hello");
 });
@@ -646,13 +646,13 @@ it("proper error if missing zero-length chunk", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   try {
     const address = await promise;
-    const response = await fetch(`http://localhost:${address.port}`);
+    const response = await fetch(`http://127.0.0.1:${address.port}`);
     expect(response.status).toBe(200);
     await response.text();
     expect.unreachable();
@@ -681,13 +681,13 @@ it("proper error if missing data in middle of chunk extension", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   try {
     const address = await promise;
-    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    await fetch(`http://127.0.0.1:${address.port}`).then(res => res.text());
     expect.unreachable();
   } catch (e) {
     expect(e?.code).toBe("ECONNRESET");
@@ -715,13 +715,13 @@ it("proper error if missing CRLF after chunk data", async () => {
         socket.end();
       });
     })
-    .listen(0, "localhost", () => {
+    .listen(0, "127.0.0.1", () => {
       resolve(server.address());
     });
 
   try {
     const address = await promise;
-    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    await fetch(`http://127.0.0.1:${address.port}`).then(res => res.text());
     expect.unreachable();
   } catch (e) {
     expect(e?.code).toBe("InvalidHTTPResponse");

--- a/test/js/web/fetch/chunked-trailing.test.js
+++ b/test/js/web/fetch/chunked-trailing.test.js
@@ -180,7 +180,9 @@ it("handles trailing headers with byte-by-byte transmission", async () => {
   expect(await res.text()).toBe("Hello");
 });
 
-it("handles trailing headers with malformed format (missing final CRLF)", async () => {
+it("rejects when the trailer section is missing its final CRLF", async () => {
+  // RFC 9112 section 7.1: chunked-body = *chunk last-chunk trailer-section CRLF.
+  // EOF before the terminating CRLF is a truncated message; node (undici) rejects this.
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
@@ -201,9 +203,12 @@ it("handles trailing headers with malformed format (missing final CRLF)", async 
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
-  expect(res.status).toBe(200);
-  expect(await res.text()).toBe("Hello");
+  try {
+    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    expect.unreachable();
+  } catch (e) {
+    expect(e?.code).toBe("ECONNRESET");
+  }
 });
 
 it("handles trailing headers with extremely large values", async () => {
@@ -233,7 +238,7 @@ it("handles trailing headers with extremely large values", async () => {
   expect(await res.text()).toBe("Hello");
 });
 
-it("handles connection close during trailing headers", async () => {
+it("rejects when the connection closes inside the trailer section", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
@@ -254,9 +259,58 @@ it("handles connection close during trailing headers", async () => {
     });
 
   const address = await promise;
-  const res = await fetch(`http://localhost:${address.port}`);
-  expect(res.status).toBe(200);
-  expect(await res.text()).toBe("Hello");
+  try {
+    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    expect.unreachable();
+  } catch (e) {
+    expect(e?.code).toBe("ECONNRESET");
+  }
+});
+
+it("rejects when the connection closes after 0\\r\\n with no terminating CRLF", async () => {
+  const { promise, resolve } = Promise.withResolvers();
+  await using server = net
+    .createServer(socket => {
+      socket.on("error", () => {}); // raw test server: tolerate client aborts (ECONNRESET)
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntrun\r\n0\r\n");
+        socket.end();
+      });
+    })
+    .listen(0, "localhost", () => {
+      resolve(server.address());
+    });
+
+  const address = await promise;
+  try {
+    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    expect.unreachable();
+  } catch (e) {
+    expect(e?.code).toBe("ECONNRESET");
+  }
+});
+
+it("rejects when the connection closes mid-trailer-line", async () => {
+  const { promise, resolve } = Promise.withResolvers();
+  await using server = net
+    .createServer(socket => {
+      socket.on("error", () => {}); // raw test server: tolerate client aborts (ECONNRESET)
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n0\r\nX-Trail: par");
+        socket.end();
+      });
+    })
+    .listen(0, "localhost", () => {
+      resolve(server.address());
+    });
+
+  const address = await promise;
+  try {
+    await fetch(`http://localhost:${address.port}`).then(res => res.text());
+    expect.unreachable();
+  } catch (e) {
+    expect(e?.code).toBe("ECONNRESET");
+  }
 });
 
 it("handles trailing headers with multiple header lines", async () => {


### PR DESCRIPTION
### What does this PR do?

A chunked response cut off after the last-chunk (`0\r\n`) but before the trailer section's terminating CRLF was being delivered by `fetch()` as a complete, successful response. RFC 9112 section 7.1 defines chunked-body as `*chunk last-chunk trailer-section CRLF`; EOF anywhere before that final CRLF is a truncated message.

```js
import net from "node:net";
const srv = net.createServer((sock) => {
  sock.once("data", () => {
    sock.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntrun\r\n0\r\n"); // no terminating CRLF
    sock.end();
  });
});
srv.listen(0, "127.0.0.1", async () => {
  try {
    const res = await fetch(`http://127.0.0.1:${srv.address().port}/`);
    console.log("RESOLVED", res.status, JSON.stringify(await res.text()));
  } catch (e) {
    console.log("REJECTED", e.name, e.code);
  }
  srv.close();
});
```

Before: `RESOLVED 200 "trun"`. After: `REJECTED Error ECONNRESET`. Node (undici) rejects the same input with `TypeError: terminated`; bun's own `node:http` client already rejects with `ECONNRESET`.

### Cause

`InternalState::is_body_complete_on_close()` treated the picohttpparser trailer-scan states (`CHUNKED_IN_TRAILERS_LINE_HEAD` / `CHUNKED_IN_TRAILERS_LINE_MIDDLE`) as complete-on-FIN. Those states mean `phr_decode_chunked` returned `-2` (needs more data); the decoder only returns `>= 0`, and `received_last_chunk` is only set, once the terminating CRLF has been consumed. `HTTPClient::on_close` / `ProxyTunnel::on_close` would then drive `finalize_body_on_eof` + `progress_update`, delivering the body as if framing were intact.

### Fix

For `Transfer-Encoding: chunked`, `is_body_complete_on_close()` now returns `received_last_chunk` instead of inspecting decoder state. A properly terminated chunked body already sets that flag and completes via `progress_update` from `on_data`, so FIN with the flag still false falls through to `ConnectionClosed` (surfaced as `ECONNRESET`), matching mid-body truncation which was already correctly rejected. The close-delimited identity path (no Content-Length, no Transfer-Encoding) is unchanged.

### How did you verify your code works?

`test/js/web/fetch/chunked-trailing.test.js` gains two new truncation cases (FIN right after `0\r\n`; FIN mid-trailer-line) and the two existing tests that asserted the lenient behavior are updated to expect rejection. The file's well-formed trailer cases (single packet, split across packets, byte-by-byte, empty body, large values, multiple header lines, with chunk extensions) continue to pass.

```
# without src/ change: 21 pass / 4 fail
# with src/ change:    25 pass / 0 fail
bun bd test test/js/web/fetch/chunked-trailing.test.js
bun bd test test/js/web/fetch/fetch-gzip.test.ts           # 70 pass (close-delimited branch of #34922 unchanged)
bun bd test test/js/web/fetch/fetch-retry-chunked.test.ts  # 1 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/chunked-trailing.test.js
bun test v1.4.0 (622e8a0d5)

test/js/web/fetch/chunked-trailing.test.js:
(pass) handles trailing headers split across packets [407.96ms]
(pass) handles trailing headers in a single packet [85.88ms]
(pass) handles trailing headers with empty body [72.02ms]
(pass) handles multiple trailing headers [70.96ms]
(pass) handles trailing headers with very long delay [162.99ms]
(pass) handles trailing headers with byte-by-byte transmission [157.35ms]
205 |   const address = await promise;
206 |   try {
207 |     await fetch(`http://127.0.0.1:${address.port}`).then(res => res.text());
208 |     expect.unreachable();
209 |   } catch (e) {
210 |     expect(e?.code).toBe("ECONNRESET");
                          ^
error: expect(received).toBe(expected)

Expected: "ECONNRESET"
Received: undefined

      at <anonymous> (/workspace/bun/test/js/web/fetch/chunked-trailing.test.js:210:21)
(fail) rejects when the trailer section is missing its final CRLF [66.49ms]
(pass) handles trailing headers with extremely larg
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (07aa9f0bf)

test/js/web/fetch/chunked-trailing.test.js:
(pass) handles trailing headers split across packets [20.99ms]
(pass) handles trailing headers in a single packet [2.66ms]
(pass) handles trailing headers with empty body [2.13ms]
(pass) handles multiple trailing headers [3.03ms]
(pass) handles trailing headers with very long delay [103.33ms]
(pass) handles trailing headers with byte-by-byte transmission [91.99ms]
(pass) rejects when the trailer section is missing its final CRLF [2.69ms]
(pass) handles trailing headers with extremely large values [2.34ms]
(pass) rejects when the connection closes inside the trailer section [2.73ms]
(pass) rejects when the connection closes after 0\r\n with no terminating CRLF [1.90ms]
(pass) rejects when the connection closes mid-trailer-line [1.73ms]
(pass) handles trailing headers with multiple header lines [2.02ms]
(pass) handles trailing headers with empty values [1.76ms]
(pass) handles delayed trailing headers [102.67ms]
(pass) handles trailing headers after the final chunk only [2.26ms]
(pass) handles chunked extensions with empty extension [1.99ms]
(pass) handles chunked extensions with simple k
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/chunked-trailing.test.js
bun test v1.4.0 (622e8a0d5)

test/js/web/fetch/chunked-trailing.test.js:
(pass) handles trailing headers split across packets [394.20ms]
(pass) handles trailing headers in a single packet [80.52ms]
(pass) handles trailing headers with empty body [71.06ms]
(pass) handles multiple trailing headers [70.02ms]
(pass) handles trailing headers with very long delay [167.31ms]
(pass) handles trailing headers with byte-by-byte transmission [156.53ms]
(pass) rejects when the trailer section is missing its final CRLF [64.01ms]
(pass) handles trailing headers with extremely large values [42.60ms]
(pass) rejects when the connection closes inside the trailer section [75.68ms]
(pass) rejects when the connection closes after 0\r\n with no terminating CRLF [61.94ms]
(pass) rejects when the connection closes mid-trailer-line [60.66ms]
(pass) handles trailing headers with multiple header lines [47.85ms]
(pass) handles trailing headers with empty values [58.27ms]
(pass) handles delayed trailing headers [166.20ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 868ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/InternalState.rs                  |   8 +-
 test/js/web/fetch/chunked-trailing.test.js | 158 +++++++++++++++++++----------
 2 files changed, 110 insertions(+), 56 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/http/InternalState.rs                       3      3      0
test/js/web/fetch/chunked-trailing.test.js      2      4      0
```

</details>

<!-- robobun:evidence:end -->