### PR TITLE
console.table: skip Symbol entries in the properties filter

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -965,9 +965,7 @@ impl<'a> TablePrinter<'a> {
         if !self.properties.is_undefined() {
             let mut properties_iter = jsc::JSArrayIterator::init(self.properties, global_object)?;
             while let Some(value) = properties_iter.next()? {
-                // Node keys an object by each entry then reads it back via
-                // ObjectKeys, so Symbol entries are dropped. Skip them here
-                // rather than let ToString throw.
+                // Node drops Symbol columns; ToString on a Symbol would throw.
                 if value.is_symbol() {
                     continue;
                 }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -965,6 +965,12 @@ impl<'a> TablePrinter<'a> {
         if !self.properties.is_undefined() {
             let mut properties_iter = jsc::JSArrayIterator::init(self.properties, global_object)?;
             while let Some(value) = properties_iter.next()? {
+                // Node keys an object by each entry then reads it back via
+                // ObjectKeys, so Symbol entries are dropped. Skip them here
+                // rather than let ToString throw.
+                if value.is_symbol() {
+                    continue;
+                }
                 columns.push(Column {
                     name: value.to_bun_string(global_object)?,
                     width: 1,

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -363,3 +363,27 @@ console.log("calls=" + calls);`,
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: box("1") + "calls=1\n", stderr: "", exitCode: 0 });
   });
 });
+
+// Node keys a null-proto object by each `properties` entry and reads the column
+// set back via ObjectKeys, so a Symbol entry is silently dropped. The native
+// path must not ToString the Symbol (which throws) and must match that output.
+describe("console.table with a Symbol in the properties filter", () => {
+  const data = [{ a: 1, b: 2 }];
+  const expected = `┌───┬───┐\n│   │ a │\n├───┼───┤\n│ 0 │ 1 │\n└───┴───┘\n`;
+
+  test("Bun.inspect.table drops the Symbol column", () => {
+    expect(Bun.inspect.table(data, [Symbol("col"), "a"])).toBe(expected);
+    // control: a non-Symbol primitive still ToStrings into a column header.
+    expect(Bun.inspect.table(data, [42, "a"])).toBe(`┌───┬────┬───┐\n│   │ 42 │ a │\n├───┼────┼───┤\n│ 0 │    │ 1 │\n└───┴────┴───┘\n`);
+  });
+
+  test("console.table drops the Symbol column", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.table([{ a: 1, b: 2 }], [Symbol("col"), "a"])`],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: expected, stderr: "", exitCode: 0 });
+  });
+});

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -374,7 +374,9 @@ describe("console.table with a Symbol in the properties filter", () => {
   test("Bun.inspect.table drops the Symbol column", () => {
     expect(Bun.inspect.table(data, [Symbol("col"), "a"])).toBe(expected);
     // control: a non-Symbol primitive still ToStrings into a column header.
-    expect(Bun.inspect.table(data, [42, "a"])).toBe(`┌───┬────┬───┐\n│   │ 42 │ a │\n├───┼────┼───┤\n│ 0 │    │ 1 │\n└───┴────┴───┘\n`);
+    expect(Bun.inspect.table(data, [42, "a"])).toBe(
+      `┌───┬────┬───┐\n│   │ 42 │ a │\n├───┼────┼───┤\n│ 0 │    │ 1 │\n└───┴────┴───┘\n`,
+    );
   });
 
   test("console.table drops the Symbol column", async () => {


### PR DESCRIPTION
## What

`console.table(data, properties)` and `Bun.inspect.table(data, properties)` throw `TypeError: Cannot convert a symbol to a string` when the `properties` array contains a Symbol. Node prints the table and drops the Symbol column.

```js
const data = [{ a: 1, b: 2 }];
console.table(data, [Symbol('col'), 'a']);
// node: prints table with just column 'a'
// bun:  TypeError: Cannot convert a symbol to a string
```

Bun's own `new console.Console(stream).table(...)` (the JS port) already has Node parity here; only the native `TablePrinter` path throws.

## Cause

`TablePrinter::print_table` pre-populates columns by iterating the `properties` array and calling `to_bun_string` (ToString) on every entry. ToString on a Symbol throws per spec.

Node [keys](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/console/constructor.js) a null-proto `map` object by each `properties` entry and later reads the column set back via `ObjectKeys(map)`, which never enumerates symbol keys, so a Symbol entry is silently dropped. It never ToStrings the entry.

## Fix

Skip `is_symbol()` entries in the `properties` iterator before coercing. Non-Symbol primitives (numbers, plain objects) still ToString into a column header, which matches Node.

## Verification

New `console.table with a Symbol in the properties filter` block in `test/js/bun/console/console-table.test.ts` covering both `Bun.inspect.table` and a spawned `console.table`, with a non-Symbol primitive control. Both new tests throw on `USE_SYSTEM_BUN=1`; all 35 existing tests in the file (plus the 35 in `bun-inspect-table.test.ts`) continue to pass under `bun bd`.

Related: #34241 addresses Symbol keys on the *data* objects but still ToStrings `properties` entries, so it does not fix this throw.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-table.test.ts
bun test v1.4.0 (43ef67de4)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [7.23ms]
(pass) console.table > expected output for: not object (number) [10.30ms]
(pass) console.table > expected output for: not object (string) [3.92ms]
(pass) console.table > expected output for: object - empty [1.61ms]
(pass) console.table > expected output for: object [2.00ms]
(pass) console.table > expected output for: array - empty [1.74ms]
(pass) console.table > expected output for: array - plain [1.54ms]
(pass) console.table > expected output for: array - object [2.04ms]
(pass) console.table > expected output for: array - objects with diff props [1.81ms]
(pass) console.table > expected output for: array - mixed [2.45ms]
(pass) console.table > expected output for: set [1.91ms]
(pass) console.table > expected output for: map [2.16ms]
(pass) conso
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (9db7a0920)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [0.11ms]
(pass) console.table > expected output for: not object (number) [0.42ms]
(pass) console.table > expected output for: not object (string) [0.03ms]
(pass) console.table > expected output for: object - empty [0.81ms]
(pass) console.table > expected output for: object [0.07ms]
(pass) console.table > expected output for: array - empty [0.01ms]
(pass) console.table > expected output for: array - plain [0.01ms]
(pass) console.table > expected output for: array - object [0.02ms]
(pass) console.table > expected output for: array - objects with diff props [0.02ms]
(pass) console.table > expected output for: array - mixed [0.01ms]
(pass) console.table > expected output for: set [0.02ms]
(pass) console.table > expected output for: map [0.05ms]
(pass) console.table > expected output for: properties [0.02ms]
(pass) console.table > expected output for: properties - empty [0.01ms]
(pass) console.table > expected output for:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-table.test.ts
bun test v1.4.0 (43ef67de4)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [8.67ms]
(pass) console.table > expected output for: not object (number) [11.48ms]
(pass) console.table > expected output for: not object (string) [2.13ms]
(pass) console.table > expected output for: object - empty [1.68ms]
(pass) console.table > expected output for: object [2.05ms]
(pass) console.table > expected output for: array - empty [1.35ms]
(pass) console.table > expected output for: array - plain [2.07ms]
(pass) console.table > expected output for: array - object [2.09ms]
(pass) console.table > expected output for: array - objects with diff props [1.84ms]
(pass) console.table > expected output for: array - mixed [2.41ms]
(pass) console.table > expected output for: set [2.00ms]
(pass) console.table > expected output for: map [2.24ms]
(pass) conso
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 752ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                  |  4 ++++
 test/js/bun/console/console-table.test.ts | 26 ++++++++++++++++++++++++++
 2 files changed, 30 insertions(+)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/ConsoleObject.rs                       2      2      0
test/js/bun/console/console-table.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->