### PR TITLE
node:sqlite: match Node's error identity and object branding

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -2579,7 +2579,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
     case ErrorCode::ERR_STREAM_UNABLE_TO_PIPE:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_STREAM_UNABLE_TO_PIPE, "Cannot pipe to a closed or destroyed stream"_s));
     case ErrorCode::ERR_ILLEGAL_CONSTRUCTOR:
-        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s));
+    case ErrorCode::ERR_ILLEGAL_CONSTRUCTOR_Error:
+        return JSC::JSValue::encode(createError(globalObject, error, "Illegal constructor"_s));
     case ErrorCode::ERR_DIR_CLOSED:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_DIR_CLOSED, "Directory handle was closed"_s));
     case ErrorCode::ERR_INSPECTOR_ALREADY_ACTIVATED: {

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -128,7 +128,11 @@ const errors: ErrorCodeMapping = [
   ["ERR_HTTP2_TOO_MANY_INVALID_FRAMES", Error],
   ["ERR_HTTP2_UNSUPPORTED_PROTOCOL", Error],
   ["ERR_HTTP2_INVALID_SETTING_VALUE", TypeError, "TypeError", RangeError],
-  ["ERR_ILLEGAL_CONSTRUCTOR", TypeError],
+  // Node.js JS-side callers (lib/internal/errors.js) construct a TypeError,
+  // but node_errors.h's THROW_ERR_ILLEGAL_CONSTRUCTOR (used by native
+  // modules such as node:sqlite) constructs a plain Error, so both variants
+  // are needed.
+  ["ERR_ILLEGAL_CONSTRUCTOR", TypeError, undefined, Error],
   ["ERR_INCOMPATIBLE_OPTION_PAIR", TypeError],
   ["ERR_INVALID_ADDRESS", Error],
   ["ERR_INVALID_ADDRESS_FAMILY", RangeError],

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -128,10 +128,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_HTTP2_TOO_MANY_INVALID_FRAMES", Error],
   ["ERR_HTTP2_UNSUPPORTED_PROTOCOL", Error],
   ["ERR_HTTP2_INVALID_SETTING_VALUE", TypeError, "TypeError", RangeError],
-  // Node.js JS-side callers (lib/internal/errors.js) construct a TypeError,
-  // but node_errors.h's THROW_ERR_ILLEGAL_CONSTRUCTOR (used by native
-  // modules such as node:sqlite) constructs a plain Error, so both variants
-  // are needed.
+  // TypeError from lib/internal/errors.js; plain Error from node_errors.h THROW_ERR_ILLEGAL_CONSTRUCTOR (node:sqlite).
   ["ERR_ILLEGAL_CONSTRUCTOR", TypeError, undefined, Error],
   ["ERR_INCOMPATIBLE_OPTION_PAIR", TypeError],
   ["ERR_INVALID_ADDRESS", Error],

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -225,6 +225,22 @@ static EncodedJSValue throwNodeState(JSGlobalObject* globalObject, ThrowScope& s
     return {};
 }
 
+// Node.js wires every node:sqlite prototype method with a V8
+// FunctionTemplate Signature, so a wrong-receiver call fails V8's signature
+// check and throws a plain TypeError("Illegal invocation") with no `.code`.
+static EncodedJSValue throwIllegalInvocation(JSGlobalObject* globalObject, ThrowScope& scope)
+{
+    scope.throwException(globalObject, JSC::createTypeError(globalObject, "Illegal invocation"_s));
+    return {};
+}
+
+// Node's native THROW_ERR_ILLEGAL_CONSTRUCTOR constructs a plain Error, not
+// the TypeError that the JS-side ERR_ILLEGAL_CONSTRUCTOR produces.
+static EncodedJSValue throwIllegalConstructor(JSGlobalObject* globalObject, ThrowScope& scope)
+{
+    return Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR_Error, "Illegal constructor"_s);
+}
+
 // Node.js installs these getters via InstanceTemplate()->SetAccessorProperty
 // (DontDelete), so they are OWN properties — Object.keys(db) lists them and
 // {...db} copies them. Install in each finishCreation rather than on the
@@ -1225,14 +1241,12 @@ JSC_DECLARE_HOST_FUNCTION(jsDatabaseSyncDeserialize);
 JSC_DECLARE_HOST_FUNCTION(jsDatabaseSyncCreateTagStore);
 JSC_DECLARE_HOST_FUNCTION(jsDatabaseSyncDispose);
 
-#define THIS_DATABASE()                                                                                                     \
-    auto& vm = JSC::getVM(globalObject);                                                                                    \
-    auto scope = DECLARE_THROW_SCOPE(vm);                                                                                   \
-    JSDatabaseSync* self = dynamicDowncast<JSDatabaseSync>(callFrame->thisValue());                                         \
-    if (!self) [[unlikely]] {                                                                                               \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "DatabaseSync"_s)); \
-        return {};                                                                                                          \
-    }
+#define THIS_DATABASE()                                                             \
+    auto& vm = JSC::getVM(globalObject);                                            \
+    auto scope = DECLARE_THROW_SCOPE(vm);                                           \
+    JSDatabaseSync* self = dynamicDowncast<JSDatabaseSync>(callFrame->thisValue()); \
+    if (!self) [[unlikely]]                                                         \
+        return throwIllegalInvocation(globalObject, scope);
 
 JSC_DEFINE_HOST_FUNCTION(jsDatabaseSyncOpen, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
@@ -2200,7 +2214,6 @@ void JSDatabaseSyncPrototype::finishCreation(VM& vm, JSGlobalObject* globalObjec
     reifyStaticProperties(vm, JSDatabaseSync::info(), JSDatabaseSyncPrototypeTableValues, *this);
     // Symbol.dispose — swallow errors if not open, matching Node.js.
     putDirectNativeFunction(vm, globalObject, vm.propertyNames->disposeSymbol, 0, jsDatabaseSyncDispose, ImplementationVisibility::Public, NoIntrinsic, 0);
-    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 
 // ─── DatabaseSync constructor ───────────────────────────────────────────────
@@ -2747,14 +2760,12 @@ JSC_DECLARE_HOST_FUNCTION(jsStatementSyncSetReturnArrays);
 JSC_DECLARE_HOST_FUNCTION(jsStatementSyncSetAllowBareNamedParameters);
 JSC_DECLARE_HOST_FUNCTION(jsStatementSyncSetAllowUnknownNamedParameters);
 
-#define THIS_STATEMENT()                                                                                                     \
-    auto& vm = JSC::getVM(globalObject);                                                                                     \
-    auto scope = DECLARE_THROW_SCOPE(vm);                                                                                    \
-    JSStatementSync* self = dynamicDowncast<JSStatementSync>(callFrame->thisValue());                                        \
-    if (!self) [[unlikely]] {                                                                                                \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "StatementSync"_s)); \
-        return {};                                                                                                           \
-    }
+#define THIS_STATEMENT()                                                              \
+    auto& vm = JSC::getVM(globalObject);                                              \
+    auto scope = DECLARE_THROW_SCOPE(vm);                                             \
+    JSStatementSync* self = dynamicDowncast<JSStatementSync>(callFrame->thisValue()); \
+    if (!self) [[unlikely]]                                                           \
+        return throwIllegalInvocation(globalObject, scope);
 
 struct StatementResetter {
     sqlite3_stmt* stmt;
@@ -3004,21 +3015,20 @@ void JSStatementSyncPrototype::finishCreation(VM& vm, JSGlobalObject*)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSStatementSync::info(), JSStatementSyncPrototypeTableValues, *this);
-    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 
 JSC_HOST_CALL_ATTRIBUTES EncodedJSValue JSStatementSyncConstructor::call(JSGlobalObject* globalObject, CallFrame*)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s);
