### PR TITLE
codegen: lay out builtin module sources in dependency order

### DIFF
--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -287,6 +287,63 @@ for (const entrypoint of bundledEntryPoints) {
 
 mark("Postprocesss modules");
 
+/**
+ * Physical layout order for the module-source blob: DFS post-order over the
+ * static require() graph, so each module sits contiguous with its transitive
+ * dependencies. Loading any builtin then reads one contiguous run of pages
+ * instead of touching sources scattered across the blob. Roots are visited in
+ * a fixed order (the popular entry modules first) so the layout is
+ * deterministic; the graph over-approximates lazy requires, which only makes
+ * neighbours of things that *might* co-load — free for layout.
+ */
+function layoutOrder(modules: string[], outputs: Map<string, string>): string[] {
+  // The bundled sources already have require() rewritten to registry lookups,
+  // `internalModuleRegistry, <index>` — the index is the position in
+  // `modules`, which makes the edge list unambiguous.
+  const requireRe = /internalModuleRegistry, ?(\d+)/g;
+  const deps = new Map<string, string[]>();
+  for (const id of modules) {
+    const src = outputs.get(id.slice(0, -3).replaceAll("/", path.sep)) ?? "";
+    const edges = new Set<string>();
+    for (const m of src.matchAll(requireRe)) {
+      const dep = modules[Number(m[1])];
+      if (dep && dep !== id) edges.add(dep);
+    }
+    deps.set(id, [...edges]);
+  }
+  const hotRoots = [
+    "node/fs.ts",
+    "node/path.ts",
+    "node/os.ts",
+    "node/util.ts",
+    "node/events.ts",
+    "node/stream.ts",
+    "node/child_process.ts",
+    "node/crypto.ts",
+    "node/http.ts",
+    "node/https.ts",
+    "node/net.ts",
+    "node/url.ts",
+    "node/buffer.ts",
+    "node/tty.ts",
+    "node/worker_threads.ts",
+    "node/zlib.ts",
+    "node/assert.ts",
+    "node/timers.ts",
+  ];
+  const roots = [...hotRoots.filter(r => deps.has(r)), ...modules];
+  const emitted = new Set<string>();
+  const order: string[] = [];
+  const visit = (id: string) => {
+    if (emitted.has(id)) return;
+    emitted.add(id);
+    for (const dep of deps.get(id) ?? []) visit(dep);
+    order.push(id);
+  };
+  for (const root of roots) visit(root);
+  return order;
+}
+
 function idToEnumName(id: string) {
   return id
     .replace(/\.[mc]?[tj]s$/, "")
@@ -357,7 +414,7 @@ let blob: Buffer;
 {
   const chunks: Buffer[] = [Buffer.from(functionsSource + "\0", "latin1")];
   let offset = chunks[0].length;
-  for (const id of moduleList.slice(0, nativeStartIndex)) {
+  for (const id of layoutOrder(moduleList.slice(0, nativeStartIndex), outputs)) {
     const enumName = idToEnumName(id);
     if (debug) {
       moduleSpans.push({ enumName, offset: 0, length: 0 });


### PR DESCRIPTION
### What does this PR do?

The embedded builtin-module source blob (`bun_internal_modules_data`) is one contiguous ~2.6 MB string with per-module offsets. Modules were concatenated in registry (sorted path) order, so a `require`'s module and its transitive dependencies sat on pages scattered across the whole blob, and a cold start faulted all over it.

This concatenates them in **DFS post-order over the static require graph** instead, so each module lands contiguous with its dependencies and loading a builtin reads one contiguous run of pages. The graph is built from the `internalModuleRegistry, N` lookups already present in the bundled output; a fixed list of popular entry modules seeds the traversal so the layout is deterministic. It stays a single blob with per-module offsets — only the byte order changes, and offsets are still emitted per module *name* (`<Enum>CodeOffset`), so ids and lookups are untouched.

**Measured** (Linux x64 release, cold page cache, kernel readahead at default 128 KB, `.rodata` residency via `mincore` after the process exits):

| workload | before | after |
|---|---|---|
| `require("node:fs")` | 6.23 MB | 5.71 MB (−8%) |
| `require("node:http")` | 7.27 MB | 6.78 MB (−7%) |

With readahead disabled (true touched set) both are unchanged (~1.6 / 2.4 MB), as expected — the same bytes are read, they're just adjacent now, so readahead pulls in useful neighbors instead of cold ones. Modest, but free: zero runtime cost and no format change.

### How did you verify your code works?

- Built release and checked the generated `InternalModuleRegistryConstants.h`: the physical order is now dependencies-before-dependents (`InternalPrimordials` first, `InternalUrl`→`NodeUrl`, `InternalUtilInspect` before `NodeUtil`, the fs subtree clustered), and every module appears exactly once.
- Ran `bun -e` / `require()` of several builtins on the rebuilt binary; behavior unchanged (the blob is only reordered).
- Residency numbers above measured with a `mincore` probe from a clean cwd on a real filesystem (tmpfs paths can't be evicted and would fake the "before").