### PR TITLE
node:async_hooks: align AsyncLocalStorage.bind()/snapshot() shape and run()/exit() thisArg with Node

### DIFF
--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -134,14 +134,40 @@ class AsyncLocalStorage {
     }
   }
 
-  static bind(fn, ...args: any) {
+  static bind(fn) {
     validateFunction(fn);
-    return this.snapshot().bind(null, fn, ...args);
+    var context = get();
+    var bound = function (this: unknown, ...args: unknown[]) {
+      var prev = get();
+      set(context);
+      try {
+        return fn.$apply(this, args);
+      } finally {
+        set(prev);
+      }
+    };
+    Object.defineProperties(bound, {
+      length: {
+        __proto__: null,
+        configurable: true,
+        enumerable: false,
+        value: fn.length,
+        writable: false,
+      },
+      name: {
+        __proto__: null,
+        configurable: true,
+        enumerable: false,
+        value: "bound",
+        writable: false,
+      },
+    });
+    return bound;
   }
 
   static snapshot() {
     var context = get();
-    return (fn, ...args) => {
+    var bound = function (fn, ...args: unknown[]) {
       var prev = get();
       set(context);
       try {
@@ -150,6 +176,14 @@ class AsyncLocalStorage {
         set(prev);
       }
     };
+    Object.defineProperty(bound, "name", {
+      __proto__: null,
+      configurable: true,
+      enumerable: false,
+      value: "bound",
+      writable: false,
+    });
+    return bound;
   }
 
   enterWith(store) {
@@ -192,7 +226,7 @@ class AsyncLocalStorage {
     // so a match here would skip installing store_value and let the callback
     // read the unmasked frame value instead.
     if (!this.#disabled && sameValue(this.getStore(), store_value)) {
-      return callback.$apply(undefined, args);
+      return callback.$apply(null, args);
     }
     var context = get() as any[]; // we make sure to .slice() before mutating
     var hasPrevious = false;
@@ -232,7 +266,7 @@ class AsyncLocalStorage {
     try {
       // $apply, not a spread: spreading goes through Array.prototype[Symbol.iterator],
       // which userland can delete (node uses ReflectApply here for the same reason).
-      return callback.$apply(undefined, args);
+      return callback.$apply(null, args);
     } finally {
       // Note: early `return` will prevent `throw` above from working. I think...
       // Set AsyncContextFrame to undefined if we are out of context values.

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -200,6 +200,72 @@ describe("AsyncLocalStorage", () => {
       alsA.disable();
     }
   });
+
+  // Node delegates ALS.bind to AsyncResource.bind, which copies fn.length and
+  // (via NamedEvaluation of `let bound`) names the result "bound". Verified
+  // against Node v26.3.0.
+  test("static bind() preserves fn.length, names the result 'bound', and forwards `this`", () => {
+    function named(a, b) {}
+    const b1 = AsyncLocalStorage.bind(named);
+    expect({ length: b1.length, name: b1.name }).toEqual({ length: 2, name: "bound" });
+
+    const b2 = AsyncLocalStorage.bind((a, b, c) => {});
+    expect({ length: b2.length, name: b2.name }).toEqual({ length: 3, name: "bound" });
+
+    expect(Object.getOwnPropertyDescriptor(b1, "length")).toEqual({
+      value: 2,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+    expect(Object.getOwnPropertyDescriptor(b1, "name")).toEqual({
+      value: "bound",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+
+    // Node's ALS.bind = AsyncResource.bind with thisArg undefined, which
+    // forwards the call-site `this` through to fn.
+    const receiver = { tag: 1 };
+    const seen = AsyncLocalStorage.bind(function (this: unknown) {
+      return this;
+    }).call(receiver);
+    expect(seen).toBe(receiver);
+  });
+
+  // Node: snapshot() = ALS.bind((cb, ...args) => cb(...args)). The arrow has
+  // one declared parameter, and AsyncResource.bind names it "bound".
+  test("static snapshot() returns a function with length 1 and name 'bound'", () => {
+    const snap = AsyncLocalStorage.snapshot();
+    expect({ length: snap.length, name: snap.name }).toEqual({ length: 1, name: "bound" });
+  });
+
+  // Node's run() is ReflectApply(fn, null, args); exit() is run(undefined, fn, ...).
+  test("run() and exit() invoke the callback with this === null", () => {
+    const als = new AsyncLocalStorage();
+    expect(
+      als.run("s", function (this: unknown) {
+        return this;
+      }),
+    ).toBeNull();
+    expect(
+      als.exit(function (this: unknown) {
+        return this;
+      }),
+    ).toBeNull();
+    // The same-value short-circuit path (store already equals the frame value).
+    als.enterWith("v");
+    try {
+      expect(
+        als.run("v", function (this: unknown) {
+          return this;
+        }),
+      ).toBeNull();
+    } finally {
+      als.disable();
+    }
+  });
 });
 
 test("AsyncResource", () => {


### PR DESCRIPTION
### What

`AsyncLocalStorage.bind(fn)` and `AsyncLocalStorage.snapshot()` now return functions whose `.length`/`.name` match Node, and `run()`/`exit()` now invoke the callback with `this === null`.

### Repro

```js
"use strict";
const { AsyncLocalStorage } = require("node:async_hooks");
function named(a, b) {}
const b = AsyncLocalStorage.bind(named);
console.log(b.length, JSON.stringify(b.name));
// node: 2 "bound"   | bun before: 0 "bound "

const als = new AsyncLocalStorage();
console.log(als.run("s", function () { return this; }));
// node: null        | bun before: undefined
```

### Cause

- `bind(fn)` was `this.snapshot().bind(null, fn)`. `snapshot()` returned an anonymous rest-param arrow, so native `Function.prototype.bind` produced `.length` 0 and `.name` `"bound "` (prefix + empty target name). The native bind also fixes `this` to `null`, so the call-site receiver was dropped. Node's `AsyncLocalStorage.bind` delegates to `AsyncResource.bind`, which copies `fn.length`, names the result `"bound"` (NamedEvaluation of `let bound`), and forwards the receiver.
- `snapshot()` returned an anonymous arrow, so `.name` was `""`. Node builds it through the same `AsyncResource.bind` path, so it is also named `"bound"`.
- `run()` passed `undefined` as `thisArg` (both the short-circuit and the normal path). Node uses `ReflectApply(fn, null, args)`, so strict-mode callbacks observe `this === null`. `exit()` goes through `run()`.

### Fix

- `AsyncLocalStorage.bind(fn)` now captures the context directly, returns a function that forwards `this` to `fn`, and sets `length`/`name` via `Object.defineProperties` to `fn.length` / `"bound"`.
- `AsyncLocalStorage.snapshot()` now returns a named function expression and sets `.name` to `"bound"` explicitly.
- Both `callback.$apply(undefined, args)` sites in `run()` are now `callback.$apply(null, args)`.

### Verification

```
$ bun-debug /tmp/repro.js
ALS.bind(named) length: 2 name: "bound"
ALS.snapshot()  length: 1 name: "bound"
run this: null
exit this: null
```

`AsyncResource.bind` already produced the correct shape on main (control).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/async_hooks/AsyncLocalStorage.test.ts
bun test v1.4.0 (ce6d28fc5)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [272.03ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [33.97ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [20.18ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [801.37ms]
(pass) AsyncLocalStorage > run() on a disabled storage does not leak the store past the callback [16.15ms]
(pass) AsyncLocalStorage > run() inside a snapshot does not expose a disabled storage's frame value [31.79ms]
(pass) AsyncLocalStorage > run(undefined)/exit() on a disabled storage re-enables it [7.87ms]
(pass) AsyncLocalStorage > run() short-circuits when the store value is unchanged (Object.is) [22.37ms]
(pass) AsyncLocalStorage > disable() mid-run then finally restores the previous value [24.37ms]
205 |   // (via NamedEvaluation of `let bound
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (179639299)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [0.33ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [0.21ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [0.12ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [10.38ms]
(pass) AsyncLocalStorage > run() on a disabled storage does not leak the store past the callback [0.15ms]
(pass) AsyncLocalStorage > run() inside a snapshot does not expose a disabled storage's frame value [0.19ms]
(pass) AsyncLocalStorage > run(undefined)/exit() on a disabled storage re-enables it [0.03ms]
(pass) AsyncLocalStorage > run() short-circuits when the store value is unchanged (Object.is) [0.18ms]
(pass) AsyncLocalStorage > disable() mid-run then finally restores the previous value [0.16ms]
(pass) AsyncLocalStorage > static bind() preserves fn.length, names the result 'bound', and forwards `this` [0.18ms]
(pass) AsyncLocalStorage > static snapshot() returns a function with length 1 and name 'bound' [0.02ms]
(pass) A
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/async_hooks/AsyncLocalStorage.test.ts
bun test v1.4.0 (ce6d28fc5)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [269.49ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [35.01ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [20.49ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [793.13ms]
(pass) AsyncLocalStorage > run() on a disabled storage does not leak the store past the callback [16.48ms]
(pass) AsyncLocalStorage > run() inside a snapshot does not expose a disabled storage's frame value [33.36ms]
(pass) AsyncLocalStorage > run(undefined)/exit() on a disabled storage re-enables it [8.06ms]
(pass) AsyncLocalStorage > run() short-circuits when the store value is unchanged (Object.is) [22.15ms]
(pass) AsyncLocalStorage > disable() mid-run then finally restores the previous value [23.20ms]
(pass) AsyncLocalStorage > static bind() pres
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 754ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8849ms)
Bundle modules (55ms)
Postprocesss modules (203ms)
Bundle Functions (820ms)
Generate Code (32ms)

[9.98s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 03s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+ce6d28fc5
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (ce6d28fc5)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [0.34ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [0.21ms]
(pass) 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/async_hooks.ts                         | 44 +++++++++++++--
 test/js/node/async_hooks/AsyncLocalStorage.test.ts | 66 ++++++++++++++++++++++
 2 files changed, 105 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/async_hooks.ts                              1      3      0
test/js/node/async_hooks/AsyncLocalStorage.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->