### PR TITLE
url: make the hostname setter a no-op on ":" outside an IPv6 bracket

### DIFF
--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -152,6 +152,24 @@ void URLDecomposition::setHostname(StringView host)
         return;
     if (fullURL.hasOpaquePath())
         return;
+
+    // https://url.spec.whatwg.org/#host-state: hostname state override returns on ':' outside '[...]'.
+    bool insideBrackets = false;
+    bool special = fullURL.hasSpecialScheme();
+    for (unsigned i = 0; i < host.length(); ++i) {
+        auto c = host[i];
+        if (c == 0x0009 || c == 0x000A || c == 0x000D)
+            continue;
+        if (c == '/' || c == '?' || c == '#' || (special && c == '\\'))
+            break;
+        if (c == ':' && !insideBrackets)
+            return;
+        if (c == '[')
+            insideBrackets = true;
+        else if (c == ']')
+            insideBrackets = false;
+    }
+
     fullURL.setHost(host);
     if (fullURL.isValid())
         setFullURL(fullURL);

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -152,6 +152,27 @@ void URLDecomposition::setHostname(StringView host)
         return;
     if (fullURL.hasOpaquePath())
         return;
+
+    // https://url.spec.whatwg.org/#host-state: with state override = hostname state, a ':'
+    // outside an IPv6 '[' ... ']' returns without setting anything. WTF::URL::setHost only
+    // guards "contains ':' and does not start with '['" so "[::1]:81" would otherwise reach
+    // the reparse and fill the port slot.
+    bool insideBrackets = false;
+    bool special = fullURL.hasSpecialScheme();
+    for (unsigned i = 0; i < host.length(); ++i) {
+        auto c = host[i];
+        if (c == 0x0009 || c == 0x000A || c == 0x000D)
+            continue;
+        if (c == '/' || c == '?' || c == '#' || (special && c == '\\'))
+            break;
+        if (c == ':' && !insideBrackets)
+            return;
+        if (c == '[')
+            insideBrackets = true;
+        else if (c == ']')
+            insideBrackets = false;
+    }
+
     fullURL.setHost(host);
     if (fullURL.isValid())
         setFullURL(fullURL);

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -152,25 +152,6 @@ void URLDecomposition::setHostname(StringView host)
         return;
     if (fullURL.hasOpaquePath())
         return;
-
-    // https://url.spec.whatwg.org/#host-state with state override = hostname state: a ':'
-    // outside '[...]' is a no-op. WTF::URL::setHost lets a bracketed "[::1]:81" through.
-    bool insideBrackets = false;
-    bool special = fullURL.hasSpecialScheme();
-    for (unsigned i = 0; i < host.length(); ++i) {
-        auto c = host[i];
-        if (c == 0x0009 || c == 0x000A || c == 0x000D)
-            continue;
-        if (c == '/' || c == '?' || c == '#' || (special && c == '\\'))
-            break;
-        if (c == ':' && !insideBrackets)
-            return;
-        if (c == '[')
-            insideBrackets = true;
-        else if (c == ']')
-            insideBrackets = false;
-    }
-
     fullURL.setHost(host);
     if (fullURL.isValid())
         setFullURL(fullURL);

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -153,10 +153,8 @@ void URLDecomposition::setHostname(StringView host)
     if (fullURL.hasOpaquePath())
         return;
 
-    // https://url.spec.whatwg.org/#host-state: with state override = hostname state, a ':'
-    // outside an IPv6 '[' ... ']' returns without setting anything. WTF::URL::setHost only
-    // guards "contains ':' and does not start with '['" so "[::1]:81" would otherwise reach
-    // the reparse and fill the port slot.
+    // https://url.spec.whatwg.org/#host-state with state override = hostname state: a ':'
+    // outside '[...]' is a no-op. WTF::URL::setHost lets a bracketed "[::1]:81" through.
     bool insideBrackets = false;
     bool special = fullURL.hasSpecialScheme();
     for (unsigned i = 0; i < host.length(); ++i) {

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -188,6 +188,40 @@ describe("url", () => {
     }
   });
 
