### PR TITLE
worker: stop every Bun.serve server on shutdown so the listen fd is released

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1820,14 +1820,9 @@ pub struct RuntimeHooks {
     /// never lazily created. Called from `WebWorker::shutdown` / `global_exit`
     /// right after `close_all_socket_groups`.
     pub close_dns_for_terminate: fn(),
-    /// `server.stop(true)` every `Bun.serve` server registered on this VM's
-    /// thread. `close_all_socket_groups` deliberately skips listen sockets
-    /// (the owning `NewServer` holds a raw `*mut us_listen_socket_t` that
-    /// would dangle), so a listener whose owner's `stop()` never runs survives
-    /// the worker and its port stays bound. The per-VM server registry lives
-    /// in `bun_runtime::RuntimeState` (b2-cycle). Called from
-    /// `WebWorker::shutdown` immediately before `close_all_socket_groups`,
-    /// while JSC is still live so `stop(true)`'s on_close callbacks can run.
+    /// `server.stop(true)` every `Bun.serve` server this VM started. The
+    /// registry lives in `bun_runtime::RuntimeState` (b2-cycle). Called from
+    /// `WebWorker::shutdown` before `close_all_socket_groups`.
     pub stop_servers_for_terminate: fn(),
 }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1820,6 +1820,15 @@ pub struct RuntimeHooks {
     /// never lazily created. Called from `WebWorker::shutdown` / `global_exit`
     /// right after `close_all_socket_groups`.
     pub close_dns_for_terminate: fn(),
+    /// `server.stop(true)` every `Bun.serve` server registered on this VM's
+    /// thread. `close_all_socket_groups` deliberately skips listen sockets
+    /// (the owning `NewServer` holds a raw `*mut us_listen_socket_t` that
+    /// would dangle), so a listener whose owner's `stop()` never runs survives
+    /// the worker and its port stays bound. The per-VM server registry lives
+    /// in `bun_runtime::RuntimeState` (b2-cycle). Called from
+    /// `WebWorker::shutdown` immediately before `close_all_socket_groups`,
+    /// while JSC is still live so `stop(true)`'s on_close callbacks can run.
+    pub stop_servers_for_terminate: fn(),
 }
 
 /// Canonical `EventLoopCtx` vtable for a `*mut VirtualMachine` owner — the JS

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1259,12 +1259,9 @@ impl WebWorker {
                 // this thread is the sole owner; `runtime_state` for this
                 // worker thread is still installed (torn down in `destroy()`).
                 unsafe { (hooks.cancel_all_timers)(vm_ptr) };
-                // `close_all_socket_groups` below skips listen sockets (their
-                // owner holds a raw `*mut us_listen_socket_t`), so stop every
-                // `Bun.serve` server now while JSC is live and `stop(true)`'s
-                // on_close JS can run. Without this the listener outlives the
-                // worker's epoll fd (step 5 frees the loop) and its port stays
-                // bound for the process lifetime.
+                // `close_all_socket_groups` below skips listen sockets; stop
+                // every `Bun.serve` server via its own `stop(true)` while JSC
+                // is live, or the listener fd outlives the worker.
                 (hooks.stop_servers_for_terminate)();
             }
             // Same reason: the GC timers are heap nodes too.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1259,6 +1259,13 @@ impl WebWorker {
                 // this thread is the sole owner; `runtime_state` for this
                 // worker thread is still installed (torn down in `destroy()`).
                 unsafe { (hooks.cancel_all_timers)(vm_ptr) };
+                // `close_all_socket_groups` below skips listen sockets (their
+                // owner holds a raw `*mut us_listen_socket_t`), so stop every
+                // `Bun.serve` server now while JSC is live and `stop(true)`'s
+                // on_close JS can run. Without this the listener outlives the
+                // worker's epoll fd (step 5 frees the loop) and its port stays
+                // bound for the process lifetime.
+                (hooks.stop_servers_for_terminate)();
             }
             // Same reason: the GC timers are heap nodes too.
             vm.gc_controller.deinit();

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1636,9 +1636,7 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
 
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
                 bun_core::handle_oom(handles.put(
-                    crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
-                        server.cast_const(),
-                    )),
+                    crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(server.cast_const())),
                     (),
                 ));
             }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1634,15 +1634,13 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
             drop(_handler_pins);
             server_ref.gc_hint_after_listen();
 
