### PR TITLE
napi: guard string creators and buffer accessors against pending VM exception

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3330,6 +3330,12 @@ extern "C" bool NapiEnv__hasPendingException(napi_env env)
     return scope.exception() != nullptr;
 }
 
+extern "C" bool NapiEnv__hasVMException(napi_env env)
+{
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(env->vm());
+    return scope.exception() != nullptr;
+}
+
 extern "C" uint32_t napi_internal_get_version(napi_env env)
 {
     return env->napiModule().nm_version;

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -121,10 +121,8 @@ impl NapiEnv {
         unsafe { NapiEnv__hasPendingException(self.as_mut_ptr()) }
     }
 
-    /// Checks only the JSC VM exception slot (`vm.m_exception`), ignoring an
-    /// exception stashed on the env by `napi_throw*`. This is the gate
-    /// `NAPI_PREAMBLE_NO_PENDING_CHECK` enforces for value constructors and
-    /// accessors that Node.js allows while a stashed exception is pending.
+    /// Checks only the JSC VM exception slot, not the env's stashed
+    /// `napi_throw*` exception. See `NAPI_PREAMBLE_NO_PENDING_CHECK`.
     pub fn has_vm_exception(&self) -> bool {
         // SAFETY: env is non-null; C++ side is read-only here.
         unsafe { NapiEnv__hasVMException(self.as_mut_ptr()) }
@@ -445,11 +443,9 @@ macro_rules! preamble {
     }};
 }
 
