### PR TITLE
test(Bun.write): tighten 8254 >2GB regression test and trim setup

### DIFF
--- a/test/regression/issue/8254.test.ts
+++ b/test/regression/issue/8254.test.ts
@@ -3,7 +3,6 @@
 
 import { expect, test } from "bun:test";
 import { tempDir } from "harness";
-import { rmSync } from "node:fs";
 import { join } from "path";
 
 test("Bun.write() should write past 2GB boundary without corruption", async () => {
@@ -20,9 +19,9 @@ test("Bun.write() should write past 2GB boundary without corruption", async () =
 
   // Two distinct fill values are enough to detect a skipped or duplicated
   // chunk at the boundary, and every byte we assert on is non-zero so a
-  // truncated or zero-filled tail (the original #8254 symptom) cannot pass
-  // by accident. Backing the 2049-part Blob with two shared 1MB buffers
-  // instead of 256 drops per-run setup from 256MB of filled pages to 2MB.
+  // zero-filled tail (the original #8254 symptom) cannot pass by accident.
+  // Backing the 2049-part Blob with two shared 1MB buffers instead of 256
+  // drops per-run setup from 256MB of filled pages to 2MB.
   const a = new Uint8Array(CHUNK_SIZE).fill(0xaa);
   const b = new Uint8Array(CHUNK_SIZE).fill(0xbb);
   const chunks: Uint8Array<ArrayBuffer>[] = [];
@@ -41,7 +40,8 @@ test("Bun.write() should write past 2GB boundary without corruption", async () =
 
   // One read spanning the 2GB boundary: last two bytes of chunk 2047 (0xbb)
   // and first two bytes of chunk 2048 (0xaa). Under the original bug the
-  // file ended at Linux's MAX_RW_COUNT and this slice came back short.
+  // preallocated tail past MAX_RW_COUNT stayed zero, so this read back as
+  // [0, 0, 0, 0].
   const around = new Uint8Array(await file.slice(TWO_GB - 2, TWO_GB + 2).arrayBuffer());
   expect([...around]).toEqual([0xbb, 0xbb, 0xaa, 0xaa]);
 
@@ -49,8 +49,4 @@ test("Bun.write() should write past 2GB boundary without corruption", async () =
   const head = new Uint8Array(await file.slice(0, 1).arrayBuffer());
   const tail = new Uint8Array(await file.slice(TOTAL - 1, TOTAL).arrayBuffer());
   expect({ head: [...head], tail: [...tail] }).toEqual({ head: [0xaa], tail: [0xaa] });
-
-  // Drop the 2GB file before `tempDir`'s dispose runs so the recursive
-  // rmSync only has an empty directory to remove.
-  rmSync(path, { force: true });
 });

--- a/test/regression/issue/8254.test.ts
+++ b/test/regression/issue/8254.test.ts
@@ -49,4 +49,4 @@ test("Bun.write() should write past 2GB boundary without corruption", async () =
   const head = new Uint8Array(await file.slice(0, 1).arrayBuffer());
   const tail = new Uint8Array(await file.slice(TOTAL - 1, TOTAL).arrayBuffer());
   expect({ head: [...head], tail: [...tail] }).toEqual({ head: [0xaa], tail: [0xaa] });
-});
+}, 30_000);

--- a/test/regression/issue/8254.test.ts
+++ b/test/regression/issue/8254.test.ts
@@ -3,6 +3,7 @@
 
 import { expect, test } from "bun:test";
 import { tempDir } from "harness";
