### PR TITLE
napi: allow napi_create_reference on any value for Node-API 10 modules (fixes better-sqlite3 13 abort on load)

### DIFF
--- a/src/jsc/bindings/NapiRef.cpp
+++ b/src/jsc/bindings/NapiRef.cpp
@@ -8,8 +8,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NapiRef);
 
 void NapiRef::ref()
 {
-    // Node's Reference::Ref(): once the value is gone (weak referent collected, or a value that
-    // cannot be held weakly was released when the count hit zero) the count stays at 0.
+    // Node's Reference::Ref(): once the value is gone, the count stays at 0.
     if (refCount == 0 && !weakValueRef.get()) {
         NAPI_LOG("ref %p (value released)", this);
         return;

--- a/src/jsc/bindings/NapiRef.cpp
+++ b/src/jsc/bindings/NapiRef.cpp
@@ -8,10 +8,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NapiRef);
 
 void NapiRef::ref()
 {
-    // Node's Reference::Ref(): once the weak referent is collected, return 0
-    // without incrementing.
-    if (refCount == 0 && !weakValueRef.isClear() && !weakValueRef.get()) {
-        NAPI_LOG("ref %p (referent collected)", this);
+    // Node's Reference::Ref(): once the value is gone (weak referent collected, or a value that
+    // cannot be held weakly was released when the count hit zero) the count stays at 0.
+    if (refCount == 0 && !weakValueRef.get()) {
+        NAPI_LOG("ref %p (value released)", this);
         return;
     }
     NAPI_LOG("ref %p %u -> %u", this, refCount, refCount + 1);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1143,7 +1143,10 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
     bool can_be_weak = true;
 
     if (!(val.isObject() || val.isCallable() || val.isSymbol())) {
-        NAPI_RETURN_EARLY_IF_FALSE(env, env->napiModule().nm_version == NAPI_VERSION_EXPERIMENTAL, napi_invalid_arg);
+        // Node-API v10 allows references to any value type (not just
+        // object/function/symbol). NAPI_VERSION_EXPERIMENTAL is INT_MAX, so
+        // `>= 10` covers it as well.
+        NAPI_RETURN_EARLY_IF_FALSE(env, env->napiModule().nm_version >= 10, napi_invalid_arg);
         can_be_weak = false;
     }
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1143,9 +1143,6 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
     bool can_be_weak = true;
 
     if (!(val.isObject() || val.isCallable() || val.isSymbol())) {
-        // Node-API v10 allows references to any value type (not just
-        // object/function/symbol). NAPI_VERSION_EXPERIMENTAL is INT_MAX, so
-        // `>= 10` covers it as well.
         NAPI_RETURN_EARLY_IF_FALSE(env, env->napiModule().nm_version >= 10, napi_invalid_arg);
         can_be_weak = false;
     }

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -789,8 +789,9 @@ public:
             strongRef.set(globalObject->vm(), value);
         }
 
-        // In NAPI non-experimental, types other than object, function and symbol can't be used as values for references.
-        // In NAPI experimental, they can be, but we must not store weak references to them.
+        // Before Node-API 10, only objects, functions and symbols can be referenced. From 10 on any
+        // value can be, but the other types are never held weakly: once the count reaches zero the
+        // value is released and value() is empty (Node's Reference::SetWeak resets the persistent).
         if (can_be_weak) {
             weakValueRef.set(value, Napi::NapiRefWeakHandleOwner::weakValueHandleOwner(), this);
         }

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -789,9 +789,7 @@ public:
             strongRef.set(globalObject->vm(), value);
         }
 
-        // Before Node-API 10, only objects, functions and symbols can be referenced. From 10 on any
-        // value can be, but the other types are never held weakly: once the count reaches zero the
-        // value is released and value() is empty (Node's Reference::SetWeak resets the persistent).
+        // Like Node's Reference::SetWeak(), a value that cannot be held weakly is released once the count reaches zero.
         if (can_be_weak) {
             weakValueRef.set(value, Napi::NapiRefWeakHandleOwner::weakValueHandleOwner(), this);
         }

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -297,5 +297,27 @@
                 "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
             ],
         },
+        {
+            "target_name": "test_create_reference_primitive_v10",
+            "sources": ["test_create_reference_primitive.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NAPI_VERSION=10",
+            ],
+        },
+        {
+            "target_name": "test_create_reference_primitive_v8",
+            "sources": ["test_create_reference_primitive.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NAPI_VERSION=8",
+            ],
+        },
     ]
 }

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1446,6 +1446,31 @@ nativeTests.test_cleanup_hook_modification_during_iteration = () => {
   addon.test();
 };
 
