### PR TITLE
fetch: accept absolute-FQDN hostnames (trailing dot) in TLS certificate verification

### DIFF
--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -218,9 +218,7 @@ fn canonical_ip_octets<'a>(
     unsafe { c_ares::ntop(af, octets.as_ptr().cast(), &mut out_ip[..]) }
 }
 
-/// Strips a single trailing `.` (the DNS root label) so an absolute FQDN
-/// compares equal to its relative form. Mirrors Node.js `unfqdn()` in
-/// lib/tls.js and RFC 6125 §6.4.2 / RFC 9525 §6.3.
+/// Strips one trailing `.` (DNS root label). Mirrors Node.js `unfqdn()` in lib/tls.js.
 #[inline]
 fn unfqdn(name: &[u8]) -> &[u8] {
     name.strip_suffix(b".").unwrap_or(name)

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -218,9 +218,18 @@ fn canonical_ip_octets<'a>(
     unsafe { c_ares::ntop(af, octets.as_ptr().cast(), &mut out_ip[..]) }
 }
 
+/// Strips a single trailing `.` (the DNS root label) so an absolute FQDN
+/// compares equal to its relative form. Mirrors Node.js `unfqdn()` in
+/// lib/tls.js and RFC 6125 §6.4.2 / RFC 9525 §6.3.
+#[inline]
+fn unfqdn(name: &[u8]) -> &[u8] {
+    name.strip_suffix(b".").unwrap_or(name)
+}
+
 /// Matches a DNS name pattern (possibly with a leading `*.` wildcard) against
 /// `hostname`. Mirrors Node.js `check()` in lib/tls.js for a single pattern.
 fn match_dns_name(pattern: &[u8], hostname: &[u8]) -> bool {
+    let pattern = unfqdn(pattern);
     if pattern.is_empty() {
         return false;
     }
@@ -258,6 +267,7 @@ fn match_dns_name(pattern: &[u8], hostname: &[u8]) -> bool {
 }
 
 pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> bool {
+    let hostname = unfqdn(hostname);
     let host_is_ip = strings::is_ip_address(hostname);
     let mut has_identifier_san = false;
 
@@ -404,6 +414,7 @@ pub fn write_server_identity_mismatch_reason(
     out: &mut dyn core::fmt::Write,
 ) -> core::fmt::Result {
     const NO_DNS: &str = "Cert does not contain a DNS name";
+    let hostname = unfqdn(hostname);
     let host = NameBytes(hostname);
     let host_is_ip = strings::is_ip_address(hostname);
 

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -127,6 +127,25 @@ describe.concurrent("fetch-tls", () => {
     });
   });
 
+  it("fetch accepts an absolute-FQDN hostname (trailing dot) for certificate verification", async () => {
+    // RFC 6125/9525: the trailing dot denotes the DNS root and is not part of
+    // the presented identifier. Node's checkServerIdentity, curl, and browsers
+    // all treat "localhost." as equivalent to "localhost" for SAN matching.
+    // Drive the verification hostname via `serverName` so the test does not
+    // depend on the OS resolver accepting "localhost." as a name.
+    await createServer(CERT_LOCALHOST_IP, async port => {
+      const res = await fetch(`https://127.0.0.1:${port}/`, {
+        keepalive: false,
+        tls: { ca: validTls.cert, serverName: "localhost." },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("Hello World");
+
+      // And the native matcher must agree with Node's tls.checkServerIdentity.
+      expect(tls.checkServerIdentity("localhost.", { subjectaltname: "DNS:localhost" } as any)).toBeUndefined();
+    });
+  });
+
   it("fetch with valid tls and non-native checkServerIdentity should work", async () => {
     await createServer(CERT_LOCALHOST_IP, async port => {
       for (const isBusy of [true, false]) {

--- a/test/js/web/fetch/fetch.tls.wildcard.test.ts
+++ b/test/js/web/fetch/fetch.tls.wildcard.test.ts
@@ -263,6 +263,25 @@ describe.concurrent("TLS wildcard hostname verification", () => {
     expect(result.error).toBeUndefined();
   });
 
+  it("fetch accepts trailing-dot FQDN against a wildcard SAN (foo.example.com. vs *.example.com)", async () => {
+    // Exercises the native certificate matcher used by fetch() (not the JS
+    // checkServerIdentity that tls.connect defaults to).
+    using server = Bun.serve({
+      port: 0,
+      tls: wildcardExampleComTls,
+      fetch() {
+        return new Response("Hello");
+      },
+    });
+
+    const res = await fetch(`https://127.0.0.1:${server.port}/`, {
+      keepalive: false,
+      tls: { ca: wildcardExampleComTls.cert, serverName: "foo.example.com." },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("Hello");
+  });
+
   it("should accept mixed-case wildcard match (FoO.ExAmPlE.cOm vs *.example.com)", async () => {
     // RFC 4343: DNS names are case-insensitive
     using server = Bun.serve({


### PR DESCRIPTION
## What does this PR do?

`fetch()` to an absolute-FQDN URL (hostname with a trailing dot, e.g. `https://localhost./` or `https://example.com./`) failed with `ERR_TLS_CERT_ALTNAME_INVALID` even when the certificate's SAN covered the name. The native certificate identity matcher compared `"localhost."` literally against `DNS:localhost` and rejected.

### Repro

```js
// cert has SAN DNS:localhost
const res = await fetch(`https://127.0.0.1:${port}/`, {
  tls: { ca, serverName: "localhost." },
});
// before: ERR_TLS_CERT_ALTNAME_INVALID
// after:  200
```

### Cause

`check_x509_server_identity` / `match_dns_name` in `src/boringssl/lib.rs` did not strip the DNS root label before comparing. Node's `checkServerIdentity` (lib/tls.js), curl, and browsers all treat `host.` as equivalent to `host` for SAN matching (RFC 6125 §6.4.2 / RFC 9525 §6.3). Bun's own `node:tls` JS implementation already does this via `unfqdn()`, so `https.get({hostname: "localhost."})` succeeded while `fetch()` did not.

### Fix

Add `unfqdn()` (strip one trailing `.`) and apply it to both the hostname and each DNS-name pattern in `check_x509_server_identity`, `match_dns_name`, and `write_server_identity_mismatch_reason`, matching Node's behavior. This also fixes the same divergence for WebSocket, `Bun.connect`, Valkey, Postgres, and MySQL TLS clients which share the native matcher.

### Verification

- `test/js/web/fetch/fetch.tls.test.ts`: `fetch` with `serverName: "localhost."` against a `DNS:localhost` cert now returns 200.
- `test/js/web/fetch/fetch.tls.wildcard.test.ts`: `fetch` with `serverName: "foo.example.com."` against a `DNS:*.example.com` cert now returns 200.
- Both tests fail with `ERR_TLS_CERT_ALTNAME_INVALID` without the `src/` change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts test/js/web/fetch/fetch.tls.wildcard.test.ts
bun test v1.4.0 (7c5546857)

test/js/web/fetch/fetch.tls.test.ts:
132 |     // the presented identifier. Node's checkServerIdentity, curl, and browsers
133 |     // all treat "localhost." as equivalent to "localhost" for SAN matching.
134 |     // Drive the verification hostname via `serverName` so the test does not
135 |     // depend on the OS resolver accepting "localhost." as a name.
136 |     await createServer(CERT_LOCALHOST_IP, async port => {
137 |       const res = await fetch(`https://127.0.0.1:${port}/`, {
                              ^
error: ERR_TLS_CERT_ALTNAME_INVALID fetching "https://127.0.0.1:46237/". For more information, pass `verbose: true` in the second argument to fetch()
  path: "https://127.0.0.1:46237/",
 errno: 0,
  code: "ERR_TLS_CERT_ALTNAME_INVALID"

      at async <anonymous> (/workspace/bun/test/js/web/fetch/fetch.tls.test.ts:137:25)
      at async createServer (/workspace/bun/test/js/web/fetch/fetch.tls.test.ts:28:9)
     
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (98ecdf4b4)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with checkServerIdentity failing should throw [20.11ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers (with AbortSignal) [37.23ms]
(pass) fetch-tls > fetch with invalid tls + rejectUnauthorized: false should not throw [35.33ms]
(pass) fetch-tls > fetch should respect rejectUnauthorized env [37.81ms]
(pass) fetch-tls > checkServerIdentity approval still transmits the request and round-trips the response [42.37ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [49.59ms]
(pass) fetch-tls > fetch with self-sign certificate tls + rejectUnauthorized: false should not throw [49.40ms]
(pass) fetch-tls > fetch with invalid tls should throw [52.92ms]
(pass) fetch-tls > fetch with self-sign tls should throw [54.15ms]
(pass) fetch-tls > checkServerIdentity rejection prevents the request from being transmitted [54.55ms]
(pass) fetch-tls > fetch should use NODE_EXTRA_CA_CERTS [44.23ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that th
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts test/js/web/fetch/fetch.tls.wildcard.test.ts
bun test v1.4.0 (7c5546857)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls should not throw [714.34ms]
(pass) fetch-tls > fetch accepts an absolute-FQDN hostname (trailing dot) for certificate verification [1719.68ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [1975.45ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1869.38ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1275.26ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1994.38ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [333.25ms]
(pass) fetch-tls > fetch with self-sign tls should throw [256.55ms]
(pass) fetch-tls > fetch with invalid tls should throw [237.68ms]
(pass) fetch-tls > fetch with checkS
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 691ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/boringssl/lib.rs                         |  9 +++++++++
 test/js/web/fetch/fetch.tls.test.ts          | 19 +++++++++++++++++++
 test/js/web/fetch/fetch.tls.wildcard.test.ts | 19 +++++++++++++++++++
 3 files changed, 47 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/boringssl/lib.rs                              5      4      0
test/js/web/fetch/fetch.tls.test.ts               1      2      0
test/js/web/fetch/fetch.tls.wildcard.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->