### PR TITLE
transpiler: key decorator flavor on experimentalDecorators only

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2448,8 +2448,7 @@ pub mod parse_worker {
         opts.features.minify_identifiers = topts.minify_identifiers;
         opts.features.minify_keep_names = topts.keep_names;
         opts.features.minify_whitespace = topts.minify_whitespace;
-        // Match tsc: emitDecoratorMetadata is a no-op unless experimentalDecorators is
-        // also set. It must not by itself select the legacy decorator lowering.
+        // tsc: emitDecoratorMetadata is inert without experimentalDecorators (TS5052).
         opts.features.emit_decorator_metadata =
             task.emit_decorator_metadata && task.experimental_decorators;
         opts.features.standard_decorators =

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2448,12 +2448,12 @@ pub mod parse_worker {
         opts.features.minify_identifiers = topts.minify_identifiers;
         opts.features.minify_keep_names = topts.keep_names;
         opts.features.minify_whitespace = topts.minify_whitespace;
-        opts.features.emit_decorator_metadata = task.emit_decorator_metadata;
-        // emitDecoratorMetadata implies legacy/experimental decorators, as it only
-        // makes sense with TypeScript's legacy decorator system (reflect-metadata).
-        // TC39 standard decorators have their own metadata mechanism.
-        opts.features.standard_decorators = !loader.is_typescript()
-            || !(task.experimental_decorators || task.emit_decorator_metadata);
+        // Match tsc: emitDecoratorMetadata is a no-op unless experimentalDecorators is
+        // also set. It must not by itself select the legacy decorator lowering.
+        opts.features.emit_decorator_metadata =
+            task.emit_decorator_metadata && task.experimental_decorators;
+        opts.features.standard_decorators =
+            !loader.is_typescript() || !task.experimental_decorators;
         opts.features.unwrap_commonjs_packages = topts.unwrap_commonjs_packages;
         opts.features.no_macros = topts.no_macros;
         // Modeled as

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1559,12 +1559,12 @@ impl<'a> Transpiler<'a> {
                     repl_mode: self.options.repl_mode,
                 };
 
-                opts.features.emit_decorator_metadata = this_parse.emit_decorator_metadata;
-                // emitDecoratorMetadata implies legacy/experimental decorators, as it only
-                // makes sense with TypeScript's legacy decorator system (reflect-metadata).
-                // TC39 standard decorators have their own metadata mechanism.
-                opts.features.standard_decorators = !loader.is_typescript()
-                    || !(this_parse.experimental_decorators || this_parse.emit_decorator_metadata);
+                // Match tsc: emitDecoratorMetadata is a no-op unless experimentalDecorators is
+                // also set. It must not by itself select the legacy decorator lowering.
+                opts.features.emit_decorator_metadata =
+                    this_parse.emit_decorator_metadata && this_parse.experimental_decorators;
+                opts.features.standard_decorators =
+                    !loader.is_typescript() || !this_parse.experimental_decorators;
                 opts.features.allow_runtime = self.options.allow_runtime;
                 opts.features.set_breakpoint_on_first_line =
                     this_parse.set_breakpoint_on_first_line;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1559,8 +1559,7 @@ impl<'a> Transpiler<'a> {
                     repl_mode: self.options.repl_mode,
                 };
 
-                // Match tsc: emitDecoratorMetadata is a no-op unless experimentalDecorators is
-                // also set. It must not by itself select the legacy decorator lowering.
+                // tsc: emitDecoratorMetadata is inert without experimentalDecorators (TS5052).
                 opts.features.emit_decorator_metadata =
                     this_parse.emit_decorator_metadata && this_parse.experimental_decorators;
                 opts.features.standard_decorators =

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6408,6 +6408,8 @@ impl<'a> Resolver<'a> {
                         let mc = unsafe { &mut *merged_config };
                         mc.emit_decorator_metadata =
                             mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
+                        mc.experimental_decorators =
+                            mc.experimental_decorators || parent_config.experimental_decorators;
                         if !parent_config.base_url.is_empty() {
                             mc.base_url = core::mem::take(&mut parent_config.base_url);
                         }

--- a/test/bundler/bundler_decorator_metadata.test.ts
+++ b/test/bundler/bundler_decorator_metadata.test.ts
@@ -1266,23 +1266,26 @@ describe("bundler", () => {
     { emitDecoratorMetadata: true },
     { experimentalDecorators: false, emitDecoratorMetadata: true },
   ]) {
-    itBundled(`decorator_metadata/StandardDecoratorsWhenExperimentalDecoratorsUnset${"experimentalDecorators" in compilerOptions ? "ExplicitFalse" : ""}`, {
-      files: {
-        "/entry.ts": /* ts */ `
+    itBundled(
+      `decorator_metadata/StandardDecoratorsWhenExperimentalDecoratorsUnset${"experimentalDecorators" in compilerOptions ? "ExplicitFalse" : ""}`,
+      {
+        files: {
+          "/entry.ts": /* ts */ `
             function d(value: any, ctx: any) {
               console.log(JSON.stringify([arguments.length, ctx?.kind, typeof ctx?.addInitializer]));
             }
             class C { @d m() {} }
             new C();
         `,
-        "/tsconfig.json": JSON.stringify({ compilerOptions }),
+          "/tsconfig.json": JSON.stringify({ compilerOptions }),
+        },
+        bundling: true,
+        run: { stdout: `[2,"method","function"]\n` },
+        onAfterBundle(api) {
+          api.expectFile("/out.js").not.toContain("__legacyDecorateClassTS");
+          api.expectFile("/out.js").not.toContain("design:type");
+        },
       },
-      bundling: true,
-      run: { stdout: `[2,"method","function"]\n` },
-      onAfterBundle(api) {
-        api.expectFile("/out.js").not.toContain("__legacyDecorateClassTS");
-        api.expectFile("/out.js").not.toContain("design:type");
-      },
-    });
+    );
   }
 });

--- a/test/bundler/bundler_decorator_metadata.test.ts
+++ b/test/bundler/bundler_decorator_metadata.test.ts
@@ -1261,4 +1261,28 @@ describe("bundler", () => {
       stdout: "true\n",
     },
   });
+
+  for (const compilerOptions of [
+    { emitDecoratorMetadata: true },
+    { experimentalDecorators: false, emitDecoratorMetadata: true },
+  ]) {
+    itBundled(`decorator_metadata/StandardDecoratorsWhenExperimentalDecoratorsUnset${"experimentalDecorators" in compilerOptions ? "ExplicitFalse" : ""}`, {
+      files: {
+        "/entry.ts": /* ts */ `
+            function d(value: any, ctx: any) {
+              console.log(JSON.stringify([arguments.length, ctx?.kind, typeof ctx?.addInitializer]));
+            }
+            class C { @d m() {} }
+            new C();
+        `,
+        "/tsconfig.json": JSON.stringify({ compilerOptions }),
+      },
+      bundling: true,
+      run: { stdout: `[2,"method","function"]\n` },
+      onAfterBundle(api) {
+        api.expectFile("/out.js").not.toContain("__legacyDecorateClassTS");
+        api.expectFile("/out.js").not.toContain("design:type");
+      },
+    });
+  }
 });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -732,6 +732,37 @@ describe("ES Decorators", () => {
       expect(out).toContain("__legacyDecorateClassTS");
       expect(out).toContain("design:type");
     });
+
+    for (const [where, base, child] of [
+      ["child", {}, { experimentalDecorators: true, emitDecoratorMetadata: true }],
+      ["base", { experimentalDecorators: true, emitDecoratorMetadata: true }, {}],
+    ] as const) {
+      test(`experimentalDecorators in the ${where} of a tsconfig extends chain selects legacy decorators`, async () => {
+        using dir = tempDir("es-dec-ts-extends", {
+          "base.json": JSON.stringify({ compilerOptions: base }),
+          "tsconfig.json": JSON.stringify({ extends: "./base.json", compilerOptions: child }),
+          "test.ts": `
+            function d(target: any, key: any, desc: any) {
+              console.log(JSON.stringify([arguments.length, typeof key, typeof desc?.value]));
+            }
+            class Foo { @d m() {} }
+            void Foo;
+          `,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+
+        const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(filterStderr(rawStderr)).toBe("");
+        expect(stdout.trim()).toBe(`[3,"string","function"]`);
+        expect(exitCode).toBe(0);
+      });
+    }
   });
 
   describe("extends clause", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -683,7 +683,10 @@ describe("ES Decorators", () => {
     // It must not flip a TypeScript file to the legacy decorator calling convention on its own.
     describe.each([
       ["emitDecoratorMetadata alone", { emitDecoratorMetadata: true }],
-      ["experimentalDecorators:false + emitDecoratorMetadata:true", { experimentalDecorators: false, emitDecoratorMetadata: true }],
+      [
+        "experimentalDecorators:false + emitDecoratorMetadata:true",
+        { experimentalDecorators: false, emitDecoratorMetadata: true },
+      ],
     ])("%s", (_label, compilerOptions) => {
       test("bun run uses standard decorators", async () => {
         using dir = tempDir("es-dec-ts-meta-only", {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -678,6 +678,57 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("class Foo\n");
       expect(exitCode).toBe(0);
     });
+
+    // tsc treats emitDecoratorMetadata as a no-op unless experimentalDecorators is also set.
+    // It must not flip a TypeScript file to the legacy decorator calling convention on its own.
+    describe.each([
+      ["emitDecoratorMetadata alone", { emitDecoratorMetadata: true }],
+      ["experimentalDecorators:false + emitDecoratorMetadata:true", { experimentalDecorators: false, emitDecoratorMetadata: true }],
+    ])("%s", (_label, compilerOptions) => {
+      test("bun run uses standard decorators", async () => {
+        using dir = tempDir("es-dec-ts-meta-only", {
+          "tsconfig.json": JSON.stringify({ compilerOptions }),
+          "test.ts": `
+            function dec(value: any, ctx: any) {
+              console.log(JSON.stringify([arguments.length, ctx?.kind, typeof ctx?.addInitializer]));
+            }
+            class Foo { @dec m() {} }
+            void Foo;
+          `,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+
+        const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(filterStderr(rawStderr)).toBe("");
+        expect(stdout.trim()).toBe(`[2,"method","function"]`);
+        expect(exitCode).toBe(0);
+      });
+
+      test("Bun.Transpiler uses standard decorators", () => {
+        const out = new Bun.Transpiler({
+          loader: "ts",
+          tsconfig: JSON.stringify({ compilerOptions }),
+        }).transformSync("function d() {} class C { @d m() {} }");
+        expect(out).not.toContain("__legacyDecorateClassTS");
+        expect(out).not.toContain("__legacyMetadataTS");
+        expect(out).toContain("__decorateElement");
+      });
+    });
+
+    test("emitDecoratorMetadata with experimentalDecorators:true still emits legacy metadata", () => {
+      const out = new Bun.Transpiler({
+        loader: "ts",
+        tsconfig: JSON.stringify({ compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true } }),
+      }).transformSync("function d() {} class C { @d m(a: number): string { return ''; } }");
+      expect(out).toContain("__legacyDecorateClassTS");
+      expect(out).toContain("design:type");
+    });
   });
 
   describe("extends clause", () => {

--- a/test/regression/issue/27526.test.ts
+++ b/test/regression/issue/27526.test.ts
@@ -1,9 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// NestJS/reflect-metadata projects need both experimentalDecorators and
-// emitDecoratorMetadata. Bun follows tsc here: emitDecoratorMetadata on its own
-// is a no-op and does not select the legacy lowering.
+// https://github.com/oven-sh/bun/issues/27526
 test("legacy decorators work when experimentalDecorators and emitDecoratorMetadata are set", async () => {
   using dir = tempDir("issue-27526", {
     "tsconfig.json": JSON.stringify({

--- a/test/regression/issue/27526.test.ts
+++ b/test/regression/issue/27526.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// When emitDecoratorMetadata is true in tsconfig but experimentalDecorators is
-// absent, Bun should use legacy decorator semantics (not TC39 standard).
-// emitDecoratorMetadata only makes sense with legacy decorators.
-test("legacy decorators work when emitDecoratorMetadata is true without experimentalDecorators", async () => {
+// NestJS/reflect-metadata projects need both experimentalDecorators and
+// emitDecoratorMetadata. Bun follows tsc here: emitDecoratorMetadata on its own
+// is a no-op and does not select the legacy lowering.
+test("legacy decorators work when experimentalDecorators and emitDecoratorMetadata are set", async () => {
   using dir = tempDir("issue-27526", {
     "tsconfig.json": JSON.stringify({
       compilerOptions: {
@@ -12,6 +12,7 @@ test("legacy decorators work when emitDecoratorMetadata is true without experime
         module: "commonjs",
         strict: true,
         esModuleInterop: true,
+        experimentalDecorators: true,
         emitDecoratorMetadata: true,
       },
     }),


### PR DESCRIPTION
## Repro

```ts
const src = "function d(...a){} class C { @d m() {} }";
const flavor = (o: string) =>
  /__legacyDecorateClassTS/.test(o) ? "LEGACY" : /__decorateElement/.test(o) ? "std" : "?";
for (const [k, c] of Object.entries({
  "no flags": {},
  "experimentalDecorators:true": { experimentalDecorators: true },
  "emitDecoratorMetadata:true ONLY": { emitDecoratorMetadata: true },
  "experimentalDecorators:false + emitDecoratorMetadata:true": { experimentalDecorators: false, emitDecoratorMetadata: true },
}))
  console.log(k, "->", flavor(new Bun.Transpiler({ loader: "ts", tsconfig: JSON.stringify({ compilerOptions: c }) }).transformSync(src)));
```

Before:
```
no flags -> std
experimentalDecorators:true -> LEGACY
emitDecoratorMetadata:true ONLY -> LEGACY
experimentalDecorators:false + emitDecoratorMetadata:true -> LEGACY
```

After (matches tsc):
```
no flags -> std
experimentalDecorators:true -> LEGACY
emitDecoratorMetadata:true ONLY -> std
experimentalDecorators:false + emitDecoratorMetadata:true -> std
```

At runtime, with tsconfig `{ experimentalDecorators: false, emitDecoratorMetadata: true }` a method decorator was being called as `(target, key, descriptor)` (legacy) instead of `(value, context)` (standard), so stage-3 decorators silently received the wrong arguments with no diagnostic.

## Cause

`src/bundler/transpiler.rs` and `src/bundler/ParseTask.rs` computed `standard_decorators = !loader.is_typescript() || !(experimental_decorators || emit_decorator_metadata)`, originally added in #27527 as a heuristic for NestJS projects that set `emitDecoratorMetadata` without `experimentalDecorators`. tsc does not do this: `emitDecoratorMetadata` is a no-op unless `experimentalDecorators` is also set (TS5052), and standard decorators are emitted.

## Fix

Key `standard_decorators` on `experimentalDecorators` alone, and gate `emit_decorator_metadata` on it as well so the metadata flag remains a no-op in the standard path.

This unmasked a pre-existing gap in the tsconfig `extends` merge: `resolver.rs` OR-merged `emit_decorator_metadata` across the chain but never merged `experimental_decorators`, so a child tsconfig setting `experimentalDecorators: true` over a base that does not was dropped. That was previously hidden by the `|| emit_decorator_metadata` fallback. The merge now copies `experimental_decorators` alongside `emit_decorator_metadata`.

The #27526 regression test is updated to set `experimentalDecorators: true` explicitly, which is what tsc (and the NestJS docs) require. Projects that relied on the old heuristic will need to add that flag to their tsconfig.

## Verification

- `test/bundler/transpiler/es-decorators.test.ts`: `bun run` and `Bun.Transpiler` for `{ emitDecoratorMetadata: true }` alone and `{ experimentalDecorators: false, emitDecoratorMetadata: true }`; a guard that both flags together still emit `__legacyDecorateClassTS` with `design:*` metadata; and two `extends`-chain tests (flag in child, flag in base) pinning legacy semantics.
- `test/bundler/bundler_decorator_metadata.test.ts`: two `itBundled` cases covering the `Bun.build` path for the same tsconfigs.

Six of the nine new cases fail on main.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_decorator_metadata.test.ts test/bundler/transpiler/es-decorators.test.ts "test/regression/issue/27526.test.ts"
bun test v1.4.0 (ac4df3440)

test/bundler/bundler_decorator_metadata.test.ts:
(pass) bundler > decorator_metadata/TypeSerialization [2545.91ms]
(pass) bundler > decorator_metadata/ImportIdentifiers [1275.87ms]
1280 |           "/tsconfig.json": JSON.stringify({ compilerOptions }),
1281 |         },
1282 |         bundling: true,
1283 |         run: { stdout: `[2,"method","function"]\n` },
1284 |         onAfterBundle(api) {
1285 |           api.expectFile("/out.js").not.toContain("__legacyDecorateClassTS");
                                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "__legacyDecorateClassTS"
Received: "var __legacyDecorateClassTS = function(decorators, target, key, desc) {\n  var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;\n  if (typeof Reflect === \"object\" && typeo
... (truncated)

release without fix: 15 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_decorator_metadata.test.ts:
(pass) bundler > decorator_metadata/TypeSerialization [45.07ms]
(pass) bundler > decorator_metadata/ImportIdentifiers [45.60ms]
1280 |           "/tsconfig.json": JSON.stringify({ compilerOptions }),
1281 |         },
1282 |         bundling: true,
1283 |         run: { stdout: `[2,"method","function"]\n` },
1284 |         onAfterBundle(api) {
1285 |           api.expectFile("/out.js").not.toContain("__legacyDecorateClassTS");
                                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "__legacyDecorateClassTS"
Received: "var __legacyDecorateClassTS = function(decorators, target, key, desc) {\n  var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;\n  if (typeof Reflect === \"object\" && typeof Reflect.decorate === \"function\")\n    r = Reflect.decorate(decorators, target, key, desc);\n  else\n    for (var i = decorators.length - 1;i >= 0; i--)\n      if (d = decorators[i])\n        r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) |
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_decorator_metadata.test.ts test/bundler/transpiler/es-decorators.test.ts "test/regression/issue/27526.test.ts"
bun test v1.4.0 (ac4df3440)

test/bundler/bundler_decorator_metadata.test.ts:
(pass) bundler > decorator_metadata/TypeSerialization [2450.29ms]
(pass) bundler > decorator_metadata/ImportIdentifiers [1259.73ms]
(pass) bundler > decorator_metadata/StandardDecoratorsWhenExperimentalDecoratorsUnset [516.30ms]
(pass) bundler > decorator_metadata/StandardDecoratorsWhenExperimentalDecoratorsUnsetExplicitFalse [560.84ms]

test/regression/issue/27526.test.ts:
(pass) legacy decorators work when experimentalDecorators and emitDecoratorMetadata are set [386.35ms]
(pass) TC39 standard decorators work when neither emitDecoratorMetadata nor experimentalDecorators is set [377.65ms]

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [383.46ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [448.33ms]
(pass) ES Decorators > clas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 804ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/ParseTask.rs                        | 11 ++--
 src/bundler/transpiler.rs                       | 11 ++--
 src/resolver/resolver.rs                        |  2 +
 test/bundler/bundler_decorator_metadata.test.ts | 27 ++++++++
 test/bundler/transpiler/es-decorators.test.ts   | 85 +++++++++++++++++++++++++
 test/regression/issue/27526.test.ts             |  7 +-
 6 files changed, 127 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/bundler/ParseTask.rs                             2      3      0
src/bundler/transpiler.rs                            2      3      0
src/resolver/resolver.rs                             3      1      0
test/bundler/bundler_decorator_metadata.test.ts      1      2      0
test/bundler/transpiler/es-decorators.test.ts        3      3      0
test/regression/issue/27526.test.ts                  2      2      0
```

</details>

<!-- robobun:evidence:end -->