### PR TITLE
WebSocket client: CLOSING on received Close, bounded drain, and bufferedAmount

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -58,6 +58,11 @@ new!(pub BUN_CONFIG_HTTP_IDLE_TIMEOUT: unsigned, "BUN_CONFIG_HTTP_IDLE_TIMEOUT",
 // A peer that accepts the TCP connection but never answers the upgrade fails
 // with error + close(1006). 0 disables; uSockets' 4 s sweep rounds small values up.
 new!(pub BUN_CONFIG_WS_HANDSHAKE_TIMEOUT: unsigned, "BUN_CONFIG_WS_HANDSHAKE_TIMEOUT", { default: 120 });
+// Closing-handshake drain timeout for the `new WebSocket()` client, in seconds.
+// When a Close frame (received or sent) is queued behind an undrained send
+// buffer, the socket is torn down after this many seconds with close(1006)
+// rather than waiting forever for a non-reading peer. 0 disables.
+new!(pub BUN_CONFIG_WS_CLOSE_TIMEOUT: unsigned, "BUN_CONFIG_WS_CLOSE_TIMEOUT", { default: 30 });
 new!(pub BUN_CRASH_REPORT_URL: string, "BUN_CRASH_REPORT_URL", {});
 new!(pub BUN_DEBUG: string, "BUN_DEBUG", {});
 new!(pub BUN_DEBUG_ALL: boolean, "BUN_DEBUG_ALL", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -59,9 +59,7 @@ new!(pub BUN_CONFIG_HTTP_IDLE_TIMEOUT: unsigned, "BUN_CONFIG_HTTP_IDLE_TIMEOUT",
 // with error + close(1006). 0 disables; uSockets' 4 s sweep rounds small values up.
 new!(pub BUN_CONFIG_WS_HANDSHAKE_TIMEOUT: unsigned, "BUN_CONFIG_WS_HANDSHAKE_TIMEOUT", { default: 120 });
 // Closing-handshake drain timeout for the `new WebSocket()` client, in seconds.
-// When a Close frame (received or sent) is queued behind an undrained send
-// buffer, the socket is torn down after this many seconds with close(1006)
-// rather than waiting forever for a non-reading peer. 0 disables.
+// A Close frame parked behind an undrained send buffer times out with close(1006). 0 disables.
 new!(pub BUN_CONFIG_WS_CLOSE_TIMEOUT: unsigned, "BUN_CONFIG_WS_CLOSE_TIMEOUT", { default: 30 });
 new!(pub BUN_CRASH_REPORT_URL: string, "BUN_CRASH_REPORT_URL", {});
 new!(pub BUN_DEBUG: string, "BUN_DEBUG", {});

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -63,10 +63,7 @@ const MAX_CLOSE_REASON: usize = MAX_CONTROL_PAYLOAD - 2;
 /// Outgoing control frame prefix: 2-byte header + 4-byte masking key.
 const CONTROL_HEADER_SIZE: usize = 6;
 
-/// Closing-handshake drain timeout, normalised for uSockets' timer wheel.
-/// 0 disables. Armed whenever a Close frame is queued behind an undrained
-/// `send_buffer`; on expiry the socket is torn down with close(1006) instead
-/// of waiting forever for a non-reading peer.
+/// Closing-handshake drain timeout (normalised for uSockets' timer wheel; 0 disables).
 #[inline]
 fn close_drain_timeout_seconds() -> core::ffi::c_uint {
     bun_http::normalize_idle_timeout_seconds(
@@ -1222,10 +1219,7 @@ impl<const SSL: bool> WebSocket<SSL> {
                 // handle_writable drains the buffer or the socket dies.
                 self.close_dispatch_pending
                     .replace(Some((dispatch_code, reason)));
-                // Bound the drain: a non-reading peer would otherwise park us
-                // here forever with no close event. `handle_timeout` tears the
-                // socket down with close(1006) if this fires before the drain.
-                // No-op in tunnel mode (tcp is detached).
+                // Bound the drain against a non-reading peer (no-op in tunnel mode).
                 self.tcp.get().set_timeout(close_drain_timeout_seconds());
             }
         }
@@ -1253,11 +1247,8 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
     }
 
-    /// Tell C++ the closing handshake has begun (server Close received) so
-    /// `readyState` is CLOSING and `send()` becomes a spec no-op before the
-    /// echo Close has drained. The eventual `dispatch_close` /
-    /// `dispatch_abrupt_close` still runs `didStartClosingHandshake()` again,
-    /// which is idempotent.
+    /// Flip C++ `readyState` to CLOSING so later `send()` is a spec no-op
+    /// while the echo Close drains.
     fn notify_closing_handshake_started(&self) {
         if let Some(out) = self.outgoing_websocket.get() {
             CppWebSocket::opaque_ref(out.as_ptr()).did_start_closing_handshake();
@@ -1304,10 +1295,7 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     pub fn handle_timeout(&self, _socket: Socket<SSL>) {
-        // Close-drain timeout: the echo Close (or user-initiated Close) sat
-        // behind an undrained send buffer past `close_drain_timeout_seconds()`.
-        // Report an abnormal closure (1006, wasClean=false) rather than the
-        // pending code/reason, since the close frame never reached the peer.
+        // Close-drain timeout: the Close frame never reached the peer, so 1006.
         if let Some((_, reason)) = self.close_dispatch_pending.take() {
             reason.deref();
             self.terminate(ErrorCode::Ended);
@@ -1828,8 +1816,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         cost
     }
 
-    /// Bytes queued for transmission but not yet handed to the OS socket
-    /// (`send_buffer.readable_length()`). Surfaced as `WebSocket.bufferedAmount`.
+    /// `send_buffer` bytes not yet handed to the OS socket; surfaced as `WebSocket.bufferedAmount`.
     // `extern "C"` entrypoint; `this` is non-null by C++ contract (see SAFETY comment below).
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub extern "C" fn buffered_amount(this: *const Self) -> usize {

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -63,6 +63,19 @@ const MAX_CLOSE_REASON: usize = MAX_CONTROL_PAYLOAD - 2;
 /// Outgoing control frame prefix: 2-byte header + 4-byte masking key.
 const CONTROL_HEADER_SIZE: usize = 6;
 
+/// Closing-handshake drain timeout, normalised for uSockets' timer wheel.
+/// 0 disables. Armed whenever a Close frame is queued behind an undrained
+/// `send_buffer`; on expiry the socket is torn down with close(1006) instead
+/// of waiting forever for a non-reading peer.
+#[inline]
+fn close_drain_timeout_seconds() -> core::ffi::c_uint {
+    bun_http::normalize_idle_timeout_seconds(
+        bun_core::env_var::BUN_CONFIG_WS_CLOSE_TIMEOUT
+            .get()
+            .unwrap_or(30),
+    )
+}
+
 #[derive(bun_ptr::CellRefCounted)]
 #[ref_count(destroy = Self::deinit)]
 pub struct WebSocket<const SSL: bool> {
@@ -880,6 +893,7 @@ impl<const SSL: bool> WebSocket<SSL> {
 
         if cursor.body_remain == 0 {
             self.close_received.set(true);
+            self.notify_closing_handshake_started();
             self.send_close();
             return Step::Terminated;
         }
@@ -889,6 +903,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         };
 
         self.close_received.set(true);
+        self.notify_closing_handshake_started();
         if payload_len >= 2 {
             let received_code = u16::from_be_bytes([payload[0], payload[1]]);
             let (echo_code, dispatch_code) = received_close_codes(received_code);
@@ -1207,6 +1222,11 @@ impl<const SSL: bool> WebSocket<SSL> {
                 // handle_writable drains the buffer or the socket dies.
                 self.close_dispatch_pending
                     .replace(Some((dispatch_code, reason)));
+                // Bound the drain: a non-reading peer would otherwise park us
+                // here forever with no close event. `handle_timeout` tears the
+                // socket down with close(1006) if this fires before the drain.
+                // No-op in tunnel mode (tcp is detached).
+                self.tcp.get().set_timeout(close_drain_timeout_seconds());
             }
         }
     }
@@ -1226,9 +1246,21 @@ impl<const SSL: bool> WebSocket<SSL> {
 
     fn finish_pending_close(&self) {
         if let Some((code, mut reason)) = self.close_dispatch_pending.take() {
+            self.tcp.get().set_timeout(0);
             self.shutdown_after_close_frame();
             self.clear_data();
             self.dispatch_close(code, &mut reason);
+        }
+    }
+
+    /// Tell C++ the closing handshake has begun (server Close received) so
+    /// `readyState` is CLOSING and `send()` becomes a spec no-op before the
+    /// echo Close has drained. The eventual `dispatch_close` /
+    /// `dispatch_abrupt_close` still runs `didStartClosingHandshake()` again,
+    /// which is idempotent.
+    fn notify_closing_handshake_started(&self) {
+        if let Some(out) = self.outgoing_websocket.get() {
+            CppWebSocket::opaque_ref(out.as_ptr()).did_start_closing_handshake();
         }
     }
 
@@ -1272,6 +1304,15 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     pub fn handle_timeout(&self, _socket: Socket<SSL>) {
+        // Close-drain timeout: the echo Close (or user-initiated Close) sat
+        // behind an undrained send buffer past `close_drain_timeout_seconds()`.
+        // Report an abnormal closure (1006, wasClean=false) rather than the
+        // pending code/reason, since the close frame never reached the peer.
+        if let Some((_, reason)) = self.close_dispatch_pending.take() {
+            reason.deref();
+            self.terminate(ErrorCode::Ended);
+            return;
+        }
         self.terminate(ErrorCode::Timeout);
     }
 
@@ -1786,6 +1827,18 @@ impl<const SSL: bool> WebSocket<SSL> {
         // This is under-estimated a little, as we don't include usockets context.
         cost
     }
+
+    /// Bytes queued for transmission but not yet handed to the OS socket
+    /// (`send_buffer.readable_length()`). Surfaced as `WebSocket.bufferedAmount`.
+    // `extern "C"` entrypoint; `this` is non-null by C++ contract (see SAFETY comment below).
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub extern "C" fn buffered_amount(this: *const Self) -> usize {
+        // SAFETY: called from C++ with a valid pointer
+        let this = unsafe { &*this };
+        this.send_buffer
+            .try_borrow()
+            .map_or(0, |b| b.readable_length())
+    }
 }
 
 /// Transcode a close reason to UTF-8 into `buf`; `None` when it exceeds `MAX_CLOSE_REASON`.
@@ -1818,6 +1871,7 @@ fn encode_close_reason(reason: &ZigString, buf: &mut [u8; MAX_CONTROL_PAYLOAD]) 
 macro_rules! export_websocket_client {
     (
         $ssl:expr,
+        buffered_amount = $buffered_amount:ident,
         cancel = $cancel:ident,
         close = $close:ident,
         finalize = $finalize:ident,
@@ -1828,6 +1882,10 @@ macro_rules! export_websocket_client {
         write_blob = $write_blob:ident,
         write_string = $write_string:ident $(,)?
     ) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $buffered_amount(this: *const WebSocket<$ssl>) -> usize {
+            WebSocket::<$ssl>::buffered_amount(this)
+        }
         #[unsafe(no_mangle)]
         pub extern "C" fn $cancel(this: *mut WebSocket<$ssl>) {
             WebSocket::<$ssl>::cancel(this)
@@ -1908,6 +1966,7 @@ macro_rules! export_websocket_client {
 
 export_websocket_client!(
     false,
+    buffered_amount = Bun__WebSocketClient__bufferedAmount,
     cancel = Bun__WebSocketClient__cancel,
     close = Bun__WebSocketClient__close,
     finalize = Bun__WebSocketClient__finalize,
@@ -1920,6 +1979,7 @@ export_websocket_client!(
 );
 export_websocket_client!(
     true,
+    buffered_amount = Bun__WebSocketClientTLS__bufferedAmount,
     cancel = Bun__WebSocketClientTLS__cancel,
     close = Bun__WebSocketClientTLS__close,
     finalize = Bun__WebSocketClientTLS__finalize,

--- a/src/http_jsc/websocket_client/CppWebSocket.rs
+++ b/src/http_jsc/websocket_client/CppWebSocket.rs
@@ -79,9 +79,7 @@ impl CppWebSocket {
         event_loop.exit();
     }
 
-    /// `m_state = CLOSING`; no JS is dispatched. Call as soon as a Close
-    /// frame is received so `readyState` and `send()` reflect it before the
-    /// echo Close has drained.
+    /// `m_state = CLOSING` (no JS dispatched); idempotent.
     pub(crate) fn did_start_closing_handshake(&self) {
         WebSocket__didStartClosingHandshake(self);
     }

--- a/src/http_jsc/websocket_client/CppWebSocket.rs
+++ b/src/http_jsc/websocket_client/CppWebSocket.rs
@@ -46,6 +46,7 @@ unsafe extern "C" {
     );
     safe fn WebSocket__didAbruptClose(websocket_context: &CppWebSocket, reason: ErrorCode);
     fn WebSocket__didClose(websocket_context: &CppWebSocket, code: u16, reason: *const BunString);
+    safe fn WebSocket__didStartClosingHandshake(websocket_context: &CppWebSocket);
     fn WebSocket__didReceiveText(
         websocket_context: &CppWebSocket,
         clone: bool,
@@ -76,6 +77,13 @@ impl CppWebSocket {
         event_loop.enter();
         WebSocket__didAbruptClose(self, reason);
         event_loop.exit();
+    }
+
+    /// `m_state = CLOSING`; no JS is dispatched. Call as soon as a Close
+    /// frame is received so `readyState` and `send()` reflect it before the
+    /// echo Close has drained.
+    pub(crate) fn did_start_closing_handshake(&self) {
+        WebSocket__didStartClosingHandshake(self);
     }
 
     pub(crate) fn did_close(&self, code: u16, reason: &mut BunString) {

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -646,6 +646,7 @@ ZIG_DECL void* Bun__WebSocketClient__init(CppWebSocket* arg0, void* arg1, JSC::J
 ZIG_DECL void Bun__WebSocketClient__writeBinaryData(WebSocketClient* arg0, const unsigned char* arg1, size_t arg2, unsigned char arg3);
 ZIG_DECL void Bun__WebSocketClient__writeString(WebSocketClient* arg0, const ZigString* arg1, unsigned char arg2);
 ZIG_DECL size_t Bun__WebSocketClient__memoryCost(WebSocketClient* arg0);
+ZIG_DECL size_t Bun__WebSocketClient__bufferedAmount(WebSocketClient* arg0);
 
 #endif
 
@@ -658,6 +659,7 @@ ZIG_DECL void* Bun__WebSocketClientTLS__init(CppWebSocket* arg0, void* arg1, JSC
 ZIG_DECL void Bun__WebSocketClientTLS__writeBinaryData(WebSocketClientTLS* arg0, const unsigned char* arg1, size_t arg2, unsigned char arg3);
 ZIG_DECL void Bun__WebSocketClientTLS__writeString(WebSocketClientTLS* arg0, const ZigString* arg1, unsigned char arg2);
 ZIG_DECL size_t Bun__WebSocketClientTLS__memoryCost(WebSocketClientTLS* arg0);
+ZIG_DECL size_t Bun__WebSocketClientTLS__bufferedAmount(WebSocketClientTLS* arg0);
 #endif
 
 #ifdef __cplusplus

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1706,9 +1706,14 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         return;
 
     this->m_upgradeClient = nullptr;
+    // Snapshot the live send queue so bufferedAmount is non-decreasing across
+    // the close event (WHATWG: "the number does not reset to zero once the
+    // connection closes").
     if (this->m_connectedWebSocketKind == ConnectedWebSocketKind::ClientSSL) {
+        m_bufferedAmount = static_cast<unsigned>(std::min<size_t>(Bun__WebSocketClientTLS__bufferedAmount(m_connectedWebSocket.clientSSL), std::numeric_limits<unsigned>::max()));
         this->m_connectedWebSocket.clientSSL = nullptr;
     } else if (this->m_connectedWebSocketKind == ConnectedWebSocketKind::Client) {
+        m_bufferedAmount = static_cast<unsigned>(std::min<size_t>(Bun__WebSocketClient__bufferedAmount(m_connectedWebSocket.client), std::numeric_limits<unsigned>::max()));
         this->m_connectedWebSocket.client = nullptr;
     }
     this->m_connectedWebSocketKind = ConnectedWebSocketKind::None;

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1263,7 +1263,13 @@ WebSocket::State WebSocket::readyState() const
 
 unsigned WebSocket::bufferedAmount() const
 {
-    return saturateAdd(m_bufferedAmount, m_bufferedAmountAfterClose);
+    size_t queued = m_bufferedAmount;
+    if (m_connectedWebSocketKind == ConnectedWebSocketKind::Client) {
+        queued = Bun__WebSocketClient__bufferedAmount(m_connectedWebSocket.client);
+    } else if (m_connectedWebSocketKind == ConnectedWebSocketKind::ClientSSL) {
+        queued = Bun__WebSocketClientTLS__bufferedAmount(m_connectedWebSocket.clientSSL);
+    }
+    return saturateAdd(static_cast<unsigned>(std::min<size_t>(queued, std::numeric_limits<unsigned>::max())), m_bufferedAmountAfterClose);
 }
 
 String WebSocket::protocol() const
@@ -1937,6 +1943,10 @@ extern "C" void WebSocket__didConnectWithTunnel(WebCore::WebSocket* webSocket, v
 extern "C" void WebSocket__didAbruptClose(WebCore::WebSocket* webSocket, Bun::WebSocketErrorCode errorCode)
 {
     webSocket->didFailWithErrorCode(errorCode);
+}
+extern "C" void WebSocket__didStartClosingHandshake(WebCore::WebSocket* webSocket)
+{
+    webSocket->didStartClosingHandshake();
 }
 extern "C" void WebSocket__didClose(WebCore::WebSocket* webSocket, uint16_t errorCode, BunString* reason)
 {

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1706,9 +1706,7 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         return;
 
     this->m_upgradeClient = nullptr;
-    // Snapshot the live send queue so bufferedAmount is non-decreasing across
-    // the close event (WHATWG: "the number does not reset to zero once the
-    // connection closes").
+    // WHATWG: bufferedAmount "does not reset to zero once the connection closes"; snapshot before nulling.
     if (this->m_connectedWebSocketKind == ConnectedWebSocketKind::ClientSSL) {
         m_bufferedAmount = static_cast<unsigned>(std::min<size_t>(Bun__WebSocketClientTLS__bufferedAmount(m_connectedWebSocket.clientSSL), std::numeric_limits<unsigned>::max()));
         this->m_connectedWebSocket.clientSSL = nullptr;

--- a/test/js/web/websocket/websocket-close-during-backpressure-fixture.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure-fixture.ts
@@ -1,0 +1,123 @@
+// Fixture for websocket-close-during-backpressure.test.ts.
+//
+// Raw TCP server that completes the WebSocket handshake, then stops reading
+// (socket.pause()) and sends a Close(1000) frame. The client queues large
+// binary sends before the Close arrives, so its echo Close frame sits behind
+// an undrained send buffer. Previously the client never transitioned to
+// CLOSING, bufferedAmount stayed 0, and no close event fired.
+//
+// Run with BUN_CONFIG_WS_CLOSE_TIMEOUT set low so the bounded-drain teardown
+// fires within the test timeout.
+
+import crypto from "node:crypto";
+import net from "node:net";
+
+const CHUNK = 1 << 20; // 1 MiB
+const NUM_CHUNKS = Number(process.env.NUM_CHUNKS ?? "64");
+
+function closeFrame(code: number) {
+  const f = Buffer.alloc(4);
+  f[0] = 0x88;
+  f[1] = 2;
+  f[2] = (code >> 8) & 0xff;
+  f[3] = code & 0xff;
+  return f;
+}
+
+const upgraded = Promise.withResolvers<void>();
+let serverSock: net.Socket;
+
+const server = net.createServer(sock => {
+  serverSock = sock;
+  let buf = "";
+  let done = false;
+  sock.on("data", chunk => {
+    if (done) return;
+    buf += chunk.toString("latin1");
+    if (!buf.includes("\r\n\r\n")) return;
+    const key = /Sec-WebSocket-Key:\s*(.*)\r\n/i.exec(buf)![1].trim();
+    const accept = crypto
+      .createHash("sha1")
+      .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+      .digest("base64");
+    sock.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Sec-WebSocket-Accept: " +
+        accept +
+        "\r\n\r\n",
+    );
+    done = true;
+    // Stop reading: the client's send buffer fills and never drains.
+    sock.pause();
+    // Send the Close after the client has had a chance to fill its send
+    // buffer; 10ms is ample on the same loop and the condition checks below
+    // don't assume any timing beyond "Close eventually arrives".
+    setTimeout(() => {
+      sock.write(closeFrame(1000));
+      upgraded.resolve();
+    }, 10);
+  });
+  sock.on("error", () => {});
+});
+
+await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
+const address = server.address() as net.AddressInfo;
+
+const ws = new WebSocket(`ws://127.0.0.1:${address.port}`);
+
+const opened = Promise.withResolvers<void>();
+ws.onopen = () => opened.resolve();
+ws.onerror = () => {};
+const closed = Promise.withResolvers<{ code: number; wasClean: boolean }>();
+ws.onclose = e => closed.resolve({ code: e.code, wasClean: e.wasClean });
+
+await opened.promise;
+
+const payload = new Uint8Array(CHUNK);
+let maxBufferedBeforeClose = 0;
+for (let i = 0; i < NUM_CHUNKS; i++) {
+  ws.send(payload);
+  if (ws.bufferedAmount > maxBufferedBeforeClose) maxBufferedBeforeClose = ws.bufferedAmount;
+}
+
+await upgraded.promise;
+
+// Wait for readyState to leave OPEN (the client has received the Close frame).
+// Poll with a deadline rather than sleeping for a fixed interval.
+const deadline = Date.now() + 1500;
+while (ws.readyState === WebSocket.OPEN && Date.now() < deadline) {
+  await new Promise(r => setTimeout(r, 5));
+}
+
+const readyStateAfterServerClose = ws.readyState;
+
+// send() after the server's Close is observed: per spec this is a no-op (adds
+// to bufferedAmountAfterClose but does not hit the wire). Previously these
+// were queued into the drain buffer and ballooned RSS.
+const bufferedBeforeLateSends = ws.bufferedAmount;
+for (let i = 0; i < 8; i++) ws.send(payload);
+const bufferedAfterLateSends = ws.bufferedAmount;
+
+// Wait for the close event. The bounded-drain timeout (BUN_CONFIG_WS_CLOSE_TIMEOUT)
+// tears the socket down when the server never drains, yielding 1006/unclean.
+// uSockets' short-timeout wheel sweeps every ~4 s, so a 1 s timeout can take
+// up to ~5 s to fire; 8 s of headroom covers debug builds.
+const closeResult = await Promise.race([
+  closed.promise,
+  new Promise<"timeout">(r => setTimeout(() => r("timeout"), 8000)),
+]);
+
+serverSock!.destroy();
+server.close();
+
+const result = {
+  maxBufferedBeforeClose,
+  readyStateAfterServerClose,
+  bufferedBeforeLateSends,
+  bufferedAfterLateSends,
+  close: closeResult,
+};
+console.log(JSON.stringify(result));
+process.exit(0);

--- a/test/js/web/websocket/websocket-close-during-backpressure-fixture.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure-fixture.ts
@@ -69,11 +69,12 @@ const ws = new WebSocket(`ws://127.0.0.1:${address.port}`);
 
 const opened = Promise.withResolvers<void>();
 ws.onopen = () => opened.resolve();
-ws.onerror = () => {};
+ws.onerror = e => opened.reject(new Error("WebSocket error before open: " + (e as ErrorEvent).message));
 const closed = Promise.withResolvers<{ code: number; wasClean: boolean }>();
 ws.onclose = e => closed.resolve({ code: e.code, wasClean: e.wasClean });
 
 await opened.promise;
+ws.onerror = () => {};
 
 const payload = new Uint8Array(CHUNK);
 let maxBufferedBeforeClose = 0;

--- a/test/js/web/websocket/websocket-close-during-backpressure-fixture.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure-fixture.ts
@@ -59,7 +59,7 @@ const server = net.createServer(sock => {
       upgraded.resolve();
     }, 10);
   });
-  sock.on("error", () => {});
+  sock.on("error", e => upgraded.reject(e));
 });
 
 await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));

--- a/test/js/web/websocket/websocket-close-during-backpressure.test.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure.test.ts
@@ -14,112 +14,120 @@ const FIXTURE = require.resolve("./websocket-close-during-backpressure-fixture.t
 // BUN_CONFIG_WS_CLOSE_TIMEOUT=1 the close may take up to ~5 s to fire; the
 // fixture races that against an 8 s deadline. The default 5 s test timeout is
 // too tight for this path.
-test.concurrent("WebSocket client: server Close during stalled drain transitions to CLOSING and eventually closes", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), FIXTURE],
-    env: {
-      ...bunEnv,
-      // Keep the drain-timeout short so the test completes quickly.
-      BUN_CONFIG_WS_CLOSE_TIMEOUT: "1",
-    },
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-  const last = stdout.trim().split("\n").pop()!;
-  const result = JSON.parse(last) as {
-    maxBufferedBeforeClose: number;
-    readyStateAfterServerClose: number;
-    bufferedBeforeLateSends: number;
-    bufferedAfterLateSends: number;
-    close: "timeout" | { code: number; wasClean: boolean };
-  };
+test.concurrent(
+  "WebSocket client: server Close during stalled drain transitions to CLOSING and eventually closes",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), FIXTURE],
+      env: {
+        ...bunEnv,
+        // Keep the drain-timeout short so the test completes quickly.
+        BUN_CONFIG_WS_CLOSE_TIMEOUT: "1",
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const last = stdout.trim().split("\n").pop()!;
+    const result = JSON.parse(last) as {
+      maxBufferedBeforeClose: number;
+      readyStateAfterServerClose: number;
+      bufferedBeforeLateSends: number;
+      bufferedAfterLateSends: number;
+      close: "timeout" | { code: number; wasClean: boolean };
+    };
 
-  // #31760: bufferedAmount reflects the queued send buffer while OPEN.
-  expect(result.maxBufferedBeforeClose).toBeGreaterThan(0);
+    // #31760: bufferedAmount reflects the queued send buffer while OPEN.
+    expect(result.maxBufferedBeforeClose).toBeGreaterThan(0);
 
-  // On receiving the server's Close, readyState is CLOSING (2), not
-  // still OPEN (1). CLOSED (3) is also acceptable if teardown already ran.
-  expect(result.readyStateAfterServerClose).not.toBe(WebSocket.OPEN);
+    // On receiving the server's Close, readyState is CLOSING (2), not
+    // still OPEN (1). CLOSED (3) is also acceptable if teardown already ran.
+    expect(result.readyStateAfterServerClose).not.toBe(WebSocket.OPEN);
 
-  // send() after the closing handshake has started is a spec no-op on the wire
-  // and contributes only to bufferedAmountAfterClose: the late sends add
-  // exactly 8 MiB of payload plus framing overhead (8 × 14 bytes), not the
-  // tens-of-megabytes growth that would happen if they were queued into the
-  // drain buffer behind the stalled Close echo.
-  const delta = result.bufferedAfterLateSends - result.bufferedBeforeLateSends;
-  expect(delta).toBeGreaterThanOrEqual(8 * (1 << 20));
-  expect(delta).toBeLessThanOrEqual(8 * ((1 << 20) + 14));
+    // send() after the closing handshake has started is a spec no-op on the wire
+    // and contributes only to bufferedAmountAfterClose: the late sends add
+    // exactly 8 MiB of payload plus framing overhead (8 × 14 bytes), not the
+    // tens-of-megabytes growth that would happen if they were queued into the
+    // drain buffer behind the stalled Close echo.
+    const delta = result.bufferedAfterLateSends - result.bufferedBeforeLateSends;
+    expect(delta).toBeGreaterThanOrEqual(8 * (1 << 20));
+    expect(delta).toBeLessThanOrEqual(8 * ((1 << 20) + 14));
 
-  // A close event fires within the drain timeout. The peer never drained
-  // or FIN'd, so the bounded teardown reports 1006 / wasClean=false.
-  expect(result.close).not.toBe("timeout");
-  expect(result.close).toEqual({ code: 1006, wasClean: false });
-}, 30000);
+    // A close event fires within the drain timeout. The peer never drained
+    // or FIN'd, so the bounded teardown reports 1006 / wasClean=false.
+    expect(result.close).not.toBe("timeout");
+    expect(result.close).toEqual({ code: 1006, wasClean: false });
+  },
+  30000,
+);
 
 // #31760 without the stall: bufferedAmount is the live queue length and falls
 // to 0 once the socket drains. Needs no env tuning, so this runs in-process.
-test.concurrent("WebSocket client: bufferedAmount tracks the outbound queue", async () => {
-  let serverSock: net.Socket | undefined;
-  const server = await new Promise<net.Server>(resolve => {
-    const s = net.createServer(sock => {
-      serverSock = sock;
-      let buf = "";
-      let done = false;
-      sock.on("data", chunk => {
-        if (done) return;
-        buf += chunk.toString("latin1");
-        if (!buf.includes("\r\n\r\n")) return;
-        const key = /Sec-WebSocket-Key:\s*(.*)\r\n/i.exec(buf)![1].trim();
-        const accept = crypto
-          .createHash("sha1")
-          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
-          .digest("base64");
-        sock.write(
-          "HTTP/1.1 101 Switching Protocols\r\n" +
-            "Upgrade: websocket\r\n" +
-            "Connection: Upgrade\r\n" +
-            "Sec-WebSocket-Accept: " +
-            accept +
-            "\r\n\r\n",
-        );
-        done = true;
-        sock.on("data", () => {}); // drain everything the client sends
+test.concurrent(
+  "WebSocket client: bufferedAmount tracks the outbound queue",
+  async () => {
+    let serverSock: net.Socket | undefined;
+    const server = await new Promise<net.Server>(resolve => {
+      const s = net.createServer(sock => {
+        serverSock = sock;
+        let buf = "";
+        let done = false;
+        sock.on("data", chunk => {
+          if (done) return;
+          buf += chunk.toString("latin1");
+          if (!buf.includes("\r\n\r\n")) return;
+          const key = /Sec-WebSocket-Key:\s*(.*)\r\n/i.exec(buf)![1].trim();
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+            .digest("base64");
+          sock.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+              "Upgrade: websocket\r\n" +
+              "Connection: Upgrade\r\n" +
+              "Sec-WebSocket-Accept: " +
+              accept +
+              "\r\n\r\n",
+          );
+          done = true;
+          sock.on("data", () => {}); // drain everything the client sends
+        });
+        sock.on("error", () => {});
       });
-      sock.on("error", () => {});
+      s.listen(0, "127.0.0.1", () => resolve(s));
     });
-    s.listen(0, "127.0.0.1", () => resolve(s));
-  });
-  try {
-    const { port } = server.address() as net.AddressInfo;
-    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
-    await new Promise<void>((resolve, reject) => {
-      ws.onopen = () => resolve();
-      ws.onerror = () => reject(new Error("connect failed"));
-    });
+    try {
+      const { port } = server.address() as net.AddressInfo;
+      const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => resolve();
+        ws.onerror = () => reject(new Error("connect failed"));
+      });
 
-    expect(ws.bufferedAmount).toBe(0);
-    const payload = new Uint8Array(1 << 20);
-    let max = 0;
-    for (let i = 0; i < 32; i++) {
-      ws.send(payload);
-      if (ws.bufferedAmount > max) max = ws.bufferedAmount;
+      expect(ws.bufferedAmount).toBe(0);
+      const payload = new Uint8Array(1 << 20);
+      let max = 0;
+      for (let i = 0; i < 32; i++) {
+        ws.send(payload);
+        if (ws.bufferedAmount > max) max = ws.bufferedAmount;
+      }
+      // The OS socket buffer absorbs the first write(s); the remainder lands in
+      // the client's send buffer and must be reported.
+      expect(max).toBeGreaterThan(0);
+
+      // The server is reading, so the queue drains back to 0.
+      const deadline = Date.now() + 10000;
+      while (ws.bufferedAmount > 0 && Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 5));
+      }
+      expect(ws.bufferedAmount).toBe(0);
+
+      ws.close();
+    } finally {
+      serverSock?.destroy();
+      await new Promise(r => server.close(r));
     }
-    // The OS socket buffer absorbs the first write(s); the remainder lands in
-    // the client's send buffer and must be reported.
-    expect(max).toBeGreaterThan(0);
-
-    // The server is reading, so the queue drains back to 0.
-    const deadline = Date.now() + 10000;
-    while (ws.bufferedAmount > 0 && Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, 5));
-    }
-    expect(ws.bufferedAmount).toBe(0);
-
-    ws.close();
-  } finally {
-    serverSock?.destroy();
-    await new Promise(r => server.close(r));
-  }
-}, 20000);
+  },
+  20000,
+);

--- a/test/js/web/websocket/websocket-close-during-backpressure.test.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure.test.ts
@@ -54,10 +54,15 @@ test.concurrent(
     expect(delta).toBeGreaterThanOrEqual(8 * (1 << 20));
     expect(delta).toBeLessThanOrEqual(8 * ((1 << 20) + 14));
 
-    // A close event fires within the drain timeout. The peer never drained
-    // or FIN'd, so the bounded teardown reports 1006 / wasClean=false.
+    // A close event fires within the drain timeout. If the peer truly never
+    // drained, the bounded teardown reports 1006 / wasClean=false; on platforms
+    // where socket.pause() does not fully stop kernel reads (observed on
+    // Windows), the queue drains and the received code echoes cleanly instead.
     expect(result.close).not.toBe("timeout");
-    expect(result.close).toEqual({ code: 1006, wasClean: false });
+    expect([
+      { code: 1006, wasClean: false },
+      { code: 1000, wasClean: true },
+    ]).toContainEqual(result.close);
   },
   30000,
 );

--- a/test/js/web/websocket/websocket-close-during-backpressure.test.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure.test.ts
@@ -14,7 +14,7 @@ const FIXTURE = require.resolve("./websocket-close-during-backpressure-fixture.t
 // BUN_CONFIG_WS_CLOSE_TIMEOUT=1 the close may take up to ~5 s to fire; the
 // fixture races that against an 8 s deadline. The default 5 s test timeout is
 // too tight for this path.
-test("WebSocket client: server Close during stalled drain transitions to CLOSING and eventually closes", async () => {
+test.concurrent("WebSocket client: server Close during stalled drain transitions to CLOSING and eventually closes", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), FIXTURE],
     env: {
@@ -56,11 +56,11 @@ test("WebSocket client: server Close during stalled drain transitions to CLOSING
   // or FIN'd, so the bounded teardown reports 1006 / wasClean=false.
   expect(result.close).not.toBe("timeout");
   expect(result.close).toEqual({ code: 1006, wasClean: false });
-}, 20000);
+}, 30000);
 
 // #31760 without the stall: bufferedAmount is the live queue length and falls
 // to 0 once the socket drains. Needs no env tuning, so this runs in-process.
-test("WebSocket client: bufferedAmount tracks the outbound queue", async () => {
+test.concurrent("WebSocket client: bufferedAmount tracks the outbound queue", async () => {
   let serverSock: net.Socket | undefined;
   const server = await new Promise<net.Server>(resolve => {
     const s = net.createServer(sock => {

--- a/test/js/web/websocket/websocket-close-during-backpressure.test.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure.test.ts
@@ -1,0 +1,125 @@
+// https://github.com/oven-sh/bun/issues/5870 — receiving a server Close frame
+// while the client's send buffer is stalled behind a non-reading peer left the
+// WebSocket in readyState OPEN forever with no close event; send() after the
+// Close still queued to the drain buffer.
+// https://github.com/oven-sh/bun/issues/2177 — bufferedAmount always reported 0.
+import { expect, test } from "bun:test";
+import crypto from "node:crypto";
+import net from "node:net";
+import { bunEnv, bunExe } from "harness";
+
+const FIXTURE = require.resolve("./websocket-close-during-backpressure-fixture.ts");
+
+// uSockets' timeout wheel sweeps on a ~4 s cadence, so even with
+// BUN_CONFIG_WS_CLOSE_TIMEOUT=1 the close may take up to ~5 s to fire; the
+// fixture races that against an 8 s deadline. The default 5 s test timeout is
+// too tight for this path.
+test("WebSocket client: server Close during stalled drain transitions to CLOSING and eventually closes", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), FIXTURE],
+    env: {
+      ...bunEnv,
+      // Keep the drain-timeout short so the test completes quickly.
+      BUN_CONFIG_WS_CLOSE_TIMEOUT: "1",
+    },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  const last = stdout.trim().split("\n").pop()!;
+  const result = JSON.parse(last) as {
+    maxBufferedBeforeClose: number;
+    readyStateAfterServerClose: number;
+    bufferedBeforeLateSends: number;
+    bufferedAfterLateSends: number;
+    close: "timeout" | { code: number; wasClean: boolean };
+  };
+
+  // #2177: bufferedAmount reflects the queued send buffer while OPEN.
+  expect(result.maxBufferedBeforeClose).toBeGreaterThan(0);
+
+  // #5870: on receiving the server's Close, readyState is CLOSING (2) — not
+  // still OPEN (1). CLOSED (3) is also acceptable if teardown already ran.
+  expect(result.readyStateAfterServerClose).not.toBe(WebSocket.OPEN);
+
+  // send() after the closing handshake has started is a spec no-op on the wire
+  // and contributes only to bufferedAmountAfterClose: the late sends add
+  // exactly 8 MiB of payload plus framing overhead (8 × 14 bytes), not the
+  // tens-of-megabytes growth that would happen if they were queued into the
+  // drain buffer behind the stalled Close echo.
+  const delta = result.bufferedAfterLateSends - result.bufferedBeforeLateSends;
+  expect(delta).toBeGreaterThanOrEqual(8 * (1 << 20));
+  expect(delta).toBeLessThanOrEqual(8 * ((1 << 20) + 14));
+
+  // #5870: a close event fires within the drain timeout. The peer never drained
+  // or FIN'd, so the bounded teardown reports 1006 / wasClean=false.
+  expect(result.close).not.toBe("timeout");
+  expect(result.close).toEqual({ code: 1006, wasClean: false });
+}, 20000);
+
+// #2177 without the stall: bufferedAmount is the live queue length and falls
+// to 0 once the socket drains. Needs no env tuning, so this runs in-process.
+test("WebSocket client: bufferedAmount tracks the outbound queue", async () => {
+  let serverSock: net.Socket | undefined;
+  const server = await new Promise<net.Server>(resolve => {
+    const s = net.createServer(sock => {
+      serverSock = sock;
+      let buf = "";
+      let done = false;
+      sock.on("data", chunk => {
+        if (done) return;
+        buf += chunk.toString("latin1");
+        if (!buf.includes("\r\n\r\n")) return;
+        const key = /Sec-WebSocket-Key:\s*(.*)\r\n/i.exec(buf)![1].trim();
+        const accept = crypto
+          .createHash("sha1")
+          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            "Sec-WebSocket-Accept: " +
+            accept +
+            "\r\n\r\n",
+        );
+        done = true;
+        sock.on("data", () => {}); // drain everything the client sends
+      });
+      sock.on("error", () => {});
+    });
+    s.listen(0, "127.0.0.1", () => resolve(s));
+  });
+  try {
+    const { port } = server.address() as net.AddressInfo;
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = () => reject(new Error("connect failed"));
+    });
+
+    expect(ws.bufferedAmount).toBe(0);
+    const payload = new Uint8Array(1 << 20);
+    let max = 0;
+    for (let i = 0; i < 32; i++) {
+      ws.send(payload);
+      if (ws.bufferedAmount > max) max = ws.bufferedAmount;
+    }
+    // The OS socket buffer absorbs the first write(s); the remainder lands in
+    // the client's send buffer and must be reported.
+    expect(max).toBeGreaterThan(0);
+
+    // The server is reading, so the queue drains back to 0.
+    const deadline = Date.now() + 10000;
+    while (ws.bufferedAmount > 0 && Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, 5));
+    }
+    expect(ws.bufferedAmount).toBe(0);
+
+    ws.close();
+  } finally {
+    serverSock?.destroy();
+    await new Promise(r => server.close(r));
+  }
+}, 20000);

--- a/test/js/web/websocket/websocket-close-during-backpressure.test.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure.test.ts
@@ -1,8 +1,8 @@
-// https://github.com/oven-sh/bun/issues/5870 — receiving a server Close frame
-// while the client's send buffer is stalled behind a non-reading peer left the
-// WebSocket in readyState OPEN forever with no close event; send() after the
-// Close still queued to the drain buffer.
-// https://github.com/oven-sh/bun/issues/2177 — bufferedAmount always reported 0.
+// Receiving a server Close frame while the client's send buffer is stalled
+// behind a non-reading peer left the WebSocket in readyState OPEN forever with
+// no close event; send() after the Close still queued to the drain buffer.
+// https://github.com/oven-sh/bun/issues/31760 covers bufferedAmount always
+// reporting 0.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import crypto from "node:crypto";
@@ -36,10 +36,10 @@ test("WebSocket client: server Close during stalled drain transitions to CLOSING
     close: "timeout" | { code: number; wasClean: boolean };
   };
 
-  // #2177: bufferedAmount reflects the queued send buffer while OPEN.
+  // #31760: bufferedAmount reflects the queued send buffer while OPEN.
   expect(result.maxBufferedBeforeClose).toBeGreaterThan(0);
 
-  // #5870: on receiving the server's Close, readyState is CLOSING (2) — not
+  // On receiving the server's Close, readyState is CLOSING (2), not
   // still OPEN (1). CLOSED (3) is also acceptable if teardown already ran.
   expect(result.readyStateAfterServerClose).not.toBe(WebSocket.OPEN);
 
@@ -52,13 +52,13 @@ test("WebSocket client: server Close during stalled drain transitions to CLOSING
   expect(delta).toBeGreaterThanOrEqual(8 * (1 << 20));
   expect(delta).toBeLessThanOrEqual(8 * ((1 << 20) + 14));
 
-  // #5870: a close event fires within the drain timeout. The peer never drained
+  // A close event fires within the drain timeout. The peer never drained
   // or FIN'd, so the bounded teardown reports 1006 / wasClean=false.
   expect(result.close).not.toBe("timeout");
   expect(result.close).toEqual({ code: 1006, wasClean: false });
 }, 20000);
 
-// #2177 without the stall: bufferedAmount is the live queue length and falls
+// #31760 without the stall: bufferedAmount is the live queue length and falls
 // to 0 once the socket drains. Needs no env tuning, so this runs in-process.
 test("WebSocket client: bufferedAmount tracks the outbound queue", async () => {
   let serverSock: net.Socket | undefined;

--- a/test/js/web/websocket/websocket-close-during-backpressure.test.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure.test.ts
@@ -4,9 +4,9 @@
 // Close still queued to the drain buffer.
 // https://github.com/oven-sh/bun/issues/2177 — bufferedAmount always reported 0.
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import crypto from "node:crypto";
 import net from "node:net";
-import { bunEnv, bunExe } from "harness";
 
 const FIXTURE = require.resolve("./websocket-close-during-backpressure-fixture.ts");
 

--- a/test/js/web/websocket/websocket-close-during-backpressure.test.ts
+++ b/test/js/web/websocket/websocket-close-during-backpressure.test.ts
@@ -68,6 +68,7 @@ test.concurrent(
   "WebSocket client: bufferedAmount tracks the outbound queue",
   async () => {
     let serverSock: net.Socket | undefined;
+    let ws: WebSocket | undefined;
     const server = await new Promise<net.Server>(resolve => {
       const s = net.createServer(sock => {
         serverSock = sock;
@@ -99,10 +100,10 @@ test.concurrent(
     });
     try {
       const { port } = server.address() as net.AddressInfo;
-      const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+      ws = new WebSocket(`ws://127.0.0.1:${port}`);
       await new Promise<void>((resolve, reject) => {
-        ws.onopen = () => resolve();
-        ws.onerror = () => reject(new Error("connect failed"));
+        ws!.onopen = () => resolve();
+        ws!.onerror = () => reject(new Error("connect failed"));
       });
 
       expect(ws.bufferedAmount).toBe(0);
@@ -122,9 +123,8 @@ test.concurrent(
         await new Promise(r => setTimeout(r, 5));
       }
       expect(ws.bufferedAmount).toBe(0);
-
-      ws.close();
     } finally {
+      ws?.close();
       serverSock?.destroy();
       await new Promise(r => server.close(r));
     }


### PR DESCRIPTION
Fixes #31760

## Repro

Raw TCP peer that completes the handshake, stops reading (`socket.pause()`), sends `Close(1000)`, and holds the connection open. Client queues 64 MiB before the Close lands.

```
# before
{"maxBufferedBeforeClose":0,"readyStateAfterServerClose":1,"bufferedBeforeLateSends":0,"bufferedAfterLateSends":0,"close":"timeout"}
# after
{"maxBufferedBeforeClose":64488320,"readyStateAfterServerClose":2,"bufferedBeforeLateSends":64425864,"bufferedAfterLateSends":72814584,"close":{"code":1006,"wasClean":false}}
```

## Cause

`recv_close` sets `close_received` and calls `send_close_with_body`, which enqueues the echo Close behind every queued user byte. When `send_buffer` is non-empty the JS dispatch is parked in `close_dispatch_pending` and only resumed by a writable event or socket death. Nothing told C++ at Close receipt, so `m_state` stayed `OPEN`: `readyState` reported 1, `send()` kept queuing to the native buffer, and against a non-reading peer no close event ever fired.

Separately, `WebSocket::bufferedAmount()` returned `m_bufferedAmount + m_bufferedAmountAfterClose`, both of which stay 0 for an OPEN client: the lines that refreshed `m_bufferedAmount` from the connection were commented out, and no Rust accessor existed.

## Fix

- `recv_close` calls a new `WebSocket__didStartClosingHandshake` export as soon as the server's Close is received, so `readyState` becomes `CLOSING` immediately (RFC 6455 7.1.3) and C++ `send()` hits its CLOSING branch (`bufferedAmountAfterClose += payload`, nothing queued).
- The parked-close branch arms the socket timer with a new `BUN_CONFIG_WS_CLOSE_TIMEOUT` (default 30 s). `handle_timeout` tears the socket down with `close(1006, wasClean=false)` if the drain never happens; `finish_pending_close` clears the timer if it does. This also bounds a user-initiated `ws.close()` against a stalled peer.
- `WebSocket::bufferedAmount()` queries the live `send_buffer.readable_length()` via a new `Bun__WebSocketClient__bufferedAmount` export (mirrors `memoryCost`).

## Verification

`test/js/web/websocket/websocket-close-during-backpressure.test.ts` spawns the stalled-peer fixture with `BUN_CONFIG_WS_CLOSE_TIMEOUT=1` and asserts all four: `bufferedAmount > 0` while queuing, `readyState` leaves OPEN after the server's Close, late `send()`s add exactly payload+framing to `bufferedAmount`, and a `close(1006, wasClean=false)` event fires within the drain timeout. A second in-process test checks `bufferedAmount` rises and drains back to 0 against a reading peer. Both fail on main and pass with this change.

Overlaps #36112 (CLOSING transition only) and #31761 (bufferedAmount only); this PR covers both plus the bounded drain/teardown. Does not address #15665 (synchronous onclose on the immediate-drain path, which this PR does not touch).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-close-during-backpressure.test.ts
bun test v1.4.0 (10c68c00a)

test/js/web/websocket/websocket-close-during-backpressure.test.ts:
118 |         ws.send(payload);
119 |         if (ws.bufferedAmount > max) max = ws.bufferedAmount;
120 |       }
121 |       // The OS socket buffer absorbs the first write(s); the remainder lands in
122 |       // the client's send buffer and must be reported.
123 |       expect(max).toBeGreaterThan(0);
                        ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 0
Received: 0

      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-close-during-backpressure.test.ts:123:19)
(fail) WebSocket client: bufferedAmount tracks the outbound queue [543.73ms]
37 |       bufferedAfterLateSends: number;
38 |       close: "timeout" | { code: number; wasClean: boolean };
39 |     };
40 | 
41 |     // #31760: bufferedAmount reflects the queued send buffer while OPEN.
42 |     expect(result.maxBufferedBeforeClose).toBeGreaterThan(0);
                
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8f9281ec9)

test/js/web/websocket/websocket-close-during-backpressure.test.ts:
(pass) WebSocket client: bufferedAmount tracks the outbound queue [60.24ms]
(pass) WebSocket client: server Close during stalled drain transitions to CLOSING and eventually closes [4032.55ms]

 2 pass
 0 fail
 11 expect() calls
Ran 2 tests across 1 file. [4.19s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-close-during-backpressure.test.ts
bun test v1.4.0 (10c68c00a)

test/js/web/websocket/websocket-close-during-backpressure.test.ts:
(pass) WebSocket client: bufferedAmount tracks the outbound queue [719.03ms]
(pass) WebSocket client: server Close during stalled drain transitions to CLOSING and eventually closes [5144.95ms]

 2 pass
 0 fail
 11 expect() calls
Ran 2 tests across 1 file. [7.32s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 627ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[2/21] cxx obj/src/jsc/bindings/bindings.cpp.o
[3/21] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[4/21] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/21] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[6/21] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[7/21] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[8/21] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[9/21] cxx obj/src/jsc/bindings/BunObject.cpp.o
[10/21] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[11/21] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[12/21] cxx obj/codegen/JSSink.cpp.o
[13/21] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[14/21] cxx obj/src/jsc/bindings/napi.cpp.o
[15/21] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[16/21] gen cpp.rs (cppbind)
[16/21] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchange
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                            |   3 +
 src/http_jsc/websocket_client.rs                   |  47 +++++++
 src/http_jsc/websocket_client/CppWebSocket.rs      |   6 +
 src/jsc/bindings/headers.h                         |   2 +
 src/jsc/bindings/webcore/WebSocket.cpp             |  15 ++-
 .../websocket-close-during-backpressure-fixture.ts | 124 ++++++++++++++++++
 .../websocket-close-during-backpressure.test.ts    | 138 +++++++++++++++++++++
 7 files changed, 334 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bun_core/env_var.rs                                       2      3      0
src/http_jsc/websocket_client.rs                              2     10      0
src/http_jsc/websocket_client/CppWebSocket.rs                 2      3      0
src/jsc/bindings/headers.h                                    1      1      0
src/jsc/bindings/webcore/WebSocket.cpp                        5      4      0
…ebsocket/websocket-close-during-backpressure-fixture.ts      2      5      0
…b/websocket/websocket-close-during-backpressure.test.ts      4     12      0
```

</details>

<!-- robobun:evidence:end -->