### PR TITLE
node:stream: forward destroy error and defer sync pull in native Readable.fromWeb adapter

### DIFF
--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -233,13 +233,13 @@ function adjustHighWaterMark(stream: NativeReadable) {
   stream[kHasResized] = true;
 }
 
-function destroy(this: NativeReadable, error: any, cb: () => void) {
+function destroy(this: NativeReadable, error: any, cb: (err?: any) => void) {
   const ptr = this.$bunNativePtr;
   if (ptr) {
     ptr.cancel(error);
   }
   if (cb) {
-    process.nextTick(cb);
+    process.nextTick(cb, error);
   }
 }
 

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -154,8 +154,8 @@ function read(this: NativeReadable, maxToRead: number) {
   $debug(
     `[${this.debugId}] pull ${chunk?.byteLength} bytes, result: ${$isPromise(result) ? "<pending>" : $isTypedArrayView(result) ? `<${result.byteLength} bytes>` : result}, closeState: ${this[kCloseState][0]}`,
   );
+  this[kPendingRead] = true;
   if ($isPromise(result)) {
-    this[kPendingRead] = true;
     return result.then(
       result => {
         $debug(
@@ -165,11 +165,15 @@ function read(this: NativeReadable, maxToRead: number) {
         this[kRemainingChunk] = handleResult(this, result, chunk, this[kCloseState][0]);
       },
       reason => {
+        this[kPendingRead] = false;
         errorOrDestroy(this, reason);
       },
     );
   } else {
-    this[kRemainingChunk] = handleResult(this, result, chunk, this[kCloseState][0]);
+    process.nextTick(() => {
+      this[kPendingRead] = false;
+      this[kRemainingChunk] = handleResult(this, result, chunk, this[kCloseState][0]);
+    });
   }
 }
 

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -563,6 +563,77 @@ it("Readable.fromWeb: destroy(err) after consuming a chunk cancels the web sourc
   });
 });
 
