### PR TITLE
Bun.build: expose build.config as a snapshot to plugin setup()

### DIFF
--- a/docs/bundler/plugins.mdx
+++ b/docs/bundler/plugins.mdx
@@ -156,8 +156,8 @@ const result = await Bun.build({
 In this example, Bun waits for both `onStart()` callbacks to complete: the 10-second sleep and the write to `bundle-time.txt`.
 
 <Note>
-  `onStart()` callbacks (like every other lifecycle callback) cannot modify the `build.config` object. To mutate
-  `build.config`, do so directly in the `setup()` function.
+  `build.config` is a read-only snapshot of the options passed to `Bun.build`. The bundler reads every option before
+  `setup()` runs, so writing to `build.config` (in `setup()` or any lifecycle callback) has no effect on the build.
 </Note>
 
 ### onResolve

--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -151,7 +151,7 @@ const result = await Bun.build({
 
 Here, Bun waits for both `onStart()` callbacks to complete: the first sleeps for 10 seconds and the second writes the bundle time to a file.
 
-`onStart()` callbacks (like every other lifecycle callback) cannot modify the `build.config` object. To mutate `build.config`, do so directly in the `setup()` function.
+`build.config` is a read-only snapshot of the options passed to `Bun.build`. The bundler reads every option before `setup()` runs, so writing to `build.config` (in `setup()` or any lifecycle callback) has no effect on the build.
 
 ### `onResolve`
 

--- a/packages/bun-plugin-svelte/README.md
+++ b/packages/bun-plugin-svelte/README.md
@@ -45,6 +45,7 @@ Bun.build({
   outdir: "dist",
   target: "browser",
   sourcemap: true, // sourcemaps not yet supported
+  conditions: ["svelte"], // resolve the "svelte" export condition used by Svelte packages
   plugins: [
     SveltePlugin({
       development: true, // turn off for prod builds. Defaults to false
@@ -52,6 +53,8 @@ Bun.build({
   ],
 });
 ```
+
+> Plugins cannot modify `Bun.build` options. If you depend on Svelte packages that only expose a `"svelte"` export condition (for example `@threlte/core`), add `conditions: ["svelte"]` to your `Bun.build` call as shown above.
 
 ## Server-Side Usage
 

--- a/packages/bun-plugin-svelte/src/index.ts
+++ b/packages/bun-plugin-svelte/src/index.ts
@@ -29,20 +29,6 @@ function SveltePlugin(options: SvelteOptions = kEmptyObject as SvelteOptions): B
   return {
     name: "bun-plugin-svelte",
     setup(builder) {
-      // resolve "svelte" export conditions
-      //
-      // FIXME: the dev server does not currently respect bundler configs; it
-      // just passes a fake one to plugins and then never uses it. we need to to
-      // update it to ~not~ do this.
-      if (builder?.config) {
-        var conditions = builder.config.conditions ?? [];
-        if (typeof conditions === "string") {
-          conditions = [conditions];
-        }
-        conditions.push("svelte");
-        builder.config.conditions = conditions;
-      }
-
       const { config = kEmptyObject as Partial<BuildConfig> } = builder;
       const baseCompileOptions = getBaseCompileOptions(options ?? (kEmptyObject as Partial<SvelteOptions>), config);
       const baseModuleCompileOptions = getBaseModuleCompileOptions(

--- a/packages/bun-plugin-svelte/test/index.test.ts
+++ b/packages/bun-plugin-svelte/test/index.test.ts
@@ -71,6 +71,7 @@ describe("when importing `.svelte.ts` files with ESM", () => {
     const res = await Bun.build({
       entrypoints: [fixturePath("svelte-export-condition.svelte")],
       outdir,
+      conditions: ["svelte"],
       plugins: [SveltePlugin()],
     });
     expect(res.success).toBeTrue();

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5642,9 +5642,10 @@ declare module "bun" {
      */
     onResolve(constraints: PluginConstraints, callback: OnResolveCallback): this;
     /**
-     * A snapshot of the config object passed to `Bun.build`. The build reads
-     * every option before plugin `setup()` runs, so mutating this object has
-     * no effect on the build and does not alter the caller's config.
+     * A shallow snapshot of the config object passed to `Bun.build`. The build
+     * reads every option before plugin `setup()` runs, so mutating this object
+     * has no effect on the build. Nested option values (such as `define` or
+     * `naming`) are shared with the caller's config and are not copied.
      */
     config: BuildConfig & { plugins: BunPlugin[] };
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5642,7 +5642,9 @@ declare module "bun" {
      */
     onResolve(constraints: PluginConstraints, callback: OnResolveCallback): this;
     /**
-     * The config object passed to `Bun.build` as is. Can be mutated.
+     * A snapshot of the config object passed to `Bun.build`. The build reads
+     * every option before plugin `setup()` runs, so mutating this object has
+     * no effect on the build and does not alter the caller's config.
      */
     config: BuildConfig & { plugins: BunPlugin[] };
 

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -343,8 +343,16 @@ export function runSetupFunction(
     return this.promises;
   };
 
+  // Expose a snapshot of the caller's config, not the live object: every
+  // option has already been consumed by the time setup() runs, so writes here
+  // must not feed back into the build or into the caller's object.
+  const configSnapshot: BuildConfigExt = { ...config };
+  if ($isJSArray(config.plugins)) configSnapshot.plugins = [...config.plugins];
+  if ($isJSArray(config.entrypoints)) configSnapshot.entrypoints = [...config.entrypoints!];
+  if ($isJSArray(config.entryPoints)) configSnapshot.entryPoints = [...config.entryPoints!];
+
   var setupResult = setup({
-    config: config,
+    config: configSnapshot,
     onDispose: notImplementedIssueFn(2771, "On-dispose callbacks"),
     onEnd,
     onLoad,
@@ -360,15 +368,15 @@ export function runSetupFunction(
     },
     // esbuild's options argument is different, we provide some interop
     initialOptions: {
-      ...config,
+      ...configSnapshot,
       bundle: true,
-      entryPoints: config.entrypoints ?? config.entryPoints ?? [],
-      minify: typeof config.minify === "boolean" ? config.minify : false,
-      minifyIdentifiers: config.minify === true || (config.minify as MinifyObj)?.identifiers,
-      minifyWhitespace: config.minify === true || (config.minify as MinifyObj)?.whitespace,
-      minifySyntax: config.minify === true || (config.minify as MinifyObj)?.syntax,
-      outbase: config.root,
-      platform: config.target === "bun" ? "node" : config.target,
+      entryPoints: configSnapshot.entrypoints ?? configSnapshot.entryPoints ?? [],
+      minify: typeof configSnapshot.minify === "boolean" ? configSnapshot.minify : false,
+      minifyIdentifiers: configSnapshot.minify === true || (configSnapshot.minify as MinifyObj)?.identifiers,
+      minifyWhitespace: configSnapshot.minify === true || (configSnapshot.minify as MinifyObj)?.whitespace,
+      minifySyntax: configSnapshot.minify === true || (configSnapshot.minify as MinifyObj)?.syntax,
+      outbase: configSnapshot.root,
+      platform: configSnapshot.target === "bun" ? "node" : configSnapshot.target,
     },
     esbuild: {},
   } as PluginBuilderExt);

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -343,13 +343,14 @@ export function runSetupFunction(
     return this.promises;
   };
 
-  // Expose a snapshot of the caller's config, not the live object: every
-  // option has already been consumed by the time setup() runs, so writes here
-  // must not feed back into the build or into the caller's object.
+  // Expose a shallow snapshot of the caller's config, not the live object:
+  // every option has already been consumed by the time setup() runs, so
+  // top-level writes here must not feed back into the build.
+  const { plugins: cfgPlugins, entrypoints: cfgEntrypoints, entryPoints: cfgEntryPoints } = config;
   const configSnapshot: BuildConfigExt = { ...config };
-  if ($isJSArray(config.plugins)) configSnapshot.plugins = [...config.plugins];
-  if ($isJSArray(config.entrypoints)) configSnapshot.entrypoints = [...config.entrypoints!];
-  if ($isJSArray(config.entryPoints)) configSnapshot.entryPoints = [...config.entryPoints!];
+  if ($isJSArray(cfgPlugins)) configSnapshot.plugins = [...cfgPlugins];
+  if ($isJSArray(cfgEntrypoints)) configSnapshot.entrypoints = [...cfgEntrypoints];
+  if ($isJSArray(cfgEntryPoints)) configSnapshot.entryPoints = [...cfgEntryPoints];
 
   var setupResult = setup({
     config: configSnapshot,

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -343,9 +343,7 @@ export function runSetupFunction(
     return this.promises;
   };
 
-  // Expose a shallow snapshot of the caller's config, not the live object:
-  // every option has already been consumed by the time setup() runs, so
-  // top-level writes here must not feed back into the build.
+  // Shallow snapshot: setup() writes must not reach the caller's object or the build.
   const { plugins: cfgPlugins, entrypoints: cfgEntrypoints, entryPoints: cfgEntryPoints } = config;
   const configSnapshot: BuildConfigExt = { ...config };
   if ($isJSArray(cfgPlugins)) configSnapshot.plugins = [...cfgPlugins];

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -479,96 +479,6 @@ pub mod js_bundler {
                 drop(slice);
             }
 
-            // Plugins must be resolved first as they are allowed to mutate the config JSValue
-            if let Some(array) = config.get_array(global_this, "plugins")? {
-                let length = array.get_length(global_this)?;
-                let mut iter = array.array_iterator(global_this)?;
-                let mut onstart_promise_array = JSValue::UNDEFINED;
-                let mut i: usize = 0;
-                while let Some(plugin) = iter.next()? {
-                    if !plugin.is_object() {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected plugin to be an object"
-                        )));
-                    }
-
-                    if let Some(slice) = plugin.get_optional_slice(global_this, b"name")? {
-                        if slice.slice().is_empty() {
-                            return Err(global_this.throw_invalid_arguments(format_args!(
-                                "Expected plugin to have a non-empty name"
-                            )));
-                        }
-                        drop(slice);
-                    } else {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected plugin to have a name"
-                        )));
-                    }
-
-                    let Some(function) = plugin.get_function(global_this, b"setup")? else {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected plugin to have a setup() function"
-                        )));
-                    };
-
-                    let bun_plugins: *mut Plugin = match **plugins {
-                        Some(p) => p,
-                        None => {
-                            let p = Plugin::create(
-                                global_this,
-                                match this.target {
-                                    Target::Bun | Target::BunMacro => jsc::BunPluginTarget::Bun,
-                                    Target::Node => jsc::BunPluginTarget::Node,
-                                    _ => jsc::BunPluginTarget::Browser,
-                                },
-                            );
-                            **plugins = Some(p);
-                            p
-                        }
-                    };
-
-                    let is_last = i == (length as usize).saturating_sub(1);
-                    // SAFETY: bun_plugins is a valid pointer created/stored above
-                    let mut plugin_result = unsafe {
-                        (*bun_plugins).add_plugin(
-                            function,
-                            config,
-                            onstart_promise_array,
-                            is_last,
-                            false,
-                        )?
-                    };
-
-                    if !plugin_result.is_empty_or_undefined_or_null() {
-                        if let Some(promise) = plugin_result.as_any_promise() {
-                            promise.set_handled(global_this.vm());
-                            // SAFETY: bun_vm() returns the live process VirtualMachine pointer.
-                            global_this.bun_vm().as_mut().wait_for_promise(promise);
-                            match promise
-                                .unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled)
-                            {
-                                jsc::PromiseResult::Pending => unreachable!(),
-                                jsc::PromiseResult::Fulfilled(val) => {
-                                    plugin_result = val;
-                                }
-                                jsc::PromiseResult::Rejected(err) => {
-                                    return Err(global_this.throw_value(err));
-                                }
-                            }
-                        }
-                    }
-
-                    if let Some(err) = plugin_result.to_error() {
-                        return Err(global_this.throw_value(err));
-                    } else if global_this.has_exception() {
-                        return Err(JsError::Thrown);
-                    }
-
-                    onstart_promise_array = plugin_result;
-                    i += 1;
-                }
-            }
-
             if let Some(macros_flag) = config.get_boolean_loose(global_this, "macros")? {
                 this.no_macros = !macros_flag;
             }
@@ -1275,6 +1185,99 @@ pub mod js_bundler {
                     return Err(global_this.throw_invalid_arguments(format_args!(
                         "Cannot use compile with target 'browser' and splitting for standalone HTML"
                     )));
+                }
+            }
+
+            // Plugin setup() runs after every other config field has been read so
+            // that writes to `build.config` inside setup() cannot alter the build
+            // (entrypoints, outdir, define, ...). `build.config` is exposed to
+            // plugins as a read-only snapshot; see BundlerPlugin.ts.
+            if let Some(array) = config.get_array(global_this, "plugins")? {
+                let length = array.get_length(global_this)?;
+                let mut iter = array.array_iterator(global_this)?;
+                let mut onstart_promise_array = JSValue::UNDEFINED;
+                let mut i: usize = 0;
+                while let Some(plugin) = iter.next()? {
+                    if !plugin.is_object() {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "Expected plugin to be an object"
+                        )));
+                    }
+
+                    if let Some(slice) = plugin.get_optional_slice(global_this, b"name")? {
+                        if slice.slice().is_empty() {
+                            return Err(global_this.throw_invalid_arguments(format_args!(
+                                "Expected plugin to have a non-empty name"
+                            )));
+                        }
+                        drop(slice);
+                    } else {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "Expected plugin to have a name"
+                        )));
+                    }
+
+                    let Some(function) = plugin.get_function(global_this, b"setup")? else {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "Expected plugin to have a setup() function"
+                        )));
+                    };
+
+                    let bun_plugins: *mut Plugin = match **plugins {
+                        Some(p) => p,
+                        None => {
+                            let p = Plugin::create(
+                                global_this,
+                                match this.target {
+                                    Target::Bun | Target::BunMacro => jsc::BunPluginTarget::Bun,
+                                    Target::Node => jsc::BunPluginTarget::Node,
+                                    _ => jsc::BunPluginTarget::Browser,
+                                },
+                            );
+                            **plugins = Some(p);
+                            p
+                        }
+                    };
+
+                    let is_last = i == (length as usize).saturating_sub(1);
+                    // SAFETY: bun_plugins is a valid pointer created/stored above
+                    let mut plugin_result = unsafe {
+                        (*bun_plugins).add_plugin(
+                            function,
+                            config,
+                            onstart_promise_array,
+                            is_last,
+                            false,
+                        )?
+                    };
+
+                    if !plugin_result.is_empty_or_undefined_or_null() {
+                        if let Some(promise) = plugin_result.as_any_promise() {
+                            promise.set_handled(global_this.vm());
+                            // SAFETY: bun_vm() returns the live process VirtualMachine pointer.
+                            global_this.bun_vm().as_mut().wait_for_promise(promise);
+                            match promise
+                                .unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled)
+                            {
+                                jsc::PromiseResult::Pending => unreachable!(),
+                                jsc::PromiseResult::Fulfilled(val) => {
+                                    plugin_result = val;
+                                }
+                                jsc::PromiseResult::Rejected(err) => {
+                                    return Err(global_this.throw_value(err));
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(err) = plugin_result.to_error() {
+                        return Err(global_this.throw_value(err));
+                    } else if global_this.has_exception() {
+                        return Err(JsError::Thrown);
+                    }
+
+                    onstart_promise_array = plugin_result;
+                    i += 1;
                 }
             }
 

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1188,10 +1188,7 @@ pub mod js_bundler {
                 }
             }
 
-            // Plugin setup() runs after every other config field has been read so
-            // that writes to `build.config` inside setup() cannot alter the build
-            // (entrypoints, outdir, define, ...). `build.config` is exposed to
-            // plugins as a read-only snapshot; see BundlerPlugin.ts.
+            // Plugin setup() runs last so writes to `build.config` cannot alter the build.
             if let Some(array) = config.get_array(global_this, "plugins")? {
                 let length = array.get_length(global_this)?;
                 let mut iter = array.array_iterator(global_this)?;

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { existsSync } from "node:fs";
 import path, { dirname, join, resolve } from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -807,7 +808,45 @@ describe("bundler", () => {
       },
       entryPoints: ["./index.ts"],
       plugins(build) {
-        expect(build.config).toBe(getConfigRef());
+        const callerConfig = getConfigRef();
+        // build.config is a snapshot, not the caller's live object
+        expect(build.config).not.toBe(callerConfig);
+        expect(build.config.entrypoints).toEqual(callerConfig.entrypoints);
+        expect(build.config.outdir).toBe(callerConfig.outdir);
+        expect(build.config.plugins).toEqual(callerConfig.plugins);
+      },
+    };
+  });
+  itBundled("plugin/ConfigMutationIsNoop", ({ root, getConfigRef }) => {
+    let callerConfig: any;
+    return {
+      files: {
+        "index.ts": `console.log("CALLERS-ENTRY", MUT_DEFINE);`,
+        "evil.ts": `console.log("PLUGIN-CHOSE-ME");`,
+      },
+      entryPoints: ["./index.ts"],
+      backend: "api",
+      define: { MUT_DEFINE: '"caller"' },
+      plugins(build) {
+        callerConfig = getConfigRef();
+        // None of these should affect the build: config is read before setup() runs.
+        build.config.entrypoints = [join(root, "evil.ts")];
+        build.config.outdir = join(root, "evil-out");
+        build.config.minify = true;
+        build.config.define = { MUT_DEFINE: '"plugin"' };
+        (build.config as any).target = "node";
+      },
+      run: {
+        stdout: "CALLERS-ENTRY caller",
+      },
+      onAfterBundle(api) {
+        const out = api.readFile("out.js");
+        expect(out).toContain("CALLERS-ENTRY");
+        expect(out).not.toContain("PLUGIN-CHOSE-ME");
+        expect(existsSync(join(api.root, "evil-out"))).toBe(false);
+        // The caller's own object was not mutated either.
+        expect(callerConfig.outdir).not.toBe(join(root, "evil-out"));
+        expect(callerConfig.define).toEqual({ MUT_DEFINE: '"caller"' });
       },
     };
   });


### PR DESCRIPTION
## Problem

`build.config` handed to a plugin's `setup()` was the caller's live config object, and `Config::from_js` re-read most fields *after* running `setup()`. A plugin could silently rewrite the build:

```ts
const res = await Bun.build({
  entrypoints: [entry], outdir: mine,
  plugins: [{ name: "p", setup(b) {
    b.config.entrypoints = [alt];   // bundle contains alt, not entry
    b.config.outdir = theirs;       // mine is never created; success: true
  } }],
});
// res.success === true, files land in `theirs`, `mine` does not exist
```

Field behavior was also inconsistent: `entrypoints`/`outdir`/`minify`/`define` were honored after `setup()`, but `target` and `plugins.push` were inert (read before the loop). An invalid `define` set inside `setup()` failed the build even though a valid one only took effect by accident of ordering.

## Cause

`src/runtime/api/JSBundler.rs` `Config::from_js` ran plugin `setup()` early (after reading only `target`) and then continued reading `entrypoints`, `outdir`, `minify`, `define`, etc. from the same `JSValue` the plugin had been given. `src/js/builtins/BundlerPlugin.ts` `runSetupFunction` passed that `JSValue` straight through as `build.config`.

## Fix

- `Config::from_js`: read every config field first, run plugin `setup()` last. Nothing re-reads `config` after `setup()`.
- `runSetupFunction`: hand `setup()` a shallow copy (`{ ...config }` with copied `entrypoints`/`plugins` arrays) so `build.config !== callerConfig` and top-level writes do not reach the caller's object.
- Updated docs (`docs/bundler/plugins.mdx`, `docs/runtime/plugins.mdx`) and the `PluginBuilder.config` JSDoc in `bun.d.ts` to describe a read-only shallow snapshot.
- Updated `plugin/Options` to assert `build.config` is a distinct object with equivalent values, and added `plugin/ConfigMutationIsNoop` covering `entrypoints`/`outdir`/`minify`/`define`/`target` writes from `setup()` plus the caller-object-unchanged check.
- `bun-plugin-svelte`: removed the `builder.config.conditions` mutation that is now a no-op. Callers that depend on the `"svelte"` export condition must pass `conditions: ["svelte"]` to `Bun.build` themselves; updated the README example and the `handles "svelte" export condition` test accordingly.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/bundler_plugin.test.ts -t "plugin/Options|plugin/ConfigMutationIsNoop"
(fail) bundler > plugin/Options           # build.config === callerConfig
(fail) bundler > plugin/ConfigMutationIsNoop   # outdir redirected, bundle not at expected path

$ bun bd test test/bundler/bundler_plugin.test.ts
 53 pass  3 todo  0 fail

$ (cd packages/bun-plugin-svelte && bun-debug test ./test/index.test.ts)
 10 pass  0 fail
```

Also re-ran `test/bundler/bun-build-api.test.ts`, `test/bundler/bundler_defer.test.ts`, `test/bundler/bundler_plugin_chain.test.ts`, `test/bundler/plugin-sync-exception-fallback.test.ts`, `test/js/bun/plugin/plugins.test.ts`: all pass. `bun run lint` is clean.

Note: this is a behavior change. Plugins that relied on mutating `build.config` in `setup()` (previously documented) will now see those writes ignored. The inconsistency (only some fields honored) meant such plugins were already fragile; the one in-tree consumer (`bun-plugin-svelte`) is updated here.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->