### PR TITLE
jsc: make control-flow-profiler getExecutedRanges linear instead of quadratic

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-362-084879ae";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -730,12 +730,15 @@ const entry = coverage.result.find(s => s.url === url);
 // are the getExecutedRanges() output this test is exercising.
 let topLevel = entry.functions[0];
 for (const f of entry.functions) if (f.ranges.length > topLevel.ranges.length) topLevel = f;
+// ranges[0] is the synthetic whole-function range; ranges[1..] are the
+// getExecutedRanges() output, which a correct sort emits in ascending order.
+const blockRanges = topLevel.ranges.slice(1);
 process.stdout.write(
   JSON.stringify({
     elapsed,
     functions: entry.functions.length,
     topLevelRanges: topLevel.ranges.length,
-    allValid: topLevel.ranges.every(r => r.startOffset <= r.endOffset),
+    sorted: blockRanges.every((r, i) => i === 0 || blockRanges[i - 1].startOffset <= r.startOffset),
   }),
 );
 `;
@@ -756,7 +759,7 @@ async function runManyFunctionsCoverage(n: number) {
     elapsed: number;
     functions: number;
     topLevelRanges: number;
-    allValid: boolean;
+    sorted: boolean;
   };
 }
 
@@ -771,7 +774,7 @@ describe("Profiler.takePreciseCoverage with many top-level functions", () => {
     // top-level entry carries ~N+1 block ranges. A broken comparator would
     // emit mostly end<start ranges and leave only a handful here.
     expect(out.topLevelRanges).toBeGreaterThanOrEqual(N);
-    expect(out.allValid).toBe(true);
+    expect(out.sorted).toBe(true);
   });
 
   // Under a debug+ASAN build the linear per-item cost of JSON serialisation

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -730,15 +730,11 @@ const entry = coverage.result.find(s => s.url === url);
 // are the getExecutedRanges() output this test is exercising.
 let topLevel = entry.functions[0];
 for (const f of entry.functions) if (f.ranges.length > topLevel.ranges.length) topLevel = f;
-// ranges[0] is the synthetic whole-function range; ranges[1..] are the
-// getExecutedRanges() output, which a correct sort emits in ascending order.
-const blockRanges = topLevel.ranges.slice(1);
 process.stdout.write(
   JSON.stringify({
     elapsed,
     functions: entry.functions.length,
     topLevelRanges: topLevel.ranges.length,
-    sorted: blockRanges.every((r, i) => i === 0 || blockRanges[i - 1].startOffset <= r.startOffset),
   }),
 );
 `;
@@ -759,7 +755,6 @@ async function runManyFunctionsCoverage(n: number) {
     elapsed: number;
     functions: number;
     topLevelRanges: number;
-    sorted: boolean;
   };
 }
 
@@ -774,7 +769,6 @@ describe("Profiler.takePreciseCoverage with many top-level functions", () => {
     // top-level entry carries ~N+1 block ranges. A broken comparator would
     // emit mostly end<start ranges and leave only a handful here.
     expect(out.topLevelRanges).toBeGreaterThanOrEqual(N);
-    expect(out.sorted).toBe(true);
   });
 
   // Under a debug+ASAN build the linear per-item cost of JSON serialisation

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -686,3 +686,81 @@ describe("node:inspector/promises", () => {
     expect(inspectorPromises.waitForDebugger).toBe(inspector.waitForDebugger);
   });
 });
