### PR TITLE
s3: Trimall signed header values per SigV4 CanonicalHeaders

### DIFF
--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -297,19 +297,23 @@ impl S3Credentials {
 
         let search_params = sign_options.search_params;
 
-        let content_disposition_canon = sign_options.content_disposition.map(sigv4_trimall);
-        let content_disposition = content_disposition_canon
-            .as_deref()
-            .filter(|s| !s.is_empty());
+        let mut content_disposition = sign_options.content_disposition;
+        if matches!(content_disposition, Some(s) if s.is_empty()) {
+            content_disposition = None;
+        }
         let mut content_type = sign_options.content_type;
         if matches!(content_type, Some(s) if s.is_empty()) {
             content_type = None;
         }
-        let content_encoding_canon = sign_options.content_encoding.map(sigv4_trimall);
-        let content_encoding = content_encoding_canon.as_deref().filter(|s| !s.is_empty());
-        let session_token_canon =
-            (!self.session_token.is_empty()).then(|| sigv4_trimall(&self.session_token));
-        let session_token = session_token_canon.as_deref().filter(|s| !s.is_empty());
+        let mut content_encoding = sign_options.content_encoding;
+        if matches!(content_encoding, Some(s) if s.is_empty()) {
+            content_encoding = None;
+        }
+        let session_token: Option<&[u8]> = if self.session_token.is_empty() {
+            None
+        } else {
+            Some(&self.session_token)
+        };
 
         let acl: Option<&'static [u8]> = sign_options.acl.map(|a| a.to_string());
         let storage_class: Option<&'static [u8]> =
@@ -1386,16 +1390,12 @@ impl CanonicalRequest {
             BStr::new(query)
         );
         if key.content_disposition {
-            w!(
-                "content-disposition:{}\n",
-                BStr::new(content_disposition.unwrap())
-            );
+            let v = sigv4_trimall(content_disposition.unwrap());
+            w!("content-disposition:{}\n", BStr::new(&v));
         }
         if key.content_encoding {
-            w!(
-                "content-encoding:{}\n",
-                BStr::new(content_encoding.unwrap())
-            );
+            let v = sigv4_trimall(content_encoding.unwrap());
+            w!("content-encoding:{}\n", BStr::new(&v));
         }
         if key.content_md5 {
             w!("content-md5:{}\n", BStr::new(content_md5.unwrap()));
@@ -1413,10 +1413,8 @@ impl CanonicalRequest {
             w!("x-amz-request-payer:requester\n");
         }
         if key.session_token {
-            w!(
-                "x-amz-security-token:{}\n",
-                BStr::new(session_token.unwrap())
-            );
+            let v = sigv4_trimall(session_token.unwrap());
+            w!("x-amz-security-token:{}\n", BStr::new(&v));
         }
         if key.storage_class {
             w!(

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -307,8 +307,8 @@ impl S3Credentials {
         }
         let content_encoding_canon = sign_options.content_encoding.map(sigv4_trimall);
         let content_encoding = content_encoding_canon.as_deref().filter(|s| !s.is_empty());
-        let session_token_canon = (!self.session_token.is_empty())
-            .then(|| sigv4_trimall(&self.session_token));
+        let session_token_canon =
+            (!self.session_token.is_empty()).then(|| sigv4_trimall(&self.session_token));
         let session_token = session_token_canon.as_deref().filter(|s| !s.is_empty());
 
         let acl: Option<&'static [u8]> = sign_options.acl.map(|a| a.to_string());

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -1442,8 +1442,7 @@ fn contains_newline_or_cr(value: &[u8]) -> bool {
     strings::index_of_any(value, b"\r\n").is_some()
 }
 
-/// AWS SigV4 CanonicalHeaders "Trimall": trim outer whitespace and collapse
-/// interior runs to a single space. Borrows when no rewrite is needed.
+/// SigV4 CanonicalHeaders "Trimall": trim outer whitespace, collapse interior runs to one space.
 fn sigv4_trimall(value: &[u8]) -> std::borrow::Cow<'_, [u8]> {
     #[inline]
     fn is_ws(b: u8) -> bool {

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -297,23 +297,19 @@ impl S3Credentials {
 
         let search_params = sign_options.search_params;
 
-        let mut content_disposition = sign_options.content_disposition;
-        if matches!(content_disposition, Some(s) if s.is_empty()) {
-            content_disposition = None;
-        }
+        let content_disposition_canon = sign_options.content_disposition.map(sigv4_trimall);
+        let content_disposition = content_disposition_canon
+            .as_deref()
+            .filter(|s| !s.is_empty());
         let mut content_type = sign_options.content_type;
         if matches!(content_type, Some(s) if s.is_empty()) {
             content_type = None;
         }
-        let mut content_encoding = sign_options.content_encoding;
-        if matches!(content_encoding, Some(s) if s.is_empty()) {
-            content_encoding = None;
-        }
-        let session_token: Option<&[u8]> = if self.session_token.is_empty() {
-            None
-        } else {
-            Some(&self.session_token)
-        };
+        let content_encoding_canon = sign_options.content_encoding.map(sigv4_trimall);
+        let content_encoding = content_encoding_canon.as_deref().filter(|s| !s.is_empty());
+        let session_token_canon = (!self.session_token.is_empty())
+            .then(|| sigv4_trimall(&self.session_token));
+        let session_token = session_token_canon.as_deref().filter(|s| !s.is_empty());
 
         let acl: Option<&'static [u8]> = sign_options.acl.map(|a| a.to_string());
         let storage_class: Option<&'static [u8]> =
@@ -1444,6 +1440,57 @@ impl CanonicalRequest {
 /// which would allow HTTP header injection if used in a header value.
 fn contains_newline_or_cr(value: &[u8]) -> bool {
     strings::index_of_any(value, b"\r\n").is_some()
+}
+
+/// AWS SigV4 CanonicalHeaders "Trimall": strip leading and trailing ASCII
+/// whitespace and collapse interior runs of whitespace to a single space.
+/// Header values on the wire are parsed with outer OWS stripped, and the
+/// server re-derives the canonical request with this transform, so the signed
+/// bytes must match. Borrows the input when no rewrite is needed.
+fn sigv4_trimall(value: &[u8]) -> std::borrow::Cow<'_, [u8]> {
+    #[inline]
+    fn is_ws(b: u8) -> bool {
+        b == b' ' || b == b'\t'
+    }
+    let mut start = 0usize;
+    let mut end = value.len();
+    while start < end && is_ws(value[start]) {
+        start += 1;
+    }
+    while end > start && is_ws(value[end - 1]) {
+        end -= 1;
+    }
+    let trimmed = &value[start..end];
+    let mut prev_ws = false;
+    let mut needs_rewrite = false;
+    for &b in trimmed {
+        if is_ws(b) {
+            if prev_ws || b != b' ' {
+                needs_rewrite = true;
+                break;
+            }
+            prev_ws = true;
+        } else {
+            prev_ws = false;
+        }
+    }
+    if !needs_rewrite {
+        return std::borrow::Cow::Borrowed(trimmed);
+    }
+    let mut out = Vec::with_capacity(trimmed.len());
+    let mut prev_ws = false;
+    for &b in trimmed {
+        if is_ws(b) {
+            if !prev_ws {
+                out.push(b' ');
+            }
+            prev_ws = true;
+        } else {
+            out.push(b);
+            prev_ws = false;
+        }
+    }
+    std::borrow::Cow::Owned(out)
 }
 
 fn is_valid_host_component(value: &[u8]) -> bool {

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -1442,11 +1442,8 @@ fn contains_newline_or_cr(value: &[u8]) -> bool {
     strings::index_of_any(value, b"\r\n").is_some()
 }
 
-/// AWS SigV4 CanonicalHeaders "Trimall": strip leading and trailing ASCII
-/// whitespace and collapse interior runs of whitespace to a single space.
-/// Header values on the wire are parsed with outer OWS stripped, and the
-/// server re-derives the canonical request with this transform, so the signed
-/// bytes must match. Borrows the input when no rewrite is needed.
+/// AWS SigV4 CanonicalHeaders "Trimall": trim outer whitespace and collapse
+/// interior runs to a single space. Borrows when no rewrite is needed.
 fn sigv4_trimall(value: &[u8]) -> std::borrow::Cow<'_, [u8]> {
     #[inline]
     fn is_ws(b: u8) -> bool {

--- a/test/js/bun/s3/s3-sigv4-header-trimall-fixture.ts
+++ b/test/js/bun/s3/s3-sigv4-header-trimall-fixture.ts
@@ -1,0 +1,105 @@
+import { createHash, createHmac } from "node:crypto";
+import net from "node:net";
+
+const ACCESS = "AKIDEXAMPLE";
+const SECRET = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+const trimall = (v: string) => v.replace(/^[ \t]+|[ \t]+$/g, "").replace(/[ \t]+/g, " ");
+
+// A minimal SigV4-verifying S3 origin. It rebuilds the canonical request from
+// the received headers the way a conforming backend does (applying Trimall to
+// every signed header value) and compares the resulting signature to the one
+// the client sent in Authorization.
+let lastRawHeaders = "";
+const server = net.createServer(sock => {
+  let buf = Buffer.alloc(0);
+  sock.on("error", () => {});
+  sock.on("data", d => {
+    buf = Buffer.concat([buf, d]);
+    while (true) {
+      const headerEnd = buf.indexOf("\r\n\r\n");
+      if (headerEnd < 0) return;
+      const head = buf.subarray(0, headerEnd).toString("latin1");
+      lastRawHeaders = head;
+      const lines = head.split("\r\n");
+      const [method, target] = lines[0].split(" ");
+      const h: Record<string, string> = {};
+      for (const l of lines.slice(1)) {
+        const i = l.indexOf(":");
+        if (i > 0) h[l.slice(0, i).toLowerCase()] = l.slice(i + 1).trim();
+      }
+      const bodyLen = Number(h["content-length"] || "0");
+      const reqLen = headerEnd + 4 + bodyLen;
+      if (buf.length < reqLen) return;
+      buf = buf.subarray(reqLen);
+      const m =
+        /Credential=([^/]+)\/(\d{8})\/([^/]+)\/([^/]+)\/aws4_request,\s*SignedHeaders=([^,]+),\s*Signature=([0-9a-f]{64})/.exec(
+          h.authorization || "",
+        );
+      let status = 400;
+      if (m) {
+        const [path, query = ""] = target.split("?");
+        const canon = [
+          method,
+          path,
+          query,
+          m[5]
+            .split(";")
+            .map(n => n + ":" + trimall(h[n] ?? "") + "\n")
+            .join(""),
+          m[5],
+          h["x-amz-content-sha256"],
+        ].join("\n");
+        const scope = m[2] + "/" + m[3] + "/" + m[4] + "/aws4_request";
+        const sts =
+          "AWS4-HMAC-SHA256\n" +
+          h["x-amz-date"] +
+          "\n" +
+          scope +
+          "\n" +
+          createHash("sha256").update(Buffer.from(canon, "latin1")).digest("hex");
+        let k = createHmac("sha256", "AWS4" + SECRET)
+          .update(m[2])
+          .digest();
+        for (const p of [m[3], m[4], "aws4_request"]) k = createHmac("sha256", k).update(p).digest();
+        status = createHmac("sha256", k).update(sts).digest("hex") === m[6] ? 200 : 403;
+      }
+      const body = status === 200 ? "" : "<Error><Code>SignatureDoesNotMatch</Code><Message>sig</Message></Error>";
+      sock.write("HTTP/1.1 " + status + " X\r\nContent-Length: " + body.length + '\r\nETag: "e"\r\n\r\n' + body);
+    }
+  });
+});
+await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+const port = (server.address() as net.AddressInfo).port;
+
+async function run(opts: Bun.S3Options, ctor: Bun.S3Options = {}) {
+  const s3 = new Bun.S3Client({
+    endpoint: "http://127.0.0.1:" + port,
+    bucket: "b",
+    accessKeyId: ACCESS,
+    secretAccessKey: SECRET,
+    region: "us-east-1",
+    ...ctor,
+  });
+  try {
+    await s3.write("obj", "x", opts);
+    return "ok";
+  } catch (e: any) {
+    return e?.code ?? String(e);
+  }
+}
+
+const cd_run = await run({ contentDisposition: 'attachment;  filename="a  b.txt"' });
+// Trimall affects only the canonical request; the raw interior whitespace goes on the wire.
+const cd_run_wire = lastRawHeaders.includes('content-disposition: attachment;  filename="a  b.txt"');
+
+const results = {
+  control: await run({ contentDisposition: 'attachment; filename="a b.txt"' }),
+  cd_run,
+  cd_run_wire,
+  cd_outer: await run({ contentDisposition: "  inline  " }),
+  ce_trailing: await run({ contentEncoding: "gzip  " }),
+  token_trailing: await run({}, { sessionToken: "TOK123abc+/= " }),
+  ce_tab: await run({ contentEncoding: "gzip,\tbr" }),
+};
+console.log(JSON.stringify(results));
+process.exit(0);

--- a/test/js/bun/s3/s3-sigv4-header-trimall.test.ts
+++ b/test/js/bun/s3/s3-sigv4-header-trimall.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from "bun:test";
+import { createHash, createHmac } from "node:crypto";
+import net from "node:net";
+
+// Fake credentials from the AWS SigV4 documentation examples.
+const ACCESS = "AKIDEXAMPLE";
+const SECRET = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+
+// AWS SigV4 CanonicalHeaders "Trimall" on the received header value.
+const trimall = (v: string) => v.trim().replace(/\s+/g, " ");
+
+// A minimal SigV4-verifying S3 origin. It rebuilds the canonical request from
+// the received headers the way a conforming backend does (applying Trimall to
+// every signed header value) and compares the resulting signature to the one
+// the client sent in Authorization.
+function createSigV4Origin(sockets: Set<net.Socket>) {
+  return net.createServer(sock => {
+    sockets.add(sock);
+    let buf = Buffer.alloc(0);
+    let done = false;
+    sock.on("error", () => {});
+    sock.on("close", () => sockets.delete(sock));
+    sock.on("data", d => {
+      buf = Buffer.concat([buf, d]);
+      const headerEnd = buf.indexOf("\r\n\r\n");
+      if (headerEnd < 0 || done) return;
+      const head = buf.subarray(0, headerEnd).toString("latin1");
+      const lines = head.split("\r\n");
+      const [method, target] = lines[0].split(" ");
+      const h: Record<string, string> = {};
+      for (const l of lines.slice(1)) {
+        const i = l.indexOf(":");
+        if (i > 0) h[l.slice(0, i).toLowerCase()] = l.slice(i + 1).trim();
+      }
+      const bodyLen = Number(h["content-length"] || "0");
+      if (buf.length - headerEnd - 4 < bodyLen) return;
+      done = true;
+      const m =
+        /Credential=([^/]+)\/(\d{8})\/([^/]+)\/([^/]+)\/aws4_request,\s*SignedHeaders=([^,]+),\s*Signature=([0-9a-f]{64})/.exec(
+          h.authorization || "",
+        );
+      let status = 400;
+      if (m) {
+        const [path, query = ""] = target.split("?");
+        const signed = m[5].split(";");
+        const canon = [
+          method,
+          path,
+          query,
+          signed.map(n => n + ":" + trimall(h[n] ?? "") + "\n").join(""),
+          m[5],
+          h["x-amz-content-sha256"],
+        ].join("\n");
+        const sts =
+          `AWS4-HMAC-SHA256\n${h["x-amz-date"]}\n${m[2]}/${m[3]}/${m[4]}/aws4_request\n` +
+          createHash("sha256").update(Buffer.from(canon, "latin1")).digest("hex");
+        let k = createHmac("sha256", "AWS4" + SECRET).update(m[2]).digest();
+        for (const p of [m[3], m[4], "aws4_request"]) k = createHmac("sha256", k).update(p).digest();
+        status = createHmac("sha256", k).update(sts).digest("hex") === m[6] ? 200 : 403;
+      }
+      const body =
+        status === 200 ? "" : "<Error><Code>SignatureDoesNotMatch</Code><Message>sig</Message></Error>";
+      sock.write(`HTTP/1.1 ${status} X\r\nContent-Length: ${body.length}\r\nETag: "e"\r\n\r\n${body}`);
+    });
+  });
+}
+
+describe("S3 SigV4 signed header Trimall", () => {
+  async function run(opts: Bun.S3Options, ctor: Bun.S3Options = {}) {
+    const sockets = new Set<net.Socket>();
+    const server = createSigV4Origin(sockets);
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      const s3 = new Bun.S3Client({
+        endpoint: `http://127.0.0.1:${port}`,
+        bucket: "b",
+        accessKeyId: ACCESS,
+        secretAccessKey: SECRET,
+        region: "us-east-1",
+        ...ctor,
+      });
+      await s3.write("obj", "x", opts);
+      return "ok";
+    } catch (e: any) {
+      return e?.code ?? String(e);
+    } finally {
+      for (const s of sockets) s.destroy();
+      server.close();
+    }
+  }
+
+  test("control: single-space value matches", async () => {
+    expect(await run({ contentDisposition: 'attachment; filename="a b.txt"' })).toBe("ok");
+  });
+
+  test("contentDisposition with interior run of spaces", async () => {
+    expect(await run({ contentDisposition: 'attachment;  filename="a  b.txt"' })).toBe("ok");
+  });
+
+  test("contentDisposition with leading and trailing whitespace", async () => {
+    expect(await run({ contentDisposition: "  inline  " })).toBe("ok");
+  });
+
+  test("contentEncoding with trailing whitespace", async () => {
+    expect(await run({ contentEncoding: "gzip  " })).toBe("ok");
+  });
+
+  test("sessionToken with trailing whitespace", async () => {
+    expect(await run({}, { sessionToken: "TOK123abc+/= " })).toBe("ok");
+  });
+
+  test("contentEncoding with interior tab", async () => {
+    expect(await run({ contentEncoding: "gzip,\tbr" })).toBe("ok");
+  });
+});

--- a/test/js/bun/s3/s3-sigv4-header-trimall.test.ts
+++ b/test/js/bun/s3/s3-sigv4-header-trimall.test.ts
@@ -1,117 +1,36 @@
 import { describe, expect, test } from "bun:test";
-import { createHash, createHmac } from "node:crypto";
-import net from "node:net";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
 
-// Fake credentials from the AWS SigV4 documentation examples.
-const ACCESS = "AKIDEXAMPLE";
-const SECRET = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
-
-// AWS SigV4 CanonicalHeaders "Trimall" on the received header value.
-const trimall = (v: string) => v.trim().replace(/\s+/g, " ");
-
-// A minimal SigV4-verifying S3 origin. It rebuilds the canonical request from
-// the received headers the way a conforming backend does (applying Trimall to
-// every signed header value) and compares the resulting signature to the one
-// the client sent in Authorization.
-function createSigV4Origin(sockets: Set<net.Socket>) {
-  return net.createServer(sock => {
-    sockets.add(sock);
-    let buf = Buffer.alloc(0);
-    let done = false;
-    sock.on("error", () => {});
-    sock.on("close", () => sockets.delete(sock));
-    sock.on("data", d => {
-      buf = Buffer.concat([buf, d]);
-      const headerEnd = buf.indexOf("\r\n\r\n");
-      if (headerEnd < 0 || done) return;
-      const head = buf.subarray(0, headerEnd).toString("latin1");
-      const lines = head.split("\r\n");
-      const [method, target] = lines[0].split(" ");
-      const h: Record<string, string> = {};
-      for (const l of lines.slice(1)) {
-        const i = l.indexOf(":");
-        if (i > 0) h[l.slice(0, i).toLowerCase()] = l.slice(i + 1).trim();
-      }
-      const bodyLen = Number(h["content-length"] || "0");
-      if (buf.length - headerEnd - 4 < bodyLen) return;
-      done = true;
-      const m =
-        /Credential=([^/]+)\/(\d{8})\/([^/]+)\/([^/]+)\/aws4_request,\s*SignedHeaders=([^,]+),\s*Signature=([0-9a-f]{64})/.exec(
-          h.authorization || "",
-        );
-      let status = 400;
-      if (m) {
-        const [path, query = ""] = target.split("?");
-        const signed = m[5].split(";");
-        const canon = [
-          method,
-          path,
-          query,
-          signed.map(n => n + ":" + trimall(h[n] ?? "") + "\n").join(""),
-          m[5],
-          h["x-amz-content-sha256"],
-        ].join("\n");
-        const sts =
-          `AWS4-HMAC-SHA256\n${h["x-amz-date"]}\n${m[2]}/${m[3]}/${m[4]}/aws4_request\n` +
-          createHash("sha256").update(Buffer.from(canon, "latin1")).digest("hex");
-        let k = createHmac("sha256", "AWS4" + SECRET)
-          .update(m[2])
-          .digest();
-        for (const p of [m[3], m[4], "aws4_request"]) k = createHmac("sha256", k).update(p).digest();
-        status = createHmac("sha256", k).update(sts).digest("hex") === m[6] ? 200 : 403;
-      }
-      const body = status === 200 ? "" : "<Error><Code>SignatureDoesNotMatch</Code><Message>sig</Message></Error>";
-      sock.write(`HTTP/1.1 ${status} X\r\nContent-Length: ${body.length}\r\nETag: "e"\r\n\r\n${body}`);
-    });
-  });
-}
+// The S3 client does not honor NO_PROXY, so an inherited proxy would hijack the
+// request to the stub server.
+const envWithoutProxy = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
 
 describe("S3 SigV4 signed header Trimall", () => {
-  async function run(opts: Bun.S3Options, ctor: Bun.S3Options = {}) {
-    const sockets = new Set<net.Socket>();
-    const server = createSigV4Origin(sockets);
-    await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
-    const port = (server.address() as net.AddressInfo).port;
-    try {
-      const s3 = new Bun.S3Client({
-        endpoint: `http://127.0.0.1:${port}`,
-        bucket: "b",
-        accessKeyId: ACCESS,
-        secretAccessKey: SECRET,
-        region: "us-east-1",
-        ...ctor,
-      });
-      await s3.write("obj", "x", opts);
-      return "ok";
-    } catch (e: any) {
-      return e?.code ?? String(e);
-    } finally {
-      for (const s of sockets) s.destroy();
-      server.close();
-    }
-  }
-
-  test("control: single-space value matches", async () => {
-    expect(await run({ contentDisposition: 'attachment; filename="a b.txt"' })).toBe("ok");
-  });
-
-  test("contentDisposition with interior run of spaces", async () => {
-    expect(await run({ contentDisposition: 'attachment;  filename="a  b.txt"' })).toBe("ok");
-  });
-
-  test("contentDisposition with leading and trailing whitespace", async () => {
-    expect(await run({ contentDisposition: "  inline  " })).toBe("ok");
-  });
-
-  test("contentEncoding with trailing whitespace", async () => {
-    expect(await run({ contentEncoding: "gzip  " })).toBe("ok");
-  });
-
-  test("sessionToken with trailing whitespace", async () => {
-    expect(await run({}, { sessionToken: "TOK123abc+/= " })).toBe("ok");
-  });
-
-  test("contentEncoding with interior tab", async () => {
-    expect(await run({ contentEncoding: "gzip,\tbr" })).toBe("ok");
+  test("signed header values are whitespace-canonicalized", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "s3-sigv4-header-trimall-fixture.ts")],
+      env: envWithoutProxy,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      control: "ok",
+      cd_run: "ok",
+      cd_run_wire: true,
+      cd_outer: "ok",
+      ce_trailing: "ok",
+      token_trailing: "ok",
+      ce_tab: "ok",
+    });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/s3/s3-sigv4-header-trimall.test.ts
+++ b/test/js/bun/s3/s3-sigv4-header-trimall.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { createHash, createHmac } from "node:crypto";
 import net from "node:net";
 
@@ -54,12 +54,13 @@ function createSigV4Origin(sockets: Set<net.Socket>) {
         const sts =
           `AWS4-HMAC-SHA256\n${h["x-amz-date"]}\n${m[2]}/${m[3]}/${m[4]}/aws4_request\n` +
           createHash("sha256").update(Buffer.from(canon, "latin1")).digest("hex");
-        let k = createHmac("sha256", "AWS4" + SECRET).update(m[2]).digest();
+        let k = createHmac("sha256", "AWS4" + SECRET)
+          .update(m[2])
+          .digest();
         for (const p of [m[3], m[4], "aws4_request"]) k = createHmac("sha256", k).update(p).digest();
         status = createHmac("sha256", k).update(sts).digest("hex") === m[6] ? 200 : 403;
       }
-      const body =
-        status === 200 ? "" : "<Error><Code>SignatureDoesNotMatch</Code><Message>sig</Message></Error>";
+      const body = status === 200 ? "" : "<Error><Code>SignatureDoesNotMatch</Code><Message>sig</Message></Error>";
       sock.write(`HTTP/1.1 ${status} X\r\nContent-Length: ${body.length}\r\nETag: "e"\r\n\r\n${body}`);
     });
   });


### PR DESCRIPTION
## What does this PR do?

`Bun.S3Client` wrote the raw option bytes for `content-disposition`, `content-encoding` and `x-amz-security-token` into the SigV4 canonical request. SigV4's CanonicalHeaders step requires each signed value to be trimmed and have sequential whitespace collapsed to a single space ("Trimall"); the server rebuilds the canonical request that way from the bytes it receives (HTTP itself strips outer field-value whitespace in transit). So any of those options carrying leading/trailing whitespace or a run of two or more interior spaces made every request fail with `403 SignatureDoesNotMatch` against a conforming backend.

Real-world faces: `contentDisposition: 'attachment; filename="My  Report.pdf"'` (double space in a user filename), a session token pasted from config with a stray trailing space.

### Fix

Add a borrow-when-possible `sigv4_trimall` helper and apply it inside `CanonicalRequest::format` when writing the `content-disposition`, `content-encoding` and `x-amz-security-token` lines. Only the signed canonical string is normalized; the original bytes still go to `pico_header_new` and the presign `response-content-disposition` encoder, matching the reference SDKs, so an interior double space in a `Content-Disposition` filename is stored on S3 exactly as the caller passed it.

## How did you verify your code works?

New `test/js/bun/s3/s3-sigv4-header-trimall.test.ts` spawns a fixture that runs a from-spec SigV4-verifying loopback origin (it rebuilds the canonical request from the received headers with Trimall applied and recomputes the signature) and exercises a control plus five whitespace cases. The fixture also asserts the interior double-space `content-disposition` value reaches the wire unchanged.

Before this change (control passes, the rest 403):
```
"cd_outer":       "SignatureDoesNotMatch"
"cd_run":         "SignatureDoesNotMatch"
"ce_tab":         "SignatureDoesNotMatch"
"ce_trailing":    "SignatureDoesNotMatch"
"control":        "ok"
"token_trailing": "SignatureDoesNotMatch"
```

After: every case is `"ok"` and `cd_run_wire` is `true`. `s3-requester-pays.test.ts`, `s3-storage-class.test.ts` and `s3-insecure.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-sigv4-header-trimall.test.ts"
bun test v1.4.0 (f1efe08d6)

test/js/bun/s3/s3-sigv4-header-trimall.test.ts:
20 |       stdout: "pipe",
21 |       stderr: "pipe",
22 |     });
23 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
24 |     expect(stderr).toBe("");
25 |     expect(JSON.parse(stdout.trim())).toEqual({
                                           ^
error: expect(received).toEqual(expected)

  {
-   "cd_outer": "ok",
-   "cd_run": "ok",
+   "cd_outer": "SignatureDoesNotMatch",
+   "cd_run": "SignatureDoesNotMatch",
    "cd_run_wire": true,
-   "ce_tab": "ok",
-   "ce_trailing": "ok",
+   "ce_tab": "SignatureDoesNotMatch",
+   "ce_trailing": "SignatureDoesNotMatch",
    "control": "ok",
-   "token_trailing": "ok",
+   "token_trailing": "SignatureDoesNotMatch",
  }

- Expected  - 5
+ Received  + 5

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-sigv4-header-trimall.test.ts:25:39)
(fail) S3 SigV4 signed header Trimall > signed header values 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (95faf79f3)

test/js/bun/s3/s3-sigv4-header-trimall.test.ts:
20 |       stdout: "pipe",
21 |       stderr: "pipe",
22 |     });
23 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
24 |     expect(stderr).toBe("");
25 |     expect(JSON.parse(stdout.trim())).toEqual({
                                           ^
error: expect(received).toEqual(expected)

  {
    "cd_outer": "ok",
    "cd_run": "ok",
-   "cd_run_wire": true,
+   "cd_run_wire": false,
    "ce_tab": "ok",
    "ce_trailing": "ok",
    "control": "ok",
    "token_trailing": "ok",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-sigv4-header-trimall.test.ts:25:39)
(fail) S3 SigV4 signed header Trimall > signed header values are whitespace-canonicalized [33.44ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [192.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-sigv4-header-trimall.test.ts"
bun test v1.4.0 (f1efe08d6)

test/js/bun/s3/s3-sigv4-header-trimall.test.ts:
(pass) S3 SigV4 signed header Trimall > signed header values are whitespace-canonicalized [1511.08ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.45s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 703ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/s3_signing/credentials.rs                     |  65 +++++++++++---
 test/js/bun/s3/s3-sigv4-header-trimall-fixture.ts | 105 ++++++++++++++++++++++
 test/js/bun/s3/s3-sigv4-header-trimall.test.ts    |  36 ++++++++
 3 files changed, 194 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/s3_signing/credentials.rs                          9     11      0
test/js/bun/s3/s3-sigv4-header-trimall-fixture.ts      0      2      0
test/js/bun/s3/s3-sigv4-header-trimall.test.ts         1      6      0
```

</details>

<!-- robobun:evidence:end -->