### PR TITLE
type:"direct" controller: signal backpressure from write() so an unpaced pump yields

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -290,9 +290,14 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
             markPromiseAsHandled(vm, wrotePromise);
             // A FileSink/NetworkSink write that could not complete returns its pending
             // promise; the sink's own drain callback resolves it.
-            if (wrotePromise->status() == JSPromise::Status::Pending) {
+            auto status = wrotePromise->status();
+            if (status == JSPromise::Status::Pending) {
                 wrotePromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
                 return NextStep::Suspended;
+            }
+            if (status == JSPromise::Status::Rejected) {
+                asyncIterFinishWithError(globalObject, op, wrotePromise->result());
+                return NextStep::Finished;
             }
         }
     }

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -271,7 +271,7 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
         if (scope.exception()) [[unlikely]]
             goto abrupt;
         if (wrote && wrote.isNumber() && wrote.asNumber() < 0) {
-            // The HTTP sink reports backpressure with a negative return: wait for the drain.
+            // The sink reports backpressure with a negative return: wait for the drain.
             MarkedArgumentBuffer flushArgs;
             flushArgs.append(jsBoolean(true));
             JSValue flushed = invokeOptionalMethod(globalObject, controller, builtinNames(vm).flushPublicName(), flushArgs);
@@ -286,8 +286,15 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
             flushPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
             return NextStep::Suspended;
         }
-        if (auto* wrotePromise = asPromise(wrote))
+        if (auto* wrotePromise = asPromise(wrote)) {
             markPromiseAsHandled(vm, wrotePromise);
+            // A FileSink/NetworkSink write that could not complete returns its pending
+            // promise; the sink's own drain callback resolves it.
+            if (wrotePromise->status() == JSPromise::Status::Pending) {
+                wrotePromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
+                return NextStep::Suspended;
+            }
+        }
     }
 
     if (op->m_iteratorDone) {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -108,6 +108,7 @@ void JSDirectStreamController::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.appendHidden(thisObject->m_array);
     visitor.appendHidden(thisObject->m_closingPromise);
     visitor.appendHidden(thisObject->m_finalChunk);
+    visitor.appendHidden(thisObject->m_drainPromise);
     Locker locker { thisObject->cellLock() };
     thisObject->m_textAccumulator.visit(locker, visitor);
 }
@@ -126,6 +127,7 @@ void JSDirectStreamController::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_array, "array"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closingPromise, "closingPromise"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_finalChunk, "finalChunk"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_drainPromise, "drainPromise"_s);
     WTF::Locker locker { thisObject->cellLock() };
     thisObject->m_textAccumulator.analyzeHeap(locker, cell, analyzer);
 }
@@ -426,10 +428,25 @@ static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject,
     }
 }
 
+void JSDirectStreamController::didDrain(JSGlobalObject* globalObject)
+{
+    m_undeliveredBytes = 0;
+    if (auto* drainPromise = m_drainPromise.get()) {
+        m_drainPromise.clear();
+        drainPromise->fulfill(getVM(globalObject), jsUndefined());
+    }
+}
+
 void JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue error)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    m_undeliveredBytes = 0;
