### PR TITLE
test(http): replace fixed sleeps with FIFO barrier in fetch-abort-ssl-context-eviction test

### DIFF
--- a/test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
+++ b/test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 
 // Evicting a custom SSL context while it still has in-flight sockets closes
 // those sockets via no-op callbacks (cleanCallbacks runs first in
@@ -14,16 +14,22 @@ import { bunEnv, bunExe } from "harness";
 // evictOldestSslContext. Aborting all requests then drains the tracker.
 //
 // In debug+ASAN builds the existing assertUnpoisoned check at
-// HTTPThread.processEvents catches the freed socket deterministically. In
-// release builds the UAF only crashes when the freed slot is reused; the
-// fixture spams same-size-class allocations to make that likely (~30% per
-// run before the fix), so loop a few times.
+// HTTPThread.processEvents catches the freed socket deterministically, so one
+// run is enough. In release builds the UAF only crashes when the freed slot is
+// reused; the fixture spams same-size-class allocations to make that likely
+// (~30% per run before the fix), so loop a few times.
 test("aborting fetches whose custom SSL context was evicted does not crash", async () => {
+  // The fixture relies on connects to TEST-NET-1 staying in-flight; strip any
+  // ambient HTTP(S) proxy so those connects aren't intercepted.
+  const env: Record<string, string | undefined> = { ...bunEnv };
+  for (const k of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy"]) delete env[k];
+
+  const runs = isASAN ? 1 : 5;
   const results = await Promise.all(
-    Array.from({ length: 5 }, async () => {
+    Array.from({ length: runs }, async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture],
-        env: bunEnv,
+        env,
         stderr: "pipe",
         stdout: "pipe",
       });
@@ -33,19 +39,22 @@ test("aborting fetches whose custom SSL context was evicted does not crash", asy
     }),
   );
 
-  for (const { stdout, stderr, exitCode } of results) {
-    expect(stderr).not.toContain("panic");
-    expect(stderr).not.toContain("Segmentation fault");
-    expect(stderr).not.toContain("poisoned");
-    expect(stdout.trim()).toBe("ok");
-    expect(exitCode).toBe(0);
-  }
-}, 120_000);
+  expect(results).toEqual(Array.from({ length: runs }, () => ({ stdout: "ok\n", stderr: "", exitCode: 0 })));
+});
 