+    return throwIllegalConstructor(globalObject, scope);
 }
 
 JSC_HOST_CALL_ATTRIBUTES EncodedJSValue JSStatementSyncConstructor::construct(JSGlobalObject* globalObject, CallFrame*)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s);
+    return throwIllegalConstructor(globalObject, scope);
 }
 
 JSStatementSyncConstructor* JSStatementSyncConstructor::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, JSObject* prototype)
@@ -3090,10 +3100,8 @@ JSC_DEFINE_HOST_FUNCTION(jsStatementSyncIteratorNext, (JSGlobalObject * globalOb
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* self = dynamicDowncast<JSStatementSyncIterator>(callFrame->thisValue());
-    if (!self) [[unlikely]] {
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "StatementSyncIterator"_s));
-        return {};
-    }
+    if (!self) [[unlikely]]
+        return throwIllegalInvocation(globalObject, scope);
     // Once exhausted, next() doesn't touch the statement — so keep
     // returning {done:true} regardless of whether the db has since been
     // closed (matches the iterator protocol's "exhausted is permanent").
@@ -3105,7 +3113,7 @@ JSC_DEFINE_HOST_FUNCTION(jsStatementSyncIteratorNext, (JSGlobalObject * globalOb
         return throwNodeState(globalObject, scope, "statement has been finalized"_s);
     }
     if (self->capturedGeneration() != stmt->resetGeneration()) {
-        return throwNodeState(globalObject, scope, "iterator was invalidated by calling run(), get(), all(), or iterate() on the backing statement"_s);
+        return throwNodeState(globalObject, scope, "iterator was invalidated"_s);
     }
     if (stmt->isStepping()) [[unlikely]] {
         return throwNodeState(globalObject, scope, "statement is currently executing"_s);
@@ -3145,10 +3153,8 @@ JSC_DEFINE_HOST_FUNCTION(jsStatementSyncIteratorReturn, (JSGlobalObject * global
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* self = dynamicDowncast<JSStatementSyncIterator>(callFrame->thisValue());
-    if (!self) [[unlikely]] {
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "StatementSyncIterator"_s));
-        return {};
-    }
+    if (!self) [[unlikely]]
+        return throwIllegalInvocation(globalObject, scope);
     // return() is the iterator-protocol cleanup hook (called implicitly by
     // for-of's IteratorClose on break/return). Cleanup must be tolerant of
     // already-closed state — throwing here would turn a benign
@@ -3265,14 +3271,12 @@ GCClient::IsoSubspace* JSNodeSqliteSession::subspaceForImpl(VM& vm)
         [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteSession = std::forward<decltype(space)>(space); });
 }
 
