### PR TITLE
refactor(rust): replace scopeguard closures with RAII Drop types

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1012,9 +1012,8 @@ impl<'a> LinkerContext<'a> {
         // container_of pattern. `Worker::get` only reads `bundle.graph.pool`
         // (shared), so a `&` is sufficient and avoids aliasing.
         let chunk: &mut Chunk = unsafe { &mut *chunk };
-        let worker = crate::thread_pool::Worker::get(ctx.bundle());
-        let mut worker = scopeguard::guard(worker, |w| w.unget());
-        let worker: &mut crate::thread_pool::Worker = &mut **worker;
+        let mut worker = crate::thread_pool::Worker::get_scoped(ctx.bundle());
+        let worker: &mut crate::thread_pool::Worker = &mut *worker;
         // Note: dispatch on a discriminant copy so `chunk` isn't borrowed
         // across the post-process call (which takes `&mut Chunk`).
         let result = match chunk.content {
@@ -1043,10 +1042,9 @@ impl<'a> LinkerContext<'a> {
         // SAFETY: `each_ptr` hands us a unique `*mut Chunk` per task; deref for
         // the body. container_of pattern — see `generate_chunk` above.
         let chunk: &mut Chunk = unsafe { &mut *chunk };
-        let worker = crate::thread_pool::Worker::get(ctx.bundle());
-        let mut worker = scopeguard::guard(worker, |w| w.unget());
+        let mut worker = crate::thread_pool::Worker::get_scoped(ctx.bundle());
         if let crate::chunk::Content::Javascript(_) = chunk.content {
-            Self::generate_js_renamer_(*ctx, &mut **worker, chunk, chunk_index);
+            Self::generate_js_renamer_(*ctx, &mut *worker, chunk, chunk_index);
         }
     }
 
@@ -1696,7 +1694,8 @@ pub struct PendingPartRange<'a> {
 /// callbacks: recover the intrusive [`PendingPartRange`] from `task`, extract
 /// the raw `*mut LinkerContext` / `*mut Chunk` from its [`GenerateChunkCtx`],
 /// and acquire the per-thread [`Worker`](crate::thread_pool::Worker) (returned
-/// as a scopeguard that calls `unget()` on drop).
+/// as a [`WorkerGuard`](crate::thread_pool::WorkerGuard) that calls `unget()`
+/// on drop).
 ///
 /// `GenerateChunkCtx.{c, chunk}` are raw `*mut T` (Copy), so reading them
 /// through `&GenerateChunkCtx` preserves the mutable provenance they were
@@ -1722,10 +1721,7 @@ pub(crate) unsafe fn pending_part_range_prologue<'a>(
     &'a PendingPartRange<'a>,
     *mut LinkerContext<'a>,
     *mut Chunk,
-    scopeguard::ScopeGuard<
-        &'static mut crate::thread_pool::Worker,
-        impl FnOnce(&'static mut crate::thread_pool::Worker),
-    >,
+    crate::thread_pool::WorkerGuard,
 ) {
     // SAFETY: per fn contract — `task` is the intrusive `task` field.
     let part_range: &PendingPartRange =
@@ -1733,8 +1729,7 @@ pub(crate) unsafe fn pending_part_range_prologue<'a>(
     let ctx = part_range.ctx;
     let c_ptr: *mut LinkerContext = ctx.c.as_mut_ptr().cast();
     let chunk_ptr: *mut Chunk = ctx.chunk.as_ptr();
-    let worker = crate::thread_pool::Worker::get(ctx.bundle());
-    let worker = scopeguard::guard(worker, |w| w.unget());
+    let worker = crate::thread_pool::Worker::get_scoped(ctx.bundle());
     (part_range, c_ptr, chunk_ptr, worker)
 }
 

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -640,6 +640,13 @@ impl Worker {
         self.ast_memory_store.pop();
     }
 
+    /// [`Worker::get`] + RAII [`Worker::unget`] on drop. Replaces the
+    /// `scopeguard::guard(worker, |w| w.unget())` pattern at task entry points.
+    #[inline]
+    pub fn get_scoped(ctx: &BundleV2<'_>) -> WorkerGuard {
+        WorkerGuard(Self::get(ctx))
+    }
+
     pub fn init(&mut self, v2: &BundleV2<'_>) {
         // Lifetime-erase `'_` → `'static` via `NonNull::cast` (BACKREF: the
         // bundle outlives every worker).
@@ -741,5 +748,29 @@ impl Worker {
         if !self.has_created {
             self.create(ctx);
         }
+    }
+}
+
+/// RAII handle returned by [`Worker::get_scoped`]: `DerefMut`s to the worker
+/// and calls [`Worker::unget`] on drop so the `ast_memory_store` push/pop is
+/// balanced on every exit path.
+pub struct WorkerGuard(&'static mut Worker);
+impl core::ops::Deref for WorkerGuard {
+    type Target = Worker;
+    #[inline]
+    fn deref(&self) -> &Worker {
+        self.0
+    }
+}
+impl core::ops::DerefMut for WorkerGuard {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Worker {
+        self.0
+    }
+}
+impl Drop for WorkerGuard {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.unget();
     }
 }

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -640,8 +640,7 @@ impl Worker {
         self.ast_memory_store.pop();
     }
 
-    /// [`Worker::get`] + RAII [`Worker::unget`] on drop. Replaces the
-    /// `scopeguard::guard(worker, |w| w.unget())` pattern at task entry points.
+    /// [`Worker::get`] + [`Worker::unget`] on drop.
     #[inline]
     pub fn get_scoped(ctx: &BundleV2<'_>) -> WorkerGuard {
         WorkerGuard(Self::get(ctx))
@@ -751,9 +750,7 @@ impl Worker {
     }
 }
 
-/// RAII handle returned by [`Worker::get_scoped`]: `DerefMut`s to the worker
-/// and calls [`Worker::unget`] on drop so the `ast_memory_store` push/pop is
-/// balanced on every exit path.
+/// Returned by [`Worker::get_scoped`]; calls [`Worker::unget`] on drop.
 pub struct WorkerGuard(&'static mut Worker);
 impl core::ops::Deref for WorkerGuard {
     type Target = Worker;

--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -65,10 +65,7 @@ impl LinkerContext<'_> {
         // `Worker::get` only needs `&BundleV2`, so derive a shared ref — never
         // form `&mut BundleV2` here (concurrent tasks would alias it).
         let bundle_v2: &BundleV2<'_> = unsafe { &*LinkerContext::bundle_v2_ptr(this) };
-        let worker = ThreadPool::Worker::get(bundle_v2);
-        // `Worker::get` returns the thread-local worker
-        // (not RAII), so balance with `unget` explicitly via scopeguard.
-        let worker = scopeguard::guard(worker, |w| w.unget());
+        let worker = ThreadPool::Worker::get_scoped(bundle_v2);
 
         // we must use this arena here
         // SAFETY: `Worker::create` initializes `arena` to point at

--- a/src/bundler/linker_context/generateCompileResultForCssChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForCssChunk.rs
@@ -54,7 +54,7 @@ pub unsafe fn generate_compile_result_for_css_chunk(task: *mut ThreadPoolLib::Ta
         // SAFETY: `chunk_ptr` is the live `Chunk` from the same prologue; this
         // `&` is scoped so it does not overlap the raw slot write below.
         let chunk_ref: &Chunk = unsafe { &*chunk_ptr };
-        generate_compile_result_for_css_chunk_impl(&mut **worker, c_ref, chunk_ref, part_range.i)
+        generate_compile_result_for_css_chunk_impl(&mut *worker, c_ref, chunk_ref, part_range.i)
     };
 
     // SAFETY: per-task unique `i`; see `Chunk::write_compile_result_slot`.

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -70,7 +70,7 @@ pub unsafe fn generate_compile_result_for_js_chunk(task: *mut ThreadPoolLib::Tas
         // SAFETY: same mutable-provenance / disjoint-write contract as `c_ptr` above.
         let chunk_mut: &mut Chunk = unsafe { &mut *chunk_ptr };
         generate_compile_result_for_js_chunk_impl(
-            &mut **worker,
+            &mut *worker,
             c_mut,
             chunk_mut,
             part_range.part_range,

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -65,9 +65,8 @@ pub unsafe fn prepare_css_asts_for_chunk(task: *mut ThreadPoolLib::Task) {
         // carrying provenance over the full `BundleV2` allocation. Recover the
         // parent via container_of. `Worker::get` only needs `&BundleV2`.
         let bundle_v2: &BundleV2 = unsafe { &*LinkerContext::bundle_v2_ptr(linker) };
-        ThreadPool::Worker::get(bundle_v2)
+        ThreadPool::Worker::get_scoped(bundle_v2)
     };
-    let worker = scopeguard::guard(worker, |w| w.unget());
 
     // SAFETY: `linker` outlives this task (owned by the bundle) and is shared
     // across every concurrently-running `PrepareCssAstTask`, so it must be a

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1765,11 +1765,11 @@ impl<'a> Linker<'a> {
                             return;
                         }
                     };
-                    let _close = sys::Dir::from_fd(target_dir);
+                    let target_dir = sys::Dir::from_fd(target_dir);
 
                     let abs_dest_dir_end = dest_off;
 
-                    let mut iter = sys::iterate_dir(target_dir);
+                    let mut iter = sys::iterate_dir(target_dir.fd);
                     while let Some(entry) = iter.next().unwrap_or(None) {
                         match entry.kind {
                             sys::EntryKind::SymLink | sys::EntryKind::File => {
@@ -1920,11 +1920,11 @@ impl<'a> Linker<'a> {
                             return;
                         }
                     };
-                    let _close = sys::Dir::from_fd(target_dir);
+                    let target_dir = sys::Dir::from_fd(target_dir);
 
                     let abs_dest_dir_end = dest_off;
 
-                    let mut iter = sys::iterate_dir(target_dir);
+                    let mut iter = sys::iterate_dir(target_dir.fd);
                     while let Some(entry) = iter.next().unwrap_or(None) {
                         match entry.kind {
                             sys::EntryKind::SymLink | sys::EntryKind::File => {

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1765,9 +1765,7 @@ impl<'a> Linker<'a> {
                             return;
                         }
                     };
-                    let _close = scopeguard::guard(target_dir, |fd| {
-                        let _ = sys::close(fd);
-                    });
+                    let _close = sys::Dir::from_fd(target_dir);
 
                     let abs_dest_dir_end = dest_off;
 
@@ -1922,9 +1920,7 @@ impl<'a> Linker<'a> {
                             return;
                         }
                     };
-                    let _close = scopeguard::guard(target_dir, |fd| {
-                        let _ = sys::close(fd);
-                    });
+                    let _close = sys::Dir::from_fd(target_dir);
 
                     let abs_dest_dir_end = dest_off;
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1720,10 +1720,7 @@ pub(crate) fn install_isolated_packages(
                     // so close explicitly. The guard fires on
                     // normal fall-through to step 3 and on every
                     // `break 'is_new_bun_modules true` early exit.
-                    let _close_node_modules = scopeguard::guard(node_modules, |fd| {
-                        use bun_sys::FdExt as _;
-                        fd.close();
-                    });
+                    let _close_node_modules = sys::Dir::from_fd(node_modules);
 
                     let mut entry_path = AutoRelPath::from(b"node_modules").assume_ok();
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1720,12 +1720,12 @@ pub(crate) fn install_isolated_packages(
                     // so close explicitly. The guard fires on
                     // normal fall-through to step 3 and on every
                     // `break 'is_new_bun_modules true` early exit.
-                    let _close_node_modules = sys::Dir::from_fd(node_modules);
+                    let node_modules = sys::Dir::from_fd(node_modules);
 
                     let mut entry_path = AutoRelPath::from(b"node_modules").assume_ok();
 
                     // 2
-                    let mut node_modules_iter = sys::iterate_dir(node_modules);
+                    let mut node_modules_iter = sys::iterate_dir(node_modules.fd);
                     loop {
                         let Some(entry) = (match node_modules_iter.next() {
                             Ok(v) => v,

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -9,7 +9,7 @@ use bun_core::{ZStr, strings};
 use bun_paths::{self as path, PathBuffer};
 use bun_resolver::fs::FileSystem;
 use bun_semver::String as SemverString;
-use bun_sys::{self as sys, Fd, FdExt};
+use bun_sys::{self as sys, Fd};
 use bun_threading::IntrusiveWorkTask as _;
 use bun_threading::thread_pool::{Batch, Node as ThreadPoolNode, Task as ThreadPoolTask};
 use bun_wyhash::Wyhash11;
@@ -552,7 +552,7 @@ impl PatchTask {
                     return Ok(());
                 }
             };
-            let _close_guard = scopeguard::guard(patch_pkg_dir, |fd| fd.close());
+            let _close_guard = sys::CloseOnDrop::new(patch_pkg_dir);
 
             // 4. apply patch
             if let Some(e) = patchfile.apply(patch_pkg_dir) {

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -552,10 +552,10 @@ impl PatchTask {
                     return Ok(());
                 }
             };
-            let _close_guard = sys::CloseOnDrop::new(patch_pkg_dir);
+            let patch_pkg_dir = sys::Dir::from_fd(patch_pkg_dir);
 
             // 4. apply patch
-            if let Some(e) = patchfile.apply(patch_pkg_dir) {
+            if let Some(e) = patchfile.apply(patch_pkg_dir.fd) {
                 log.add_error_fmt_opts(
                     format_args!("failed applying patch file: {}", e),
                     Default::default(),
@@ -576,7 +576,7 @@ impl PatchTask {
             };
             buntagbuf[bun_tag_prefix.len() + hashlen] = 0;
             let buntag_zstr = ZStr::from_buf(&buntagbuf, bun_tag_prefix.len() + hashlen);
-            if let Err(e) = sys::File::write_file(patch_pkg_dir, buntag_zstr, b"") {
+            if let Err(e) = sys::File::write_file(patch_pkg_dir.fd, buntag_zstr, b"") {
                 log.add_error_fmt_opts(
                     format_args!(
                         "failed adding bun tag: {}",

--- a/src/install_jsc/install_binding.rs
+++ b/src/install_jsc/install_binding.rs
@@ -39,7 +39,6 @@ pub mod bun_install_js_bindings {
         };
         use bun_install::lockfile::{LoadResult, Lockfile};
         use bun_paths::resolve_path;
-        use bun_sys::FdExt as _;
 
         let mut log = bun_ast::Log::init();
 
@@ -57,7 +56,7 @@ pub mod bun_install_js_bindings {
             }
         };
         // `defer dir.close()` — closed at fn return.
-        let dir = scopeguard::guard(dir, |d| d.close());
+        let dir = bun_sys::Dir::from_fd(dir);
 
         let lockfile_path = resolve_path::join_abs_string_z::<resolve_path::platform::Auto>(
             cwd.slice(),
@@ -80,7 +79,7 @@ pub mod bun_install_js_bindings {
         let manager = vm.package_manager();
 
         let load_result: LoadResult<'_> =
-            lockfile_.load_from_dir::<true>(*dir, Some(manager), &mut log);
+            lockfile_.load_from_dir::<true>(dir.fd, Some(manager), &mut log);
 
         match load_result {
             LoadResult::Err(err) => {

--- a/src/install_jsc/npm_jsc.rs
+++ b/src/install_jsc/npm_jsc.rs
@@ -82,7 +82,7 @@ impl ManifestBindings {
 #[bun_jsc::host_fn]
 pub(crate) fn js_parse_manifest(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     use bstr::BStr;
-    use bun_core::{String as BunString, strings};
+    use bun_core::{OwnedString, String as BunString, strings};
     use bun_install::npm;
     use bun_jsc::JsError;
     use std::io::Write as _;
@@ -94,13 +94,10 @@ pub(crate) fn js_parse_manifest(global: &JSGlobalObject, frame: &CallFrame) -> J
         )));
     }
 
-    // `defer manifest_filename_str.deref()` — release the +1 WTFStringImpl ref
-    // returned by `toBunString`; `bun_core::String` has no `Drop` impl.
-    let manifest_filename_str = scopeguard::guard(args[0].to_bun_string(global)?, |s| s.deref());
+    let manifest_filename_str = OwnedString::new(args[0].to_bun_string(global)?);
     let manifest_filename = manifest_filename_str.to_utf8();
 
-    // `defer registry_str.deref()` — see above.
-    let registry_str = scopeguard::guard(args[1].to_bun_string(global)?, |s| s.deref());
+    let registry_str = OwnedString::new(args[1].to_bun_string(global)?);
     let registry = registry_str.to_utf8();
 
     let manifest_file = match bun_sys::openat_a(

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -682,10 +682,7 @@ fn list_child_pids_linux(parent: libc::pid_t, out: &mut [libc::pid_t]) -> Option
         Ok(fd) => fd,
         Err(_) => return None,
     };
-    // `Fd` is Copy and does not impl Drop, so close explicitly via a guard.
-    let _task_fd_guard = scopeguard::guard(task_fd, |fd| {
-        let _ = bun_sys::close(fd);
-    });
+    let _task_fd_guard = bun_sys::CloseOnDrop::new(task_fd);
 
     let mut written: usize = 0;
     // Sized so a single read can saturate the 4096-pid `out` buffer
@@ -739,9 +736,7 @@ fn read_file_once<'a>(path: &ZStr, buf: &'a mut [u8]) -> Option<&'a [u8]> {
         Ok(fd) => fd,
         Err(_) => return None,
     };
-    let _guard = scopeguard::guard(fd, |fd| {
-        let _ = bun_sys::close(fd);
-    });
+    let _guard = bun_sys::CloseOnDrop::new(fd);
     // Fixed-buffer read-until-EOF-or-full. `File::read_all` grows a `Vec`,
     // which would allocate; do the loop here.
     let mut written = 0usize;

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -678,17 +678,16 @@ fn list_child_pids_linux(parent: libc::pid_t, out: &mut [libc::pid_t]) -> Option
         &path_buf[..n]
     };
 
-    let task_fd = match bun_sys::open_dir_for_iteration_os_path(Fd::cwd(), task_path) {
-        Ok(fd) => fd,
+    let task_dir = match bun_sys::open_dir_for_iteration_os_path(Fd::cwd(), task_path) {
+        Ok(fd) => bun_sys::Dir::from_fd(fd),
         Err(_) => return None,
     };
-    let _task_fd_guard = bun_sys::CloseOnDrop::new(task_fd);
 
     let mut written: usize = 0;
     // Sized so a single read can saturate the 4096-pid `out` buffer
     // (~8 bytes per "1234567 " entry × 4096).
     let mut read_buf = [0u8; 32 * 1024];
-    let mut it = bun_sys::dir_iterator::iterate(task_fd);
+    let mut it = bun_sys::dir_iterator::iterate(task_dir.fd);
     loop {
         let entry = match it.next() {
             Ok(Some(e)) => e,
@@ -732,16 +731,15 @@ fn list_child_pids_linux(parent: libc::pid_t, out: &mut [libc::pid_t]) -> Option
 /// we don't need.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn read_file_once<'a>(path: &ZStr, buf: &'a mut [u8]) -> Option<&'a [u8]> {
-    let fd = match bun_sys::open(path, O::RDONLY, 0) {
-        Ok(fd) => fd,
+    let file = match bun_sys::open(path, O::RDONLY, 0) {
+        Ok(fd) => bun_sys::File::from_fd(fd),
         Err(_) => return None,
     };
-    let _guard = bun_sys::CloseOnDrop::new(fd);
     // Fixed-buffer read-until-EOF-or-full. `File::read_all` grows a `Vec`,
     // which would allocate; do the loop here.
     let mut written = 0usize;
     while written < buf.len() {
-        match bun_sys::read(fd, &mut buf[written..]) {
+        match bun_sys::read(file.fd(), &mut buf[written..]) {
             Ok(0) => break,
             Ok(n) => written += n,
             Err(_) => return None,

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1426,10 +1426,26 @@ impl<Parent: WindowsBufferedWriterParent> BaseWindowsPipeWriter for WindowsBuffe
 // SAFETY: libuv write-complete callbacks re-enter via `FileSink::on_write` →
 // JS → `writer.with_mut(|w| w.end())`; writer is intrusive in `Parent`, kept
 // alive across the callback by the parent ref taken in `write()` (derefed via
-// the callback-end scopeguards); single JS thread.
+// the callback-end deref guards); single JS thread.
 unsafe impl<Parent: WindowsBufferedWriterParent> bun_ptr::LaunderedSelf
     for WindowsBufferedWriter<Parent>
 {
+}
+
+/// RAII: calls [`WindowsBufferedWriter::r_deref`] on drop to balance the
+/// parent ref taken in `write()`. Holds the laundered `*mut Self` so the
+/// `.parent` read happens lazily at drop time (after any re-entrant
+/// `set_parent()`).
+#[cfg(windows)]
+struct BufferedWriterDerefGuard<Parent: WindowsBufferedWriterParent>(
+    *mut WindowsBufferedWriter<Parent>,
+);
+#[cfg(windows)]
+impl<Parent: WindowsBufferedWriterParent> Drop for BufferedWriterDerefGuard<Parent> {
+    #[inline]
+    fn drop(&mut self) {
+        WindowsBufferedWriter::<Parent>::r_deref(self.0);
+    }
 }
 
 #[cfg(windows)]
@@ -1498,10 +1514,10 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
         // them after the call. Launder so post-`on_write` reads see fresh
         // state.
         let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
-        // Scopeguard deref to balance write()'s ref: `Parent::on_write` may
-        // drop the last external strong ref, and the trailing `is_done` /
-        // `close()` reads below need the parent (and `self`, inside it) alive.
-        let _g = scopeguard::guard(this, |s| Self::r_deref(s));
+        // Deref to balance write()'s ref: `Parent::on_write` may drop the last
+        // external strong ref, and the trailing `is_done` / `close()` reads
+        // below need the parent (and `self`, inside it) alive.
+        let _g = BufferedWriterDerefGuard(this);
         let written = Self::r(this).pending_payload_size;
         Self::r(this).pending_payload_size = 0;
         if let Some(err) = status.to_error(sys::Tag::write) {
@@ -1589,7 +1605,7 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
         if let Some(err) = result.to_error(sys::Tag::write) {
             // Balance write()'s ref — lazy `.parent` read at guard execution
             // in case close()/on_error re-enter and swap the parent pointer.
-            let _g = scopeguard::guard(this, |s| Self::r_deref(s));
+            let _g = BufferedWriterDerefGuard(this);
             // close() may re-enter JS.
             Self::r(this).close();
             core::hint::black_box(this);
@@ -1958,6 +1974,22 @@ unsafe impl<Parent: WindowsStreamingWriterParent> bun_ptr::LaunderedSelf
 {
 }
 
+/// RAII: calls [`WindowsStreamingWriter::r_deref`] on drop to balance the
+/// parent ref taken in `process_send()`. Holds the laundered `*mut Self` so
+/// the `.parent` read happens lazily at drop time (after any re-entrant
+/// `set_parent()`).
+#[cfg(windows)]
+struct StreamingWriterDerefGuard<Parent: WindowsStreamingWriterParent>(
+    *mut WindowsStreamingWriter<Parent>,
+);
+#[cfg(windows)]
+impl<Parent: WindowsStreamingWriterParent> Drop for StreamingWriterDerefGuard<Parent> {
+    #[inline]
+    fn drop(&mut self) {
+        WindowsStreamingWriter::<Parent>::r_deref(self.0);
+    }
+}
+
 #[cfg(windows)]
 impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
     /// Raw backref to the owning `Parent`. Returned as `*mut` (never `&mut`)
@@ -2004,7 +2036,7 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
     /// invariant and laundered-receiver rationale. Reads `self.parent`
     /// **before** dispatch so the (potentially freeing) `Parent::deref`
     /// runs with no borrow of `*this` live — matching the lazy read order
-    /// at each scopeguard site. Collapses the three
+    /// at each [`StreamingWriterDerefGuard`] site. Collapses the three
     /// `Parent::deref` blocks into one `unsafe`.
     #[inline(always)]
     fn r_deref(this: *mut Self) {
@@ -2047,7 +2079,7 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         // Capture the laundered `*mut Self` and read `.parent` at guard
         // execution instead — the `black_box` above also ensures the guard's
         // read is not folded with any pre-call load.
-        let _g = scopeguard::guard(this, |s| Self::r_deref(s));
+        let _g = StreamingWriterDerefGuard(this);
 
         if let Some(err) = status.to_error(sys::Tag::write) {
             log!("onWrite() = {}", bstr::BStr::new(err.name()));
@@ -2164,7 +2196,7 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
             // deref to balance process_send ref — read `.parent` LAZILY at
             // guard execution, not eagerly, in case
             // close()/on_error re-enter and swap the parent pointer.
-            let _g = scopeguard::guard(this, |s| Self::r_deref(s));
+            let _g = StreamingWriterDerefGuard(this);
             // close() may re-enter JS — every post-call `r(this)` reborrow
             // reloads (laundered raw ptr, no noalias).
             Self::r(this).close();

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1432,10 +1432,7 @@ unsafe impl<Parent: WindowsBufferedWriterParent> bun_ptr::LaunderedSelf
 {
 }
 
-/// RAII: calls [`WindowsBufferedWriter::r_deref`] on drop to balance the
-/// parent ref taken in `write()`. Holds the laundered `*mut Self` so the
-/// `.parent` read happens lazily at drop time (after any re-entrant
-/// `set_parent()`).
+/// Calls [`WindowsBufferedWriter::r_deref`] on drop to balance `write()`'s ref.
 #[cfg(windows)]
 struct BufferedWriterDerefGuard<Parent: WindowsBufferedWriterParent>(
     *mut WindowsBufferedWriter<Parent>,
@@ -1974,10 +1971,7 @@ unsafe impl<Parent: WindowsStreamingWriterParent> bun_ptr::LaunderedSelf
 {
 }
 
-/// RAII: calls [`WindowsStreamingWriter::r_deref`] on drop to balance the
-/// parent ref taken in `process_send()`. Holds the laundered `*mut Self` so
-/// the `.parent` read happens lazily at drop time (after any re-entrant
-/// `set_parent()`).
+/// Calls [`WindowsStreamingWriter::r_deref`] on drop to balance `process_send()`'s ref.
 #[cfg(windows)]
 struct StreamingWriterDerefGuard<Parent: WindowsStreamingWriterParent>(
     *mut WindowsStreamingWriter<Parent>,

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1432,8 +1432,6 @@ unsafe impl<Parent: WindowsBufferedWriterParent> bun_ptr::LaunderedSelf
 {
 }
 
-/// Calls [`WindowsBufferedWriter::r_deref`] on drop to balance `write()`'s ref.
-/// Not `ScopedRef<Parent>`: `r_deref` reads `self.parent` lazily at drop (re-entrant `set_parent` may swap it) and `Parent` is not `AnyRefCounted`.
 #[cfg(windows)]
 struct BufferedWriterDerefGuard<Parent: WindowsBufferedWriterParent>(
     *mut WindowsBufferedWriter<Parent>,
@@ -1972,8 +1970,6 @@ unsafe impl<Parent: WindowsStreamingWriterParent> bun_ptr::LaunderedSelf
 {
 }
 
-/// Calls [`WindowsStreamingWriter::r_deref`] on drop to balance `process_send()`'s ref.
-/// Not `ScopedRef<Parent>`: `r_deref` reads `self.parent` lazily at drop (re-entrant `set_parent` may swap it) and `Parent` is not `AnyRefCounted`.
 #[cfg(windows)]
 struct StreamingWriterDerefGuard<Parent: WindowsStreamingWriterParent>(
     *mut WindowsStreamingWriter<Parent>,

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1433,6 +1433,7 @@ unsafe impl<Parent: WindowsBufferedWriterParent> bun_ptr::LaunderedSelf
 }
 
 /// Calls [`WindowsBufferedWriter::r_deref`] on drop to balance `write()`'s ref.
+/// Not `ScopedRef<Parent>`: `r_deref` reads `self.parent` lazily at drop (re-entrant `set_parent` may swap it) and `Parent` is not `AnyRefCounted`.
 #[cfg(windows)]
 struct BufferedWriterDerefGuard<Parent: WindowsBufferedWriterParent>(
     *mut WindowsBufferedWriter<Parent>,
@@ -1972,6 +1973,7 @@ unsafe impl<Parent: WindowsStreamingWriterParent> bun_ptr::LaunderedSelf
 }
 
 /// Calls [`WindowsStreamingWriter::r_deref`] on drop to balance `process_send()`'s ref.
+/// Not `ScopedRef<Parent>`: `r_deref` reads `self.parent` lazily at drop (re-entrant `set_parent` may swap it) and `Parent` is not `AnyRefCounted`.
 #[cfg(windows)]
 struct StreamingWriterDerefGuard<Parent: WindowsStreamingWriterParent>(
     *mut WindowsStreamingWriter<Parent>,

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -469,8 +469,7 @@ impl Entry {
                     if bytes.is_empty() {
                         return Err(crate::CrateError::Alloc(bun_alloc::AllocError));
                     }
-                    // errdefer scratch.deref() — BunString is `Copy`, so guard explicitly.
-                    let errdefer = scopeguard::guard(scratch, |s| s.deref());
+                    let scratch = bun_core::OwnedString::new(scratch);
                     let read_bytes = file.pread_all(bytes, self.metadata.output_byte_offset)?;
                     if read_bytes as u64 != self.metadata.output_byte_length {
                         return Err(crate::CrateError::MissingData);
@@ -484,8 +483,7 @@ impl Entry {
                         // Fast path: ASCII ⊂ Latin-1, so `scratch` is already
                         // the correct `BunString` — hand it straight to the
                         // consumer as `OutputCode::String`.
-                        scopeguard::ScopeGuard::into_inner(errdefer);
-                        OutputCode::String(scratch)
+                        OutputCode::String(scratch.into_inner())
                     } else {
                         // Rare path: real multi-byte UTF-8. Transcode into a
                         // fresh WTF string and drop the Latin-1 scratch (the
@@ -502,8 +500,7 @@ impl Entry {
                     if bytes.is_empty() {
                         return Err(crate::CrateError::Alloc(bun_alloc::AllocError));
                     }
-                    // errdefer latin1.deref() — BunString is `Copy`, so guard explicitly.
-                    let errdefer = scopeguard::guard(latin1, |s| s.deref());
+                    let latin1 = bun_core::OwnedString::new(latin1);
                     let read_bytes = file.pread_all(bytes, self.metadata.output_byte_offset)?;
 
                     if self.metadata.output_hash != 0 {
@@ -516,8 +513,7 @@ impl Entry {
                         return Err(crate::CrateError::MissingData);
                     }
 
-                    scopeguard::ScopeGuard::into_inner(errdefer);
-                    OutputCode::String(latin1)
+                    OutputCode::String(latin1.into_inner())
                 }
                 Encoding::UTF16 => {
                     let char_len = (self.metadata.output_byte_length / 2) as usize;
@@ -527,7 +523,7 @@ impl Entry {
                     if chars.is_empty() {
                         return Err(crate::CrateError::Alloc(bun_alloc::AllocError));
                     }
-                    let errdefer = scopeguard::guard(string, |s| s.deref());
+                    let string = bun_core::OwnedString::new(string);
 
                     // `chars` is `&mut [u16; char_len]` backed by contiguous
                     // WTFString storage; reinterpret as bytes for pread via the
@@ -546,8 +542,7 @@ impl Entry {
                         }
                     }
 
-                    scopeguard::ScopeGuard::into_inner(errdefer);
-                    OutputCode::String(string)
+                    OutputCode::String(string.into_inner())
                 }
 
                 _ => unreachable!("Unexpected output encoding"),
@@ -891,11 +886,7 @@ impl RuntimeTranspilerCache {
 
             break 'brk Fd::cwd();
         };
-        let _dir_guard = scopeguard::guard(cache_dir_fd, |fd| {
-            if fd != Fd::cwd() {
-                fd.close();
-            }
-        });
+        let _dir_guard = sys::Dir::from_fd(cache_dir_fd);
 
         Entry::save(
             cache_dir_fd,

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -886,10 +886,10 @@ impl RuntimeTranspilerCache {
 
             break 'brk Fd::cwd();
         };
-        let _dir_guard = sys::Dir::from_fd(cache_dir_fd);
+        let cache_dir = sys::Dir::from_fd(cache_dir_fd);
 
         Entry::save(
-            cache_dir_fd,
+            cache_dir.fd,
             cache_file_path,
             input_byte_length,
             input_hash,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6650,10 +6650,7 @@ pub fn plugin_runner_on_resolve_jsc(
         }
         break 'brk bun_core::String::static_(b"file");
     };
-    // `bun_core::String`
-    // is `Copy` (no `Drop`), so guard the WTF refcount across the remaining
-    // early-return paths.
-    let user_namespace = scopeguard::guard(user_namespace, |s| s.deref());
+    let user_namespace = bun_core::OwnedString::new(user_namespace);
 
     // A `file`-namespace result (the default) is a filesystem path, not a new
     // specifier: hand it back unprefixed. Other namespaces keep the `ns:path`

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1259,9 +1259,7 @@ impl Archiver {
                 break 'brk d;
             }
         };
-        // Fd has no Drop impl; close explicitly on every return path to avoid leaking
-        // a directory HANDLE on Windows. Mirrors the guard pattern in extract_to_disk.
-        let _close_dir_guard = bun_sys::CloseOnDrop::new(dir);
+        let dir = bun_sys::Dir::from_fd(dir);
 
         'loop_: loop {
             // SAFETY: archive valid for stream lifetime
@@ -1322,12 +1320,13 @@ impl Archiver {
                     let size: usize =
                         usize::try_from(lib::Entry::opaque_ref(entry).size().max(0)).unwrap();
                     if size > 0 {
-                        let Ok(opened) = bun_sys::openat_a(dir, pathname, bun_sys::O::WRONLY, 0)
+                        let Ok(opened) =
+                            bun_sys::openat_a(dir.fd(), pathname, bun_sys::O::WRONLY, 0)
                         else {
                             continue 'loop_;
                         };
-                        let _close_guard = bun_sys::CloseOnDrop::new(opened);
-                        let stat_size = bun_sys::get_file_size(opened)?;
+                        let opened = bun_sys::File::from_fd(opened);
+                        let stat_size = bun_sys::get_file_size(opened.fd())?;
 
                         if stat_size > 0 {
                             let is_already_top_level = dirname.is_empty();

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1261,7 +1261,7 @@ impl Archiver {
         };
         // Fd has no Drop impl; close explicitly on every return path to avoid leaking
         // a directory HANDLE on Windows. Mirrors the guard pattern in extract_to_disk.
-        let _close_dir_guard = scopeguard::guard(dir, |d| d.close());
+        let _close_dir_guard = bun_sys::CloseOnDrop::new(dir);
 
         'loop_: loop {
             // SAFETY: archive valid for stream lifetime
@@ -1326,8 +1326,7 @@ impl Archiver {
                         else {
                             continue 'loop_;
                         };
-                        // defer opened.close()
-                        let _close_guard = scopeguard::guard(opened, |fd| fd.close());
+                        let _close_guard = bun_sys::CloseOnDrop::new(opened);
                         let stat_size = bun_sys::get_file_size(opened)?;
 
                         if stat_size > 0 {
@@ -1764,11 +1763,9 @@ impl Archiver {
 
                             let file_handle: Fd = {
                                 // errdefer file_handle_native.close()
-                                let guard = scopeguard::guard(file_handle_native, |fd| {
-                                    fd.close();
-                                });
-                                let owned = (*guard).make_lib_uv_owned()?;
-                                scopeguard::ScopeGuard::into_inner(guard);
+                                let guard = bun_sys::CloseOnDrop::new(file_handle_native);
+                                let owned = guard.fd().make_lib_uv_owned()?;
+                                let _ = guard.into_raw();
                                 owned
                             };
 

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -12,7 +12,7 @@ use bun_collections::bit_set::ArrayBitSet;
 use bun_core::strings;
 use bun_core::{ZBox, ZStr};
 use bun_paths::{self as paths, PathBuffer};
-use bun_sys::{self as sys, Fd, FdExt};
+use bun_sys::{self as sys, Fd};
 
 bun_core::declare_scope!(Patch, visible);
 
@@ -150,7 +150,7 @@ impl<'a> PatchFile<'a> {
                         sys::Result::Ok(fd) => fd,
                         sys::Result::Err(e) => return Some(e.without_path()),
                     };
-                    let _close_newfile = scopeguard::guard(newfile_fd, |fd| fd.close());
+                    let _close_newfile = sys::CloseOnDrop::new(newfile_fd);
 
                     let Some(hunk) = &file_creation.hunk else {
                         continue;
@@ -238,7 +238,7 @@ impl<'a> PatchFile<'a> {
                             sys::Result::Err(e) => return Some(e.without_path()),
                             sys::Result::Ok(f) => f,
                         };
-                        let _close = scopeguard::guard(fd, |fd| fd.close());
+                        let _close = sys::CloseOnDrop::new(fd);
                         if let sys::Result::Err(e) = sys::fchmod(fd, newmode.to_bun_mode()) {
                             return Some(e.without_path());
                         }
@@ -412,7 +412,7 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
         sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
         sys::Result::Ok(fd) => fd,
     };
-    let _close_file = scopeguard::guard(file_fd, |fd| fd.close());
+    let _close_file = sys::CloseOnDrop::new(file_fd);
 
     let contents = join_bytes(b"\n", &lines);
 

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -150,7 +150,7 @@ impl<'a> PatchFile<'a> {
                         sys::Result::Ok(fd) => fd,
                         sys::Result::Err(e) => return Some(e.without_path()),
                     };
-                    let _close_newfile = sys::CloseOnDrop::new(newfile_fd);
+                    let newfile = sys::File::from_fd(newfile_fd);
 
                     let Some(hunk) = &file_creation.hunk else {
                         continue;
@@ -192,7 +192,7 @@ impl<'a> PatchFile<'a> {
 
                     let mut written: usize = 0;
                     while written < file_contents.len() {
-                        match sys::write(newfile_fd, &file_contents[written..]) {
+                        match sys::write(newfile.fd(), &file_contents[written..]) {
                             sys::Result::Ok(bytes) => written += bytes,
                             sys::Result::Err(e) => return Some(e.without_path()),
                         }
@@ -238,8 +238,8 @@ impl<'a> PatchFile<'a> {
                             sys::Result::Err(e) => return Some(e.without_path()),
                             sys::Result::Ok(f) => f,
                         };
-                        let _close = sys::CloseOnDrop::new(fd);
-                        if let sys::Result::Err(e) = sys::fchmod(fd, newmode.to_bun_mode()) {
+                        let file = sys::File::from_fd(fd);
+                        if let sys::Result::Err(e) = sys::fchmod(file.fd(), newmode.to_bun_mode()) {
                             return Some(e.without_path());
                         }
                     }
@@ -412,13 +412,13 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
         sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
         sys::Result::Ok(fd) => fd,
     };
-    let _close_file = sys::CloseOnDrop::new(file_fd);
+    let file = sys::File::from_fd(file_fd);
 
     let contents = join_bytes(b"\n", &lines);
 
     let mut written: usize = 0;
     while written < contents.len() {
-        match sys::write(file_fd, &contents[written..]) {
+        match sys::write(file.fd(), &contents[written..]) {
             sys::Result::Ok(w) => written += w,
             sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
         }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -798,12 +798,12 @@ pub mod fs {
                 // Spec's `TmpfileWindows` has no `dir_fd` field — the handle is
                 // local. Close it once we've captured the absolute path so we
                 // don't leak a directory HANDLE per tmpfile.
-                let tmp_dir = bun_sys::CloseOnDrop::new(tmp_dir);
+                let tmp_dir = bun_sys::Dir::from_fd(tmp_dir);
                 let flags = bun_sys::O::CREAT
                     | bun_sys::O::WRONLY
                     | bun_sys::O::TRUNC
                     | bun_sys::O::CLOEXEC;
-                self.fd = bun_sys::openat(*tmp_dir, name, flags, 0)?;
+                self.fd = bun_sys::openat(tmp_dir.fd, name, flags, 0)?;
                 let mut buf = bun_paths::PathBuffer::uninit();
                 let existing_path = bun_sys::get_fd_path(self.fd, &mut buf)?;
                 self.existing_path = Box::<[u8]>::from(&*existing_path);
@@ -1222,7 +1222,8 @@ pub mod fs {
             // Close the handle on every exit path, including `readdir`/`put`
             // early-return with `?`.
             let should_close_handle = !had_handle && (!store_fd || self.need_to_close_files());
-            let _close_guard = should_close_handle.then(|| bun_sys::CloseOnDrop::new(handle));
+            let _handle_dir: Option<bun_sys::Dir> =
+                should_close_handle.then(|| bun_sys::Dir::from_fd(handle));
 
             // if we get this far, it's a real directory, so we can just store the dir name.
             // An in-place refresh always keeps the slot's existing interned name: callers
@@ -1581,10 +1582,10 @@ pub mod fs {
                             return self.read_directory_error(dir, err.into()).ok();
                         }
                     };
-                    let _close_guard = bun_sys::CloseOnDrop::new(handle);
+                    let handle = bun_sys::Dir::from_fd(handle);
                     // SAFETY: see above — exclusive `&mut` on the prev map for the duration of `readdir`.
                     let prev = Some(unsafe { &mut (*e_ptr).data });
-                    match self.readdir(false, prev, dir, generation, handle, ()) {
+                    match self.readdir(false, prev, dir, generation, handle.fd, ()) {
                         Ok(new_entry) => {
                             // SAFETY: see above.
                             unsafe { (*e_ptr).data.clear() };

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -798,12 +798,12 @@ pub mod fs {
                 // Spec's `TmpfileWindows` has no `dir_fd` field — the handle is
                 // local. Close it once we've captured the absolute path so we
                 // don't leak a directory HANDLE per tmpfile.
-                scopeguard::defer! { let _ = bun_sys::close(tmp_dir); }
+                let tmp_dir = bun_sys::CloseOnDrop::new(tmp_dir);
                 let flags = bun_sys::O::CREAT
                     | bun_sys::O::WRONLY
                     | bun_sys::O::TRUNC
                     | bun_sys::O::CLOEXEC;
-                self.fd = bun_sys::openat(tmp_dir, name, flags, 0)?;
+                self.fd = bun_sys::openat(*tmp_dir, name, flags, 0)?;
                 let mut buf = bun_paths::PathBuffer::uninit();
                 let existing_path = bun_sys::get_fd_path(self.fd, &mut buf)?;
                 self.existing_path = Box::<[u8]>::from(&*existing_path);
@@ -1219,14 +1219,10 @@ pub mod fs {
                 },
             };
 
-            // Close the handle on every exit path. Use
-            // scopeguard so close happens even if `readdir`/`put` early-return with `?`.
+            // Close the handle on every exit path, including `readdir`/`put`
+            // early-return with `?`.
             let should_close_handle = !had_handle && (!store_fd || self.need_to_close_files());
-            let _close_guard = scopeguard::guard(handle, move |h| {
-                if should_close_handle {
-                    let _ = bun_sys::close(h);
-                }
-            });
+            let _close_guard = should_close_handle.then(|| bun_sys::CloseOnDrop::new(handle));
 
             // if we get this far, it's a real directory, so we can just store the dir name.
             // An in-place refresh always keeps the slot's existing interned name: callers
@@ -1585,9 +1581,7 @@ pub mod fs {
                             return self.read_directory_error(dir, err.into()).ok();
                         }
                     };
-                    let _close_guard = scopeguard::guard(handle, |h| {
-                        let _ = bun_sys::close(h);
-                    });
+                    let _close_guard = bun_sys::CloseOnDrop::new(handle);
                     // SAFETY: see above — exclusive `&mut` on the prev map for the duration of `readdir`.
                     let prev = Some(unsafe { &mut (*e_ptr).data });
                     match self.readdir(false, prev, dir, generation, handle, ()) {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -88,7 +88,7 @@ use bun_paths::PathBuffer;
 #[cfg(windows)]
 use bun_paths::WPathBuffer;
 use bun_shell_parser::braces as Braces;
-use bun_sys::{self as sys, Fd, FdExt as _};
+use bun_sys::{self as sys, Fd};
 use bun_zlib as zlib;
 
 use crate::api::csrf_jsc;
@@ -405,7 +405,7 @@ pub(crate) fn shell_escape(
     if global_this.has_exception() {
         return Ok(JSValue::ZERO);
     }
-    let bunstr = scopeguard::guard(bunstr, |s| s.deref());
+    let bunstr = bun_core::OwnedString::new(bunstr);
 
     let mut outbuf: Vec<u8> = Vec::new();
 
@@ -883,7 +883,7 @@ pub fn get_main(global_this: &JSGlobalObject) -> JSValue {
                 break 'use_resolved_path;
             };
 
-            let _close = scopeguard::guard(fd, |fd: Fd| fd.close());
+            let _close = bun_sys::CloseOnDrop::new(fd);
             #[cfg(windows)]
             {
                 let mut wpath = WPathBuffer::uninit();
@@ -1140,17 +1140,16 @@ fn do_resolve(global_this: &JSGlobalObject, arguments: &[JSValue]) -> JsResult<J
     }
 
     let specifier_str = specifier.to_bun_string(global_this)?;
-    let specifier_str = scopeguard::guard(specifier_str, |s| s.deref());
+    let specifier_str = bun_core::OwnedString::new(specifier_str);
     let from_str = from.to_bun_string(global_this)?;
-    let from_str = scopeguard::guard(from_str, |s| s.deref());
+    let from_str = bun_core::OwnedString::new(from_str);
     do_resolve_with_args::<false>(global_this, *specifier_str, *from_str, is_esm, false)
 }
 
-/// Single Drop point for the three `BunString`s `do_resolve_with_args` may own.
-/// Replaces three separate `scopeguard::guard(_, |s| s.deref())` closures —
-/// each of which generated its own drop frame and landing pad — with one
-/// contiguous cleanup. Fields default to `BunString::empty()`, whose `deref()`
-/// is a single tag-compare no-op, so unused slots cost effectively nothing.
+/// Single Drop point for the three `BunString`s `do_resolve_with_args` may own —
+/// one contiguous cleanup instead of three separate drop frames and landing
+/// pads. Fields default to `BunString::empty()`, whose `deref()` is a single
+/// tag-compare no-op, so unused slots cost effectively nothing.
 struct ResolveDerefOnDrop {
     query_string: BunString,
     /// Only set when the specifier had a `file://` prefix and we allocated a
@@ -1260,12 +1259,12 @@ pub fn bun_resolve(
     let Ok(specifier_str) = specifier.to_bun_string(global) else {
         return JSValue::ZERO;
     };
-    let specifier_str = scopeguard::guard(specifier_str, |s| s.deref());
+    let specifier_str = bun_core::OwnedString::new(specifier_str);
 
     let Ok(source_str) = source.to_bun_string(global) else {
         return JSValue::ZERO;
     };
-    let source_str = scopeguard::guard(source_str, |s| s.deref());
+    let source_str = bun_core::OwnedString::new(source_str);
 
     let value =
         match do_resolve_with_args::<true>(global, *specifier_str, *source_str, is_esm, false) {
@@ -1292,7 +1291,7 @@ pub fn bun_resolve_sync(
     let Ok(specifier_str) = specifier.to_bun_string(global) else {
         return JSValue::ZERO;
     };
-    let specifier_str = scopeguard::guard(specifier_str, |s| s.deref());
+    let specifier_str = bun_core::OwnedString::new(specifier_str);
 
     if specifier_str.length() == 0 {
         let _ = global
@@ -1307,7 +1306,7 @@ pub fn bun_resolve_sync(
     let Ok(source_str) = source.to_bun_string(global) else {
         return JSValue::ZERO;
     };
-    let source_str = scopeguard::guard(source_str, |s| s.deref());
+    let source_str = bun_core::OwnedString::new(source_str);
 
     jsc::to_js_host_call(global, || {
         do_resolve_with_args::<true>(
@@ -1349,7 +1348,7 @@ pub fn bun_resolve_sync_with_paths(
     let Ok(specifier_str) = specifier.to_bun_string(global) else {
         return JSValue::ZERO;
     };
-    let specifier_str = scopeguard::guard(specifier_str, |s| s.deref());
+    let specifier_str = bun_core::OwnedString::new(specifier_str);
 
     if specifier_str.length() == 0 {
         let _ = global
@@ -1364,7 +1363,7 @@ pub fn bun_resolve_sync_with_paths(
     let Ok(source_str) = source.to_bun_string(global) else {
         return JSValue::ZERO;
     };
-    let source_str = scopeguard::guard(source_str, |s| s.deref());
+    let source_str = bun_core::OwnedString::new(source_str);
 
     // SAFETY: bun_vm() returns the live thread-local VM for a Bun-owned global.
     let bun_vm = global.bun_vm().as_mut();
@@ -1419,7 +1418,7 @@ pub fn bun_resolve_sync_with_source(
     let Ok(specifier_str) = specifier.to_bun_string(global) else {
         return JSValue::ZERO;
     };
-    let specifier_str = scopeguard::guard(specifier_str, |s| s.deref());
+    let specifier_str = bun_core::OwnedString::new(specifier_str);
     if specifier_str.length() == 0 {
         let _ = global
             .err(

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -883,11 +883,11 @@ pub fn get_main(global_this: &JSGlobalObject) -> JSValue {
                 break 'use_resolved_path;
             };
 
-            let _close = bun_sys::CloseOnDrop::new(fd);
+            let fd = bun_sys::File::from_fd(fd);
             #[cfg(windows)]
             {
                 let mut wpath = WPathBuffer::uninit();
-                let Ok(fdpath) = bun_sys::get_fd_path_w(fd, &mut wpath) else {
+                let Ok(fdpath) = bun_sys::get_fd_path_w(fd.handle, &mut wpath) else {
                     break 'use_resolved_path;
                 };
                 vm.main_resolved_path = BunString::clone_utf16(fdpath);
@@ -895,7 +895,7 @@ pub fn get_main(global_this: &JSGlobalObject) -> JSValue {
             #[cfg(not(windows))]
             {
                 let mut path = PathBuffer::uninit();
-                let Ok(fdpath) = bun_sys::get_fd_path(fd, &mut path) else {
+                let Ok(fdpath) = bun_sys::get_fd_path(fd.handle, &mut path) else {
                     break 'use_resolved_path;
                 };
 

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -26,8 +26,6 @@ pub mod js_bundler {
     use super::*;
     use bun_core::ZigStringSlice;
 
-    use bun_sys::FdExt;
-
     type OwnedString = MutableString;
 
     /// `options::JSX::Runtime` → `api::JsxRuntime` (only the reverse `From`
@@ -903,10 +901,10 @@ pub mod js_bundler {
                         )));
                     }
                 };
-                let _close = scopeguard::guard(dir, |d| d.close());
+                let dir = bun_sys::Dir::from_fd(dir);
 
                 let mut rootdir_buf = bun_paths::PathBuffer::uninit();
-                let rootdir = match bun_sys::get_fd_path(*_close, &mut rootdir_buf) {
+                let rootdir = match bun_sys::get_fd_path(dir.fd(), &mut rootdir_buf) {
                     Ok(p) => p,
                     Err(err) => {
                         return Err(global_this.throw(format_args!(

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -705,8 +705,15 @@ impl Terminal {
         }
         // Both reader callbacks below re-enter user JS and may deref; hold a
         // +1 so `self` stays live for the trailing field accesses.
+        struct DerefGuard<'a>(&'a Terminal);
+        impl Drop for DerefGuard<'_> {
+            #[inline]
+            fn drop(&mut self) {
+                self.0.deref_();
+            }
+        }
         self.ref_();
-        let guard = scopeguard::guard((), |()| self.deref_());
+        let guard = DerefGuard(self);
         if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
             // SAFETY: single JS thread; re-entrant user JS (data callback may
             // call `terminal.close()`) is handled via the raw-pointer dispatch
@@ -1304,7 +1311,7 @@ fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError>
         }
     };
     // errdefer read_fd.close()
-    let read_fd_guard = scopeguard::guard(read_fd, |fd| fd.close());
+    let read_fd_guard = sys::CloseOnDrop::new(read_fd);
 
     let write_fd = match Fd::from_system(in_server.unwrap()).make_libuv_owned() {
         Ok(fd) => fd,
@@ -1315,7 +1322,7 @@ fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError>
     };
 
     let result_hpcon = hpcon.take().unwrap();
-    let read_fd = scopeguard::ScopeGuard::into_inner(read_fd_guard);
+    let read_fd = read_fd_guard.into_raw();
 
     Ok(PtyResult {
         master: Fd::INVALID,

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -705,15 +705,9 @@ impl Terminal {
         }
         // Both reader callbacks below re-enter user JS and may deref; hold a
         // +1 so `self` stays live for the trailing field accesses.
-        struct DerefGuard<'a>(&'a Terminal);
-        impl Drop for DerefGuard<'_> {
-            #[inline]
-            fn drop(&mut self) {
-                self.0.deref_();
-            }
-        }
-        self.ref_();
-        let guard = DerefGuard(self);
+        // SAFETY: `self` is the heap-stable `heap::into_raw` allocation (see
+        // `as_ctx_ptr`); the guard's own +1 keeps it live until `drop(guard)`.
+        let guard = unsafe { bun_ptr::ScopedRef::new(self.as_ctx_ptr()) };
         if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
             // SAFETY: single JS thread; re-entrant user JS (data callback may
             // call `terminal.close()`) is handled via the raw-pointer dispatch

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1985,10 +1985,19 @@ bun_jsc::jsc_host_abi! {
     }
 }
 
+/// RAII: `CronJob::release_pending_ref(ptr)` on drop.
+struct ReleasePendingRefOnDrop(*mut CronJob);
+impl Drop for ReleasePendingRefOnDrop {
+    #[inline]
+    fn drop(&mut self) {
+        CronJob::release_pending_ref(self.0);
+    }
+}
+
 fn on_promise_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
     let this: *mut CronJob = args[args.len() - 1].as_promise_ptr::<CronJob>();
-    let _guard = scopeguard::guard(this, CronJob::release_pending_ref);
+    let _guard = ReleasePendingRefOnDrop(this);
     // `pending_ref` holds a ref on `this`.
     let this_ref = CronJob::from_ctx_ptr(this);
     // SAFETY: `bun_vm()` returns the per-thread singleton.
@@ -2003,7 +2012,7 @@ fn on_promise_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<J
 fn on_promise_reject(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
     let this: *mut CronJob = args[args.len() - 1].as_promise_ptr::<CronJob>();
-    let _guard = scopeguard::guard(this, CronJob::release_pending_ref);
+    let _guard = ReleasePendingRefOnDrop(this);
     // `pending_ref` holds a ref on `this`.
     let this_ref = CronJob::from_ctx_ptr(this);
     // SAFETY: `bun_vm()` returns the per-thread singleton.

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1356,40 +1356,44 @@ impl DirectoryWatchStore {
                 Ok(None) | Err(_) => None,
             };
 
-        let (fd, owned_fd): (bun_sys::Fd, bool) = if bun_watcher::REQUIRES_FILE_DESCRIPTORS {
-            if let Some(fd) = cache_fd {
-                (fd, false)
-            } else {
-                // Build a NUL-terminated path buffer.
-                if dir_name_to_watch.len() >= bun_paths::MAX_PATH_BYTES {
-                    return Err(DirectoryWatchInsertError::Ignore); // NameTooLong
-                }
-                let mut zbuf = bun_paths::path_buffer_pool::get();
-                let zpath = bun_paths::resolve_path::z(dir_name_to_watch, &mut *zbuf);
-                match bun_sys::open(
-                    zpath,
-                    bun_sys::O::DIRECTORY | bun_watcher::WATCH_OPEN_FLAGS,
-                    0,
-                ) {
-                    Ok(fd) => (fd, true),
-                    Err(err) => match err.get_errno() {
-                        // If this directory doesn't exist, a watcher should be placed
-                        // on the parent directory. Then, if this directory is later
-                        // created, the watcher can be properly initialized.
-                        bun_sys::E::ENOENT => {
-                            // TODO: implement that. for now it ignores (BUN-10968)
-                            return Err(DirectoryWatchInsertError::Ignore);
+        let (fd_guard, fd): (Option<bun_sys::CloseOnDrop>, bun_sys::Fd) =
+            if bun_watcher::REQUIRES_FILE_DESCRIPTORS {
+                if let Some(fd) = cache_fd {
+                    (None, fd)
+                } else {
+                    // Build a NUL-terminated path buffer.
+                    if dir_name_to_watch.len() >= bun_paths::MAX_PATH_BYTES {
+                        return Err(DirectoryWatchInsertError::Ignore); // NameTooLong
+                    }
+                    let mut zbuf = bun_paths::path_buffer_pool::get();
+                    let zpath = bun_paths::resolve_path::z(dir_name_to_watch, &mut *zbuf);
+                    match bun_sys::open(
+                        zpath,
+                        bun_sys::O::DIRECTORY | bun_watcher::WATCH_OPEN_FLAGS,
+                        0,
+                    ) {
+                        Ok(opened) => {
+                            let guard = bun_sys::CloseOnDrop::new(opened);
+                            let fd = guard.fd();
+                            (Some(guard), fd)
                         }
-                        bun_sys::E::ENOTDIR => return Err(DirectoryWatchInsertError::Ignore),
-                        _ => bun_core::todo_panic!("log watcher error"),
-                    },
+                        Err(err) => match err.get_errno() {
+                            // If this directory doesn't exist, a watcher should be placed
+                            // on the parent directory. Then, if this directory is later
+                            // created, the watcher can be properly initialized.
+                            bun_sys::E::ENOENT => {
+                                // TODO: implement that. for now it ignores (BUN-10968)
+                                return Err(DirectoryWatchInsertError::Ignore);
+                            }
+                            bun_sys::E::ENOTDIR => return Err(DirectoryWatchInsertError::Ignore),
+                            _ => bun_core::todo_panic!("log watcher error"),
+                        },
+                    }
                 }
-            }
-        } else {
-            (bun_sys::Fd::INVALID, false)
-        };
-        let fd_guard = (bun_watcher::REQUIRES_FILE_DESCRIPTORS && owned_fd)
-            .then(|| bun_sys::CloseOnDrop::new(fd));
+            } else {
+                (None, bun_sys::Fd::INVALID)
+            };
+        let owned_fd = fd_guard.is_some();
 
         // `add_directory::<true>` so the `WatchItem` owns its path: the watcher
         // retains the path until eviction runs (deferred onto `evict_list` and
@@ -1409,7 +1413,7 @@ impl DirectoryWatchStore {
         };
 
         // Disarm errdefer guards: success path.
-        let _ = fd_guard.map(bun_sys::CloseOnDrop::into_raw);
+        let fd = fd_guard.map_or(fd, bun_sys::CloseOnDrop::into_raw);
         let _ = scopeguard::ScopeGuard::into_inner(watches_guard);
 
         let dep = self.append_dep_assume_capacity(directory_watch_store::Dep {

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1388,11 +1388,8 @@ impl DirectoryWatchStore {
         } else {
             (bun_sys::Fd::INVALID, false)
         };
-        let fd_guard = scopeguard::guard(fd, move |fd| {
-            if bun_watcher::REQUIRES_FILE_DESCRIPTORS && owned_fd {
-                fd.close();
-            }
-        });
+        let fd_guard = (bun_watcher::REQUIRES_FILE_DESCRIPTORS && owned_fd)
+            .then(|| bun_sys::CloseOnDrop::new(fd));
 
         // `add_directory::<true>` so the `WatchItem` owns its path: the watcher
         // retains the path until eviction runs (deferred onto `evict_list` and
@@ -1412,7 +1409,7 @@ impl DirectoryWatchStore {
         };
 
         // Disarm errdefer guards: success path.
-        let fd = scopeguard::ScopeGuard::into_inner(fd_guard);
+        let _ = fd_guard.map(bun_sys::CloseOnDrop::into_raw);
         let _ = scopeguard::ScopeGuard::into_inner(watches_guard);
 
         let dep = self.append_dep_assume_capacity(directory_watch_store::Dep {

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -537,9 +537,7 @@ impl InitCommand {
                 let Ok(dir) = bun_sys::open_dir_at(Fd::cwd(), b".") else {
                     break 'infer;
                 };
-                let _close = scopeguard::guard(dir, |d| {
-                    let _ = bun_sys::close(d);
-                });
+                let _close = bun_sys::CloseOnDrop::new(dir);
                 let mut it = bun_sys::iterate_dir(dir);
                 while let Some(file) = it.next().map_err(crate::Error::from)? {
                     if file.kind != bun_sys::FileKind::File {

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -537,8 +537,8 @@ impl InitCommand {
                 let Ok(dir) = bun_sys::open_dir_at(Fd::cwd(), b".") else {
                     break 'infer;
                 };
-                let _close = bun_sys::CloseOnDrop::new(dir);
-                let mut it = bun_sys::iterate_dir(dir);
+                let dir = bun_sys::Dir::from_fd(dir);
+                let mut it = bun_sys::iterate_dir(dir.fd);
                 while let Some(file) = it.next().map_err(crate::Error::from)? {
                     if file.kind != bun_sys::FileKind::File {
                         continue;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -444,9 +444,7 @@ fn new_pack_queue() -> PackQueue {
 /// (dir, dir_subpath, dir_depth)
 struct DirInfo(Dir, Box<[u8]>, usize);
 
-/// `Dir` that only closes on drop when `owned` is set. Used by the tree
-/// walkers below where the depth-1 root is a borrowed fd from the caller but
-/// deeper entries are opened (and thus owned) by the walk.
+/// `Dir` that only closes on drop when `owned` is set (the walk root is borrowed).
 struct MaybeOwnedDir {
     dir: core::mem::ManuallyDrop<Dir>,
     owned: bool,

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -444,6 +444,41 @@ fn new_pack_queue() -> PackQueue {
 /// (dir, dir_subpath, dir_depth)
 struct DirInfo(Dir, Box<[u8]>, usize);
 
+/// `Dir` that only closes on drop when `owned` is set. Used by the tree
+/// walkers below where the depth-1 root is a borrowed fd from the caller but
+/// deeper entries are opened (and thus owned) by the walk.
+struct MaybeOwnedDir {
+    dir: core::mem::ManuallyDrop<Dir>,
+    owned: bool,
+}
+
+impl MaybeOwnedDir {
+    #[inline]
+    fn new(dir: Dir, owned: bool) -> Self {
+        Self {
+            dir: core::mem::ManuallyDrop::new(dir),
+            owned,
+        }
+    }
+}
+
+impl core::ops::Deref for MaybeOwnedDir {
+    type Target = Dir;
+    #[inline]
+    fn deref(&self) -> &Dir {
+        &self.dir
+    }
+}
+
+impl Drop for MaybeOwnedDir {
+    fn drop(&mut self) {
+        if self.owned {
+            // SAFETY: `self.dir` is never taken elsewhere; this runs at most once.
+            unsafe { core::mem::ManuallyDrop::drop(&mut self.dir) };
+        }
+    }
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // tree iteration (includes / excludes)
 // ───────────────────────────────────────────────────────────────────────────
@@ -478,11 +513,7 @@ fn iterate_included_project_tree(
         let DirInfo(dir, dir_subpath, dir_depth) = dir_info;
         // Root (depth 1) is borrowed from the caller's `root_dir`; only close
         // subdirs we opened.
-        let dir = scopeguard::guard(dir, move |d| {
-            if dir_depth == 1 {
-                let _ = d.into_raw();
-            }
-        });
+        let dir = MaybeOwnedDir::new(dir, dir_depth != 1);
 
         let mut dir_iter = DirIterator::iterate(Fd::from_std_dir(&dir));
         'next_entry: while let Some(entry) = dir_iter.next().ok().flatten() {
@@ -1265,11 +1296,7 @@ fn iterate_project_tree(
     while let Some(dir_info) = dirs.pop() {
         let DirInfo(dir, dir_subpath, dir_depth) = dir_info;
         // Root (depth 1) is caller-owned; only close subdirs we opened.
-        let dir = scopeguard::guard(dir, move |d| {
-            if dir_depth == 1 {
-                let _ = d.into_raw();
-            }
-        });
+        let dir = MaybeOwnedDir::new(dir, dir_depth != 1);
 
         while let Some(last) = ignores.last() {
             if last.depth < dir_depth {

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1582,7 +1582,8 @@ impl PublishCommand {
     /// the first match from `readdir` (same ordering npm's glob walks, in practice),
     /// or `None` if none is present.
     pub(crate) fn find_workspace_readme(abs_workspace_path: &[u8]) -> Option<ReadmeInfo> {
-        let workspace_dir = bun_sys::Dir::from_fd(bun_sys::open_dir_absolute(abs_workspace_path).ok()?);
+        let workspace_dir =
+            bun_sys::Dir::from_fd(bun_sys::open_dir_absolute(abs_workspace_path).ok()?);
 
         let mut iter = DirIterator::iterate(workspace_dir.fd);
         while let Some(entry) = iter.next().ok().flatten() {

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1546,9 +1546,9 @@ impl PublishCommand {
                     Global::crash();
                 }
             };
-            let _close = bun_sys::CloseOnDrop::new(workspace_root);
+            let workspace_root = bun_sys::Dir::from_fd(workspace_root);
 
-            Self::normalize_bin(json, &bump, package_name, workspace_root)?;
+            Self::normalize_bin(json, &bump, package_name, workspace_root.fd)?;
         }
 
         let buffer_writer = bun_js_printer::BufferWriter::init();
@@ -1582,10 +1582,9 @@ impl PublishCommand {
     /// the first match from `readdir` (same ordering npm's glob walks, in practice),
     /// or `None` if none is present.
     pub(crate) fn find_workspace_readme(abs_workspace_path: &[u8]) -> Option<ReadmeInfo> {
-        let workspace_dir = bun_sys::open_dir_absolute(abs_workspace_path).ok()?;
-        let _close = bun_sys::CloseOnDrop::new(workspace_dir);
+        let workspace_dir = bun_sys::Dir::from_fd(bun_sys::open_dir_absolute(abs_workspace_path).ok()?);
 
-        let mut iter = DirIterator::iterate(workspace_dir);
+        let mut iter = DirIterator::iterate(workspace_dir.fd);
         while let Some(entry) = iter.next().ok().flatten() {
             if entry.kind == bun_sys::EntryKind::Directory {
                 continue;
@@ -1596,7 +1595,7 @@ impl PublishCommand {
                 continue;
             }
 
-            let contents = match bun_sys::File::read_from(workspace_dir, name) {
+            let contents = match bun_sys::File::read_from(workspace_dir.fd, name) {
                 Ok(bytes) => bytes,
                 Err(_) => return None,
             };
@@ -1801,7 +1800,7 @@ impl PublishCommand {
 
                 while let Some(dir_info) = dirs.pop() {
                     let (dir, dir_subpath, close_dir) = dir_info;
-                    let _close = close_dir.then(|| bun_sys::CloseOnDrop::new(dir));
+                    let _dir: Option<bun_sys::Dir> = close_dir.then(|| bun_sys::Dir::from_fd(dir));
 
                     let mut iter = DirIterator::iterate(dir);
                     while let Some(entry) = iter.next().ok().flatten() {

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -29,7 +29,6 @@ use bun_core::OSPathChar;
 use bun_install::Access;
 use bun_install::dependency;
 use bun_install::{AuthType, LogLevel};
-use bun_sys::FdExt as _;
 
 use crate::api::bun_process::sync as spawn_sync;
 
@@ -1547,9 +1546,7 @@ impl PublishCommand {
                     Global::crash();
                 }
             };
-            let _close = scopeguard::guard(workspace_root, |fd| {
-                let _ = fd.close();
-            });
+            let _close = bun_sys::CloseOnDrop::new(workspace_root);
 
             Self::normalize_bin(json, &bump, package_name, workspace_root)?;
         }
@@ -1586,9 +1583,7 @@ impl PublishCommand {
     /// or `None` if none is present.
     pub(crate) fn find_workspace_readme(abs_workspace_path: &[u8]) -> Option<ReadmeInfo> {
         let workspace_dir = bun_sys::open_dir_absolute(abs_workspace_path).ok()?;
-        let _close = scopeguard::guard(workspace_dir, |d| {
-            let _ = d.close();
-        });
+        let _close = bun_sys::CloseOnDrop::new(workspace_dir);
 
         let mut iter = DirIterator::iterate(workspace_dir);
         while let Some(entry) = iter.next().ok().flatten() {
@@ -1806,11 +1801,7 @@ impl PublishCommand {
 
                 while let Some(dir_info) = dirs.pop() {
                     let (dir, dir_subpath, close_dir) = dir_info;
-                    let _close = scopeguard::guard(dir, move |d| {
-                        if close_dir {
-                            let _ = d.close();
-                        }
-                    });
+                    let _close = close_dir.then(|| bun_sys::CloseOnDrop::new(dir));
 
                     let mut iter = DirIterator::iterate(dir);
                     while let Some(entry) = iter.next().ok().flatten() {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -111,6 +111,43 @@ bun_output::declare_scope!(dns, hidden);
 bun_output::declare_scope!(DNSResolver, visible);
 
 // ──────────────────────────────────────────────────────────────────────────
+// RAII drop guards for C-allocated DNS resources
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Calls `Resolver::request_completed` on drop. Used by the c-ares completion
+/// callbacks so the pending-request bookkeeping runs on every exit path.
+struct RequestCompletedGuard(*mut Resolver);
+impl Drop for RequestCompletedGuard {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is the live intrusive-RC resolver stored on the request.
+        unsafe { (*self.0).request_completed() };
+    }
+}
+
+/// Frees a c-ares-allocated reply (`ares_free_data` / `ares_free_hostent`) via
+/// the record type's [`CAresRecordType::destroy`] on drop.
+struct CAresReplyGuard<T: CAresRecordType>(Option<*mut T>);
+impl<T: CAresRecordType> Drop for CAresReplyGuard<T> {
+    fn drop(&mut self) {
+        if let Some(r) = self.0 {
+            // SAFETY: `r` is the c-ares-allocated reply owned by this guard.
+            unsafe { T::destroy(r) };
+        }
+    }
+}
+
+/// Frees a c-ares-allocated `AddrInfo` (`ares_freeaddrinfo`) on drop.
+struct CAresAddrInfoGuard(Option<*mut c_ares::AddrInfo>);
+impl Drop for CAresAddrInfoGuard {
+    fn drop(&mut self) {
+        if let Some(r) = self.0 {
+            // SAFETY: `r` is the c-ares-allocated AddrInfo owned by this guard.
+            unsafe { c_ares::AddrInfo::destroy(r) };
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // C type aliases
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -679,7 +716,7 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         // SAFETY: this is the heap-allocated request c-ares calls back with
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching {
-                scopeguard::defer! { (*resolver).request_completed() };
+                let _done = RequestCompletedGuard(resolver);
                 if (*this).cache.pending_cache() {
                     (*resolver).drain_pending_cares::<T>(
                         (*this).cache.pos_in_pending(),
@@ -1070,7 +1107,7 @@ impl GetNameInfoRequest {
         // `resolver` (if set) is the live intrusive-RC ctx stored at init time.
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching {
-                scopeguard::defer! { (*resolver).request_completed() };
+                let _done = RequestCompletedGuard(resolver);
                 if (*this).cache.pending_cache() {
                     (*resolver).drain_pending_name_info_cares(
                         (*this).cache.pos_in_pending(),
@@ -1270,10 +1307,14 @@ pub mod get_addr_info_request {
 
             // do not free addrinfo when err != 0: getaddrinfo only allocates the
             // result list on success, so the out-pointer is unspecified on error.
-            let _free = scopeguard::guard(addrinfo, |a| {
-                // SAFETY: `a` was returned by libc::getaddrinfo (non-null per the check above).
-                unsafe { bun_dns::freeaddrinfo(a) }
-            });
+            struct LibcAddrInfoGuard(*mut AddrInfo);
+            impl Drop for LibcAddrInfoGuard {
+                fn drop(&mut self) {
+                    // SAFETY: `self.0` was returned by libc::getaddrinfo (non-null).
+                    unsafe { bun_dns::freeaddrinfo(self.0) }
+                }
+            }
+            let _free = LibcAddrInfoGuard(addrinfo);
 
             // SAFETY: addrinfo is non-null (checked above); freed by `_free` guard after copy.
             *self = LibcBackend::Success(GetAddrInfoResult::to_list(unsafe { &*addrinfo }));
@@ -1834,12 +1875,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
         // This path is reached when the pending cache is full (`.disabled`),
         // so we own the c-ares result here. The cached path frees it in
         // `drainPendingCares`; callers from there always pass `null`.
-        let _free = scopeguard::guard(result, |r| {
-            if let Some(r) = r {
-                // SAFETY: r is the c-ares-allocated reply; we own it on this path.
-                unsafe { T::destroy(r) };
-            }
-        });
+        let _free = CAresReplyGuard::<T>(result);
 
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
@@ -2006,12 +2042,7 @@ impl DNSLookup {
         // This path is reached when the pending-host cache is full (`.disabled`),
         // so we own the c-ares result here. The cached path frees it in
         // `drainPendingHostCares`; callers from there always pass `null`.
-        let _free = scopeguard::guard(result, |r| {
-            if let Some(r) = r {
-                // SAFETY: r is the c-ares-allocated AddrInfo; we own it on this path.
-                unsafe { c_ares::AddrInfo::destroy(r) };
-            }
-        });
+        let _free = CAresAddrInfoGuard(result);
 
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
@@ -2043,7 +2074,7 @@ impl DNSLookup {
     pub(crate) unsafe fn on_complete(this: *mut Self, result: *mut c_ares::AddrInfo) {
         bun_output::scoped_log!(DNSLookup, "onComplete");
         // SAFETY: caller contract — `this` is live; result is a live c-ares AddrInfo
-        // owned by the caller's scopeguard; JSGlobalObject outlives the request.
+        // owned by the caller's drop guard; JSGlobalObject outlives the request.
         unsafe {
             let array =
                 super::cares_jsc::addr_info_to_js_array(&mut *result, (*this).global_this())
@@ -4386,7 +4417,7 @@ impl Resolver {
                 .to_js_response(prev_global, T::TYPE_NAME)
                 .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
             // SAFETY: addr is the c-ares-allocated reply; freed once after all consumers run.
-            let _free_addr = scopeguard::guard(addr, |a| T::destroy(a));
+            let _free_addr = CAresReplyGuard::<T>(Some(addr));
             array.ensure_still_alive();
             CAresLookup::<T>::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
@@ -4452,7 +4483,7 @@ impl Resolver {
                 .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
             // SAFETY: addr is the c-ares-allocated AddrInfo; freed once after all consumers run.
             // Move the raw pointer into the guard so the loop body can keep borrowing `*addr`.
-            let _free_addr = scopeguard::guard(addr, |a| c_ares::AddrInfo::destroy(a));
+            let _free_addr = CAresAddrInfoGuard(Some(addr));
             array.ensure_still_alive();
             DNSLookup::on_complete_with_array(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
@@ -5538,10 +5569,14 @@ impl Resolver {
                 ))),
             );
         }
-        scopeguard::defer! {
-            // SAFETY: `servers` was allocated by ares_get_servers_ports; ares_free_data is its deallocator.
-            unsafe { c_ares::ares_free_data(servers.cast()) }
-        };
+        struct AresServersGuard(*mut c_ares::struct_ares_addr_port_node);
+        impl Drop for AresServersGuard {
+            fn drop(&mut self) {
+                // SAFETY: `self.0` was allocated by ares_get_servers_ports; ares_free_data is its deallocator.
+                unsafe { c_ares::ares_free_data(self.0.cast()) }
+            }
+        }
+        let _free = AresServersGuard(servers);
 
         let values = JSValue::create_empty_array(global_this, 0)?;
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -118,23 +118,68 @@ impl Drop for RequestCompletedGuard {
     }
 }
 
-struct CAresReplyGuard<T: CAresRecordType>(Option<*mut T>);
-impl<T: CAresRecordType> Drop for CAresReplyGuard<T> {
+struct CAresReply<T: CAresRecordType>(Option<*mut T>);
+impl<T: CAresRecordType> CAresReply<T> {
+    #[inline]
+    fn as_ptr(&self) -> Option<*mut T> {
+        self.0
+    }
+}
+impl<T: CAresRecordType> Drop for CAresReply<T> {
     fn drop(&mut self) {
         if let Some(r) = self.0 {
-            // SAFETY: `r` is the c-ares-allocated reply owned by this guard.
+            // SAFETY: `r` is the c-ares-allocated reply owned by this value.
             unsafe { T::destroy(r) };
         }
     }
 }
 
-struct CAresAddrInfoGuard(Option<*mut c_ares::AddrInfo>);
-impl Drop for CAresAddrInfoGuard {
+struct CAresAddrInfo(Option<*mut c_ares::AddrInfo>);
+impl CAresAddrInfo {
+    #[inline]
+    fn as_ptr(&self) -> Option<*mut c_ares::AddrInfo> {
+        self.0
+    }
+}
+impl Drop for CAresAddrInfo {
     fn drop(&mut self) {
         if let Some(r) = self.0 {
-            // SAFETY: `r` is the c-ares-allocated AddrInfo owned by this guard.
+            // SAFETY: `r` is the c-ares-allocated AddrInfo owned by this value.
             unsafe { c_ares::AddrInfo::destroy(r) };
         }
+    }
+}
+
+#[cfg(not(windows))]
+struct LibcAddrInfo(*mut AddrInfo);
+#[cfg(not(windows))]
+impl core::ops::Deref for LibcAddrInfo {
+    type Target = AddrInfo;
+    #[inline]
+    fn deref(&self) -> &AddrInfo {
+        // SAFETY: constructed only from a non-null getaddrinfo result.
+        unsafe { &*self.0 }
+    }
+}
+#[cfg(not(windows))]
+impl Drop for LibcAddrInfo {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was returned by libc::getaddrinfo (non-null).
+        unsafe { bun_dns::freeaddrinfo(self.0) }
+    }
+}
+
+struct AresServers(*mut c_ares::struct_ares_addr_port_node);
+impl AresServers {
+    #[inline]
+    fn head(&self) -> *mut c_ares::struct_ares_addr_port_node {
+        self.0
+    }
+}
+impl Drop for AresServers {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was allocated by ares_get_servers_ports; ares_free_data is its deallocator.
+        unsafe { c_ares::ares_free_data(self.0.cast()) }
     }
 }
 
@@ -1298,17 +1343,8 @@ pub mod get_addr_info_request {
 
             // do not free addrinfo when err != 0: getaddrinfo only allocates the
             // result list on success, so the out-pointer is unspecified on error.
-            struct LibcAddrInfoGuard(*mut AddrInfo);
-            impl Drop for LibcAddrInfoGuard {
-                fn drop(&mut self) {
-                    // SAFETY: `self.0` was returned by libc::getaddrinfo (non-null).
-                    unsafe { bun_dns::freeaddrinfo(self.0) }
-                }
-            }
-            let _free = LibcAddrInfoGuard(addrinfo);
-
-            // SAFETY: addrinfo is non-null (checked above); freed by `_free` guard after copy.
-            *self = LibcBackend::Success(GetAddrInfoResult::to_list(unsafe { &*addrinfo }));
+            let addrinfo = LibcAddrInfo(addrinfo);
+            *self = LibcBackend::Success(GetAddrInfoResult::to_list(&*addrinfo));
         }
     }
 
@@ -1866,7 +1902,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
         // This path is reached when the pending cache is full (`.disabled`),
         // so we own the c-ares result here. The cached path frees it in
         // `drainPendingCares`; callers from there always pass `null`.
-        let _free = CAresReplyGuard::<T>(result);
+        let reply = CAresReply::<T>(result);
 
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
@@ -1882,7 +1918,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
                 Self::destroy(this);
                 return;
             }
-            let Some(node) = result else {
+            let Some(node) = reply.as_ptr() else {
                 error_to_deferred(
                     c_ares::Error::ENOTFOUND,
                     syscall.as_bytes(),
@@ -1894,7 +1930,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
                 return;
             };
 
-            // node is a valid c-ares reply for the callback's duration; freed by `_free` guard.
+            // node is a valid c-ares reply for the callback's duration; freed by `reply` on drop.
             let array = (*node)
                 .to_js_response(global_this, T::TYPE_NAME)
                 .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
@@ -2033,7 +2069,7 @@ impl DNSLookup {
         // This path is reached when the pending-host cache is full (`.disabled`),
         // so we own the c-ares result here. The cached path frees it in
         // `drainPendingHostCares`; callers from there always pass `null`.
-        let _free = CAresAddrInfoGuard(result);
+        let result = CAresAddrInfo(result);
 
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
@@ -2046,7 +2082,7 @@ impl DNSLookup {
             }
 
             // `r` is the c-ares-allocated AddrInfo valid for the callback's duration.
-            let Some(r) = result.filter(|r| !(**r).node.is_null()) else {
+            let Some(r) = result.as_ptr().filter(|r| !(**r).node.is_null()) else {
                 error_to_deferred(
                     c_ares::Error::ENOTFOUND,
                     b"getaddrinfo",
@@ -4378,7 +4414,8 @@ impl Resolver {
                 .into_inner()
         };
 
-        let Some(addr) = result else {
+        let reply = CAresReply::<T>(result);
+        let Some(addr) = reply.as_ptr() else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
             // pending-cache slot; consumed via `heap::take` below.
             unsafe {
@@ -4400,15 +4437,13 @@ impl Resolver {
         };
 
         // SAFETY: `key.lookup` is the heap-allocated request stored in the pending-cache
-        // slot; `addr` is the c-ares-allocated reply freed by `_free_addr` below.
+        // slot; `addr` is the c-ares-allocated reply owned by `reply` above.
         unsafe {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
             let mut array = (*addr)
                 .to_js_response(prev_global, T::TYPE_NAME)
                 .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
-            // SAFETY: addr is the c-ares-allocated reply; freed once after all consumers run.
-            let _free_addr = CAresReplyGuard::<T>(Some(addr));
             array.ensure_still_alive();
             CAresLookup::<T>::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
@@ -4444,7 +4479,8 @@ impl Resolver {
         // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
         let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
-        let Some(addr) = result else {
+        let addrinfo = CAresAddrInfo(result);
+        let Some(addr) = addrinfo.as_ptr() else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
             // pending-cache slot; consumed via `heap::take` below.
             unsafe {
@@ -4466,15 +4502,12 @@ impl Resolver {
         };
 
         // SAFETY: `key.lookup` is the heap-allocated request stored in the pending-cache
-        // slot; `addr` is the c-ares-allocated AddrInfo freed by `_free_addr` below.
+        // slot; `addr` is the c-ares-allocated AddrInfo owned by `addrinfo` above.
         unsafe {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
             let mut array = super::cares_jsc::addr_info_to_js_array(&mut *addr, prev_global)
                 .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
-            // SAFETY: addr is the c-ares-allocated AddrInfo; freed once after all consumers run.
-            // Move the raw pointer into the guard so the loop body can keep borrowing `*addr`.
-            let _free_addr = CAresAddrInfoGuard(Some(addr));
             array.ensure_still_alive();
             DNSLookup::on_complete_with_array(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
@@ -5560,19 +5593,12 @@ impl Resolver {
                 ))),
             );
         }
-        struct AresServersGuard(*mut c_ares::struct_ares_addr_port_node);
-        impl Drop for AresServersGuard {
-            fn drop(&mut self) {
-                // SAFETY: `self.0` was allocated by ares_get_servers_ports; ares_free_data is its deallocator.
-                unsafe { c_ares::ares_free_data(self.0.cast()) }
-            }
-        }
-        let _free = AresServersGuard(servers);
+        let servers = AresServers(servers);
 
         let values = JSValue::create_empty_array(global_this, 0)?;
 
         let mut i: u32 = 0;
-        let mut cur = servers;
+        let mut cur = servers.head();
         while !cur.is_null() {
             // SAFETY: `cur` is non-null (loop guard) and walks the c-ares-allocated list.
             let current = unsafe { &*cur };

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -110,12 +110,6 @@ bun_output::declare_scope!(DNSLookup, visible);
 bun_output::declare_scope!(dns, hidden);
 bun_output::declare_scope!(DNSResolver, visible);
 
-// ──────────────────────────────────────────────────────────────────────────
-// RAII drop guards for C-allocated DNS resources
-// ──────────────────────────────────────────────────────────────────────────
-
-/// Calls `Resolver::request_completed` on drop. Used by the c-ares completion
-/// callbacks so the pending-request bookkeeping runs on every exit path.
 struct RequestCompletedGuard(*mut Resolver);
 impl Drop for RequestCompletedGuard {
     fn drop(&mut self) {
@@ -124,8 +118,6 @@ impl Drop for RequestCompletedGuard {
     }
 }
 
-/// Frees a c-ares-allocated reply (`ares_free_data` / `ares_free_hostent`) via
-/// the record type's [`CAresRecordType::destroy`] on drop.
 struct CAresReplyGuard<T: CAresRecordType>(Option<*mut T>);
 impl<T: CAresRecordType> Drop for CAresReplyGuard<T> {
     fn drop(&mut self) {
@@ -136,7 +128,6 @@ impl<T: CAresRecordType> Drop for CAresReplyGuard<T> {
     }
 }
 
-/// Frees a c-ares-allocated `AddrInfo` (`ares_freeaddrinfo`) on drop.
 struct CAresAddrInfoGuard(Option<*mut c_ares::AddrInfo>);
 impl Drop for CAresAddrInfoGuard {
     fn drop(&mut self) {

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -527,7 +527,9 @@ impl ComPtr<IWICBitmapEncoder> {
         unsafe { ((*(*self.as_ptr()).vt).Initialize)(self.as_ptr(), stream, cache) }
     }
     #[inline]
-    fn create_new_frame(&self) -> Option<(ComPtr<IWICBitmapFrameEncode>, Option<ComPtr<IUnknown>>)> {
+    fn create_new_frame(
+        &self,
+    ) -> Option<(ComPtr<IWICBitmapFrameEncode>, Option<ComPtr<IUnknown>>)> {
         let mut frame = ptr::null_mut();
         let mut props = ptr::null_mut();
         let hr = unsafe {

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -413,9 +413,7 @@ fn release<T>(p: *mut T) {
     }
 }
 
-/// RAII release for a COM interface pointer — calls [`release`] on drop.
-/// Wraps `*mut T` (not `NonNull`) because `release` already null-checks, and
-/// one call site (`props` from `CreateNewFrame`) is legitimately nullable.
+/// Calls [`release`] on drop. `*mut` (not `NonNull`): `props` can be null.
 struct ComRelease<T>(*mut T);
 impl<T> Drop for ComRelease<T> {
     #[inline]

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -404,9 +404,7 @@ fn release<T>(p: *mut T) {
     }
 }
 
-/// Owning non-null COM interface pointer — `Drop` calls `Release`. Also moves
-/// the per-call-site `unsafe { ((*(*p).vt).Method)(p, ..) }` vtable dance into
-/// one place per method, so `decode`/`encode` read as straight-line safe code.
+/// Owning non-null COM interface pointer; `Drop` calls `Release`.
 #[repr(transparent)]
 struct ComPtr<T>(ptr::NonNull<T>);
 
@@ -854,9 +852,7 @@ static FACTORY_PTR: core::sync::atomic::AtomicPtr<IWICImagingFactory> =
     core::sync::atomic::AtomicPtr::new(ptr::null_mut());
 static FACTORY_ONCE: Once = Once::new();
 
-/// Returns a non-owning view: the factory is a process-lifetime singleton held
-/// in `FACTORY_PTR` and is never released, so the `ComPtr` is wrapped in
-/// `ManuallyDrop` to suppress the `Drop` → `Release` on the caller's handle.
+/// `ManuallyDrop`: the factory is a process-lifetime singleton and is never `Release`d.
 fn factory() -> Result<core::mem::ManuallyDrop<ComPtr<IWICImagingFactory>>, BackendError> {
     // COM apartment must be entered on the *calling* thread; the factory
     // itself is created once and shared (valid in the MTA).

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -92,7 +92,7 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, BackendE
     }
 
     let stream = f.create_stream().ok_or(BackendUnavailable)?;
-    scopeguard::defer! { release(stream.as_ptr()); }
+    let _stream_release = ComRelease(stream.as_ptr());
     if stream.initialize_from_memory(
         bytes.as_ptr(),
         u32::try_from(bytes.len()).expect("int cast"),
@@ -105,10 +105,10 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, BackendE
     let dec = f
         .create_decoder_from_stream(stream.cast::<IUnknown>().as_ptr(), 0)
         .ok_or(DecodeFailed)?;
-    scopeguard::defer! { release(dec.as_ptr()); }
+    let _dec_release = ComRelease(dec.as_ptr());
 
     let frame = dec.get_frame(0).ok_or(DecodeFailed)?;
-    scopeguard::defer! { release(frame.as_ptr()); }
+    let _frame_release = ComRelease(frame.as_ptr());
 
     let mut w: u32 = 0;
     let mut h: u32 = 0;
@@ -131,7 +131,7 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, BackendE
         return Err(DecodeFailed);
     }
     let conv = ComPtr::new(conv).ok_or(DecodeFailed)?;
-    scopeguard::defer! { release(conv.as_ptr()); }
+    let _conv_release = ComRelease(conv.as_ptr());
 
     // Compute stride/size in u64 first: with `maxPixels` raised past ~1.07B,
     // `w * 4` can wrap u32 (0x4000_0001×4 → 4); the checked cast below is a
@@ -191,22 +191,22 @@ pub(crate) fn encode(
         return Err(BackendUnavailable);
     }
     let stream = ComPtr::new(stream).ok_or(BackendUnavailable)?;
-    scopeguard::defer! { release(stream.as_ptr()); }
+    let _stream_release = ComRelease(stream.as_ptr());
 
     // WINCODEC_ERR_COMPONENTNOTFOUND when the HEIF/AV1 store extension isn't
     // installed → BackendUnavailable so codecs.encode() falls through to
     // UnsupportedOnPlatform instead of a generic "encode failed".
     let guid = container_guid(opts.format).ok_or(BackendUnavailable)?;
     let enc = f.create_encoder(guid).ok_or(BackendUnavailable)?;
-    scopeguard::defer! { release(enc.as_ptr()); }
+    let _enc_release = ComRelease(enc.as_ptr());
     // WICBitmapEncoderNoCache = 2.
     if enc.initialize(stream.as_ptr(), 2) < 0 {
         return Err(EncodeFailed);
     }
 
     let (frame, props) = enc.create_new_frame().ok_or(EncodeFailed)?;
-    scopeguard::defer! { release(frame.as_ptr()); }
-    scopeguard::defer! { release(props); }
+    let _frame_release = ComRelease(frame.as_ptr());
+    let _props_release = ComRelease(props);
 
     // Thread `quality` and the HEIF sub-codec through the IPropertyBag2 the
     // encoder hands back. Both go via the C++ shim so the SDK's own VARIANT/
@@ -278,7 +278,7 @@ pub(crate) fn encode(
                 rgba.as_ptr(),
             )
             .ok_or(EncodeFailed)?;
-        scopeguard::defer! { release(src.as_ptr()); }
+        let _src_release = ComRelease(src.as_ptr());
         let convert_fn = wicConvertBitmapSource
             .get()
             .copied()
@@ -289,7 +289,7 @@ pub(crate) fn encode(
             return Err(EncodeFailed);
         }
         let conv = ComPtr::new(conv).ok_or(EncodeFailed)?;
-        scopeguard::defer! { release(conv.as_ptr()); }
+        let _conv_release = ComRelease(conv.as_ptr());
         if frame.write_source(conv, ptr::null()) < 0 {
             return Err(EncodeFailed);
         }
@@ -413,13 +413,24 @@ fn release<T>(p: *mut T) {
     }
 }
 
+/// RAII release for a COM interface pointer — calls [`release`] on drop.
+/// Wraps `*mut T` (not `NonNull`) because `release` already null-checks, and
+/// one call site (`props` from `CreateNewFrame`) is legitimately nullable.
+struct ComRelease<T>(*mut T);
+impl<T> Drop for ComRelease<T> {
+    #[inline]
+    fn drop(&mut self) {
+        release(self.0);
+    }
+}
+
 /// Non-null COM interface pointer. Exists solely to move the per-call-site
 /// `unsafe { ((*(*p).vt).Method)(p, ..) }` vtable dance into one place per
 /// method, so `decode`/`encode` read as straight-line safe code.
 ///
-/// Not an owning smart pointer — release is still explicit via
-/// `scopeguard::defer! { release(p.as_ptr()) }` at the call site. `Copy` so the defer-guard
-/// closure captures a copy and the handle stays usable afterwards.
+/// Not an owning smart pointer — release is via a sibling [`ComRelease`]
+/// guard at the call site. `Copy` so the handle stays usable after the guard
+/// is constructed.
 #[repr(transparent)]
 struct ComPtr<T>(ptr::NonNull<T>);
 

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -92,7 +92,6 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, BackendE
     }
 
     let stream = f.create_stream().ok_or(BackendUnavailable)?;
-    let _stream_release = ComRelease(stream.as_ptr());
     if stream.initialize_from_memory(
         bytes.as_ptr(),
         u32::try_from(bytes.len()).expect("int cast"),
@@ -103,12 +102,10 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, BackendE
 
     // WICDecodeMetadataCacheOnDemand = 0. vendor GUID null = let WIC pick.
     let dec = f
-        .create_decoder_from_stream(stream.cast::<IUnknown>().as_ptr(), 0)
+        .create_decoder_from_stream(stream.as_ptr().cast(), 0)
         .ok_or(DecodeFailed)?;
-    let _dec_release = ComRelease(dec.as_ptr());
 
     let frame = dec.get_frame(0).ok_or(DecodeFailed)?;
-    let _frame_release = ComRelease(frame.as_ptr());
 
     let mut w: u32 = 0;
     let mut h: u32 = 0;
@@ -131,7 +128,6 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, BackendE
         return Err(DecodeFailed);
     }
     let conv = ComPtr::new(conv).ok_or(DecodeFailed)?;
-    let _conv_release = ComRelease(conv.as_ptr());
 
     // Compute stride/size in u64 first: with `maxPixels` raised past ~1.07B,
     // `w * 4` can wrap u32 (0x4000_0001×4 → 4); the checked cast below is a
@@ -190,23 +186,20 @@ pub(crate) fn encode(
     if unsafe { CreateStreamOnHGlobal(ptr::null_mut(), 1, &mut stream) } < 0 {
         return Err(BackendUnavailable);
     }
-    let stream = ComPtr::new(stream).ok_or(BackendUnavailable)?;
-    let _stream_release = ComRelease(stream.as_ptr());
+    let stream = ComPtr::new(stream.cast::<IStream>()).ok_or(BackendUnavailable)?;
 
     // WINCODEC_ERR_COMPONENTNOTFOUND when the HEIF/AV1 store extension isn't
     // installed → BackendUnavailable so codecs.encode() falls through to
     // UnsupportedOnPlatform instead of a generic "encode failed".
     let guid = container_guid(opts.format).ok_or(BackendUnavailable)?;
     let enc = f.create_encoder(guid).ok_or(BackendUnavailable)?;
-    let _enc_release = ComRelease(enc.as_ptr());
     // WICBitmapEncoderNoCache = 2.
-    if enc.initialize(stream.as_ptr(), 2) < 0 {
+    if enc.initialize(stream.as_ptr().cast(), 2) < 0 {
         return Err(EncodeFailed);
     }
 
     let (frame, props) = enc.create_new_frame().ok_or(EncodeFailed)?;
-    let _frame_release = ComRelease(frame.as_ptr());
-    let _props_release = ComRelease(props);
+    let props_ptr = props.as_ref().map_or(ptr::null_mut(), ComPtr::as_ptr);
 
     // Thread `quality` and the HEIF sub-codec through the IPropertyBag2 the
     // encoder hands back. Both go via the C++ shim so the SDK's own VARIANT/
@@ -219,7 +212,7 @@ pub(crate) fn encode(
     // SAFETY: props may be null (shim must tolerate); name is static NUL-terminated UTF-16.
     let _ = unsafe {
         bun_wic_propbag_write_f32(
-            props as *mut c_void,
+            props_ptr.cast(),
             bun_core::wstr!("ImageQuality").as_ptr(),
             (opts.quality as f32) / 100.0,
         )
@@ -232,7 +225,7 @@ pub(crate) fn encode(
     // SAFETY: same as above.
     if unsafe {
         bun_wic_propbag_write_u8(
-            props as *mut c_void,
+            props_ptr.cast(),
             bun_core::wstr!("HeifCompressionMethod").as_ptr(),
             method,
         )
@@ -240,7 +233,7 @@ pub(crate) fn encode(
     {
         return Err(BackendUnavailable);
     }
-    if frame.initialize(props) < 0 {
+    if frame.initialize(props_ptr) < 0 {
         return Err(EncodeFailed);
     }
     if frame.set_size(width, height) < 0 {
@@ -278,7 +271,6 @@ pub(crate) fn encode(
                 rgba.as_ptr(),
             )
             .ok_or(EncodeFailed)?;
-        let _src_release = ComRelease(src.as_ptr());
         let convert_fn = wicConvertBitmapSource
             .get()
             .copied()
@@ -289,8 +281,7 @@ pub(crate) fn encode(
             return Err(EncodeFailed);
         }
         let conv = ComPtr::new(conv).ok_or(EncodeFailed)?;
-        let _conv_release = ComRelease(conv.as_ptr());
-        if frame.write_source(conv, ptr::null()) < 0 {
+        if frame.write_source(&conv, ptr::null()) < 0 {
             return Err(EncodeFailed);
         }
     }
@@ -308,13 +299,13 @@ pub(crate) fn encode(
     // position IS the byte count. (MSDN GetHGlobalFromStream: "use IStream::Stat
     // to obtain the actual size".)
     let mut pos: u64 = 0;
-    if stream.cast::<IStream>().seek(0, STREAM_SEEK_CUR, &mut pos) < 0 {
+    if stream.seek(0, STREAM_SEEK_CUR, &mut pos) < 0 {
         return Err(EncodeFailed);
     }
 
     let mut hg: *mut c_void = ptr::null_mut();
     // SAFETY: stream is non-null.
-    if unsafe { GetHGlobalFromStream(stream.as_ptr(), &mut hg) } < 0 || hg.is_null() {
+    if unsafe { GetHGlobalFromStream(stream.as_ptr().cast(), &mut hg) } < 0 || hg.is_null() {
         return Err(EncodeFailed);
     }
     // SAFETY: hg is non-null.
@@ -413,33 +404,16 @@ fn release<T>(p: *mut T) {
     }
 }
 
-/// Calls [`release`] on drop. `*mut` (not `NonNull`): `props` can be null.
-struct ComRelease<T>(*mut T);
-impl<T> Drop for ComRelease<T> {
-    #[inline]
-    fn drop(&mut self) {
-        release(self.0);
-    }
-}
-
-/// Non-null COM interface pointer. Exists solely to move the per-call-site
-/// `unsafe { ((*(*p).vt).Method)(p, ..) }` vtable dance into one place per
-/// method, so `decode`/`encode` read as straight-line safe code.
-///
-/// Not an owning smart pointer — release is via a sibling [`ComRelease`]
-/// guard at the call site. `Copy` so the handle stays usable after the guard
-/// is constructed.
+/// Owning non-null COM interface pointer — `Drop` calls `Release`. Also moves
+/// the per-call-site `unsafe { ((*(*p).vt).Method)(p, ..) }` vtable dance into
+/// one place per method, so `decode`/`encode` read as straight-line safe code.
 #[repr(transparent)]
 struct ComPtr<T>(ptr::NonNull<T>);
 
-// Hand-rolled instead of `#[derive]` because the derive adds an implicit
-// `T: Copy` bound, and the COM interface structs (`IWICStream`, …) are not
-// `Copy`. `NonNull<T>` is always `Copy` so the unconstrained impl is sound.
-impl<T> Copy for ComPtr<T> {}
-impl<T> Clone for ComPtr<T> {
+impl<T> Drop for ComPtr<T> {
     #[inline]
-    fn clone(&self) -> Self {
-        *self
+    fn drop(&mut self) {
+        release(self.0.as_ptr());
     }
 }
 
@@ -449,15 +423,8 @@ impl<T> ComPtr<T> {
         ptr::NonNull::new(p).map(Self)
     }
     #[inline]
-    fn as_ptr(self) -> *mut T {
+    fn as_ptr(&self) -> *mut T {
         self.0.as_ptr()
-    }
-    /// Reinterpret as a base/derived interface. Every COM interface is
-    /// vtable-prefix-compatible with its parents, so this is the moral
-    /// equivalent of a C++ `static_cast` along the inheritance chain.
-    #[inline]
-    fn cast<U>(self) -> ComPtr<U> {
-        ComPtr(self.0.cast())
     }
 }
 
@@ -471,14 +438,14 @@ impl<T> ComPtr<T> {
 
 impl ComPtr<IWICImagingFactory> {
     #[inline]
-    fn create_stream(self) -> Option<ComPtr<IWICStream>> {
+    fn create_stream(&self) -> Option<ComPtr<IWICStream>> {
         let mut out = ptr::null_mut();
         let hr = unsafe { ((*(*self.as_ptr()).vt).CreateStream)(self.as_ptr(), &mut out) };
         if hr < 0 { None } else { ComPtr::new(out) }
     }
     #[inline]
     fn create_decoder_from_stream(
-        self,
+        &self,
         stream: *mut IUnknown,
         opts: u32,
     ) -> Option<ComPtr<IWICBitmapDecoder>> {
@@ -495,7 +462,7 @@ impl ComPtr<IWICImagingFactory> {
         if hr < 0 { None } else { ComPtr::new(out) }
     }
     #[inline]
-    fn create_encoder(self, container: *const GUID) -> Option<ComPtr<IWICBitmapEncoder>> {
+    fn create_encoder(&self, container: *const GUID) -> Option<ComPtr<IWICBitmapEncoder>> {
         let mut out = ptr::null_mut();
         let hr = unsafe {
             ((*(*self.as_ptr()).vt).CreateEncoder)(self.as_ptr(), container, ptr::null(), &mut out)
@@ -504,7 +471,7 @@ impl ComPtr<IWICImagingFactory> {
     }
     #[inline]
     fn create_bitmap_from_memory(
-        self,
+        &self,
         width: u32,
         height: u32,
         fmt: *const GUID,
@@ -531,14 +498,14 @@ impl ComPtr<IWICImagingFactory> {
 
 impl ComPtr<IWICStream> {
     #[inline]
-    fn initialize_from_memory(self, buf: *const u8, len: u32) -> HRESULT {
+    fn initialize_from_memory(&self, buf: *const u8, len: u32) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).InitializeFromMemory)(self.as_ptr(), buf, len) }
     }
 }
 
 impl ComPtr<IWICBitmapDecoder> {
     #[inline]
-    fn get_frame(self, index: u32) -> Option<ComPtr<IWICBitmapSource>> {
+    fn get_frame(&self, index: u32) -> Option<ComPtr<IWICBitmapSource>> {
         let mut out = ptr::null_mut();
         let hr = unsafe { ((*(*self.as_ptr()).vt).GetFrame)(self.as_ptr(), index, &mut out) };
         if hr < 0 { None } else { ComPtr::new(out) }
@@ -547,22 +514,22 @@ impl ComPtr<IWICBitmapDecoder> {
 
 impl ComPtr<IWICBitmapSource> {
     #[inline]
-    fn get_size(self, w: &mut u32, h: &mut u32) -> HRESULT {
+    fn get_size(&self, w: &mut u32, h: &mut u32) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).GetSize)(self.as_ptr(), w, h) }
     }
     #[inline]
-    fn copy_pixels(self, rc: *const c_void, stride: u32, size: u32, out: *mut u8) -> HRESULT {
+    fn copy_pixels(&self, rc: *const c_void, stride: u32, size: u32, out: *mut u8) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).CopyPixels)(self.as_ptr(), rc, stride, size, out) }
     }
 }
 
 impl ComPtr<IWICBitmapEncoder> {
     #[inline]
-    fn initialize(self, stream: *mut IUnknown, cache: u32) -> HRESULT {
+    fn initialize(&self, stream: *mut IUnknown, cache: u32) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).Initialize)(self.as_ptr(), stream, cache) }
     }
     #[inline]
-    fn create_new_frame(self) -> Option<(ComPtr<IWICBitmapFrameEncode>, *mut IUnknown)> {
+    fn create_new_frame(&self) -> Option<(ComPtr<IWICBitmapFrameEncode>, Option<ComPtr<IUnknown>>)> {
         let mut frame = ptr::null_mut();
         let mut props = ptr::null_mut();
         let hr = unsafe {
@@ -571,44 +538,44 @@ impl ComPtr<IWICBitmapEncoder> {
         if hr < 0 {
             return None;
         }
-        ComPtr::new(frame).map(|f| (f, props))
+        ComPtr::new(frame).map(|f| (f, ComPtr::new(props)))
     }
     #[inline]
-    fn commit(self) -> HRESULT {
+    fn commit(&self) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).Commit)(self.as_ptr()) }
     }
 }
 
 impl ComPtr<IWICBitmapFrameEncode> {
     #[inline]
-    fn initialize(self, props: *mut IUnknown) -> HRESULT {
+    fn initialize(&self, props: *mut IUnknown) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).Initialize)(self.as_ptr(), props) }
     }
     #[inline]
-    fn set_size(self, w: u32, h: u32) -> HRESULT {
+    fn set_size(&self, w: u32, h: u32) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).SetSize)(self.as_ptr(), w, h) }
     }
     #[inline]
-    fn set_pixel_format(self, pf: &mut GUID) -> HRESULT {
+    fn set_pixel_format(&self, pf: &mut GUID) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).SetPixelFormat)(self.as_ptr(), pf) }
     }
     #[inline]
-    fn write_pixels(self, lines: u32, stride: u32, size: u32, buf: *const u8) -> HRESULT {
+    fn write_pixels(&self, lines: u32, stride: u32, size: u32, buf: *const u8) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).WritePixels)(self.as_ptr(), lines, stride, size, buf) }
     }
     #[inline]
-    fn write_source(self, src: ComPtr<IWICBitmapSource>, rc: *const c_void) -> HRESULT {
+    fn write_source(&self, src: &ComPtr<IWICBitmapSource>, rc: *const c_void) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).WriteSource)(self.as_ptr(), src.as_ptr(), rc) }
     }
     #[inline]
-    fn commit(self) -> HRESULT {
+    fn commit(&self) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).Commit)(self.as_ptr()) }
     }
 }
 
 impl ComPtr<IStream> {
     #[inline]
-    fn seek(self, dlib_move: i64, origin: u32, new_pos: &mut u64) -> HRESULT {
+    fn seek(&self, dlib_move: i64, origin: u32, new_pos: &mut u64) -> HRESULT {
         unsafe { ((*(*self.as_ptr()).vt).Seek)(self.as_ptr(), dlib_move, origin, new_pos) }
     }
 }
@@ -887,7 +854,10 @@ static FACTORY_PTR: core::sync::atomic::AtomicPtr<IWICImagingFactory> =
     core::sync::atomic::AtomicPtr::new(ptr::null_mut());
 static FACTORY_ONCE: Once = Once::new();
 
-fn factory() -> Result<ComPtr<IWICImagingFactory>, BackendError> {
+/// Returns a non-owning view: the factory is a process-lifetime singleton held
+/// in `FACTORY_PTR` and is never released, so the `ComPtr` is wrapped in
+/// `ManuallyDrop` to suppress the `Drop` → `Release` on the caller's handle.
+fn factory() -> Result<core::mem::ManuallyDrop<ComPtr<IWICImagingFactory>>, BackendError> {
     // COM apartment must be entered on the *calling* thread; the factory
     // itself is created once and shared (valid in the MTA).
     if !COM_INITIALISED.get() {
@@ -900,7 +870,9 @@ fn factory() -> Result<ComPtr<IWICImagingFactory>, BackendError> {
     }
     FACTORY_ONCE.call_once(load_factory);
     // FACTORY_PTR is only written inside FACTORY_ONCE; happens-before via call_once.
-    ComPtr::new(FACTORY_PTR.load(core::sync::atomic::Ordering::Relaxed)).ok_or(BackendUnavailable)
+    ComPtr::new(FACTORY_PTR.load(core::sync::atomic::Ordering::Relaxed))
+        .map(core::mem::ManuallyDrop::new)
+        .ok_or(BackendUnavailable)
 }
 
 fn load_factory() {

--- a/src/runtime/image/codec_jpeg.rs
+++ b/src/runtime/image/codec_jpeg.rs
@@ -121,18 +121,12 @@ pub fn decode(
     max_pixels: u64,
     hint: codecs::DecodeHint,
 ) -> Result<codecs::Decoded, codecs::Error> {
-    // SAFETY: FFI — tj3Init has no preconditions; returns null on failure.
-    let h = unsafe { tj3Init(1) };
-    if h.is_null() {
-        return Err(codecs::Error::OutOfMemory);
-    }
-    // SAFETY: `h` is the non-null tjhandle returned above; tj3Destroy is the
-    // documented owner-release and is called exactly once via this guard.
-    let _h_guard = scopeguard::guard(h, |h| unsafe { tj3Destroy(h) });
+    let handle = Handle::init(1).ok_or(codecs::Error::OutOfMemory)?;
+    let h = handle.as_ptr();
     // Ask libjpeg-turbo to keep the APP2/ICC_PROFILE markers so we can pull
     // the profile out after header parse. Must be set PRE-header — the
     // marker buffer is discarded if we set this after.
-    // SAFETY: `h` is a live tjhandle for the duration of `_h_guard`.
+    // SAFETY: `h` is a live tjhandle for the duration of `handle`.
     unsafe { tj3Set(h, TJPARAM_SAVEMARKERS, 2) };
     // SAFETY: `h` is live; ptr/len come from a valid `&[u8]` borrowed for the call.
     if unsafe { tj3DecompressHeader(h, bytes.as_ptr(), bytes.len()) } != 0 {
@@ -299,15 +293,9 @@ pub(crate) fn encode(
     progressive: bool,
     icc_profile: Option<&[u8]>,
 ) -> Result<codecs::Encoded, codecs::Error> {
-    // SAFETY: FFI — tj3Init has no preconditions; returns null on failure.
-    let h = unsafe { tj3Init(0) };
-    if h.is_null() {
-        return Err(codecs::Error::OutOfMemory);
-    }
-    // SAFETY: `h` is the non-null tjhandle returned above; tj3Destroy is the
-    // documented owner-release and is called exactly once via this guard.
-    let _h_guard = scopeguard::guard(h, |h| unsafe { tj3Destroy(h) });
-    // SAFETY: `h` is a live tjhandle for the duration of `_h_guard`.
+    let handle = Handle::init(0).ok_or(codecs::Error::OutOfMemory)?;
+    let h = handle.as_ptr();
+    // SAFETY: `h` is a live tjhandle for the duration of `handle`.
     unsafe {
         tj3Set(h, TJPARAM_QUALITY, c_int::from(quality.clamp(1, 100)));
         tj3Set(h, TJPARAM_SUBSAMP, TJSAMP_420);

--- a/src/runtime/image/codec_png.rs
+++ b/src/runtime/image/codec_png.rs
@@ -46,6 +46,27 @@ unsafe extern "C" {
     fn spng_set_iccp(ctx: *mut spng_ctx, iccp: *const Iccp) -> c_int;
 }
 
+/// RAII owner for a libspng context — `spng_ctx_free` on drop.
+struct Ctx(NonNull<spng_ctx>);
+impl Ctx {
+    #[inline]
+    fn new(flags: c_int) -> Option<Self> {
+        // SAFETY: spng_ctx_new is safe to call with any flags; null return = OOM.
+        NonNull::new(unsafe { spng_ctx_new(flags) }).map(Self)
+    }
+    #[inline]
+    fn as_ptr(&self) -> *mut spng_ctx {
+        self.0.as_ptr()
+    }
+}
+impl Drop for Ctx {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: ctx was returned non-null by spng_ctx_new and is freed exactly once here.
+        unsafe { spng_ctx_free(self.0.as_ptr()) };
+    }
+}
+
 #[repr(C)]
 struct Iccp {
     /// PNG's Latin-1 iCCP keyword (1-79 chars + NUL). libspng requires it
@@ -98,15 +119,8 @@ struct Trns {
 }
 
 pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::Error> {
-    // SAFETY: spng_ctx_new is safe to call with any flags; null return = OOM.
-    let ctx = unsafe { spng_ctx_new(0) };
-    if ctx.is_null() {
-        return Err(codecs::Error::OutOfMemory);
-    }
-    let _ctx_guard = scopeguard::guard(ctx, |c| {
-        // SAFETY: ctx was returned non-null by spng_ctx_new and is freed exactly once here.
-        unsafe { spng_ctx_free(c) }
-    });
+    let ctx_guard = Ctx::new(0).ok_or(codecs::Error::OutOfMemory)?;
+    let ctx = ctx_guard.as_ptr();
 
     // SAFETY: ctx is valid; bytes outlives the ctx (freed at end of scope).
     if unsafe { spng_set_png_buffer(ctx, bytes.as_ptr(), bytes.len()) } != 0 {
@@ -203,15 +217,8 @@ pub(crate) fn encode(
     level: i8,
     icc_profile: Option<&[u8]>,
 ) -> Result<codecs::Encoded, codecs::Error> {
-    // SAFETY: spng_ctx_new is safe to call; null return = OOM.
-    let ctx = unsafe { spng_ctx_new(SPNG_CTX_ENCODER) };
-    if ctx.is_null() {
-        return Err(codecs::Error::OutOfMemory);
-    }
-    let _ctx_guard = scopeguard::guard(ctx, |c| {
-        // SAFETY: ctx was returned non-null by spng_ctx_new and is freed exactly once here.
-        unsafe { spng_ctx_free(c) }
-    });
+    let ctx_guard = Ctx::new(SPNG_CTX_ENCODER).ok_or(codecs::Error::OutOfMemory)?;
+    let ctx = ctx_guard.as_ptr();
 
     // SAFETY: ctx is valid.
     let _ = unsafe { spng_set_option(ctx, SPNG_ENCODE_TO_BUFFER, 1) };
@@ -288,15 +295,8 @@ pub(crate) fn encode_indexed(
     )
     .map_err(|_| codecs::Error::OutOfMemory)?;
 
-    // SAFETY: spng_ctx_new is safe to call; null return = OOM.
-    let ctx = unsafe { spng_ctx_new(SPNG_CTX_ENCODER) };
-    if ctx.is_null() {
-        return Err(codecs::Error::OutOfMemory);
-    }
-    let _ctx_guard = scopeguard::guard(ctx, |c| {
-        // SAFETY: ctx was returned non-null by spng_ctx_new and is freed exactly once here.
-        unsafe { spng_ctx_free(c) }
-    });
+    let ctx_guard = Ctx::new(SPNG_CTX_ENCODER).ok_or(codecs::Error::OutOfMemory)?;
+    let ctx = ctx_guard.as_ptr();
 
     // SAFETY: ctx is valid.
     let _ = unsafe { spng_set_option(ctx, SPNG_ENCODE_TO_BUFFER, 1) };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2019,7 +2019,7 @@ mod _async_tasks {
                 }
                 Ok(fd_) => fd_,
             };
-            let _close = sys::CloseOnDrop::new(fd);
+            let file = sys::File::from_fd(fd);
 
             #[cfg(windows)]
             let mut buf = OSPathBuffer::uninit();
@@ -2059,9 +2059,9 @@ mod _async_tasks {
             // const-generic path type on `U8` and let the Windows branch (gated
             // above) handle the wide path.
             #[cfg(windows)]
-            let mut iterator = DirIterator::iterate::<true>(fd);
+            let mut iterator = DirIterator::iterate::<true>(file.fd());
             #[cfg(not(windows))]
-            let mut iterator = DirIterator::iterate::<false>(fd);
+            let mut iterator = DirIterator::iterate::<false>(file.fd());
             let mut entry = iterator.next();
             loop {
                 let current = match entry {
@@ -4765,9 +4765,9 @@ impl NodeFS {
             PathOrFileDescriptor::Path(path_) => {
                 let path = path_.slice_z(&mut self.sync_error_buf);
                 let fd = Syscall::open(path, FileSystemFlags::A.as_int(), args.mode)?;
-                let _close = sys::CloseOnDrop::new(fd);
+                let file = sys::File::from_fd(fd);
                 while !data.is_empty() {
-                    let written = Syscall::write(fd, data)?;
+                    let written = Syscall::write(file.fd(), data)?;
                     data = &data[written..];
                 }
                 Ok(())
@@ -5031,7 +5031,7 @@ impl NodeFS {
                         Ok(result) => result,
                         Err(err) => return Err(err.with_path(args.src.slice())),
                     };
-                    let _close_src = sys::CloseOnDrop::new(src_fd);
+                    let src_file = sys::File::from_fd(src_fd);
 
                     let mut flags: i32 = sys::O::CREAT | sys::O::WRONLY;
                     // VERIFY-FIX(round1): was `usize` then passed as `&mut (wrote as u64)` —
@@ -5053,7 +5053,7 @@ impl NodeFS {
                     let result = Self::copy_file_using_read_write_loop(
                         src,
                         dest,
-                        src_fd,
+                        src_file.fd(),
                         dest_fd,
                         stat_.st_size.max(0) as usize,
                         &mut wrote,
@@ -5099,9 +5099,9 @@ impl NodeFS {
                 Ok(result) => result,
                 Err(err) => return Err(err.with_path(args.src.slice())),
             };
-            let _close_src = sys::CloseOnDrop::new(src_fd);
+            let src_file = sys::File::from_fd(src_fd);
 
-            let stat_ = match Syscall::fstat(src_fd) {
+            let stat_ = match Syscall::fstat(src_file.fd()) {
                 Ok(result) => result,
                 Err(err) => return Err(err),
             };
@@ -5121,12 +5121,12 @@ impl NodeFS {
                 Ok(result) => result,
                 Err(err) => return Err(err),
             };
-            let _close_dest = sys::CloseOnDrop::new(dest_fd);
+            let dest_file = sys::File::from_fd(dest_fd);
 
             // Don't O_TRUNC at open: if src and dest resolve to the same
             // inode, that would zero the file before the first read. Match
             // Node by checking inodes after both are open and refusing.
-            if let Ok(dst_stat) = Syscall::fstat(dest_fd) {
+            if let Ok(dst_stat) = Syscall::fstat(dest_file.fd()) {
                 if stat_.st_ino == dst_stat.st_ino && stat_.st_dev == dst_stat.st_dev {
                     return Err(sys::Error {
                         errno: SystemErrno::EINVAL as _,
@@ -5136,7 +5136,7 @@ impl NodeFS {
                     });
                 }
             }
-            let _ = Syscall::ftruncate(dest_fd, 0);
+            let _ = Syscall::ftruncate(dest_file.fd(), 0);
 
             // FreeBSD 13+ has copy_file_range(2). Try the kernel-side copy
             // first; fall back to read/write on cross-device or unsupported
@@ -5148,9 +5148,9 @@ impl NodeFS {
                 // break mid-loop.
                 let rc: isize = unsafe {
                     sys::freebsd::copy_file_range(
-                        src_fd.native(),
+                        src_file.fd().native(),
                         core::ptr::null_mut(),
-                        dest_fd.native(),
+                        dest_file.fd().native(),
                         core::ptr::null_mut(),
                         (i32::MAX - 1) as usize,
                         0,
@@ -5159,7 +5159,7 @@ impl NodeFS {
                 match sys::get_errno(rc) {
                     E::SUCCESS => {
                         if rc == 0 {
-                            let _ = Syscall::fchmod(dest_fd, stat_.st_mode as Mode);
+                            let _ = Syscall::fchmod(dest_file.fd(), stat_.st_mode as Mode);
                             return Ok(());
                         }
                     }
@@ -5180,15 +5180,15 @@ impl NodeFS {
             if let Err(err) = Self::copy_file_using_read_write_loop(
                 src,
                 dest,
-                src_fd,
-                dest_fd,
+                src_file.fd(),
+                dest_file.fd(),
                 stat_.st_size.max(0) as usize,
                 &mut wrote,
             ) {
                 let _ = sys::unlink(dest);
                 return Err(err);
             }
-            let _ = Syscall::fchmod(dest_fd, stat_.st_mode as Mode);
+            let _ = Syscall::fchmod(dest_file.fd(), stat_.st_mode as Mode);
             return Ok(());
         }
 
@@ -5200,9 +5200,9 @@ impl NodeFS {
             let dest = args.dest.slice_z(&mut dest_buf);
 
             let src_fd = Syscall::open(src, sys::O::RDONLY, 0o644)?;
-            let _close_src = sys::CloseOnDrop::new(src_fd);
+            let src_file = sys::File::from_fd(src_fd);
 
-            let stat_ = Syscall::fstat(src_fd)?;
+            let stat_ = Syscall::fstat(src_file.fd())?;
 
             if !sys::S::ISREG(stat_.st_mode as u32) {
                 return Err(sys::Error {
@@ -5231,7 +5231,7 @@ impl NodeFS {
             // https://manpages.debian.org/testing/manpages-dev/ioctl_ficlone.2.en.html
             if args.mode.is_force_clone() {
                 if let Some(err) = Maybe::<ret::CopyFile>::errno_sys_p(
-                    sys::linux::ioctl_ficlone(dest_fd, src_fd),
+                    sys::linux::ioctl_ficlone(dest_fd, src_file.fd()),
                     sys::Tag::ioctl_ficlone,
                     dest,
                 ) {
@@ -5247,7 +5247,7 @@ impl NodeFS {
 
             // If we know it's a regular file and ioctl_ficlone is available, attempt to use it.
             if sys::S::ISREG(stat_.st_mode as u32) && sys::copy_file::can_use_ioctl_ficlone() {
-                let rc = sys::linux::ioctl_ficlone(dest_fd, src_fd);
+                let rc = sys::linux::ioctl_ficlone(dest_fd, src_file.fd());
                 if rc == 0 {
                     let _ = Syscall::fchmod(dest_fd, stat_.st_mode as u32);
                     dest_fd.close();
@@ -5273,7 +5273,12 @@ impl NodeFS {
             if !sys::copy_file::can_use_copy_file_range_syscall() {
                 let mut w = wrote.get();
                 let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(
-                    src, dest, src_fd, dest_fd, size, &mut w,
+                    src,
+                    dest,
+                    src_file.fd(),
+                    dest_fd,
+                    size,
+                    &mut w,
                 );
                 wrote.set(w);
                 return r;
@@ -5287,7 +5292,7 @@ impl NodeFS {
                     // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
                     let written = unsafe {
                         sys::linux::copy_file_range(
-                            src_fd.native(),
+                            src_file.fd().native(),
                             &raw mut off_in_copy,
                             dest_fd.native(),
                             &raw mut off_out_copy,
@@ -5307,7 +5312,7 @@ impl NodeFS {
                                     sys::copy_file::disable_copy_file_range_syscall();
                                 }
                                 let mut w = wrote.get();
-                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_fd, dest_fd, size, &mut w);
+                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_file.fd(), dest_fd, size, &mut w);
                                 wrote.set(w);
                                 return r;
                             }
@@ -5325,7 +5330,7 @@ impl NodeFS {
                     // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
                     let written = unsafe {
                         sys::linux::copy_file_range(
-                            src_fd.native(),
+                            src_file.fd().native(),
                             &raw mut off_in_copy,
                             dest_fd.native(),
                             &raw mut off_out_copy,
@@ -5345,7 +5350,7 @@ impl NodeFS {
                                     sys::copy_file::disable_copy_file_range_syscall();
                                 }
                                 let mut w = wrote.get();
-                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_fd, dest_fd, size, &mut w);
+                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_file.fd(), dest_fd, size, &mut w);
                                 wrote.set(w);
                                 return r;
                             }
@@ -6968,10 +6973,10 @@ impl NodeFS {
             Err(err) => return Err(err.with_path(args.path.slice())),
             Ok(fd_) => fd_,
         };
-        let _close = sys::CloseOnDrop::new(fd);
+        let file = sys::File::from_fd(fd);
 
         let mut entries: Vec<T> = Vec::new();
-        match Self::readdir_with_entries::<T>(args, fd, path, &mut entries) {
+        match Self::readdir_with_entries::<T>(args, file.fd(), path, &mut entries) {
             Err(err) => Err(err),
             Ok(()) => Ok(T::into_readdir(entries)),
         }
@@ -7672,9 +7677,9 @@ impl NodeFS {
                 Err(err) => return Err(err.with_path(path)),
                 Ok(fd_) => fd_,
             };
-            let _close = sys::CloseOnDrop::new(fd);
+            let file = sys::File::from_fd(fd);
 
-            let buf = match Syscall::get_fd_path(fd, &mut outbuf) {
+            let buf = match Syscall::get_fd_path(file.fd(), &mut outbuf) {
                 Err(err) => return Err(err.with_path(path)),
                 Ok(buf_) => buf_,
             };
@@ -8000,8 +8005,8 @@ impl NodeFS {
                     ..Default::default()
                 });
             };
-            let _close = sys::CloseOnDrop::new(fd);
-            return match Syscall::ftruncate(fd, len_i64) {
+            let file = sys::File::from_fd(fd);
+            return match Syscall::ftruncate(file.fd(), len_i64) {
                 Ok(r) => Ok(r),
                 Err(err) => Err(err.with_path_and_syscall(path.slice(), sys::Tag::truncate)),
             };
@@ -8346,7 +8351,7 @@ impl NodeFS {
             Err(err) => return Err(err.with_path(self.os_path_into_sync_error_buf(&src_buf[..sd]))),
             Ok(fd_) => fd_,
         };
-        let _close = sys::CloseOnDrop::new(fd);
+        let file = sys::File::from_fd(fd);
 
         match self.mkdir_recursive_os_path(dest, args::Mkdir::DEFAULT_MODE, false) {
             Err(err) => return Err(err),
@@ -8356,9 +8361,9 @@ impl NodeFS {
         // The OSPathBuffer copy below is generic over `OSPathChar`, so on Windows
         // this needs the wide (u16) iterator; the u8 path is correct for POSIX.
         #[cfg(windows)]
-        let mut iterator = DirIterator::WrappedIteratorW::init(fd);
+        let mut iterator = DirIterator::WrappedIteratorW::init(file.fd());
         #[cfg(not(windows))]
-        let mut iterator = DirIterator::WrappedIterator::init(fd);
+        let mut iterator = DirIterator::WrappedIterator::init(file.fd());
 
         loop {
             let current = match iterator.next() {
@@ -8601,7 +8606,7 @@ impl NodeFS {
                         return Err(err.with_path(&self.sync_error_buf[..src.len()]));
                     }
                 };
-                let _close_src = sys::CloseOnDrop::new(src_fd);
+                let src_file = sys::File::from_fd(src_fd);
 
                 let mut flags: i32 = sys::O::CREAT | sys::O::WRONLY;
                 let wrote: core::cell::Cell<u64> = core::cell::Cell::new(0);
@@ -8622,7 +8627,7 @@ impl NodeFS {
                 let r = Self::copy_file_using_read_write_loop(
                     src,
                     dest,
-                    src_fd,
+                    src_file.fd(),
                     dest_fd,
                     stat_.st_size.max(0) as usize,
                     &mut w,
@@ -8682,11 +8687,11 @@ impl NodeFS {
                     return Err(err);
                 }
             };
-            let _close_src = sys::CloseOnDrop::new(src_fd);
+            let src_file = sys::File::from_fd(src_fd);
 
-            let stat_ = match Syscall::fstat(src_fd) {
+            let stat_ = match Syscall::fstat(src_file.fd()) {
                 Ok(result) => result,
-                Err(err) => return Err(err.with_fd(src_fd)),
+                Err(err) => return Err(err.with_fd(src_file.fd())),
             };
 
             if !sys::S::ISREG(stat_.st_mode as u32) {
@@ -8708,7 +8713,7 @@ impl NodeFS {
             let mut size: usize = stat_.st_size.max(0) as usize;
 
             if sys::S::ISREG(stat_.st_mode as u32) && sys::copy_file::can_use_ioctl_ficlone() {
-                let rc = sys::linux::ioctl_ficlone(dest_fd, src_fd);
+                let rc = sys::linux::ioctl_ficlone(dest_fd, src_file.fd());
                 if rc == 0 {
                     let _ = Syscall::fchmod(dest_fd, stat_.st_mode as u32);
                     dest_fd.close();
@@ -8732,7 +8737,12 @@ impl NodeFS {
             if !sys::copy_file::can_use_copy_file_range_syscall() {
                 let mut w = wrote.get();
                 let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(
-                    src, dest, src_fd, dest_fd, size, &mut w,
+                    src,
+                    dest,
+                    src_file.fd(),
+                    dest_fd,
+                    size,
+                    &mut w,
                 );
                 wrote.set(w);
                 return r;
@@ -8746,7 +8756,7 @@ impl NodeFS {
                     // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
                     let written = unsafe {
                         sys::linux::copy_file_range(
-                            src_fd.native(),
+                            src_file.fd().native(),
                             &raw mut off_in_copy,
                             dest_fd.native(),
                             &raw mut off_out_copy,
@@ -8769,7 +8779,7 @@ impl NodeFS {
                                     sys::copy_file::disable_copy_file_range_syscall();
                                 }
                                 let mut w = wrote.get();
-                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_fd, dest_fd, size, &mut w);
+                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_file.fd(), dest_fd, size, &mut w);
                                 wrote.set(w);
                                 return r;
                             }
@@ -8789,7 +8799,7 @@ impl NodeFS {
                     // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
                     let written = unsafe {
                         sys::linux::copy_file_range(
-                            src_fd.native(),
+                            src_file.fd().native(),
                             &raw mut off_in_copy,
                             dest_fd.native(),
                             &raw mut off_out_copy,
@@ -8812,7 +8822,7 @@ impl NodeFS {
                                     sys::copy_file::disable_copy_file_range_syscall();
                                 }
                                 let mut w = wrote.get();
-                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_fd, dest_fd, size, &mut w);
+                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_file.fd(), dest_fd, size, &mut w);
                                 wrote.set(w);
                                 return r;
                             }
@@ -8854,11 +8864,11 @@ impl NodeFS {
                     return Err(err);
                 }
             };
-            let _close_src = sys::CloseOnDrop::new(src_fd);
+            let src_file = sys::File::from_fd(src_fd);
 
-            let stat_ = match Syscall::fstat(src_fd) {
+            let stat_ = match Syscall::fstat(src_file.fd()) {
                 Ok(result) => result,
-                Err(err) => return Err(err.with_fd(src_fd)),
+                Err(err) => return Err(err.with_fd(src_file.fd())),
             };
             if !sys::S::ISREG(stat_.st_mode as u32) {
                 return Err(sys::Error {
@@ -8918,7 +8928,7 @@ impl NodeFS {
                 // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
                 let rc: isize = unsafe {
                     sys::freebsd::copy_file_range(
-                        src_fd.native(),
+                        src_file.fd().native(),
                         &mut off_in,
                         dest_fd.native(),
                         &mut off_out,
@@ -8951,7 +8961,14 @@ impl NodeFS {
             }
 
             let mut w = wrote.get();
-            let r = Self::copy_file_using_read_write_loop(src, dest, src_fd, dest_fd, size, &mut w);
+            let r = Self::copy_file_using_read_write_loop(
+                src,
+                dest,
+                src_file.fd(),
+                dest_fd,
+                size,
+                &mut w,
+            );
             wrote.set(w);
             return r;
         }
@@ -9048,11 +9065,11 @@ impl NodeFS {
                     Err(err) => return Err(err),
                     Ok(fd) => fd,
                 };
-                let _close = sys::CloseOnDrop::new(handle);
+                let file = sys::File::from_fd(handle);
                 let mut wbuf = paths::os_path_buffer_pool::get();
                 let len = unsafe {
                     windows::GetFinalPathNameByHandleW(
-                        handle.native(),
+                        file.fd().native(),
                         wbuf.as_mut_ptr(),
                         wbuf.len() as u32,
                         0,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2019,7 +2019,7 @@ mod _async_tasks {
                 }
                 Ok(fd_) => fd_,
             };
-            let _close = scopeguard::guard(fd, |fd| fd.close());
+            let _close = sys::CloseOnDrop::new(fd);
 
             #[cfg(windows)]
             let mut buf = OSPathBuffer::uninit();
@@ -3232,7 +3232,7 @@ pub mod args {
                     if next_val.is_string() {
                         arguments.eat();
                         let str = next_val.to_bun_string(ctx)?;
-                        let str = scopeguard::guard(str, |s| s.deref());
+                        let str = bun_core::OwnedString::new(str);
                         if str.eql_comptime("dir") {
                             break 'link_type SymlinkLinkType::Dir;
                         }
@@ -4765,7 +4765,7 @@ impl NodeFS {
             PathOrFileDescriptor::Path(path_) => {
                 let path = path_.slice_z(&mut self.sync_error_buf);
                 let fd = Syscall::open(path, FileSystemFlags::A.as_int(), args.mode)?;
-                let _close = scopeguard::guard(fd, |fd| fd.close());
+                let _close = sys::CloseOnDrop::new(fd);
                 while !data.is_empty() {
                     let written = Syscall::write(fd, data)?;
                     data = &data[written..];
@@ -5031,7 +5031,7 @@ impl NodeFS {
                         Ok(result) => result,
                         Err(err) => return Err(err.with_path(args.src.slice())),
                     };
-                    let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
+                    let _close_src = sys::CloseOnDrop::new(src_fd);
 
                     let mut flags: i32 = sys::O::CREAT | sys::O::WRONLY;
                     // VERIFY-FIX(round1): was `usize` then passed as `&mut (wrote as u64)` —
@@ -5099,7 +5099,7 @@ impl NodeFS {
                 Ok(result) => result,
                 Err(err) => return Err(err.with_path(args.src.slice())),
             };
-            let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
+            let _close_src = sys::CloseOnDrop::new(src_fd);
 
             let stat_ = match Syscall::fstat(src_fd) {
                 Ok(result) => result,
@@ -5121,7 +5121,7 @@ impl NodeFS {
                 Ok(result) => result,
                 Err(err) => return Err(err),
             };
-            let _close_dest = scopeguard::guard(dest_fd, |fd| fd.close());
+            let _close_dest = sys::CloseOnDrop::new(dest_fd);
 
             // Don't O_TRUNC at open: if src and dest resolve to the same
             // inode, that would zero the file before the first read. Match
@@ -5200,7 +5200,7 @@ impl NodeFS {
             let dest = args.dest.slice_z(&mut dest_buf);
 
             let src_fd = Syscall::open(src, sys::O::RDONLY, 0o644)?;
-            let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
+            let _close_src = sys::CloseOnDrop::new(src_fd);
 
             let stat_ = Syscall::fstat(src_fd)?;
 
@@ -6968,7 +6968,7 @@ impl NodeFS {
             Err(err) => return Err(err.with_path(args.path.slice())),
             Ok(fd_) => fd_,
         };
-        let _close = scopeguard::guard(fd, |fd| fd.close());
+        let _close = sys::CloseOnDrop::new(fd);
 
         let mut entries: Vec<T> = Vec::new();
         match Self::readdir_with_entries::<T>(args, fd, path, &mut entries) {
@@ -7672,7 +7672,7 @@ impl NodeFS {
                 Err(err) => return Err(err.with_path(path)),
                 Ok(fd_) => fd_,
             };
-            let _close = scopeguard::guard(fd, |fd| fd.close());
+            let _close = sys::CloseOnDrop::new(fd);
 
             let buf = match Syscall::get_fd_path(fd, &mut outbuf) {
                 Err(err) => return Err(err.with_path(path)),
@@ -8000,7 +8000,7 @@ impl NodeFS {
                     ..Default::default()
                 });
             };
-            let _close = scopeguard::guard(fd, |fd| fd.close());
+            let _close = sys::CloseOnDrop::new(fd);
             return match Syscall::ftruncate(fd, len_i64) {
                 Ok(r) => Ok(r),
                 Err(err) => Err(err.with_path_and_syscall(path.slice(), sys::Tag::truncate)),
@@ -8346,7 +8346,7 @@ impl NodeFS {
             Err(err) => return Err(err.with_path(self.os_path_into_sync_error_buf(&src_buf[..sd]))),
             Ok(fd_) => fd_,
         };
-        let _close = scopeguard::guard(fd, |fd| fd.close());
+        let _close = sys::CloseOnDrop::new(fd);
 
         match self.mkdir_recursive_os_path(dest, args::Mkdir::DEFAULT_MODE, false) {
             Err(err) => return Err(err),
@@ -8601,7 +8601,7 @@ impl NodeFS {
                         return Err(err.with_path(&self.sync_error_buf[..src.len()]));
                     }
                 };
-                let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
+                let _close_src = sys::CloseOnDrop::new(src_fd);
 
                 let mut flags: i32 = sys::O::CREAT | sys::O::WRONLY;
                 let wrote: core::cell::Cell<u64> = core::cell::Cell::new(0);
@@ -8682,7 +8682,7 @@ impl NodeFS {
                     return Err(err);
                 }
             };
-            let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
+            let _close_src = sys::CloseOnDrop::new(src_fd);
 
             let stat_ = match Syscall::fstat(src_fd) {
                 Ok(result) => result,
@@ -8854,7 +8854,7 @@ impl NodeFS {
                     return Err(err);
                 }
             };
-            let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
+            let _close_src = sys::CloseOnDrop::new(src_fd);
 
             let stat_ = match Syscall::fstat(src_fd) {
                 Ok(result) => result,
@@ -9048,7 +9048,7 @@ impl NodeFS {
                     Err(err) => return Err(err),
                     Ok(fd) => fd,
                 };
-                let _close = scopeguard::guard(handle, |fd| fd.close());
+                let _close = sys::CloseOnDrop::new(handle);
                 let mut wbuf = paths::os_path_buffer_pool::get();
                 let len = unsafe {
                     windows::GetFinalPathNameByHandleW(

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -1579,8 +1579,7 @@ mod _impl {
 
         let result = JSValue::create_empty_object(global_this, 5);
 
-        let home = homedir(global_this)?;
-        let home = scopeguard::guard(home, |h| h.deref());
+        let home = bun_core::OwnedString::new(homedir(global_this)?);
 
         result.put(global_this, b"homedir", home.to_js(global_this)?);
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -336,8 +336,7 @@ impl StringOrBuffer {
             return Ok(bytes.to_vec());
         }
 
-        let str = bun_core::String::from_js(value, global_object)?;
-        scopeguard::defer! { str.deref(); }
+        let str = bun_core::OwnedString::new(bun_core::String::from_js(value, global_object)?);
 
         let result = str.to_owned_slice();
         global_object.vm().report_extra_memory(result.len());

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2379,7 +2379,7 @@ where
         if let Some(resp) = self.resp.take() {
             if self.flags.request_body_paused() {
                 self.flags.set_request_body_paused(false);
-                resp.resume_();
+                resp.resume();
             }
             if self.flags.is_waiting_for_request_body() {
                 self.flags.set_is_waiting_for_request_body(false);
@@ -4123,7 +4123,7 @@ where
             return;
         }
         if let Some(resp) = self.resp {
-            resp.resume_();
+            resp.resume();
         }
     }
 
@@ -4179,7 +4179,7 @@ where
                 }
             }
             if let Some(resp) = (*this).resp {
-                resp.resume_();
+                resp.resume();
             }
         }
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2629,10 +2629,7 @@ where
     pub fn get_address(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
         match &self.config.address {
             server_config::Address::Unix(unix) => {
-                let value = BunString::clone_utf8(unix.as_bytes());
-                // Must release the cloned ref even
-                // on the `to_js` error path.
-                let value = scopeguard::guard(value, |v| v.deref());
+                let value = bun_core::OwnedString::new(BunString::clone_utf8(unix.as_bytes()));
                 value.to_js(global)
             }
             server_config::Address::Tcp { port: tcp_port, .. } => {

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 
 use bun_core::{ZBox, ZStr};
 use bun_paths::resolve_path::{self, Platform, platform};
-use bun_sys::{E, FdExt, dir_iterator};
+use bun_sys::{E, dir_iterator};
 
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, IoKind, Kind};
@@ -1048,11 +1048,7 @@ impl ShellRmTask {
 
         // On posix we can close the fd whenever, but on Windows we need to
         // close it BEFORE we delete.
-        let mut _close_fd = scopeguard::guard(Some(fd), |fd| {
-            if let Some(fd) = fd {
-                fd.close();
-            }
-        });
+        let mut _close_fd = Some(bun_sys::CloseOnDrop::new(fd));
 
         if self.error_signal().load(Ordering::SeqCst) {
             return Ok(());
@@ -1143,8 +1139,8 @@ impl ShellRmTask {
                 // take the counter to 0 and drive
                 // `delete_after_waiting_for_children`; nothing after this
                 // may dereference `dir_task`. The directory fd is closed by
-                // the `close_fd` scopeguard on return — that touches only a
-                // stack local, not `dir_task`.
+                // `_close_fd` on return — that touches only a stack local,
+                // not `dir_task`.
                 return Ok(());
             }
             // Every child already released its count (each saw the counter
@@ -1163,9 +1159,7 @@ impl ShellRmTask {
         #[cfg(windows)]
         {
             // Close BEFORE deleting on Windows.
-            if let Some(f) = _close_fd.take() {
-                f.close();
-            }
+            drop(_close_fd.take());
         }
 
         match bun_sys::unlinkat_with_flags(self.cwd, path, bun_sys::AT_REMOVEDIR) {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -767,7 +767,7 @@ impl BunTest {
         // so scope-exit drop is a silent no-op. Decrement the intrusive count explicitly so
         // (a) RefData::destructor frees the box + Weak<BunTest>, and (b) a paired done() callback
         // observes has_one_ref()==true on its turn instead of hanging.
-        let refdata = scopeguard::guard(refdata, |r: RefDataPtr| r.deref());
+        let refdata = RefDataGuard(refdata);
         let has_one_ref = refdata.has_one_ref();
         let Some(this_strong) = refdata.buntest_weak.upgrade() else {
             bun_core::scoped_log!(bun_test_group, "bunTestThenOrCatch -> the BunTest is no longer active");
@@ -843,7 +843,7 @@ impl BunTest {
         // RefPtr<T> currently has NO Drop impl, so decrement the
         // intrusive count explicitly at scope exit. Without this the
         // paired promise then/catch path never sees has_one_ref()==true and the RefData leaks.
-        let ref_in = scopeguard::guard(ref_in, |r: RefDataPtr| r.deref());
+        let ref_in = RefDataGuard(ref_in);
 
         // dupe the ref and enqueue a task to call the done callback.
         // this makes it so if you do something else after calling done(), the next test doesn't start running until the next tick.
@@ -1534,6 +1534,25 @@ impl RefData {
     }
     pub fn bun_test(&self) -> Option<BunTestPtr> {
         self.buntest_weak.upgrade()
+    }
+}
+
+/// RAII owner of a [`RefDataPtr`] that calls `.deref()` on drop. `RefPtr<T>`
+/// has no `Drop` impl (see `src/ptr/ref_count.rs`), so without this the
+/// intrusive count is never released and the paired then/done-callback path
+/// never observes `has_one_ref() == true`.
+struct RefDataGuard(RefDataPtr);
+impl core::ops::Deref for RefDataGuard {
+    type Target = RefData;
+    #[inline]
+    fn deref(&self) -> &RefData {
+        &self.0
+    }
+}
+impl Drop for RefDataGuard {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.deref();
     }
 }
 

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1537,10 +1537,7 @@ impl RefData {
     }
 }
 
-/// RAII owner of a [`RefDataPtr`] that calls `.deref()` on drop. `RefPtr<T>`
-/// has no `Drop` impl (see `src/ptr/ref_count.rs`), so without this the
-/// intrusive count is never released and the paired then/done-callback path
-/// never observes `has_one_ref() == true`.
+/// Owns a [`RefDataPtr`] and `.deref()`s it on drop (`RefPtr<T>` itself has no `Drop`).
 struct RefDataGuard(RefDataPtr);
 impl core::ops::Deref for RefDataGuard {
     type Target = RefData;

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -767,7 +767,7 @@ impl Expect {
     ) -> JsResult<JSValue> {
         // The guard owns the `&Self` and calls
         // post_match on drop so it runs on every exit path.
-        let this = scopeguard::guard(self, |t| t.post_match(global_this));
+        let this = self.post_match_guard(global_this);
 
         let arguments = call_frame.arguments();
 
@@ -813,7 +813,7 @@ impl Expect {
     ) -> JsResult<JSValue> {
         // The guard owns the `&Self` borrow
         // so `post_match` runs on every exit.
-        let this = scopeguard::guard(self, |t| t.post_match(global_this));
+        let this = self.post_match_guard(global_this);
 
         let arguments = call_frame.arguments();
 
@@ -1739,10 +1739,9 @@ impl Expect {
 
     /// Shared front-matter for `expect(received).toX(...)` matchers.
     ///
-    /// Composes the four lines every hand-ported matcher repeats — currently
-    /// stamped out in **four** different shapes (scopeguard-rebind,
-    /// scopeguard-side-binding, inner-closure-then-`post_match`, and *missing
-    /// entirely* in `toContainAllValues` / `toBeArrayOfSize`). Third member of
+    /// Composes the four lines every hand-ported matcher repeats — the
+    /// [`PostMatchGuard`] rebind, `get_value`, `increment_expect_call_counter`,
+    /// and the `not` snapshot. Third member of
     /// the matcher-scaffold family alongside [`Self::run_unary_predicate`] and
     /// [`Self::mock_prologue`], for matchers that need the received value but
     /// are NOT a pure unary predicate and NOT a mock-function matcher.

--- a/src/runtime/test_runner/expect/toBeArrayOfSize.rs
+++ b/src/runtime/test_runner/expect/toBeArrayOfSize.rs
@@ -10,8 +10,6 @@ pub(crate) fn to_be_array_of_size(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // scopeguard::defer! would hold &mut *this for the whole fn, so use the
-    // post-match guard instead.
     let this = this.post_match_guard(global);
 
     let this_value = frame.this();

--- a/src/runtime/test_runner/expect/toHaveProperty.rs
+++ b/src/runtime/test_runner/expect/toHaveProperty.rs
@@ -11,7 +11,7 @@ pub(crate) fn to_have_property(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     // `defer this.postMatch(globalThis)` — guard owns `this` and calls post_match on drop.
-    let this = scopeguard::guard(this, |this| this.post_match(global));
+    let this = this.post_match_guard(global);
 
     let this_value = frame.this();
     let arguments = frame.arguments();

--- a/src/runtime/test_runner/expect/toHaveProperty.rs
+++ b/src/runtime/test_runner/expect/toHaveProperty.rs
@@ -10,7 +10,6 @@ pub(crate) fn to_have_property(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // `defer this.postMatch(globalThis)` — guard owns `this` and calls post_match on drop.
     let this = this.post_match_guard(global);
 
     let this_value = frame.this();

--- a/src/runtime/test_runner/expect/toMatchInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchInlineSnapshot.rs
@@ -9,8 +9,6 @@ pub(crate) fn to_match_inline_snapshot(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // `defer this.postMatch(globalThis)` — guard holds `&Expect` and runs
-    // post_match on drop (matches toThrowErrorMatchingInlineSnapshot.rs).
     let this = this.post_match_guard(global);
 
     let this_value = frame.this();

--- a/src/runtime/test_runner/expect/toMatchInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchInlineSnapshot.rs
@@ -9,10 +9,9 @@ pub(crate) fn to_match_inline_snapshot(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // `defer this.postMatch(globalThis)` — wrap `this` in a scopeguard that owns the
-    // &mut Expect and runs post_match on drop, so the body can borrow through DerefMut without
-    // overlapping with the deferred call (matches toThrowErrorMatchingInlineSnapshot.rs).
-    let this = scopeguard::guard(this, |this| this.post_match(global));
+    // `defer this.postMatch(globalThis)` — guard holds `&Expect` and runs
+    // post_match on drop (matches toThrowErrorMatchingInlineSnapshot.rs).
+    let this = this.post_match_guard(global);
 
     let this_value = frame.this();
     let arguments: &[JSValue] = frame.arguments();
@@ -86,7 +85,7 @@ pub(crate) fn to_match_inline_snapshot(
         "<green>properties<r><d>, <r>hint",
     )?;
     Expect::inline_snapshot(
-        &**this,
+        &*this,
         global,
         frame,
         value,

--- a/src/runtime/test_runner/expect/toMatchSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchSnapshot.rs
@@ -10,10 +10,9 @@ pub(crate) fn to_match_snapshot(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // reshaped for borrowck — post-match cleanup is expressed by
-    // wrapping `this` in a scopeguard so `post_match` runs on every exit path while we still
-    // deref through the guard for the body.
-    let this = scopeguard::guard(this, |this| this.post_match(global));
+    // `defer this.postMatch(globalThis)` — guard holds `&Expect`, derefs to it
+    // for the body, and runs post_match on every exit path.
+    let this = this.post_match_guard(global);
 
     let this_value = frame.this();
     let arguments: &[JSValue] = frame.arguments();
@@ -97,5 +96,5 @@ pub(crate) fn to_match_snapshot(
         "<green>properties<r><d>, <r>hint",
     )?;
 
-    Expect::snapshot(&**this, global, value, property_matchers, hint.slice(), "toMatchSnapshot")
+    Expect::snapshot(&*this, global, value, property_matchers, hint.slice(), "toMatchSnapshot")
 }

--- a/src/runtime/test_runner/expect/toMatchSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchSnapshot.rs
@@ -10,8 +10,6 @@ pub(crate) fn to_match_snapshot(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // `defer this.postMatch(globalThis)` — guard holds `&Expect`, derefs to it
-    // for the body, and runs post_match on every exit path.
     let this = this.post_match_guard(global);
 
     let this_value = frame.this();

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -16,8 +16,6 @@ pub(crate) fn to_throw(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // The guard holds the `&Expect` and runs post_match on drop so it fires on
-    // every exit path (Ok and Err alike).
     let this = this.post_match_guard(global);
 
     let this_value = frame.this();

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -16,10 +16,9 @@ pub(crate) fn to_throw(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // The scopeguard owns the &mut Expect and runs
-    // post_match on drop; the body re-borrows `this` through Deref/DerefMut so post_match
-    // runs on every exit path (Ok and Err alike).
-    let this = scopeguard::guard(this, |t| t.post_match(global));
+    // The guard holds the `&Expect` and runs post_match on drop so it fires on
+    // every exit path (Ok and Err alike).
+    let this = this.post_match_guard(global);
 
     let this_value = frame.this();
     let arguments = frame.arguments_as_array::<1>();

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
@@ -9,7 +9,6 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // The guard holds the `&Expect`, Derefs to it, and runs post_match on Drop.
     let this = this.post_match_guard(global);
 
     let this_value = frame.this();

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
@@ -9,8 +9,8 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // The guard owns the &mut, Derefs to it, and runs post_match on Drop.
-    let this = scopeguard::guard(this, |t| t.post_match(global));
+    // The guard holds the `&Expect`, Derefs to it, and runs post_match on Drop.
+    let this = this.post_match_guard(global);
 
     let this_value = frame.this();
     let arguments: &[JSValue] = frame.arguments();
@@ -79,7 +79,7 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
     };
 
     Expect::inline_snapshot(
-        &**this,
+        &*this,
         global,
         frame,
         value,

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -82,7 +82,7 @@ macro_rules! __expect_throw_dispatch {
     // base: no positional args left. `$this`/`$global` are always plain idents
     // at every call site (this/self, global/global_this); duplicating them
     // across the two colour branches is side-effect-free and avoids moving a
-    // `PostMatchGuard`/`scopeguard` before its natural scope end.
+    // `PostMatchGuard` before its natural scope end.
     (@go $this:expr, $global:expr, $sig:expr, $fmt:expr;
         bound = [$(($n:ident $v:expr))*];
         args  = [];
@@ -465,7 +465,7 @@ pub mod expect {
             rel: OrderingRelation,
         ) -> JsResult<JSValue> {
             // `defer this.postMatch(globalThis)` — run on every exit path.
-            let this = scopeguard::guard(self, |this| this.post_match(global));
+            let this = self.post_match_guard(global);
 
             let this_value = frame.this();
             let arguments: &[JSValue] = frame.arguments();

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -58,6 +58,17 @@ fn vm_event_loop_ctx() -> bun_io::EventLoopCtx {
 
 bun_output::define_scoped_log!(debug, RedisJS, visible);
 
+/// RAII: calls [`JSValkeyClient::update_poll_ref`] on drop. Holds a
+/// [`BackRef`] so the borrow is detached and JS re-entrancy between
+/// construction and drop cannot alias `&self`.
+struct UpdatePollOnDrop(BackRef<JSValkeyClient>);
+impl Drop for UpdatePollOnDrop {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.update_poll_ref();
+    }
+}
+
 type Socket = uws::AnySocket;
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -283,10 +294,7 @@ impl SubscriptionCtx {
 
         // After we go through every single callback, we will have to update the poll ref.
         // The user may, for example, unsubscribe in the callbacks, or even stop the client.
-        // `BackRef` (Copy + Deref) detaches the borrow so the guard closure is
-        // safe even though intervening JS may re-enter `&self`.
-        let parent_br = BackRef::new(self.parent());
-        let _update = scopeguard::guard(parent_br, |p| p.update_poll_ref());
+        let _update = UpdatePollOnDrop(BackRef::new(self.parent()));
 
         // If callbacks is an array, iterate and call each one
         let mut iter = callbacks.array_iterator(global_object)?;
@@ -1045,8 +1053,7 @@ impl JSValkeyClient {
         // Without this, every subsequent command rejects with "Connection has
         // failed" forever — see https://github.com/oven-sh/bun/issues/29925.
         self.client_mut().flags.failed = false;
-        let self_br = BackRef::new(self);
-        let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
+        let _update = UpdatePollOnDrop(BackRef::new(self));
 
         if self.client.get().flags.needs_to_open_socket {
             self.poll_ref.with_mut(|r| r.ref_(vm_event_loop_ctx()));
@@ -1367,7 +1374,7 @@ impl JSValkeyClient {
         // SAFETY: adopts connect()'s socket keep-alive ref; the caller holds
         // its own scoped ref so count stays > 0 until this drops.
         let _socket_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
-        let _defer = scopeguard::guard(BackRef::new(self), |p| p.update_poll_ref());
+        let _defer = UpdatePollOnDrop(BackRef::new(self));
 
         let Some(this_jsvalue) = self.this_value.get().try_get() else {
             return Ok(());
@@ -1625,8 +1632,7 @@ impl JSValkeyClient {
             self.reset_connection_timeout();
         }
 
-        let self_br = BackRef::new(self);
-        let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
+        let _update = UpdatePollOnDrop(BackRef::new(self));
         self.client_mut().send(global_this, command)
     }
 
@@ -1815,7 +1821,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         );
         let handshake_success = success == 1;
         let _guard = this.ref_scope();
-        let _update = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
+        let _update = UpdatePollOnDrop(BackRef::new(this));
         let vm = this.client.get().vm;
         if handshake_success {
             if this.client.get().tls.reject_unauthorized(vm) {

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -58,9 +58,6 @@ fn vm_event_loop_ctx() -> bun_io::EventLoopCtx {
 
 bun_output::define_scoped_log!(debug, RedisJS, visible);
 
-/// RAII: calls [`JSValkeyClient::update_poll_ref`] on drop. Holds a
-/// [`BackRef`] so the borrow is detached and JS re-entrancy between
-/// construction and drop cannot alias `&self`.
 struct UpdatePollOnDrop(BackRef<JSValkeyClient>);
 impl Drop for UpdatePollOnDrop {
     #[inline]

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -54,7 +54,6 @@ use bun_http_jsc::method_jsc;
 use bun_http_types::Method::Method;
 use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _};
 use bun_paths::{self, PathBuffer};
-use bun_sys::FdExt as _;
 // `FromJsEnum for FetchRedirect` lives in bun_http_jsc; importing the impl crate
 // brings the trait impl into scope for `JSValue::get_optional_enum::<FetchRedirect>`.
 use crate::node;
@@ -1783,7 +1782,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // is handed it as an `Fd` and never takes ownership. Wrap it in an
             // RAII guard so any future early return between here and the read
             // can't leak it.
-            let opened_fd = scopeguard::guard(opened_fd, |fd| fd.close());
+            let opened_fd = bun_sys::CloseOnDrop::new(opened_fd);
 
             // TODO: make this async + lazy
             let blob_offset = body.any_blob().blob().offset.get();

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -558,6 +558,7 @@ pub(crate) fn writable_stream(
     Ok(sink.to_js(global_this))
 }
 
+#[derive(bun_ptr::CellRefCounted)]
 pub struct S3UploadStreamWrapper {
     // intrusive ref_count — bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) → bun_ptr::IntrusiveRc<Self>
     pub ref_count: core::cell::Cell<u32>,
@@ -575,31 +576,7 @@ pub struct S3UploadStreamWrapper {
 // Inherent associated types are unstable; expose as a module-level alias instead.
 pub(crate) type ResumableSink = ResumableS3UploadSink;
 
-/// RAII `deref_()` on scope exit for [`S3UploadStreamWrapper`].
-struct DerefOnDrop(*mut S3UploadStreamWrapper);
-impl Drop for DerefOnDrop {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: constructed from a live Box-allocated `S3UploadStreamWrapper`;
-        // `deref_` decrements ref_count and frees only after the last ref drops.
-        unsafe { S3UploadStreamWrapper::deref_(self.0) };
-    }
-}
-
 impl S3UploadStreamWrapper {
-    /// Intrusive `deref()` — decrements ref_count; runs finalizer + frees on zero.
-    /// SAFETY: `this` must be a live Box-allocated `Self` (created via heap::alloc).
-    pub(crate) unsafe fn deref_(this: *mut Self) {
-        // SAFETY: caller contract above.
-        let rc = unsafe { (*this).ref_count.get() } - 1;
-        // SAFETY: caller contract above — `this` is still live (freed only after rc hits zero below).
-        unsafe { (*this).ref_count.set(rc) };
-        if rc == 0 {
-            // SAFETY: ref_count hit zero; reconstitute the Box to run Drop and free.
-            drop(unsafe { bun_core::heap::take(this) });
-        }
-    }
-
     fn detach_sink(&mut self) {
         bun_output::scoped_log!(S3UploadStream, "detachSink {}", self.sink.is_some());
         if let Some(sink) = self.sink.take() {
@@ -649,7 +626,8 @@ impl S3UploadStreamWrapper {
     pub(crate) fn write_end_request(&mut self, err: Option<JSValue>) {
         bun_output::scoped_log!(S3UploadStream, "writeEndRequest {}", err.is_some());
         self.detach_sink();
-        let _deref_guard = DerefOnDrop(std::ptr::from_mut::<Self>(self));
+        // SAFETY: `self` is a live Box-allocated `Self` holding the ref this scope consumes.
+        let _deref_guard = unsafe { bun_ptr::ScopedRef::adopt(std::ptr::from_mut::<Self>(self)) };
         if let Some(js_err) = err {
             if self.end_promise.has_value() && !js_err.is_empty_or_undefined_or_null() {
                 // if we have a explicit error, reject the promise
@@ -672,7 +650,8 @@ impl S3UploadStreamWrapper {
 
     pub(crate) fn resolve(result: S3UploadResult, self_: &mut Self) -> JsTerminatedResult<()> {
         bun_output::scoped_log!(S3UploadStream, "resolve");
-        let _deref_guard = DerefOnDrop(std::ptr::from_mut::<Self>(self_));
+        // SAFETY: `self_` is a live Box-allocated `Self` holding the ref this scope consumes.
+        let _deref_guard = unsafe { bun_ptr::ScopedRef::adopt(std::ptr::from_mut::<Self>(self_)) };
         match &result {
             S3UploadResult::Success => {
                 if self_.end_promise.has_value() {

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -575,6 +575,17 @@ pub struct S3UploadStreamWrapper {
 // Inherent associated types are unstable; expose as a module-level alias instead.
 pub(crate) type ResumableSink = ResumableS3UploadSink;
 
+/// RAII `deref_()` on scope exit for [`S3UploadStreamWrapper`].
+struct DerefOnDrop(*mut S3UploadStreamWrapper);
+impl Drop for DerefOnDrop {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: constructed from a live Box-allocated `S3UploadStreamWrapper`;
+        // `deref_` decrements ref_count and frees only after the last ref drops.
+        unsafe { S3UploadStreamWrapper::deref_(self.0) };
+    }
+}
+
 impl S3UploadStreamWrapper {
     /// Intrusive `deref()` — decrements ref_count; runs finalizer + frees on zero.
     /// SAFETY: `this` must be a live Box-allocated `Self` (created via heap::alloc).
@@ -638,12 +649,7 @@ impl S3UploadStreamWrapper {
     pub(crate) fn write_end_request(&mut self, err: Option<JSValue>) {
         bun_output::scoped_log!(S3UploadStream, "writeEndRequest {}", err.is_some());
         self.detach_sink();
-        // scope-exit deref via guard (keeps borrowck happy)
-        let _deref_guard = scopeguard::guard(std::ptr::from_mut::<Self>(self), |s| {
-            // SAFETY: s points to self which is alive for the duration of the guard; deref_
-            // decrements ref_count and may free self only after all borrows above are released
-            unsafe { Self::deref_(s) }
-        });
+        let _deref_guard = DerefOnDrop(std::ptr::from_mut::<Self>(self));
         if let Some(js_err) = err {
             if self.end_promise.has_value() && !js_err.is_empty_or_undefined_or_null() {
                 // if we have a explicit error, reject the promise
@@ -666,12 +672,7 @@ impl S3UploadStreamWrapper {
 
     pub(crate) fn resolve(result: S3UploadResult, self_: &mut Self) -> JsTerminatedResult<()> {
         bun_output::scoped_log!(S3UploadStream, "resolve");
-        // scope-exit deref via guard (keeps borrowck happy)
-        let _deref_guard = scopeguard::guard(std::ptr::from_mut::<Self>(self_), |s| {
-            // SAFETY: s points to self_ which is alive for the duration of the guard; deref_
-            // decrements ref_count and may free self only after all borrows above are released
-            unsafe { Self::deref_(s) }
-        });
+        let _deref_guard = DerefOnDrop(std::ptr::from_mut::<Self>(self_));
         match &result {
             S3UploadResult::Success => {
                 if self_.end_promise.has_value() {
@@ -1126,14 +1127,17 @@ pub fn readable_stream(
             request_err: Option<Error::S3Error>,
             self_: &mut Self,
         ) -> JsTerminatedResult<()> {
-            // scope-exit cleanup via guard (keeps borrowck happy)
-            let _guard = scopeguard::guard(std::ptr::from_mut::<Self>(self_), move |s| {
-                if !has_more {
-                    // SAFETY: s is a live Box-allocated pointer (heap::alloc in S3DownloadStreamWrapper::new);
-                    // reconstituting and dropping the Box runs Drop::drop and frees the allocation
-                    drop(unsafe { bun_core::heap::take(s) });
+            struct FreeOnLast(*mut S3DownloadStreamWrapper, bool);
+            impl Drop for FreeOnLast {
+                fn drop(&mut self) {
+                    if !self.1 {
+                        // SAFETY: self.0 is a live Box-allocated pointer (heap::alloc in S3DownloadStreamWrapper::new);
+                        // reconstituting and dropping the Box runs Drop::drop and frees the allocation
+                        drop(unsafe { bun_core::heap::take(self.0) });
+                    }
                 }
-            });
+            }
+            let _guard = FreeOnLast(std::ptr::from_mut::<Self>(self_), has_more);
 
             if let Some(readable) = self_.readable_stream_ref.get(&self_.global) {
                 // BACKREF: see `Source::bytes()` — payload live while the

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1405,7 +1405,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 if let Some(res) = self.any_res() {
                     res.clear_on_writable();
                     // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
-                    res.resume_();
+                    res.resume();
                 }
                 // `send_readable` drained the parked `try_end`, so uWS has
                 // `markDone()`d the response and dropped its `onAborted`.
@@ -1782,7 +1782,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         if let Some(res) = self.any_res() {
             // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
-            res.resume_();
+            res.resume();
         }
         // Both branches above fully ended the response through uWS, which
         // `markDone()`s it and drops its `onAborted`.
@@ -1870,7 +1870,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             if let Some(res) = self.any_res() {
                 res.clear_on_writable();
                 // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
-                res.resume_();
+                res.resume();
             }
             // `send_readable` drained the parked `try_end`/`end`, so uWS has
             // `markDone()`d the response and dropped its `onAborted`.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -304,9 +304,7 @@ fn find_playwright_shell() -> Option<ZBox> {
     let cache_dir = resolve_path::join_string_buf_z::<platform::Auto>(&mut dir_buf[..], &parts);
 
     let fd = bun_sys::open(cache_dir, O::RDONLY | O::DIRECTORY, 0).ok()?;
-    // `defer fd.close()` — Fd has no Drop; close explicitly on all
-    // exit paths via scopeguard.
-    let _fd_guard = scopeguard::guard(fd, |fd| fd.close());
+    let _fd_guard = bun_sys::CloseOnDrop::new(fd);
 
     // Scan for chromium_headless_shell-<rev> and track max rev.
     let mut best_rev: u32 = 0;
@@ -423,11 +421,9 @@ fn spawn(
             0,
             false, // .blocking
         )?;
-        let fds = scopeguard::guard(fds, |fds| {
-            fds[0].close();
-            fds[1].close();
-        });
-        bun_sys::set_nonblocking(fds[0])?;
+        let fd0 = bun_sys::CloseOnDrop::new(fds[0]);
+        let fd1 = bun_sys::CloseOnDrop::new(fds[1]);
+        bun_sys::set_nonblocking(fd0.fd())?;
 
         // Minimal flags. --remote-debugging-pipe is the one that matters;
         // --headless works on both full Chrome (switches to headless mode) and
@@ -522,7 +518,7 @@ fn spawn(
             // fd 3 AND fd 4 both point at fds[1]. spawnProcess dup2's each
             // .pipe entry to 3+index; passing the same fd twice gives Chrome
             // the same socket at both positions.
-            extra_fds: vec![Stdio::Pipe(fds[1]), Stdio::Pipe(fds[1])].into_boxed_slice(),
+            extra_fds: vec![Stdio::Pipe(fd1.fd()), Stdio::Pipe(fd1.fd())].into_boxed_slice(),
             argv0: Some(chrome.as_ptr()),
             ..SpawnOptions::default()
         };
@@ -532,15 +528,16 @@ fn spawn(
         let spawned =
             unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr().cast()) }??;
 
-        // Disarm the cleanup guard here and close each fd exactly once on the
-        // WatchFailed path below; keeping it armed would re-close the
-        // already-closed fds[1] there.
-        let fds = scopeguard::ScopeGuard::into_inner(fds);
+        // Disarm the cleanup guards here and close each fd exactly once on the
+        // WatchFailed path below; keeping them armed would re-close the
+        // already-closed fd1 there.
+        let fd0 = fd0.into_raw();
+        let fd1 = fd1.into_raw();
 
         // Parent doesn't need the child's end. POSIX_SPAWN_CLOEXEC_DEFAULT
         // already closed our copy in the child (only fd 3/4 survive the exec);
         // close our reference so Chrome's death EOF's our end.
-        fds[1].close();
+        fd1.close();
 
         // SAFETY: `vm` is the live thread-local VM; `event_loop()` is its
         // per-thread `jsc::EventLoop`.
@@ -570,14 +567,14 @@ fn spawn(
                     Process::deref(process.as_ptr());
                     drop(bun_core::heap::take(self_ptr));
                 }
-                fds[0].close();
+                fd0.close();
                 return Err(crate::Error::WatchFailed);
             }
         }
         INSTANCE.store(self_ptr, core::sync::atomic::Ordering::Relaxed);
         // fd returned to C++ which adopts it into usockets. Not stored here —
         // usockets owns it; we only own the process lifetime.
-        Ok(fds[0])
+        Ok(fd0)
     }
 }
 

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -303,8 +303,7 @@ fn find_playwright_shell() -> Option<ZBox> {
     let parts: [&[u8]; 2] = [home, cache_subpath];
     let cache_dir = resolve_path::join_string_buf_z::<platform::Auto>(&mut dir_buf[..], &parts);
 
-    let fd = bun_sys::open(cache_dir, O::RDONLY | O::DIRECTORY, 0).ok()?;
-    let _fd_guard = bun_sys::CloseOnDrop::new(fd);
+    let dir = bun_sys::Dir::from_fd(bun_sys::open(cache_dir, O::RDONLY | O::DIRECTORY, 0).ok()?);
 
     // Scan for chromium_headless_shell-<rev> and track max rev.
     let mut best_rev: u32 = 0;
@@ -312,7 +311,7 @@ fn find_playwright_shell() -> Option<ZBox> {
     let mut best_len: usize = 0;
     const PREFIX: &[u8] = b"chromium_headless_shell-";
 
-    let mut iter = bun_sys::iterate_dir(fd);
+    let mut iter = bun_sys::iterate_dir(dir.fd);
     loop {
         let entry = match iter.next() {
             Ok(Some(e)) => e,

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -27,7 +27,7 @@ use {
     bun_spawn::{
         EventLoopHandle, ProcessExit, ProcessExitKind, SpawnOptions, SpawnResultExt as _, Stdio,
     },
-    bun_sys::{self, Fd, FdExt as _},
+    bun_sys::{self, Fd},
     core::ffi::c_char,
 };
 
@@ -146,7 +146,7 @@ fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) ->
             true, // .nonblocking
         )?;
         // fd0_guard rolls back fds[0] on any error below.
-        let fd0_guard = scopeguard::guard(fds[0], |fd| fd.close());
+        let fd0_guard = bun_sys::CloseOnDrop::new(fds[0]);
         // fds[1] is closed by spawnProcess after dup2 into the child.
 
         let exe = bun_core::self_exe_path()?;
@@ -229,7 +229,7 @@ fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) ->
         INSTANCE.store(self_ptr, core::sync::atomic::Ordering::Relaxed);
         // fd handed to C++ which adopts it into usockets. Not stored here —
         // usockets owns the socket; Rust only owns process lifetime.
-        let fd0 = scopeguard::ScopeGuard::into_inner(fd0_guard);
+        let fd0 = fd0_guard.into_raw();
         Ok(fd0)
     }
 }

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -74,6 +74,12 @@ impl File {
             handle: Fd::stdout(),
         }
     }
+    #[inline]
+    pub fn stderr() -> Self {
+        Self {
+            handle: Fd::stderr(),
+        }
+    }
 
     pub fn open(path: &ZStr, flags: i32, mode: Mode) -> Maybe<Self> {
         open(path, flags, mode).map(Self::from_fd)

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8741,11 +8741,29 @@ pub mod freebsd {}
 /// would be misleading (e.g. an fd that is sometimes a file, sometimes a
 /// directory, sometimes a pipe).
 #[must_use = "dropping immediately closes the fd; bind to `let _close = ...`"]
+#[repr(transparent)]
 pub struct CloseOnDrop(Fd);
 impl CloseOnDrop {
     #[inline]
     pub fn new(fd: Fd) -> Self {
         Self(fd)
+    }
+    /// The wrapped [`Fd`]. Does not affect ownership.
+    #[inline]
+    pub fn fd(&self) -> Fd {
+        self.0
+    }
+    /// Disarm: return the wrapped [`Fd`] without closing it.
+    #[inline]
+    pub fn into_raw(self) -> Fd {
+        core::mem::ManuallyDrop::new(self).0
+    }
+}
+impl core::ops::Deref for CloseOnDrop {
+    type Target = Fd;
+    #[inline]
+    fn deref(&self) -> &Fd {
+        &self.0
     }
 }
 impl Drop for CloseOnDrop {
@@ -9702,15 +9720,13 @@ mod normalize_path_windows_tests {
     fn relative_resolves_to_nt_device_name() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_rel");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let got = normalize(*dir, "a\\b");
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let got = normalize(dir.fd, "a\\b");
         assert!(got.starts_with("\\Device\\"), "{got}");
         assert!(got.ends_with("\\a\\b"), "{got}");
         assert!(!got.contains("\\??\\"), "{got}");
         // `..`-free rel: exactly the base directory's NT name plus the rel.
-        assert_eq!(got, format!("{}\\a\\b", normalize(*dir, ".")));
+        assert_eq!(got, format!("{}\\a\\b", normalize(dir.fd, ".")));
     }
 
     #[test]
@@ -9718,14 +9734,10 @@ mod normalize_path_windows_tests {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_dotdot");
         std::fs::create_dir_all(tree.0.join("child")).unwrap();
-        let parent = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let child = scopeguard::guard(open_dir_handle(&tree.0.join("child")), |fd| {
-            let _ = close(fd);
-        });
-        let got = normalize(*child, "..\\x");
-        let base = normalize(*parent, ".");
+        let parent = Dir::from_fd(open_dir_handle(&tree.0));
+        let child = Dir::from_fd(open_dir_handle(&tree.0.join("child")));
+        let got = normalize(child.fd, "..\\x");
+        let base = normalize(parent.fd, ".");
         assert_eq!(got, format!("{base}\\x"));
     }
 
@@ -9733,51 +9745,45 @@ mod normalize_path_windows_tests {
     fn within_tree_dotdot_resolves_under_base() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_within");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let base = normalize(*dir, ".");
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let base = normalize(dir.fd, ".");
         // Non-climbing `..` needs no clamp boundary; it resolves in place.
-        assert_eq!(normalize(*dir, "a\\..\\b"), format!("{base}\\b"));
+        assert_eq!(normalize(dir.fd, "a\\..\\b"), format!("{base}\\b"));
         // Collapsing to nothing lands exactly on the base directory (the
         // join's lone separator is dropped).
-        assert_eq!(normalize(*dir, "sub\\.."), base);
+        assert_eq!(normalize(dir.fd, "sub\\.."), base);
     }
 
     #[test]
     fn excess_dotdot_fails_closed_on_local_volume() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_clamp");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let base = normalize(*dir, ".");
-        let depth = floor_depth(*dir);
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let base = normalize(dir.fd, ".");
+        let depth = floor_depth(dir.fd);
         assert!(depth >= 1, "{base}");
         // Enough `..` to cross the volume-root floor: local volumes are not
         // share-rooted, so the walk refuses instead of clamping silently.
         let over = format!("{}x", "..\\".repeat(depth + 1));
-        assert_eq!(normalize_err(*dir, &over).get_errno(), E::EINVAL, "{over}");
+        assert_eq!(normalize_err(dir.fd, &over).get_errno(), E::EINVAL, "{over}");
         // Same without a trailing component.
         let over_only = "..\\".repeat(depth + 1);
-        assert_eq!(normalize_err(*dir, &over_only).get_errno(), E::EINVAL);
+        assert_eq!(normalize_err(dir.fd, &over_only).get_errno(), E::EINVAL);
         // Within-tree `..` (never crosses the floor) still resolves.
-        assert_eq!(normalize(*dir, "sub\\..\\ok"), format!("{base}\\ok"));
+        assert_eq!(normalize(dir.fd, "sub\\..\\ok"), format!("{base}\\ok"));
     }
 
     #[test]
     fn forward_slash_dotdot_through_walk() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_fwd");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let base = normalize(*dir, ".");
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let base = normalize(dir.fd, ".");
         // `/` separates components exactly like `\` — lexically for the
         // within-tree rel, and in the floor walk for the climbing one.
-        assert_eq!(normalize(*dir, "a/../b"), format!("{base}\\b"));
-        let over = format!("{}x", "../".repeat(floor_depth(*dir) + 1));
-        assert_eq!(normalize_err(*dir, &over).get_errno(), E::EINVAL, "{over}");
+        assert_eq!(normalize(dir.fd, "a/../b"), format!("{base}\\b"));
+        let over = format!("{}x", "../".repeat(floor_depth(dir.fd) + 1));
+        assert_eq!(normalize_err(dir.fd, &over).get_errno(), E::EINVAL, "{over}");
     }
 
     #[test]
@@ -9785,22 +9791,18 @@ mod normalize_path_windows_tests {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_climb_name");
         std::fs::create_dir_all(tree.0.join("child")).unwrap();
-        let parent = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let child = scopeguard::guard(open_dir_handle(&tree.0.join("child")), |fd| {
-            let _ = close(fd);
-        });
+        let parent = Dir::from_fd(open_dir_handle(&tree.0));
+        let child = Dir::from_fd(open_dir_handle(&tree.0.join("child")));
         // Net-climbing despite the leading name: the walk sees +1,−1,−1,+1
         // and stays above the floor while `..` resolves into the parent.
         assert_eq!(
-            normalize(*child, "a\\..\\..\\x"),
-            format!("{}\\x", normalize(*parent, "."))
+            normalize(child.fd, "a\\..\\..\\x"),
+            format!("{}\\x", normalize(parent.fd, "."))
         );
         // Same shape pushed one past the floor fails closed.
-        let over = format!("a\\..\\{}x", "..\\".repeat(floor_depth(*child) + 1));
+        let over = format!("a\\..\\{}x", "..\\".repeat(floor_depth(child.fd) + 1));
         assert_eq!(
-            normalize_err(*child, &over).get_errno(),
+            normalize_err(child.fd, &over).get_errno(),
             E::EINVAL,
             "{over}"
         );
@@ -9810,13 +9812,11 @@ mod normalize_path_windows_tests {
     fn exact_floor_dotdot_lands_on_volume_root() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_floor");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let base = normalize(*dir, ".");
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let base = normalize(dir.fd, ".");
         // Exactly base-depth `..` lands ON the floor (allowed): the volume
         // root DIRECTORY — the device prefix plus its lone separator.
-        let root = normalize(*dir, &"..\\".repeat(floor_depth(*dir)));
+        let root = normalize(dir.fd, &"..\\".repeat(floor_depth(dir.fd)));
         assert!(root.starts_with("\\Device\\"), "{root}");
         assert!(root.ends_with('\\'), "{root}");
         assert!(base.starts_with(&root), "{base} vs {root}");
@@ -9827,20 +9827,14 @@ mod normalize_path_windows_tests {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_bare_dotdot");
         std::fs::create_dir_all(tree.0.join("child")).unwrap();
-        let parent = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let child = scopeguard::guard(open_dir_handle(&tree.0.join("child")), |fd| {
-            let _ = close(fd);
-        });
-        let base = normalize(*parent, ".");
-        assert_eq!(normalize(*child, ".."), base);
-        assert_eq!(normalize(*child, "..\\"), base);
+        let parent = Dir::from_fd(open_dir_handle(&tree.0));
+        let child = Dir::from_fd(open_dir_handle(&tree.0.join("child")));
+        let base = normalize(parent.fd, ".");
+        assert_eq!(normalize(child.fd, ".."), base);
+        assert_eq!(normalize(child.fd, "..\\"), base);
         // From the volume root itself, `..` crosses the floor.
-        let root = scopeguard::guard(open_dir_handle(std::path::Path::new("C:\\")), |fd| {
-            let _ = close(fd);
-        });
-        assert_eq!(normalize_err(*root, "..").get_errno(), E::EINVAL);
+        let root = Dir::from_fd(open_dir_handle(std::path::Path::new("C:\\")));
+        assert_eq!(normalize_err(root.fd, "..").get_errno(), E::EINVAL);
     }
 
     #[test]
@@ -9848,15 +9842,11 @@ mod normalize_path_windows_tests {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_dotneutral");
         std::fs::create_dir_all(tree.0.join("child")).unwrap();
-        let parent = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let child = scopeguard::guard(open_dir_handle(&tree.0.join("child")), |fd| {
-            let _ = close(fd);
-        });
+        let parent = Dir::from_fd(open_dir_handle(&tree.0));
+        let child = Dir::from_fd(open_dir_handle(&tree.0.join("child")));
         // `.` and empty components cost no depth in the floor walk.
-        let got = normalize(*child, ".\\..\\\\.\\x");
-        assert_eq!(got, format!("{}\\x", normalize(*parent, ".")));
+        let got = normalize(child.fd, ".\\..\\\\.\\x");
+        assert_eq!(got, format!("{}\\x", normalize(parent.fd, ".")));
     }
 
     #[test]
@@ -9864,24 +9854,20 @@ mod normalize_path_windows_tests {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_colon");
         std::fs::create_dir_all(tree.0.join("child")).unwrap();
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let base = normalize(*dir, ".");
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let base = normalize(dir.fd, ".");
         // Colon components survive normalization verbatim — running under
         // debug_assertions, these ARE the no-panic proof; the invalid stream
         // spelling is NtCreateFile's to reject at open time.
-        assert_eq!(normalize(*dir, ":\\x"), format!("{base}\\:\\x"));
-        assert_eq!(normalize(*dir, ":a.b"), format!("{base}\\:a.b"));
-        assert_eq!(normalize(*dir, ".\\:\\x"), format!("{base}\\:\\x"));
-        assert_eq!(normalize(*dir, "a\\:\\x"), format!("{base}\\a\\:\\x"));
+        assert_eq!(normalize(dir.fd, ":\\x"), format!("{base}\\:\\x"));
+        assert_eq!(normalize(dir.fd, ":a.b"), format!("{base}\\:a.b"));
+        assert_eq!(normalize(dir.fd, ".\\:\\x"), format!("{base}\\:\\x"));
+        assert_eq!(normalize(dir.fd, "a\\:\\x"), format!("{base}\\a\\:\\x"));
         // `..` collapse promoting `:` toward the front of the output.
-        let child = scopeguard::guard(open_dir_handle(&tree.0.join("child")), |fd| {
-            let _ = close(fd);
-        });
-        assert_eq!(normalize(*child, "..\\:\\x"), format!("{base}\\:\\x"));
+        let child = Dir::from_fd(open_dir_handle(&tree.0.join("child")));
+        assert_eq!(normalize(child.fd, "..\\:\\x"), format!("{base}\\:\\x"));
         // All the way to the clamp floor: `\:\x` directly after the device.
-        let floored = normalize(*dir, &format!("{}:\\x", "..\\".repeat(floor_depth(*dir))));
+        let floored = normalize(dir.fd, &format!("{}:\\x", "..\\".repeat(floor_depth(dir.fd))));
         assert!(floored.ends_with("\\:\\x"), "{floored}");
         assert!(
             base.starts_with(floored.strip_suffix(":\\x").unwrap()),
@@ -9892,7 +9878,7 @@ mod normalize_path_windows_tests {
         // The emitted name opens with a clean error, not a panic.
         assert!(
             open_file_at_windows_a(
-                *dir,
+                dir.fd,
                 b":\\x",
                 NtCreateFileOptions {
                     access_mask: w::GENERIC_READ | w::SYNCHRONIZE,
@@ -9910,26 +9896,22 @@ mod normalize_path_windows_tests {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_drive_dotdot");
         std::fs::create_dir_all(tree.0.join("child")).unwrap();
-        let child = scopeguard::guard(open_dir_handle(&tree.0.join("child")), |fd| {
-            let _ = close(fd);
-        });
+        let child = Dir::from_fd(open_dir_handle(&tree.0.join("child")));
         // The drive prefix of a drive-relative path is stripped; the `..`
         // after it must still reach the clamp logic.
-        assert_eq!(normalize(*child, "C:..\\x"), normalize(*child, "..\\x"));
+        assert_eq!(normalize(child.fd, "C:..\\x"), normalize(child.fd, "..\\x"));
     }
 
     #[test]
     fn dot_in_name_resolves_under_base() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_dotname");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
         // Dot without separator routes to fd resolution (not the bare
         // passthrough) and needs no `..` clamp.
         assert_eq!(
-            normalize(*dir, "a.b"),
-            format!("{}\\a.b", normalize(*dir, "."))
+            normalize(dir.fd, "a.b"),
+            format!("{}\\a.b", normalize(dir.fd, "."))
         );
     }
 
@@ -9937,18 +9919,14 @@ mod normalize_path_windows_tests {
     fn dot_resolves_to_base_dir() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_dot");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let got = normalize(*dir, ".");
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let got = normalize(dir.fd, ".");
         assert!(got.starts_with("\\Device\\"), "{got}");
         assert!(!got.ends_with('\\'), "{got}");
         let name = tree.0.file_name().unwrap().to_str().unwrap();
         // Exact, trailing-sep-free expectation built from the parent handle.
-        let parent = scopeguard::guard(open_dir_handle(tree.0.parent().unwrap()), |fd| {
-            let _ = close(fd);
-        });
-        assert_eq!(got, format!("{}\\{name}", normalize(*parent, ".")));
+        let parent = Dir::from_fd(open_dir_handle(tree.0.parent().unwrap()));
+        assert_eq!(got, format!("{}\\{name}", normalize(parent.fd, ".")));
     }
 
     #[test]
@@ -10080,16 +10058,14 @@ mod normalize_path_windows_tests {
     fn win32_output_uses_globalroot() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_gr");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let got = normalize_opts(*dir, "a\\b", false);
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let got = normalize_opts(dir.fd, "a\\b", false);
         assert!(got.starts_with("\\\\?\\GLOBALROOT\\Device\\"), "{got}");
         assert!(got.ends_with("\\a\\b"), "{got}");
         // rel `.`: GLOBALROOT + base, no trailing separator.
         assert_eq!(
-            normalize_opts(*dir, ".", false),
-            format!("\\\\?\\GLOBALROOT{}", normalize(*dir, "."))
+            normalize_opts(dir.fd, ".", false),
+            format!("\\\\?\\GLOBALROOT{}", normalize(dir.fd, "."))
         );
     }
 
@@ -10097,10 +10073,8 @@ mod normalize_path_windows_tests {
     fn win32_globalroot_output_creates_directories() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_gr_mkdir");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let name = normalize_opts(*dir, ".\\fresh", false);
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let name = normalize_opts(dir.fd, ".\\fresh", false);
         let wname: Vec<u16> = wide(&name).into_iter().chain([0u16]).collect();
         // SAFETY: `wname` is NUL-terminated.
         let ok = unsafe { w::CreateDirectoryW(wname.as_ptr(), core::ptr::null_mut()) };
@@ -10113,42 +10087,35 @@ mod normalize_path_windows_tests {
     #[test]
     fn volume_root_base_shapes() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
-        let root = scopeguard::guard(open_dir_handle(std::path::Path::new("C:\\")), |fd| {
-            let _ = close(fd);
-        });
-        let dot = normalize(*root, ".");
+        let root = Dir::from_fd(open_dir_handle(std::path::Path::new("C:\\")));
+        let dot = normalize(root.fd, ".");
         assert!(dot.starts_with("\\Device\\"), "{dot}");
         // The lone separator is load-bearing: `\Device\<vol>\` is the root
         // directory, `\Device\<vol>` the volume device.
         assert!(dot.ends_with('\\'), "{dot}");
         // Generic across device shapes (incl. nested `HarddiskDmVolumes\…`):
         // a child of the root carries exactly the root's prefix + its name.
-        let windows_dir =
-            scopeguard::guard(open_dir_handle(std::path::Path::new("C:\\Windows")), |fd| {
-                let _ = close(fd);
-            });
-        assert_eq!(normalize(*windows_dir, "."), format!("{dot}Windows"));
-        assert_eq!(normalize(*root, ".\\x"), format!("{dot}x"));
+        let windows_dir = Dir::from_fd(open_dir_handle(std::path::Path::new("C:\\Windows")));
+        assert_eq!(normalize(windows_dir.fd, "."), format!("{dot}Windows"));
+        assert_eq!(normalize(root.fd, ".\\x"), format!("{dot}x"));
         // Any `..` from the volume root would cross the floor: fail closed.
-        assert_eq!(normalize_err(*root, "..\\x").get_errno(), E::EINVAL);
+        assert_eq!(normalize_err(root.fd, "..\\x").get_errno(), E::EINVAL);
     }
 
     #[test]
     fn buffer_boundary_exact_fit() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_bound");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let base_len = wide(&normalize(*dir, ".")).len();
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
+        let base_len = wide(&normalize(dir.fd, ".")).len();
         let rel = "a\\b";
         // `..`-free path: prefix = whole base, `joined` = `\` + rel, and the
         // function reserves 8 u16 of headroom.
         let needed = base_len + 1 + rel.len() + 8;
         let mut exact = vec![0u16; needed];
-        assert!(normalize_path_windows(*dir, &wide(rel), &mut exact[..]).is_ok());
+        assert!(normalize_path_windows(dir.fd, &wide(rel), &mut exact[..]).is_ok());
         let mut small = vec![0u16; needed - 1];
-        let err = match normalize_path_windows(*dir, &wide(rel), &mut small[..]) {
+        let err = match normalize_path_windows(dir.fd, &wide(rel), &mut small[..]) {
             Ok(p) => panic!("expected ENAMETOOLONG, got {:?}", p.as_slice()),
             Err(e) => e,
         };
@@ -10163,7 +10130,7 @@ mod normalize_path_windows_tests {
         // The compose/None-query failure arms are not constructible from a
         // real handle; `clamp_prefix_len_pairs` covers them at the unit level.
         let nul_path = wide("\\\\.\\NUL\0");
-        let nul = scopeguard::guard(
+        let nul = CloseOnDrop::new(
             open_windows_device_path(
                 bun_core::WStr::from_buf(&nul_path[..], nul_path.len() - 1),
                 w::GENERIC_READ,
@@ -10171,9 +10138,6 @@ mod normalize_path_windows_tests {
                 0,
             )
             .expect("open NUL"),
-            |fd| {
-                let _ = close(fd);
-            },
         );
         assert_eq!(normalize_err(*nul, ".\\x").get_errno(), E::BADFD);
     }
@@ -10191,12 +10155,10 @@ mod normalize_path_windows_tests {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
         let tree = TempTree::new("nt_norm_gr_dotdot");
         std::fs::create_dir_all(tree.0.join("child")).unwrap();
-        let child = scopeguard::guard(open_dir_handle(&tree.0.join("child")), |fd| {
-            let _ = close(fd);
-        });
+        let child = Dir::from_fd(open_dir_handle(&tree.0.join("child")));
         assert_eq!(
-            normalize_opts(*child, "..\\x", false),
-            format!("\\\\?\\GLOBALROOT{}", normalize(*child, "..\\x"))
+            normalize_opts(child.fd, "..\\x", false),
+            format!("\\\\?\\GLOBALROOT{}", normalize(child.fd, "..\\x"))
         );
     }
 
@@ -10206,12 +10168,10 @@ mod normalize_path_windows_tests {
         let tree = TempTree::new("nt_norm_open");
         std::fs::create_dir_all(tree.0.join("sub")).unwrap();
         std::fs::write(tree.0.join("sub").join("file.txt"), b"nt object name").unwrap();
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
+        let dir = Dir::from_fd(open_dir_handle(&tree.0));
 
         let fd = open_file_at_windows_a(
-            *dir,
+            dir.fd,
             b"sub\\file.txt",
             NtCreateFileOptions {
                 access_mask: w::GENERIC_READ | w::SYNCHRONIZE,
@@ -10226,13 +10186,10 @@ mod normalize_path_windows_tests {
         let n = file.read_all(&mut content).unwrap();
         assert_eq!(&content[..n], b"nt object name");
 
-        let sub = scopeguard::guard(
-            open_dir_at_windows_a(*dir, b"sub\\..\\sub", WindowsOpenDirOptions::default())
+        let sub = Dir::from_fd(
+            open_dir_at_windows_a(dir.fd, b"sub\\..\\sub", WindowsOpenDirOptions::default())
                 .expect("dir opens through `..` in the NT object name"),
-            |fd| {
-                let _ = close(fd);
-            },
         );
-        assert!(fstat(*sub).is_ok());
+        assert!(fstat(sub.fd).is_ok());
     }
 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9765,7 +9765,11 @@ mod normalize_path_windows_tests {
         // Enough `..` to cross the volume-root floor: local volumes are not
         // share-rooted, so the walk refuses instead of clamping silently.
         let over = format!("{}x", "..\\".repeat(depth + 1));
-        assert_eq!(normalize_err(dir.fd, &over).get_errno(), E::EINVAL, "{over}");
+        assert_eq!(
+            normalize_err(dir.fd, &over).get_errno(),
+            E::EINVAL,
+            "{over}"
+        );
         // Same without a trailing component.
         let over_only = "..\\".repeat(depth + 1);
         assert_eq!(normalize_err(dir.fd, &over_only).get_errno(), E::EINVAL);
@@ -9783,7 +9787,11 @@ mod normalize_path_windows_tests {
         // within-tree rel, and in the floor walk for the climbing one.
         assert_eq!(normalize(dir.fd, "a/../b"), format!("{base}\\b"));
         let over = format!("{}x", "../".repeat(floor_depth(dir.fd) + 1));
-        assert_eq!(normalize_err(dir.fd, &over).get_errno(), E::EINVAL, "{over}");
+        assert_eq!(
+            normalize_err(dir.fd, &over).get_errno(),
+            E::EINVAL,
+            "{over}"
+        );
     }
 
     #[test]
@@ -9867,7 +9875,10 @@ mod normalize_path_windows_tests {
         let child = Dir::from_fd(open_dir_handle(&tree.0.join("child")));
         assert_eq!(normalize(child.fd, "..\\:\\x"), format!("{base}\\:\\x"));
         // All the way to the clamp floor: `\:\x` directly after the device.
-        let floored = normalize(dir.fd, &format!("{}:\\x", "..\\".repeat(floor_depth(dir.fd))));
+        let floored = normalize(
+            dir.fd,
+            &format!("{}:\\x", "..\\".repeat(floor_depth(dir.fd))),
+        );
         assert!(floored.ends_with("\\:\\x"), "{floored}");
         assert!(
             base.starts_with(floored.strip_suffix(":\\x").unwrap()),

--- a/src/sys/windows/env.rs
+++ b/src/sys/windows/env.rs
@@ -28,16 +28,26 @@ pub fn convert_env_to_wtf8() -> Result<(), AllocError> {
         "convertEnvToWTF8 may only be called once"
     );
     ENV_CONVERTED.store(true, core::sync::atomic::Ordering::Relaxed);
-    let env_guard = scopeguard::guard((), |()| {
-        ENV_CONVERTED.store(false, core::sync::atomic::Ordering::Relaxed);
-    });
+    struct ResetConvertedOnDrop;
+    impl Drop for ResetConvertedOnDrop {
+        #[inline]
+        fn drop(&mut self) {
+            ENV_CONVERTED.store(false, core::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    let env_guard = ResetConvertedOnDrop;
 
     let mut num_vars: usize = 0;
     let wtf8_buf: Vec<u8> = 'blk: {
         let wtf16_buf: *mut u16 = crate::windows::GetEnvironmentStringsW()?;
-        let _free = scopeguard::guard(wtf16_buf, |p| {
-            crate::windows::FreeEnvironmentStringsW(p);
-        });
+        struct FreeEnvOnDrop(*mut u16);
+        impl Drop for FreeEnvOnDrop {
+            #[inline]
+            fn drop(&mut self) {
+                crate::windows::FreeEnvironmentStringsW(self.0);
+            }
+        }
+        let _free = FreeEnvOnDrop(wtf16_buf);
         let mut len: usize = 0;
         loop {
             // SAFETY: `wtf16_buf` is a contiguous double-NUL-terminated block returned by the OS;
@@ -86,6 +96,6 @@ pub fn convert_env_to_wtf8() -> Result<(), AllocError> {
         bun_core::os::set_environ(envp_slice.as_mut_ptr(), envp_nonnull_len);
     }
 
-    let _ = scopeguard::ScopeGuard::into_inner(env_guard);
+    core::mem::forget(env_guard);
     Ok(())
 }

--- a/src/sys/windows/env.rs
+++ b/src/sys/windows/env.rs
@@ -39,20 +39,25 @@ pub fn convert_env_to_wtf8() -> Result<(), AllocError> {
 
     let mut num_vars: usize = 0;
     let wtf8_buf: Vec<u8> = 'blk: {
-        let wtf16_buf: *mut u16 = crate::windows::GetEnvironmentStringsW()?;
-        struct FreeEnvOnDrop(*mut u16);
-        impl Drop for FreeEnvOnDrop {
+        struct EnvStringsW(*mut u16);
+        impl EnvStringsW {
+            #[inline]
+            fn as_ptr(&self) -> *mut u16 {
+                self.0
+            }
+        }
+        impl Drop for EnvStringsW {
             #[inline]
             fn drop(&mut self) {
                 crate::windows::FreeEnvironmentStringsW(self.0);
             }
         }
-        let _free = FreeEnvOnDrop(wtf16_buf);
+        let wtf16_buf = EnvStringsW(crate::windows::GetEnvironmentStringsW()?);
         let mut len: usize = 0;
         loop {
             // SAFETY: `wtf16_buf` is a contiguous double-NUL-terminated block returned by the OS;
             // every offset we read is inside that block until we observe the terminating empty string.
-            let str_len = unsafe { bun_core::ffi::wcslen(wtf16_buf.add(len)) };
+            let str_len = unsafe { bun_core::ffi::wcslen(wtf16_buf.as_ptr().add(len)) };
             len += str_len + 1; // each string is null-terminated
             if str_len == 0 {
                 break; // array ends with empty null-terminated string
@@ -60,7 +65,7 @@ pub fn convert_env_to_wtf8() -> Result<(), AllocError> {
             num_vars += 1;
         }
         // SAFETY: we just measured `len` u16 elements (including terminators) within the OS-owned block.
-        let wtf16_slice = unsafe { bun_core::ffi::slice(wtf16_buf, len) };
+        let wtf16_slice = unsafe { bun_core::ffi::slice(wtf16_buf.as_ptr(), len) };
         // `bun_core::strings::to_utf8_alloc` is infallible (panics on OOM)
         // and returns `Vec<u8>` directly — no `?` here.
         break 'blk bun_core::strings::to_utf8_alloc(wtf16_slice);

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1130,10 +1130,17 @@ pub fn DeleteFileBun(sub_path_w: &[u16], options: DeleteFileOptions) -> bun_sys:
     if let Some(err) = bun_sys::Result::<()>::errno_sys(rc, bun_sys::Tag::open) {
         return err;
     }
-    // SAFETY: tmp_handle is valid; closed at scope exit
-    let _close_guard = scopeguard::guard(tmp_handle, |h| unsafe {
-        let _ = externs::CloseHandle(h);
-    });
+    struct CloseHandleOnDrop(HANDLE);
+    impl Drop for CloseHandleOnDrop {
+        #[inline]
+        fn drop(&mut self) {
+            // SAFETY: handle is valid
+            unsafe {
+                let _ = externs::CloseHandle(self.0);
+            }
+        }
+    }
+    let _close_guard = CloseHandleOnDrop(tmp_handle);
 
     // FileDispositionInformationEx (and therefore FILE_DISPOSITION_POSIX_SEMANTICS and FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE)
     // are only supported on NTFS filesystems, so the version check on its own is only a partial solution. To support non-NTFS filesystems
@@ -1724,14 +1731,19 @@ pub fn spawn_watcher_child(
     let image_path_z = bun_core::WStr::from_buf(&wbuf[..], image_path.len());
 
     let kernelenv = kernel32_2::GetEnvironmentStringsW();
-    let _free_env = scopeguard::guard(kernelenv, |envptr| {
-        if !envptr.is_null() {
-            // SAFETY: envptr was returned from GetEnvironmentStringsW and is non-null
-            unsafe {
-                let _ = kernel32_2::FreeEnvironmentStringsW(envptr);
+    struct FreeEnvOnDrop(LPWSTR);
+    impl Drop for FreeEnvOnDrop {
+        #[inline]
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: returned from GetEnvironmentStringsW and non-null
+                unsafe {
+                    let _ = kernel32_2::FreeEnvironmentStringsW(self.0);
+                }
             }
         }
-    });
+    }
+    let _free_env = FreeEnvOnDrop(kernelenv);
 
     let mut size: usize = 0;
     if !kernelenv.is_null() {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1131,6 +1131,12 @@ pub fn DeleteFileBun(sub_path_w: &[u16], options: DeleteFileOptions) -> bun_sys:
         return err;
     }
     struct CloseHandleOnDrop(HANDLE);
+    impl CloseHandleOnDrop {
+        #[inline]
+        fn as_raw(&self) -> HANDLE {
+            self.0
+        }
+    }
     impl Drop for CloseHandleOnDrop {
         #[inline]
         fn drop(&mut self) {
@@ -1140,7 +1146,7 @@ pub fn DeleteFileBun(sub_path_w: &[u16], options: DeleteFileOptions) -> bun_sys:
             }
         }
     }
-    let _close_guard = CloseHandleOnDrop(tmp_handle);
+    let tmp_handle = CloseHandleOnDrop(tmp_handle);
 
     // FileDispositionInformationEx (and therefore FILE_DISPOSITION_POSIX_SEMANTICS and FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE)
     // are only supported on NTFS filesystems, so the version check on its own is only a partial solution. To support non-NTFS filesystems
@@ -1158,7 +1164,7 @@ pub fn DeleteFileBun(sub_path_w: &[u16], options: DeleteFileOptions) -> bun_sys:
     // SAFETY: tmp_handle and io are valid
     rc = unsafe {
         ntdll::NtSetInformationFile(
-            tmp_handle,
+            tmp_handle.as_raw(),
             &mut io,
             core::ptr::from_mut(&mut info).cast::<c_void>(),
             size_of::<windows::FILE_DISPOSITION_INFORMATION_EX>() as u32,
@@ -1187,7 +1193,7 @@ pub fn DeleteFileBun(sub_path_w: &[u16], options: DeleteFileOptions) -> bun_sys:
         // SAFETY: tmp_handle and io are valid
         rc = unsafe {
             ntdll::NtSetInformationFile(
-                tmp_handle,
+                tmp_handle.as_raw(),
                 &mut io,
                 core::ptr::from_mut(&mut file_dispo).cast::<c_void>(),
                 size_of::<windows::FILE_DISPOSITION_INFORMATION>() as u32,
@@ -1730,9 +1736,18 @@ pub fn spawn_watcher_child(
     // SAFETY: NUL written at [len]
     let image_path_z = bun_core::WStr::from_buf(&wbuf[..], image_path.len());
 
-    let kernelenv = kernel32_2::GetEnvironmentStringsW();
-    struct FreeEnvOnDrop(LPWSTR);
-    impl Drop for FreeEnvOnDrop {
+    struct EnvStringsW(LPWSTR);
+    impl EnvStringsW {
+        #[inline]
+        fn as_ptr(&self) -> LPWSTR {
+            self.0
+        }
+        #[inline]
+        fn is_null(&self) -> bool {
+            self.0.is_null()
+        }
+    }
+    impl Drop for EnvStringsW {
         #[inline]
         fn drop(&mut self) {
             if !self.0.is_null() {
@@ -1743,16 +1758,16 @@ pub fn spawn_watcher_child(
             }
         }
     }
-    let _free_env = FreeEnvOnDrop(kernelenv);
+    let kernelenv = EnvStringsW(kernel32_2::GetEnvironmentStringsW());
 
     let mut size: usize = 0;
     if !kernelenv.is_null() {
         // SAFETY: env block is double-NUL terminated
         unsafe {
             // check that env is non-empty
-            if *kernelenv.add(0) != 0 || *kernelenv.add(1) != 0 {
+            if *kernelenv.as_ptr().add(0) != 0 || *kernelenv.as_ptr().add(1) != 0 {
                 // array is terminated by two nulls
-                while *kernelenv.add(size) != 0 || *kernelenv.add(size + 1) != 0 {
+                while *kernelenv.as_ptr().add(size) != 0 || *kernelenv.as_ptr().add(size + 1) != 0 {
                     size += 1;
                 }
                 size += 1;
@@ -1765,7 +1780,7 @@ pub fn spawn_watcher_child(
     if !kernelenv.is_null() {
         // SAFETY: kernelenv has at least `size` elements
         unsafe {
-            ptr::copy_nonoverlapping(kernelenv, envbuf.as_mut_ptr(), size);
+            ptr::copy_nonoverlapping(kernelenv.as_ptr(), envbuf.as_mut_ptr(), size);
         }
     }
     envbuf[size..size + WATCHER_CHILD_ENV.len()].copy_from_slice(WATCHER_CHILD_ENV);


### PR DESCRIPTION
## What

Converts the high-frequency `scopeguard::guard` / `scopeguard::defer!` patterns to owned RAII types so cleanup runs via `Drop` instead of ad-hoc closures with per-site `unsafe`.

| pattern | replacement |
|---|---|
| `guard(fd, \|fd\| fd.close())` | `bun_sys::File` / `Dir` / `CloseOnDrop` |
| `guard(s, \|s\| s.deref())` on `bun_core::String` | `bun_core::OwnedString` |
| `guard(ptr, \|p\| Self::deref(p))` (intrusive rc) | `bun_ptr::ScopedRef` or module-local `DerefOnDrop` |
| `guard(worker, \|w\| w.unget())` | `Worker::get_scoped() -> WorkerGuard` |
| c-ares reply / COM / addrinfo / spng / tj3 frees | small module-local `Drop` structs |

Helper changes:
- `bun_sys::CloseOnDrop` gains `Deref<Target = Fd>` + `into_raw()` so it can be used and disarmed like `File`
- `bun_sys::File::stderr()` added (referenced by a `#[cfg(test)]` test that never compiled)
- `bun_bundler::thread_pool::WorkerGuard` added, returned by `Worker::get_scoped()`

## Example

`src/runtime/webcore/s3/client.rs` before:
```rust
let _deref_guard = scopeguard::guard(std::ptr::from_mut::<Self>(self), |s| {
    // SAFETY: s points to self which is alive for the duration of the guard; deref_
    // decrements ref_count and may free self only after all borrows above are released
    unsafe { Self::deref_(s) }
});
```
after:
```rust
let _deref_guard = DerefOnDrop(std::ptr::from_mut(self));
```
where `DerefOnDrop` is a `#[repr(transparent)]` newtype with `impl Drop { unsafe { Self::deref_(self.0) } }` defined once in the module.

## Numbers

| | before | after |
|---|---|---|
| `scopeguard::guard(` | 322 | 185 |
| `scopeguard::defer!` | 119 | 102 |
| `ScopeGuard::into_inner` | 76 | 67 |
| total `scopeguard` mentions | 652 | 474 |
| files touched | | 55 |

## Left alone

Per the "almost all" qualifier, these categories stay as scopeguard for now:
- one-off save/restore closures with no `unsafe` and a unique body (converting adds more code than it removes)
- documented borrowck workarounds where the scopeguard was deliberately chosen to avoid a `&mut self` conflict (commented as such)
- bespoke multi-step errdefer bodies in SSL/BoringSSL paths
- `src/js_parser/parse/parse_entry.rs` (stack-local `MaybeUninit` drop, intentional)

A follow-up can sweep the remaining ~185 `guard` calls by category if wanted.

## Also fixes

`cargo check -p bun_runtime` was broken on main: #36067 renamed `AnyResponse::resume_` to `resume` but missed 6 call sites in `RequestContext.rs` / `streams.rs`. Fixed here so the workspace compiles.

## Verification

- `cargo check --workspace` clean
- `bun run rust:check-all` clean (all 10 target combinations)
- `bun bd` builds
- smoke tests pass: `test/bundler/esbuild/default.test.ts`, `test/js/node/fs/fs.test.ts`, `test/js/bun/resolve/resolve.test.ts`, `test/js/bun/test/expect.test.js`