### PR TITLE
ci: spawn the docker test-service coordinator on darwin shards too

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -526,8 +526,8 @@ async function runTests() {
   if (
     isCI &&
     !isWindows &&
-    spawnSync("docker", ["compose", "version"], { stdio: "ignore" }).status === 0 &&
-    (isLinux || spawnSync("docker", ["version"], { stdio: "ignore" }).status === 0)
+    spawnSync("docker", ["compose", "version"], { stdio: "ignore", timeout: 5_000 }).status === 0 &&
+    (isLinux || spawnSync("docker", ["version"], { stdio: "ignore", timeout: 5_000 }).status === 0)
   ) {
     const coordinatorSocket = join(tmpdir(), `bun-docker-${process.pid}.sock`);
     const coordinator = spawn(execPath, [join(cwd, "test", "docker", "coordinator.ts"), ...tests], {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -511,10 +511,24 @@ async function runTests() {
   // it through the unix socket in BUN_DOCKER_COORDINATOR (inherited by every
   // spawned test process); ensure() waits for the coordinator's ready message
   // instead of shelling out to compose itself. Without the env var, ensure()
-  // falls back to running compose directly. Linux-only — macOS / Windows CI
-  // don't run docker tests. Lifetime is tied to this process via the stdin
-  // pipe.
-  if (isCI && isLinux && spawnSync("docker", ["compose", "version"], { stdio: "ignore" }).status === 0) {
+  // falls back to running compose directly. POSIX-only because the coordinator
+  // listens on a unix socket. darwin shards run the mysql/postgres/valkey
+  // regression tests via describeWithContainer (DOCKER_HOST points at a sidecar
+  // VM), so without this prestart the first mysql_plain consumer in a shard
+  // pays the full `compose build + up --wait` inline. Windows CI has no docker.
+  // On darwin, docker tests are optional: isDockerEnabled() returns false (not
+  // throws) when the sidecar is unreachable, and describeWithContainer becomes
+  // `.todo`. Setting BUN_DOCKER_COORDINATOR bypasses that check, so the darwin
+  // arm of the gate also probes the daemon with `docker version` and leaves the
+  // coordinator unspawned when it fails. Linux keeps the compose-only check so
+  // a slow-booting dockerd still gets the coordinator (whose later ensure()
+  // re-probes). Lifetime is tied to this process via the stdin pipe.
+  if (
+    isCI &&
+    !isWindows &&
+    spawnSync("docker", ["compose", "version"], { stdio: "ignore" }).status === 0 &&
+    (isLinux || spawnSync("docker", ["version"], { stdio: "ignore" }).status === 0)
+  ) {
     const coordinatorSocket = join(tmpdir(), `bun-docker-${process.pid}.sock`);
     const coordinator = spawn(execPath, [join(cwd, "test", "docker", "coordinator.ts"), ...tests], {
       stdio: ["pipe", "pipe", "inherit"],


### PR DESCRIPTION
## Problem

`scripts/runner.node.mjs` spawns the docker test-service coordinator (`test/docker/coordinator.ts`) only when `isCI && isLinux`, with an inline comment saying "macOS / Windows CI don't run docker tests". That comment is stale: darwin shards run the mysql/postgres/valkey regression tests (`test/regression/issue/{21311,24850,26030,26063,28632}.test.ts` and others) via `describeWithContainer`, with `DOCKER_HOST` pointing at a per-job sidecar VM.

Without the coordinator there is no prestart and no per-shard compose dedup, so the first consumer of each service in a darwin shard pays `docker compose build` + `up -d --wait` inside its `beforeAll`.

## Evidence

[Build 83134, darwin 14 aarch64 shard 2](https://buildkite.com/bun/bun/builds/83134#019fa22d-3703-479c-8d26-597be20eb41d):

```
t=1785134335283  start test/regression/issue/24850.test.ts
t=1785134359391  "Container ready via docker-compose: mysql_plain at 192.168.64.1:32771"
t=1785134359472  next file
```

24.1s wall-clock for ~100ms of test work; `26030` immediately after took 1.4s because the container was warm. No `COORDINATOR_READY` line anywhere in the log. The cost varies with the darwin host's image cache state (~3s when the image is already built, ~24s cold).

## Fix

Change the gate from `isCI && isLinux` to `isCI && !isWindows` (the coordinator listens on a unix socket, which works on macOS; Windows CI has no docker).

On darwin the gate additionally probes the daemon with `docker version`. Docker tests on darwin are optional: `isDockerEnabled()` returns `false` rather than throwing when the sidecar is unreachable, and `describeWithContainer` becomes `.todo`. Setting `BUN_DOCKER_COORDINATOR` bypasses that check, so the coordinator is only spawned when the daemon is actually reachable at shard start, and the `.todo` path is preserved when it is not. Linux keeps the compose-only check so a slow-booting dockerd still gets the coordinator (whose own `ensure()` re-probes later).

Both `spawnSync` probes are bounded at 5s: over `DOCKER_HOST=tcp://...` a silently-dropping endpoint would otherwise block for the Go dial timeout (~75s on macOS). On timeout `status` is `null` so the gate falls through without extra handling.

### Behavior note: sidecar loss after shard start

Once the daemon is reachable at shard start and `BUN_DOCKER_COORDINATOR` is exported, a sidecar that dies later in the shard now hard-fails the handful of `describeWithContainer` callers that are not wrapped in `if (isDockerEnabled())` (`21311`, `24850`, `26030` and a few `js/sql` files), rather than turning them into `.todo`. This matches Linux semantics and is intentional: the docker-last test ordering means those files run at the end of the shard, and a sidecar that was healthy at start and died before any docker test ran is an infra fault worth surfacing rather than silently dropping coverage. Most callers already guard on `isDockerEnabled()` and keep the `.todo` fallback regardless.

## Why this is the right change

The coordinator is already platform-agnostic: it talks to docker through the CLI (which honors `DOCKER_HOST`), listens on a plain unix socket, and inherits the runner's environment. Nothing in `test/docker/coordinator.ts` or `test/docker/index.ts` is Linux-specific. The docker-last test ordering in `getRelevantTests()` already runs unconditionally on every platform; this change just makes the prestart half of that optimisation apply on darwin too.

## Verification

CI scripts only; no `src/` or `test/` change. Verified:
- `node --check scripts/runner.node.mjs` passes
- `prettier --check` passes
- Linux path is unchanged: `!isWindows && ... && (isLinux || ...)` short-circuits to the same condition as before on Linux
- darwin path with daemon unreachable: in [build 83255](https://buildkite.com/bun/bun/builds/83255) the darwin 14 x64 shard (no sidecar) and darwin 26 aarch64 shards (sidecar booted but daemon unreachable) correctly skip the coordinator and fall through to `.todo`
- `spawnSync` timeout returns `{status: null, signal: "SIGTERM"}`, so `=== 0` is false on a hung probe

Overlaps textually with #34480 (which adds a dockerd poll loop inside the same block); whichever lands second is a trivial rebase.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->