### PR TITLE
node:crypto: reject RSA modulusLength that BoringSSL would round down

### DIFF
--- a/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
@@ -110,6 +110,15 @@ std::optional<RsaKeyPairJobCtx> RsaKeyPairJobCtx::fromJS(JSC::JSGlobalObject* gl
     V::validateUint32(scope, globalObject, modulusLengthValue, "options.modulusLength"_s, jsUndefined(), &modulusLength);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
 
+    // BoringSSL's RSA_generate_key_ex rounds the requested size down to a multiple of
+    // 128 bits (vendor/boringssl/crypto/fipsmodule/rsa/rsa_impl.cc.inc). Passing the
+    // value through unchecked would silently return a key up to 127 bits weaker than
+    // requested, so reject sizes that cannot be generated exactly.
+    if (modulusLength % 128 != 0) {
+        ERR::OUT_OF_RANGE(scope, globalObject, "options.modulusLength"_s, "a multiple of 128"_s, modulusLengthValue);
+        return std::nullopt;
+    }
+
     JSValue publicExponentValue = optionsValue.get(globalObject, Identifier::fromString(vm, "publicExponent"_s));
     RETURN_IF_EXCEPTION(scope, std::nullopt);
     uint32_t publicExponent = 0x10001;

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1449,7 +1449,7 @@ describe("crypto.KeyObjects", () => {
       passphrase: "top secret",
     });
   });
-  // SKIPED because we round the key size to the nearest multiple of 8 like documented
+  // BoringSSL only generates RSA moduli that are multiples of 128 bits, so 513 is rejected.
   test.skip(`this tests check that generateKeyPair returns correct bit length in KeyObject's asymmetricKeyDetails.`, async () => {
     // This tests check that generateKeyPair returns correct bit length in
     // https://github.com/nodejs/node/issues/46102#issuecomment-1372153541
@@ -1470,6 +1470,41 @@ describe("crypto.KeyObjects", () => {
     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: KeyObject; privateKey: KeyObject }>);
     expect(publicKey.asymmetricKeyDetails?.modulusLength).toBe(513);
     expect(privateKey.asymmetricKeyDetails?.modulusLength).toBe(513);
+  });
+
+  // BoringSSL's RSA_generate_key_ex rounds the requested modulus down to a multiple of
+  // 128 bits. Previously Bun passed the request through unchanged, so asking for 1023
+  // or 3000 bits silently returned an 896- or 2944-bit key. https://github.com/oven-sh/bun/issues/5740
+  describe("generateKeyPair('rsa') never silently returns a smaller modulus than requested", () => {
+    const outcome = (modulusLength: number) => {
+      try {
+        const { publicKey } = generateKeyPairSync("rsa", { modulusLength });
+        return publicKey.asymmetricKeyDetails?.modulusLength;
+      } catch (e) {
+        return { code: (e as NodeJS.ErrnoException).code };
+      }
+    };
+
+    test("generateKeyPairSync", () => {
+      expect({
+        1023: outcome(1023),
+        1024: outcome(1024),
+        3000: outcome(3000),
+      }).toEqual({
+        1023: { code: "ERR_OUT_OF_RANGE" },
+        1024: 1024,
+        3000: { code: "ERR_OUT_OF_RANGE" },
+      });
+    });
+
+    test("generateKeyPair validates before scheduling", () => {
+      expect(() => generateKeyPair("rsa", { modulusLength: 1023 }, () => {})).toThrow(
+        expect.objectContaining({
+          code: "ERR_OUT_OF_RANGE",
+          message: expect.stringContaining("multiple of 128"),
+        }),
+      );
+    });
   });
 
   type TestRunInContextArg =


### PR DESCRIPTION
Fixes #5740.

## Repro

```js
import crypto from 'node:crypto';
for (const req of [1023, 3000, 4095, 2048]) {
  const { publicKey } = crypto.generateKeyPairSync('rsa', { modulusLength: req });
  console.log(`requested=${req} got=${publicKey.asymmetricKeyDetails.modulusLength}`);
}
```

On `main` this silently returns a weaker key than requested:

```
requested=1023 got=896
requested=3000 got=2944
requested=4095 got=3968
requested=2048 got=2048
```

Node v26 (OpenSSL) honors 1023, 3000, and 4095 exactly.

## Cause

`RsaKeyPairJobCtx::fromJS` passes `modulusLength` straight to `EVP_PKEY_CTX_set_rsa_keygen_bits`, and BoringSSL's `RSA_generate_key_ex` masks it with `bits &= ~127` (`vendor/boringssl/crypto/fipsmodule/rsa/rsa_impl.cc.inc:736`). Nothing on the way in checked for that rounding and nothing on the way out compared the generated modulus against the request.

This is the `node:crypto` sibling of #33477; that PR fixes only the WebCrypto path (`CryptoKeyRSA::generatePair`), which does not reach `generateKeyPair`.

## Fix

Reject a `modulusLength` that is not a multiple of 128 with `ERR_OUT_OF_RANGE` in `RsaKeyPairJobCtx::fromJS`, before the key is generated. The check sits ahead of the `rsa`/`rsa-pss` branch so it covers both variants. Sizes BoringSSL generates exactly (512, 1024, 2048, 3072, 4096, ...) are unchanged.

After:

```
RangeError: The value of "options.modulusLength" is out of range. It must be a multiple of 128. Received 1023
 code: "ERR_OUT_OF_RANGE"
```

Node's own `test-crypto-keygen-bit-length.js` already skips on `process.features.openssl_is_boringssl` for this exact limitation, so no upstream test is affected.

## Verification

New tests in `test/js/node/crypto/crypto.key-objects.test.ts` cover both `generateKeyPairSync` and the async `generateKeyPair`.

<details>
<summary>test output</summary>

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/crypto/crypto.key-objects.test.ts -t "never silently"
  {
-   "1023": { "code": "ERR_OUT_OF_RANGE" },
+   "1023": 896,
    "1024": 1024,
-   "3000": { "code": "ERR_OUT_OF_RANGE" },
+   "3000": 2944,
  }
 0 pass  2 fail

$ bun bd test test/js/node/crypto/crypto.key-objects.test.ts
 87 pass  0 fail
```

`test-crypto-keygen-async-rsa.js`, `test-crypto-keygen-sync.js`, and `test-crypto-keygen-bit-length.js` still pass.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/crypto/crypto.key-objects.test.ts

<!-- robobun:evidence:end -->