### PR TITLE
bun test: keep injecting jest globals alongside a partial bun:test import

### DIFF
--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1717,20 +1717,19 @@ impl<'a> Parser<'a> {
                 break 'outer;
             }
 
+            // A user import from one of these modules does not suppress
+            // injection: names the user imported shadow the pre-declared
+            // `Kind::Unbound` refs (so their `use_count_estimate` stays 0 and
+            // they are skipped below), while any remaining jest globals the
+            // file references are still synthesized. The only thing left to do
+            // here is invalidate the transpiler cache when the import path
+            // itself will be rewritten at resolve time.
             for item in p.import_records.items() {
-                // skip if they did import it
-                if item.path.text == b"bun:test"
-                    || item.path.text == b"@jest/globals"
-                    || item.path.text == b"vitest"
-                {
+                if item.path.text == b"@jest/globals" || item.path.text == b"vitest" {
                     if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
-                        // If we rewrote import paths, we need to disable the runtime transpiler cache
-                        if item.path.text != b"bun:test" {
-                            cache.input_hash = None;
-                        }
+                        cache.input_hash = None;
                     }
-
-                    break 'outer;
+                    break;
                 }
             }
 

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1717,13 +1717,9 @@ impl<'a> Parser<'a> {
                 break 'outer;
             }
 
