### PR TITLE
Bun.serve: reject disturbed ReadableStream response bodies with ERR_BODY_ALREADY_USED

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3164,6 +3164,20 @@ where
                 if let Some(stream) = readable_stream {
                     *value = Body::Value::Used;
 
+                    if stream.is_disturbed(global_this) {
+                        this.response_body_readable_stream_ref.deinit();
+                        let js_err = global_this
+                            .err(
+                                jsc::ErrorCode::BODY_ALREADY_USED,
+                                format_args!(
+                                    "Response body already used. A Response body can only be sent once; create a new Response for each request."
+                                ),
+                            )
+                            .to_js();
+                        this.run_error_handler(js_err);
+                        return;
+                    }
+
                     if stream.is_locked(global_this) {
                         stream_log!("was locked but it shouldn't be");
                         let err = jsc::SystemError {

--- a/test/js/bun/http/serve-reused-response.test.ts
+++ b/test/js/bun/http/serve-reused-response.test.ts
@@ -61,13 +61,75 @@ describe("returning a Response with an already-used body", () => {
     },
   );
 
-  it("returning a Response whose body was consumed before returning calls the error handler", async () => {
+  const consumedBodies = {
+    string: () => new Response("consumed before returning"),
+    "Response.json": () => Response.json({ key: "consumed before returning" }),
+    Blob: () => new Response(new Blob(["consumed before returning"])),
+    "ReadableStream (start)": () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("consumed before returning"));
+            controller.close();
+          },
+        }),
+      ),
+    "ReadableStream (pull)": () => {
+      let i = 0;
+      return new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (i++ === 0) controller.enqueue(new TextEncoder().encode("consumed before returning"));
+            else controller.close();
+          },
+        }),
+      );
+    },
+  };
+
+  it.each(Object.keys(consumedBodies) as (keyof typeof consumedBodies)[])(
+    "returning a Response whose %s body was consumed before returning calls the error handler",
+    async kind => {
+      const errors: unknown[] = [];
+      await using server = serve({
+        port: 0,
+        async fetch() {
+          const response = consumedBodies[kind]();
+          await response.text();
+          expect(response.bodyUsed).toBe(true);
+          return response;
+        },
+        error(err: any) {
+          errors.push({ code: err.code, name: err.constructor.name, message: err.message });
+          return new Response("handled", { status: 500 });
+        },
+      });
+
+      const response = await fetch(server.url);
+      expect(await response.text()).toBe("handled");
+      expect(response.status).toBe(500);
+      expect(errors).toEqual([alreadyUsedError]);
+    },
+  );
+
+  it("returning a Response whose ReadableStream body was partially read calls the error handler", async () => {
     const errors: unknown[] = [];
     await using server = serve({
       port: 0,
       async fetch() {
-        const response = new Response("consumed before returning");
-        await response.text();
+        const response = new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("AAAA"));
+              controller.enqueue(new TextEncoder().encode("BBBB"));
+              controller.close();
+            },
+          }),
+        );
+        const reader = response.body!.getReader();
+        await reader.read();
+        reader.releaseLock();
+        expect(response.bodyUsed).toBe(true);
         return response;
       },
       error(err: any) {
@@ -77,6 +139,7 @@ describe("returning a Response with an already-used body", () => {
     });
 
     const response = await fetch(server.url);
+    // Must not silently serve only the unread remainder ("BBBB").
     expect(await response.text()).toBe("handled");
     expect(response.status).toBe(500);
     expect(errors).toEqual([alreadyUsedError]);


### PR DESCRIPTION
## Repro

```js
const mk = () => new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("HELLO")); c.close(); } });
const srv = Bun.serve({
  port: 0,
  async fetch() {
    const resp = new Response(mk());
    await resp.text();          // handler consumed the body
    // resp.bodyUsed === true
    return resp;
  },
  error(e) { return new Response("ERR:" + e.code, { status: 500 }); },
});
const r = await fetch(srv.url);
console.log(r.status, JSON.stringify(await r.text()), r.headers.get("content-length"));
// before: 200 "" 0          (error() never invoked)
// after:  500 "ERR:ERR_BODY_ALREADY_USED"
srv.stop(true);
```

String/Blob/Uint8Array/`Response.json` bodies already 500 with `ERR_BODY_ALREADY_USED` here (since #33118). A Response whose **ReadableStream** body the handler consumed was served as a silent empty `200` with `Content-Length: 0`, and a partially-read stream (`getReader()` + `read()` + `releaseLock()`) silently served only the unread remainder.

## Cause

After `await resp.text()` on a stream body, the body stays `Body::Value::Locked` with `action = GetText` and the disturbed stream still in the Response's JS-side `stream` cache slot. `do_render_with_body` re-reads that stream via `get_body_readable_stream`, but the Locked arm only checked `stream.is_locked()`, not `stream.is_disturbed()`. A consumed stream is disturbed but not locked, so it fell through to `do_render_stream` and rendered as empty.

## Fix

Check `is_disturbed()` on the response's ReadableStream in `do_render_with_body` and route to the same `ERR_BODY_ALREADY_USED` error-handler path as the existing `Body::Value::Used` arm.

## Verification

Extended `test/js/bun/http/serve-reused-response.test.ts` to cover the stream variants (start-source, pull-source, partial-read-then-releaseLock) alongside the existing string/blob cases.

```
# before (system bun): 3 fail
  ReadableStream (start) body was consumed before returning  -> received ""
  ReadableStream (pull) body was consumed before returning   -> received ""
  ReadableStream body was partially read                     -> received "BBBB"
# after: 12 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-reused-response.test.ts
bun test v1.4.0 (4416cc88f)

test/js/bun/http/serve-reused-response.test.ts:
(pass) returning a Response with an already-used body > returning the same string-bodied Response twice calls the error handler [43.57ms]
(pass) returning a Response with an already-used body > returning the same Uint8Array-bodied Response twice calls the error handler [23.37ms]
(pass) returning a Response with an already-used body > returning the same stream-bodied Response twice calls the error handler [31.90ms]
(pass) returning a Response with an already-used body > returning a Response whose string body was consumed before returning calls the error handler [31.65ms]
(pass) returning a Response with an already-used body > returning a Response whose Response.json body was consumed before returning calls the error handler [19.06ms]
(pass) returning a Response with an already-used body > returning a Response whose Blob body was consumed before returning calls the error handler [20.01ms]
104 |           return new 
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/http/serve-reused-response.test.ts:
(pass) returning a Response with an already-used body > returning the same string-bodied Response twice calls the error handler [2.68ms]
(pass) returning a Response with an already-used body > returning the same Uint8Array-bodied Response twice calls the error handler [0.70ms]
(pass) returning a Response with an already-used body > returning the same stream-bodied Response twice calls the error handler [2.58ms]
(pass) returning a Response with an already-used body > returning a Response whose string body was consumed before returning calls the error handler [0.92ms]
(pass) returning a Response with an already-used body > returning a Response whose Response.json body was consumed before returning calls the error handler [0.58ms]
(pass) returning a Response with an already-used body > returning a Response whose Blob body was consumed before returning calls the error handler [0.76ms]
104 |           return new Response("handled", { status: 500 });
105 |         },
106 |       });
107 | 
108 |       const response = await fetch(server.url);
109 |       expect(await response.text()).toB
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-reused-response.test.ts
bun test v1.4.0 (4416cc88f)

test/js/bun/http/serve-reused-response.test.ts:
(pass) returning a Response with an already-used body > returning the same string-bodied Response twice calls the error handler [41.46ms]
(pass) returning a Response with an already-used body > returning the same Uint8Array-bodied Response twice calls the error handler [22.59ms]
(pass) returning a Response with an already-used body > returning the same stream-bodied Response twice calls the error handler [29.19ms]
(pass) returning a Response with an already-used body > returning a Response whose string body was consumed before returning calls the error handler [30.93ms]
(pass) returning a Response with an already-used body > returning a Response whose Response.json body was consumed before returning calls the error handler [17.26ms]
(pass) returning a Response with an already-used body > returning a Response whose Blob body was consumed before returning calls the error handler [18.66ms]
(pass) returning a Response
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 691ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/85] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/85] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs           | 14 ++++++
 test/js/bun/http/serve-reused-response.test.ts | 69 ++++++++++++++++++++++++--
 2 files changed, 80 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/runtime/server/RequestContext.rs                5      1      0
test/js/bun/http/serve-reused-response.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->