### PR TITLE
fetch: make the response-header phase an absolute deadline

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3618,11 +3618,18 @@ impl<'a> HTTPClient<'a> {
             buffer.list.as_slice()
         };
 
-        // Persist the unparsed tail for the next `on_data` and re-arm the
-        // receive timeout. When `needs_move`, `to_read` is a suffix of
-        // `incoming_data` and is copied into the (currently empty) accumulation
-        // buffer; otherwise `to_read` is a suffix of `buffer`, so the consumed
-        // prefix is drained and `buffer` is moved back into state.
+        // Persist the unparsed tail for the next `on_data`. When `needs_move`,
+        // `to_read` is a suffix of `incoming_data` and is copied into the
+        // (currently empty) accumulation buffer; otherwise `to_read` is a
+        // suffix of `buffer`, so the consumed prefix is drained and `buffer`
+        // is moved back into state.
+        //
+        // Deliberately does NOT re-arm the socket timer: the timer armed at
+        // request-write time stays monotonic for the whole response-header
+        // phase, so it acts as an absolute headers deadline (undici's
+        // `headersTimeout`). Re-arming here let a server that drips one
+        // header line per <idle-timeout> pin the request forever. The timer
+        // is re-armed below once headers are complete, for the body phase.
         macro_rules! short_read {
             () => {{
                 bun_core::scoped_log!(fetch, "handleShortRead");
@@ -3638,7 +3645,6 @@ impl<'a> HTTPClient<'a> {
                         .drain_front(buffer.list.len().saturating_sub(keep));
                     self.state.response_message_buffer = buffer;
                 }
-                self.set_timeout(&socket);
                 return;
             }};
         }
@@ -3726,6 +3732,12 @@ impl<'a> HTTPClient<'a> {
                 return;
             }
         };
+
+        // Headers are complete: re-arm the idle timer for the body phase.
+        // `short_read!()` above deliberately leaves the timer untouched so the
+        // header phase has an absolute deadline; this is the boundary where
+        // the body-idle semantics begin.
+        self.set_timeout(&socket);
 
         if (self.state.content_encoding_i as usize) < response.headers.list.len()
             && !self.state.flags.did_set_content_encoding

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3068,3 +3068,95 @@ it("an explicit numeric `timeout` extends the socket idle deadline past the defa
   expect(out.withDefault).toStartWith("ERR:");
   expect(exitCode).toBe(0);
 }, 60_000);