+  // https://url.spec.whatwg.org/#host-state: with state override = hostname state, a ':'
+  // outside an IPv6 '[' ... ']' returns without setting anything. The hostname setter must
+  // never touch the port. Every expected href below matches Node.
+  it.each([
+    // bracketed IPv6 followed by ":port" is a no-op, not a port write
+    ["http://a/p", "[::1]:81", "http://a/p"],
+    ["https://a/p", "[2001:db8::7]:8443", "https://a/p"],
+    ["ws://u:pw@a/p", "[::1]:6666", "ws://u:pw@a/p"],
+    ["http://a/p", "[::ffff:127.0.0.1]:22", "http://a/p"],
+    ["http://a/p", "[::1]:", "http://a/p"],
+    ["http://a:1/p", "[::1]:81", "http://a:1/p"],
+    ["sc://a/p", "[::1]:81", "sc://a/p"],
+    ["file://a/p", "[::1]:81", "file://a/p"],
+    // tab/newline are stripped first, so the ':' is still outside the brackets
+    ["http://a/p", "[::1]\t:81", "http://a/p"],
+    ["http://a/p", "\t[::1]:81", "http://a/p"],
+    // '/', '?', '#', '\\' end the host before the ':' is reached, so these still apply
+    ["http://a/p", "[::1]/x:81", "http://[::1]/p"],
+    ["http://a/p", "[::1]?x:81", "http://[::1]/p"],
+    ["http://a/p", "[::1]#x:81", "http://[::1]/p"],
+    ["http://a/p", "[::1]\\x:81", "http://[::1]/p"],
+    // ':' before any terminator is a no-op regardless of what follows
+    ["http://a/p", "[::1]:81/x", "http://a/p"],
+    // the existing non-bracketed rejection still holds
+    ["http://a/p", "h:81", "http://a/p"],
+    // a plain bracketed IPv6 is still accepted
+    ["http://a/p", "[::1]", "http://[::1]/p"],
+    ["http://a:1/p", "[::1]", "http://[::1]:1/p"],
+  ])("hostname setter never writes the port: new URL(%j).hostname = %j", (base, value, expected) => {
+    const url = new URL(base);
+    url.hostname = value;
+    expect({ href: url.href, port: url.port }).toEqual({ href: expected, port: new URL(expected).port });
+  });
+
   describe("URL.canParse", () => {
     (
       [

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -203,12 +203,17 @@ describe("url", () => {
     ["file://a/p", "[::1]:81", "file://a/p"],
     // tab/newline are stripped first, so the ':' is still outside the brackets
     ["http://a/p", "[::1]\t:81", "http://a/p"],
+    ["http://a/p", "[::1]\n:81", "http://a/p"],
+    ["http://a/p", "[::1]\r:81", "http://a/p"],
+    ["http://a/p", "[::1]\r\n:81", "http://a/p"],
     ["http://a/p", "\t[::1]:81", "http://a/p"],
-    // '/', '?', '#', '\\' end the host before the ':' is reached, so these still apply
+    // '/', '?', '#' (and '\\' on special schemes) end the host before the ':' is reached
     ["http://a/p", "[::1]/x:81", "http://[::1]/p"],
     ["http://a/p", "[::1]?x:81", "http://[::1]/p"],
     ["http://a/p", "[::1]#x:81", "http://[::1]/p"],
     ["http://a/p", "[::1]\\x:81", "http://[::1]/p"],
+    // '\\' is not a terminator on a non-special scheme, so the ':' after it is still rejected
+    ["sc://a/p", "[::1]\\x:81", "sc://a/p"],
     // ':' before any terminator is a no-op regardless of what follows
     ["http://a/p", "[::1]:81/x", "http://a/p"],
     // the existing non-bracketed rejection still holds


### PR DESCRIPTION
## What

`url.hostname = "[::1]:81"` was writing both the host *and* the port. The `hostname` setter is the one place spec-guaranteed never to touch the port, so this silently retargeted requests.

```js
const u = new URL("http://a/p");
u.hostname = "[::1]:81";
u.href;
// bun 1.4.0:  "http://[::1]:81/p"
// spec/Node:  "http://a/p"   (no-op)
```

Reproduces on any special scheme with a bracketed IPv6 literal followed by `:<anything>`, as long as the URL has no existing port (an existing port made the recomposed string unparsable, which accidentally no-opped).

## Why

`URLDecomposition::setHostname` forwards to WTF `URL::setHost`, whose colon guard is:

```cpp
if (newHost.contains(':') && !newHost.startsWith('['))
    return false;
```

A value that starts with `[` bypasses the guard entirely, so `[::1]:81` reaches the reparse of `left(hostStart) + "[::1]:81" + substring(m_hostEnd)` and `:81` lands in the port slot.

Per the URL Standard's [host state](https://url.spec.whatwg.org/#host-state) with *state override = hostname state*, a `:` outside the IPv6 brackets returns immediately without setting anything.

## Fix

Scan the value in `URLDecomposition::setHostname` the way the spec state machine does: skip ASCII tab/newline, stop at the host terminators (`/`, `?`, `#`, and `\\` for special schemes) that `URL::setHost` already truncates at, and return early on the first `:` seen outside `[` ... `]`.

## Verification

18 new cases in `test/js/web/url/url.test.ts`, all cross-checked against Node: the 8 that previously leaked a port now no-op, and the 10 that were already correct (plain `[::1]`, terminator-before-colon, non-bracketed `h:81`) are kept as regression guards.

```
USE_SYSTEM_BUN=1 bun test test/js/web/url/url.test.ts -t "hostname setter never writes the port"
  8 fail, 10 pass
bun bd test test/js/web/url/url.test.ts
  36 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (10f551cdf)

test/js/web/url/url.test.ts:
(pass) url > URL throws [19.81ms]
(pass) url > should have correct origin and protocol [15.45ms]
(pass) url > blob urls [8.84ms]
(pass) url > prints [11.21ms]
(pass) url > works [19.24ms]
222 |     ["http://a/p", "[::1]", "http://[::1]/p"],
223 |     ["http://a:1/p", "[::1]", "http://[::1]:1/p"],
224 |   ])("hostname setter never writes the port: new URL(%j).hostname = %j", (base, value, expected) => {
225 |     const url = new URL(base);
226 |     url.hostname = value;
227 |     expect({ href: url.href, port: url.port }).toEqual({ href: expected, port: new URL(expected).port });
                                                     ^
error: expect(received).toEqual(expected)

  {
-   "href": "http://a/p",
-   "port": "",
+   "href": "http://[::1]:81/p",
+   "port": "81",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/url/url.test.ts:227:48)
(fail) url > hostname setter never writes the port: new URL("http://a/p"
... (truncated)

release without fix: 13 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/url/url.test.ts:
(pass) url > URL throws [0.28ms]
(pass) url > should have correct origin and protocol [0.23ms]
(pass) url > blob urls [0.14ms]
(pass) url > prints [0.25ms]
(pass) url > works [0.25ms]
222 |     ["http://a/p", "[::1]", "http://[::1]/p"],
223 |     ["http://a:1/p", "[::1]", "http://[::1]:1/p"],
224 |   ])("hostname setter never writes the port: new URL(%j).hostname = %j", (base, value, expected) => {
225 |     const url = new URL(base);
226 |     url.hostname = value;
227 |     expect({ href: url.href, port: url.port }).toEqual({ href: expected, port: new URL(expected).port });
                                                     ^
error: expect(received).toEqual(expected)

  {
-   "href": "http://a/p",
-   "port": "",
+   "href": "http://[::1]:81/p",
+   "port": "81",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/url/url.test.ts:227:48)
(fail) url > hostname setter never writes the port: new URL("http://a/p").hostname = "[::1]:81" [0.31ms]
222 |     ["http://a/p", "[::1]", "http://[::1]/p"],
223 |     ["http://a:1/p", "[::1]", "http://[::1]:1/p"],
224 |   ])("h
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (10f551cdf)

test/js/web/url/url.test.ts:
(pass) url > URL throws [12.76ms]
(pass) url > should have correct origin and protocol [13.11ms]
(pass) url > blob urls [9.01ms]
(pass) url > prints [7.86ms]
(pass) url > works [12.88ms]
(pass) url > hostname setter never writes the port: new URL("http://a/p").hostname = "[::1]:81" [2.64ms]
(pass) url > hostname setter never writes the port: new URL("https://a/p").hostname = "[2001:db8::7]:8443" [0.73ms]
(pass) url > hostname setter never writes the port: new URL("ws://u:pw@a/p").hostname = "[::1]:6666" [0.63ms]
(pass) url > hostname setter never writes the port: new URL("http://a/p").hostname = "[::ffff:127.0.0.1]:22" [0.58ms]
(pass) url > hostname setter never writes the port: new URL("http://a/p").hostname = "[::1]:" [0.80ms]
(pass) url > hostname setter never writes the port: new URL("http://a:1/p").hostname = "[::1]:81" [0.63ms]
(pass) url > hostname setter never writes the port: new URL("sc://a/p").hostname = "[::1]:81" [0.58ms]
(pass) url > hos
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 718ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/URLDecomposition.cpp | 18 ++++++++++++++++
 test/js/web/url/url.test.ts           | 39 +++++++++++++++++++++++++++++++++++
 2 files changed, 57 insertions(+)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/URLDecomposition.cpp      4      5      0
test/js/web/url/url.test.ts                3      3      0
```

</details>

<!-- robobun:evidence:end -->