+nativeTests.test_create_reference_primitive_by_version = () => {
+  const v10 = require("./build/Debug/test_create_reference_primitive_v10.node");
+  const v8 = require("./build/Debug/test_create_reference_primitive_v8.node");
+  const cases = [
+    ["undefined", undefined],
+    ["null", null],
+    ["boolean", true],
+    ["number", 1.5],
+    ["string", "s"],
+    ["bigint", 7n],
+    ["symbol", Symbol("sym")],
+    ["object", { a: 1 }],
+    ["function", () => 0],
+  ];
+  for (const [declared, addon] of [
+    [10, v10],
+    [8, v8],
+  ]) {
+    for (const [name, value] of cases) {
+      const { status, roundTrip, declared: d } = addon.create_ref(value);
+      console.log(`declared=${declared} header=${d} ${name}: status=${status} roundTrip=${roundTrip}`);
+    }
+  }
+};
+
 // Test for napi_typeof with boxed primitive objects (String, Number, Boolean)
 // See: https://github.com/oven-sh/bun/issues/25351
 nativeTests.test_napi_typeof_boxed_primitives = () => {

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1457,6 +1457,7 @@ nativeTests.test_create_reference_primitive_by_version = () => {
     ["string", "s"],
     ["bigint", 7n],
     ["symbol", Symbol("sym")],
+    ["registered symbol", Symbol.for("test_create_reference_primitive")],
     ["object", { a: 1 }],
     ["function", () => 0],
   ];
@@ -1465,8 +1466,10 @@ nativeTests.test_create_reference_primitive_by_version = () => {
     [8, v8],
   ]) {
     for (const [name, value] of cases) {
-      const { status, roundTrip, declared: d } = addon.create_ref(value);
-      console.log(`declared=${declared} header=${d} ${name}: status=${status} roundTrip=${roundTrip}`);
+      const { status, roundTrip, heldAtZero, reref, declared: d } = addon.create_ref(value);
+      let line = `declared=${declared} header=${d} ${name}: status=${status}`;
+      if (status === 0) line += ` roundTrip=${roundTrip} heldAtZero=${heldAtZero} reref=${reref}`;
+      console.log(line);
     }
   }
 };

--- a/test/napi/napi-app/test_create_reference_primitive.c
+++ b/test/napi/napi-app/test_create_reference_primitive.c
@@ -1,6 +1,10 @@
 // Built twice (NAPI_VERSION=10 and NAPI_VERSION=8) to pin the
 // napi_create_reference gate: version >= 10 accepts any value type,
 // older versions only accept object/function/symbol.
+//
+// Values that cannot be held weakly (everything but objects, functions and
+// symbols) are released when the count reaches zero: napi_get_reference_value
+// then yields NULL and napi_reference_ref leaves the count at 0.
 #include <js_native_api.h>
 #include <node_api.h>
 #include <stdio.h>
