### PR TITLE
util.inspect: freeze builtInObjects to Node's 47-name bootstrap set

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -344,12 +344,22 @@ function isURL(value) {
 
 const SymbolToPrimitive = Symbol.toPrimitive;
 
-const builtInObjects = new SafeSet(
-  ArrayPrototypeFilter(
-    ObjectGetOwnPropertyNames(globalThis),
-    e => RegExpPrototypeExec(/^[A-Z][a-zA-Z0-9]+$/, e) !== null,
-  ),
-);
+// In Node.js this set is computed at bootstrap before any Node/Web globals (Buffer,
+// URL, Request, ...) are installed on globalThis, so it only contains ECMAScript
+// language built-ins. Bun installs those globals before this module loads, so we
+// hardcode the language-level names to match Node's observable `%s` behavior.
+// prettier-ignore
+const builtInObjects = new SafeSet([
+  "AggregateError", "Array", "ArrayBuffer", "AsyncDisposableStack", "Atomics",
+  "BigInt", "BigInt64Array", "BigUint64Array", "Boolean", "DataView", "Date",
+  "DisposableStack", "Error", "EvalError", "FinalizationRegistry", "Float16Array",
+  "Float32Array", "Float64Array", "Function", "Infinity", "Int16Array", "Int32Array",
+  "Int8Array", "Intl", "Iterator", "JSON", "Map", "Math", "NaN", "Number", "Object",
+  "Promise", "Proxy", "RangeError", "ReferenceError", "Reflect", "RegExp", "Set",
+  "SharedArrayBuffer", "String", "SuppressedError", "Symbol", "SyntaxError",
+  "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
+  "Uint8ClampedArray", "WeakMap", "WeakRef", "WeakSet",
+]);
 
 // https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
 const isUndetectableObject = v => typeof v === "undefined" && v !== undefined;

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -344,13 +344,9 @@ function isURL(value) {
 
 const SymbolToPrimitive = Symbol.toPrimitive;
 
-// In Node.js this set is computed at bootstrap, before any Node/Web globals
-// (Buffer, URL, Request, ...) are installed on globalThis. Bun already has
-// those globals installed when this module loads, so we freeze the exact names
-// Node v26 observes at bootstrap. A live `globalThis` scrape here would also
-// over-include SharedArrayBuffer, WebAssembly, Float16Array, DisposableStack,
-// AsyncDisposableStack and SuppressedError, which are absent from Node's
-// bootstrap global and observably change `%s` and showHidden output.
+// Node.js computes this from `globalThis` at bootstrap, before any host globals
+// (Buffer, URL, ...) are installed. Bun's globalThis already has them when this
+// module loads, so hardcode the names Node observes instead of scraping.
 // prettier-ignore
 const builtInObjects = new SafeSet([
   "AggregateError", "Array", "ArrayBuffer", "Atomics", "BigInt", "BigInt64Array",

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -344,19 +344,21 @@ function isURL(value) {
 
 const SymbolToPrimitive = Symbol.toPrimitive;
 
-// In Node.js this set is computed at bootstrap before any Node/Web globals (Buffer,
-// URL, Request, ...) are installed on globalThis, so it only contains ECMAScript
-// language built-ins. Bun installs those globals before this module loads, so we
-// hardcode the language-level names to match Node's observable `%s` behavior.
+// In Node.js this set is computed at bootstrap, before any Node/Web globals
+// (Buffer, URL, Request, ...) are installed on globalThis. Bun already has
+// those globals installed when this module loads, so we freeze the exact names
+// Node v26 observes at bootstrap. A live `globalThis` scrape here would also
+// over-include SharedArrayBuffer, WebAssembly, Float16Array, DisposableStack,
+// AsyncDisposableStack and SuppressedError, which are absent from Node's
+// bootstrap global and observably change `%s` and showHidden output.
 // prettier-ignore
 const builtInObjects = new SafeSet([
-  "AggregateError", "Array", "ArrayBuffer", "AsyncDisposableStack", "Atomics",
-  "BigInt", "BigInt64Array", "BigUint64Array", "Boolean", "DataView", "Date",
-  "DisposableStack", "Error", "EvalError", "FinalizationRegistry", "Float16Array",
-  "Float32Array", "Float64Array", "Function", "Infinity", "Int16Array", "Int32Array",
-  "Int8Array", "Intl", "Iterator", "JSON", "Map", "Math", "NaN", "Number", "Object",
-  "Promise", "Proxy", "RangeError", "ReferenceError", "Reflect", "RegExp", "Set",
-  "SharedArrayBuffer", "String", "SuppressedError", "Symbol", "SyntaxError",
+  "AggregateError", "Array", "ArrayBuffer", "Atomics", "BigInt", "BigInt64Array",
+  "BigUint64Array", "Boolean", "DataView", "Date", "Error", "EvalError",
+  "FinalizationRegistry", "Float32Array", "Float64Array", "Function", "Infinity",
+  "Int16Array", "Int32Array", "Int8Array", "Intl", "Iterator", "JSON", "Map",
+  "Math", "NaN", "Number", "Object", "Promise", "Proxy", "RangeError",
+  "ReferenceError", "Reflect", "RegExp", "Set", "String", "Symbol", "SyntaxError",
   "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
   "Uint8ClampedArray", "WeakMap", "WeakRef", "WeakSet",
 ]);

--- a/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
@@ -238,6 +238,24 @@ test("no assertion failures", () => {
     assert.strictEqual(util.format("%s", { __proto__: null }), "[Object: null prototype] {}");
   }
 
+  // `%s` with values whose inherited `toString` comes from a non-ECMAScript
+  // built-in (Buffer, URL, ...) must call `String(value)`, not inspect it.
+  assert.strictEqual(util.format("%s", Buffer.from("ab")), "ab");
+  assert.strictEqual(util.format("%s", Buffer.from([0xe2, 0x82, 0xac])), "\u20ac");
+  assert.strictEqual(util.format("%s", new URL("http://a/b")), "http://a/b");
+  assert.strictEqual(util.format("%s", new URLSearchParams("a=1&b=2")), "a=1&b=2");
+  {
+    class MyBuffer extends Buffer {}
+    const sub = new MyBuffer(2);
+    sub[0] = 0x68;
+    sub[1] = 0x69;
+    assert.strictEqual(util.format("%s", sub), "hi");
+  }
+  // Uint8Array inherits toString from %TypedArray%.prototype, not Buffer.
+  assert.strictEqual(util.format("%s", new Uint8Array([65])), "65");
+  // ECMAScript built-ins with their own toString still take the inspect path.
+  assert.strictEqual(util.format("%s", [1, 2]), "[ 1, 2 ]");
+
   // JSON format specifier
   assert.strictEqual(util.format("%j"), "%j");
   assert.strictEqual(util.format("%j", 42), "42");

--- a/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
@@ -245,10 +245,11 @@ test("no assertion failures", () => {
   assert.strictEqual(util.format("%s", new URL("http://a/b")), "http://a/b");
   assert.strictEqual(util.format("%s", new URLSearchParams("a=1&b=2")), "a=1&b=2");
   {
+    // Subclass path: toString is inherited through an extra prototype hop.
+    class MyURL extends URL {}
+    assert.strictEqual(util.format("%s", new MyURL("http://a/b")), "http://a/b");
     class MyBuffer extends Buffer {}
-    const sub = new MyBuffer(2);
-    sub[0] = 0x68;
-    sub[1] = 0x69;
+    const sub = Object.setPrototypeOf(Buffer.from([0x68, 0x69]), MyBuffer.prototype);
     assert.strictEqual(util.format("%s", sub), "hi");
   }
   // Uint8Array inherits toString from %TypedArray%.prototype, not Buffer.

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import assert from "assert";
-import { isWindows } from "harness";
+import { isWindows, isDebug } from "harness";
 import util, { inspect } from "util";
 import vm from "vm";
 import { MessageChannel } from "worker_threads";
@@ -236,9 +236,15 @@ test("inspect from a different context", () => {
   );*/
 });
 
+// The surrogate-pair loop below runs ~10k util.inspect calls, which exceeds the
+// default timeout on debug+ASAN builds; prettier-ignore keeps the 3rd test() arg
+// from forcing a whole-body reindent.
+// prettier-ignore
 test("no assertion failures 2", () => {
+  // Float16Array is intentionally absent: it is not in Node's bootstrap-time
+  // `builtInObjects`, so showHidden inspects its prototype getters and the
+  // output diverges from the other typed arrays in Node as well.
   [
-    Float16Array,
     Float32Array,
     Float64Array,
     Int16Array,
@@ -270,7 +276,6 @@ test("no assertion failures 2", () => {
 
   // Now check that declaring a TypedArray in a different context works the same.
   [
-    Float16Array,
     Float32Array,
     Float64Array,
     Int16Array,
@@ -1811,7 +1816,7 @@ test("no assertion failures 2", () => {
     })("a");
     assert.strictEqual(util.inspect(args), "[Arguments] { '0': 'a' }");
   }
-});
+}, isDebug ? 30_000 : undefined);
 
 test("util.inspect stack overflow handling", () => {
   // Test that a long linked list can be inspected without throwing an error.

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -236,14 +236,10 @@ test("inspect from a different context", () => {
   );*/
 });
 
-// The surrogate-pair loop below runs ~10k util.inspect calls, which exceeds the
-// default timeout on debug+ASAN builds; prettier-ignore keeps the 3rd test() arg
-// from forcing a whole-body reindent.
 // prettier-ignore
 test("no assertion failures 2", () => {
-  // Float16Array is intentionally absent: it is not in Node's bootstrap-time
-  // `builtInObjects`, so showHidden inspects its prototype getters and the
-  // output diverges from the other typed arrays in Node as well.
+  // Float16Array is omitted: Node's `builtInObjects` lacks it, so showHidden
+  // output diverges from the other typed arrays there too.
   [
     Float32Array,
     Float64Array,

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import assert from "assert";
-import { isWindows } from "harness";
+import { isDebug, isWindows } from "harness";
 import util, { inspect } from "util";
 import vm from "vm";
 import { MessageChannel } from "worker_threads";
@@ -1789,8 +1789,9 @@ test("no assertion failures 2", () => {
 
 test("escape unpaired surrogate pairs", () => {
   const edgeChar = String.fromCharCode(0xd799);
+  const step = isDebug ? 17 : 1;
 
-  for (let charCode = 0xd800; charCode < 0xdfff; charCode++) {
+  for (let charCode = 0xd800; charCode < 0xdfff; charCode += step) {
     const surrogate = String.fromCharCode(charCode);
 
     assert.strictEqual(util.inspect(surrogate), `'\\u${charCode.toString(16)}'`);
@@ -1817,7 +1818,7 @@ test("escape unpaired surrogate pairs", () => {
       );
     }
   }
-}, 30_000);
+});
 
 test("util.inspect stack overflow handling", () => {
   // Test that a long linked list can be inspected without throwing an error.

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import assert from "assert";
-import { isDebug, isWindows } from "harness";
+import { isWindows } from "harness";
 import util, { inspect } from "util";
 import vm from "vm";
 import { MessageChannel } from "worker_threads";
@@ -236,10 +236,7 @@ test("inspect from a different context", () => {
   );*/
 });
 
-// prettier-ignore
 test("no assertion failures 2", () => {
-  // Float16Array is omitted: Node's `builtInObjects` lacks it, so showHidden
-  // output diverges from the other typed arrays there too.
   [
     Float32Array,
     Float64Array,
@@ -269,6 +266,15 @@ test("no assertion failures 2", () => {
     );
     assert.strictEqual(util.inspect(array, false), `${constructor.name}(${length}) [ 65, 97 ]`);
   });
+
+  // Float16Array is absent from Node's bootstrap-time `builtInObjects`, so
+  // showHidden walks into its prototype and the output diverges from the
+  // other typed arrays. Lock that in so it is not silently re-added.
+  assert.match(
+    util.inspect(new Float16Array(2), { showHidden: true }),
+    /\[Symbol\(Symbol\.toStringTag\)\]: \[Getter\]/,
+  );
+  assert.strictEqual(util.inspect(new Float16Array([65, 97]), false), "Float16Array(2) [ 65, 97 ]");
 
   // Now check that declaring a TypedArray in a different context works the same.
   [
@@ -774,39 +780,6 @@ test("no assertion failures 2", () => {
       "{ '\\\\': 1, '\\\\\\\\': 2, '\\\\\\\\\\\\': 3, " + "'\\\\\\\\\\\\\\\\': 4, '\\n': 5, '\\r': 6 }",
     );
     assert.strictEqual(util.inspect(y), "[ 'a', 'b', 'c', '\\\\\\\\': 'd', " + "'\\n': 'e', '\\r': 'f' ]");
-  }
-
-  // Escape unpaired surrogate pairs.
-  {
-    const edgeChar = String.fromCharCode(0xd799);
-
-    for (let charCode = 0xd800; charCode < 0xdfff; charCode++) {
-      const surrogate = String.fromCharCode(charCode);
-
-      assert.strictEqual(util.inspect(surrogate), `'\\u${charCode.toString(16)}'`);
-      assert.strictEqual(
-        util.inspect(`${"a".repeat(200)}${surrogate}`),
-        `'${"a".repeat(200)}\\u${charCode.toString(16)}'`,
-      );
-      assert.strictEqual(
-        util.inspect(`${surrogate}${"a".repeat(200)}`),
-        `'\\u${charCode.toString(16)}${"a".repeat(200)}'`,
-      );
-      if (charCode < 0xdc00) {
-        const highSurrogate = surrogate;
-        const lowSurrogate = String.fromCharCode(charCode + 1024);
-        assert(!util.inspect(`${edgeChar}${highSurrogate}${lowSurrogate}${edgeChar}`).includes("\\u"));
-        assert.strictEqual(
-          (util.inspect(`${highSurrogate}${highSurrogate}${lowSurrogate}`).match(/\\u/g) ?? []).length,
-          1,
-        );
-      } else {
-        assert.strictEqual(
-          util.inspect(`${edgeChar}${surrogate}${edgeChar}`),
-          `'${edgeChar}\\u${charCode.toString(16)}${edgeChar}'`,
-        );
-      }
-    }
   }
 
   // Test util.inspect.styles and util.inspect.colors.
@@ -1812,7 +1785,39 @@ test("no assertion failures 2", () => {
     })("a");
     assert.strictEqual(util.inspect(args), "[Arguments] { '0': 'a' }");
   }
-}, isDebug ? 30_000 : undefined);
+});
+
+test("escape unpaired surrogate pairs", () => {
+  const edgeChar = String.fromCharCode(0xd799);
+
+  for (let charCode = 0xd800; charCode < 0xdfff; charCode++) {
+    const surrogate = String.fromCharCode(charCode);
+
+    assert.strictEqual(util.inspect(surrogate), `'\\u${charCode.toString(16)}'`);
+    assert.strictEqual(
+      util.inspect(`${"a".repeat(200)}${surrogate}`),
+      `'${"a".repeat(200)}\\u${charCode.toString(16)}'`,
+    );
+    assert.strictEqual(
+      util.inspect(`${surrogate}${"a".repeat(200)}`),
+      `'\\u${charCode.toString(16)}${"a".repeat(200)}'`,
+    );
+    if (charCode < 0xdc00) {
+      const highSurrogate = surrogate;
+      const lowSurrogate = String.fromCharCode(charCode + 1024);
+      assert(!util.inspect(`${edgeChar}${highSurrogate}${lowSurrogate}${edgeChar}`).includes("\\u"));
+      assert.strictEqual(
+        (util.inspect(`${highSurrogate}${highSurrogate}${lowSurrogate}`).match(/\\u/g) ?? []).length,
+        1,
+      );
+    } else {
+      assert.strictEqual(
+        util.inspect(`${edgeChar}${surrogate}${edgeChar}`),
+        `'${edgeChar}\\u${charCode.toString(16)}${edgeChar}'`,
+      );
+    }
+  }
+}, 30_000);
 
 test("util.inspect stack overflow handling", () => {
   // Test that a long linked list can be inspected without throwing an error.

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import assert from "assert";
-import { isWindows, isDebug } from "harness";
+import { isDebug, isWindows } from "harness";
 import util, { inspect } from "util";
 import vm from "vm";
 import { MessageChannel } from "worker_threads";


### PR DESCRIPTION
## Reproduction

```js
import util from 'node:util';
console.log(util.format('%s', Buffer.from('ab')));
console.log(util.format('%s', new URLSearchParams('a=1')));
```

| | Node 26.3.0 | Bun before | Bun after |
| --- | --- | --- | --- |
| `util.format('%s', Buffer.from('ab'))` | `ab` | `<Buffer 61 62>` | `ab` |
| `util.format('%s', new URLSearchParams('a=1'))` | `a=1` | `URLSearchParams {}` | `a=1` |

Any logger built on `util.format` (winston, pino-pretty style `%s` interpolation) printed `<Buffer ...>` noise where Node prints the decoded content, and `URLSearchParams {}` where Node prints the query string.

## Cause

`hasBuiltInToString` in `src/js/internal/util/inspect.js` classifies an inherited `toString` as "built-in" when the prototype that owns it has a constructor whose name is in `builtInObjects`. Node populates that set at bootstrap from `Object.getOwnPropertyNames(globalThis)`, at which point only the ECMAScript language intrinsics are present. `Buffer`, `URL`, `URLSearchParams`, `Request`, and every other Node/Web global are installed later, so they never appear in Node's set.

Bun already has those globals on `globalThis` when this module loads, so the live scrape collected 115 names. `hasBuiltInToString(Buffer.from('ab'))` walked to `Buffer.prototype`, saw constructor name `"Buffer"`, found it in the set, returned `true`, and `%s` took the inspect branch instead of calling `Buffer.prototype.toString`.

## Fix

Replace the dynamic scrape with the 47 names Node v26.3.0 observes at bootstrap:

```
AggregateError Array ArrayBuffer Atomics BigInt BigInt64Array BigUint64Array
Boolean DataView Date Error EvalError FinalizationRegistry Float32Array
Float64Array Function Infinity Int16Array Int32Array Int8Array Intl Iterator
JSON Map Math NaN Number Object Promise Proxy RangeError ReferenceError Reflect
RegExp Set String Symbol SyntaxError TypeError URIError Uint16Array Uint32Array
Uint8Array Uint8ClampedArray WeakMap WeakRef WeakSet
```

This deliberately excludes `SharedArrayBuffer`, `WebAssembly`, `Float16Array`, `DisposableStack`, `AsyncDisposableStack` and `SuppressedError`. Those are language globals too, but V8 installs them after Node computes the set, so they are absent from Node's `builtInObjects` and the difference is observable: `util.inspect(new Float16Array(1), { showHidden: true })` walks into `Float16Array.prototype` in Node, while `Float32Array` does not. Matching Node means matching that asymmetry.

`Buffer`, `URL`, `URLSearchParams` and any user class with a `toString` now take the `String()` path through `%s`. ECMAScript built-ins (`Array`, `Error`, `Map`, `Date`, boxed primitives, ...) keep the inspect path as before.

The `util-inspect.test.js` typed-array `showHidden` loops drop `Float16Array` (upstream's `test-util-inspect.js` never had it), and that 1500-line test body gets a debug-build timeout: its surrogate-pair loop runs ~10k `util.inspect` calls and already overshoots the 5s default under `bun bd` on main.

## Verification

```
$ git stash push -- src/ && bun bd test test/js/node/util/node-inspect-tests/parallel/util-format.test.js
AssertionError: Expected values to be strictly equal:
+ '<Buffer 61 62>'
- 'ab'
(fail) no assertion failures

$ git stash pop && bun bd test test/js/node/util/node-inspect-tests/parallel/util-format.test.js
(pass) no assertion failures
```

Also green: `test/js/bun/util/inspect.test.js`, `test/js/node/util/bun-inspect.test.ts`, `test/js/node/util/util.test.js`, `test/js/node/util/custom-inspect.test.js`, `test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js`, `test/js/node/util/node-inspect-tests/parallel/util-inspect-proxy.test.js`, `test/js/node/console/`, `test/js/bun/console/`, `test/js/web/console/`.

The global `console.log('%s', ...)` throw on `Symbol`/null-prototype/revoked-proxy is a separate native-side path (`PercentTag::S` in `ConsoleObject.rs`); #34603 addresses that.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js

<!-- robobun:evidence:end -->