### PR TITLE
Bun.Cookie: reject SameSite=None/Partitioned/__Secure-/__Host- without Secure

### DIFF
--- a/docs/runtime/cookies.mdx
+++ b/docs/runtime/cookies.mdx
@@ -147,6 +147,8 @@ cookies.delete({
 });
 ```
 
+For a `__Host-` or `__Secure-` name, `delete()` adds `Secure` to the expiring cookie so the browser accepts it. For a `__Host-` name it also uses `path: "/"` and no `domain`, ignoring any supplied values, since that is the only shape the browser could have stored.
+
 #### `toJSON(): Record<string, string>`
 
 Converts the cookie map to a serializable format.

--- a/docs/runtime/cookies.mdx
+++ b/docs/runtime/cookies.mdx
@@ -113,6 +113,15 @@ const cookie = new Bun.Cookie("visited", "true");
 cookies.set(cookie);
 ```
 
+Browsers reject a `SameSite=None` cookie that isn't also `Secure`, and likewise a `Partitioned` cookie (CHIPS) that isn't `Secure`. Bun throws a `TypeError` for these combinations instead of emitting a header every browser would drop:
+
+```ts title="secure-required.ts" icon="/icons/typescript.svg"
+cookies.set("session", "abc123", { sameSite: "none", secure: true });
+
+cookies.set("session", "abc123", { sameSite: "none" }); // TypeError
+cookies.set("id", "abc123", { partitioned: true }); // TypeError
+```
+
 #### `delete(name: string): void`
 
 #### `delete(options: CookieStoreDeleteOptions): void`
@@ -386,9 +395,10 @@ interface CookieInit {
   path?: string;
   expires?: number | Date | string;
   secure?: boolean;
-  /** Defaults to `lax`. */
+  /** Defaults to `"lax"`. `"none"` requires `secure: true`. */
   sameSite?: CookieSameSite;
   httpOnly?: boolean;
+  /** Requires `secure: true`. */
   partitioned?: boolean;
   maxAge?: number;
 }

--- a/docs/runtime/cookies.mdx
+++ b/docs/runtime/cookies.mdx
@@ -113,13 +113,20 @@ const cookie = new Bun.Cookie("visited", "true");
 cookies.set(cookie);
 ```
 
-Browsers reject a `SameSite=None` cookie that isn't also `Secure`, and likewise a `Partitioned` cookie (CHIPS) that isn't `Secure`. Bun throws a `TypeError` for these combinations instead of emitting a header every browser would drop:
+Browsers drop a cookie whose attributes violate RFC 6265bis, so Bun throws a `TypeError` for these combinations instead of emitting a header every browser would ignore:
+
+- `sameSite: "none"` requires `secure: true`.
+- `partitioned: true` (CHIPS) requires `secure: true`.
+- A `__Secure-` name prefix requires `secure: true`.
+- A `__Host-` name prefix requires `secure: true`, no `domain`, and a `path` of `"/"`.
 
 ```ts title="secure-required.ts" icon="/icons/typescript.svg"
 cookies.set("session", "abc123", { sameSite: "none", secure: true });
+cookies.set("__Host-session", "abc123", { secure: true });
 
 cookies.set("session", "abc123", { sameSite: "none" }); // TypeError
 cookies.set("id", "abc123", { partitioned: true }); // TypeError
