### PR TITLE
napi: tolerate pending VM exception in ArrayBuffer/typed-array info accessors (debug/asan abort)

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/ExceptionScope.h>
+#include <JavaScriptCore/FrameTracers.h>
 #include <JavaScriptCore/FunctionConstructor.h>
 #include <JavaScriptCore/Heap.h>
 #include <JavaScriptCore/Identifier.h>
@@ -3319,6 +3320,26 @@ extern "C" void napi_internal_remove_finalizer(napi_env env, napi_finalize callb
 extern "C" void napi_internal_check_gc(napi_env env)
 {
     env->checkGC();
+}
+
+extern "C" JSC::EncodedJSValue Bun__JSValue__getArrayBufferViewBuffer(JSC::EncodedJSValue, JSC::JSGlobalObject*);
+
+// napi_is_arraybuffer / napi_get_{arraybuffer,typedarray,dataview,buffer}_info
+// are CHECK_ENV (not NAPI_PREAMBLE) in Node.js, so they must succeed with a
+// VM exception already pending. JSC__JSValue__asArrayBuffer opens with
+// ASSERT_NO_PENDING_EXCEPTION; SuspendExceptionScope stashes vm.m_exception
+// for the read and restores it, so the assertion holds and the addon's
+// exception survives.
+extern "C" bool napi_internal_as_array_buffer(napi_env env, JSC::EncodedJSValue value, Bun__ArrayBuffer* out)
+{
+    JSC::SuspendExceptionScope suspend(env->vm());
+    return JSC__JSValue__asArrayBuffer(value, env->globalObject(), out);
+}
+
+extern "C" JSC::EncodedJSValue napi_internal_get_array_buffer_view_buffer(napi_env env, JSC::EncodedJSValue value)
+{
+    JSC::SuspendExceptionScope suspend(env->vm());
+    return Bun__JSValue__getArrayBufferViewBuffer(value, env->globalObject());
 }
 
 extern "C" bool NapiEnv__hasPendingException(napi_env env)

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3324,8 +3324,7 @@ extern "C" void napi_internal_check_gc(napi_env env)
 
 extern "C" JSC::EncodedJSValue Bun__JSValue__getArrayBufferViewBuffer(JSC::EncodedJSValue, JSC::JSGlobalObject*);
 
-// Node.js does not gate these accessors behind NAPI_PREAMBLE. Stash any
-// pending exception around ASSERT_NO_PENDING_EXCEPTION in the callee.
+// Stash any pending exception around the callee's ASSERT_NO_PENDING_EXCEPTION (Node.js CHECK_ENV accessors).
 extern "C" bool napi_internal_as_array_buffer(napi_env env, JSC::EncodedJSValue value, Bun__ArrayBuffer* out)
 {
     JSC::SuspendExceptionScope suspend(env->vm());

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3324,12 +3324,8 @@ extern "C" void napi_internal_check_gc(napi_env env)
 
 extern "C" JSC::EncodedJSValue Bun__JSValue__getArrayBufferViewBuffer(JSC::EncodedJSValue, JSC::JSGlobalObject*);
 
-// napi_is_arraybuffer / napi_get_{arraybuffer,typedarray,dataview,buffer}_info
-// are CHECK_ENV (not NAPI_PREAMBLE) in Node.js, so they must succeed with a
-// VM exception already pending. JSC__JSValue__asArrayBuffer opens with
-// ASSERT_NO_PENDING_EXCEPTION; SuspendExceptionScope stashes vm.m_exception
-// for the read and restores it, so the assertion holds and the addon's
-// exception survives.
+// Node.js does not gate these accessors behind NAPI_PREAMBLE. Stash any
+// pending exception around ASSERT_NO_PENDING_EXCEPTION in the callee.
 extern "C" bool napi_internal_as_array_buffer(napi_env env, JSC::EncodedJSValue value, Bun__ArrayBuffer* out)
 {
     JSC::SuspendExceptionScope suspend(env->vm());

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -132,10 +132,8 @@ impl NapiEnv {
         unsafe { napi_internal_check_gc(self.as_mut_ptr()) };
     }
 
-    /// `JSValue::as_array_buffer` for CHECK_ENV accessor entry points.
-    /// Stashes any VM-pending exception around the metadata read so the
-    /// caller sees `napi_ok` (matching Node.js) instead of tripping
-    /// `ASSERT_NO_PENDING_EXCEPTION` in `JSC__JSValue__asArrayBuffer`.
+    /// `JSValue::as_array_buffer` that tolerates a VM-pending exception
+    /// (Node.js does not gate these accessors behind `NAPI_PREAMBLE`).
     pub fn as_array_buffer(&self, value: JSValue) -> Option<jsc::ArrayBuffer> {
         let mut out = jsc::ArrayBuffer::default();
         // SAFETY: env is non-null; `out` is a live exclusive borrow.
@@ -147,8 +145,7 @@ impl NapiEnv {
         }
     }
 
-    /// `JSValue::get_array_buffer_view_buffer` under the same
-    /// suspended-exception scope as [`Self::as_array_buffer`].
+    /// `JSValue::get_array_buffer_view_buffer`, same scope as [`Self::as_array_buffer`].
     pub fn get_array_buffer_view_buffer(&self, value: JSValue) -> JSValue {
         // SAFETY: env is non-null.
         unsafe { napi_internal_get_array_buffer_view_buffer(self.as_mut_ptr(), value) }

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -139,7 +139,7 @@ impl NapiEnv {
     pub fn as_array_buffer(&self, value: JSValue) -> Option<jsc::ArrayBuffer> {
         let mut out = jsc::ArrayBuffer::default();
         // SAFETY: env is non-null; `out` is a live exclusive borrow.
-        if unsafe { napi_internal_as_array_buffer(self.as_mut_ptr(), value, &mut out) } {
+        if unsafe { napi_internal_as_array_buffer(self.as_mut_ptr(), value, &raw mut out) } {
             out.value = value;
             Some(out)
         } else {

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -132,8 +132,7 @@ impl NapiEnv {
         unsafe { napi_internal_check_gc(self.as_mut_ptr()) };
     }
 
-    /// `JSValue::as_array_buffer` that tolerates a VM-pending exception
-    /// (Node.js does not gate these accessors behind `NAPI_PREAMBLE`).
+    /// `JSValue::as_array_buffer` that tolerates a VM-pending exception (Node.js CHECK_ENV accessor).
     pub fn as_array_buffer(&self, value: JSValue) -> Option<jsc::ArrayBuffer> {
         let mut out = jsc::ArrayBuffer::default();
         // SAFETY: env is non-null; `out` is a live exclusive borrow.

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -74,6 +74,12 @@ unsafe extern "C" {
     fn NapiEnv__deref(env: *mut NapiEnv);
     fn NapiEnv__ref(env: *mut NapiEnv);
     fn napi_set_last_error(env: napi_env, status: NapiStatus) -> napi_status;
+    fn napi_internal_as_array_buffer(
+        env: *mut NapiEnv,
+        value: JSValue,
+        out: *mut jsc::ArrayBuffer,
+    ) -> bool;
+    fn napi_internal_get_array_buffer_view_buffer(env: *mut NapiEnv, value: JSValue) -> JSValue;
 }
 
 impl NapiEnv {
@@ -124,6 +130,28 @@ impl NapiEnv {
     pub fn check_gc(&self) {
         // SAFETY: env is non-null; C++ side is read-only here.
         unsafe { napi_internal_check_gc(self.as_mut_ptr()) };
+    }
+
+    /// `JSValue::as_array_buffer` for CHECK_ENV accessor entry points.
+    /// Stashes any VM-pending exception around the metadata read so the
+    /// caller sees `napi_ok` (matching Node.js) instead of tripping
+    /// `ASSERT_NO_PENDING_EXCEPTION` in `JSC__JSValue__asArrayBuffer`.
+    pub fn as_array_buffer(&self, value: JSValue) -> Option<jsc::ArrayBuffer> {
+        let mut out = jsc::ArrayBuffer::default();
+        // SAFETY: env is non-null; `out` is a live exclusive borrow.
+        if unsafe { napi_internal_as_array_buffer(self.as_mut_ptr(), value, &mut out) } {
+            out.value = value;
+            Some(out)
+        } else {
+            None
+        }
+    }
+
+    /// `JSValue::get_array_buffer_view_buffer` under the same
+    /// suspended-exception scope as [`Self::as_array_buffer`].
+    pub fn get_array_buffer_view_buffer(&self, value: JSValue) -> JSValue {
+        // SAFETY: env is non-null.
+        unsafe { napi_internal_get_array_buffer_view_buffer(self.as_mut_ptr(), value) }
     }
 
     pub fn get_and_clear_pending_exception(&self) -> Option<JSValue> {
@@ -1358,8 +1386,8 @@ pub(super) extern "C" fn napi_is_arraybuffer(
     // ArrayBuffer in JSC, so `js_type` alone can't tell them apart. Node's
     // `napi_is_arraybuffer` maps to V8's `IsArrayBuffer()`, which is false for
     // SharedArrayBuffer, so exclude shared buffers here too.
-    *result = value
-        .as_array_buffer(env.to_js())
+    *result = env
+        .as_array_buffer(value)
         .is_some_and(|ab| ab.typed_array_type == jsc::JSType::ArrayBuffer && !ab.shared);
     env.ok()
 }
@@ -1395,7 +1423,7 @@ pub(super) extern "C" fn napi_get_arraybuffer_info(
     let env = get_env!(env_);
     env.check_gc();
     let arraybuffer = arraybuffer_.get();
-    let Some(array_buffer) = arraybuffer.as_array_buffer(env.to_js()) else {
+    let Some(array_buffer) = env.as_array_buffer(arraybuffer) else {
         return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);
     };
     if array_buffer.typed_array_type != jsc::JSType::ArrayBuffer {
@@ -1434,7 +1462,7 @@ pub(super) extern "C" fn napi_get_typedarray_info(
     }
     let _keep = jsc::EnsureStillAlive(typedarray);
 
-    let Some(array_buffer) = typedarray.as_array_buffer(env.to_js()) else {
+    let Some(array_buffer) = env.as_array_buffer(typedarray) else {
         return env.invalid_arg();
     };
     // SAFETY: `maybe_type` is null or a valid exclusive out-param per N-API contract.
@@ -1454,7 +1482,7 @@ pub(super) extern "C" fn napi_get_typedarray_info(
 
     // SAFETY: `maybe_arraybuffer` is null or a valid exclusive out-param per N-API contract.
     if let Some(arraybuffer) = unsafe { maybe_arraybuffer.as_mut() } {
-        arraybuffer.set(env, typedarray.get_array_buffer_view_buffer(env.to_js()));
+        arraybuffer.set(env, env.get_array_buffer_view_buffer(typedarray));
     }
 
     // SAFETY: `maybe_byte_offset` is null or a valid exclusive out-param per N-API contract.
@@ -1508,14 +1536,14 @@ pub(super) extern "C" fn napi_get_dataview_info(
     if dataview.is_empty() {
         return env.invalid_arg();
     }
-    let Some(array_buffer) = dataview.as_array_buffer(env.to_js()) else {
+    let Some(array_buffer) = env.as_array_buffer(dataview) else {
         return NapiEnv::set_last_error(Some(env), NapiStatus::object_expected);
     };
     write_out(maybe_bytelength, array_buffer.byte_len);
     write_out(maybe_data, array_buffer.ptr);
     // SAFETY: `maybe_arraybuffer` is null or a valid exclusive out-param per N-API contract.
     if let Some(arraybuffer) = unsafe { maybe_arraybuffer.as_mut() } {
-        arraybuffer.set(env, dataview.get_array_buffer_view_buffer(env.to_js()));
+        arraybuffer.set(env, env.get_array_buffer_view_buffer(dataview));
     }
     // SAFETY: `maybe_byte_offset` is null or a valid exclusive out-param per N-API contract.
     if let Some(byte_offset) = unsafe { maybe_byte_offset.as_mut() } {
@@ -2068,7 +2096,7 @@ pub(super) extern "C" fn napi_get_buffer_info(
     bun_output::scoped_log!(napi, "napi_get_buffer_info");
     let env = get_env!(env_);
     let value = value_.get();
-    let Some(array_buf) = value.as_array_buffer(env.to_js()) else {
+    let Some(array_buf) = env.as_array_buffer(value) else {
         return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);
     };
 

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2892,6 +2892,89 @@ static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// napi_is_arraybuffer / napi_get_{arraybuffer,typedarray,dataview,buffer}_info
+// are CHECK_ENV in Node.js: they must return napi_ok with a VM exception
+// already pending and leave it untouched. Route the exception onto the VM
+// with napi_throw(E) then napi_call_function (returns 10, promotes E into the
+// VM), then call each accessor. Debug/ASAN builds previously aborted in
+// JSC__JSValue__asArrayBuffer's ASSERT_NO_PENDING_EXCEPTION.
+static napi_value test_arraybuffer_info_with_vm_exception(
+    const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  napi_value global, isNaN, ab, ta, dv, buf, bufctor;
+  void *ab_data;
+  NODE_API_CALL(env, napi_get_global(env, &global));
+  NODE_API_CALL(env, napi_get_named_property(env, global, "isNaN", &isNaN));
+  NODE_API_CALL(env, napi_create_arraybuffer(env, 64, &ab_data, &ab));
+  NODE_API_CALL(env, napi_create_typedarray(env, napi_uint8_array, 16, ab, 8,
+                                            &ta));
+  NODE_API_CALL(env, napi_create_dataview(env, 16, ab, 8, &dv));
+  NODE_API_CALL(env,
+                napi_get_named_property(env, global, "Buffer", &bufctor));
+  NODE_API_CALL(env, napi_get_named_property(env, bufctor, "alloc", &bufctor));
+  napi_value sixteen;
+  NODE_API_CALL(env, napi_create_int32(env, 16, &sixteen));
+  NODE_API_CALL(env, napi_call_function(env, global, bufctor, 1, &sixteen,
+                                        &buf));
+
+  // Arm: E1 pending on the VM.
+  napi_value msg, err, r;
+  NODE_API_CALL(env, napi_create_string_utf8(env, "E1", 2, &msg));
+  NODE_API_CALL(env, napi_create_error(env, nullptr, msg, &err));
+  NODE_API_CALL(env, napi_throw(env, err));
+  napi_status st = napi_call_function(env, global, isNaN, 0, nullptr, &r);
+  printf("napi_call_function: status=%d\n", (int)st);
+
+  bool is_ab = false;
+  st = napi_is_arraybuffer(env, ab, &is_ab);
+  printf("napi_is_arraybuffer: status=%d result=%s\n", (int)st,
+         is_ab ? "true" : "false");
+
+  void *data = nullptr;
+  size_t len = 0;
+  st = napi_get_arraybuffer_info(env, ab, &data, &len);
+  printf("napi_get_arraybuffer_info: status=%d len=%zu same_data=%s\n",
+         (int)st, len, data == ab_data ? "true" : "false");
+
+  napi_typedarray_type ty;
+  size_t ta_len = 0, ta_off = 0;
+  void *ta_data = nullptr;
+  napi_value ta_ab = nullptr;
+  st = napi_get_typedarray_info(env, ta, &ty, &ta_len, &ta_data, &ta_ab,
+                                &ta_off);
+  printf(
+      "napi_get_typedarray_info: status=%d type=%d len=%zu off=%zu ab=%s\n",
+      (int)st, (int)ty, ta_len, ta_off, ta_ab ? "set" : "null");
+
+  size_t dv_len = 0, dv_off = 0;
+  void *dv_data = nullptr;
+  napi_value dv_ab = nullptr;
+  st = napi_get_dataview_info(env, dv, &dv_len, &dv_data, &dv_ab, &dv_off);
+  printf("napi_get_dataview_info: status=%d len=%zu off=%zu ab=%s\n", (int)st,
+         dv_len, dv_off, dv_ab ? "set" : "null");
+
+  void *buf_data = nullptr;
+  size_t buf_len = 0;
+  st = napi_get_buffer_info(env, buf, &buf_data, &buf_len);
+  printf("napi_get_buffer_info: status=%d len=%zu\n", (int)st, buf_len);
+
+  bool pending = false;
+  napi_is_exception_pending(env, &pending);
+  printf("pending_after=%s\n", pending ? "true" : "false");
+
+  napi_value exc, exc_msg;
+  NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exc));
+  if (napi_coerce_to_string(env, exc, &exc_msg) == napi_ok) {
+    char sbuf[64];
+    size_t n;
+    napi_get_value_string_utf8(env, exc_msg, sbuf, sizeof(sbuf), &n);
+    printf("exception=%s\n", sbuf);
+  }
+
+  return ok(env);
+}
+
 // Regression test: PROPERTY_NAME_FROM_UTF8 must copy string data.
 // Previously it used StringImpl::createWithoutCopying for ASCII strings,
 // which could leave dangling pointers in JSC's atom string table.
@@ -3562,6 +3645,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_pending_exception_gate);
+  REGISTER_FUNCTION(env, exports, test_arraybuffer_info_with_vm_exception);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_status);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -433,6 +433,22 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("side_effect arr[7]=undefined");
       expect(result).toContain("side_effect script_ran=false");
     });
+
+    it("ArrayBuffer/typed-array info accessors succeed while a VM exception is pending", async () => {
+      // napi_throw(E) + napi_call_function puts E into vm.m_exception. The
+      // CHECK_ENV accessors must return napi_ok (Node.js does not gate them)
+      // and leave E untouched. Debug/ASAN builds previously aborted in
+      // ASSERT_NO_PENDING_EXCEPTION inside JSC__JSValue__asArrayBuffer.
+      const result = await checkSameOutput("test_arraybuffer_info_with_vm_exception", []);
+      expect(result).toContain("napi_call_function: status=10");
+      expect(result).toContain("napi_is_arraybuffer: status=0 result=true");
+      expect(result).toContain("napi_get_arraybuffer_info: status=0 len=64 same_data=true");
+      expect(result).toContain("napi_get_typedarray_info: status=0 type=1 len=16 off=8 ab=set");
+      expect(result).toContain("napi_get_dataview_info: status=0 len=16 off=8 ab=set");
+      expect(result).toContain("napi_get_buffer_info: status=0 len=16");
+      expect(result).toContain("pending_after=true");
+      expect(result).toContain("exception=Error: E1");
+    });
   });
 
   describe("napi_async_work", () => {


### PR DESCRIPTION
## Repro

Under debug/ASAN builds this sequence aborts:

```c
napi_throw(env, err);                            // E stashed on env
napi_call_function(env, g, isNaN, 0, NULL, &r);  // 10: promotes E into vm.m_exception
napi_get_typedarray_info(env, ta, &t, &l, &d, &ab, &off);  // node/release bun: 0; debug/asan: SIGABRT
```

```
ASSERTION FAILED: !exception() || m_vm.hasPendingTerminationException()
ExceptionScope.h(63) : void JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

Same abort for `napi_get_arraybuffer_info`, `napi_get_dataview_info`, `napi_get_buffer_info`, and `napi_is_arraybuffer`. Node.js and release Bun both return `napi_ok` (these are pure metadata reads, CHECK_ENV not NAPI_PREAMBLE in Node) and the exception propagates catchably.

Sibling of #36091 (`napi_create_string_*`), different sink: no allocation here, just the `ASSERT_NO_PENDING_EXCEPTION(globalObject)` that opens `JSC__JSValue__asArrayBuffer`.

## Cause

All five Rust accessors use the bare `get_env!` prologue (no pending-exception check, matching Node's CHECK_ENV) and call `JSValue::as_array_buffer` -> `JSC__JSValue__asArrayBuffer`, whose first statement is `ASSERT_NO_PENDING_EXCEPTION(globalObject)` (`assertNoExceptionExceptTermination`). With `vm.m_exception` set by the preceding `napi_call_function`, that release-asserts. Release builds compile the macro to `void()`, so only asserts builds die.

## Fix

Add `napi_internal_as_array_buffer` / `napi_internal_get_array_buffer_view_buffer` in `napi.cpp` that wrap the shared metadata readers under `JSC::SuspendExceptionScope`, which stashes `vm.m_exception` for the duration and restores it on return. The five Rust accessors now route through these via `NapiEnv::as_array_buffer` / `NapiEnv::get_array_buffer_view_buffer` instead of the general-purpose `JSValue::as_array_buffer`. The caller's exception is preserved and the accessors return `napi_ok`, matching Node.

The existing `JSC__JSValue__asArrayBuffer` and its assertion are unchanged: the ~40 Bun-internal callers that reach it after Bun's own exception checks keep the defense.

## Test

`test_arraybuffer_info_with_vm_exception` in `test/napi/napi-app/standalone_tests.cpp` arms the VM exception via `napi_throw` + `napi_call_function`, then calls all five accessors (with the `arraybuffer` out-param non-null so the view-buffer path is covered too) and asserts `status=0`, correct geometry, `pending_after=true`, and that `Error: E1` survives. Diffed against Node byte-for-byte via `checkSameOutput`.

Fail-before (src/ stashed, `bun bd test`): aborts with `assertNoExceptionExceptTermination`, exit 134.
After: all five return 0 with the exception preserved; 24 related napi tests and the upstream `test_typedarray`/`test_dataview` suites pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->