### PR TITLE
fetch: reject bad client tls material with the BoringSSL reason instead of FailedToOpenSocket

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -95,14 +95,9 @@ fn ssl_config_intern_for_http(config: SSLConfig) -> http::ssl_config::SharedPtr 
     http::ssl_config::global_registry::intern(config)
 }
 
-/// Build the client `SSL_CTX` on the JS thread so bad cert/key material rejects
-/// with the BoringSSL reason (`ERR_OSSL_*`), matching `node:tls`
-/// `createSecureContext`. The HTTP thread builds this context lazily and can
-/// only surface `FailedToOpenSocket` for these failures: uSockets leaves `*err`
-/// at `.none` for cert/key, and the detail is on the thread-local error queue.
-///
-/// Skipped when no client identity is supplied so ca-only / serverName-only
-/// requests incur no extra build.
+/// Build the client `SSL_CTX` now so bad cert/key rejects with `ERR_OSSL_*`
+/// like `node:tls`; the HTTP thread's lazy build can only report
+/// `FailedToOpenSocket` because the BoringSSL error queue is thread-local.
 fn validate_client_tls_identity(global: &JSGlobalObject, config: &SSLConfig) -> JsResult<()> {
     let has_client_identity = config.cert.is_some()
         || config.key.is_some()

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -95,9 +95,7 @@ fn ssl_config_intern_for_http(config: SSLConfig) -> http::ssl_config::SharedPtr 
     http::ssl_config::global_registry::intern(config)
 }
 
-/// Build the client `SSL_CTX` now so bad cert/key rejects with `ERR_OSSL_*`
-/// like `node:tls`; the HTTP thread's lazy build can only report
-/// `FailedToOpenSocket` because the BoringSSL error queue is thread-local.
+/// Probe the client `SSL_CTX` so bad cert/key rejects with `ERR_OSSL_*` instead of the HTTP thread's generic `FailedToOpenSocket`.
 fn validate_client_tls_identity(global: &JSGlobalObject, config: &SSLConfig) -> JsResult<()> {
     let has_client_identity = config.cert.is_some()
         || config.key.is_some()
@@ -117,9 +115,11 @@ fn validate_client_tls_identity(global: &JSGlobalObject, config: &SSLConfig) -> 
             unsafe { bun_boringssl_sys::SSL_CTX_free(ctx) };
             Ok(())
         }
-        None => Err(global.throw_value(
-            crate::socket::uws_jsc::create_bun_socket_error_to_js(err, global),
-        )),
+        None => Err(
+            global.throw_value(crate::socket::uws_jsc::create_bun_socket_error_to_js(
+                err, global,
+            )),
+        ),
     }
 }
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -777,6 +777,34 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                 return Ok(JSValue::ZERO);
                             }
                             Ok(Some(config)) => {
+                                // The HTTP thread builds this SSL_CTX lazily and, on a cert/key
+                                // parse failure, can only surface a generic FailedToOpenSocket
+                                // (the BoringSSL error queue is thread-local and uSockets does
+                                // not set `*err` for bad cert/key). Build it here so a bad
+                                // client identity rejects with the same ERR_OSSL_* code as
+                                // node:tls createSecureContext.
+                                if config.requires_custom_request_ctx {
+                                    let mut err = bun_uws::create_bun_socket_error_t::none;
+                                    match config
+                                        .as_usockets_for_client_verification()
+                                        .create_ssl_context(&mut err)
+                                    {
+                                        Some(ctx) => {
+                                            // SAFETY: `create_ssl_context` hands back a +1
+                                            // ref; release it. The HTTP thread builds its
+                                            // own from the interned config.
+                                            unsafe { bun_boringssl_sys::SSL_CTX_free(ctx) };
+                                        }
+                                        None => {
+                                            return Err(global_this.throw_value(
+                                                crate::socket::uws_jsc::create_bun_socket_error_to_js(
+                                                    err,
+                                                    global_this,
+                                                ),
+                                            ));
+                                        }
+                                    }
+                                }
                                 // Intern via `ssl_config::global_registry` for dedup and pointer equality
                                 break 'extract_ssl_config Some(ssl_config_intern_for_http(config));
                             }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -95,6 +95,39 @@ fn ssl_config_intern_for_http(config: SSLConfig) -> http::ssl_config::SharedPtr 
     http::ssl_config::global_registry::intern(config)
 }
 
