### PR TITLE
FileReader: release the io-ref in on_cancel when close() doesn't reach on_reader_done

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -537,9 +537,8 @@ impl FileReader {
         if !self.reader().is_done() {
             self.reader().close();
         }
-        // `close()` has no-op paths that never dispatch `on_reader_done`
-        // (`PollOrFd::close_impl` with an already-invalid fd); release the
-        // io-ref here so `finalize_detach` never sees `done && waiting`.
+        // `done = true` means no more io, so the io-ref is this function's to
+        // release; `close()` is not contract-bound to dispatch `on_reader_done`.
         if self.waiting_for_on_reader_done.get() {
             self.waiting_for_on_reader_done.set(false);
             let parent = self.parent();

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -537,13 +537,9 @@ impl FileReader {
         if !self.reader().is_done() {
             self.reader().close();
         }
-        // `close()` normally reaches `on_reader_done` (which clears
-        // `waiting_for_on_reader_done` and releases the io-ref), but
-        // `PollOrFd::close_impl` skips the callback when the handle's fd is
-        // already invalid, and `close_handle` is a no-op when `CLOSE_HANDLE`
-        // is unset. In either case the io-ref taken in `on_start`/`from_pipe`
-        // is stranded and `finalize_detach` would observe `done && waiting`.
-        // Release it here; idempotent with `on_reader_done`'s own clear.
+        // `close()` has no-op paths that never dispatch `on_reader_done`
+        // (`PollOrFd::close_impl` with an already-invalid fd); release the
+        // io-ref here so `finalize_detach` never sees `done && waiting`.
         if self.waiting_for_on_reader_done.get() {
             self.waiting_for_on_reader_done.set(false);
             let parent = self.parent();

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -537,6 +537,20 @@ impl FileReader {
         if !self.reader().is_done() {
             self.reader().close();
         }
+        // `close()` normally reaches `on_reader_done` (which clears
+        // `waiting_for_on_reader_done` and releases the io-ref), but
+        // `PollOrFd::close_impl` skips the callback when the handle's fd is
+        // already invalid, and `close_handle` is a no-op when `CLOSE_HANDLE`
+        // is unset. In either case the io-ref taken in `on_start`/`from_pipe`
+        // is stranded and `finalize_detach` would observe `done && waiting`.
+        // Release it here; idempotent with `on_reader_done`'s own clear.
+        if self.waiting_for_on_reader_done.get() {
+            self.waiting_for_on_reader_done.set(false);
+            let parent = self.parent();
+            // SAFETY: see `parent()`. `waiting` implies `increment_count` ran,
+            // so `ref_count >= 2` and this cannot free the box.
+            let _ = unsafe { Source::decrement_count(parent) };
+        }
     }
 
     // NOTE: not `impl Drop` — FileReader is embedded as `Source.context` and this is

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -393,14 +393,11 @@ test.skipIf(isWindows)(
   30_000,
 );
 
-// Post-cancel invariant: after cancelling a from_pipe FileReader, the Strong
-// pin (the io-ref taken by `from_pipe`) must be released so the wrapper is
-// collectable. This scenario reaches FileReader::on_cancel with
-// waiting_for_on_reader_done = true; on current main the release happens via
-// close() → on_reader_done. It guards against any future change that makes
-// on_cancel return with the io-ref still held (which would be a silent
-// NewSource<FileReader> leak in release and a `done && waiting` debug_assert
-// at finalize_detach in assertion builds).
+// Post-cancel invariant: after cancelling a from_pipe FileReader that never
+// received data, the io-ref taken by `from_pipe` must be released so the
+// wrapper is collectable. A stranded ref is a silent NewSource<FileReader>
+// leak in release and a `done && waiting` debug_assert at finalize_detach in
+// assertion builds.
 test.skipIf(isWindows)(
   "cancelling a subprocess stdout FileReader before any data releases the io-ref",
   async () => {

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -393,19 +393,14 @@ test.skipIf(isWindows)(
   30_000,
 );
 
-// FileReader::on_cancel sets `done = true` and calls `reader().close()`. In the
-// normal case `close()` reaches `on_reader_done`, which clears
-// `waiting_for_on_reader_done` and releases the io-ref taken by `from_pipe`.
-// If `close()` does not reach `on_reader_done` (PollOrFd::close_impl skips the
-// callback when the handle's fd is already invalid), the io-ref is stranded
-// with `done = true` and `finalize_detach` later observes `done && waiting`,
-// which is a debug_assert in assertion builds and a refcount leak in release.
-//
-// This test asserts the post-cancel invariant directly: after cancelling a
-// from_pipe FileReader, the Strong pin must be released so the wrapper becomes
-// collectable. It cancels before any data arrives (the io-ref is the only
-// thing keeping the wrapper protected) so a stranded ref shows up as a
-// surviving FileInternalReadableStreamSource after GC.
+// Post-cancel invariant: after cancelling a from_pipe FileReader, the Strong
+// pin (the io-ref taken by `from_pipe`) must be released so the wrapper is
+// collectable. This scenario reaches FileReader::on_cancel with
+// waiting_for_on_reader_done = true; on current main the release happens via
+// close() → on_reader_done. It guards against any future change that makes
+// on_cancel return with the io-ref still held (which would be a silent
+// NewSource<FileReader> leak in release and a `done && waiting` debug_assert
+// at finalize_detach in assertion builds).
 test.skipIf(isWindows)(
   "cancelling a subprocess stdout FileReader before any data releases the io-ref",
   async () => {

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -392,3 +392,98 @@ test.skipIf(isWindows)(
   },
   30_000,
 );
+
+// FileReader::on_cancel sets `done = true` and calls `reader().close()`. In the
+// normal case `close()` reaches `on_reader_done`, which clears
+// `waiting_for_on_reader_done` and releases the io-ref taken by `from_pipe`.
+// If `close()` does not reach `on_reader_done` (PollOrFd::close_impl skips the
+// callback when the handle's fd is already invalid), the io-ref is stranded
+// with `done = true` and `finalize_detach` later observes `done && waiting`,
+// which is a debug_assert in assertion builds and a refcount leak in release.
+//
+// This test asserts the post-cancel invariant directly: after cancelling a
+// from_pipe FileReader, the Strong pin must be released so the wrapper becomes
+// collectable. It cancels before any data arrives (the io-ref is the only
+// thing keeping the wrapper protected) so a stranded ref shows up as a
+// surviving FileInternalReadableStreamSource after GC.
+test.skipIf(isWindows)(
+  "cancelling a subprocess stdout FileReader before any data releases the io-ref",
+  async () => {
+    const script = /* js */ `
+      const { heapStats } = require("bun:jsc");
+      const count = () =>
+        heapStats().objectTypeCounts.FileInternalReadableStreamSource ?? 0;
+      const prot = () =>
+        heapStats().protectedObjectTypeCounts.FileInternalReadableStreamSource ?? 0;
+
+      // Warm up so per-class lazy structure allocation is in the baseline.
+      {
+        const p = Bun.spawn({
+          cmd: ["sleep", "0.3"],
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "ignore",
+          lazy: true,
+        });
+        await p.stdout.cancel();
+        p.kill();
+        await p.exited;
+      }
+      for (let i = 0; i < 10; i++) { Bun.gc(true); await Bun.sleep(1); }
+      const base = count();
+
+      const ITERS = 6;
+      async function once() {
+        // lazy:true mirrors child_process: from_pipe transfers an Fd-backed
+        // handle (poll registration is deferred), so the only Strong root is
+        // the io-ref that on_cancel must release.
+        const p = Bun.spawn({
+          cmd: ["sleep", "5"],
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "ignore",
+          lazy: true,
+        });
+        // Materialize the FileReader (waiting_for_on_reader_done = true) and
+        // cancel it before any data can arrive.
+        await p.stdout.cancel();
+        // The Subprocess wrapper caches stdout and has_pending_activity keeps
+        // it alive while the process runs, so reap it now and drop every JS
+        // reference; only the io-ref can keep the source alive past here.
+        p.kill();
+        await p.exited;
+      }
+      for (let i = 0; i < ITERS; i++) await once();
+
+      const protectedAfterCancel = prot();
+      for (let i = 0; i < 20; i++) { Bun.gc(true); await Bun.sleep(1); }
+      const aliveAfterCancel = count() - base;
+
+      console.log(JSON.stringify({
+        iters: ITERS, base, protectedAfterCancel, aliveAfterCancel,
+      }));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    let result: { iters: number; protectedAfterCancel: number; aliveAfterCancel: number };
+    try {
+      result = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`fixture did not emit JSON (exit ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`);
+    }
+    // After cancel, nothing should keep the wrapper Strong-protected.
+    expect(result.protectedAfterCancel).toBe(0);
+    // The wrappers must be collectable; one may survive via a conservatively
+    // rooted stack slot (same caveat as the first test in this file).
+    expect(result.aliveAfterCancel).toBeLessThanOrEqual(1);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
## What

`test/js/node/test/parallel/test-stdin-from-file-spawn.js` panicked on the linux x64-asan lane (build 83189) with:

```
panic: assertion failed: !(self.done.get() && self.waiting_for_on_reader_done.get())
```

in `FileReader::finalize_detach`. The assertion says a `FileReader` cannot reach its JS finalizer with both `done` and `waiting_for_on_reader_done` set: `waiting` means the io-ref taken by `from_pipe`/`on_start` is still held (which upgrades the JS wrapper to `Strong`, so it should not be collectable), and `done` means `on_cancel` has run and nothing will ever call `on_reader_done` to release that ref.

## Change

`FileReader::on_cancel` now releases the io-ref itself after `close()` returns. `on_cancel` is the only place that sets `done = true` (other than `finalize_detach`), so once it runs no more io will fire and the io-ref is its responsibility. Today `close()` always reaches `on_reader_done` for every in-tree `from_pipe` producer (subprocess pipes have a valid fd and `CLOSE_HANDLE` set, traced below), so this block is a no-op on current main; the release is idempotent with `on_reader_done`'s own check-and-clear. `waiting == true` implies a prior `increment_count`, so `ref_count >= 2` and the decrement cannot free the box mid-`&self`.

## Why

This is defensive hardening, not a root-cause fix. I traced every producer of `waiting_for_on_reader_done = true` and every transition to an invalid reader fd:

- `from_pipe` (ReadableStream.rs:420) sets `waiting` after `PosixBufferedReader::from()` transferred a handle whose fd came from `SubprocessPipeReader::start()` → `reader.start(fd, true)`, which stores `handle = PollOrFd::Fd(fd)`.
- `on_start`'s lazy path (FileReader.rs:417) sets `waiting` only when `pollable` with a `debug_assert!(opened.fd.is_valid())` guard; on error it clears `waiting` before returning.
- `on_start`'s non-lazy path (FileReader.rs:438) sets `waiting` only when `POLLABLE`, which is inserted after `start()` stored a real fd.
- `PollOrFd::close_impl` skips its callback only when `get_fd() == INVALID`, which for a live `Poll` never holds (the fd is set at construction and invalidated only inside `close_impl` itself); every path that reaches `handle.close(cb)` with `waiting == true` has a valid fd and fires `done()` → `on_reader_done()`.
- `CLOSE_HANDLE` defaults on and is transferred wholesale by `from()`; the only removers are `FileResponseStream` and the shell `IOReader`, neither of which go through `from_pipe`.

So no in-tree path today produces `(waiting = true, fd invalid)` at `on_cancel` entry. The CI panic is a single sighting; 800+ local debug+asan runs under `BUN_GARBAGE_COLLECTOR_LEVEL=1` and 4-way parallel stress did not reproduce it, and the release-asan artifact is not fetchable from this environment to symbolize the stack. Build 83189's branch is 3 commits behind main (merge-base 6c12afd8ea) and the reporter's diff is unrelated (`fs.cp` non-UTF8 names).

`close()` is not contract-bound to dispatch `on_reader_done` for every reader state, and relying on it for the io-ref release means a future reader change (or a state I have not found) can strand the ref silently. Having `on_cancel` own the release makes the `done && waiting` state structurally impossible through `on_cancel`, which is the only producer of `done = true`.

## Verification

`test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts` gains a post-cancel invariant check: after cancelling a `from_pipe` `FileReader` that never received data, no `FileInternalReadableStreamSource` remains Strong-protected and the wrappers are collectable. On current main this is satisfied by the existing `close()` → `on_reader_done` path, so the test is a guard against regressing that invariant rather than a reproduction of the CI panic. The three existing lifetime-invariant tests in that file, `spawn-unread-stdout-gc.test.ts`, `native-source-onclose-leak.test.ts`, `process-stdin.test.ts`, and `spawn-streaming-stdout.test.ts` all pass under `bun bd`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/test/parallel/test-stdin-from-file-spawn.js test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts

<!-- robobun:evidence:end -->