### PR TITLE
js_printer: parenthesize inlined negative enum value on LHS of **

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1532,6 +1532,14 @@ pub mod __gated_printer {
                         ExprData::EAwait(_) | ExprData::EUndefined(_) | ExprData::ENumber(_) => {
                             v.left_level = Level::Call;
                         }
+                        // EDot/EIndex may be rewritten to a (possibly negative) number by
+                        // cross-module enum inlining at print time; the bump is a no-op
+                        // for a member expression that stays a member expression.
+                        ExprData::EDot(_) | ExprData::EIndex(_) => {
+                            if self.options.ts_enums.is_some() {
+                                v.left_level = Level::Call;
+                            }
+                        }
                         ExprData::EBoolean(_) | ExprData::EBranchBoolean(_) => {
                             // When minifying, booleans are printed as "!0 and "!1"
                             if self.options.minify_syntax {
@@ -6305,18 +6313,7 @@ pub mod __gated_printer {
             level: Level,
         ) {
             match inlined {
-                js_ast::InlinedEnumValueDecoded::Number(num) => {
-                    // The EDot/EIndex this replaces is a valid UpdateExpression on the
-                    // left of `**`; a negative number is not. Bump the level so
-                    // print_number parenthesizes when needed, matching what
-                    // binary_check_and_prepare does for a direct ENumber left operand.
-                    let level = if level == Level::Exponentiation {
-                        Level::Call
-                    } else {
-                        level
-                    };
-                    self.print_number(num, level)
-                }
+                js_ast::InlinedEnumValueDecoded::Number(num) => self.print_number(num, level),
                 // TODO: extract printString
                 js_ast::InlinedEnumValueDecoded::String(str) => self.print_expr(
                     // Arena-owned `*const EString` (encoded non-null at NaN-box time);

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1518,11 +1518,7 @@ pub mod __gated_printer {
                 // "**" can't contain certain unary expressions
                 Op::Code::BinPow => {
                     // An inlined enum prints its wrapped value, so look through it.
-                    let mut left = &e.left.data;
-                    if let ExprData::EInlinedEnum(inlined) = left {
-                        left = &inlined.value.data;
-                    }
-                    match left {
+                    match e.left.unwrap_inlined().data {
                         ExprData::EUnary(left) => {
                             if Op::Code::unary_assign_target(left.op) == js_ast::AssignTarget::None
                             {
@@ -1532,10 +1528,8 @@ pub mod __gated_printer {
                         ExprData::EAwait(_) | ExprData::EUndefined(_) | ExprData::ENumber(_) => {
                             v.left_level = Level::Call;
                         }
-                        // EDot/EIndex may be rewritten to a (possibly negative) number by
-                        // cross-module enum inlining at print time; the bump is a no-op
-                        // for a member expression that stays a member expression.
                         ExprData::EDot(_) | ExprData::EIndex(_) => {
+                            // Cross-module enum inlining may replace these with a number
                             if self.options.ts_enums.is_some() {
                                 v.left_level = Level::Call;
                             }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1517,7 +1517,12 @@ pub mod __gated_printer {
                 }
                 // "**" can't contain certain unary expressions
                 Op::Code::BinPow => {
-                    match &e.left.data {
+                    // An inlined enum prints its wrapped value, so look through it.
+                    let mut left = &e.left.data;
+                    if let ExprData::EInlinedEnum(inlined) = left {
+                        left = &inlined.value.data;
+                    }
+                    match left {
                         ExprData::EUnary(left) => {
                             if Op::Code::unary_assign_target(left.op) == js_ast::AssignTarget::None
                             {
@@ -6300,7 +6305,18 @@ pub mod __gated_printer {
             level: Level,
         ) {
             match inlined {
-                js_ast::InlinedEnumValueDecoded::Number(num) => self.print_number(num, level),
+                js_ast::InlinedEnumValueDecoded::Number(num) => {
+                    // The EDot/EIndex this replaces is a valid UpdateExpression on the
+                    // left of `**`; a negative number is not. Bump the level so
+                    // print_number parenthesizes when needed, matching what
+                    // binary_check_and_prepare does for a direct ENumber left operand.
+                    let level = if level == Level::Exponentiation {
+                        Level::Call
+                    } else {
+                        level
+                    };
+                    self.print_number(num, level)
+                }
                 // TODO: extract printString
                 js_ast::InlinedEnumValueDecoded::String(str) => self.print_expr(
                     // Arena-owned `*const EString` (encoded non-null at NaN-box time);

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2236,6 +2236,40 @@ describe("bundler", () => {
       ]);
     },
   });
+  itBundled("ts/EnumCrossModuleInliningExponentiationLHS", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { E } from './enums'
+        // A negative inlined value on the left of ** must be parenthesized:
+        // "-5 ** 2" is a SyntaxError.
+        console.log(E.Neg ** 2, E['Neg'] ** 2, E.Pos ** 2, 2 ** E.Neg)
+      `,
+      "/enums.ts": /* ts */ `
+        export enum E { Neg = -5, Pos = 5 }
+      `,
+    },
+    minifySyntax: false,
+    run: { stdout: "25 25 25 0.03125" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("(-5)");
+      expect(out).not.toMatch(/[^(]-5 \/\* Neg \*\/ \*\*/);
+    },
+  });
+  itBundled("ts/EnumCrossModuleInliningExponentiationLHSMinify", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { E } from './enums'
+        console.log(E.Neg ** 2, E['Neg'] ** 2, E.Pos ** 2, 2 ** E.Neg)
+      `,
+      "/enums.ts": /* ts */ `
+        export enum E { Neg = -5, Pos = 5 }
+      `,
+    },
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    run: { stdout: "25 25 25 0.03125" },
+  });
   itBundled("ts/EnumExportClause", {
     files: {
       "/entry.ts": /* ts */ `

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2243,17 +2243,21 @@ describe("bundler", () => {
         // A negative inlined value on the left of ** must be parenthesized:
         // "-5 ** 2" is a SyntaxError.
         console.log(E.Neg ** 2, E['Neg'] ** 2, E.Pos ** 2, 2 ** E.Neg)
+        // The operand of a prefix unary needs no extra parentheses.
+        console.log(-E.Neg, ~E.Neg, 2 ** E.Pos)
       `,
       "/enums.ts": /* ts */ `
         export enum E { Neg = -5, Pos = 5 }
       `,
     },
     minifySyntax: false,
-    run: { stdout: "25 25 25 0.03125" },
+    run: { stdout: "25 25 25 0.03125\n5 4 32" },
     onAfterBundle(api) {
       const out = api.readFile("/out.js");
-      expect(out).toContain("(-5)");
-      expect(out).not.toMatch(/[^(]-5 \/\* Neg \*\/ \*\*/);
+      expect(out).toContain("(-5) /* Neg */ ** 2");
+      expect(out).toContain("- -5 /* Neg */");
+      expect(out).not.toContain("-(-5)");
+      expect(out).not.toContain("(5)");
     },
   });
   itBundled("ts/EnumCrossModuleInliningExponentiationLHSMinify", {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -149,6 +149,27 @@ describe("Bun.Transpiler", () => {
       expect(lastLine(ts.parsedMin(pre + 'export let y = Foo?.["A"];', false))).toBe("export let y = Foo?.A;");
       expect(lastLine(ts.parsedMin(pre + 'export let y = Bar?.["a-b"];', false))).toBe('export let y = Bar?.["a-b"];');
     });
+    it("parenthesizes inlined enum on LHS of **", () => {
+      const lastLine = out => out.trimEnd().split("\n").at(-1);
+      const neg = "const enum E { X = -5 }\n";
+      const pos = "const enum E { X = 5 }\n";
+      const str = "const enum E { X = 'a' }\n";
+      // A negative inlined value on the left of ** must be parenthesized:
+      // "-5 ** 2" is a SyntaxError.
+      expect(lastLine(ts.parsed(neg + "export let y = E.X ** 2;", false))).toBe("export let y = (-5) /* X */ ** 2;");
+      expect(lastLine(ts.parsed(neg + "export let y = E['X'] ** 2;", false))).toBe("export let y = (-5) /* X */ ** 2;");
+      // No extra parentheses for non-negative numbers, strings, or the right operand.
+      expect(lastLine(ts.parsed(pos + "export let y = E.X ** 2;", false))).toBe("export let y = 5 /* X */ ** 2;");
+      expect(lastLine(ts.parsed(str + "export let y = E.X ** 2;", false))).toBe('export let y = "a" /* X */ ** 2;');
+      expect(lastLine(ts.parsed(neg + "export let y = 2 ** E.X;", false))).toBe("export let y = 2 ** -5 /* X */;");
+      // Every emitted form must be syntactically valid.
+      for (const pre of [neg, pos, str]) {
+        for (const expr of ["E.X ** 2", "E['X'] ** 2", "2 ** E.X"]) {
+          const out = ts.parsed(pre + `export let y = ${expr};`, false).replace(/^export /gm, "");
+          expect(() => new Function(out)).not.toThrow();
+        }
+      }
+    });
   });
 
   describe("TypeScript", () => {


### PR DESCRIPTION
## Repro

```ts
const enum E { X = -5 }
export const y = E.X ** 2;
```

`Bun.Transpiler({loader: "ts"}).transformSync(...)` and `bun build` both emit:

```js
export const y = -5 /* X */ ** 2;
```

which is a `SyntaxError` (a `UnaryExpression` is not a valid left operand of `**`).

The cross-module bundler path has the same problem:

```ts
// enums.ts
export enum E { Neg = -5 }
// entry.ts
import { E } from "./enums";
console.log(E.Neg ** 2);
```

```
$ bun build entry.ts --minify
var o=-5**2;console.log(o);export{o as y};
          ^ error: Unexpected **
```

## Cause

`binary_check_and_prepare` bumps `left_level` to `Call` when the left operand of `**` is an `ENumber`, so `print_number` parenthesizes a negative value. Two paths bypass that bump and reach `print_number` at `Level::Exponentiation`, which does not wrap negatives:

1. Same-file inlining: the parser rewrites `E.X` to `EInlinedEnum(ENumber(-5))`. The BinPow left-operand match had no `EInlinedEnum` arm, so `left_level` stayed at `Exponentiation`.
2. Cross-module inlining: the left operand is an `EDot`/`EIndex` over an `EImportIdentifier`. The printer substitutes the enum value via `print_inlined_enum` at print time, calling `print_number(num, level)` with the incoming `Exponentiation` level.

## Fix

Both handled in the BinPow arm of `binary_check_and_prepare`:

* Look through `EInlinedEnum` at its wrapped value before the left-operand match.
* Bump `left_level` to `Call` for `EDot`/`EIndex` when `options.ts_enums` is populated. `EDot`/`EIndex` printing only uses the incoming level on the `print_inlined_enum` path, so the bump is a no-op for a member expression that is not inlined (`obj.b ** 2` still prints without parentheses).

Non-negative numbers and string enum values were already valid on the left of `**` and continue to print without extra parentheses. The right operand is unaffected. A cross-module inlined enum under a prefix unary (`-E.Neg`) still prints as `- -5`, not `-(-5)`, since the bump is scoped to the BinPow left operand.

## Verification

New tests in `test/bundler/transpiler/transpiler.test.js` (same-file `EInlinedEnum` path) and `test/bundler/esbuild/ts.test.ts` (cross-module `print_inlined_enum` path, plain and minified, plus the prefix-unary no-over-wrap assertion) fail against the unfixed build with the `Unexpected **` syntax error and pass with the fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 32 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/ts.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (b87a5cbd8)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.42ms]
(pass) Bun.Transpiler > normalizes \r\n [5.60ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.64ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.97ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.33ms]
(pass) Bun.Transpiler > property access inlining > works [2.02ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.45ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [16.87ms]
154 |       const neg = "const enum E { X = -5 }\n";
155 |       const pos = "const enum E { X = 5 }\n";
156 |       const str = "const enum E { X = 'a' }\n";
157 |       // A negative inlined value on the left of ** must be parenthesized:
158 |       // "-5 ** 2" is a SyntaxError.
159 |       expect(l
... (truncated)

release without fix: 18 failed, 32 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.11ms]
(pass) Bun.Transpiler > normalizes \r\n [0.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.09ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
141 |     });
142 |     it("bails out on optional-chain index into enum", () => {
143 |       const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
144 |       const lastLine = out => out.trimEnd().split("\n").at(-1);
145 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo["A"];', false))).toBe("export let y = 0 /* A */;");
146 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo?.["A"];', false))).toBe('export let y = Foo?.["A"];');
                                                                                   ^
error: expect(received).toBe(expected)

Expected: "export let y = F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 32 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/ts.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (b87a5cbd8)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.42ms]
(pass) Bun.Transpiler > normalizes \r\n [5.60ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.76ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.72ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.38ms]
(pass) Bun.Transpiler > property access inlining > works [2.05ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.29ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [16.74ms]
(pass) Bun.Transpiler > property access inlining > parenthesizes inlined enum on LHS of ** [36.56ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.48ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.52ms]
(pass) Bun.Transpiler > Type
... (truncated)

release with fix: 32 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 770ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/971] cc obj/vendor/libarchive/libarchive/archive_read_support_format_cab.c.o
[2/971] cc obj/vendor/libarchive/libarchive/archive_string.c.o
[3/971] cc obj/vendor/libarchive/libarchive/archive_write_add_filter_compress.c.o
[4/971] cc obj/vendor/libarchive/libarchive/archive_write_add_filter_gzip.c.o
[5/971] cc obj/vendor/libarchive/libarchive/archive_write_add_filter_program.c.o
[6/971] cc obj/vendor/libarchive/libarchive/archive_write_add_filter_uuencode.c.o
[7/971] cc obj/vendor/libarchive/libarchive/archive_write_add_filter_xz.c.o
[8/971] cc obj/vendor/libarchive/libarchive/archive_write_add_filter_zstd.c.o
[9/971] cc obj/vendor/libarchive/libarchive/archive_write_add_filter_lz4.c.o
[10/971] cc obj/vendor/libarchive/libarchive/archive_write_set_format.c.o
[11/971] cc obj/vendor/libarchive/libarchive/archive_write_set_format_by_name.c.o
[12/971] cc obj/vendor/libarchive/libarchive/archive_write_set_format_cpio.c.o
[13/971] cc obj/vendor/libarchive/libarchive/archive_write_set_format_raw.c.o
[14/971] cc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs                      |  9 ++++++-
 test/bundler/esbuild/ts.test.ts            | 38 ++++++++++++++++++++++++++++++
 test/bundler/transpiler/transpiler.test.js | 21 +++++++++++++++++
 3 files changed, 67 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_printer/lib.rs                           8      6      0
test/bundler/esbuild/ts.test.ts                 2      2      0
test/bundler/transpiler/transpiler.test.js      5      1      0
```

</details>

<!-- robobun:evidence:end -->