### PR TITLE
Windows: release FileSink keep-alive ref for Bun.file(fd).writer() on a borrowed fd

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2464,7 +2464,14 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         self.is_done = true;
 
         if !self.has_pending_data() {
-            if !self.owns_fd {
+            // `close()` must run so `Parent::on_close` fires and the FileSink
+            // keep-alive ref is released. For File/SyncFile `close()` already
+            // honours `!owns_fd` (it takes the `detach_borrowed_fd()` arm and
+            // leaves the fd open). For Pipe/Tty the callers dup a borrowed fd
+            // before `start()`, so `owns_fd` is true there and skipping only
+            // avoids `uv_close` on a handle that adopted a fd we never owned.
+            if !self.owns_fd && !matches!(self.source, Some(Source::File(_) | Source::SyncFile(_)))
+            {
                 return;
             }
             self.close();

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2464,12 +2464,9 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         self.is_done = true;
 
         if !self.has_pending_data() {
-            // `close()` must run so `Parent::on_close` fires and the FileSink
-            // keep-alive ref is released. For File/SyncFile `close()` already
-            // honours `!owns_fd` (it takes the `detach_borrowed_fd()` arm and
-            // leaves the fd open). For Pipe/Tty the callers dup a borrowed fd
-            // before `start()`, so `owns_fd` is true there and skipping only
-            // avoids `uv_close` on a handle that adopted a fd we never owned.
+            // `close()` must run so `Parent::on_close` fires. File/SyncFile's
+            // close path already honours `!owns_fd` via `detach_borrowed_fd()`;
+            // Pipe/Tty would `uv_close` the caller's handle, so still skip.
             if !self.owns_fd && !matches!(self.source, Some(Source::File(_) | Source::SyncFile(_)))
             {
                 return;

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2466,8 +2466,7 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         if !self.has_pending_data() {
             if !self.owns_fd && !matches!(self.source, Some(Source::File(_) | Source::SyncFile(_)))
             {
-                // Pipe/Tty `close()` would `uv_close` the caller's handle;
-                // File's close path already honours `!owns_fd`.
+                // Pipe/Tty close() would uv_close the caller's handle; File honours !owns_fd.
                 return;
             }
             self.close();

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2464,11 +2464,10 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         self.is_done = true;
 
         if !self.has_pending_data() {
-            // `close()` must run so `Parent::on_close` fires. File/SyncFile's
-            // close path already honours `!owns_fd` via `detach_borrowed_fd()`;
-            // Pipe/Tty would `uv_close` the caller's handle, so still skip.
             if !self.owns_fd && !matches!(self.source, Some(Source::File(_) | Source::SyncFile(_)))
             {
+                // Pipe/Tty `close()` would `uv_close` the caller's handle;
+                // File's close path already honours `!owns_fd`.
                 return;
             }
             self.close();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1506,6 +1506,19 @@ impl BlobExt for Blob {
                         false
                     }
                 };
+
+                let borrowed = matches!(pathlike, PathOrFileDescriptor::Fd(_));
+                let (writer_fd, owns_fd) =
+                    match dup_borrowed_pipe_for_uv(fd, borrowed, is_stdout_or_stderr) {
+                        bun_sys::Result::Ok(r) => r,
+                        bun_sys::Result::Err(err) => {
+                            return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                                global_this,
+                                err.to_js(global_this),
+                            ));
+                        }
+                    };
+
                 let sink = webcore::FileSink::init(
                     fd,
                     jsc::EventLoopHandle::init(
@@ -1517,19 +1530,20 @@ impl BlobExt for Blob {
                     ),
                 );
                 // SAFETY: `init` returns a freshly-allocated +1 *mut FileSink.
-                unsafe {
-                    (*sink)
-                        .writer
-                        .with_mut(|w| w.owns_fd = !matches!(pathlike, PathOrFileDescriptor::Fd(_)))
-                };
+                unsafe { (*sink).writer.with_mut(|w| w.owns_fd = owns_fd) };
 
                 #[cfg(windows)]
                 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
+                #[cfg(windows)]
+                use bun_sys::FdExt as _;
                 if is_stdout_or_stderr {
                     // SAFETY: sink is live; sole owner here.
                     if let bun_sys::Result::Err(err) =
-                        unsafe { (*sink).writer.with_mut(|w| w.start_sync(fd, false)) }
+                        unsafe { (*sink).writer.with_mut(|w| w.start_sync(writer_fd, false)) }
                     {
+                        if owns_fd {
+                            writer_fd.close();
+                        }
                         unsafe { webcore::FileSink::deref(sink) };
                         return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
@@ -1539,8 +1553,11 @@ impl BlobExt for Blob {
                 } else {
                     // SAFETY: sink is live; sole owner here.
                     if let bun_sys::Result::Err(err) =
-                        unsafe { (*sink).writer.with_mut(|w| w.start(fd, true)) }
+                        unsafe { (*sink).writer.with_mut(|w| w.start(writer_fd, true)) }
                     {
+                        if owns_fd {
+                            writer_fd.close();
+                        }
                         unsafe { webcore::FileSink::deref(sink) };
                         return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
@@ -1816,6 +1833,7 @@ impl BlobExt for Blob {
         #[cfg(windows)]
         {
             use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
+            use bun_sys::FdExt as _;
 
             let pathlike = &store.data.as_file().pathlike;
             // SAFETY: bun_vm() never returns null for a Bun-owned global.
@@ -1857,6 +1875,15 @@ impl BlobExt for Blob {
                 )
             };
 
+            let borrowed = matches!(pathlike, PathOrFileDescriptor::Fd(_));
+            let (writer_fd, owns_fd) =
+                match dup_borrowed_pipe_for_uv(fd, borrowed, is_stdout_or_stderr) {
+                    bun_sys::Result::Ok(r) => r,
+                    bun_sys::Result::Err(err) => {
+                        return Err(global_this.throw_value(err.to_js(global_this)));
+                    }
+                };
+
             let sink = webcore::FileSink::init(
                 fd,
                 jsc::EventLoopHandle::init(
@@ -1869,18 +1896,19 @@ impl BlobExt for Blob {
             );
             // SAFETY: `init` returns a freshly-allocated +1 *mut FileSink; sole owner here.
             let sink_mut = unsafe { &mut *sink };
-            sink_mut
-                .writer
-                .with_mut(|w| w.owns_fd = !matches!(pathlike, PathOrFileDescriptor::Fd(_)));
+            sink_mut.writer.with_mut(|w| w.owns_fd = owns_fd);
 
             let start_result = sink_mut.writer.with_mut(|w| {
                 if is_stdout_or_stderr {
-                    w.start_sync(fd, false)
+                    w.start_sync(writer_fd, false)
                 } else {
-                    w.start(fd, true)
+                    w.start(writer_fd, true)
                 }
             });
             if let bun_sys::Result::Err(err) = start_result {
+                if owns_fd {
+                    writer_fd.close();
+                }
                 // SAFETY: release the +1 ref from `init`.
                 unsafe { webcore::FileSink::deref(sink) };
                 return Err(global_this.throw_value(err.to_js(global_this)));
@@ -5385,6 +5413,36 @@ pub fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
 }
 
 const WRITE_PERMISSIONS: bun_sys::Mode = 0o664;
+
+/// `Source::open` adopts a pipe/tty fd into a `uv_pipe_t`/`uv_tty_t`, which
+/// owns (and will close) the underlying HANDLE. For a caller-supplied fd we
+/// hand the writer a dup so `owns_fd` stays true: `end()` then runs `close()`,
+/// `on_close` fires, and the keep-alive ref taken on the first pending write
+/// is released. stdout/stderr are opened via `start_sync` (no uv handle), and
+/// file handles do not take ownership, so neither needs a dup.
+#[cfg(windows)]
+fn dup_borrowed_pipe_for_uv(
+    fd: Fd,
+    borrowed: bool,
+    is_stdout_or_stderr: bool,
+) -> bun_sys::Result<(Fd, bool)> {
+    use bun_sys::FdExt as _;
+    use bun_sys::windows::libuv as uv;
+    if borrowed
+        && !is_stdout_or_stderr
+        && matches!(
+            uv::uv_guess_handle(fd.uv()),
+            uv::HandleType::NamedPipe | uv::HandleType::Tty
+        )
+    {
+        let dup = bun_sys::dup(fd).and_then(|d| {
+            d.make_lib_uv_owned_for_syscall(bun_sys::Tag::dup, bun_sys::ErrorCase::CloseOnFail)
+        })?;
+        bun_sys::Result::Ok((dup, true))
+    } else {
+        bun_sys::Result::Ok((fd, !borrowed))
+    }
+}
 
 #[cfg(not(windows))]
 fn write_string_to_file_fast<const NEEDS_OPEN: bool>(

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5417,8 +5417,7 @@ pub fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
 
 const WRITE_PERMISSIONS: bun_sys::Mode = 0o664;
 
-/// `uv_pipe_open`/`uv_tty_init` adopt (and later close) the HANDLE, so a
-/// borrowed pipe/tty fd is dup'd and the writer owns the dup.
+/// Dup a borrowed pipe/tty fd so the writer owns the handle `uv_pipe_open` adopts.
 #[cfg(windows)]
 fn dup_borrowed_pipe_for_uv(
     fd: Fd,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1508,16 +1508,19 @@ impl BlobExt for Blob {
                 };
 
                 let borrowed = matches!(pathlike, PathOrFileDescriptor::Fd(_));
-                let (writer_fd, owns_fd) =
-                    match dup_borrowed_pipe_for_uv(fd, borrowed, is_stdout_or_stderr) {
-                        bun_sys::Result::Ok(r) => r,
-                        bun_sys::Result::Err(err) => {
-                            return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                let (writer_fd, owns_fd) = match dup_borrowed_pipe_for_uv(
+                    fd,
+                    borrowed,
+                    is_stdout_or_stderr,
+                ) {
+                    bun_sys::Result::Ok(r) => r,
+                    bun_sys::Result::Err(err) => {
+                        return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                                 global_this,
                                 err.to_js(global_this),
                             ));
-                        }
-                    };
+                    }
+                };
 
                 let sink = webcore::FileSink::init(
                     fd,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5417,12 +5417,9 @@ pub fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
 
 const WRITE_PERMISSIONS: bun_sys::Mode = 0o664;
 
-/// `Source::open` adopts a pipe/tty fd into a `uv_pipe_t`/`uv_tty_t`, which
-/// owns (and will close) the underlying HANDLE. For a caller-supplied fd we
-/// hand the writer a dup so `owns_fd` stays true: `end()` then runs `close()`,
-/// `on_close` fires, and the keep-alive ref taken on the first pending write
-/// is released. stdout/stderr are opened via `start_sync` (no uv handle), and
-/// file handles do not take ownership, so neither needs a dup.
+/// `uv_pipe_open`/`uv_tty_init` adopt (and later close) the HANDLE, so a
+/// borrowed pipe/tty fd is dup'd and the writer owns the dup. stdout/stderr
+/// use `start_sync` and file handles are not adopted, so neither is dup'd.
 #[cfg(windows)]
 fn dup_borrowed_pipe_for_uv(
     fd: Fd,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5418,8 +5418,7 @@ pub fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
 const WRITE_PERMISSIONS: bun_sys::Mode = 0o664;
 
 /// `uv_pipe_open`/`uv_tty_init` adopt (and later close) the HANDLE, so a
-/// borrowed pipe/tty fd is dup'd and the writer owns the dup. stdout/stderr
-/// use `start_sync` and file handles are not adopted, so neither is dup'd.
+/// borrowed pipe/tty fd is dup'd and the writer owns the dup.
 #[cfg(windows)]
 fn dup_borrowed_pipe_for_uv(
     fd: Fd,

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -540,42 +540,45 @@ describe.skipIf(!isWindows).each([
   ["file", "fileFd"],
 ])("does not leak native FileSink for a borrowed %s fd on Windows", (kind, fdExpr) => {
   it("releases the keep-alive ref and leaves the caller's fd open", async () => {
+    const dir = tmpdirSync();
     const childSrc = /* js */ `
       const { fileSinkInternals } = require("bun:internal-for-testing");
       const fs = require("node:fs");
-      const os = require("node:os");
-      const path = require("node:path");
 
       const iterations = 8;
-      const fileFd = fs.openSync(path.join(os.tmpdir(), "filesink-borrowed-" + process.pid), "w");
+      const tmpPath = ${JSON.stringify(join(dir, "borrowed"))};
+      const fileFd = fs.openSync(tmpPath, "w");
+      try {
+        async function once() {
+          const w = Bun.file(${fdExpr}).writer();
+          const p = w.write("x");
+          if (p && typeof p.then === "function") await p;
+          await Promise.resolve(w.end()).catch(() => {});
+        }
 
-      async function once() {
-        const w = Bun.file(${fdExpr}).writer();
-        const p = w.write("x");
-        if (p && typeof p.then === "function") await p;
-        await Promise.resolve(w.end()).catch(() => {});
-      }
-
-      // Warm up so any one-off allocations are in the baseline.
-      await once();
-      Bun.gc(true);
-      const baseline = fileSinkInternals.liveCount();
-
-      for (let i = 0; i < iterations; i++) await once();
-
-      for (let i = 0; i < 50; i++) {
+        // Warm up so any one-off allocations are in the baseline.
+        await once();
         Bun.gc(true);
-        if (fileSinkInternals.liveCount() <= baseline) break;
-        await Bun.sleep(10);
+        const baseline = fileSinkInternals.liveCount();
+
+        for (let i = 0; i < iterations; i++) await once();
+
+        for (let i = 0; i < 50; i++) {
+          Bun.gc(true);
+          if (fileSinkInternals.liveCount() <= baseline) break;
+          await Bun.sleep(10);
+        }
+        const leaked = fileSinkInternals.liveCount() - baseline;
+
+        // The caller's fd must still be open after the writer's end().
+        let fdOpen = true;
+        try { fs.fstatSync(${fdExpr}); } catch { fdOpen = false; }
+
+        process.stdout.write(JSON.stringify({ leaked, fdOpen, iterations }));
+      } finally {
+        fs.closeSync(fileFd);
+        try { fs.unlinkSync(tmpPath); } catch {}
       }
-      const leaked = fileSinkInternals.liveCount() - baseline;
-
-      // The caller's fd must still be open after the writer's end().
-      let fdOpen = true;
-      try { fs.fstatSync(${fdExpr}); } catch { fdOpen = false; }
-      fs.closeSync(fileFd);
-
-      process.stdout.write(JSON.stringify({ leaked, fdOpen, iterations }));
     `;
 
     // child_process.spawn gives the child a named-pipe fd 3 on Windows;

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -2,6 +2,7 @@ import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
+import { spawn as cpSpawn } from "node:child_process";
 import { join } from "node:path";
 
 describe("FileSink", () => {
@@ -522,6 +523,84 @@ it.skipIf(!isPosix)("does not leak native FileSink when a pending write fails (E
   // One straggler whose JS wrapper has not yet been finalized is acceptable;
   // more than that indicates a native leak.
   expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
+});
+
+// On Windows `Bun.file(fd).writer()` on a borrowed fd set `owns_fd = false`
+// and the writer's `end()` early-returned without calling `close()`, so
+// `on_close` never fired and the `must_be_kept_alive_until_eof` self-ref taken
+// on the first pending write was never released: every iteration leaked one
+// native FileSink for the rest of the process. For pipe/tty fds the fd is now
+// dup'd before `uv_pipe_open` so the writer owns (and closes) its own handle;
+// for file fds `end()` now lets `close()` run since the File close path
+// already honours `!owns_fd`. In both cases the caller's fd must stay open.
+// Runs in a subprocess so the native live counter starts from a known baseline
+// and the parent can drain the pipe.
+describe.skipIf(!isWindows).each([
+  ["pipe", "3"],
+  ["file", "fileFd"],
+])("does not leak native FileSink for a borrowed %s fd on Windows", (kind, fdExpr) => {
+  it("releases the keep-alive ref and leaves the caller's fd open", async () => {
+    const childSrc = /* js */ `
+      const { fileSinkInternals } = require("bun:internal-for-testing");
+      const fs = require("node:fs");
+      const os = require("node:os");
+      const path = require("node:path");
+
+      const iterations = 8;
+      const fileFd = fs.openSync(path.join(os.tmpdir(), "filesink-borrowed-" + process.pid), "w");
+
+      async function once() {
+        const w = Bun.file(${fdExpr}).writer();
+        const p = w.write("x");
+        if (p && typeof p.then === "function") await p;
+        await Promise.resolve(w.end()).catch(() => {});
+      }
+
+      // Warm up so any one-off allocations are in the baseline.
+      await once();
+      Bun.gc(true);
+      const baseline = fileSinkInternals.liveCount();
+
+      for (let i = 0; i < iterations; i++) await once();
+
+      for (let i = 0; i < 50; i++) {
+        Bun.gc(true);
+        if (fileSinkInternals.liveCount() <= baseline) break;
+        await Bun.sleep(10);
+      }
+      const leaked = fileSinkInternals.liveCount() - baseline;
+
+      // The caller's fd must still be open after the writer's end().
+      let fdOpen = true;
+      try { fs.fstatSync(${fdExpr}); } catch { fdOpen = false; }
+      fs.closeSync(fileFd);
+
+      process.stdout.write(JSON.stringify({ leaked, fdOpen, iterations }));
+    `;
+
+    // child_process.spawn gives the child a named-pipe fd 3 on Windows;
+    // draining it here keeps the child's writes from ever blocking.
+    const cp = cpSpawn(bunExe(), ["--no-install", "-e", childSrc], {
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe", "pipe"],
+    });
+    cp.stdio[3]!.on("data", () => {});
+    let stdout = "";
+    let stderr = "";
+    cp.stdout!.on("data", d => (stdout += d));
+    cp.stderr!.on("data", d => (stderr += d));
+    const code = await new Promise<number>(resolve => cp.on("close", c => resolve(c ?? -1)));
+
+    expect(stderr).toBe("");
+    const { leaked, fdOpen, iterations } = JSON.parse(stdout);
+    // Without the fix every iteration leaks one native FileSink (leaked ==
+    // iterations). One straggler whose JS wrapper has not yet been finalized
+    // is acceptable.
+    expect(fdOpen).toBe(true);
+    expect(leaked).toBeLessThanOrEqual(1);
+    expect(leaked).toBeLessThan(iterations);
+    expect(code).toBe(0);
+  });
 });
 
 it("start() without path/fd on an already-open writer does not crash", async () => {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -592,7 +592,10 @@ describe.skipIf(!isWindows).each([
     let stderr = "";
     cp.stdout!.on("data", d => (stdout += d));
     cp.stderr!.on("data", d => (stderr += d));
-    const code = await new Promise<number>(resolve => cp.on("close", c => resolve(c ?? -1)));
+    const code = await new Promise<number>((resolve, reject) => {
+      cp.on("error", reject);
+      cp.on("close", c => resolve(c ?? -1));
+    });
 
     expect(stderr).toBe("");
     const { leaked, fdOpen, iterations } = JSON.parse(stdout);


### PR DESCRIPTION
## Reproduction

```js
// child spawned with stdio[3] = 'pipe'
for (let i = 0; i < 8; i++) {
  const w = Bun.file(3).writer();
  await w.write('x');
  await w.end();
}
Bun.gc(true);
// fileSinkInternals.liveCount() == 8  (before: one per iteration leaked)
```

## Cause

Both Windows sink-creation blocks in `Blob.rs` (`get_writer` and `pipe_readable_stream_to_blob`) set `writer.owns_fd = false` for a caller-supplied fd and then called `writer.start(fd, true)`, which calls `Source::open` and for a named-pipe/tty fd creates a `uv_pipe_t`/`uv_tty_t` that adopts the underlying HANDLE. Every `uv_write` is async so the first write returns `Pending` and `FileSink::to_result` takes the `must_be_kept_alive_until_eof` self-ref. On `end()`:

```rust
// WindowsStreamingWriter::end()
if !self.has_pending_data() {
    if !self.owns_fd { return; }   // <-- on_close never fires
    self.close();
}
```

`close()` never runs, `Parent::on_close` never fires, and `clear_keep_alive_ref` is never called: one native `FileSink` (and its `Box<uv::Pipe>`) leaks for the process lifetime per writer. A borrowed regular-file fd leaks the same way via the `Source::File` path.

## Fix

- New `dup_borrowed_pipe_for_uv()` helper: for a borrowed pipe/tty fd, `DuplicateHandle` + wrap as a uv fd, and pass that to `start()` with `owns_fd = true`. `end()` then runs `close()`, `on_close` fires, the keep-alive ref is released, and `uv_close` only closes the dup so the caller's fd stays open. Both `get_writer` and `pipe_readable_stream_to_blob` call the helper; a path-opened fd (or the dup) is now also closed if `start()` itself fails, which it was not before.
- `WindowsStreamingWriter::end()` now lets `close()` run for a borrowed `Source::File`/`SyncFile`: the File close path already routes through `detach_borrowed_fd()` and leaves the fd open, it just never reached there. Pipe/Tty with `!owns_fd` still early-return, but the dup above makes that state unreachable from the Blob paths.

## Verification

New Windows-only tests in `test/js/bun/util/filesink.test.ts` spawn a child with `stdio[3] = 'pipe'` and a temp-file fd, run 8 `Bun.file(fd).writer()` / `write` / `end` iterations, and assert `fileSinkInternals.liveCount()` did not grow and `fstatSync(fd)` still succeeds.

| | system bun | this PR |
| --- | --- | --- |
| pipe fd | `Received: 8` | pass |
| file fd | `Received: 8` | pass |

`filesink.test.ts`, `bun-write.test.js`, `spawn-stdin-readable-stream.test.ts`, `child-process-stdio.test.js`, `process-stdio.test.ts` all pass on Windows x64 debug. `bun run rust:check-all` is clean on all 10 targets.

## Related

#35993 applies the same dup to `get_writer` as part of backing `createWriteStream` with a FileSink; this PR covers `pipe_readable_stream_to_blob` as well (reachable today via S3 `Bun.write` to a pipe fd, and via plain `Bun.write(Bun.file(pipeFd), readableStream)` once #31689 lands). Overlap with #35993 is the identical `get_writer` hunk and the `end()` condition.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesink.test.ts

<!-- robobun:evidence:end -->