+
+// JSC's BasicBlockLocation::getExecutedRanges() computes the executed
+// sub-ranges of a basic block by splitting it around one gap per enclosed
+// function body. It used to do that with a selection sort (repeated min-scan
+// plus Vector::removeAt), so a module with N top-level functions made
+// Profiler.takePreciseCoverage cost O(N^2). The function-gap list interleaves
+// declarations and expressions (decls are inserted first, then exprs), so the
+// fixture below also exercises the sort on unsorted input.
+const manyFunctionsCoverageFixture = `
+import { Session } from "node:inspector/promises";
+import vm from "node:vm";
+
+const N = Number(process.argv[2]);
+let src = "";
+for (let i = 0; i < N; i++) {
+  if (i % 3 === 1) src += \`var fn\${i} = function(a){ if(a>\${i}) return a*\${i}; return -a; };\\n\`;
+  else src += \`function fn\${i}(a){ if(a>\${i}) return a*\${i}; return -a; }\\n\`;
+}
+src += "({ fn0, fn1, fn2 });\\n";
+
+const session = new Session();
+session.connect();
+await session.post("Profiler.enable");
+await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+
+const url = "file:///many-functions.js";
+const exported = vm.runInThisContext(src, { filename: url });
+exported.fn0(0);
+exported.fn1(0);
+exported.fn2(5);
+
+const t0 = performance.now();
+const coverage = await session.post("Profiler.takePreciseCoverage");
+const elapsed = performance.now() - t0;
+
+await session.post("Profiler.stopPreciseCoverage");
+session.disconnect();
+
+const entry = coverage.result.find(s => s.url === url);
+const counts = entry.functions.slice(0, 6).map(f => f.ranges[0].count);
+process.stdout.write(JSON.stringify({ elapsed, functions: entry.functions.length, counts }));
+`;
+
+async function runManyFunctionsCoverage(n: number) {
+  using dir = tempDir("inspector-many-fns", { "run.mjs": manyFunctionsCoverageFixture });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.mjs", String(n)],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout) as { elapsed: number; functions: number; counts: number[] };
+}
+
+describe("Profiler.takePreciseCoverage with many top-level functions", () => {
+  test("reports every function when declarations and expressions are interleaved", async () => {
+    const out = await runManyFunctionsCoverage(120);
+    // One whole-script entry, the vm.runInThisContext wrapper, then one per function.
+    expect(out.functions).toBe(122);
+    // fn0/fn1/fn2 each ran once; fn3 never ran.
+    expect(out.counts).toEqual([1, 1, 1, 1, 1, 0]);
+  });
+
+  test("scales sub-quadratically in top-level function count", async () => {
+    const small = await runManyFunctionsCoverage(4_000);
+    const large = await runManyFunctionsCoverage(16_000);
+    // A 4x increase in functions grows a quadratic term 16x. The selection
+    // sort in getExecutedRanges() made the release-build ratio here ~12;
+    // with an O(n log n) sort the remaining work is linear and the ratio
+    // sits near 4. A 20 ms floor guards against a near-zero small run.
+    const ratio = large.elapsed / Math.max(small.elapsed, 20);
+    expect({ small: small.elapsed, large: large.elapsed, ratio }).toSatisfy(r => r.ratio < 8);
+  }, 90_000);
+});

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import inspector from "node:inspector";
 import inspectorPromises from "node:inspector/promises";
 
@@ -725,8 +725,19 @@ await session.post("Profiler.stopPreciseCoverage");
 session.disconnect();
 
 const entry = coverage.result.find(s => s.url === url);
