### PR TITLE
redis: drop unsolicited frames that arrive before the HELLO reply

### DIFF
--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -1013,13 +1013,9 @@ impl ValkeyClient {
                 Ok(())
             }
             _ => {
-                // HELLO only ever answers with a Map (success) or an Error
-                // (auth failure / unknown command). Any other frame arriving
-                // before the handshake completes is unsolicited noise from the
-                // peer (e.g. a proxy greeting line), not the HELLO reply.
-                // Drop it and keep waiting so the real HELLO reply is paired
-                // with HELLO instead of shifting every subsequent command's
-                // reply by one for the lifetime of the connection.
+                // HELLO only replies Map or Error. Anything else is unsolicited
+                // (e.g. a proxy greeting); drop it so the real HELLO reply is
+                // paired with HELLO instead of shifting later replies by one.
                 debug!("Dropping unsolicited non-HELLO frame before handshake completes");
                 Ok(())
             }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -979,22 +979,6 @@ impl ValkeyClient {
                 self.fail(err, RedisError::AuthenticationFailed)?;
                 Ok(())
             }
-            RESPValue::SimpleString(str_) => {
-                if str_.as_ref() == b"OK" {
-                    self.status = Status::Connected;
-                    self.flags.is_authenticated = true;
-                    self.flags.is_reconnecting = false;
-                    self.retry_attempts = 0;
-                    self.on_valkey_connect(value)?;
-                    return Ok(());
-                }
-                self.fail(
-                    b"Authentication failed (unexpected response)",
-                    RedisError::AuthenticationFailed,
-                )?;
-
-                Ok(())
-            }
             RESPValue::Map(map) => {
                 // This is the HELLO response map
                 debug!("Got HELLO response map with {} entries", map.len());
@@ -1029,10 +1013,14 @@ impl ValkeyClient {
                 Ok(())
             }
             _ => {
-                self.fail(
-                    b"Authentication failed with unexpected response",
-                    RedisError::AuthenticationFailed,
-                )?;
+                // HELLO only ever answers with a Map (success) or an Error
+                // (auth failure / unknown command). Any other frame arriving
+                // before the handshake completes is unsolicited noise from the
+                // peer (e.g. a proxy greeting line), not the HELLO reply.
+                // Drop it and keep waiting so the real HELLO reply is paired
+                // with HELLO instead of shifting every subsequent command's
+                // reply by one for the lifetime of the connection.
+                debug!("Dropping unsolicited non-HELLO frame before handshake completes");
                 Ok(())
             }
         }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -975,7 +975,7 @@ impl ValkeyClient {
         debug!("Processing HELLO response");
 
         match value {
-            RESPValue::Error(err) => {
+            RESPValue::Error(err) | RESPValue::BlobError(err) => {
                 self.fail(err, RedisError::AuthenticationFailed)?;
                 Ok(())
             }

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -396,7 +396,7 @@ describe("Valkey: Auto-Reconnect In-Flight Commands", () => {
         for (const args of readCommands(state)) {
           const name = (args[0] ?? "").toUpperCase();
           if (name === "HELLO") {
-            socket.write("+OK\r\n");
+            socket.write("%1\r\n+proto\r\n:3\r\n");
             if (connection === 2) {
               secondHello.resolve();
             }

--- a/test/js/valkey/reliability/resp-nesting-depth.test.ts
+++ b/test/js/valkey/reliability/resp-nesting-depth.test.ts
@@ -39,10 +39,10 @@ function countRespCommands(data: Buffer): number {
 
 /**
  * Creates a minimal mock Redis server that parses incoming RESP command
- * frames. The first command (HELLO handshake) gets +OK; each subsequent
- * command receives the next crafted payload (the last one is repeated when
- * there are more commands than payloads). Handles the case where multiple
- * commands arrive in a single TCP chunk.
+ * frames. The first command (HELLO handshake) gets a RESP3 map; each
+ * subsequent command receives the next crafted payload (the last one is
+ * repeated when there are more commands than payloads). Handles the case
+ * where multiple commands arrive in a single TCP chunk.
  */
 function createMockRedisServer(payload: Buffer | Buffer[]): Promise<{ server: net.Server; port: number }> {
   const payloads = Array.isArray(payload) ? payload : [payload];
@@ -54,8 +54,8 @@ function createMockRedisServer(payload: Buffer | Buffer[]): Promise<{ server: ne
         const numCmds = countRespCommands(data);
         for (let i = 0; i < numCmds; i++) {
           if (commandsSeen === 0) {
-            // Respond to HELLO handshake with a simple OK
-            socket.write("+OK\r\n");
+            // Respond to HELLO handshake with a minimal RESP3 map
+            socket.write("%1\r\n+proto\r\n:3\r\n");
           } else {
             // Each subsequent command gets the next crafted payload
             socket.write(payloads[Math.min(commandsSeen - 1, payloads.length - 1)]);
@@ -107,7 +107,7 @@ describe("Valkey: RESP Nesting Depth Handling", () => {
       });
 
       try {
-        // The HELLO handshake should succeed (mock returns +OK).
+        // The HELLO handshake should succeed (mock returns a RESP3 map).
         // The next command triggers the deeply nested response.
         await client.send("PING", []);
         expect.unreachable();
@@ -190,7 +190,7 @@ describe("Valkey: RESP Nesting Depth Handling", () => {
             const n = countRespCommands(data);
             for (let i = 0; i < n; i++) {
               if (cmdsSeen === 0) {
-                socket.write("+OK\\r\\n");
+                socket.write("%1\\r\\n+proto\\r\\n:3\\r\\n");
               } else {
                 socket.write(payload);
               }

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -322,7 +322,7 @@ test.concurrent("rejects a RESP simple-string reply whose line terminator never 
       const server = net.createServer(socket => {
         socket.on("data", (data: Buffer) => {
           if (data.includes("HELLO")) {
-            socket.write("+OK\r\n");
+            socket.write("%1\r\n+proto\r\n:3\r\n");
           }
           if (data.includes("PING")) {
             socket.write(payload, () => {
@@ -402,8 +402,8 @@ test.concurrent("getBuffer replies survive GC with adopted backing stores intact
       return Buffer.concat([Buffer.from("$" + payload.length + "\\r\\n"), payload, CRLF]);
     }
 
-    // Mock server: +OK to the HELLO handshake, then shift one queued reply
-    // per GET frame (frames may coalesce when commands are auto-pipelined).
+    // Mock server: RESP3 map to the HELLO handshake, then shift one queued
+    // reply per GET frame (frames may coalesce when commands are auto-pipelined).
     let pending = "";
     let saidHello = false;
     const server = net.createServer(socket => {
@@ -411,7 +411,7 @@ test.concurrent("getBuffer replies survive GC with adopted backing stores intact
         if (!saidHello) {
           if (data.includes("HELLO")) {
             saidHello = true;
-            socket.write("+OK\\r\\n");
+            socket.write("%1\\r\\n+proto\\r\\n:3\\r\\n");
           }
           return;
         }

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -315,7 +315,7 @@ test.concurrent("RedisClient survives GC across many short-lived instances", asy
 // unterminated line is treated as a partial reply; when the server closes
 // mid-line the pending command is rejected as connection-closed.
 test.concurrent("rejects a RESP simple-string reply whose line terminator never arrives", async () => {
-  // Minimal mock Redis server: replies +OK to the HELLO handshake, then
+  // Minimal mock Redis server: RESP3 map to the HELLO handshake, then
   // answers the next command with `payload`.
   function listen(payload: Buffer, endAfterPayload: boolean): Promise<{ server: net.Server; port: number }> {
     return new Promise((resolve, reject) => {

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -174,7 +174,7 @@ describe("Valkey incremental reply scanning", () => {
     return { count, offset };
   }
 
-  /** Minimal mock server: +OK for the HELLO handshake, then one callback per later command. */
+  /** Minimal mock server: RESP3 map for the HELLO handshake, then one callback per later command. */
   function createMockValkeyServer(
     onCommand: (commandIndex: number, socket: net.Socket) => void,
   ): Promise<{ server: net.Server; port: number; sockets: net.Socket[] }> {
@@ -222,7 +222,7 @@ describe("Valkey incremental reply scanning", () => {
     const { server, port, sockets } = await createMockValkeyServer((commandIndex, socket) => {
       if (commandIndex === 0) {
         // HELLO handshake.
-        socket.write("+OK\r\n");
+        socket.write("%1\r\n+proto\r\n:3\r\n");
         return;
       }
       // Command 1: bulk string ($<len>) — resuming the scan only needs a length
@@ -265,4 +265,91 @@ describe("Valkey incremental reply scanning", () => {
       server.close();
     }
   }, 90_000);
+});
+
+describe("Valkey HELLO handshake", () => {
+  const CRLF = "\r\n";
+  // Minimal RESP3 HELLO reply: a Map with proto=3.
+  const HELLO_MAP = `%1${CRLF}+proto${CRLF}:3${CRLF}`;
+
+  type PerSocket = { buf: string };
+
+  /**
+   * Mock server that writes `preamble` as soon as the socket opens (before it
+   * has read any bytes from the client), then answers HELLO with a RESP3 map
+   * and GET/PING with fixed values.
+   */
+  function serverWithPreamble(preamble: string): TCPSocketListener<PerSocket> {
+    return Bun.listen<PerSocket>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(s) {
+          s.data = { buf: "" };
+          if (preamble) s.write(preamble);
+        },
+        data(s, chunk) {
+          s.data.buf += chunk.toString("latin1");
+          let m: RegExpMatchArray | null;
+          while ((m = s.data.buf.match(/^\*\d+\r\n(?:\$\d+\r\n[^\r]*\r\n)+/))) {
+            s.data.buf = s.data.buf.slice(m[0].length);
+            const args = [...m[0].matchAll(/\$\d+\r\n([^\r]*)\r\n/g)].map(x => x[1]);
+            const name = args[0].toUpperCase();
+            if (name === "HELLO") {
+              s.write(HELLO_MAP);
+            } else if (name === "GET") {
+              const body = `v${args[1].slice(1)}`;
+              s.write(`$${body.length}${CRLF}${body}${CRLF}`);
+            } else {
+              s.write(`+PONG${CRLF}`);
+            }
+          }
+        },
+        error() {},
+        close() {},
+      },
+    });
+  }
+
+  // An unsolicited frame that reaches the client before the HELLO reply must
+  // not be consumed as the HELLO reply. Previously the handshake accepted any
+  // leading frame (including a bare `+OK`), so the real HELLO map was then
+  // delivered as the reply to the first user command and every subsequent
+  // reply on the connection was shifted by one.
+  test.each([
+    ["simple string +OK", `+OK${CRLF}`],
+    ["integer", `:1${CRLF}`],
+    ["two frames", `+OK${CRLF}:1${CRLF}`],
+  ])("drops an unsolicited %s frame arriving before the HELLO reply", async (_label, preamble) => {
+    const server = serverWithPreamble(preamble);
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+    client.onconnect = client.onclose = () => {};
+    try {
+      const hello = await client.connect();
+      expect(hello).toEqual({ proto: 3 });
+      expect(await client.get("k1")).toBe("v1");
+      expect(await client.get("k2")).toBe("v2");
+      expect(await client.send("PING", [])).toBe("PONG");
+    } finally {
+      client.close();
+      server.stop(true);
+    }
+  });
+
+  // Control: the same server without a stray preamble must behave identically.
+  test("pairs replies correctly when the server emits no pre-HELLO frame", async () => {
+    const server = serverWithPreamble("");
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+    client.onconnect = client.onclose = () => {};
+    try {
+      const hello = await client.connect();
+      expect(hello).toEqual({ proto: 3 });
+      expect(await client.get("k1")).toBe("v1");
+      expect(await client.get("k2")).toBe("v2");
+      expect(await client.send("PING", [])).toBe("PONG");
+    } finally {
+      client.close();
+      server.stop(true);
+    }
+  });
 });

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -34,10 +34,10 @@ function consumeRespArray(buf: Buffer): number {
   return off;
 }
 
-// Minimal Redis-ish server. It replies +OK to the first command (HELLO) so the
-// client's authentication handshake succeeds, then +PONG to everything else.
-// Buffers and frames RESP arrays so commands split across packets (or batched
-// into one) are each answered exactly once.
+// Minimal Redis-ish server. It replies with a RESP3 map to the first command
+// (HELLO) so the client's authentication handshake succeeds, then +PONG to
+// everything else. Buffers and frames RESP arrays so commands split across
+// packets (or batched into one) are each answered exactly once.
 function fakeServer(serverOpts: tls.TlsOptions): tls.Server {
   const server = tls.createServer(serverOpts, socket => {
     let buf = Buffer.alloc(0);
@@ -47,7 +47,7 @@ function fakeServer(serverOpts: tls.TlsOptions): tls.Server {
       let consumed: number;
       while ((consumed = consumeRespArray(buf)) > 0) {
         buf = buf.subarray(consumed);
-        socket.write(seen++ === 0 ? "+OK\r\n" : "+PONG\r\n");
+        socket.write(seen++ === 0 ? "%1\r\n+proto\r\n:3\r\n" : "+PONG\r\n");
       }
     });
     socket.on("error", () => {});


### PR DESCRIPTION
## Repro

A server or middlebox that emits one stray RESP frame before answering `HELLO` makes `connect()` resolve on the stray frame, and the real `HELLO` reply is then delivered as the reply to the first user command. Every reply on the connection is shifted by one for its whole lifetime, silently, with `connected === true`:

```js
const MAP = "%2\r\n+server\r\n+redis\r\n+proto\r\n:3\r\n";
const server = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: {
  open(s) { s.data = ""; s.write("+OK\r\n"); },          // stray greeting
  data(s, chunk) {
    s.data += chunk.toString();
    let m; while ((m = s.data.match(/^\*\d+\r\n(?:\$\d+\r\n[^\r]*\r\n)+/))) {
      s.data = s.data.slice(m[0].length);
      const a = [...m[0].matchAll(/\$\d+\r\n([^\r]*)\r\n/g)].map(x => x[1]);
      const n = a[0].toUpperCase();
      s.write(n === "HELLO" ? MAP : n === "GET" ? `$2\r\nv${a[1].slice(1)}\r\n` : "+PONG\r\n");
    }
  },
}});
const c = new Bun.RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
await c.connect();
console.log("GET k1 ->", await c.get("k1")); // { server:"redis", proto:3 }  (expected "v1")
console.log("GET k2 ->", await c.get("k2")); // "v1"                          (expected "v2")
console.log("PING   ->", await c.ping());    // "v2"                          (expected "PONG")
```

## Cause

`handle_hello_response` treated the first frame to arrive while `!is_authenticated` as the `HELLO` reply. It accepted a bare `+OK` as a completed RESP3 handshake and failed authentication on any other non-Map frame, even though `HELLO` never replies with either: it is always a Map (success) or an Error (auth failure / unknown command).

By contrast, after the handshake completes, an unsolicited non-push frame with no in-flight command to pair with is already silently dropped. The handshake path was the one place a stray frame was consumed instead of dropped.

## Fix

Only accept `Map` and `Error` as the `HELLO` reply. Any other frame type that arrives before the handshake completes is unsolicited; drop it and keep waiting so the real `HELLO` map is paired with `HELLO` and subsequent user command replies stay aligned.

The in-tree mock servers that lazily replied `+OK` to `HELLO` are updated to return the minimal RESP3 map (`%1\r\n+proto\r\n:3\r\n`) the client now requires.

## Verification

New `Valkey HELLO handshake` describe block in `test/js/valkey/valkey-incremental-scan.test.ts` covers a stray `+OK`, a stray integer, and two stray frames before the `HELLO` reply, plus a no-preamble control. All three preamble cases fail on main (the `+OK` case shifts replies; the integer case fails auth with `ERR_REDIS_CONNECTION_CLOSED`) and pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/valkey/valkey-tls-verify.test.ts

<!-- robobun:evidence:end -->