-/// Like `preamble!` but only guards against a VM-level exception, not an
-/// exception stashed on the env by `napi_throw*` (mirrors
-/// `NAPI_PREAMBLE_NO_PENDING_CHECK`). Use this for value constructors and
-/// accessors that Node.js allows with a stashed exception pending but whose
-/// bodies reach JSC helpers that assert the VM has no exception.
+/// Like `preamble!` but only guards against a VM-level exception (mirrors
+/// `NAPI_PREAMBLE_NO_PENDING_CHECK`). For entry points whose bodies reach JSC
+/// helpers that assert the VM has no exception.
 macro_rules! preamble_no_pending_check {
     ($env:expr) => {{
         let env = get_env!($env);

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -71,6 +71,7 @@ unsafe extern "C" {
     fn NapiEnv__globalObject(env: *mut NapiEnv) -> *mut JSGlobalObject;
     fn NapiEnv__getAndClearPendingException(env: *mut NapiEnv, out: *mut JSValue) -> bool;
     fn NapiEnv__hasPendingException(env: *mut NapiEnv) -> bool;
+    fn NapiEnv__hasVMException(env: *mut NapiEnv) -> bool;
     fn NapiEnv__deref(env: *mut NapiEnv);
     fn NapiEnv__ref(env: *mut NapiEnv);
     fn napi_set_last_error(env: napi_env, status: NapiStatus) -> napi_status;
@@ -118,6 +119,15 @@ impl NapiEnv {
     pub fn has_pending_exception(&self) -> bool {
         // SAFETY: env is non-null; C++ side is read-only here.
         unsafe { NapiEnv__hasPendingException(self.as_mut_ptr()) }
+    }
+
+    /// Checks only the JSC VM exception slot (`vm.m_exception`), ignoring an
+    /// exception stashed on the env by `napi_throw*`. This is the gate
+    /// `NAPI_PREAMBLE_NO_PENDING_CHECK` enforces for value constructors and
+    /// accessors that Node.js allows while a stashed exception is pending.
+    pub fn has_vm_exception(&self) -> bool {
+        // SAFETY: env is non-null; C++ side is read-only here.
+        unsafe { NapiEnv__hasVMException(self.as_mut_ptr()) }
     }
 
     /// Assert that we're not currently performing garbage collection
@@ -435,6 +445,21 @@ macro_rules! preamble {
     }};
 }
 
+/// Like `preamble!` but only guards against a VM-level exception, not an
+/// exception stashed on the env by `napi_throw*` (mirrors
+/// `NAPI_PREAMBLE_NO_PENDING_CHECK`). Use this for value constructors and
+/// accessors that Node.js allows with a stashed exception pending but whose
+/// bodies reach JSC helpers that assert the VM has no exception.
+macro_rules! preamble_no_pending_check {
+    ($env:expr) => {{
+        let env = get_env!($env);
+        if env.has_vm_exception() {
+            return env.pending_exception();
+        }
+        env
+    }};
+}
+
 macro_rules! get_out {
     ($env:expr, $ptr:expr) => {
         // SAFETY: caller passes raw out pointer; we treat non-null as &mut borrow.
@@ -623,7 +648,7 @@ pub(super) extern "C" fn napi_create_string_latin1(
     length: usize,
     result_: *mut napi_value,
 ) -> napi_status {
-    let env = get_env!(env_);
+    let env = preamble_no_pending_check!(env_);
     let result = get_out!(env, result_);
 
     let slice: &[u8] = 'brk: {
@@ -679,7 +704,7 @@ pub(super) extern "C" fn napi_create_string_utf8(
     length: usize,
     result_: *mut napi_value,
 ) -> napi_status {
-    let env = get_env!(env_);
+    let env = preamble_no_pending_check!(env_);
     let result = get_out!(env, result_);
 
     let slice: &[u8] = 'brk: {
@@ -720,7 +745,7 @@ pub(super) extern "C" fn napi_create_string_utf16(
     length: usize,
     result_: *mut napi_value,
 ) -> napi_status {
-    let env = get_env!(env_);
+    let env = preamble_no_pending_check!(env_);
     let result = get_out!(env, result_);
 
     let slice: &[u16] = 'brk: {
@@ -1347,7 +1372,7 @@ pub(super) extern "C" fn napi_is_arraybuffer(
     result_: *mut bool,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_is_arraybuffer");
-    let env = get_env!(env_);
+    let env = preamble_no_pending_check!(env_);
     env.check_gc();
     let result = get_out!(env, result_);
     let value = value_.get();
@@ -1392,7 +1417,7 @@ pub(super) extern "C" fn napi_get_arraybuffer_info(
     byte_length: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_arraybuffer_info");
-    let env = get_env!(env_);
+    let env = preamble_no_pending_check!(env_);
     env.check_gc();
     let arraybuffer = arraybuffer_.get();
     let Some(array_buffer) = arraybuffer.as_array_buffer(env.to_js()) else {
@@ -1426,7 +1451,7 @@ pub(super) extern "C" fn napi_get_typedarray_info(
     maybe_byte_offset: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_typedarray_info");
-    let env = get_env!(env_);
+    let env = preamble_no_pending_check!(env_);
     env.check_gc();
     let typedarray = typedarray_.get();
     if typedarray.is_empty_or_undefined_or_null() {
@@ -1502,7 +1527,7 @@ pub(super) extern "C" fn napi_get_dataview_info(
     maybe_byte_offset: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_dataview_info");
-    let env = get_env!(env_);
+    let env = preamble_no_pending_check!(env_);
     env.check_gc();
     let dataview = dataview_.get();
     if dataview.is_empty() {
@@ -2066,7 +2091,7 @@ pub(super) extern "C" fn napi_get_buffer_info(
     length: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_buffer_info");
-    let env = get_env!(env_);
+    let env = preamble_no_pending_check!(env_);
     let value = value_.get();
     let Some(array_buf) = value.as_array_buffer(env.to_js()) else {
         return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2952,6 +2952,10 @@ static napi_value test_vm_pending_exception_no_abort(
   printf("napi_get_dataview_info: survived\n");
   napi_get_buffer_info(env, buffer, &ptr_out, &len_out);
   printf("napi_get_buffer_info: survived\n");
+  napi_create_array(env, &out);
+  printf("napi_create_array: survived\n");
+  napi_create_array_with_length(env, 4, &out);
+  printf("napi_create_array_with_length: survived\n");
 
   // The original exception must still be pending and catchable.
   bool pending = false;

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2892,6 +2892,98 @@ static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// napi_throw() followed by napi_call_function() promotes the stashed exception
+// into vm.m_exception. With a VM-level exception pending, the string creators
+// and buffer-info accessors below reach C++ helpers that assert "no pending
+// exception" under debug/assert builds (release builds compile the check out).
+// The entry points must refuse with napi_pending_exception before touching
+// those helpers, and leave the pending exception intact.
+static napi_value test_vm_pending_exception_no_abort(
+    const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  // Build every input before arming the exception.
+  napi_value global, isNaN, arraybuffer, typedarray, dataview, buffer;
+  void *ab_data;
+  void *buf_data;
+  NODE_API_CALL(env, napi_get_global(env, &global));
+  NODE_API_CALL(env, napi_get_named_property(env, global, "isNaN", &isNaN));
+  NODE_API_CALL(env,
+                napi_create_arraybuffer(env, 16, &ab_data, &arraybuffer));
+  NODE_API_CALL(env, napi_create_typedarray(env, napi_uint8_array, 16,
+                                            arraybuffer, 0, &typedarray));
+  NODE_API_CALL(env,
+                napi_create_dataview(env, 16, arraybuffer, 0, &dataview));
+  NODE_API_CALL(env,
+                napi_create_buffer_copy(env, 4, "abcd", &buf_data, &buffer));
+
+  // Arm: E pending on env, then napi_call_function pushes it onto the VM.
+  napi_value msg, err;
+  NODE_API_CALL(env, napi_create_string_utf8(env, "E1", 2, &msg));
+  NODE_API_CALL(env, napi_create_error(env, nullptr, msg, &err));
+  NODE_API_CALL(env, napi_throw(env, err));
+  napi_value r;
+  napi_status call_st =
+      napi_call_function(env, global, isNaN, 0, nullptr, &r);
+  printf("napi_call_function: pending_exception=%s\n",
+         call_st == napi_pending_exception ? "true" : "false");
+
+  napi_value out;
+  bool bool_out;
+  void *ptr_out;
+  size_t len_out;
+  napi_typedarray_type ta_type;
+  const char16_t utf16[] = {'x', 0};
+
+  napi_create_string_utf8(env, "x", 1, &out);
+  printf("napi_create_string_utf8: survived\n");
+  napi_create_string_latin1(env, "x", 1, &out);
+  printf("napi_create_string_latin1: survived\n");
+  napi_create_string_utf16(env, utf16, 1, &out);
+  printf("napi_create_string_utf16: survived\n");
+  napi_is_arraybuffer(env, arraybuffer, &bool_out);
+  printf("napi_is_arraybuffer: survived\n");
+  napi_get_arraybuffer_info(env, arraybuffer, &ptr_out, &len_out);
+  printf("napi_get_arraybuffer_info: survived\n");
+  napi_get_typedarray_info(env, typedarray, &ta_type, &len_out, &ptr_out,
+                           &out, &len_out);
+  printf("napi_get_typedarray_info: survived\n");
+  napi_get_dataview_info(env, dataview, &len_out, &ptr_out, &out, &len_out);
+  printf("napi_get_dataview_info: survived\n");
+  napi_get_buffer_info(env, buffer, &ptr_out, &len_out);
+  printf("napi_get_buffer_info: survived\n");
+
+  // The original exception must still be pending and catchable.
+  bool pending = false;
+  napi_is_exception_pending(env, &pending);
+  napi_value exc;
+  NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exc));
+  napi_value exc_msg;
+  char exc_buf[16];
+  size_t exc_len = 0;
+  NODE_API_CALL(env, napi_get_named_property(env, exc, "message", &exc_msg));
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, exc_msg, exc_buf,
+                                                sizeof(exc_buf), &exc_len));
+  printf("exception: pending=%s message=%s\n", pending ? "true" : "false",
+         exc_buf);
+
+  // Second route: napi_create_bigint_words past the engine cap throws a
+  // RangeError directly into the VM; the next string-creator call must also
+  // survive. Node accepts 1M words so this route is a no-op there.
+  static uint64_t words[1000001];
+  napi_value big;
+  napi_create_bigint_words(env, 0, 1000001, words, &big);
+  napi_create_string_utf8(env, "y", 1, &out);
+  printf("bigint_route: survived\n");
+  pending = false;
+  napi_is_exception_pending(env, &pending);
+  if (pending) {
+    NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exc));
+  }
+
+  return ok(env);
+}
+
 // Regression test: PROPERTY_NAME_FROM_UTF8 must copy string data.
 // Previously it used StringImpl::createWithoutCopying for ASCII strings,
 // which could leave dangling pointers in JSC's atom string table.
@@ -3562,6 +3654,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_pending_exception_gate);
+  REGISTER_FUNCTION(env, exports, test_vm_pending_exception_no_abort);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_status);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -446,6 +446,8 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         "napi_get_typedarray_info",
         "napi_get_dataview_info",
         "napi_get_buffer_info",
+        "napi_create_array",
+        "napi_create_array_with_length",
       ]) {
         expect(result).toContain(`${fn}: survived`);
       }

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -433,6 +433,25 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("side_effect arr[7]=undefined");
       expect(result).toContain("side_effect script_ran=false");
     });
+
+    it("does not abort when a VM exception is already pending", async () => {
+      const result = await checkSameOutput("test_vm_pending_exception_no_abort", []);
+      expect(result).toContain("napi_call_function: pending_exception=true");
+      for (const fn of [
+        "napi_create_string_utf8",
+        "napi_create_string_latin1",
+        "napi_create_string_utf16",
+        "napi_is_arraybuffer",
+        "napi_get_arraybuffer_info",
+        "napi_get_typedarray_info",
+        "napi_get_dataview_info",
+        "napi_get_buffer_info",
+      ]) {
+        expect(result).toContain(`${fn}: survived`);
+      }
+      expect(result).toContain("exception: pending=true message=E1");
+      expect(result).toContain("bigint_route: survived");
+    });
   });
 
   describe("napi_async_work", () => {


### PR DESCRIPTION
## Repro

```c
napi_throw(env, err);                         // E stashed on env
napi_call_function(env, g, fn, 0, NULL, &r);  // returns 10, E now in vm.m_exception
napi_create_string_utf8(env, "x", 1, &out);   // debug/assert: SIGABRT
```

```
ASSERTION FAILED: Unexpected exception observed ...
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

Release builds return `napi_ok` and keep running; the assertion is compiled out there. The same abort is reachable without an addon throw via `napi_create_bigint_words` past the engine cap (throws a `RangeError` into the VM, returns 10), then any of the eight calls below.

## Cause

The Rust `napi_create_string_{utf8,latin1,utf16}` and `napi_{is_arraybuffer,get_arraybuffer_info,get_typedarray_info,get_dataview_info,get_buffer_info}` entry points used the bare `get_env!` prologue and then called into C++ helpers (`BunString__transferToJS` / `BunString__createUTF8ForJS` / `JSC__JSValue__asArrayBuffer`) whose exception-validation scope asserts the VM has no pending exception when they return a value. With `vm.m_exception` already set, that assertion fails.

## Fix

Add `preamble_no_pending_check!` in `napi_body.rs` (the Rust mirror of `NAPI_PREAMBLE_NO_PENDING_CHECK`): it returns `napi_pending_exception` when `vm.m_exception` is set but leaves an env-stashed `napi_throw*` exception alone. Use it at all eight sites.

Only the VM slot is gated because (a) a stashed exception never reaches the asserting helpers, and (b) Node.js allows these calls with a stashed exception pending: the existing `test_deferred_exceptions` uses `napi_create_string_utf8` immediately after a `ThrowAsJavaScriptException()` and expects `napi_ok`, via `checkSameOutput`. The fuller `preamble!` (which also gates on the stash) would regress that. With a VM exception pending Node.js still returns `napi_ok` from these eight; Bun now returns `napi_pending_exception`, which joins the existing status divergence shared with `napi_create_object` et al rather than aborting.

## Test

`test_vm_pending_exception_no_abort` in `test/napi/napi-app/standalone_tests.cpp` arms a VM exception via `napi_throw` + `napi_call_function`, calls all eight entry points, and asserts the original `Error: E1` is still pending and catchable afterwards. It then re-arms via the `napi_create_bigint_words` overflow route and calls `napi_create_string_utf8` again. Output matches Node byte-for-byte via `checkSameOutput`.

Fail-before (`src/` stashed, `bun bd test test/napi/napi.test.ts -t 'does not abort when a VM exception'`): aborts with `releaseAssertNoException`, exit 134.
After: passes; `test_deferred_exceptions` and `test_pending_exception_gate` unchanged.

Related: #36091 takes the alternative node-parity approach (suspend the exception and return `napi_ok`) for the three string creators only.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->