### PR TITLE
js_printer: preserve __proto__ key vs shorthand form in object literals

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4551,12 +4551,9 @@ pub mod __gated_printer {
                 set_flag(&mut item.flags, js_ast::flags::Property::IsComputed, true);
             }
 
-            // "{ __proto__: x }" sets the prototype, while "{ __proto__ }" and
-            // "{ ['__proto__']: x }" define an own data property (Annex B.3.1).
-            // The shorthand and colon forms are therefore not interchangeable
-            // for this one key name. A property carrying an `initializer` is a
-            // destructuring target, where both forms just read the property and
-            // are equivalent, so the gate does not apply.
+            // Annex B.3.1: `{__proto__: x}` sets [[Prototype]]; shorthand and
+            // computed forms define an own property instead. An `initializer`
+            // means a destructuring target, where the two forms are equivalent.
             let is_proto_setter_key = !IS_JSON
                 && !item.flags.contains(js_ast::flags::Property::IsComputed)
                 && item.kind == G::PropertyKind::Normal
@@ -4565,10 +4562,6 @@ pub mod __gated_printer {
                 && matches!(&key.data, ExprData::EString(s) if s.eql_comptime(b"__proto__"));
 
             if is_proto_setter_key && item.flags.contains(js_ast::flags::Property::WasShorthand) {
-                // A shorthand `__proto__` whose value identifier was renamed or
-                // rewritten can no longer print as `{ __proto__ }`; expanding it
-                // to `{ __proto__: x }` would change it into a prototype setter,
-                // so print it as a computed key instead.
                 let stays_shorthand = match item.value.as_ref().map(|v| &v.data) {
                     Some(ExprData::EIdentifier(e)) => self.name_for_symbol(e.ref_) == b"__proto__",
                     Some(ExprData::EImportIdentifier(e))
@@ -4624,10 +4617,6 @@ pub mod __gated_printer {
                     if key_str.is_utf8() {
                         key_str.resolve_rope_if_needed(self.bump);
                         self.print_space_before_identifier();
-                        // Never introduce the shorthand form for `__proto__`:
-                        // `{ __proto__: x }` sets the prototype, `{ __proto__ }`
-                        // does not. Only keep it shorthand if it was written
-                        // that way (handled above for the renamed case).
                         let mut allow_shorthand = !is_proto_setter_key
                             || item.flags.contains(js_ast::flags::Property::WasShorthand);
                         if !IS_JSON && lexer::is_identifier(key_str.slice8()) {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4551,6 +4551,39 @@ pub mod __gated_printer {
                 set_flag(&mut item.flags, js_ast::flags::Property::IsComputed, true);
             }
 
+            // "{ __proto__: x }" sets the prototype, while "{ __proto__ }" and
+            // "{ ['__proto__']: x }" define an own data property (Annex B.3.1).
+            // The shorthand and colon forms are therefore not interchangeable
+            // for this one key name.
+            let is_proto_setter_key = !IS_JSON
+                && !item.flags.contains(js_ast::flags::Property::IsComputed)
+                && item.kind == G::PropertyKind::Normal
+                && !item.flags.contains(js_ast::flags::Property::IsMethod)
+                && matches!(&key.data, ExprData::EString(s) if s.eql_comptime(b"__proto__"));
+
+            if is_proto_setter_key && item.flags.contains(js_ast::flags::Property::WasShorthand) {
+                // A shorthand `__proto__` whose value identifier was renamed or
+                // rewritten can no longer print as `{ __proto__ }`; expanding it
+                // to `{ __proto__: x }` would change it into a prototype setter,
+                // so print it as a computed key instead.
+                let stays_shorthand = match item.value.as_ref().map(|v| &v.data) {
+                    Some(ExprData::EIdentifier(e)) => self.name_for_symbol(e.ref_) == b"__proto__",
+                    Some(ExprData::EImportIdentifier(e))
+                        if self.options.input_files_for_dev_server.is_none() =>
+                    {
+                        let ref_ = self.symbols().follow(e.ref_);
+                        self.symbols()
+                            .get_const(ref_)
+                            .is_some_and(|sym| sym.namespace_alias.is_none())
+                            && self.name_for_symbol(e.ref_) == b"__proto__"
+                    }
+                    _ => false,
+                };
+                if !stays_shorthand {
+                    set_flag(&mut item.flags, js_ast::flags::Property::IsComputed, true);
+                }
+            }
+
             if !IS_JSON && item.flags.contains(js_ast::flags::Property::IsComputed) {
                 self.print(b"[");
                 self.print_expr(key, Level::Comma, ExprFlag::none());
@@ -4588,7 +4621,12 @@ pub mod __gated_printer {
                     if key_str.is_utf8() {
                         key_str.resolve_rope_if_needed(self.bump);
                         self.print_space_before_identifier();
-                        let mut allow_shorthand = true;
+                        // Never introduce the shorthand form for `__proto__`:
+                        // `{ __proto__: x }` sets the prototype, `{ __proto__ }`
+                        // does not. Only keep it shorthand if it was written
+                        // that way (handled above for the renamed case).
+                        let mut allow_shorthand = !is_proto_setter_key
+                            || item.flags.contains(js_ast::flags::Property::WasShorthand);
                         if !IS_JSON && lexer::is_identifier(key_str.slice8()) {
                             self.print_identifier(key_str.slice8());
                         } else {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4554,11 +4554,14 @@ pub mod __gated_printer {
             // "{ __proto__: x }" sets the prototype, while "{ __proto__ }" and
             // "{ ['__proto__']: x }" define an own data property (Annex B.3.1).
             // The shorthand and colon forms are therefore not interchangeable
-            // for this one key name.
+            // for this one key name. A property carrying an `initializer` is a
+            // destructuring target, where both forms just read the property and
+            // are equivalent, so the gate does not apply.
             let is_proto_setter_key = !IS_JSON
                 && !item.flags.contains(js_ast::flags::Property::IsComputed)
                 && item.kind == G::PropertyKind::Normal
                 && !item.flags.contains(js_ast::flags::Property::IsMethod)
+                && item.initializer.is_none()
                 && matches!(&key.data, ExprData::EString(s) if s.eql_comptime(b"__proto__"));
 
             if is_proto_setter_key && item.flags.contains(js_ast::flags::Property::WasShorthand) {
@@ -4635,37 +4638,35 @@ pub mod __gated_printer {
                         }
 
                         // Use a shorthand property if the names are the same
-                        if let Some(val) = &item.value {
-                            match &val.data {
-                                ExprData::EIdentifier(e) => {
-                                    if key_str.slice8() == self.name_for_symbol(e.ref_) {
-                                        if let Some(initial) = &item.initializer {
-                                            self.print_initializer(*initial);
-                                        }
-                                        if allow_shorthand {
-                                            return;
-                                        }
-                                    }
-                                }
-                                ExprData::EImportIdentifier(e) => 'inner: {
-                                    let ref_ = self.symbols().follow(e.ref_);
-                                    if self.options.input_files_for_dev_server.is_some() {
-                                        break 'inner;
-                                    }
-                                    if let Some(symbol) = self.symbols().get_const(ref_) {
-                                        if symbol.namespace_alias.is_none()
-                                            && key_str.slice8() == self.name_for_symbol(e.ref_)
-                                        {
+                        if allow_shorthand {
+                            if let Some(val) = &item.value {
+                                match &val.data {
+                                    ExprData::EIdentifier(e) => {
+                                        if key_str.slice8() == self.name_for_symbol(e.ref_) {
                                             if let Some(initial) = &item.initializer {
                                                 self.print_initializer(*initial);
                                             }
-                                            if allow_shorthand {
+                                            return;
+                                        }
+                                    }
+                                    ExprData::EImportIdentifier(e) => 'inner: {
+                                        let ref_ = self.symbols().follow(e.ref_);
+                                        if self.options.input_files_for_dev_server.is_some() {
+                                            break 'inner;
+                                        }
+                                        if let Some(symbol) = self.symbols().get_const(ref_) {
+                                            if symbol.namespace_alias.is_none()
+                                                && key_str.slice8() == self.name_for_symbol(e.ref_)
+                                            {
+                                                if let Some(initial) = &item.initializer {
+                                                    self.print_initializer(*initial);
+                                                }
                                                 return;
                                             }
                                         }
                                     }
+                                    _ => {}
                                 }
-                                _ => {}
                             }
                         }
                     } else if !IS_JSON && self.can_print_identifier_utf16(key_str.slice16()) {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4551,9 +4551,7 @@ pub mod __gated_printer {
                 set_flag(&mut item.flags, js_ast::flags::Property::IsComputed, true);
             }
 
-            // Annex B.3.1: `{__proto__: x}` sets [[Prototype]]; shorthand and
-            // computed forms define an own property instead. An `initializer`
-            // means a destructuring target, where the two forms are equivalent.
+            // Annex B.3.1: only a literal `__proto__:` key sets [[Prototype]]; shorthand and computed forms do not.
             let is_proto_setter_key = !IS_JSON
                 && !item.flags.contains(js_ast::flags::Property::IsComputed)
                 && item.kind == G::PropertyKind::Normal

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1397,6 +1397,105 @@ describe("bundler", () => {
       stdout: "false",
     },
   });
+  // `{ __proto__: v }` sets the prototype; the shorthand `{ __proto__ }` and the
+  // computed `{ ["__proto__"]: v }` forms define an own property instead. The
+  // printer must never convert between the shorthand and colon forms for this key.
+  for (const [label, opts] of [
+    ["", {}],
+    ["MinifySyntax", { minifySyntax: true }],
+    ["MinifyAll", { minifySyntax: true, minifyWhitespace: true, minifyIdentifiers: true }],
+  ] as const) {
+    itBundled(`edgecase/ProtoKeyFormIsNotShorthand${label}`, {
+      files: {
+        "/entry.ts": /* js */ `
+          const __proto__ = { marker: "P" };
+          const viaKey = { __proto__: __proto__ };
+          const viaStringKey = { "__proto__": __proto__ };
+          console.log(JSON.stringify([
+            Object.hasOwn(viaKey, "__proto__"),
+            Object.getPrototypeOf(viaKey).marker,
+            Object.hasOwn(viaStringKey, "__proto__"),
+            Object.getPrototypeOf(viaStringKey).marker,
+          ]));
+        `,
+      },
+      ...opts,
+      run: { stdout: '[false,"P",false,"P"]' },
+    });
+    itBundled(`edgecase/ProtoShorthandIsOwnProperty${label}`, {
+      files: {
+        "/entry.ts": /* js */ `
+          const __proto__ = { marker: "P" };
+          const viaShort = { __proto__ };
+          const viaComputed = { ["__proto__"]: __proto__ };
+          console.log(JSON.stringify([
+            Object.hasOwn(viaShort, "__proto__"),
+            Object.getPrototypeOf(viaShort) === Object.prototype,
+            Object.hasOwn(viaComputed, "__proto__"),
+            Object.getPrototypeOf(viaComputed) === Object.prototype,
+          ]));
+        `,
+      },
+      ...opts,
+      run: { stdout: "[true,true,true,true]" },
+    });
+  }
+  itBundled(`edgecase/ProtoShorthandRenamedEmitsComputedKey`, {
+    files: {
+      "/entry.ts": /* js */ `
+        const __proto__ = { marker: "P" };
+        console.log(JSON.stringify({ __proto__ }));
+      `,
+    },
+    minifyIdentifiers: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toMatch(/\[['"]__proto__['"]\]\s*:/);
+    },
+    run: { stdout: '{"__proto__":{"marker":"P"}}' },
+  });
+  itBundled(`edgecase/ProtoShorthandAcrossModulesMinified`, {
+    files: {
+      "/entry.ts": /* js */ `
+        import { __proto__ } from "./other.ts";
+        const viaShort = { __proto__ };
+        console.log(JSON.stringify([
+          Object.hasOwn(viaShort, "__proto__"),
+          Object.getPrototypeOf(viaShort) === Object.prototype,
+          viaShort.__proto__.marker,
+        ]));
+      `,
+      "/other.ts": /* js */ `
+        export const __proto__ = { marker: "P" };
+      `,
+    },
+    minifyIdentifiers: true,
+    run: { stdout: '[true,true,"P"]' },
+  });
+  test.concurrent("edgecase/ProtoKeyVsShorthandAtRuntime", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const __proto__ = { marker: "P" };
+         const viaKey = { __proto__: __proto__ };
+         const viaShort = { __proto__ };
+         console.log(JSON.stringify([
+           Object.hasOwn(viaKey, "__proto__"),
+           Object.getPrototypeOf(viaKey).marker,
+           Object.hasOwn(viaShort, "__proto__"),
+           Object.getPrototypeOf(viaShort) === Object.prototype,
+         ]));`,
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: '[false,"P",true,true]',
+      stderr: "",
+      exitCode: 0,
+    });
+  });
   itBundled("edgecase/ImportOptionsArgument", {
     files: {
       "/entry.js": `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1471,6 +1471,29 @@ describe("bundler", () => {
     minifyIdentifiers: true,
     run: { stdout: '[true,true,"P"]' },
   });
+  // In a destructuring target both `{ __proto__ }` and `{ __proto__: __proto__ }`
+  // just read the property; the shorthand gate must not apply there and must not
+  // double-print the default-value initializer.
+  for (const [label, opts] of [
+    ["", {}],
+    ["Minify", { minifySyntax: true, minifyWhitespace: true, minifyIdentifiers: true }],
+  ] as const) {
+    itBundled(`edgecase/ProtoLonghandDestructuringWithDefault${label}`, {
+      files: {
+        "/entry.ts": /* js */ `
+          let __proto__;
+          ({ __proto__: __proto__ = { m: 1 } } = Object.create(null));
+          console.log(JSON.stringify(__proto__));
+          ({ __proto__: __proto__ = { m: 2 } } = {});
+          console.log(__proto__ === Object.prototype);
+          ({ __proto__: __proto__ } = { a: 1 });
+          console.log(__proto__ === Object.prototype);
+        `,
+      },
+      ...opts,
+      run: { stdout: '{"m":1}\ntrue\ntrue' },
+    });
+  }
   test.concurrent("edgecase/ProtoKeyVsShorthandAtRuntime", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
### What does this PR do?

Per Annex B.3.1, `{ __proto__: v }` sets `[[Prototype]]`, while the shorthand `{ __proto__ }` and the computed `{ ["__proto__"]: v }` forms define an own data property. The printer was converting between the key and shorthand forms for `__proto__`, changing semantics in both directions.

```js
const __proto__ = { marker: "P" };
const viaKey = { __proto__: __proto__ };   // spec: sets prototype
const viaShort = { __proto__ };            // spec: own property
console.log(Object.hasOwn(viaKey, "__proto__"), Object.getPrototypeOf(viaKey).marker);
console.log(Object.hasOwn(viaShort, "__proto__"), Object.getPrototypeOf(viaShort) === Object.prototype);
// node:               false P / true true
// bun run (before):   true undefined / true true
// bun build --minify: emits {__proto__:r} for both, so node prints false P / false false
```

**Face 1** (`bun run`, `bun build`, `bun build --minify-syntax`): `{ __proto__: __proto__ }` was collapsed to the shorthand `{ __proto__ }`, turning a prototype setter into an own property.

**Face 2** (`bun build --minify-identifiers`): `{ __proto__ }` was expanded to `{ __proto__: r }` once the value identifier was renamed, turning an own property into a prototype setter in the emitted artifact.

`print_property` used the same shorthand/longhand heuristic for every identifier key: collapse to shorthand whenever the key text matches the printed symbol name, and fall through to `key: value` otherwise. `__proto__` is the one key name where those two forms are not equivalent.

Fix in `print_property`:

- Detect the prototype-setter key form (`!IsComputed`, `Normal` kind, not a method, no destructuring initializer, key string is `"__proto__"`) once, before the key is printed.
- When that key was written as shorthand (`WasShorthand`) and the value can no longer print as the identifier `__proto__` (renamed, namespace-aliased import, or rewritten), force `IsComputed` so it prints as `["__proto__"]: v` and stays an own property.
- Gate the `allow_shorthand` collapse on `WasShorthand` for this key so `{ __proto__: __proto__ }` is never shortened, and guard the whole key==name shorthand arm on `allow_shorthand` so the destructuring default initializer is not printed twice.

esbuild handles this the same way (keeps the form verbatim, emits a computed key on rename).

### How did you verify your code works?

```
$ bun bd build --no-bundle repro.js
const viaKey = { __proto__: __proto__ };
const viaShort = { __proto__ };

$ bun bd build --minify repro.js
var _={marker:"P"},o={__proto__:_},t={["__proto__"]:_};...

$ bun bd repro.js
false P
true true
```

New `edgecase/Proto*` tests in `test/bundler/bundler_edgecase.test.ts` cover both faces across no-minify / `--minify-syntax` / full `--minify`, the cross-module `import { __proto__ }` shorthand case, the longhand-destructuring-with-default case, and the runtime transpiler path via `bun -e`. `bun bd test test/bundler/bundler_edgecase.test.ts`: 128 pass / 0 fail. `bundler_minify.test.ts`, `bundler_loader.test.ts`, `esbuild/extra.test.ts` also green.
