### PR TITLE
docs(http/stream-file): confine the static file server example to a root directory

### DIFF
--- a/docs/guides/http/stream-file.mdx
+++ b/docs/guides/http/stream-file.mdx
@@ -32,14 +32,40 @@ new Response(Bun.file("./img.png")).headers.get("Content-Type");
 
 ---
 
-Putting it all together with [`Bun.serve()`](/runtime/http/server).
+Putting it all together with [`Bun.serve()`](/runtime/http/server), a static file server that serves files from a `./public` directory.
+
+`new URL(req.url).pathname` is an absolute path (it begins with `/`), so passing it straight to `Bun.file()` would read from the filesystem root and serve any file the process can read. Always resolve the request path against a fixed root directory and refuse anything that escapes it.
 
 ```ts server.ts icon="/icons/typescript.svg"
-// static file server
+import path from "node:path";
+import { realpathSync } from "node:fs";
+
+const root = realpathSync(path.resolve("./public"));
+
 Bun.serve({
   async fetch(req) {
-    const path = new URL(req.url).pathname;
-    const file = Bun.file(path);
+    let pathname: string;
+    try {
+      pathname = decodeURIComponent(new URL(req.url).pathname);
+    } catch {
+      return new Response("Bad Request", { status: 400 });
+    }
+
+    // Resolve under the root and refuse anything that escapes it
+    const resolved = path.resolve(root, "." + pathname);
+    if (resolved !== root && !resolved.startsWith(root + path.sep)) return new Response("Forbidden", { status: 403 });
+
+    // Refuse symlinks that point outside the root
+    let real: string;
+    try {
+      real = realpathSync(resolved);
+    } catch {
+      return new Response("Not Found", { status: 404 });
+    }
+    if (real !== root && !real.startsWith(root + path.sep)) return new Response("Forbidden", { status: 403 });
+
+    const file = Bun.file(real);
+    if (!(await file.exists())) return new Response("Not Found", { status: 404 });
     return new Response(file);
   },
 });


### PR DESCRIPTION
The "Putting it all together" example in `docs/guides/http/stream-file.mdx` was labeled `// static file server` and looked like this:

```ts
Bun.serve({
  async fetch(req) {
    const path = new URL(req.url).pathname;
    const file = Bun.file(path);   // absolute path, rooted at /
    return new Response(file);
  },
});
```

`new URL(req.url).pathname` is an absolute string, so `Bun.file(path)` opens whatever the URL names starting from the filesystem root. No traversal or encoding tricks needed: a raw `GET /etc/hostname` (or any other readable absolute path) returns `200` with that file's bytes, while `GET /hello.txt` for a file in the working directory returns `404`. Anyone copying this example as a static file server exposes every file the Bun process can read.

## Change

Replaces the example with one that confines responses to a `./public` directory:

- `decodeURIComponent` on the pathname, rejecting malformed percent-encoding with `400`.
- `path.resolve(root, "." + pathname)` and a prefix check against `root + path.sep`, rejecting anything outside with `403`.
- `realpathSync` and the same prefix check on the result, rejecting symlinks that point outside the root with `403`.
- `404` for anything that does not exist.

A short paragraph before the code block explains why the raw pathname must never be passed to `Bun.file()`.

## Verification

Ran the new example against a raw-socket client on stock 1.4.0:

```
/hello.txt                      HTTP/1.1 200 OK          HELLO
/etc/hostname                   HTTP/1.1 404 Not Found
/tmp/sentinel.txt               HTTP/1.1 404 Not Found
/../sentinel.txt                HTTP/1.1 404 Not Found
/%2e%2e/%2e%2e/etc/hostname     HTTP/1.1 404 Not Found
/escape (symlink -> /tmp/...)   HTTP/1.1 403 Forbidden
/nope                           HTTP/1.1 404 Not Found
/%ff                            HTTP/1.1 400 Bad Request
```

The old example returned `200` with the file contents for `/etc/hostname` and `/tmp/sentinel.txt`.

Grepped `docs/` for other `new URL(req.url).pathname` uses; the remaining occurrences are equality comparisons (`if (url.pathname === "/")`) and are unaffected.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->