+import { rmSync } from "node:fs";
 import { join } from "path";
 
 test("Bun.write() should write past 2GB boundary without corruption", async () => {
@@ -10,39 +11,46 @@ test("Bun.write() should write past 2GB boundary without corruption", async () =
 
   const TWO_GB = 2 ** 31;
   const CHUNK_SIZE = 1024 * 1024; // 1MB
-  // Force a second write iteration by crossing the 2GB boundary
+  // Force a second write iteration by crossing the 2GB boundary (write()
+  // on Linux and Darwin both cap a single call below 2^31, so one extra
+  // chunk guarantees Bun.write's partial-write loop runs at least twice).
   const NUM_CHUNKS = Math.floor(TWO_GB / CHUNK_SIZE) + 1;
+  const TOTAL = NUM_CHUNKS * CHUNK_SIZE;
   const path = join(tmpbase, "large-file.bin");
 
-  // Only 256 distinct fill values exist, so back the >2GB part list with 256
-  // shared 1MB buffers instead of 2049 distinct ones. The blob is still >2GB
-  // and the boundary verification below is unchanged, but peak RSS drops by
-  // ~2GB, which keeps the test under the CI runners' memory ceiling.
-  const distinct: Uint8Array<ArrayBuffer>[] = [];
-  for (let i = 0; i < 256; i++) {
-    const chunk = new Uint8Array(CHUNK_SIZE);
-    chunk.fill(i);
-    distinct.push(chunk);
-  }
+  // Two distinct fill values are enough to detect a skipped or duplicated
+  // chunk at the boundary, and every byte we assert on is non-zero so a
+  // truncated or zero-filled tail (the original #8254 symptom) cannot pass
+  // by accident. Backing the 2049-part Blob with two shared 1MB buffers
+  // instead of 256 drops per-run setup from 256MB of filled pages to 2MB.
+  const a = new Uint8Array(CHUNK_SIZE).fill(0xaa);
+  const b = new Uint8Array(CHUNK_SIZE).fill(0xbb);
   const chunks: Uint8Array<ArrayBuffer>[] = [];
   for (let i = 0; i < NUM_CHUNKS; i++) {
-    chunks.push(distinct[i % 256]);
+    chunks.push(i & 1 ? b : a);
   }
 
   const blob = new Blob(chunks);
-  const written = await Bun.write(path, blob);
+  expect(blob.size).toBe(TOTAL);
 
-  expect(written).toBeGreaterThan(TWO_GB);
+  const written = await Bun.write(path, blob);
+  expect(written).toBe(TOTAL);
 
   const file = Bun.file(path);
+  expect(file.size).toBe(TOTAL);
 
-  // Check bytes just before and after 2GB boundary
-  const positions = [TWO_GB - 1, TWO_GB, TWO_GB + 1];
+  // One read spanning the 2GB boundary: last two bytes of chunk 2047 (0xbb)
+  // and first two bytes of chunk 2048 (0xaa). Under the original bug the
+  // file ended at Linux's MAX_RW_COUNT and this slice came back short.
+  const around = new Uint8Array(await file.slice(TWO_GB - 2, TWO_GB + 2).arrayBuffer());
+  expect([...around]).toEqual([0xbb, 0xbb, 0xaa, 0xaa]);
 
-  for (const pos of positions) {
-    const buf = new Uint8Array(await file.slice(pos, pos + 1).arrayBuffer());
+  // First and last byte: chunk 0 and chunk 2048 are both even -> 0xaa.
+  const head = new Uint8Array(await file.slice(0, 1).arrayBuffer());
+  const tail = new Uint8Array(await file.slice(TOTAL - 1, TOTAL).arrayBuffer());
+  expect({ head: [...head], tail: [...tail] }).toEqual({ head: [0xaa], tail: [0xaa] });
 
-    const expected = Math.floor(pos / CHUNK_SIZE) % 256;
-    expect(buf[0]).toBe(expected);
-  }
+  // Drop the 2GB file before `tempDir`'s dispose runs so the recursive
+  // rmSync only has an empty directory to remove.
+  rmSync(path, { force: true });
 });


### PR DESCRIPTION
This test writes a >2GB Blob via `Bun.write()` to exercise the partial-write loop (issue #8254). It was flagged as slow (~10s on debian 13 aarch64, ~12s `default` in expected-durations).

### Why this is correct

The previous test asserted on byte value `0` at positions `2^31` and `2^31 + 1` (chunk 2048 has fill value `2048 % 256 == 0`). The original #8254 symptom was a zero-filled tail past `MAX_RW_COUNT`, so those two assertions would also accept the corrupted output. Only the `2^31 - 1` check (expected `255`) was doing any work. Switching to two alternating non-zero fill values (`0xaa`/`0xbb`) makes every byte assertion reject a zero-filled or short tail.

The rest is setup reduction: 2 shared 1MB source buffers instead of 256 drops the pre-Blob fill from 256MB to 2MB and gives the `new Blob(chunks)` flatten a hot 2MB working set. The 2GB disk write itself cannot be shrunk; `write()` is clamped at a compile-time `MAX_COUNT` below `2^31` on Linux and Darwin (`src/sys/lib.rs:1528`) with no runtime override, so actually crossing 2GB is the only way to drive `do_write_loop_posix` through a second iteration.

### Assertions strengthened

- `expect(written).toBe(TOTAL)` (was `.toBeGreaterThan(TWO_GB)`)
- `expect(blob.size).toBe(TOTAL)` and `expect(file.size).toBe(TOTAL)` are new
- boundary slice `[2^31 - 2, 2^31 + 2)` checked via one `toEqual([0xbb, 0xbb, 0xaa, 0xaa])` (was three one-byte reads, two of which expected `0`)
- head and tail byte checks are new

### Timing

Local x86_64, `bun bd test test/regression/issue/8254.test.ts`, interleaved 5 rounds each:

| | before | after |
| --- | --- | --- |
| release (`USE_SYSTEM_BUN=1`) | 2.88s median | 1.95s median |
| debug+ASAN (`bun bd`) | ~4.7s | ~4.0s |

The remaining time is the 2GB disk write plus (under ASAN) test-runner startup; neither is reducible from the test side.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/8254.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/8254.test.ts"
bun test v1.4.0 (cc3cb207a)

test/regression/issue/8254.test.ts:
(pass) Bun.write() should write past 2GB boundary without corruption [3449.78ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [5.42s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/8254.test.ts | 54 ++++++++++++++++++++------------------
 1 file changed, 29 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
test/regression/issue/8254.test.ts      6      7      0
```

</details>

<!-- robobun:evidence:end -->