+    if (auto* drainPromise = m_drainPromise.get()) {
+        m_drainPromise.clear();
+        drainPromise->reject(vm, error);
+    }
 
     const bool wasClosed = m_closed;
     if (!wasClosed) {
@@ -625,9 +642,8 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* stream = m_stream.get();
-    if (!stream || stream->m_state != ReadableStreamState::Readable)
-        return;
-    if (m_deferClose != 0) {
+    bool streamReadable = stream && stream->m_state == ReadableStreamState::Readable;
+    if (streamReadable && m_deferClose != 0) {
         m_deferClose = 1;
         m_deferCloseReason.set(vm, this, reason);
         return;
@@ -637,8 +653,15 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
     // No "Closing" stream state exists: m_closed set here is what blocks re-entry.
     m_closed = true;
 
+    // A writer suspended on flush(true) resumes; source.close() sets the async-iterable
+    // source's m_cancelled so the flush-fulfilled reaction settles instead of re-driving.
+    didDrain(globalObject);
     callUnderlyingSourceClose(vm, globalObject, this, reason);
     RETURN_IF_EXCEPTION(scope, );
+    // readableStreamCancel closes the stream before calling here; the buffered bytes are
+    // discarded and the final-chunk delivery below is skipped.
+    if (!streamReadable)
+        return;
 
     JSValue flushed;
     {
@@ -715,6 +738,7 @@ void JSDirectStreamController::onFlush(JSGlobalObject* globalObject)
         m_pendingRead.clear();
         JSValue flushed = flushDirectSink(vm, globalObject, this);
         RETURN_IF_EXCEPTION(scope, );
+        didDrain(globalObject);
         if (byteLengthOf(flushed)) {
             // A non-promise read request at the head is the active consumer: deliver the
             // chunk through its own chunkSteps and leave the head-of-line promise pending
@@ -749,6 +773,7 @@ void JSDirectStreamController::onFlush(JSGlobalObject* globalObject)
     if (readableStreamGetNumReadRequests(stream) > 0) {
         JSValue flushed = flushDirectSink(vm, globalObject, this);
         RETURN_IF_EXCEPTION(scope, );
+        didDrain(globalObject);
         if (byteLengthOf(flushed)) {
             if (m_pullInFlight && readableStreamGetNumReadRequests(stream) > 1)
                 m_pullAgain = true;
@@ -862,6 +887,26 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject *
         return throwVMTypeError(globalObject, scope, directControllerClosedMessage);
     JSValue wrote = writeToDirectSink(globalObject, controller, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
+    // Pump guard: the ArrayBuffer sink has no backpressure of its own, so write() signals it
+    // here once the buffered batch crosses the highWaterMark. A waiting consumer is handed the
+    // batch in-tick so the caller keeps pumping; with no consumer the negative return tells
+    // the caller to flush(true) and suspend until didDrain resolves.
+    if (controller->m_sinkKind == DirectSinkKind::ArrayBuffer && wrote.isNumber()) {
+        double n = wrote.asNumber();
+        if (n > 0) {
+            controller->m_undeliveredBytes += static_cast<uint64_t>(n);
+            if (controller->m_undeliveredBytes > controller->m_highWaterMark) {
+                if (directControllerHasWaitingConsumer(controller, controller->m_stream.get())) {
+                    controller->onFlush(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                } else {
+                    controller->armEndOfTickFlush(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    return JSValue::encode(jsNumber(-(n + 1)));
+                }
+            }
+        }
+    }
     controller->armEndOfTickFlush(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(wrote);
@@ -892,6 +937,17 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectFlush, (JSGlobalObject *
         return throwVMTypeError(globalObject, scope, directControllerClosedMessage);
     controller->onFlush(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
+    // flush(true): the backpressure await point. Delivery above ran didDrain when a consumer
+    // was waiting; bytes remaining mean nobody is reading yet, so hand back a promise that
+    // the next delivery/close/error settles.
+    if (callFrame->argument(1).toBoolean(globalObject) && controller->m_undeliveredBytes) {
+        auto* drainPromise = controller->m_drainPromise.get();
+        if (!drainPromise) {
+            drainPromise = JSPromise::create(vm, globalObject->promiseStructure());
+            controller->m_drainPromise.set(vm, controller, drainPromise);
+        }
+        return JSValue::encode(drainPromise);
+    }
     return JSValue::encode(jsUndefined());
 }
 
@@ -973,8 +1029,11 @@ void setUpDirectStreamController(JSC::JSGlobalObject* globalObject, JSReadableSt
         controller->m_arrayBufferSink.set(vm, controller, sink);
         JSObject* options = constructEmptyObject(globalObject);
         // Forwarded iff the raw strategy highWaterMark is a non-zero, non-NaN number.
-        if (stream->m_bunHighWaterMarkIsNumber && highWaterMark != 0 && !std::isnan(highWaterMark))
+        if (stream->m_bunHighWaterMarkIsNumber && highWaterMark != 0 && !std::isnan(highWaterMark)) {
             options->putDirect(vm, builtinNames(vm).highWaterMarkPublicName(), jsNumber(highWaterMark), 0);
+            if (std::isfinite(highWaterMark) && highWaterMark > 0)
+                controller->m_highWaterMark = static_cast<uint64_t>(highWaterMark);
+        }
         options->putDirect(vm, builtinNames(vm).streamPublicName(), jsBoolean(true), 0);
         options->putDirect(vm, builtinNames(vm).asUint8ArrayPublicName(), jsBoolean(true), 0);
         MarkedArgumentBuffer startArgs;

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -1031,8 +1031,10 @@ void setUpDirectStreamController(JSC::JSGlobalObject* globalObject, JSReadableSt
         // Forwarded iff the raw strategy highWaterMark is a non-zero, non-NaN number.
         if (stream->m_bunHighWaterMarkIsNumber && highWaterMark != 0 && !std::isnan(highWaterMark)) {
             options->putDirect(vm, builtinNames(vm).highWaterMarkPublicName(), jsNumber(highWaterMark), 0);
-            if (std::isfinite(highWaterMark) && highWaterMark > 0)
-                controller->m_highWaterMark = static_cast<uint64_t>(highWaterMark);
+            if (highWaterMark > 0)
+                controller->m_highWaterMark = std::isfinite(highWaterMark)
+                    ? static_cast<uint64_t>(highWaterMark)
+                    : std::numeric_limits<uint64_t>::max();
         }
         options->putDirect(vm, builtinNames(vm).streamPublicName(), jsBoolean(true), 0);
         options->putDirect(vm, builtinNames(vm).asUint8ArrayPublicName(), jsBoolean(true), 0);

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -888,15 +888,18 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject *
     JSValue wrote = writeToDirectSink(globalObject, controller, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
     // Pump guard: the ArrayBuffer sink has no backpressure of its own, so write() signals it
-    // here once the buffered batch crosses the highWaterMark. A waiting consumer is handed the
-    // batch in-tick so the caller keeps pumping; with no consumer the negative return tells
-    // the caller to flush(true) and suspend until didDrain resolves.
+    // here once the buffered batch crosses the highWaterMark. A waiting consumer outside the
+    // initial pull frame is handed the batch in-tick so the caller keeps pumping; inside that
+    // frame (m_deferFlush == -1) onPull's own deferred onFlush owns delivery to the head-of-
+    // line promise, so always return negative there to avoid producing a second batch before
+    // callDirectPull has returned. With no consumer the negative return tells the caller to
+    // flush(true) and suspend until didDrain resolves.
     if (controller->m_sinkKind == DirectSinkKind::ArrayBuffer && wrote.isNumber()) {
         double n = wrote.asNumber();
         if (n > 0) {
             controller->m_undeliveredBytes += static_cast<uint64_t>(n);
             if (controller->m_undeliveredBytes > controller->m_highWaterMark) {
-                if (directControllerHasWaitingConsumer(controller, controller->m_stream.get())) {
+                if (controller->m_deferFlush != -1 && directControllerHasWaitingConsumer(controller, controller->m_stream.get())) {
                     controller->onFlush(globalObject);
                     RETURN_IF_EXCEPTION(scope, {});
                 } else {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -1031,10 +1031,13 @@ void setUpDirectStreamController(JSC::JSGlobalObject* globalObject, JSReadableSt
         // Forwarded iff the raw strategy highWaterMark is a non-zero, non-NaN number.
         if (stream->m_bunHighWaterMarkIsNumber && highWaterMark != 0 && !std::isnan(highWaterMark)) {
             options->putDirect(vm, builtinNames(vm).highWaterMarkPublicName(), jsNumber(highWaterMark), 0);
+            // A double above UINT64_MAX (including Infinity) saturates; the compare is in the
+            // wide type so the cast never sees an out-of-range value.
+            constexpr double maxU64 = static_cast<double>(std::numeric_limits<uint64_t>::max());
             if (highWaterMark > 0)
-                controller->m_highWaterMark = std::isfinite(highWaterMark)
-                    ? static_cast<uint64_t>(highWaterMark)
-                    : std::numeric_limits<uint64_t>::max();
+                controller->m_highWaterMark = highWaterMark >= maxU64
+                    ? std::numeric_limits<uint64_t>::max()
+                    : static_cast<uint64_t>(highWaterMark);
         }
         options->putDirect(vm, builtinNames(vm).streamPublicName(), jsBoolean(true), 0);
         options->putDirect(vm, builtinNames(vm).asUint8ArrayPublicName(), jsBoolean(true), 0);

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -32,7 +32,8 @@ public:
 
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_stream, m_underlyingSource, m_pull, m_pendingRead,
-    // m_deferCloseReason, m_arrayBufferSink, m_array, m_closingPromise, m_finalChunk, and
+    // m_deferCloseReason, m_arrayBufferSink, m_array, m_closingPromise, m_finalChunk,
+    // m_drainPromise, and
     // the barrier container m_textAccumulator.pieces (via
     // m_textAccumulator.visit(locker, visitor) inside ONE `Locker { cellLock() }` scope
     // taken by THIS visitChildrenImpl — cellLock() is non-recursive; see StreamQueue.h).
@@ -83,6 +84,14 @@ public:
 
     // ArrayBuffer sink: a real Bun.ArrayBufferSink cell (ArrayBuffer kind only).
     JSC::WriteBarrier<JSC::JSObject> m_arrayBufferSink;
+    // ArrayBuffer-sink pump guard: bytes write()'d since the last flushDirectSink delivery,
+    // the byte threshold at which write() signals backpressure (the strategy highWaterMark
+    // when numeric, else 64 KiB), and the promise flush(true) returns while over that
+    // threshold with no waiting consumer. Resolved by didDrain on delivery/close, rejected
+    // by handleError. Text/Array sinks never increment m_undeliveredBytes so never guard.
+    uint64_t m_undeliveredBytes { 0 };
+    uint64_t m_highWaterMark { 65536 };
+    JSC::WriteBarrier<JSC::JSPromise> m_drainPromise;
 
     // Text sink: the ONE shared createTextStream accumulator value type
     // (BunStandaloneTextSink.h), also owned by the standalone JSBunStandaloneTextSink — one
@@ -112,6 +121,8 @@ public:
     void onFlush(JSC::JSGlobalObject*);
     // handleDirectStreamError.
     void handleError(JSC::JSGlobalObject*, JSC::JSValue error);
+    // Resolve m_drainPromise and reset m_undeliveredBytes; called on every delivery and close.
+    void didDrain(JSC::JSGlobalObject*);
 
 private:
     JSDirectStreamController(JSC::VM&, JSC::Structure*, Bun::WebStreams::DirectSinkKind);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -429,9 +429,10 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
         auto* controller = uncheckedDowncast<WebCore::JSDirectStreamController>(stream->m_controller.get());
         controller->onClose(globalObject, reason);
         RETURN_IF_EXCEPTION(scope, nullptr);
-        // readableStreamClose above already moved the stream out of Readable, so onClose
-        // early-returned; a direct read still pending on the controller settles as done here
-        // (a canceled read resolves with { value: undefined, done: true }).
+        // readableStreamClose above already moved the stream out of Readable, so onClose ran
+        // didDrain and source.close() and returned before touching m_pendingRead; a direct
+        // read still pending on the controller settles as done here (a canceled read resolves
+        // with { value: undefined, done: true }).
         if (auto* pendingRead = controller->m_pendingRead.get()) {
             controller->m_pendingRead.clear();
             JSObject* doneResult = createIteratorResultObject(globalObject, jsUndefined(), true);

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -365,7 +365,7 @@ describe("spawn stdin ReadableStream", () => {
           const child = Bun.spawn({
             cmd: [process.execPath, "-e", "setTimeout(() => {}, 1e9)"],
             stdin: (${useIterator} ? iterate : readable)(() => {
-              if (++produced === 1) queueMicrotask(() => child.kill());
+              if (++produced === 1) setImmediate(() => child.kill());
             }),
             stdout: "ignore",
             stderr: "ignore",
@@ -412,7 +412,7 @@ describe("spawn stdin ReadableStream", () => {
         const chunk = Buffer.alloc(256 * 1024, "x");
         let produced = 0;
         function producedOne() {
-          if (++produced === 1) queueMicrotask(() => child.kill());
+          if (++produced === 1) setImmediate(() => child.kill());
         }
         async function* iterate() {
           while (true) {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -321,12 +321,13 @@ describe("spawn stdin ReadableStream", () => {
     expect(exitCode).toBe(0);
   });
 
-  // The ReadableStream -> stdin FileSink pump intentionally does not await the
-  // Promise FileSink.write() returns for writes it cannot complete synchronously
-  // (a full pipe on POSIX, every pipe write on Windows). When the child dies
-  // while one is in flight, the sink rejects that Promise with EPIPE; the pump
-  // must mark it handled or it surfaces as an unhandled rejection in the parent.
-  // Run in a child process so a stray rejection lands on its counter.
+  // A 256 KiB write to a child that never reads stdin cannot complete
+  // synchronously (a full pipe on POSIX, every pipe write on Windows), so
+  // FileSink.write() returns its pending Promise. The async-iterable pump
+  // suspends on that Promise; the spec-ReadableStream pump marks it handled and
+  // keeps reading. When the child dies while that write is in flight, neither
+  // path may surface an unhandled EPIPE rejection in the parent. Run in a child
+  // process so a stray rejection lands on its counter.
   async function expectNoUnhandledRejectionWhenChildDies(useIterator: boolean) {
     await using proc = Bun.spawn({
       cmd: [
@@ -356,15 +357,15 @@ describe("spawn stdin ReadableStream", () => {
         }
 
         // The child never reads its stdin, so a 256 KiB write can never finish
-        // and the sink always holds an in-flight write. Once a few chunks have
-        // been handed to the sink, kill the child. How far the pump gets before
-        // the parent notices the death varies, so run several rounds.
+        // and the sink always holds an in-flight write. Kill the child once the
+        // first chunk has been handed off; how far the pump gets before the
+        // parent notices the death varies, so run several rounds.
         function round() {
           let produced = 0;
           const child = Bun.spawn({
             cmd: [process.execPath, "-e", "setTimeout(() => {}, 1e9)"],
             stdin: (${useIterator} ? iterate : readable)(() => {
-              if (++produced === 4) child.kill();
+              if (++produced === 1) queueMicrotask(() => child.kill());
             }),
             stdout: "ignore",
             stderr: "ignore",
@@ -411,7 +412,7 @@ describe("spawn stdin ReadableStream", () => {
         const chunk = Buffer.alloc(256 * 1024, "x");
         let produced = 0;
         function producedOne() {
-          if (++produced === 4) child.kill();
+          if (++produced === 1) queueMicrotask(() => child.kill());
         }
         async function* iterate() {
           while (true) {

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -156,17 +156,17 @@ describe("Response(async iterable).body: direct-controller pump guard", () => {
     expect(result.error).toBeUndefined();
     // Reaching reads === 5 proves the event loop is alive: each step awaited a timer.
     expect(result.reads).toBe(5);
-    expect(result.ticks).toBeGreaterThan(0);
     // Five 64 KiB batches of 1 KiB chunks plus the resume-and-suspend overlap.
-    expect(result.yields).toBeLessThanOrEqual(4000);
+    expect(result.yields).toBeLessThan(1000);
     expect(exitCode).toBe(0);
   });
 
   test.concurrent("cancel while suspended runs the generator's finally", async () => {
     const { result, exitCode } = await runFace(`
       let reads = 0;
-      let returned = false;
-      async function* wrapped() { try { yield* g(); } finally { returned = true; } }
+      let returnedResolve;
+      const returned = new Promise(res => { returnedResolve = res; });
+      async function* wrapped() { try { yield* g(); } finally { returnedResolve(true); } }
       const r = new Response(wrapped()).body.getReader();
       (async () => {
         while (true) {
@@ -175,8 +175,7 @@ describe("Response(async iterable).body: direct-controller pump guard", () => {
           reads++;
           if (reads === 3) {
             await r.cancel();
-            await new Promise(res => setTimeout(res, 0));
-            process.stdout.write(JSON.stringify({ reads, yields, ticks, returned }) + "\\n");
+            process.stdout.write(JSON.stringify({ reads, yields, ticks, returned: await returned }) + "\\n");
             process.exit(0);
           }
         }

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -264,7 +264,10 @@ describe("Response(async iterable).body: direct-controller pump guard", () => {
   // pump loop synchronously inside the first callDirectPull frame. Both, across every
   // non-Promise reader kind, must deliver the exact total.
   test.concurrent.each([
-    ["async function*", `async function* it() { for (let i = 0; i < 300; i++) yield new Uint8Array(1024).fill(0x61); }`],
+    [
+      "async function*",
+      `async function* it() { for (let i = 0; i < 300; i++) yield new Uint8Array(1024).fill(0x61); }`,
+    ],
     [
       "Promise.resolve next()",
       `function it() {

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -307,6 +307,13 @@ describe("Response(async iterable).body: direct-controller pump guard", () => {
           await new Response(it()).body.pipeTo(new WritableStream({ write(c) { total += c.byteLength; } }));
           out.pipeTo = total;
         }
+        {
+          let total = 0;
+          await new Response(it()).body
+            .pipeThrough(new TransformStream())
+            .pipeTo(new WritableStream({ write(c) { total += c.byteLength; } }));
+          out.pipeThrough = total;
+        }
         process.stdout.write(JSON.stringify(out) + "\\n");
         `,
       ],
@@ -316,7 +323,12 @@ describe("Response(async iterable).body: direct-controller pump guard", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual({ reader: 300 * 1024, forAwait: 300 * 1024, pipeTo: 300 * 1024 });
+    expect(JSON.parse(stdout.trim())).toEqual({
+      reader: 300 * 1024,
+      forAwait: 300 * 1024,
+      pipeTo: 300 * 1024,
+      pipeThrough: 300 * 1024,
+    });
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("Response.bytes() with async iterable body does not crash with null deref", async () => {
@@ -51,4 +51,275 @@ test("Response.arrayBuffer() with async iterable body does not crash with null d
 
   expect(stdout).not.toContain("null is not an object");
   expect(exitCode).toBe(0);
+});
+
+// An async generator that never awaits fulfills every next() synchronously, so the direct
+// controller's drive loop would pump it forever (zero event-loop ticks, unbounded buffer)
+// without the controller's own backpressure signal. Each face runs in a subprocess whose
+// generator has a yield cap: on an unguarded build it hits that cap with ticks=0; with the
+// guard the paced consumer's five reads finish first.
+describe("Response(async iterable).body: direct-controller pump guard", () => {
+  const producer = (cap: number) => `
+    const chunk = new Uint8Array(1024);
+    let yields = 0;
+    let ticks = 0;
+    async function* g() {
+      while (true) {
+        yield chunk;
+        if (++yields > ${cap}) {
+          process.stdout.write(JSON.stringify({ error: "unbounded", yields, ticks }) + "\\n");
+          process.exit(1);
+        }
+      }
+    }
+    setInterval(() => ticks++, 10);
+  `;
+  const report = `
+    process.stdout.write(JSON.stringify({ reads, yields, ticks }) + "\\n");
+    process.exit(0);
+  `;
+
+  async function runFace(consumer: string, cap = 4000) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", producer(cap) + consumer],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    return { result, exitCode };
+  }
+
+  test.concurrent.each([
+    [
+      "getReader()",
+      `
+      const r = new Response(g()).body.getReader();
+      let reads = 0;
+      (async () => {
+        while (true) {
+          const { done } = await r.read();
+          if (done) break;
+          reads++;
+          await new Promise(res => setTimeout(res, 1));
+          if (reads === 5) { await r.cancel(); ${report} }
+        }
+      })();
+      `,
+    ],
+    [
+      "for-await",
+      `
+      let reads = 0;
+      (async () => {
+        for await (const c of new Response(g()).body) {
+          reads++;
+          await new Promise(res => setTimeout(res, 1));
+          if (reads === 5) { ${report} }
+        }
+      })();
+      `,
+    ],
+    [
+      "pipeTo",
+      `
+      let reads = 0;
+      new Response(g()).body.pipeTo(new WritableStream({
+        write() {
+          reads++;
+          if (reads === 5) { ${report} }
+          return new Promise(res => setTimeout(res, 1));
+        },
+      })).catch(() => {});
+      `,
+    ],
+    [
+      "pipeThrough",
+      `
+      let reads = 0;
+      const r = new Response(g()).body.pipeThrough(new TransformStream()).getReader();
+      (async () => {
+        while (true) {
+          const { done } = await r.read();
+          if (done) break;
+          reads++;
+          await new Promise(res => setTimeout(res, 1));
+          if (reads === 5) { await r.cancel(); ${report} }
+        }
+      })();
+      `,
+    ],
+  ])("paced %s consumer is not starved", async (_name, consumer) => {
+    const { result, exitCode } = await runFace(consumer);
+    expect(result.error).toBeUndefined();
+    // Reaching reads === 5 proves the event loop is alive: each step awaited a timer.
+    expect(result.reads).toBe(5);
+    expect(result.ticks).toBeGreaterThan(0);
+    // Five 64 KiB batches of 1 KiB chunks plus the resume-and-suspend overlap.
+    expect(result.yields).toBeLessThanOrEqual(4000);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("cancel while suspended runs the generator's finally", async () => {
+    const { result, exitCode } = await runFace(`
+      let reads = 0;
+      let returned = false;
+      async function* wrapped() { try { yield* g(); } finally { returned = true; } }
+      const r = new Response(wrapped()).body.getReader();
+      (async () => {
+        while (true) {
+          const { done } = await r.read();
+          if (done) break;
+          reads++;
+          if (reads === 3) {
+            await r.cancel();
+            await new Promise(res => setTimeout(res, 0));
+            process.stdout.write(JSON.stringify({ reads, yields, ticks, returned }) + "\\n");
+            process.exit(0);
+          }
+        }
+      })();
+    `);
+    expect(result.error).toBeUndefined();
+    expect(result).toMatchObject({ reads: 3, returned: true });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("spawn stdin: a full pipe's pending write suspends the pump", async () => {
+    // A child that never reads stdin fills the pipe buffer, so FileSink.write() returns a
+    // pending promise; the pump must suspend on it instead of buffering without bound.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const chunk = new Uint8Array(65536);
+        let yields = 0;
+        let ticks = 0;
+        async function* g() {
+          while (true) {
+            yield chunk;
+            if (++yields > 2000) {
+              process.stdout.write(JSON.stringify({ error: "unbounded", yields, ticks }) + "\\n");
+              process.exit(1);
+            }
+          }
+        }
+        setInterval(() => ticks++, 10);
+        const child = Bun.spawn({
+          cmd: [process.execPath, "-e", "setTimeout(() => {}, 120000)"],
+          stdin: new Response(g()).body,
+          stdout: "ignore",
+          stderr: "ignore",
+        });
+        (async () => {
+          while (ticks < 3) await new Promise(res => setTimeout(res, 10));
+          child.kill();
+          await child.exited;
+          process.stdout.write(JSON.stringify({ ticks, yields }) + "\\n");
+          process.exit(0);
+        })();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect(result.error).toBeUndefined();
+    expect(result.ticks).toBeGreaterThanOrEqual(3);
+    expect(result.yields).toBeLessThan(2000);
+    expect(exitCode).toBe(0);
+  });
+
+  // The guard is scoped to the ArrayBuffer sink kind: .text() uses the Text sink and a
+  // reader that is always waiting, so the guard must never trip for a finite producer.
+  test.concurrent(".text() on a finite producer is not guarded", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const chunk = new Uint8Array(1024).fill(0x61);
+        async function* g() { for (let i = 0; i < 5000; i++) yield chunk; }
+        const t = await new Response(g()).text();
+        process.stdout.write(JSON.stringify({ len: t.length }) + "\\n");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ len: 5000 * 1024 });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bounded producer still delivers every byte", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const chunk = new Uint8Array(1024).fill(0x61);
+        async function* g() { for (let i = 0; i < 300; i++) yield chunk; }
+        const r = new Response(g()).body.getReader();
+        let total = 0;
+        while (true) {
+          const { done, value } = await r.read();
+          if (done) break;
+          total += value.byteLength;
+        }
+        process.stdout.write(JSON.stringify({ total }) + "\\n");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ total: 300 * 1024 });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("strategy highWaterMark sets the guard threshold", async () => {
+    // A user type:"direct" stream: highWaterMark 8192 with 1 KiB writes means the first
+    // negative return (and so the first batch to the reader) is after the 9th write.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        let negativeAt = -1;
+        const s = new ReadableStream({
+          type: "direct",
+          async pull(c) {
+            for (let i = 1; i <= 200; i++) {
+              const n = c.write(new Uint8Array(1024));
+              if (typeof n === "number" && n < 0) { negativeAt = i; break; }
+            }
+            c.close();
+          },
+        }, { highWaterMark: 8192 });
+        const r = s.getReader();
+        const first = await r.read();
+        await r.cancel();
+        process.stdout.write(JSON.stringify({ negativeAt, firstLen: first.value?.byteLength ?? 0 }) + "\\n");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ negativeAt: 9, firstLen: 9 * 1024 });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -53,11 +53,12 @@ test("Response.arrayBuffer() with async iterable body does not crash with null d
   expect(exitCode).toBe(0);
 });
 
-// An async generator that never awaits fulfills every next() synchronously, so the direct
-// controller's drive loop would pump it forever (zero event-loop ticks, unbounded buffer)
-// without the controller's own backpressure signal. Each face runs in a subprocess whose
-// generator has a yield cap: on an unguarded build it hits that cap with ticks=0; with the
-// guard the paced consumer's five reads finish first.
+// An async generator that never awaits still returns a Pending next() (yield's implicit
+// Await), but the fulfilled reaction immediately calls next() again, so without the
+// controller's own backpressure signal the drive loop is a tight microtask chain that starves
+// timers and buffers without bound. Each face runs in a subprocess whose generator has a yield
+// cap: on an unguarded build it hits that cap with ticks=0; with the guard the paced consumer's
+// five reads finish first.
 describe("Response(async iterable).body: direct-controller pump guard", () => {
   const producer = (cap: number) => `
     const chunk = new Uint8Array(1024);

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -259,22 +259,52 @@ describe("Response(async iterable).body: direct-controller pump guard", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("bounded producer still delivers every byte", async () => {
+  // Byte-count controls. An async generator's yield has an implicit await so next() is never
+  // already-fulfilled; a manual iterator returning Promise.resolve(...) IS, which makes the
+  // pump loop synchronously inside the first callDirectPull frame. Both, across every
+  // non-Promise reader kind, must deliver the exact total.
+  test.concurrent.each([
+    ["async function*", `async function* it() { for (let i = 0; i < 300; i++) yield new Uint8Array(1024).fill(0x61); }`],
+    [
+      "Promise.resolve next()",
+      `function it() {
+         let k = 0;
+         return { [Symbol.asyncIterator]() { return this; }, next() {
+           if (k++ >= 300) return Promise.resolve({ done: true, value: undefined });
+           return Promise.resolve({ value: new Uint8Array(1024).fill(0x61), done: false });
+         } };
+       }`,
+    ],
+  ])("bounded %s producer delivers every byte to every reader kind", async (_name, iteratorSource) => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
-        const chunk = new Uint8Array(1024).fill(0x61);
-        async function* g() { for (let i = 0; i < 300; i++) yield chunk; }
-        const r = new Response(g()).body.getReader();
-        let total = 0;
-        while (true) {
-          const { done, value } = await r.read();
-          if (done) break;
-          total += value.byteLength;
+        ${iteratorSource}
+        const expected = 300 * 1024;
+        const out = {};
+        {
+          const r = new Response(it()).body.getReader();
+          let total = 0;
+          while (true) {
+            const { done, value } = await r.read();
+            if (done) break;
+            total += value.byteLength;
+          }
+          out.reader = total;
         }
-        process.stdout.write(JSON.stringify({ total }) + "\\n");
+        {
+          let total = 0;
+          for await (const c of new Response(it()).body) total += c.byteLength;
+          out.forAwait = total;
+        }
+        {
+          let total = 0;
+          await new Response(it()).body.pipeTo(new WritableStream({ write(c) { total += c.byteLength; } }));
+          out.pipeTo = total;
+        }
+        process.stdout.write(JSON.stringify(out) + "\\n");
         `,
       ],
       env: bunEnv,
@@ -283,7 +313,7 @@ describe("Response(async iterable).body: direct-controller pump guard", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual({ total: 300 * 1024 });
+    expect(JSON.parse(stdout.trim())).toEqual({ reader: 300 * 1024, forAwait: 300 * 1024, pipeTo: 300 * 1024 });
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
## Problem

A `type:"direct"` ReadableStream driven by an async generator that never awaits wedges the process:

```js
const chunk = new Uint8Array(1024);
async function* g() { while (true) yield chunk; }
setInterval(() => console.error("tick"), 10); // never fires
const r = new Response(g()).body.getReader();
while (true) {
  await r.read();                               // never resolves
  await new Promise(res => setTimeout(res, 1));
}
```

`driveAsyncIterator` pumps `iterator.next()` into `controller.write()` in a tight promise-reaction chain whose only suspension is a negative return from `write()`. The ArrayBufferSink always returns the positive byte count, and delivery to the reader only happens via the end-of-tick flush that the loop never lets run. A paced `getReader()`/`for await`/`pipeTo`/`pipeThrough` consumer gets zero chunks, zero timers fire, and RSS grows to OOM. The `Bun.spawn` stdin FileSink face buffers unbounded for the same reason: its `write()` returns a pending Promise that the loop marks handled and ignores.

## Fix

Put the guard on the controller, not the one pump that hit it:

- `boundDirectWrite` (ArrayBuffer sink only): track bytes written since the last delivery. Once past the strategy `highWaterMark` (default 64 KiB), a waiting consumer is handed the batch in-tick via `onFlush` and the caller keeps pumping; with no waiting consumer return `-(n+1)` so the caller awaits `flush(true)`.
- `boundDirectFlush(true)`: the await point. When bytes remain after the in-call `onFlush`, return a drain promise held on the controller (`m_drainPromise`).
- `didDrain`: reset `m_undeliveredBytes` and fulfill `m_drainPromise` on every `flushDirectSink` delivery and on close; `handleError` rejects it.
- `onClose`: run `didDrain` and the underlying source's `close()` before the stream-state early return, so `reader.cancel()` on a Direct stream now reaches the source (the async-iterable source sets `m_cancelled` and `return()`s the generator) and the flush-fulfilled reaction settles instead of re-driving.
- The async-iterable drive loop additionally suspends on a still-pending `Promise` returned from `write()` (FileSink on a full pipe), via the same flush-fulfilled reaction.

Text/Array sinks never increment the byte count, and the negative return is gated on `!directControllerHasWaitingConsumer`, so `.text()`/`.bytes()`/`readMany()` and any always-reading loop are never throttled. The Bun.serve HTTP sink already signals via a negative return and is unchanged.

## Verification

`test/js/web/fetch/body-async-iterator.test.ts` adds a subprocess harness: `getReader()`, `for await`, `pipeTo`, `pipeThrough`, cancel-while-suspended, and `Bun.spawn` stdin faces each cap the generator's yield count; on the unfixed build every one reports `{error:"unbounded", ticks:0}`, with the fix they report `reads=5` and `ticks>0`. The `.text()` finite-producer and bounded-producer byte-count controls pass both ways. A `highWaterMark: 8192` strategy test observes the first negative return after the 9th 1 KiB write.

`test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`: the two tests that killed the child after four 256 KiB chunks were handed off relied on the pump buffering without bound; they now kill after the first chunk, since the async-iterable pump suspends on the first pending FileSink write.

Alternative to #36092 (loop-side yield counter): this puts the signal on the controller so any `type:"direct"` pull that writes in a loop observes it, and honors the user's `highWaterMark`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream.test.ts test/js/web/fetch/body-async-iterator.test.ts
bun test v1.4.0 (d2f311bb0)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [1539.46ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [1601.43ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [1713.65ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [1658.81ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [1577.79ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [1567.28ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [1538.52ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [1696.02ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [1590.96ms]
(pass) spawn 
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (cb8bb5216)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [33.98ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [27.12ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [26.44ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [104.78ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [26.01ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [98.97ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [32.83ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [39.15ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [33.99ms]
(pass) spawn stdin ReadableStream > erroring the stdin ReadableStream does not surface an unhandled rejection [87.40ms]
(pass) spawn stdin ReadableStream > in-flight write when the child dies does not surface an unhandled rejection [15.57ms]
(pass) spawn
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream.test.ts test/js/web/fetch/body-async-iterator.test.ts
bun test v1.4.0 (d2f311bb0)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [1558.44ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [1631.41ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [1576.66ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [1603.44ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [1618.80ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [1543.88ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [1511.40ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [1589.58ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [1516.85ms]
(pass) spawn 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1375ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/11] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[2/11] cxx obj/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp.o
[3/11] cxx obj/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp.o
[4/11] gen cpp.rs (cppbind)
[4/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 25s
[7/11] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[8/11] link bun-profile
[10/11] strip bun
[10/11] bun-profile --revision
1.4.0-canary.1+d2f311bb0
[build] done
bun test v1.4.0-canary.1 (d2f311bb0)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [27.79ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple ch
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/BunAsyncIterableSource.cpp     |  16 +-
 .../webcore/streams/JSDirectStreamController.cpp   |  75 ++++-
 .../webcore/streams/JSDirectStreamController.h     |  13 +-
 .../webcore/streams/ReadableStreamOperations.cpp   |   7 +-
 .../bun/spawn/spawn-stdin-readable-stream.test.ts  |  23 +-
 test/js/web/fetch/body-async-iterator.test.ts      | 318 ++++++++++++++++++++-
 6 files changed, 430 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp      2      2      0
…c/bindings/webcore/streams/JSDirectStreamController.cpp      5     15      0
…jsc/bindings/webcore/streams/JSDirectStreamController.h      1      3      0
…c/bindings/webcore/streams/ReadableStreamOperations.cpp      3      1      0
test/js/bun/spawn/spawn-stdin-readable-stream.test.ts         2      6      0
test/js/web/fetch/body-async-iterator.test.ts                 5     11      0
```

</details>

<!-- robobun:evidence:end -->