### PR TITLE
net/resolver: report EMFILE as EMFILE instead of ECONNREFUSED/MODULE_NOT_FOUND/code-less listen error

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -730,7 +730,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_socket(int domain, int type, int protocol, in
 
     if (UNLIKELY(created_fd == -1)) {
         if (err != NULL) {
-            *err = errno;
+            *err = LIBUS_ERR;
         }
         return LIBUS_SOCKET_ERROR;
     }
@@ -743,7 +743,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_socket(int domain, int type, int protocol, in
 
     if (UNLIKELY(created_fd == -1)) {
         if (err != NULL) {
-            *err = errno;
+            *err = LIBUS_ERR;
         }
         return LIBUS_SOCKET_ERROR;
     }

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1214,7 +1214,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
     struct addrinfo *listenAddr;
     for (struct addrinfo *a = result; a != NULL; a = a->ai_next) {
         if (a->ai_family == AF_INET6) {
-            listenFd = bsd_create_socket(a->ai_family, a->ai_socktype, a->ai_protocol, NULL);
+            listenFd = bsd_create_socket(a->ai_family, a->ai_socktype, a->ai_protocol, error);
             if (listenFd == LIBUS_SOCKET_ERROR) {
                 continue;
             }
@@ -1231,7 +1231,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
 
     for (struct addrinfo *a = result; a != NULL; a = a->ai_next) {
         if (a->ai_family == AF_INET) {
-            listenFd = bsd_create_socket(a->ai_family, a->ai_socktype, a->ai_protocol, NULL);
+            listenFd = bsd_create_socket(a->ai_family, a->ai_socktype, a->ai_protocol, error);
             if (listenFd == LIBUS_SOCKET_ERROR) {
                 continue;
             }
@@ -1391,7 +1391,7 @@ static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, 
 static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_listen_socket_unix(const char* path, int options, struct sockaddr_un* server_address, size_t addrlen, int* error) {
     LIBUS_SOCKET_DESCRIPTOR listenFd = LIBUS_SOCKET_ERROR;
 
-    listenFd = bsd_create_socket(AF_UNIX, SOCK_STREAM, 0, NULL);
+    listenFd = bsd_create_socket(AF_UNIX, SOCK_STREAM, 0, error);
 
     if (listenFd == LIBUS_SOCKET_ERROR) {
         return LIBUS_SOCKET_ERROR;

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -701,6 +701,11 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         c->connecting_head = s;
         s->connect_state = c;
     }
+    if (opened > 0) {
+        /* A sibling's socket() failure is no longer the outcome once any
+         * address has a connect in flight; the async result decides. */
+        c->error = 0;
+    }
     return opened;
 }
 

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -674,6 +674,7 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         /* The deferred-DNS path does not carry a local binding. */
         LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(&addr, NULL, c->options);
         if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
+            c->error = LIBUS_ERR;
             continue;
         }
         bsd_socket_nodelay(connect_socket_fd, 1);
@@ -741,7 +742,9 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
     if (opened == 0) {
         /* Same as the exhausted path in us_internal_socket_after_open: a
          * real connect failure must not be reported as a caller abort. */
-        c->error = ECONNREFUSED;
+        if (c->error == 0) {
+            c->error = ECONNREFUSED;
+        }
         us_connecting_socket_close(c);
     }
 }
@@ -782,7 +785,9 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
                      * us_connecting_socket_close defaults c->error to
                      * ECONNABORTED (caller abort) and never invalidates the
                      * DNS cache entry for the dead host. */
-                    c->error = ECONNREFUSED;
+                    if (c->error == 0) {
+                        c->error = ECONNREFUSED;
+                    }
                     us_connecting_socket_close(c);
                 }
             }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -664,6 +664,14 @@ struct us_socket_t *us_socket_group_connect_unix(struct us_socket_group_t *group
     return connect_socket;
 }
 
+static int is_fd_or_memory_exhaustion(int err) {
+#ifdef _WIN32
+    return err == WSAEMFILE || err == WSAENOBUFS;
+#else
+    return err == EMFILE || err == ENFILE || err == ENOBUFS || err == ENOMEM;
+#endif
+}
+
 int start_connections(struct us_connecting_socket_t *c, int count) {
     int opened = 0;
     struct us_socket_group_t *group = c->group;
@@ -674,8 +682,9 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         /* The deferred-DNS path does not carry a local binding. */
         LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(&addr, NULL, c->options);
         if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
-            if (c->error == 0) {
-                c->error = LIBUS_ERR;
+            int err = LIBUS_ERR;
+            if (c->error == 0 && is_fd_or_memory_exhaustion(err)) {
+                c->error = err;
             }
             continue;
         }
@@ -687,7 +696,7 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
             int saved_errno = LIBUS_ERR;
             bsd_close_socket(connect_socket_fd);
             us_poll_free(poll, loop);
-            if (c->error == 0) {
+            if (c->error == 0 && is_fd_or_memory_exhaustion(saved_errno)) {
                 c->error = saved_errno;
             }
             continue;

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -684,8 +684,12 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         struct us_poll_t *poll = &s->p;
         us_poll_init(poll, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
         if (us_poll_start_rc(poll, loop, LIBUS_SOCKET_WRITABLE) != 0) {
+            int saved_errno = LIBUS_ERR;
             bsd_close_socket(connect_socket_fd);
             us_poll_free(poll, loop);
+            if (c->error == 0) {
+                c->error = saved_errno;
+            }
             continue;
         }
         ++opened;

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -674,7 +674,9 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         /* The deferred-DNS path does not carry a local binding. */
         LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(&addr, NULL, c->options);
         if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
-            c->error = LIBUS_ERR;
+            if (c->error == 0) {
+                c->error = LIBUS_ERR;
+            }
             continue;
         }
         bsd_socket_nodelay(connect_socket_fd, 1);

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -705,7 +705,7 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         c->connecting_head = s;
         s->connect_state = c;
     }
-    if (opened > 0) {
+    if (opened > 0 || c->connecting_head != NULL) {
         /* A sibling's socket() failure is no longer the outcome once any
          * address has a connect in flight; the async result decides. */
         c->error = 0;

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -279,7 +279,7 @@ impl SystemErrno {
     /// Process-wide fd/memory exhaustion; propagate instead of caching as not-found or reporting as refused.
     #[inline]
     pub fn is_fd_or_memory_exhaustion(self) -> bool {
-        matches!(self, Self::EMFILE | Self::ENFILE | Self::ENOMEM)
+        matches!(self, Self::EMFILE | Self::ENFILE | Self::ENOBUFS | Self::ENOMEM)
     }
 
     /// Unchecked discriminant cast.

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -276,9 +276,7 @@ pub fn e_from_negated(errno: core::ffi::c_int) -> E {
 }
 
 impl SystemErrno {
-    /// Process-wide fd or memory exhaustion. These say nothing about the
-    /// identity of the resource being opened; callers that would otherwise
-    /// cache "not found" or report "refused" should propagate the errno.
+    /// Process-wide fd/memory exhaustion; propagate instead of caching as not-found or reporting as refused.
     #[inline]
     pub fn is_fd_or_memory_exhaustion(self) -> bool {
         matches!(self, Self::EMFILE | Self::ENFILE | Self::ENOMEM)

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -276,6 +276,14 @@ pub fn e_from_negated(errno: core::ffi::c_int) -> E {
 }
 
 impl SystemErrno {
+    /// Process-wide fd or memory exhaustion. These say nothing about the
+    /// identity of the resource being opened; callers that would otherwise
+    /// cache "not found" or report "refused" should propagate the errno.
+    #[inline]
+    pub fn is_fd_or_memory_exhaustion(self) -> bool {
+        matches!(self, Self::EMFILE | Self::ENFILE | Self::ENOMEM)
+    }
+
     /// Unchecked discriminant cast.
     ///
     /// On POSIX the enum is dense `0..MAX`, so we debug-assert `n < MAX`.

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -279,7 +279,10 @@ impl SystemErrno {
     /// Process-wide fd/memory exhaustion; propagate instead of caching as not-found or reporting as refused.
     #[inline]
     pub fn is_fd_or_memory_exhaustion(self) -> bool {
-        matches!(self, Self::EMFILE | Self::ENFILE | Self::ENOBUFS | Self::ENOMEM)
+        matches!(
+            self,
+            Self::EMFILE | Self::ENFILE | Self::ENOBUFS | Self::ENOMEM
+        )
     }
 
     /// Unchecked discriminant cast.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4335,6 +4335,35 @@ impl VirtualMachine {
         );
         if let Err(err_) = resolve_result {
             let err = err_;
+            // fd/memory exhaustion during resolution is not "module not
+            // found": surface it as the system error Node would, so `.code`
+            // names the errno instead of ERR_MODULE_NOT_FOUND. Other Sys
+            // errors keep flowing to the ResolveMessage path, which may
+            // already carry better context from the resolver's log.
+            let sys_errno = match &err {
+                crate::CrateError::Resolver(bun_resolver::Error::Sys(e))
+                | crate::CrateError::Sys(e)
+                    if matches!(
+                        *e,
+                        bun_errno::SystemErrno::EMFILE
+                            | bun_errno::SystemErrno::ENFILE
+                            | bun_errno::SystemErrno::ENOMEM
+                    ) =>
+                {
+                    Some(*e)
+                }
+                _ => None,
+            };
+            if let Some(errno) = sys_errno {
+                let js_err = crate::SystemError::from(
+                    bun_sys::Error::new(errno, bun_sys::Tag::open)
+                        .with_path(specifier_utf8.slice())
+                        .to_system_error(),
+                )
+                .to_error_instance(global);
+                *res = ErrorableString::err(ErrorCode(ErrorCode::JS_ERROR_OBJECT), js_err);
+                return Ok(());
+            }
             let import_kind = if is_esm {
                 bun_ast::ImportKind::Stmt
             } else if is_user_require_resolve {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4335,11 +4335,8 @@ impl VirtualMachine {
         );
         if let Err(err_) = resolve_result {
             let err = err_;
-            // fd/memory exhaustion during resolution is not "module not
-            // found": surface it as the system error Node would, so `.code`
-            // names the errno instead of ERR_MODULE_NOT_FOUND. Other Sys
-            // errors keep flowing to the ResolveMessage path, which may
-            // already carry better context from the resolver's log.
+            // fd/memory exhaustion surfaces as a SystemError (so `.code` is
+            // the errno); other Sys errors keep the ResolveMessage path.
             let sys_errno = match &err {
                 crate::CrateError::Resolver(bun_resolver::Error::Sys(e))
                 | crate::CrateError::Sys(e)

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4335,16 +4335,10 @@ impl VirtualMachine {
         );
         if let Err(err_) = resolve_result {
             let err = err_;
-            // fd/memory exhaustion surfaces as a SystemError; other Sys errors keep the ResolveMessage path.
             let sys_errno = match &err {
                 crate::CrateError::Resolver(bun_resolver::Error::Sys(e))
                 | crate::CrateError::Sys(e)
-                    if matches!(
-                        *e,
-                        bun_errno::SystemErrno::EMFILE
-                            | bun_errno::SystemErrno::ENFILE
-                            | bun_errno::SystemErrno::ENOMEM
-                    ) =>
+                    if e.is_fd_or_memory_exhaustion() =>
                 {
                     Some(*e)
                 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4335,8 +4335,7 @@ impl VirtualMachine {
         );
         if let Err(err_) = resolve_result {
             let err = err_;
-            // fd/memory exhaustion surfaces as a SystemError (so `.code` is
-            // the errno); other Sys errors keep the ResolveMessage path.
+            // fd/memory exhaustion surfaces as a SystemError; other Sys errors keep the ResolveMessage path.
             let sys_errno = match &err {
                 crate::CrateError::Resolver(bun_resolver::Error::Sys(e))
                 | crate::CrateError::Sys(e)

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1110,6 +1110,23 @@ pub mod fs {
             err: crate::Error,
         ) -> crate::CrateResult<&'static mut EntriesOption> {
             if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE {
+                // Process-wide fd/memory exhaustion says nothing about this
+                // directory. The entries cache is not generation-gated for
+                // `Err` values, so persisting one would keep failing reads
+                // until an explicit cache bust.
+                if matches!(
+                    err,
+                    crate::Error::Sys(bun_errno::SystemErrno::EMFILE)
+                        | crate::Error::Sys(bun_errno::SystemErrno::ENFILE)
+                        | crate::Error::Sys(bun_errno::SystemErrno::ENOMEM)
+                ) {
+                    return Ok(temp_entries_option_write(EntriesOption::Err(
+                        dir_entry::Err {
+                            original_err: err,
+                            canonical_error: err,
+                        },
+                    )));
+                }
                 let mut get_or_put_result = self.entries.get_or_put(dir)?;
                 if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
                     self.entries.mark_not_found(get_or_put_result);

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1110,10 +1110,8 @@ pub mod fs {
             err: crate::Error,
         ) -> crate::CrateResult<&'static mut EntriesOption> {
             if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE {
-                // Process-wide fd/memory exhaustion says nothing about this
-                // directory. The entries cache is not generation-gated for
-                // `Err` values, so persisting one would keep failing reads
-                // until an explicit cache bust.
+                // fd/memory exhaustion is transient; caching it would stick
+                // (Err entries are not generation-gated).
                 if matches!(
                     err,
                     crate::Error::Sys(bun_errno::SystemErrno::EMFILE)

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1110,19 +1110,15 @@ pub mod fs {
             err: crate::Error,
         ) -> crate::CrateResult<&'static mut EntriesOption> {
             if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE {
-                // fd/memory exhaustion is transient; Err entries are not generation-gated so don't cache.
-                if matches!(
-                    err,
-                    crate::Error::Sys(bun_errno::SystemErrno::EMFILE)
-                        | crate::Error::Sys(bun_errno::SystemErrno::ENFILE)
-                        | crate::Error::Sys(bun_errno::SystemErrno::ENOMEM)
-                ) {
-                    return Ok(temp_entries_option_write(EntriesOption::Err(
-                        dir_entry::Err {
-                            original_err: err,
-                            canonical_error: err,
-                        },
-                    )));
+                if let crate::Error::Sys(e) = err {
+                    if e.is_fd_or_memory_exhaustion() {
+                        return Ok(temp_entries_option_write(EntriesOption::Err(
+                            dir_entry::Err {
+                                original_err: err,
+                                canonical_error: err,
+                            },
+                        )));
+                    }
                 }
                 let mut get_or_put_result = self.entries.get_or_put(dir)?;
                 if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1110,8 +1110,7 @@ pub mod fs {
             err: crate::Error,
         ) -> crate::CrateResult<&'static mut EntriesOption> {
             if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE {
-                // fd/memory exhaustion is transient; caching it would stick
-                // (Err entries are not generation-gated).
+                // fd/memory exhaustion is transient; Err entries are not generation-gated so don't cache.
                 if matches!(
                     err,
                     crate::Error::Sys(bun_errno::SystemErrno::EMFILE)

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1884,26 +1884,26 @@ impl<'a> Resolver<'a> {
             // Run node's resolution rules (e.g. adding ".js")
             let mut normalizer = ResolvePath::PosixToWinNormalizer::default();
             let mut entry = MatchResult::default();
-            if self
-                .load_as_file_or_directory(
-                    normalizer.resolve(source_dir, import_path),
-                    kind,
-                    &mut entry,
-                )
-                .is_success()
-            {
-                return ResultUnion::Success(Result {
-                    dirname_fd: entry.dirname_fd,
-                    path_pair: entry.path_pair,
-                    diff_case: entry.diff_case,
-                    package_json: entry.package_json,
-                    file_fd: entry.file_fd,
-                    jsx: self.opts.jsx.clone(),
-                    ..Default::default()
-                });
+            match self.load_as_file_or_directory(
+                normalizer.resolve(source_dir, import_path),
+                kind,
+                &mut entry,
+            ) {
+                MatchStatus::Success => {
+                    return ResultUnion::Success(Result {
+                        dirname_fd: entry.dirname_fd,
+                        path_pair: entry.path_pair,
+                        diff_case: entry.diff_case,
+                        package_json: entry.package_json,
+                        file_fd: entry.file_fd,
+                        jsx: self.opts.jsx.clone(),
+                        ..Default::default()
+                    });
+                }
+                MatchStatus::Failure(e) => return ResultUnion::Failure(e),
+                MatchStatus::Pending(p) => return ResultUnion::Pending(*p),
+                MatchStatus::NotFound => return ResultUnion::NotFound,
             }
-
-            return ResultUnion::NotFound;
         }
 
         // Check both relative and package paths for CSS URL tokens, with relative
@@ -2172,20 +2172,18 @@ impl<'a> Resolver<'a> {
             self.extension_order = self.opts.extension_order.kind(kind, true);
         }
         let mut res = MatchResult::default();
-        let ret = if self
-            .load_as_file_or_directory(abs_path, kind, &mut res)
-            .is_success()
-        {
-            ResultUnion::Success(Result {
+        let ret = match self.load_as_file_or_directory(abs_path, kind, &mut res) {
+            MatchStatus::Success => ResultUnion::Success(Result {
                 path_pair: res.path_pair,
                 diff_case: res.diff_case,
                 dirname_fd: res.dirname_fd,
                 package_json: res.package_json,
                 jsx: self.opts.jsx.clone(),
                 ..Default::default()
-            })
-        } else {
-            ResultUnion::NotFound
+            }),
+            MatchStatus::Failure(e) => ResultUnion::Failure(e),
+            MatchStatus::Pending(p) => ResultUnion::Pending(*p),
+            MatchStatus::NotFound => ResultUnion::NotFound,
         };
         self.extension_order = prev_extension_order;
         ret
@@ -2200,7 +2198,7 @@ impl<'a> Resolver<'a> {
     ) -> ResultUnion {
         let mut import_path = unremapped_import_path;
         let mut source_dir_info: DirInfoRef = match self.dir_info_cached(source_dir) {
-            Err(_) => return ResultUnion::NotFound,
+            Err(e) => return ResultUnion::Failure(e),
             Ok(Some(d)) => d,
             Ok(None) => 'dir: {
                 // It is possible to resolve with a source file that does not exist:
@@ -2233,7 +2231,7 @@ impl<'a> Resolver<'a> {
                 // the drive root should always exist.
                 while let Some(current) = bun_paths::dirname(closest_dir) {
                     match self.dir_info_cached(current) {
-                        Err(_) => return ResultUnion::NotFound,
+                        Err(e) => return ResultUnion::Failure(e),
                         Ok(Some(dir)) => break 'dir dir,
                         Ok(None) => {}
                     }
@@ -4371,6 +4369,17 @@ impl<'a> Resolver<'a> {
                                 );
                                 break 'open_dir FD::INVALID;
                             }
+                            // fd/memory exhaustion says nothing about whether the
+                            // directory exists; caching it as not-found would lie about
+                            // the filesystem until the next cache bust.
+                            if matches!(
+                                err,
+                                crate::Error::Sys(bun_errno::SystemErrno::EMFILE)
+                                    | crate::Error::Sys(bun_errno::SystemErrno::ENFILE)
+                                    | crate::Error::Sys(bun_errno::SystemErrno::ENOMEM)
+                            ) {
+                                return Err(err);
+                            }
                             let cached_dir_entry_result = rfs!()
                                 .entries
                                 .get_or_put(queue_top_unsafe_path)
@@ -5409,14 +5418,14 @@ impl<'a> Resolver<'a> {
         let dir_info: DirInfoRef = match self.dir_info_cached(path) {
             Ok(Some(d)) => d,
             Ok(None) => dec_ret!(MatchStatus::NotFound),
-            Err(_err) => {
+            Err(err) => {
                 #[cfg(debug_assertions)]
                 bun_core::pretty_errorln!(
                     "err: {} reading {}",
-                    bstr::BStr::new(_err.name()),
+                    bstr::BStr::new(err.name()),
                     bstr::BStr::new(path)
                 );
-                dec_ret!(MatchStatus::NotFound);
+                dec_ret!(MatchStatus::Failure(err));
             }
         };
         let mut package_json: Option<*const PackageJSON> = None;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2698,24 +2698,31 @@ impl<'a> Resolver<'a> {
                                         .resolve(b"/", esm.subpath, &exports_map.root);
                                         // ESModule temporary dropped here; `self` is unborrowed.
 
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
-                                        {
-                                            out.is_node_module = true;
-                                            out.module_type = module_type;
-                                            self.extension_order = prev_extension_order;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                        match self.handle_esm_resolution(
+                                            esm_resolution,
+                                            abs_package_path,
+                                            kind,
+                                            package_json,
+                                            esm.subpath,
+                                            out,
+                                        ) {
+                                            MatchStatus::Success => {
+                                                out.is_node_module = true;
+                                                out.module_type = module_type;
+                                                self.extension_order = prev_extension_order;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Success;
                                             }
-                                            return MatchStatus::Success;
+                                            MatchStatus::Failure(e) => {
+                                                self.extension_order = prev_extension_order;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Failure(e);
+                                            }
+                                            _ => {}
                                         }
                                     }
 
@@ -2757,24 +2764,31 @@ impl<'a> Resolver<'a> {
                                             &esm.subpath[0..esm.subpath.len() - 3],
                                             &exports_map.root,
                                         );
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
-                                        {
-                                            out.is_node_module = true;
-                                            out.module_type = module_type;
-                                            self.extension_order = prev_extension_order;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                        match self.handle_esm_resolution(
+                                            esm_resolution,
+                                            abs_package_path,
+                                            kind,
+                                            package_json,
+                                            esm.subpath,
+                                            out,
+                                        ) {
+                                            MatchStatus::Success => {
+                                                out.is_node_module = true;
+                                                out.module_type = module_type;
+                                                self.extension_order = prev_extension_order;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Success;
                                             }
-                                            return MatchStatus::Success;
+                                            MatchStatus::Failure(e) => {
+                                                self.extension_order = prev_extension_order;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Failure(e);
+                                            }
+                                            _ => {}
                                         }
                                     }
 
@@ -3205,22 +3219,28 @@ impl<'a> Resolver<'a> {
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
-                                        {
-                                            out.is_node_module = true;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                        match self.handle_esm_resolution(
+                                            esm_resolution,
+                                            abs_package_path,
+                                            kind,
+                                            package_json,
+                                            esm.subpath,
+                                            out,
+                                        ) {
+                                            MatchStatus::Success => {
+                                                out.is_node_module = true;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Success;
                                             }
-                                            return MatchStatus::Success;
+                                            MatchStatus::Failure(e) => {
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Failure(e);
+                                            }
+                                            _ => {}
                                         }
                                     }
 
@@ -3247,22 +3267,28 @@ impl<'a> Resolver<'a> {
                                             &esm.subpath[0..esm.subpath.len() - 3],
                                             &exports_map.root,
                                         );
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
-                                        {
-                                            out.is_node_module = true;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                        match self.handle_esm_resolution(
+                                            esm_resolution,
+                                            abs_package_path,
+                                            kind,
+                                            package_json,
+                                            esm.subpath,
+                                            out,
+                                        ) {
+                                            MatchStatus::Success => {
+                                                out.is_node_module = true;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Success;
                                             }
-                                            return MatchStatus::Success;
+                                            MatchStatus::Failure(e) => {
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Failure(e);
+                                            }
+                                            _ => {}
                                         }
                                     }
 
@@ -3692,14 +3718,13 @@ impl<'a> Resolver<'a> {
             Status::Exact | Status::ExactEndsWithStar => {
                 let resolved_dir_info = match self
                     .dir_info_cached(bun_paths::dirname(abs_esm_path).unwrap())
-                    .ok()
-                    .flatten()
                 {
-                    Some(d) => d,
-                    None => {
+                    Ok(Some(d)) => d,
+                    Ok(None) => {
                         esm_resolution.status = Status::ModuleNotFound;
                         return MatchStatus::NotFound;
                     }
+                    Err(e) => return MatchStatus::Failure(e),
                 };
                 let entries = match resolved_dir_info.get_entries_ref(self.generation) {
                     Some(e) => e,
@@ -4404,14 +4429,10 @@ impl<'a> Resolver<'a> {
                                 );
                                 break 'open_dir FD::INVALID;
                             }
-                            // fd/memory exhaustion is transient; don't cache as not-found.
-                            if matches!(
-                                err,
-                                crate::Error::Sys(bun_errno::SystemErrno::EMFILE)
-                                    | crate::Error::Sys(bun_errno::SystemErrno::ENFILE)
-                                    | crate::Error::Sys(bun_errno::SystemErrno::ENOMEM)
-                            ) {
-                                return Err(err);
+                            if let crate::Error::Sys(e) = err {
+                                if e.is_fd_or_memory_exhaustion() {
+                                    return Err(err);
+                                }
                             }
                             let cached_dir_entry_result = rfs!()
                                 .entries

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4430,6 +4430,17 @@ impl<'a> Resolver<'a> {
                             }
                             if let crate::Error::Sys(e) = err {
                                 if e.is_fd_or_memory_exhaustion() {
+                                    if enable_logging {
+                                        let _ = self.log_mut().add_error_fmt(
+                                            None,
+                                            bun_ast::Loc::default(),
+                                            format_args!(
+                                                "Cannot read directory \"{}\": {}",
+                                                bstr::BStr::new(queue_top_unsafe_path),
+                                                bstr::BStr::new(err.name())
+                                            ),
+                                        );
+                                    }
                                     return Err(err);
                                 }
                             }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2521,14 +2521,20 @@ impl<'a> Resolver<'a> {
         if let Some(tsconfig) = dir_info.enclosing_tsconfig_json {
             // Try path substitutions first
             if tsconfig.paths.count() > 0 {
-                if self
-                    .match_tsconfig_paths(tsconfig, import_path, kind, out)
-                    .is_success()
-                {
-                    if let Some(d) = self.debug_logs.as_mut() {
-                        d.decrease_indent();
+                match self.match_tsconfig_paths(tsconfig, import_path, kind, out) {
+                    MatchStatus::Success => {
+                        if let Some(d) = self.debug_logs.as_mut() {
+                            d.decrease_indent();
+                        }
+                        return MatchStatus::Success;
                     }
-                    return MatchStatus::Success;
+                    MatchStatus::Failure(e) => {
+                        if let Some(d) = self.debug_logs.as_mut() {
+                            d.decrease_indent();
+                        }
+                        return MatchStatus::Failure(e);
+                    }
+                    _ => {}
                 }
             }
 
@@ -2539,11 +2545,20 @@ impl<'a> Resolver<'a> {
                     &[base, import_path],
                     bufs!(load_as_file_or_directory_via_tsconfig_base_path),
                 ) {
-                    if self.load_as_file_or_directory(abs, kind, out).is_success() {
-                        if let Some(d) = self.debug_logs.as_mut() {
-                            d.decrease_indent();
+                    match self.load_as_file_or_directory(abs, kind, out) {
+                        MatchStatus::Success => {
+                            if let Some(d) = self.debug_logs.as_mut() {
+                                d.decrease_indent();
+                            }
+                            return MatchStatus::Success;
                         }
-                        return MatchStatus::Success;
+                        MatchStatus::Failure(e) => {
+                            if let Some(d) = self.debug_logs.as_mut() {
+                                d.decrease_indent();
+                            }
+                            return MatchStatus::Failure(e);
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -2805,15 +2820,22 @@ impl<'a> Resolver<'a> {
                         }
                     }
 
-                    if self
-                        .load_as_file_or_directory(abs_path, kind, out)
-                        .is_success()
-                    {
-                        self.extension_order = prev_extension_order;
-                        if let Some(d) = self.debug_logs.as_mut() {
-                            d.decrease_indent();
+                    match self.load_as_file_or_directory(abs_path, kind, out) {
+                        MatchStatus::Success => {
+                            self.extension_order = prev_extension_order;
+                            if let Some(d) = self.debug_logs.as_mut() {
+                                d.decrease_indent();
+                            }
+                            return MatchStatus::Success;
                         }
-                        return MatchStatus::Success;
+                        MatchStatus::Failure(e) => {
+                            self.extension_order = prev_extension_order;
+                            if let Some(d) = self.debug_logs.as_mut() {
+                                d.decrease_indent();
+                            }
+                            return MatchStatus::Failure(e);
+                        }
+                        _ => {}
                     }
                     self.extension_order = prev_extension_order;
                 }
@@ -2846,14 +2868,20 @@ impl<'a> Resolver<'a> {
                         bstr::BStr::new(abs_path)
                     ));
                 }
-                if self
-                    .load_as_file_or_directory(abs_path, kind, out)
-                    .is_success()
-                {
-                    if let Some(d) = self.debug_logs.as_mut() {
-                        d.decrease_indent();
+                match self.load_as_file_or_directory(abs_path, kind, out) {
+                    MatchStatus::Success => {
+                        if let Some(d) = self.debug_logs.as_mut() {
+                            d.decrease_indent();
+                        }
+                        return MatchStatus::Success;
                     }
-                    return MatchStatus::Success;
+                    MatchStatus::Failure(e) => {
+                        if let Some(d) = self.debug_logs.as_mut() {
+                            d.decrease_indent();
+                        }
+                        return MatchStatus::Failure(e);
+                    }
+                    _ => {}
                 }
             }
         }
@@ -3286,15 +3314,21 @@ impl<'a> Resolver<'a> {
                                 ));
                             }
 
-                            if self
-                                .load_as_file_or_directory(abs_path, kind, out)
-                                .is_success()
-                            {
-                                out.is_node_module = true;
-                                if let Some(d) = self.debug_logs.as_mut() {
-                                    d.decrease_indent();
+                            match self.load_as_file_or_directory(abs_path, kind, out) {
+                                MatchStatus::Success => {
+                                    out.is_node_module = true;
+                                    if let Some(d) = self.debug_logs.as_mut() {
+                                        d.decrease_indent();
+                                    }
+                                    return MatchStatus::Success;
                                 }
-                                return MatchStatus::Success;
+                                MatchStatus::Failure(e) => {
+                                    if let Some(d) = self.debug_logs.as_mut() {
+                                        d.decrease_indent();
+                                    }
+                                    return MatchStatus::Failure(e);
+                                }
+                                _ => {}
                             }
                         }
                     }
@@ -3816,15 +3850,16 @@ impl<'a> Resolver<'a> {
                 // If this was resolved against an expansion key ending in a "/"
                 // instead of a "*", we need to try CommonJS-style implicit
                 // extension and/or directory detection.
-                if self
-                    .load_as_file_or_directory(abs_esm_path, kind, out)
-                    .is_success()
-                {
-                    out.is_node_module = true;
-                    out.package_json = out
-                        .package_json
-                        .or_else(|| Some(std::ptr::from_ref(package_json)));
-                    return MatchStatus::Success;
+                match self.load_as_file_or_directory(abs_esm_path, kind, out) {
+                    MatchStatus::Success => {
+                        out.is_node_module = true;
+                        out.package_json = out
+                            .package_json
+                            .or_else(|| Some(std::ptr::from_ref(package_json)));
+                        return MatchStatus::Success;
+                    }
+                    MatchStatus::Failure(e) => return MatchStatus::Failure(e),
+                    _ => {}
                 }
                 esm_resolution.status = Status::ModuleNotFound;
                 MatchStatus::NotFound
@@ -4673,11 +4708,10 @@ impl<'a> Resolver<'a> {
                                 self.fs_ref().abs_buf(&parts, bufs!(tsconfig_path_abs));
                         }
 
-                        if self
-                            .load_as_file_or_directory(absolute_original_path, kind, out)
-                            .is_success()
-                        {
-                            return MatchStatus::Success;
+                        match self.load_as_file_or_directory(absolute_original_path, kind, out) {
+                            MatchStatus::Success => return MatchStatus::Success,
+                            MatchStatus::Failure(e) => return MatchStatus::Failure(e),
+                            _ => {}
                         }
                     }
                 }
@@ -4798,11 +4832,10 @@ impl<'a> Resolver<'a> {
                     continue;
                 };
 
-                if self
-                    .load_as_file_or_directory(absolute_original_path, kind, out)
-                    .is_success()
-                {
-                    return MatchStatus::Success;
+                match self.load_as_file_or_directory(absolute_original_path, kind, out) {
+                    MatchStatus::Success => return MatchStatus::Success,
+                    MatchStatus::Failure(e) => return MatchStatus::Failure(e),
+                    _ => {}
                 }
             }
         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3716,16 +3716,15 @@ impl<'a> Resolver<'a> {
 
         match esm_resolution.status {
             Status::Exact | Status::ExactEndsWithStar => {
-                let resolved_dir_info = match self
-                    .dir_info_cached(bun_paths::dirname(abs_esm_path).unwrap())
-                {
-                    Ok(Some(d)) => d,
-                    Ok(None) => {
-                        esm_resolution.status = Status::ModuleNotFound;
-                        return MatchStatus::NotFound;
-                    }
-                    Err(e) => return MatchStatus::Failure(e),
-                };
+                let resolved_dir_info =
+                    match self.dir_info_cached(bun_paths::dirname(abs_esm_path).unwrap()) {
+                        Ok(Some(d)) => d,
+                        Ok(None) => {
+                            esm_resolution.status = Status::ModuleNotFound;
+                            return MatchStatus::NotFound;
+                        }
+                        Err(e) => return MatchStatus::Failure(e),
+                    };
                 let entries = match resolved_dir_info.get_entries_ref(self.generation) {
                     Some(e) => e,
                     None => {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4404,9 +4404,7 @@ impl<'a> Resolver<'a> {
                                 );
                                 break 'open_dir FD::INVALID;
                             }
-                            // fd/memory exhaustion says nothing about whether the
-                            // directory exists; caching it as not-found would lie about
-                            // the filesystem until the next cache bust.
+                            // fd/memory exhaustion is transient; don't cache as not-found.
                             if matches!(
                                 err,
                                 crate::Error::Sys(bun_errno::SystemErrno::EMFILE)

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5225,6 +5225,35 @@ unsafe fn resolve_hook(
             &mut result_query,
         )
     } {
+        // fd/memory exhaustion during resolution is not "module not found":
+        // surface it as the system error Node would, so `.code` names the
+        // errno instead of MODULE_NOT_FOUND. Other Sys errors keep flowing
+        // to the ResolveMessage path, which may already carry better context
+        // from the resolver's log.
+        let sys_errno = match &err {
+            crate::Error::Resolver(bun_resolver::Error::Sys(e)) | crate::Error::Sys(e)
+                if matches!(
+                    *e,
+                    bun_errno::SystemErrno::EMFILE
+                        | bun_errno::SystemErrno::ENFILE
+                        | bun_errno::SystemErrno::ENOMEM
+                ) =>
+            {
+                Some(*e)
+            }
+            _ => None,
+        };
+        if let Some(errno) = sys_errno {
+            let js_err = bun_jsc::SystemError::from(
+                bun_sys::Error::new(errno, bun_sys::Tag::open)
+                    .with_path(specifier_utf8.slice())
+                    .to_system_error(),
+            )
+            .to_error_instance(global_ref);
+            // SAFETY: per fn contract.
+            unsafe { *res = ErrorableString::err(ErrorCode(ErrorCode::JS_ERROR_OBJECT), js_err) };
+            return true;
+        }
         // Synthesise a `ResolveMessage` from the first
         // `.resolve`-tagged log msg, or fall back to `ResolveMessage::fmt`.
         let msg: bun_ast::Msg = 'brk: {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5225,11 +5225,8 @@ unsafe fn resolve_hook(
             &mut result_query,
         )
     } {
-        // fd/memory exhaustion during resolution is not "module not found":
-        // surface it as the system error Node would, so `.code` names the
-        // errno instead of MODULE_NOT_FOUND. Other Sys errors keep flowing
-        // to the ResolveMessage path, which may already carry better context
-        // from the resolver's log.
+        // fd/memory exhaustion surfaces as a SystemError (so `.code` is the
+        // errno); other Sys errors keep the ResolveMessage path.
         let sys_errno = match &err {
             crate::Error::Resolver(bun_resolver::Error::Sys(e)) | crate::Error::Sys(e)
                 if matches!(

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5225,15 +5225,9 @@ unsafe fn resolve_hook(
             &mut result_query,
         )
     } {
-        // fd/memory exhaustion surfaces as a SystemError; other Sys errors keep the ResolveMessage path.
         let sys_errno = match &err {
             crate::Error::Resolver(bun_resolver::Error::Sys(e)) | crate::Error::Sys(e)
-                if matches!(
-                    *e,
-                    bun_errno::SystemErrno::EMFILE
-                        | bun_errno::SystemErrno::ENFILE
-                        | bun_errno::SystemErrno::ENOMEM
-                ) =>
+                if e.is_fd_or_memory_exhaustion() =>
             {
                 Some(*e)
             }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5225,8 +5225,7 @@ unsafe fn resolve_hook(
             &mut result_query,
         )
     } {
-        // fd/memory exhaustion surfaces as a SystemError (so `.code` is the
-        // errno); other Sys errors keep the ResolveMessage path.
+        // fd/memory exhaustion surfaces as a SystemError; other Sys errors keep the ResolveMessage path.
         let sys_errno = match &err {
             crate::Error::Resolver(bun_resolver::Error::Sys(e)) | crate::Error::Sys(e)
                 if matches!(

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1558,13 +1558,8 @@ fn connect_finish<const IS_SSL: bool>(
                 bun_sys::SystemErrno::ENOENT as c_int
             }
         } else {
-            // A synchronous TCP connect failure is either socket() itself
-            // failing (EMFILE/ENFILE/ENOBUFS/ENOMEM: local resource
-            // exhaustion) or the local bind() for localAddress/localPort
-            // failing (EADDRINUSE: port busy, EADDRNOTAVAIL: address not
-            // local, EACCES: privileged port, EINVAL: address family
-            // mismatch); everything else stays ECONNREFUSED. Mirrors
-            // handle_connect_error's whitelist.
+            // socket()/bind() errnos keep their identity; anything else is
+            // reported as ECONNREFUSED. Mirrors handle_connect_error.
             let os_errno = bun_sys::last_errno();
             if os_errno == bun_sys::SystemErrno::EADDRINUSE as c_int
                 || os_errno == bun_sys::SystemErrno::EADDRNOTAVAIL as c_int

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1558,8 +1558,7 @@ fn connect_finish<const IS_SSL: bool>(
                 bun_sys::SystemErrno::ENOENT as c_int
             }
         } else {
-            // socket()/bind() errnos keep their identity; anything else is
-            // reported as ECONNREFUSED. Mirrors handle_connect_error.
+            // socket()/bind() errnos keep their identity; anything else becomes ECONNREFUSED.
             let os_errno = bun_sys::last_errno();
             if os_errno == bun_sys::SystemErrno::EADDRINUSE as c_int
                 || os_errno == bun_sys::SystemErrno::EADDRNOTAVAIL as c_int

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1558,17 +1558,22 @@ fn connect_finish<const IS_SSL: bool>(
                 bun_sys::SystemErrno::ENOENT as c_int
             }
         } else {
-            // A synchronous TCP connect failure is almost always the local
-            // bind() (localAddress/localPort) failing - preserve the errnos a
-            // bind() meaningfully produces (EADDRINUSE: port busy,
-            // EADDRNOTAVAIL: address not local, EACCES: privileged port,
-            // EINVAL: address family mismatch); everything else stays
-            // ECONNREFUSED. Mirrors handle_connect_error's whitelist.
+            // A synchronous TCP connect failure is either socket() itself
+            // failing (EMFILE/ENFILE/ENOBUFS/ENOMEM: local resource
+            // exhaustion) or the local bind() for localAddress/localPort
+            // failing (EADDRINUSE: port busy, EADDRNOTAVAIL: address not
+            // local, EACCES: privileged port, EINVAL: address family
+            // mismatch); everything else stays ECONNREFUSED. Mirrors
+            // handle_connect_error's whitelist.
             let os_errno = bun_sys::last_errno();
             if os_errno == bun_sys::SystemErrno::EADDRINUSE as c_int
                 || os_errno == bun_sys::SystemErrno::EADDRNOTAVAIL as c_int
                 || os_errno == bun_sys::SystemErrno::EACCES as c_int
                 || os_errno == bun_sys::SystemErrno::EINVAL as c_int
+                || os_errno == bun_sys::SystemErrno::EMFILE as c_int
+                || os_errno == bun_sys::SystemErrno::ENFILE as c_int
+                || os_errno == bun_sys::SystemErrno::ENOBUFS as c_int
+                || os_errno == bun_sys::SystemErrno::ENOMEM as c_int
             {
                 os_errno
             } else {

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1119,8 +1119,10 @@ impl<const SSL: bool> NewSocket<SSL> {
             debug_assert!(errno >= 0);
             // Unix-path connect errors keep their real code (a non-socket file
             // is ENOTSOCK, a permission-denied path is EACCES, a missing one is
-            // ENOENT, an inexpressible path is EINVAL); everything else stays
-            // ECONNREFUSED.
+            // ENOENT, an inexpressible path is EINVAL). Local resource
+            // exhaustion (EMFILE/ENFILE/ENOBUFS/ENOMEM: socket() itself
+            // failed) also keeps its real code so callers can tell a local fd
+            // limit from a refused peer; everything else stays ECONNREFUSED.
             let errno_: c_int = if errno == sys::SystemErrno::ENOENT as c_int
                 || errno == sys::SystemErrno::ENOTSOCK as c_int
                 || errno == sys::SystemErrno::EACCES as c_int
@@ -1128,6 +1130,10 @@ impl<const SSL: bool> NewSocket<SSL> {
                 || errno == sys::SystemErrno::ECONNRESET as c_int
                 || errno == sys::SystemErrno::EADDRINUSE as c_int
                 || errno == sys::SystemErrno::EADDRNOTAVAIL as c_int
+                || errno == sys::SystemErrno::EMFILE as c_int
+                || errno == sys::SystemErrno::ENFILE as c_int
+                || errno == sys::SystemErrno::ENOBUFS as c_int
+                || errno == sys::SystemErrno::ENOMEM as c_int
             {
                 errno
             } else {
@@ -1147,6 +1153,14 @@ impl<const SSL: bool> NewSocket<SSL> {
                 BunString::static_("EADDRINUSE")
             } else if errno == sys::SystemErrno::EADDRNOTAVAIL as c_int {
                 BunString::static_("EADDRNOTAVAIL")
+            } else if errno == sys::SystemErrno::EMFILE as c_int {
+                BunString::static_("EMFILE")
+            } else if errno == sys::SystemErrno::ENFILE as c_int {
+                BunString::static_("ENFILE")
+            } else if errno == sys::SystemErrno::ENOBUFS as c_int {
+                BunString::static_("ENOBUFS")
+            } else if errno == sys::SystemErrno::ENOMEM as c_int {
+                BunString::static_("ENOMEM")
             } else {
                 BunString::static_("ECONNREFUSED")
             };

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1117,8 +1117,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             )
         } else {
             debug_assert!(errno >= 0);
-            // Unix-path errnos and local resource exhaustion keep their
-            // identity; anything else is reported as ECONNREFUSED.
+            // Unix-path and resource-exhaustion errnos keep their identity; anything else becomes ECONNREFUSED.
             let errno_: c_int = if errno == sys::SystemErrno::ENOENT as c_int
                 || errno == sys::SystemErrno::ENOTSOCK as c_int
                 || errno == sys::SystemErrno::EACCES as c_int

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1117,12 +1117,8 @@ impl<const SSL: bool> NewSocket<SSL> {
             )
         } else {
             debug_assert!(errno >= 0);
-            // Unix-path connect errors keep their real code (a non-socket file
-            // is ENOTSOCK, a permission-denied path is EACCES, a missing one is
-            // ENOENT, an inexpressible path is EINVAL). Local resource
-            // exhaustion (EMFILE/ENFILE/ENOBUFS/ENOMEM: socket() itself
-            // failed) also keeps its real code so callers can tell a local fd
-            // limit from a refused peer; everything else stays ECONNREFUSED.
+            // Unix-path errnos and local resource exhaustion keep their
+            // identity; anything else is reported as ECONNREFUSED.
             let errno_: c_int = if errno == sys::SystemErrno::ENOENT as c_int
                 || errno == sys::SystemErrno::ENOTSOCK as c_int
                 || errno == sys::SystemErrno::EACCES as c_int

--- a/test/js/node/net/emfile-error-code.test.ts
+++ b/test/js/node/net/emfile-error-code.test.ts
@@ -37,6 +37,7 @@ const probe = async () => {
     s.once("connect", () => { s.destroy(); r(null); }).once("error", e => r({ code: e.code, syscall: e.syscall }));
   });
   try { req(mod + ".cjs"); out.require = null; } catch (e) { out.require = { code: e.code, syscall: e.syscall, path: e.path }; }
+  try { req("emfile-pkg"); out.requireBare = null; } catch (e) { out.requireBare = { code: e.code, syscall: e.syscall }; }
   try { await import(mod + ".mjs"); out.import = null; } catch (e) { out.import = { code: e.code, syscall: e.syscall, path: e.path }; }
   out.listen = await new Promise(r => {
     const s = net.createServer();
@@ -60,6 +61,8 @@ describe.skipIf(!isPosix)("EMFILE is reported as EMFILE", () => {
       "probe.mjs": fixture,
       "mod/m.cjs": "module.exports = 42;",
       "mod/m.mjs": "export const v = 42;",
+      "node_modules/emfile-pkg/package.json": JSON.stringify({ name: "emfile-pkg", main: "index.js" }),
+      "node_modules/emfile-pkg/index.js": "module.exports = 42;",
     });
     // Bun raises RLIMIT_NOFILE on startup; `ulimit -n` lowers both soft and
     // hard in dash/bash so the raise cannot exceed it. 512 leaves room for
@@ -88,6 +91,7 @@ describe.skipIf(!isPosix)("EMFILE is reported as EMFILE", () => {
     expect(parsed.exhausted).toEqual({
       connect: { code: "EMFILE", syscall: "connect" },
       require: { code: "EMFILE", syscall: "open", path: String(dir) + "/mod/m.cjs" },
+      requireBare: { code: "EMFILE", syscall: "open" },
       import: { code: "EMFILE", syscall: "open", path: String(dir) + "/mod/m.mjs" },
       listen: { code: "EMFILE", syscall: "listen" },
     });
@@ -95,6 +99,7 @@ describe.skipIf(!isPosix)("EMFILE is reported as EMFILE", () => {
     expect(parsed.recovered).toEqual({
       connect: null,
       require: null,
+      requireBare: null,
       import: null,
       listen: null,
     });

--- a/test/js/node/net/emfile-error-code.test.ts
+++ b/test/js/node/net/emfile-error-code.test.ts
@@ -52,11 +52,12 @@ for (const fd of held) fs.closeSync(fd);
 const recovered = await probe();
 srv.close();
 
-process.stdout.write(JSON.stringify({ exhausted, recovered }));
+process.stdout.write(JSON.stringify({ exhausted, recovered }) + "\\n");
 `;
 
 describe.skipIf(!isPosix)("EMFILE is reported as EMFILE", () => {
-  test.concurrent("net.connect, require, import, net.listen under fd exhaustion", async () => {
+  // Subprocess startup under debug+ASAN dominates; the probe itself is fast.
+  test.concurrent("net.connect, require, import, net.listen under fd exhaustion", { timeout: 15000 }, async () => {
     using dir = tempDir("emfile-error-code", {
       "probe.mjs": fixture,
       "mod/m.cjs": "module.exports = 42;",
@@ -83,10 +84,14 @@ describe.skipIf(!isPosix)("EMFILE is reported as EMFILE", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    if (!stdout.startsWith("{")) {
-      throw new Error("no JSON on stdout; stderr:\n" + stderr);
+    // Builds without the fix may append a panic backtrace to stdout after the
+    // JSON (auto-install's MiniEventLoop init hits eventfd()=EMFILE); parse
+    // only the first line so the assertion below shows the wrong codes.
+    const first = stdout.split("\n", 1)[0];
+    if (!first.startsWith("{")) {
+      throw new Error("no JSON on stdout; stdout:\n" + stdout + "\nstderr:\n" + stderr);
     }
-    const parsed = JSON.parse(stdout);
+    const parsed = JSON.parse(first);
 
     expect(parsed.exhausted).toEqual({
       connect: { code: "EMFILE", syscall: "connect" },

--- a/test/js/node/net/emfile-error-code.test.ts
+++ b/test/js/node/net/emfile-error-code.test.ts
@@ -1,0 +1,104 @@
+// At RLIMIT_NOFILE, bun used to mis-attribute the failing socket()/open() as
+// ECONNREFUSED / MODULE_NOT_FOUND / code-less "Failed to listen". These must
+// surface the real errno so callers branching on `err.code` (connection pools,
+// optional-dependency fallbacks, supervisors) don't take the wrong branch.
+//
+// No fault injection: a child exhausts its own fd table with real
+// fs.openSync("/dev/null") under a lowered soft limit.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+
+const fixture = `
+import fs from "node:fs";
+import net from "node:net";
+import util from "node:util";
+import { createRequire } from "node:module";
+
+const req = createRequire(import.meta.url);
+const mod = process.argv[2];
+
+// Warm every lazily-loaded module before exhausting fds.
+const srv = net.createServer(() => {});
+await new Promise(r => srv.listen(0, "127.0.0.1", r));
+await new Promise(r => {
+  const s = net.connect(srv.address().port, "127.0.0.1");
+  s.once("connect", () => { s.destroy(); r(); }).once("error", r);
+});
+await new Promise(r => { const s = net.createServer(); s.listen(0, "127.0.0.1", () => s.close(r)); });
+void util.inspect(new Error("warmup"));
+
+const held = [];
+for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
+
+const probe = async () => {
+  const out = {};
+  out.connect = await new Promise(r => {
+    const s = net.connect(srv.address().port, "127.0.0.1");
+    s.once("connect", () => { s.destroy(); r(null); }).once("error", e => r({ code: e.code, syscall: e.syscall }));
+  });
+  try { req(mod + ".cjs"); out.require = null; } catch (e) { out.require = { code: e.code, syscall: e.syscall, path: e.path }; }
+  try { await import(mod + ".mjs"); out.import = null; } catch (e) { out.import = { code: e.code, syscall: e.syscall, path: e.path }; }
+  out.listen = await new Promise(r => {
+    const s = net.createServer();
+    s.once("error", e => r({ code: e.code, syscall: e.syscall }));
+    s.listen(0, "127.0.0.1", () => s.close(() => r(null)));
+  });
+  return out;
+};
+
+const exhausted = await probe();
+for (const fd of held) fs.closeSync(fd);
+const recovered = await probe();
+srv.close();
+
+process.stdout.write(JSON.stringify({ exhausted, recovered }));
+`;
+
+describe.skipIf(!isPosix)("EMFILE is reported as EMFILE", () => {
+  test.concurrent("net.connect, require, import, net.listen under fd exhaustion", async () => {
+    using dir = tempDir("emfile-error-code", {
+      "probe.mjs": fixture,
+      "mod/m.cjs": "module.exports = 42;",
+      "mod/m.mjs": "export const v = 42;",
+    });
+    // Bun raises RLIMIT_NOFILE on startup; `ulimit -n` lowers both soft and
+    // hard in dash/bash so the raise cannot exceed it. 512 leaves room for
+    // the runtime's own fds (including debug builds loading JS from disk).
+    await using proc = Bun.spawn({
+      cmd: [
+        "/bin/sh",
+        "-c",
+        `ulimit -n 512 && exec "$1" "$2" "$3"`,
+        "sh",
+        bunExe(),
+        "probe.mjs",
+        String(dir) + "/mod/m",
+      ],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (!stdout.startsWith("{")) {
+      throw new Error("no JSON on stdout; stderr:\n" + stderr);
+    }
+    const parsed = JSON.parse(stdout);
+
+    expect(parsed.exhausted).toEqual({
+      connect: { code: "EMFILE", syscall: "connect" },
+      require: { code: "EMFILE", syscall: "open", path: String(dir) + "/mod/m.cjs" },
+      import: { code: "EMFILE", syscall: "open", path: String(dir) + "/mod/m.mjs" },
+      listen: { code: "EMFILE", syscall: "listen" },
+    });
+    // Freeing the fds must fully recover; nothing was cached as a permanent failure.
+    expect(parsed.recovered).toEqual({
+      connect: null,
+      require: null,
+      import: null,
+      listen: null,
+    });
+
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
At RLIMIT_NOFILE, `socket()`/`open()` fail with EMFILE before any `connect()` or `stat()` runs. Bun was losing that errno at three surfaces, each of which steers common retry/fallback logic the wrong way:

| surface | before | after |
|---|---|---|
| `net.connect` to a live peer | `code: 'ECONNREFUSED'` | `code: 'EMFILE', syscall: 'connect'` |
| `require()`/`import()` of a file that exists | `code: 'MODULE_NOT_FOUND'` / `'ERR_MODULE_NOT_FOUND'` | `code: 'EMFILE', syscall: 'open', path: ...` |
| `net.createServer().listen()` | `code: undefined` | `code: 'EMFILE', syscall: 'listen'` |

Node reports `EMFILE` on all three. The misattribution has teeth: connection pools and circuit breakers treat `ECONNREFUSED` as "peer is dead" and eject healthy backends when the fix is local fd cleanup; the `try { require(m) } catch (e) { if (e.code === 'MODULE_NOT_FOUND') useFallback() }` pattern (bufferutil/fsevents-style) silently degrades under transient fd pressure; a supervisor branching on `err.code` gets `undefined` from `listen()`.

## Repro

```sh
sh -c 'ulimit -n 256; exec bun emfile.mjs'
```
```js
// emfile.mjs
import fs from "node:fs"; import net from "node:net"; import os from "node:os"; import { createRequire } from "node:module";
const say = (t, e) => console.log(t, e ? `code=${e.code} syscall=${e.syscall}` : "OK");
const mod = `${os.tmpdir()}/m-${process.pid}`; fs.writeFileSync(mod + ".cjs", "module.exports=42;"); fs.writeFileSync(mod + ".mjs", "export const v=42;");
const req = createRequire(import.meta.url);
const srv = net.createServer(() => {}); await new Promise(r => srv.listen(0, "127.0.0.1", r));
const held = []; for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
say("connect:", await new Promise(r => { const s = net.connect(srv.address().port, "127.0.0.1"); s.once("connect", () => { s.destroy(); r(null); }).once("error", r); }));
try { req(mod + ".cjs"); say("require:", null); } catch (e) { say("require:", e); }
try { await import(mod + ".mjs"); say("import:", null); } catch (e) { say("import:", e); }
say("listen:", await new Promise(r => { const s = net.createServer(); s.once("error", r); s.listen(0, "127.0.0.1", () => s.close(() => r(null))); }));
for (const fd of held) fs.closeSync(fd);
srv.close();
```

## Cause

- **connect**: two whitelists (`Listener.rs` `connect_finish`, `socket_body.rs` `handle_connect_error`) rewrote any non-whitelisted errno to ECONNREFUSED; the whitelist covered bind() errnos but not `socket()` resource exhaustion. On the async-DNS path, `start_connections` discarded the `socket()` errno entirely and the caller hard-coded `c->error = ECONNREFUSED`.
- **listen**: `bsd_create_listen_socket` / `internal_bsd_create_listen_socket_unix` passed `NULL` for the `error` out-param to `bsd_create_socket`, so `socket()=EMFILE` reached `Listener::listen` as `errno=0` and `.code` was never attached. (`Bun.serve` was already correct because it reads thread-local errno instead.)
- **resolver**: `dir_info_cached_miss` treated any open failure as `mark_not_found` + `Ok(None)`; `load_as_file_or_directory`'s absolute/relative call sites collapsed any non-Success to `NotFound` via `.is_success()`; `ResolveMessage.get_code()` derives `.code` solely from `ImportKind`, so even a propagated Sys error would have become `MODULE_NOT_FOUND`. Separately, `read_directory_error` cached `EntriesOption::Err(EMFILE)` in the entries map, which is not generation-gated for `Err` values.

## Fix

- `bsd.c`: pass the `error` out-param through to `bsd_create_socket` for listen (TCP and unix).
- `context.c`: record the `socket()` errno into `c->error` in `start_connections`; only default to ECONNREFUSED when no errno was recorded.
- `Listener.rs` / `socket_body.rs`: add EMFILE/ENFILE/ENOBUFS/ENOMEM to the connect-error whitelist.
- `resolver.rs`: EMFILE/ENFILE/ENOMEM in `dir_info_cached_miss` returns `Err` without caching as not-found; `load_as_file_or_directory`'s `dir_info_cached` call propagates `Err` as `MatchStatus::Failure`; the absolute-path and relative-path call sites match on `MatchStatus` instead of `.is_success()`.
- `lib.rs` `read_directory_error`: EMFILE/ENFILE/ENOMEM are returned via the thread-local temp slot, not persisted in the entries cache.
- `jsc_hooks.rs` / `VirtualMachine.rs`: when `resolve()` fails with EMFILE/ENFILE/ENOMEM, throw a SystemError (`code`/`syscall: 'open'`/`path`) matching Node, instead of a ResolveMessage. Other Sys errors keep the existing ResolveMessage path which may carry richer context from the resolver's log.

Recovery after freeing fds is clean: none of the three surfaces caches the transient failure.

## Verification

`test/js/node/net/emfile-error-code.test.ts` spawns a child under `ulimit -n 512` that exhausts its own fd table with real `fs.openSync("/dev/null")`, probes all four surfaces, frees the fds, and probes again. Before: connect reports ECONNREFUSED, require/import report MODULE_NOT_FOUND/ERR_MODULE_NOT_FOUND, listen reports `code: undefined`. After: all four report `code: 'EMFILE'` with the correct `syscall` (and `path` for require/import), and all four succeed after freeing fds.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/net/emfile-error-code.test.ts
bun test v1.4.0 (6f599252b)

test/js/node/net/emfile-error-code.test.ts:
91 |     if (!first.startsWith("{")) {
92 |       throw new Error("no JSON on stdout; stdout:\n" + stdout + "\nstderr:\n" + stderr);
93 |     }
94 |     const parsed = JSON.parse(first);
95 | 
96 |     expect(parsed.exhausted).toEqual({
                                  ^
error: expect(received).toEqual(expected)

  {
    "connect": {
-     "code": "EMFILE",
+     "code": "ECONNREFUSED",
      "syscall": "connect",
    },
    "import": {
-     "code": "EMFILE",
-     "path": "/tmp/emfile-error-code_LQURUp/mod/m.mjs",
-     "syscall": "open",
-   },
-   "listen": {
-     "code": "EMFILE",
-     "syscall": "listen",
+     "code": "ERR_MODULE_NOT_FOUND",
    },
+   "listen": {},
    "require": {
-     "code": "EMFILE",
-     "path": "/tmp/emfile-error-code_LQURUp/mod/m.cjs",
-     "syscall": "open",
+     "code": "MODULE_NOT_FOUND",
    },
    "requireBare": {
-     "code": "EMFILE",
-     "syscall": "open",
+     "code": "M
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ac2ba4cd5)

test/js/node/net/emfile-error-code.test.ts:
(pass) EMFILE is reported as EMFILE > net.connect, require, import, net.listen under fd exhaustion [48.00ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [209.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/net/emfile-error-code.test.ts
bun test v1.4.0 (6f599252b)

test/js/node/net/emfile-error-code.test.ts:
(pass) EMFILE is reported as EMFILE > net.connect, require, import, net.listen under fd exhaustion [2410.40ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [4.42s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 689ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cc obj/packages/bun-usockets/src/bsd.c.o
[2/8] cc obj/packages/bun-usockets/src/context.c.o
[3/8] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/bsd.c            |  10 +-
 packages/bun-usockets/src/context.c        |  29 ++-
 src/errno/lib.rs                           |   9 +
 src/jsc/VirtualMachine.rs                  |  19 ++
 src/resolver/lib.rs                        |  10 +
 src/resolver/resolver.rs                   | 391 +++++++++++++++++------------
 src/runtime/jsc_hooks.rs                   |  19 ++
 src/runtime/socket/Listener.rs             |  11 +-
 src/runtime/socket/socket_body.rs          |  17 +-
 test/js/node/net/emfile-error-code.test.ts | 114 +++++++++
 10 files changed, 452 insertions(+), 177 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-usockets/src/bsd.c                 4      3      0
packages/bun-usockets/src/context.c             7     11      0
src/errno/lib.rs                                2      3      0
src/jsc/VirtualMachine.rs                       6      6      0
src/resolver/lib.rs                             3      4      0
src/resolver/resolver.rs                       18     24      0
src/runtime/jsc_hooks.rs                        8      7      0
src/runtime/socket/Listener.rs                  2      3      0
src/runtime/socket/socket_body.rs               3      3      0
test/js/node/net/emfile-error-code.test.ts      2      9      0
```

</details>

<!-- robobun:evidence:end -->

## Out of scope

- **Windows `net.connect`**: the connect-error whitelist compares raw `c_int` against POSIX-numbered `SystemErrno` discriminants, so `WSAEMFILE (10024)` does not match `EMFILE (24)`. This is the pre-existing shape of every entry in that whitelist (EADDRINUSE etc. have the same mismatch) and affects code this PR did not introduce. Normalizing via `SystemErrno::init()` before the compare, and reading `WSAGetLastError()` instead of CRT `errno` in `connect_finish`, belongs in a dedicated Windows-connect-errno PR. The listen path is fixed here (the out-param now carries `LIBUS_ERR` and `Listener::listen` already normalizes it).
- **`err.path` for non-absolute specifiers**: the SystemError carries the specifier (e.g. `'emfile-pkg'`) rather than the directory `open()` actually failed on. Threading that directory out of `dir_info_cached_miss` requires widening `bun_resolver::Error`; the specifier is at least the thing the caller passed to `require()`, and `err.code === 'EMFILE'` (the branch callers key on) is correct regardless.
- **tsconfig `paths` / browser-field remap under fd exhaustion**: a further transitive layer of `.is_success()` / `.ok().flatten()` callers (resolver.rs 987/1186/1837/1843/2112/2148/2267/2373/etc.) still collapse `Failure` to not-found. These are not regressions (pre-PR they also reported MODULE_NOT_FOUND) and are reachable only with a tsconfig `paths` remap or a `browser` field whose target directory is uncached at the moment of exhaustion.

- **Async-DNS connect test coverage**: the test's connect probe uses an IP literal, which routes through `us_socket_group_connect_resolved_dns` and the `Listener.rs`/`socket_body.rs` whitelists. The `start_connections` hunks in context.c fix the same class on the DNS-fanout path and are covered by the three resolved-comment traces, but a deterministic hostname probe under real fd exhaustion would pull in the DNS thread's own fd dependencies.