-            if global_object.bun_vm().test_isolation_enabled {
-                if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                    bun_core::handle_oom(handles.put(
-                        crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
-                            server.cast_const(),
-                        )),
-                        (),
-                    ));
-                }
+            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+                bun_core::handle_oom(handles.put(
+                    crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
+                        server.cast_const(),
+                    )),
+                    (),
+                ));
             }
 
             // `init` moved `config` into the server (`mem::take`), so the

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1644,17 +1644,23 @@ fn stop_servers_for_terminate() {
     if state.is_null() {
         return;
     }
-    // `stop(true)` → `stop_listening` removes the entry, so snapshot first.
-    // SAFETY: live boxed per-thread `RuntimeState`; single JS thread.
-    let servers: Vec<crate::server::AnyServer> = unsafe { &(*state).isolation_handles }
-        .iter()
-        .filter_map(|(h, ())| match h {
-            IsolationHandle::Server(s) => Some(*s),
-            _ => None,
-        })
-        .collect();
-    for mut s in servers {
-        s.stop(true);
+    // `stop(true)`'s on_close JS can register a new server; re-scan until
+    // none remain. `stop_listening` removes the entry, so snapshot per pass.
+    for _ in 0..128 {
+        // SAFETY: live boxed per-thread `RuntimeState`; single JS thread.
+        let servers: Vec<crate::server::AnyServer> = unsafe { &(*state).isolation_handles }
+            .iter()
+            .filter_map(|(h, ())| match h {
+                IsolationHandle::Server(s) => Some(*s),
+                _ => None,
+            })
+            .collect();
+        if servers.is_empty() {
+            return;
+        }
+        for mut s in servers {
+            s.stop(true);
+        }
     }
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1637,21 +1637,16 @@ fn close_dns_for_terminate() {
     }
 }
 
-/// `RuntimeHooks::stop_servers_for_terminate` — `stop(true)` every
-/// `Bun.serve` server this VM started so its listen socket closes before
-/// `close_all_socket_groups` (which skips listeners) and the worker loop are
-/// torn down. Walks [`IsolationHandle::Server`] entries only; watchers stay
-/// for their own finalizers.
+/// [`RuntimeHooks::stop_servers_for_terminate`] — `stop(true)` every
+/// registered `Bun.serve` server. Walks [`IsolationHandle::Server`] only.
 fn stop_servers_for_terminate() {
     let state = runtime_state();
     if state.is_null() {
         return;
     }
+    // `stop(true)` → `stop_listening` removes the entry, so snapshot first.
     // SAFETY: live boxed per-thread `RuntimeState`; single JS thread.
-    let handles = unsafe { &mut (*state).isolation_handles };
-    // `stop(true)` → `stop_listening` removes the entry from `handles`, so
-    // snapshot first and iterate the snapshot.
-    let servers: Vec<crate::server::AnyServer> = handles
+    let servers: Vec<crate::server::AnyServer> = unsafe { &(*state).isolation_handles }
         .iter()
         .filter_map(|(h, ())| match h {
             IsolationHandle::Server(s) => Some(*s),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1487,6 +1487,7 @@ pub(crate) static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     retroactively_report_discovered_tests,
     cancel_all_timers,
     close_dns_for_terminate,
+    stop_servers_for_terminate,
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -1633,6 +1634,32 @@ fn close_dns_for_terminate() {
     // of the `OnceCell` only (the resolver's own state is interior-mutable).
     if let Some(gd) = unsafe { &(*state).global_dns_data }.get() {
         gd.resolver.close_channel_for_terminate();
+    }
+}
+
+/// `RuntimeHooks::stop_servers_for_terminate` — `stop(true)` every
+/// `Bun.serve` server this VM started so its listen socket closes before
+/// `close_all_socket_groups` (which skips listeners) and the worker loop are
+/// torn down. Walks [`IsolationHandle::Server`] entries only; watchers stay
+/// for their own finalizers.
+fn stop_servers_for_terminate() {
+    let state = runtime_state();
+    if state.is_null() {
+        return;
+    }
+    // SAFETY: live boxed per-thread `RuntimeState`; single JS thread.
+    let handles = unsafe { &mut (*state).isolation_handles };
+    // `stop(true)` → `stop_listening` removes the entry from `handles`, so
+    // snapshot first and iterate the snapshot.
+    let servers: Vec<crate::server::AnyServer> = handles
+        .iter()
+        .filter_map(|(h, ())| match h {
+            IsolationHandle::Server(s) => Some(*s),
+            _ => None,
+        })
+        .collect();
+    for mut s in servers {
+        s.stop(true);
     }
 }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1559,12 +1559,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub fn stop_listening(&mut self, abrupt: bool) {
         // httplog!("stopListening", .{});
 
-        if self.vm().test_isolation_enabled {
-            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles.swap_remove(&crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
-                    core::ptr::from_ref(self),
-                )));
-            }
+        if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+            handles.swap_remove(&crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
+                core::ptr::from_ref(self),
+            )));
         }
 
         if Self::HAS_H3 {
@@ -1954,12 +1952,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // This should've already been handled in stop_listening; however, when
         // the JS VM terminates, it hypothetically might not call stop_listening.
         this_ref.notify_inspector_server_stopped();
-        if this_ref.vm().test_isolation_enabled {
-            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles.swap_remove(&crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
-                    this.cast_const(),
-                )));
-            }
+        if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+            handles.swap_remove(&crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
+                this.cast_const(),
+            )));
         }
 
         // owned-field cleanup (all_closed_promise / user_routes / config /

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux } from "harness";
 import { join } from "path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