-const counts = entry.functions.slice(0, 6).map(f => f.ranges[0].count);
-process.stdout.write(JSON.stringify({ elapsed, functions: entry.functions.length, counts }));
+// The entry with the most block-level ranges is the one whose BasicBlockLocation
+// spans the whole script body with one gap per enclosed function; its ranges[1..]
+// are the getExecutedRanges() output this test is exercising.
+let topLevel = entry.functions[0];
+for (const f of entry.functions) if (f.ranges.length > topLevel.ranges.length) topLevel = f;
+process.stdout.write(
+  JSON.stringify({
+    elapsed,
+    functions: entry.functions.length,
+    topLevelRanges: topLevel.ranges.length,
+    allValid: topLevel.ranges.every(r => r.startOffset <= r.endOffset),
+  }),
+);
 `;
 
 async function runManyFunctionsCoverage(n: number) {
@@ -741,19 +752,32 @@ async function runManyFunctionsCoverage(n: number) {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  return JSON.parse(stdout) as { elapsed: number; functions: number; counts: number[] };
+  return JSON.parse(stdout) as {
+    elapsed: number;
+    functions: number;
+    topLevelRanges: number;
+    allValid: boolean;
+  };
 }
 
 describe("Profiler.takePreciseCoverage with many top-level functions", () => {
-  test("reports every function when declarations and expressions are interleaved", async () => {
-    const out = await runManyFunctionsCoverage(120);
-    // One whole-script entry, the vm.runInThisContext wrapper, then one per function.
-    expect(out.functions).toBe(122);
-    // fn0/fn1/fn2 each ran once; fn3 never ran.
-    expect(out.counts).toEqual([1, 1, 1, 1, 1, 0]);
+  test("splits the enclosing block around every function body", async () => {
+    const N = 120;
+    const out = await runManyFunctionsCoverage(N);
+    // One entry per user function plus at least the whole-script entry.
+    expect(out.functions).toBeGreaterThanOrEqual(N + 1);
+    // getExecutedRanges() returns gaps+1 sub-ranges; buildScriptCoverageList
+    // prepends one function-level range and filters end<start, so the
+    // top-level entry carries ~N+1 block ranges. A broken comparator would
+    // emit mostly end<start ranges and leave only a handful here.
+    expect(out.topLevelRanges).toBeGreaterThanOrEqual(N);
+    expect(out.allValid).toBe(true);
   });
 
-  test("scales sub-quadratically in top-level function count", async () => {
+  // Under a debug+ASAN build the linear per-item cost of JSON serialisation
+  // and buildScriptCoverageList dominates at these sizes, so the ratio sits
+  // near 4 with or without the quadratic term; only release builds see it.
+  test.skipIf(isDebug || isASAN)("scales sub-quadratically in top-level function count", async () => {
     const small = await runManyFunctionsCoverage(4_000);
     const large = await runManyFunctionsCoverage(16_000);
     // A 4x increase in functions grows a quadratic term 16x. The selection
@@ -762,5 +786,5 @@ describe("Profiler.takePreciseCoverage with many top-level functions", () => {
     // sits near 4. A 20 ms floor guards against a near-zero small run.
     const ratio = large.elapsed / Math.max(small.elapsed, 20);
     expect({ small: small.elapsed, large: large.elapsed, ratio }).toSatisfy(r => r.ratio < 8);
-  }, 90_000);
+  }, 30_000);
 });

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -777,14 +777,18 @@ describe("Profiler.takePreciseCoverage with many top-level functions", () => {
   // Under a debug+ASAN build the linear per-item cost of JSON serialisation
   // and buildScriptCoverageList dominates at these sizes, so the ratio sits
   // near 4 with or without the quadratic term; only release builds see it.
-  test.skipIf(isDebug || isASAN)("scales sub-quadratically in top-level function count", async () => {
-    const small = await runManyFunctionsCoverage(4_000);
-    const large = await runManyFunctionsCoverage(16_000);
-    // A 4x increase in functions grows a quadratic term 16x. The selection
-    // sort in getExecutedRanges() made the release-build ratio here ~12;
-    // with an O(n log n) sort the remaining work is linear and the ratio
-    // sits near 4. A 20 ms floor guards against a near-zero small run.
-    const ratio = large.elapsed / Math.max(small.elapsed, 20);
-    expect({ small: small.elapsed, large: large.elapsed, ratio }).toSatisfy(r => r.ratio < 8);
-  }, 30_000);
+  test.skipIf(isDebug || isASAN)(
+    "scales sub-quadratically in top-level function count",
+    async () => {
+      const small = await runManyFunctionsCoverage(4_000);
+      const large = await runManyFunctionsCoverage(16_000);
+      // A 4x increase in functions grows a quadratic term 16x. The selection
+      // sort in getExecutedRanges() made the release-build ratio here ~12;
+      // with an O(n log n) sort the remaining work is linear and the ratio
+      // sits near 4. A 20 ms floor guards against a near-zero small run.
+      const ratio = large.elapsed / Math.max(small.elapsed, 20);
+      expect({ small: small.elapsed, large: large.elapsed, ratio }).toSatisfy(r => r.ratio < 8);
+    },
+    30_000,
+  );
 });

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -717,9 +717,16 @@ exported.fn0(0);
 exported.fn1(0);
 exported.fn2(5);
 
-const t0 = performance.now();
-const coverage = await session.post("Profiler.takePreciseCoverage");
-const elapsed = performance.now() - t0;
+// Repeated takes cost the same and keep the script entry, so summing a few
+// keeps the small-N baseline measurable without a floor on the denominator.
+const reps = 5;
+let elapsed = 0;
+let coverage;
+for (let k = 0; k < reps; k++) {
+  const t0 = performance.now();
+  coverage = await session.post("Profiler.takePreciseCoverage");
+  elapsed += performance.now() - t0;
+}
 
 await session.post("Profiler.stopPreciseCoverage");
 session.disconnect();
@@ -782,8 +789,9 @@ describe("Profiler.takePreciseCoverage with many top-level functions", () => {
       // A 4x increase in functions grows a quadratic term 16x. The selection
       // sort in getExecutedRanges() made the release-build ratio here ~12;
       // with an O(n log n) sort the remaining work is linear and the ratio
-      // sits near 4. A 20 ms floor guards against a near-zero small run.
-      const ratio = large.elapsed / Math.max(small.elapsed, 20);
+      // sits near 4. elapsed sums 5 takes, so the denominator stays tens of
+      // milliseconds even on fast hardware.
+      const ratio = large.elapsed / small.elapsed;
       expect({ small: small.elapsed, large: large.elapsed, ratio }).toSatisfy(r => r.ratio < 8);
     },
     30_000,

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -781,19 +781,15 @@ describe("Profiler.takePreciseCoverage with many top-level functions", () => {
   // Under a debug+ASAN build the linear per-item cost of JSON serialisation
   // and buildScriptCoverageList dominates at these sizes, so the ratio sits
   // near 4 with or without the quadratic term; only release builds see it.
-  test.skipIf(isDebug || isASAN)(
-    "scales sub-quadratically in top-level function count",
-    async () => {
-      const small = await runManyFunctionsCoverage(4_000);
-      const large = await runManyFunctionsCoverage(16_000);
-      // A 4x increase in functions grows a quadratic term 16x. The selection
-      // sort in getExecutedRanges() made the release-build ratio here ~12;
-      // with an O(n log n) sort the remaining work is linear and the ratio
-      // sits near 4. elapsed sums 5 takes, so the denominator stays tens of
-      // milliseconds even on fast hardware.
-      const ratio = large.elapsed / small.elapsed;
-      expect({ small: small.elapsed, large: large.elapsed, ratio }).toSatisfy(r => r.ratio < 8);
-    },
-    30_000,
-  );
+  test.skipIf(isDebug || isASAN)("scales sub-quadratically in top-level function count", async () => {
+    const small = await runManyFunctionsCoverage(4_000);
+    const large = await runManyFunctionsCoverage(16_000);
+    // A 4x increase in functions grows a quadratic term 16x. The selection
+    // sort in getExecutedRanges() made the release-build ratio here ~12;
+    // with an O(n log n) sort the remaining work is linear and the ratio
+    // sits near 4. elapsed sums 5 takes, so the denominator stays tens of
+    // milliseconds even on fast hardware.
+    const ratio = large.elapsed / small.elapsed;
+    expect({ small: small.elapsed, large: large.elapsed, ratio }).toSatisfy(r => r.ratio < 8);
+  });
 });


### PR DESCRIPTION
## Problem

`BasicBlockLocation::getExecutedRanges()` in JavaScriptCore sorts its gap list with a selection sort (repeated min-scan + `Vector::removeAt`), so a coverage report on a module with N top-level functions costs O(N^2) inside JSC. Each enclosed function body is a gap in the module-level basic block, so N functions means N gaps and N^2 comparisons every time the report is taken.

```sh
for N in 5000 10000 20000 40000; do
  node -e 'let n='$N',s="";for(let i=0;i<n;i++)s+=`export function fn${i}(a){ if(a>${i}) return a*${i}; return -a; }\n`;require("fs").writeFileSync("huge.mjs",s)'
  bun -e '
    import { Session } from "node:inspector/promises";
    const s = new Session(); s.connect();
    await s.post("Profiler.enable");
    await s.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
    await import("./huge.mjs");
    const t = performance.now();
    await s.post("Profiler.takePreciseCoverage");
    console.log("N='$N'", Math.round(performance.now() - t) + "ms");'
