### PR TITLE
docs(websocket): add Origin check to cookie-authenticated upgrade examples

### DIFF
--- a/docs/guides/websocket/context.mdx
+++ b/docs/guides/websocket/context.mdx
@@ -37,7 +37,7 @@ Bun.serve({
 
 ---
 
-It's common to read cookies/headers from the incoming request to identify the connecting client. When doing so, validate the `Origin` header before calling `server.upgrade()`. Browsers attach cookies to cross-origin WebSocket handshakes, so without this check any website can open a socket authenticated as the current user ([cross-site WebSocket hijacking](https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking)).
+It's common to read cookies/headers from the incoming request to identify the connecting client. When doing so, validate the `Origin` header before calling `server.upgrade()`. Depending on the cookie's `SameSite` attribute, browsers can attach session cookies to cross-origin WebSocket handshakes, so without this check another website may be able to open a socket authenticated as the current user ([cross-site WebSocket hijacking](https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking)).
 
 ```ts server.ts icon="/icons/typescript.svg"
 type WebSocketData = {

--- a/docs/guides/websocket/context.mdx
+++ b/docs/guides/websocket/context.mdx
@@ -37,7 +37,7 @@ Bun.serve({
 
 ---
 
-It's common to read cookies/headers from the incoming request to identify the connecting client.
+It's common to read cookies/headers from the incoming request to identify the connecting client. When doing so, validate the `Origin` header before calling `server.upgrade()`. Browsers attach cookies to cross-origin WebSocket handshakes, so without this check any website can open a socket authenticated as the current user ([cross-site WebSocket hijacking](https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking)).
 
 ```ts server.ts icon="/icons/typescript.svg"
 type WebSocketData = {
@@ -46,8 +46,16 @@ type WebSocketData = {
   userId: string;
 };
 
+const ALLOWED_ORIGINS = new Set(["https://my-app.example"]);
+
 Bun.serve({
   async fetch(req, server) {
+    // reject cross-origin upgrade attempts before reading cookies
+    const origin = req.headers.get("origin");
+    if (!origin || !ALLOWED_ORIGINS.has(origin)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     // use a library to parse cookies
     const cookies = parseCookies(req.headers.get("Cookie"));
     const token = cookies["X-Token"];

--- a/docs/guides/websocket/pubsub.mdx
+++ b/docs/guides/websocket/pubsub.mdx
@@ -13,17 +13,19 @@ const ALLOWED_ORIGINS = new Set(["https://my-app.example"]);
 
 const server = Bun.serve({
   fetch(req, server) {
-    // Reject cross-origin WebSocket handshakes before trusting cookies,
-    // otherwise any site can open an authenticated socket as the victim.
-    const origin = req.headers.get("origin");
-    if (!origin || !ALLOWED_ORIGINS.has(origin)) {
-      return new Response("Forbidden", { status: 403 });
-    }
+    if (req.headers.get("upgrade") === "websocket") {
+      // Reject cross-origin WebSocket handshakes before trusting cookies,
+      // otherwise any site can open an authenticated socket as the victim.
+      const origin = req.headers.get("origin");
+      if (!origin || !ALLOWED_ORIGINS.has(origin)) {
+        return new Response("Forbidden", { status: 403 });
+      }
 
-    const cookies = req.headers.get("cookie");
-    const username = getUsernameFromCookies(cookies);
-    const success = server.upgrade(req, { data: { username } });
-    if (success) return undefined;
+      const cookies = req.headers.get("cookie");
+      const username = getUsernameFromCookies(cookies);
+      const success = server.upgrade(req, { data: { username } });
+      if (success) return undefined;
+    }
 
     return new Response("Hello world");
   },

--- a/docs/guides/websocket/pubsub.mdx
+++ b/docs/guides/websocket/pubsub.mdx
@@ -13,7 +13,7 @@ const ALLOWED_ORIGINS = new Set(["https://my-app.example"]);
 
 const server = Bun.serve({
   fetch(req, server) {
-    if (req.headers.get("upgrade") === "websocket") {
+    if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
       // Reject cross-origin WebSocket handshakes before trusting cookies,
       // otherwise any site can open an authenticated socket as the victim.
       const origin = req.headers.get("origin");

--- a/docs/guides/websocket/pubsub.mdx
+++ b/docs/guides/websocket/pubsub.mdx
@@ -9,8 +9,17 @@ Bun's server-side `WebSocket` API includes native pub-sub. Subscribe a socket to
 This code snippet implements a single-channel chat server.
 
 ```ts server.ts icon="/icons/typescript.svg"
+const ALLOWED_ORIGINS = new Set(["https://my-app.example"]);
+
 const server = Bun.serve({
   fetch(req, server) {
+    // Reject cross-origin WebSocket handshakes before trusting cookies,
+    // otherwise any site can open an authenticated socket as the victim.
+    const origin = req.headers.get("origin");
+    if (!origin || !ALLOWED_ORIGINS.has(origin)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     const cookies = req.headers.get("cookie");
     const username = getUsernameFromCookies(cookies);
     const success = server.upgrade(req, { data: { username } });

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -196,7 +196,7 @@ socket.addEventListener("message", event => {
 
 Cookies set on the page are sent with the WebSocket upgrade request and available on `req.headers` in the `fetch` handler. Parse them to identify the connecting user and set `data` accordingly.
 
-Because the WebSocket handshake is a simple `GET`, browsers attach those cookies even when the connection is opened by a page on another origin, and the same-origin policy does not block the response. If you authenticate the upgrade from a cookie, **always validate `req.headers.get("origin")` against an allowlist** before calling `server.upgrade()`. Skipping this check allows [cross-site WebSocket hijacking](https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking): any site the user visits can open a fully authenticated socket and read every message.
+The WebSocket handshake is a simple `GET` that is not covered by the same-origin policy, so a page on another origin can open a connection and, depending on the cookie's `SameSite` attribute and the browser's defaults, have the session cookie attached. If you authenticate the upgrade from a cookie, **always validate `req.headers.get("origin")` against an allowlist** before calling `server.upgrade()`, regardless of your `SameSite` settings. Skipping this check exposes the server to [cross-site WebSocket hijacking](https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking): a hostile site can open a fully authenticated socket as the victim and read every message.
 
 </Warning>
 

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -113,7 +113,7 @@ Bun.serve({
     const sessionId = await generateSessionId();
     server.upgrade(req, {
       headers: { // [!code ++]
-        "Set-Cookie": `SessionId=${sessionId}`, // [!code ++]
+        "Set-Cookie": `SessionId=${sessionId}; HttpOnly; Secure; SameSite=Lax; Path=/`, // [!code ++]
       }, // [!code ++]
     });
   },
@@ -134,8 +134,18 @@ type WebSocketData = {
   authToken: string;
 };
 
+const ALLOWED_ORIGINS = new Set(["https://my-app.example"]);
+
 Bun.serve({
   fetch(req, server) {
+    // When authenticating with cookies, always verify the Origin header.
+    // Browsers send cookies on cross-origin WebSocket handshakes, so without
+    // this check any website could open a socket authenticated as your user.
+    const origin = req.headers.get("origin");
+    if (!origin || !ALLOWED_ORIGINS.has(origin)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     const cookies = new Bun.CookieMap(req.headers.get("cookie")!);
 
     server.upgrade(req, {
@@ -181,12 +191,14 @@ socket.addEventListener("message", event => {
 });
 ```
 
-<Info>
-**Identifying users**
+<Warning>
+**Identifying users with cookies**
 
 Cookies set on the page are sent with the WebSocket upgrade request and available on `req.headers` in the `fetch` handler. Parse them to identify the connecting user and set `data` accordingly.
 
-</Info>
+Because the WebSocket handshake is a simple `GET`, browsers attach those cookies even when the connection is opened by a page on another origin, and the same-origin policy does not block the response. If you authenticate the upgrade from a cookie, **always validate `req.headers.get("origin")` against an allowlist** before calling `server.upgrade()`. Skipping this check allows [cross-site WebSocket hijacking](https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking): any site the user visits can open a fully authenticated socket and read every message.
+
+</Warning>
 
 ### Pub/Sub
 


### PR DESCRIPTION
## What

The WebSocket docs authenticate `server.upgrade()` from a request cookie without checking the `Origin` header. Because the WebSocket handshake is a plain `GET` that carries cookies and is not subject to the same-origin policy, the examples as written are copy-paste vulnerable to cross-site WebSocket hijacking: any page the user visits can open a fully authenticated socket and read every message.

Chromium/Firefox default `SameSite=Lax` on unflagged cookies partially mitigates this, but Safari has no Lax default, and any `SameSite=None` or legacy session cookie remains exposed. The docs' own `Set-Cookie: SessionId=...` example set no flags at all.

## Repro

Using the Contextual data example from `docs/runtime/http/websockets.mdx` verbatim with a stubbed `getUserFromToken`:

```ts
const server = Bun.serve({
  port: 0, hostname: "127.0.0.1",
  fetch(req, server) {
    const cookies = new Bun.CookieMap(req.headers.get("cookie")!);
    server.upgrade(req, { data: { authToken: cookies.get("X-Token") } });
  },
  websocket: {
    open(ws) { ws.send(ws.data.authToken === "s3cr3t" ? "AUTHENTICATED as alice" : "anon"); },
    message() {},
  },
});

// attacker page context: hostile Origin, victim's cookie rides along
const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`, {
  headers: { origin: "https://evil.attacker.example", cookie: "X-Token=s3cr3t" },
});
ws.onmessage = e => console.log(e.data); // AUTHENTICATED as alice
```

The handshake is accepted for any `Origin`.

## Fix

- `docs/runtime/http/websockets.mdx`
  - Contextual data example now validates `req.headers.get("origin")` against an allowlist before reading cookies.
  - `Set-Cookie` example now sets `HttpOnly; Secure; SameSite=Lax; Path=/`.
  - The "Identifying users" note is now a `<Warning>` that explains the cross-site hijacking risk and why the Origin check is required.
- `docs/guides/websocket/context.mdx`: cookie-auth example validates `Origin` first; prose links to the CSWSH reference.
- `docs/guides/websocket/pubsub.mdx`: `getUsernameFromCookies` example validates `Origin` first.

## Verification

With the Origin check in place, a hostile `Origin` is rejected with `403` while the allowed origin upgrades normally:

```
no-origin-check: AUTHENTICATED as alice
with-origin-check, hostile: REJECTED (good)
with-origin-check, allowed: AUTHENTICATED
```

Docs-only change; no runtime code touched.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->