### PR TITLE
Bun.build: throw when plugin hooks are registered after setup()

### DIFF
--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -170,9 +170,6 @@ export function runSetupFunction(
     [RegExp, napiModule: unknown, symbol: string, external?: undefined | unknown][]
   >();
 
-  // Hook registration pushes to the local maps above, which are committed to
-  // the native side exactly once in processSetupResult(). Registrations after
-  // that point would be silently ignored, so throw instead.
   var setupComplete = false;
   function ensureSetup(name: string) {
     if (setupComplete) {

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -294,7 +294,6 @@ export function runSetupFunction(
   }
 
   const processSetupResult = () => {
-    setupComplete = true;
     var anyOnLoad = false,
       anyOnResolve = false;
 
@@ -404,20 +403,22 @@ export function runSetupFunction(
       setupResult = $peekPromiseSettledValue(setupResult);
     } else {
       return setupResult.$then(() => {
+        setupComplete = true;
         let selfPromises;
         if (is_last && (selfPromises = self.promises) !== undefined && selfPromises.length > 0) {
           const awaitAll = Promise.all(selfPromises);
-          return awaitAll.$then(processSetupResult, closeSetupAndRethrow);
+          return awaitAll.$then(processSetupResult);
         }
         return processSetupResult();
       }, closeSetupAndRethrow);
     }
   }
 
+  setupComplete = true;
   let pendingPromises;
   if (is_last && (pendingPromises = this.promises) !== undefined && pendingPromises.length > 0) {
     const awaitAll = Promise.all(pendingPromises);
-    return awaitAll.$then(processSetupResult, closeSetupAndRethrow);
+    return awaitAll.$then(processSetupResult);
   }
 
   return processSetupResult();

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -170,6 +170,19 @@ export function runSetupFunction(
     [RegExp, napiModule: unknown, symbol: string, external?: undefined | unknown][]
   >();
 
+  // Hook registration pushes to the local maps above, which are committed to
+  // the native side exactly once in processSetupResult(). Registrations after
+  // that point would be silently ignored, so throw instead.
+  var setupComplete = false;
+  function ensureSetup(name: string) {
+    if (setupComplete) {
+      throw new TypeError(
+        name +
+          "() must be called within a plugin's setup() function. Plugin hooks cannot be registered during the build or after it has finished.",
+      );
+    }
+  }
+
   function validate(filterObject: PluginConstraints, callback, map, symbol, external) {
     if (!filterObject || !$isObject(filterObject)) {
       throw new TypeError('Expected an object with "filter" RegExp');
@@ -226,11 +239,13 @@ export function runSetupFunction(
   }
 
   function onLoad(this: PluginBuilder, filterObject: PluginConstraints, callback: OnLoadCallback): PluginBuilder {
+    ensureSetup("onLoad");
     validate(filterObject, callback, onLoadPlugins, undefined, undefined);
     return this;
   }
 
   function onResolve(this: PluginBuilder, filterObject: PluginConstraints, callback): PluginBuilder {
+    ensureSetup("onResolve");
     validate(filterObject, callback, onResolvePlugins, undefined, undefined);
     return this;
   }
@@ -240,12 +255,14 @@ export function runSetupFunction(
     filterObject: PluginConstraints,
     { napiModule, external, symbol }: { napiModule: unknown; symbol: string; external?: undefined | unknown },
   ): PluginBuilder {
+    ensureSetup("onBeforeParse");
     validate(filterObject, napiModule, onBeforeParsePlugins, symbol, external);
     return this;
   }
 
   const self = this;
   function onStart(this: PluginBuilder, callback): PluginBuilder {
+    ensureSetup("onStart");
     if (isBake) {
       throw new TypeError("onStart() is not supported in Bake yet");
     }
@@ -269,6 +286,7 @@ export function runSetupFunction(
   }
 
   function onEnd(this: PluginBuilder, callback: Function): PluginBuilder {
+    ensureSetup("onEnd");
     if (!$isCallable(callback)) throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
 
     if (!self.onEndCallbacks) self.onEndCallbacks = [];
@@ -279,6 +297,7 @@ export function runSetupFunction(
   }
 
   const processSetupResult = () => {
+    setupComplete = true;
     var anyOnLoad = false,
       anyOnResolve = false;
 
@@ -343,35 +362,45 @@ export function runSetupFunction(
     return this.promises;
   };
 
-  var setupResult = setup({
-    config: config,
-    onDispose: notImplementedIssueFn(2771, "On-dispose callbacks"),
-    onEnd,
-    onLoad,
-    onResolve,
-    onBeforeParse,
-    onStart,
-    resolve: notImplementedIssueFn(2771, "build.resolve()"),
-    module: () => {
-      throw new TypeError("module() is not supported in Bun.build() yet. Only via Bun.plugin() at runtime");
-    },
-    addPreload: () => {
-      throw new TypeError("addPreload() is not supported in Bun.build() yet.");
-    },
-    // esbuild's options argument is different, we provide some interop
-    initialOptions: {
-      ...config,
-      bundle: true,
-      entryPoints: config.entrypoints ?? config.entryPoints ?? [],
-      minify: typeof config.minify === "boolean" ? config.minify : false,
-      minifyIdentifiers: config.minify === true || (config.minify as MinifyObj)?.identifiers,
-      minifyWhitespace: config.minify === true || (config.minify as MinifyObj)?.whitespace,
-      minifySyntax: config.minify === true || (config.minify as MinifyObj)?.syntax,
-      outbase: config.root,
-      platform: config.target === "bun" ? "node" : config.target,
-    },
-    esbuild: {},
-  } as PluginBuilderExt);
+  const closeSetupAndRethrow = err => {
+    setupComplete = true;
+    throw err;
+  };
+
+  var setupResult;
+  try {
+    setupResult = setup({
+      config: config,
+      onDispose: notImplementedIssueFn(2771, "On-dispose callbacks"),
+      onEnd,
+      onLoad,
+      onResolve,
+      onBeforeParse,
+      onStart,
+      resolve: notImplementedIssueFn(2771, "build.resolve()"),
+      module: () => {
+        throw new TypeError("module() is not supported in Bun.build() yet. Only via Bun.plugin() at runtime");
+      },
+      addPreload: () => {
+        throw new TypeError("addPreload() is not supported in Bun.build() yet.");
+      },
+      // esbuild's options argument is different, we provide some interop
+      initialOptions: {
+        ...config,
+        bundle: true,
+        entryPoints: config.entrypoints ?? config.entryPoints ?? [],
+        minify: typeof config.minify === "boolean" ? config.minify : false,
+        minifyIdentifiers: config.minify === true || (config.minify as MinifyObj)?.identifiers,
+        minifyWhitespace: config.minify === true || (config.minify as MinifyObj)?.whitespace,
+        minifySyntax: config.minify === true || (config.minify as MinifyObj)?.syntax,
+        outbase: config.root,
+        platform: config.target === "bun" ? "node" : config.target,
+      },
+      esbuild: {},
+    } as PluginBuilderExt);
+  } catch (err) {
+    closeSetupAndRethrow(err);
+  }
 
   if (setupResult && $isPromise(setupResult)) {
     if ($peekPromiseStatus(setupResult) === 1) {
@@ -381,17 +410,17 @@ export function runSetupFunction(
         let selfPromises;
         if (is_last && (selfPromises = self.promises) !== undefined && selfPromises.length > 0) {
           const awaitAll = Promise.all(selfPromises);
-          return awaitAll.$then(processSetupResult);
+          return awaitAll.$then(processSetupResult, closeSetupAndRethrow);
         }
         return processSetupResult();
-      });
+      }, closeSetupAndRethrow);
     }
   }
 
   let pendingPromises;
   if (is_last && (pendingPromises = this.promises) !== undefined && pendingPromises.length > 0) {
     const awaitAll = Promise.all(pendingPromises);
-    return awaitAll.$then(processSetupResult);
+    return awaitAll.$then(processSetupResult, closeSetupAndRethrow);
   }
 
   return processSetupResult();

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 import path, { dirname, join, resolve } from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -1607,5 +1608,215 @@ describe("bundler", () => {
         expect(asyncCompleted).toBe(true);
       },
     };
+  });
+});
+
+describe("plugin hook registration after setup", () => {
+  const lateHookMessage = /must be called within a plugin's setup\(\) function/;
+
+  const files = {
+    "entry.ts": `import x from "./first.ts"; console.log(x)`,
+    "first.ts": `import z from "./second.ts"; export default "F" + z`,
+    "second.ts": `export default "-DISK"`,
+  };
+
+  async function buildWith(
+    dir: string,
+    setup: (b: import("bun").PluginBuilder) => void | Promise<void>,
+    opts: { throws?: boolean } = {},
+  ) {
+    const { throws = true } = opts;
+    return await Bun.build({
+      entrypoints: [path.join(dir, "entry.ts")],
+      throw: throws,
+      plugins: [{ name: "late", setup }],
+    });
+  }
+
+  test("onLoad inside a running onLoad callback throws", async () => {
+    using dir = tempDir("plugin-late-onload", files);
+    const result = await buildWith(
+      String(dir),
+      b => {
+        b.onLoad({ filter: /first\.ts$/ }, () => {
+          // Previously this was accepted and silently dropped; now it must throw.
+          b.onLoad({ filter: /second\.ts$/ }, () => ({ contents: `export default "-PLUGIN"`, loader: "ts" }));
+          return { contents: `import z from "./second.ts"; export default "F"+z`, loader: "ts" };
+        });
+      },
+      { throws: false },
+    );
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(l => l.message);
+    expect(messages.find(m => lateHookMessage.test(m))).toMatch(/onLoad\(\)/);
+  });
+
+  test("onResolve inside a running onResolve callback throws", async () => {
+    using dir = tempDir("plugin-late-onresolve", files);
+    const result = await buildWith(
+      String(dir),
+      b => {
+        b.onResolve({ filter: /first\.ts$/ }, args => {
+          b.onResolve({ filter: /second\.ts$/ }, () => undefined);
+          return { path: path.join(String(dir), "first.ts") };
+        });
+      },
+      { throws: false },
+    );
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(l => l.message);
+    expect(messages.find(m => lateHookMessage.test(m))).toMatch(/onResolve\(\)/);
+  });
+
+  test("onLoad inside a running onResolve callback throws", async () => {
+    using dir = tempDir("plugin-late-mix", files);
+    const result = await buildWith(
+      String(dir),
+      b => {
+        b.onResolve({ filter: /first\.ts$/ }, args => {
+          b.onLoad({ filter: /second\.ts$/ }, () => ({ contents: `export default "-PLUGIN"`, loader: "ts" }));
+          return { path: path.join(String(dir), "first.ts") };
+        });
+      },
+      { throws: false },
+    );
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(l => l.message);
+    expect(messages.find(m => lateHookMessage.test(m))).toMatch(/onLoad\(\)/);
+  });
+
+  test("onEnd inside a running onEnd callback throws", async () => {
+    using dir = tempDir("plugin-late-onend", { "entry.ts": `export default 1` });
+    const order: string[] = [];
+    let thrown: unknown;
+    try {
+      await Bun.build({
+        entrypoints: [path.join(String(dir), "entry.ts")],
+        plugins: [
+          {
+            name: "late",
+            setup(b) {
+              b.onEnd(() => {
+                order.push("first");
+                b.onEnd(() => order.push("nested"));
+              });
+            },
+          },
+        ],
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(order).toEqual(["first"]);
+    expect(String(thrown)).toMatch(lateHookMessage);
+    expect(String(thrown)).toMatch(/onEnd\(\)/);
+  });
+
+  test("onStart inside a running onLoad callback throws", async () => {
+    using dir = tempDir("plugin-late-onstart", files);
+    const result = await buildWith(
+      String(dir),
+      b => {
+        b.onLoad({ filter: /first\.ts$/ }, () => {
+          b.onStart(() => {});
+          return { contents: `export default 1`, loader: "ts" };
+        });
+      },
+      { throws: false },
+    );
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(l => l.message);
+    expect(messages.find(m => lateHookMessage.test(m))).toMatch(/onStart\(\)/);
+  });
+
+  for (const method of ["onLoad", "onResolve", "onStart", "onEnd", "onBeforeParse"] as const) {
+    test(`stale builder: ${method} throws after the build has finished`, async () => {
+      using dir = tempDir("plugin-stale", { "entry.ts": `export default 1` });
+      let stale!: import("bun").PluginBuilder;
+      const result = await Bun.build({
+        entrypoints: [path.join(String(dir), "entry.ts")],
+        plugins: [
+          {
+            name: "capture",
+            setup(b) {
+              stale = b;
+            },
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+      expect(() => {
+        if (method === "onStart" || method === "onEnd") {
+          (stale[method] as any)(() => {});
+        } else if (method === "onBeforeParse") {
+          stale.onBeforeParse({ filter: /x/ }, { napiModule: {} as any, symbol: "x" });
+        } else {
+          (stale[method] as any)({ filter: /x/ }, () => {});
+        }
+      }).toThrow(TypeError);
+      expect(() => {
+        if (method === "onStart" || method === "onEnd") {
+          (stale[method] as any)(() => {});
+        } else if (method === "onBeforeParse") {
+          stale.onBeforeParse({ filter: /x/ }, { napiModule: {} as any, symbol: "x" });
+        } else {
+          (stale[method] as any)({ filter: /x/ }, () => {});
+        }
+      }).toThrow(lateHookMessage);
+    });
+  }
+
+  test("one build's builder throws when used in another build's setup", async () => {
+    using dir = tempDir("plugin-cross-build", { "entry.ts": `export default 1` });
+    let first!: import("bun").PluginBuilder;
+    await Bun.build({
+      entrypoints: [path.join(String(dir), "entry.ts")],
+      plugins: [
+        {
+          name: "a",
+          setup(b) {
+            first = b;
+          },
+        },
+      ],
+    });
+    let thrown: unknown;
+    await Bun.build({
+      entrypoints: [path.join(String(dir), "entry.ts")],
+      plugins: [
+        {
+          name: "b",
+          setup(_b) {
+            try {
+              first.onLoad({ filter: /x/ }, () => ({ contents: "", loader: "ts" }));
+            } catch (e) {
+              thrown = e;
+            }
+          },
+        },
+      ],
+    });
+    expect(thrown).toBeInstanceOf(TypeError);
+    expect((thrown as Error).message).toMatch(lateHookMessage);
+  });
+
+  test("registration during setup (including onStart) is still valid", async () => {
+    using dir = tempDir("plugin-valid-reg", files);
+    let hits = 0;
+    const result = await buildWith(String(dir), b => {
+      b.onLoad({ filter: /first\.ts$/ }, () => ({
+        contents: `import z from "./second.ts"; export default "F"+z`,
+        loader: "ts",
+      }));
+      b.onStart(() => {
+        b.onLoad({ filter: /second\.ts$/ }, () => {
+          hits++;
+          return { contents: `export default "-PLUGIN"`, loader: "ts" };
+        });
+      });
+    });
+    expect(result.success).toBe(true);
+    expect(hits).toBe(1);
+    expect(await result.outputs[0].text()).toContain("-PLUGIN");
   });
 });

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1639,7 +1639,6 @@ describe("plugin hook registration after setup", () => {
       String(dir),
       b => {
         b.onLoad({ filter: /first\.ts$/ }, () => {
-          // Previously this was accepted and silently dropped; now it must throw.
           b.onLoad({ filter: /second\.ts$/ }, () => ({ contents: `export default "-PLUGIN"`, loader: "ts" }));
           return { contents: `import z from "./second.ts"; export default "F"+z`, loader: "ts" };
         });
@@ -1745,7 +1744,7 @@ describe("plugin hook registration after setup", () => {
         ],
       });
       expect(result.success).toBe(true);
-      expect(() => {
+      const call = () => {
         if (method === "onStart" || method === "onEnd") {
           (stale[method] as any)(() => {});
         } else if (method === "onBeforeParse") {
@@ -1753,16 +1752,9 @@ describe("plugin hook registration after setup", () => {
         } else {
           (stale[method] as any)({ filter: /x/ }, () => {});
         }
-      }).toThrow(TypeError);
-      expect(() => {
-        if (method === "onStart" || method === "onEnd") {
-          (stale[method] as any)(() => {});
-        } else if (method === "onBeforeParse") {
-          stale.onBeforeParse({ filter: /x/ }, { napiModule: {} as any, symbol: "x" });
-        } else {
-          (stale[method] as any)({ filter: /x/ }, () => {});
-        }
-      }).toThrow(lateHookMessage);
+      };
+      expect(call).toThrow(TypeError);
+      expect(call).toThrow(lateHookMessage);
     });
   }
 

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1633,6 +1633,14 @@ describe("plugin hook registration after setup", () => {
     });
   }
 
+  function expectLateHookError(result: Awaited<ReturnType<typeof Bun.build>>, method: string) {
+    const logs = result.logs.map(l => l.message);
+    expect({ success: result.success, logs }).toEqual({
+      success: false,
+      logs: expect.arrayContaining([expect.stringMatching(new RegExp(`^${method}\\(\\).*${lateHookMessage.source}`))]),
+    });
+  }
+
   test("onLoad inside a running onLoad callback throws", async () => {
     using dir = tempDir("plugin-late-onload", files);
     const result = await buildWith(
@@ -1645,9 +1653,7 @@ describe("plugin hook registration after setup", () => {
       },
       { throws: false },
     );
-    expect(result.success).toBe(false);
-    const messages = result.logs.map(l => l.message);
-    expect(messages.find(m => lateHookMessage.test(m))).toMatch(/onLoad\(\)/);
+    expectLateHookError(result, "onLoad");
   });
 
   test("onResolve inside a running onResolve callback throws", async () => {
@@ -1662,9 +1668,7 @@ describe("plugin hook registration after setup", () => {
       },
       { throws: false },
     );
-    expect(result.success).toBe(false);
-    const messages = result.logs.map(l => l.message);
-    expect(messages.find(m => lateHookMessage.test(m))).toMatch(/onResolve\(\)/);
+    expectLateHookError(result, "onResolve");
   });
 
   test("onLoad inside a running onResolve callback throws", async () => {
@@ -1679,9 +1683,7 @@ describe("plugin hook registration after setup", () => {
       },
       { throws: false },
     );
-    expect(result.success).toBe(false);
-    const messages = result.logs.map(l => l.message);
-    expect(messages.find(m => lateHookMessage.test(m))).toMatch(/onLoad\(\)/);
+    expectLateHookError(result, "onLoad");
   });
 
   test("onEnd inside a running onEnd callback throws", async () => {
@@ -1723,9 +1725,7 @@ describe("plugin hook registration after setup", () => {
       },
       { throws: false },
     );
-    expect(result.success).toBe(false);
-    const messages = result.logs.map(l => l.message);
-    expect(messages.find(m => lateHookMessage.test(m))).toMatch(/onStart\(\)/);
+    expectLateHookError(result, "onStart");
   });
 
   for (const method of ["onLoad", "onResolve", "onStart", "onEnd", "onBeforeParse"] as const) {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1792,7 +1792,33 @@ describe("plugin hook registration after setup", () => {
     expect((thrown as Error).message).toMatch(lateHookMessage);
   });
 
-  test("registration during setup (including onStart) is still valid", async () => {
+  for (const position of ["only", "first", "last"] as const) {
+    test(`async onStart registering after an await throws (plugin position: ${position})`, async () => {
+      using dir = tempDir("plugin-async-onstart", { "entry.ts": `export default 1` });
+      const p: import("bun").BunPlugin = {
+        name: "a",
+        setup(b) {
+          b.onStart(async () => {
+            await Promise.resolve();
+            b.onLoad({ filter: /never/ }, () => ({ contents: "", loader: "ts" }));
+          });
+        },
+      };
+      const noop: import("bun").BunPlugin = { name: "noop", setup() {} };
+      const plugins = position === "only" ? [p] : position === "first" ? [p, noop] : [noop, p];
+      let thrown: unknown;
+      try {
+        await Bun.build({ entrypoints: [path.join(String(dir), "entry.ts")], plugins });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeDefined();
+      expect(String(thrown)).toMatch(lateHookMessage);
+      expect(String(thrown)).toMatch(/onLoad\(\)/);
+    });
+  }
+
+  test("registration during setup (including a synchronous onStart body) is still valid", async () => {
     using dir = tempDir("plugin-valid-reg", files);
     let hits = 0;
     const result = await buildWith(String(dir), b => {
@@ -1806,6 +1832,29 @@ describe("plugin hook registration after setup", () => {
           return { contents: `export default "-PLUGIN"`, loader: "ts" };
         });
       });
+    });
+    expect(result.success).toBe(true);
+    expect(hits).toBe(1);
+    expect(await result.outputs[0].text()).toContain("-PLUGIN");
+  });
+
+  test("registration after an await inside async setup() is still valid", async () => {
+    using dir = tempDir("plugin-async-setup", files);
+    let hits = 0;
+    const result = await Bun.build({
+      entrypoints: [path.join(String(dir), "entry.ts")],
+      plugins: [
+        {
+          name: "async-setup",
+          async setup(b) {
+            await Promise.resolve();
+            b.onLoad({ filter: /second\.ts$/ }, () => {
+              hits++;
+              return { contents: `export default "-PLUGIN"`, loader: "ts" };
+            });
+          },
+        },
+      ],
     });
     expect(result.success).toBe(true);
     expect(hits).toBe(1);


### PR DESCRIPTION
## Repro

```js
await Bun.build({ entrypoints: [e], plugins: [{ name: 'late', setup(b) {
  b.onLoad({ filter: /first\.ts$/ }, () => {
    b.onLoad({ filter: /second\.ts$/ }, () => ({ contents: '...' })); // accepted, silently dropped
    return { contents: 'import z from "./second.ts"; ...' };
  });
}}] });
```

The inner `onLoad` was accepted without error but never ran; `second.ts` loaded from disk. Behaviour depended on *where* the late call happened:

| registered from | `onLoad`/`onResolve` | `onStart` | `onEnd` |
| --- | --- | --- | --- |
| inside running `onLoad`/`onResolve` | accepted, **dropped** | accepted, **dropped** | accepted, **dropped** |
| inside `onStart` | accepted, **honored** | accepted, **honored** | accepted, **honored** |
| inside running `onEnd` | accepted, **dropped** | accepted, **dropped** | accepted, **runs** |
| on a stale builder after the build finished | accepted, **no-op** | accepted, **no-op** | accepted, **no-op** |

No error anywhere. (esbuild's JS API is also silent here, but it is at least consistent: late registrations are uniformly dropped.)

## Cause

`runSetupFunction` in `src/js/builtins/BundlerPlugin.ts` collects `onLoad`/`onResolve`/`onBeforeParse` into per-setup `Map`s that the closures capture, then `processSetupResult()` commits them to the native filter table and to `this.onLoad`/`this.onResolve` exactly once. Any call after that commit still pushes to the local maps, which are never read again. `onEnd` pushes directly to `self.onEndCallbacks`, which `runOnEndCallbacks` iterates with `for..of`, so a nested `onEnd` was picked up mid-iteration. `onStart` runs its callback synchronously during setup, so registrations from a sync `onStart` land before the commit and happen to work.

## Fix

Close registration as soon as `setup()` has returned (or its returned promise has resolved). A `setupComplete` flag is set on every exit from setup: sync return, already-fulfilled promise, pending-promise resolution, sync throw, and async rejection. `onLoad`, `onResolve`, `onBeforeParse`, `onStart`, and `onEnd` check it first and throw:

```
TypeError: onLoad() must be called within a plugin's setup() function. Plugin hooks cannot be registered during the build or after it has finished.
```

Registrations made while `setup()` is executing continue to work: direct calls inside `setup()`, calls after an `await` inside an `async setup()`, and calls inside a synchronous `onStart` body (which runs during `setup()`). Registrations after an `await` inside an `async` `onStart` callback now consistently throw regardless of the plugin's position in the array.

## Verification

```
bun bd test test/bundler/bundler_plugin.test.ts -t 'plugin hook registration after setup'
```

16 new cases covering `onLoad`/`onResolve`/`onStart`/`onEnd`/`onBeforeParse` called from a running callback, on a stale builder, across builds, and from an async `onStart` at each plugin position (only / first-of-two / last-of-two); plus guards that registration during `setup()`, inside a sync `onStart`, and after an await inside async `setup()` still work. 14/16 fail on the released build and all pass with the fix. Existing `bundler_plugin.test.ts`, `bundler_defer.test.ts`, `bundler_plugin_chain.test.ts`, `plugin-error-nested-throw.test.ts`, `plugin-sync-exception-fallback.test.ts`, and `test/js/bun/plugin/plugins.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->