### PR TITLE
cli(run): export INIT_CWD to package.json scripts

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -678,7 +678,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
         env_loader
             .map
-            .put_default(b"INIT_CWD", strings::without_trailing_slash(top_level_dir))
+            .put(
+                b"INIT_CWD",
+                bun_paths::string_paths::without_trailing_slash_windows_path(top_level_dir),
+            )
             .expect("unreachable");
 
         // Propagate --no-orphans / [run] noOrphans to the script's env so any

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -676,6 +676,11 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             .put_default(b"npm_config_local_prefix", top_level_dir)
             .expect("unreachable");
 
+        env_loader
+            .map
+            .put_default(b"INIT_CWD", strings::without_trailing_slash(top_level_dir))
+            .expect("unreachable");
+
         // Propagate --no-orphans / [run] noOrphans to the script's env so any
         // Bun process the script spawns enables its own watchdog. The env
         // loader snapshots `environ` before flag parsing runs, so the

--- a/test/cli/run/run-process-env.test.ts
+++ b/test/cli/run/run-process-env.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunExe, bunRunAsScript, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRunAsScript, tempDirWithFiles } from "harness";
+import path from "node:path";
+import fs from "node:fs";
 
 describe("process.env", () => {
   test("npm_lifecycle_event", () => {
@@ -24,5 +26,34 @@ describe("process.env", () => {
     });
     const { stdout } = bunRunAsScript(dir, "first");
     expect(stdout).toBe("second");
+  });
+
+  test("INIT_CWD is set to the directory bun run was invoked from", async () => {
+    const dir = tempDirWithFiles("init-cwd", {
+      "package.json": JSON.stringify({
+        name: "p",
+        version: "1.0.0",
+        scripts: { envcheck: `'${bunExe()}' print-env.js` },
+      }),
+      "print-env.js": `process.stdout.write(JSON.stringify({ INIT_CWD: process.env.INIT_CWD, cwd: process.cwd() }));`,
+      "sub/deep/.keep": "",
+    });
+    const invokeFrom = fs.realpathSync(path.join(dir, "sub", "deep"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--silent", "envcheck"],
+      env: { ...bunEnv, INIT_CWD: undefined },
+      cwd: invokeFrom,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      INIT_CWD: invokeFrom,
+      cwd: fs.realpathSync(dir),
+    });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/run-process-env.test.ts
+++ b/test/cli/run/run-process-env.test.ts
@@ -28,6 +28,7 @@ describe("process.env", () => {
     expect(stdout).toBe("second");
   });
 
+  // https://github.com/oven-sh/bun/issues/21088
   test("INIT_CWD is set to the directory bun run was invoked from", async () => {
     const dir = tempDirWithFiles("init-cwd", {
       "package.json": JSON.stringify({
@@ -42,7 +43,7 @@ describe("process.env", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", "--silent", "envcheck"],
-      env: { ...bunEnv, INIT_CWD: undefined },
+      env: { ...bunEnv, INIT_CWD: "/should/be/overwritten" },
       cwd: invokeFrom,
       stdout: "pipe",
       stderr: "pipe",
@@ -54,6 +55,32 @@ describe("process.env", () => {
       INIT_CWD: invokeFrom,
       cwd: fs.realpathSync(dir),
     });
+    expect(exitCode).toBe(0);
+  });
+
+  test("INIT_CWD is reset by a nested bun run", async () => {
+    const dir = tempDirWithFiles("init-cwd-nested", {
+      "package.json": JSON.stringify({
+        scripts: { outer: `'${bunExe()}' run --silent --cwd packages/foo inner` },
+      }),
+      "packages/foo/package.json": JSON.stringify({
+        scripts: { inner: `'${bunExe()}' ../../print-env.js` },
+      }),
+      "print-env.js": `process.stdout.write(JSON.stringify({ INIT_CWD: process.env.INIT_CWD }));`,
+    });
+    const root = fs.realpathSync(dir);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--silent", "outer"],
+      env: { ...bunEnv, INIT_CWD: "/should/be/overwritten" },
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ INIT_CWD: path.join(root, "packages", "foo") });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/run-process-env.test.ts
+++ b/test/cli/run/run-process-env.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, bunRunAsScript, tempDirWithFiles } from "harness";
-import path from "node:path";
 import fs from "node:fs";
+import path from "node:path";
 
 describe("process.env", () => {
   test("npm_lifecycle_event", () => {


### PR DESCRIPTION
## What

`bun run <script>` now exports `INIT_CWD` (the directory the command was invoked from) to the script's environment, matching npm and matching what `bun install` lifecycle scripts already do.

Part of #21088 (the `INIT_CWD` portion; `npm_command` and `npm_config_local_prefix` left for follow-up).

## Repro

```sh
mkdir -p p/sub/deep && cd p
echo '{"name":"p","version":"1.0.0","scripts":{"envcheck":"echo IC=[$INIT_CWD]"}}' > package.json
cd sub/deep
bun run --silent envcheck
```

Before: `IC=[]`
After: `IC=[/.../p/sub/deep]` (same as `npm run --silent envcheck`)

## Cause

`configure_env_for_run_impl` seeds `npm_lifecycle_event`, `npm_config_local_prefix`, `npm_package_*`, etc., but never `INIT_CWD`. The install path (`PackageManager::configure_env_for_scripts_run`) sets it separately after the fact, which is why `bun install` lifecycle scripts already had it but `bun run` did not.

## Fix

Set `INIT_CWD` in `configure_env_for_run_impl` unconditionally (`.put()`), sourced from `top_level_dir` which at that point is the invocation cwd. Unconditional write matches npm (which does `process.env.INIT_CWD = process.cwd()` at CLI entry) and the `npm_lifecycle_event` precedent in the same function, so a nested `bun run` resets `INIT_CWD` to its own invocation directory rather than inheriting the outer value. The trailing-slash trim uses `without_trailing_slash_windows_path` so a Windows drive-root cwd `C:\` is preserved instead of becoming drive-relative `C:`.

This covers `bun run`, `bunx`, and `--filter` since they share this env setup. (`bun pm pack` and install lifecycle hooks go through `PackageManager::init` which `chdir`s to the package root before this runs, so they continue to see the package root as `INIT_CWD`; that is a pre-existing limitation tracked separately.)

## Verification

```
(pass) process.env > INIT_CWD is set to the directory bun run was invoked from
(pass) process.env > INIT_CWD is reset by a nested bun run
```

Both fail on canary, pass with the fix.

## Not in this PR

The other two discrepancies from #21088, left for follow-up:
- `npm_command` is `run-script` (npm uses `run`)
- `npm_config_local_prefix` is the invocation cwd rather than the package root

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/run-process-env.test.ts
bun test v1.4.0 (5db4a15d5)

test/cli/run/run-process-env.test.ts:
(pass) process.env > npm_lifecycle_event [419.71ms]
(pass) process.env > npm_lifecycle_event should have the value of the last call [523.84ms]
49 |       stderr: "pipe",
50 |     });
51 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
52 | 
53 |     expect(stderr).toBe("");
54 |     expect(JSON.parse(stdout)).toEqual({
                                    ^
error: expect(received).toEqual(expected)

  {
-   "INIT_CWD": "/tmp/init-cwd_94VNtf/sub/deep",
+   "INIT_CWD": "/should/be/overwritten",
    "cwd": "/tmp/init-cwd_94VNtf",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/run/run-process-env.test.ts:54:32)
(fail) process.env > INIT_CWD is set to the directory bun run was invoked from [1237.75ms]
78 |       stderr: "pipe",
79 |     });
80 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6f9897d99)

test/cli/run/run-process-env.test.ts:
(pass) process.env > npm_lifecycle_event [14.57ms]
(pass) process.env > npm_lifecycle_event should have the value of the last call [15.29ms]
(pass) process.env > INIT_CWD is set to the directory bun run was invoked from [25.14ms]
(pass) process.env > INIT_CWD is reset by a nested bun run [28.97ms]

 4 pass
 0 fail
 8 expect() calls
Ran 4 tests across 1 file. [239.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/run-process-env.test.ts
bun test v1.4.0 (5db4a15d5)

test/cli/run/run-process-env.test.ts:
(pass) process.env > npm_lifecycle_event [428.87ms]
(pass) process.env > npm_lifecycle_event should have the value of the last call [524.92ms]
(pass) process.env > INIT_CWD is set to the directory bun run was invoked from [1215.91ms]
(pass) process.env > INIT_CWD is reset by a nested bun run [1344.65ms]

 4 pass
 0 fail
 8 expect() calls
Ran 4 tests across 1 file. [5.49s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 735ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 06s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+5db4a15d5
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (5db4a15d5)

test/cli/run/run-process-env.test.ts:
(pass) process.env > npm_lifecycle_event [13.78ms]
(pass) process.env > npm_lifecycle_event should have the value of the last call [14.92ms]
(pass) process.env > INIT_CWD is set to the directory bun run was invoked from [25.99ms]
(pass) process.env > INIT_CWD is reset by a nested bun run
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/run_command.rs       |  8 +++++
 test/cli/run/run-process-env.test.ts | 60 +++++++++++++++++++++++++++++++++++-
 2 files changed, 67 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/runtime/cli/run_command.rs            3      2      0
test/cli/run/run-process-env.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->