+
+// The response-header phase is an absolute deadline, not an idle timer: a
+// server that drips one header line per second must still time out. Before the
+// fix, every partial-header read re-armed the idle timer, so a drip faster
+// than the idle window pinned the request (and its socket/request-cap slot)
+// forever; undici rejects the same drip with HeadersTimeoutError.
+it("a dripping response header does not reset the idle timer", async () => {
+  // The child runs with BUN_CONFIG_HTTP_IDLE_TIMEOUT=5 (2 ticks of uSockets'
+  // 4s sweep; 1-4s map to a single tick and would fire on the next sweep
+  // regardless of re-arming, which would mask the bug) and talks to a raw TCP
+  // server.
+  //   /drip: writes the status line then one header line every second, never
+  //          finishing the header block. Each drip is well under the 5s idle
+  //          window, so an idle timer would never fire. The header-phase
+  //          deadline must fire anyway (within ~8s).
+  //   /body: writes complete headers immediately, then one body byte every
+  //          second for 12s. Body bytes must still re-arm the idle timer, so
+  //          this resolves with the full payload even though it runs longer
+  //          than the header deadline.
+  const script = /* js */ `
+    const net = require("node:net");
+    const DRIP_MS = 1000;
+    const BODY_CHUNKS = 12;
+    const WATCHDOG_MS = 20_000;
+    const srv = net.createServer(s => {
+      s.on("error", () => {});
+      s.once("data", d => {
+        if (d.includes("GET /drip")) {
+          s.write("HTTP/1.1 200 OK\\r\\n");
+          let n = 0;
+          const iv = setInterval(
+            () => (s.destroyed ? clearInterval(iv) : s.write("X-Drip-" + n++ + ": v\\r\\n")),
+            DRIP_MS,
+          );
+        } else {
+          s.write("HTTP/1.1 200 OK\\r\\nConnection: close\\r\\n\\r\\n");
+          let n = 0;
+          const iv = setInterval(() => {
+            if (s.destroyed) return clearInterval(iv);
+            s.write("x");
+            if (++n === BODY_CHUNKS) { clearInterval(iv); s.end(); }
+          }, DRIP_MS);
+        }
+      });
+    });
+    await new Promise(r => srv.listen(0, "127.0.0.1", r));
+    const base = "http://127.0.0.1:" + srv.address().port;
+    const t0 = Date.now();
+    const pending = tag => new Promise(r => setTimeout(r, WATCHDOG_MS, { [tag]: "pending" }));
+    const [drip, body] = await Promise.all([
+      Promise.race([
+        fetch(base + "/drip").then(
+          () => ({ drip: "resolved" }),
+          e => ({ drip: String(e?.name ?? e?.code ?? e), ms: Date.now() - t0 }),
+        ),
+        pending("drip"),
+      ]),
+      Promise.race([
+        fetch(base + "/body").then(r => r.text()).then(
+          t => ({ body: "ok", len: t.length }),
+          e => ({ body: "ERR:" + (e?.name ?? e?.code ?? e) }),
+        ),
+        pending("body"),
+      ]),
+    ]);
+    console.log(JSON.stringify({ ...drip, ...body }));
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, BUN_CONFIG_HTTP_IDLE_TIMEOUT: "5" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout.trim().split("\n").pop()!) as {
+    drip: string;
+    ms?: number;
+    body: string;
+    len?: number;
+  };
+  // /body dripped for ~12s at 1s/byte with a 5s idle window and still
+  // resolved: body bytes still re-arm the idle timer.
+  expect({ body: out.body, len: out.len }).toEqual({ body: "ok", len: 12 });
+  // /drip must have rejected with a timeout inside the watchdog window.
+  // Before the fix this stayed "pending": every dripped header line re-armed
+  // the 5s idle timer, and 1s < 5s keeps it ahead of the sweep forever.
+  expect(out.drip).toMatch(/Timeout/i);
+  expect(out.ms).toBeLessThan(20_000);
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
The HTTP/1.1 client's only response-phase bound is the socket idle timer (default 300s, `BUN_CONFIG_HTTP_IDLE_TIMEOUT`), armed at `on_open` and re-armed on every read. `handle_on_data_headers`' short-read path re-armed it on each partial header chunk, so a server that drips one header line per `<idle-timeout>` pins the request, its socket, and a request-cap slot indefinitely. Every other stalled-response state (silent TLS handshake, zero response bytes, mid-headers silence, mid-body stall) times out; the drip is the one state that does not. undici rejects the identical drip with `HeadersTimeoutError` at its absolute 300s headers deadline.

## Repro

```js
import net from "node:net";
const srv = net.createServer(s => {
  s.once("data", () => {
    s.write("HTTP/1.1 200 OK\r\n");
    let n = 0;
    setInterval(() => s.write(`X-Drip-${n++}: v\r\n`), 1000);
  });
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));
await fetch(`http://127.0.0.1:${srv.address().port}/`);
```

```console
$ BUN_CONFIG_HTTP_IDLE_TIMEOUT=5 bun repro.mjs
# never resolves or rejects; each 1s drip re-arms the 5s idle timer
```

The only way to bound this today is `AbortSignal.timeout(N)`.

## Cause

`src/http/lib.rs` `handle_on_data_headers` `short_read!()` called `self.set_timeout(&socket)` on every partial parse, so any header byte reset the idle window.

## Fix

Drop the re-arm from `short_read!()` so the timer armed at request-write stays monotonic for the whole response-header phase, turning it into an absolute headers deadline (undici parity). Re-arm once after `handle_response_metadata` succeeds so the body phase starts with a fresh idle window; body reads continue to re-arm per byte as before.

## Verification

`test/js/web/fetch/fetch.test.ts` gains a test that spawns a child with `BUN_CONFIG_HTTP_IDLE_TIMEOUT=5` against a raw TCP server. `/drip` drips one header line per second and never finishes the header block; `/body` sends complete headers immediately then drips one body byte per second for 12s. `/drip` must reject with `TimeoutError` inside the watchdog window (it stayed `"pending"` before); `/body` must still resolve with the full payload, proving body-idle re-arm is preserved.

The idle window is 5s because that is the smallest value that maps to two uSockets sweep ticks (`(seconds+3)>>2`). 1-4s map to a single tick and fire on the next 4s sweep regardless of re-arming, which would mask the bug.

```console
$ bun bd test test/js/web/fetch/fetch.test.ts -t "dripping response header"
 1 pass, 0 fail

$ USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch.test.ts -t "dripping response header"
error: expect(received).toMatch(expected)
Expected substring or pattern: /Timeout/i
Received: "pending"
 0 pass, 1 fail
```

The neighbouring `{timeout: N}` idle-override test and `fetch-keepalive.test.ts` pass unchanged.

Related to #2994 (connect-phase timeout) and complementary to #33338, which adds per-request timeout option names but keeps the re-arm on every read, so a header drip would still pin `socketTimeout`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->