@@ -173,6 +173,95 @@ test.skipIf(!isASAN)(
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+  },
+  timeout,
+);
+
+// Regression: a Bun.serve() listen socket in a worker was never closed when
+// the worker exited. WebWorker::shutdown()'s close_all_socket_groups() skips
+// listen sockets (the owner holds a raw *mut us_listen_socket_t), and nothing
+// else called stop() on the server, so the fd survived on a destroyed epoll
+// instance: the port stayed bound process-wide and new clients were accepted
+// by the kernel into a backlog no thread serviced. Covers all three shutdown
+// entry points (terminate(), worker process.exit(), unref'd natural exit).
+test(
+  "a worker's Bun.serve() listen socket is closed when the worker exits",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { connect } = require("net");
+        const mk = body => "data:text/javascript," + encodeURIComponent(body);
+        const serve = "const s = Bun.serve({ port: 0, fetch: () => new Response('W') });";
+
+        // After the worker's "close" event the port must be free: a raw TCP
+        // connect is the observable signal (ECONNREFUSED vs. ACCEPTED into a
+        // kernel backlog nothing accept()s).
+        const probe = port =>
+          new Promise(res => {
+            const s = connect(port, "127.0.0.1");
+            s.once("connect", () => { s.destroy(); res("ACCEPTED"); });
+            s.once("error", e => res(e.code));
+          });
+
+        async function cycle(body, terminate) {
+          const w = new Worker(mk(body));
+          const port = await new Promise(r =>
+            w.addEventListener("message", e => r(e.data), { once: true }),
+          );
+          const closed = new Promise(r => w.addEventListener("close", r, { once: true }));
+          if (terminate) w.terminate();
+          await closed;
+          return probe(port);
+        }
+
+        // One warm-up cycle so lazily-created per-process fds (event-loop
+        // timers, DNS, net module) don't count against the leak delta below.
+        await cycle(serve + "postMessage(s.port);", true);
+
+        const fdCount = ${isLinux}
+          ? () => require("fs").readdirSync("/proc/self/fd").length
+          : () => 0;
+        const before = fdCount();
+
+        const out = {};
+        out.terminate = await cycle(serve + "postMessage(s.port);", true);
+        out.processExit = await cycle(
+          serve + "postMessage(s.port); setTimeout(() => process.exit(0), 20);",
+          false,
+        );
+        out.unrefNatural = await cycle(serve + "s.unref(); postMessage(s.port);", false);
+        // Two more terminate cycles so the fd delta is meaningful.
+        for (let i = 0; i < 2; i++) await cycle(serve + "postMessage(s.port);", true);
+
+        out.fdDelta = fdCount() - before;
+        console.log(JSON.stringify(out));
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    expect({
+      terminate: out.terminate,
+      processExit: out.processExit,
+      unrefNatural: out.unrefNatural,
+    }).toEqual({
+      terminate: "ECONNREFUSED",
+      processExit: "ECONNREFUSED",
+      unrefNatural: "ECONNREFUSED",
+    });
+    if (isLinux) {
+      // Unfixed: one listen fd per cycle (>= 5). Allow 1 for incidental fds.
+      expect(out.fdDelta).toBeLessThanOrEqual(1);
+    }
+    expect(exitCode).toBe(0);
   },
   timeout,
 );

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -208,11 +208,13 @@ test(
 
         async function cycle(body, terminate) {
           const w = new Worker(mk(body));
-          const port = await new Promise(r =>
-            w.addEventListener("message", e => r(e.data), { once: true }),
-          );
+          const port = await new Promise((resolve, reject) => {
+            w.addEventListener("message", e => resolve(e.data), { once: true });
+            w.addEventListener("error", e => reject(e.error ?? e.message), { once: true });
+          });
           const closed = new Promise(r => w.addEventListener("close", r, { once: true }));
           if (terminate) w.terminate();
+          else w.postMessage(0);
           await closed;
           return probe(port);
         }
@@ -229,7 +231,7 @@ test(
         const out = {};
         out.terminate = await cycle(serve + "postMessage(s.port);", true);
         out.processExit = await cycle(
-          serve + "postMessage(s.port); setTimeout(() => process.exit(0), 20);",
+          serve + "postMessage(s.port); self.onmessage = () => process.exit(0);",
           false,
         );
         out.unrefNatural = await cycle(serve + "s.unref(); postMessage(s.port);", false);
@@ -258,8 +260,9 @@ test(
       unrefNatural: "ECONNREFUSED",
     });
     if (isLinux) {
-      // Unfixed: one listen fd per cycle (>= 5). Allow 1 for incidental fds.
-      expect(out.fdDelta).toBeLessThanOrEqual(1);
+      // Unfixed: one listen fd per cycle (>= 5). Allow a couple of incidental
+      // fds (net.connect client sockets, worker message channels).
+      expect(out.fdDelta).toBeLessThanOrEqual(2);
     }
     expect(exitCode).toBe(0);
   },