+// destroy(err) on the native-backed fromWeb adapter (Blob.stream(), Response.body)
+// must emit 'error' before 'close', matching Node and the JS-adapter path. The
+// native _destroy previously called its callback without forwarding the error,
+// so only 'close' fired and an unhandled destroy error was silently dropped.
+it.each([
+  ["Blob.stream()", () => new Blob(["hello"]).stream()],
+  ["Response.body", () => new Response("hello").body],
+])("Readable.fromWeb over native %s: destroy(err) emits 'error' before 'close'", async (_name, makeWeb) => {
+  const r = Readable.fromWeb(makeWeb());
+  const events = [];
+  r.on("error", e => events.push("error:" + e.code));
+  r.on("close", () => events.push("close"));
+  let fin = "pending";
+  finished(r, e => {
+    fin = e ? e.code : "clean";
+  });
+  r.destroy(Object.assign(new Error("boom"), { code: "EBOOM" }));
+  await new Promise(resolve => r.once("close", resolve));
+  expect({ events, finished: fin, errored: r.errored?.code }).toEqual({
+    events: ["error:EBOOM", "close"],
+    finished: "EBOOM",
+    errored: "EBOOM",
+  });
+});
+
+it("Readable.fromWeb over native stream: destroy(err) with no 'error' listener surfaces as uncaughtException", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { Readable } = require("node:stream");
+        process.on("uncaughtException", e => console.log("UNCAUGHT:" + e.code));
+        const r = Readable.fromWeb(new Blob(["hello"]).stream());
+        r.on("close", () => console.log("CLOSE"));
+        r.destroy(Object.assign(new Error("boom"), { code: "EBOOM" }));
+        setImmediate(() => setImmediate(() => {}));
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Node: emitting 'error' with no listener throws, which interrupts emitErrorCloseNT
+  // before it can emit 'close', so only the uncaughtException line is printed.
+  expect({ out: stdout.trim().split("\n"), err: stderr }).toEqual({
+    out: ["UNCAUGHT:EBOOM"],
+    err: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
+it("Readable.fromWeb over native stream: breaking out of for-await emits 'error' ABORT_ERR", async () => {
+  const r = Readable.fromWeb(new Blob([Buffer.alloc(1000, "a")]).stream());
+  const events = [];
+  r.on("error", e => events.push("error:" + e.code));
+  r.on("close", () => events.push("close"));
+  let seen = 0;
+  for await (const chunk of r) {
+    seen++;
+    break;
+    void chunk;
+  }
+  await new Promise(resolve => r.once("close", resolve));
+  expect({ seen, events, errored: r.errored?.code }).toEqual({
+    seen: 1,
+    events: ["error:ABORT_ERR", "close"],
+    errored: "ABORT_ERR",
+  });
+});
+
 it("Readable.toWeb(Readable.fromWeb(rs)).cancel(reason) propagates to the web source", async () => {
   let cancelReason;
   const web = new ReadableStream({

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -634,6 +634,30 @@ it("Readable.fromWeb over native stream: breaking out of for-await emits 'error'
   });
 });
 
+it("Readable.fromWeb over native stream: read(n) beyond buffered returns null until more arrives", async () => {
+  const total = 300000;
+  const r = Readable.fromWeb(new Response(new Uint8Array(total)).body);
+  await new Promise(resolve => r.once("readable", resolve));
+  const buffered = r.readableLength;
+  // The native adapter delivers the body in chunks; first 'readable' doesn't carry everything.
+  expect(buffered).toBeGreaterThan(0);
+  expect(buffered).toBeLessThan(total);
+  expect(r.readableEnded).toBe(false);
+  // n > buffered while not ended: Node's fromWeb returns null and schedules more
+  // reading. The native _read previously pushed synchronously, so the request was
+  // satisfied in the same frame.
+  const over = r.read(buffered + 5000);
+  expect({ over, stillBuffered: r.readableLength }).toEqual({ over: null, stillBuffered: buffered });
+  // Drain the rest and confirm no bytes were lost.
+  let seen = 0;
+  r.on("readable", () => {
+    let c;
+    while ((c = r.read()) !== null) seen += c.length;
+  });
+  await new Promise(resolve => r.once("end", resolve));
+  expect(seen).toBe(total);
+});
+
 it("Readable.toWeb(Readable.fromWeb(rs)).cancel(reason) propagates to the web source", async () => {
   let cancelReason;
   const web = new ReadableStream({


### PR DESCRIPTION
## What

Two Node-compat gaps in the native-backed `Readable.fromWeb()` adapter (`Blob.stream()`, `Response.body`, fetch bodies):

**1. `destroy(err)` drops the error.** No `'error'` event fires (only `'close'`), and with no `'error'` listener the error Node would surface as an `uncaughtException` is silently swallowed. Same for the `AbortError` that `break` out of `for await` constructs. `readable.errored` and `finished()` still report it because `checkError` runs before `_destroy`.

```js
import { Readable } from "node:stream";
const r = Readable.fromWeb(new Response("x").body);
r.on("error", e => console.log("error:" + e.message));
r.on("close", () => console.log("close"));
r.destroy(new Error("boom"));
// node:  error:boom, close
// bun:   close
```

**2. `read(n)` with n > `readableLength` returns a full chunk instead of null.** The native `_read` calls `ptr.pull()` which can return synchronously; `push()` then runs inside the `_read` frame, and `Readable.prototype.read` legally re-runs `howMuchToRead` against the freshly-pushed data. Node's `fromWeb` `_read` is async, so the same call returns `null` and the rest arrives on `'readable'`.

```js
const r = Readable.fromWeb(new Response(new Uint8Array(300000)).body);
await new Promise(res => r.once("readable", res));
r.readableLength;              // 81920 (first chunk)
r.read(r.readableLength + 5000);
// node:  null (then 'readable' with the rest)
// bun:   Buffer(86920)
```

`fromWeb` over a JS-authored `ReadableStream` already matches Node on both.

## Why

`src/js/internal/streams/native-readable.ts`:

- `destroy(err, cb)` ended with `process.nextTick(cb)`, never forwarding `err`. `destroy.ts`'s `onDestroy` therefore received `undefined` and took the `emitCloseNT` branch instead of `emitErrorCloseNT`.
- The synchronous `pull()` branch called `handleResult` (and thus `push()`) inline, so `read()` observed the new data in the same call.

## Fix

- Forward the error: `process.nextTick(cb, error)`.
- Defer the synchronous pull result via `process.nextTick` under the existing `kPendingRead` guard, mirroring the promise branch. Also clear `kPendingRead` on pull rejection so a failed async pull doesn't wedge subsequent reads.

## Verification

Five tests in `test/js/node/stream/node-stream.test.js` covering `Blob.stream()` / `Response.body` destroy(err) event ordering, the no-listener `uncaughtException` path, the `for await` break `ABORT_ERR` path, and `read(n)` past the buffered length. All fail on main and pass with the fix; the full file (103 pass) is unchanged otherwise.
