### PR TITLE
test(util-inspect): sample surrogate boundaries instead of all 2047 code units

### DIFF
--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -779,7 +779,8 @@ test("no assertion failures 2", () => {
   {
     const edgeChar = String.fromCharCode(0xd799);
 
-    for (let charCode = 0xd800; charCode < 0xdfff; charCode++) {
+    // Upstream walks all 2047 surrogate code units; the escape is a range check, so cover the boundaries.
+    for (const charCode of [0xd800, 0xd801, 0xda00, 0xdbfe, 0xdbff, 0xdc00, 0xdc01, 0xde00, 0xdffd, 0xdffe]) {
       const surrogate = String.fromCharCode(charCode);
 
       assert.strictEqual(util.inspect(surrogate), `'\\u${charCode.toString(16)}'`);


### PR DESCRIPTION
## Problem

`bun bd test test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js` fails locally on main:

```
(fail) no assertion failures 2 [7810.78ms]
  ^ this test timed out after 5000ms.
```

CI doesn't see it because `scripts/runner.node.mjs` overrides the per-test timeout.

## Cause

The unpaired-surrogate escape block walks every code unit from `0xd800` to `0xdffe` (2047 iterations, ~9k `util.inspect` calls with 200-char strings). Under a debug+ASAN build that loop alone runs for ~4.3s; the rest of the 1500-line test body pushes it over 5s.

## Fix

inspect.js detects lone surrogates with a range regex (`[\\ud800-\\udbff]` / `[\\udc00-\\udfff]`) and a single `>= 0xd800 && <= 0xdfff` compare; there is no per-codepoint table. The 10 boundary/interior samples below cover both high-surrogate and low-surrogate branches, including the exact transition points `0xdbff`/`0xdc00`:

```js
[0xd800, 0xd801, 0xda00, 0xdbfe, 0xdbff, 0xdc00, 0xdc01, 0xde00, 0xdffd, 0xdffe]
```

REVIEW.md: "Don't raise per-test timeouts to make a slow test pass; shrink the workload."

## Verification

```
$ bun bd test test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
(pass) no assertion failures [278.65ms]
(pass) inspect from a different context [68.81ms]
(pass) no assertion failures 2 [2092.55ms]
(pass) util.inspect stack overflow handling [510.42ms]
(pass) no assertion failures 3 [2944.85ms]
Ran 5 tests across 1 file. [8.55s]
```

Release build still runs the same assertions in a few ms.

## Note

#36138 carries a ride-along for this as part of its `builtInObjects` change (moving the block to its own test with `step = isDebug ? 17 : 1`). A stride of 17 from `0xd800` lands on `0xdbfc` then `0xdc0d`, skipping the `0xdbff`/`0xdc00` boundary. This PR is the standalone minimal version; happy to close if #36138 lands first.

This change is test-only; there is no `src/` diff to prove fail-before against.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->