+/// Build the client `SSL_CTX` on the JS thread so bad cert/key material rejects
+/// with the BoringSSL reason (`ERR_OSSL_*`), matching `node:tls`
+/// `createSecureContext`. The HTTP thread builds this context lazily and can
+/// only surface `FailedToOpenSocket` for these failures: uSockets leaves `*err`
+/// at `.none` for cert/key, and the detail is on the thread-local error queue.
+///
+/// Skipped when no client identity is supplied so ca-only / serverName-only
+/// requests incur no extra build.
+fn validate_client_tls_identity(global: &JSGlobalObject, config: &SSLConfig) -> JsResult<()> {
+    let has_client_identity = config.cert.is_some()
+        || config.key.is_some()
+        || !config.cert_file_name.is_null()
+        || !config.key_file_name.is_null();
+    if !has_client_identity {
+        return Ok(());
+    }
+    let mut err = bun_uws::create_bun_socket_error_t::none;
+    match config
+        .as_usockets_for_client_verification()
+        .create_ssl_context(&mut err)
+    {
+        Some(ctx) => {
+            // SAFETY: `create_ssl_context` returns a +1 ref; the HTTP thread
+            // builds its own from the interned config, so release this one.
+            unsafe { bun_boringssl_sys::SSL_CTX_free(ctx) };
+            Ok(())
+        }
+        None => Err(global.throw_value(
+            crate::socket::uws_jsc::create_bun_socket_error_to_js(err, global),
+        )),
+    }
+}
+
 /// Build the refcounted `bun_s3_signing::S3Credentials` from the lower-tier
 /// `bun_dotenv::S3Credentials` POD mirror. The dotenv crate (T2) cannot name
 /// `bun_s3_signing` types (would be an upward dep), so the conversion lives at
@@ -777,40 +810,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                 return Ok(JSValue::ZERO);
                             }
                             Ok(Some(config)) => {
-                                // The HTTP thread builds this SSL_CTX lazily and, on a cert/key
-                                // parse failure, can only surface a generic FailedToOpenSocket
-                                // (the BoringSSL error queue is thread-local and uSockets does
-                                // not set `*err` for bad cert/key). Build it here so a bad
-                                // client identity rejects with the same ERR_OSSL_* code as
-                                // node:tls createSecureContext. Only probe when a client
-                                // identity is present so ca-only / serverName-only configs
-                                // keep hitting the HTTP-thread cache without an extra build.
-                                let has_client_identity = config.cert.is_some()
-                                    || config.key.is_some()
-                                    || !config.cert_file_name.is_null()
-                                    || !config.key_file_name.is_null();
-                                if has_client_identity {
-                                    let mut err = bun_uws::create_bun_socket_error_t::none;
-                                    match config
-                                        .as_usockets_for_client_verification()
-                                        .create_ssl_context(&mut err)
-                                    {
-                                        Some(ctx) => {
-                                            // SAFETY: `create_ssl_context` hands back a +1
-                                            // ref; release it. The HTTP thread builds its
-                                            // own from the interned config.
-                                            unsafe { bun_boringssl_sys::SSL_CTX_free(ctx) };
-                                        }
-                                        None => {
-                                            return Err(global_this.throw_value(
-                                                crate::socket::uws_jsc::create_bun_socket_error_to_js(
-                                                    err,
-                                                    global_this,
-                                                ),
-                                            ));
-                                        }
-                                    }
-                                }
+                                validate_client_tls_identity(global_this, &config)?;
                                 // Intern via `ssl_config::global_registry` for dedup and pointer equality
                                 break 'extract_ssl_config Some(ssl_config_intern_for_http(config));
                             }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -782,8 +782,14 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                 // (the BoringSSL error queue is thread-local and uSockets does
                                 // not set `*err` for bad cert/key). Build it here so a bad
                                 // client identity rejects with the same ERR_OSSL_* code as
