### PR TITLE
js_printer: parenthesize missing-import void 0 on LHS of **

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1533,6 +1533,12 @@ pub mod __gated_printer {
                                 v.left_level = Level::Call;
                             }
                         }
+                        ExprData::EImportIdentifier(_) => {
+                            // When minifying, a missing import prints as "void 0"
+                            if self.options.minify_syntax {
+                                v.left_level = Level::Call;
+                            }
+                        }
                         _ => {}
                     }
                 }

--- a/test/bundler/esbuild/importstar.test.ts
+++ b/test/bundler/esbuild/importstar.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "../expectBundled";
 
 // Tests ported from:
@@ -860,6 +860,32 @@ describe("bundler", () => {
     },
     bundleWarnings: {
       "/entry.js": [`Import "foo" will always be undefined because there is no matching export in "foo.js"`],
+    },
+  });
+  itBundled("importstar/NamespaceImportMissingES6ExponentiationLHS", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from './foo'
+        // A missing import prints as "void 0" under minify_syntax, which is not
+        // a valid left operand of ** unless parenthesized.
+        console.log(ns.nope ** 2, 2 ** ns.nope, ns.x ** 2)
+      `,
+      "/foo.js": `export const x = 3`,
+    },
+    minifySyntax: true,
+    run: {
+      stdout: "NaN NaN 9",
+    },
+    bundleWarnings: {
+      "/entry.js": [`Import "nope" will always be undefined because there is no matching export in "foo.js"`],
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("(void 0) ** 2");
+      expect(out).toContain("2 ** void 0");
+      // The existing export and the right operand stay unwrapped.
+      expect(out).not.toContain("(2 ** void 0)");
+      expect(out).not.toMatch(/\(\w+\) \*\* 2/);
     },
   });
   itBundled("importstar/ExportOtherCommonJS", {


### PR DESCRIPTION
## Repro

```js
// foo.js
export const x = 3;
// entry.js
import * as ns from './foo';
console.log(ns.nope ** 2);
```

```
$ bun build entry.js --minify-syntax
console.log(void 0 ** 2);
                   ^
error: Unexpected **
```

The linker emits a "will always be undefined" warning but still produces a bundle, and that bundle is a `SyntaxError` (`UnaryExpression` is not a valid left operand of `**`).

## Cause

A namespace-import property with no matching export is rewritten to `EImportIdentifier` with `import_item_status == Missing`. The printer's `EImportIdentifier` handler calls `print_undefined(loc, level)`, which under `--minify-syntax` emits unwrapped `void 0` when `level < Prefix`. The BinPow left-operand match in `binary_check_and_prepare` has no `EImportIdentifier` arm, so `left_level` stays at `Level::Exponentiation`, and the output is `void 0 ** 2`.

## Fix

Add an `EImportIdentifier` arm to the BinPow left-operand match, bumping `left_level` to `Call` when `minify_syntax` is enabled. This mirrors the existing `EBoolean` arm (booleans print as `!0`/`!1` under the same option). When the import is not missing the printer emits an identifier or a member access, neither of which consults the incoming level, so the bump is a no-op there; and without `minify_syntax` the printer emits the identifier `undefined`, which is already a valid left operand.

Sibling of #36133, which handles the enum-inlining path on the same operand.

## Verification

New `importstar/NamespaceImportMissingES6ExponentiationLHS` in `test/bundler/esbuild/importstar.test.ts` fails against the unfixed build (bundle contains `void 0 ** 2` and does not run) and passes with the fix. It also asserts no extra parentheses are added for the right operand or for an existing export.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/importstar.test.ts
bun test v1.4.0 (549a14b7f)

test/bundler/esbuild/importstar.test.ts:
(pass) bundler > importstar/ImportStarUnused [1275.03ms]
(pass) bundler > importstar/ImportStarCapture [597.61ms]
(pass) bundler > importstar/ImportStarNoCapture [545.66ms]
(pass) bundler > importstar/ImportStarExportImportStarUnused [519.30ms]
(pass) bundler > importstar/ImportStarExportImportStarNoCapture [476.94ms]
(pass) bundler > importstar/ImportStarExportImportStarCapture [445.60ms]
(pass) bundler > importstar/ImportStarExportStarAsUnused [528.10ms]
(pass) bundler > importstar/ImportStarExportStarAsNoCapture [561.91ms]
(pass) bundler > importstar/ImportStarExportStarAsCapture [582.46ms]
(pass) bundler > importstar/ImportStarExportStarUnused [1013.08ms]
(pass) bundler > importstar/ImportStarExportStarNoCapture [589.04ms]
(pass) bundler > importstar/ImportStarExportStarCapture [481.20ms]
(pass) bundler > importstar/ImportStarCommonJSUnused [492.46ms]
(pass) bundler > importstar/ImportStarCommonJSCapture [620.91ms]
(pass) b
... (truncated)

release without fix: 1 failed, 4 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/esbuild/importstar.test.ts:
(pass) bundler > importstar/ImportStarUnused [37.00ms]
(pass) bundler > importstar/ImportStarCapture [23.39ms]
(pass) bundler > importstar/ImportStarNoCapture [24.41ms]
(pass) bundler > importstar/ImportStarExportImportStarUnused [27.80ms]
(pass) bundler > importstar/ImportStarExportImportStarNoCapture [25.48ms]
(pass) bundler > importstar/ImportStarExportImportStarCapture [22.98ms]
(pass) bundler > importstar/ImportStarExportStarAsUnused [23.17ms]
(pass) bundler > importstar/ImportStarExportStarAsNoCapture [24.39ms]
(pass) bundler > importstar/ImportStarExportStarAsCapture [22.96ms]
(pass) bundler > importstar/ImportStarExportStarUnused [23.43ms]
(pass) bundler > importstar/ImportStarExportStarNoCapture [29.49ms]
(pass) bundler > importstar/ImportStarExportStarCapture [24.61ms]
(pass) bundler > importstar/ImportStarCommonJSUnused [24.92ms]
(pass) bundler > importstar/ImportStarCommonJSCapture [23.42ms]
(pass) bundler > importstar/ImportStarCommonJSNoCapture [24.17ms]
(pass) bundler > importstar/ImportStarAndCommonJS [4.32ms]
(pass) bundler > importstar/ImportStarNoBundleUnused [24.10ms]

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/importstar.test.ts
bun test v1.4.0 (549a14b7f)

test/bundler/esbuild/importstar.test.ts:
(pass) bundler > importstar/ImportStarUnused [1124.70ms]
(pass) bundler > importstar/ImportStarCapture [475.02ms]
(pass) bundler > importstar/ImportStarNoCapture [452.10ms]
(pass) bundler > importstar/ImportStarExportImportStarUnused [477.50ms]
(pass) bundler > importstar/ImportStarExportImportStarNoCapture [459.18ms]
(pass) bundler > importstar/ImportStarExportImportStarCapture [458.33ms]
(pass) bundler > importstar/ImportStarExportStarAsUnused [416.00ms]
(pass) bundler > importstar/ImportStarExportStarAsNoCapture [467.30ms]
(pass) bundler > importstar/ImportStarExportStarAsCapture [564.47ms]
(pass) bundler > importstar/ImportStarExportStarUnused [568.23ms]
(pass) bundler > importstar/ImportStarExportStarNoCapture [570.35ms]
(pass) bundler > importstar/ImportStarExportStarCapture [1016.47ms]
(pass) bundler > importstar/ImportStarCommonJSUnused [518.94ms]
(pass) bundler > importstar/ImportStarCommonJSCapture [499.65ms]
(pass) b
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     549a14b7f5
  features     baseline

22 deps, 108 codegen, 1171 objects in 1052ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [22.00ms]
[2/1234] gen ErrorCode+*.h
[3/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [7.00ms]
[4/1234] fetch picohttpparser
[picohttpparser] up to date
[5/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [19.00ms]
[6/1234] gen bindgenv2
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch zlib
[zlib] up to date
[9/1234] fetch tinycc
[tinycc] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs                   |  6 ++++++
 test/bundler/esbuild/importstar.test.ts | 28 +++++++++++++++++++++++++++-
 2 files changed, 33 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js_printer/lib.rs                        7      1      0
test/bundler/esbuild/importstar.test.ts      2      2      0
```

</details>

**self-review** · no surviving concerns

28 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->