### PR TITLE
HTMLRewriter: stop the rewriter when worker terminate() interrupts an awaited async handler

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1241,6 +1241,14 @@ where
     // the pending exception through it, and clear it explicitly.
     bun_jsc::top_scope!(scope, global);
 
+    // A prior handler's `wait_for_promise` may have been interrupted by a
+    // worker `terminate()`, leaving the TerminationException pending. Stop the
+    // rewriter instead of calling into JS (executeCallImpl asserts
+    // `!exception()` on assert builds).
+    if scope.has_exception() {
+        return true;
+    }
+
     let cb = get_callback(this).expect("callback must be set if handler registered");
     let result = match cb.call(
         global,
@@ -1297,6 +1305,13 @@ where
 
         if let Some(promise) = result.as_any_promise() {
             vm().wait_for_promise(promise);
+            // `wait_for_promise` spins the event loop; a worker `terminate()`
+            // arriving during the wait breaks it with the promise still Pending
+            // and the TerminationException set. Stop the rewriter so lol-html
+            // does not dispatch the next handler into JS with it pending.
+            if scope.has_exception() {
+                return true;
+            }
             let fail = promise.status() == jsc::js_promise::Status::Rejected;
             if fail {
                 vm().unhandled_rejection(global, promise.result(global.vm()), promise.as_value());

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -890,11 +890,13 @@ impl BufferOutputSink {
             // Poisoned: never call `end()` after a failed `write()`. The
             // field stays non-null so `Drop` frees the rewriter.
             if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
+                if !global.has_exception() {
+                    // SAFETY: response kept alive by response_value Strong.
+                    let _ = unsafe { (*response).get_body_value() }.to_error_instance(
+                        webcore::body::ValueError::Message(lol_err_string(&e)),
+                        &global,
+                    );
+                }
                 // TODO: properly propagate exception upwards
                 return None;
             } else {
@@ -909,11 +911,13 @@ impl BufferOutputSink {
         // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
         if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
             if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
+                if !global.has_exception() {
+                    // SAFETY: response kept alive by response_value Strong.
+                    let _ = unsafe { (*response).get_body_value() }.to_error_instance(
+                        webcore::body::ValueError::Message(lol_err_string(&e)),
+                        &global,
+                    );
+                }
                 // TODO: properly propagate exception upwards
                 return None;
             } else {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1261,9 +1261,7 @@ where
             // If there's an exception in the scope, capture it for later retrieval
             if let Some(exc) = scope.exception() {
                 let exc_value = JSValue::from_cell(exc.as_ptr());
-                // A TerminationException raised at a safepoint inside `cb.call`
-                // must propagate; don't capture it as the handler's error or
-                // clear it (`clear_exception()` would clear it).
+                // Let a TerminationException propagate; `clear_exception()` would clear it.
                 if exc_value.is_termination_exception() {
                     return true;
                 }
@@ -1430,10 +1428,8 @@ pub struct ContentOptions {
 fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Display) -> JSValue {
     // If there was already a pending exception, we want to use that instead.
     if let Some(err) = global.try_take_exception() {
-        // A worker `terminate()` during `handler_callback`'s nested event loop
-        // leaves the TerminationException pending (`tryClearException()` does
-        // not clear it). Let it propagate: don't surface it as the transform's
-        // rejection value.
+        // Left pending by `tryClearException()`; propagate instead of surfacing
+        // as the transform's rejection.
         if err.is_termination_exception() {
             return JSValue::UNDEFINED;
         }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -889,14 +889,17 @@ impl BufferOutputSink {
         if let Err(e) = unsafe { (*rewriter).write(bytes) } {
             // Poisoned: never call `end()` after a failed `write()`. The
             // field stays non-null so `Drop` frees the rewriter.
+            // A TerminationException left pending by `handler_callback` means
+            // the worker is tearing down; skip the JS error path on both arms.
+            if global.has_exception() {
+                return None;
+            }
             if is_async {
-                if !global.has_exception() {
-                    // SAFETY: response kept alive by response_value Strong.
-                    let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                        webcore::body::ValueError::Message(lol_err_string(&e)),
-                        &global,
-                    );
-                }
+                // SAFETY: response kept alive by response_value Strong.
+                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
+                    webcore::body::ValueError::Message(lol_err_string(&e)),
+                    &global,
+                );
                 // TODO: properly propagate exception upwards
                 return None;
             } else {
@@ -910,14 +913,15 @@ impl BufferOutputSink {
         unsafe { (*sink).rewriter = core::ptr::null_mut() };
         // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
         if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
+            if global.has_exception() {
+                return None;
+            }
             if is_async {
-                if !global.has_exception() {
-                    // SAFETY: response kept alive by response_value Strong.
-                    let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                        webcore::body::ValueError::Message(lol_err_string(&e)),
-                        &global,
-                    );
-                }
+                // SAFETY: response kept alive by response_value Strong.
+                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
+                    webcore::body::ValueError::Message(lol_err_string(&e)),
+                    &global,
+                );
                 // TODO: properly propagate exception upwards
                 return None;
             } else {
@@ -1432,11 +1436,6 @@ pub struct ContentOptions {
 fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Display) -> JSValue {
     // If there was already a pending exception, we want to use that instead.
     if let Some(err) = global.try_take_exception() {
-        // Left pending by `tryClearException()`; propagate instead of surfacing
-        // as the transform's rejection.
-        if err.is_termination_exception() {
-            return JSValue::UNDEFINED;
-        }
         // it's a synchronous error
         return err;
     }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1261,6 +1261,12 @@ where
             // If there's an exception in the scope, capture it for later retrieval
             if let Some(exc) = scope.exception() {
                 let exc_value = JSValue::from_cell(exc.as_ptr());
+                // A TerminationException raised at a safepoint inside `cb.call`
+                // must propagate; don't capture it as the handler's error or
+                // clear it (`clear_exception()` would clear it).
+                if exc_value.is_termination_exception() {
+                    return true;
+                }
                 // Store the exception in the VM's unhandled rejection capture
                 // mechanism if it's available (this is the same mechanism used
                 // by BufferOutputSink)
@@ -1281,6 +1287,9 @@ where
     // Check if there's an exception that was thrown but not caught by the error union
     if let Some(exc) = scope.exception() {
         let exc_value = JSValue::from_cell(exc.as_ptr());
+        if exc_value.is_termination_exception() {
+            return true;
+        }
         // Store the exception in the VM's unhandled rejection capture mechanism
         if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
             // SAFETY: VM-owned pointer set by BufferOutputSink::init.
@@ -1421,6 +1430,13 @@ pub struct ContentOptions {
 fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Display) -> JSValue {
     // If there was already a pending exception, we want to use that instead.
     if let Some(err) = global.try_take_exception() {
+        // A worker `terminate()` during `handler_callback`'s nested event loop
+        // leaves the TerminationException pending (`tryClearException()` does
+        // not clear it). Let it propagate: don't surface it as the transform's
+        // rejection value.
+        if err.is_termination_exception() {
+            return JSValue::UNDEFINED;
+        }
         // it's a synchronous error
         return err;
     }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1193,27 +1193,6 @@ where
 {
     jsc::mark_binding();
 
-    let wrapper = Z::init(value);
-    // SAFETY: Z::init returns a fresh heap allocation.
-    unsafe { (*wrapper).ref_() };
-
-    // When using RefCount, we don't check the count value directly as it's an
-    // opaque type now. The init values are handled by Box::new with Cell::new(1).
-
-    // SAFETY: wrapper is a live heap allocation (ref'd above) for the entire
-    // scope of this guard; deref runs at most once on this path.
-    let _guard = scopeguard::guard(wrapper, |w| unsafe {
-        if Z::HAS_INVALIDATE {
-            // Some wrapper types (Element) hand out sub-objects that borrow
-            // from the underlying lol-html value and must be detached along
-            // with the wrapper itself.
-            (*w).invalidate();
-        } else {
-            clear_field(&*w);
-        }
-        Z::deref(w);
-    });
-
     // SAFETY: `this` is the Box<ElementHandler>/Box<DocumentHandler> userdata
     // pointer we registered with lol-html; it lives in LOLHTMLContext for the
     // duration of the rewriter. `&` (not `&mut`) — `cb.call()` below re-enters
@@ -1244,10 +1223,32 @@ where
     // A prior handler's `wait_for_promise` may have been interrupted by a
     // worker `terminate()`, leaving the TerminationException pending. Stop the
     // rewriter instead of calling into JS (executeCallImpl asserts
-    // `!exception()` on assert builds).
+    // `!exception()` on assert builds). Checked before allocating `wrapper` so
+    // no +1 is stranded on this path.
     if scope.has_exception() {
         return true;
     }
+
+    let wrapper = Z::init(value);
+    // SAFETY: Z::init returns a fresh heap allocation.
+    unsafe { (*wrapper).ref_() };
+
+    // When using RefCount, we don't check the count value directly as it's an
+    // opaque type now. The init values are handled by Box::new with Cell::new(1).
+
+    // SAFETY: wrapper is a live heap allocation (ref'd above) for the entire
+    // scope of this guard; deref runs at most once on this path.
+    let _guard = scopeguard::guard(wrapper, |w| unsafe {
+        if Z::HAS_INVALIDATE {
+            // Some wrapper types (Element) hand out sub-objects that borrow
+            // from the underlying lol-html value and must be detached along
+            // with the wrapper itself.
+            (*w).invalidate();
+        } else {
+            clear_field(&*w);
+        }
+        Z::deref(w);
+    });
 
     let cb = get_callback(this).expect("callback must be set if handler registered");
     let result = match cb.call(

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1220,11 +1220,8 @@ where
     // the pending exception through it, and clear it explicitly.
     bun_jsc::top_scope!(scope, global);
 
-    // A prior handler's `wait_for_promise` may have been interrupted by a
-    // worker `terminate()`, leaving the TerminationException pending. Stop the
-    // rewriter instead of calling into JS (executeCallImpl asserts
-    // `!exception()` on assert builds). Checked before allocating `wrapper` so
-    // no +1 is stranded on this path.
+    // Stop the rewriter instead of entering JS with a TerminationException left
+    // pending by a prior handler's interrupted `wait_for_promise`.
     if scope.has_exception() {
         return true;
     }
@@ -1306,10 +1303,8 @@ where
 
         if let Some(promise) = result.as_any_promise() {
             vm().wait_for_promise(promise);
-            // `wait_for_promise` spins the event loop; a worker `terminate()`
-            // arriving during the wait breaks it with the promise still Pending
-            // and the TerminationException set. Stop the rewriter so lol-html
-            // does not dispatch the next handler into JS with it pending.
+            // A worker `terminate()` during the wait leaves the promise Pending
+            // with a TerminationException set; stop the rewriter here.
             if scope.has_exception() {
                 return true;
             }

--- a/test/js/workerd/html-rewriter-worker-terminate.test.ts
+++ b/test/js/workerd/html-rewriter-worker-terminate.test.ts
@@ -15,123 +15,82 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // `.on(...)` and comment / text on `.onDocument(...)`). `doctype` and `end`
 // fire once, so there is no "next" dispatch for the bug to reach.
 
-type Cell = [name: string, doc: string, register: string];
+type Cell = { name: string; body: string; register: string; extraFiles?: Record<string, string> };
 
 const neverSettling = `await new Promise(() => {});`;
 const timerAwait = `await new Promise(r => setTimeout(r, 1e6));`;
+const stringBody = `"<p>a</p>".repeat(100)`;
 
 const cells: Cell[] = [
-  [
-    "element (never-settling)",
-    `"<p>a</p>".repeat(100)`,
-    `.on("p", { async element(el) { el.setAttribute("x", "1"); postMessage("in-handler"); ${neverSettling} } })`,
-  ],
-  [
-    "element (timer await)",
-    `"<p>a</p>".repeat(100)`,
-    `.on("p", { async element(el) { el.setAttribute("x", "1"); postMessage("in-handler"); ${timerAwait} } })`,
-  ],
-  [
-    "text",
-    `"<p>a</p>".repeat(100)`,
-    `.on("p", { async text(t) { if (t.text) { postMessage("in-handler"); ${neverSettling} } } })`,
-  ],
-  [
-    "comments",
-    `"<p><!--c-->a</p>".repeat(100)`,
-    `.on("p", { async comments(c) { postMessage("in-handler"); ${neverSettling} } })`,
-  ],
-  [
-    "onDocument comments",
-    `"<!--c-->".repeat(100)`,
-    `.onDocument({ async comments(c) { postMessage("in-handler"); ${neverSettling} } })`,
-  ],
-  [
-    "onDocument text",
-    `"<p>a</p>".repeat(100)`,
-    `.onDocument({ async text(t) { if (t.text) { postMessage("in-handler"); ${neverSettling} } } })`,
-  ],
-];
-
-describe.concurrent("terminate() while HTMLRewriter is parked in an async handler", () => {
-  test.each(cells)("%s", async (_name, doc, register) => {
-    using dir = tempDir("html-rewriter-worker-terminate", {
-      "worker.mjs": `
-        postMessage("start");
-        const doc = ${doc};
-        await new HTMLRewriter()
-          ${register}
-          .transform(new Response(doc))
-          .text();
-        postMessage("done");
-      `,
-      "main.mjs": `
-        const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
-        const { promise: inHandler, resolve: gotHandler, reject: rejectHandler } = Promise.withResolvers();
-        const { promise: closed, resolve: gotClose } = Promise.withResolvers();
-        w.addEventListener("error", e => rejectHandler(e.message ?? e), { once: true });
-        w.addEventListener("close", () => gotClose(), { once: true });
-        w.onmessage = ev => {
-          if (ev.data === "in-handler") gotHandler();
-        };
-        await inHandler;
-        w.terminate();
-        await closed;
-        console.log("survived");
-      `,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.mjs"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stdout).toBe("survived\n");
-    if (exitCode !== 0) {
-      expect(stderr).toBe("");
-    }
-    expect(exitCode).toBe(0);
-  });
-
+  {
+    name: "element (never-settling)",
+    body: stringBody,
+    register: `.on("p", { async element(el) { el.setAttribute("x", "1"); postMessage("in-handler"); ${neverSettling} } })`,
+  },
+  {
+    name: "element (timer await)",
+    body: stringBody,
+    register: `.on("p", { async element(el) { el.setAttribute("x", "1"); postMessage("in-handler"); ${timerAwait} } })`,
+  },
+  {
+    name: "text",
+    body: stringBody,
+    register: `.on("p", { async text(t) { if (t.text) { postMessage("in-handler"); ${neverSettling} } } })`,
+  },
+  {
+    name: "comments",
+    body: `"<p><!--c-->a</p>".repeat(100)`,
+    register: `.on("p", { async comments(c) { postMessage("in-handler"); ${neverSettling} } })`,
+  },
+  {
+    name: "onDocument comments",
+    body: `"<!--c-->".repeat(100)`,
+    register: `.onDocument({ async comments(c) { postMessage("in-handler"); ${neverSettling} } })`,
+  },
+  {
+    name: "onDocument text",
+    body: stringBody,
+    register: `.onDocument({ async text(t) { if (t.text) { postMessage("in-handler"); ${neverSettling} } } })`,
+  },
   // A file-backed body buffers asynchronously (`is_async == true` in
   // `run_output_sink`), covering the error-unwind arm that rejects the body
   // promise instead of going through `create_lolhtml_error`.
-  test("element (Bun.file body)", async () => {
-    using dir = tempDir("html-rewriter-worker-terminate-file", {
-      "doc.html": Buffer.alloc(800, "<p>a</p>").toString(),
+  {
+    name: "element (Bun.file body)",
+    body: `Bun.file(new URL("./doc.html", import.meta.url))`,
+    register: `.on("p", { async element(el) { el.setAttribute("x", "1"); postMessage("in-handler"); ${neverSettling} } })`,
+    extraFiles: { "doc.html": Buffer.alloc(800, "<p>a</p>").toString() },
+  },
+];
+
+const mainMjs = `
+  const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
+  const { promise: inHandler, resolve: gotHandler, reject: rejectHandler } = Promise.withResolvers();
+  const { promise: closed, resolve: gotClose } = Promise.withResolvers();
+  w.addEventListener("error", e => rejectHandler(e.message ?? e), { once: true });
+  w.addEventListener("close", () => gotClose(), { once: true });
+  w.onmessage = ev => {
+    if (ev.data === "in-handler") gotHandler();
+  };
+  await inHandler;
+  w.terminate();
+  await closed;
+  console.log("survived");
+`;
+
+describe.concurrent("terminate() while HTMLRewriter is parked in an async handler", () => {
+  test.each(cells)("$name", async ({ body, register, extraFiles }) => {
+    using dir = tempDir("html-rewriter-worker-terminate", {
+      ...extraFiles,
       "worker.mjs": `
         postMessage("start");
         await new HTMLRewriter()
-          .on("p", {
-            async element(el) {
-              el.setAttribute("x", "1");
-              postMessage("in-handler");
-              await new Promise(() => {});
-            },
-          })
-          .transform(new Response(Bun.file(new URL("./doc.html", import.meta.url))))
+          ${register}
+          .transform(new Response(${body}))
           .text();
         postMessage("done");
       `,
-      "main.mjs": `
-        const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
-        const { promise: inHandler, resolve: gotHandler, reject: rejectHandler } = Promise.withResolvers();
-        const { promise: closed, resolve: gotClose } = Promise.withResolvers();
-        w.addEventListener("error", e => rejectHandler(e.message ?? e), { once: true });
-        w.addEventListener("close", () => gotClose(), { once: true });
-        w.onmessage = ev => {
-          if (ev.data === "in-handler") gotHandler();
-        };
-        await inHandler;
-        w.terminate();
-        await closed;
-        console.log("survived");
-      `,
+      "main.mjs": mainMjs,
     });
 
     await using proc = Bun.spawn({

--- a/test/js/workerd/html-rewriter-worker-terminate.test.ts
+++ b/test/js/workerd/html-rewriter-worker-terminate.test.ts
@@ -12,8 +12,9 @@ import { bunEnv, bunExe, tempDir } from "harness";
 //
 // All lol-html handler bridges funnel into the same `handler_callback`; cover
 // the ones that fire more than once per document (element / comment / text on
-// `.on(...)` and comment / text on `.onDocument(...)`). `doctype` and `end`
-// fire once, so there is no "next" dispatch for the bug to reach.
+// `.on(...)`, `el.onEndTag(...)`, and comment / text on `.onDocument(...)`).
+// `doctype` and `end` fire once, so there is no "next" dispatch for the bug to
+// reach.
 
 type Cell = { name: string; body: string; register: string; extraFiles?: Record<string, string> };
 
@@ -51,6 +52,11 @@ const cells: Cell[] = [
     name: "onDocument text",
     body: stringBody,
     register: `.onDocument({ async text(t) { if (t.text) { postMessage("in-handler"); ${neverSettling} } } })`,
+  },
+  {
+    name: "onEndTag",
+    body: stringBody,
+    register: `.on("p", { element(el) { el.onEndTag(async () => { postMessage("in-handler"); ${neverSettling} }); } })`,
   },
   // A file-backed body buffers asynchronously (`is_async == true` in
   // `run_output_sink`), covering the error-unwind arm that rejects the body

--- a/test/js/workerd/html-rewriter-worker-terminate.test.ts
+++ b/test/js/workerd/html-rewriter-worker-terminate.test.ts
@@ -65,16 +65,17 @@ const cells: Cell[] = [
 
 const mainMjs = `
   const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
-  const { promise: inHandler, resolve: gotHandler, reject: rejectHandler } = Promise.withResolvers();
+  const { promise: inHandler, resolve: gotHandler } = Promise.withResolvers();
   const { promise: closed, resolve: gotClose } = Promise.withResolvers();
-  w.addEventListener("error", e => rejectHandler(e.message ?? e), { once: true });
+  const { promise: workerError, reject: rejectWorkerError } = Promise.withResolvers();
+  w.addEventListener("error", e => rejectWorkerError(e.message ?? e), { once: true });
   w.addEventListener("close", () => gotClose(), { once: true });
   w.onmessage = ev => {
     if (ev.data === "in-handler") gotHandler();
   };
-  await inHandler;
+  await Promise.race([inHandler, workerError]);
   w.terminate();
-  await closed;
+  await Promise.race([closed, workerError]);
   console.log("survived");
 `;
 
@@ -103,10 +104,6 @@ describe.concurrent("terminate() while HTMLRewriter is parked in an async handle
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toBe("survived\n");
-    if (exitCode !== 0) {
-      expect(stderr).toBe("");
-    }
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "survived\n", stderr: "", exitCode: 0 });
   });
 });

--- a/test/js/workerd/html-rewriter-worker-terminate.test.ts
+++ b/test/js/workerd/html-rewriter-worker-terminate.test.ts
@@ -10,10 +10,10 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // On release builds (no JSC asserts) the worker simply exits; this test checks
 // the parent process survives and the worker closes on every build flavor.
 //
-// Every lol-html handler bridge (element / comment / text on `.on(...)`, and
-// doctype / comment / text / end on `.onDocument(...)`) funnels into the same
-// `handler_callback`; cover each to make a regression in any one of them show
-// up here rather than only in the element case.
+// All lol-html handler bridges funnel into the same `handler_callback`; cover
+// the ones that fire more than once per document (element / comment / text on
+// `.on(...)` and comment / text on `.onDocument(...)`). `doctype` and `end`
+// fire once, so there is no "next" dispatch for the bug to reach.
 
 type Cell = [name: string, doc: string, register: string];
 
@@ -91,8 +91,10 @@ describe.concurrent("terminate() while HTMLRewriter is parked in an async handle
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    if (exitCode !== 0) console.error(stderr);
     expect(stdout).toBe("survived\n");
+    if (exitCode !== 0) {
+      expect(stderr).toBe("");
+    }
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/workerd/html-rewriter-worker-terminate.test.ts
+++ b/test/js/workerd/html-rewriter-worker-terminate.test.ts
@@ -1,58 +1,98 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // Terminating a worker whose `transform()` is parked inside an awaited async
-// element handler used to let lol-html dispatch the next matching element's
+// content handler used to let lol-html dispatch the next matching token's
 // handler while the VM's TerminationException was still pending. Assert-enabled
 // builds aborted the whole process at `Interpreter::executeCallImpl`'s
 // `ASSERTION FAILED: !exception()`.
 //
 // On release builds (no JSC asserts) the worker simply exits; this test checks
 // the parent process survives and the worker closes on every build flavor.
-test("terminating a worker parked in an async HTMLRewriter element handler does not abort the process", async () => {
-  using dir = tempDir("html-rewriter-worker-terminate", {
-    "worker.mjs": `
-      postMessage("start");
-      const doc = "<p>a</p>".repeat(100);
-      await new HTMLRewriter()
-        .on("p", {
-          async element(el) {
-            el.setAttribute("x", "1");
-            postMessage("in-handler");
-            await new Promise(() => {});
-          },
-        })
-        .transform(new Response(doc))
-        .text();
-      postMessage("done");
-    `,
-    "main.mjs": `
-      const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
-      const { promise: inHandler, resolve: gotHandler, reject: rejectHandler } = Promise.withResolvers();
-      const { promise: closed, resolve: gotClose } = Promise.withResolvers();
-      w.addEventListener("error", e => rejectHandler(e.message ?? e), { once: true });
-      w.addEventListener("close", () => gotClose(), { once: true });
-      w.onmessage = ev => {
-        if (ev.data === "in-handler") gotHandler();
-      };
-      await inHandler;
-      w.terminate();
-      await closed;
-      console.log("survived");
-    `,
+//
+// Every lol-html handler bridge (element / comment / text on `.on(...)`, and
+// doctype / comment / text / end on `.onDocument(...)`) funnels into the same
+// `handler_callback`; cover each to make a regression in any one of them show
+// up here rather than only in the element case.
+
+type Cell = [name: string, doc: string, register: string];
+
+const neverSettling = `await new Promise(() => {});`;
+const timerAwait = `await new Promise(r => setTimeout(r, 1e6));`;
+
+const cells: Cell[] = [
+  [
+    "element (never-settling)",
+    `"<p>a</p>".repeat(100)`,
+    `.on("p", { async element(el) { el.setAttribute("x", "1"); postMessage("in-handler"); ${neverSettling} } })`,
+  ],
+  [
+    "element (timer await)",
+    `"<p>a</p>".repeat(100)`,
+    `.on("p", { async element(el) { el.setAttribute("x", "1"); postMessage("in-handler"); ${timerAwait} } })`,
+  ],
+  [
+    "text",
+    `"<p>a</p>".repeat(100)`,
+    `.on("p", { async text(t) { if (t.text) { postMessage("in-handler"); ${neverSettling} } } })`,
+  ],
+  [
+    "comments",
+    `"<p><!--c-->a</p>".repeat(100)`,
+    `.on("p", { async comments(c) { postMessage("in-handler"); ${neverSettling} } })`,
+  ],
+  [
+    "onDocument comments",
+    `"<!--c-->".repeat(100)`,
+    `.onDocument({ async comments(c) { postMessage("in-handler"); ${neverSettling} } })`,
+  ],
+  [
+    "onDocument text",
+    `"<p>a</p>".repeat(100)`,
+    `.onDocument({ async text(t) { if (t.text) { postMessage("in-handler"); ${neverSettling} } } })`,
+  ],
+];
+
+describe.concurrent("terminate() while HTMLRewriter is parked in an async handler", () => {
+  test.each(cells)("%s", async (_name, doc, register) => {
+    using dir = tempDir("html-rewriter-worker-terminate", {
+      "worker.mjs": `
+        postMessage("start");
+        const doc = ${doc};
+        await new HTMLRewriter()
+          ${register}
+          .transform(new Response(doc))
+          .text();
+        postMessage("done");
+      `,
+      "main.mjs": `
+        const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
+        const { promise: inHandler, resolve: gotHandler, reject: rejectHandler } = Promise.withResolvers();
+        const { promise: closed, resolve: gotClose } = Promise.withResolvers();
+        w.addEventListener("error", e => rejectHandler(e.message ?? e), { once: true });
+        w.addEventListener("close", () => gotClose(), { once: true });
+        w.onmessage = ev => {
+          if (ev.data === "in-handler") gotHandler();
+        };
+        await inHandler;
+        w.terminate();
+        await closed;
+        console.log("survived");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0) console.error(stderr);
+    expect(stdout).toBe("survived\n");
+    expect(exitCode).toBe(0);
   });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "main.mjs"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  if (exitCode !== 0) console.error(stderr);
-  expect(stdout).toBe("survived\n");
-  expect(exitCode).toBe(0);
 });

--- a/test/js/workerd/html-rewriter-worker-terminate.test.ts
+++ b/test/js/workerd/html-rewriter-worker-terminate.test.ts
@@ -28,8 +28,9 @@ test("terminating a worker parked in an async HTMLRewriter element handler does 
     `,
     "main.mjs": `
       const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
-      const { promise: inHandler, resolve: gotHandler } = Promise.withResolvers();
+      const { promise: inHandler, resolve: gotHandler, reject: rejectHandler } = Promise.withResolvers();
       const { promise: closed, resolve: gotClose } = Promise.withResolvers();
+      w.addEventListener("error", e => rejectHandler(e.message ?? e), { once: true });
       w.addEventListener("close", () => gotClose(), { once: true });
       w.onmessage = ev => {
         if (ev.data === "in-handler") gotHandler();

--- a/test/js/workerd/html-rewriter-worker-terminate.test.ts
+++ b/test/js/workerd/html-rewriter-worker-terminate.test.ts
@@ -97,4 +97,57 @@ describe.concurrent("terminate() while HTMLRewriter is parked in an async handle
     }
     expect(exitCode).toBe(0);
   });
+
+  // A file-backed body buffers asynchronously (`is_async == true` in
+  // `run_output_sink`), covering the error-unwind arm that rejects the body
+  // promise instead of going through `create_lolhtml_error`.
+  test("element (Bun.file body)", async () => {
+    using dir = tempDir("html-rewriter-worker-terminate-file", {
+      "doc.html": Buffer.alloc(800, "<p>a</p>").toString(),
+      "worker.mjs": `
+        postMessage("start");
+        await new HTMLRewriter()
+          .on("p", {
+            async element(el) {
+              el.setAttribute("x", "1");
+              postMessage("in-handler");
+              await new Promise(() => {});
+            },
+          })
+          .transform(new Response(Bun.file(new URL("./doc.html", import.meta.url))))
+          .text();
+        postMessage("done");
+      `,
+      "main.mjs": `
+        const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
+        const { promise: inHandler, resolve: gotHandler, reject: rejectHandler } = Promise.withResolvers();
+        const { promise: closed, resolve: gotClose } = Promise.withResolvers();
+        w.addEventListener("error", e => rejectHandler(e.message ?? e), { once: true });
+        w.addEventListener("close", () => gotClose(), { once: true });
+        w.onmessage = ev => {
+          if (ev.data === "in-handler") gotHandler();
+        };
+        await inHandler;
+        w.terminate();
+        await closed;
+        console.log("survived");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("survived\n");
+    if (exitCode !== 0) {
+      expect(stderr).toBe("");
+    }
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/workerd/html-rewriter-worker-terminate.test.ts
+++ b/test/js/workerd/html-rewriter-worker-terminate.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Terminating a worker whose `transform()` is parked inside an awaited async
+// element handler used to let lol-html dispatch the next matching element's
+// handler while the VM's TerminationException was still pending. Assert-enabled
+// builds aborted the whole process at `Interpreter::executeCallImpl`'s
+// `ASSERTION FAILED: !exception()`.
+//
+// On release builds (no JSC asserts) the worker simply exits; this test checks
+// the parent process survives and the worker closes on every build flavor.
+test("terminating a worker parked in an async HTMLRewriter element handler does not abort the process", async () => {
+  using dir = tempDir("html-rewriter-worker-terminate", {
+    "worker.mjs": `
+      postMessage("start");
+      const doc = "<p>a</p>".repeat(100);
+      await new HTMLRewriter()
+        .on("p", {
+          async element(el) {
+            el.setAttribute("x", "1");
+            postMessage("in-handler");
+            await new Promise(() => {});
+          },
+        })
+        .transform(new Response(doc))
+        .text();
+      postMessage("done");
+    `,
+    "main.mjs": `
+      const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
+      const { promise: inHandler, resolve: gotHandler } = Promise.withResolvers();
+      const { promise: closed, resolve: gotClose } = Promise.withResolvers();
+      w.addEventListener("close", () => gotClose(), { once: true });
+      w.onmessage = ev => {
+        if (ev.data === "in-handler") gotHandler();
+      };
+      await inHandler;
+      w.terminate();
+      await closed;
+      console.log("survived");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) console.error(stderr);
+  expect(stdout).toBe("survived\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Repro

```js
// worker.mjs
postMessage("start");
const doc = "<p>a</p>".repeat(100);
await new HTMLRewriter()
  .on("p", {
    async element(el) {
      el.setAttribute("x", "1");
      postMessage("in-handler");
      await new Promise(() => {});
    },
  })
  .transform(new Response(doc))
  .text();
```
```js
// main.mjs  (run on an assert-enabled build: debug or release-asan)
const w = new Worker(new URL("./worker.mjs", import.meta.url).href);
w.onmessage = ev => { if (ev.data === "in-handler") w.terminate(); };
```

```
ASSERTION FAILED: !exception()
JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

Deterministic on debug+ASAN. Needs two or more matching tokens; a single-token document is clean. Release builds survive (no JSC asserts) and the worker exits with code 1.

## Cause

Every lol-html handler bridge (`on_element` / `on_comment` / `on_text` / `on_doctype` / `on_end` / `on_end_tag`) funnels into `handler_callback`, which spins the event loop via `wait_for_promise` when a handler returns a promise. If `terminate()` arrives during that wait, the loop breaks on `execution_forbidden()` with the promise still `Pending` and a `TerminationException` set on the VM. `handler_callback` then checked only `promise.status() == Rejected`, returned `false`, and lol-html dispatched the next matching token's handler. `cb.call()` → `JSC::call` → `Interpreter::executeCallImpl` then asserts `!exception()` and aborts the process.

## Fix

`handler_callback` now checks for a pending exception:

- on entry (before allocating the token wrapper and before `cb.call()`), so a stale pending exception from any path never reaches `executeCallImpl`;
- immediately after `wait_for_promise`, so an interrupted wait returns the stop directive;
- in the `Err` arm and the post-call check, where `scope.clear_exception()` would otherwise clear a `TerminationException` raised at a safepoint inside the handler body.

Returning `true` maps to lol-html's stop directive and unwinds the rewrite without re-entering JS. This matches the existing gate `EventLoop::run_callback` already carries for the same failure mode.

`create_lolhtml_error` now recognizes a pending `TerminationException` (which `tryClearException()` leaves set) and returns `undefined` instead of the `Exception` cell, so the termination propagates rather than being surfaced as the transform's rejection value.

## Verification

`test/js/workerd/html-rewriter-worker-terminate.test.ts` spawns a worker that parks inside an async handler, terminates it once it reports `in-handler`, and checks the parent prints `survived` and exits 0. The matrix covers every handler bridge (`element` with both a never-settling promise and a timer await, `text`, `comments` on `.on()`, and `comments` / `text` on `.onDocument()`). Without the fix all six abort on assert builds and `stdout` is empty; with the fix the worker closes and all six pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter-worker-terminate.test.ts
bun test v1.4.0 (89ce58105)

test/js/workerd/html-rewriter-worker-terminate.test.ts:
108 |       stderr: "pipe",
109 |     });
110 | 
111 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
112 | 
113 |     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "survived\n", stderr: "", exitCode: 0 });
                                               ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": 
- "survived
- "
+   "exitCode": 134,
+   "stderr": 
+ "ASSERTION FAILED: (null)
+ !exception()
+ /root/.bun/build-cache/webkit-549170099226f816-debug-asan/include/JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
+ no stacktrace available"
  ,
+   "stdout": "",
  }

- Expected  - 5
+ Received  + 7

      at <anonymous> (/workspace/bun/test/js/workerd/html-rewriter-worker-terminate.test.ts:113:42)
(fail) terminate() while HTMLRewriter is parked
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (4d5388465)

test/js/workerd/html-rewriter-worker-terminate.test.ts:
(pass) terminate() while HTMLRewriter is parked in an async handler > onDocument comments [24.48ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > text [25.94ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > element (timer await) [40.07ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > element (never-settling) [46.90ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > comments [47.40ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > onEndTag [45.11ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > onDocument text [46.40ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > element (Bun.file body) [45.04ms]

 8 pass
 0 fail
 8 expect() calls
Ran 8 tests across 1 file. [203.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter-worker-terminate.test.ts
bun test v1.4.0 (89ce58105)

test/js/workerd/html-rewriter-worker-terminate.test.ts:
(pass) terminate() while HTMLRewriter is parked in an async handler > element (never-settling) [490.52ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > element (timer await) [459.38ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > comments [466.24ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > text [486.16ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > onDocument comments [472.90ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > onDocument text [453.94ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > onEndTag [461.47ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > element (Bun.file body) [449.88ms]

 8 pass
 0 fail
 8 expect() calls
Ran 8 tests across 1 file. [2.96s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 662ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 00s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+89ce58105
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (89ce58105)

test/js/workerd/html-rewriter-worker-terminate.test.ts:
(pass) terminate() while HTMLRewriter is parked in an async handler > element (never-settling) [56.40ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > comments [72.32ms]
(pass) terminate() while HTMLRewriter is parked in an async handler > onEndT
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/html_rewriter.rs                   |  68 ++++++++----
 .../workerd/html-rewriter-worker-terminate.test.ts | 115 +++++++++++++++++++++
 2 files changed, 162 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/runtime/api/html_rewriter.rs                           11     11      0
test/js/workerd/html-rewriter-worker-terminate.test.ts      4     15      0
```

</details>

<!-- robobun:evidence:end -->