@@ -14,6 +18,8 @@ static napi_value create_ref(napi_env env, napi_callback_info info) {
   napi_status status = napi_create_reference(env, arg, 1, &ref);
 
   uint32_t round_trip_ok = 0;
+  uint32_t held_at_zero = 0;
+  uint32_t count_after_reref = 0;
   if (status == napi_ok) {
     napi_value got = NULL;
     napi_get_reference_value(env, ref, &got);
@@ -24,6 +30,15 @@ static napi_value create_ref(napi_env env, napi_callback_info info) {
     uint32_t rc = 0;
     napi_reference_ref(env, ref, &rc);
     napi_reference_unref(env, ref, &rc);
+    napi_reference_unref(env, ref, &rc);
+
+    // The caller still holds the value, so a weakly held one is still here;
+    // anything else has been released.
+    got = NULL;
+    napi_get_reference_value(env, ref, &got);
+    held_at_zero = got != NULL ? 1 : 0;
+
+    napi_reference_ref(env, ref, &count_after_reref);
     napi_delete_reference(env, ref);
   }
 
@@ -36,6 +51,10 @@ static napi_value create_ref(napi_env env, napi_callback_info info) {
   napi_set_named_property(env, out, "declared", v);
   napi_create_uint32(env, round_trip_ok, &v);
   napi_set_named_property(env, out, "roundTrip", v);
+  napi_create_uint32(env, held_at_zero, &v);
+  napi_set_named_property(env, out, "heldAtZero", v);
+  napi_create_uint32(env, count_after_reref, &v);
+  napi_set_named_property(env, out, "reref", v);
   return out;
 }
 

--- a/test/napi/napi-app/test_create_reference_primitive.c
+++ b/test/napi/napi-app/test_create_reference_primitive.c
@@ -1,0 +1,48 @@
+// Built twice (NAPI_VERSION=10 and NAPI_VERSION=8) to pin the
+// napi_create_reference gate: version >= 10 accepts any value type,
+// older versions only accept object/function/symbol.
+#include <js_native_api.h>
+#include <node_api.h>
+#include <stdio.h>
+
+static napi_value create_ref(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value arg;
+  napi_get_cb_info(env, info, &argc, &arg, NULL, NULL);
+
+  napi_ref ref = NULL;
+  napi_status status = napi_create_reference(env, arg, 1, &ref);
+
+  uint32_t round_trip_ok = 0;
+  if (status == napi_ok) {
+    napi_value got = NULL;
+    napi_get_reference_value(env, ref, &got);
+    bool eq = false;
+    napi_strict_equals(env, arg, got, &eq);
+    round_trip_ok = eq ? 1 : 0;
+
+    uint32_t rc = 0;
+    napi_reference_ref(env, ref, &rc);
+    napi_reference_unref(env, ref, &rc);
+    napi_delete_reference(env, ref);
+  }
+
+  napi_value out;
+  napi_create_object(env, &out);
+  napi_value v;
+  napi_create_int32(env, (int32_t)status, &v);
+  napi_set_named_property(env, out, "status", v);
+  napi_create_int32(env, NAPI_VERSION, &v);
+  napi_set_named_property(env, out, "declared", v);
+  napi_create_uint32(env, round_trip_ok, &v);
+  napi_set_named_property(env, out, "roundTrip", v);
+  return out;
+}
+
+NAPI_MODULE_INIT(/* napi_env env, napi_value exports */) {
+  napi_value fn;
+  napi_create_function(env, "create_ref", NAPI_AUTO_LENGTH, create_ref, NULL,
+                       &fn);
+  napi_set_named_property(env, exports, "create_ref", fn);
+  return exports;
+}

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -346,28 +346,20 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it("napi_create_reference accepts primitives when the module declares NAPI_VERSION >= 10", async () => {
       // Node.js keys the primitive-reference gate on the module's declared
       // Node-API version: >= 10 may reference any napi_valuetype, < 10 only
-      // object/function/symbol. checkSameOutput asserts parity with Node for
-      // both addon builds.
+      // object/function/symbol. A value that cannot be held weakly is released
+      // once the count reaches zero (heldAtZero=0) and a later ref stays at 0;
+      // weakly held values survive (the test still holds them) and ref again to
+      // 1. checkSameOutput asserts parity with Node for both addon builds.
       const result = await checkSameOutput("test_create_reference_primitive_by_version", []);
+      const notWeakable = ["undefined", "null", "boolean", "number", "string", "bigint"];
+      const weakable = ["symbol", "registered symbol", "object", "function"];
       // napi_ok = 0, napi_invalid_arg = 1
-      expect(result).toContain("declared=10 header=10 undefined: status=0 roundTrip=1");
-      expect(result).toContain("declared=10 header=10 null: status=0 roundTrip=1");
-      expect(result).toContain("declared=10 header=10 boolean: status=0 roundTrip=1");
-      expect(result).toContain("declared=10 header=10 number: status=0 roundTrip=1");
-      expect(result).toContain("declared=10 header=10 string: status=0 roundTrip=1");
-      expect(result).toContain("declared=10 header=10 bigint: status=0 roundTrip=1");
-      expect(result).toContain("declared=10 header=10 symbol: status=0 roundTrip=1");
-      expect(result).toContain("declared=10 header=10 object: status=0 roundTrip=1");
-      expect(result).toContain("declared=10 header=10 function: status=0 roundTrip=1");
-      expect(result).toContain("declared=8 header=8 undefined: status=1 roundTrip=0");
-      expect(result).toContain("declared=8 header=8 null: status=1 roundTrip=0");
-      expect(result).toContain("declared=8 header=8 boolean: status=1 roundTrip=0");
-      expect(result).toContain("declared=8 header=8 number: status=1 roundTrip=0");
-      expect(result).toContain("declared=8 header=8 string: status=1 roundTrip=0");
-      expect(result).toContain("declared=8 header=8 bigint: status=1 roundTrip=0");
-      expect(result).toContain("declared=8 header=8 symbol: status=0 roundTrip=1");
-      expect(result).toContain("declared=8 header=8 object: status=0 roundTrip=1");
-      expect(result).toContain("declared=8 header=8 function: status=0 roundTrip=1");
+      expect(result.split(/\r?\n/)).toEqual([
+        ...notWeakable.map(name => `declared=10 header=10 ${name}: status=0 roundTrip=1 heldAtZero=0 reref=0`),
+        ...weakable.map(name => `declared=10 header=10 ${name}: status=0 roundTrip=1 heldAtZero=1 reref=1`),
+        ...notWeakable.map(name => `declared=8 header=8 ${name}: status=1`),
+        ...weakable.map(name => `declared=8 header=8 ${name}: status=0 roundTrip=1 heldAtZero=1 reref=1`),
+      ]);
     });
   });
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -343,6 +343,32 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       // This tests the fix for napi_reference_unref underflow protection
       await checkSameOutput("test_ref_unref_underflow", []);
     });
