### PR TITLE
Response(async iterable).body: bound the drive loop so a paced reader is not starved

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -311,8 +311,7 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
                 flushPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
                 return NextStep::Suspended;
             }
-            // write() is user-reachable (Array sink returns raw `.byteLength`, and the own
-            // `write` property is writable), so clamp before the double→uint64_t cast.
+            // write() is user-reachable, so clamp the double before casting.
             if (std::isfinite(wroteNumber) && wroteNumber > 0)
                 op->m_syncDriveBytes += static_cast<uint64_t>(std::min(wroteNumber, static_cast<double>(asyncIterSyncDriveYieldThreshold)));
             if (op->m_syncDriveBytes >= asyncIterSyncDriveYieldThreshold && !op->m_iteratorDone && asyncIterControllerIsYieldable(controller))

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -7,6 +7,7 @@
 #include "BunClientData.h"
 #include "DOMClientIsoSubspaces.h"
 #include "DOMIsoSubspaces.h"
+#include "JSDirectStreamController.h"
 #include "JSDOMBinding.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMWrapperCache.h"
@@ -92,6 +93,11 @@ static void driveAsyncIterator(JSGlobalObject*, JSAsyncIteratorSourceOperation*)
 static void asyncIterReturnIteratorAndSettle(JSGlobalObject*, JSAsyncIteratorSourceOperation*);
 static void asyncIterFinishWithError(JSGlobalObject*, JSAsyncIteratorSourceOperation*, JSValue error);
 
+// The sync drive loop is bounded to this many written bytes before it yields back to the
+// pulling consumer; without the bound a synchronously-fulfilling iterator never lets the
+// reader observe a chunk and runs the process to OOM.
+static constexpr uint64_t asyncIterSyncDriveYieldThreshold = 64 * 1024;
+
 // invokeOptionalMethod returns the EMPTY value when the method is not callable; the empty
 // value reports isCell(), so it must never reach a downcast.
 static JSPromise* asPromise(JSValue value)
@@ -99,6 +105,20 @@ static JSPromise* asPromise(JSValue value)
     if (!value || !value.isCell())
         return nullptr;
     return dynamicDowncast<JSPromise>(value);
+}
+
+// Sync-drive backpressure yield: the pull promise resolves (so the direct controller delivers
+// the buffered batch to the waiting reader) and m_running clears so the next pull() call
+// re-enters driveAsyncIterator. m_done is NOT set.
+static void asyncIterYieldForBackpressure(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op)
+{
+    auto& vm = getVM(globalObject);
+    op->m_running = false;
+    op->m_syncDriveBytes = 0;
+    if (auto* pullPromise = op->m_pullPromise.get()) {
+        op->m_pullPromise.clear();
+        pullPromise->fulfill(vm, jsUndefined());
+    }
 }
 
 static void settlePullPromiseResolved(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op)
@@ -223,7 +243,14 @@ enum class NextStep : uint8_t {
     ContinueLoop,
     Suspended,
     Finished,
+    Yield,
 };
+
+static bool asyncIterControllerIsYieldable(JSObject* controller)
+{
+    auto* direct = dynamicDowncast<JSDirectStreamController>(controller);
+    return direct && direct->m_sinkKind == DirectSinkKind::ArrayBuffer;
+}
 
 // One iteration result: write the value (a final `return v` is still written), honor the
 // sink's backpressure protocol (`wrote < 0` -> await flush(true)), then finish when done.
@@ -270,24 +297,33 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
         JSValue wrote = invokeOptionalMethod(globalObject, controller, WebCore::builtinNames(vm).writePublicName(), writeArgs);
         if (scope.exception()) [[unlikely]]
             goto abrupt;
