### PR TITLE
source-lints: add node_fs.rs to dead-code escape inventory

### DIFF
--- a/test/internal/source-lints/dead-code-escape-limits.json
+++ b/test/internal/source-lints/dead-code-escape-limits.json
@@ -22,6 +22,7 @@
   "src/runtime/image/backend_coregraphics.rs": 14,
   "src/runtime/image/codecs.rs": 1,
   "src/runtime/node/fs_events.rs": 3,
+  "src/runtime/node/node_fs.rs": 2,
   "src/runtime/server/NodeHTTPResponse.rs": 1,
   "src/spawn_sys/posix_spawn.rs": 4
 }


### PR DESCRIPTION
## What

Adds `src/runtime/node/node_fs.rs: 2` to the dead-code escape inventory so the `dead-code-escapes` source-lint passes again on main.

## Why

#36067 (bfd1e926f3) renamed `_cp_symlink` → `cp_symlink` and `_cp_open_dest_with_mkdir` → `cp_open_dest_with_mkdir`, moving the dead-code suppression from the leading underscore (which the inventory regex does not match) to explicit `#[cfg_attr(..., allow(dead_code))]` attributes:

```rust
#[cfg_attr(any(windows, target_os = "macos"), allow(dead_code))]
fn cp_symlink(&mut self, ...) { ... }

#[cfg_attr(windows, allow(dead_code))]
fn cp_open_dest_with_mkdir(&mut self, ...) { ... }
```

Both functions are called from the Linux/FreeBSD arms of `copy_single_file_sync` (lines 8613, 8680, 8706, 8852, 8878) and are only dead on the platforms named in the predicate, so the escapes are legitimate per the test's own rules. The inventory file was simply not regenerated, and the GitHub Actions `source-lints` workflow has been failing on every main commit since:

```
(fail) #[allow(dead_code)] escapes > src/runtime/node/node_fs.rs (0)
error: src/runtime/node/node_fs.rs has 2 item-level #[allow(dead_code)] escapes, up from 0.
```

Failed runs: 30249533282 (bfd1e926f3), 30249969141, 30250537591, 30250867335.

## How

Regenerated with `bun ./test/internal/source-lints/dead-code-escapes.test.ts` per the test's instructions.

## Verification

```
$ bun test test/internal/source-lints/dead-code-escapes.test.ts
...
(pass) #[allow(dead_code)] escapes > src/runtime/node/node_fs.rs (2)
...
 26 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->