-                                // node:tls createSecureContext.
-                                if config.requires_custom_request_ctx {
+                                // node:tls createSecureContext. Only probe when a client
+                                // identity is present so ca-only / serverName-only configs
+                                // keep hitting the HTTP-thread cache without an extra build.
+                                let has_client_identity = config.cert.is_some()
+                                    || config.key.is_some()
+                                    || !config.cert_file_name.is_null()
+                                    || !config.key_file_name.is_null();
+                                if has_client_identity {
                                     let mut err = bun_uws::create_bun_socket_error_t::none;
                                     match config
                                         .as_usockets_for_client_verification()

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -697,5 +698,81 @@ describe.concurrent("fetch-tls", () => {
       expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
       expect(stderr).toContain("ignoring extra certs");
     }
+  });
+
+  describe("client tls material errors carry the BoringSSL reason", () => {
+    // These used to collapse to { code: "FailedToOpenSocket", message: "Was
+    // there a typo in the url or port?" } because the SSL_CTX is built lazily
+    // on the HTTP thread, which only ever returned a generic init failure.
+    const keysDir = join(import.meta.dir, "..", "..", "node", "test", "fixtures", "keys");
+    const readKey = (name: string) => readFileSync(join(keysDir, name), "utf8");
+
+    const agent1Cert = readKey("agent1-cert.pem");
+    const agent1Key = readKey("agent1-key.pem");
+    const agent2Key = readKey("agent2-key.pem");
+    const rsaCert = readKey("rsa_cert.crt");
+    // rsa_private.pem re-encrypted with pass:'password' (see fixtures/keys/Makefile).
+    const rsaEncryptedKey = readKey("rsa_private_encrypted.pem");
+
+    async function rejection(clientTls: TLSOptions) {
+      await using server = Bun.serve({
+        port: 0,
+        tls: CERT_LOCALHOST_IP,
+        fetch: () => new Response("ok"),
+      });
+      let caught: any;
+      await fetch(server.url, { tls: { ...clientTls, rejectUnauthorized: false } as any }).then(
+        r => r.text(),
+        e => (caught = e),
+      );
+      return caught;
+    }
+
+    it("cert/key mismatch rejects with ERR_OSSL_X509_KEY_VALUES_MISMATCH", async () => {
+      const err = await rejection({ cert: agent1Cert, key: agent2Key });
+      expect(err).toBeInstanceOf(Error);
+      expect({ code: err.code, library: err.library, reason: err.reason }).toEqual({
+        code: "ERR_OSSL_X509_KEY_VALUES_MISMATCH",
+        library: "X.509 certificate routines",
+        reason: "KEY_VALUES_MISMATCH",
+      });
+      expect(err.message).not.toContain("typo in the url or port");
+    });
+
+    it("wrong passphrase rejects with the BoringSSL decrypt reason", async () => {
+      const err = await rejection({ cert: rsaCert, key: rsaEncryptedKey, passphrase: "wrong" });
+      expect(err).toBeInstanceOf(Error);
+      // BoringSSL reports this from ERR_LIB_CIPHER, which Node's library-prefix
+      // map does not cover, so the code has no library segment.
+      expect({ code: err.code, library: err.library, reason: err.reason }).toEqual({
+        code: "ERR_OSSL_BAD_DECRYPT",
+        library: "Cipher functions",
+        reason: "BAD_DECRYPT",
+      });
+      expect(err.message).not.toContain("typo in the url or port");
+    });
+
+    it("non-PEM cert string rejects with ERR_OSSL_PEM_NO_START_LINE", async () => {
+      const err = await rejection({ cert: "not a pem", key: agent1Key });
+      expect(err).toBeInstanceOf(Error);
+      expect({ code: err.code, library: err.library, reason: err.reason }).toEqual({
+        code: "ERR_OSSL_PEM_NO_START_LINE",
+        library: "PEM routines",
+        reason: "NO_START_LINE",
+      });
+      expect(err.message).not.toContain("typo in the url or port");
+    });
+
+    it("matching cert/key still succeeds", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        tls: CERT_LOCALHOST_IP,
+        fetch: () => new Response("ok"),
+      });
+      const res = await fetch(server.url, {
+        tls: { cert: agent1Cert, key: agent1Key, rejectUnauthorized: false } as any,
+      });
+      expect(await res.text()).toBe("ok");
+    });
   });
 });


### PR DESCRIPTION
`fetch(url, { tls: { cert, key, passphrase } })` with a bad client identity (cert/key mismatch, wrong passphrase, a file path passed where PEM contents are expected) rejected with the generic connection error:

```js
{ code: "FailedToOpenSocket", message: "Was there a typo in the url or port?" }
```

All three failure modes were indistinguishable, had no OpenSSL code, and the message pointed the user at the URL when the problem was their cert material.

### Reproduction

```js
using srv = Bun.serve({ port: 0, tls: serverCert, fetch: () => new Response("ok") });
for (const [name, tls] of [
  ["mismatch",   { cert: certA, key: keyB }],
  ["wrong-pass", { cert: certA, key: encryptedKeyA, passphrase: "wrong" }],
  ["junk-pem",   { cert: "not a pem", key: keyA }],
  ["control",    { cert: certA, key: keyA }],
])
  console.log(name, await fetch(srv.url, { tls: { ...tls, rejectUnauthorized: false } })
    .then(r => r.text(), e => ({ code: e.code, reason: e.reason })));
```

Before:
```
mismatch   { code: "FailedToOpenSocket", reason: undefined }
wrong-pass { code: "FailedToOpenSocket", reason: undefined }
junk-pem   { code: "FailedToOpenSocket", reason: undefined }
control    "ok"
```

