### PR TITLE
cli: handle -v/--version in the node argv0 shim

### DIFF
--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1524,6 +1524,19 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_run_as_node(log: &mut bun_ast::Log) -> CmdResult {
+        // `node -v` / `node --version`: print `process.version` and exit 0,
+        // matching Node.js. Must run before `init()` because `RUN_TABLE` has no
+        // `-v`/`--version` entry, so clap would reject `-v` and drop
+        // `--version`. Stop at the first positional or `--` so a script's own
+        // `--version` flag is left alone (`node app.js --version`).
+        for a in bun::argv().iter().skip(1) {
+            match a {
+                b"-v" | b"--version" => print_node_version_and_exit(),
+                b"--" => break,
+                _ if a.first() != Some(&b'-') => break,
+                _ => {}
+            }
+        }
         let ctx = init(Tag::RunAsNodeCommand, log)?;
         run_command::RunCommand::exec_as_if_node(ctx)
     }
@@ -2302,6 +2315,17 @@ pub fn print_revision_and_exit() -> ! {
     let w = Output::writer();
     let _ = w.write_all(Global::package_json_version_with_revision.as_bytes());
     let _ = w.write_all(b"\n");
+    Output::flush();
+    Global::exit(0);
+}
+
+#[cold]
+pub fn print_node_version_and_exit() -> ! {
+    let w = Output::writer();
+    let _ = w.write_all(
+        const_format::concatcp!("v", bun_core::Environment::REPORTED_NODEJS_VERSION, "\n")
+            .as_bytes(),
+    );
     Output::flush();
     Global::exit(0);
 }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1524,8 +1524,7 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_run_as_node(log: &mut bun_ast::Log) -> CmdResult {
-        // `node -v` / `node --version` → `process.version`. RUN_TABLE has no
-        // entry for these; stop at the script so `node app.js --version` is untouched.
+        // Handle `node -v`/`--version` before init(): RUN_TABLE has no entry for them.
         for a in bun::argv().iter().skip(1) {
             match a {
                 b"-v" | b"--version" => print_node_version_and_exit(),

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1524,15 +1524,12 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_run_as_node(log: &mut bun_ast::Log) -> CmdResult {
-        // `node -v` / `node --version`: print `process.version` and exit 0,
-        // matching Node.js. Must run before `init()` because `RUN_TABLE` has no
-        // `-v`/`--version` entry, so clap would reject `-v` and drop
-        // `--version`. Stop at the first positional or `--` so a script's own
-        // `--version` flag is left alone (`node app.js --version`).
+        // `node -v` / `node --version` → `process.version`. RUN_TABLE has no
+        // entry for these; stop at the script so `node app.js --version` is untouched.
         for a in bun::argv().iter().skip(1) {
             match a {
                 b"-v" | b"--version" => print_node_version_and_exit(),
-                b"--" => break,
+                b"--" | b"-" => break,
                 _ if a.first() != Some(&b'-') => break,
                 _ => {}
             }

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -87,6 +87,38 @@ describe("fake node cli", () => {
     expect(fakeNodeRun(temp, ["-e", "console.log('pass')"]).stdout).toBe("pass");
   });
 
+  describe("-v / --version", () => {
+    // Engine-version preflights (node-gyp, prepare/postinstall scripts) run
+    // `node --version` through the bun-node shim; it must behave like Node.js
+    // and print `v<process.version>` with exit 0.
+    test.each(["-v", "--version"])("node %s prints process.version", flag => {
+      const temp = tempDirWithFiles("fake-node", {});
+      const result = Bun.spawnSync([bunExe(), "--bun", "node", flag], {
+        cwd: temp,
+        env: { ...bunEnv, NODE_ENV: undefined },
+        stdin: Buffer.alloc(0),
+      });
+      expect(result.stderr.toString()).toBe("");
+      expect(result.stdout.toString()).toBe(process.version + "\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    test("node --version matches node -e 'console.log(process.version)'", () => {
+      const temp = tempDirWithFiles("fake-node", {});
+      const evaled = fakeNodeRun(temp, ["-e", "console.log(process.version)"]).stdout;
+      expect(fakeNodeRun(temp, ["--version"]).stdout).toBe(evaled);
+      expect(fakeNodeRun(temp, ["-v"]).stdout).toBe(evaled);
+    });
+
+    test("node script.js --version passes the flag through to the script", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "index.js": "console.log(JSON.stringify(process.argv.slice(2)))",
+      });
+      expect(fakeNodeRun(temp, ["index.js", "--version"]).stdout).toBe(JSON.stringify(["--version"]));
+      expect(fakeNodeRun(temp, ["index.js", "-v"]).stdout).toBe(JSON.stringify(["-v"]));
+    });
+  });
+
   test("process args work", () => {
     const temp = tempDirWithFiles("fake-node", {
       "index.js": "console.log(JSON.stringify(process.argv.slice(1)))",

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -117,6 +117,14 @@ describe("fake node cli", () => {
       expect(fakeNodeRun(temp, ["index.js", "--version"]).stdout).toBe(JSON.stringify(["--version"]));
       expect(fakeNodeRun(temp, ["index.js", "-v"]).stdout).toBe(JSON.stringify(["-v"]));
     });
+
+    test("node -- index.js --version passes the flag through to the script", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "index.js": "console.log(JSON.stringify(process.argv.slice(2)))",
+      });
+      expect(fakeNodeRun(temp, ["--", "index.js", "--version"]).stdout).toBe(JSON.stringify(["--version"]));
+      expect(fakeNodeRun(temp, ["--", "index.js", "-v"]).stdout).toBe(JSON.stringify(["-v"]));
+    });
   });
 
   test("process args work", () => {


### PR DESCRIPTION
## What

`node -v` and `node --version` now print `v<process.version>` and exit 0 when bun is invoked through its `node` argv0 shim (the `/tmp/bun-node-<rev>/node` symlink that `bun run`/`--bun` put on `PATH`).

## Repro

With no real `node` on `PATH`:

```sh
cat > package.json <<'JSON'
{"scripts":{"probe":"node -e 'console.log(process.version)'; node --version; echo rc1=$?; node -v >/dev/null 2>&1; echo rc2=$?"}}
JSON
PATH=/usr/bin:/bin bun run probe
```

Before:
```
v26.3.0
error: Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.
rc1=1
rc2=1
```

After:
```
v26.3.0
v26.3.0
rc1=0
rc2=0
```

## Cause

`RunAsNodeCommand` parses argv with `RUN_TABLE`, which has no `-v`/`--version` entry (those live in `AUTO_ONLY_PARAMS`). So:

- `--version` was an unknown long flag, silently dropped (node-mode clears `WARN_ON_UNRECOGNIZED_FLAG`), leaving `ctx.positionals` empty and hitting `exec_as_if_node_missing_script()` → `error: Missing script to execute` (rc 1).
- `-v` was an unknown short flag, which clap's short-flag chainer hard-rejects (`streaming.rs::chainging`) → `error: Invalid Argument '-v'` plus the full `bun run` usage screen (rc 1).

This broke engine-version preflights (`node --version` in prepare/postinstall/CI scripts, node-gyp's version probe) on machines without a real `node` installed, while `node -e`/`-p`/`file.js` through the same shim worked fine.

## Fix

Scan argv in `exec_run_as_node` before `init()` runs clap: if `-v`/`--version` appears before the first positional (or `--`), print `v<REPORTED_NODEJS_VERSION>\n` and exit 0. `node app.js --version` is unaffected; the flag still reaches the script.

## Tests

Added to `test/cli/run/as-node.test.ts`:
- `node -v` / `node --version` print `process.version` with exit 0
- the shim's output matches `node -e 'console.log(process.version)'`
- `node script.js --version` still passes `--version` through to the script

```
USE_SYSTEM_BUN=1 bun test test/cli/run/as-node.test.ts -t version   # 3 fail, 1 pass
bun bd test test/cli/run/as-node.test.ts                            # 15 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/as-node.test.ts
bun test v1.4.0 (fea90e29b)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [411.52ms]
(pass) fake node cli > doesnt resolve bins [390.23ms]
(pass) fake node cli > doesnt resolve scripts [401.47ms]
(pass) fake node cli > can run a script named run.js [396.59ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [407.89ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [392.87ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [405.56ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [399.19ms]
(pass) fake node cli > node -e  [394.95ms]
 96 |       const result = Bun.spawnSync([bunExe(), "--bun", "node", flag], {
 97 |         cwd: temp,
 98 |         env: { ...bunEnv, NODE_ENV: undefined },
 99 |         stdin: Buffer.alloc(0),
100 |       });
101 |       expect(result.stderr.toString()).toBe("");
                                             ^
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [21.91ms]
(pass) fake node cli > doesnt resolve bins [18.35ms]
(pass) fake node cli > doesnt resolve scripts [17.33ms]
(pass) fake node cli > can run a script named run.js [16.93ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [17.38ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [16.90ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [17.95ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [16.89ms]
(pass) fake node cli > node -e  [13.61ms]
 96 |       const result = Bun.spawnSync([bunExe(), "--bun", "node", flag], {
 97 |         cwd: temp,
 98 |         env: { ...bunEnv, NODE_ENV: undefined },
 99 |         stdin: Buffer.alloc(0),
100 |       });
101 |       expect(result.stderr.toString()).toBe("");
                                             ^
error: expect(received).toBe(expected)

- ""
+ "error: Invalid Argument '-v'
+ error: "node" exited with code 1
+ "

- Expected  - 1
+ Received  + 3

      at <a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/as-node.test.ts
bun test v1.4.0 (fea90e29b)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [404.00ms]
(pass) fake node cli > doesnt resolve bins [376.78ms]
(pass) fake node cli > doesnt resolve scripts [388.46ms]
(pass) fake node cli > can run a script named run.js [397.33ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [403.36ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [397.51ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [382.50ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [410.34ms]
(pass) fake node cli > node -e  [395.49ms]
(pass) fake node cli > -v / --version > node -v prints process.version [256.81ms]
(pass) fake node cli > -v / --version > node --version prints process.version [232.85ms]
(pass) fake node cli > -v / --version > node --version matches node -e 'console.log(process.version)' [856.08ms]
(pass) fake node cli > -v / -
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 748ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/mod.rs       | 20 ++++++++++++++++++++
 test/cli/run/as-node.test.ts | 40 ++++++++++++++++++++++++++++++++++++++++
 2 files changed, 60 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                          reads  edits  tests
src/runtime/cli/mod.rs           11      6      0
test/cli/run/as-node.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->