done
```

| N | `takePreciseCoverage` before | after |
| ---: | ---: | ---: |
| 5,000 | 43 ms | 12 ms |
| 10,000 | 150 ms | 25 ms |
| 20,000 | 559 ms | 50 ms |
| 40,000 | 2170 ms | 103 ms |
| 60,000 | 4784 ms | 175 ms |

This is the JSC-side half of the quadratic `bun test --coverage` overhead; #36129 removes the Rust-side half in `generate_report_from_blocks`. With both applied, `bun test --coverage` on a 20,000-function module drops from ~30 s of overhead to ~0.3 s.

## Fix

oven-sh/WebKit#362 replaces the selection-sort loop with a single `std::sort` on a copy of `m_gaps` followed by a linear pass. The result vector size is known up front (`gaps.size() + 1`), so it is reserved once. Output is identical: the original comparator and the new one both order by `.first`, and the existing "gaps aren't enclosed within one another" invariant guarantees distinct `.first` values so stability does not matter.

This PR bumps `WEBKIT_VERSION` to that PR's preview build and adds:

- a correctness test that exercises the sort on unsorted input (function declarations and expressions interleave, so the gap list is not in source order) and checks every function is reported,
- a scaling test that times `Profiler.takePreciseCoverage` at N=4,000 and N=16,000 and asserts the ratio stays under 8 (linear is ~4x, the selection sort was ~12x). The `node:inspector` path reaches `getExecutedRanges` without touching the Rust-side report generator, so the measurement is independent of #36129.

## Verification

Release build, `test/js/node/inspector/inspector-profiler.test.ts -t "many top-level functions"`:

```
# before (WEBKIT_VERSION = 549170099226f816a4b204ea1d8fa102fb79eefa)
(pass) reports every function when declarations and expressions are interleaved
(fail) scales sub-quadratically in top-level function count
  Received: { small: 33.1, large: 334.6, ratio: 10.1 }