+cookies.set("__Host-session", "abc123"); // TypeError
 ```
 
 #### `delete(name: string): void`
@@ -388,6 +395,10 @@ const cookie = Bun.Cookie.from("session", "abc123", {
 
 ```ts title="types.ts" icon="/icons/typescript.svg"
 interface CookieInit {
+  /**
+   * A name starting with `__Secure-` requires `secure`, and a name starting with `__Host-`
+   * requires `secure`, no `domain`, and a `path` of `"/"`.
+   */
   name?: string;
   value?: string;
   domain?: string;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9592,6 +9592,11 @@ declare module "bun" {
     | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">];
 
   interface CookieInit {
+    /**
+     * A name starting with `__Secure-` requires `secure`, and a name starting with `__Host-`
+     * requires `secure`, no `domain`, and a `path` of `"/"`. Browsers ignore cookies that use
+     * one of these prefixes without meeting its requirements.
+     */
     name?: string;
     value?: string;
     domain?: string;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9672,12 +9672,14 @@ declare module "bun" {
     value: string;
 
     /**
-     * The cookie's `Domain` attribute, or `undefined` if not set
+     * The cookie's `Domain` attribute, or `undefined` if not set. Assigning a
+     * non-empty value throws a `TypeError` if `name` starts with `__Host-`.
      */
     domain?: string;
 
     /**
-     * The cookie's `Path` attribute. Defaults to `/`.
+     * The cookie's `Path` attribute. Defaults to `"/"`. Assigning any value
+     * other than `"/"` throws a `TypeError` if `name` starts with `__Host-`.
      */
     path: string;
 
@@ -9688,7 +9690,8 @@ declare module "bun" {
 
     /**
      * Whether the cookie has the `Secure` attribute. Setting this to `false`
-     * throws a `TypeError` if `sameSite` is `"none"` or `partitioned` is `true`.
+     * throws a `TypeError` if `sameSite` is `"none"`, `partitioned` is `true`,
+     * or `name` starts with `__Secure-` or `__Host-`.
      */
     secure: boolean;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9599,9 +9599,16 @@ declare module "bun" {
     path?: string;
     expires?: number | Date | string;
     secure?: boolean;
-    /** Defaults to `lax`. */
+    /**
+     * Defaults to `"lax"`. `"none"` requires `secure: true`; browsers reject a
+     * `SameSite=None` cookie that is not `Secure`.
+     */
     sameSite?: CookieSameSite;
     httpOnly?: boolean;
+    /**
+     * Requires `secure: true`; browsers reject a `Partitioned` cookie that is
+     * not `Secure`.
+     */
     partitioned?: boolean;
     maxAge?: number;
   }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9682,17 +9682,22 @@ declare module "bun" {
     expires?: Date;
 
     /**
-     * Whether the cookie has the `Secure` attribute
+     * Whether the cookie has the `Secure` attribute. Setting this to `false`
+     * throws a `TypeError` if `sameSite` is `"none"` or `partitioned` is `true`.
      */
     secure: boolean;
 
     /**
-     * The cookie's `SameSite` attribute. Defaults to `lax`.
+     * The cookie's `SameSite` attribute. Defaults to `"lax"`. Setting this to
+     * `"none"` requires `secure` to be `true`; browsers reject a `SameSite=None`
+     * cookie that is not `Secure`.
      */
     sameSite: CookieSameSite;
 
     /**
-     * Whether the cookie has the `Partitioned` attribute
+     * Whether the cookie has the `Partitioned` attribute. Setting this to `true`
+     * requires `secure` to be `true`; browsers reject a `Partitioned` cookie
+     * that is not `Secure`.
      */
     partitioned: boolean;
 

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -51,9 +51,7 @@ ExceptionOr<Ref<Cookie>> Cookie::create(const String& name, const String& value,
     return adoptRef(*new Cookie(name, value, domain, path, expires, secure, sameSite, httpOnly, maxAge, partitioned));
 }
 
-// RFC 6265bis 5.6.20: a cookie with SameSite=None that is not Secure is rejected by the user agent.
-// CHIPS (draft-cutler-httpbis-partitioned-cookies 2.3) likewise requires Partitioned cookies to be
-// Secure. Emitting either attribute without Secure produces a header every modern browser drops.
+// RFC 6265bis 5.6.20 (SameSite=None) and CHIPS (Partitioned) both require Secure; browsers drop the cookie otherwise.
 ExceptionOr<void> Cookie::validateSecureRequired(bool secure, CookieSameSite sameSite, bool partitioned)
 {
     if (secure) {

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -51,17 +51,44 @@ ExceptionOr<Ref<Cookie>> Cookie::create(const String& name, const String& value,
     return adoptRef(*new Cookie(name, value, domain, path, expires, secure, sameSite, httpOnly, maxAge, partitioned));
 }
 
-// RFC 6265bis 5.6.20 (SameSite=None) and CHIPS (Partitioned) both require Secure; browsers drop the cookie otherwise.
-ExceptionOr<void> Cookie::validateSecureRequired(bool secure, CookieSameSite sameSite, bool partitioned)
+bool Cookie::hasHostPrefix(const String& name)
 {
-    if (secure) {
-        return {};
+    return name.startsWithIgnoringASCIICase("__Host-"_s);
+}
+
+bool Cookie::hasSecurePrefix(const String& name)
+{
+    return name.startsWithIgnoringASCIICase("__Secure-"_s);
+}
+
+// RFC 6265bis attribute combinations that every browser rejects. Checked on the "set a cookie"
+// path (CookieInit construction, CookieMap::set, and the prototype setters); parse() reports
+// what was on the wire and does not run this.
+ExceptionOr<void> Cookie::validateAttributes(const String& name, const String& domain, const String& path, bool secure, CookieSameSite sameSite, bool partitioned)
+{
+    if (!secure) {
+        // RFC 6265bis 5.6.20 step 17 and CHIPS: browsers drop the cookie without Secure.
+        if (sameSite == CookieSameSite::None) {
+            return Exception { TypeError, "Invalid cookie: \"sameSite: none\" requires secure: true"_s };
+        }
+        if (partitioned) {
+            return Exception { TypeError, "Invalid cookie: \"partitioned: true\" requires secure: true"_s };
+        }
+        // RFC 6265bis 4.1.3: the name prefixes are matched case-insensitively.
+        if (hasHostPrefix(name)) {
+            return Exception { TypeError, "Invalid cookie: \"__Host-\" name prefix requires secure: true"_s };
+        }
+        if (hasSecurePrefix(name)) {
+            return Exception { TypeError, "Invalid cookie: \"__Secure-\" name prefix requires secure: true"_s };
+        }
     }
-    if (sameSite == CookieSameSite::None) {
-        return Exception { TypeError, "Invalid cookie: \"sameSite: none\" requires secure: true"_s };
-    }
-    if (partitioned) {
-        return Exception { TypeError, "Invalid cookie: \"partitioned: true\" requires secure: true"_s };
+    if (hasHostPrefix(name)) {
+        if (!domain.isEmpty()) {
+            return Exception { TypeError, "Invalid cookie: \"__Host-\" name prefix does not allow a domain"_s };
+        }
+        if (path != "/"_s) {
+            return Exception { TypeError, "Invalid cookie: \"__Host-\" name prefix requires path: \"/\""_s };
+        }
     }
     return {};
 }

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -61,20 +61,16 @@ bool Cookie::hasSecurePrefix(const String& name)
     return name.startsWithIgnoringASCIICase("__Secure-"_s);
 }
 
-// RFC 6265bis attribute combinations that every browser rejects. Checked on the "set a cookie"
-// path (CookieInit construction, CookieMap::set, and the prototype setters); parse() reports
-// what was on the wire and does not run this.
+// RFC 6265bis 4.1.3 / 5.6.20 and CHIPS: attribute combinations every browser rejects. Not run by parse().
 ExceptionOr<void> Cookie::validateAttributes(const String& name, const String& domain, const String& path, bool secure, CookieSameSite sameSite, bool partitioned)
 {
     if (!secure) {
-        // RFC 6265bis 5.6.20 step 17 and CHIPS: browsers drop the cookie without Secure.
         if (sameSite == CookieSameSite::None) {
             return Exception { TypeError, "Invalid cookie: \"sameSite: none\" requires secure: true"_s };
         }
         if (partitioned) {
             return Exception { TypeError, "Invalid cookie: \"partitioned: true\" requires secure: true"_s };
         }
-        // RFC 6265bis 4.1.3: the name prefixes are matched case-insensitively.
         if (hasHostPrefix(name)) {
             return Exception { TypeError, "Invalid cookie: \"__Host-\" name prefix requires secure: true"_s };
         }

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -51,6 +51,23 @@ ExceptionOr<Ref<Cookie>> Cookie::create(const String& name, const String& value,
     return adoptRef(*new Cookie(name, value, domain, path, expires, secure, sameSite, httpOnly, maxAge, partitioned));
 }
 
+// RFC 6265bis 5.6.20: a cookie with SameSite=None that is not Secure is rejected by the user agent.
+// CHIPS (draft-cutler-httpbis-partitioned-cookies 2.3) likewise requires Partitioned cookies to be
+// Secure. Emitting either attribute without Secure produces a header every modern browser drops.
+ExceptionOr<void> Cookie::validateSecureRequired(bool secure, CookieSameSite sameSite, bool partitioned)
+{
+    if (secure) {
+        return {};
+    }
+    if (sameSite == CookieSameSite::None) {
+        return Exception { TypeError, "Invalid cookie: \"sameSite: none\" requires secure: true"_s };
+    }
+    if (partitioned) {
+        return Exception { TypeError, "Invalid cookie: \"partitioned: true\" requires secure: true"_s };
+    }
+    return {};
+}
+
 String Cookie::serialize(JSC::VM& vm, const std::span<const Ref<Cookie>> cookies)
 {
     if (cookies.empty())

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -61,29 +61,37 @@ bool Cookie::hasSecurePrefix(const String& name)
     return name.startsWithIgnoringASCIICase("__Secure-"_s);
 }
 
+ExceptionOr<void> Cookie::validateSecureRequired(const String& name, CookieSameSite sameSite, bool partitioned)
+{
+    if (sameSite == CookieSameSite::None) {
+        return Exception { TypeError, sameSiteNoneSecureMessage };
+    }
+    if (partitioned) {
+        return Exception { TypeError, partitionedSecureMessage };
+    }
+    if (hasHostPrefix(name)) {
+        return Exception { TypeError, hostPrefixSecureMessage };
+    }
+    if (hasSecurePrefix(name)) {
+        return Exception { TypeError, securePrefixSecureMessage };
+    }
+    return {};
+}
+
 // RFC 6265bis 4.1.3 / 5.6.20 and CHIPS: attribute combinations every browser rejects. Not run by parse().
 ExceptionOr<void> Cookie::validateAttributes(const String& name, const String& domain, const String& path, bool secure, CookieSameSite sameSite, bool partitioned)
 {
     if (!secure) {
-        if (sameSite == CookieSameSite::None) {
-            return Exception { TypeError, "Invalid cookie: \"sameSite: none\" requires secure: true"_s };
-        }
-        if (partitioned) {
-            return Exception { TypeError, "Invalid cookie: \"partitioned: true\" requires secure: true"_s };
-        }
-        if (hasHostPrefix(name)) {
-            return Exception { TypeError, "Invalid cookie: \"__Host-\" name prefix requires secure: true"_s };
-        }
-        if (hasSecurePrefix(name)) {
-            return Exception { TypeError, "Invalid cookie: \"__Secure-\" name prefix requires secure: true"_s };
+        if (auto validation = validateSecureRequired(name, sameSite, partitioned); validation.hasException()) {
+            return validation.releaseException();
         }
     }
     if (hasHostPrefix(name)) {
         if (!domain.isEmpty()) {
-            return Exception { TypeError, "Invalid cookie: \"__Host-\" name prefix does not allow a domain"_s };
+            return Exception { TypeError, hostPrefixDomainMessage };
         }
         if (path != "/"_s) {
-            return Exception { TypeError, "Invalid cookie: \"__Host-\" name prefix requires path: \"/\""_s };
+            return Exception { TypeError, hostPrefixPathMessage };
         }
     }
     return {};

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -75,8 +75,8 @@ public:
         if (!isValidCookieDomain(domain)) {
             return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
         }
-        if (auto validation = validateAttributes(m_name, domain, m_path, m_secure, m_sameSite, m_partitioned); validation.hasException()) {
-            return validation.releaseException();
+        if (!domain.isEmpty() && hasHostPrefix(m_name)) {
+            return Exception { TypeError, hostPrefixDomainMessage };
         }
         m_domain = domain;
         return {};
@@ -88,8 +88,8 @@ public:
         if (!isValidCookiePath(path)) {
             return Exception { TypeError, "Invalid cookie path: contains invalid characters"_s };
         }
-        if (auto validation = validateAttributes(m_name, m_domain, path, m_secure, m_sameSite, m_partitioned); validation.hasException()) {
-            return validation.releaseException();
+        if (path != "/"_s && hasHostPrefix(m_name)) {
+            return Exception { TypeError, hostPrefixPathMessage };
         }
         m_path = path;
         return {};
@@ -102,8 +102,10 @@ public:
     bool secure() const { return m_secure; }
     ExceptionOr<void> setSecure(bool secure)
     {
-        if (auto validation = validateAttributes(m_name, m_domain, m_path, secure, m_sameSite, m_partitioned); validation.hasException()) {
-            return validation.releaseException();
+        if (!secure) {
+            if (auto validation = validateSecureRequired(m_name, m_sameSite, m_partitioned); validation.hasException()) {
+                return validation.releaseException();
+            }
         }
         m_secure = secure;
         return {};
@@ -112,8 +114,8 @@ public:
     CookieSameSite sameSite() const { return m_sameSite; }
     ExceptionOr<void> setSameSite(CookieSameSite sameSite)
     {
-        if (auto validation = validateAttributes(m_name, m_domain, m_path, m_secure, sameSite, m_partitioned); validation.hasException()) {
-            return validation.releaseException();
+        if (sameSite == CookieSameSite::None && !m_secure) {
+            return Exception { TypeError, sameSiteNoneSecureMessage };
         }
         m_sameSite = sameSite;
         return {};
@@ -128,8 +130,8 @@ public:
     bool partitioned() const { return m_partitioned; }
     ExceptionOr<void> setPartitioned(bool partitioned)
     {
-        if (auto validation = validateAttributes(m_name, m_domain, m_path, m_secure, m_sameSite, partitioned); validation.hasException()) {
-            return validation.releaseException();
+        if (partitioned && !m_secure) {
+            return Exception { TypeError, partitionedSecureMessage };
         }
         m_partitioned = partitioned;
         return {};
@@ -152,7 +154,16 @@ public:
 
     static ExceptionOr<void> validateAttributes(const String& name, const String& domain, const String& path, bool secure, CookieSameSite sameSite, bool partitioned);
 
+    static constexpr auto sameSiteNoneSecureMessage = "Invalid cookie: \"sameSite: none\" requires secure: true"_s;
+    static constexpr auto partitionedSecureMessage = "Invalid cookie: \"partitioned: true\" requires secure: true"_s;
+    static constexpr auto hostPrefixSecureMessage = "Invalid cookie: \"__Host-\" name prefix requires secure: true"_s;
+    static constexpr auto securePrefixSecureMessage = "Invalid cookie: \"__Secure-\" name prefix requires secure: true"_s;
+    static constexpr auto hostPrefixDomainMessage = "Invalid cookie: \"__Host-\" name prefix does not allow a domain"_s;
+    static constexpr auto hostPrefixPathMessage = "Invalid cookie: \"__Host-\" name prefix requires path: \"/\""_s;
+
 private:
+    static ExceptionOr<void> validateSecureRequired(const String& name, CookieSameSite sameSite, bool partitioned);
+
     Cookie(const String& name, const String& value,
         const String& domain, const String& path,
         int64_t expires, bool secure, CookieSameSite sameSite,

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -53,6 +53,9 @@ public:
         if (!isValidCookieDomain(init.domain)) {
             return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
         }
+        if (auto validation = validateSecureRequired(init.secure, init.sameSite, init.partitioned); validation.hasException()) {
+            return validation.releaseException();
+        }
 
         return create(init.name, init.value, init.domain, init.path, init.expires, init.secure, init.sameSite, init.httpOnly, init.maxAge, init.partitioned);
     }
@@ -91,10 +94,24 @@ public:
     bool hasExpiry() const { return m_expires != emptyExpiresAtValue; }
 
     bool secure() const { return m_secure; }
-    void setSecure(bool secure) { m_secure = secure; }
+    ExceptionOr<void> setSecure(bool secure)
+    {
+        if (auto validation = validateSecureRequired(secure, m_sameSite, m_partitioned); validation.hasException()) {
+            return validation.releaseException();
+        }
+        m_secure = secure;
+        return {};
+    }
 
     CookieSameSite sameSite() const { return m_sameSite; }
-    void setSameSite(CookieSameSite sameSite) { m_sameSite = sameSite; }
+    ExceptionOr<void> setSameSite(CookieSameSite sameSite)
+    {
+        if (auto validation = validateSecureRequired(m_secure, sameSite, m_partitioned); validation.hasException()) {
+            return validation.releaseException();
+        }
+        m_sameSite = sameSite;
+        return {};
+    }
 
     bool httpOnly() const { return m_httpOnly; }
     void setHttpOnly(bool httpOnly) { m_httpOnly = httpOnly; }
@@ -103,7 +120,14 @@ public:
     void setMaxAge(double maxAge) { m_maxAge = maxAge; }
 
     bool partitioned() const { return m_partitioned; }
-    void setPartitioned(bool partitioned) { m_partitioned = partitioned; }
+    ExceptionOr<void> setPartitioned(bool partitioned)
+    {
+        if (auto validation = validateSecureRequired(m_secure, m_sameSite, partitioned); validation.hasException()) {
+            return validation.releaseException();
+        }
+        m_partitioned = partitioned;
+        return {};
+    }
 
     bool isExpired() const;
 
@@ -116,6 +140,8 @@ public:
     static bool isValidCookieValue(const String& value); // values are uri component encoded, so this isn't needed
     static bool isValidCookiePath(const String& path);
     static bool isValidCookieDomain(const String& domain);
+
+    static ExceptionOr<void> validateSecureRequired(bool secure, CookieSameSite sameSite, bool partitioned);
 
 private:
     Cookie(const String& name, const String& value,

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -53,7 +53,7 @@ public:
         if (!isValidCookieDomain(init.domain)) {
             return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
         }
-        if (auto validation = validateSecureRequired(init.secure, init.sameSite, init.partitioned); validation.hasException()) {
+        if (auto validation = validateAttributes(init.name, init.domain, init.path, init.secure, init.sameSite, init.partitioned); validation.hasException()) {
             return validation.releaseException();
         }
 
@@ -75,6 +75,9 @@ public:
         if (!isValidCookieDomain(domain)) {
             return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
         }
+        if (auto validation = validateAttributes(m_name, domain, m_path, m_secure, m_sameSite, m_partitioned); validation.hasException()) {
+            return validation.releaseException();
+        }
         m_domain = domain;
         return {};
     }
@@ -84,6 +87,9 @@ public:
     {
         if (!isValidCookiePath(path)) {
             return Exception { TypeError, "Invalid cookie path: contains invalid characters"_s };
+        }
+        if (auto validation = validateAttributes(m_name, m_domain, path, m_secure, m_sameSite, m_partitioned); validation.hasException()) {
+            return validation.releaseException();
         }
         m_path = path;
         return {};
@@ -96,7 +102,7 @@ public:
     bool secure() const { return m_secure; }
     ExceptionOr<void> setSecure(bool secure)
     {
-        if (auto validation = validateSecureRequired(secure, m_sameSite, m_partitioned); validation.hasException()) {
+        if (auto validation = validateAttributes(m_name, m_domain, m_path, secure, m_sameSite, m_partitioned); validation.hasException()) {
             return validation.releaseException();
         }
         m_secure = secure;
@@ -106,7 +112,7 @@ public:
     CookieSameSite sameSite() const { return m_sameSite; }
     ExceptionOr<void> setSameSite(CookieSameSite sameSite)
     {
-        if (auto validation = validateSecureRequired(m_secure, sameSite, m_partitioned); validation.hasException()) {
+        if (auto validation = validateAttributes(m_name, m_domain, m_path, m_secure, sameSite, m_partitioned); validation.hasException()) {
             return validation.releaseException();
         }
         m_sameSite = sameSite;
@@ -122,7 +128,7 @@ public:
     bool partitioned() const { return m_partitioned; }
     ExceptionOr<void> setPartitioned(bool partitioned)
     {
-        if (auto validation = validateSecureRequired(m_secure, m_sameSite, partitioned); validation.hasException()) {
+        if (auto validation = validateAttributes(m_name, m_domain, m_path, m_secure, m_sameSite, partitioned); validation.hasException()) {
             return validation.releaseException();
         }
         m_partitioned = partitioned;
@@ -141,7 +147,10 @@ public:
     static bool isValidCookiePath(const String& path);
     static bool isValidCookieDomain(const String& domain);
 
-    static ExceptionOr<void> validateSecureRequired(bool secure, CookieSameSite sameSite, bool partitioned);
+    static bool hasHostPrefix(const String& name);
+    static bool hasSecurePrefix(const String& name);
+
+    static ExceptionOr<void> validateAttributes(const String& name, const String& domain, const String& path, bool secure, CookieSameSite sameSite, bool partitioned);
 
 private:
     Cookie(const String& name, const String& value,

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -180,11 +180,18 @@ void CookieMap::removeInternal(const String& name)
     });
 }
 
-void CookieMap::set(Ref<Cookie> cookie)
+ExceptionOr<void> CookieMap::set(Ref<Cookie> cookie)
 {
+    // A Cookie can reach here straight from Cookie.parse(), which reports what was on the
+    // wire without enforcing the Secure requirement, so re-check before it is emitted.
+    if (auto validation = Cookie::validateSecureRequired(cookie->secure(), cookie->sameSite(), cookie->partitioned()); validation.hasException()) {
+        return validation.releaseException();
+    }
+
     removeInternal(cookie->name());
     // Add the new cookie
     m_modifiedCookies.append(WTF::move(cookie));
+    return {};
 }
 
 ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -182,8 +182,8 @@ void CookieMap::removeInternal(const String& name)
 
 ExceptionOr<void> CookieMap::set(Ref<Cookie> cookie)
 {
-    // Cookie.parse() does not enforce this; re-check before emitting.
-    if (auto validation = Cookie::validateSecureRequired(cookie->secure(), cookie->sameSite(), cookie->partitioned()); validation.hasException()) {
+    // Cookie.parse() does not enforce these rules; re-check before emitting.
+    if (auto validation = Cookie::validateAttributes(cookie->name(), cookie->domain(), cookie->path(), cookie->secure(), cookie->sameSite(), cookie->partitioned()); validation.hasException()) {
         return validation.releaseException();
     }
 
@@ -195,20 +195,26 @@ ExceptionOr<void> CookieMap::set(Ref<Cookie> cookie)
 
 ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
 {
-    removeInternal(options.name);
-
     String name = options.name;
     String domain = options.domain;
     String path = options.path;
-    bool secure = name.startsWithIgnoringASCIICase("__Secure-"_s) || name.startsWithIgnoringASCIICase("__Host-"_s);
+    // The expiring cookie must satisfy the prefix rules or the browser ignores it and the
+    // original cookie stays. A __Host- cookie could only have been accepted with no Domain
+    // and Path=/, so the tombstone is normalized to the only shape the browser can have stored.
+    bool hasHostPrefix = Cookie::hasHostPrefix(name);
+    bool secure = hasHostPrefix || Cookie::hasSecurePrefix(name);
+    if (hasHostPrefix) {
+        domain = String();
+        path = "/"_s;
+    }
 
-    // Add the new cookie
     auto cookie_exception = Cookie::create(name, ""_s, domain, path, 1, secure, CookieSameSite::Lax, false, std::numeric_limits<double>::quiet_NaN(), false);
     if (cookie_exception.hasException()) {
         return cookie_exception.releaseException();
     }
-    auto cookie = cookie_exception.releaseReturnValue();
-    m_modifiedCookies.append(WTF::move(cookie));
+
+    removeInternal(name);
+    m_modifiedCookies.append(cookie_exception.releaseReturnValue());
     return {};
 }
 

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -182,8 +182,7 @@ void CookieMap::removeInternal(const String& name)
 
 ExceptionOr<void> CookieMap::set(Ref<Cookie> cookie)
 {
-    // A Cookie can reach here straight from Cookie.parse(), which reports what was on the
-    // wire without enforcing the Secure requirement, so re-check before it is emitted.
+    // Cookie.parse() does not enforce this; re-check before emitting.
     if (auto validation = Cookie::validateSecureRequired(cookie->secure(), cookie->sameSite(), cookie->partitioned()); validation.hasException()) {
         return validation.releaseException();
     }

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -198,9 +198,7 @@ ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
     String name = options.name;
     String domain = options.domain;
     String path = options.path;
-    // The expiring cookie must satisfy the prefix rules or the browser ignores it and the
-    // original cookie stays. A __Host- cookie could only have been accepted with no Domain
-    // and Path=/, so the tombstone is normalized to the only shape the browser can have stored.
+    // Normalize a __Host- tombstone to the only shape a browser can have stored (RFC 6265bis 4.1.3.2).
     bool hasHostPrefix = Cookie::hasHostPrefix(name);
     bool secure = hasHostPrefix || Cookie::hasSecurePrefix(name);
     if (hasHostPrefix) {

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -36,7 +36,7 @@ public:
 
     bool has(const String& name) const;
 
-    void set(Ref<Cookie>);
+    ExceptionOr<void> set(Ref<Cookie>);
 
     Ref<CookieMap> clone();
 

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -775,7 +775,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsCookiePrototypeSetter_secure, (JSGlobalObject * lexic
     auto& impl = thisObject->wrapped();
     auto value = convert<IDLBoolean>(*lexicalGlobalObject, JSValue::decode(encodedValue));
     RETURN_IF_EXCEPTION(throwScope, false);
-    impl.setSecure(value);
+    WebCore::propagateException(*lexicalGlobalObject, throwScope, impl.setSecure(value));
     return true;
 }
 
@@ -815,7 +815,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsCookiePrototypeSetter_sameSite, (JSGlobalObject * lex
         return false;
     }
 
-    impl.setSameSite(sameSite);
+    WebCore::propagateException(*lexicalGlobalObject, throwScope, impl.setSameSite(sameSite));
     return true;
 }
 
@@ -901,7 +901,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsCookiePrototypeSetter_partitioned, (JSGlobalObject * 
     auto& impl = thisObject->wrapped();
     auto value = convert<IDLBoolean>(*lexicalGlobalObject, JSValue::decode(encodedValue));
     RETURN_IF_EXCEPTION(throwScope, false);
-    impl.setPartitioned(value);
+    WebCore::propagateException(*lexicalGlobalObject, throwScope, impl.setPartitioned(value));
     return true;
 }
 

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -382,7 +382,7 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_setBody(JSC::JSGl
     if (arg0.isObject() && JSCookie::toWrapped(vm, arg0)) {
         auto* cookieImpl = JSCookie::toWrapped(vm, arg0);
         if (cookieImpl)
-            impl.set(Ref<Cookie>(*cookieImpl));
+            WebCore::propagateException(*lexicalGlobalObject, throwScope, impl.set(Ref<Cookie>(*cookieImpl)));
         return JSValue::encode(jsUndefined());
     } else if (arg0.isObject()) {
         auto* obj = arg0.getObject();
@@ -418,7 +418,7 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_setBody(JSC::JSGl
     }
     auto cookie = cookie_exception.releaseReturnValue();
 
-    impl.set(WTF::move(cookie));
+    WebCore::propagateException(*lexicalGlobalObject, throwScope, impl.set(WTF::move(cookie)));
 
     return JSValue::encode(jsUndefined());
 }

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -453,6 +453,32 @@ describe("delete with prefixed cookie names", () => {
       "id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
     ]);
   });
+
+  test("deleting a __Host- cookie ignores domain and path options", () => {
+    // The browser could only have stored a __Host- cookie with no Domain and Path=/, so the
+    // expiring cookie is normalized to that shape instead of rejected.
+    const map = new Bun.CookieMap("__Host-id=1");
+    map.delete({ name: "__Host-id", domain: "example.com", path: "/admin" });
+    expect(map.toSetCookieHeaders()).toEqual([
+      "__Host-id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax",
+    ]);
+    expect(map.get("__Host-id")).toBeNull();
+  });
+
+  test("deleting a __Secure- cookie preserves domain and path options", () => {
+    const map = new Bun.CookieMap("__Secure-id=1");
+    map.delete({ name: "__Secure-id", domain: "example.com", path: "/admin" });
+    expect(map.toSetCookieHeaders()).toEqual([
+      "__Secure-id=; Domain=example.com; Path=/admin; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax",
+    ]);
+  });
+
+  test("a rejected delete leaves the existing entry in place", () => {
+    const map = new Bun.CookieMap("a=1");
+    expect(() => map.delete({ name: "a", path: ";" })).toThrow("Invalid cookie path");
+    expect(map.get("a")).toBe("1");
+    expect(map.toSetCookieHeaders()).toEqual([]);
+  });
 });
 
 describe("invalid delete usage", () => {

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -475,6 +475,7 @@ describe("delete with prefixed cookie names", () => {
 
   test("a rejected delete leaves the existing entry in place", () => {
     const map = new Bun.CookieMap("a=1");
+    expect(() => map.delete({ name: "a", path: ";" })).toThrow(TypeError);
     expect(() => map.delete({ name: "a", path: ";" })).toThrow("Invalid cookie path");
     expect(map.get("a")).toBe("1");
     expect(map.toSetCookieHeaders()).toEqual([]);

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -125,7 +125,9 @@ describe("SameSite=None / Partitioned require Secure", () => {
     });
 
     test("partitioned: true with secure: true includes Secure", () => {
-      expect(make({ partitioned: true, secure: true }).toString()).toBe("s=v; Path=/; Secure; Partitioned; SameSite=Lax");
+      expect(make({ partitioned: true, secure: true }).toString()).toBe(
+        "s=v; Path=/; Secure; Partitioned; SameSite=Lax",
+      );
     });
 
     test("both together with secure: true", () => {

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -99,72 +99,108 @@ describe("Bun.Cookie validation tests", () => {
   });
 });
 
-// RFC 6265bis 5.6.20: a browser rejects SameSite=None without Secure. CHIPS likewise requires
-// Partitioned cookies to be Secure. Bun refuses to build a cookie a browser would silently drop.
-describe("SameSite=None / Partitioned require Secure", () => {
+// RFC 6265bis: browsers drop a SameSite=None or Partitioned cookie that isn't Secure, and a
+// __Secure-/__Host- cookie that doesn't meet the prefix rules. Bun refuses to build a cookie
+// every browser would silently drop.
+describe("attribute combinations every browser rejects", () => {
   const sameSiteNoneError = /"sameSite: none" requires secure: true/;
   const partitionedError = /"partitioned: true" requires secure: true/;
+  const hostSecureError = /"__Host-" name prefix requires secure: true/;
+  const hostDomainError = /"__Host-" name prefix does not allow a domain/;
+  const hostPathError = /"__Host-" name prefix requires path: "\/"/;
+  const securePrefixError = /"__Secure-" name prefix requires secure: true/;
 
   const expectTypeError = (fn: () => unknown, message: RegExp) => {
     expect(fn).toThrow(TypeError);
     expect(fn).toThrow(message);
   };
 
-  describe.each([
-    ["new Bun.Cookie(name, value, options)", (o: Bun.CookieInit) => new Bun.Cookie("s", "v", o)],
-    ["new Bun.Cookie(options)", (o: Bun.CookieInit) => new Bun.Cookie({ name: "s", value: "v", ...o })],
-    ["Bun.Cookie.from(name, value, options)", (o: Bun.CookieInit) => Bun.Cookie.from("s", "v", o)],
-  ] as const)("%s", (_, make) => {
-    test("sameSite: 'none' without secure throws", () => {
-      expectTypeError(() => make({ sameSite: "none" }), sameSiteNoneError);
-      expectTypeError(() => make({ sameSite: "none", secure: false }), sameSiteNoneError);
+  const setEntryPoints = [
+    ["new Bun.Cookie(name, value, options)", (n: string, o: Bun.CookieInit) => new Bun.Cookie(n, "v", o)],
+    ["new Bun.Cookie(options)", (n: string, o: Bun.CookieInit) => new Bun.Cookie({ name: n, value: "v", ...o })],
+    ["Bun.Cookie.from(name, value, options)", (n: string, o: Bun.CookieInit) => Bun.Cookie.from(n, "v", o)],
+    [
+      "CookieMap.set(name, value, options)",
+      (n: string, o: Bun.CookieInit) => {
+        const map = new Bun.CookieMap();
+        map.set(n, "v", o);
+        return Bun.Cookie.parse(map.toSetCookieHeaders()[0]);
+      },
+    ],
+  ] as const;
+
+  describe.each(setEntryPoints)("%s", (_, make) => {
+    test.each([
+      ["sameSite: 'none' without secure", "s", { sameSite: "none" } as const, sameSiteNoneError],
+      ["sameSite: 'none' with secure: false", "s", { sameSite: "none", secure: false } as const, sameSiteNoneError],
+      ["partitioned: true without secure", "s", { partitioned: true }, partitionedError],
+      ["partitioned: true with secure: false", "s", { partitioned: true, secure: false }, partitionedError],
+      ["__Host- without secure", "__Host-s", {}, hostSecureError],
+      ["__Host- with a domain", "__Host-s", { secure: true, domain: "example.com" }, hostDomainError],
+      ["__Host- with a non-/ path", "__Host-s", { secure: true, path: "/admin" }, hostPathError],
+      ["__Host- with an empty path", "__Host-s", { secure: true, path: "" }, hostPathError],
+      ["__Secure- without secure", "__Secure-s", {}, securePrefixError],
+      ["__Secure- with secure: false", "__Secure-s", { secure: false }, securePrefixError],
+    ])("throws for %s", (_, name, options, error) => {
+      expectTypeError(() => make(name, options), error);
     });
 
-    test("partitioned: true without secure throws", () => {
-      expectTypeError(() => make({ partitioned: true }), partitionedError);
-      expectTypeError(() => make({ partitioned: true, secure: false }), partitionedError);
+    test.each([
+      [{ sameSite: "none", secure: true } as const, "s=v; Path=/; Secure; SameSite=None"],
+      [{ partitioned: true, secure: true }, "s=v; Path=/; Secure; Partitioned; SameSite=Lax"],
+      [{ sameSite: "none", partitioned: true, secure: true } as const, "s=v; Path=/; Secure; Partitioned; SameSite=None"],
+    ])("accepts %p", (options, serialized) => {
+      expect(make("s", options).toString()).toBe(serialized);
     });
 
-    test("sameSite: 'none' with secure: true includes Secure", () => {
-      expect(make({ sameSite: "none", secure: true }).toString()).toBe("s=v; Path=/; Secure; SameSite=None");
-    });
-
-    test("partitioned: true with secure: true includes Secure", () => {
-      expect(make({ partitioned: true, secure: true }).toString()).toBe(
-        "s=v; Path=/; Secure; Partitioned; SameSite=Lax",
-      );
-    });
-
-    test("both together with secure: true", () => {
-      expect(make({ sameSite: "none", partitioned: true, secure: true }).toString()).toBe(
-        "s=v; Path=/; Secure; Partitioned; SameSite=None",
-      );
+    test.each([
+      ["__Host-s", { secure: true }, "__Host-s=v; Path=/; Secure; SameSite=Lax"],
+      ["__Host-s", { secure: true, sameSite: "none" } as const, "__Host-s=v; Path=/; Secure; SameSite=None"],
+      ["__Secure-s", { secure: true }, "__Secure-s=v; Path=/; Secure; SameSite=Lax"],
+      [
+        "__Secure-s",
+        { secure: true, domain: "example.com", path: "/admin" },
+        "__Secure-s=v; Domain=example.com; Path=/admin; Secure; SameSite=Lax",
+      ],
+    ])("accepts prefixed %p with %p", (name, options, serialized) => {
+      expect(make(name, options).toString()).toBe(serialized);
     });
   });
 
-  test("CookieMap.set throws for the same combinations", () => {
-    const map = new Bun.CookieMap();
-    expectTypeError(() => map.set("s", "v", { sameSite: "none" }), sameSiteNoneError);
-    expectTypeError(() => map.set("p", "v", { partitioned: true }), partitionedError);
-    expectTypeError(() => map.set({ name: "s", value: "v", sameSite: "none", httpOnly: true }), sameSiteNoneError);
-    expect(map.size).toBe(0);
+  test("the name prefix is matched case-insensitively, like browsers do", () => {
+    expectTypeError(() => new Bun.Cookie("__host-s", "v"), hostSecureError);
+    expectTypeError(() => new Bun.Cookie("__SECURE-s", "v"), securePrefixError);
+  });
 
-    map.set("s", "v", { sameSite: "none", secure: true });
-    map.set("p", "v", { partitioned: true, secure: true });
-    expect(map.toSetCookieHeaders()).toEqual([
-      "s=v; Path=/; Secure; SameSite=None",
-      "p=v; Path=/; Secure; Partitioned; SameSite=Lax",
-    ]);
+  test("a name that merely contains a prefix token is unaffected", () => {
+    expect(new Bun.Cookie("x__Host-s", "v").toString()).toBe("x__Host-s=v; Path=/; SameSite=Lax");
+    expect(new Bun.Cookie("__Host", "v").toString()).toBe("__Host=v; Path=/; SameSite=Lax");
+    expect(new Bun.Cookie("__Secure", "v").toString()).toBe("__Secure=v; Path=/; SameSite=Lax");
+  });
+
+  test("Cookie.parse reports what was on the wire without throwing", () => {
+    const cases = [
+      ["a=b; SameSite=None", { sameSite: "none", secure: false }],
+      ["a=b; Partitioned", { partitioned: true, secure: false }],
+      ["__Host-a=b", { name: "__Host-a", secure: false }],
+      ["__Host-a=b; Domain=example.com; Secure", { name: "__Host-a", domain: "example.com", secure: true }],
+      ["__Secure-a=b", { name: "__Secure-a", secure: false }],
+    ] as const;
+    for (const [header, expected] of cases) {
+      const parsed = Bun.Cookie.parse(header);
+      for (const [key, value] of Object.entries(expected)) {
+        expect(parsed[key as keyof Bun.Cookie]).toBe(value);
+      }
+    }
   });
 
   test.each([
-    ["s=v; SameSite=None", "sameSite", "none", sameSiteNoneError, "s=v; Path=/; Secure; SameSite=None"],
-    ["p=v; Partitioned", "partitioned", true, partitionedError, "p=v; Path=/; Secure; Partitioned; SameSite=Lax"],
-  ] as const)("CookieMap.set(Cookie) re-validates a parsed %p cookie", (header, attr, expected, error, fixed) => {
-    // Cookie.parse() reports what was on the wire; the Secure requirement is only enforced
-    // when the cookie is handed back to the write path.
+    ["s=v; SameSite=None", sameSiteNoneError, "s=v; Path=/; Secure; SameSite=None"],
+    ["p=v; Partitioned", partitionedError, "p=v; Path=/; Secure; Partitioned; SameSite=Lax"],
+    ["__Host-s=v", hostSecureError, "__Host-s=v; Path=/; Secure; SameSite=Lax"],
+    ["__Secure-s=v", securePrefixError, "__Secure-s=v; Path=/; Secure; SameSite=Lax"],
+  ] as const)("CookieMap.set(Cookie) re-validates a parsed %p cookie", (header, error, fixed) => {
     const parsed = Bun.Cookie.parse(header);
-    expect(parsed[attr]).toBe(expected);
     expect(parsed.secure).toBe(false);
 
     const map = new Bun.CookieMap();
@@ -219,6 +255,38 @@ describe("SameSite=None / Partitioned require Secure", () => {
       p.secure = false;
       expect(p.secure).toBe(false);
     });
+
+    test("secure = false throws on a prefixed cookie", () => {
+      const host = new Bun.Cookie("__Host-s", "v", { secure: true });
+      expectTypeError(() => (host.secure = false), hostSecureError);
+      expect(host.secure).toBe(true);
+
+      const sec = new Bun.Cookie("__Secure-s", "v", { secure: true });
+      expectTypeError(() => (sec.secure = false), securePrefixError);
+      expect(sec.secure).toBe(true);
+    });
+
+    test("domain / path setters throw on a __Host- cookie", () => {
+      const host = new Bun.Cookie("__Host-s", "v", { secure: true });
+      expectTypeError(() => (host.domain = "example.com"), hostDomainError);
+      expectTypeError(() => (host.path = "/admin"), hostPathError);
+      expectTypeError(() => (host.path = ""), hostPathError);
+      expect(host.toString()).toBe("__Host-s=v; Path=/; Secure; SameSite=Lax");
+
+      // __Secure- only constrains the secure flag.
+      const sec = new Bun.Cookie("__Secure-s", "v", { secure: true });
+      sec.domain = "example.com";
+      sec.path = "/admin";
+      expect(sec.toString()).toBe("__Secure-s=v; Domain=example.com; Path=/admin; Secure; SameSite=Lax");
+    });
+
+    test("setters on an unprefixed cookie are otherwise unaffected", () => {
+      const c = new Bun.Cookie("a", "v", { secure: true });
+      c.secure = false;
+      c.domain = "example.com";
+      c.path = "/admin";
+      expect(c.toString()).toBe("a=v; Domain=example.com; Path=/admin; SameSite=Lax");
+    });
   });
 
   test("Bun.serve req.cookies.set emits Secure alongside SameSite=None", async () => {
@@ -227,13 +295,17 @@ describe("SameSite=None / Partitioned require Secure", () => {
       routes: {
         "/": req => {
           req.cookies.set("session", "TOKEN", { sameSite: "none", secure: true, httpOnly: true });
+          req.cookies.set("__Host-id", "TOKEN", { secure: true });
           return new Response("ok");
         },
       },
       fetch: () => new Response("nf", { status: 404 }),
     });
     const res = await fetch(server.url);
-    expect(res.headers.getSetCookie()).toEqual(["session=TOKEN; Path=/; Secure; HttpOnly; SameSite=None"]);
+    expect(res.headers.getSetCookie()).toEqual([
+      "session=TOKEN; Path=/; Secure; HttpOnly; SameSite=None",
+      "__Host-id=TOKEN; Path=/; Secure; SameSite=Lax",
+    ]);
     expect(res.status).toBe(200);
   });
 

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -127,6 +127,14 @@ describe("attribute combinations every browser rejects", () => {
         return Bun.Cookie.parse(map.toSetCookieHeaders()[0]);
       },
     ],
+    [
+      "CookieMap.set(options)",
+      (n: string, o: Bun.CookieInit) => {
+        const map = new Bun.CookieMap();
+        map.set({ name: n, value: "v", ...o });
+        return Bun.Cookie.parse(map.toSetCookieHeaders()[0]);
+      },
+    ],
   ] as const;
 
   describe.each(setEntryPoints)("%s", (_, make) => {
@@ -294,6 +302,25 @@ describe("attribute combinations every browser rejects", () => {
       c.domain = "example.com";
       c.path = "/admin";
       expect(c.toString()).toBe("a=v; Domain=example.com; Path=/admin; SameSite=Lax");
+    });
+
+    test("a setter only rejects violations involving the field being changed", () => {
+      // A parsed __Host- cookie can be wrong on several axes at once. Each setter guards only its
+      // own field, so the cookie can be repaired one field at a time instead of deadlocking.
+      const c = Bun.Cookie.parse("__Host-s=v; Domain=example.com; Path=/admin");
+      expect(c.secure).toBe(false);
+      expect(c.domain).toBe("example.com");
+      expect(c.path).toBe("/admin");
+
+      c.secure = true;
+      c.domain = "";
+      c.path = "/";
+      expect(c.toString()).toBe("__Host-s=v; Path=/; Secure; SameSite=Lax");
+
+      // Each assignment that would itself introduce a violation is still rejected.
+      expectTypeError(() => (c.secure = false), hostSecureError);
+      expectTypeError(() => (c.domain = "example.com"), hostDomainError);
+      expectTypeError(() => (c.path = "/admin"), hostPathError);
     });
   });
 

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -220,6 +220,11 @@ describe("attribute combinations every browser rejects", () => {
     map.set("s", "old");
     expectTypeError(() => map.set("s", "new", { sameSite: "none" }), sameSiteNoneError);
     expect(map.get("s")).toBe("old");
+
+    // set(Cookie) path: validation must run before the old entry is removed.
+    expectTypeError(() => map.set(Bun.Cookie.parse("s=new; SameSite=None")), sameSiteNoneError);
+    expect(map.get("s")).toBe("old");
+    expect(map.toSetCookieHeaders()).toEqual(["s=old; Path=/; SameSite=Lax"]);
   });
 
   describe("property setters on an existing Cookie", () => {

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -148,7 +148,10 @@ describe("attribute combinations every browser rejects", () => {
     test.each([
       [{ sameSite: "none", secure: true } as const, "s=v; Path=/; Secure; SameSite=None"],
       [{ partitioned: true, secure: true }, "s=v; Path=/; Secure; Partitioned; SameSite=Lax"],
-      [{ sameSite: "none", partitioned: true, secure: true } as const, "s=v; Path=/; Secure; Partitioned; SameSite=None"],
+      [
+        { sameSite: "none", partitioned: true, secure: true } as const,
+        "s=v; Path=/; Secure; Partitioned; SameSite=None",
+      ],
     ])("accepts %p", (options, serialized) => {
       expect(make("s", options).toString()).toBe(serialized);
     });

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -105,19 +105,24 @@ describe("SameSite=None / Partitioned require Secure", () => {
   const sameSiteNoneError = /"sameSite: none" requires secure: true/;
   const partitionedError = /"partitioned: true" requires secure: true/;
 
+  const expectTypeError = (fn: () => unknown, message: RegExp) => {
+    expect(fn).toThrow(TypeError);
+    expect(fn).toThrow(message);
+  };
+
   describe.each([
     ["new Bun.Cookie(name, value, options)", (o: Bun.CookieInit) => new Bun.Cookie("s", "v", o)],
     ["new Bun.Cookie(options)", (o: Bun.CookieInit) => new Bun.Cookie({ name: "s", value: "v", ...o })],
     ["Bun.Cookie.from(name, value, options)", (o: Bun.CookieInit) => Bun.Cookie.from("s", "v", o)],
   ] as const)("%s", (_, make) => {
     test("sameSite: 'none' without secure throws", () => {
-      expect(() => make({ sameSite: "none" })).toThrow(sameSiteNoneError);
-      expect(() => make({ sameSite: "none", secure: false })).toThrow(sameSiteNoneError);
+      expectTypeError(() => make({ sameSite: "none" }), sameSiteNoneError);
+      expectTypeError(() => make({ sameSite: "none", secure: false }), sameSiteNoneError);
     });
 
     test("partitioned: true without secure throws", () => {
-      expect(() => make({ partitioned: true })).toThrow(partitionedError);
-      expect(() => make({ partitioned: true, secure: false })).toThrow(partitionedError);
+      expectTypeError(() => make({ partitioned: true }), partitionedError);
+      expectTypeError(() => make({ partitioned: true, secure: false }), partitionedError);
     });
 
     test("sameSite: 'none' with secure: true includes Secure", () => {
@@ -139,9 +144,9 @@ describe("SameSite=None / Partitioned require Secure", () => {
 
   test("CookieMap.set throws for the same combinations", () => {
     const map = new Bun.CookieMap();
-    expect(() => map.set("s", "v", { sameSite: "none" })).toThrow(sameSiteNoneError);
-    expect(() => map.set("p", "v", { partitioned: true })).toThrow(partitionedError);
-    expect(() => map.set({ name: "s", value: "v", sameSite: "none", httpOnly: true })).toThrow(sameSiteNoneError);
+    expectTypeError(() => map.set("s", "v", { sameSite: "none" }), sameSiteNoneError);
+    expectTypeError(() => map.set("p", "v", { partitioned: true }), partitionedError);
+    expectTypeError(() => map.set({ name: "s", value: "v", sameSite: "none", httpOnly: true }), sameSiteNoneError);
     expect(map.size).toBe(0);
 
     map.set("s", "v", { sameSite: "none", secure: true });
@@ -152,33 +157,36 @@ describe("SameSite=None / Partitioned require Secure", () => {
     ]);
   });
 
-  test("CookieMap.set(Cookie) re-validates a parsed cookie", () => {
-    // Cookie.parse() reports what was on the wire; a non-Secure SameSite=None cookie is only
-    // rejected when it is handed back to the write path.
-    const parsed = Bun.Cookie.parse("s=v; SameSite=None");
-    expect(parsed.sameSite).toBe("none");
+  test.each([
+    ["s=v; SameSite=None", "sameSite", "none", sameSiteNoneError, "s=v; Path=/; Secure; SameSite=None"],
+    ["p=v; Partitioned", "partitioned", true, partitionedError, "p=v; Path=/; Secure; Partitioned; SameSite=Lax"],
+  ] as const)("CookieMap.set(Cookie) re-validates a parsed %p cookie", (header, attr, expected, error, fixed) => {
+    // Cookie.parse() reports what was on the wire; the Secure requirement is only enforced
+    // when the cookie is handed back to the write path.
+    const parsed = Bun.Cookie.parse(header);
+    expect(parsed[attr]).toBe(expected);
     expect(parsed.secure).toBe(false);
 
     const map = new Bun.CookieMap();
-    expect(() => map.set(parsed)).toThrow(sameSiteNoneError);
+    expectTypeError(() => map.set(parsed), error);
     expect(map.toSetCookieHeaders()).toEqual([]);
 
     parsed.secure = true;
     map.set(parsed);
-    expect(map.toSetCookieHeaders()).toEqual(["s=v; Path=/; Secure; SameSite=None"]);
+    expect(map.toSetCookieHeaders()).toEqual([fixed]);
   });
 
   test("a rejected CookieMap.set leaves the existing entry in place", () => {
     const map = new Bun.CookieMap();
     map.set("s", "old");
-    expect(() => map.set("s", "new", { sameSite: "none" })).toThrow(sameSiteNoneError);
+    expectTypeError(() => map.set("s", "new", { sameSite: "none" }), sameSiteNoneError);
     expect(map.get("s")).toBe("old");
   });
 
   describe("property setters on an existing Cookie", () => {
     test("sameSite = 'none' throws while secure is false", () => {
       const c = new Bun.Cookie("s", "v");
-      expect(() => (c.sameSite = "none")).toThrow(sameSiteNoneError);
+      expectTypeError(() => (c.sameSite = "none"), sameSiteNoneError);
       expect(c.sameSite).toBe("lax");
 
       c.secure = true;
@@ -188,7 +196,7 @@ describe("SameSite=None / Partitioned require Secure", () => {
 
     test("partitioned = true throws while secure is false", () => {
       const c = new Bun.Cookie("p", "v");
-      expect(() => (c.partitioned = true)).toThrow(partitionedError);
+      expectTypeError(() => (c.partitioned = true), partitionedError);
       expect(c.partitioned).toBe(false);
 
       c.secure = true;
@@ -198,14 +206,14 @@ describe("SameSite=None / Partitioned require Secure", () => {
 
     test("secure = false throws while sameSite is 'none' or partitioned is true", () => {
       const c = new Bun.Cookie("s", "v", { secure: true, sameSite: "none" });
-      expect(() => (c.secure = false)).toThrow(sameSiteNoneError);
+      expectTypeError(() => (c.secure = false), sameSiteNoneError);
       expect(c.secure).toBe(true);
       c.sameSite = "lax";
       c.secure = false;
       expect(c.secure).toBe(false);
 
       const p = new Bun.Cookie("p", "v", { secure: true, partitioned: true });
-      expect(() => (p.secure = false)).toThrow(partitionedError);
+      expectTypeError(() => (p.secure = false), partitionedError);
       expect(p.secure).toBe(true);
       p.partitioned = false;
       p.secure = false;
@@ -240,13 +248,17 @@ describe("SameSite=None / Partitioned require Secure", () => {
           } catch (e) {
             caught = e;
           }
-          return Response.json({ message: String(caught) });
+          return Response.json({
+            name: caught instanceof TypeError ? caught.name : "not a TypeError",
+            message: caught instanceof Error ? caught.message : String(caught),
+          });
         },
       },
       fetch: () => new Response("nf", { status: 404 }),
     });
     const res = await fetch(server.url);
     const body = await res.json();
+    expect(body.name).toBe("TypeError");
     expect(body.message).toMatch(sameSiteNoneError);
     expect(res.headers.getSetCookie()).toEqual([]);
     expect(res.status).toBe(200);

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -99,6 +99,158 @@ describe("Bun.Cookie validation tests", () => {
   });
 });
 
+// RFC 6265bis 5.6.20: a browser rejects SameSite=None without Secure. CHIPS likewise requires
+// Partitioned cookies to be Secure. Bun refuses to build a cookie a browser would silently drop.
+describe("SameSite=None / Partitioned require Secure", () => {
+  const sameSiteNoneError = /"sameSite: none" requires secure: true/;
+  const partitionedError = /"partitioned: true" requires secure: true/;
+
+  describe.each([
+    ["new Bun.Cookie(name, value, options)", (o: Bun.CookieInit) => new Bun.Cookie("s", "v", o)],
+    ["new Bun.Cookie(options)", (o: Bun.CookieInit) => new Bun.Cookie({ name: "s", value: "v", ...o })],
+    ["Bun.Cookie.from(name, value, options)", (o: Bun.CookieInit) => Bun.Cookie.from("s", "v", o)],
+  ] as const)("%s", (_, make) => {
+    test("sameSite: 'none' without secure throws", () => {
+      expect(() => make({ sameSite: "none" })).toThrow(sameSiteNoneError);
+      expect(() => make({ sameSite: "none", secure: false })).toThrow(sameSiteNoneError);
+    });
+
+    test("partitioned: true without secure throws", () => {
+      expect(() => make({ partitioned: true })).toThrow(partitionedError);
+      expect(() => make({ partitioned: true, secure: false })).toThrow(partitionedError);
+    });
+
+    test("sameSite: 'none' with secure: true includes Secure", () => {
+      expect(make({ sameSite: "none", secure: true }).toString()).toBe("s=v; Path=/; Secure; SameSite=None");
+    });
+
+    test("partitioned: true with secure: true includes Secure", () => {
+      expect(make({ partitioned: true, secure: true }).toString()).toBe("s=v; Path=/; Secure; Partitioned; SameSite=Lax");
+    });
+
+    test("both together with secure: true", () => {
+      expect(make({ sameSite: "none", partitioned: true, secure: true }).toString()).toBe(
+        "s=v; Path=/; Secure; Partitioned; SameSite=None",
+      );
+    });
+  });
+
+  test("CookieMap.set throws for the same combinations", () => {
+    const map = new Bun.CookieMap();
+    expect(() => map.set("s", "v", { sameSite: "none" })).toThrow(sameSiteNoneError);
+    expect(() => map.set("p", "v", { partitioned: true })).toThrow(partitionedError);
+    expect(() => map.set({ name: "s", value: "v", sameSite: "none", httpOnly: true })).toThrow(sameSiteNoneError);
+    expect(map.size).toBe(0);
+
+    map.set("s", "v", { sameSite: "none", secure: true });
+    map.set("p", "v", { partitioned: true, secure: true });
+    expect(map.toSetCookieHeaders()).toEqual([
+      "s=v; Path=/; Secure; SameSite=None",
+      "p=v; Path=/; Secure; Partitioned; SameSite=Lax",
+    ]);
+  });
+
+  test("CookieMap.set(Cookie) re-validates a parsed cookie", () => {
+    // Cookie.parse() reports what was on the wire; a non-Secure SameSite=None cookie is only
+    // rejected when it is handed back to the write path.
+    const parsed = Bun.Cookie.parse("s=v; SameSite=None");
+    expect(parsed.sameSite).toBe("none");
+    expect(parsed.secure).toBe(false);
+
+    const map = new Bun.CookieMap();
+    expect(() => map.set(parsed)).toThrow(sameSiteNoneError);
+    expect(map.toSetCookieHeaders()).toEqual([]);
+
+    parsed.secure = true;
+    map.set(parsed);
+    expect(map.toSetCookieHeaders()).toEqual(["s=v; Path=/; Secure; SameSite=None"]);
+  });
+
+  test("a rejected CookieMap.set leaves the existing entry in place", () => {
+    const map = new Bun.CookieMap();
+    map.set("s", "old");
+    expect(() => map.set("s", "new", { sameSite: "none" })).toThrow(sameSiteNoneError);
+    expect(map.get("s")).toBe("old");
+  });
+
+  describe("property setters on an existing Cookie", () => {
+    test("sameSite = 'none' throws while secure is false", () => {
+      const c = new Bun.Cookie("s", "v");
+      expect(() => (c.sameSite = "none")).toThrow(sameSiteNoneError);
+      expect(c.sameSite).toBe("lax");
+
+      c.secure = true;
+      c.sameSite = "none";
+      expect(c.toString()).toBe("s=v; Path=/; Secure; SameSite=None");
+    });
+
+    test("partitioned = true throws while secure is false", () => {
+      const c = new Bun.Cookie("p", "v");
+      expect(() => (c.partitioned = true)).toThrow(partitionedError);
+      expect(c.partitioned).toBe(false);
+
+      c.secure = true;
+      c.partitioned = true;
+      expect(c.toString()).toBe("p=v; Path=/; Secure; Partitioned; SameSite=Lax");
+    });
+
+    test("secure = false throws while sameSite is 'none' or partitioned is true", () => {
+      const c = new Bun.Cookie("s", "v", { secure: true, sameSite: "none" });
+      expect(() => (c.secure = false)).toThrow(sameSiteNoneError);
+      expect(c.secure).toBe(true);
+      c.sameSite = "lax";
+      c.secure = false;
+      expect(c.secure).toBe(false);
+
+      const p = new Bun.Cookie("p", "v", { secure: true, partitioned: true });
+      expect(() => (p.secure = false)).toThrow(partitionedError);
+      expect(p.secure).toBe(true);
+      p.partitioned = false;
+      p.secure = false;
+      expect(p.secure).toBe(false);
+    });
+  });
+
+  test("Bun.serve req.cookies.set emits Secure alongside SameSite=None", async () => {
+    using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/": req => {
+          req.cookies.set("session", "TOKEN", { sameSite: "none", secure: true, httpOnly: true });
+          return new Response("ok");
+        },
+      },
+      fetch: () => new Response("nf", { status: 404 }),
+    });
+    const res = await fetch(server.url);
+    expect(res.headers.getSetCookie()).toEqual(["session=TOKEN; Path=/; Secure; HttpOnly; SameSite=None"]);
+    expect(res.status).toBe(200);
+  });
+
+  test("Bun.serve req.cookies.set without secure throws before reaching the wire", async () => {
+    using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/": req => {
+          let caught: unknown;
+          try {
+            req.cookies.set("session", "TOKEN", { sameSite: "none", httpOnly: true });
+          } catch (e) {
+            caught = e;
+          }
+          return Response.json({ message: String(caught) });
+        },
+      },
+      fetch: () => new Response("nf", { status: 404 }),
+    });
+    const res = await fetch(server.url);
+    const body = await res.json();
+    expect(body.message).toMatch(sameSiteNoneError);
+    expect(res.headers.getSetCookie()).toEqual([]);
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("Expires serialization", () => {
   // RFC 6265 expects an IMF-fixdate: "Wdy, DD Mon YYYY HH:MM:SS GMT".
   // Date.prototype.toUTCString() produces exactly that, so the two must agree.

--- a/test/js/bun/util/cookie.test.js
+++ b/test/js/bun/util/cookie.test.js
@@ -552,7 +552,14 @@ describe("cookie.serialize(name, value, options)", function () {
 
   describe('with "partitioned" option', function () {
     it("should include partitioned flag when true", function () {
-      expect(cookie.serialize("foo", "bar", { partitioned: true })).toEqual("foo=bar; Partitioned; SameSite=Lax");
+      // Bun deviates from the `cookie` package here: CHIPS requires Secure, so
+      // partitioned without secure is a TypeError instead of an always-dropped header.
+      expect(cookie.serialize("foo", "bar", { partitioned: true, secure: true })).toEqual(
+        "foo=bar; Secure; Partitioned; SameSite=Lax",
+      );
+      expect(() => cookie.serialize("foo", "bar", { partitioned: true })).toThrow(
+        /"partitioned: true" requires secure: true/,
+      );
     });
 
     it("should not include partitioned flag when false", function () {
@@ -646,7 +653,14 @@ describe("cookie.serialize(name, value, options)", function () {
     });
 
     it("should set sameSite none", function () {
-      expect(cookie.serialize("foo", "bar", { sameSite: "none" })).toEqual("foo=bar; SameSite=None");
+      // Bun deviates from the `cookie` package here: SameSite=None requires Secure, so
+      // sameSite: "none" without secure is a TypeError instead of an always-dropped header.
+      expect(cookie.serialize("foo", "bar", { sameSite: "none", secure: true })).toEqual(
+        "foo=bar; Secure; SameSite=None",
+      );
+      expect(() => cookie.serialize("foo", "bar", { sameSite: "none" })).toThrow(
+        /"sameSite: none" requires secure: true/,
+      );
     });
 
     it.failing("should set sameSite strict when true", function () {


### PR DESCRIPTION
## Repro

```js
console.log(new Bun.Cookie("s", "v", { sameSite: "none" }).toString());
console.log(new Bun.Cookie("p", "v", { partitioned: true }).toString());
console.log(new Bun.Cookie("__Host-x", "v", {}).toString());
console.log(new Bun.Cookie("__Host-x", "v", { secure: true, domain: "e.com" }).toString());
console.log(new Bun.Cookie("__Secure-x", "v", {}).toString());

using server = Bun.serve({
  port: 0,
  routes: {
    "/": req => {
      req.cookies.set("session", "TOKEN", { sameSite: "none", httpOnly: true });
      return new Response("ok");
    },
  },
});
console.log((await fetch(server.url)).headers.getSetCookie());
```

```
s=v; Path=/; SameSite=None
p=v; Path=/; Partitioned; SameSite=Lax
__Host-x=v; Path=/; SameSite=Lax
__Host-x=v; Domain=e.com; Path=/; Secure; SameSite=Lax
__Secure-x=v; Path=/; SameSite=Lax
[ "session=TOKEN; Path=/; HttpOnly; SameSite=None" ]
```

Every browser drops every one of those cookies:

- RFC 6265bis 5.6.20 step 17: `SameSite=None` without `Secure` is rejected.
- CHIPS: `Partitioned` without `Secure` is rejected.
- RFC 6265bis 4.1.3: a `__Secure-` name needs `Secure`; a `__Host-` name needs `Secure`, no `Domain`, and `Path=/`.

So a cross-site auth or `__Host-` session cookie set through the documented API silently never lands, with no error anywhere.

## Cause

`Cookie::create(CookieInit)`, which is what every `new Bun.Cookie(...)`, `Bun.Cookie.from`, `CookieMap.set` and `req.cookies.set` funnel into, validated name/path/domain characters only. Nothing checked any of the cross-attribute rules above. The serializer `Cookie::appendTo` emits `; Secure`, `; Partitioned` and `; SameSite=None` independently, and the `domain`/`path`/`secure`/`sameSite`/`partitioned` setters could mutate an already-constructed cookie into one of these states without any check.

## Fix

`Cookie::validateAttributes(name, domain, path, secure, sameSite, partitioned)` holds the four rules and runs at every point a cookie can reach the wire:

- `Cookie::create(CookieInit)`, the "set a cookie" entry behind `new Bun.Cookie`, `Cookie.from`, and `CookieMap.set(name, value, options)`
- `CookieMap::set(Cookie)`, so a cookie that came from `Cookie.parse` is re-checked before it is emitted
- the `domain`, `path`, `secure`, `sameSite` and `partitioned` property setters (`name` is getter-only), each guarding only the rule its own field participates in, so a cookie parsed with several violations at once can be repaired one field at a time

Violations throw a `TypeError`. `Cookie.parse` is unchanged: it reports what was on the wire, and a parsed cookie can be repaired (`cookie.secure = true`) before being set.

Two things fall out of routing through one validator:

- A rejected `CookieMap.set` or `.delete` no longer drops the existing entry first; the fallible step now happens before `removeInternal`.
- `CookieMap.delete` of a `__Host-` name normalizes the tombstone to `Secure`, no `Domain`, `Path=/` instead of forwarding the caller's `domain`/`path`. The browser could only have stored that shape, so `delete` stays infallible.

Supersedes #33459, which did the `__Secure-`/`__Host-` half of this separately.

## Verification

```
$ bun bd test test/js/bun/cookie/ test/js/bun/util/cookie.test.js test/js/bun/http/bun-serve-cookies.test.ts
 374 pass, 18 skip, 0 fail
```

With `src/` reverted to main, 55 of the new tests fail.

<details>
<summary>After the fix</summary>

```
TypeError: Invalid cookie: "sameSite: none" requires secure: true
TypeError: Invalid cookie: "partitioned: true" requires secure: true
TypeError: Invalid cookie: "__Host-" name prefix requires secure: true
TypeError: Invalid cookie: "__Host-" name prefix does not allow a domain
TypeError: Invalid cookie: "__Secure-" name prefix requires secure: true
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 67 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-map.test.ts test/js/bun/cookie/cookie.test.ts test/js/bun/util/cookie.test.js
bun test v1.4.0 (400759887)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [5.27ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [4.81ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [4.93ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [152.76ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.53ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [5.92ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [4.75ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [4.58ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.22ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any or
... (truncated)

release without fix: 18 skipped
bun test v1.4.0-canary.1 (50a052fd2)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [1.51ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.08ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [1.32ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [16.97ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.15ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [0.08ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [0.07ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [0.02ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [0.13ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.serialize creates cookie string [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > can create an empty CookieMap [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > can create Cook
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-map.test.ts test/js/bun/cookie/cookie.test.ts test/js/bun/util/cookie.test.js
bun test v1.4.0 (400759887)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [5.21ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [4.66ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [4.85ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [151.75ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.85ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [6.20ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [4.81ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [4.59ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.24ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any or
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 708ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/12] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/12] cxx obj/src/jsc/bindings/BunObject.cpp.o
[3/12] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[4/12] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[5/12] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[6/12] gen cpp.rs (cppbind)
[6/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/cookies.mdx                 |  25 ++-
 packages/bun-types/bun.d.ts              |  32 +++-
 src/jsc/bindings/Cookie.cpp              |  46 ++++++
 src/jsc/bindings/Cookie.h                |  52 +++++-
 src/jsc/bindings/CookieMap.cpp           |  24 ++-
 src/jsc/bindings/CookieMap.h             |   2 +-
 src/jsc/bindings/webcore/JSCookie.cpp    |   6 +-
 src/jsc/bindings/webcore/JSCookieMap.cpp |   4 +-
 test/js/bun/cookie/cookie-map.test.ts    |  27 +++
 test/js/bun/cookie/cookie.test.ts        | 273 +++++++++++++++++++++++++++++++
 test/js/bun/util/cookie.test.js          |  18 +-
 11 files changed, 484 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
docs/runtime/cookies.mdx                      3      3      0
packages/bun-types/bun.d.ts                   4      3      0
src/jsc/bindings/Cookie.cpp                   5      5      0
src/jsc/bindings/Cookie.h                     2      5      0
src/jsc/bindings/CookieMap.cpp                4      4      0
src/jsc/bindings/CookieMap.h                  1      1      0
src/jsc/bindings/webcore/JSCookie.cpp         1      3      0
src/jsc/bindings/webcore/JSCookieMap.cpp      1      4      0
test/js/bun/cookie/cookie-map.test.ts         2      1      0
test/js/bun/cookie/cookie.test.ts             6      5      0
test/js/bun/util/cookie.test.js               1      2      0
```

</details>

<!-- robobun:evidence:end -->
