### PR TITLE
fs: short write in createWriteStream overwrites head of file (NaN position coerced to 0)

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -527,7 +527,7 @@ function writeAll(data, size, pos, cb, retries = 0) {
 
     retries = bytesWritten ? 0 : retries + 1;
     size -= bytesWritten;
-    pos += bytesWritten;
+    if (pos !== undefined) pos += bytesWritten;
 
     // Try writing non-zero number of bytes up to 5 times.
     if (retries > 5) {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3843,7 +3843,9 @@ pub mod args {
                         }
                         // BigInt is a Bun extension kept for this overload.
                         let position = i52::offset_from_js(current).or_else(|| {
-                            current.is_big_int().then(|| (current.to_int64() << 12) >> 12)
+                            current
+                                .is_big_int()
+                                .then(|| (current.to_int64() << 12) >> 12)
                         });
                         if let Some(position @ 0..) = position {
                             args.position = Some(position);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -10204,8 +10204,7 @@ impl NodeFSFunctionEnum {
 struct i52;
 impl i52 {
     const MIN: i64 = -(1i64 << 51);
-    /// Node's `GetOffset`: only a safe JS integer selects positional I/O;
-    /// anything else (NaN, ±Inf, fractional, non-number) means "current offset".
+    /// Node's `GetOffset`: only a safe JS integer selects positional I/O.
     #[inline]
     fn offset_from_js(v: JSValue) -> Option<i64> {
         let n = v.get_number()?;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2823,10 +2823,6 @@ pub mod args {
                 // each element and pin its backing store until completion.
                 arguments.will_be_async,
             )?;
-            // Node: lib/fs.js does `if (typeof position !== 'number') position
-            // = null`, and native GetOffset() returns -1 (non-positional)
-            // unless the value is a safe JS integer. Either selects the
-            // current file offset.
             let position: Option<u64> = arguments
                 .next_eat()
                 .and_then(i52::offset_from_js)
@@ -3845,9 +3841,7 @@ pub mod args {
                         if !(current.is_number() || current.is_big_int()) {
                             break 'parse;
                         }
-                        // Numbers go through Node's GetOffset rule; BigInt is a
-                        // Bun extension kept for the buffer overload (see the
-                        // "writeSync works with bigint" test).
+                        // BigInt is a Bun extension kept for this overload.
                         let position = i52::offset_from_js(current)
                             .or_else(|| current.is_big_int().then(|| current.to_int64()));
                         if let Some(position @ 0..) = position {
@@ -10210,10 +10204,8 @@ impl NodeFSFunctionEnum {
 struct i52;
 impl i52 {
     const MIN: i64 = -(1i64 << 51);
-    /// Node's `GetOffset` (src/node_file.cc): the `position` argument to
-    /// `write`/`writev`/`readv` selects positional I/O only when it is a safe
-    /// JS integer. NaN, ±Infinity, a fractional value, a non-number, or a
-    /// value outside `Number.MAX_SAFE_INTEGER` all mean "current file offset".
+    /// Node's `GetOffset`: only a safe JS integer selects positional I/O;
+    /// anything else (NaN, ±Inf, fractional, non-number) means "current offset".
     #[inline]
     fn offset_from_js(v: JSValue) -> Option<i64> {
         let n = v.get_number()?;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3842,8 +3842,9 @@ pub mod args {
                             break 'parse;
                         }
                         // BigInt is a Bun extension kept for this overload.
-                        let position = i52::offset_from_js(current)
-                            .or_else(|| current.is_big_int().then(|| current.to_int64()));
+                        let position = i52::offset_from_js(current).or_else(|| {
+                            current.is_big_int().then(|| (current.to_int64() << 12) >> 12)
+                        });
                         if let Some(position @ 0..) = position {
                             args.position = Some(position);
                         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2814,7 +2814,7 @@ pub mod args {
         }
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self> {
             let fd = FD::from_js_required(ctx, arguments)?;
-            let mut buffers = VectorArrayBuffer::from_js(
+            let buffers = VectorArrayBuffer::from_js(
                 ctx,
                 arguments.protect_eat_next().ok_or_else(|| {
                     ctx.throw_invalid_arguments(format_args!("Expected an ArrayBufferView[]"))
@@ -2823,21 +2823,14 @@ pub mod args {
                 // each element and pin its backing store until completion.
                 arguments.will_be_async,
             )?;
-            let mut position: Option<u64> = None;
-            if let Some(pos_value) = arguments.next_eat() {
-                if !pos_value.is_undefined_or_null() {
-                    if pos_value.is_number() {
-                        position = Some(pos_value.to_int64() as u64);
-                    } else {
-                        // `buffers` never reaches the Unprotect hook on this
-                        // path; drop its element roots and pins here.
-                        buffers.release();
-                        return Err(
-                            ctx.throw_invalid_arguments(format_args!("position must be a number"))
-                        );
-                    }
-                }
-            }
+            // Node: lib/fs.js does `if (typeof position !== 'number') position
+            // = null`, and native GetOffset() returns -1 (non-positional)
+            // unless the value is a safe JS integer. Either selects the
+            // current file offset.
+            let position: Option<u64> = arguments
+                .next_eat()
+                .and_then(i52::offset_from_js)
+                .and_then(|p| u64::try_from(p).ok());
             Ok(Self {
                 fd,
                 buffers,
@@ -3852,19 +3845,20 @@ pub mod args {
                         if !(current.is_number() || current.is_big_int()) {
                             break 'parse;
                         }
-                        let position = i52::from_js(current);
-                        if position >= 0 {
+                        // Numbers go through Node's GetOffset rule; BigInt is a
+                        // Bun extension kept for the buffer overload (see the
+                        // "writeSync works with bigint" test).
+                        let position = i52::offset_from_js(current)
+                            .or_else(|| current.is_big_int().then(|| current.to_int64()));
+                        if let Some(position @ 0..) = position {
                             args.position = Some(position);
                         }
                         arguments.eat();
                     }
                     // fs.write(fd, string[, position[, encoding]], callback)
                     _ => {
-                        if current.is_number() {
-                            let position = i52::from_js(current);
-                            if position >= 0 {
-                                args.position = Some(position);
-                            }
+                        if let Some(position @ 0..) = i52::offset_from_js(current) {
+                            args.position = Some(position);
                         }
                         // Node consumes the position slot whatever its type
                         // (null, undefined, a non-number); the encoding is
@@ -10216,10 +10210,14 @@ impl NodeFSFunctionEnum {
 struct i52;
 impl i52 {
     const MIN: i64 = -(1i64 << 51);
-    /// Truncate to the low
-    /// 52 bits and sign-extend bit 51.
+    /// Node's `GetOffset` (src/node_file.cc): the `position` argument to
+    /// `write`/`writev`/`readv` selects positional I/O only when it is a safe
+    /// JS integer. NaN, ±Infinity, a fractional value, a non-number, or a
+    /// value outside `Number.MAX_SAFE_INTEGER` all mean "current file offset".
     #[inline]
-    fn from_js(v: JSValue) -> i64 {
-        (v.to_int64() << 12) >> 12
+    fn offset_from_js(v: JSValue) -> Option<i64> {
+        let n = v.get_number()?;
+        (n.is_finite() && n.trunc() == n && n.abs() <= bun_jsc::MAX_SAFE_INTEGER as f64)
+            .then_some(n as i64)
     }
 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3841,13 +3841,7 @@ pub mod args {
                         if !(current.is_number() || current.is_big_int()) {
                             break 'parse;
                         }
-                        // BigInt is a Bun extension kept for this overload.
-                        let position = i52::offset_from_js(current).or_else(|| {
-                            current
-                                .is_big_int()
-                                .then(|| (current.to_int64() << 12) >> 12)
-                        });
-                        if let Some(position @ 0..) = position {
+                        if let Some(position @ 0..) = i52::offset_from_js(current) {
                             args.position = Some(position);
                         }
                         arguments.eat();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2076,105 +2076,102 @@ describe.each([
   ["1.5", 1.5],
   ["MAX_SAFE_INTEGER+1", Number.MAX_SAFE_INTEGER + 1],
   ["5n", 5n],
-] as [string, any][])(
-  "fs.write with position=%s uses the current file offset",
-  (_label, position) => {
-    it("writeSync(fd, buffer, offset, length, position)", () => {
-      using dir = tempDir("fs-write-pos-buf", {});
-      const p = join(String(dir), "out.txt");
-      const fd = openSync(p, "w");
-      try {
-        writeSync(fd, "AAAAAAAAAA");
-        writeSync(fd, Buffer.from("XX"), 0, 2, position);
-      } finally {
-        closeSync(fd);
-      }
-      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAXX");
-    });
+] as [string, any][])("fs.write with position=%s uses the current file offset", (_label, position) => {
+  it("writeSync(fd, buffer, offset, length, position)", () => {
+    using dir = tempDir("fs-write-pos-buf", {});
+    const p = join(String(dir), "out.txt");
+    const fd = openSync(p, "w");
+    try {
+      writeSync(fd, "AAAAAAAAAA");
+      writeSync(fd, Buffer.from("XX"), 0, 2, position);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAXX");
+  });
 
-    it("writeSync(fd, string, position)", () => {
-      using dir = tempDir("fs-write-pos-str", {});
-      const p = join(String(dir), "out.txt");
-      const fd = openSync(p, "w");
-      try {
-        writeSync(fd, "AAAAAAAAAA");
-        writeSync(fd, "YY", position);
-      } finally {
-        closeSync(fd);
-      }
-      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAYY");
-    });
+  it("writeSync(fd, string, position)", () => {
+    using dir = tempDir("fs-write-pos-str", {});
+    const p = join(String(dir), "out.txt");
+    const fd = openSync(p, "w");
+    try {
+      writeSync(fd, "AAAAAAAAAA");
+      writeSync(fd, "YY", position);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAYY");
+  });
 
-    it("fs.write(fd, buffer, offset, length, position, cb)", async () => {
-      using dir = tempDir("fs-write-pos-cb", {});
-      const p = join(String(dir), "out.txt");
-      const fd = openSync(p, "w");
-      try {
-        writeSync(fd, "AAAAAAAAAA");
-        const { promise, resolve, reject } = Promise.withResolvers<number>();
-        fs.write(fd, Buffer.from("ZZ"), 0, 2, position, (err, n) => (err ? reject(err) : resolve(n)));
-        expect(await promise).toBe(2);
-      } finally {
-        closeSync(fd);
-      }
-      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAZZ");
-    });
+  it("fs.write(fd, buffer, offset, length, position, cb)", async () => {
+    using dir = tempDir("fs-write-pos-cb", {});
+    const p = join(String(dir), "out.txt");
+    const fd = openSync(p, "w");
+    try {
+      writeSync(fd, "AAAAAAAAAA");
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      fs.write(fd, Buffer.from("ZZ"), 0, 2, position, (err, n) => (err ? reject(err) : resolve(n)));
+      expect(await promise).toBe(2);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAZZ");
+  });
 
-    it("writevSync(fd, buffers, position)", () => {
-      using dir = tempDir("fs-writev-pos", {});
-      const p = join(String(dir), "out.txt");
-      const fd = openSync(p, "w");
-      try {
-        writeSync(fd, "AAAAAAAAAA");
-        expect(writevSync(fd, [Buffer.from("V"), Buffer.from("V")], position as any)).toBe(2);
-      } finally {
-        closeSync(fd);
-      }
-      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAVV");
-    });
+  it("writevSync(fd, buffers, position)", () => {
+    using dir = tempDir("fs-writev-pos", {});
+    const p = join(String(dir), "out.txt");
+    const fd = openSync(p, "w");
+    try {
+      writeSync(fd, "AAAAAAAAAA");
+      expect(writevSync(fd, [Buffer.from("V"), Buffer.from("V")], position as any)).toBe(2);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAVV");
+  });
 
-    it("readvSync(fd, buffers, position)", () => {
-      using dir = tempDir("fs-readv-pos", { "in.txt": "ABCDEFGHIJ" });
-      const fd = openSync(join(String(dir), "in.txt"), "r");
-      try {
-        readSync(fd, Buffer.alloc(3), 0, 3, null);
-        const b = Buffer.alloc(3);
-        expect(readvSync(fd, [b], position as any)).toBe(3);
-        expect(b.toString()).toBe("DEF");
-      } finally {
-        closeSync(fd);
-      }
-    });
+  it("readvSync(fd, buffers, position)", () => {
+    using dir = tempDir("fs-readv-pos", { "in.txt": "ABCDEFGHIJ" });
+    const fd = openSync(join(String(dir), "in.txt"), "r");
+    try {
+      readSync(fd, Buffer.alloc(3), 0, 3, null);
+      const b = Buffer.alloc(3);
+      expect(readvSync(fd, [b], position as any)).toBe(3);
+      expect(b.toString()).toBe("DEF");
+    } finally {
+      closeSync(fd);
+    }
+  });
 
-    it("FileHandle.write(buffer, offset, length, position)", async () => {
-      using dir = tempDir("fs-fh-write-pos", {});
-      const p = join(String(dir), "out.txt");
-      writeFileSync(p, "AAAAAAAAAA");
-      const fh = await promises.open(p, "r+");
-      try {
-        await fh.read(Buffer.alloc(10), 0, 10, null);
-        await fh.write(Buffer.from("WW"), 0, 2, position);
-      } finally {
-        await fh.close();
-      }
-      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAWW");
-    });
+  it("FileHandle.write(buffer, offset, length, position)", async () => {
+    using dir = tempDir("fs-fh-write-pos", {});
+    const p = join(String(dir), "out.txt");
+    writeFileSync(p, "AAAAAAAAAA");
+    const fh = await promises.open(p, "r+");
+    try {
+      await fh.read(Buffer.alloc(10), 0, 10, null);
+      await fh.write(Buffer.from("WW"), 0, 2, position);
+    } finally {
+      await fh.close();
+    }
+    expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAWW");
+  });
 
-    it("FileHandle.writev(buffers, position)", async () => {
-      using dir = tempDir("fs-fh-writev-pos", {});
-      const p = join(String(dir), "out.txt");
-      writeFileSync(p, "AAAAAAAAAA");
-      const fh = await promises.open(p, "r+");
-      try {
-        await fh.read(Buffer.alloc(10), 0, 10, null);
-        await fh.writev([Buffer.from("QQ")], position);
-      } finally {
-        await fh.close();
-      }
-      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAQQ");
-    });
-  },
-);
+  it("FileHandle.writev(buffers, position)", async () => {
+    using dir = tempDir("fs-fh-writev-pos", {});
+    const p = join(String(dir), "out.txt");
+    writeFileSync(p, "AAAAAAAAAA");
+    const fh = await promises.open(p, "r+");
+    try {
+      await fh.read(Buffer.alloc(10), 0, 10, null);
+      await fh.writev([Buffer.from("QQ")], position);
+    } finally {
+      await fh.close();
+    }
+    expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAQQ");
+  });
+});
 
 describe("fs.readv/writev with a non-number position uses the current file offset", () => {
   it.each([null, undefined, "3", {}, true] as const)("writevSync position=%p", position => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3815,11 +3815,17 @@ describe("createWriteStream", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stderr, out: JSON.parse(stdout.trim()), exitCode }).toEqual({
-      stderr: "",
-      out: { ev: ["error:EFBIG"], bytesWritten: 1048576, size: 1048576, head: "AAAAAAAA" },
-      exitCode: 0,
-    });
+    const result = JSON.parse(stdout.trim());
+    // `ulimit -f` block size is 512 (dash/busybox) or 1024 (bash); assert the
+    // invariant, not the exact clamp point.
+    expect({
+      stderr,
+      ev: result.ev,
+      head: result.head,
+      sizeMatchesBytesWritten: result.size === result.bytesWritten,
+      exitCode,
+    }).toEqual({ stderr: "", ev: ["error:EFBIG"], head: "AAAAAAAA", sizeMatchesBytesWritten: true, exitCode: 0 });
+    expect(result.size).toBeWithin(1, 4 << 20);
   });
 
   it("should emit open and call close callback", done => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2065,6 +2065,112 @@ describe("writeSync", () => {
   });
 });
 
+// Node's native GetOffset (src/node_file.cc) returns -1 ("current file offset")
+// unless IsSafeJsInt(value) holds. A NaN/±Infinity/fractional/out-of-range
+// position must not become offset 0: that is what caused createWriteStream's
+// short-write retry loop (pos = undefined + n -> NaN) to overwrite the head of
+// the file on a partial write.
+describe.each([NaN, Infinity, -Infinity, 1.5, Number.MAX_SAFE_INTEGER + 1] as const)(
+  "fs.write with position=%p uses the current file offset",
+  position => {
+    it("writeSync(fd, buffer, offset, length, position)", () => {
+      using dir = tempDir("fs-write-pos-buf", {});
+      const p = join(String(dir), "out.txt");
+      const fd = openSync(p, "w");
+      try {
+        writeSync(fd, "AAAAAAAAAA");
+        writeSync(fd, Buffer.from("XX"), 0, 2, position);
+      } finally {
+        closeSync(fd);
+      }
+      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAXX");
+    });
+
+    it("writeSync(fd, string, position)", () => {
+      using dir = tempDir("fs-write-pos-str", {});
+      const p = join(String(dir), "out.txt");
+      const fd = openSync(p, "w");
+      try {
+        writeSync(fd, "AAAAAAAAAA");
+        writeSync(fd, "YY", position);
+      } finally {
+        closeSync(fd);
+      }
+      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAYY");
+    });
+
+    it("fs.write(fd, buffer, offset, length, position, cb)", async () => {
+      using dir = tempDir("fs-write-pos-cb", {});
+      const p = join(String(dir), "out.txt");
+      const fd = openSync(p, "w");
+      try {
+        writeSync(fd, "AAAAAAAAAA");
+        const { promise, resolve, reject } = Promise.withResolvers<number>();
+        fs.write(fd, Buffer.from("ZZ"), 0, 2, position, (err, n) => (err ? reject(err) : resolve(n)));
+        expect(await promise).toBe(2);
+      } finally {
+        closeSync(fd);
+      }
+      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAZZ");
+    });
+
+    it("writevSync(fd, buffers, position)", () => {
+      using dir = tempDir("fs-writev-pos", {});
+      const p = join(String(dir), "out.txt");
+      const fd = openSync(p, "w");
+      try {
+        writeSync(fd, "AAAAAAAAAA");
+        expect(writevSync(fd, [Buffer.from("V"), Buffer.from("V")], position as any)).toBe(2);
+      } finally {
+        closeSync(fd);
+      }
+      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAVV");
+    });
+
+    it("readvSync(fd, buffers, position)", () => {
+      using dir = tempDir("fs-readv-pos", { "in.txt": "ABCDEFGHIJ" });
+      const fd = openSync(join(String(dir), "in.txt"), "r");
+      try {
+        readSync(fd, Buffer.alloc(3), 0, 3, null);
+        const b = Buffer.alloc(3);
+        expect(readvSync(fd, [b], position as any)).toBe(3);
+        expect(b.toString()).toBe("DEF");
+      } finally {
+        closeSync(fd);
+      }
+    });
+  },
+);
+
+describe("fs.readv/writev with a non-number position uses the current file offset", () => {
+  it.each([null, undefined, "3", {}, true] as const)("writevSync position=%p", position => {
+    using dir = tempDir("fs-writev-nonnum", {});
+    const p = join(String(dir), "out.txt");
+    const fd = openSync(p, "w");
+    try {
+      writeSync(fd, "AAAAAAAAAA");
+      expect(writevSync(fd, [Buffer.from("XY")], position as any)).toBe(2);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAXY");
+  });
+
+  it("writevSync with a non-negative integer position is still positional", () => {
+    using dir = tempDir("fs-writev-int", {});
+    const p = join(String(dir), "out.txt");
+    writeFileSync(p, "0123456789");
+    const fd = openSync(p, "r+");
+    try {
+      readSync(fd, Buffer.alloc(4), 0, 4, null);
+      expect(writevSync(fd, [Buffer.from("XY")], 8)).toBe(2);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(p, "utf8")).toBe("01234567XY");
+  });
+});
+
 describe("readFileSync", () => {
   it("works", () => {
     gc();
@@ -3626,6 +3732,94 @@ describe("createWriteStream", () => {
     await done2;
 
     expect(readFileSync(streamPath, "utf8")).toBe("first line\nsecond line\n");
+  });
+
+  // A short write from the kernel (ENOSPC, RLIMIT_FSIZE, EDQUOT) makes
+  // writeAll retry with pos = undefined + n -> NaN. fs.write used to coerce a
+  // NaN position to 0, so the retried tail was pwritten at the HEAD of the
+  // file and the loop reported success. Reproduced here with a custom fs.write
+  // that returns a short count.
+  it("short write does not overwrite the head of the file", async () => {
+    using dir = tempDir("cws-short-write", {});
+    const p = join(String(dir), "out.bin");
+    const data = Buffer.concat([
+      Buffer.alloc(4, "A"),
+      Buffer.alloc(4, "B"),
+      Buffer.alloc(4, "C"),
+      Buffer.alloc(4, "D"),
+    ]);
+
+    const writes: Array<{ length: number; position: unknown }> = [];
+    const stream = createWriteStream(p, {
+      fs: {
+        open: fs.open,
+        close: fs.close,
+        fsync: fs.fsync,
+        // writev intentionally omitted so only the writeAll path is exercised.
+        write(fd: number, buffer: Buffer, offset: number, length: number, position: unknown, cb: any) {
+          writes.push({ length, position });
+          // First call: accept 4 bytes out of 16; subsequent calls accept all.
+          const take = writes.length === 1 ? 4 : length;
+          return fs.write(fd, buffer, offset, take, position as any, cb);
+        },
+      } as any,
+    });
+    const events: string[] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    stream.on("error", e => (events.push("error:" + (e as NodeJS.ErrnoException).code), resolve()));
+    stream.on("finish", () => events.push("finish"));
+    stream.on("close", resolve);
+    stream.write(data);
+    stream.end();
+    await promise;
+
+    expect({
+      events,
+      bytesWritten: stream.bytesWritten,
+      contents: readFileSync(p, "utf8"),
+      writes,
+    }).toEqual({
+      events: ["finish"],
+      bytesWritten: 16,
+      contents: "AAAABBBBCCCCDDDD",
+      // The retry must keep position undefined (current offset), not NaN.
+      writes: [
+        { length: 16, position: undefined },
+        { length: 12, position: undefined },
+      ],
+    });
+  });
+
+  it.skipIf(!isLinux)("surfaces EFBIG when RLIMIT_FSIZE truncates a write", async () => {
+    using dir = tempDir("cws-efbig", {});
+    const out = join(String(dir), "out.bin");
+    const script = `
+      const fs = require("node:fs");
+      const MB = 1 << 20;
+      const big = Buffer.concat([..."ABCD"].map(c => Buffer.alloc(MB, c)));
+      const s = fs.createWriteStream(${JSON.stringify(out)});
+      const ev = [];
+      s.on("error", e => ev.push("error:" + e.code));
+      s.on("finish", () => ev.push("finish"));
+      s.on("close", () => {
+        const b = fs.readFileSync(${JSON.stringify(out)});
+        console.log(JSON.stringify({ ev, bytesWritten: s.bytesWritten, size: b.length, head: b.subarray(0, 8).toString() }));
+      });
+      s.write(big);
+      s.end();
+    `;
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `ulimit -f 2048; exec "${bunExe()}" -e '${script.replace(/'/g, "'\\''")}'`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, out: JSON.parse(stdout.trim()), exitCode }).toEqual({
+      stderr: "",
+      out: { ev: ["error:EFBIG"], bytesWritten: 1048576, size: 1048576, head: "AAAAAAAA" },
+      exitCode: 0,
+    });
   });
 
   it("should emit open and call close callback", done => {
@@ -5603,15 +5797,22 @@ it("fs.writev keeps buffers attached while the write is in flight", async () => 
     buf.buffer.transfer();
     expect(buf.buffer.detached).toBe(true);
 
-    // A rejected call must not leave the buffers held either.
-    const other = new Uint8Array(new ArrayBuffer(8));
-    expect(() => fs.writev(fd, [other], "not a position" as any, () => {})).toThrow();
+    // A non-number position is treated as "current offset" (Node.js behavior);
+    // the buffer is still pinned for the duration of the async write.
+    const other = new Uint8Array(new ArrayBuffer(8)).fill(0x44);
+    const second = Promise.withResolvers<number>();
+    fs.writev(fd, [other], "not a position" as any, (err, n) => (err ? second.reject(err) : second.resolve(n)));
+    other.buffer.transfer();
+    expect(other.buffer.detached).toBe(false);
+    expect(await second.promise).toBe(8);
     other.buffer.transfer();
     expect(other.buffer.detached).toBe(true);
   } finally {
     closeSync(fd);
   }
-  expect(readFileSync(file, "latin1")).toBe("CCCCCCCC");
+  // The first writev was positional (pwritev at 0) so the file offset is still
+  // 0 when the second, non-positional writev runs.
+  expect(readFileSync(file, "latin1")).toBe("DDDDDDDD");
 });
 
 it("fs.write keeps the source buffer attached while the write is in flight", async () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1990,20 +1990,19 @@ describe.concurrent("writev/readv with more than IOV_MAX buffers", () => {
 });
 
 describe("writeSync", () => {
-  it("works with bigint", () => {
-    const dest = join(tmpdir(), "writeSync-large-file-bigint.txt");
+  it("treats a bigint position as the current offset", () => {
+    // Node's fs.write does `if (typeof position !== 'number') position = null`
+    // for the buffer overload; GetOffset then returns -1. fs.read accepts
+    // bigint positions, but fs.write does not.
+    const dest = join(tmpdir(), "writeSync-bigint-position.txt");
     rmSync(dest, { force: true });
 
     const writefd = openSync(dest, "w");
+    writeSync(writefd, Buffer.from("AAAA"));
     writeSync(writefd, Buffer.from([0x10]), 0, 1, 400n as any);
     closeSync(writefd);
 
-    const fd = openSync(dest, "r");
-    const out = Buffer.alloc(1);
-    const bytes = readSync(fd, out, 0, 1, 400 as any);
-    expect(bytes).toBe(1);
-    expect(out[0]).toBe(0x10);
-    closeSync(fd);
+    expect(readFileSync(dest, "latin1")).toBe("AAAA\x10");
     rmSync(dest, { force: true });
   });
 
@@ -2070,9 +2069,16 @@ describe("writeSync", () => {
 // position must not become offset 0: that is what caused createWriteStream's
 // short-write retry loop (pos = undefined + n -> NaN) to overwrite the head of
 // the file on a partial write.
-describe.each([NaN, Infinity, -Infinity, 1.5, Number.MAX_SAFE_INTEGER + 1] as const)(
-  "fs.write with position=%p uses the current file offset",
-  position => {
+describe.each([
+  ["NaN", NaN],
+  ["Infinity", Infinity],
+  ["-Infinity", -Infinity],
+  ["1.5", 1.5],
+  ["MAX_SAFE_INTEGER+1", Number.MAX_SAFE_INTEGER + 1],
+  ["5n", 5n],
+] as [string, any][])(
+  "fs.write with position=%s uses the current file offset",
+  (_label, position) => {
     it("writeSync(fd, buffer, offset, length, position)", () => {
       using dir = tempDir("fs-write-pos-buf", {});
       const p = join(String(dir), "out.txt");
@@ -2138,6 +2144,34 @@ describe.each([NaN, Infinity, -Infinity, 1.5, Number.MAX_SAFE_INTEGER + 1] as co
       } finally {
         closeSync(fd);
       }
+    });
+
+    it("FileHandle.write(buffer, offset, length, position)", async () => {
+      using dir = tempDir("fs-fh-write-pos", {});
+      const p = join(String(dir), "out.txt");
+      writeFileSync(p, "AAAAAAAAAA");
+      const fh = await promises.open(p, "r+");
+      try {
+        await fh.read(Buffer.alloc(10), 0, 10, null);
+        await fh.write(Buffer.from("WW"), 0, 2, position);
+      } finally {
+        await fh.close();
+      }
+      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAWW");
+    });
+
+    it("FileHandle.writev(buffers, position)", async () => {
+      using dir = tempDir("fs-fh-writev-pos", {});
+      const p = join(String(dir), "out.txt");
+      writeFileSync(p, "AAAAAAAAAA");
+      const fh = await promises.open(p, "r+");
+      try {
+        await fh.read(Buffer.alloc(10), 0, 10, null);
+        await fh.writev([Buffer.from("QQ")], position);
+      } finally {
+        await fh.close();
+      }
+      expect(readFileSync(p, "utf8")).toBe("AAAAAAAAAAQQ");
     });
   },
 );


### PR DESCRIPTION
## Reproduction

```sh
$ cat repro.mjs
import fs from "node:fs"; import os from "node:os"; import { spawnSync } from "node:child_process";
const MB = 1 << 20;
if (process.argv[2] !== "child") {
  const r = spawnSync("sh", ["-c", `ulimit -f 2048; exec "${process.execPath}" "${process.argv[1]}" child`], { stdio: "inherit" });
  process.exit(r.status ?? 1);
}
const p = `${os.tmpdir()}/pw-${process.pid}.bin`;
const big = Buffer.concat([..."ABCD"].map(c => Buffer.alloc(MB, c)));
const s = fs.createWriteStream(p), ev = [];
s.on("error", e => ev.push("error:" + e.code)).on("finish", () => ev.push("finish"));
s.on("close", () => {
  const b = fs.readFileSync(p);
  console.log(JSON.stringify({ ev, bytesWritten: s.bytesWritten, size: b.length, head: b.subarray(0, 8).toString() }));
});
s.write(big); s.end();

$ node repro.mjs
{"ev":["error:EFBIG"],"bytesWritten":1048576,"size":1048576,"head":"AAAAAAAA"}

$ bun repro.mjs    # before
{"ev":["finish"],"bytesWritten":4194304,"size":1048576,"head":"DDDDDDDD"}
```

Any short write from the kernel (disk full / `ENOSPC`, quota / `EDQUOT`, `RLIMIT_FSIZE`) triggers this: the unwritten tail is re-written at offset 0, the head of the file is destroyed, and the stream emits `'finish'` with `bytesWritten` reporting the full size.

The primitive without `createWriteStream`:

```js
const fd = fs.openSync(p, "w");
fs.writeSync(fd, "AAAAAAAAAA");
fs.writeSync(fd, Buffer.from("XX"), 0, 2, NaN);
// node: "AAAAAAAAAAXX"   bun (before): "XXAAAAAAAA"
```

## Cause

`writeAll` in `src/js/internal/fs/streams.ts` retries a short write with `pos += bytesWritten`. `pos` starts as `undefined` (no `start` option) so the retry passes `NaN`. Node's `writeAll` does the same; it works there because Node's native `GetOffset` ([src/node_file.cc](https://github.com/nodejs/node/blob/main/src/node_file.cc)) returns `-1` (current file offset) for any value that isn't a safe JS integer.

Bun's `fs.write` argument parser instead ran `i52::from_js(NaN)`, which is `(to_int64(NaN) << 12) >> 12 = 0`, and set `args.position = Some(0)`. strace confirms: `write(4 MiB) = 1048576`, then `pwrite64(3 MiB, 0)`, `pwrite64(2 MiB, 0)`, `pwrite64(1 MiB, 0)`; the remaining size reaches zero so the loop reports success. `-Infinity`, fractional values, and numbers past `MAX_SAFE_INTEGER` mis-coerced the same way, and the `fs.readv`/`fs.writev` `position` parser had the same defect (plus it threw on non-number values Node accepts).

## Fix

`i52::offset_from_js` now implements Node's `GetOffset`: a `position` selects `pwrite`/`pwritev`/`preadv` only when `Number.isSafeInteger(position)`. Every other shape (NaN, ±Infinity, fractional, out-of-range, non-number) leaves `position = None` so dispatch picks the non-positional syscall at the current offset. The `fs.write` buffer and string overloads and the shared `readv`/`writev` parser all go through it. This includes BigInt, which Bun previously honored as a positional write on the buffer overload; the `writeSync works with bigint` test now asserts the Node behavior (current offset).

`writeAll` also now keeps `pos` undefined across retries, so a custom `options.fs.write` observes the same argument Node passes.

## Verification

New `describe.each` in `test/js/node/fs/fs.test.ts` runs `writeSync` (buffer and string), async `fs.write`, `writevSync`, `readvSync`, `FileHandle.write`, and `FileHandle.writev` against each of `NaN`, `±Infinity`, `1.5`, `MAX_SAFE_INTEGER + 1`, and `5n` and asserts the I/O happens at the current offset; a second block covers non-number `writevSync` positions. Two `createWriteStream` tests cover the headline bug: one simulates a short write via `options.fs.write` and asserts the retry position stays `undefined` and the file reads `AAAABBBBCCCCDDDD`; one (Linux) runs the `ulimit -f` repro and asserts `{ev: ["error:EFBIG"], bytesWritten: 1048576, head: "AAAAAAAA"}`.

40 of the 49 new cases fail on the unfixed build (the others are guard cases or +Infinity which already happened to truncate to `-1`). All pass with this change, along with the existing `writeSync`/`writev`/`readv` suites and Node's `test-fs-writev*`/`test-fs-readv*` parallel tests.

Supersedes #32292 (the `readv`/`writev` half of this same class).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->