-#define THIS_SESSION()                                                                                                 \
-    auto& vm = JSC::getVM(globalObject);                                                                               \
-    auto scope = DECLARE_THROW_SCOPE(vm);                                                                              \
-    JSNodeSqliteSession* self = dynamicDowncast<JSNodeSqliteSession>(callFrame->thisValue());                          \
-    if (!self) [[unlikely]] {                                                                                          \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "Session"_s)); \
-        return {};                                                                                                     \
-    }
+#define THIS_SESSION()                                                                        \
+    auto& vm = JSC::getVM(globalObject);                                                      \
+    auto scope = DECLARE_THROW_SCOPE(vm);                                                     \
+    JSNodeSqliteSession* self = dynamicDowncast<JSNodeSqliteSession>(callFrame->thisValue()); \
+    if (!self) [[unlikely]]                                                                   \
+        return throwIllegalInvocation(globalObject, scope);
 
 static EncodedJSValue sessionChangesetCommon(JSGlobalObject* globalObject, CallFrame* callFrame,
     int (*fn)(sqlite3_session*, int*, void**))
@@ -3370,14 +3374,14 @@ JSC_HOST_CALL_ATTRIBUTES EncodedJSValue JSNodeSqliteSessionConstructor::call(JSG
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s);
+    return throwIllegalConstructor(globalObject, scope);
 }
 
 JSC_HOST_CALL_ATTRIBUTES EncodedJSValue JSNodeSqliteSessionConstructor::construct(JSGlobalObject* globalObject, CallFrame*)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s);
+    return throwIllegalConstructor(globalObject, scope);
 }
 
 JSNodeSqliteSessionConstructor* JSNodeSqliteSessionConstructor::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, JSObject* prototype)
@@ -3742,14 +3746,12 @@ JSStatementSync* JSNodeSqliteTagStore::prepare(JSGlobalObject* globalObject, Thr
     return stmtObj;
 }
 
