### PR TITLE
napi: enqueue external ArrayBuffer finalize_cb instead of running it inside detach

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1308,7 +1308,7 @@ extern "C" napi_status napi_detach_arraybuffer(napi_env env,
         // the JSArrayBuffer cell is finalized so the finalizer fires on GC.
         ArrayBufferContents contents;
         arrayBuffer->transferTo(vm, contents);
-        vm.heap.addFinalizer(jsArrayBuffer, [contents = WTF::move(contents)](JSCell*) mutable { });
+        vm.heap.addFinalizer(jsArrayBuffer, [contents = WTF::move(contents)](JSCell*) mutable {});
     }
     NAPI_RETURN_SUCCESS(env);
 }

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1298,14 +1298,10 @@ extern "C" napi_status napi_detach_arraybuffer(napi_env env,
     // is a no-op in both engines, so treat that as success.
     NAPI_RETURN_EARLY_IF_FALSE(env, arrayBuffer->isDetached() || arrayBuffer->isDetachable(), napi_detachable_arraybuffer_expected);
     if (!arrayBuffer->isDetached()) {
-        // V8's ArrayBuffer::Detach() leaves the BackingStore owned by the
-        // ArrayBuffer object, so a napi_create_external_arraybuffer finalizer
-        // (attached to the BackingStore deleter) runs when the ArrayBuffer is
-        // collected, not inside this call. JSC's ArrayBuffer::detach() drops
-        // the contents immediately, which would run the destructor
-        // (NapiExternalBufferDestructor -> the addon's finalize_cb)
-        // synchronously here. Move the contents out and keep them alive until
-        // the JSArrayBuffer cell is finalized so the finalizer fires on GC.
+        // ArrayBuffer::detach() would drop the contents (and run the napi
+        // finalize_cb) synchronously; V8 keeps the BackingStore until GC.
+        // Hold the moved-out contents in a heap finalizer on this cell so
+        // the destructor fires on collection instead.
         ArrayBufferContents contents;
         arrayBuffer->transferTo(vm, contents);
         vm.heap.addFinalizer(jsArrayBuffer, [contents = WTF::move(contents)](JSCell*) mutable {});

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1298,10 +1298,7 @@ extern "C" napi_status napi_detach_arraybuffer(napi_env env,
     // is a no-op in both engines, so treat that as success.
     NAPI_RETURN_EARLY_IF_FALSE(env, arrayBuffer->isDetached() || arrayBuffer->isDetachable(), napi_detachable_arraybuffer_expected);
     if (!arrayBuffer->isDetached()) {
-        // ArrayBuffer::detach() would drop the contents (and run the napi
-        // finalize_cb) synchronously; V8 keeps the BackingStore until GC.
-        // Hold the moved-out contents in a heap finalizer on this cell so
-        // the destructor fires on collection instead.
+        // detach() would fire the napi finalize_cb synchronously; hold the contents until GC to match V8.
         ArrayBufferContents contents;
         arrayBuffer->transferTo(vm, contents);
         vm.heap.addFinalizer(jsArrayBuffer, [contents = WTF::move(contents)](JSCell*) mutable {});

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1298,7 +1298,17 @@ extern "C" napi_status napi_detach_arraybuffer(napi_env env,
     // is a no-op in both engines, so treat that as success.
     NAPI_RETURN_EARLY_IF_FALSE(env, arrayBuffer->isDetached() || arrayBuffer->isDetachable(), napi_detachable_arraybuffer_expected);
     if (!arrayBuffer->isDetached()) {
-        arrayBuffer->detach(vm);
+        // V8's ArrayBuffer::Detach() leaves the BackingStore owned by the
+        // ArrayBuffer object, so a napi_create_external_arraybuffer finalizer
+        // (attached to the BackingStore deleter) runs when the ArrayBuffer is
+        // collected, not inside this call. JSC's ArrayBuffer::detach() drops
+        // the contents immediately, which would run the destructor
+        // (NapiExternalBufferDestructor -> the addon's finalize_cb)
+        // synchronously here. Move the contents out and keep them alive until
+        // the JSArrayBuffer cell is finalized so the finalizer fires on GC.
+        ArrayBufferContents contents;
+        arrayBuffer->transferTo(vm, contents);
+        vm.heap.addFinalizer(jsArrayBuffer, [contents = WTF::move(contents)](JSCell*) mutable { });
     }
     NAPI_RETURN_SUCCESS(env);
 }

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1298,10 +1298,7 @@ extern "C" napi_status napi_detach_arraybuffer(napi_env env,
     // is a no-op in both engines, so treat that as success.
     NAPI_RETURN_EARLY_IF_FALSE(env, arrayBuffer->isDetached() || arrayBuffer->isDetachable(), napi_detachable_arraybuffer_expected);
     if (!arrayBuffer->isDetached()) {
-        // detach() would fire the napi finalize_cb synchronously; hold the contents until GC to match V8.
-        ArrayBufferContents contents;
-        arrayBuffer->transferTo(vm, contents);
-        vm.heap.addFinalizer(jsArrayBuffer, [contents = WTF::move(contents)](JSCell*) mutable {});
+        arrayBuffer->detach(vm);
     }
     NAPI_RETURN_SUCCESS(env);
 }
@@ -2325,9 +2322,10 @@ public:
 
     void run(void* data) override
     {
-        if (m_armed) {
+        if (m_armed && m_cb) {
             NAPI_LOG("external buffer finalizer");
-            m_env->doFinalizer(m_cb, data, m_hint);
+            // Node's BackingStore deleter posts via SetImmediateThreadsafe, so finalize_cb never runs inside detach/GC.
+            napi_internal_enqueue_finalizer(m_env.ptr(), m_cb, data, m_hint);
         }
     }
 

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -39,6 +39,21 @@ nativeTests.test_napi_handle_scope_finalizer = async () => {
   await gcUntil(() => nativeTests.was_finalize_called());
 };
 
+nativeTests.test_detach_external_arraybuffer_finalizer = async () => {
+  // Keep the detached wrapper reachable the whole time: Node fires the
+  // finalizer on the next event-loop turn regardless, so reachability must
+  // not gate it.
+  const ab = nativeTests.create_and_detach_external_arraybuffer();
+  console.log("before tick count =", nativeTests.get_detach_finalize_count());
+  // Node posts via SetImmediateThreadsafe; one setImmediate is enough there,
+  // but allow a few turns so both engines' task queues have drained.
+  for (let i = 0; i < 10 && nativeTests.get_detach_finalize_count() === 0; i++) {
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  console.log("after tick count =", nativeTests.get_detach_finalize_count());
+  console.log("wrapper is ArrayBuffer =", ab instanceof ArrayBuffer, "byteLength =", ab.byteLength);
+};
+
 nativeTests.test_napi_async_work_execute_null_check = () => {
   const res = nativeTests.create_async_work_with_null_execute();
   if (res) {

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2597,14 +2597,15 @@ test_external_arraybuffer_finalizer(const Napi::CallbackInfo &info) {
 }
 
 // Regression test: napi_detach_arraybuffer on an external ArrayBuffer must
-// not run the finalize_cb synchronously inside the detach call. In Node/V8
-// the BackingStore stays owned by the ArrayBuffer object across Detach(),
-// so the deleter (finalize_cb) only runs when the ArrayBuffer is collected.
+// not run the finalize_cb synchronously inside the detach call. Node's
+// BackingStore deleter posts the callback via env->SetImmediateThreadsafe,
+// so it fires on the next event-loop turn regardless of whether the
+// ArrayBuffer wrapper is still reachable.
 static int detach_finalize_count = 0;
 static char detach_backing[256];
 
 static napi_value
-test_detach_external_arraybuffer_finalizer(const Napi::CallbackInfo &info) {
+create_and_detach_external_arraybuffer(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
 
   detach_finalize_count = 0;
@@ -2634,16 +2635,17 @@ test_detach_external_arraybuffer_finalizer(const Napi::CallbackInfo &info) {
   printf("second detach status=%d finalize_count after second detach=%d\n",
          (int)detach2, detach_finalize_count);
 
-  // Hold the ArrayBuffer across a few GC cycles: the finalizer must not fire
-  // while the object is still reachable.
-  napi_ref ab_ref;
-  NODE_API_CALL(env, napi_create_reference(env, arraybuffer, 1, &ab_ref));
-  run_gc(info);
-  run_gc(info);
-  printf("finalize_count while reachable=%d\n", detach_finalize_count);
+  // Return the (detached, zero-length) ArrayBuffer so the JS driver can keep
+  // it reachable across an event-loop turn and observe the count then.
+  fflush(stdout);
+  return arraybuffer;
+}
 
-  NODE_API_CALL(env, napi_delete_reference(env, ab_ref));
-  return ok(env);
+static napi_value get_detach_finalize_count(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value v;
+  NODE_API_CALL(env, napi_create_int32(env, detach_finalize_count, &v));
+  return v;
 }
 
 // Regression test: napi_create_external_arraybuffer while a napi exception
@@ -3607,8 +3609,8 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, napi_get_typeof);
   REGISTER_FUNCTION(env, exports, test_external_buffer_data_lifetime);
   REGISTER_FUNCTION(env, exports, test_external_arraybuffer_finalizer);
-  REGISTER_FUNCTION(env, exports,
-                    test_detach_external_arraybuffer_finalizer);
+  REGISTER_FUNCTION(env, exports, create_and_detach_external_arraybuffer);
+  REGISTER_FUNCTION(env, exports, get_detach_finalize_count);
   REGISTER_FUNCTION(env, exports,
                     test_external_arraybuffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports,

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2596,6 +2596,56 @@ test_external_arraybuffer_finalizer(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// Regression test: napi_detach_arraybuffer on an external ArrayBuffer must
+// not run the finalize_cb synchronously inside the detach call. In Node/V8
+// the BackingStore stays owned by the ArrayBuffer object across Detach(),
+// so the deleter (finalize_cb) only runs when the ArrayBuffer is collected.
+static int detach_finalize_count = 0;
+static char detach_backing[256];
+
+static napi_value
+test_detach_external_arraybuffer_finalizer(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  detach_finalize_count = 0;
+
+  napi_value arraybuffer;
+  NODE_API_CALL(env, napi_create_external_arraybuffer(
+                         env, detach_backing, sizeof detach_backing,
+                         +[](napi_env, void *, void *) {
+                           detach_finalize_count++;
+                         },
+                         nullptr, &arraybuffer));
+
+  napi_status detach_status = napi_detach_arraybuffer(env, arraybuffer);
+
+  // The finalizer must not have run inside napi_detach_arraybuffer.
+  printf("detach status=%d finalize_count during detach=%d\n",
+         (int)detach_status, detach_finalize_count);
+
+  bool is_detached = false;
+  NODE_API_CALL(env,
+                napi_is_detached_arraybuffer(env, arraybuffer, &is_detached));
+  printf("is_detached=%s\n", is_detached ? "true" : "false");
+
+  // A second detach on the same (now-detached) buffer is a no-op and must
+  // also not fire the finalizer.
+  napi_status detach2 = napi_detach_arraybuffer(env, arraybuffer);
+  printf("second detach status=%d finalize_count after second detach=%d\n",
+         (int)detach2, detach_finalize_count);
+
+  // Hold the ArrayBuffer across a few GC cycles: the finalizer must not fire
+  // while the object is still reachable.
+  napi_ref ab_ref;
+  NODE_API_CALL(env, napi_create_reference(env, arraybuffer, 1, &ab_ref));
+  run_gc(info);
+  run_gc(info);
+  printf("finalize_count while reachable=%d\n", detach_finalize_count);
+
+  NODE_API_CALL(env, napi_delete_reference(env, ab_ref));
+  return ok(env);
+}
+
 // Regression test: napi_create_external_arraybuffer while a napi exception
 // is pending (via napi_throw_error). Whatever status is returned, the
 // function must not adopt external_data and then leave the destructor
@@ -3557,6 +3607,8 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, napi_get_typeof);
   REGISTER_FUNCTION(env, exports, test_external_buffer_data_lifetime);
   REGISTER_FUNCTION(env, exports, test_external_arraybuffer_finalizer);
+  REGISTER_FUNCTION(env, exports,
+                    test_detach_external_arraybuffer_finalizer);
   REGISTER_FUNCTION(env, exports,
                     test_external_arraybuffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports,

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -388,15 +388,17 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).not.toContain("FAIL");
     });
 
-    it("napi_detach_arraybuffer does not run finalize_cb synchronously", async () => {
+    it("napi_detach_arraybuffer defers finalize_cb to the event loop instead of running it synchronously", async () => {
       const result = await checkSameOutput("test_detach_external_arraybuffer_finalizer", []);
-      // `run_gc` writes "GC did run" via console.log while the addon writes via
-      // printf; on Windows the CRT buffers printf so relative ordering is not
-      // stable. Assert on the addon's lines only.
+      // Not during detach:
       expect(result).toContain("detach status=0 finalize_count during detach=0");
       expect(result).toContain("is_detached=true");
       expect(result).toContain("second detach status=0 finalize_count after second detach=0");
-      expect(result).toContain("finalize_count while reachable=0");
+      // Still 0 synchronously after returning to JS (no event-loop turn yet):
+      expect(result).toContain("before tick count = 0");
+      // Fired exactly once after an event-loop turn, while the wrapper is still reachable:
+      expect(result).toContain("after tick count = 1");
+      expect(result).toContain("wrapper is ArrayBuffer = true byteLength = 0");
     });
   });
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -387,6 +387,18 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("PASS: caller retains ownership on failure with pending exception");
       expect(result).not.toContain("FAIL");
     });
+
+    it("napi_detach_arraybuffer does not run finalize_cb synchronously", async () => {
+      const result = await checkSameOutput("test_detach_external_arraybuffer_finalizer", []);
+      expect(result.split(/\r?\n/)).toEqual([
+        "detach status=0 finalize_count during detach=0",
+        "is_detached=true",
+        "second detach status=0 finalize_count after second detach=0",
+        "GC did run",
+        "GC did run",
+        "finalize_count while reachable=0",
+      ]);
+    });
   });
 
   describe("pending-exception gate", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -390,14 +390,13 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
 
     it("napi_detach_arraybuffer does not run finalize_cb synchronously", async () => {
       const result = await checkSameOutput("test_detach_external_arraybuffer_finalizer", []);
-      expect(result.split(/\r?\n/)).toEqual([
-        "detach status=0 finalize_count during detach=0",
-        "is_detached=true",
-        "second detach status=0 finalize_count after second detach=0",
-        "GC did run",
-        "GC did run",
-        "finalize_count while reachable=0",
-      ]);
+      // `run_gc` writes "GC did run" via console.log while the addon writes via
+      // printf; on Windows the CRT buffers printf so relative ordering is not
+      // stable. Assert on the addon's lines only.
+      expect(result).toContain("detach status=0 finalize_count during detach=0");
+      expect(result).toContain("is_detached=true");
+      expect(result).toContain("second detach status=0 finalize_count after second detach=0");
+      expect(result).toContain("finalize_count while reachable=0");
     });
   });
 


### PR DESCRIPTION
## What

`napi_detach_arraybuffer` on an external ArrayBuffer was running the addon's `finalize_cb` synchronously inside the detach call. Node.js defers it to the next event-loop turn.

## Repro

```c
static int fin_ran = 0; static char backing[256];
static void fin(napi_env env, void* d, void* h) { fin_ran++; }

napi_create_external_arraybuffer(env, backing, sizeof backing, fin, NULL, &ab);
napi_detach_arraybuffer(env, ab);
fprintf(stderr, "finalizer-ran-DURING-detach=%d\n", fin_ran);   // node: 0   bun: 1
```

An addon that treats `finalize_cb` as its "safe to free" signal sees it fire mid-detach, and any JS the finalizer runs (via `napi_call_function`) executes re-entrantly inside `napi_detach_arraybuffer`.

## Cause

JSC's `ArrayBuffer::detach()` drops the `ArrayBufferContents` immediately, running its destructor synchronously. `NapiExternalBufferDestructor::run()` called `env->doFinalizer(...)`, which invokes `finalize_cb` synchronously whenever not inside GC.

In Node, V8 also drops the `BackingStore` synchronously inside `Detach()`, but Node's `BackingStore` deleter (`CallbackInfo::OnBackingStoreFree`) posts `finalize_cb` via `env->SetImmediateThreadsafe`, so the callback fires on the next event-loop turn regardless of whether the ArrayBuffer wrapper is still reachable.

## Fix

`NapiExternalBufferDestructor::run()` now always enqueues `finalize_cb` via `napi_internal_enqueue_finalizer` instead of potentially running it synchronously. `napi_detach_arraybuffer` itself is unchanged, so non-external buffers continue to free their backing immediately on detach.

This also covers the same timing for `napi_create_external_buffer`, and for the normal GC path (where the old code already deferred via `doFinalizer`'s `inGC()` branch).

## Verification

```
=== node ===
finalizer-ran-DURING-detach=0
immediately after detach, still reachable, ran = 0
after setImmediate, still reachable, ran = 1
after drop+gc, ran = 1
=== bun (fixed) ===
finalizer-ran-DURING-detach=0
immediately after detach, still reachable, ran = 0
after setImmediate, still reachable, ran = 1
after drop+gc, ran = 1
```

New test `test_detach_external_arraybuffer_finalizer` in `test/napi/napi.test.ts` compares output against Node (via `checkSameOutput`) and asserts the finalizer has not fired synchronously, then that it has fired exactly once after an event-loop turn while the wrapper is still reachable.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->