### PR TITLE
fetch: make the idle timer an absolute deadline for the response header block

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3623,14 +3623,8 @@ impl<'a> HTTPClient<'a> {
         // `to_read` is a suffix of `incoming_data` and is copied into the
         // (currently empty) accumulation buffer; otherwise `to_read` is a suffix
         // of `buffer`, so the consumed prefix is drained and `buffer` is moved
-        // back into state.
-        //
-        // Intentionally does NOT re-arm the idle timer: a server that trickles
-        // one header byte per interval shorter than `idle_timeout_seconds`
-        // would otherwise keep the request alive forever. Leaving the timer as
-        // armed by `on_open` / `on_writable` makes it an absolute deadline for
-        // the header block to complete (undici `headersTimeout` semantics); the
-        // body path (`on_data` Body/BodyChunk) still re-arms per chunk.
+        // back into state. Does not re-arm the idle timer (header phase is an
+        // absolute deadline; see [`IDLE_TIMEOUT_SECONDS`]).
         macro_rules! short_read {
             () => {{
                 bun_core::scoped_log!(fetch, "handleShortRead");
@@ -3824,10 +3818,8 @@ impl<'a> HTTPClient<'a> {
         }
 
         if self.proxy_tunnel.is_some() {
-            // Re-arm only once the origin's header block has completed, same as
-            // the non-proxy dispatch below: the inner TLS handshake and the
-            // origin's response headers are bounded absolutely (the timer stays
-            // as armed by `on_writable`), and body chunks re-arm per read.
+            // Body phase only, mirroring the non-proxy dispatch below (header
+            // phase is an absolute deadline; see [`IDLE_TIMEOUT_SECONDS`]).
             if matches!(
                 self.state.response_stage,
                 ResponseStage::Body | ResponseStage::BodyChunk

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3821,11 +3821,11 @@ impl<'a> HTTPClient<'a> {
         if self.proxy_tunnel.is_some() {
             // Body phase only, mirroring the non-proxy dispatch below (header
             // phase is an absolute deadline; see [`IDLE_TIMEOUT_SECONDS`]).
+            debug_assert!(!self.state.flags.receive_paused); // maybe_pause_receive bails on proxy_tunnel
             if matches!(
                 self.state.response_stage,
                 ResponseStage::Body | ResponseStage::BodyChunk
-            ) && !self.state.flags.receive_paused
-            {
+            ) {
                 self.set_timeout(&socket);
             }
             self.proxy_tunnel_mut().unwrap().receive(incoming_data);

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -261,9 +261,10 @@ pub static OVERRIDDEN_DEFAULT_USER_AGENT: std::sync::OnceLock<&'static [u8]> =
     std::sync::OnceLock::new();
 
 /// Idle timeout for HTTP client sockets, in seconds. The timer is armed in
-/// `on_open` (so it covers the TLS handshake) and re-armed on every read/write;
-/// if no bytes move in either direction for this long the request fails with
-/// `error.Timeout`. 0 disables the timer (matching `disable_timeout = true`).
+/// `on_open` (so it covers the TLS handshake) and re-armed on writes and on
+/// body-phase reads; response-header reads do not re-arm it, so it is an
+/// absolute deadline for the header block to complete (undici `headersTimeout`
+/// semantics). 0 disables the timer (matching `disable_timeout = true`).
 /// Overridable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`. Default is 5 minutes — the
 /// previous hard-coded value — so unchanged environments see identical
 /// behaviour except that the handshake phase is now also covered. Values
@@ -3823,8 +3824,17 @@ impl<'a> HTTPClient<'a> {
         }
 
         if self.proxy_tunnel.is_some() {
-            // if we have a tunnel we dont care about the other stages, we will just tunnel the data
-            self.set_timeout(&socket);
+            // Re-arm only once the origin's header block has completed, same as
+            // the non-proxy dispatch below: the inner TLS handshake and the
+            // origin's response headers are bounded absolutely (the timer stays
+            // as armed by `on_writable`), and body chunks re-arm per read.
+            if matches!(
+                self.state.response_stage,
+                ResponseStage::Body | ResponseStage::BodyChunk
+            ) && !self.state.flags.receive_paused
+            {
+                self.set_timeout(&socket);
+            }
             self.proxy_tunnel_mut().unwrap().receive(incoming_data);
             return;
         }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3727,6 +3727,8 @@ impl<'a> HTTPClient<'a> {
                 return;
             }
         };
+        // Headers complete: start the body-idle window fresh (see [`IDLE_TIMEOUT_SECONDS`]).
+        self.set_timeout(&socket);
 
         if (self.state.content_encoding_i as usize) < response.headers.list.len()
             && !self.state.flags.did_set_content_encoding

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3785,7 +3785,6 @@ impl<'a> HTTPClient<'a> {
                 return;
             }
         } else if self.state.response_stage == ResponseStage::BodyChunk {
-            self.set_timeout(&socket);
             let report_progress = match self.handle_response_body_chunked_encoding(to_read) {
                 Ok(b) => b,
                 Err(err) => {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3618,11 +3618,18 @@ impl<'a> HTTPClient<'a> {
             buffer.list.as_slice()
         };
 
-        // Persist the unparsed tail for the next `on_data` and re-arm the
-        // receive timeout. When `needs_move`, `to_read` is a suffix of
-        // `incoming_data` and is copied into the (currently empty) accumulation
-        // buffer; otherwise `to_read` is a suffix of `buffer`, so the consumed
-        // prefix is drained and `buffer` is moved back into state.
+        // Persist the unparsed tail for the next `on_data`. When `needs_move`,
+        // `to_read` is a suffix of `incoming_data` and is copied into the
+        // (currently empty) accumulation buffer; otherwise `to_read` is a suffix
+        // of `buffer`, so the consumed prefix is drained and `buffer` is moved
+        // back into state.
+        //
+        // Intentionally does NOT re-arm the idle timer: a server that trickles
+        // one header byte per interval shorter than `idle_timeout_seconds`
+        // would otherwise keep the request alive forever. Leaving the timer as
+        // armed by `on_open` / `on_writable` makes it an absolute deadline for
+        // the header block to complete (undici `headersTimeout` semantics); the
+        // body path (`on_data` Body/BodyChunk) still re-arms per chunk.
         macro_rules! short_read {
             () => {{
                 bun_core::scoped_log!(fetch, "handleShortRead");
@@ -3638,7 +3645,6 @@ impl<'a> HTTPClient<'a> {
                         .drain_front(buffer.list.len().saturating_sub(keep));
                     self.state.response_message_buffer = buffer;
                 }
-                self.set_timeout(&socket);
                 return;
             }};
         }

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3068,3 +3068,83 @@ it("an explicit numeric `timeout` extends the socket idle deadline past the defa
   expect(out.withDefault).toStartWith("ERR:");
   expect(exitCode).toBe(0);
 }, 60_000);
+
+it("the idle timer is an absolute deadline for the response header block (not re-armed by a byte drip)", async () => {
+  // A server that trickles one response-header byte at a time, each interval
+  // shorter than the request's idle timeout, must not be able to keep the
+  // request alive indefinitely. The idle timer is armed when the request is
+  // written and is not re-armed on partial header reads, so it bounds how long
+  // the header block may take to arrive in total (undici `headersTimeout`
+  // semantics). Once the header block completes the body path re-arms per
+  // chunk, so a slow-but-steady body is still accepted.
+  const HEAD = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n";
+  const BODY = "hello";
+  const DRIP_MS = 2_000;
+  const DRIP_N = 10; // header drip sends this many single bytes, then the rest at once
+  const IDLE_MS = 5_000;
+
+  const sockets = new Set<net.Socket>();
+  const intervals = new Set<ReturnType<typeof setInterval>>();
+  const reset = () => {
+    for (const iv of intervals) clearInterval(iv);
+    intervals.clear();
+    for (const s of sockets) s.destroy();
+    sockets.clear();
+  };
+  const server = net.createServer(sock => {
+    sockets.add(sock);
+    sock.on("close", () => sockets.delete(sock));
+    sock.on("error", () => {});
+    sock.once("data", chunk => {
+      // /h drips DRIP_N header bytes then bursts the rest + body.
+      // /b bursts the header block then drips the body byte-by-byte.
+      const headerDrip = chunk.includes("/h ");
+      if (!headerDrip) sock.write(HEAD);
+      const dripped = headerDrip ? HEAD.slice(0, DRIP_N) : BODY;
+      const tail = headerDrip ? HEAD.slice(DRIP_N) + BODY : "";
+      let i = 0;
+      const iv = setInterval(() => {
+        if (sock.destroyed) {
+          clearInterval(iv);
+          intervals.delete(iv);
+          return;
+        }
+        if (i < dripped.length) {
+          sock.write(dripped[i++]);
+        } else {
+          clearInterval(iv);
+          intervals.delete(iv);
+          sock.end(tail);
+        }
+      }, DRIP_MS);
+      intervals.add(iv);
+    });
+  });
+  await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as AddressInfo).port;
+
+  try {
+    const settle = (path: string) =>
+      fetch(`http://127.0.0.1:${port}${path}`, { timeout: IDLE_MS }).then(
+        async r => ({ ok: true as const, status: r.status, body: await r.text() }),
+        e => ({ ok: false as const, name: e?.name as string, message: String(e?.message ?? e) }),
+      );
+
+    // Header drip: DRIP_N bytes * DRIP_MS = ~20s of drip before the response
+    // would complete. The 5s idle deadline (served by uSockets' 4s-tick sweep,
+    // so worst case ~9s) must fire first. On a build that re-arms the timer on
+    // every partial header read this resolves with 200 after the full drip.
+    const hdr = await settle("/h");
+    expect(hdr).toEqual({ ok: false, name: "TimeoutError", message: "The operation timed out." });
+    reset();
+
+    // Body drip: headers arrive in one write, then the 5-byte body trickles at
+    // DRIP_MS/byte (~10s total). Each body chunk re-arms the idle timer, so
+    // this resolves despite taking longer than IDLE_MS overall.
+    const bod = await settle("/b");
+    expect(bod).toEqual({ ok: true, status: 200, body: "hello" });
+  } finally {
+    reset();
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}, 60_000);

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3077,20 +3077,14 @@ it("the idle timer is an absolute deadline for the response header block (not re
   // the header block may take to arrive in total (undici `headersTimeout`
   // semantics). Once the header block completes the body path re-arms per
   // chunk, so a slow-but-steady body is still accepted.
-  const HEAD = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n";
-  const BODY = "hello";
+  const BODY = "abc";
+  const HEAD = `HTTP/1.1 200 OK\r\nContent-Length: ${BODY.length}\r\n\r\n`;
   const DRIP_MS = 2_000;
   const DRIP_N = 10; // header drip sends this many single bytes, then the rest at once
   const IDLE_MS = 5_000;
 
   const sockets = new Set<net.Socket>();
   const intervals = new Set<ReturnType<typeof setInterval>>();
-  const reset = () => {
-    for (const iv of intervals) clearInterval(iv);
-    intervals.clear();
-    for (const s of sockets) s.destroy();
-    sockets.clear();
-  };
   const server = net.createServer(sock => {
     sockets.add(sock);
     sock.on("close", () => sockets.delete(sock));
@@ -3130,21 +3124,21 @@ it("the idle timer is an absolute deadline for the response header block (not re
         e => ({ ok: false as const, name: e?.name as string, message: String(e?.message ?? e) }),
       );
 
-    // Header drip: DRIP_N bytes * DRIP_MS = ~20s of drip before the response
-    // would complete. The 5s idle deadline (served by uSockets' 4s-tick sweep,
-    // so worst case ~9s) must fire first. On a build that re-arms the timer on
-    // every partial header read this resolves with 200 after the full drip.
-    const hdr = await settle("/h");
-    expect(hdr).toEqual({ ok: false, name: "TimeoutError", message: "The operation timed out." });
-    reset();
-
-    // Body drip: headers arrive in one write, then the 5-byte body trickles at
-    // DRIP_MS/byte (~10s total). Each body chunk re-arms the idle timer, so
-    // this resolves despite taking longer than IDLE_MS overall.
-    const bod = await settle("/b");
-    expect(bod).toEqual({ ok: true, status: 200, body: "hello" });
+    // /h: DRIP_N bytes * DRIP_MS = ~20s of drip before the response would
+    // complete; the 5s idle deadline (uSockets 4s-tick sweep, so ~5-9s) must
+    // fire first. A build that re-arms on every partial header read resolves
+    // 200 after the full drip instead.
+    // /b: headers arrive in one write, then the 3-byte body trickles at
+    // DRIP_MS/byte (~8s). Each body chunk re-arms the idle timer, so this
+    // resolves despite taking longer than IDLE_MS overall.
+    const [hdr, bod] = await Promise.all([settle("/h"), settle("/b")]);
+    expect({ hdr, bod }).toEqual({
+      hdr: { ok: false, name: "TimeoutError", message: "The operation timed out." },
+      bod: { ok: true, status: 200, body: BODY },
+    });
   } finally {
-    reset();
+    for (const iv of intervals) clearInterval(iv);
+    for (const s of sockets) s.destroy();
     await new Promise<void>(r => server.close(() => r()));
   }
 }, 60_000);


### PR DESCRIPTION
A server that trickles one response-header byte at a time, each interval shorter than the request's idle timeout, can keep a `fetch()` alive indefinitely. The HTTP client re-arms its socket idle timer inside the `short_read!` path of `handle_on_data_headers`, so every dripped byte resets the clock. A fully silent stall in the same phase is already bounded by the same timer (armed at `on_open`); only the drip defeats it.

## Reproduction

```js
import net from "net";
const FULL = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
const server = net.createServer(sock => {
  sock.on("data", () => {});
  let i = 0;
  const iv = setInterval(() => {
    if (sock.destroyed) return clearInterval(iv);
    if (i < 10) sock.write(FULL[i++]);
    else { clearInterval(iv); sock.end(FULL.slice(i)); }
  }, 2000);
});
await new Promise(r => server.listen(0, "127.0.0.1", r));
await fetch(`http://127.0.0.1:${server.address().port}/`, { timeout: 5000 });
// 1.4.0-canary: resolves 200 after ~22s. With this change: TimeoutError at ~5-9s.
```

The same shape with no bytes written (silent stall) already rejects with `TimeoutError: The operation timed out.` on the existing build, so `AbortSignal.timeout()` is the only way to bound the drip case today.

## Change

- Drop the `set_timeout` call from `short_read!` in `handle_on_data_headers`. The timer stays as armed by `on_open` / `on_writable`, so it is an absolute deadline for the header block (undici `headersTimeout` semantics).
- Gate the proxy-tunnel `on_data` re-arm on `response_stage == Body | BodyChunk`, mirroring the non-proxy dispatch, so the same deadline holds for HTTPS through a CONNECT proxy.
- Re-arm once right after `handle_response_metadata` succeeds so the body phase starts with a fresh idle window rather than whatever was left of the header deadline (folded from #36146). Body reads continue to re-arm per chunk (undici `bodyTimeout` semantics).
- Update the `IDLE_TIMEOUT_SECONDS` doc comment to describe the new header-phase behaviour.

The default deadline is unchanged (300 s / `BUN_CONFIG_HTTP_IDLE_TIMEOUT` / per-request `timeout`), and `{timeout: false}` still disables it.

## Verification

New test in `test/js/web/fetch/fetch.test.ts`: a raw `net.Server` drips 10 header bytes at 2 s each against `{timeout: 5000}` and must reject with `TimeoutError`, then drips a 5-byte body after a burst header block and must resolve with 200.

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch.test.ts -t "absolute deadline"
(fail)  header drip resolves {status: 200, body: "hello"} after 22011 ms

$ bun bd test test/js/web/fetch/fetch.test.ts -t "absolute deadline"
(pass)  [18250 ms]
```

`bun-install-stalled-tls.test.ts`, `fetch-keepalive.test.ts`, the adjacent "explicit numeric \`timeout\` extends the socket idle deadline" test, and `proxy.test.ts` / `proxy-stress-lifecycle.test.ts` / `proxy-stress-matrix.test.ts` (496 proxy tests total, including the trickled-tunnel-bytes cases) all pass on the debug build.

## Scope

HTTP/1 only. Related: #33338 adds `connectTimeout` / `socketTimeout` / whole-request `timeout` as per-request options with no change to the header-phase re-arm; this change is independent and composes with it. A `headersTimeout` option distinct from the body-phase idle value can follow once the per-request plumbing in #33338 lands.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->