+// The HTTP client thread's queued_tasks are popped FIFO and each task's
+// start_queued_task → start_() creates its custom SSL context and runs the
+// cache-size eviction check synchronously before returning. A plain HTTP
+// fetch queued after the 65 SSL fetches therefore cannot start until every
+// SSL context exists and eviction has fired for indices 60..64, so awaiting
+// that barrier fetch replaces the 5s/0.5s sleeps the original fixture used.
 const fixture = /* js */ `
 const N = 65; // > ssl_context_cache_max_size (60)
 const controllers = [];
 const promises = [];
+
+await using server = Bun.serve({ port: 0, fetch: () => new Response("sync") });
+const barrier = () => fetch(server.url).then(r => r.arrayBuffer());
 
 // Phase 1: 65 distinct TLS configs to a hung target. The 61st+ trigger
 // evictOldestSslContext, which (before the fix) closed the oldest context's
@@ -60,9 +69,7 @@ for (let i = 0; i < N; i++) {
     }).catch(() => {})
   );
 }
-
-// Creating 60+ SSL contexts is slow in debug+ASAN builds.
-await Bun.sleep(5000);
+await barrier();
 
 // Phase 2: spam non-SSL us_connecting_socket_t allocs (same mimalloc size
 // class as the evicted SSL semi-socket) so the freed slots are reused with
@@ -75,7 +82,7 @@ for (let i = 0; i < 200; i++) {
     fetch("http://does-not-resolve-" + i + ".invalid/", { signal: ac.signal }).catch(() => {})
   );
 }
-await Bun.sleep(500);
+await barrier();
 
 // Abort everything — drainQueuedShutdowns walks the tracker.
 for (const ac of controllers) ac.abort();

--- a/test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
+++ b/test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
@@ -20,8 +20,11 @@ import { bunEnv, bunExe, isASAN } from "harness";
 // (~30% per run before the fix), so loop a few times.
 test("aborting fetches whose custom SSL context was evicted does not crash", async () => {
   // The fixture relies on connects to TEST-NET-1 staying in-flight; strip any
-  // ambient HTTP(S) proxy so those connects aren't intercepted.
-  const env: Record<string, string | undefined> = { ...bunEnv };
+  // ambient HTTP(S) proxy so those connects aren't intercepted. Raise the
+  // per-process request cap so all 65+200 requests plus both barriers start in
+  // one FIFO drain pass (default cap is 256; 65+200+1 would defer the second
+  // barrier behind async .invalid DNS failures).
+  const env: Record<string, string | undefined> = { ...bunEnv, BUN_CONFIG_MAX_HTTP_REQUESTS: "512" };
   for (const k of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy"]) delete env[k];
 
   const runs = isASAN ? 1 : 5;


### PR DESCRIPTION
## What

`test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts` is one of the slower single-test files in the suite (11s wall-clock on darwin 26 aarch64, build #83134). Almost all of it is two fixed sleeps inside the fixture:

```js
await Bun.sleep(5000);   // wait for 65 SSL_CTX creations
// ... phase 2 ...
await Bun.sleep(500);    // wait for 200 us_connecting_socket_t allocs
```

## Change

**Barrier fetch instead of sleep.** `HttpThread.queued_tasks` is an MPSC queue drained FIFO, and each task's `start_queued_task → start_()` creates its custom SSL context and runs the `count() > SSL_CONTEXT_CACHE_MAX_SIZE` eviction check synchronously before returning (`src/http/HTTPThread.rs:555-568`, `src/http/lib.rs:2706-2856`). So a plain HTTP fetch queued behind the 65 SSL fetches cannot start until every context exists and eviction has fired for indices 60..64. Awaiting that barrier fetch (against a local `Bun.serve({ port: 0 })`) is therefore an exact sync point for the condition the 5s sleep was approximating. Same reasoning applies to the 0.5s sleep after Phase 2: `us_socket_group_connect` allocates the `us_connecting_socket_t` synchronously before returning (`packages/bun-usockets/src/context.c:613`), so every Phase 2 allocation has happened by the time the second barrier resolves. The child is spawned with `BUN_CONFIG_MAX_HTTP_REQUESTS=512` so 65+200+barriers all fit under the per-process cap; at the default 256 the second barrier would be request #267 and land in `deferred_tasks` behind nine async `.invalid` NXDOMAINs, reintroducing a (small) timing dependency.

**Single run under ASAN.** The test's own comment documents that `assert_abort_tracker_sockets_alive` catches a stale tracker entry deterministically on the next loop tick under ASAN (`src/http/HTTPThread.rs:1190-1198`, `#[cfg(bun_asan)]` body). The five-run loop only exists to make the ~30% release-mode UAF likely. So: `isASAN ? 1 : 5` runs.

**Stronger assertion.** Dropped the three `expect(stderr).not.toContain('panic' | 'Segmentation fault' | 'poisoned')` checks (a crash already fails the `stdout === 'ok'` / `exitCode === 0` checks) in favour of a single `toEqual` on `{ stdout: 'ok\\n', stderr: '', exitCode: 0 }` per run. `stderr: ''` is strictly stronger than the three substring checks, and the diff on failure names the crashing run and shows its full stderr.

**Proxy env stripped.** The fixture relies on connects to `https://192.0.2.1/` staying in-flight; under an ambient `HTTP(S)_PROXY` those get answered by the proxy and the test silently stops exercising the eviction-with-active-socket path. Strip the proxy env vars for the subprocess so it behaves the same everywhere.

**Dropped the 120s per-test timeout.** The CI runner supplies its own per-test timeout (`scripts/runner.node.mjs:1607-1612`).

## Timing

`time bun bd test test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts` on linux x64 debug+ASAN:

|              | test body | file total | wall |
|--------------|-----------|------------|------|
| before       | 6582 ms   | 9.79 s     | 12.07 s |
| after        | 755 ms    | 2.83 s     | 3.90 s |

Release (`USE_SYSTEM_BUN=1 bun test ...`, 5 runs): 58–74 ms test body, 198–245 ms file total. Ran 3× each to check for variance; no flakes.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
bun test v1.4.0 (cda4d8827)

test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts:
(pass) aborting fetches whose custom SSL context was evicted does not crash [767.20ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [2.74s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../http/fetch-abort-ssl-context-eviction.test.ts  | 48 +++++++++++++---------
 1 file changed, 29 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…st/js/bun/http/fetch-abort-ssl-context-eviction.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->