### PR DESCRIPTION
## Repro

```js
const w = new Worker(
  "data:text/javascript," +
  encodeURIComponent("const s = Bun.serve({ port: 0, fetch: () => new Response('W') }); postMessage(s.port);"),
);
const port = await new Promise(r => w.addEventListener("message", e => r(e.data), { once: true }));
w.terminate();
await new Promise(r => w.addEventListener("close", r, { once: true }));
require("net").connect(port, "127.0.0.1")
  .once("connect", () => console.log("ACCEPTED"))   // before: ACCEPTED (kernel backlog, no accept())
  .once("error", e => console.log(e.code));          // after:  ECONNREFUSED
```

After `worker.terminate()` the worker's `Bun.serve` listen socket stayed open for the life of the process. `strace` shows the worker thread owns its own uSockets loop (`epoll_create1` + `socket`/`bind`/`listen(fd,512)` + `epoll_ctl(ADD, listen_fd)`); on terminate it closes only its wakeup fd, then its epoll fd itself (`uWS::Loop::clearLoopAtThreadExit`), and exits. The listen fd is never `close()`d, survives process-wide on a destroyed epoll instance, and the kernel keeps completing handshakes into its 512-entry accept queue that nothing `accept()`s. Same for worker `process.exit()` and an `unref()`'d server whose worker exits naturally.

## Cause

`WebWorker::shutdown()`'s `close_all_socket_groups()` deliberately skips listen sockets (`us_loop_close_all_groups` passes `also_listeners = 0`) because the owning Rust object holds a raw `*mut us_listen_socket_t` that would dangle. The intent is that the owner closes its listener itself, but nothing in `shutdown()` called `NewServer::stop()`, and `NewServer::finalize()` (reached from `lastChanceToFinalize()` in step 3) defers to `deinit_if_we_can()`, which early-returns while `has_listener()` is true.

A per-VM live-server registry already exists (`RuntimeState::isolation_handles` with `IsolationHandle::Server`, walked by `close_isolation_handles()` doing `s.stop(true)`), but it was populated only when `test_isolation_enabled` and never walked from worker teardown.

## Fix

Register every `Bun.serve` server into that registry unconditionally (drop the `test_isolation_enabled` gate at the registration and both removal sites), and add a `RuntimeHooks::stop_servers_for_terminate` slot that walks the registry's `Server` entries and calls `stop(true)` on each. `WebWorker::shutdown()` calls it in step 2 immediately before `close_all_socket_groups()`, while JSC is still live so `stop(true)`'s abrupt-close on_close callbacks can run. `stop(true)` closes the listener via `us_listen_socket_close` and drops any accepted connections; `finalize()` then sees `has_listener() == false` and can reach `schedule_deinit`. All three worker exit paths (`terminate()`, worker `process.exit()`, unref'd natural exit) funnel through the single `shutdown()`.

## Verification

```
# before (1.4.0)
terminate:     ACCEPTED   processExit: ACCEPTED   unrefNatural: ACCEPTED   fdDelta: +5
# after
terminate:     ECONNREFUSED   processExit: ECONNREFUSED   unrefNatural: ECONNREFUSED   fdDelta: 0
```

New test in `test/js/web/workers/worker-terminate-lifetime.test.ts` probes each exit path with a raw TCP connect (ECONNREFUSED vs ACCEPTED) and checks `/proc/self/fd` delta on Linux. Fails on `main` with ACCEPTED on all three paths, passes with this change.

Supersedes #36094, which closes the listener in `finalize()` instead; this approach runs the proper `stop(true)` path earlier (step 2, VM fully live) and reuses the existing registry.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->