### PR TITLE
node:tls: re-check server identity on resumed sessions

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -356,8 +356,11 @@ function onClientHandshake(self, socket, success, verifyError) {
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1107
   try {
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1662-L1673
+    // Unlike Node, don't gate on !isSessionReused(): BoringSSL keeps the peer
+    // chain on a resumed SSL_SESSION, so re-check it against this servername.
+    // The gate alone is the cross-servername resume of CVE-2026-48934.
     const { checkServerIdentity } = self[bunTLSConnectOptions];
-    if (!verifyError && !self.isSessionReused() && typeof checkServerIdentity === "function") {
+    if (!verifyError && typeof checkServerIdentity === "function") {
       const options = self[kConnectOptions];
       const hostname = self.servername || options?.host || options?.socket?._host || self._host || "localhost";
       const cert = self.getPeerCertificate(true);

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1993,3 +1993,108 @@ describe.each([
     });
   });
 });
+
+it.each(["TLSv1.3", "TLSv1.2"] as const)(
+  "%s: re-checks server identity on a resumed session (cross-servername resume must not authorize)",
+  async version => {
+    // A resumed handshake sends no certificate, so a ticket alone says nothing
+    // about the name the peer was verified for. BoringSSL keeps the peer chain
+    // on the SSL_SESSION, and Bun re-checks that certificate against the current
+    // servername. Without the check, any peer that can decrypt the ticket (a
+    // vhost on the same context, a server that shares ticket keys) is authorized
+    // under a name its certificate does not cover. Node had the same hole
+    // (CVE-2026-48934). Node closes it earlier: it does not offer a session that
+    // was authenticated for another servername.
+    await using server = tls.createServer({ ...COMMON_CERT_, minVersion: version, maxVersion: version }, c => {
+      c.on("error", () => {});
+      c.end("x");
+    });
+    server.on("tlsClientError", () => {});
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as AddressInfo).port;
+
+    // Full handshake: capture the ticket. The server ends the connection, so by
+    // 'close' the post-handshake NewSessionTicket has arrived.
+    let ticket: Buffer | undefined;
+    const first = tlsConnect({
+      port,
+      host: "127.0.0.1",
+      ca: COMMON_CERT_.cert,
+      servername: "localhost",
+      minVersion: version,
+      maxVersion: version,
+    });
+    first.on("session", s => (ticket = s));
+    first.on("data", () => {});
+    first.on("error", () => {});
+    await once(first, "close");
+    expect(first.authorized).toBe(true);
+    expect(Buffer.isBuffer(ticket)).toBe(true);
+
+    type Outcome = {
+      reused: boolean;
+      authorized: boolean;
+      authorizationError: unknown;
+      identityChecks: [string, unknown][];
+      result: string;
+    };
+    const resume = (servername: string) =>
+      new Promise<Outcome>(resolve => {
+        const identityChecks: [string, unknown][] = [];
+        let done = false;
+        let reused = false;
+        const s = tlsConnect({
+          port,
+          host: "127.0.0.1",
+          ca: COMMON_CERT_.cert,
+          servername,
+          session: ticket,
+          minVersion: version,
+          maxVersion: version,
+          checkServerIdentity: (host, cert) => {
+            identityChecks.push([host, cert?.subject?.CN]);
+            return tls.checkServerIdentity(host, cert);
+          },
+        });
+        const finish = (result: string) => {
+          if (done) return;
+          done = true;
+          s.destroy();
+          resolve({
+            reused,
+            authorized: s.authorized,
+            authorizationError: s.authorizationError,
+            identityChecks,
+            result,
+          });
+        };
+        s.on("secureConnect", () => (reused = s.isSessionReused()));
+        s.on("data", () => finish("ok"));
+        s.on("close", () => finish("ok"));
+        s.on("error", (e: NodeJS.ErrnoException) => finish(String(e.code ?? e.message)));
+      });
+
+    // Resuming under a servername the certificate does not cover is rejected:
+    // the stored peer certificate (CN=server-bun, SAN=localhost) is re-checked
+    // against the new servername and fails exactly as it would on a full
+    // handshake.
+    expect(await resume("not-in-cert.example")).toEqual({
+      reused: false,
+      authorized: false,
+      authorizationError: "ERR_TLS_CERT_ALTNAME_INVALID",
+      identityChecks: [["not-in-cert.example", "server-bun"]],
+      result: "ERR_TLS_CERT_ALTNAME_INVALID",
+    });
+
+    // Resuming under the same servername still authorizes. checkServerIdentity
+    // runs again, on the stored certificate. Node does not call it on a resumed
+    // session.
+    expect(await resume("localhost")).toEqual({
+      reused: true,
+      authorized: true,
+      authorizationError: null,
+      identityChecks: [["localhost", "server-bun"]],
+      result: "ok",
+    });
+  },
+);


### PR DESCRIPTION
### Problem

- `tls.connect({ servername: "hostb.test", session })` with a `session` captured for `hosta.test` resumes and reports `authorized: true`. `checkServerIdentity` never runs, and the certificate covers only `hosta.test`.
- The cause is the `!self.isSessionReused()` term in the gate of `onClientHandshake` (`src/js/node/net.ts:360`), copied from Node in #34598. Tags `bun-v1.4.0` to `bun-v1.4.2` contain it.
- A resumed handshake sends no certificate. With the gate, any peer that can decrypt the ticket is authorized under any name.

