### PR TITLE
node:buffer: reject non-Uint8Array views in Buffer.compare and buf.equals

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -830,7 +830,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_compareBody(JSC::JSGlobal
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     auto castedThisValue = callFrame->argument(0);
-    JSC::JSArrayBufferView* castedThis = dynamicDowncast<JSC::JSArrayBufferView>(castedThisValue);
+    JSC::JSUint8Array* castedThis = dynamicDowncast<JSC::JSUint8Array>(castedThisValue);
     if (!castedThis) [[unlikely]] {
         return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "buf1"_s, "Buffer or Uint8Array"_s, castedThisValue);
     }
@@ -840,7 +840,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_compareBody(JSC::JSGlobal
     }
 
     auto buffer = callFrame->argument(1);
-    JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
+    JSC::JSUint8Array* view = dynamicDowncast<JSC::JSUint8Array>(buffer);
     if (!view) [[unlikely]] {
         return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "buf2"_s, "Buffer or Uint8Array"_s, buffer);
     }
@@ -864,8 +864,8 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_compareBody(JSC::JSGlobal
     auto targetLength = targetEnd - targetStart;
     auto actualLength = std::min(sourceLength, targetLength);
 
-    auto sourceStartPtr = reinterpret_cast<unsigned char*>(castedThis->vector()) + sourceStart;
-    auto targetStartPtr = reinterpret_cast<unsigned char*>(view->vector()) + targetStart;
+    auto sourceStartPtr = castedThis->typedVector() + sourceStart;
+    auto targetStartPtr = view->typedVector() + targetStart;
 
     auto result = actualLength > 0 ? memcmp(sourceStartPtr, targetStartPtr, actualLength) : 0;
 
@@ -1304,13 +1304,8 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_equalsBody(JSC::JSGlobalObj
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    if (callFrame->argumentCount() < 1) {
-        throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
-        return {};
-    }
-
-    auto buffer = callFrame->uncheckedArgument(0);
-    JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
+    auto buffer = callFrame->argument(0);
+    JSC::JSUint8Array* view = dynamicDowncast<JSC::JSUint8Array>(buffer);
     if (!view) [[unlikely]] {
         return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "otherBuffer"_s, "Buffer or Uint8Array"_s, buffer);
     }
@@ -1323,7 +1318,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_equalsBody(JSC::JSGlobalObj
     size_t a_length = castedThis->byteLength();
     size_t b_length = view->byteLength();
     auto sourceStartPtr = castedThis->typedVector();
-    auto targetStartPtr = reinterpret_cast<unsigned char*>(view->vector());
+    auto targetStartPtr = view->typedVector();
 
     // same pointer, same length, same contents
     if (sourceStartPtr == targetStartPtr && a_length == b_length)

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1866,6 +1866,7 @@ for (let withOverridenBufferWrite of [false, true]) {
           ["Int8Array", new Int8Array([1, 2, 3, 4])],
           ["Int16Array", new Int16Array([1, 2])],
           ["Int32Array", new Int32Array([1])],
+          ["Float16Array", new Float16Array([1, 2])],
           ["Float32Array", new Float32Array([1])],
           ["Float64Array", new Float64Array(1)],
           ["BigInt64Array", new BigInt64Array(1)],

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1850,6 +1850,64 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(a.equals(b)).toBe(false);
       });
 
+      it("Buffer.prototype.equals rejects non-Uint8Array TypedArrays and DataView", () => {
+        const buf = Buffer.from([1, 2, 3, 4]);
+        const invalidArgType = { code: "ERR_INVALID_ARG_TYPE", name: "TypeError" };
+        for (const other of [
+          new Uint16Array([1, 2]),
+          new Uint32Array([1]),
+          new Int8Array([1, 2, 3, 4]),
+          new Int16Array([1, 2]),
+          new Float32Array([1]),
+          new Float64Array(1),
+          new BigInt64Array(1),
+          new Uint8ClampedArray([1, 2, 3, 4]),
+          new DataView(new ArrayBuffer(4)),
+        ]) {
+          expect(() => buf.equals(other)).toThrow(
+            expect.objectContaining({
+              ...invalidArgType,
+              message: expect.stringContaining('"otherBuffer" argument must be an instance of Buffer or Uint8Array'),
+            }),
+          );
+        }
+        expect(() => buf.equals()).toThrow(expect.objectContaining(invalidArgType));
+        expect(buf.equals(new Uint8Array([1, 2, 3, 4]))).toBe(true);
+      });
+
+      it("Buffer.compare rejects non-Uint8Array TypedArrays and DataView", () => {
+        const buf = Buffer.from([1, 2, 3, 4]);
+        const invalidArgType = { code: "ERR_INVALID_ARG_TYPE", name: "TypeError" };
+        for (const other of [
+          new Uint16Array([1, 2]),
+          new Int8Array([1, 2, 3, 4]),
+          new Float32Array([1]),
+          new Uint8ClampedArray([1, 2, 3, 4]),
+          new DataView(new ArrayBuffer(4)),
+        ]) {
+          expect(() => Buffer.compare(buf, other)).toThrow(
+            expect.objectContaining({
+              ...invalidArgType,
+              message: expect.stringContaining('"buf2" argument must be an instance of Buffer or Uint8Array'),
+            }),
+          );
+          expect(() => Buffer.compare(other, buf)).toThrow(
+            expect.objectContaining({
+              ...invalidArgType,
+              message: expect.stringContaining('"buf1" argument must be an instance of Buffer or Uint8Array'),
+            }),
+          );
+          expect(() => buf.compare(other)).toThrow(
+            expect.objectContaining({
+              ...invalidArgType,
+              message: expect.stringContaining('"target" argument must be an instance of Buffer or Uint8Array'),
+            }),
+          );
+        }
+        expect(Buffer.compare(buf, new Uint8Array([1, 2, 3, 4]))).toBe(0);
+        expect(Buffer.compare(new Uint8Array([1, 2, 3, 4]), buf)).toBe(0);
+      });
+
       it("Buffer.compare", () => {
         var a = new Uint8Array(10);
         a[2] = 1;

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1850,62 +1850,49 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(a.equals(b)).toBe(false);
       });
 
-      it("Buffer.prototype.equals rejects non-Uint8Array TypedArrays and DataView", () => {
+      describe("Buffer.compare/equals rejects non-Uint8Array views", () => {
         const buf = Buffer.from([1, 2, 3, 4]);
         const invalidArgType = { code: "ERR_INVALID_ARG_TYPE", name: "TypeError" };
-        for (const other of [
-          new Uint16Array([1, 2]),
-          new Uint32Array([1]),
-          new Int8Array([1, 2, 3, 4]),
-          new Int16Array([1, 2]),
-          new Float32Array([1]),
-          new Float64Array(1),
-          new BigInt64Array(1),
-          new Uint8ClampedArray([1, 2, 3, 4]),
-          new DataView(new ArrayBuffer(4)),
-        ]) {
-          expect(() => buf.equals(other)).toThrow(
-            expect.objectContaining({
-              ...invalidArgType,
-              message: expect.stringContaining('"otherBuffer" argument must be an instance of Buffer or Uint8Array'),
-            }),
-          );
-        }
-        expect(() => buf.equals()).toThrow(expect.objectContaining(invalidArgType));
-        expect(buf.equals(new Uint8Array([1, 2, 3, 4]))).toBe(true);
-      });
+        const mustBe = arg =>
+          expect.objectContaining({
+            ...invalidArgType,
+            message: expect.stringContaining(`"${arg}" argument must be an instance of Buffer or Uint8Array`),
+          });
 
-      it("Buffer.compare rejects non-Uint8Array TypedArrays and DataView", () => {
-        const buf = Buffer.from([1, 2, 3, 4]);
-        const invalidArgType = { code: "ERR_INVALID_ARG_TYPE", name: "TypeError" };
-        for (const other of [
-          new Uint16Array([1, 2]),
-          new Int8Array([1, 2, 3, 4]),
-          new Float32Array([1]),
-          new Uint8ClampedArray([1, 2, 3, 4]),
-          new DataView(new ArrayBuffer(4)),
-        ]) {
-          expect(() => Buffer.compare(buf, other)).toThrow(
+        it.each([
+          ["Uint8ClampedArray", new Uint8ClampedArray([1, 2, 3, 4])],
+          ["Uint16Array", new Uint16Array([1, 2])],
+          ["Uint32Array", new Uint32Array([1])],
+          ["Int8Array", new Int8Array([1, 2, 3, 4])],
+          ["Int16Array", new Int16Array([1, 2])],
+          ["Int32Array", new Int32Array([1])],
+          ["Float32Array", new Float32Array([1])],
+          ["Float64Array", new Float64Array(1)],
+          ["BigInt64Array", new BigInt64Array(1)],
+          ["BigUint64Array", new BigUint64Array(1)],
+          ["DataView", new DataView(new ArrayBuffer(4))],
+        ])("%s", (_, other) => {
+          expect(() => buf.equals(other)).toThrow(mustBe("otherBuffer"));
+          expect(() => Buffer.compare(buf, other)).toThrow(mustBe("buf2"));
+          expect(() => Buffer.compare(other, buf)).toThrow(mustBe("buf1"));
+          expect(() => buf.compare(other)).toThrow(mustBe("target"));
+        });
+
+        it("buf.equals() with no argument throws ERR_INVALID_ARG_TYPE", () => {
+          expect(() => buf.equals()).toThrow(
             expect.objectContaining({
               ...invalidArgType,
-              message: expect.stringContaining('"buf2" argument must be an instance of Buffer or Uint8Array'),
+              message:
+                'The "otherBuffer" argument must be an instance of Buffer or Uint8Array. Received undefined',
             }),
           );
-          expect(() => Buffer.compare(other, buf)).toThrow(
-            expect.objectContaining({
-              ...invalidArgType,
-              message: expect.stringContaining('"buf1" argument must be an instance of Buffer or Uint8Array'),
-            }),
-          );
-          expect(() => buf.compare(other)).toThrow(
-            expect.objectContaining({
-              ...invalidArgType,
-              message: expect.stringContaining('"target" argument must be an instance of Buffer or Uint8Array'),
-            }),
-          );
-        }
-        expect(Buffer.compare(buf, new Uint8Array([1, 2, 3, 4]))).toBe(0);
-        expect(Buffer.compare(new Uint8Array([1, 2, 3, 4]), buf)).toBe(0);
+        });
+
+        it("Uint8Array is accepted", () => {
+          expect(buf.equals(new Uint8Array([1, 2, 3, 4]))).toBe(true);
+          expect(Buffer.compare(buf, new Uint8Array([1, 2, 3, 4]))).toBe(0);
+          expect(Buffer.compare(new Uint8Array([1, 2, 3, 4]), buf)).toBe(0);
+        });
       });
 
       it("Buffer.compare", () => {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1882,8 +1882,7 @@ for (let withOverridenBufferWrite of [false, true]) {
           expect(() => buf.equals()).toThrow(
             expect.objectContaining({
               ...invalidArgType,
-              message:
-                'The "otherBuffer" argument must be an instance of Buffer or Uint8Array. Received undefined',
+              message: 'The "otherBuffer" argument must be an instance of Buffer or Uint8Array. Received undefined',
             }),
           );
         });


### PR DESCRIPTION
Fixes #5880.

### What

Static `Buffer.compare(buf1, buf2)` and `Buffer.prototype.equals(other)` accepted any `ArrayBufferView` (all TypedArray kinds plus `DataView`) and compared their raw bytes. Node.js only accepts `Buffer` or `Uint8Array` for these arguments and throws `ERR_INVALID_ARG_TYPE` for everything else.

Bun was also internally inconsistent: the instance method `buf.compare(target)` already used the strict `JSUint8Array` downcast, so `Buffer.compare(a, dv)` returned `0` while `a.compare(dv)` threw.

### Repro

```js
const dv = new DataView(new Uint8Array([1, 2, 3, 4]).buffer);
Buffer.compare(Buffer.from("01020304", "hex"), dv);
// bun (before): 0
// node:         TypeError [ERR_INVALID_ARG_TYPE]: The "buf2" argument must be an instance of Buffer or Uint8Array.

Buffer.from([1, 2]).equals(new Uint16Array([0x0201]));
// bun (before): true (byte-level compare)
// node:         TypeError [ERR_INVALID_ARG_TYPE]
```

### Cause

`jsBufferConstructorFunction_compareBody` and `jsBufferPrototypeFunction_equalsBody` used `dynamicDowncast<JSC::JSArrayBufferView>` for their arguments, which matches every TypedArray and `DataView`. The prototype `compare` body already used `dynamicDowncast<JSC::JSUint8Array>`.

### Fix

Change both to `dynamicDowncast<JSC::JSUint8Array>` so they match the instance `compare` path and Node's `isUint8Array` check. While here, `buf.equals()` with no argument now throws `ERR_INVALID_ARG_TYPE` with "Received undefined" instead of `ERR_MISSING_ARGS`, matching Node.

### Verification

- New tests in `test/js/node/buffer.test.js` cover all TypedArray kinds, `Uint8ClampedArray`, and `DataView` for both `Buffer.compare` (both argument positions), `buf.compare`, and `buf.equals`.
- Tests fail on main with "Received function did not throw" and pass with this change.
- `test/js/node/test/parallel/test-buffer-{compare,equals,compare-offset}.js` all pass.
- Full `test/js/node/buffer.test.js` (621 pass, 1 skip).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 26 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
bun test v1.4.0 (f379d3b22)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [86.01ms]
(pass) with native Buffer.write > #9120 alloc [60.60ms]
(pass) with native Buffer.write > isAscii [61.01ms]
(pass) with native Buffer.write > isUtf8 [62.62ms]
(pass) with native Buffer.write > Buffer global is settable [56.11ms]
(pass) with native Buffer.write > length overflow [60.33ms]
(pass) with native Buffer.write > truncate input values [189.74ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [59.33ms]
(pass) with native Buffer.write > Buffer.from() [58.23ms]
(pass) with native Buffer.write > offset properties [59.77ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [69.48ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [64.24ms]
(pass) with native Buffer.write > invalid encoding [68.18ms]
(pass) with native Buffer.write > create 0-length buffers [62.36ms]
(pass) with native Buffer.write > write() beyond end of buff
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a292418af)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [3.85ms]
(pass) with native Buffer.write > #9120 alloc [2.55ms]
(pass) with native Buffer.write > isAscii [2.82ms]
(pass) with native Buffer.write > isUtf8 [2.92ms]
(pass) with native Buffer.write > Buffer global is settable [2.08ms]
(pass) with native Buffer.write > length overflow [2.06ms]
(pass) with native Buffer.write > truncate input values [2.43ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [2.12ms]
(pass) with native Buffer.write > Buffer.from() [1.92ms]
(pass) with native Buffer.write > offset properties [2.16ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [2.33ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [2.17ms]
(pass) with native Buffer.write > invalid encoding [2.12ms]
(pass) with native Buffer.write > create 0-length buffers [1.98ms]
(pass) with native Buffer.write > write() beyond end of buffer [2.12ms]
(pass) with native Buffer.write > write BigInt beyond 64-bit range [2.61ms]
(pass) with native Buffer.write > write BigInt64 with insufficient buffer space
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
bun test v1.4.0 (f379d3b22)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [120.38ms]
(pass) with native Buffer.write > #9120 alloc [92.39ms]
(pass) with native Buffer.write > isAscii [93.00ms]
(pass) with native Buffer.write > isUtf8 [94.36ms]
(pass) with native Buffer.write > Buffer global is settable [92.91ms]
(pass) with native Buffer.write > length overflow [89.54ms]
(pass) with native Buffer.write > truncate input values [288.16ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [82.48ms]
(pass) with native Buffer.write > Buffer.from() [92.61ms]
(pass) with native Buffer.write > offset properties [87.31ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [98.63ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [94.31ms]
(pass) with native Buffer.write > invalid encoding [102.87ms]
(pass) with native Buffer.write > create 0-length buffers [85.32ms]
(pass) with native Buffer.write > write() beyond end of bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 908ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/7] cxx obj/src/jsc/bindings/JSBuffer.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 24s
[4/7] link bun-profile
[5/7] bun-profile --revision
1.4.0-canary.1+f379d3b22
[7/7] strip bun
[build] done
bun test v1.4.0-canary.1 (f379d3b22)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [3.67ms]
(pass) with native Buffer.write > #9120 alloc [2.87ms]
(pass) with native Buffer.write > isAscii [2.97ms]
(pass) with native Buffer.write > isUtf8 [3.15ms]
(pass) with nativ
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSBuffer.cpp | 19 +++++++-----------
 test/js/node/buffer.test.js   | 45 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 52 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/jsc/bindings/JSBuffer.cpp      2      2      0
test/js/node/buffer.test.js        1      3      0
```

</details>

<!-- robobun:evidence:end -->