-            // A user import from one of these modules does not suppress
-            // injection: names the user imported shadow the pre-declared
-            // `Kind::Unbound` refs (so their `use_count_estimate` stays 0 and
-            // they are skipped below), while any remaining jest globals the
-            // file references are still synthesized. The only thing left to do
-            // here is invalidate the transpiler cache when the import path
-            // itself will be rewritten at resolve time.
+            // User-imported names already shadow the `Kind::Unbound` jest refs
+            // (use_count_estimate stays 0), so the per-name filter below skips
+            // them; only disable the cache for paths rewritten at resolve time.
             for item in p.import_records.items() {
                 if item.path.text == b"@jest/globals" || item.path.text == b"vitest" {
                     if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -362,7 +362,7 @@ pub mod Runtime {
         pub fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 17] = [
+            let bools: [bool; 18] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -380,7 +380,7 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
-                // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
+                self.inject_jest_globals,
             ];
 
             // `[bool; N]` is N bytes of 0x00/0x01.

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,11 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-const EXPECTED_VERSION: u32 = 23;
+/// Version 24: A partial `bun:test` import no longer suppresses jest-global
+/// injection. Entries written before this left `input_hash` intact on the
+/// `bun:test` arm, so stale un-injected output would be served after upgrading
+/// (#4007).
+const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,10 +43,10 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-/// Version 24: A partial `bun:test` import no longer suppresses jest-global
-/// injection. Entries written before this left `input_hash` intact on the
-/// `bun:test` arm, so stale un-injected output would be served after upgrading
-/// (#4007).
+/// Version 24: `inject_jest_globals` participates in the features hash, and a
+/// partial `bun:test` import no longer suppresses jest-global injection. Stale
+/// un-injected entries were otherwise served after upgrading and across
+/// `bun run` -> `bun test` on the same binary (#4007).
 const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -261,6 +261,43 @@ describe("transpiler cache", () => {
     expect(run(["--feature=OTHER", "--feature=SUPER_SECRET"])).toBe("enabled");
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
+
+  test("bun run entry does not poison bun test's jest-global injection", () => {
+    const filler = Buffer.alloc(50 * 1024, "/").toString();
+    writeFileSync(
+      join(temp_dir, "helper.js"),
+      `export const jestType = typeof jest;
+export const describeType = typeof describe;
+//${filler}`,
+    );
+    writeFileSync(
+      join(temp_dir, "runner.js"),
+      `import { jestType, describeType } from "./helper.js";
+console.log(jestType, describeType);`,
+    );
+    writeFileSync(
+      join(temp_dir, "check.test.js"),
+      `import { jestType, describeType } from "./helper.js";
+test("helper sees injected globals under bun test", () => {
+  expect({ jestType, describeType }).toEqual({ jestType: "object", describeType: "function" });
+});`,
+    );
+
+    const a = bunRun(join(temp_dir, "runner.js"), env);
+    expect(a.stdout).toBe("undefined undefined");
+    expect(existsSync(cache_dir)).toBeTrue();
+    expect(newCacheCount()).toBeGreaterThanOrEqual(1);
+
+    const t = Bun.spawnSync({
+      cmd: [bunExe(), "test", "check.test.js"],
+      cwd: temp_dir,
+      env,
+    });
+    const out = t.stderr.toString() + t.stdout.toString();
+    expect(out).toContain("1 pass");
+    expect(out).toContain("0 fail");
+    expect(t.exitCode).toBe(0);
+  });
 });
 
 test("rejects cached module records containing out-of-range string indices", () => {

--- a/test/js/bun/test/test-auto-import-jest-globals.test.js
+++ b/test/js/bun/test/test-auto-import-jest-globals.test.js
@@ -1,3 +1,5 @@
+import { bunEnv, bunExe, tempDir } from "harness";
+
 test("Jest auto imports", () => {
   expect(true).toBe(true);
   expect(typeof describe).toBe("function");
@@ -21,4 +23,76 @@ test("Jest's globals aren't available in every file", async () => {
   expect(typeof jestGlobals.beforeEach).toBe("undefined");
   expect(typeof jestGlobals.afterAll).toBe("undefined");
   expect(typeof jestGlobals.afterEach).toBe("undefined");
+});
+
+describe("partial bun:test import keeps the un-imported jest globals", () => {
+  const body = `{
+  expect(typeof test).toBe("function");
+  expect(typeof describe).toBe("function");
+  expect(typeof expect).toBe("function");
+  expect(typeof beforeAll).toBe("function");
+  expect(typeof beforeEach).toBe("function");
+  expect(typeof afterAll).toBe("function");
+  expect(typeof afterEach).toBe("function");
+  expect(typeof jest).toBe("object");
+  expect(typeof vi).toBe("object");
+  expect(typeof xit).toBe("function");
+  expect(typeof xtest).toBe("function");
+  expect(typeof xdescribe).toBe("function");
+  expect(typeof expectTypeOf).toBe("function");
+  expect(typeof it).toBe("function");
+});`;
+
+  const cases = {
+    "import { it } from bun:test": `import { it } from "bun:test";\nit("globals", () => ${body}`,
+    "import { mock } from bun:test": `import { mock } from "bun:test";\nexpect(typeof mock).toBe("function");\nit("globals", () => ${body}`,
+    "import { it } from @jest/globals": `import { it } from "@jest/globals";\nit("globals", () => ${body}`,
+    "import { it } from vitest": `import { it } from "vitest";\nit("globals", () => ${body}`,
+    "import * as t from bun:test": `import * as t from "bun:test";\nt.it("globals", () => ${body}`,
+    "const { it } = require(bun:test)": `const { it } = require("bun:test");\nit("globals", () => ${body}`,
+  };
+
+  for (const [name, source] of Object.entries(cases)) {
+    test.concurrent(name, async () => {
+      using dir = tempDir("jest-globals-partial-import", {
+        "partial.test.js": source,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "partial.test.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("1 pass");
+      expect(stderr).toContain("0 fail");
+      expect(stderr).not.toContain("error:");
+      expect(stdout).not.toContain("undefined");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test.concurrent("imported name is not double-injected", async () => {
+    using dir = tempDir("jest-globals-no-double-inject", {
+      "partial.test.js": `import { it, describe } from "bun:test";
+describe("d", () => {
+  it("t", () => {
+    expect(typeof test).toBe("function");
+  });
+});`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "partial.test.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("1 pass");
+    expect(stderr).not.toContain("has already been declared");
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/test-auto-import-jest-globals.test.js
+++ b/test/js/bun/test/test-auto-import-jest-globals.test.js
@@ -64,11 +64,10 @@ describe("partial bun:test import keeps the un-imported jest globals", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain("1 pass");
       expect(stderr).toContain("0 fail");
       expect(stderr).not.toContain("error:");
-      expect(stdout).not.toContain("undefined");
       expect(exitCode).toBe(0);
     });
   }


### PR DESCRIPTION
## What

Importing any single name from `bun:test` (or `@jest/globals` / `vitest`) silently removed every documented auto-global from that file. `test`, `describe`, `expect`, `beforeAll`, `jest`, `vi`, `xit`, etc. all became `undefined`, so the file's real tests never ran (top-level `ReferenceError: test is not defined`).

```js
// bun test import-kills-globals.test.js
import { it } from "bun:test";          // any single name is enough
it("globals survive a partial import?", () => {
  console.log(typeof test, typeof describe, typeof expect, typeof beforeAll);
  // before: undefined undefined undefined undefined
  // after:  function function function function
});
```

The docs describe the imports as additive, and Jest's own `@jest/globals` import never removes the globals, so a Jest file that adds one Bun-only import (`mock`, `setDefaultTimeout`) would lose `describe`/`test`.

## Cause

`src/js_parser/parse/parse_entry.rs` scanned `import_records` for `bun:test` / `@jest/globals` / `vitest` and did `break 'outer` on the first match, skipping the entire synthetic-import block. The gate was all-or-nothing on the presence of the import, not per-name.

## Fix

Drop the early `break 'outer`. The per-name filter that follows already handles the overlap correctly: names the user imported shadow the pre-declared `Kind::Unbound` refs (when `declare_common_js_symbol` finds an existing module-scope member it registers the generated ref on `module_scope.generated`, not `.members`), so their `use_count_estimate` stays 0 and they are skipped. Only the un-imported globals the file actually references are emitted as a second `import { ... } from "bun:test"` (or `const { ... } = require("bun:test")` for CJS).

This also adds `inject_jest_globals` to the runtime transpiler cache's features hash and bumps the cache version to 24. Without that, an un-injected entry written under `bun run` (or a pre-upgrade `bun test`) would be served on the next `bun test` of the same file, since cache lookup runs before the injection block and the features hash previously excluded this flag.

## Verification

`test/js/bun/test/test-auto-import-jest-globals.test.js` gained 7 spawned cases covering `bun:test` / `@jest/globals` / `vitest` named imports, a `* as` namespace import, `require("bun:test")`, importing a non-global export (`mock`), and a no-duplicate-declaration check when the user-imported name is also referenced. All fail on current canary with `ReferenceError: expect is not defined` and pass with this change.

`test/cli/run/transpiler-cache.test.ts` gained a cross-mode case that caches a helper referencing `typeof jest`/`typeof describe` under `bun run` and then loads it under `bun test`. On 1.3.14 the cached entry is served and the inner test sees `undefined`/`undefined`; with this change the `bun test` run misses the cache and re-transpiles with injection.

Fixes #4007

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts test/js/bun/test/test-auto-import-jest-globals.test.js
bun test v1.4.0 (f369677e0)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [599.86ms]
(pass) transpiler cache > works with empty files [569.22ms]
(pass) transpiler cache > ignores files under the minimum cache size [268.56ms]
(pass) transpiler cache > it is indeed content addressable [882.91ms]
(pass) transpiler cache > doing 50 buns at once does not crash [1623.16ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [590.70ms]
(pass) transpiler cache > works if the cache is not user-readable [881.91ms]
(pass) transpiler cache > works if the cache is not user-writable [300.77ms]
(pass) transpiler cache > does not inline process.env [594.34ms]
(pass) transpiler cache > --feature flag invalidates cache [1743.83ms]
292 |       cmd: [bunExe(), "test", "check.test.js"],
293 |       cwd: temp_dir,
294 |       env,
295 |     });
296 |     const out = t.stderr.toString() + t.stdou
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b1b8aca9f)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [27.70ms]
(pass) transpiler cache > works with empty files [25.17ms]
(pass) transpiler cache > ignores files under the minimum cache size [12.53ms]
(pass) transpiler cache > it is indeed content addressable [48.10ms]
(pass) transpiler cache > doing 50 buns at once does not crash [241.56ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [25.90ms]
(pass) transpiler cache > works if the cache is not user-readable [38.90ms]
(pass) transpiler cache > works if the cache is not user-writable [12.88ms]
(pass) transpiler cache > does not inline process.env [25.64ms]
(pass) transpiler cache > --feature flag invalidates cache [72.31ms]
(pass) transpiler cache > bun run entry does not poison bun test's jest-global injection [28.29ms]
(pass) rejects cached module records containing out-of-range string indices [45.21ms]

test/js/bun/test/test-auto-import-jest-globals.test.js:
(pass) Jest auto imports [0.08ms]
(pass) Jest's globals aren't available in every file [0.39ms]
(pass) partial bun:test import keeps the un-imported 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts test/js/bun/test/test-auto-import-jest-globals.test.js
bun test v1.4.0 (f369677e0)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [633.63ms]
(pass) transpiler cache > works with empty files [581.66ms]
(pass) transpiler cache > ignores files under the minimum cache size [264.85ms]
(pass) transpiler cache > it is indeed content addressable [891.35ms]
(pass) transpiler cache > doing 50 buns at once does not crash [1610.71ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [593.90ms]
(pass) transpiler cache > works if the cache is not user-readable [890.47ms]
(pass) transpiler cache > works if the cache is not user-writable [295.50ms]
(pass) transpiler cache > does not inline process.env [588.68ms]
(pass) transpiler cache > --feature flag invalidates cache [1732.96ms]
(pass) transpiler cache > bun run entry does not poison bun test's jest-global injection [584.12ms]
(pass) rejects cached module records containing out-of-range st
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 736ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_entry.rs                 | 17 ++---
 src/js_parser/parser.rs                            |  4 +-
 src/jsc/RuntimeTranspilerCache.rs                  |  6 +-
 test/cli/run/transpiler-cache.test.ts              | 37 +++++++++++
 .../bun/test/test-auto-import-jest-globals.test.js | 73 ++++++++++++++++++++++
 5 files changed, 123 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js_parser/parse/parse_entry.rs                          3      2      0
src/js_parser/parser.rs                                     3      1      0
src/jsc/RuntimeTranspilerCache.rs                           4      3      0
test/cli/run/transpiler-cache.test.ts                       2      1      0
test/js/bun/test/test-auto-import-jest-globals.test.js      2      4      0
```

</details>

<!-- robobun:evidence:end -->