### Fix

- Remove the term. `checkServerIdentity` now runs on a resumed session, against the certificate Bun keeps from the original handshake.
- Correct because `authorized` then means the same on both handshake kinds: the certificate covers this `servername`. A resume under the original name still authorizes.
- Node fixed the same hole as CVE-2026-48934 (nodejs/node@9cc4e32375, in v22.23.0, v24.17.0, v26.3.1). Node does not offer a session authenticated for another servername. Both fixes reject the mismatched name.
- Verified: `test/js/node/tls/node-tls-connect.test.ts` (new `it.each` over TLSv1.3 and TLSv1.2, fails on main, passes here). Also the vendored Node resume, ticket and agent-session tests.

### Background

- Session resumption: the client presents a ticket from an earlier connection, and both sides skip the certificate exchange.
- `checkServerIdentity(hostname, cert)` is the `node:tls` hostname check against the certificate SAN and CN.
- OpenSSL drops the peer chain on resume, so Node has nothing to check and skips the call. BoringSSL keeps the chain on the `SSL_SESSION`, so `getPeerCertificate()` in Bun returns the original certificate.
- The `node:https` Agent cache is keyed by servername and `fetch()` never resumes. Only a caller that passes `session:` across hostnames is affected.

<details><summary>Notes</summary>

**Outcome table** (server certificate covers only `hosta.test`, client connects with `servername: "hostb.test"` and the `hosta.test` session):

| | bun main (before) | bun (this PR) | node <= 26.3.0 | node >= 26.3.1 |
|---|---|---|---|---|
| `authorized` | `true` | `false` | `true` | `false` |
| error | none | `ERR_TLS_CERT_ALTNAME_INVALID` | none | error of the full handshake |
| `checkServerIdentity` | not called | called with hosta's certificate | not called | called on the new certificate |
| session resumed | yes | yes | yes | no, Node drops the session |

**Node's own regression tests.** `test-tls-session-reuse-different-servername.js` and `test-https-session-reuse-different-servername.js` do not pass verbatim with this change. They assert `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, the error of the full handshake that Node falls back to. Bun resumes, re-checks the kept certificate, and rejects with `ERR_TLS_CERT_ALTNAME_INVALID`. To match the error code, Bun must also bind the session to the servername. Node does this with a prefix on the `getSession()` / `'session'` buffer, which changes the format of that buffer. BoringSSL has no `SSL_SESSION_get0_hostname`, so there is no cheaper source for the name. That is a separate decision and is not part of this PR.

**Empty certificate on resume.** No extra branch is needed. `getPeerCertificate(true)` returns `{}` (truthy) when the native side has no certificate. `checkServerIdentity(hostname, {})` then returns `ERR_TLS_CERT_ALTNAME_INVALID` ("Cert does not contain a DNS name").

**User `checkServerIdentity` hooks** now also run on resumed connections. They see the certificate that issued the ticket, so a pinning hook still passes.

**Two-server variant** (a second server with an untrusted certificate that shares the ticket keys). Bun cannot run it yet: the server `ticketKeys` option is validated but not applied (#28691). On a resume the client keeps the certificate of the original server, whichever peer accepts the ticket. The hostname check in this PR covers that variant.

**Merge order.** #32824 carries a hunk that adds the gate again. #33734 proposed the gate and is closed.

**Suites run on the debug build:** `node-tls-connect.test.ts` (57 pass, 0 fail), `test-tls-client-resume.js`, `test-tls-client-resume-12.js`, `test-https-client-resume.js`, `test-https-client-checkServerIdentity.js`, `test-tls-check-server-identity.js`, `test-tls-ticket.js`, `test-https-agent-session-reuse.js`, `test-https-agent-disable-session-reuse.js`, `test-https-agent-session-eviction.js`, `test-https-agent-session-injection.js`, `test/regression/issue/25190.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 7 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [6.96ms]
(pass) should thow ECONNRESET if FIN is received before handshake [606.31ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [15.49ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [200.35ms]
(pass) should be able to grab the JSStreamSocket constructor [25.98ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [162.40ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [163.72ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port
... (truncated)

release without fix: 5 failed, 18 skipped
bun test v1.4.2 (744846f84)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.05ms]
(pass) should thow ECONNRESET if FIN is received before handshake [6.32ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.19ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [3.99ms]
(pass) should be able to grab the JSStreamSocket constructor [0.31ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [6.93ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [8.43ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.connect > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [4.61ms]
(pass) should thow ECONNRESET if FIN is received before handshake [373.00ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.83ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [114.16ms]
(pass) should be able to grab the JSStreamSocket constructor [14.52ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [120.56ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [135.06ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port 
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1506ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/30] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/30] gen cpp.rs (cppbind)
[3/30] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/30] gen JS modules (bundle-modules)
Preprocess modules (15432ms)
Bundle modules (213ms)
Postprocesss modules (511ms)
Bundle Functions (1036ms)
Generate Code (192ms)

[17.43s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/19] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_which v0.0.0 (/workspace/bun/src/which)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/spawn
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                        |   5 +-
 test/js/node/tls/node-tls-connect.test.ts | 105 ++++++++++++++++++++++++++++++
 2 files changed, 109 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 2 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/net.ts                             6      4     31
test/js/node/tls/node-tls-connect.test.ts      4      7     31
```

</details>

<!-- robobun:evidence:end -->