-        if (wrote && wrote.isNumber() && wrote.asNumber() < 0) {
-            // The HTTP sink reports backpressure with a negative return: wait for the drain.
-            MarkedArgumentBuffer flushArgs;
-            flushArgs.append(jsBoolean(true));
-            JSValue flushed = invokeOptionalMethod(globalObject, controller, builtinNames(vm).flushPublicName(), flushArgs);
-            if (scope.exception()) [[unlikely]]
-                goto abrupt;
-            JSPromise* flushPromise = asPromise(flushed);
-            if (!flushPromise) {
-                flushPromise = promiseResolvedWith(globalObject, flushed ? flushed : jsUndefined());
+        if (wrote && wrote.isNumber()) {
+            double wroteNumber = wrote.asNumber();
+            if (wroteNumber < 0) {
+                // The HTTP sink reports backpressure with a negative return: wait for the drain.
+                MarkedArgumentBuffer flushArgs;
+                flushArgs.append(jsBoolean(true));
+                JSValue flushed = invokeOptionalMethod(globalObject, controller, builtinNames(vm).flushPublicName(), flushArgs);
                 if (scope.exception()) [[unlikely]]
                     goto abrupt;
+                JSPromise* flushPromise = asPromise(flushed);
+                if (!flushPromise) {
+                    flushPromise = promiseResolvedWith(globalObject, flushed ? flushed : jsUndefined());
+                    if (scope.exception()) [[unlikely]]
+                        goto abrupt;
+                }
+                flushPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
+                return NextStep::Suspended;
             }
-            flushPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
+            op->m_syncDriveBytes += static_cast<uint64_t>(wroteNumber);
+            if (op->m_syncDriveBytes >= asyncIterSyncDriveYieldThreshold && !op->m_iteratorDone && asyncIterControllerIsYieldable(controller))
+                return NextStep::Yield;
+        } else if (auto* wrotePromise = asPromise(wrote)) {
+            // FileSink/NetworkSink backpressure: write() returned its pending promise.
+            markPromiseAsHandled(vm, wrotePromise);
+            wrotePromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
             return NextStep::Suspended;
         }
-        if (auto* wrotePromise = asPromise(wrote))
-            markPromiseAsHandled(vm, wrotePromise);
     }
 
     if (op->m_iteratorDone) {
@@ -360,9 +396,12 @@ static void driveAsyncIterator(JSGlobalObject* globalObject, JSAsyncIteratorSour
         }
         auto status = nextPromise->status();
         if (status == JSPromise::Status::Fulfilled) {
-            if (asyncIterHandleNextResult(globalObject, op, nextPromise->result()) != NextStep::ContinueLoop)
-                return;
-            continue;
+            auto step = asyncIterHandleNextResult(globalObject, op, nextPromise->result());
+            if (step == NextStep::ContinueLoop)
+                continue;
+            if (step == NextStep::Yield)
+                asyncIterYieldForBackpressure(globalObject, op);
+            return;
         }
         if (status == JSPromise::Status::Rejected) {
             markPromiseAsHandled(vm, nextPromise);
@@ -387,14 +426,18 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceNextFulfilled,
         asyncIterReturnIteratorAndSettle(globalObject, op);
         return JSValue::encode(jsUndefined());
     }
-    if (asyncIterHandleNextResult(globalObject, op, callFrame->argument(0)) == NextStep::ContinueLoop)
+    auto step = asyncIterHandleNextResult(globalObject, op, callFrame->argument(0));
+    if (step == NextStep::ContinueLoop)
         driveAsyncIterator(globalObject, op);
+    else if (step == NextStep::Yield)
+        asyncIterYieldForBackpressure(globalObject, op);
     return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceFlushFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
+    op->m_syncDriveBytes = 0;
     if (op->m_done)
         return JSValue::encode(jsUndefined());
     if (op->m_cancelled) {
@@ -476,6 +519,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourcePull, (JSGl
     auto* pullPromise = JSPromise::create(vm, globalObject->promiseStructure());
     op->m_pullPromise.set(vm, op, pullPromise);
     op->m_running = true;
+    op->m_syncDriveBytes = 0;
     driveAsyncIterator(globalObject, op);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(pullPromise);

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -311,7 +311,10 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
                 flushPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
                 return NextStep::Suspended;
             }
-            op->m_syncDriveBytes += static_cast<uint64_t>(wroteNumber);
+            // write() is user-reachable (Array sink returns raw `.byteLength`, and the own
+            // `write` property is writable), so clamp before the double→uint64_t cast.
+            if (std::isfinite(wroteNumber) && wroteNumber > 0)
+                op->m_syncDriveBytes += static_cast<uint64_t>(std::min(wroteNumber, static_cast<double>(asyncIterSyncDriveYieldThreshold)));
             if (op->m_syncDriveBytes >= asyncIterSyncDriveYieldThreshold && !op->m_iteratorDone && asyncIterControllerIsYieldable(controller))
                 return NextStep::Yield;
         } else if (auto* wrotePromise = asPromise(wrote)) {

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -93,9 +93,7 @@ static void driveAsyncIterator(JSGlobalObject*, JSAsyncIteratorSourceOperation*)
 static void asyncIterReturnIteratorAndSettle(JSGlobalObject*, JSAsyncIteratorSourceOperation*);
 static void asyncIterFinishWithError(JSGlobalObject*, JSAsyncIteratorSourceOperation*, JSValue error);
 
-// The sync drive loop is bounded to this many written bytes before it yields back to the
-// pulling consumer; without the bound a synchronously-fulfilling iterator never lets the
-// reader observe a chunk and runs the process to OOM.
+// Written bytes after which the pump yields to the pulling consumer (ArrayBuffer direct sink).
 static constexpr uint64_t asyncIterSyncDriveYieldThreshold = 64 * 1024;
 
 // invokeOptionalMethod returns the EMPTY value when the method is not callable; the empty
@@ -107,9 +105,7 @@ static JSPromise* asPromise(JSValue value)
     return dynamicDowncast<JSPromise>(value);
 }
 
-// Sync-drive backpressure yield: the pull promise resolves (so the direct controller delivers
-// the buffered batch to the waiting reader) and m_running clears so the next pull() call
-// re-enters driveAsyncIterator. m_done is NOT set.
+// Backpressure yield: resolve the pull promise without setting m_done so the next pull() resumes.
 static void asyncIterYieldForBackpressure(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op)
 {
     auto& vm = getVM(globalObject);

--- a/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
@@ -46,6 +46,9 @@ public:
     // {done:true, value} still writes the value first; this remembers the done across a
     // backpressure suspension on that final write.
     bool m_iteratorDone : 1 { false };
+    // Bytes written by the sync drive since the last suspension; bounds the sync loop for
+    // sinks that never signal backpressure themselves (the ArrayBuffer direct controller).
+    uint64_t m_syncDriveBytes { 0 };
 
 private:
     JSAsyncIteratorSourceOperation(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
@@ -46,8 +46,7 @@ public:
     // {done:true, value} still writes the value first; this remembers the done across a
     // backpressure suspension on that final write.
     bool m_iteratorDone : 1 { false };
-    // Bytes written by the sync drive since the last suspension; bounds the sync loop for
-    // sinks that never signal backpressure themselves (the ArrayBuffer direct controller).
+    // Bytes written since the last suspension; bounds the ArrayBuffer-sink pump.
     uint64_t m_syncDriveBytes { 0 };
 
 private:

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -321,12 +321,13 @@ describe("spawn stdin ReadableStream", () => {
     expect(exitCode).toBe(0);
   });
 
-  // The ReadableStream -> stdin FileSink pump intentionally does not await the
-  // Promise FileSink.write() returns for writes it cannot complete synchronously
-  // (a full pipe on POSIX, every pipe write on Windows). When the child dies
-  // while one is in flight, the sink rejects that Promise with EPIPE; the pump
-  // must mark it handled or it surfaces as an unhandled rejection in the parent.
-  // Run in a child process so a stray rejection lands on its counter.
+  // A 256 KiB write to a child that never reads stdin cannot complete
+  // synchronously (a full pipe on POSIX, every pipe write on Windows), so
+  // FileSink.write() returns its pending Promise. The async-iterable pump
+  // suspends on that Promise; the spec-ReadableStream pump marks it handled and
+  // keeps reading. When the child dies while that write is in flight, neither
+  // path may surface an unhandled EPIPE rejection in the parent. Run in a child
+  // process so a stray rejection lands on its counter.
   async function expectNoUnhandledRejectionWhenChildDies(useIterator: boolean) {
     await using proc = Bun.spawn({
       cmd: [
@@ -356,15 +357,15 @@ describe("spawn stdin ReadableStream", () => {
         }
 
         // The child never reads its stdin, so a 256 KiB write can never finish
-        // and the sink always holds an in-flight write. Once a few chunks have
-        // been handed to the sink, kill the child. How far the pump gets before
-        // the parent notices the death varies, so run several rounds.
+        // and the sink always holds an in-flight write. Kill the child once the
+        // first chunk has been handed off; how far the pump gets before the
+        // parent notices the death varies, so run several rounds.
         function round() {
           let produced = 0;
           const child = Bun.spawn({
             cmd: [process.execPath, "-e", "setTimeout(() => {}, 1e9)"],
             stdin: (${useIterator} ? iterate : readable)(() => {
-              if (++produced === 4) child.kill();
+              if (++produced === 1) queueMicrotask(() => child.kill());
             }),
             stdout: "ignore",
             stderr: "ignore",
@@ -411,7 +412,7 @@ describe("spawn stdin ReadableStream", () => {
         const chunk = Buffer.alloc(256 * 1024, "x");
         let produced = 0;
         function producedOne() {
-          if (++produced === 4) child.kill();
+          if (++produced === 1) queueMicrotask(() => child.kill());
         }
         async function* iterate() {
           while (true) {

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -71,8 +71,6 @@ describe("Response(async iterable).body with an unpaced producer", () => {
         }
       }
     }
-    let ticks = 0;
-    setInterval(() => ticks++, 10);
     ${consumer}
   `;
   const readerLoop = `
@@ -87,7 +85,7 @@ describe("Response(async iterable).body with an unpaced producer", () => {
         await new Promise(res => setTimeout(res, 1));
         if (reads === 5) {
           await r.cancel();
-          process.stdout.write(JSON.stringify({ ticks, reads, yields }) + "\\n");
+          process.stdout.write(JSON.stringify({ reads, yields }) + "\\n");
           process.exit(0);
         }
       }
@@ -100,7 +98,7 @@ describe("Response(async iterable).body with an unpaced producer", () => {
         reads++;
         await new Promise(res => setTimeout(res, 1));
         if (reads === 5) {
-          process.stdout.write(JSON.stringify({ ticks, reads, yields }) + "\\n");
+          process.stdout.write(JSON.stringify({ reads, yields }) + "\\n");
           process.exit(0);
         }
       }
@@ -112,7 +110,7 @@ describe("Response(async iterable).body with an unpaced producer", () => {
       write() {
         reads++;
         if (reads === 5) {
-          process.stdout.write(JSON.stringify({ ticks, reads, yields }) + "\\n");
+          process.stdout.write(JSON.stringify({ reads, yields }) + "\\n");
           process.exit(0);
         }
         return new Promise(res => setTimeout(res, 1));
@@ -135,8 +133,8 @@ describe("Response(async iterable).body with an unpaced producer", () => {
     expect(stderr).toBe("");
     const result = JSON.parse(stdout.trim());
     expect(result.error).toBeUndefined();
+    // Reaching reads === 5 proves the event loop is alive: each step awaited a timer.
     expect(result.reads).toBe(5);
-    expect(result.ticks).toBeGreaterThan(0);
     // Each read() drives the generator at most to the 64 KiB batch boundary: 5 reads of
     // 1 KiB chunks is at most 5 * 64 yields.
     expect(result.yields).toBeLessThanOrEqual(5 * 64);

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("Response.bytes() with async iterable body does not crash with null deref", async () => {
@@ -51,4 +51,173 @@ test("Response.arrayBuffer() with async iterable body does not crash with null d
 
   expect(stdout).not.toContain("null is not an object");
   expect(exitCode).toBe(0);
+});
+
+// #5640: a Response body built from an async iterable with no awaited I/O must not starve
+// the event loop or run the pump unbounded while a paced reader is consuming it.
+describe("Response(async iterable).body with an unpaced producer", () => {
+  const yieldLimit = 2000;
+  const makeScript = (consumer: string) => `
+    const chunk = new Uint8Array(1024);
+    let yields = 0;
+    async function* g() {
+      while (true) {
+        yield chunk;
+        // Without backpressure the pump runs in a tight promise-reaction loop and nothing
+        // below the generator ever runs; the yield cap is the only way out.
+        if (++yields > ${yieldLimit}) {
+          process.stdout.write(JSON.stringify({ error: "unbounded", yields }) + "\\n");
+          process.exit(1);
+        }
+      }
+    }
+    let ticks = 0;
+    setInterval(() => ticks++, 10);
+    ${consumer}
+  `;
+  const readerLoop = `
+    let reads = 0;
+    const body = new Response(g()).body;
+    (async () => {
+      const r = body.getReader();
+      while (true) {
+        const { done } = await r.read();
+        if (done) break;
+        reads++;
+        await new Promise(res => setTimeout(res, 1));
+        if (reads === 5) {
+          await r.cancel();
+          process.stdout.write(JSON.stringify({ ticks, reads, yields }) + "\\n");
+          process.exit(0);
+        }
+      }
+    })();
+  `;
+  const forAwaitLoop = `
+    let reads = 0;
+    (async () => {
+      for await (const c of new Response(g()).body) {
+        reads++;
+        await new Promise(res => setTimeout(res, 1));
+        if (reads === 5) {
+          process.stdout.write(JSON.stringify({ ticks, reads, yields }) + "\\n");
+          process.exit(0);
+        }
+      }
+    })();
+  `;
+  const pipeToLoop = `
+    let reads = 0;
+    new Response(g()).body.pipeTo(new WritableStream({
+      write() {
+        reads++;
+        if (reads === 5) {
+          process.stdout.write(JSON.stringify({ ticks, reads, yields }) + "\\n");
+          process.exit(0);
+        }
+        return new Promise(res => setTimeout(res, 1));
+      },
+    })).catch(() => {});
+  `;
+
+  test.concurrent.each([
+    ["getReader()", readerLoop],
+    ["for-await", forAwaitLoop],
+    ["pipeTo", pipeToLoop],
+  ])("paced %s consumer is not starved", async (_name, consumer) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", makeScript(consumer)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect(result.error).toBeUndefined();
+    expect(result.reads).toBe(5);
+    expect(result.ticks).toBeGreaterThan(0);
+    // Each read() drives the generator at most to the 64 KiB batch boundary: 5 reads of
+    // 1 KiB chunks is at most 5 * 64 yields.
+    expect(result.yields).toBeLessThanOrEqual(5 * 64);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("spawn stdin ReadableStream backpressure suspends the pump", async () => {
+    // A child that never reads stdin fills the pipe buffer, so FileSink's write() goes
+    // pending; the pump must suspend on that promise instead of buffering without bound.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const chunk = new Uint8Array(65536);
+        let yields = 0;
+        async function* g() {
+          while (true) {
+            yield chunk;
+            if (++yields > ${yieldLimit}) {
+              process.stdout.write(JSON.stringify({ error: "unbounded", yields }) + "\\n");
+              process.exit(1);
+            }
+          }
+        }
+        let ticks = 0;
+        setInterval(() => ticks++, 10);
+        const child = Bun.spawn({
+          cmd: [process.execPath, "-e", "setTimeout(() => {}, 120000)"],
+          stdin: new Response(g()).body,
+          stdout: "ignore",
+          stderr: "ignore",
+        });
+        (async () => {
+          // Once the pipe is full the pump suspends; wait for the event loop to prove it.
+          while (ticks < 3) await new Promise(res => setTimeout(res, 10));
+          child.kill();
+          await child.exited;
+          process.stdout.write(JSON.stringify({ ticks, yields }) + "\\n");
+          process.exit(0);
+        })();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect(result.error).toBeUndefined();
+    expect(result.ticks).toBeGreaterThanOrEqual(3);
+    expect(result.yields).toBeLessThan(yieldLimit);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bounded producer still delivers every byte", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const chunk = new Uint8Array(1024).fill(0x61);
+        async function* g() { for (let i = 0; i < 300; i++) yield chunk; }
+        const r = new Response(g()).body.getReader();
+        let total = 0;
+        while (true) {
+          const { done, value } = await r.read();
+          if (done) break;
+          total += value.byteLength;
+        }
+        process.stdout.write(JSON.stringify({ total }) + "\\n");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ total: 300 * 1024 });
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Problem

An async iterable body with no awaited I/O, e.g.

```js
const chunk = new Uint8Array(1 << 20);
async function* g() { while (true) yield chunk; }
setInterval(() => console.error('tick'), 50); // never fires
const r = new Response(g()).body.getReader();
while (true) {
  await r.read();                               // never resolves
  await new Promise(res => setTimeout(res, 10));
}
```

wedges the process at 100% CPU, RSS climbs to OOM, and no timer ever fires. Node ticks normally and delivers ~1 read per 10 ms with flat RSS. The same producer starves every demand-driven consumer of the body (`getReader`, `for await`, `pipeTo`, `fetch` request body, `Bun.spawn` stdin).

## Cause

`driveAsyncIterator` in `BunAsyncIterableSource.cpp` pumps `iterator.next()` results into `controller.write()` in an unbounded promise-reaction chain whose only suspension point is a negative return from `write()`. The HTTP response sink returns `-(len+1)` under backpressure, but the ArrayBuffer direct controller (reader/for-await/pipeTo) and FileSink always return a positive byte count or a pending Promise. Reader delivery only happens when the pull promise settles, which for a synchronously-fulfilling iterator never happens.

## Fix

Two guards at the drive-loop/controller-write level:

- For the ArrayBuffer direct controller, track bytes written since the last `pull()`; once 64 KiB has been buffered, resolve the pull promise so `onDirectPullFulfilled` flushes the batch to the waiting reader, and resume on the reader's next `read()`. The guard only applies to this controller kind: native JSSink controllers have their own backpressure signal, and the Text/Array/one-shot sinks accumulate to `end()` with no per-batch delivery to re-pull on.
- When `write()` itself returns a Promise (FileSink/NetworkSink pending on a full pipe), suspend on it via the same flush-fulfilled reaction instead of marking it handled and continuing.

The Bun.serve HTTP sink path already signals via the negative return and is unchanged.

## Tests

`test/js/web/fetch/body-async-iterator.test.ts` adds subprocess harness tests for the paced `getReader` / `for-await` / `pipeTo` consumers and a `Bun.spawn` stdin FileSink test; each fails on the unfixed build with `{error:"unbounded"}` and passes with the fix. A bounded-producer sanity test covers the correctness of the batched delivery.

`test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`: the two existing tests that killed the child after 4 × 256 KiB chunks had been handed off relied on the pump buffering without bound. With FileSink backpressure honored the async-iterable pump suspends after the first write that fills the pipe, so kill once the first chunk is handed off instead.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream.test.ts test/js/web/fetch/body-async-iterator.test.ts
bun test v1.4.0 (e67f8a8aa)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [1470.99ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [1464.30ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [1494.79ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [1492.62ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [1488.94ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [1499.78ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [1545.79ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [1682.73ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [1496.94ms]
(pass) spawn 
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (9751bb6f4)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [30.05ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [35.11ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [26.71ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [104.68ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [35.00ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [95.74ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [28.65ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [28.82ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [24.89ms]
(pass) spawn stdin ReadableStream > erroring the stdin ReadableStream does not surface an unhandled rejection [82.52ms]
(pass) spawn stdin ReadableStream > in-flight write when the child dies does not surface an unhandled rejection [13.23ms]
(pass) spawn
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream.test.ts test/js/web/fetch/body-async-iterator.test.ts
bun test v1.4.0 (e67f8a8aa)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [1445.16ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [1459.05ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [1437.31ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [1472.25ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [1455.14ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [1455.81ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [1472.60ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [1487.31ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [1443.57ms]
(pass) spawn 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 726ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp.o
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/BunAsyncIterableSource.cpp     |  76 ++++++---
 .../streams/JSAsyncIteratorSourceOperation.h       |   2 +
 .../bun/spawn/spawn-stdin-readable-stream.test.ts  |  23 +--
 test/js/web/fetch/body-async-iterator.test.ts      | 169 ++++++++++++++++++++-
 4 files changed, 241 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp      6     21      0
…ndings/webcore/streams/JSAsyncIteratorSourceOperation.h      3      3      0
test/js/bun/spawn/spawn-stdin-readable-stream.test.ts         1      3      0
test/js/web/fetch/body-async-iterator.test.ts                 2      8      0
```

</details>

<!-- robobun:evidence:end -->