### PR TITLE
test(serve): fix darwin flake in the respond-without-reading-body backpressure test

### DIFF
--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3547,7 +3547,8 @@ describe("request body backpressure", () => {
 
       // The socket was resumed, so the upload pump (still parked on `drain`)
       // moves past the plateau as the server discards the remaining body.
-      while (getSent() === sentBeforeGate) await Bun.sleep(25);
+      const deadline = Date.now() + 2000;
+      while (getSent() === sentBeforeGate && Date.now() < deadline) await Bun.sleep(25);
       expect(getSent()).toBeGreaterThan(sentBeforeGate);
     } finally {
       sock.destroy();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3273,7 +3273,7 @@ describe("request body backpressure", () => {
   // bytes of `fill`, pausing on `drain`. Resolves once the client's `sent`
   // counter has plateaued for 12×25 ms (backpressure engaged) or it finished
   // the whole body (the bug).
-  async function pumpUploadUntilPlateau(port: number, total: number, fill: number) {
+  async function pumpUploadUntilPlateau(port: number, total: number, fill: number, connection = "close") {
     const block = Buffer.alloc(256 * 1024, fill);
     const sock = net.connect(port, "127.0.0.1");
     await new Promise<void>((resolve, reject) => {
@@ -3282,7 +3282,7 @@ describe("request body backpressure", () => {
     });
     sock.on("error", () => {});
     sock.on("data", () => {});
-    sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${total}\r\nConnection: close\r\n\r\n`);
+    sock.write(`PUT /up HTTP/1.1\r\nHost: x\r\nContent-Length: ${total}\r\nConnection: ${connection}\r\n\r\n`);
 
     let sent = 0;
     let drainWaiters = 0;
@@ -3310,7 +3310,7 @@ describe("request body backpressure", () => {
         last = sent;
       }
     }
-    return { sock, sentBeforeGate: sent, drainWaiters };
+    return { sock, sentBeforeGate: sent, drainWaiters, getSent: () => sent };
   }
 
   it("applies backpressure to a streamed request body when the handler reads slowly", async () => {
@@ -3499,9 +3499,13 @@ describe("request body backpressure", () => {
   }
 
   it("releases a paused request body when the handler responds without reading it", async () => {
-    // The handler never touches req.body, so the pre-stream pause engages and is
-    // released by detach_response()'s resume once the response is sent. Without
-    // that resume the socket stays paused and the client never sees the response.
+    // The handler never touches req.body, so the pre-stream pause engages. Once
+    // the response is sent detach_response() resumes the socket; without that the
+    // keep-alive connection would stay paused and the client's upload could never
+    // progress past the plateau. `Connection: close` cannot observe this: uWS
+    // force-closes right after the response, and close() with unread body bytes
+    // in the kernel recv buffer sends RST on macOS, which both EPIPEs the still-
+    // running upload pump and can drop the response before the client reads it.
     const TOTAL = 32 * 1024 * 1024;
     const gate = Promise.withResolvers<void>();
     const serverDone = Promise.withResolvers<void>();
@@ -3520,19 +3524,18 @@ describe("request body backpressure", () => {
       },
     });
 
-    const { sock, sentBeforeGate } = await pumpUploadUntilPlateau(server.port, TOTAL, 2);
+    const { sock, sentBeforeGate, getSent } = await pumpUploadUntilPlateau(server.port, TOTAL, 2, "keep-alive");
     try {
       expect(sentBeforeGate).toBeGreaterThan(0);
       expect(sentBeforeGate).toBeLessThan(TOTAL);
 
-      const response = new Promise<string>((resolve, reject) => {
+      const response = new Promise<string>(resolve => {
         let buf = "";
         sock.removeAllListeners("data");
         sock.on("data", d => {
           buf += d.toString("latin1");
-          if (buf.includes("\r\n\r\n")) resolve(buf);
+          if (buf.includes("ignored")) resolve(buf);
         });
-        sock.once("error", reject);
         sock.once("close", () => resolve(buf));
       });
 
@@ -3541,6 +3544,11 @@ describe("request body backpressure", () => {
       const resp = await response;
       expect(resp).toStartWith("HTTP/1.1 200 ");
       expect(resp).toContain("ignored");
+
+      // The socket was resumed, so the upload pump (still parked on `drain`)
+      // moves past the plateau as the server discards the remaining body.
+      while (getSent() === sentBeforeGate) await Bun.sleep(25);
+      expect(getSent()).toBeGreaterThan(sentBeforeGate);
     } finally {
       sock.destroy();
     }


### PR DESCRIPTION
`serve.test.ts` has been red on the darwin lanes since #36072 landed (main #83238, also the PR's own build #83229 as a retry-flake). The subtest is `request body backpressure > releases a paused request body when the handler responds without reading it`, which #36072 added to cover the `detach_response()` resume at `RequestContext.rs:2382`.

```
EPIPE: broken pipe, write
 syscall: "write",
   errno: -32,
    code: "EPIPE"
✗ request body backpressure > releases a paused request body when the handler responds without reading it
```

## Cause

The test sends a 32 MiB `PUT` over a raw `net.Socket` with `Connection: close`, lets the server's pre-stream pause stall the upload, then has the handler respond without touching `req.body` and waits for the client to receive the response.

Once the handler returns, `render_bytes()` writes the response via `try_end()` and uWS does `shutdown(SHUT_WR)` immediately followed by `close()` (`HttpResponse.h:860-871`). Because the socket was paused, the unread body bytes are still sitting in the kernel recv buffer, and `close()` with unread recv data sends **RST**. On macOS that RST races two things:

1. the upload pump's `sock.once('drain', writeMore)`, which is still armed from `pumpUploadUntilPlateau`; when it fires and writes into the reset peer the socket emits EPIPE, which the test's `sock.once('error', reject)` turns into a failure, and
2. delivery of the already-written response bytes, which the RST can drop before the client's `'data'` handler sees them.

On Linux the `'data'` event reliably wins the race, so the test passed there; on darwin it loses ~70-80% of the time (verified on `darwin-test-arm64-3` and `darwin-test-x64-2` with the main #83238 binary).

`detach_response()`'s `resp.resume()` is also a no-op on this path: for a simple text body `try_end()` has already closed the socket by the time it runs (`us_socket_resume` early-returns on a closed socket). So with `Connection: close` the test was not actually observing the code it was written to cover.

## Fix

Switch this one test to `Connection: keep-alive`. The server does not close after responding, so there is no RST, the response is delivered deterministically, and `detach_response()`'s resume runs on a live socket. The test now additionally asserts that the client's upload progresses past the plateau after the response, which is the direct observable of the resume (without it the keep-alive socket would stay paused and `getSent()` would never move).

Also: resolve the response promise on the body content rather than the header terminator, and drop the `sock.once('error', reject)`; neither race applies on a keep-alive connection but both were latent flake on the old path. The `pumpUploadUntilPlateau` helper gains a `connection` parameter (defaulting to `"close"`, so the other five callers are untouched) and returns a `getSent()` accessor.

## Verification

With the main #83238 `bun` binary:

| lane | before | after |
| --- | --- | --- |
| darwin 26 aarch64 (`darwin-test-arm64-3`) | 7/10 fail (EPIPE) | 50/50 pass |
| darwin 14 x64 (`darwin-test-x64-2`) | 8/10 fail (EPIPE) | 20/20 pass |
| linux x64 debug+ASAN | 10/10 pass | 10/10 pass |

`USE_SYSTEM_BUN=1 bun test test/js/bun/http/serve.test.ts -t 'releases a paused'` still fails on `toBeLessThan(TOTAL)` (no #36006 backpressure), so the test still exercises the same `src/` change. This is a test-only diff; fail-before is against a Bun without #36006, not against this PR's own `src/`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->