-#define THIS_TAGSTORE()                                                                                                    \
-    auto& vm = JSC::getVM(globalObject);                                                                                   \
-    auto scope = DECLARE_THROW_SCOPE(vm);                                                                                  \
-    JSNodeSqliteTagStore* self = dynamicDowncast<JSNodeSqliteTagStore>(callFrame->thisValue());                            \
-    if (!self) [[unlikely]] {                                                                                              \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "SQLTagStore"_s)); \
-        return {};                                                                                                         \
-    }
+#define THIS_TAGSTORE()                                                                         \
+    auto& vm = JSC::getVM(globalObject);                                                        \
+    auto scope = DECLARE_THROW_SCOPE(vm);                                                       \
+    JSNodeSqliteTagStore* self = dynamicDowncast<JSNodeSqliteTagStore>(callFrame->thisValue()); \
+    if (!self) [[unlikely]]                                                                     \
+        return throwIllegalInvocation(globalObject, scope);
 
 // Shared tag execution: prepare/reset/bind then delegate to the same
 // post-bind step drivers StatementSync uses (statementStep{Run,Get,All}),
@@ -3834,7 +3836,6 @@ void JSNodeSqliteTagStorePrototype::finishCreation(VM& vm, JSGlobalObject*)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSNodeSqliteTagStore::info(), JSNodeSqliteTagStorePrototypeTableValues, *this);
-    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 
 const ClassInfo JSNodeSqliteTagStoreConstructor::s_info = { "SQLTagStore"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNodeSqliteTagStoreConstructor) };
@@ -3843,14 +3844,14 @@ JSC_HOST_CALL_ATTRIBUTES EncodedJSValue JSNodeSqliteTagStoreConstructor::call(JS
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s);
+    return throwIllegalConstructor(globalObject, scope);
 }
 
 JSC_HOST_CALL_ATTRIBUTES EncodedJSValue JSNodeSqliteTagStoreConstructor::construct(JSGlobalObject* globalObject, CallFrame*)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s);
+    return throwIllegalConstructor(globalObject, scope);
 }
 
 JSNodeSqliteTagStoreConstructor* JSNodeSqliteTagStoreConstructor::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, JSObject* prototype)

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -225,17 +225,14 @@ static EncodedJSValue throwNodeState(JSGlobalObject* globalObject, ThrowScope& s
     return {};
 }
 
-// Node.js wires every node:sqlite prototype method with a V8
-// FunctionTemplate Signature, so a wrong-receiver call fails V8's signature
-// check and throws a plain TypeError("Illegal invocation") with no `.code`.
+// Matches V8's FunctionTemplate Signature rejection: plain TypeError, no .code.
 static EncodedJSValue throwIllegalInvocation(JSGlobalObject* globalObject, ThrowScope& scope)
 {
     scope.throwException(globalObject, JSC::createTypeError(globalObject, "Illegal invocation"_s));
     return {};
 }
 
-// Node's native THROW_ERR_ILLEGAL_CONSTRUCTOR constructs a plain Error, not
-// the TypeError that the JS-side ERR_ILLEGAL_CONSTRUCTOR produces.
+// Matches node_errors.h THROW_ERR_ILLEGAL_CONSTRUCTOR: plain Error, not TypeError.
 static EncodedJSValue throwIllegalConstructor(JSGlobalObject* globalObject, ThrowScope& scope)
 {
     return Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR_Error, "Illegal constructor"_s);

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -2238,6 +2238,104 @@ describe("module exports", () => {
   });
 });
 