+    it("napi_create_reference accepts primitives when the module declares NAPI_VERSION >= 10", async () => {
+      // Node.js keys the primitive-reference gate on the module's declared
+      // Node-API version: >= 10 may reference any napi_valuetype, < 10 only
+      // object/function/symbol. checkSameOutput asserts parity with Node for
+      // both addon builds.
+      const result = await checkSameOutput("test_create_reference_primitive_by_version", []);
+      // napi_ok = 0, napi_invalid_arg = 1
+      expect(result).toContain("declared=10 header=10 undefined: status=0 roundTrip=1");
+      expect(result).toContain("declared=10 header=10 null: status=0 roundTrip=1");
+      expect(result).toContain("declared=10 header=10 boolean: status=0 roundTrip=1");
+      expect(result).toContain("declared=10 header=10 number: status=0 roundTrip=1");
+      expect(result).toContain("declared=10 header=10 string: status=0 roundTrip=1");
+      expect(result).toContain("declared=10 header=10 bigint: status=0 roundTrip=1");
+      expect(result).toContain("declared=10 header=10 symbol: status=0 roundTrip=1");
+      expect(result).toContain("declared=10 header=10 object: status=0 roundTrip=1");
+      expect(result).toContain("declared=10 header=10 function: status=0 roundTrip=1");
+      expect(result).toContain("declared=8 header=8 undefined: status=1 roundTrip=0");
+      expect(result).toContain("declared=8 header=8 null: status=1 roundTrip=0");
+      expect(result).toContain("declared=8 header=8 boolean: status=1 roundTrip=0");
+      expect(result).toContain("declared=8 header=8 number: status=1 roundTrip=0");
+      expect(result).toContain("declared=8 header=8 string: status=1 roundTrip=0");
+      expect(result).toContain("declared=8 header=8 bigint: status=1 roundTrip=0");
+      expect(result).toContain("declared=8 header=8 symbol: status=0 roundTrip=1");
+      expect(result).toContain("declared=8 header=8 object: status=0 roundTrip=1");
+      expect(result).toContain("declared=8 header=8 function: status=0 roundTrip=1");
+    });
   });
 
   describe("napi_get_version / node_api_create_external_string_*", () => {


### PR DESCRIPTION
### Problem
- `better-sqlite3@13` (npm `latest`, a `NAPI_VERSION=10` addon) aborts Bun at load with `panic: NAPI FATAL ERROR: Error::New napi_get_last_error_info`. Sentry [BUN-4KH6](https://bun-p9.sentry.io/issues/?query=BUN-4KH6) (macOS, Linux), [BUN-4233](https://bun-p9.sentry.io/issues/?query=BUN-4233) (Windows x64) and [BUN-4QSA](https://bun-p9.sentry.io/issues/?query=BUN-4QSA) (Windows arm64), all inside the `napi_register_module_v1` call in `Process_functionDlopen`.
- The addon caches strings with `Napi::Persistent`. `napi_create_reference` (`src/jsc/bindings/napi.cpp`) accepts such a value only from a `NAPI_VERSION_EXPERIMENTAL` module, Node from version 10 on. The addon gets `napi_invalid_arg`, and node-addon-api (exceptions disabled) turns that into `napi_fatal_error` on the next call.

### Fix
- `napi_create_reference` gates on `nm_version >= 10`. `NAPI_VERSION_EXPERIMENTAL` is `INT_MAX`, so it stays covered. The existing `can_be_weak = false` path holds the value strongly and releases it at count 0, as Node does.
- `NapiRef::ref()` keeps the count at 0 once the value is released. Before, it counted back up to 1 with no value behind it. Node's `Reference::Ref()` returns 0 there.
- Verified: `test/napi/napi.test.ts` ("napi_create_reference accepts primitives ...") builds one addon at `NAPI_VERSION=10` and `=8` and pins 10 value kinds against Node. It fails on the unfixed binary. Also the full `napi.test.ts` (176 pass) and the `better-sqlite3@13.0.3` prebuild on the debug build.

### Background
- A Node-API addon declares the version it was built against. Bun keeps it in `nm_version`. Node keys some behaviors on it, and version 10 (Node 22.14) is where references to any value type became official.
- A `napi_ref` (`NapiRef`) holds its value strongly while the count is above 0. At 0, objects, functions and symbols are held weakly. The other types have no weak form, so at 0 the value is released.
- The `better_sqlite3.node` filename check in `process.dlopen` stays. Without it the V8 API builds (v12 and older) die in the dynamic loader. The v13 prebuilds have other filenames. Details in Notes.

<details><summary>Notes</summary>

Repro: `bun add better-sqlite3@13 && bun -e "new (require('better-sqlite3'))(':memory:')"` exits 134 on 1.4.0 and on main. 1.3.14 fails the same way, so this is not a 1.4 regression. v13 became `latest` in June.

Rebased onto main (`01c4e2fd6d`) on 2026-08-20 without conflicts. The diff is unchanged from the previous revision.

Stack on the release binary (`gdb`, breakpoint on `napi_fatal_error`, `better-sqlite3@13.0.3` `prebuilds/linux-x64.node`):

```
napi_fatal_error
Napi::Error::Fatal(char const*, char const*)
Napi::Error::New(napi_env__*)
InitAll(Napi::Env, Napi::Object)
napi_register_module_v1
Bun::Process_functionDlopen
```

All three Sentry issues have the same shape: `Process_functionDlopen` at `BunProcess.cpp:735` in 1.4.0 (`34cbb9a40`) is the `napi_register_module_v1` call, then addon frames, then `napi_fatal_error`. The Windows events name the module `win32-x64.node` (BUN-4233) or `win32-arm64.node` (BUN-4QSA), which are the v13 prebuilds. Sentry groups them per platform because the addon frames have no symbols. The constructor in user reports only matters because v13 requires the prebuild lazily inside `new Database()` (`lib/database.js`). `src/util/constants.cpp` in v13 says: "Persistent references to strings require Node-API version 10."

How the status becomes an abort: better-sqlite3 builds with `NAPI_DISABLE_CPP_EXCEPTIONS`. A failed `Napi::Persistent` returns an empty reference whose env is null. The next wrapper call does `NAPI_THROW_IF_FAILED(nullptr, ...)`, which is `Napi::Error::New(nullptr)`, whose `napi_get_last_error_info` call fails on the null env and ends in `napi_fatal_error`.

Filename check in `BunProcess.cpp` (added in #24384 for issue #4290, which is still open): `better-sqlite3@12.11.1` gets `ERR_DLOPEN_FAILED` with the "not yet supported" message. The same `better_sqlite3.node` copied to another name and passed to `process.dlopen` kills the process: `bun: symbol lookup error: ... undefined symbol: _ZN2v86Symbol11GetIteratorEPNS_7IsolateE`, exit 127. So the check still does its job for v12 and older. Two things about it are stale and can change in a separate PR: it blocks a v13 built from source with `node-gyp rebuild` (v13 has `gypfile: false` and no install script, so the prebuilds are used on every platform Bun ships for), and its message could tell v12 users to upgrade to v13.

Previous revision, also verified on the debug (ASAN) build with `better-sqlite3@13.0.3`: CRUD, transactions, `iterate()`, pluck/raw/expand, user functions, aggregates, table-valued functions, safe integers, blobs, serialize/deserialize, backup, `SqliteError` codes, 2000 statements plus GC, close, an ESM import, and three `worker_threads` that leave databases open at teardown. All matched Node.

Node's upstream `test_reference_by_node_api_version` shape (`NAPI_VERSION=10` and `=9` targets) passes on this branch and fails on main with `Invalid argument`. The vendored copy in `test/napi/node-napi-tests` does not have that test yet.

`test/napi/node-napi-tests/test/js-native-api/test_reference` and `test_reference_double_free`: all pass except that `test_reference/test.js` hits the 5 s per-test limit on the local debug (ASAN) build. Run directly it exits 0 in 27 s. It runs 1000 full GCs, and its addon uses object, external and symbol values at the default Node-API version, so the changed code does not affect it. The file passed in the previous CI run of this branch.

Previous CI run of this diff (before the rebase): every job that ran passed. The build ended as canceled with only the macOS 14 arm64 test job unfinished. The annotated test failures were unrelated files that passed on retry or alone.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->

