### PR TITLE
js_printer: print `0 / 0` and `void 0` where a local binding or `with` object shadows `NaN` / `undefined`

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1402,8 +1402,7 @@ impl<'a> Options<'a> {
     }
 }
 
-/// Globals the printer spells by name for a synthesized value (`ENumber` NaN,
-/// `EUndefined`) that some binding in the file declares too.
+/// Globals the printer spells by name for synthesized values that the file also binds.
 #[derive(Clone, Copy, Default)]
 pub(crate) struct ShadowedGlobalNames {
     pub nan: bool,
@@ -1711,11 +1710,9 @@ pub(crate) mod __gated_printer {
         // Always carried; gated at call sites with MAY_HAVE_MODULE_INFO.
         pub(crate) module_info: Option<&'a mut analyze_transpiled_module::ModuleInfo>,
 
-        /// The file declares its own `NaN` / `undefined` binding and no bundler
-        /// renamer moved it aside, so the bare global name could resolve to it.
+        /// Set by `print_ast`, where no bundler renamer moved such a binding aside.
         pub(crate) shadowed_globals: ShadowedGlobalNames,
-        /// Depth of `with` statement bodies around the current print position;
-        /// inside one, any bare global name may resolve to a property instead.
+        /// Depth of enclosing `with` bodies, where a bare global name may hit a property.
         pub(crate) with_nesting: u32,
 
         /// Arena for transient allocations during printing (rope flattening,
@@ -2178,8 +2175,7 @@ pub(crate) mod __gated_printer {
             self.with_nesting == 0 && !self.shadowed_globals.nan
         }
 
-        /// Without a bundler renamer nothing reserves `Infinity`, so only trust
-        /// the bare name when one ran (the value prints as `1 / 0` otherwise).
+        /// Only a bundler renamer reserves `Infinity`. Without one the value prints as `1 / 0`.
         fn infinity_is_global_here(&self) -> bool {
             self.with_nesting == 0 && self.options.has_run_symbol_renamer
         }
@@ -6978,8 +6974,7 @@ pub(crate) mod __gated_printer {
                     self.print_space_before_identifier();
                     self.print(b"NaN");
                 } else {
-                    // Only where `NaN` could be captured: `0 / 0` need not evaluate
-                    // to the same NaN bit pattern as the global.
+                    // Not used everywhere: `0 / 0` need not have the global's NaN bit pattern.
                     let wrap = level.gte(Level::Multiply);
                     if wrap {
                         self.print(b"(");

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1402,6 +1402,34 @@ impl<'a> Options<'a> {
     }
 }
 
+/// Globals the printer spells by name for a synthesized value (`ENumber` NaN,
+/// `EUndefined`) that some binding in the file declares too.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct ShadowedGlobalNames {
+    pub nan: bool,
+    pub undefined: bool,
+}
+
+impl ShadowedGlobalNames {
+    pub(crate) fn scan(symbols: &js_ast::symbol::Map) -> Self {
+        let mut shadowed = Self::default();
+        for symbol in symbols.symbols_for_source.iter().flatten() {
+            if matches!(
+                symbol.kind,
+                js_ast::symbol::Kind::Unbound | js_ast::symbol::Kind::Label
+            ) {
+                continue;
+            }
+            match symbol.original_name.slice() {
+                b"NaN" => shadowed.nan = true,
+                b"undefined" => shadowed.undefined = true,
+                _ => {}
+            }
+        }
+        shadowed
+    }
+}
+
 impl<'a> Default for Options<'a> {
     fn default() -> Self {
         Self {
@@ -1682,6 +1710,13 @@ pub(crate) mod __gated_printer {
         pub(crate) was_lazy_export: bool,
         // Always carried; gated at call sites with MAY_HAVE_MODULE_INFO.
         pub(crate) module_info: Option<&'a mut analyze_transpiled_module::ModuleInfo>,
+
+        /// The file declares its own `NaN` / `undefined` binding and no bundler
+        /// renamer moved it aside, so the bare global name could resolve to it.
+        pub(crate) shadowed_globals: ShadowedGlobalNames,
+        /// Depth of `with` statement bodies around the current print position;
+        /// inside one, any bare global name may resolve to a property instead.
+        pub(crate) with_nesting: u32,
 
         /// Arena for transient allocations during printing (rope flattening,
         /// UTF-16→UTF-8 transcoding).
@@ -2130,9 +2165,24 @@ pub(crate) mod __gated_printer {
             Level::Comma
         }
 
+        /// A bare `undefined` printed at the current position reads the global.
+        fn undefined_is_global_here(&self) -> bool {
+            self.with_nesting == 0 && !self.shadowed_globals.undefined
+        }
+
+        fn nan_is_global_here(&self) -> bool {
+            self.with_nesting == 0 && !self.shadowed_globals.nan
+        }
+
+        /// Without a bundler renamer nothing reserves `Infinity`, so only trust
+        /// the bare name when one ran (the value prints as `1 / 0` otherwise).
+        fn infinity_is_global_here(&self) -> bool {
+            self.with_nesting == 0 && self.options.has_run_symbol_renamer
+        }
+
         #[inline]
         pub(crate) fn print_undefined(&mut self, loc: bun_ast::Loc, level: Level) {
-            if self.options.minify_syntax {
+            if self.options.minify_syntax || !self.undefined_is_global_here() {
                 if level.gte(Level::Prefix) {
                     self.add_source_mapping(loc);
                     self.print(b"(void 0)");
@@ -4727,11 +4777,12 @@ pub(crate) mod __gated_printer {
 
         /// Whether a number used as a non-computed property name must be printed as a
         /// computed property instead, because `print_number` would render it as
-        /// something that is not a valid property name (e.g. "-1", "1/0", "1 / 0").
+        /// something that is not a valid property name (e.g. "-1", "1/0", "0 / 0").
         pub(crate) fn number_property_key_must_be_computed(&self, value: f64) -> bool {
             value.is_sign_negative()
+                || (value.is_nan() && !self.nan_is_global_here())
                 || (value == f64::INFINITY
-                    && (self.options.minify_syntax || !self.options.has_run_symbol_renamer))
+                    && (self.options.minify_syntax || !self.infinity_is_global_here()))
         }
 
         /// `E::ObjectJSON` (JSON-only): always printed in JSON shape.
@@ -5936,7 +5987,9 @@ pub(crate) mod __gated_printer {
                     self.print(b"(");
                     self.print_expr(s.value, Level::Lowest, ExprFlag::none());
                     self.print(b")");
+                    self.with_nesting += 1;
                     self.print_body(s.body);
+                    self.with_nesting -= 1;
                 }
                 StmtData::SLabel(s) => {
                     if !self.options.minify_whitespace && self.options.indent.count > 0 {
@@ -6917,12 +6970,32 @@ pub(crate) mod __gated_printer {
         pub(crate) fn print_number(&mut self, value: f64, level: Level) {
             let abs_value = value.abs();
             if value.is_nan() {
-                self.print_space_before_identifier();
-                self.print(b"NaN");
+                if IS_JSON || self.nan_is_global_here() {
+                    self.print_space_before_identifier();
+                    self.print(b"NaN");
+                } else {
+                    // Only where `NaN` could be captured: `0 / 0` need not evaluate
+                    // to the same NaN bit pattern as the global.
+                    let wrap = level.gte(Level::Multiply);
+                    if wrap {
+                        self.print(b"(");
+                    } else {
+                        self.print_space_before_identifier();
+                    }
+                    if self.options.minify_whitespace {
+                        self.print(b"0/0");
+                    } else {
+                        self.print(b"0 / 0");
+                    }
+                    if wrap {
+                        self.print(b")");
+                    }
+                }
             } else if value.is_infinite() {
                 let is_neg_inf = value.is_sign_negative();
-                let wrap = ((!self.options.has_run_symbol_renamer || self.options.minify_syntax)
-                    && level.gte(Level::Multiply))
+                let as_identifier =
+                    IS_JSON || (!self.options.minify_syntax && self.infinity_is_global_here());
+                let wrap = (!as_identifier && level.gte(Level::Multiply))
                     || (is_neg_inf && level.gte(Level::Prefix));
 
                 if wrap {
@@ -6936,8 +7009,7 @@ pub(crate) mod __gated_printer {
                     self.print_space_before_identifier();
                 }
 
-                // If we are not running the symbol renamer, we must not print "Infinity".
-                if IS_JSON || (!self.options.minify_syntax && self.options.has_run_symbol_renamer) {
+                if as_identifier {
                     self.print(b"Infinity");
                 } else if self.options.minify_whitespace {
                     self.print(b"1/0");
@@ -7030,6 +7102,8 @@ pub(crate) mod __gated_printer {
                 stack_overflowed: false,
                 was_lazy_export: false,
                 module_info: None,
+                shadowed_globals: ShadowedGlobalNames::default(),
+                with_nesting: 0,
             }
         }
 
@@ -7817,6 +7891,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     // `tree.module_scope` instead (lives for `'a`).
     let module_scope = &tree.module_scope;
     let stable_source_indices = [source.index.0];
+    let shadowed_globals = ShadowedGlobalNames::scan(&symbols);
     let renamer: rename::Renamer<'_, '_> = if opts.minify_identifiers {
         let mut reserved_names = rename::compute_initial_reserved_names(opts.module_type)?;
         for child in module_scope.children.slice() {
@@ -7927,6 +8002,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         source_map_builder,
     );
     printer.was_lazy_export = tree.has_lazy_export;
+    printer.shadowed_globals = shadowed_globals;
     // Borrowck: `opts` was moved into `Printer::init`; populate
     // `printer.module_info` by taking it back out of `printer.options`
     // (see `print_with_writer_and_platform`).

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1842,6 +1842,10 @@ pub(crate) mod __gated_printer {
                         ExprData::EAwait(_) | ExprData::EUndefined(_) | ExprData::ENumber(_) => {
                             v.left_level = Level::Call;
                         }
+                        // A missing import item prints like `EUndefined`, possibly as "void 0"
+                        ExprData::EImportIdentifier(_) => {
+                            v.left_level = Level::Call;
+                        }
                         ExprData::EBoolean(_) | ExprData::EBranchBoolean(_) => {
                             // When minifying, booleans are printed as "!0 and "!1"
                             if self.options.minify_syntax {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -58,7 +58,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
-const EXPECTED_VERSION: u32 = 30;
+/// Version 31: NaN and undefined print as `0 / 0` and `void 0` where the file shadows the global name.
+const EXPECTED_VERSION: u32 = 31;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3401,6 +3401,29 @@ describe("bundler", () => {
       },
     });
   }
+  // The renamer cannot help inside a `with` body: there the bare names may
+  // resolve to properties of the object, so the printer spells the values
+  // `0 / 0`, `1 / 0` and `void 0` instead. A cross-file const enum key that
+  // inlines to NaN must then print as a computed property.
+  for (const minify of [false, true]) {
+    itBundled(`edgecase/WithStatementNaNInfinityUndefined${minify ? "Minified" : ""}`, {
+      files: {
+        "/entry.ts": /* js */ `
+          import { E } from "./enum.ts";
+          with ({ NaN: "n", Infinity: "i", undefined: "u" }) {
+            console.write(JSON.stringify([String(+"x"), String(1e999), String(-1e999), String(void 0), { [E.N]: 1, [E.I]: 2 }]));
+          }
+        `,
+        "/enum.ts": /* ts */ `
+          export const enum E { N = 0 / 0, I = 1 / 0 }
+        `,
+      },
+      format: "cjs",
+      minifySyntax: minify,
+      minifyWhitespace: minify,
+      run: { stdout: '["NaN","Infinity","-Infinity","undefined",{"NaN":1,"Infinity":2}]' },
+    });
+  }
   // The macro module is transpiled by the macro VM, not by the bundler. That
   // VM has to be created from the build's transform options, or the macro
   // module does not see `--define` and `--loader`. The `Bun.build()` variant

--- a/test/bundler/esbuild/importstar.test.ts
+++ b/test/bundler/esbuild/importstar.test.ts
@@ -898,6 +898,28 @@ describe.concurrent("bundler", () => {
       "/entry.js": [`Import "foo" will always be undefined because there is no matching export in "foo.js"`],
     },
   });
+  // A missing import prints as `void 0` when minifying and inside a `with`
+  // body. That is not a valid left operand of `**` unless parenthesized.
+  for (const minifySyntax of [false, true]) {
+    itBundled(`importstar/NamespaceImportMissingES6ExponentiationLHS${minifySyntax ? "MinifySyntax" : ""}`, {
+      files: {
+        "/entry.js": /* js */ `
+          import * as ns from './foo'
+          console.log(ns.nope ** 2, 2 ** ns.nope, ns.x ** 2)
+          with ({}) console.log(ns.nope ** 2)
+        `,
+        "/foo.js": `export const x = 3`,
+      },
+      format: "cjs",
+      minifySyntax,
+      run: {
+        stdout: "NaN NaN 9\nNaN",
+      },
+      bundleWarnings: {
+        "/entry.js": [`Import "nope" will always be undefined because there is no matching export in "foo.js"`],
+      },
+    });
+  }
   itBundled("importstar/ExportOtherCommonJS", {
     files: {
       "/entry.js": `export {bar} from './foo'`,

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -210,6 +210,41 @@ test("math.pow", () => {
   expect(20.4 ** -0.5 + "").toEqual("0.22140372138502384");
 });
 
+// The runtime transpiler folds `0 / 0` and `+"a"` to a NaN value and prints it
+// back by name. No renamer runs on this path, so a binding named `NaN` in the
+// file, or a `with` object, must not capture the printed value.
+describe("folded NaN next to a binding of the same name", () => {
+  async function run(source: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("parameter, function-expression name and block-scoped binding", async () => {
+    expect(
+      await run(`
+        (function (NaN) { console.log(String(0 / 0), Number.isNaN(0 / 0), 0 / 0 === NaN, Object.keys({ [0 / 0]: 1 })[0]); })(5);
+        const f = function NaN() { return String(+"a"); };
+        console.log(f());
+        { let NaN = 6; console.log(String(0 / 0), NaN); }
+      `),
+    ).toEqual({ stdout: "NaN true false NaN\nNaN\nNaN 6\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("with statement object", async () => {
+    expect(
+      await run(
+        `with ({ NaN: 5, undefined: 6, Infinity: 7 }) console.log(String(0 / 0), String(void 0), String(1e999));`,
+      ),
+    ).toEqual({ stdout: "NaN undefined Infinity\n", stderr: "", exitCode: 0 });
+  });
+});
+
 describe("unterminated string literals in large files", () => {
   test("reports an unterminated string literal at the end of a large JavaScript file", async () => {
     using dir = tempDir("transpiler-long-unterminated-js", {

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -236,6 +236,22 @@ describe("folded NaN next to a binding of the same name", () => {
     ).toEqual({ stdout: "NaN true false NaN\nNaN\nNaN 6\n", stderr: "", exitCode: 0 });
   });
 
+  // The NaN sibling of #7263: the folded initializer read the binding in its own TDZ.
+  test.concurrent("module-level const NaN initialized from a folded NaN", async () => {
+    using dir = tempDir("runtime-transpiler-const-nan", {
+      "index.mjs": `export const NaN = 0 / 0;\nconst undefined = void 0;\nconsole.log(String(NaN), String(undefined), Number.isNaN(+"a"));`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "NaN undefined true\n", stderr: "", exitCode: 0 });
+  });
+
   test.concurrent("with statement object", async () => {
     expect(
       await run(

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5787,6 +5787,12 @@ describe("synthesized undefined and NaN next to a binding of the same name", () 
     );
   });
 
+  it("sees a binding that a data loader synthesizes for a top-level key", () => {
+    expect(plain.transformSync('NaN = "n"\nx = nan', "toml")).toBe(
+      'var NaN = "n", x = 0 / 0;\n\nexport {\n  NaN,\n  x\n};\nexport default {\n  NaN,\n  x\n};\n',
+    );
+  });
+
   it("still evaluates to the global values at runtime", () => {
     const out = minifier.transformSync(`
       var result = (function (undefined, NaN) {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5743,6 +5743,7 @@ describe("synthesized undefined and NaN next to a binding of the same name", () 
     expect(plain.transformSync("class undefined {}\nexport let r = [void 0, undefined];")).toBe(
       "class undefined {\n}\nexport let r = [void 0, undefined];\n",
     );
+    expect(plain.transformSync("export let undefined = void 0;")).toBe("export let undefined = void 0;\n");
     expect(
       minifier.transformSync("export let r = (undefined => [(void 0) ** x, (void 0).x, x + void 0, -void 0])();"),
     ).toBe("export let r=((undefined)=>[(void 0)**x,(void 0).x,x+void 0,NaN])();");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5729,6 +5729,83 @@ describe("numeric property keys that overflow to Infinity", () => {
   });
 });
 
+// A folded or synthesized undefined / NaN value has no binding of its own, and without the
+// bundler's renamer a same-named binding in the file (or an enclosing `with` object) would
+// capture the bare global name. The printer spells the value `void 0` / `0 / 0` there instead.
+describe("synthesized undefined and NaN next to a binding of the same name", () => {
+  const plain = new Bun.Transpiler({ loader: "ts" });
+  const minifier = new Bun.Transpiler({ loader: "ts", minifyWhitespace: true });
+
+  it("prints void 0 when the file binds undefined", () => {
+    expect(plain.transformSync("export let r = (function (undefined) { return void 0 === undefined; })(1);")).toBe(
+      "export let r = function(undefined) {\n  return undefined === void 0;\n}(1);\n",
+    );
+    expect(plain.transformSync("class undefined {}\nexport let r = [void 0, undefined];")).toBe(
+      "class undefined {\n}\nexport let r = [void 0, undefined];\n",
+    );
+    expect(
+      minifier.transformSync("export let r = (undefined => [(void 0) ** x, (void 0).x, x + void 0, -void 0])();"),
+    ).toBe("export let r=((undefined)=>[(void 0)**x,(void 0).x,x+void 0,NaN])();");
+  });
+
+  it("prints 0 / 0 when the file binds NaN", () => {
+    expect(plain.transformSync(`export let r = (function (NaN) { return [+"a", NaN]; })(1);`)).toBe(
+      "export let r = function(NaN) {\n  return [0 / 0, NaN];\n}(1);\n",
+    );
+    expect(minifier.transformSync(`export let f = function NaN() { return +"a" };`)).toBe(
+      "export let f=function NaN(){return 0/0};",
+    );
+    expect(plain.transformSync(`import { NaN } from "./x";\nexport let r = [+"a", NaN];`)).toBe(
+      'import { NaN } from "./x";\nexport let r = [0 / 0, NaN];\n',
+    );
+    expect(plain.transformSync(`try {} catch (NaN) {}\nexport let r = +"a";`)).toBe(
+      "try {} catch (NaN) {}\nexport let r = 0 / 0;\n",
+    );
+    // parenthesized wherever a bare `NaN` token would have bound tighter than `0 / 0`
+    expect(
+      minifier.transformSync(
+        `export let r = (NaN => [x ** +"a", (+"a") ** x, (+"a").toFixed(), x / +"a", +"a" / x, { [0 / 0]: 1 }])();`,
+      ),
+    ).toBe("export let r=((NaN)=>[x**(0/0),(0/0)**x,(0/0).toFixed(),x/(0/0),0/0/x,{[0/0]:1}])();");
+  });
+
+  it("keeps the bare names when nothing in the file binds them", () => {
+    // references to the globals themselves are not bindings
+    expect(plain.transformSync(`export let r = [void 0, +"a", 1e999, undefined, NaN, typeof undefined];`)).toBe(
+      'export let r = [undefined, NaN, 1 / 0, undefined, NaN, "undefined"];\n',
+    );
+    // a label and a property name live in other namespaces
+    expect(plain.transformSync(`NaN: for (;;) break NaN;\nexport let r = { NaN: +"a" }.NaN;`)).toBe(
+      "NaN:\n  for (;; )\n    break NaN;\nexport let r = { NaN: NaN }.NaN;\n",
+    );
+  });
+
+  it("prints the expression forms inside a with statement body", () => {
+    expect(plain.transformSync(`with (x) y = [void 0, +"a", 1e999];\nz = [void 0, +"a"];`)).toBe(
+      "with (x)\n  y = [void 0, 0 / 0, 1 / 0];\nz = [undefined, NaN];\n",
+    );
+  });
+
+  it("still evaluates to the global values at runtime", () => {
+    const out = minifier.transformSync(`
+      var result = (function (undefined, NaN) {
+        return [void 0 === undefined, typeof void 0, Number.isNaN(+"a"), 0 / 0 === NaN, Object.keys({ [0 / 0]: 1 })[0]];
+      })(1, 2);
+      with ({ NaN: 3, undefined: 4, Infinity: 5 }) result.push(String(0 / 0), String(void 0), String(1e999));
+    `);
+    expect(new Function(`${out}; return result;`)()).toEqual([
+      false,
+      "undefined",
+      true,
+      false,
+      "NaN",
+      "NaN",
+      "undefined",
+      "Infinity",
+    ]);
+  });
+});
+
 describe("parse error flood", () => {
   it("reports duplicate-binding floods in linear time", async () => {
     await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem
- `export const NaN = 0 / 0;` throws `ReferenceError: Cannot access 'NaN' before initialization` under `bun run`, and `(function (NaN) { return Number.isNaN(0 / 0) })(5)` returns `false`. `Bun.Transpiler` prints `let undefined = void 0` as `let undefined = undefined;`. This is the `NaN` / `undefined` sibling of #7263. No user reported it.
- Cause: in `src/js_printer/lib.rs`, `print_number` always prints a NaN value as `NaN`, and `print_undefined` prints `undefined` when `minify_syntax` is off. Without the bundler renamer (`bun run`, `--no-bundle`, `Bun.Transpiler`, REPL) a same-named binding captures that name. #41909 fixed the bundler half. Inside a `with` body the names can also hit the object's properties, on every path.

### Fix
- `print_ast` (the entry point without that renamer) scans the file's symbols once for a bound `NaN` or `undefined`. In such a file the printer emits `0 / 0` and `void 0`, parenthesized where needed, like the `1 / 0` fix for #7263.
- The printer counts `with` nesting like esbuild and uses the expression forms inside a `with` body. A missing import item on the left of `**` gets parentheses, since it can print as `void 0` (absorbs #36134).
- Other files print as before. `RuntimeTranspilerCache` version 30 -> 31. Self-reviewed: 3 concerns raised, 3 addressed.
- Verified: new cases in `transpiler.test.js`, `runtime-transpiler.test.ts`, `bundler_edgecase.test.ts`, `esbuild/importstar.test.ts` fail on 1.4.x and pass here.

### Background
- The parser turns an unbound `undefined` / `NaN` / `Infinity` identifier into `EUndefined` / `ENumber`. Folding, macros and const enums make such nodes too, so the printer must name the global.
- The bundler renames every symbol and, since #41909, reserves these names. The paths above run no renamer. `Infinity` was already safe there: it prints as `1 / 0`.

This PR now carries only what main lacks after #41909. #36122 and #36134 are closed in favor of it.

<details><summary>Notes</summary>

- State of main after #41909, checked with a debug build: every bundler cell of the repro table matches node. Still wrong: `bun run` for NaN (`0 / 0` and `+"a"` fold to NaN because the runtime transpiler enables inlining), `bun build --no-bundle` and `Bun.Transpiler` for `undefined` (`void 0` prints as `undefined`) and for NaN with `--minify-syntax` or `+"a"`, and `with ({NaN, Infinity, undefined}) {...}` on every path.
- `bun run` was already right for `undefined` because the runtime transpiler sets `minify_syntax`, which prints `void 0`. `bun test --coverage` turns `minify_syntax` off and goes through the same `print_ast` path, so it gets the fix too.
- The earlier shape of this PR computed three `shadows_*` options at both print entry points. The bundler entry point no longer needs it (#41909), `shadows_infinity` had no effect left, and the flags moved from `Options` to printer state set by `print_ast`, so no caller changes are needed (transpiler, REPL, `pm diff` normalizer).
- #36122 tracked the same fact with a parser-side `ConstValuesDeclared` bitflag threaded through `Ast`. The symbol table already holds it, so this version derives it at the one place that consumes it.
- The fallback fires for the whole file when any scope binds the name, and also for a TS `enum` member or an `export { NaN } from` re-export of that name. That only costs the `0 / 0` spelling, never correctness. Labels and unbound references do not count.
- `0 / 0` is not emitted for unshadowed files on purpose: its NaN bit pattern is not guaranteed to match the global's across engines, CPUs and JIT tiers (#36122 hit this on aarch64 with `-(0/0)`).
- esbuild 0.21 prints `(function(NaN) { console.log(Number.isNaN(NaN), NaN); })(5)` and `void 0 ** 2` for the same inputs, so there is no reference behaviour to copy for those. The `with` handling mirrors its `withNesting`.
- Self-review concerns: (1, 2) `ns.missing ** 2` inside a `with` body or in a file that binds `undefined` printed `void 0 ** 2`, a SyntaxError. Fixed by the `EImportIdentifier` arm in the `**` left-operand check, with a test. (3) The description did not say that no user reported this. It now does and cites #7263.
- Rebase notes for neighbours: #35739 and #41743 each touch one nearby hunk in `lib.rs`. The overlap is mechanical.
- Not covered, as before: a `var NaN` introduced by direct `eval`, a bundler-path binding that direct `eval` pins (`must_not_be_renamed`), and a REPL binding from an earlier line.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 failed, 37 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/esbuild/importstar.test.ts test/bundler/transpiler/runtime-transpiler.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [591.06ms]
(pass) bundler > edgecase/EmptyCommonJSModule [418.37ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [498.09ms]
(pass) bundler > edgecase/ImportStarFunction [449.01ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [386.89ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [127.90ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [546.30ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [269.90ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [269.91ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [260.56ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [148.02ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [436.75ms]
(todo)
... (truncated)

release without fix: 6 failed, 37 skipped
bun test v1.4.3-canary.1 (1788e56bd)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [14.23ms]
(pass) bundler > edgecase/EmptyCommonJSModule [12.56ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [11.15ms]
(pass) bundler > edgecase/ImportStarFunction [12.06ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [12.46ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [5.45ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [12.27ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [7.23ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [5.47ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [6.23ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [4.39ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [12.18ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [10.48ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [4.01ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [2.70ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDefaul
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 37 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/esbuild/importstar.test.ts test/bundler/transpiler/runtime-transpiler.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [541.20ms]
(pass) bundler > edgecase/EmptyCommonJSModule [427.41ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [413.31ms]
(pass) bundler > edgecase/ImportStarFunction [393.18ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [476.29ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [123.88ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [460.02ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [338.23ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [292.45ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [267.92ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [127.34ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [502.51ms]
(todo)
... (truncated)

release with fix: 37 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 840ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/136] gen cpp.rs (cppbind)
[3/136] gen JS modules (bundle-modules)
Preprocess modules (11164ms)
Bundle modules (85ms)
Postprocesss modules (209ms)
Bundle Functions (724ms)
Generate Code (51ms)

[12.25s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/136] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mimalloc_sys)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs                              | 93 +++++++++++++++++++---
 src/jsc/RuntimeTranspilerCache.rs                  |  3 +-
 test/bundler/bundler_edgecase.test.ts              | 23 ++++++
 test/bundler/esbuild/importstar.test.ts            | 22 +++++
 test/bundler/transpiler/runtime-transpiler.test.ts | 51 ++++++++++++
 test/bundler/transpiler/transpiler.test.js         | 84 +++++++++++++++++++
 6 files changed, 266 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js_printer/lib.rs                                   0      0      4
src/jsc/RuntimeTranspilerCache.rs                       0      0      4
test/bundler/bundler_edgecase.test.ts                   0      0      0
test/bundler/esbuild/importstar.test.ts                 0      0      0
test/bundler/transpiler/runtime-transpiler.test.ts      0      0      0
test/bundler/transpiler/transpiler.test.js              0      0      4
```

</details>

**root cause** · written by the author bot

The printer emitted the bare identifiers `undefined`, `NaN`, and `Infinity` for their corresponding special values, so a local binding with the same name or a property on a `with` object could capture the reference and change the program's meaning. The fix scans the symbol table for shadowed `NaN` and `undefined` bindings and tracks `with` statement nesting, then prints context safe equivalents such as `void 0`, `0/0`, and `1/0` with correct precedence and parenthesization whenever a bare identifier could be captured, while also using computed syntax for numeric property keys that require i…

<!-- robobun:evidence:end -->
