### PR TITLE
docs(Bun.serve): escape error output and gate stack traces in the error() example

### DIFF
--- a/docs/runtime/http/error-handling.mdx
+++ b/docs/runtime/http/error-handling.mdx
@@ -22,7 +22,7 @@ In development mode, Bun surfaces errors in-browser with a built-in error page.
 
 To handle server-side errors, implement an `error` handler. Return a `Response` to serve to the client when an error occurs. In `development` mode, this response replaces Bun's default error page.
 
-Error messages and stack traces often contain request input (paths, query parameters, header values) and absolute filesystem paths. If you render them as HTML, escape them with [`Bun.escapeHTML`](/runtime/utils#bun-escapehtml), and only return them to the client in development. In production, log the error on the server and respond with a generic message.
+Error messages and stack traces often contain request input (paths, query parameters, header values) and absolute filesystem paths. If you render them as HTML, escape them with [`Bun.escapeHTML`](/runtime/utils#bun-escapehtml), and avoid returning them to clients in production; log the error on the server and respond with a generic message instead.
 
 ```ts
 const dev = process.env.NODE_ENV !== "production";

--- a/docs/runtime/http/error-handling.mdx
+++ b/docs/runtime/http/error-handling.mdx
@@ -22,16 +22,22 @@ In development mode, Bun surfaces errors in-browser with a built-in error page.
 
 To handle server-side errors, implement an `error` handler. Return a `Response` to serve to the client when an error occurs. In `development` mode, this response replaces Bun's default error page.
 
+Error messages and stack traces often contain request input (paths, query parameters, header values) and absolute filesystem paths. If you render them as HTML, escape them with [`Bun.escapeHTML`](/runtime/utils#bun-escapehtml), and only return them to the client in development. In production, log the error on the server and respond with a generic message.
+
 ```ts
+const dev = process.env.NODE_ENV !== "production";
+
 Bun.serve({
+  development: dev,
   fetch(req) {
     throw new Error("woops!");
   },
   error(error) {
-    return new Response(`<pre>${error}\n${error.stack}</pre>`, {
-      headers: {
-        "Content-Type": "text/html",
-      },
+    console.error(error);
+    if (!dev) return new Response("Internal Server Error", { status: 500 });
+    return new Response(`<pre>${Bun.escapeHTML(`${error}\n${error.stack}`)}</pre>`, {
+      status: 500,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   },
 });


### PR DESCRIPTION
## Problem

The `error()` callback example in `docs/runtime/http/error-handling.mdx` interpolated `${error}` and `${error.stack}` directly into a `text/html` response with no escaping and no production gate. Many built-in errors echo request input verbatim (for example `new URL(x)` produces `"...x..." cannot be parsed as a URL`, and `Bun.file(p)` ENOENT embeds `p`), so copying the example as-is yields reflected XSS plus absolute-path disclosure for every client.

Repro (documented handler + one ordinary app line validating a user URL):

```ts
const s = Bun.serve({
  port: 0,
  hostname: "127.0.0.1",
  fetch(req) {
    new URL(new URL(req.url).searchParams.get("url")!);
    return new Response("ok");
  },
  error(error) {
    return new Response(`<pre>${error}\n${error.stack}</pre>`, {
      headers: { "Content-Type": "text/html" },
    });
  },
});
console.log(await (await fetch(`http://127.0.0.1:${s.port}/?url=%3Cimg%20src=x%20onerror=alert(document.domain)%3E`)).text());
```

Output (200 `text/html`):

```
<pre>TypeError [ERR_INVALID_URL]: "<img src=x onerror=alert(document.domain)>" cannot be parsed as a URL.
TypeError: "<img src=x onerror=alert(document.domain)>" cannot be parsed as a URL.
    at URL (unknown)
    at fetch (/abs/path/server.ts:5:9)</pre>
```

The `<img onerror>` executes in a browser and the stack leaks the absolute source path.

## Fix

Update the example to:

- wrap the interpolated text in `Bun.escapeHTML()` before placing it inside `<pre>`
- return `status: 500` (previously defaulted to 200)
- gate the detailed response on `process.env.NODE_ENV !== "production"`, returning a generic `Internal Server Error` otherwise
- `console.error(error)` so production still logs the failure server-side

A short paragraph before the snippet explains why error text must be escaped and why stack traces should not reach production clients.

## Verification

With the updated handler, the same request now yields:

```
status: 500 text/html; charset=utf-8
<pre>TypeError [ERR_INVALID_URL]: &quot;&lt;img src=x onerror=alert(document.domain)&gt;&quot; cannot be parsed as a URL.
...</pre>
```

and with `NODE_ENV=production`:

```
status: 500 text/plain;charset=utf-8
Internal Server Error
```

Docs-only change; no runtime code touched.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->