### PR TITLE
fetch(tls): surface ERR_OSSL_* for bad client cert/key instead of FailedToOpenSocket

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -494,19 +494,9 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     uws::create_bun_socket_error_t::none
                     | uws::create_bun_socket_error_t::invalid_ciphers
                     | uws::create_bun_socket_error_t::invalid_ecdh_curve => {
-                        // us_ssl_ctx_build_raw returns NULL with *err left at
-                        // .none for client cert/key/passphrase failures; the
-                        // real cause is only on this thread's BoringSSL error
-                        // queue. Capture it here (same thread as the failed
-                        // SSL_CTX_* calls) so the JS thread can surface
-                        // ERR_OSSL_* instead of a generic FailedToOpenSocket.
-                        let packed = bun_boringssl_sys::ERR_get_error();
-                        if packed != 0 {
-                            bun_boringssl_sys::ERR_clear_error();
-                            InitError::ClientTLSSetup(packed)
-                        } else {
-                            InitError::FailedToOpenSocket
-                        }
+                        crate::error::take_boringssl_error()
+                            .map(|p| InitError::ClientTLSSetup(p.get()))
+                            .unwrap_or(InitError::FailedToOpenSocket)
                     }
                 });
             }

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -494,7 +494,19 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     uws::create_bun_socket_error_t::none
                     | uws::create_bun_socket_error_t::invalid_ciphers
                     | uws::create_bun_socket_error_t::invalid_ecdh_curve => {
-                        InitError::FailedToOpenSocket
+                        // us_ssl_ctx_build_raw returns NULL with *err left at
+                        // .none for client cert/key/passphrase failures; the
+                        // real cause is only on this thread's BoringSSL error
+                        // queue. Capture it here (same thread as the failed
+                        // SSL_CTX_* calls) so the JS thread can surface
+                        // ERR_OSSL_* instead of a generic FailedToOpenSocket.
+                        let packed = bun_boringssl_sys::ERR_get_error();
+                        if packed != 0 {
+                            bun_boringssl_sys::ERR_clear_error();
+                            InitError::ClientTLSSetup(packed)
+                        } else {
+                            InitError::FailedToOpenSocket
+                        }
                     }
                 });
             }

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -370,7 +370,7 @@ fn on_init_error_noop(err: InitError, opts: &InitOpts) -> ! {
         InitError::InvalidCRL => {
             Output::err("HTTPThread", "the provided CRL is invalid", ());
         }
-        InitError::FailedToOpenSocket => {
+        InitError::FailedToOpenSocket | InitError::ClientTLSSetup(_) => {
             bun_core::err_generic!("failed to start HTTP client thread");
         }
     }
@@ -543,6 +543,7 @@ impl HttpThread {
 
                     return Err(match err {
                         InitError::InvalidCRL => crate::Error::InvalidCRL,
+                        InitError::ClientTLSSetup(code) => crate::Error::ClientTLSSetup(code),
                         InitError::FailedToOpenSocket
                         | InitError::InvalidCA
                         | InitError::InvalidCAFile

--- a/src/http/InitError.rs
+++ b/src/http/InitError.rs
@@ -10,4 +10,9 @@ pub enum InitError {
     InvalidCA,
     #[error("InvalidCRL")]
     InvalidCRL,
+    /// SSL_CTX construction failed while loading client cert/key material.
+    /// Carries the packed BoringSSL error (from `ERR_get_error()`), captured on
+    /// the thread that built the context so the JS thread can format it later.
+    #[error("ClientTLSSetup")]
+    ClientTLSSetup(u32),
 }

--- a/src/http/InitError.rs
+++ b/src/http/InitError.rs
@@ -10,8 +10,7 @@ pub enum InitError {
     InvalidCA,
     #[error("InvalidCRL")]
     InvalidCRL,
-    /// Client cert/key failed to load into the SSL_CTX; payload is the packed
-    /// BoringSSL error from [`crate::error::take_boringssl_error`].
+    /// Packed BoringSSL error from [`crate::error::take_boringssl_error`].
     #[error("ClientTLSSetup")]
     ClientTLSSetup(u32),
 }

--- a/src/http/InitError.rs
+++ b/src/http/InitError.rs
@@ -10,9 +10,8 @@ pub enum InitError {
     InvalidCA,
     #[error("InvalidCRL")]
     InvalidCRL,
-    /// SSL_CTX construction failed while loading client cert/key material.
-    /// Carries the packed BoringSSL error (from `ERR_get_error()`), captured on
-    /// the thread that built the context so the JS thread can format it later.
+    /// Client cert/key failed to load into the SSL_CTX; payload is the packed
+    /// BoringSSL error from [`crate::error::take_boringssl_error`].
     #[error("ClientTLSSetup")]
     ClientTLSSetup(u32),
 }

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -628,9 +628,19 @@ impl ProxyTunnel {
                     bun_core::out_of_memory();
                 }
 
-                // invalid TLS Options
+                // invalid TLS Options: create_ssl_context leaves the detail
+                // on this thread's BoringSSL error queue (same thread as the
+                // failed SSL_CTX_* calls). Surface it the way the direct
+                // (non-proxy) path does instead of a generic ConnectionRefused.
+                let packed = bun_boringssl_sys::ERR_get_error();
+                let fail = if packed != 0 {
+                    bun_boringssl_sys::ERR_clear_error();
+                    crate::Error::ClientTLSSetup(packed)
+                } else {
+                    crate::Error::ConnectionRefused
+                };
                 proxy_tunnel_ref.detach_and_deref();
-                this.close_and_fail::<IS_SSL>(crate::Error::ConnectionRefused, socket);
+                this.close_and_fail::<IS_SSL>(fail, socket);
                 return;
             }
         }

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -627,18 +627,9 @@ impl ProxyTunnel {
                 if e == InitError::OutOfMemory {
                     bun_core::out_of_memory();
                 }
-
-                // invalid TLS Options: create_ssl_context leaves the detail
-                // on this thread's BoringSSL error queue (same thread as the
-                // failed SSL_CTX_* calls). Surface it the way the direct
-                // (non-proxy) path does instead of a generic ConnectionRefused.
-                let packed = bun_boringssl_sys::ERR_get_error();
-                let fail = if packed != 0 {
-                    bun_boringssl_sys::ERR_clear_error();
-                    crate::Error::ClientTLSSetup(packed)
-                } else {
-                    crate::Error::ConnectionRefused
-                };
+                let fail = crate::error::take_boringssl_error()
+                    .map(|p| crate::Error::ClientTLSSetup(p.get()))
+                    .unwrap_or(crate::Error::ConnectionRefused);
                 proxy_tunnel_ref.detach_and_deref();
                 this.close_and_fail::<IS_SSL>(fail, socket);
                 return;

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -93,6 +93,11 @@ pub enum Error {
     HTTP3ContentLengthMismatch,
     #[error("FailedToOpenSocket")]
     FailedToOpenSocket,
+    /// Loading the client TLS certificate/key into the SSL_CTX failed. Carries
+    /// the packed BoringSSL error code so the consumer can produce Node's
+    /// `ERR_OSSL_*` shape.
+    #[error("ClientTLSSetup")]
+    ClientTLSSetup(u32),
     #[error("InvalidCRL")]
     InvalidCRL,
     #[error("UnsupportedProxyProtocol")]
@@ -306,6 +311,7 @@ impl Error {
             Self::HTTP3StreamReset => "HTTP3StreamReset",
             Self::HTTP3ContentLengthMismatch => "HTTP3ContentLengthMismatch",
             Self::FailedToOpenSocket => "FailedToOpenSocket",
+            Self::ClientTLSSetup(_) => "ClientTLSSetup",
             Self::InvalidCRL => "InvalidCRL",
             Self::UnsupportedProxyProtocol => "UnsupportedProxyProtocol",
             Self::Cert(e) => <&'static str>::from(e),

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -93,9 +93,8 @@ pub enum Error {
     HTTP3ContentLengthMismatch,
     #[error("FailedToOpenSocket")]
     FailedToOpenSocket,
-    /// Loading the client TLS certificate/key into the SSL_CTX failed. Carries
-    /// the packed BoringSSL error code so the consumer can produce Node's
-    /// `ERR_OSSL_*` shape.
+    /// Client cert/key failed to load into the SSL_CTX; payload is the packed
+    /// BoringSSL error that becomes `ERR_OSSL_*` at the JS boundary.
     #[error("ClientTLSSetup")]
     ClientTLSSetup(u32),
     #[error("InvalidCRL")]
@@ -259,6 +258,15 @@ pub enum CertError {
     NAME_CONSTRAINTS_WITHOUT_SANS,
     #[error("UNKNOWN_CERTIFICATE_VERIFICATION_ERROR")]
     UNKNOWN_CERTIFICATE_VERIFICATION_ERROR,
+}
+
+/// Pop + drain this thread's BoringSSL error queue. Call immediately after a
+/// failed `create_ssl_context` on the same thread (the queue is thread-local).
+pub fn take_boringssl_error() -> Option<core::num::NonZeroU32> {
+    let packed = bun_boringssl_sys::ERR_get_error();
+    let packed = core::num::NonZeroU32::new(packed)?;
+    bun_boringssl_sys::ERR_clear_error();
+    Some(packed)
 }
 
 impl Error {

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -93,8 +93,7 @@ pub enum Error {
     HTTP3ContentLengthMismatch,
     #[error("FailedToOpenSocket")]
     FailedToOpenSocket,
-    /// Client cert/key failed to load into the SSL_CTX; payload is the packed
-    /// BoringSSL error that becomes `ERR_OSSL_*` at the JS boundary.
+    /// Packed BoringSSL error from [`take_boringssl_error`]; surfaces as `ERR_OSSL_*`.
     #[error("ClientTLSSetup")]
     ClientTLSSetup(u32),
     #[error("InvalidCRL")]
@@ -260,8 +259,7 @@ pub enum CertError {
     UNKNOWN_CERTIFICATE_VERIFICATION_ERROR,
 }
 
-/// Pop + drain this thread's BoringSSL error queue. Call immediately after a
-/// failed `create_ssl_context` on the same thread (the queue is thread-local).
+/// Pop+drain the thread-local BoringSSL error queue right after a failed `create_ssl_context`.
 pub fn take_boringssl_error() -> Option<core::num::NonZeroU32> {
     let packed = bun_boringssl_sys::ERR_get_error();
     let packed = core::num::NonZeroU32::new(packed)?;

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1275,7 +1275,7 @@ fn http_thread_on_init_error(err: http::InitError, opts: &http::http_thread::Ini
         http::InitError::InvalidCRL => {
             Output::err("HTTPThread", "the CRL is invalid", ());
         }
-        http::InitError::FailedToOpenSocket => {
+        http::InitError::FailedToOpenSocket | http::InitError::ClientTLSSetup(_) => {
             Output::err_generic("failed to start HTTP client thread", ());
         }
     }

--- a/src/runtime/crypto/boringssl_jsc.rs
+++ b/src/runtime/crypto/boringssl_jsc.rs
@@ -52,10 +52,8 @@ fn static_cstr<'a>(ptr: *const core::ffi::c_char) -> Option<&'a [u8]> {
     if bytes.is_empty() { None } else { Some(bytes) }
 }
 
-/// Node's `ERR_OSSL_<LIB>_<REASON>` (or `ERR_SSL_<REASON>`) code string.
 fn build_err_ossl_code(err_code: u32, reason: &[u8]) -> Vec<u8> {
     let lib = lib_short_name((err_code >> 24) & 0xff);
-    // Don't generate codes like "ERR_OSSL_SSL_".
     let prefix = if lib == "SSL_" { "" } else { "OSSL_" };
     let mut code = Vec::with_capacity(4 + prefix.len() + lib.len() + reason.len());
     code.extend_from_slice(b"ERR_");
@@ -65,8 +63,7 @@ fn build_err_ossl_code(err_code: u32, reason: &[u8]) -> Vec<u8> {
     code
 }
 
-/// JSC-free `(code, message)` formatter for a packed BoringSSL error. Pure
-/// table lookups on the `u32`, so callable from any thread.
+/// JSC-free `(ERR_OSSL_* code, message)` for a packed BoringSSL error; thread-agnostic lookup.
 pub fn err_code_and_message(err_code: u32) -> (Vec<u8>, Vec<u8>) {
     let mut outbuf = [0u8; 128 + 1];
     // SAFETY: outbuf is a valid writable buffer of outbuf.len() bytes.

--- a/src/runtime/crypto/boringssl_jsc.rs
+++ b/src/runtime/crypto/boringssl_jsc.rs
@@ -52,6 +52,22 @@ fn static_cstr<'a>(ptr: *const core::ffi::c_char) -> Option<&'a [u8]> {
     if bytes.is_empty() { None } else { Some(bytes) }
 }
 
+/// Compose Node's `ERR_OSSL_<LIB>_<REASON>` code (or `ERR_SSL_<REASON>` for the
+/// SSL library) from a packed BoringSSL error's library number and reason
+/// string. Shared by [`err_code_and_message`] and [`err_to_js`] so the two
+/// paths cannot drift.
+fn build_err_ossl_code(err_code: u32, reason: &[u8]) -> Vec<u8> {
+    let lib = lib_short_name((err_code >> 24) & 0xff);
+    // Don't generate codes like "ERR_OSSL_SSL_".
+    let prefix = if lib == "SSL_" { "" } else { "OSSL_" };
+    let mut code = Vec::with_capacity(4 + prefix.len() + lib.len() + reason.len());
+    code.extend_from_slice(b"ERR_");
+    code.extend_from_slice(prefix.as_bytes());
+    code.extend_from_slice(lib.as_bytes());
+    code.extend_from_slice(reason);
+    code
+}
+
 /// Format a packed BoringSSL error into `(code, message)` strings without
 /// touching JSC. `code` is Node's `ERR_OSSL_<LIB>_<REASON>` (or `ERR_SSL_*` for
 /// the SSL library); `message` is the raw `ERR_error_string_n` output. Both
@@ -69,18 +85,9 @@ pub fn err_code_and_message(err_code: u32) -> (Vec<u8>, Vec<u8>) {
     }
     let message = bun_core::slice_to_nul(&outbuf[..]).to_vec();
 
-    let code = if let Some(reason) = static_cstr(boring::ERR_reason_error_string(err_code)) {
-        let lib = lib_short_name((err_code >> 24) & 0xff);
-        let prefix = if lib == "SSL_" { "" } else { "OSSL_" };
-        let mut code = Vec::with_capacity(4 + prefix.len() + lib.len() + reason.len());
-        code.extend_from_slice(b"ERR_");
-        code.extend_from_slice(prefix.as_bytes());
-        code.extend_from_slice(lib.as_bytes());
-        code.extend_from_slice(reason);
-        code
-    } else {
-        Vec::new()
-    };
+    let code = static_cstr(boring::ERR_reason_error_string(err_code))
+        .map(|reason| build_err_ossl_code(err_code, reason))
+        .unwrap_or_default();
 
     (code, message)
 }
@@ -89,19 +96,7 @@ pub fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
     // The message is the raw ERR_error_string output
     // ("error:0b000074:X.509 certificate routines:OPENSSL_internal:..."),
     // exactly what Node built against BoringSSL produces - no prefix.
-    let mut outbuf = [0u8; 128 + 1];
-    let message_buf = &mut outbuf[..];
-
-    // SAFETY: message_buf is a valid writable buffer of message_buf.len() bytes.
-    unsafe {
-        boring::ERR_error_string_n(
-            err_code,
-            message_buf.as_mut_ptr().cast::<core::ffi::c_char>(),
-            message_buf.len(),
-        );
-    }
-
-    let error_message: &[u8] = bun_core::slice_to_nul(&outbuf[..]);
+    let (code, error_message) = err_code_and_message(err_code);
     if error_message.is_empty() {
         return global
             .err(
@@ -114,9 +109,7 @@ pub fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
     // A plain Error carrying Node's library/function/reason/code decomposition
     // of the OpenSSL error, the way ThrowCryptoError builds it: the code is
     // ERR_OSSL_<LIB>_<REASON> (or ERR_SSL_<REASON> for the SSL library).
-    // The message must own its bytes - `outbuf` is a stack buffer and the
-    // error instance outlives this frame.
-    let err = BunString::clone_utf8(error_message).to_error_instance(global);
+    let err = BunString::clone_utf8(&error_message).to_error_instance(global);
 
     if let Some(library) = static_cstr(boring::ERR_lib_error_string(err_code)) {
         err.put(global, b"library", ZigString::init(library).to_js(global));
@@ -126,15 +119,8 @@ pub fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
     }
     if let Some(reason) = static_cstr(boring::ERR_reason_error_string(err_code)) {
         err.put(global, b"reason", ZigString::init(reason).to_js(global));
-
-        let lib = lib_short_name((err_code >> 24) & 0xff);
-        // Don't generate codes like "ERR_OSSL_SSL_".
-        let prefix = if lib == "SSL_" { "" } else { "OSSL_" };
-        let mut code = Vec::with_capacity(4 + prefix.len() + lib.len() + reason.len());
-        code.extend_from_slice(b"ERR_");
-        code.extend_from_slice(prefix.as_bytes());
-        code.extend_from_slice(lib.as_bytes());
-        code.extend_from_slice(reason);
+    }
+    if !code.is_empty() {
         err.put(global, b"code", ZigString::init(&code).to_js(global));
     }
 

--- a/src/runtime/crypto/boringssl_jsc.rs
+++ b/src/runtime/crypto/boringssl_jsc.rs
@@ -52,10 +52,7 @@ fn static_cstr<'a>(ptr: *const core::ffi::c_char) -> Option<&'a [u8]> {
     if bytes.is_empty() { None } else { Some(bytes) }
 }
 
-/// Compose Node's `ERR_OSSL_<LIB>_<REASON>` code (or `ERR_SSL_<REASON>` for the
-/// SSL library) from a packed BoringSSL error's library number and reason
-/// string. Shared by [`err_code_and_message`] and [`err_to_js`] so the two
-/// paths cannot drift.
+/// Node's `ERR_OSSL_<LIB>_<REASON>` (or `ERR_SSL_<REASON>`) code string.
 fn build_err_ossl_code(err_code: u32, reason: &[u8]) -> Vec<u8> {
     let lib = lib_short_name((err_code >> 24) & 0xff);
     // Don't generate codes like "ERR_OSSL_SSL_".
@@ -68,11 +65,8 @@ fn build_err_ossl_code(err_code: u32, reason: &[u8]) -> Vec<u8> {
     code
 }
 
-/// Format a packed BoringSSL error into `(code, message)` strings without
-/// touching JSC. `code` is Node's `ERR_OSSL_<LIB>_<REASON>` (or `ERR_SSL_*` for
-/// the SSL library); `message` is the raw `ERR_error_string_n` output. Both
-/// lookups are pure table reads keyed on the `u32`, so the thread that calls
-/// this need not be the thread that produced the error.
+/// JSC-free `(code, message)` formatter for a packed BoringSSL error. Pure
+/// table lookups on the `u32`, so callable from any thread.
 pub fn err_code_and_message(err_code: u32) -> (Vec<u8>, Vec<u8>) {
     let mut outbuf = [0u8; 128 + 1];
     // SAFETY: outbuf is a valid writable buffer of outbuf.len() bytes.
@@ -93,9 +87,6 @@ pub fn err_code_and_message(err_code: u32) -> (Vec<u8>, Vec<u8>) {
 }
 
 pub fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
-    // The message is the raw ERR_error_string output
-    // ("error:0b000074:X.509 certificate routines:OPENSSL_internal:..."),
-    // exactly what Node built against BoringSSL produces - no prefix.
     let (code, error_message) = err_code_and_message(err_code);
     if error_message.is_empty() {
         return global
@@ -106,9 +97,7 @@ pub fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
             .to_js();
     }
 
-    // A plain Error carrying Node's library/function/reason/code decomposition
-    // of the OpenSSL error, the way ThrowCryptoError builds it: the code is
-    // ERR_OSSL_<LIB>_<REASON> (or ERR_SSL_<REASON> for the SSL library).
+    // Node's ThrowCryptoError shape: .message/.library/.function/.reason/.code.
     let err = BunString::clone_utf8(&error_message).to_error_instance(global);
 
     if let Some(library) = static_cstr(boring::ERR_lib_error_string(err_code)) {

--- a/src/runtime/crypto/boringssl_jsc.rs
+++ b/src/runtime/crypto/boringssl_jsc.rs
@@ -52,6 +52,39 @@ fn static_cstr<'a>(ptr: *const core::ffi::c_char) -> Option<&'a [u8]> {
     if bytes.is_empty() { None } else { Some(bytes) }
 }
 
+/// Format a packed BoringSSL error into `(code, message)` strings without
+/// touching JSC. `code` is Node's `ERR_OSSL_<LIB>_<REASON>` (or `ERR_SSL_*` for
+/// the SSL library); `message` is the raw `ERR_error_string_n` output. Both
+/// lookups are pure table reads keyed on the `u32`, so the thread that calls
+/// this need not be the thread that produced the error.
+pub fn err_code_and_message(err_code: u32) -> (Vec<u8>, Vec<u8>) {
+    let mut outbuf = [0u8; 128 + 1];
+    // SAFETY: outbuf is a valid writable buffer of outbuf.len() bytes.
+    unsafe {
+        boring::ERR_error_string_n(
+            err_code,
+            outbuf.as_mut_ptr().cast::<core::ffi::c_char>(),
+            outbuf.len(),
+        );
+    }
+    let message = bun_core::slice_to_nul(&outbuf[..]).to_vec();
+
+    let code = if let Some(reason) = static_cstr(boring::ERR_reason_error_string(err_code)) {
+        let lib = lib_short_name((err_code >> 24) & 0xff);
+        let prefix = if lib == "SSL_" { "" } else { "OSSL_" };
+        let mut code = Vec::with_capacity(4 + prefix.len() + lib.len() + reason.len());
+        code.extend_from_slice(b"ERR_");
+        code.extend_from_slice(prefix.as_bytes());
+        code.extend_from_slice(lib.as_bytes());
+        code.extend_from_slice(reason);
+        code
+    } else {
+        Vec::new()
+    };
+
+    (code, message)
+}
+
 pub fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
     // The message is the raw ERR_error_string output
     // ("error:0b000074:X.509 certificate routines:OPENSSL_internal:..."),

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1326,6 +1326,26 @@ impl FetchTasklet {
             }
         }
 
+        if let http::Error::ClientTLSSetup(packed) = fail {
+            let (ossl_code, ossl_msg) = crate::crypto::boringssl_jsc::err_code_and_message(packed);
+            let code = if ossl_code.is_empty() {
+                BunString::static_(fail.name())
+            } else {
+                BunString::clone_utf8(&ossl_code)
+            };
+            let message = if ossl_msg.is_empty() {
+                BunString::static_("Failed to load client TLS certificate or key")
+            } else {
+                BunString::clone_utf8(&ossl_msg)
+            };
+            return BodyValueError::SystemError(jsc::SystemError {
+                code: code.into(),
+                message: message.into(),
+                path: path.into(),
+                ..Default::default()
+            });
+        }
+
         let code = if fail == http::Error::ConnectionClosed {
             BunString::static_("ECONNRESET")
         } else {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { once } from "node:events";
 import { readFileSync } from "node:fs";
+import net from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -739,5 +741,36 @@ describe.concurrent("fetch tls: client cert/key load errors surface the OpenSSL 
     expect(err.message).not.toContain("typo in the url");
     // The failing URL is attached like every other fetch rejection.
     expect(err.path).toBe(server.url.href);
+  });
+
+  // The http-proxy -> https-target CONNECT-tunnel path builds the client
+  // SSL_CTX at ProxyTunnel::start, after the proxy replies 200; that site must
+  // surface the same ERR_OSSL_* code instead of a generic ConnectionRefused.
+  it.each(cases)("via http CONNECT proxy: %s", async (_name, clientTls, codePattern) => {
+    const proxy = net.createServer(client => {
+      client.once("data", () => {
+        client.write("HTTP/1.1 200 Connection established\r\n\r\n");
+      });
+    });
+    proxy.listen(0, "127.0.0.1");
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as net.AddressInfo).port;
+    try {
+      let err: any;
+      try {
+        await fetch(`https://127.0.0.1:1/`, {
+          proxy: `http://127.0.0.1:${proxyPort}`,
+          tls: { rejectUnauthorized: false, ...clientTls },
+        });
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeDefined();
+      expect(err.code).toMatch(codePattern);
+      expect(err.code).not.toBe("ConnectionRefused");
+      expect(err.code).not.toBe("FailedToOpenSocket");
+    } finally {
+      proxy.close();
+    }
   });
 });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -748,6 +748,7 @@ describe.concurrent("fetch tls: client cert/key load errors surface the OpenSSL 
   // surface the same ERR_OSSL_* code instead of a generic ConnectionRefused.
   it.each(cases)("via http CONNECT proxy: %s", async (_name, clientTls, codePattern) => {
     const proxy = net.createServer(client => {
+      client.on("error", () => {});
       client.once("data", () => {
         client.write("HTTP/1.1 200 Connection established\r\n\r\n");
       });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -697,5 +698,46 @@ describe.concurrent("fetch-tls", () => {
       expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
       expect(stderr).toContain("ignoring extra certs");
     }
+  });
+});
+
+// When client cert/key material fails to load into the SSL_CTX, fetch used to
+// surface a generic FailedToOpenSocket "Was there a typo in the url or port?"
+// even though the same misconfiguration via node:https reports the real
+// BoringSSL error (ERR_OSSL_X509_KEY_VALUES_MISMATCH, ERR_OSSL_BAD_DECRYPT,
+// ERR_OSSL_PEM_NO_START_LINE).
+describe.concurrent("fetch tls: client cert/key load errors surface the OpenSSL code", () => {
+  const nodeTlsFixture = (f: string) =>
+    readFileSync(join(import.meta.dir, "..", "..", "node", "tls", "fixtures", f), "utf8");
+  const rsaCert = nodeTlsFixture("rsa_cert.crt");
+  const rsaEncryptedKey = nodeTlsFixture("rsa_private_encrypted.pem");
+
+  const cases: [string, { cert: string; key: string; passphrase?: string }, RegExp][] = [
+    ["cert/key mismatch", { cert: validTls.cert, key: expiredTls.key }, /^ERR_OSSL_X509_KEY_VALUES_MISMATCH$/],
+    ["encrypted key, wrong passphrase", { cert: rsaCert, key: rsaEncryptedKey, passphrase: "wrong" }, /^ERR_OSSL_/],
+    ["encrypted key, no passphrase", { cert: rsaCert, key: rsaEncryptedKey }, /^ERR_OSSL_/],
+    ["non-PEM cert string", { cert: "not a pem", key: validTls.key }, /^ERR_OSSL_PEM_NO_START_LINE$/],
+    ["non-PEM key string", { cert: validTls.cert, key: "not a pem" }, /^ERR_OSSL_PEM_NO_START_LINE$/],
+  ];
+
+  it.each(cases)("%s", async (_name, clientTls, codePattern) => {
+    using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      fetch: () => new Response("ok"),
+    });
+
+    let err: any;
+    try {
+      await fetch(server.url, { tls: { ca: validTls.cert, ...clientTls } });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.code).toMatch(codePattern);
+    expect(err.code).not.toBe("FailedToOpenSocket");
+    expect(err.message).not.toContain("typo in the url");
+    // The failing URL is attached like every other fetch rejection.
+    expect(err.path).toBe(server.url.href);
   });
 });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -205,23 +205,29 @@ describe.concurrent("fetch-tls", () => {
   // read the freed AsyncHTTP clone and called through a null callback pointer.
   // The fixture drives that exact traffic shape and exits non-zero on any
   // unexpected outcome; every failure must surface as a catchable error.
-  it("rejects a trusted cert with a mismatched hostname cleanly under abort/timeout/keepalive churn", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "fetch.tls.cert-mismatch-churn.fixture.ts")],
-      env: { ...bunEnv, BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Check stderr for sanitizer reports first (and unconditionally): a
-    // recovered ASAN report can leave exit code 0, and on an abort this
-    // surfaces the actual report instead of a bare exit-code mismatch.
-    // Don't assert emptiness: debug builds emit benign startup noise.
-    expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
-    // Fixture reports unexpected outcomes on stdout.
-    expect(stdout).toStartWith("OK ");
-    expect(exitCode).toBe(0);
-  });
+  it(
+    "rejects a trusted cert with a mismatched hostname cleanly under abort/timeout/keepalive churn",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, "fetch.tls.cert-mismatch-churn.fixture.ts")],
+        env: { ...bunEnv, BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // Check stderr for sanitizer reports first (and unconditionally): a
+      // recovered ASAN report can leave exit code 0, and on an abort this
+      // surfaces the actual report instead of a bare exit-code mismatch.
+      // Don't assert emptiness: debug builds emit benign startup noise.
+      expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
+      // Fixture reports unexpected outcomes on stdout.
+      expect(stdout).toStartWith("OK ");
+      expect(exitCode).toBe(0);
+    },
+    // The fixture is a debug+ASAN subprocess driving hundreds of TLS
+    // handshakes; on main it already ran at ~4.2-5.0s against the 5s default.
+    isASAN ? 20000 : 10000,
+  );
 
   // When checkServerIdentity is provided, the HTTP thread sends an intermediate
   // progress update carrying the server certificate before response headers


### PR DESCRIPTION
`fetch(url, {tls: {cert, key, passphrase, ...}})` collapsed every client certificate/key load failure into the same `FailedToOpenSocket "Was there a typo in the url or port?"` error, with no OpenSSL code, while `node:https` in the same process reports the real codes (`ERR_OSSL_X509_KEY_VALUES_MISMATCH`, `ERR_OSSL_BAD_DECRYPT`, `ERR_OSSL_PEM_NO_START_LINE`). This makes mTLS / enterprise-proxy client-cert misconfiguration look like a URL typo.

### Reproduction

```js
import { tls as A, expiredTls as B } from "./test/harness.ts";
using server = Bun.serve({ port: 0, tls: A, fetch: () => new Response("ok") });
for (const [name, t] of Object.entries({
  "cert/key mismatch": { cert: A.cert, key: B.key },
  "non-PEM cert":      { cert: "not a pem", key: A.key },
})) {
  try { await fetch(server.url, { tls: { ca: A.cert, ...t } }); }
  catch (e) { console.log(name.padEnd(20), e.code, "|", e.message); }
}
```

Before:
```
cert/key mismatch    FailedToOpenSocket | Was there a typo in the url or port?
non-PEM cert         FailedToOpenSocket | Was there a typo in the url or port?
```

After:
```
cert/key mismatch    ERR_OSSL_X509_KEY_VALUES_MISMATCH | error:0b000074:X.509 certificate routines:OPENSSL_internal:KEY_VALUES_MISMATCH
non-PEM cert         ERR_OSSL_PEM_NO_START_LINE | error:0900006e:PEM routines:OPENSSL_internal:NO_START_LINE
```

### Cause

`us_ssl_ctx_build_raw` (`packages/bun-usockets/src/crypto/openssl.c`) returns `NULL` with `*err` left at `CREATE_BUN_SOCKET_ERROR_NONE` for client cert/key/passphrase failures; the real cause is only on the calling thread's BoringSSL error queue. `SecureContext` (the `node:https` path) reads that queue via `ERR_get_error()` on the JS thread and formats it with `boringssl_jsc::err_to_js`. The fetch-client `SSL_CTX` is built on the **HTTP thread** at two sites that never read the queue:

* `HTTPContext::init_with_opts` (direct TLS connect) mapped `(None, err == none)` to `InitError::FailedToOpenSocket`, which became `http::Error::FailedToOpenSocket` and the "typo in the url" message in `FetchTasklet::on_reject`.
* `ProxyTunnel::start` (http-proxy CONNECT tunnel to an https target) mapped `SSLWrapper::init_from_options` failure to `crate::Error::ConnectionRefused`.

### Fix

Add `http::error::take_boringssl_error()` which pops and drains the thread-local BoringSSL error queue, and call it at both `create_ssl_context` failure sites immediately after the failed `SSL_CTX_*` calls. Carry the packed `u32` in new `InitError::ClientTLSSetup` / `http::Error::ClientTLSSetup` variants. `FetchTasklet::on_reject` formats it via a new JSC-free `boringssl_jsc::err_code_and_message` helper (the same `ERR_OSSL_<LIB>_<REASON>` composition `err_to_js` now also uses) into a SystemError with `.code` (`ERR_OSSL_*`), `.message` (`ERR_error_string_n` output) and `.path` (the request URL). The explicit CA/CRL enum arms are unchanged.

### Verification

`test/js/web/fetch/fetch.tls.test.ts` gains two `it.each` blocks (direct + via http CONNECT proxy) covering cert/key mismatch, encrypted key with wrong/missing passphrase, and non-PEM cert/key input; each asserts `err.code` matches `^ERR_OSSL_` and the old `FailedToOpenSocket`/`ConnectionRefused`/"typo in the url" shapes are gone. All ten cases fail on `main` and pass with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.0 (96c737581)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1149.78ms]
(pass) fetch-tls > fetch with valid tls should not throw [1785.73ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1845.66ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [295.70ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2180.69ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [2133.61ms]
(pass) fetch-tls > fetch with self-sign tls should throw [168.82ms]
(pass) fetch-tls > fetch with invalid tls should throw [159.18ms]
(pass) fetch-tls > fetch with checkServerIdentity failing should throw [276.95ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [665.66m
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ed7988cfa)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers (with AbortSignal) [39.37ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [47.09ms]
(pass) fetch-tls > fetch should respect rejectUnauthorized env [38.96ms]
(pass) fetch-tls > checkServerIdentity approval still transmits the request and round-trips the response [43.85ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [1570.57ms]
(pass) fetch tls: client cert/key load errors surface the OpenSSL code > cert/key mismatch [1.79ms]
(pass) fetch tls: client cert/key load errors surface the OpenSSL code > encrypted key, wrong passphrase [1.68ms]
(pass) fetch tls: client cert/key load errors surface the OpenSSL code > encrypted key, no passphrase [1.58ms]
(pass) fetch tls: client cert/key load errors surface the OpenSSL code > non-PEM cert string [1.46ms]
(pass) fetch tls: client cert/key load errors surface the OpenSSL code > non-PEM key string [1.42ms]
(pas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.0 (96c737581)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1155.69ms]
(pass) fetch-tls > fetch with valid tls should not throw [1797.39ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1861.62ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [309.79ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2208.29ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [2146.71ms]
(pass) fetch-tls > fetch with self-sign tls should throw [162.61ms]
(pass) fetch-tls > fetch with invalid tls should throw [161.41ms]
(pass) fetch-tls > fetch with checkServerIdentity failing should throw [281.42ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [672.85m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 649ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/HTTPContext.rs                   |   4 +-
 src/http/HTTPThread.rs                    |   3 +-
 src/http/InitError.rs                     |   3 +
 src/http/ProxyTunnel.rs                   |   7 +-
 src/http/error.rs                         |  12 ++++
 src/install/PackageManager.rs             |   2 +-
 src/runtime/crypto/boringssl_jsc.rs       |  55 +++++++-------
 src/runtime/webcore/fetch/FetchTasklet.rs |  20 ++++++
 test/js/web/fetch/fetch.tls.test.ts       | 116 +++++++++++++++++++++++++-----
 9 files changed, 174 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/HTTPContext.rs                        2      4      0
src/http/HTTPThread.rs                         3      2      0
src/http/InitError.rs                          2      3      0
src/http/ProxyTunnel.rs                        3      2      0
src/http/error.rs                              4      6      0
src/install/PackageManager.rs                  1      1      0
src/runtime/crypto/boringssl_jsc.rs            4      6      0
src/runtime/webcore/fetch/FetchTasklet.rs      3      1      0
test/js/web/fetch/fetch.tls.test.ts            6     10      0
```

</details>

<!-- robobun:evidence:end -->

### Scope

The WebSocket client builds its SSL_CTX at two sibling sites (`WebSocketProxyTunnel::start` and `WebSocketUpgradeClient::connect` in `src/http_jsc/websocket_client/`) with the same queue-discarding shape. Those route through `bun_http_jsc` with an event-based error surface (close code + `error` event, not a rejected promise with a `SystemError`), so threading `ERR_OSSL_*` there needs a new `http_jsc::Error` variant and close-code mapping; deferred to a follow-up. This PR does not change WebSocket behavior.