+describe("error identity and branding (Node.js parity)", () => {
+  const thrown = (fn: () => void) => {
+    try {
+      fn();
+    } catch (e) {
+      return e as Error & { code?: string };
+    }
+    throw new Error("expected to throw");
+  };
+
+  test("instances have no Symbol.toStringTag (Object.prototype.toString is [object Object])", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE TABLE t (x INTEGER)");
+    const stmt = db.prepare("SELECT x FROM t");
+    const tagStore = db.createTagStore();
+    expect({
+      db: Object.prototype.toString.call(db),
+      stmt: Object.prototype.toString.call(stmt),
+      tagStore: Object.prototype.toString.call(tagStore),
+      dbTag: db[Symbol.toStringTag],
+      stmtTag: stmt[Symbol.toStringTag],
+      tagStoreTag: tagStore[Symbol.toStringTag],
+    }).toEqual({
+      db: "[object Object]",
+      stmt: "[object Object]",
+      tagStore: "[object Object]",
+      dbTag: undefined,
+      stmtTag: undefined,
+      tagStoreTag: undefined,
+    });
+    db.close();
+  });
+
+  test("StatementSync/Session/SQLTagStore constructors throw plain Error with ERR_ILLEGAL_CONSTRUCTOR", () => {
+    const db = new DatabaseSync(":memory:");
+    const TagStoreCtor = db.createTagStore().constructor as new () => unknown;
+    db.close();
+    for (const [name, fn] of [
+      ["new StatementSync()", () => new StatementSync()],
+      ["StatementSync()", () => (StatementSync as () => void)()],
+      ["new Session()", () => new Session()],
+      ["new SQLTagStore()", () => new TagStoreCtor()],
+    ] as const) {
+      const e = thrown(fn);
+      expect({ name, ctor: e.constructor.name, code: e.code, message: e.message, isTypeError: e instanceof TypeError }).toEqual({
+        name,
+        ctor: "Error",
+        code: "ERR_ILLEGAL_CONSTRUCTOR",
+        message: "Illegal constructor",
+        isTypeError: false,
+      });
+    }
+  });
+
+  test("prototype methods called on a wrong receiver throw TypeError('Illegal invocation') with no .code", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE TABLE t (x)");
+    const it = db.prepare("SELECT 1").iterate();
+    const IterProto = Object.getPrototypeOf(it);
+    const TagProto = Object.getPrototypeOf(db.createTagStore());
+    it.return();
+    db.close();
+    for (const [name, fn] of [
+      ["DatabaseSync.close", DatabaseSync.prototype.close],
+      ["DatabaseSync.exec", DatabaseSync.prototype.exec],
+      ["StatementSync.run", StatementSync.prototype.run],
+      ["StatementSync.all", StatementSync.prototype.all],
+      ["Session.close", Session.prototype.close],
+      ["SQLTagStore.run", TagProto.run],
+      ["iterate().next", IterProto.next],
+      ["iterate().return", IterProto.return],
+    ] as const) {
+      const e = thrown(() => fn.call({}));
+      expect({ name, isTypeError: e instanceof TypeError, message: e.message, code: e.code }).toEqual({
+        name,
+        isTypeError: true,
+        message: "Illegal invocation",
+        code: undefined,
+      });
+    }
+  });
+
+  test("iterate().next() after the statement is re-run throws ERR_INVALID_STATE with Node's exact message", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE TABLE t (x); INSERT INTO t VALUES (1),(2)");
+    const stmt = db.prepare("SELECT x FROM t");
+    const it = stmt.iterate();
+    it.next();
+    stmt.run();
+    const e = thrown(() => it.next());
+    expect({ code: e.code, message: e.message }).toEqual({
+      code: "ERR_INVALID_STATE",
+      message: "iterator was invalidated",
+    });
+    db.close();
+  });
+});
+
 describe("loadExtension() / enableLoadExtension()", () => {
   test.skipIf(sqliteHasLoadExtension)(
     "{allowExtension: true} throws with a setCustomSQLite hint when the library was built with OMIT_LOAD_EXTENSION",

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -2282,7 +2282,13 @@ describe("error identity and branding (Node.js parity)", () => {
       ["new SQLTagStore()", () => new TagStoreCtor()],
     ] as const) {
       const e = thrown(fn);
-      expect({ name, ctor: e.constructor.name, code: e.code, message: e.message, isTypeError: e instanceof TypeError }).toEqual({
+      expect({
+        name,
+        ctor: e.constructor.name,
+        code: e.code,
+        message: e.message,
+        isTypeError: e instanceof TypeError,
+      }).toEqual({
         name,
         ctor: "Error",
         code: "ERR_ILLEGAL_CONSTRUCTOR",


### PR DESCRIPTION
Closes the brand + error-identity gap between Bun's `node:sqlite` and Node v26.3.0. Behaviour of every method is unchanged; only the identity of errors and the `Object.prototype.toString` brand are affected.

## Repro

```js
import { DatabaseSync, StatementSync, Session } from "node:sqlite";
const shape = f => { try { f(); } catch (e) { return { name: e.name, code: e.code, msg: e.message }; } };
const db = new DatabaseSync(":memory:"); db.exec("create table t(x); insert into t values(1),(2)");
const st = db.prepare("select x from t"); const sess = db.createSession();
console.log(Object.prototype.toString.call(db), Object.prototype.toString.call(st), Object.prototype.toString.call(sess));
console.log(shape(() => new StatementSync()));
console.log(shape(() => DatabaseSync.prototype.close.call({})));
const it = st.iterate(); it.next(); st.run();
console.log(shape(() => it.next()));
```

Node v26.3.0:
```
[object Object] [object Object] [object Object]
{ name: 'Error', code: 'ERR_ILLEGAL_CONSTRUCTOR', msg: 'Illegal constructor' }
{ name: 'TypeError', code: undefined, msg: 'Illegal invocation' }
{ name: 'Error', code: 'ERR_INVALID_STATE', msg: 'iterator was invalidated' }
```

Bun before:
```
[object DatabaseSync] [object StatementSync] [object Object]
{ name: 'TypeError', code: 'ERR_ILLEGAL_CONSTRUCTOR', msg: 'Illegal constructor' }
{ name: 'TypeError', code: 'ERR_INVALID_THIS', msg: 'Expected this to be instanceof DatabaseSync, but received an instance of Object' }
{ name: 'Error', code: 'ERR_INVALID_STATE', msg: 'iterator was invalidated by calling run(), get(), all(), or iterate() on the backing statement' }
```

Bun after: byte-identical to Node.

## Cause

- `JSDatabaseSyncPrototype` / `JSStatementSyncPrototype` / `JSNodeSqliteTagStorePrototype` installed `@@toStringTag`; Node's `node_sqlite.cc` never does, so its instances brand as `[object Object]`.
- `ErrorCode::ERR_ILLEGAL_CONSTRUCTOR` maps to `TypeError` in Bun (matching Node's JS-side `lib/internal/errors.js`), but Node's native `THROW_ERR_ILLEGAL_CONSTRUCTOR` in `node_errors.h` constructs a plain `Error`. `node:sqlite` is native, so `new StatementSync()` is a plain `Error` in Node.
- The `THIS_*` receiver macros threw Bun's `ERR_INVALID_THIS`. In Node every prototype method is installed via a V8 `FunctionTemplate` with a `Signature`, and V8's signature check throws a bare `TypeError("Illegal invocation")` with no `.code`.
- The invalidated-iterator message carried extra explanatory text; Node emits exactly `"iterator was invalidated"`.

## Fix

- Remove `JSC_TO_STRING_TAG_WITHOUT_TRANSITION()` from the three prototypes.
- Add an `Error`-typed variant of `ERR_ILLEGAL_CONSTRUCTOR` to `ErrorCode.ts` and use it in the `StatementSync` / `Session` / `SQLTagStore` constructors. Other `ERR_ILLEGAL_CONSTRUCTOR` call sites (Web APIs, streams) stay on `TypeError`.
- Replace every receiver check with a local `throwIllegalInvocation` that throws a plain `TypeError("Illegal invocation")`.
- Trim the iterator-invalidated message to match Node verbatim.

## Verification

- `test/js/node/sqlite/node-sqlite.test.ts` gains four tests covering brand, constructor error class, wrong-receiver error, and the iterator message; all fail on `main` and pass with the fix.
- Full `node-sqlite.test.ts` run: 119 pass / 0 fail.
- Upstream `test/js/node/test/parallel/test-sqlite-*.js`: 147 pass / 0 fail.
- `error-code-mirror.test.ts` passes (Rust/C++ enum alignment is unaffected by the new variant).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/sqlite/node-sqlite.test.ts

<!-- robobun:evidence:end -->