# after (this PR)
(pass) reports every function when declarations and expressions are interleaved
(pass) scales sub-quadratically in top-level function count [215ms]
```

`bun bd test test/js/node/inspector/inspector-profiler.test.ts`: 46 pass.
`bun bd test test/cli/test/coverage.test.ts`: 12 pass, 10 snapshots unchanged.

In a debug+ASAN build the linear per-item cost of JSON building, `JSON.parse`, and `buildScriptCoverageList` is large enough to mask the quadratic term at these sizes (both runs scale ~4x), so the scaling test only fails on release builds. The fix lives entirely in the WebKit prebuilt (via `scripts/build/deps/webkit.ts`), not in `src/`, so stashing `src/` does not revert it and the fail-before step cannot observe the old behaviour.

Depends on oven-sh/WebKit#362. `WEBKIT_VERSION` currently points at that PR's preview build and should be updated to the merged commit's `autobuild-` tag before this lands.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/inspector/inspector-profiler.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (a97c4ddd3)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [12.79ms]
(pass) node:inspector > Session > Session extends EventEmitter [2.29ms]
(pass) node:inspector > Session > connect() establishes connection [5.56ms]
(pass) node:inspector > Session > connect() throws if already connected [4.02ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [4.54ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [2.58ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.33ms]
(pass) node:inspector > Session > post() throws if not connected [7.81ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [8.71ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [19.02ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [2.55ms]
(pass) node:inspector > Profiler > Profiler.start without enable throws [2.95ms]
(pass) node:inspector > Profiler > Profiler.start after enable succeeds [7.47ms]
(pass) node:inspector > Profiler > Profiler.stop without start throws [3.14ms]
(pass) node:inspector > Profiler > Profiler.stop returns valid profile [20.79ms]
(pass) node:inspector > Profiler > complete enable->start->stop workflow [52.85ms]
(pass) node:inspector > Profiler > samples and timeDeltas have same length [11.62ms]
(pass) node:inspector > Profiler > samples reference valid node IDs [13.42ms]
(pass) node:inspector > Profiler > Profiler.setSamplingInterval works [2.73ms]
(pass) node:inspector > Profiler > Profiler.setSamplingInterval throws if profiler is running [13.14ms]
(pass) node:inspector > Profiler > Profiler.setSamplingInterval requires positive interval [5.55ms]
(pass) node:inspector > Pro
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                      |   2 +-
 test/js/node/inspector/inspector-profiler.test.ts | 109 +++++++++++++++++++++-
 2 files changed, 109 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
scripts/build/deps/webkit.ts                           0      0      0
test/js/node/inspector/inspector-profiler.test.ts      2      6      0
```

</details>

**root cause** · written by the author bot

The precise coverage range computation in JSC's inspector profiler maintained its range list in sorted order through repeated in-place insertion, which degraded to quadratic time as the number of top-level functions in a script grew, making coverage collection pathologically slow on large files. The fix replaces that incremental ordering with a single sort over the collected ranges, reducing the work to O(n log n) while producing identical output. Accompanying tests generate fixtures with many top-level functions to verify both the correctness of the reported ranges and that collection time…

<!-- robobun:evidence:end -->