After:
```
mismatch   { code: "ERR_OSSL_X509_KEY_VALUES_MISMATCH", reason: "KEY_VALUES_MISMATCH" }
wrong-pass { code: "ERR_OSSL_BAD_DECRYPT",              reason: "BAD_DECRYPT" }
junk-pem   { code: "ERR_OSSL_PEM_NO_START_LINE",        reason: "NO_START_LINE" }
control    "ok"
```

(Node with OpenSSL reports the second as `ERR_OSSL_EVP_BAD_DECRYPT`; BoringSSL attributes it to `ERR_LIB_CIPHER`, which is not in Node's library-prefix map, so the code has no library segment. The `library`/`reason` fields still identify it.)

### Cause

The client `SSL_CTX` for a custom `tls` config is built lazily on the HTTP thread (`HTTPContext::init_with_client_config` -> `init_with_opts` -> C `us_ssl_ctx_build_raw`). When cert or key parsing fails, every branch does `ssl_ctx_build_fail(); return NULL;` without setting the `*err` out-param, so it stays `CREATE_BUN_SOCKET_ERROR_NONE`; the real reason sits on the thread-local BoringSSL error queue. `init_with_opts` maps `none` to `InitError::FailedToOpenSocket`, `HTTPThread` maps that to `http::Error::FailedToOpenSocket`, and `FetchTasklet` renders the "typo" message. There is no `ERR_get_error` anywhere in `src/http/`.

`node:tls` `SecureContext::create_private` calls the same `create_ssl_context`, but on `err == none` routes through `create_bun_socket_error_to_js`, whose `.none` arm already calls `err_to_js(global, ERR_get_error())` and decorates the error with Node's `code`/`library`/`reason` shape.

### Fix

In `fetch.rs`, right after `SSLConfig::from_js` returns a config that would require a custom SSL context (`requires_custom_request_ctx`), build the `SSL_CTX` eagerly on the JS thread. On `None`, throw via `create_bun_socket_error_to_js(err, global)` (the same helper `node:tls` and `Bun.listen` use) so the rejection carries the BoringSSL `code`/`library`/`reason` and a real stack. On success, release the probe context; the HTTP thread builds its own from the interned config as before. Guarding on `requires_custom_request_ctx` means `{ rejectUnauthorized: false }` and other option-only configs incur no extra build.

### Testing

Four new cases in `test/js/web/fetch/fetch.tls.test.ts` using the existing Node key fixtures: cert/key mismatch, wrong passphrase on an encrypted key, non-PEM cert string, and a control with matching material. The first three fail on main with `FailedToOpenSocket` and pass with distinct `ERR_OSSL_*` codes after the fix; the control passes on both.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.0 (2651349dc)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1163.43ms]
(pass) fetch-tls > fetch with valid tls should not throw [1809.47ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1874.12ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [315.71ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2219.04ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [2168.99ms]
(pass) fetch-tls > fetch with self-sign tls should throw [170.64ms]
(pass) fetch-tls > fetch with invalid tls should throw [165.85ms]
(pass) fetch-tls > fetch with checkServerIdentity failing should throw [284.45ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [685.72m
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls should not throw [1540.90ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [42.53ms]
(pass) fetch-tls > checkServerIdentity approval still transmits the request and round-trips the response [39.95ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1560.57ms]
(pass) fetch-tls > fetch should use NODE_EXTRA_CA_CERTS [41.31ms]
729 |     }
730 | 
731 |     it("cert/key mismatch rejects with ERR_OSSL_X509_KEY_VALUES_MISMATCH", async () => {
732 |       const err = await rejection({ cert: agent1Cert, key: agent2Key });
733 |       expect(err).toBeInstanceOf(Error);
734 |       expect({ code: err.code, library: err.library, reason: err.reason }).toEqual({
                                                                                 ^
error: expect(received).toEqual(expected)

  {
-   "code": "ERR_OSSL_X509_KEY_VALUES_MISMATCH",
-   "library": "X.509 certificate routines",
-   "reason": "KEY_VALUES_MISMATCH",
+   "code": "FailedToOpenSocket",
+   "library": unde
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.0 (2651349dc)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1149.04ms]
(pass) fetch-tls > fetch with valid tls should not throw [1789.31ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1850.20ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [310.62ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2193.23ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [2144.99ms]
(pass) fetch-tls > fetch with self-sign tls should throw [166.24ms]
(pass) fetch-tls > fetch with invalid tls should throw [161.03ms]
(pass) fetch-tls > fetch with checkServerIdentity failing should throw [281.50ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [676.25m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 753ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/fetch.rs        | 29 ++++++++++++++
 test/js/web/fetch/fetch.tls.test.ts | 77 +++++++++++++++++++++++++++++++++++++
 2 files changed, 106 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/webcore/fetch.rs             7      6      0
test/js/web/fetch/fetch.tls.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->