### PR TITLE
Bun.serve: add HTTP/2 server support via ALPN on the TLS listener

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -798,6 +798,18 @@ declare module "bun" {
       http3?: boolean;
 
       /**
+       * Also accept HTTP/2 on the TLS listener. Requires {@link tls}.
+       *
+       * HTTP/2 is negotiated via ALPN on the same port as HTTP/1.1 — there is
+       * no separate listener. Because the socket is adopted from the HTTP/1.1
+       * TLS context after the handshake, {@link http1} must remain enabled.
+       *
+       * @default false
+       * @experimental
+       */
+      http2?: boolean;
+
+      /**
        * Listen for HTTP/1.1 over TCP. Set to `false` together with
        * `http3: true` to serve HTTP/3 only.
        * @default true

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -162,6 +162,14 @@ public:
                 if (success) *success = false;
                 return std::move(*this);
             }
+            /* sni_cb swaps ssl->ctx to this per-SNI SSL_CTX *before*
+             * BoringSSL reads alpn_select_cb, so the h2 ALPN callback
+             * on the root sslCtx never fires for SNI-routed
+             * connections. Install it on the fresh domainCtx too
+             * (no-op at select time if h2Context isn't live). */
+            if (httpContext->getSocketContextData()->hasH2()) {
+                installH2Alpn<SSL>(domainCtx, httpContext->getSocketContextData());
+            }
             /* Queue for any listeners not yet created. We hold one SSL_CTX ref;
              * each listen socket took its own via SSL_CTX_up_ref. */
             pendingServerNames.push_back({hostname_pattern, domainCtx, domainRouter});
@@ -204,6 +212,16 @@ public:
     /* Returns the SSL_CTX* of this app, or nullptr. */
     void *getNativeHandle() {
         return sslCtx;
+    }
+
+    /* H2App reaches in to install the ALPN cb on every SSL_CTX this
+     * app might serve a connection from. Kept here rather than
+     * widening `sslCtx`/`pendingServerNames` to public. */
+    struct ssl_ctx_st *getSslCtx() { return sslCtx; }
+    HttpContext<SSL> *getHttpContext() { return httpContext; }
+    template <typename Fn>
+    void forEachPendingServerNameSslCtx(Fn &&fn) {
+        if constexpr (SSL) for (auto &p : pendingServerNames) fn(p.ctx);
     }
 
     /* Attaches a "filter" function to track socket connections/disconnections */
@@ -386,6 +404,14 @@ public:
         us_socket_group_close_all(httpContext->getSocketGroup());
         for (us_socket_group_t *g : webSocketGroups) {
             us_socket_group_close_all(g);
+        }
+        if constexpr (SSL) {
+            /* H2 adopts sockets out of httpContext into its own group
+             * (via us_socket_adopt), so closing httpContext alone
+             * leaves those connections open. Mirror the WS walk. */
+            if (auto *child = httpContext->getSocketContextData()->h2Context) {
+                uws_internal_h2_close_all(child);
+            }
         }
 
         return std::move(*this);

--- a/packages/bun-uws/src/Http2App.h
+++ b/packages/bun-uws/src/Http2App.h
@@ -1,0 +1,338 @@
+#ifndef UWS_H2APP_H
+#define UWS_H2APP_H
+// clang-format off
+
+#include "App.h"
+#include "Http2Context.h"
+
+#include <openssl/ssl.h>
+
+namespace uWS {
+
+/* TemplatedApp-shaped front for HTTP/2. Route registration mirrors SSLApp
+ * so the C ABI in libuwsockets_h2.cpp can stay 1:1 with the existing
+ * uws_app_* surface.
+ *
+ * Unlike H3App (which opens its own UDP socket), H2App attaches to an
+ * existing SSLApp: it creates its own socket group, installs an ALPN
+ * select callback offering "h2,http/1.1" on the parent's SSL_CTX (and
+ * each per-SNI SSL_CTX via addServerName), and takes over sockets that
+ * negotiate "h2" at the top of HttpContext<true>::onData. The SSL* stays
+ * on the adopted socket, so TLS decryption continues transparently. */
+struct H2App {
+    Http2Context *http2Context;
+    /* Kept so the destructor can null the parent's adoption hook — the
+     * H1 context typically outlives H2App by a few frames (server.zig
+     * destroys h2_app before app), and a late on_data on a connected
+     * socket would otherwise consult freed memory. */
+    HttpContextData<true> *parentData;
+
+    /* `parentApp` is the HTTP/1 SSLApp; we read its root sslCtx and any
+     * already-queued per-SNI ctxs to install the ALPN cb on each (sni_cb
+     * swaps ssl->ctx before BoringSSL reads alpn_select_cb, so every
+     * SSL_CTX that can serve a connection needs a copy). Subsequent SNI
+     * entries are covered by TemplatedApp::addServerName. */
+    static H2App *create(TemplatedApp<true> *parentApp, unsigned idleTimeoutS = 0) {
+        if (!parentApp || parentApp->constructorFailed()) return nullptr;
+        Http2Context *ctx = Http2Context::create(Loop::get(), idleTimeoutS);
+        if (!ctx) return nullptr;
+        auto *parentData = parentApp->getHttpContext()->getSocketContextData();
+        installH2Alpn<true>(parentApp->getSslCtx(), parentData);
+        parentApp->forEachPendingServerNameSslCtx([&](SSL_CTX *sniCtx) {
+            installH2Alpn<true>(sniCtx, parentData);
+        });
+        parentData->h2Context = ctx;
+        return new H2App{ctx, parentData};
+    }
+
+    bool constructorFailed() { return http2Context == nullptr; }
+    ~H2App() {
+        if (parentData && parentData->h2Context == http2Context) {
+            parentData->h2Context = nullptr;
+        }
+        if (http2Context) http2Context->free();
+    }
+
+#define H2_METHOD(name, verb)                                                            \
+    H2App &&name(std::string_view pattern,                                               \
+                 MoveOnlyFunction<void(Http2Response *, Http2Request *)> &&handler) {    \
+        http2Context->onHttp(verb, pattern, std::move(handler));                         \
+        return std::move(*this);                                                         \
+    }
+    H2_METHOD(get, "get")
+    H2_METHOD(post, "post")
+    H2_METHOD(put, "put")
+    H2_METHOD(del, "delete")
+    H2_METHOD(patch, "patch")
+    H2_METHOD(head, "head")
+    H2_METHOD(options, "options")
+    H2_METHOD(connect, "connect")
+    H2_METHOD(trace, "trace")
+    H2_METHOD(any, "*")
+#undef H2_METHOD
+
+    void clearRoutes() {
+        http2Context->getContextData()->router =
+            decltype(http2Context->getContextData()->router){};
+    }
+    /* GOAWAY + drain. The child context is freed in the destructor. */
+    void close() { http2Context->shutdown(); }
+    void *getNativeHandle() { return http2Context; }
+
+    /* Called from HttpContext<true>::onData (declared extern there so
+     * HttpContext.h doesn't include this file). Inspects ALPN and, if
+     * "h2", destructs the H1 ext, adopts the socket into our group,
+     * and dispatches the initial bytes (the preface + client SETTINGS
+     * that arrived in the same read). Returns the possibly relocated
+     * socket, or null if the socket stays in the H1 group untouched. */
+    static us_socket_t *adoptIfNegotiated(Http2Context *ctx,
+                                          us_socket_t *s, int oldExtSize,
+                                          char *data, int length) {
+        SSL *ssl = (SSL *) us_socket_get_native_handle(s);
+        if (!ssl) return nullptr;
+        const unsigned char *proto = nullptr; unsigned int protoLen = 0;
+        SSL_get0_alpn_selected(ssl, &proto, &protoLen);
+        if (!(protoLen == 2 && proto[0] == 'h' && proto[1] == '2')) return nullptr;
+
+        /* Tear down the H1 per-socket state before realloc. */
+        ((HttpResponseData<true> *) us_socket_ext(s))->~HttpResponseData<true>();
+
+        /* kind .dynamic → dispatch via group.vtable (h2VTable). The SSL*
+         * stays on the socket, so TLS decryption continues. */
+        us_socket_t *ns = us_socket_adopt(s, ctx->getSocketGroup(),
+            US_SOCKET_KIND_DYNAMIC, oldExtSize, sizeof(Http2Connection));
+        /* us_socket_adopt doesn't fire on_open for an already-open
+         * socket, so initialise the new ext and send our SETTINGS here. */
+        new (us_socket_ext(ns)) Http2Connection();
+        auto *c = Http2Context::conn(ns);
+        c->initHpack();
+        ((AsyncSocket<true> *) ns)->cork();
+        ctx->sendServerPreface(ns);
+        c->dispatchDepth++;
+        if (length > 0) ctx->onData(ns, data, length);
+        if (!us_socket_is_closed(ns)) {
+            c->dispatchDepth--;
+            ctx->sweep(ns);
+            ((AsyncSocket<true> *) ns)->uncork();
+            us_socket_timeout(ns, ctx->getContextData()->idleTimeoutS);
+        }
+        return ns;
+    }
+};
+
+/* ─────── Http2Response out-of-line methods that need Http2Context ─────── */
+
+inline void Http2Response::sendBufferedHeaders(bool endStream) {
+    context()->writeHeaders(socket, id, &data, endStream);
+}
+
+inline Http2Response *Http2Response::writeContinue() {
+    /* RFC 9113 §8.1: a 1xx is its own HEADERS frame without END_STREAM. */
+    Http2ResponseData tmp;
+    tmp.appendHeader(":status", 7, "100", 3);
+    context()->writeHeaders(socket, id, &tmp, false);
+    return this;
+}
+
+inline Http2Response *Http2Response::cork(MoveOnlyFunction<void()> &&fn) {
+    /* Cache the socket: once fn() returns, `this` may be in
+     * pendingDelete. We do NOT sweep here — the caller above cork()
+     * (StaticRoute.on, RequestContext paths) still holds `resp` and
+     * touches it right after cork returns, and sweep()'s
+     * goaway-close would fire on_close → ~Http2Connection → free
+     * pendingDelete (including `this`) under the caller. H3 gets the
+     * same guarantee because lsquic defers stream teardown to the next
+     * process_conns(). */
+    us_socket_t *s = socket;
+    Http2Connection *c = Http2Context::conn(s);
+    auto *as = (AsyncSocket<true> *) s;
+    bool was = as->isCorked();
+    if (!was) as->cork();
+    fn();
+    if (!us_socket_is_closed(s)) {
+        if (!was && as->isCorked()) as->uncork();
+        /* The async-resolve path reaches here outside any uSockets
+         * event (dispatchDepth == 0), so there is no on_data/on_writable
+         * epilogue to call sweep() for us. If this response was the
+         * last stream on a GOAWAY connection, close the write side now
+         * so the client receives EOF after the final END_STREAM and
+         * hangs up, which in turn fires on_end → on_close → cleanup.
+         * Shutdown is safe here where sweep()'s us_socket_close() is
+         * not: it doesn't free anything or fire on_close synchronously,
+         * so the caller can still touch `this` after cork() returns. */
+        if (c->dispatchDepth == 0 && c->goaway && c->streams.empty() &&
+            !us_socket_is_shut_down(s)) {
+            us_socket_shutdown(s);
+        }
+    }
+    return this;
+}
+
+inline Http2Response *Http2Response::resume() {
+    if (!paused) return this;
+    paused = false;
+    if (recvWindow < h2::LOCAL_INIT_WINDOW / 2) {
+        uint32_t inc = (uint32_t)(h2::LOCAL_INIT_WINDOW - recvWindow);
+        context()->writeWindowUpdate(socket, id, inc);
+        recvWindow = h2::LOCAL_INIT_WINDOW;
+        ((AsyncSocket<true> *) socket)->uncork();
+    }
+    return this;
+}
+
+inline bool Http2Response::write(std::string_view body, size_t *writtenPtr) {
+    flushHeaders();
+    if (data.backpressure.length() != 0) {
+        data.backpressure.append(body.data(), body.length());
+        if (writtenPtr) *writtenPtr = 0;
+        return false;
+    }
+    size_t w = context()->writeData(socket, this, body.data(), body.length(), false);
+    data.offset += (uint64_t) w;
+    if (writtenPtr) *writtenPtr = w;
+    if (w < body.length()) {
+        data.backpressure.append(body.data() + w, body.length() - w);
+        return false;
+    }
+    return ((AsyncSocket<true> *) socket)->getBufferedAmount() < 256 * 1024;
+}
+
+inline void Http2Response::endWithoutBody(std::optional<size_t> cl, bool) {
+    if (cl.has_value() && !(data.state & Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+        writeHeader("content-length", (uint64_t) *cl);
+    }
+    if (data.state & Http2ResponseData::HTTP_WRITE_CALLED) {
+        context()->writeData(socket, this, "", 0, true);
+    } else {
+        writeStatus("200 OK");
+        sendBufferedHeaders(true);
+    }
+    markDone();
+}
+
+inline bool Http2Response::sendTerminatingChunk(bool) {
+    flushHeaders();
+    if (data.backpressure.length() != 0) {
+        data.endAfterDrain = true;
+        return false;
+    }
+    context()->writeData(socket, this, "", 0, true);
+    markDone();
+    return true;
+}
+
+inline bool Http2Response::internalEnd(std::string_view body, uint64_t totalSize,
+                                        bool optional, bool, bool) {
+    data.totalSize = totalSize;
+    if (!(data.state & Http2ResponseData::HTTP_WRITE_CALLED)) {
+        writeStatus("200 OK");
+        if (!(data.state & Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER) && totalSize) {
+            writeHeader("content-length", totalSize);
+            data.state |= Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+        }
+        if (body.empty() && data.offset == totalSize) {
+            sendBufferedHeaders(true);
+            markDone();
+            return true;
+        }
+        sendBufferedHeaders(false);
+        data.state |= Http2ResponseData::HTTP_WRITE_CALLED;
+    }
+
+    if (data.backpressure.length() != 0) {
+        if (optional) return false;
+        data.backpressure.append(body.data(), body.length());
+        data.endAfterDrain = true;
+        return false;
+    }
+
+    size_t w = body.empty() ? 0
+        : context()->writeData(socket, this, body.data(), body.length(), false);
+    data.offset += (uint64_t) w;
+    if (w < body.length()) {
+        if (optional) return false;
+        data.backpressure.append(body.data() + w, body.length() - w);
+        data.endAfterDrain = true;
+        return false;
+    }
+
+    if (data.offset >= totalSize) {
+        context()->writeData(socket, this, "", 0, true);
+        markDone();
+        return true;
+    }
+    return false;
+}
+
+inline bool Http2Response::drain() {
+    while (data.backpressure.length() != 0) {
+        size_t w = context()->writeData(socket, this, data.backpressure.data(),
+                                         data.backpressure.length(), false);
+        if (w == 0) return false;
+        data.offset += (uint64_t) w;
+        data.backpressure.erase((unsigned) w);
+    }
+    if (data.endAfterDrain) {
+        data.endAfterDrain = false;
+        context()->writeData(socket, this, "", 0, true);
+        markDone();
+        return true;
+    }
+    if (data.onWritable) {
+        return data.onWritable(this, data.offset, data.writableUserData);
+    }
+    return true;
+}
+
+inline void Http2Response::markDone() {
+    data.onWritable = nullptr;
+    data.inStream = nullptr;
+    data.state |= Http2ResponseData::HTTP_END_CALLED;
+    data.state &= ~Http2ResponseData::HTTP_RESPONSE_PENDING;
+    /* §8.1: a server MAY send RST_STREAM(NO_ERROR) after a complete
+     * response to stop the client pushing a body we won't read. */
+    if (!data.remoteClosed) {
+        context()->writeRstStream(socket, id, h2::ERR_NO_ERROR);
+        data.remoteClosed = true;
+    }
+    maybeDestroy();
+}
+
+inline void Http2Response::close() {
+    if (!us_socket_is_closed(socket)) {
+        context()->writeRstStream(socket, id, h2::ERR_CANCEL);
+    }
+    data.remoteClosed = true;
+    data.state &= ~Http2ResponseData::HTTP_RESPONSE_PENDING;
+    data.state |= Http2ResponseData::HTTP_END_CALLED;
+    maybeDestroy();
+}
+
+inline void Http2Response::maybeDestroy() {
+    if (!hasResponded() || !data.remoteClosed) return;
+    if (dead) return;
+    dead = true;
+    Http2Connection *c = Http2Context::conn(socket);
+    c->streams.erase(id);
+    /* Like H3: fire onAborted so the holder drops its pointer — it
+     * distinguishes via hasResponded(). */
+    if (data.onAborted) {
+        auto cb = data.onAborted;
+        data.onAborted = nullptr;
+        cb(this, data.userData);
+    }
+    /* The caller may still hold `this` on its stack (e.g. Zig's
+     * StaticRoute calls clearAborted() right after tryEnd(), and the
+     * async render path touches `resp` after the promise resolves).
+     * Always defer the free to the next sweep() — on_data/on_writable
+     * exit for the sync path, connection close for anything that
+     * slips through. The GOAWAY last-stream close also stays in
+     * sweep(): closing here would run on_close → ~Http2Connection →
+     * free pendingDelete (including `this`) while the caller is still
+     * on the stack. */
+    c->pendingDelete.append(this);
+}
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2App.h
+++ b/packages/bun-uws/src/Http2App.h
@@ -22,9 +22,10 @@ namespace uWS {
 struct H2App {
     Http2Context *http2Context;
     /* Kept so the destructor can null the parent's adoption hook — the
-     * H1 context typically outlives H2App by a few frames (server.zig
-     * destroys h2_app before app), and a late on_data on a connected
-     * socket would otherwise consult freed memory. */
+     * H1 context typically outlives H2App by a few frames
+     * (src/runtime/server/mod.rs deinit() destroys h2_app before app),
+     * and a late on_data on a connected socket would otherwise consult
+     * freed memory. */
     HttpContextData<true> *parentData;
 
     /* `parentApp` is the HTTP/1 SSLApp; we read its root sslCtx and any
@@ -321,6 +322,19 @@ inline void Http2Response::maybeDestroy() {
     dead = true;
     Http2Connection *c = Http2Context::conn(socket);
     c->streams.erase(id);
+    /* Park before the JS-reentrant callback (same ordering as
+     * abortStream()/handleRstStream()) so a server.stop() reached
+     * via onAborted that fired on_close synchronously still frees
+     * `this` via ~Http2Connection. The caller may still hold `this`
+     * on its stack (e.g. Rust's StaticRoute calls clearAborted()
+     * right after tryEnd(), and the async render path touches `resp`
+     * after the promise resolves), so the actual free is deferred to
+     * the next sweep() — on_data/on_writable exit for the sync path,
+     * connection close for anything that slips through. The GOAWAY
+     * last-stream close also stays in sweep(): closing here would run
+     * on_close → ~Http2Connection → free pendingDelete (including
+     * `this`) while the caller is still on the stack. */
+    c->pendingDelete.append(this);
     /* Like H3: fire onAborted so the holder drops its pointer — it
      * distinguishes via hasResponded(). */
     if (data.onAborted) {
@@ -328,16 +342,6 @@ inline void Http2Response::maybeDestroy() {
         data.onAborted = nullptr;
         cb(this, data.userData);
     }
-    /* The caller may still hold `this` on its stack (e.g. Zig's
-     * StaticRoute calls clearAborted() right after tryEnd(), and the
-     * async render path touches `resp` after the promise resolves).
-     * Always defer the free to the next sweep() — on_data/on_writable
-     * exit for the sync path, connection close for anything that
-     * slips through. The GOAWAY last-stream close also stays in
-     * sweep(): closing here would run on_close → ~Http2Connection →
-     * free pendingDelete (including `this`) while the caller is still
-     * on the stack. */
-    c->pendingDelete.append(this);
 }
 
 }

--- a/packages/bun-uws/src/Http2App.h
+++ b/packages/bun-uws/src/Http2App.h
@@ -202,6 +202,13 @@ inline void Http2Response::endWithoutBody(std::optional<size_t> cl, bool) {
         writeHeader("content-length", (uint64_t) *cl);
     }
     if (data.state & Http2ResponseData::HTTP_WRITE_CALLED) {
+        /* Earlier write()s may have left bytes in backpressure; sending
+         * END_STREAM now would close the stream before drain() framed
+         * them. Defer to endAfterDrain like sendTerminatingChunk(). */
+        if (data.backpressure.length() != 0) {
+            data.endAfterDrain = true;
+            return;
+        }
         context()->writeData(socket, this, "", 0, true);
     } else {
         writeStatus("200 OK");

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -1,0 +1,1031 @@
+#ifndef UWS_H2CONTEXT_H
+#define UWS_H2CONTEXT_H
+// clang-format off
+
+/* HTTP/2 server for Bun.serve(). Built on the same uSockets TLS socket as
+ * the HTTP/1 context: an ALPN select cb offers "h2,http/1.1" and, after the
+ * handshake, sockets that negotiated "h2" are adopted into this child
+ * context. Per-connection state (HPACK codecs, flow control, stream map,
+ * frame-parse buffer) lives in the socket ext; each stream is a
+ * heap-allocated Http2Response.
+ *
+ * Public surface (Http2App/Response/Request) mirrors Http3* so Zig's
+ * AnyResponse/AnyRequest `inline else` dispatch works unchanged.
+ *
+ * RFC 9113 (framing, flow control, §6.*), RFC 7541/lshpack (HPACK). Minimal
+ * but conformant: SETTINGS/PING/WINDOW_UPDATE handled, PRIORITY and
+ * PUSH_PROMISE are acknowledged-and-ignored (server push disabled), HPACK
+ * errors and framing violations tear the connection down with GOAWAY. */
+
+#include "Loop.h"
+#include "AsyncSocket.h"
+#include "AsyncSocketData.h"
+#include "Http2ContextData.h"
+#include "Http2ResponseData.h"
+#include "MoveOnlyFunction.h"
+
+#include <lshpack.h>
+
+#include <wtf/Vector.h>
+#include <map>
+#include <cstring>
+#include <string_view>
+
+namespace uWS {
+
+struct Http2Request;
+struct Http2Response;
+struct Http2Context;
+
+/* ─────── wire constants (RFC 9113 §6) ─────── */
+namespace h2 {
+    static constexpr std::string_view PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+    static constexpr int32_t DEFAULT_WINDOW   = 65535;
+    static constexpr uint32_t DEFAULT_FRAME   = 16384;
+    static constexpr size_t FRAME_HEADER_SIZE = 9;
+    static constexpr uint32_t MAX_HEADER_LIST = 64 * 1024;
+    static constexpr uint32_t MAX_STREAMS     = 128;
+    /* Advertise a generous per-stream window so downloads aren't throttled
+     * by the spec default. Connection window is also bumped on open. */
+    static constexpr int32_t LOCAL_INIT_WINDOW = 1024 * 1024;
+
+    enum FrameType : uint8_t {
+        DATA = 0, HEADERS = 1, PRIORITY = 2, RST_STREAM = 3, SETTINGS = 4,
+        PUSH_PROMISE = 5, PING = 6, GOAWAY = 7, WINDOW_UPDATE = 8, CONTINUATION = 9,
+    };
+    enum Flags : uint8_t {
+        END_STREAM = 0x1, ACK = 0x1, END_HEADERS = 0x4, PADDED = 0x8, PRIO = 0x20,
+    };
+    /* Prefixed — winerror.h on Windows #defines NO_ERROR, and several of
+     * the others collide with other platform headers. */
+    enum ErrorCode : uint32_t {
+        ERR_NO_ERROR = 0, ERR_PROTOCOL = 1, ERR_INTERNAL = 2, ERR_FLOW_CONTROL = 3,
+        ERR_STREAM_CLOSED = 5, ERR_FRAME_SIZE = 6, ERR_REFUSED_STREAM = 7, ERR_CANCEL = 8,
+        ERR_COMPRESSION = 9, ERR_ENHANCE_YOUR_CALM = 11,
+    };
+
+    static inline void writeFrameHeader(char *dst, uint32_t len, uint8_t type,
+                                        uint8_t flags, uint32_t stream) {
+        dst[0] = (char)((len >> 16) & 0xff);
+        dst[1] = (char)((len >> 8) & 0xff);
+        dst[2] = (char)(len & 0xff);
+        dst[3] = (char) type;
+        dst[4] = (char) flags;
+        dst[5] = (char)((stream >> 24) & 0x7f);
+        dst[6] = (char)((stream >> 16) & 0xff);
+        dst[7] = (char)((stream >> 8) & 0xff);
+        dst[8] = (char)(stream & 0xff);
+    }
+}
+
+/* ─────── per-connection state (socket ext) ─────── */
+struct Http2Connection : AsyncSocketData<true> {
+    struct lshpack_enc enc;
+    struct lshpack_dec dec;
+    bool hpackInit = false;
+    bool prefaceConsumed = false;
+    bool sentPreface = false;
+    bool goaway = false;
+
+    /* Frame-parse accumulator. Bytes are appended here until a complete
+     * 9-byte header + payload is available, then drained. */
+    std::string rx;
+    /* Header-block-fragment accumulator across HEADERS + CONTINUATION.
+     * `continuationStream` is the only stream allowed to send frames until
+     * END_HEADERS (§6.10). */
+    std::string headerBlock;
+    uint32_t continuationStream = 0;
+    bool continuationEndStream = false;
+
+    /* Flow control. */
+    int32_t connSendWindow = h2::DEFAULT_WINDOW;
+    int32_t connRecvWindow = h2::LOCAL_INIT_WINDOW;
+    /* Peer's SETTINGS. */
+    uint32_t remoteMaxFrame = h2::DEFAULT_FRAME;
+    int32_t remoteInitialWindow = h2::DEFAULT_WINDOW;
+
+    /* Highest client stream ID seen; used for GOAWAY. */
+    uint32_t lastStreamId = 0;
+
+    /* Live streams, keyed by client-initiated odd IDs. std::map over
+     * HashMap for ordered iteration (drain fairness) and stable pointers
+     * across insert. */
+    std::map<uint32_t, Http2Response *> streams;
+    /* Streams that completed while a callback was on the stack. We can't
+     * `delete` inside markDone() because the caller (Zig's StaticRoute,
+     * RequestContext.renderBytes, …) still holds the pointer and calls
+     * clearAborted()/clearOnWritable() right after tryEnd() returns.
+     * H3 gets away with this because lsquic defers stream teardown to
+     * the next process_conns(); we mimic that by sweeping at the end of
+     * each frame-dispatch pass. */
+    WTF::Vector<Http2Response *, 4> pendingDelete;
+    int dispatchDepth = 0;
+
+    ~Http2Connection();
+
+    void initHpack() {
+        if (hpackInit) return;
+        lshpack_enc_init(&enc);
+        lshpack_dec_init(&dec);
+        hpackInit = true;
+    }
+};
+
+}
+
+/* Http2Response needs Http2Connection defined, and Http2Context needs both. */
+#include "Http2Response.h"
+#include "Http2Request.h"
+
+namespace uWS {
+
+inline Http2Connection::~Http2Connection() {
+    for (auto &kv : streams) delete kv.second;
+    streams.clear();
+    for (auto *r : pendingDelete) delete r;
+    pendingDelete.shrink(0);
+    if (hpackInit) {
+        lshpack_enc_cleanup(&enc);
+        lshpack_dec_cleanup(&dec);
+    }
+}
+
+/* Heap-allocated owner of one H2 server's socket group + router. Mirrors
+ * HttpContext<SSL>'s shape: `group.ext` points back to `this` so vtable
+ * handlers recover the typed context via fromSocket(). Sockets are adopted
+ * into `group` from HttpContext<true>::onData once ALPN negotiates h2; the
+ * SSL* stays on the socket, so TLS decryption continues transparently. */
+struct Http2Context {
+
+    us_socket_group_t group{};
+    Http2ContextData data;
+
+    Http2ContextData *getContextData() { return &data; }
+    us_socket_group_t *getSocketGroup() { return &group; }
+
+    static Http2Context *fromSocket(us_socket_t *s) {
+        return (Http2Context *) us_socket_group_ext(us_socket_group(s));
+    }
+    static Http2ContextData *getContextData(us_socket_t *s) {
+        return &fromSocket(s)->data;
+    }
+    static Http2Connection *conn(us_socket_t *s) {
+        return (Http2Connection *) us_socket_ext(s);
+    }
+
+    /* ── vtable handlers ────────────────────────────────────────────── */
+
+    static us_socket_t *onOpen(us_socket_t *s, int, char *, int) {
+        new (us_socket_ext(s)) Http2Connection();
+        conn(s)->initHpack();
+        fromSocket(s)->sendServerPreface(s);
+        us_socket_timeout(s, getContextData(s)->idleTimeoutS);
+        return s;
+    }
+
+    static us_socket_t *onClose(us_socket_t *s, int, void *) {
+        ((AsyncSocket<true> *) s)->uncorkWithoutSending();
+        Http2Connection *c = conn(s);
+        /* onAborted may re-enter JS → drainMicrotasks → resolve a
+         * *sibling* stream's pending response → end() →
+         * maybeDestroy() → c->streams.erase(sibling). That can free
+         * the map node any map iterator points at, so snapshot the
+         * response pointers first and iterate the snapshot.
+         * dispatchDepth keeps the Http2Response heap objects alive
+         * (parked in pendingDelete) until ~Http2Connection frees
+         * everything in one pass. */
+        c->dispatchDepth++;
+        WTF::Vector<Http2Response *, 16> live;
+        live.reserveCapacity(c->streams.size());
+        for (auto &kv : c->streams) live.append(kv.second);
+        for (auto *r : live) {
+            if (r->dead) continue;
+            Http2ResponseData *d = r->getHttpResponseData();
+            if (d->onAborted) d->onAborted(r, d->userData);
+        }
+        c->~Http2Connection();
+        return s;
+    }
+
+    static us_socket_t *onSocketData(us_socket_t *s, char *data, int length) {
+        if (us_socket_is_shut_down(s)) return s;
+        us_socket_ref(s);
+        ((AsyncSocket<true> *) s)->cork();
+        Http2Connection *c = conn(s);
+        c->dispatchDepth++;
+        fromSocket(s)->onData(s, data, length);
+        if (!us_socket_is_closed(s)) {
+            c->dispatchDepth--;
+            fromSocket(s)->sweep(s);
+            us_socket_unref(s);
+            ((AsyncSocket<true> *) s)->uncork();
+            us_socket_timeout(s, getContextData(s)->idleTimeoutS);
+        }
+        return s;
+    }
+
+    static us_socket_t *onWritable(us_socket_t *s) {
+        auto *as = (AsyncSocket<true> *) s;
+        if (as->getBufferedAmount() > 0) {
+            as->flush();
+            if (as->getBufferedAmount() > 0) {
+                us_socket_timeout(s, getContextData(s)->idleTimeoutS);
+                return s;
+            }
+        }
+        Http2Connection *c = conn(s);
+        c->dispatchDepth++;
+        fromSocket(s)->drainStreams(s);
+        if (!us_socket_is_closed(s)) {
+            c->dispatchDepth--;
+            fromSocket(s)->sweep(s);
+            us_socket_timeout(s, getContextData(s)->idleTimeoutS);
+        }
+        return s;
+    }
+
+    static us_socket_t *onEnd(us_socket_t *s) {
+        ((AsyncSocket<true> *) s)->uncorkWithoutSending();
+        return us_socket_close(s, 0, nullptr);
+    }
+
+    static us_socket_t *onTimeout(us_socket_t *s) {
+        Http2Connection *c = conn(s);
+        /* Same iterator-safety as onClose: onTimeout can re-enter
+         * JS and erase a sibling stream from the map. */
+        c->dispatchDepth++;
+        WTF::Vector<Http2Response *, 16> live;
+        live.reserveCapacity(c->streams.size());
+        for (auto &kv : c->streams) live.append(kv.second);
+        for (auto *r : live) {
+            if (r->dead) continue;
+            Http2ResponseData *d = r->getHttpResponseData();
+            if (d->onTimeout) d->onTimeout(r, d->userData);
+            /* A `timeout` listener (or a microtask it drained) may have
+             * called server.stop(true) → us_socket_group_close_all →
+             * force-drain → onClose(s) → ~Http2Connection(), which
+             * deleted every Http2Response* this snapshot holds and
+             * destructed `c` in place. Same guard as drainStreams(). */
+            if (us_socket_is_closed(s)) return s;
+        }
+        c->dispatchDepth--;
+        ((AsyncSocket<true> *) s)->uncorkWithoutSending();
+        return us_socket_close(s, 0, nullptr);
+    }
+
+    static inline const us_socket_vtable_t h2VTable = {
+        /* on_open */         &onOpen,
+        /* on_data */         &onSocketData,
+        /* on_fd */           nullptr,
+        /* on_writable */     &onWritable,
+        /* on_close */        &onClose,
+        /* on_timeout */      &onTimeout,
+        /* on_long_timeout */ nullptr,
+        /* on_end */          &onEnd,
+        /* on_connect_error */nullptr,
+        /* on_connecting_error */ nullptr,
+        /* on_handshake */    nullptr,
+    };
+
+    /* No listener of its own — sockets are adopted from the parent
+     * HttpContext<true> once ALPN picks h2. The group just carries the
+     * vtable and collects adopted sockets for close-all/timeout-sweep. */
+    static Http2Context *create(Loop *loop, unsigned int idleTimeoutS) {
+        auto *ctx = new Http2Context;
+        us_socket_group_init(&ctx->group, (us_loop_t *) loop, &h2VTable, ctx);
+        ctx->data.idleTimeoutS = idleTimeoutS ? idleTimeoutS : 10;
+        return ctx;
+    }
+
+    void free() {
+        us_socket_group_deinit(&group);
+        delete this;
+    }
+
+    /* GOAWAY every live connection. The group itself is freed in free(). */
+    void shutdown() {
+        for (us_socket_t *s = group.head_sockets; s;) {
+            us_socket_t *next = s->next;
+            if (!us_socket_is_closed(s)) {
+                writeGoaway(s, conn(s)->lastStreamId, h2::ERR_NO_ERROR);
+                ((AsyncSocket<true> *) s)->flush();
+                if (conn(s)->streams.empty()) us_socket_close(s, 0, nullptr);
+                else conn(s)->goaway = true;
+            }
+            s = next;
+        }
+    }
+
+    void onHttp(std::string_view method, std::string_view pattern,
+                MoveOnlyFunction<void(Http2Response *, Http2Request *)> &&handler) {
+        Http2ContextData *cd = getContextData();
+        std::vector<std::string_view> methods =
+            method == "*" ? std::vector<std::string_view>{"*"} : std::vector<std::string_view>{method};
+        cd->router.add(methods, pattern, [handler = std::move(handler)](auto *router) mutable {
+            auto &ud = router->getUserData();
+            ud.httpRequest->setYield(false);
+            ud.httpRequest->setParameters(router->getParameters());
+            handler(ud.httpResponse, ud.httpRequest);
+            return !ud.httpRequest->getYield();
+        }, method == "*" ? cd->router.LOW_PRIORITY : cd->router.MEDIUM_PRIORITY);
+    }
+
+    /* ─────── outbound framing ─────── */
+
+    void writeFrame(us_socket_t *s, uint8_t type, uint8_t flags,
+                    uint32_t stream, const char *payload, uint32_t len) {
+        char hdr[h2::FRAME_HEADER_SIZE];
+        h2::writeFrameHeader(hdr, len, type, flags, stream);
+        auto *as = (AsyncSocket<true> *) s;
+        as->write(hdr, (int) sizeof(hdr), false, (int) len);
+        if (len) as->write(payload, (int) len, false, 0);
+    }
+
+    void sendServerPreface(us_socket_t *s) {
+        Http2Connection *c = conn(s);
+        if (c->sentPreface) return;
+        c->sentPreface = true;
+        /* SETTINGS_MAX_CONCURRENT_STREAMS, SETTINGS_INITIAL_WINDOW_SIZE,
+         * SETTINGS_MAX_FRAME_SIZE (matches the 1 MiB enforced in onData so
+         * §4.2's advertised↔enforced limits agree), SETTINGS_MAX_HEADER_LIST_SIZE.
+         * Push stays at its default (1) but a PUSH_PROMISE from a client is
+         * a protocol error regardless. */
+        unsigned char p[24];
+        auto put = [&](int off, uint16_t id, uint32_t v) {
+            p[off] = (unsigned char)(id >> 8); p[off+1] = (unsigned char) id;
+            p[off+2] = (unsigned char)(v >> 24); p[off+3] = (unsigned char)(v >> 16);
+            p[off+4] = (unsigned char)(v >> 8); p[off+5] = (unsigned char) v;
+        };
+        put(0, 3, h2::MAX_STREAMS);
+        put(6, 4, (uint32_t) h2::LOCAL_INIT_WINDOW);
+        put(12, 5, 1u << 20);
+        put(18, 6, h2::MAX_HEADER_LIST);
+        writeFrame(s, h2::SETTINGS, 0, 0, (const char *) p, sizeof(p));
+        /* Connection window starts at 64KiB regardless of SETTINGS; open it
+         * to match the per-stream window so the first upload isn't
+         * throttled before our first WINDOW_UPDATE. */
+        writeWindowUpdate(s, 0, (uint32_t)(h2::LOCAL_INIT_WINDOW - h2::DEFAULT_WINDOW));
+    }
+
+    void writeWindowUpdate(us_socket_t *s, uint32_t stream, uint32_t inc) {
+        if (inc == 0) return;
+        unsigned char p[4] = {(unsigned char)(inc >> 24), (unsigned char)(inc >> 16),
+                              (unsigned char)(inc >> 8), (unsigned char) inc};
+        writeFrame(s, h2::WINDOW_UPDATE, 0, stream, (const char *) p, 4);
+    }
+
+    void writeRstStream(us_socket_t *s, uint32_t stream, uint32_t code) {
+        unsigned char p[4] = {(unsigned char)(code >> 24), (unsigned char)(code >> 16),
+                              (unsigned char)(code >> 8), (unsigned char) code};
+        writeFrame(s, h2::RST_STREAM, 0, stream, (const char *) p, 4);
+    }
+
+    void writeGoaway(us_socket_t *s, uint32_t lastStream, uint32_t code) {
+        unsigned char p[8] = {
+            (unsigned char)((lastStream >> 24) & 0x7f), (unsigned char)(lastStream >> 16),
+            (unsigned char)(lastStream >> 8), (unsigned char) lastStream,
+            (unsigned char)(code >> 24), (unsigned char)(code >> 16),
+            (unsigned char)(code >> 8), (unsigned char) code,
+        };
+        writeFrame(s, h2::GOAWAY, 0, 0, (const char *) p, 8);
+    }
+
+    /* Serialise a HEADERS frame via HPACK. Headers larger than
+     * remoteMaxFrame are split into HEADERS + CONTINUATION. */
+    void writeHeaders(us_socket_t *s, uint32_t stream, Http2ResponseData *d,
+                      bool endStream) {
+        Http2Connection *c = conn(s);
+        static thread_local WTF::Vector<unsigned char, 4096> buf;
+        buf.shrink(0);
+        const char *base = d->hdrBuf.span().data();
+        for (auto &h : d->hdrs) {
+            /* lsxpack wants name+value contiguous; hdrBuf is laid out that
+             * way (appendHeader lowercases the name in-place). lshpack
+             * narrows offsets/lengths to lsxpack_strlen_t (uint16_t), so
+             * pass a per-header base instead of a cumulative offset —
+             * otherwise crossing 64 KiB of response headers wraps the
+             * offset and encodes garbage. A single header whose name+
+             * value exceeds 64 KiB is clamped for the same reason. */
+            size_t nameOff = (size_t)(uintptr_t) h.name;
+            unsigned nlen = h.name_len;
+            unsigned vlen = h.value_len;
+            if (nlen > LSXPACK_MAX_STRLEN) nlen = LSXPACK_MAX_STRLEN;
+            if ((size_t) nlen + vlen > LSXPACK_MAX_STRLEN)
+                vlen = (unsigned)(LSXPACK_MAX_STRLEN - nlen);
+            struct lsxpack_header xh;
+            lsxpack_header_set_offset2(&xh, base + nameOff, 0, nlen, nlen, vlen);
+            /* Worst case is one literal byte per input byte plus ~6 bytes
+             * of varint framing. */
+            size_t need = buf.size() + h.name_len + h.value_len + 32;
+            if (buf.capacity() < need) buf.reserveCapacity(need);
+            buf.grow(buf.capacity());
+            unsigned char *out = buf.mutableSpan().data();
+            unsigned char *p = lshpack_enc_encode(&c->enc, out + (need - (h.name_len + h.value_len + 32)),
+                                                  out + buf.size(), &xh);
+            buf.shrink((size_t)(p - out));
+        }
+        d->hdrBuf.shrink(0);
+        d->hdrs.shrink(0);
+
+        const unsigned char *block = buf.span().data();
+        size_t remaining = buf.size();
+        bool first = true;
+        do {
+            size_t chunk = remaining < c->remoteMaxFrame ? remaining : c->remoteMaxFrame;
+            bool last = chunk == remaining;
+            uint8_t flags = last ? h2::END_HEADERS : 0;
+            if (first && endStream) flags |= h2::END_STREAM;
+            writeFrame(s, first ? h2::HEADERS : h2::CONTINUATION, flags, stream,
+                       (const char *) block, (uint32_t) chunk);
+            block += chunk; remaining -= chunk; first = false;
+        } while (remaining);
+    }
+
+    /* Push body bytes into DATA frames under both flow-control windows and
+     * the socket's backpressure. Returns bytes framed; END_STREAM is set on
+     * the final frame only if `end` and everything fit. */
+    size_t writeData(us_socket_t *s, Http2Response *r, const char *data,
+                     size_t len, bool end) {
+        Http2Connection *c = conn(s);
+        size_t sent = 0;
+        while (true) {
+            int32_t window = c->connSendWindow < r->sendWindow ? c->connSendWindow : r->sendWindow;
+            if (window <= 0 && len > sent) break;
+            size_t room = (size_t)(window < 0 ? 0 : window);
+            size_t chunk = len - sent;
+            if (chunk > room) chunk = room;
+            if (chunk > c->remoteMaxFrame) chunk = c->remoteMaxFrame;
+            bool last = (sent + chunk == len);
+            uint8_t flags = (last && end) ? h2::END_STREAM : 0;
+            writeFrame(s, h2::DATA, flags, r->id, data + sent, (uint32_t) chunk);
+            c->connSendWindow -= (int32_t) chunk;
+            r->sendWindow -= (int32_t) chunk;
+            sent += chunk;
+            if (last) break;
+            /* Don't keep copying into AsyncSocket backpressure once the
+             * kernel stopped accepting — onWritable resumes us. */
+            if (((AsyncSocket<true> *) s)->getBufferedAmount() > 256 * 1024) break;
+        }
+        return sent;
+    }
+
+    /* Free streams that completed while a handler was on the stack, and
+     * close the connection if GOAWAY was sent and the last stream just
+     * drained. The close check is independent of pendingDelete so a
+     * late event can still close after the list drained earlier. */
+    void sweep(us_socket_t *s) {
+        Http2Connection *c = conn(s);
+        if (c->dispatchDepth > 0) return;
+        if (!c->pendingDelete.isEmpty()) {
+            for (auto *r : c->pendingDelete) delete r;
+            c->pendingDelete.shrink(0);
+        }
+        if (c->goaway && c->streams.empty() && !us_socket_is_closed(s)) {
+            ((AsyncSocket<true> *) s)->uncork();
+            us_socket_close(s, 0, nullptr);
+        }
+    }
+
+    /* Called from on_writable once TCP drained. Flush each stream's
+     * backpressure then give onWritable a turn. drain() → onWritable
+     * can re-enter JS → drainMicrotasks → complete a *sibling* stream
+     * → c->streams.erase(sibling), so iterate a snapshot instead of
+     * the live map. dispatchDepth (set in the caller) keeps the heap
+     * objects alive in pendingDelete until sweep(). */
+    void drainStreams(us_socket_t *s) {
+        Http2Connection *c = conn(s);
+        WTF::Vector<Http2Response *, 16> live;
+        live.reserveCapacity(c->streams.size());
+        for (auto &kv : c->streams) live.append(kv.second);
+        for (auto *r : live) {
+            if (r->dead) continue;
+            if (!r->drain()) continue;
+            /* drain() may have completed the response and closed the
+             * socket via GOAWAY-last-stream. */
+            if (us_socket_is_closed(s)) return;
+        }
+    }
+
+    /* ─────── inbound framing ─────── */
+
+    void protocolError(us_socket_t *s, uint32_t code) {
+        writeGoaway(s, conn(s)->lastStreamId, code);
+        ((AsyncSocket<true> *) s)->uncork();
+        us_socket_shutdown(s);
+        us_socket_close(s, 0, nullptr);
+    }
+
+    void onData(us_socket_t *s, const char *data, int length) {
+        Http2Connection *c = conn(s);
+        c->rx.append(data, (size_t) length);
+
+        if (!c->prefaceConsumed) {
+            if (c->rx.size() < h2::PREFACE.size()) return;
+            if (memcmp(c->rx.data(), h2::PREFACE.data(), h2::PREFACE.size()) != 0) {
+                return protocolError(s, h2::ERR_PROTOCOL);
+            }
+            c->rx.erase(0, h2::PREFACE.size());
+            c->prefaceConsumed = true;
+        }
+
+        size_t off = 0;
+        while (c->rx.size() - off >= h2::FRAME_HEADER_SIZE) {
+            const unsigned char *p = (const unsigned char *) c->rx.data() + off;
+            uint32_t len = ((uint32_t) p[0] << 16) | ((uint32_t) p[1] << 8) | p[2];
+            uint8_t type = p[3], flags = p[4];
+            uint32_t stream = (((uint32_t) p[5] & 0x7f) << 24) |
+                              ((uint32_t) p[6] << 16) | ((uint32_t) p[7] << 8) | p[8];
+            if (len > (1u << 20)) { /* hard cap regardless of advertised */
+                return protocolError(s, h2::ERR_FRAME_SIZE);
+            }
+            if (c->rx.size() - off < h2::FRAME_HEADER_SIZE + len) break;
+            const char *payload = c->rx.data() + off + h2::FRAME_HEADER_SIZE;
+
+            /* §6.10: once a HEADERS without END_HEADERS is received, only
+             * CONTINUATION for that stream is allowed until END_HEADERS. */
+            if (c->continuationStream &&
+                !(type == h2::CONTINUATION && stream == c->continuationStream)) {
+                return protocolError(s, h2::ERR_PROTOCOL);
+            }
+
+            switch (type) {
+            case h2::SETTINGS:
+                /* §6.5: stream ID MUST be 0. */
+                if (stream != 0) return protocolError(s, h2::ERR_PROTOCOL);
+                handleSettings(s, flags, payload, len);
+                break;
+            case h2::WINDOW_UPDATE: handleWindowUpdate(s, stream, payload, len); break;
+            case h2::PING:
+                /* §6.7: stream ID MUST be 0. */
+                if (stream != 0) return protocolError(s, h2::ERR_PROTOCOL);
+                handlePing(s, flags, payload, len);
+                break;
+            case h2::HEADERS: handleHeaders(s, stream, flags, payload, len); break;
+            case h2::CONTINUATION: handleContinuation(s, stream, flags, payload, len); break;
+            case h2::DATA: handleData(s, stream, flags, payload, len); break;
+            case h2::RST_STREAM:
+                /* §6.4: stream ID MUST NOT be 0. */
+                if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
+                handleRstStream(s, stream, payload, len);
+                break;
+            case h2::GOAWAY:
+                /* §6.8: stream ID MUST be 0; payload ≥ 8 (debug data
+                 * MAY follow the 8-byte fixed prefix). */
+                if (stream != 0 || len < 8) return protocolError(s, h2::ERR_PROTOCOL);
+                conn(s)->goaway = true;
+                if (conn(s)->streams.empty()) {
+                    ((AsyncSocket<true> *) s)->uncork();
+                    us_socket_close(s, 0, nullptr);
+                    return;
+                }
+                break;
+            case h2::PRIORITY:
+                /* §6.3: stream ID MUST NOT be 0. */
+                if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
+                if (len != 5) return protocolError(s, h2::ERR_FRAME_SIZE);
+                break;
+            case h2::PUSH_PROMISE:
+                return protocolError(s, h2::ERR_PROTOCOL);
+            default: /* §4.1: unknown types MUST be ignored. */ break;
+            }
+            if (us_socket_is_closed(s)) return;
+            off += h2::FRAME_HEADER_SIZE + len;
+        }
+        if (off) c->rx.erase(0, off);
+    }
+
+    void handleSettings(us_socket_t *s, uint8_t flags, const char *p, uint32_t len) {
+        Http2Connection *c = conn(s);
+        if (flags & h2::ACK) {
+            if (len != 0) return protocolError(s, h2::ERR_FRAME_SIZE);
+            return;
+        }
+        if (len % 6 != 0) return protocolError(s, h2::ERR_FRAME_SIZE);
+        bool windowGrew = false;
+        for (uint32_t i = 0; i < len; i += 6) {
+            const unsigned char *e = (const unsigned char *) p + i;
+            uint16_t id = ((uint16_t) e[0] << 8) | e[1];
+            uint32_t v = ((uint32_t) e[2] << 24) | ((uint32_t) e[3] << 16) |
+                         ((uint32_t) e[4] << 8) | e[5];
+            switch (id) {
+            case 1: /* HEADER_TABLE_SIZE */
+                lshpack_enc_set_max_capacity(&c->enc, v); break;
+            case 2: /* ENABLE_PUSH — §6.5.2: MUST be 0 or 1 */
+                if (v > 1) return protocolError(s, h2::ERR_PROTOCOL);
+                break;
+            case 4: { /* INITIAL_WINDOW_SIZE — §6.9.2 also adjusts open streams */
+                if (v > 0x7fffffff) return protocolError(s, h2::ERR_FLOW_CONTROL);
+                int32_t delta = (int32_t) v - c->remoteInitialWindow;
+                c->remoteInitialWindow = (int32_t) v;
+                for (auto &kv : c->streams) {
+                    /* §6.9.2: a delta that pushes any window past 2³¹-1
+                     * is a connection FLOW_CONTROL_ERROR. Widen to
+                     * int64 like the WINDOW_UPDATE paths so a prior
+                     * WINDOW_UPDATE to INT32_MAX can't drive this add
+                     * into signed overflow. Going negative is
+                     * explicitly allowed. */
+                    if ((int64_t) kv.second->sendWindow + delta > 0x7fffffff)
+                        return protocolError(s, h2::ERR_FLOW_CONTROL);
+                    kv.second->sendWindow += delta;
+                }
+                if (delta > 0) windowGrew = true;
+                break;
+            }
+            case 5: /* MAX_FRAME_SIZE */
+                if (v < h2::DEFAULT_FRAME || v > 0xffffff)
+                    return protocolError(s, h2::ERR_PROTOCOL);
+                c->remoteMaxFrame = v; break;
+            default: break; /* §6.5.2: unknown settings MUST be ignored */
+            }
+        }
+        writeFrame(s, h2::SETTINGS, h2::ACK, 0, nullptr, 0);
+        /* A raised INITIAL_WINDOW_SIZE is the SETTINGS-path equivalent
+         * of a per-stream WINDOW_UPDATE (§6.9.2 is explicit that both
+         * adjust the same window). Clients that BDP-autotune —
+         * nghttp2, Chrome — open the window this way. Drain now so
+         * streams parked on flow-control backpressure resume,
+         * mirroring handleWindowUpdate. */
+        if (windowGrew) drainStreams(s);
+    }
+
+    void handlePing(us_socket_t *s, uint8_t flags, const char *p, uint32_t len) {
+        if (len != 8) return protocolError(s, h2::ERR_FRAME_SIZE);
+        if (flags & h2::ACK) return;
+        writeFrame(s, h2::PING, h2::ACK, 0, p, 8);
+    }
+
+    /* Server-initiated stream reset: emit RST_STREAM on the wire AND tear
+     * the stream down locally (erase, fire onAborted so the handler drops
+     * its pointer, park for sweep). Called from on_data so dispatchDepth
+     * keeps the heap object alive in pendingDelete; sweep() runs the
+     * goaway-last-stream close at a safe point. */
+    void abortStream(us_socket_t *s, uint32_t stream, uint32_t code) {
+        writeRstStream(s, stream, code);
+        Http2Connection *c = conn(s);
+        auto it = c->streams.find(stream);
+        if (it == c->streams.end()) return;
+        Http2Response *r = it->second;
+        Http2ResponseData *d = r->getHttpResponseData();
+        c->streams.erase(it);
+        r->dead = true;
+        d->remoteClosed = true;
+        /* Park in pendingDelete *before* the JS-reentrant callback so a
+         * server.stop() in an abort listener that happened to fire
+         * on_close synchronously would still free `r` cleanly via
+         * ~Http2Connection — same defensive shape as handleRstStream's
+         * is_closed guard. dispatchDepth>0 keeps sweep() from freeing
+         * it mid-callback. */
+        c->pendingDelete.append(r);
+        if (d->onAborted) {
+            auto cb = d->onAborted;
+            d->onAborted = nullptr;
+            cb(r, d->userData);
+        }
+    }
+
+    void handleWindowUpdate(us_socket_t *s, uint32_t stream, const char *p, uint32_t len) {
+        if (len != 4) return protocolError(s, h2::ERR_FRAME_SIZE);
+        Http2Connection *c = conn(s);
+        /* §5.1: any frame other than HEADERS/PRIORITY on an idle stream
+         * is a connection PROTOCOL_ERROR. On a *closed* stream
+         * WINDOW_UPDATE is a permitted race (§5.1 "An endpoint MUST
+         * ignore WINDOW_UPDATE or RST_STREAM frames received in this
+         * state") — falls through to the find()-miss below. Checking
+         * here also stops abortStream() in the inc==0 branch from
+         * emitting an RST_STREAM on an idle stream, which is itself a
+         * §6.4 violation. */
+        if (stream != 0 && stream > c->lastStreamId)
+            return protocolError(s, h2::ERR_PROTOCOL);
+        uint32_t inc = (((uint32_t)(unsigned char) p[0] & 0x7f) << 24) |
+                       ((uint32_t)(unsigned char) p[1] << 16) |
+                       ((uint32_t)(unsigned char) p[2] << 8) |
+                       (uint32_t)(unsigned char) p[3];
+        if (inc == 0) {
+            /* §6.9: zero increment is a connection error on stream 0,
+             * a stream error otherwise. Idle is rejected above; on a
+             * closed stream §5.1 says MUST ignore, so don't let
+             * abortStream's unconditional RST fire on a stream we
+             * already forgot. */
+            if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
+            if (c->streams.find(stream) != c->streams.end())
+                abortStream(s, stream, h2::ERR_PROTOCOL);
+            return;
+        }
+        if (stream == 0) {
+            if ((int64_t) c->connSendWindow + inc > 0x7fffffff)
+                return protocolError(s, h2::ERR_FLOW_CONTROL);
+            c->connSendWindow += (int32_t) inc;
+            drainStreams(s);
+        } else if (auto it = c->streams.find(stream); it != c->streams.end()) {
+            if ((int64_t) it->second->sendWindow + inc > 0x7fffffff) {
+                abortStream(s, stream, h2::ERR_FLOW_CONTROL);
+                return;
+            }
+            it->second->sendWindow += (int32_t) inc;
+            it->second->drain();
+        }
+    }
+
+    void handleHeaders(us_socket_t *s, uint32_t stream, uint8_t flags,
+                       const char *p, uint32_t len) {
+        Http2Connection *c = conn(s);
+        if (stream == 0 || (stream & 1) == 0)
+            return protocolError(s, h2::ERR_PROTOCOL);
+        /* Strip PADDED and PRIORITY prefixes before collecting the HPACK block. */
+        uint32_t pad = 0;
+        if (flags & h2::PADDED) {
+            if (len < 1) return protocolError(s, h2::ERR_FRAME_SIZE);
+            pad = (uint8_t) p[0]; p++; len--;
+        }
+        if (flags & h2::PRIO) {
+            if (len < 5) return protocolError(s, h2::ERR_FRAME_SIZE);
+            p += 5; len -= 5;
+        }
+        if (pad > len) return protocolError(s, h2::ERR_PROTOCOL);
+        len -= pad;
+
+        c->headerBlock.assign(p, len);
+        c->continuationEndStream = (flags & h2::END_STREAM) != 0;
+        if (!(flags & h2::END_HEADERS)) {
+            c->continuationStream = stream;
+            return;
+        }
+        dispatchHeaders(s, stream, c->continuationEndStream);
+    }
+
+    void handleContinuation(us_socket_t *s, uint32_t stream, uint8_t flags,
+                            const char *p, uint32_t len) {
+        Http2Connection *c = conn(s);
+        /* §6.10: CONTINUATION without a preceding HEADERS-in-progress
+         * is a connection PROTOCOL_ERROR. The equality check below
+         * doesn't cover this when both are 0 (idle), which would
+         * otherwise fall through to dispatchHeaders(s, 0, …) and
+         * emit RST_STREAM on stream 0 — itself a §6.4 violation. */
+        if (c->continuationStream == 0 || stream != c->continuationStream)
+            return protocolError(s, h2::ERR_PROTOCOL);
+        c->headerBlock.append(p, len);
+        if (c->headerBlock.size() > h2::MAX_HEADER_LIST)
+            return protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
+        if (flags & h2::END_HEADERS) {
+            c->continuationStream = 0;
+            dispatchHeaders(s, stream, c->continuationEndStream);
+        }
+    }
+
+    void dispatchHeaders(us_socket_t *s, uint32_t stream, bool endStream) {
+        Http2Connection *c = conn(s);
+
+        /* Trailers on an open stream: decode (HPACK state is connection-
+         * scoped) but only deliver the FIN. */
+        if (auto it = c->streams.find(stream); it != c->streams.end()) {
+            Http2Response *r = it->second;
+            if (!decodeHeaderBlock(s, nullptr)) return;
+            if (r->getHttpResponseData()->remoteClosed) {
+                /* §5.1: HEADERS in half-closed(remote) → STREAM_CLOSED.
+                 * Tear down locally too: once we RST we MUST NOT write
+                 * further frames (§6.4), so the handler's eventual
+                 * response would be a protocol violation. */
+                abortStream(s, stream, h2::ERR_STREAM_CLOSED);
+            } else if (endStream) {
+                deliverFin(s, r);
+            } else {
+                /* §8.1: a second HEADERS that doesn't terminate the
+                 * stream is a malformed request (trailers MUST carry
+                 * END_STREAM). */
+                writeRstStream(s, stream, h2::ERR_PROTOCOL);
+                deliverFin(s, r);
+            }
+            return;
+        }
+
+        if (stream <= c->lastStreamId) {
+            /* §5.1.1: new stream IDs MUST monotonically increase; an
+             * unexpected stream identifier is a connection error of
+             * type PROTOCOL_ERROR (h2spec 5.1.1/2 expects GOAWAY). */
+            return protocolError(s, h2::ERR_PROTOCOL);
+        }
+        c->lastStreamId = stream;
+
+        if (c->goaway || c->streams.size() >= h2::MAX_STREAMS) {
+            if (!decodeHeaderBlock(s, nullptr)) return;
+            writeRstStream(s, stream, h2::ERR_REFUSED_STREAM);
+            return;
+        }
+
+        WTF::Vector<Http2Header, 32> hdrs;
+        std::string store;
+        if (!decodeHeaderBlock(s, &hdrs, &store)) return;
+
+        auto *res = new Http2Response(s, stream, c->remoteInitialWindow);
+        res->getHttpResponseData()->reset();
+        res->getHttpResponseData()->remoteClosed = endStream;
+        c->streams.emplace(stream, res);
+
+        Http2Request req(hdrs, store, res);
+        /* §8.3.1: :method and :path MUST be present (unless CONNECT,
+         * which this server doesn't support). A request omitting
+         * either is malformed → stream PROTOCOL_ERROR per §8.1.1. */
+        if (req.getCaseSensitiveMethod().empty() || req.getFullUrl().empty()) {
+            abortStream(s, stream, h2::ERR_PROTOCOL);
+            return;
+        }
+        if (req.getHeader("expect") == "100-continue") res->writeContinue();
+
+        Http2ContextData *cd = getContextData();
+        cd->router.getUserData() = {res, &req};
+        if (!cd->router.route(req.getMethod(), req.getUrl())) {
+            res->writeStatus("404 Not Found");
+            res->end({}, false);
+            return;
+        }
+        if (us_socket_is_closed(s)) return;
+
+        /* The handler may have responded synchronously, in which case
+         * markDone() → maybeDestroy() already freed `res`. Re-look it
+         * up; if gone, we're done. */
+        auto it = c->streams.find(stream);
+        if (it == c->streams.end()) return;
+        Http2ResponseData *d = it->second->getHttpResponseData();
+        if (endStream && d->inStream) {
+            d->inStream(it->second, "", 0, true, d->userData);
+        }
+    }
+
+    /* Decode the accumulated header block into `out` (name/value views into
+     * `store`). Returns false on HPACK error (connection already torn down).
+     * When out==nullptr only the decoder state is advanced. */
+    bool decodeHeaderBlock(us_socket_t *s, WTF::Vector<Http2Header, 32> *out,
+                           std::string *store = nullptr) {
+        /* Decode scratch. Decoded bytes are copied into `store` before the
+         * next loop iteration and never read after return; lshpack is pure
+         * C so there's no JS re-entry mid-decode. Same lifetime as
+         * writeHeaders()'s thread_local encode buffer — saves 64 KiB per
+         * connection vs. embedding this in the socket ext. */
+        static thread_local char hpackBuf[h2::MAX_HEADER_LIST];
+        Http2Connection *c = conn(s);
+        const unsigned char *src = (const unsigned char *) c->headerBlock.data();
+        const unsigned char *end = src + c->headerBlock.size();
+        if (store) store->reserve(c->headerBlock.size() * 2 + 256);
+        size_t used = 0;
+        while (src < end) {
+            struct lsxpack_header xh;
+            lsxpack_header_prepare_decode(&xh, hpackBuf, 0, sizeof(hpackBuf));
+            int rc = lshpack_dec_decode(&c->dec, &src, end, &xh);
+            if (rc != 0) {
+                protocolError(s, h2::ERR_COMPRESSION);
+                return false;
+            }
+            if (!out) continue;
+            size_t nlen = xh.name_len, vlen = xh.val_len;
+            if (used + nlen + vlen > h2::MAX_HEADER_LIST) {
+                protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
+                return false;
+            }
+            store->append(hpackBuf + xh.name_offset, nlen);
+            store->append(hpackBuf + xh.val_offset, vlen);
+            out->append({(const char *)(uintptr_t) used, (unsigned) nlen,
+                         (const char *)(uintptr_t)(used + nlen), (unsigned) vlen});
+            used += nlen + vlen;
+        }
+        c->headerBlock.clear();
+        if (out) {
+            const char *base = store->data();
+            for (auto &h : *out) {
+                h.name = base + (uintptr_t) h.name;
+                h.value = base + (uintptr_t) h.value;
+            }
+        }
+        return true;
+    }
+
+    void handleData(us_socket_t *s, uint32_t stream, uint8_t flags,
+                    const char *p, uint32_t len) {
+        Http2Connection *c = conn(s);
+        if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
+        uint32_t flowLen = len;
+        uint32_t pad = 0;
+        if (flags & h2::PADDED) {
+            if (len < 1) return protocolError(s, h2::ERR_FRAME_SIZE);
+            pad = (uint8_t) p[0]; p++; len--;
+        }
+        if (pad > len) return protocolError(s, h2::ERR_PROTOCOL);
+        len -= pad;
+
+        /* §6.9: connection window is consumed even for unknown/reset streams. */
+        c->connRecvWindow -= (int32_t) flowLen;
+        /* §6.9.1: a receiver MAY treat overshoot as FLOW_CONTROL_ERROR. We
+         * do — h2spec 6.9.1/1-2 expect it, and nginx/nghttp2 enforce it. */
+        if (c->connRecvWindow < 0) return protocolError(s, h2::ERR_FLOW_CONTROL);
+        if (c->connRecvWindow < h2::LOCAL_INIT_WINDOW / 2) {
+            writeWindowUpdate(s, 0, (uint32_t)(h2::LOCAL_INIT_WINDOW - c->connRecvWindow));
+            c->connRecvWindow = h2::LOCAL_INIT_WINDOW;
+        }
+
+        auto it = c->streams.find(stream);
+        if (it == c->streams.end()) {
+            /* DATA for a stream we already finished or refused. §6.1:
+             * STREAM_CLOSED. Don't blow the connection. */
+            if (stream <= c->lastStreamId)
+                writeRstStream(s, stream, h2::ERR_STREAM_CLOSED);
+            else
+                return protocolError(s, h2::ERR_PROTOCOL);
+            return;
+        }
+        Http2Response *r = it->second;
+        Http2ResponseData *d = r->getHttpResponseData();
+        if (d->remoteClosed) {
+            /* §5.1: DATA in half-closed(remote) is a STREAM_CLOSED stream
+             * error. The stream is still in c->streams because the
+             * server's response hasn't completed yet. Tear down locally
+             * too so the handler sees an abort — once we RST we MUST
+             * NOT write further frames on this stream (§6.4). */
+            abortStream(s, stream, h2::ERR_STREAM_CLOSED);
+            return;
+        }
+        bool fin = (flags & h2::END_STREAM) != 0;
+        r->recvWindow -= (int32_t) flowLen;
+        if (r->recvWindow < 0) {
+            abortStream(s, stream, h2::ERR_FLOW_CONTROL);
+            return;
+        }
+        /* Flag half-closed(remote) *before* dispatching the final chunk so
+         * a handler that responds synchronously inside inStream reaches
+         * markDone() with remoteClosed set and doesn't emit the §8.1
+         * early-RST(NO_ERROR) for a body the client already ended. */
+        if (fin) d->remoteClosed = true;
+
+        if (d->inStream) {
+            d->inStream(r, p, len, fin, d->userData);
+            if (us_socket_is_closed(s)) return;
+            /* inStream may have responded synchronously and freed `r`. */
+            it = c->streams.find(stream);
+            if (it == c->streams.end()) return;
+            r = it->second;
+            if (!fin && r->recvWindow < h2::LOCAL_INIT_WINDOW / 2 && !r->paused) {
+                writeWindowUpdate(s, stream, (uint32_t)(h2::LOCAL_INIT_WINDOW - r->recvWindow));
+                r->recvWindow = h2::LOCAL_INIT_WINDOW;
+            }
+        } else if (!fin && len > 0) {
+            /* Handler never armed onData (GET/HEAD/… per
+             * hasRequestBody()); drop the upload rather than buffer
+             * unboundedly. Route through abortStream so the local
+             * side is torn down too — deliverFin would only set
+             * remoteClosed, and with hasResponded()==false
+             * maybeDestroy() returns early, so the handler's later
+             * response would write to a stream we already RST'd. */
+            abortStream(s, stream, h2::ERR_CANCEL);
+            return;
+        }
+        if (fin) r->maybeDestroy();
+    }
+
+    /* Terminate the request body: mark half-closed(remote), deliver
+     * last=true to inStream so `await req.text()`/ReadableStream
+     * resolve, then maybeDestroy. remoteClosed is set *before* the
+     * dispatch so a handler that responds synchronously inside
+     * inStream reaches markDone() with the client side marked closed
+     * and doesn't emit the §8.1 early RST(NO_ERROR). */
+    void deliverFin(us_socket_t *s, Http2Response *r) {
+        Http2ResponseData *d = r->getHttpResponseData();
+        d->remoteClosed = true;
+        if (d->inStream) {
+            d->inStream(r, "", 0, true, d->userData);
+            if (us_socket_is_closed(s)) return;
+            /* inStream may have responded synchronously; maybeDestroy()
+             * is idempotent via `dead`. */
+        }
+        r->maybeDestroy();
+    }
+
+    void handleRstStream(us_socket_t *s, uint32_t stream, const char *, uint32_t len) {
+        if (len != 4) return protocolError(s, h2::ERR_FRAME_SIZE);
+        Http2Connection *c = conn(s);
+        auto it = c->streams.find(stream);
+        if (it == c->streams.end()) {
+            /* §6.4/§5.1: RST_STREAM on an idle stream is a connection
+             * PROTOCOL_ERROR; on a closed stream it's a permitted race
+             * ("An endpoint MUST ignore … RST_STREAM frames received
+             * in this state"). */
+            if (stream > c->lastStreamId) return protocolError(s, h2::ERR_PROTOCOL);
+            return;
+        }
+        Http2Response *r = it->second;
+        Http2ResponseData *d = r->getHttpResponseData();
+        c->streams.erase(it);
+        if (d->onAborted) d->onAborted(r, d->userData);
+        delete r;
+        /* onAborted re-enters JS; a server.stop() in an abort listener
+         * can close this socket. Check before touching `c` — `r` is
+         * ours regardless (erased from the map before the callback),
+         * so delete it above either way. */
+        if (us_socket_is_closed(s)) return;
+        if (c->goaway && c->streams.empty()) {
+            ((AsyncSocket<true> *) s)->uncork();
+            us_socket_close(s, 0, nullptr);
+        }
+    }
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -9,8 +9,8 @@
  * frame-parse buffer) lives in the socket ext; each stream is a
  * heap-allocated Http2Response.
  *
- * Public surface (Http2App/Response/Request) mirrors Http3* so Zig's
- * AnyResponse/AnyRequest `inline else` dispatch works unchanged.
+ * Public surface (Http2App/Response/Request) mirrors Http3* so Rust's
+ * AnyResponse/AnyRequest match-dispatch works unchanged.
  *
  * RFC 9113 (framing, flow control, §6.*), RFC 7541/lshpack (HPACK). Minimal:
  * SETTINGS/PING/WINDOW_UPDATE handled, PRIORITY and PUSH_PROMISE are
@@ -115,7 +115,7 @@ struct Http2Connection : AsyncSocketData<true> {
      * across insert. */
     std::map<uint32_t, Http2Response *> streams;
     /* Streams that completed while a callback was on the stack. We can't
-     * `delete` inside markDone() because the caller (Zig's StaticRoute,
+     * `delete` inside markDone() because the caller (Rust's StaticRoute,
      * RequestContext.renderBytes, …) still holds the pointer and calls
      * clearAborted()/clearOnWritable() right after tryEnd() returns.
      * H3 gets away with this because lsquic defers stream teardown to
@@ -826,10 +826,19 @@ struct Http2Context {
         }
 
         if (stream <= c->lastStreamId) {
-            /* §5.1.1: new stream IDs MUST monotonically increase; an
-             * unexpected stream identifier is a connection error of
-             * type PROTOCOL_ERROR (h2spec 5.1.1/2 expects GOAWAY). */
-            return protocolError(s, h2::ERR_PROTOCOL);
+            /* §5.1 closed: HEADERS racing our own RST_STREAM(NO_ERROR)
+             * (markDone's early-response path) lands here once the
+             * stream is erased from the map. Decode so HPACK stays in
+             * sync for siblings, then stream-scoped STREAM_CLOSED —
+             * mirroring handleData's not-in-map branch. Without a
+             * tombstone we can't distinguish this from §5.1.1's
+             * out-of-order new-stream case; h2spec 5.1.1/2 accepts
+             * RST_STREAM here, and nginx/nghttp2 make the same
+             * tradeoff so an early 401/429 doesn't GOAWAY the whole
+             * multiplexed connection. */
+            if (!decodeHeaderBlock(s, nullptr)) return;
+            writeRstStream(s, stream, h2::ERR_STREAM_CLOSED);
+            return;
         }
         c->lastStreamId = stream;
 

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -499,9 +499,11 @@ struct Http2Context {
         for (auto &kv : c->streams) live.append(kv.second);
         for (auto *r : live) {
             if (r->dead) continue;
-            if (!r->drain()) continue;
-            /* drain() may have completed the response and closed the
-             * socket via GOAWAY-last-stream. */
+            r->drain();
+            /* drain() → onWritable re-enters JS; a server.stop(true) or
+             * GOAWAY-last-stream close there frees every pointer in this
+             * snapshot via onClose → ~Http2Connection. Check regardless
+             * of drain()'s return so the backpressured path is covered. */
             if (us_socket_is_closed(s)) return;
         }
     }
@@ -816,7 +818,7 @@ struct Http2Context {
         std::string store;
         if (!decodeHeaderBlock(s, &hdrs, &store)) return;
 
-        auto *res = new Http2Response(s, stream, c->remoteInitialWindow);
+        auto *res = new Http2Response(s, stream, c->remoteInitialWindow, h2::LOCAL_INIT_WINDOW);
         res->getHttpResponseData()->reset();
         res->getHttpResponseData()->remoteClosed = endStream;
         c->streams.emplace(stream, res);
@@ -880,6 +882,19 @@ struct Http2Context {
             if (used + nlen + vlen > h2::MAX_HEADER_LIST) {
                 protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
                 return false;
+            }
+            /* §8.2.1: field names MUST NOT contain uppercase and MUST be
+             * valid tokens. A malformed name is a PROTOCOL_ERROR on the
+             * connection (the HPACK decoder state is already advanced). */
+            const char *np = hpackBuf + xh.name_offset;
+            if (nlen == 0) { protocolError(s, h2::ERR_PROTOCOL); return false; }
+            for (size_t j = 0; j < nlen; j++) {
+                unsigned char b = (unsigned char) np[j];
+                if ((unsigned)(b - 'A') < 26u || b == 0 || b == '\r' ||
+                    b == '\n' || b == ' ' || b == '\t') {
+                    protocolError(s, h2::ERR_PROTOCOL);
+                    return false;
+                }
             }
             store->append(hpackBuf + xh.name_offset, nlen);
             store->append(hpackBuf + xh.val_offset, vlen);
@@ -1012,17 +1027,19 @@ struct Http2Context {
         Http2Response *r = it->second;
         Http2ResponseData *d = r->getHttpResponseData();
         c->streams.erase(it);
-        if (d->onAborted) d->onAborted(r, d->userData);
-        delete r;
-        /* onAborted re-enters JS; a server.stop() in an abort listener
-         * can close this socket. Check before touching `c` — `r` is
-         * ours regardless (erased from the map before the callback),
-         * so delete it above either way. */
-        if (us_socket_is_closed(s)) return;
-        if (c->goaway && c->streams.empty()) {
-            ((AsyncSocket<true> *) s)->uncork();
-            us_socket_close(s, 0, nullptr);
+        r->dead = true;
+        d->remoteClosed = true;
+        /* Park before the JS-reentrant callback so a server.stop() in an
+         * abort listener that fires on_close → ~Http2Connection still
+         * frees `r` cleanly. dispatchDepth>0 (set in onSocketData) keeps
+         * sweep() from freeing mid-callback. */
+        c->pendingDelete.append(r);
+        if (d->onAborted) {
+            auto cb = d->onAborted;
+            d->onAborted = nullptr;
+            cb(r, d->userData);
         }
+        /* goaway-last-stream close is handled by sweep() at on_data exit. */
     }
 };
 

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -12,10 +12,13 @@
  * Public surface (Http2App/Response/Request) mirrors Http3* so Zig's
  * AnyResponse/AnyRequest `inline else` dispatch works unchanged.
  *
- * RFC 9113 (framing, flow control, §6.*), RFC 7541/lshpack (HPACK). Minimal
- * but conformant: SETTINGS/PING/WINDOW_UPDATE handled, PRIORITY and
- * PUSH_PROMISE are acknowledged-and-ignored (server push disabled), HPACK
- * errors and framing violations tear the connection down with GOAWAY. */
+ * RFC 9113 (framing, flow control, §6.*), RFC 7541/lshpack (HPACK). Minimal:
+ * SETTINGS/PING/WINDOW_UPDATE handled, PRIORITY and PUSH_PROMISE are
+ * acknowledged-and-ignored (server push disabled), HPACK errors and
+ * framing violations tear the connection down with GOAWAY. §8.2.1
+ * field-name/value bytes are validated; §8.2.2 connection-specific
+ * headers and the §8.3.1 pseudo-header ordering/dup rules are not yet
+ * enforced (h2spec 8.1.2.* gaps). */
 
 #include "Loop.h"
 #include "AsyncSocket.h"
@@ -200,8 +203,19 @@ struct Http2Context {
         for (auto &kv : c->streams) live.append(kv.second);
         for (auto *r : live) {
             if (r->dead) continue;
+            /* Same dead=true + copy-and-null shape as abortStream()/
+             * handleRstStream(): onAborted re-enters JS and a future
+             * registrant that called end()/close() on `r` before
+             * detaching would otherwise reach maybeDestroy() with
+             * dead=false and fire onAborted a second time. */
+            r->dead = true;
             Http2ResponseData *d = r->getHttpResponseData();
-            if (d->onAborted) d->onAborted(r, d->userData);
+            d->remoteClosed = true;
+            if (d->onAborted) {
+                auto cb = d->onAborted;
+                d->onAborted = nullptr;
+                cb(r, d->userData);
+            }
         }
         c->~Http2Connection();
         return s;
@@ -801,9 +815,12 @@ struct Http2Context {
             } else {
                 /* §8.1: a second HEADERS that doesn't terminate the
                  * stream is a malformed request (trailers MUST carry
-                 * END_STREAM). */
-                writeRstStream(s, stream, h2::ERR_PROTOCOL);
-                deliverFin(s, r);
+                 * END_STREAM). Tear down locally like the
+                 * remoteClosed branch above — writeRstStream alone
+                 * would leave the stream in c->streams and the async
+                 * handler's later end() would emit frames after our
+                 * RST (§6.4 MUST NOT). */
+                abortStream(s, stream, h2::ERR_PROTOCOL);
             }
             return;
         }
@@ -899,11 +916,12 @@ struct Http2Context {
             }
             size_t nlen = xh.name_len, vlen = xh.val_len;
             /* §8.2.1: field names MUST NOT contain uppercase and MUST be
-             * valid tokens (RFC 9110 §5.6.2 tchar, lowercase-only). Flag
-             * via `malformed` — the caller RSTs the stream — and keep
-             * decoding so the connection-scoped HPACK state stays valid
-             * for sibling streams. Runs regardless of `out` so trailer
-             * blocks (decoded state-only) are checked too. */
+             * valid tokens (RFC 9110 §5.6.2 tchar, lowercase-only); field
+             * values MUST NOT contain NUL, CR or LF. Flag via `malformed`
+             * — the caller RSTs the stream — and keep decoding so the
+             * connection-scoped HPACK state stays valid for sibling
+             * streams. Runs regardless of `out` so trailer blocks
+             * (decoded state-only) are checked too. */
             if (malformed && !*malformed) {
                 const char *np = hpackBuf + xh.name_offset;
                 if (nlen == 0) *malformed = true;
@@ -914,6 +932,11 @@ struct Http2Context {
                         *malformed = true;
                         break;
                     }
+                }
+                const char *vp = hpackBuf + xh.val_offset;
+                for (size_t j = 0; !*malformed && j < vlen; j++) {
+                    unsigned char b = (unsigned char) vp[j];
+                    if (b == 0 || b == '\r' || b == '\n') *malformed = true;
                 }
             }
             if (!out || (malformed && *malformed)) continue;

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -816,7 +816,16 @@ struct Http2Context {
 
         WTF::Vector<Http2Header, 32> hdrs;
         std::string store;
-        if (!decodeHeaderBlock(s, &hdrs, &store)) return;
+        bool malformed = false;
+        if (!decodeHeaderBlock(s, &hdrs, &store, &malformed)) return;
+        if (malformed) {
+            /* §8.1.1: a malformed request MUST be a stream
+             * PROTOCOL_ERROR. The HPACK decoder state was advanced
+             * above, so the connection (and sibling streams) stay
+             * healthy. */
+            writeRstStream(s, stream, h2::ERR_PROTOCOL);
+            return;
+        }
 
         auto *res = new Http2Response(s, stream, c->remoteInitialWindow, h2::LOCAL_INIT_WINDOW);
         res->getHttpResponseData()->reset();
@@ -854,10 +863,13 @@ struct Http2Context {
     }
 
     /* Decode the accumulated header block into `out` (name/value views into
-     * `store`). Returns false on HPACK error (connection already torn down).
-     * When out==nullptr only the decoder state is advanced. */
+     * `store`). Returns false on HPACK/size error (connection already torn
+     * down). When out==nullptr only the decoder state is advanced. A
+     * non-null `malformed` out-param receives §8.2.1 per-stream malformed
+     * findings; HPACK state stays consistent so the caller can RST the
+     * stream without tearing down the connection. */
     bool decodeHeaderBlock(us_socket_t *s, WTF::Vector<Http2Header, 32> *out,
-                           std::string *store = nullptr) {
+                           std::string *store = nullptr, bool *malformed = nullptr) {
         /* Decode scratch. Decoded bytes are copied into `store` before the
          * next loop iteration and never read after return; lshpack is pure
          * C so there's no JS re-entry mid-decode. Same lifetime as
@@ -877,25 +889,28 @@ struct Http2Context {
                 protocolError(s, h2::ERR_COMPRESSION);
                 return false;
             }
-            if (!out) continue;
+            if (!out || (malformed && *malformed)) continue;
             size_t nlen = xh.name_len, vlen = xh.val_len;
             if (used + nlen + vlen > h2::MAX_HEADER_LIST) {
                 protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
                 return false;
             }
             /* §8.2.1: field names MUST NOT contain uppercase and MUST be
-             * valid tokens. A malformed name is a PROTOCOL_ERROR on the
-             * connection (the HPACK decoder state is already advanced). */
+             * valid tokens (RFC 9110 §5.6.2 tchar, lowercase-only). Flag
+             * via `malformed` — the caller RSTs the stream — and keep
+             * decoding so the connection-scoped HPACK state stays valid
+             * for sibling streams. */
             const char *np = hpackBuf + xh.name_offset;
-            if (nlen == 0) { protocolError(s, h2::ERR_PROTOCOL); return false; }
+            if (nlen == 0) { if (malformed) *malformed = true; continue; }
             for (size_t j = 0; j < nlen; j++) {
                 unsigned char b = (unsigned char) np[j];
-                if ((unsigned)(b - 'A') < 26u || b == 0 || b == '\r' ||
-                    b == '\n' || b == ' ' || b == '\t') {
-                    protocolError(s, h2::ERR_PROTOCOL);
-                    return false;
+                if (b < 0x21 || b >= 0x7f || (unsigned)(b - 'A') < 26u ||
+                    (b == ':' && j != 0)) {
+                    if (malformed) *malformed = true;
+                    break;
                 }
             }
+            if (malformed && *malformed) continue;
             store->append(hpackBuf + xh.name_offset, nlen);
             store->append(hpackBuf + xh.val_offset, vlen);
             out->append({(const char *)(uintptr_t) used, (unsigned) nlen,

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -781,7 +781,15 @@ struct Http2Context {
          * scoped) but only deliver the FIN. */
         if (auto it = c->streams.find(stream); it != c->streams.end()) {
             Http2Response *r = it->second;
-            if (!decodeHeaderBlock(s, nullptr)) return;
+            bool malformed = false;
+            if (!decodeHeaderBlock(s, nullptr, nullptr, &malformed)) return;
+            if (malformed) {
+                /* §8.2.1 applies to trailer field names too; §8.1.1 says
+                 * a malformed message MUST be a stream PROTOCOL_ERROR.
+                 * HPACK state was advanced above, siblings stay healthy. */
+                abortStream(s, stream, h2::ERR_PROTOCOL);
+                return;
+            }
             if (r->getHttpResponseData()->remoteClosed) {
                 /* §5.1: HEADERS in half-closed(remote) → STREAM_CLOSED.
                  * Tear down locally too: once we RST we MUST NOT write
@@ -889,28 +897,30 @@ struct Http2Context {
                 protocolError(s, h2::ERR_COMPRESSION);
                 return false;
             }
-            if (!out || (malformed && *malformed)) continue;
             size_t nlen = xh.name_len, vlen = xh.val_len;
-            if (used + nlen + vlen > h2::MAX_HEADER_LIST) {
-                protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
-                return false;
-            }
             /* §8.2.1: field names MUST NOT contain uppercase and MUST be
              * valid tokens (RFC 9110 §5.6.2 tchar, lowercase-only). Flag
              * via `malformed` — the caller RSTs the stream — and keep
              * decoding so the connection-scoped HPACK state stays valid
-             * for sibling streams. */
-            const char *np = hpackBuf + xh.name_offset;
-            if (nlen == 0) { if (malformed) *malformed = true; continue; }
-            for (size_t j = 0; j < nlen; j++) {
-                unsigned char b = (unsigned char) np[j];
-                if (b < 0x21 || b >= 0x7f || (unsigned)(b - 'A') < 26u ||
-                    (b == ':' && j != 0)) {
-                    if (malformed) *malformed = true;
-                    break;
+             * for sibling streams. Runs regardless of `out` so trailer
+             * blocks (decoded state-only) are checked too. */
+            if (malformed && !*malformed) {
+                const char *np = hpackBuf + xh.name_offset;
+                if (nlen == 0) *malformed = true;
+                for (size_t j = 0; j < nlen; j++) {
+                    unsigned char b = (unsigned char) np[j];
+                    if (b < 0x21 || b >= 0x7f || (unsigned)(b - 'A') < 26u ||
+                        (b == ':' && j != 0)) {
+                        *malformed = true;
+                        break;
+                    }
                 }
             }
-            if (malformed && *malformed) continue;
+            if (!out || (malformed && *malformed)) continue;
+            if (used + nlen + vlen > h2::MAX_HEADER_LIST) {
+                protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
+                return false;
+            }
             store->append(hpackBuf + xh.name_offset, nlen);
             store->append(hpackBuf + xh.val_offset, vlen);
             out->append({(const char *)(uintptr_t) used, (unsigned) nlen,

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -48,6 +48,7 @@ namespace h2 {
     static constexpr size_t FRAME_HEADER_SIZE = 9;
     static constexpr uint32_t MAX_HEADER_LIST = 64 * 1024;
     static constexpr uint32_t MAX_STREAMS     = 128;
+    static constexpr uint32_t MAX_RESETS      = 1000;
     /* Advertise a generous per-stream window so downloads aren't throttled
      * by the spec default. Connection window is also bumped on open. */
     static constexpr int32_t LOCAL_INIT_WINDOW = 1024 * 1024;
@@ -109,6 +110,9 @@ struct Http2Connection : AsyncSocketData<true> {
 
     /* Highest client stream ID seen; used for GOAWAY. */
     uint32_t lastStreamId = 0;
+    /* Client RST_STREAMs since open; caps the HEADERS→RST flood
+     * (CVE-2023-44487) that MAX_STREAMS can't see. */
+    uint32_t resetCount = 0;
 
     /* Live streams, keyed by client-initiated odd IDs. std::map over
      * HashMap for ordered iteration (drain fairness) and stable pointers
@@ -760,6 +764,8 @@ struct Http2Context {
         if (pad > len) return protocolError(s, h2::ERR_PROTOCOL);
         len -= pad;
 
+        if (len > h2::MAX_HEADER_LIST)
+            return protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
         c->headerBlock.assign(p, len);
         c->continuationEndStream = (flags & h2::END_STREAM) != 0;
         if (!(flags & h2::END_HEADERS)) {
@@ -924,9 +930,11 @@ struct Http2Context {
                 return false;
             }
             size_t nlen = xh.name_len, vlen = xh.val_len;
-            /* §8.2.1: field names MUST NOT contain uppercase and MUST be
-             * valid tokens (RFC 9110 §5.6.2 tchar, lowercase-only); field
-             * values MUST NOT contain NUL, CR or LF. Flag via `malformed`
+            /* §8.2.1: field names MUST NOT contain bytes in 0x00-0x20,
+             * 0x41-0x5a (uppercase), 0x7f-0xff, or a non-leading colon;
+             * field values MUST NOT contain NUL, CR or LF. (The RFC 9110
+             * tchar delimiter set is a §8.2.1 SHOULD, deferred alongside
+             * §8.2.2/§8.3.1 in the file header.) Flag via `malformed`
              * — the caller RSTs the stream — and keep decoding so the
              * connection-scoped HPACK state stays valid for sibling
              * streams. Runs regardless of `out` so trailer blocks
@@ -1081,6 +1089,11 @@ struct Http2Context {
             if (stream > c->lastStreamId) return protocolError(s, h2::ERR_PROTOCOL);
             return;
         }
+        /* CVE-2023-44487: a HEADERS→RST flood keeps c->streams.size()
+         * near 0 so MAX_STREAMS never trips. Bound the cumulative
+         * client resets per connection like nginx/Go/nghttp2 do. */
+        if (++c->resetCount > h2::MAX_RESETS)
+            return protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
         Http2Response *r = it->second;
         Http2ResponseData *d = r->getHttpResponseData();
         c->streams.erase(it);

--- a/packages/bun-uws/src/Http2ContextData.h
+++ b/packages/bun-uws/src/Http2ContextData.h
@@ -1,0 +1,23 @@
+#ifndef UWS_H2CONTEXTDATA_H
+#define UWS_H2CONTEXTDATA_H
+
+#include "HttpRouter.h"
+
+namespace uWS {
+
+struct Http2Response;
+struct Http2Request;
+
+/* Mirrors Http3ContextData so the H3 routing shape applies unchanged. */
+struct Http2ContextData {
+    struct RouterData {
+        Http2Response *httpResponse;
+        Http2Request *httpRequest;
+    };
+    HttpRouter<RouterData> router;
+    unsigned int idleTimeoutS = 10;
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2Request.h
+++ b/packages/bun-uws/src/Http2Request.h
@@ -1,0 +1,118 @@
+#ifndef UWS_H2REQUEST_H
+#define UWS_H2REQUEST_H
+// clang-format off
+
+#include "Http2ResponseData.h"
+#include "QueryParser.h"
+
+#include <wtf/Vector.h>
+#include <string_view>
+#include <utility>
+
+namespace uWS {
+
+struct Http2Response;
+
+/* Mirrors Http3Request so the router/handler shape is identical. Backed by
+ * a decoded HPACK header list; pseudo headers (:method, :path, :authority)
+ * become method/url/host. */
+struct Http2Request {
+
+    Http2Request(WTF::Vector<Http2Header, 32> &headers, std::string & /*store*/,
+                 Http2Response *r)
+        : hdrs(headers), response(r) {
+        for (auto &h : hdrs) {
+            std::string_view name{h.name, h.name_len};
+            std::string_view value{h.value, h.value_len};
+            if (name == ":method") {
+                method = value;
+            } else if (name == ":path") {
+                fullUrl = value;
+                size_t q = value.find('?');
+                url = q == std::string_view::npos ? value : value.substr(0, q);
+                /* Keep the leading '?' — getDecodedQueryValue drops it. */
+                query = q == std::string_view::npos ? std::string_view{} : value.substr(q);
+            } else if (name == ":authority") {
+                authority = value;
+            } else if (authority.empty() && name.size() == 4 && equalsIgnoreCase(name, "host")) {
+                /* RFC 9113 §8.3.1: a request MUST include :authority OR a
+                 * Host field. Promote the literal Host so getHeader("host"),
+                 * req.url, and the forEachHeader synthesis all agree. HPACK
+                 * delivers pseudo-headers first, so :authority (if any)
+                 * always wins. */
+                authority = value;
+            }
+        }
+    }
+
+    bool isAncient() { return false; }
+    bool getYield() { return yield; }
+    void setYield(bool y) { yield = y; }
+
+    std::string_view getUrl() { return url; }
+    std::string_view getFullUrl() { return fullUrl; }
+    std::string_view getQuery() { return query.empty() ? query : query.substr(1); }
+    std::string_view getQuery(std::string_view key) { return getDecodedQueryValue(key, query); }
+    std::string_view getCaseSensitiveMethod() { return method; }
+    Http2Response *getResponse() { return response; }
+
+    /* HttpRequest::getMethod() lowercases in place; we own no writable
+     * buffer, so write into a per-request scratch instead. */
+    std::string_view getMethod() {
+        size_t n = method.size() < sizeof(methodLower) ? method.size() : sizeof(methodLower);
+        for (size_t i = 0; i < n; i++) {
+            char c = method[i];
+            methodLower[i] = (char)(c | ((unsigned char)(c - 'A') < 26 ? 0x20 : 0));
+        }
+        return {methodLower, n};
+    }
+
+    std::string_view getHeader(std::string_view lowerCasedHeader) {
+        if (lowerCasedHeader == "host") return authority;
+        for (auto &h : hdrs) {
+            if (h.name_len == lowerCasedHeader.size() &&
+                equalsIgnoreCase({h.name, h.name_len}, lowerCasedHeader)) {
+                return {h.value, h.value_len};
+            }
+        }
+        return {};
+    }
+
+    template <typename Fn> void forEachHeader(Fn &&fn) {
+        for (auto &h : hdrs) {
+            std::string_view name{h.name, h.name_len};
+            if (!name.empty() && name[0] == ':') continue;
+            /* Drop the literal Host — :authority is synthesised below so
+             * req.headers.get('host') matches req.url and isn't
+             * comma-joined. */
+            if (!authority.empty() && name.size() == 4 && equalsIgnoreCase(name, "host")) continue;
+            fn(name, std::string_view{h.value, h.value_len});
+        }
+        if (!authority.empty()) fn(std::string_view{"host"}, authority);
+    }
+
+    void setParameters(std::pair<int, std::string_view *> p) { params = p; }
+    std::string_view getParameter(unsigned short index) {
+        return (int) index > params.first ? std::string_view{} : params.second[index];
+    }
+
+private:
+    static bool equalsIgnoreCase(std::string_view a, std::string_view b) {
+        if (a.size() != b.size()) return false;
+        for (size_t i = 0; i < a.size(); i++) {
+            if ((a[i] | 0x20) != (b[i] | 0x20)) return false;
+        }
+        return true;
+    }
+
+    WTF::Vector<Http2Header, 32> &hdrs;
+    Http2Response *response;
+    std::string_view method, url, fullUrl, query, authority;
+    std::pair<int, std::string_view *> params{-1, nullptr};
+    char methodLower[32];
+    bool yield = false;
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2Request.h
+++ b/packages/bun-uws/src/Http2Request.h
@@ -100,7 +100,10 @@ private:
     static bool equalsIgnoreCase(std::string_view a, std::string_view b) {
         if (a.size() != b.size()) return false;
         for (size_t i = 0; i < a.size(); i++) {
-            if ((a[i] | 0x20) != (b[i] | 0x20)) return false;
+            char ca = a[i], cb = b[i];
+            ca = (char)(ca | ((unsigned char)(ca - 'A') < 26 ? 0x20 : 0));
+            cb = (char)(cb | ((unsigned char)(cb - 'A') < 26 ? 0x20 : 0));
+            if (ca != cb) return false;
         }
         return true;
     }

--- a/packages/bun-uws/src/Http2Response.h
+++ b/packages/bun-uws/src/Http2Response.h
@@ -1,0 +1,159 @@
+#ifndef UWS_H2RESPONSE_H
+#define UWS_H2RESPONSE_H
+// clang-format off
+
+#include "Http2ResponseData.h"
+#include "AsyncSocket.h"
+#include "LoopData.h"
+
+#include <charconv>
+#include <optional>
+#include <string_view>
+
+namespace uWS {
+
+struct Http2Context;
+struct Http2Connection;
+
+/* API mirror of Http3Response / HttpResponse<SSL>. Heap-allocated per
+ * stream (the socket ext holds the connection, not the stream), so unlike
+ * the H1/H3 variants `this` is an actual object rather than an overlay on
+ * a uSockets handle. */
+struct Http2Response {
+    us_socket_t *socket;
+    uint32_t id;
+    int32_t sendWindow;
+    int32_t recvWindow;
+    bool paused = false;
+    bool dead = false;
+    Http2ResponseData data;
+
+    Http2Response(us_socket_t *s, uint32_t stream, int32_t remoteInitWin)
+        : socket(s), id(stream), sendWindow(remoteInitWin),
+          recvWindow((int32_t) 1024 * 1024) {}
+
+    Http2ResponseData *getHttpResponseData() { return &data; }
+    Http2Context *context() {
+        return (Http2Context *) us_socket_group_ext(us_socket_group(socket));
+    }
+
+    Http2Response *writeStatus(std::string_view status) {
+        if (data.state & Http2ResponseData::HTTP_STATUS_CALLED) return this;
+        data.state |= Http2ResponseData::HTTP_STATUS_CALLED;
+        /* Zig hands us "200 OK"; HTTP/2 wants only the 3-digit code. */
+        std::string_view code = status.size() >= 3 ? status.substr(0, 3) : std::string_view{"200"};
+        data.appendHeader(":status", 7, code.data(), (unsigned) code.size());
+        return this;
+    }
+
+    Http2Response *writeHeader(std::string_view key, std::string_view value) {
+        writeStatus("200 OK");
+        data.appendHeader(key.data(), (unsigned) key.size(),
+                          value.data(), (unsigned) value.size());
+        return this;
+    }
+
+    Http2Response *writeHeader(std::string_view key, uint64_t value) {
+        char buf[24];
+        auto r = std::to_chars(buf, buf + sizeof(buf), value);
+        return writeHeader(key, std::string_view{buf, (size_t)(r.ptr - buf)});
+    }
+
+    void writeMark() {
+        if (data.state & Http2ResponseData::HTTP_WROTE_DATE_HEADER) return;
+        data.state |= Http2ResponseData::HTTP_WROTE_DATE_HEADER;
+        LoopData *ld = (LoopData *) us_loop_ext(us_socket_group_loop(us_socket_group(socket)));
+        writeHeader("date", std::string_view{ld->date, 29});
+    }
+
+    Http2Response *writeContinue();
+
+    void flushHeaders(bool /*immediately*/ = false) {
+        if (!(data.state & Http2ResponseData::HTTP_WRITE_CALLED)) {
+            writeStatus("200 OK");
+            sendBufferedHeaders(false);
+            data.state |= Http2ResponseData::HTTP_WRITE_CALLED;
+        }
+    }
+
+    bool write(std::string_view body, size_t *writtenPtr = nullptr);
+    void end(std::string_view body = {}, bool closeConnection = false) {
+        internalEnd(body, body.length(), false, true, closeConnection);
+    }
+    std::pair<bool, bool> tryEnd(std::string_view body, uint64_t totalSize = 0, bool close = false) {
+        bool ok = internalEnd(body, totalSize, true, true, close);
+        return {ok, ok || hasResponded()};
+    }
+    void endWithoutBody(std::optional<size_t> reportedContentLength = std::nullopt,
+                        bool /*closeConnection*/ = false);
+    bool sendTerminatingChunk(bool /*closeConnection*/ = false);
+
+    bool hasResponded() {
+        return !(data.state & Http2ResponseData::HTTP_RESPONSE_PENDING);
+    }
+
+    uint64_t getWriteOffset() { return data.offset; }
+    void overrideWriteOffset(uint64_t o) { data.offset = o; }
+    void setWriteOffset(uint64_t o) { data.offset = o; }
+    size_t getBufferedAmount() {
+        return data.backpressure.length() +
+               ((AsyncSocket<true> *) socket)->getBufferedAmount();
+    }
+
+    Http2Response *pause() { paused = true; return this; }
+    Http2Response *resume();
+
+    Http2Response *cork(MoveOnlyFunction<void()> &&fn);
+    void uncork() {}
+    bool isCorked() { return false; }
+
+    void close();
+    void *getNativeHandle() { return this; }
+    void *getSocketData() { return data.socketData; }
+    bool isConnectRequest() { return false; }
+    void setTimeout(uint8_t) {}
+    void resetTimeout() {}
+    void prepareForSendfile() {}
+
+    Http2Response *onWritable(void *ud, Http2ResponseData::OnWritableCallback h) {
+        data.writableUserData = ud; data.onWritable = h; return this;
+    }
+    Http2Response *clearOnWritable() {
+        data.onWritable = nullptr; data.writableUserData = nullptr; return this;
+    }
+    Http2Response *onAborted(void *ud, Http2ResponseData::OnAbortedCallback h) {
+        data.userData = ud; data.onAborted = h; return this;
+    }
+    Http2Response *clearOnAborted() { data.onAborted = nullptr; return this; }
+    Http2Response *onTimeout(void *ud, Http2ResponseData::OnTimeoutCallback h) {
+        data.onTimeout = h; if (h) data.userData = ud; return this;
+    }
+    Http2Response *clearOnTimeout() { data.onTimeout = nullptr; return this; }
+    void onData(void *ud, Http2ResponseData::OnDataCallback h) {
+        data.inStream = h; if (h) data.userData = ud;
+    }
+    Http2Response *clearOnWritableAndAborted() {
+        /* Like H3: leave onAborted armed so the holder learns when the
+         * stream object is freed post-completion. */
+        data.onWritable = nullptr; return this;
+    }
+
+    bool drain();
+    void maybeDestroy();
+    std::string_view getRemoteAddressAsText() {
+        return ((AsyncSocket<true> *) socket)->getRemoteAddressAsText();
+    }
+    std::string_view getRemoteAddress() {
+        return ((AsyncSocket<true> *) socket)->getRemoteAddress();
+    }
+
+private:
+    void sendBufferedHeaders(bool endStream);
+    bool internalEnd(std::string_view body, uint64_t totalSize, bool optional,
+                     bool allowContentLength, bool closeConnection);
+    void markDone();
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2Response.h
+++ b/packages/bun-uws/src/Http2Response.h
@@ -28,9 +28,10 @@ struct Http2Response {
     bool dead = false;
     Http2ResponseData data;
 
-    Http2Response(us_socket_t *s, uint32_t stream, int32_t remoteInitWin)
+    Http2Response(us_socket_t *s, uint32_t stream, int32_t remoteInitWin,
+                  int32_t localInitWin)
         : socket(s), id(stream), sendWindow(remoteInitWin),
-          recvWindow((int32_t) 1024 * 1024) {}
+          recvWindow(localInitWin) {}
 
     Http2ResponseData *getHttpResponseData() { return &data; }
     Http2Context *context() {

--- a/packages/bun-uws/src/Http2Response.h
+++ b/packages/bun-uws/src/Http2Response.h
@@ -41,7 +41,7 @@ struct Http2Response {
     Http2Response *writeStatus(std::string_view status) {
         if (data.state & Http2ResponseData::HTTP_STATUS_CALLED) return this;
         data.state |= Http2ResponseData::HTTP_STATUS_CALLED;
-        /* Zig hands us "200 OK"; HTTP/2 wants only the 3-digit code. */
+        /* Rust hands us "200 OK"; HTTP/2 wants only the 3-digit code. */
         std::string_view code = status.size() >= 3 ? status.substr(0, 3) : std::string_view{"200"};
         data.appendHeader(":status", 7, code.data(), (unsigned) code.size());
         return this;

--- a/packages/bun-uws/src/Http2ResponseData.h
+++ b/packages/bun-uws/src/Http2ResponseData.h
@@ -1,0 +1,103 @@
+#ifndef UWS_H2RESPONSEDATA_H
+#define UWS_H2RESPONSEDATA_H
+
+#include "AsyncSocketData.h"
+
+#include <wtf/Vector.h>
+#include <cstdint>
+#include <cstring>
+
+namespace uWS {
+
+struct Http2Response;
+
+/* One name/value pair for the outgoing header block. Same shape as
+ * us_quic_header_t so the Zig side and the tests can reason about both
+ * transports identically. */
+struct Http2Header {
+    const char *name;
+    unsigned int name_len;
+    const char *value;
+    unsigned int value_len;
+};
+
+/* Per-stream response state. Same bit values and callback shapes as
+ * HttpResponseData / Http3ResponseData so Zig's State enum and the
+ * uws_res_* C ABI stay 1:1. Heap-allocated (one per stream, many per
+ * connection). */
+struct Http2ResponseData {
+    using OnWritableCallback = bool (*)(Http2Response *, uint64_t, void *);
+    using OnAbortedCallback = void (*)(Http2Response *, void *);
+    using OnTimeoutCallback = void (*)(Http2Response *, void *);
+    using OnDataCallback = void (*)(Http2Response *, const char *, size_t, bool, void *);
+
+    enum : uint8_t {
+        HTTP_STATUS_CALLED = 1,
+        HTTP_WRITE_CALLED = 2,
+        HTTP_END_CALLED = 4,
+        HTTP_RESPONSE_PENDING = 8,
+        HTTP_CONNECTION_CLOSE = 16,
+        HTTP_WROTE_CONTENT_LENGTH_HEADER = 32,
+        HTTP_WROTE_DATE_HEADER = 64,
+    };
+
+    void *userData = nullptr;
+    /* See Http3ResponseData for why onWritable gets its own userData. */
+    void *writableUserData = nullptr;
+    void *socketData = nullptr;
+    OnWritableCallback onWritable = nullptr;
+    OnAbortedCallback onAborted = nullptr;
+    OnDataCallback inStream = nullptr;
+    OnTimeoutCallback onTimeout = nullptr;
+
+    /* Outgoing headers buffered until the first body write/end so they go
+     * out as one HEADERS frame. Inline capacity keeps typical responses
+     * off the heap. Offsets stored as pointers (cast through uintptr_t)
+     * so hdrBuf can realloc; resolved against hdrBuf.data() at send. */
+    WTF::Vector<char, 256> hdrBuf;
+    WTF::Vector<Http2Header, 16> hdrs;
+
+    /* Body bytes the stream's send window (or TCP) couldn't accept yet. */
+    BackPressure backpressure;
+    bool endAfterDrain = false;
+    bool remoteClosed = false;
+
+    uint64_t offset = 0;
+    uint64_t totalSize = 0;
+    uint8_t state = 0;
+
+    void appendHeader(const char *name, unsigned nlen, const char *value, unsigned vlen) {
+        size_t off = hdrBuf.size();
+        hdrBuf.grow(off + nlen + vlen);
+        char *dst = hdrBuf.mutableSpan().data() + off;
+        for (unsigned i = 0; i < nlen; i++) {
+            /* RFC 9113 §8.2.1: field names MUST be lowercase. */
+            char c = name[i];
+            dst[i] = (char)(c | ((unsigned char)(c - 'A') < 26 ? 0x20 : 0));
+        }
+        memcpy(dst + nlen, value, vlen);
+        hdrs.append({(const char *)(uintptr_t) off, nlen,
+                     (const char *)(uintptr_t)(off + nlen), vlen});
+    }
+
+    void reset() {
+        userData = nullptr;
+        writableUserData = nullptr;
+        onWritable = nullptr;
+        onAborted = nullptr;
+        inStream = nullptr;
+        onTimeout = nullptr;
+        hdrBuf.shrink(0);
+        hdrs.shrink(0);
+        backpressure.clear();
+        endAfterDrain = false;
+        remoteClosed = false;
+        offset = 0;
+        totalSize = 0;
+        state = HTTP_RESPONSE_PENDING;
+    }
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2ResponseData.h
+++ b/packages/bun-uws/src/Http2ResponseData.h
@@ -12,7 +12,7 @@ namespace uWS {
 struct Http2Response;
 
 /* One name/value pair for the outgoing header block. Same shape as
- * us_quic_header_t so the Zig side and the tests can reason about both
+ * us_quic_header_t so the Rust side and the tests can reason about both
  * transports identically. */
 struct Http2Header {
     const char *name;
@@ -22,7 +22,7 @@ struct Http2Header {
 };
 
 /* Per-stream response state. Same bit values and callback shapes as
- * HttpResponseData / Http3ResponseData so Zig's State enum and the
+ * HttpResponseData / Http3ResponseData so Rust's State enum and the
  * uws_res_* C ABI stay 1:1. Heap-allocated (one per stream, many per
  * connection). */
 struct Http2ResponseData {

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -36,8 +36,65 @@
 #include <array>
 #include <mutex>
 
+/* Defined in libuwsockets_h2.cpp; called from the SSL on_data hook when
+ * h2Context is set. Takes the Http2Context* as void* so this header
+ * doesn't include Http2App.h. Declared out here (C linkage, global)
+ * rather than inside the function body so the name isn't mangled. */
+extern "C" us_socket_t *uws_internal_h2_adopt(
+    void *h2Context, us_socket_t *s, int oldExtSize,
+    char *data, int length);
+extern "C" void uws_internal_h2_close_all(void *h2Context);
+
+/* Forward decl; SSL_CTX_set_alpn_select_cb signature is stable across
+ * OpenSSL/BoringSSL so avoid pulling the full openssl headers here. */
+extern "C" void SSL_CTX_set_alpn_select_cb(
+    struct ssl_ctx_st *ctx,
+    int (*cb)(struct ssl_st *ssl, const unsigned char **out, unsigned char *outlen,
+              const unsigned char *in, unsigned int inlen, void *arg),
+    void *arg);
 
 namespace uWS {
+
+/* ALPN select cb for the h2: true path. Walks the client's wire-format
+ * list by hand (SSL_select_next_proto isn't available on every BoringSSL
+ * build we ship). Gated on parentData->h2Context being live so
+ * connections that race ~H2App fall back to http/1.1 instead of
+ * negotiating h2 with nowhere to adopt into. Declared here (not in
+ * Http2App.h) so TemplatedApp can install it on the root SSL_CTX and on
+ * each per-SNI SSL_CTX — sni_cb swaps ssl->ctx before BoringSSL reads
+ * alpn_select_cb, so every context that can serve a connection needs a
+ * copy. */
+template <bool SSL>
+inline void installH2Alpn(struct ssl_ctx_st *sslCtx, HttpContextData<SSL> *parentData) {
+    if constexpr (SSL) {
+        if (!sslCtx) return;
+        SSL_CTX_set_alpn_select_cb(sslCtx,
+            [](struct ssl_st *, const unsigned char **out, unsigned char *outlen,
+               const unsigned char *in, unsigned int inlen, void *arg) -> int {
+                auto *pd = (HttpContextData<true> *) arg;
+                bool offerH2 = pd && pd->hasH2();
+                if (offerH2) for (unsigned int i = 0; i + 1 <= inlen;) {
+                    unsigned int l = in[i];
+                    if (i + 1 + l > inlen) break;
+                    if (l == 2 && in[i+1] == 'h' && in[i+2] == '2') {
+                        *out = in + i + 1; *outlen = 2;
+                        return 0; /* SSL_TLSEXT_ERR_OK */
+                    }
+                    i += 1 + l;
+                }
+                for (unsigned int i = 0; i + 1 <= inlen;) {
+                    unsigned int l = in[i];
+                    if (i + 1 + l > inlen) break;
+                    if (l == 8 && memcmp(in + i + 1, "http/1.1", 8) == 0) {
+                        *out = in + i + 1; *outlen = 8;
+                        return 0; /* SSL_TLSEXT_ERR_OK */
+                    }
+                    i += 1 + l;
+                }
+                return 3; /* SSL_TLSEXT_ERR_NOACK */
+            }, parentData);
+    }
+}
 
 namespace detail {
 
@@ -274,6 +331,30 @@ private:
 
     template <bool IsNodeHttp>
     static us_socket_t *onData(us_socket_t *s, char *data, int length) {
+        if constexpr (SSL && !IsNodeHttp) {
+            /* If an H2App attached to us and the client picked "h2"
+             * via ALPN, hand the socket to the H2 group before the
+             * HTTP/1 parser ever sees the preface. on_handshake
+             * isn't a reliable hook (openssl.c defers it behind the
+             * first app-data read for servers, so a TLS 1.3 flight
+             * that bundles Finished + preface delivers here first),
+             * so check at the top of on_data instead. The adopter
+             * does its own ALPN check and returns null when the
+             * socket isn't h2 — a two-pointer read from the SSL
+             * object, so taking it on every on_data for http/1.1
+             * sockets is negligible. When it does adopt, it
+             * destructs our ext in place and returns the (possibly
+             * relocated) socket, whose own on_data takes over for
+             * subsequent reads. */
+            HttpContextData<SSL> *hcd = getSocketContextDataS(s);
+            if (hcd->h2Context && !us_socket_is_shut_down(s)) {
+                us_socket_t *ns = uws_internal_h2_adopt(
+                    hcd->h2Context, s, sizeof(HttpResponseData<SSL>),
+                    data, length);
+                if (ns) return ns;
+            }
+        }
+
         // ref the socket to make sure we process it entirely before it is closed
         us_socket_ref(s);
 

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -51,6 +51,11 @@ struct alignas(16) HttpContextData {
     template <bool> friend struct HttpContext;
     template <bool> friend struct HttpResponse;
     template <bool> friend struct TemplatedApp;
+    friend struct H2App;
+public:
+    /* Read by the ALPN select cb (a plain C function pointer, so it
+     * can't be a friend) to gate offering "h2". */
+    bool hasH2() const { return h2Context != nullptr; }
 private:
     std::vector<MoveOnlyFunction<void(HttpResponse<SSL> *, int)>> filterHandlers;
     using OnSocketDataCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket, const char *data, int length, bool last);
@@ -78,6 +83,11 @@ private:
     OnSocketDataCallback onSocketData = nullptr;
     OnSocketUpgradedCallback onSocketUpgraded = nullptr;
     OnClientErrorCallback onClientError = nullptr;
+    /* Populated by H2App::create(). When set, HttpContext::onData
+     * checks ALPN and hands sockets that negotiated "h2" to this
+     * context (an Http2Context*; held as void* to avoid the include)
+     * instead of the HTTP/1 parser. */
+    void *h2Context = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
 

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -5,6 +5,7 @@ const classes = [
   "FileSink",
   "HTTPResponseSink",
   "HTTPSResponseSink",
+  "H2ResponseSink",
   "H3ResponseSink",
   "NetworkSink",
 ];
@@ -1030,6 +1031,7 @@ function rustSink() {
     FileSink: "crate::webcore::file_sink::FileSink",
     HTTPResponseSink: "crate::webcore::streams::HTTPResponseSink",
     HTTPSResponseSink: "crate::webcore::streams::HTTPSResponseSink",
+    H2ResponseSink: "crate::webcore::streams::H2ResponseSink",
     H3ResponseSink: "crate::webcore::streams::H3ResponseSink",
     NetworkSink: "crate::webcore::streams::NetworkSink",
   };

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -94,6 +94,7 @@ unsafe extern "C" {
         arg2: *mut c_void,
     );
     safe fn WebCore__FetchHeaders__createFromH3(arg0: *mut c_void) -> *mut FetchHeaders;
+    safe fn WebCore__FetchHeaders__createFromH2(arg0: *mut c_void) -> *mut FetchHeaders;
 
     safe fn WebCore__FetchHeaders__createFromJS(
         arg0: &JSGlobalObject,
@@ -188,6 +189,11 @@ impl FetchHeaders {
     pub fn create_from_h3(h3_request: *mut c_void) -> NonNull<FetchHeaders> {
         NonNull::new(WebCore__FetchHeaders__createFromH3(h3_request))
             .expect("WebCore__FetchHeaders__createFromH3 returned null")
+    }
+
+    pub fn create_from_h2(h2_request: *mut c_void) -> NonNull<FetchHeaders> {
+        NonNull::new(WebCore__FetchHeaders__createFromH2(h2_request))
+            .expect("WebCore__FetchHeaders__createFromH2 returned null")
     }
 
     pub fn to_uws_response(&mut self, kind: ResponseKind, uws_response: *mut c_void) {

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -2,6 +2,7 @@
 #include "JSCookieMap.h"
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Response.h>
+#include <bun-uws/src/Http2Response.h>
 #include "helpers.h"
 #include <wtf/text/ParsingUtilities.h>
 #include <JavaScriptCore/ObjectConstructor.h>
@@ -34,6 +35,9 @@ extern "C" void CookieMap__write(CookieMap* cookie_map, JSC::JSGlobalObject* glo
         break;
     case UWSResponseKind::H3:
         CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http3Response*>(arg2));
+        break;
+    case UWSResponseKind::H2:
+        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http2Response*>(arg2));
         break;
     }
 }

--- a/src/jsc/bindings/NativePromiseContext.h
+++ b/src/jsc/bindings/NativePromiseContext.h
@@ -45,6 +45,8 @@ public:
         BodyValueBufferer,
         HTTPSServerH3RequestContext,
         DebugHTTPSServerH3RequestContext,
+        HTTPSServerH2RequestContext,
+        DebugHTTPSServerH2RequestContext,
     };
 
     static NativePromiseContext* create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag);

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -15,6 +15,7 @@
 #include "JSDOMExceptionHandling.h"
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Response.h>
+#include <bun-uws/src/Http2Response.h>
 #include "ZigGeneratedClasses.h"
 #include "ScriptExecutionContext.h"
 #include "AsyncContextFrame.h"
@@ -1552,6 +1553,59 @@ static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, uWS::H
     }
 }
 
+static void writeFetchHeadersToH2Response(WebCore::FetchHeaders& headers, uWS::Http2Response* res)
+{
+    auto& internalHeaders = headers.internalHeaders();
+    auto* data = res->getHttpResponseData();
+
+    auto writeOne = [&](const WTF::StringView& name, const WTF::StringView& value) {
+        WTF::CString nameStr, valueStr;
+        std::string_view nameView, valueView;
+        if (name.is8Bit()) {
+            const auto s = name.span8();
+            nameView = std::string_view(reinterpret_cast<const char*>(s.data()), s.size());
+        } else {
+            nameStr = name.utf8();
+            nameView = std::string_view(nameStr.data(), nameStr.length());
+        }
+        if (value.is8Bit()) {
+            const auto s = value.span8();
+            valueView = std::string_view(reinterpret_cast<const char*>(s.data()), s.size());
+        } else {
+            valueStr = value.utf8();
+            valueView = std::string_view(valueStr.data(), valueStr.length());
+        }
+        res->writeHeader(nameView, valueView);
+    };
+
+    for (auto& value : internalHeaders.getSetCookieHeaders()) {
+        if (value.is8Bit()) {
+            const auto s = value.span8();
+            res->writeHeader(std::string_view("set-cookie", 10), std::string_view(reinterpret_cast<const char*>(s.data()), s.size()));
+        } else {
+            WTF::CString v = value.utf8();
+            res->writeHeader(std::string_view("set-cookie", 10), std::string_view(v.data(), v.length()));
+        }
+    }
+
+    for (const auto& header : internalHeaders.commonHeaders()) {
+        if (header.key == WebCore::HTTPHeaderName::ContentLength) {
+            if (!(data->state & uWS::Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+                data->state |= uWS::Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+                res->writeMark();
+            }
+        }
+        if (header.key == WebCore::HTTPHeaderName::Date) {
+            data->state |= uWS::Http2ResponseData::HTTP_WROTE_DATE_HEADER;
+        }
+        writeOne(WebCore::httpHeaderNameString(header.key), header.value);
+    }
+
+    for (auto& header : internalHeaders.uncommonHeaders()) {
+        writeOne(header.key, header.value);
+    }
+}
+
 extern "C" void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0, UWSResponseKind kind, void* arg2)
 {
     switch (kind) {
@@ -1563,6 +1617,9 @@ extern "C" void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0
         break;
     case UWSResponseKind::H3:
         writeFetchHeadersToH3Response(*arg0, reinterpret_cast<uWS::Http3Response*>(arg2));
+        break;
+    case UWSResponseKind::H2:
+        writeFetchHeadersToH2Response(*arg0, reinterpret_cast<uWS::Http2Response*>(arg2));
         break;
     }
 }

--- a/src/jsc/bindings/ServerRouteList.cpp
+++ b/src/jsc/bindings/ServerRouteList.cpp
@@ -5,6 +5,7 @@
 #include <JavaScriptCore/Structure.h>
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Request.h>
+#include <bun-uws/src/Http2Request.h>
 #include "ZigGeneratedClasses.h"
 #include "AsyncContextFrame.h"
 #include "ServerRouteList.h"
@@ -287,6 +288,20 @@ extern "C" JSC::EncodedJSValue Bun__ServerRouteList__callRouteH3(
     JSC::EncodedJSValue routeListObject,
     JSC::EncodedJSValue* requestObject,
     uWS::Http3Request* req)
+{
+    JSValue routeListValue = JSValue::decode(routeListObject);
+    ServerRouteList* routeList = uncheckedDowncast<ServerRouteList>(routeListValue);
+    return JSValue::encode(routeList->callRoute(globalObject, index, requestPtr, serverObject, requestObject, req));
+}
+
+extern "C" JSC::EncodedJSValue Bun__ServerRouteList__callRouteH2(
+    Zig::GlobalObject* globalObject,
+    uint32_t index,
+    void* requestPtr,
+    JSC::EncodedJSValue serverObject,
+    JSC::EncodedJSValue routeListObject,
+    JSC::EncodedJSValue* requestObject,
+    uWS::Http2Request* req)
 {
     JSValue routeListValue = JSValue::decode(routeListObject);
     ServerRouteList* routeList = uncheckedDowncast<ServerRouteList>(routeListValue);

--- a/src/jsc/bindings/Sink.h
+++ b/src/jsc/bindings/Sink.h
@@ -11,9 +11,10 @@ enum SinkID : uint8_t {
     HTTPSResponseSink = 5,
     NetworkSink = 6,
     H3ResponseSink = 7,
+    H2ResponseSink = 8,
 
 };
 static constexpr unsigned numberOfSinkIDs
-    = 8;
+    = 9;
 
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2678,6 +2678,16 @@ void GlobalObject::finishCreation(VM& vm)
             init.setConstructor(constructor);
         });
 
+    m_JSH2ResponseSinkClassStructure.initLater(
+        [](LazyClassStructure::Initializer& init) {
+            auto* prototype = createJSSinkPrototype(init.vm, init.global, WebCore::SinkID::H2ResponseSink);
+            auto* structure = JSH2ResponseSink::createStructure(init.vm, init.global, prototype);
+            auto* constructor = JSH2ResponseSinkConstructor::create(init.vm, init.global, JSH2ResponseSinkConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), prototype);
+            init.setPrototype(prototype);
+            init.setStructure(structure);
+            init.setConstructor(constructor);
+        });
+
     m_JSBufferClassStructure.initLater(
         [](LazyClassStructure::Initializer& init) {
             auto* prototype = WebCore::createBufferPrototype(init.vm, init.global);
@@ -4080,6 +4090,22 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH3__onResolve;
     } else if (handler == Bun__HTTPRequestContextDebugH3__onResolveStream) {
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH3__onResolveStream;
+    } else if (handler == Bun__HTTPRequestContextH2__onReject) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH2__onReject;
+    } else if (handler == Bun__HTTPRequestContextH2__onRejectStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH2__onRejectStream;
+    } else if (handler == Bun__HTTPRequestContextH2__onResolve) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH2__onResolve;
+    } else if (handler == Bun__HTTPRequestContextH2__onResolveStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH2__onResolveStream;
+    } else if (handler == Bun__HTTPRequestContextDebugH2__onReject) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH2__onReject;
+    } else if (handler == Bun__HTTPRequestContextDebugH2__onRejectStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH2__onRejectStream;
+    } else if (handler == Bun__HTTPRequestContextDebugH2__onResolve) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH2__onResolve;
+    } else if (handler == Bun__HTTPRequestContextDebugH2__onResolveStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH2__onResolveStream;
     } else {
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -251,6 +251,10 @@ public:
     JSC::Structure* H3ResponseSinkStructure() const { return m_JSH3ResponseSinkClassStructure.getInitializedOnMainThread(this); }
     JSC::JSObject* H3ResponseSink() { return m_JSH3ResponseSinkClassStructure.constructorInitializedOnMainThread(this); }
     JSC::JSValue H3ResponseSinkPrototype() const { return m_JSH3ResponseSinkClassStructure.prototypeInitializedOnMainThread(this); }
+
+    JSC::Structure* H2ResponseSinkStructure() const { return m_JSH2ResponseSinkClassStructure.getInitializedOnMainThread(this); }
+    JSC::JSObject* H2ResponseSink() { return m_JSH2ResponseSinkClassStructure.constructorInitializedOnMainThread(this); }
+    JSC::JSValue H2ResponseSinkPrototype() const { return m_JSH2ResponseSinkClassStructure.prototypeInitializedOnMainThread(this); }
     JSC::JSValue JSReadableNetworkSinkControllerPrototype() const { return m_JSFetchTaskletChunkedRequestControllerPrototype.getInitializedOnMainThread(this); }
 
     JSC::Structure* JSBufferListStructure() const { return m_JSBufferListClassStructure.getInitializedOnMainThread(this); }
@@ -412,8 +416,16 @@ public:
         Bun__HTTPRequestContextDebugH3__onRejectStream,
         Bun__HTTPRequestContextDebugH3__onResolve,
         Bun__HTTPRequestContextDebugH3__onResolveStream,
+        Bun__HTTPRequestContextH2__onReject,
+        Bun__HTTPRequestContextH2__onRejectStream,
+        Bun__HTTPRequestContextH2__onResolve,
+        Bun__HTTPRequestContextH2__onResolveStream,
+        Bun__HTTPRequestContextDebugH2__onReject,
+        Bun__HTTPRequestContextDebugH2__onRejectStream,
+        Bun__HTTPRequestContextDebugH2__onResolve,
+        Bun__HTTPRequestContextDebugH2__onResolveStream,
     };
-    static constexpr size_t promiseFunctionsSize = 42;
+    static constexpr size_t promiseFunctionsSize = 50;
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 
@@ -557,6 +569,7 @@ public:
     V(private, LazyClassStructure, m_JSHTTPSResponseSinkClassStructure)                                      \
     V(private, LazyClassStructure, m_JSNetworkSinkClassStructure)                                            \
     V(private, LazyClassStructure, m_JSH3ResponseSinkClassStructure)                                         \
+    V(private, LazyClassStructure, m_JSH2ResponseSinkClassStructure)                                         \
                                                                                                              \
     V(private, LazyClassStructure, m_JSStringDecoderClassStructure)                                          \
     V(public, LazyClassStructure, m_JSDatabaseSyncClassStructure)                                            \

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -110,6 +110,7 @@
 #include <string_view>
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Request.h>
+#include <bun-uws/src/Http2Request.h>
 #include <bun-usockets/src/internal/internal.h>
 #include "IDLTypes.h"
 #include "JSDOMBinding.h"
@@ -2122,6 +2123,31 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
 WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
 {
     auto* req = reinterpret_cast<uWS::Http3Request*>(arg1);
+
+    auto* headers = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::None, {} });
+    headers->relaxAdoptionRequirement();
+
+    HTTPHeaderMap map = HTTPHeaderMap();
+    req->forEachHeader([&](std::string_view name, std::string_view val) {
+        StringView nameView = StringView(std::span { reinterpret_cast<const Latin1Character*>(name.data()), name.length() });
+        std::span<Latin1Character> data;
+        auto value = String::createUninitialized(val.length(), data);
+        if (val.length() > 0)
+            memcpy(data.data(), val.data(), val.length());
+
+        HTTPHeaderName hn;
+        if (WebCore::findHTTPHeaderName(nameView, hn)) {
+            map.add(hn, WTF::move(value));
+        } else {
+            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+        }
+    });
+    headers->setInternalHeaders(WTF::move(map));
+    return headers;
+}
+WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH2(void* arg1)
+{
+    auto* req = reinterpret_cast<uWS::Http2Request*>(arg1);
 
     auto* headers = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::None, {} });
     headers->relaxAdoptionRequirement();

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -52,6 +52,7 @@ enum class UWSResponseKind : int32_t {
     TCP = 0,
     SSL = 1,
     H3 = 2,
+    H2 = 3,
 };
 #endif
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -87,6 +87,7 @@ CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromJS(JSC::JSGloba
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void* arg0);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1);
+CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH2(void* arg1);
 CPP_DECL JSC::EncodedJSValue WebCore__FetchHeaders__createValue(JSC::JSGlobalObject* arg0, StringPointer* arg1, StringPointer* arg2, const ZigString* arg3, uint32_t arg4);
 CPP_DECL void WebCore__FetchHeaders__deref(WebCore::FetchHeaders* arg0);
 CPP_DECL void WebCore__FetchHeaders__fastGet_(WebCore::FetchHeaders* arg0, unsigned char arg1, ZigString* arg2);
@@ -598,6 +599,26 @@ ZIG_DECL void H3ResponseSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(H3ResponseSink__write);
 #endif
 
+CPP_DECL JSC::EncodedJSValue H2ResponseSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
+CPP_DECL JSC::EncodedJSValue H2ResponseSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
+CPP_DECL void H2ResponseSink__detachPtr(JSC::EncodedJSValue JSValue0);
+CPP_DECL void* H2ResponseSink__fromJS(JSC::EncodedJSValue JSValue1);
+CPP_DECL void H2ResponseSink__onClose(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1);
+CPP_DECL void H2ResponseSink__onReady(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::EncodedJSValue JSValue2);
+
+#ifdef __cplusplus
+
+ZIG_DECL JSC::EncodedJSValue H2ResponseSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__construct);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__end);
+ZIG_DECL JSC::EncodedJSValue SYSV_ABI SYSV_ABI H2ResponseSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
+ZIG_DECL void H2ResponseSink__finalize(void* arg0);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__flush);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__start);
+ZIG_DECL void H2ResponseSink__updateRef(void* arg0, bool arg1);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__write);
+#endif
+
 #ifdef __cplusplus
 
 ZIG_DECL void Bun__WebSocketHTTPClient__cancel(WebSocketHTTPClient* arg0);
@@ -739,6 +760,15 @@ BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH3__onResolve);
 BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH3__onReject);
 BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH3__onResolveStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH3__onRejectStream);
+
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextH2__onResolve);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextH2__onReject);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextH2__onResolveStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextH2__onRejectStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH2__onResolve);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH2__onReject);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH2__onResolveStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH2__onRejectStream);
 
 BUN_DECLARE_HOST_FUNCTION(Bun__FileSink__onResolveStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__FileSink__onRejectStream);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -363,6 +363,7 @@ static void startJSSinkController(JSC::VM& vm, JSGlobalObject* globalObject, JSO
     BUN_START_JSSINK_CONTROLLER(JSReadableHTTPResponseSinkController)
     BUN_START_JSSINK_CONTROLLER(JSReadableHTTPSResponseSinkController)
     BUN_START_JSSINK_CONTROLLER(JSReadableH3ResponseSinkController)
+    BUN_START_JSSINK_CONTROLLER(JSReadableH2ResponseSinkController)
     BUN_START_JSSINK_CONTROLLER(JSReadableNetworkSinkController)
 #undef BUN_START_JSSINK_CONTROLLER
     throwTypeError(globalObject, scope, "Unknown direct controller. This is a bug in Bun."_s);

--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -29,18 +29,24 @@ use crate::api::server;
 use crate::webcore::body;
 
 // Request contexts are a single generic
-// `NewRequestContext<ThisServer, SSL, DEBUG, HTTP3>`; alias the six
+// `NewRequestContext<ThisServer, SSL, DEBUG, MUX>`; alias the eight
 // concrete monomorphizations here so the tag↔type mapping stays readable.
-type HTTPServerRequestContext = server::NewRequestContext<server::HTTPServer, false, false, false>;
-type HTTPSServerRequestContext = server::NewRequestContext<server::HTTPSServer, true, false, false>;
+type HTTPServerRequestContext =
+    server::NewRequestContext<server::HTTPServer, false, false, { server::MUX_H1 }>;
+type HTTPSServerRequestContext =
+    server::NewRequestContext<server::HTTPSServer, true, false, { server::MUX_H1 }>;
 type DebugHTTPServerRequestContext =
-    server::NewRequestContext<server::DebugHTTPServer, false, true, false>;
+    server::NewRequestContext<server::DebugHTTPServer, false, true, { server::MUX_H1 }>;
 type DebugHTTPSServerRequestContext =
-    server::NewRequestContext<server::DebugHTTPSServer, true, true, false>;
+    server::NewRequestContext<server::DebugHTTPSServer, true, true, { server::MUX_H1 }>;
 type HTTPSServerH3RequestContext =
-    server::NewRequestContext<server::HTTPSServer, true, false, true>;
+    server::NewRequestContext<server::HTTPSServer, true, false, { server::MUX_H3 }>;
 type DebugHTTPSServerH3RequestContext =
-    server::NewRequestContext<server::DebugHTTPSServer, true, true, true>;
+    server::NewRequestContext<server::DebugHTTPSServer, true, true, { server::MUX_H3 }>;
+type HTTPSServerH2RequestContext =
+    server::NewRequestContext<server::HTTPSServer, true, false, { server::MUX_H2 }>;
+type DebugHTTPSServerH2RequestContext =
+    server::NewRequestContext<server::DebugHTTPSServer, true, true, { server::MUX_H2 }>;
 
 /// Must match Bun::NativePromiseContext::Tag in NativePromiseContext.h.
 /// One entry per concrete native type — the tag is packed into the pointer's
@@ -56,10 +62,12 @@ pub enum Tag {
     BodyValueBufferer,
     HTTPSServerH3RequestContext,
     DebugHTTPSServerH3RequestContext,
+    HTTPSServerH2RequestContext,
+    DebugHTTPSServerH2RequestContext,
 }
 
 impl Tag {
-    pub const COUNT: usize = 7;
+    pub const COUNT: usize = 9;
 
     #[inline]
     const fn from_raw(n: u8) -> Tag {
@@ -71,6 +79,8 @@ impl Tag {
             4 => Tag::BodyValueBufferer,
             5 => Tag::HTTPSServerH3RequestContext,
             6 => Tag::DebugHTTPSServerH3RequestContext,
+            7 => Tag::HTTPSServerH2RequestContext,
+            8 => Tag::DebugHTTPSServerH2RequestContext,
             _ => unreachable!(),
         }
     }
@@ -84,24 +94,26 @@ pub(crate) trait NativePromiseContextType {
 
 // Layering note: blanket-impl over `ThisServer` so that ANY server
 // type (mod.rs::NewServer or server_body::NewServer) yields the same Tag —
-// the tag depends only on (SSL, DBG, H3), never on the server type.
-const fn npc_tag_for(ssl: bool, dbg: bool, h3: bool) -> Tag {
-    match (ssl, dbg, h3) {
-        (false, false, false) => Tag::HTTPServerRequestContext,
-        (true, false, false) => Tag::HTTPSServerRequestContext,
-        (false, true, false) => Tag::DebugHTTPServerRequestContext,
-        (true, true, false) => Tag::DebugHTTPSServerRequestContext,
-        (true, false, true) => Tag::HTTPSServerH3RequestContext,
-        (true, true, true) => Tag::DebugHTTPSServerH3RequestContext,
-        // H3 requires TLS; (false, _, true) is never instantiated. Map to a
-        // valid tag so const-eval succeeds; runtime never observes this.
-        (false, _, true) => Tag::HTTPServerRequestContext,
+// the tag depends only on (SSL, DBG, MUX), never on the server type.
+const fn npc_tag_for(ssl: bool, dbg: bool, mux: u8) -> Tag {
+    match (ssl, dbg, mux) {
+        (false, false, server::MUX_H1) => Tag::HTTPServerRequestContext,
+        (true, false, server::MUX_H1) => Tag::HTTPSServerRequestContext,
+        (false, true, server::MUX_H1) => Tag::DebugHTTPServerRequestContext,
+        (true, true, server::MUX_H1) => Tag::DebugHTTPSServerRequestContext,
+        (true, false, server::MUX_H3) => Tag::HTTPSServerH3RequestContext,
+        (true, true, server::MUX_H3) => Tag::DebugHTTPSServerH3RequestContext,
+        (true, false, server::MUX_H2) => Tag::HTTPSServerH2RequestContext,
+        (true, true, server::MUX_H2) => Tag::DebugHTTPSServerH2RequestContext,
+        // H2/H3 require TLS; (false, _, MUX_H2|MUX_H3) is never instantiated.
+        // Map to a valid tag so const-eval succeeds; runtime never observes this.
+        _ => Tag::HTTPServerRequestContext,
     }
 }
-impl<ThisServer, const SSL: bool, const DBG: bool, const H3: bool> NativePromiseContextType
-    for server::NewRequestContext<ThisServer, SSL, DBG, H3>
+impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> NativePromiseContextType
+    for server::NewRequestContext<ThisServer, SSL, DBG, MUX>
 {
-    const TAG: Tag = npc_tag_for(SSL, DBG, H3);
+    const TAG: Tag = npc_tag_for(SSL, DBG, MUX);
 }
 impl NativePromiseContextType for body::ValueBufferer<'_> {
     const TAG: Tag = Tag::BodyValueBufferer;
@@ -151,16 +163,17 @@ pub(crate) extern "C" fn Bun__NativePromiseContext__destroy(ctx: *mut c_void, ta
 /// outside the sweep phase.
 ///
 /// Zero-allocation: the ctx pointer and our Tag are packed into the task's
-/// `ptr` slot (pointer in high bits, tag in low 3 bits — the target types
-/// are all >= 8-byte aligned). See PosixSignalTask for the same trick with
-/// signal numbers.
+/// `ptr` slot (pointer in the low 56 bits, tag in the top byte — user-space
+/// pointers on every Bun target leave the top byte zero; same trick
+/// `WTF::CompactPointerTuple` uses on the C++ side). See PosixSignalTask for
+/// the low-bit variant of this idiom.
 ///
 /// Layout of `Task.ptr` (read back as `usize` in dispatch):
 ///
-///     bits 63..3           bits 2..0
-///     ┌────────────────────┬─────────┐
-///     │ ctx ptr (aligned)  │ our Tag │
-///     └────────────────────┴─────────┘
+///     bits 63..56   bits 55..0
+///     ┌──────────┬────────────────────┐
+///     │ our Tag  │ ctx ptr            │
+///     └──────────┴────────────────────┘
 ///
 /// `Task` stores `{ tag, ptr }` as separate fields, so the discriminant is
 /// carried in `Task.tag` and only the ctx|Tag packing remains in `Task.ptr`.
@@ -171,7 +184,8 @@ impl Taskable for DeferredDerefTask {
 }
 
 impl DeferredDerefTask {
-    const TAG_MASK: usize = 0b111;
+    const TAG_SHIFT: usize = 56;
+    const TAG_MASK: usize = 0xFF << Self::TAG_SHIFT;
 
     pub(crate) fn schedule(ctx: *mut c_void, tag: Tag) {
         // SAFETY: called from the JS thread (GC sweep → C++ destructor); the
@@ -190,7 +204,7 @@ impl DeferredDerefTask {
         // build it directly — dispatch unpacks via `task.ptr as usize`.
         let task = Task::new(
             <DeferredDerefTask as Taskable>::TAG,
-            (addr | (tag as usize)) as *mut (),
+            (addr | ((tag as usize) << Self::TAG_SHIFT)) as *mut (),
         );
         // SAFETY: event_loop() returns the VM's owned EventLoop; we are the
         // sole mutator on the JS thread here.
@@ -198,7 +212,7 @@ impl DeferredDerefTask {
     }
 
     pub(crate) fn run_from_js_thread(packed_ptr: usize) {
-        let tag = Tag::from_raw((packed_ptr & Self::TAG_MASK) as u8);
+        let tag = Tag::from_raw((packed_ptr >> Self::TAG_SHIFT) as u8);
         let ctx = (packed_ptr & !Self::TAG_MASK) as *mut c_void;
         // SAFETY: ctx was packed in `schedule` from a live intrusive-refcounted
         // pointer of the type indicated by `tag`; we are on the JS thread.
@@ -230,21 +244,19 @@ impl DeferredDerefTask {
                 Tag::DebugHTTPSServerH3RequestContext => {
                     (*ctx.cast::<DebugHTTPSServerH3RequestContext>()).deref()
                 }
+                Tag::HTTPSServerH2RequestContext => {
+                    (*ctx.cast::<HTTPSServerH2RequestContext>()).deref()
+                }
+                Tag::DebugHTTPSServerH2RequestContext => {
+                    (*ctx.cast::<DebugHTTPSServerH2RequestContext>()).deref()
+                }
             }
         }
     }
 }
 
-// Low 3 bits hold the tag; verify both capacity and alignment slack so adding
-// a tag or a packed field can't silently break the packing.
-const _: () = assert!(Tag::COUNT <= DeferredDerefTask::TAG_MASK + 1);
-const _: () =
-    assert!(core::mem::align_of::<HTTPServerRequestContext>() > DeferredDerefTask::TAG_MASK);
-const _: () =
-    assert!(core::mem::align_of::<HTTPSServerRequestContext>() > DeferredDerefTask::TAG_MASK);
-const _: () =
-    assert!(core::mem::align_of::<DebugHTTPServerRequestContext>() > DeferredDerefTask::TAG_MASK);
-const _: () =
-    assert!(core::mem::align_of::<DebugHTTPSServerRequestContext>() > DeferredDerefTask::TAG_MASK);
-const _: () =
-    assert!(core::mem::align_of::<body::ValueBufferer<'_>>() > DeferredDerefTask::TAG_MASK);
+// Top byte holds the tag; verify capacity so adding a tag can't silently
+// overflow the packing. No alignment constraint — the top byte of a
+// user-space pointer is zero on every Bun target.
+const _: () = assert!(Tag::COUNT <= (1usize << (64 - DeferredDerefTask::TAG_SHIFT)));
+const _: () = assert!(core::mem::size_of::<usize>() == 8);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1606,7 +1606,7 @@ fn on_report_error_request(dev: &mut DevServer, req: &mut Request, resp: AnyResp
         AnyResponse::TCP(r) => {
             ErrorReportRequest::run(dev, req, bun_uws_sys::response::TCPResponse::as_handle(r))
         }
-        AnyResponse::H3(_) => not_found(resp),
+        AnyResponse::H3(_) | AnyResponse::H2(_) => not_found(resp),
     }
 }
 
@@ -1619,7 +1619,7 @@ fn on_unref_source_map_request(dev: &mut DevServer, req: &mut Request, resp: Any
         AnyResponse::TCP(r) => {
             UnrefSourceMapRequest::run(dev, req, bun_uws_sys::response::TCPResponse::as_handle(r))
         }
-        AnyResponse::H3(_) => not_found(resp),
+        AnyResponse::H3(_) | AnyResponse::H2(_) => not_found(resp),
     }
 }
 

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -10,14 +10,19 @@ use crate::webcore::CookieMap;
 pub use super::request_context::AdditionalOnAbortCallback;
 use super::request_context::RequestContext;
 use super::{DebugHTTPSServer, DebugHTTPServer, HTTPSServer, HTTPServer};
+use super::{MUX_H1, MUX_H2, MUX_H3};
 
-// The six monomorphizations of `NewRequestContext` (ssl × debug × h3).
-type HttpCtx = RequestContext<HTTPServer, false, false, false>;
-type HttpsCtx = RequestContext<HTTPSServer, true, false, false>;
-type DebugHttpCtx = RequestContext<DebugHTTPServer, false, true, false>;
-type DebugHttpsCtx = RequestContext<DebugHTTPSServer, true, true, false>;
-type HttpsH3Ctx = RequestContext<HTTPSServer, true, false, true>;
-type DebugHttpsH3Ctx = RequestContext<DebugHTTPSServer, true, true, true>;
+// The eight monomorphizations of `NewRequestContext` (ssl × debug × mux).
+// H2/H3 are TLS-only, so the non-SSL × {H2,H3} combinations are never
+// instantiated and map to `CtxTag::None`.
+type HttpCtx = RequestContext<HTTPServer, false, false, { MUX_H1 }>;
+type HttpsCtx = RequestContext<HTTPSServer, true, false, { MUX_H1 }>;
+type DebugHttpCtx = RequestContext<DebugHTTPServer, false, true, { MUX_H1 }>;
+type DebugHttpsCtx = RequestContext<DebugHTTPSServer, true, true, { MUX_H1 }>;
+type HttpsH2Ctx = RequestContext<HTTPSServer, true, false, { MUX_H2 }>;
+type DebugHttpsH2Ctx = RequestContext<DebugHTTPSServer, true, true, { MUX_H2 }>;
+type HttpsH3Ctx = RequestContext<HTTPSServer, true, false, { MUX_H3 }>;
+type DebugHttpsH3Ctx = RequestContext<DebugHTTPSServer, true, true, { MUX_H3 }>;
 
 // The `bun_ptr::impl_tagged_ptr_union!` macro hits the orphan rule from
 // outside `bun_ptr`, so store `(tag: u8, ptr: *mut ())` as two fields.
@@ -35,6 +40,8 @@ pub enum CtxTag {
     DebugHttps,
     HttpsH3,
     DebugHttpsH3,
+    HttpsH2,
+    DebugHttpsH2,
 }
 
 #[derive(Copy, Clone)]
@@ -56,27 +63,30 @@ pub trait CtxKind {
     const TAG: CtxTag;
 }
 
-const fn ctx_tag_for(ssl: bool, dbg: bool, h3: bool) -> CtxTag {
-    match (ssl, dbg, h3) {
-        (false, false, false) => CtxTag::Http,
-        (true, false, false) => CtxTag::Https,
-        (false, true, false) => CtxTag::DebugHttp,
-        (true, true, false) => CtxTag::DebugHttps,
-        (true, false, true) => CtxTag::HttpsH3,
-        (true, true, true) => CtxTag::DebugHttpsH3,
-        // H3 requires TLS; (false, _, true) is never instantiated. Map to
-        // None so a stray dispatch is a no-op rather than a wild cast.
-        (false, _, true) => CtxTag::None,
+const fn ctx_tag_for(ssl: bool, dbg: bool, mux: u8) -> CtxTag {
+    match (ssl, dbg, mux) {
+        (false, false, MUX_H1) => CtxTag::Http,
+        (true, false, MUX_H1) => CtxTag::Https,
+        (false, true, MUX_H1) => CtxTag::DebugHttp,
+        (true, true, MUX_H1) => CtxTag::DebugHttps,
+        (true, false, MUX_H2) => CtxTag::HttpsH2,
+        (true, true, MUX_H2) => CtxTag::DebugHttpsH2,
+        (true, false, MUX_H3) => CtxTag::HttpsH3,
+        (true, true, MUX_H3) => CtxTag::DebugHttpsH3,
+        // H2/H3 require TLS; (false, _, MUX_H2|MUX_H3) is never instantiated.
+        // Map to None so a stray dispatch is a no-op rather than a wild cast.
+        (false, _, _) => CtxTag::None,
+        (true, _, _) => CtxTag::None,
     }
 }
 
 // Blanket impl over the const-generic params so any `Ctx: RequestCtx` (which
-// is always a `RequestContext<_, SSL, DBG, H3>`) also satisfies `CtxKind`
-// without callers having to spell the six concrete types.
-impl<ThisServer, const SSL: bool, const DBG: bool, const H3: bool> CtxKind
-    for RequestContext<ThisServer, SSL, DBG, H3>
+// is always a `RequestContext<_, SSL, DBG, MUX>`) also satisfies `CtxKind`
+// without callers having to spell the concrete types.
+impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> CtxKind
+    for RequestContext<ThisServer, SSL, DBG, MUX>
 {
-    const TAG: CtxTag = ctx_tag_for(SSL, DBG, H3);
+    const TAG: CtxTag = ctx_tag_for(SSL, DBG, MUX);
 }
 
 impl AnyRequestContext {
@@ -90,8 +100,8 @@ impl AnyRequestContext {
 
 /// Dispatch `$body` to the concrete RequestContext type behind the tagged
 /// pointer. The pointer types only differ in their const-generic parameters
-/// (ssl/debug/http3), so every method body is identical — this collapses what
-/// used to be six hand-written switch arms per accessor.
+/// (ssl/debug/mux), so every method body is identical — this collapses what
+/// would otherwise be eight hand-written switch arms per accessor.
 ///
 /// Rust closures cannot be generic over
 /// `T`, so a macro is the closest structural equivalent.
@@ -119,6 +129,8 @@ macro_rules! dispatch {
             CtxTag::DebugHttps => arm!(DebugHttpsCtx),
             CtxTag::HttpsH3 => arm!(HttpsH3Ctx),
             CtxTag::DebugHttpsH3 => arm!(DebugHttpsH3Ctx),
+            CtxTag::HttpsH2 => arm!(HttpsH2Ctx),
+            CtxTag::DebugHttpsH2 => arm!(DebugHttpsH2Ctx),
         }
     }};
 }
@@ -168,12 +180,12 @@ impl AnyRequestContext {
     /// Wont actually set anything if `self` is `.none`
     pub fn set_request(self, req: *mut uws::Request) {
         dispatch!(self, (), |T, ctx| {
-            if T::IS_H3 {
-                // H3 populates url/headers eagerly
+            if T::IS_MUX {
+                // H2/H3 populate url/headers eagerly
                 return;
             }
-            // `ctx.req` is `Option<*mut Req<SSL,H3>>` where
-            // `Req<_,_> = c_void` (erased handle). For non-H3 the underlying
+            // `ctx.req` is `Option<*mut Req<SSL,MUX>>` where
+            // `Req<_,_> = c_void` (erased handle). For H1 the underlying
             // type is always `uws::Request`, so the cast is purely nominal.
             ctx.req = Some(req.cast::<c_void>());
         })
@@ -181,7 +193,7 @@ impl AnyRequestContext {
 
     pub fn get_request(self) -> Option<*mut uws::Request> {
         dispatch!(self, None, |T, ctx| {
-            if T::IS_H3 {
+            if T::IS_MUX {
                 // url/headers already on the Request
                 return None;
             }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -567,8 +567,8 @@ fn can_sendfile(resp: AnyResponse, file_type: FileType, length: Option<u64>) -> 
     }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
-        // sendfile() needs a real socket fd; SSL writes go through BIO and H3
-        // through lsquic stream frames — neither has one.
+        // sendfile() needs a real socket fd; SSL writes go through BIO and
+        // H2/H3 through multiplexed stream frames — none has one.
         if !matches!(resp, AnyResponse::TCP(_)) {
             return false;
         }

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -256,6 +256,13 @@ impl FileRoute {
                 }
                 // tag == .H3 → no alt-svc header
             }
+            AnyResponse::H2(s) => {
+                let s = bun_opaque::opaque_deref_mut(s);
+                for (name, value) in names.iter().zip(values) {
+                    s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
+                }
+                // tag == .H2 → no alt-svc header
+            }
         }
 
         if !self.has_last_modified_header {
@@ -281,6 +288,12 @@ impl FileRoute {
                 let mut b = bun_core::fmt::ItoaBuf::new();
                 let s = bun_core::fmt::itoa(&mut b, status);
                 // S008: `h3::Response` is an `opaque_ffi!` ZST — safe deref.
+                bun_opaque::opaque_deref_mut(r).write_status(s);
+            }
+            AnyResponse::H2(r) => {
+                let mut b = bun_core::fmt::ItoaBuf::new();
+                let s = bun_core::fmt::itoa(&mut b, status);
+                // S008: `h2::Response` is an `opaque_ffi!` ZST — safe deref.
                 bun_opaque::opaque_deref_mut(r).write_status(s);
             }
         }

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -261,7 +261,11 @@ impl FileRoute {
                 for (name, value) in names.iter().zip(values) {
                     s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
                 }
-                // tag == .H2 → no alt-svc header
+                if let Some(srv) = self.server.get() {
+                    if let Some(alt) = srv.h3_alt_svc() {
+                        s.write_header(b"alt-svc", alt);
+                    }
+                }
             }
         }
 

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -285,7 +285,7 @@ impl Route {
                             resp,
                         ));
                     }
-                    AnyRequest::H3(_) => {
+                    AnyRequest::H3(_) | AnyRequest::H2(_) => {
                         resp.write_status(b"503 Service Unavailable");
                         resp.end(b"DevServer HMR is HTTP/1.1 only", true);
                     }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1150,6 +1150,9 @@ fn write_head_internal(
         uws::AnyResponse::H3(_) => {
             bun_core::Output::panic(format_args!("node:http does not support HTTP/3 responses"));
         }
+        uws::AnyResponse::H2(_) => {
+            bun_core::Output::panic(format_args!("node:http does not support HTTP/2 responses"));
+        }
     }
 }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -37,16 +37,20 @@ impl AdditionalOnAbortCallback {
 }
 
 // NOTE (transport selection): the response/request handle types vary with
-// `(ssl_enabled, http3)`. Stable Rust cannot drive an associated type from a
-// const-generic `bool` without specialization, and an early `Transport`
-// helper-trait approach forced `where TransportFor<SSL,H3>: Transport` bounds
+// `(ssl_enabled, mux)`. Stable Rust cannot drive an associated type from a
+// const-generic without specialization, and an early `Transport`
+// helper-trait approach forced `where TransportFor<SSL,MUX>: Transport` bounds
 // onto every generic that named `RequestContext` (which Rust then *cannot*
-// discharge for a generic `const SSL: bool` — only the four concrete combos
+// discharge for a generic `const SSL: bool` — only the concrete combos
 // have impls). So instead the `resp` field stores `uws::AnyResponse` (a Copy
-// enum over the three concrete handles) and dispatches at runtime — same shape
+// enum over the concrete handles) and dispatches at runtime — same shape
 // as `AnyRequestContext` / `AnyServer`. The const params still pick which
-// variant `create()` constructs and gate H3-specific code paths.
-pub type Req<const SSL_ENABLED: bool, const HTTP3: bool> = c_void;
+// variant `create()` constructs and gate multiplexed-transport code paths.
+pub const MUX_H1: u8 = 0;
+pub const MUX_H2: u8 = 1;
+pub const MUX_H3: u8 = 2;
+
+pub type Req<const SSL_ENABLED: bool, const MUX: u8> = c_void;
 
 /// Extract the raw FFI pointer from an `AnyResponse` for C-ABI shims that
 /// take `*mut c_void` (e.g. `FetchHeaders::to_uws_response`, `CookieMap::write`).
@@ -56,6 +60,7 @@ fn any_response_as_ptr(r: uws::AnyResponse) -> *mut c_void {
         uws::AnyResponse::SSL(p) => p.cast::<c_void>(),
         uws::AnyResponse::TCP(p) => p.cast::<c_void>(),
         uws::AnyResponse::H3(p) => p.cast::<c_void>(),
+        uws::AnyResponse::H2(p) => p.cast::<c_void>(),
     }
 }
 
@@ -65,10 +70,10 @@ fn any_response_as_ptr(r: uws::AnyResponse) -> *mut c_void {
 /// frame unwinds), so reads/writes are safe `Cell` ops — no raw `*mut bool`.
 pub type DeferDeinitFlag = bun_ptr::BackRef<core::cell::Cell<bool>>;
 
-pub type ResponseStream<const SSL_ENABLED: bool, const HTTP3: bool> =
-    crate::webcore::streams::HTTPServerWritable<SSL_ENABLED, HTTP3>;
-pub type ResponseStreamJSSink<const SSL_ENABLED: bool, const HTTP3: bool> =
-    crate::webcore::streams::HTTPServerWritableJSSink<SSL_ENABLED, HTTP3>;
+pub type ResponseStream<const SSL_ENABLED: bool, const MUX: u8> =
+    crate::webcore::streams::HTTPServerWritable<SSL_ENABLED, MUX>;
+pub type ResponseStreamJSSink<const SSL_ENABLED: bool, const MUX: u8> =
+    crate::webcore::streams::HTTPServerWritableJSSink<SSL_ENABLED, MUX>;
 
 /// This pre-allocates up to 2,048 RequestContext structs.
 /// It costs about 655,632 bytes.
@@ -80,28 +85,24 @@ pub const REQUEST_CONTEXT_POOL_CAPACITY: usize = if bun_alloc::heap_breakdown::E
     2048
 };
 
-pub type RequestContextStackAllocator<
-    ThisServer,
-    const SSL: bool,
-    const DBG: bool,
-    const H3: bool,
-> = bun_collections::hive_array::Fallback<
-    RequestContext<ThisServer, SSL, DBG, H3>,
-    REQUEST_CONTEXT_POOL_CAPACITY,
->;
+pub type RequestContextStackAllocator<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> =
+    bun_collections::hive_array::Fallback<
+        RequestContext<ThisServer, SSL, DBG, MUX>,
+        REQUEST_CONTEXT_POOL_CAPACITY,
+    >;
 
 pub struct RequestContext<
     ThisServer,
     const SSL_ENABLED: bool,
     const DEBUG_MODE: bool,
-    const HTTP3: bool,
+    const MUX: u8,
 > {
     /// BACKREF to the embedding `Server` — the server owns this request
     /// context (allocated from its `HiveArray` pool) and outlives it, so the
     /// pointee is live for the holder's entire lifetime. `None` once detached.
     pub server: Option<bun_ptr::BackRef<ThisServer>>,
     pub resp: Option<uws::AnyResponse>,
-    pub req: Option<*mut Req<SSL_ENABLED, HTTP3>>,
+    pub req: Option<*mut Req<SSL_ENABLED, MUX>>,
     pub request_weakref: request::WeakRef,
     // NOTE: `Arc<AbortSignal>` was wrong —
     // `AbortSignal` is an opaque ZST FFI handle; an `Arc` of a ZST never owns
@@ -153,7 +154,7 @@ pub struct RequestContext<
     /// chunked / H3 bodies consumed as a stream are capped against this.
     pub request_body_streamed_len: usize,
 
-    pub sink: Option<NonNull<ResponseStreamJSSink<SSL_ENABLED, HTTP3>>>,
+    pub sink: Option<NonNull<ResponseStreamJSSink<SSL_ENABLED, MUX>>>,
     pub byte_stream: Option<NonNull<ByteStream>>,
     /// This keeps the Response body's ReadableStream alive.
     pub response_body_readable_stream_ref: readable_stream::Strong,
@@ -177,12 +178,14 @@ pub struct RequestContext<
     // TODO: support builtin compression
 }
 
-impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const HTTP3: bool>
-    RequestContext<ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3>
+impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const MUX: u8>
+    RequestContext<ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>
 where
     ThisServer: ServerLike + 'static,
 {
-    pub const IS_H3: bool = HTTP3;
+    pub const IS_H3: bool = MUX == MUX_H3;
+    pub const IS_H2: bool = MUX == MUX_H2;
+    pub const IS_MUX: bool = MUX != MUX_H1;
 
     pub fn memory_cost(&self) -> usize {
         // The Sink and ByteStream aren't owned by this.
@@ -251,14 +254,14 @@ use bun_jsc::SysErrorJsc as _;
 /// callback must drop it on every exit path. Holds the raw pointer (not
 /// `&mut`) so the body can keep using its own `&mut Self` view without
 /// borrowck conflict; the `&mut` is formed only at drop time.
-struct RequestContextRef<ThisServer, const SSL: bool, const DBG: bool, const H3: bool>(
-    *mut RequestContext<ThisServer, SSL, DBG, H3>,
+struct RequestContextRef<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8>(
+    *mut RequestContext<ThisServer, SSL, DBG, MUX>,
 )
 where
     ThisServer: ServerLike + 'static;
 
-impl<ThisServer, const SSL: bool, const DBG: bool, const H3: bool> Drop
-    for RequestContextRef<ThisServer, SSL, DBG, H3>
+impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> Drop
+    for RequestContextRef<ThisServer, SSL, DBG, MUX>
 where
     ThisServer: ServerLike + 'static,
 {
@@ -432,7 +435,7 @@ pub trait RequestContextHostFns {
 // ABI wrappers in `request_ctx_exports!`, so they need no `extern` ABI and
 // have no caller preconditions (bodies use safe `opaque_deref`). The wrappers
 // carry `#[bun_jsc::host_call]` for the C++-visible symbol.
-fn host_on_resolve<ThisServer, const SSL: bool, const DBG: bool, const H3: bool>(
+fn host_on_resolve<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8>(
     g: *mut JSGlobalObject,
     f: *mut CallFrame,
 ) -> JSValue
@@ -444,10 +447,10 @@ where
     let (g, f) = (bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(f));
     bun_jsc::to_js_host_fn_result(
         g,
-        RequestContext::<ThisServer, SSL, DBG, H3>::on_resolve(g, f),
+        RequestContext::<ThisServer, SSL, DBG, MUX>::on_resolve(g, f),
     )
 }
-fn host_on_reject<ThisServer, const SSL: bool, const DBG: bool, const H3: bool>(
+fn host_on_reject<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8>(
     g: *mut JSGlobalObject,
     f: *mut CallFrame,
 ) -> JSValue
@@ -459,10 +462,10 @@ where
     let (g, f) = (bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(f));
     bun_jsc::to_js_host_fn_result(
         g,
-        RequestContext::<ThisServer, SSL, DBG, H3>::on_reject(g, f),
+        RequestContext::<ThisServer, SSL, DBG, MUX>::on_reject(g, f),
     )
 }
-fn host_on_resolve_stream<ThisServer, const SSL: bool, const DBG: bool, const H3: bool>(
+fn host_on_resolve_stream<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8>(
     g: *mut JSGlobalObject,
     f: *mut CallFrame,
 ) -> JSValue
@@ -474,10 +477,10 @@ where
     let (g, f) = (bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(f));
     bun_jsc::to_js_host_fn_result(
         g,
-        RequestContext::<ThisServer, SSL, DBG, H3>::on_resolve_stream(g, f),
+        RequestContext::<ThisServer, SSL, DBG, MUX>::on_resolve_stream(g, f),
     )
 }
-fn host_on_reject_stream<ThisServer, const SSL: bool, const DBG: bool, const H3: bool>(
+fn host_on_reject_stream<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8>(
     g: *mut JSGlobalObject,
     f: *mut CallFrame,
 ) -> JSValue
@@ -489,12 +492,12 @@ where
     let (g, f) = (bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(f));
     bun_jsc::to_js_host_fn_result(
         g,
-        RequestContext::<ThisServer, SSL, DBG, H3>::on_reject_stream(g, f),
+        RequestContext::<ThisServer, SSL, DBG, MUX>::on_reject_stream(g, f),
     )
 }
 
-impl<ThisServer, const SSL: bool, const DBG: bool, const H3: bool> RequestContextHostFns
-    for RequestContext<ThisServer, SSL, DBG, H3>
+impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> RequestContextHostFns
+    for RequestContext<ThisServer, SSL, DBG, MUX>
 where
     ThisServer: ServerLike + 'static,
 {
@@ -504,19 +507,19 @@ where
     // `GlobalObject::promiseHandlerID` compares against (ZigGlobalObject.cpp),
     // and the exported wrapper has a different address from the generic it
     // forwards to. We route through a const-fn lookup keyed on the
-    // (SSL, DEBUG, H3) tuple so the blanket impl can name concrete exports.
-    const ON_RESOLVE: bun_jsc::JSHostFn = exported_host_fns(SSL, DBG, H3).0;
-    const ON_REJECT: bun_jsc::JSHostFn = exported_host_fns(SSL, DBG, H3).1;
-    const ON_RESOLVE_STREAM: bun_jsc::JSHostFn = exported_host_fns(SSL, DBG, H3).2;
-    const ON_REJECT_STREAM: bun_jsc::JSHostFn = exported_host_fns(SSL, DBG, H3).3;
+    // (SSL, DEBUG, MUX) tuple so the blanket impl can name concrete exports.
+    const ON_RESOLVE: bun_jsc::JSHostFn = exported_host_fns(SSL, DBG, MUX).0;
+    const ON_REJECT: bun_jsc::JSHostFn = exported_host_fns(SSL, DBG, MUX).1;
+    const ON_RESOLVE_STREAM: bun_jsc::JSHostFn = exported_host_fns(SSL, DBG, MUX).2;
+    const ON_REJECT_STREAM: bun_jsc::JSHostFn = exported_host_fns(SSL, DBG, MUX).3;
 }
 
-impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const HTTP3: bool>
-    RequestContext<ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3>
+impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const MUX: u8>
+    RequestContext<ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>
 where
     ThisServer: ServerLike + 'static,
 {
-    const RESP_KIND: uws::ResponseKind = uws::ResponseKind::from(SSL_ENABLED, HTTP3);
+    const RESP_KIND: uws::ResponseKind = uws::ResponseKind::from(SSL_ENABLED, MUX);
 
     /// Reborrow the owning server. `server` is a BACKREF (LIFETIMES.tsv): set
     /// at construction in `init()` from the `NewServer` that owns the request
@@ -566,7 +569,7 @@ where
     /// `do_render_stream`; this `RequestContext` is its sole owner until
     /// [`destroy_sink`] consumes it. Single-threaded — no other `&mut` alias.
     #[inline]
-    fn sink_mut<'r>(&mut self) -> Option<&'r mut ResponseStreamJSSink<SSL_ENABLED, HTTP3>> {
+    fn sink_mut<'r>(&mut self) -> Option<&'r mut ResponseStreamJSSink<SSL_ENABLED, MUX>> {
         // SAFETY: see fn doc — heap JSSink owned by this ctx, sole live
         // mutable view, single-threaded.
         self.sink.map(|p| unsafe { &mut *p.as_ptr() })
@@ -838,7 +841,7 @@ where
             let wrapper = unsafe { &mut *wrapper_ptr.as_ptr() };
             wrapper.sink.finalize();
             if let Some(sink_global) = wrapper.sink.global_this {
-                ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+                ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
                     &mut wrapper.sink.signal,
                     &sink_global,
                 );
@@ -858,8 +861,7 @@ where
 
         if let Some(server) = self.server.take() {
             // server is a BACKREF; pool put + onRequestComplete
-            server
-                .release_request_context(std::ptr::from_mut::<Self>(self).cast::<c_void>(), HTTP3);
+            server.release_request_context(std::ptr::from_mut::<Self>(self).cast::<c_void>(), MUX);
             // SAFETY: `&mut` through the backref — the server outlives this
             // context and no other borrow of it is live here.
             unsafe { (*server.as_ptr()).on_request_complete() };
@@ -1185,7 +1187,7 @@ where
     /// `on_stream_close` invokes it on a freed pool slot.
     pub fn end_already_responded_stream(&mut self) {
         ctx_log!("endAlreadyRespondedStream");
-        debug_assert!(!HTTP3);
+        debug_assert!(!Self::IS_MUX);
         // `resp` may be freed (see above); the sink resumed it at `ended_response = true`.
         self.flags.set_request_body_paused(false);
         if self.resp.take().is_some() {
@@ -1269,23 +1271,23 @@ where
     }
 
     #[inline]
-    fn any_request(r: *mut Req<SSL_ENABLED, HTTP3>) -> uws::AnyRequest {
-        if HTTP3 {
-            uws::AnyRequest::H3(r.cast::<bun_uws_sys::h3::Request>())
-        } else {
-            uws::AnyRequest::H1(r.cast::<bun_uws_sys::Request>())
+    fn any_request(r: *mut Req<SSL_ENABLED, MUX>) -> uws::AnyRequest {
+        match MUX {
+            MUX_H3 => uws::AnyRequest::H3(r.cast::<bun_uws_sys::h3::Request>()),
+            MUX_H2 => uws::AnyRequest::H2(r.cast::<bun_uws_sys::h2::Request>()),
+            _ => uws::AnyRequest::H1(r.cast::<bun_uws_sys::Request>()),
         }
     }
 
     #[inline]
-    fn req_method(r: *mut Req<SSL_ENABLED, HTTP3>) -> &'static [u8] {
+    fn req_method(r: *mut Req<SSL_ENABLED, MUX>) -> &'static [u8] {
         // SAFETY: r is a live uWS/lsquic request handle for the duration of
-        // the request callback; both surfaces return request-owned slices.
+        // the request callback; all surfaces return request-owned slices.
         unsafe {
-            if HTTP3 {
-                (*r.cast::<bun_uws_sys::h3::Request>()).method()
-            } else {
-                (*r.cast::<bun_uws_sys::Request>()).method()
+            match MUX {
+                MUX_H3 => (*r.cast::<bun_uws_sys::h3::Request>()).method(),
+                MUX_H2 => (*r.cast::<bun_uws_sys::h2::Request>()).method(),
+                _ => (*r.cast::<bun_uws_sys::Request>()).method(),
             }
         }
     }
@@ -1293,7 +1295,7 @@ where
     pub fn create(
         this: &mut core::mem::MaybeUninit<Self>,
         server: *const ThisServer,
-        req: *mut Req<SSL_ENABLED, HTTP3>,
+        req: *mut Req<SSL_ENABLED, MUX>,
         resp: uws::AnyResponse,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<Method>,
@@ -1378,11 +1380,11 @@ where
         // `RequestContext` user-data pointer registered with uWS.
         let this = unsafe { &mut *this };
         debug_assert!(this.resp.is_some());
-        // An HTTP/3 stream is destroyed once both sides FIN, so this also
-        // fires after a successful end(). HTTP/1 sockets persist for
+        // A multiplexed (H2/H3) stream is destroyed once both sides FIN, so
+        // this also fires after a successful end(). HTTP/1 sockets persist for
         // keep-alive, so the equivalent never happens there. Drop the
         // pointer; everything else cleans up via the resolve/reject path.
-        if HTTP3 {
+        if Self::IS_MUX {
             // SAFETY: FFI handle
             if resp.has_responded() {
                 this.resp = None;
@@ -1451,10 +1453,8 @@ where
             // (repr(transparent) over the sink). `abort` takes the raw pointer
             // because the teardown it can re-enter frees the sink.
             unsafe {
-                ResponseStream::<SSL_ENABLED, HTTP3>::abort(
-                    sink_ptr
-                        .as_ptr()
-                        .cast::<ResponseStream<SSL_ENABLED, HTTP3>>(),
+                ResponseStream::<SSL_ENABLED, MUX>::abort(
+                    sink_ptr.as_ptr().cast::<ResponseStream<SSL_ENABLED, MUX>>(),
                 );
             }
             return;
@@ -1989,16 +1989,16 @@ where
     /// Tear down a heap `ResponseStreamJSSink` allocated by `do_render_stream`.
     /// JSSink<T> is `repr(transparent)` so the inner-ptr free matches the
     /// outer allocation.
-    fn destroy_sink(ptr: NonNull<ResponseStreamJSSink<SSL_ENABLED, HTTP3>>) {
+    fn destroy_sink(ptr: NonNull<ResponseStreamJSSink<SSL_ENABLED, MUX>>) {
         // `ptr` was `heap::alloc`'d in do_render_stream and is being consumed
         // exactly once here. `JSSink<T>` is repr(transparent), so the inner
         // `HTTPServerWritable` shares the allocation Layout.
-        ResponseStream::<SSL_ENABLED, HTTP3>::destroy(
-            ptr.as_ptr().cast::<ResponseStream<SSL_ENABLED, HTTP3>>(),
+        ResponseStream::<SSL_ENABLED, MUX>::destroy(
+            ptr.as_ptr().cast::<ResponseStream<SSL_ENABLED, MUX>>(),
         );
     }
 
-    fn do_render_stream(pair: *mut StreamPair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3>) {
+    fn do_render_stream(pair: *mut StreamPair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>) {
         ctx_log!("doRenderStream");
         // SAFETY: pair is a stack local threaded through cork user-data.
         let pair = unsafe { &mut *pair };
@@ -2025,10 +2025,11 @@ where
             uws::AnyResponse::SSL(p) => p.cast::<c_void>(),
             uws::AnyResponse::TCP(p) => p.cast::<c_void>(),
             uws::AnyResponse::H3(p) => p.cast::<c_void>(),
+            uws::AnyResponse::H2(p) => p.cast::<c_void>(),
         };
 
-        let response_stream_box = Box::new(ResponseStreamJSSink::<SSL_ENABLED, HTTP3> {
-            sink: ResponseStream::<SSL_ENABLED, HTTP3> {
+        let response_stream_box = Box::new(ResponseStreamJSSink::<SSL_ENABLED, MUX> {
+            sink: ResponseStream::<SSL_ENABLED, MUX> {
                 res: Some(raw_res),
                 buffer: Vec::<u8>::default(),
                 on_first_write: Some(Self::handle_first_stream_write_thunk),
@@ -2045,7 +2046,7 @@ where
         let response_stream = unsafe { &mut *response_stream_ptr.as_ptr() };
 
         response_stream.sink.signal = crate::webcore::sink::SinkSignal::<
-            ResponseStream<SSL_ENABLED, HTTP3>,
+            ResponseStream<SSL_ENABLED, MUX>,
         >::init(JSValue::ZERO);
 
         // explicitly set it to a dead pointer
@@ -2061,13 +2062,12 @@ where
         // We are already corked!
         // `Option<NonNull<c_void>>` is layout-compatible with `*mut c_void` (niche).
         let signal_ptr_slot = (&raw mut response_stream.sink.signal.ptr).cast::<*mut c_void>();
-        let assignment_result: JSValue =
-            ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::assign_to_stream(
-                global_this,
-                stream.value,
-                &mut response_stream.sink,
-                signal_ptr_slot,
-            );
+        let assignment_result: JSValue = ResponseStreamJSSink::<SSL_ENABLED, MUX>::assign_to_stream(
+            global_this,
+            stream.value,
+            &mut response_stream.sink,
+            signal_ptr_slot,
+        );
 
         assignment_result.ensure_still_alive();
 
@@ -2088,7 +2088,7 @@ where
 
         if let Some(err_value) = assignment_result.to_error() {
             stream_log!("returned an error");
-            ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+            ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
                 &mut response_stream.sink.signal,
                 global_this,
             );
@@ -2099,7 +2099,7 @@ where
 
         if resp.has_responded() {
             stream_log!("done");
-            ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+            ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
                 &mut response_stream.sink.signal,
                 global_this,
             );
@@ -2214,7 +2214,7 @@ where
             } else {
                 // if is not a promise we treat it as Error
                 stream_log!("returned an error");
-                ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+                ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
                     &mut response_stream.sink.signal,
                     global_this,
                 );
@@ -2225,7 +2225,7 @@ where
         }
 
         if this.is_aborted_or_ended() {
-            ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+            ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
                 &mut response_stream.sink.signal,
                 global_this,
             );
@@ -2256,7 +2256,7 @@ where
                     stream_log!("is not locked");
                     response_stream.sink.on_first_write = None;
                     response_stream.sink.ctx = None;
-                    ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+                    ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
                         &mut response_stream.sink.signal,
                         global_this,
                     );
@@ -2274,7 +2274,7 @@ where
         stream_log!("is in progress, but did not return a Promise. Finalizing request context");
         response_stream.sink.on_first_write = None;
         response_stream.sink.ctx = None;
-        ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+        ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
             &mut response_stream.sink.signal,
             global_this,
         );
@@ -2295,16 +2295,16 @@ where
 
     fn to_async_without_abort_handler(
         &mut self,
-        req: *mut Req<SSL_ENABLED, HTTP3>,
+        req: *mut Req<SSL_ENABLED, MUX>,
         request_object: &mut Request,
     ) {
         debug_assert!(self.server.is_some());
 
-        // For HTTP/3, prepareJsRequestContextFor() already eagerly
-        // populated url+headers (the lazy getRequest() path is H1-only),
-        // so the guards below short-circuit and `req` is never read.
-        if !HTTP3 {
-            // `Req<SSL,H3>` is erased to `c_void`; for !HTTP3 the concrete
+        // For multiplexed transports, prepareJsRequestContextFor() already
+        // eagerly populated url+headers (the lazy getRequest() path is
+        // H1-only), so the guards below short-circuit and `req` is never read.
+        if !Self::IS_MUX {
+            // `Req<SSL,MUX>` is erased to `c_void`; for H1 the concrete
             // type is `uws::Request`, so the cast is nominal.
             request_object
                 .request_context
@@ -2317,7 +2317,7 @@ where
 
         // we have to clone the request headers here since they will soon belong to a different request
         if !request_object.has_fetch_headers() {
-            if !HTTP3 {
+            if !Self::IS_MUX {
                 // `HeadersRef::create_from_uws` adopts the freshly-allocated +1 ref.
                 request_object.set_fetch_headers(Some(response::HeadersRef::create_from_uws(req)));
             }
@@ -2328,7 +2328,7 @@ where
         request_object.request_context.detach_request();
     }
 
-    pub fn to_async(&mut self, req: *mut Req<SSL_ENABLED, HTTP3>, request_object: &mut Request) {
+    pub fn to_async(&mut self, req: *mut Req<SSL_ENABLED, MUX>, request_object: &mut Request) {
         ctx_log!("toAsync");
         self.to_async_without_abort_handler(req, request_object);
         if DEBUG_MODE {
@@ -2408,7 +2408,7 @@ where
     /// # Safety
     /// `pair` must point to a live stack-local `HeaderResponseSizePair` threaded through cork user-data.
     pub(crate) fn do_render_head_response_after_s3_size_resolved(
-        pair: *mut HeaderResponseSizePair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3>,
+        pair: *mut HeaderResponseSizePair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>,
     ) {
         // SAFETY: caller upholds the fn-level contract — `pair` points to a
         // live stack-local `HeaderResponseSizePair` threaded through cork user-data.
@@ -2454,7 +2454,7 @@ where
     }
 
     fn do_render_head_response(
-        pair: *mut HeaderResponsePair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3>,
+        pair: *mut HeaderResponsePair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>,
     ) {
         // SAFETY: pair is a stack local threaded through cork user-data.
         let pair = unsafe { &mut *pair };
@@ -2510,7 +2510,7 @@ where
         if !body_decides_framing {
             if let Some(headers) = response.get_init_headers_mut() {
                 // first respect the headers
-                if !HTTP3 {
+                if !Self::IS_MUX {
                     if let Some(transfer_encoding) =
                         headers.fast_get(jsc::HTTPHeaderName::TransferEncoding)
                     {
@@ -2608,7 +2608,7 @@ where
             }
             Body::Value::Locked(_) => {
                 this.render_metadata();
-                if !HTTP3 {
+                if !Self::IS_MUX {
                     // SAFETY: FFI handle
                     resp.write_header(b"transfer-encoding", b"chunked");
                 }
@@ -2875,7 +2875,7 @@ where
                 .sink
                 .global_this
                 .expect("sink.global_this set in do_render_stream");
-            ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+            ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
                 &mut wrapper.sink.signal,
                 &sink_global,
             );
@@ -2907,9 +2907,9 @@ where
         // This resolution can run arbitrarily later than the end: e.g. a
         // direct stream whose `pull()` calls `controller.end()` and then
         // awaits a promise the user only settles after the client has
-        // disconnected. H3 keeps the end_stream() path: its `resp` is still
-        // alive here and its still-armed onAborted must be disarmed.
-        if !HTTP3 && ended_response {
+        // disconnected. H2/H3 keep the end_stream() path: their `resp` is
+        // still alive here and its still-armed onAborted must be disarmed.
+        if !Self::IS_MUX && ended_response {
             req.end_already_responded_stream();
             return;
         }
@@ -2974,7 +2974,7 @@ where
                 .sink
                 .global_this
                 .expect("sink.global_this set in do_render_stream");
-            ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+            ResponseStreamJSSink::<SSL_ENABLED, MUX>::detach(
                 &mut wrapper.sink.signal,
                 &sink_global,
             );
@@ -3075,9 +3075,9 @@ where
         }
         // HTTP/1 only: the sink already fully ended the response, so `resp`
         // can no longer be dereferenced (see `end_already_responded_stream`).
-        // H3 keeps the end_stream() path: its `resp` is still alive here and
-        // its still-armed onAborted must be disarmed.
-        if !HTTP3 && ended_response {
+        // H2/H3 keep the end_stream() path: their `resp` is still alive here
+        // and its still-armed onAborted must be disarmed.
+        if !Self::IS_MUX && ended_response {
             req.end_already_responded_stream();
             return;
         }
@@ -3432,7 +3432,7 @@ where
         true
     }
 
-    fn ensure_pathname(&self) -> PathnameFormatter<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3> {
+    fn ensure_pathname(&self) -> PathnameFormatter<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, MUX> {
         PathnameFormatter { ctx: self }
     }
 
@@ -3704,10 +3704,10 @@ where
             resp.write_header(b"content-type", &content_type.value);
         }
 
-        // Advertise the QUIC endpoint on H1/H2 responses so browsers can
+        // Advertise the QUIC endpoint on H1 responses so browsers can
         // discover it (RFC 7838). Multiple Alt-Svc fields are valid, so a
         // user-supplied one composes rather than conflicts.
-        if !HTTP3 {
+        if !Self::IS_MUX {
             // SAFETY: BACKREF
             if let Some(alt) = self.server().h3_alt_svc() {
                 resp.write_header(b"alt-svc", alt);
@@ -3794,8 +3794,8 @@ where
         ctx_log!("writeHeaders");
         headers.fast_remove(jsc::HTTPHeaderName::ContentLength);
         headers.fast_remove(jsc::HTTPHeaderName::TransferEncoding);
-        if HTTP3 {
-            // RFC 9114 §4.2: connection-specific fields are malformed.
+        if Self::IS_MUX {
+            // RFC 9113 §8.2.2 / RFC 9114 §4.2: connection-specific fields are malformed.
             headers.fast_remove(jsc::HTTPHeaderName::Connection);
             headers.fast_remove(jsc::HTTPHeaderName::KeepAlive);
             headers.fast_remove(jsc::HTTPHeaderName::ProxyConnection);
@@ -3954,7 +3954,7 @@ where
                         resp.write_status(b"413 Payload Too Large");
                     }
                 }
-                this.end_without_body(!HTTP3);
+                this.end_without_body(!Self::IS_MUX);
                 return;
             }
 
@@ -4051,7 +4051,7 @@ where
                         resp.write_status(b"413 Payload Too Large");
                     }
                 }
-                this.end_without_body(!HTTP3);
+                this.end_without_body(!Self::IS_MUX);
                 return;
             }
 
@@ -4220,10 +4220,13 @@ where
             self.resume_request_body_socket();
             // TODO: check if is someone calling onStartBuffering other than onStartBufferingCallback
             // if is not, this should be removed and only keep protect + setAbortHandler
-            // HTTP/3 (RFC 9114): Content-Length is optional; the body is
-            // delimited by stream FIN, so the H1 "no CL + no TE ⇒ empty"
-            // shortcut would drop it.
-            if !HTTP3 && !self.flags.is_transfer_encoding() && self.request_body_content_len == 0 {
+            // H2/H3: Content-Length is optional; the body is delimited by
+            // stream FIN, so the H1 "no CL + no TE ⇒ empty" shortcut would
+            // drop it.
+            if !Self::IS_MUX
+                && !self.flags.is_transfer_encoding()
+                && self.request_body_content_len == 0
+            {
                 // no content-length or 0 content-length
                 // no transfer-encoding
                 if let Some(body) = self.request_body_mut() {
@@ -4315,22 +4318,23 @@ const MAX_REQUEST_BODY_PREALLOCATE_LENGTH: usize = 1024 * 256;
 /// Pause socket reads at this many unconsumed request-body bytes (two 512 KB uWS recv buffers).
 const REQUEST_BODY_HIGH_WATER_MARK: usize = 1024 * 1024;
 
-// Trap host fn for the `(false, _, true)` arms of `exported_host_fns`. Those
-// `RequestContext` monomorphs (plain-HTTP/3) are type-reachable via the
-// blanket H3 impls but never serve requests at runtime — HTTP/3 always
-// implies TLS. If a future refactor ever routes a promise reaction through
-// one, fail loudly here instead of silently mismatching `promiseHandlerID`.
+// Trap host fn for the `(false, _, MUX_H2|MUX_H3)` arms of
+// `exported_host_fns`. Those `RequestContext` monomorphs (plain-HTTP H2/H3)
+// are type-reachable via the blanket impls but never serve requests at
+// runtime — H2/H3 always imply TLS. If a future refactor ever routes a
+// promise reaction through one, fail loudly here instead of silently
+// mismatching `promiseHandlerID`.
 bun_jsc::jsc_host_abi! {
     #[cold]
     unsafe fn unreachable_host_fn(_g: *mut JSGlobalObject, _f: *mut CallFrame) -> JSValue {
-        unreachable!("RequestContext promise reaction for non-TLS HTTP/3 instantiation");
+        unreachable!("RequestContext promise reaction for non-TLS H2/H3 instantiation");
     }
 }
 
 // ─── per-monomorphization C-ABI exports ──────────────────────────────────────
 // The exported symbol name is "Bun__HTTPRequestContext" + (debug ? "Debug" : "")
-// + (h3 ? "H3" : ssl ? "TLS" : "") + "__on*".
-// Rust generics cannot own `#[no_mangle]` symbols, so each of the 6 concrete
+// + (h3 ? "H3" : h2 ? "H2" : ssl ? "TLS" : "") + "__on*".
+// Rust generics cannot own `#[no_mangle]` symbols, so each of the 8 concrete
 // instantiations × 4 callbacks is spelled out via `request_ctx_exports!`. The
 // generic body lives on the `impl<ThisServer, ..> RequestContext` block above
 // (`on_resolve` / `on_reject` / `on_resolve_stream` / `on_reject_stream`); each
@@ -4338,7 +4342,7 @@ bun_jsc::jsc_host_abi! {
 // `.zero` on error) over the monomorphic associated fn.
 macro_rules! request_ctx_exports {
     ($(
-        ($srv:ty, $ssl:literal, $dbg:literal, $h3:literal) =>
+        ($srv:ty, $ssl:literal, $dbg:literal, $mux:ident) =>
         $on_resolve:ident, $on_reject:ident, $on_resolve_stream:ident, $on_reject_stream:ident
     );* $(;)?) => {$(
         // Named C-ABI symbols for the C++ side. The bodies forward to the
@@ -4347,58 +4351,59 @@ macro_rules! request_ctx_exports {
         #[unsafe(no_mangle)]
         #[bun_jsc::host_call]
         pub fn $on_resolve(g: *mut JSGlobalObject, f: *mut CallFrame) -> JSValue {
-            host_on_resolve::<$srv, $ssl, $dbg, $h3>(g, f)
+            host_on_resolve::<$srv, $ssl, $dbg, { $mux }>(g, f)
         }
         #[unsafe(no_mangle)]
         #[bun_jsc::host_call]
         pub fn $on_reject(g: *mut JSGlobalObject, f: *mut CallFrame) -> JSValue {
-            host_on_reject::<$srv, $ssl, $dbg, $h3>(g, f)
+            host_on_reject::<$srv, $ssl, $dbg, { $mux }>(g, f)
         }
         #[unsafe(no_mangle)]
         #[bun_jsc::host_call]
         pub fn $on_resolve_stream(g: *mut JSGlobalObject, f: *mut CallFrame) -> JSValue {
-            host_on_resolve_stream::<$srv, $ssl, $dbg, $h3>(g, f)
+            host_on_resolve_stream::<$srv, $ssl, $dbg, { $mux }>(g, f)
         }
         #[unsafe(no_mangle)]
         #[bun_jsc::host_call]
         pub fn $on_reject_stream(g: *mut JSGlobalObject, f: *mut CallFrame) -> JSValue {
-            host_on_reject_stream::<$srv, $ssl, $dbg, $h3>(g, f)
+            host_on_reject_stream::<$srv, $ssl, $dbg, { $mux }>(g, f)
         }
     )*
 
-    /// Map the `(SSL, DEBUG, H3)` const-generic tuple to the concrete
+    /// Map the `(SSL, DEBUG, MUX)` const-generic tuple to the concrete
     /// `#[no_mangle]` promise-reaction exports above. Used by the blanket
     /// `RequestContextHostFns` impl so `Self::ON_*` resolves to the *same*
     /// address C++'s `GlobalObject::promiseHandlerID` compares against.
     ///
-    /// Only the six instantiations spelled out in `request_ctx_exports!` are
-    /// ever constructed; the remaining `(false, _, true)` arms (plain-HTTP/3
-    /// without TLS) are unreachable and fall back to the generic shims so the
-    /// const-eval has a value of the right type.
+    /// Only the eight instantiations spelled out in `request_ctx_exports!` are
+    /// ever constructed; the remaining `(false, _, MUX_H2|MUX_H3)` arms
+    /// (plain-HTTP H2/H3 without TLS) are unreachable and fall back to the
+    /// trap shim so the const-eval has a value of the right type.
     const fn exported_host_fns(
         ssl: bool,
         debug: bool,
-        h3: bool,
+        mux: u8,
     ) -> (
         bun_jsc::JSHostFn,
         bun_jsc::JSHostFn,
         bun_jsc::JSHostFn,
         bun_jsc::JSHostFn,
     ) {
-        match (ssl, debug, h3) {
+        match (ssl, debug, mux) {
             $(
-                ($ssl, $dbg, $h3) => (
+                ($ssl, $dbg, $mux) => (
                     $on_resolve,
                     $on_reject,
                     $on_resolve_stream,
                     $on_reject_stream,
                 ),
             )*
-            // `(false, _, true)` — plain-HTTP/3 — is type-instantiated by the
-            // blanket H3 impls in server_body.rs but never reaches the promise
-            // path at runtime (HTTP/3 requires TLS). We can't const-panic here
-            // because rustc evaluates this assoc const for every monomorph; a
-            // runtime trap keeps the failure loud without breaking the build.
+            // `(false, _, MUX_H2|MUX_H3)` — plain-HTTP H2/H3 — is
+            // type-instantiated by the blanket impls in server_body.rs but
+            // never reaches the promise path at runtime (H2/H3 require TLS).
+            // We can't const-panic here because rustc evaluates this assoc
+            // const for every monomorph; a runtime trap keeps the failure loud
+            // without breaking the build.
             _ => (
                 unreachable_host_fn,
                 unreachable_host_fn,
@@ -4410,63 +4415,72 @@ macro_rules! request_ctx_exports {
     };
 }
 request_ctx_exports! {
-    (crate::server::HTTPServer,       false, false, false) =>
+    (crate::server::HTTPServer,       false, false, MUX_H1) =>
         Bun__HTTPRequestContext__onResolve,
         Bun__HTTPRequestContext__onReject,
         Bun__HTTPRequestContext__onResolveStream,
         Bun__HTTPRequestContext__onRejectStream;
-    (crate::server::HTTPSServer,      true,  false, false) =>
+    (crate::server::HTTPSServer,      true,  false, MUX_H1) =>
         Bun__HTTPRequestContextTLS__onResolve,
         Bun__HTTPRequestContextTLS__onReject,
         Bun__HTTPRequestContextTLS__onResolveStream,
         Bun__HTTPRequestContextTLS__onRejectStream;
-    (crate::server::DebugHTTPServer,  false, true,  false) =>
+    (crate::server::DebugHTTPServer,  false, true,  MUX_H1) =>
         Bun__HTTPRequestContextDebug__onResolve,
         Bun__HTTPRequestContextDebug__onReject,
         Bun__HTTPRequestContextDebug__onResolveStream,
         Bun__HTTPRequestContextDebug__onRejectStream;
-    (crate::server::DebugHTTPSServer, true,  true,  false) =>
+    (crate::server::DebugHTTPSServer, true,  true,  MUX_H1) =>
         Bun__HTTPRequestContextDebugTLS__onResolve,
         Bun__HTTPRequestContextDebugTLS__onReject,
         Bun__HTTPRequestContextDebugTLS__onResolveStream,
         Bun__HTTPRequestContextDebugTLS__onRejectStream;
-    (crate::server::HTTPSServer,      true,  false, true)  =>
+    (crate::server::HTTPSServer,      true,  false, MUX_H3) =>
         Bun__HTTPRequestContextH3__onResolve,
         Bun__HTTPRequestContextH3__onReject,
         Bun__HTTPRequestContextH3__onResolveStream,
         Bun__HTTPRequestContextH3__onRejectStream;
-    (crate::server::DebugHTTPSServer, true,  true,  true)  =>
+    (crate::server::DebugHTTPSServer, true,  true,  MUX_H3) =>
         Bun__HTTPRequestContextDebugH3__onResolve,
         Bun__HTTPRequestContextDebugH3__onReject,
         Bun__HTTPRequestContextDebugH3__onResolveStream,
         Bun__HTTPRequestContextDebugH3__onRejectStream;
+    (crate::server::HTTPSServer,      true,  false, MUX_H2) =>
+        Bun__HTTPRequestContextH2__onResolve,
+        Bun__HTTPRequestContextH2__onReject,
+        Bun__HTTPRequestContextH2__onResolveStream,
+        Bun__HTTPRequestContextH2__onRejectStream;
+    (crate::server::DebugHTTPSServer, true,  true,  MUX_H2) =>
+        Bun__HTTPRequestContextDebugH2__onResolve,
+        Bun__HTTPRequestContextDebugH2__onReject,
+        Bun__HTTPRequestContextDebugH2__onResolveStream,
+        Bun__HTTPRequestContextDebugH2__onRejectStream;
 }
 
-pub struct StreamPair<'a, ThisServer, const SSL: bool, const DBG: bool, const H3: bool> {
-    pub this: &'a mut RequestContext<ThisServer, SSL, DBG, H3>,
+pub struct StreamPair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> {
+    pub this: &'a mut RequestContext<ThisServer, SSL, DBG, MUX>,
     pub stream: WebCore::ReadableStream,
 }
 
-pub struct HeaderResponseSizePair<'a, ThisServer, const SSL: bool, const DBG: bool, const H3: bool>
-{
-    pub this: &'a mut RequestContext<ThisServer, SSL, DBG, H3>,
+pub struct HeaderResponseSizePair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> {
+    pub this: &'a mut RequestContext<ThisServer, SSL, DBG, MUX>,
     pub size: usize,
 }
 
-pub struct HeaderResponsePair<'a, ThisServer, const SSL: bool, const DBG: bool, const H3: bool> {
-    pub this: &'a mut RequestContext<ThisServer, SSL, DBG, H3>,
+pub struct HeaderResponsePair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> {
+    pub this: &'a mut RequestContext<ThisServer, SSL, DBG, MUX>,
     /// The JS wrapper's cell pointer, not a `&mut Response`: the receiving
     /// frame hands it to `set_response`, which stores it in a `WeakPtr` that
     /// outlives any reborrow. The cell is GC-rooted by the constructing frame.
     pub response: *mut Response,
 }
 
-pub struct PathnameFormatter<'a, ThisServer, const SSL: bool, const DBG: bool, const H3: bool> {
-    ctx: &'a RequestContext<ThisServer, SSL, DBG, H3>,
+pub struct PathnameFormatter<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> {
+    ctx: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
 }
 
-impl<'a, ThisServer, const SSL: bool, const DBG: bool, const H3: bool> core::fmt::Display
-    for PathnameFormatter<'a, ThisServer, SSL, DBG, H3>
+impl<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> core::fmt::Display
+    for PathnameFormatter<'a, ThisServer, SSL, DBG, MUX>
 where
     ThisServer: ServerLike + 'static,
 {
@@ -4484,10 +4498,10 @@ where
                 // formatter impl.
                 // SAFETY: req is the live uWS request handle.
                 let url: &[u8] = unsafe {
-                    if H3 {
-                        (*req.cast::<bun_uws_sys::h3::Request>()).url()
-                    } else {
-                        (*req.cast::<bun_uws_sys::Request>()).url()
+                    match MUX {
+                        MUX_H3 => (*req.cast::<bun_uws_sys::h3::Request>()).url(),
+                        MUX_H2 => (*req.cast::<bun_uws_sys::h2::Request>()).url(),
+                        _ => (*req.cast::<bun_uws_sys::Request>()).url(),
                     }
                 };
                 return write!(writer, "{}", bstr::BStr::new(url));
@@ -4499,8 +4513,8 @@ where
 }
 
 // `WebCore::Wrap<Self>::init(this)` requires `Self: PipeHandler`.
-impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const HTTP3: bool>
-    WebCore::PipeHandler for RequestContext<ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3>
+impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const MUX: u8>
+    WebCore::PipeHandler for RequestContext<ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>
 where
     ThisServer: ServerLike + 'static,
 {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -46,9 +46,7 @@ impl AdditionalOnAbortCallback {
 // enum over the concrete handles) and dispatches at runtime — same shape
 // as `AnyRequestContext` / `AnyServer`. The const params still pick which
 // variant `create()` constructs and gate multiplexed-transport code paths.
-pub const MUX_H1: u8 = 0;
-pub const MUX_H2: u8 = 1;
-pub const MUX_H3: u8 = 2;
+pub use uws::{MUX_H1, MUX_H2, MUX_H3};
 
 pub type Req<const SSL_ENABLED: bool, const MUX: u8> = c_void;
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1275,7 +1275,8 @@ where
         match MUX {
             MUX_H3 => uws::AnyRequest::H3(r.cast::<bun_uws_sys::h3::Request>()),
             MUX_H2 => uws::AnyRequest::H2(r.cast::<bun_uws_sys::h2::Request>()),
-            _ => uws::AnyRequest::H1(r.cast::<bun_uws_sys::Request>()),
+            MUX_H1 => uws::AnyRequest::H1(r.cast::<bun_uws_sys::Request>()),
+            _ => unreachable!(),
         }
     }
 
@@ -1287,7 +1288,8 @@ where
             match MUX {
                 MUX_H3 => (*r.cast::<bun_uws_sys::h3::Request>()).method(),
                 MUX_H2 => (*r.cast::<bun_uws_sys::h2::Request>()).method(),
-                _ => (*r.cast::<bun_uws_sys::Request>()).method(),
+                MUX_H1 => (*r.cast::<bun_uws_sys::Request>()).method(),
+                _ => unreachable!(),
             }
         }
     }
@@ -3704,10 +3706,10 @@ where
             resp.write_header(b"content-type", &content_type.value);
         }
 
-        // Advertise the QUIC endpoint on H1 responses so browsers can
+        // Advertise the QUIC endpoint on H1/H2 responses so browsers can
         // discover it (RFC 7838). Multiple Alt-Svc fields are valid, so a
         // user-supplied one composes rather than conflicts.
-        if !Self::IS_MUX {
+        if !Self::IS_H3 {
             // SAFETY: BACKREF
             if let Some(alt) = self.server().h3_alt_svc() {
                 resp.write_header(b"alt-svc", alt);

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -59,6 +59,7 @@ pub struct ServerConfig {
     pub allow_hot: bool,
     pub ipv6_only: bool,
     pub http3: bool,
+    pub http2: bool,
     pub http1: bool,
 
     pub had_routes_object: bool,
@@ -92,6 +93,7 @@ impl Default for ServerConfig {
             allow_hot: true,
             ipv6_only: false,
             http3: false,
+            http2: false,
             http1: true,
             had_routes_object: false,
             static_routes: Vec::new(),
@@ -276,6 +278,7 @@ impl ServerConfig {
             allow_hot: self.allow_hot,
             ipv6_only: self.ipv6_only,
             http3: self.http3,
+            http2: self.http2,
             http1: self.http1,
             had_routes_object: self.had_routes_object,
             static_routes: core::mem::take(&mut self.static_routes),
@@ -466,7 +469,71 @@ pub(crate) fn apply_static_route_h3<T>(
     }
 }
 
-/// Per-route trait that `apply_static_route{,_h3}` monomorphizes over
+/// # Safety
+/// `entry` must be a live route pointer that outlives `app` — it is registered
+/// as the uWS userdata and dereferenced from request callbacks for the lifetime
+/// of the app.
+// Forwards `entry` to `T::set_server` and to uWS as opaque userdata without
+// dereferencing it here; not_unsafe_ptr_arg_deref is a false positive on
+// opaque-token forwarding.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub(crate) fn apply_static_route_h2<T>(
+    server: AnyServer,
+    app: &mut uws::h2::App,
+    entry: *mut T,
+    path: &[u8],
+    method: http_method::Optional,
+    path_has_user_head_route: bool,
+) where
+    T: StaticRouteLike<false>,
+{
+    // SAFETY: caller passes a live route pointer for the lifetime of the app.
+    unsafe { T::set_server(entry, server) };
+
+    fn handler<T: StaticRouteLike<false>>(
+        route: &mut T,
+        req: &mut uws::h2::Request,
+        resp: &mut uws::h2::Response,
+    ) {
+        // SAFETY: `route` is the `entry` userdata kept alive by the route table.
+        unsafe {
+            T::on_request(
+                route,
+                bun_uws_sys::AnyRequest::H2(req),
+                bun_uws_sys::AnyResponse::H2(resp),
+            )
+        };
+    }
+    fn head<T: StaticRouteLike<false>>(
+        route: &mut T,
+        req: &mut uws::h2::Request,
+        resp: &mut uws::h2::Response,
+    ) {
+        // SAFETY: see `handler` above.
+        unsafe {
+            T::on_head_request(
+                route,
+                bun_uws_sys::AnyRequest::H2(req),
+                bun_uws_sys::AnyResponse::H2(resp),
+            )
+        };
+    }
+
+    if !path_has_user_head_route && serves_head(&method) {
+        app.head(path, entry, head::<T>);
+    }
+    match method {
+        http_method::Optional::Any => app.any(path, entry, handler::<T>),
+        http_method::Optional::Method(m) => {
+            let mut iter = m.iter();
+            while let Some(method_) = iter.next() {
+                app.method(method_, path, entry, handler::<T>);
+            }
+        }
+    }
+}
+
+/// Per-route trait that `apply_static_route{,_h2,_h3}` monomorphizes over
 /// (`StaticRoute`/`FileRoute`/`HTMLBundle.Route`).
 /// Receivers are raw `*mut Self` because the route is registered as the uWS
 /// userdata pointer and the inherent impls (`StaticRoute::on_request` etc.) need
@@ -1293,6 +1360,13 @@ impl ServerConfig {
             return Err(JsError::Thrown);
         }
 
+        if let Some(v) = arg.get(global, "http2")? {
+            args.http2 = v.to_boolean();
+        }
+        if global.has_exception() {
+            return Err(JsError::Thrown);
+        }
+
         if let Some(v) = arg.get(global, "http1")? {
             args.http1 = v.to_boolean();
         }
@@ -1430,6 +1504,16 @@ impl ServerConfig {
             }
         }
 
+        if args.http2 && args.ssl_config.is_none() {
+            return Err(
+                global.throw_invalid_arguments(format_args!("HTTP/2 requires 'tls' to be set"))
+            );
+        }
+        if args.http2 && !args.http1 {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "http2 requires http1 (it shares the TCP listener via ALPN)"
+            )));
+        }
         if args.http3 {
             if args.ssl_config.is_none() {
                 return Err(

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -477,6 +477,12 @@ impl StaticRoute {
                 // S008: `h3::Response` is an `opaque_ffi!` ZST — safe deref.
                 bun_opaque::opaque_deref_mut(r).write_status(s);
             }
+            AnyResponse::H2(r) => {
+                let mut b = bun_core::fmt::ItoaBuf::new();
+                let s = bun_core::fmt::itoa(&mut b, status);
+                // S008: `h2::Response` is an `opaque_ffi!` ZST — safe deref.
+                bun_opaque::opaque_deref_mut(r).write_status(s);
+            }
         }
     }
 
@@ -499,7 +505,7 @@ impl StaticRoute {
                 &buf[value.offset as usize..][..value.length as usize],
             );
         }
-        if !matches!(resp, AnyResponse::H3(_)) {
+        if !matches!(resp, AnyResponse::H3(_) | AnyResponse::H2(_)) {
             if let Some(srv) = self.server.get() {
                 if let Some(alt) = srv.h3_alt_svc() {
                     resp.write_header(b"alt-svc", alt);

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -505,7 +505,7 @@ impl StaticRoute {
                 &buf[value.offset as usize..][..value.length as usize],
             );
         }
-        if !matches!(resp, AnyResponse::H3(_) | AnyResponse::H2(_)) {
+        if !matches!(resp, AnyResponse::H3(_)) {
             if let Some(srv) = self.server.get() {
                 if let Some(alt) = srv.h3_alt_svc() {
                     resp.write_header(b"alt-svc", alt);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -96,6 +96,11 @@ pub use node_http_response::NodeHTTPResponse;
 #[path = "RequestContext.rs"]
 pub mod request_context;
 pub use request_context::RequestContext as NewRequestContext;
+// Transport discriminant for the `const MUX: u8` generic on
+// `RequestContext`/pools/sinks. H2 and H3 share every stream-multiplexed
+// semantic branch (`MUX != MUX_H1`); only concrete response/request type
+// selection branches on H2 vs H3.
+pub use request_context::{MUX_H1, MUX_H2, MUX_H3};
 
 #[path = "AnyRequestContext.rs"]
 pub mod any_request_context;
@@ -224,6 +229,9 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     // Never set when !SSL.
     pub h3_app: Option<*mut uws_sys::h3::App>,
     pub h3_listener: Option<*mut uws_sys::h3::ListenSocket>,
+    // Never set when !SSL. H2 adopts sockets from `app` via ALPN — no
+    // `h2_listener` (it shares the TCP/TLS listen socket).
+    pub h2_app: Option<*mut uws_sys::h2::App>,
     /// Cached `h3=":<port>"; ma=86400` for Alt-Svc on H1 responses; formatted
     /// once in onH3Listen so renderMetadata doesn't reformat per-request.
     pub h3_alt_svc: Box<[u8]>,
@@ -262,11 +270,17 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     /// via a callback the body fires) early-return instead of re-running the
     /// downgrade/teardown while the outer frame still holds `&mut self`.
     deinit_running: core::cell::Cell<bool>,
-    pub request_pool: *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>,
+    pub request_pool:
+        *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, { MUX_H1 }>,
     /// Null until the H3 listen path runs (`HAS_H3 && config.http3`); never
     /// allocated when `!SSL`. Kept as a raw nullable pointer rather than a
     /// conditional field so the struct stays uniform across monomorphizations.
-    pub h3_request_pool: *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>,
+    pub h3_request_pool:
+        *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, { MUX_H3 }>,
+    /// Null until the H2 listen path runs (`HAS_H2 && config.http2`); never
+    /// allocated when `!SSL`.
+    pub h2_request_pool:
+        *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, { MUX_H2 }>,
     /// Authoritative GC root for the `server.stop()` promise. Lazily filled by
     /// `get_all_closed_promise`; read in `deinit_if_we_can` (which can run
     /// after the wrapper is collected, so a wrapper-traced slot would not
@@ -340,7 +354,7 @@ fn any_response_from<const SSL: bool>(resp: *mut uws_sys::NewAppResponse<SSL>) -
 
 /// HTTP/1 `RequestContext` for a given server monomorphization.
 pub type ServerRequestContext<const SSL: bool, const DEBUG: bool> =
-    request_context::RequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, false>;
+    request_context::RequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, { MUX_H1 }>;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum CreateJsRequest {
@@ -419,6 +433,7 @@ impl Drop for DetachRequestOnDrop {
 
 impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub const HAS_H3: bool = SSL;
+    pub const HAS_H2: bool = SSL;
 
     // ── raw-field accessors ──────────────────────────────────────────────────
 
@@ -1584,6 +1599,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
         }
 
+        if Self::HAS_H2 && self.listener.is_some() {
+            if let Some(h2a) = self.h2_app {
+                // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
+                // GOAWAY on live H2 connections; the shared TCP listener is
+                // closed by the H1 path below. Gated on `listener` so a second
+                // stop() doesn't re-walk sockets (H3 uses h3_listener.take()).
+                bun_opaque::opaque_deref_mut(h2a).close();
+            }
+        }
+
         let Some(listener) = self.listener.take() else {
             if Self::HAS_H3 && self.h3_app.is_some() {
                 self.unref();
@@ -1971,6 +1996,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 unsafe { uws_sys::h3::App::destroy(h3a) };
             }
         }
+        if Self::HAS_H2 {
+            if let Some(h2a) = this_ref.h2_app.take() {
+                // SAFETY: live H2::App handle owned by this server.
+                unsafe { uws_sys::h2::App::destroy(h2a) };
+            }
+        }
         if let Some(app) = this_ref.app.take() {
             // SAFETY: live uws App handle owned by this server.
             unsafe { uws_sys::NewApp::<SSL>::destroy(app) };
@@ -2012,6 +2043,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             listener: None,
             h3_app: None,
             h3_listener: None,
+            h2_app: None,
             h3_alt_svc: Box::<[u8]>::default(),
             js_value: jsc::JsRef::empty(),
             pending_requests: 0,
@@ -2022,6 +2054,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // the H3-listen path (`listen()` below) so HTTPS servers that
             // don't enable `config.http3` don't pay either.
             h3_request_pool: core::ptr::null_mut(),
+            h2_request_pool: core::ptr::null_mut(),
             all_closed_promise: jsc::JSPromiseStrong::default(),
             poll_ref: KeepAlive::default(),
             flags: ServerFlags::default(),
@@ -2207,6 +2240,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             );
                         }
                     }
+                    if Self::HAS_H2 {
+                        if let Some(h2_app) = self.h2_app {
+                            // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
+                            bun_opaque::opaque_deref_mut(h2_app).any(
+                                path,
+                                ud.cast::<UserRoute<SSL, DEBUG>>(),
+                                Self::on_h2_user_route_request,
+                            );
+                        }
+                    }
                     if is_star_path {
                         star_methods_covered_by_user = http_method::Set::all();
                     }
@@ -2237,6 +2280,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 path,
                                 ud.cast::<UserRoute<SSL, DEBUG>>(),
                                 Self::on_h3_user_route_request,
+                            );
+                        }
+                    }
+                    if Self::HAS_H2 {
+                        if let Some(h2_app) = self.h2_app {
+                            // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
+                            bun_opaque::opaque_deref_mut(h2_app).method(
+                                method_val,
+                                path,
+                                ud.cast::<UserRoute<SSL, DEBUG>>(),
+                                Self::on_h2_user_route_request,
                             );
                         }
                     }
@@ -2280,6 +2334,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     let h3_app = bun_opaque::opaque_deref_mut(h3_app);
                     h3_app.head(p, self_ptr, Self::on_h3_request);
                     h3_app.any(p, self_ptr, Self::on_h3_request);
+                }
+            }
+            if Self::HAS_H2 {
+                if let Some(h2_app) = self.h2_app {
+                    // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
+                    let h2_app = bun_opaque::opaque_deref_mut(h2_app);
+                    h2_app.head(p, self_ptr, Self::on_h2_request);
+                    h2_app.any(p, self_ptr, Self::on_h2_request);
                 }
             }
         }
@@ -2346,6 +2408,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             );
                         }
                     }
+                    if Self::HAS_H2 {
+                        if let Some(h2_app) = self.h2_app {
+                            server_config::apply_static_route_h2::<StaticRoute>(
+                                any_server,
+                                // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
+                                bun_opaque::opaque_deref_mut(h2_app),
+                                p.as_ptr(),
+                                &entry.path,
+                                entry.method,
+                                path_has_user_head_route,
+                            );
+                        }
+                    }
                 }
                 AnyRoute::File(p) => {
                     server_config::apply_static_route::<SSL, FileRoute>(
@@ -2369,6 +2444,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             );
                         }
                     }
+                    if Self::HAS_H2 {
+                        if let Some(h2_app) = self.h2_app {
+                            server_config::apply_static_route_h2::<FileRoute>(
+                                any_server,
+                                // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
+                                bun_opaque::opaque_deref_mut(h2_app),
+                                p.as_ptr(),
+                                &entry.path,
+                                entry.method,
+                                path_has_user_head_route,
+                            );
+                        }
+                    }
                 }
                 AnyRoute::Html(r) => {
                     server_config::apply_static_route::<SSL, html_bundle::Route>(
@@ -2385,6 +2473,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
+                                r.as_ptr(),
+                                &entry.path,
+                                entry.method,
+                                path_has_user_head_route,
+                            );
+                        }
+                    }
+                    if Self::HAS_H2 {
+                        if let Some(h2_app) = self.h2_app {
+                            server_config::apply_static_route_h2::<html_bundle::Route>(
+                                any_server,
+                                // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
+                                bun_opaque::opaque_deref_mut(h2_app),
                                 r.as_ptr(),
                                 &entry.path,
                                 entry.method,
@@ -2439,8 +2540,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
 
         // Snapshot "/*" coverage from user/static routes before DevServer
-        // (which is H1-only and not mirrored to the H3 router) marks it full.
-        let h3_star_covered = star_methods_covered_by_user;
+        // (which is H1-only and not mirrored to the H2/H3 routers) marks it full.
+        let mux_star_covered = star_methods_covered_by_user;
 
         // --- 8. Handle DevServer routes & track "/*" coverage ---
         let mut has_dev_server_for_star_path = false;
@@ -2526,10 +2627,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             if let Some(h3_app) = self.h3_app {
                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                 let h3_app = bun_opaque::opaque_deref_mut(h3_app);
-                if h3_star_covered == http_method::Set::all() {
+                if mux_star_covered == http_method::Set::all() {
                     // user/static "/*" already covers every method
                 } else if has_any_user_route_for_star_path || has_static_route_for_star_path {
-                    for m in !h3_star_covered {
+                    for m in !mux_star_covered {
                         if has_on_request {
                             h3_app.method(m, b"/*", self_ptr, Self::on_h3_request);
                         } else {
@@ -2540,6 +2641,29 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     h3_app.any(b"/*", self_ptr, Self::on_h3_request);
                 } else {
                     h3_app.any(b"/*", self_ptr, Self::on_h3_404);
+                }
+            }
+        }
+
+        // H2 fallback — identical ladder to H3 above.
+        if Self::HAS_H2 {
+            if let Some(h2_app) = self.h2_app {
+                // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
+                let h2_app = bun_opaque::opaque_deref_mut(h2_app);
+                if mux_star_covered == http_method::Set::all() {
+                    // user/static "/*" already covers every method
+                } else if has_any_user_route_for_star_path || has_static_route_for_star_path {
+                    for m in !mux_star_covered {
+                        if has_on_request {
+                            h2_app.method(m, b"/*", self_ptr, Self::on_h2_request);
+                        } else {
+                            h2_app.method(m, b"/*", self_ptr, Self::on_h2_404);
+                        }
+                    }
+                } else if has_on_request {
+                    h2_app.any(b"/*", self_ptr, Self::on_h2_request);
+                } else {
+                    h2_app.any(b"/*", self_ptr, Self::on_h2_404);
                 }
             }
         }
@@ -2629,6 +2753,28 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             };
             // SAFETY: `this` is the live boxed server from `init()`; no other borrow is live.
             unsafe { (*this).app = Some(app) };
+
+            if Self::HAS_H2 && this_ref.config.http2 {
+                let idle_timeout = this_ref.config.idle_timeout as u32;
+                // H2 attaches to the parent SSLApp's SSL_CTX (installs the ALPN
+                // select cb) — must run before the listen socket accepts so the
+                // first handshake sees it.
+                let h2 =
+                    uws_sys::h2::App::create(app.cast::<uws_sys::NewApp<true>>(), idle_timeout);
+                if h2.is_none() {
+                    if !global.has_exception() {
+                        let _ = global.throw(format_args!("Failed to create HTTP/2 server"));
+                    }
+                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
+                    Self::deinit(this);
+                    return JSValue::ZERO;
+                }
+                // SAFETY: `this` is the live boxed server; uniquely owned here.
+                unsafe {
+                    (*this).h2_app = h2;
+                    (*this).h2_request_pool = <Self as ServerPools<SSL, DEBUG>>::h2_request_pool();
+                }
+            }
 
             if Self::HAS_H3 && this_ref.config.http3 {
                 let idle_timeout = this_ref.config.idle_timeout as u32;
@@ -3227,7 +3373,7 @@ mod trampoline {
 
 // ─── per-monomorphization request pools ──────────────────────────────────────
 // Rust generics cannot own statics, so
-// declare one `thread_local!` per concrete (SSL, DEBUG, H3) combo via macro and
+// declare one `thread_local!` per concrete (SSL, DEBUG, MUX) combo via macro and
 // hand the leaked pointer back through a trait.
 //
 // THREAD-SAFETY: this MUST be thread-local, not process-global. `hive_array::
@@ -3235,16 +3381,19 @@ mod trampoline {
 // a process-static would race when two `Bun.serve` instances run on distinct
 // Worker threads (each Worker has its own event loop and may host a server).
 pub trait ServerPools<const SSL: bool, const DEBUG: bool>: Sized {
-    fn request_pool() -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>;
+    fn request_pool()
+    -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, { MUX_H1 }>;
     fn h3_request_pool()
-    -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>;
+    -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, { MUX_H3 }>;
+    fn h2_request_pool()
+    -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, { MUX_H2 }>;
 }
 
 macro_rules! impl_server_pools {
     ($(($ssl:literal, $debug:literal)),* $(,)?) => {$(
         impl ServerPools<$ssl, $debug> for NewServer<$ssl, $debug> {
-            fn request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, false> {
-                type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, false>;
+            fn request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, { MUX_H1 }> {
+                type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, { MUX_H1 }>;
                 thread_local! {
                     static POOL: core::cell::Cell<*mut Pool> =
                         const { core::cell::Cell::new(core::ptr::null_mut()) };
@@ -3261,8 +3410,23 @@ macro_rules! impl_server_pools {
                     p
                 })
             }
-            fn h3_request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, true> {
-                type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, true>;
+            fn h3_request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, { MUX_H3 }> {
+                type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, { MUX_H3 }>;
+                thread_local! {
+                    static POOL: core::cell::Cell<*mut Pool> =
+                        const { core::cell::Cell::new(core::ptr::null_mut()) };
+                }
+                POOL.with(|cell| {
+                    let mut p = cell.get();
+                    if p.is_null() {
+                        p = Pool::new_boxed().as_ptr();
+                        cell.set(p);
+                    }
+                    p
+                })
+            }
+            fn h2_request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, { MUX_H2 }> {
+                type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, { MUX_H2 }>;
                 thread_local! {
                     static POOL: core::cell::Cell<*mut Pool> =
                         const { core::cell::Cell::new(core::ptr::null_mut()) };
@@ -3369,7 +3533,7 @@ pub trait ServerLike {
     /// Erased to `*mut c_void` so the trait stays object-safe and doesn't need
     /// to name `RequestContext<Self, ..>` (which would re-introduce the
     /// generic-parameter cycle this trait exists to break).
-    fn release_request_context(&self, ctx: *mut c_void, is_h3: bool);
+    fn release_request_context(&self, ctx: *mut c_void, mux: u8);
 }
 
 impl<const SSL: bool, const DEBUG: bool> ServerLike for NewServer<SSL, DEBUG> {
@@ -3416,24 +3580,33 @@ impl<const SSL: bool, const DEBUG: bool> ServerLike for NewServer<SSL, DEBUG> {
     fn terminated(&self) -> bool {
         self.flags.contains(ServerFlags::TERMINATED)
     }
-    fn release_request_context(&self, ctx: *mut c_void, is_h3: bool) {
+    fn release_request_context(&self, ctx: *mut c_void, mux: u8) {
         // SAFETY: ctx was allocated from this exact pool by `prepare_js_request_context`;
-        // it is `RequestContext<Self, SSL, DEBUG, is_h3>` by construction.
+        // it is `RequestContext<Self, SSL, DEBUG, mux>` by construction.
         unsafe {
-            if is_h3 {
-                (*self.h3_request_pool).put(&raw mut *ctx.cast::<request_context::RequestContext<
-                    Self,
-                    SSL,
-                    DEBUG,
-                    true,
-                >>());
-            } else {
-                (*self.request_pool).put(&raw mut *ctx.cast::<request_context::RequestContext<
-                    Self,
-                    SSL,
-                    DEBUG,
-                    false,
-                >>());
+            match mux {
+                MUX_H3 => {
+                    (*self.h3_request_pool).put(
+                        &raw mut *ctx
+                            .cast::<request_context::RequestContext<Self, SSL, DEBUG, { MUX_H3 }>>(
+                            ),
+                    );
+                }
+                MUX_H2 => {
+                    (*self.h2_request_pool).put(
+                        &raw mut *ctx
+                            .cast::<request_context::RequestContext<Self, SSL, DEBUG, { MUX_H2 }>>(
+                            ),
+                    );
+                }
+                _ => {
+                    (*self.request_pool).put(&raw mut *ctx.cast::<request_context::RequestContext<
+                        Self,
+                        SSL,
+                        DEBUG,
+                        { MUX_H1 },
+                    >>());
+                }
             }
         }
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -64,35 +64,49 @@ pub(super) use super::static_route::StaticRoute;
 // ─── RequestCtx trait ────────────────────────────────────────────────────────
 // NOTE: Stable Rust has no inherent
 // associated types, so the per-monomorphization handle types are surfaced via
-// this local trait. Only `IS_H3` is consumed for control flow; `Req`/`Resp`
-// are erased to `c_void` to match `super::request_context::{Req, Resp}`.
+// this local trait. `MUX` selects the transport; `IS_MUX` (= H2∨H3) gates every
+// stream-multiplexed semantic branch, `IS_H2`/`IS_H3` gate only concrete-type
+// picks. `Req`/`Resp` are erased to `c_void` to match
+// `super::request_context::{Req, Resp}`.
 pub(super) trait RequestCtx: super::any_request_context::CtxKind {
     type Req: ReqLike;
     type Resp: RespLike;
-    const IS_H3: bool;
+    const MUX: u8;
+    const IS_H2: bool = Self::MUX == uws::MUX_H2;
+    const IS_H3: bool = Self::MUX == uws::MUX_H3;
+    const IS_MUX: bool = Self::MUX != uws::MUX_H1;
 }
 impl<ThisServer, const SSL: bool, const DBG: bool> RequestCtx
-    for NewRequestContext<ThisServer, SSL, DBG, false>
+    for NewRequestContext<ThisServer, SSL, DBG, { uws::MUX_H1 }>
 where
-    NewRequestContext<ThisServer, SSL, DBG, false>: super::any_request_context::CtxKind,
+    NewRequestContext<ThisServer, SSL, DBG, { uws::MUX_H1 }>: super::any_request_context::CtxKind,
 {
     type Req = uws_sys::Request;
     type Resp = uws_sys::NewAppResponse<SSL>;
-    const IS_H3: bool = false;
+    const MUX: u8 = uws::MUX_H1;
 }
 impl<ThisServer, const SSL: bool, const DBG: bool> RequestCtx
-    for NewRequestContext<ThisServer, SSL, DBG, true>
+    for NewRequestContext<ThisServer, SSL, DBG, { uws::MUX_H2 }>
 where
-    NewRequestContext<ThisServer, SSL, DBG, true>: super::any_request_context::CtxKind,
+    NewRequestContext<ThisServer, SSL, DBG, { uws::MUX_H2 }>: super::any_request_context::CtxKind,
+{
+    type Req = uws_sys::h2::Request;
+    type Resp = uws_sys::h2::Response;
+    const MUX: u8 = uws::MUX_H2;
+}
+impl<ThisServer, const SSL: bool, const DBG: bool> RequestCtx
+    for NewRequestContext<ThisServer, SSL, DBG, { uws::MUX_H3 }>
+where
+    NewRequestContext<ThisServer, SSL, DBG, { uws::MUX_H3 }>: super::any_request_context::CtxKind,
 {
     type Req = uws_sys::h3::Request;
     type Resp = uws_sys::h3::Response;
-    const IS_H3: bool = true;
+    const MUX: u8 = uws::MUX_H3;
 }
 
 /// Field/method surface needed on the generic `Ctx` so the bodies of
 /// `handle_request_for` / `prepare_js_request_context_for` / `on_saved_request`
-/// can be written without naming the concrete `RequestContext<_, SSL, DBG, H3>`
+/// can be written without naming the concrete `RequestContext<_, SSL, DBG, MUX>`
 /// type. Implemented via blanket impl below for every `NewRequestContext<..>`.
 #[allow(clippy::too_many_arguments)]
 pub(super) trait RequestCtxOps: RequestCtx {
@@ -139,8 +153,8 @@ pub(super) trait RequestCtxOps: RequestCtx {
     fn on_request_body_stream_drained_callback(this: Option<*mut c_void>);
 }
 
-impl<ThisServer, const SSL: bool, const DBG: bool, const H3: bool> RequestCtxOps
-    for NewRequestContext<ThisServer, SSL, DBG, H3>
+impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: u8> RequestCtxOps
+    for NewRequestContext<ThisServer, SSL, DBG, MUX>
 where
     Self: RequestCtx,
     ThisServer: super::ServerLike + 'static,
@@ -245,18 +259,18 @@ where
     #[inline]
     fn arm_on_data(&mut self, resp: &mut Self::Resp) {
         // NOTE: route via the type-erased `AnyResponse::on_data` so the
-        // body stays generic over `Ctx::Resp` (H1 SSL/TCP/H3).
-        fn handler<S, const SSL_: bool, const DBG_: bool, const H3_: bool>(
-            ctx: *mut NewRequestContext<S, SSL_, DBG_, H3_>,
+        // body stays generic over `Ctx::Resp` (H1 SSL/TCP/H2/H3).
+        fn handler<S, const SSL_: bool, const DBG_: bool, const MUX_: u8>(
+            ctx: *mut NewRequestContext<S, SSL_, DBG_, MUX_>,
             chunk: &[u8],
             last: bool,
         ) where
             S: super::ServerLike + 'static,
         {
-            NewRequestContext::<S, SSL_, DBG_, H3_>::on_buffered_body_chunk(ctx, chunk, last);
+            NewRequestContext::<S, SSL_, DBG_, MUX_>::on_buffered_body_chunk(ctx, chunk, last);
         }
         RespLike::to_any_response(resp).on_data(
-            handler::<ThisServer, SSL, DBG, H3>,
+            handler::<ThisServer, SSL, DBG, MUX>,
             std::ptr::from_mut::<Self>(self),
         );
     }
@@ -310,6 +324,24 @@ impl ReqLike for uws_sys::Request {
         uws_sys::Request::set_yield(self, y)
     }
 }
+impl ReqLike for uws_sys::h2::Request {
+    #[inline]
+    fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
+        uws_sys::h2::Request::header(self, name)
+    }
+    #[inline]
+    fn method(&mut self) -> &[u8] {
+        uws_sys::h2::Request::method(self)
+    }
+    #[inline]
+    fn url(&mut self) -> &[u8] {
+        uws_sys::h2::Request::url(self)
+    }
+    #[inline]
+    fn set_yield(&mut self, y: bool) {
+        uws_sys::h2::Request::set_yield(self, y)
+    }
+}
 impl ReqLike for uws_sys::h3::Request {
     #[inline]
     fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
@@ -330,7 +362,7 @@ impl ReqLike for uws_sys::h3::Request {
 }
 
 pub(super) trait RespLike {
-    const IS_H3: bool;
+    const IS_MUX: bool;
     fn write_status(&mut self, status: &[u8]);
     fn end_without_body(&mut self, close_connection: bool);
     fn timeout(&mut self, seconds: u8);
@@ -338,7 +370,7 @@ pub(super) trait RespLike {
     fn to_any_response(&mut self) -> uws::AnyResponse;
 }
 impl<const SSL: bool> RespLike for uws_sys::NewAppResponse<SSL> {
-    const IS_H3: bool = false;
+    const IS_MUX: bool = false;
     #[inline]
     fn write_status(&mut self, s: &[u8]) {
         uws_sys::NewAppResponse::<SSL>::write_status(self, s)
@@ -377,8 +409,35 @@ impl<const SSL: bool> RespLike for uws_sys::NewAppResponse<SSL> {
         }
     }
 }
+impl RespLike for uws_sys::h2::Response {
+    const IS_MUX: bool = true;
+    #[inline]
+    fn write_status(&mut self, s: &[u8]) {
+        uws_sys::h2::Response::write_status(self, s)
+    }
+    #[inline]
+    fn end_without_body(&mut self, c: bool) {
+        uws_sys::h2::Response::end_without_body(self, c)
+    }
+    #[inline]
+    fn timeout(&mut self, s: u8) {
+        uws_sys::h2::Response::timeout(self, s)
+    }
+    #[inline]
+    fn on_timeout_warn(&mut self, ud: *mut c_void) {
+        uws_sys::h2::Response::on_timeout(
+            self,
+            |_: &mut c_void, _: &mut uws_sys::h2::Response| on_timeout_for_idle_warn(),
+            ud,
+        );
+    }
+    #[inline]
+    fn to_any_response(&mut self) -> uws::AnyResponse {
+        uws::AnyResponse::from(std::ptr::from_mut::<Self>(self))
+    }
+}
 impl RespLike for uws_sys::h3::Response {
-    const IS_H3: bool = true;
+    const IS_MUX: bool = true;
     #[inline]
     fn write_status(&mut self, s: &[u8]) {
         uws_sys::h3::Response::write_status(self, s)
@@ -410,14 +469,14 @@ impl RespLike for uws_sys::h3::Response {
 /// `pending_requests`, so `self` can outlive the wrapper between the
 /// finalizer and the next-tick `schedule_deinit`). 503 instead of
 /// dispatching into a dead handler shadow. One helper so every dispatch
-/// trampoline gets the same guard. H1 closes the connection; H3 ends only
-/// this stream (`!R::IS_H3`) so sibling streams on the same QUIC connection
+/// trampoline gets the same guard. H1 closes the connection; H2/H3 end only
+/// this stream (`!R::IS_MUX`) so sibling streams on the same connection
 /// survive — same per-protocol close treatment as the other reject fast
 /// paths.
 #[inline]
 pub(super) fn respond_stopped_503<R: RespLike + ?Sized>(resp: &mut R) {
     resp.write_status(b"503 Service Unavailable");
-    resp.end_without_body(!R::IS_H3);
+    resp.end_without_body(!R::IS_MUX);
 }
 
 /// RFC 6455 §4.1: |Sec-WebSocket-Key| is the base64 encoding of a 16-byte
@@ -433,9 +492,11 @@ fn is_valid_sec_websocket_key(key: &[u8]) -> bool {
 }
 
 pub(super) type ServerRequestContext<const SSL: bool, const DEBUG: bool> =
-    NewRequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, false>;
+    NewRequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, { uws::MUX_H1 }>;
+pub(super) type ServerH2RequestContext<const SSL: bool, const DEBUG: bool> =
+    NewRequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, { uws::MUX_H2 }>;
 pub(super) type ServerH3RequestContext<const SSL: bool, const DEBUG: bool> =
-    NewRequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, true>;
+    NewRequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, { uws::MUX_H3 }>;
 
 // ─── BunInfo (moved from bun_core::Global) ───────────────────────────────────
 // `generate()` builds the JSON AST by hand: an `E.Object` with
@@ -1300,8 +1361,12 @@ impl<const SSL: bool, const DEBUG: bool> uws_sys::web_socket::WebSocketUpgradeSe
 where
     // NOTE: see the bounded `impl NewServer` below for why these are
     // spelled out — `on_web_socket_upgrade` lives in that impl.
-    NewRequestContext<Self, SSL, DEBUG, false>: super::request_context::RequestContextHostFns,
-    NewRequestContext<Self, SSL, DEBUG, true>: super::request_context::RequestContextHostFns,
+    NewRequestContext<Self, SSL, DEBUG, { uws::MUX_H1 }>:
+        super::request_context::RequestContextHostFns,
+    NewRequestContext<Self, SSL, DEBUG, { uws::MUX_H2 }>:
+        super::request_context::RequestContextHostFns,
+    NewRequestContext<Self, SSL, DEBUG, { uws::MUX_H3 }>:
+        super::request_context::RequestContextHostFns,
 {
     unsafe fn on_websocket_upgrade(
         this: *mut Self,
@@ -1384,12 +1449,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG>
 where
     // NOTE (const-generic dispatch): `RequestContextHostFns` (the host-fn
-    // export table) is blanket-impl'd per (SSL,DBG,H3) tuple in
+    // export table) is blanket-impl'd per (SSL,DBG,MUX) tuple in
     // `RequestContext.rs` for `ThisServer: ServerLike`; restating it here lets
     // method bodies name `<NewRequestContext<..> as RequestContextHostFns>::ON_*`
     // without each method repeating the bound.
-    NewRequestContext<Self, SSL, DEBUG, false>: super::request_context::RequestContextHostFns,
-    NewRequestContext<Self, SSL, DEBUG, true>: super::request_context::RequestContextHostFns,
+    NewRequestContext<Self, SSL, DEBUG, { uws::MUX_H1 }>:
+        super::request_context::RequestContextHostFns,
+    NewRequestContext<Self, SSL, DEBUG, { uws::MUX_H2 }>:
+        super::request_context::RequestContextHostFns,
+    NewRequestContext<Self, SSL, DEBUG, { uws::MUX_H3 }>:
+        super::request_context::RequestContextHostFns,
 {
     // NOTE: there is no `getPluginsAsync` method or `AnyServer` dispatcher;
     // the live HTMLBundle path goes through `get_or_load_plugins`.
@@ -1872,7 +1941,7 @@ where
                             // we must write the status first so that 200 OK isn't written
                             raw_response.write_status(b"101 Switching Protocols");
                             fetch_headers_to_use.to_uws_response(
-                                ResponseKind::from(SSL, false),
+                                ResponseKind::from(SSL, uws::MUX_H1),
                                 raw_response.socket().cast::<c_void>(),
                             );
                         }
@@ -2141,14 +2210,14 @@ where
             if let Some(h) = fetch_headers_to_use {
                 // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
                 bun_opaque::opaque_deref_mut(h).to_uws_response(
-                    ResponseKind::from(SSL, false),
+                    ResponseKind::from(SSL, uws::MUX_H1),
                     resp.socket().cast::<c_void>(),
                 );
             }
             if let Some(c) = cookies_to_write.as_mut() {
                 c.write(
                     global,
-                    ResponseKind::from(SSL, false),
+                    ResponseKind::from(SSL, uws::MUX_H1),
                     resp.socket().cast::<c_void>(),
                 )?;
             }
@@ -2209,6 +2278,11 @@ where
         // SAFETY: `on_reload` is only reachable while the server is running
         // (`self.app` set in `listen()`).
         self.app_mut().clear_routes();
+        if Self::HAS_H2 {
+            if let Some(h2a) = self.h2_app {
+                bun_opaque::opaque_deref_mut(h2a).clear_routes();
+            }
+        }
         if Self::HAS_H3 {
             if let Some(h3a) = self.h3_app {
                 bun_opaque::opaque_deref_mut(h3a).clear_routes();
@@ -2317,6 +2391,11 @@ where
         }
         self.config = self.config.clone_for_reloading_static_routes()?;
         self.app_mut().clear_routes();
+        if Self::HAS_H2 {
+            if let Some(h2a) = self.h2_app {
+                bun_opaque::opaque_deref_mut(h2a).clear_routes();
+            }
+        }
         if Self::HAS_H3 {
             if let Some(h3a) = self.h3_app {
                 bun_opaque::opaque_deref_mut(h3a).clear_routes();
@@ -2768,6 +2847,37 @@ where
     // `notify_inspector_server_stopped` lives in the unbounded impl block
     // above so the unbounded `deinit()` (mod.rs) can call it.
 
+    pub fn on_h2_request(&mut self, req: &mut uws::H2::Request, resp: &mut uws::H2::Response) {
+        if !Self::HAS_H2 {
+            unreachable!();
+        }
+        if self.config.on_request.is_empty() {
+            return Self::on_h2_404(self, req, resp);
+        }
+        self.on_request_for::<ServerH2RequestContext<SSL, DEBUG>>(req, resp);
+    }
+
+    pub fn on_h2_user_route_request(
+        user_route: &mut UserRoute<SSL, DEBUG>,
+        req: &mut uws::H2::Request,
+        resp: &mut uws::H2::Response,
+    ) {
+        if !Self::HAS_H2 {
+            unreachable!();
+        }
+        Self::on_user_route_request_for::<ServerH2RequestContext<SSL, DEBUG>>(
+            user_route, req, resp,
+        );
+    }
+
+    pub fn on_h2_404(_this: &mut Self, _req: &mut uws::H2::Request, resp: &mut uws::H2::Response) {
+        if !Self::HAS_H2 {
+            unreachable!();
+        }
+        resp.write_status(b"404 Not Found");
+        resp.end(b"", false);
+    }
+
     pub fn on_h3_request(&mut self, req: &mut uws::H3::Request, resp: &mut uws::H3::Response) {
         if !Self::HAS_H3 {
             unreachable!();
@@ -2894,6 +3004,8 @@ where
         let server_request_list = Self::js_route_list_get_cached(server_js).unwrap();
         let call_route = if Ctx::IS_H3 {
             Bun__ServerRouteList__callRouteH3
+        } else if Ctx::IS_H2 {
+            Bun__ServerRouteList__callRouteH2
         } else {
             Bun__ServerRouteList__callRoute
         };
@@ -3004,9 +3116,9 @@ where
         //
         // We first validate the self-reported request body length so that
         // we avoid needing to worry as much about what memory to free.
-        // RFC 9114 §4.2: an HTTP/3 message containing a transfer-encoding
-        // header field is malformed.
-        if Ctx::IS_H3 {
+        // RFC 9113 §8.2.2 / RFC 9114 §4.2: an HTTP/2 or HTTP/3 message
+        // containing a transfer-encoding header field is malformed.
+        if Ctx::IS_MUX {
             if ReqLike::header(req, b"transfer-encoding").is_some() {
                 RespLike::write_status(resp, b"400 Bad Request");
                 RespLike::end_without_body(resp, false);
@@ -3027,12 +3139,13 @@ where
                     0
                 };
 
-                // Abort the request very early. For H3 a per-request error
-                // is a stream error (RFC 9114 §4.1.2); close_connection
-                // would CONNECTION_CLOSE every sibling stream on the conn.
+                // Abort the request very early. For H2/H3 a per-request error
+                // is a stream error (RFC 9113 §8 / RFC 9114 §4.1.2);
+                // close_connection would tear down every sibling stream on
+                // the connection.
                 if len > self.config.max_request_body_size {
                     RespLike::write_status(resp, b"413 Request Entity Too Large");
-                    RespLike::end_without_body(resp, !Ctx::IS_H3);
+                    RespLike::end_without_body(resp, !Ctx::IS_MUX);
                     return None;
                 }
 
@@ -3080,6 +3193,22 @@ where
                     "H3 request dispatched but h3_request_pool was never allocated (listen() H3 path not taken)"
                 );
                 let slot = (*self.h3_request_pool).claim();
+                Ctx::create_in(
+                    slot.addr().as_ptr().cast(),
+                    self_ptr,
+                    req,
+                    resp,
+                    should_deinit_context,
+                    method,
+                );
+                // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
+                slot.assume_init().as_ptr().cast()
+            } else if Ctx::IS_H2 {
+                debug_assert!(
+                    !self.h2_request_pool.is_null(),
+                    "H2 request dispatched but h2_request_pool was never allocated (listen() H2 path not taken)"
+                );
+                let slot = (*self.h2_request_pool).claim();
                 Ctx::create_in(
                     slot.addr().as_ptr().cast(),
                     self_ptr,
@@ -3144,15 +3273,17 @@ where
         let request_object: &mut Request = unsafe { &mut *request_object_ptr };
 
         // The lazy `getRequest()` path that backs Request.url / .headers
-        // is `*uws.Request`-typed; for HTTP/3 we populate both eagerly so
-        // the rest of the pipeline never needs to know which transport
-        // delivered the bytes.
-        if Ctx::IS_H3 {
-            // SAFETY: create_from_h3 returns a +1-ref FetchHeaders; adopt into RAII wrapper.
+        // is `*uws.Request`-typed; for HTTP/2 and HTTP/3 we populate both
+        // eagerly so the rest of the pipeline never needs to know which
+        // transport delivered the bytes.
+        if Ctx::IS_MUX {
+            // SAFETY: create_from_h2/h3 return a +1-ref FetchHeaders; adopt into RAII wrapper.
             request_object.set_fetch_headers(Some(unsafe {
-                crate::webcore::response::HeadersRef::adopt(FetchHeaders::create_from_h3(
-                    std::ptr::from_mut(req).cast::<c_void>(),
-                ))
+                crate::webcore::response::HeadersRef::adopt(if Ctx::IS_H2 {
+                    FetchHeaders::create_from_h2(std::ptr::from_mut(req).cast::<c_void>())
+                } else {
+                    FetchHeaders::create_from_h3(std::ptr::from_mut(req).cast::<c_void>())
+                })
             }));
             // NOTE: `ReqLike::{url,header}` both borrow `&mut req`; the
             // returned slices alias the same uWS-owned header buffer. Format
@@ -3197,10 +3328,11 @@ where
             ctx.set_request_body_content_len(req_len);
             let is_te = ReqLike::header(req, b"transfer-encoding").is_some();
             ctx.set_is_transfer_encoding(is_te);
-            // HTTP/3 (RFC 9114 §4.2.2): Content-Length is optional and
-            // Transfer-Encoding is forbidden; the body is terminated by
-            // the QUIC stream FIN, so always arm onData for body methods.
-            if req_len > 0 || is_te || Ctx::IS_H3 {
+            // HTTP/2 (RFC 9113) / HTTP/3 (RFC 9114 §4.2.2): Content-Length is
+            // optional and Transfer-Encoding is forbidden; the body is
+            // terminated by the stream END_STREAM/FIN, so always arm onData
+            // for body methods.
+            if req_len > 0 || is_te || Ctx::IS_MUX {
                 // we defer pre-allocating the body until we receive the first chunk
                 // that way if the client is lying about how big the body is or the client aborts
                 // we don't waste memory
@@ -4004,6 +4136,16 @@ unsafe extern "C" {
         route_list_object: JSValue,
         request_object: &mut JSValue,
         req: *mut c_void, // *uws.Request
+    ) -> JSValue;
+
+    safe fn Bun__ServerRouteList__callRouteH2(
+        global: &JSGlobalObject,
+        index: u32,
+        request_ptr: *mut Request,
+        server_object: JSValue,
+        route_list_object: JSValue,
+        request_object: &mut JSValue,
+        req: *mut c_void,
     ) -> JSValue;
 
     safe fn Bun__ServerRouteList__callRouteH3(

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -208,9 +208,7 @@ impl HasAutoFlusher for file_sink::FileSink {
     }
 }
 
-impl<const SSL: bool, const HTTP3: bool> HasAutoFlusher
-    for streams::HTTPServerWritable<SSL, HTTP3>
-{
+impl<const SSL: bool, const MUX: u8> HasAutoFlusher for streams::HTTPServerWritable<SSL, MUX> {
     #[inline]
     fn auto_flusher(&self) -> &AutoFlusher {
         &self.auto_flusher

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -76,6 +76,7 @@ pub enum Start {
     FileSink(FileSinkOptions),
     HTTPSResponseSink,
     HTTPResponseSink,
+    H2ResponseSink,
     H3ResponseSink,
     NetworkSink,
     Ready,
@@ -93,6 +94,7 @@ pub enum StartTag {
     FileSink,
     HTTPSResponseSink,
     HTTPResponseSink,
+    H2ResponseSink,
     H3ResponseSink,
     NetworkSink,
     Ready,
@@ -159,6 +161,9 @@ impl Start {
             }
             StartTag::HTTPResponseSink => {
                 Self::from_js_with_tag::<{ StartTag::HTTPResponseSink }>(global_this, value)
+            }
+            StartTag::H2ResponseSink => {
+                Self::from_js_with_tag::<{ StartTag::H2ResponseSink }>(global_this, value)
             }
             StartTag::H3ResponseSink => {
                 Self::from_js_with_tag::<{ StartTag::H3ResponseSink }>(global_this, value)
@@ -277,6 +282,7 @@ impl Start {
             StartTag::NetworkSink
             | StartTag::HTTPSResponseSink
             | StartTag::HTTPResponseSink
+            | StartTag::H2ResponseSink
             | StartTag::H3ResponseSink => {
                 let mut empty = true;
                 let mut chunk_size: BlobSizeType = 2048;
@@ -974,10 +980,10 @@ impl SignalVTable {
 // Selecting the response type from the const generics would require an
 // associated-type trait keyed on them. The pointer is kept opaque at the
 // type level; all dispatch happens at runtime through `any_res()` / `uws::AnyResponse`.
-pub type UwsResponse<const SSL: bool, const HTTP3: bool> = c_void;
+pub type UwsResponse<const SSL: bool, const MUX: u8> = c_void;
 
-pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
-    pub res: Option<*mut UwsResponse<SSL, HTTP3>>,
+pub struct HTTPServerWritable<const SSL: bool, const MUX: u8> {
+    pub res: Option<*mut UwsResponse<SSL, MUX>>,
     pub buffer: Vec<u8>,
     pub pooled_buffer: Option<NonNull<ByteListPoolNode>>,
     pub offset: BlobSizeType,
@@ -1017,7 +1023,7 @@ pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub auto_flusher: AutoFlusher,
 }
 
-impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTTP3> {
+impl<const SSL: bool, const MUX: u8> Default for HTTPServerWritable<SSL, MUX> {
     fn default() -> Self {
         Self {
             res: None,
@@ -1043,7 +1049,7 @@ impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTT
     }
 }
 
-impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
+impl<const SSL: bool, const MUX: u8> HTTPServerWritable<SSL, MUX> {
     /// Borrow the JS global stored at construction.
     ///
     /// Invariant: `global_this` is set before first use (any auto-flusher
@@ -1065,8 +1071,10 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.buffer.capacity() as usize
     }
 
-    pub const NAME: &'static str = if HTTP3 {
+    pub const NAME: &'static str = if MUX == uws::MUX_H3 {
         "H3ResponseSink"
+    } else if MUX == uws::MUX_H2 {
+        "H2ResponseSink"
     } else if SSL {
         "HTTPSResponseSink"
     } else {
@@ -1077,24 +1085,27 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
 /// Per-monomorphization JSSink wrapper alias. Mirrors
 /// `pub const JSSink = Sink.JSSink(@This(), name)`.
-pub type HTTPServerWritableJSSink<const SSL: bool, const HTTP3: bool> =
-    crate::webcore::sink::JSSink<HTTPServerWritable<SSL, HTTP3>>;
+pub type HTTPServerWritableJSSink<const SSL: bool, const MUX: u8> =
+    crate::webcore::sink::JSSink<HTTPServerWritable<SSL, MUX>>;
 
 // `HTTPServerWritable` is exposed to JS via `Sink.JSSink(@This(), name)` where
-// `name` ∈ {HTTPResponseSink, HTTPSResponseSink, H3ResponseSink}. Const-generics
-// can't drive `#[link_name]`, so declare all three extern sets in a private mod
-// and dispatch at call time on `(SSL, HTTP3)`. The branch is on const generics;
-// the optimizer folds it to a direct call per monomorphization.
+// `name` ∈ {HTTPResponseSink, HTTPSResponseSink, H2ResponseSink, H3ResponseSink}.
+// Const-generics can't drive `#[link_name]`, so declare all four extern sets in a
+// private mod and dispatch at call time on `(SSL, MUX)`. The branch is on const
+// generics; the optimizer folds it to a direct call per monomorphization.
 mod http_sink_abi {
     crate::decl_js_sink_externs!("HTTPResponseSink" as http);
     crate::decl_js_sink_externs!("HTTPSResponseSink" as https);
+    crate::decl_js_sink_externs!("H2ResponseSink" as h2);
     crate::decl_js_sink_externs!("H3ResponseSink" as h3);
 }
 
 macro_rules! http_sink_dispatch {
     ($f:ident($($arg:expr),*)) => {
-        if HTTP3 {
+        if MUX == uws::MUX_H3 {
             http_sink_abi::h3::$f($($arg),*)
+        } else if MUX == uws::MUX_H2 {
+            http_sink_abi::h2::$f($($arg),*)
         } else if SSL {
             http_sink_abi::https::$f($($arg),*)
         } else {
@@ -1103,8 +1114,8 @@ macro_rules! http_sink_dispatch {
     };
 }
 
-impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkAbi
-    for HTTPServerWritable<SSL, HTTP3>
+impl<const SSL: bool, const MUX: u8> crate::webcore::sink::JsSinkAbi
+    for HTTPServerWritable<SSL, MUX>
 {
     fn from_js_extern(value: JSValue) -> usize {
         http_sink_dispatch!(from_js(value))
@@ -1138,13 +1149,15 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkAbi
     }
 }
 
-impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
+impl<const SSL: bool, const MUX: u8> HTTPServerWritable<SSL, MUX> {
     /// Const-generic → runtime dispatch for the type-erased `res` field.
     #[inline]
     fn any_res(&self) -> Option<uws::AnyResponse> {
         let res = self.res?;
-        Some(if HTTP3 {
+        Some(if MUX == uws::MUX_H3 {
             uws::AnyResponse::H3(res.cast::<uws::H3::Response>())
+        } else if MUX == uws::MUX_H2 {
+            uws::AnyResponse::H2(res.cast::<uws::H2::Response>())
         } else if SSL {
             uws::AnyResponse::SSL(res.cast::<uws::Response<true>>())
         } else {
@@ -1337,7 +1350,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         &self.buffer[self.offset as usize..]
     }
 
-    pub fn on_writable(&mut self, write_offset: u64, _res: *mut UwsResponse<SSL, HTTP3>) -> bool {
+    pub fn on_writable(&mut self, write_offset: u64, _res: *mut UwsResponse<SSL, MUX>) -> bool {
         // write_offset is the amount of data that was written not how much we need to write
         bun_core::scoped_log!(HTTPServerWritableLog, "onWritable ({})", write_offset);
         // onWritable reset backpressure state to allow flushing
@@ -1999,13 +2012,15 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 // `JsSinkType` impl: routes the codegen `${name}__{construct,write,end,flush,
 // start,getInternalFd,memoryCost}` thunks (via `JSSink::<Self>::js_*`) into
 // the inherent streaming methods above. Mirrors `Sink.JSSink(@This(), name)`.
-impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkType
-    for HTTPServerWritable<SSL, HTTP3>
+impl<const SSL: bool, const MUX: u8> crate::webcore::sink::JsSinkType
+    for HTTPServerWritable<SSL, MUX>
 {
     const NAME: &'static str = Self::NAME;
     const HAS_FLUSH_FROM_JS: bool = true;
-    const START_TAG: Option<StartTag> = Some(if HTTP3 {
+    const START_TAG: Option<StartTag> = Some(if MUX == uws::MUX_H3 {
         StartTag::H3ResponseSink
+    } else if MUX == uws::MUX_H2 {
+        StartTag::H2ResponseSink
     } else if SSL {
         StartTag::HTTPSResponseSink
     } else {
@@ -2050,9 +2065,10 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkType
     }
 }
 
-pub type HTTPSResponseSink = HTTPServerWritable<true, false>;
-pub type HTTPResponseSink = HTTPServerWritable<false, false>;
-pub type H3ResponseSink = HTTPServerWritable<true, true>;
+pub type HTTPSResponseSink = HTTPServerWritable<true, { uws::MUX_H1 }>;
+pub type HTTPResponseSink = HTTPServerWritable<false, { uws::MUX_H1 }>;
+pub type H2ResponseSink = HTTPServerWritable<true, { uws::MUX_H2 }>;
+pub type H3ResponseSink = HTTPServerWritable<true, { uws::MUX_H3 }>;
 
 // ──────────────────────────────────────────────────────────────────────────
 // NetworkSink

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -31,7 +31,7 @@ pub use bun_uws_sys::{
 /// hook, so no `catch_unwind` wrapper is emitted.
 pub use bun_jsc_macros::uws_callback;
 pub use bun_uws_sys::response::State;
-pub use bun_uws_sys::{h3 as H3, quic, udp, vtable};
+pub use bun_uws_sys::{h2 as H2, h3 as H3, quic, udp, vtable};
 pub type Socket = us_socket_t;
 
 /// Bare BoringSSL `SSL_CTX`. `SSL_CTX_up_ref`/`SSL_CTX_free` is the refcount;
@@ -47,6 +47,13 @@ pub type SslCtx = bun_boringssl::c::SSL_CTX;
 /// (`bun_runtime::server`, `bake::dev_server`) all name the *same* opaque.
 pub use bun_uws_sys::WebSocketUpgradeContext;
 
+/// Multiplexing selector for the `const MUX: u8` generic on request/response
+/// contexts. `MUX_H1` covers both plain TCP and TLS HTTP/1.1 (SSL is a
+/// separate const); `MUX_H2`/`MUX_H3` are always TLS.
+pub const MUX_H1: u8 = 0;
+pub const MUX_H2: u8 = 1;
+pub const MUX_H3: u8 = 2;
+
 /// Recovers the concrete uWS response type from `*mut c_void` across the
 /// Rust→C++ boundary. Mirrors `UWSResponseKind` in headers-handwritten.h.
 #[repr(i32)]
@@ -55,16 +62,21 @@ pub enum ResponseKind {
     Tcp = 0,
     Ssl = 1,
     H3 = 2,
+    H2 = 3,
 }
 
 impl ResponseKind {
-    pub const fn from(ssl: bool, http3: bool) -> ResponseKind {
-        if http3 {
-            ResponseKind::H3
-        } else if ssl {
-            ResponseKind::Ssl
-        } else {
-            ResponseKind::Tcp
+    pub const fn from(ssl: bool, mux: u8) -> ResponseKind {
+        match mux {
+            MUX_H3 => ResponseKind::H3,
+            MUX_H2 => ResponseKind::H2,
+            _ => {
+                if ssl {
+                    ResponseKind::Ssl
+                } else {
+                    ResponseKind::Tcp
+                }
+            }
         }
     }
 }

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -1,5 +1,6 @@
 use core::ffi::c_ushort;
 
+use crate::h2::Request as H2Request;
 use crate::h3::Request as H3Request;
 
 /// Transport-agnostic request handle. Static/file routes (and RangeRequest)
@@ -8,6 +9,7 @@ use crate::h3::Request as H3Request;
 pub enum AnyRequest {
     H1(*mut Request),
     H3(*mut H3Request),
+    H2(*mut H2Request),
 }
 
 impl AnyRequest {
@@ -18,24 +20,28 @@ impl AnyRequest {
         match self {
             Self::H1(r) => bun_opaque::opaque_deref_mut(*r).header(name),
             Self::H3(r) => bun_opaque::opaque_deref_mut(*r).header(name),
+            Self::H2(r) => bun_opaque::opaque_deref_mut(*r).header(name),
         }
     }
     pub fn method(&self) -> &[u8] {
         match self {
             Self::H1(r) => bun_opaque::opaque_deref_mut(*r).method(),
             Self::H3(r) => bun_opaque::opaque_deref_mut(*r).method(),
+            Self::H2(r) => bun_opaque::opaque_deref_mut(*r).method(),
         }
     }
     pub fn url(&self) -> &[u8] {
         match self {
             Self::H1(r) => bun_opaque::opaque_deref_mut(*r).url(),
             Self::H3(r) => bun_opaque::opaque_deref_mut(*r).url(),
+            Self::H2(r) => bun_opaque::opaque_deref_mut(*r).url(),
         }
     }
     pub fn set_yield(&mut self, y: bool) {
         match self {
             Self::H1(r) => bun_opaque::opaque_deref_mut(*r).set_yield(y),
             Self::H3(r) => bun_opaque::opaque_deref_mut(*r).set_yield(y),
+            Self::H2(r) => bun_opaque::opaque_deref_mut(*r).set_yield(y),
         }
     }
 }

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -611,16 +611,20 @@ unsafe impl<const SSL: bool> OpaqueHandle for Response<SSL> {}
 // SAFETY: `h3::Response` is a `#[repr(C)]` ZST (`UnsafeCell<[u8; 0]>`) with
 // align 1; C++ owns the real bytes.
 unsafe impl OpaqueHandle for H3Response {}
+// SAFETY: `h2::Response` is a `#[repr(C)]` ZST (`UnsafeCell<[u8; 0]>`) with
+// align 1; C++ owns the real bytes.
+unsafe impl OpaqueHandle for H2Response {}
 
 #[derive(Clone, Copy)]
 pub enum AnyResponse {
     SSL(*mut TLSResponse),
     TCP(*mut TCPResponse),
     H3(*mut H3Response),
+    H2(*mut H2Response),
 }
 
 // Helper: dispatch to the underlying response, calling the same-named method on each
-// variant. The three arms are written out by hand.
+// variant. The four arms are written out by hand.
 //
 // The per-variant `*mut → &mut` deref is internalized via `OpaqueHandle`
 // (S019): each variant payload is a ZST opaque, so the deref is sound by
@@ -640,16 +644,21 @@ macro_rules! any_dispatch {
                 let $r = H3Response::as_handle(ptr);
                 $body
             }
+            AnyResponse::H2(ptr) => {
+                let $r = H2Response::as_handle(ptr);
+                $body
+            }
         }
     };
 }
 
-/// Stamp the per-variant ZST adapter triplet and register it via the matching
-/// `Response<SSL>` / `H3Response` `$method`.
+/// Stamp the per-variant ZST adapter set and register it via the matching
+/// `Response<SSL>` / `H2Response` / `H3Response` `$method`.
 /// Each arm is a generic fn *item* monomorphized over `<U, H>`,
 /// so it is itself a ZST satisfying both the `Response<SSL>` bound
-/// (`Fn(*mut U, …)`) and the `H3Response` bound (`Fn(&mut U, …)`). The H3 arm
-/// bridges its `&mut U` to the body's uniform `*mut U` via `ptr::from_mut`.
+/// (`Fn(*mut U, …)`) and the `H2Response`/`H3Response` bound (`Fn(&mut U, …)`).
+/// The H2/H3 arms bridge their `&mut U` to the body's uniform `*mut U` via
+/// `ptr::from_mut`.
 ///
 /// Syntax:
 ///   any_response_register_cb! {
@@ -657,8 +666,8 @@ macro_rules! any_dispatch {
 ///       <U, H: [bounds…]>
 ///       |u $(, pre: PreTy)* ; r, any $(, post: PostTy)*| -> Ret { body }
 ///   }
-/// - `u` is bound as `*mut U` in the body (H3's `&mut U` is rebound).
-/// - `r` is the typed `&mut {TLS,TCP,H3}Response` param; `any` is the
+/// - `u` is bound as `*mut U` in the body (H2/H3's `&mut U` is rebound).
+/// - `r` is the typed `&mut {TLS,TCP,H2,H3}Response` param; `any` is the
 ///   `AnyResponse` re-wrap of `r`. Underscore-prefix either if unused.
 macro_rules! any_response_register_cb {
     (
@@ -681,10 +690,16 @@ macro_rules! any_response_register_cb {
             let $any = AnyResponse::H3(std::ptr::from_mut($r));
             $($body)*
         }
+        fn h2<$U, $H: $($bound)*>($u: &mut $U $(, $pre: $pre_ty)*, $r: &mut H2Response $(, $post: $post_ty)*) -> $ret {
+            let $u = std::ptr::from_mut::<$U>($u);
+            let $any = AnyResponse::H2(std::ptr::from_mut($r));
+            $($body)*
+        }
         match $self {
             AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).$method(ssl::<$U, $H>, $opt_data),
             AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).$method(tcp::<$U, $H>, $opt_data),
             AnyResponse::H3(ptr) => H3Response::as_handle(ptr).$method(h3::<$U, $H>, $opt_data),
+            AnyResponse::H2(ptr) => H2Response::as_handle(ptr).$method(h2::<$U, $H>, $opt_data),
         }
     }};
 }
@@ -695,6 +710,7 @@ impl AnyResponse {
             AnyResponse::SSL(resp) => resp,
             AnyResponse::TCP(_) => panic!("Expected SSL response, got TCP response"),
             AnyResponse::H3(_) => panic!("Expected SSL response, got H3 response"),
+            AnyResponse::H2(_) => panic!("Expected SSL response, got H2 response"),
         }
     }
 
@@ -703,6 +719,7 @@ impl AnyResponse {
             AnyResponse::SSL(_) => panic!("Expected TCP response, got SSL response"),
             AnyResponse::TCP(resp) => resp,
             AnyResponse::H3(_) => panic!("Expected TCP response, got H3 response"),
+            AnyResponse::H2(_) => panic!("Expected TCP response, got H2 response"),
         }
     }
 
@@ -729,6 +746,7 @@ impl AnyResponse {
     pub fn socket(self) -> *mut c::uws_res {
         match self {
             AnyResponse::H3(_) => panic!("socket() is not available for HTTP/3 responses"),
+            AnyResponse::H2(_) => panic!("socket() is not available for HTTP/2 responses"),
             AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).downcast(),
             AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).downcast(),
         }
@@ -850,12 +868,14 @@ impl AnyResponse {
                     .close(crate::us_socket::CloseCode::failure);
             }
             AnyResponse::H3(ptr) => H3Response::as_handle(ptr).force_close(),
+            AnyResponse::H2(ptr) => H2Response::as_handle(ptr).force_close(),
         }
     }
 
     pub fn get_native_handle(self) -> Fd {
         match self {
             AnyResponse::H3(_) => bun_core::Fd::INVALID,
+            AnyResponse::H2(_) => bun_core::Fd::INVALID,
             AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).get_native_handle(),
             AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).get_native_handle(),
         }
@@ -947,10 +967,11 @@ impl AnyResponse {
         ctx: Option<&mut WebSocketUpgradeContext>,
     ) -> *mut Socket {
         match self {
-            // server.upgrade() returns false before reaching here for H3
-            // (request_context.get(RequestContext) is null — the H3 ctx is a
+            // server.upgrade() returns false before reaching here for H3/H2
+            // (request_context.get(RequestContext) is null — the H3/H2 ctx is a
             // different type and upgrade_context is never set).
             AnyResponse::H3(_) => unreachable!(),
+            AnyResponse::H2(_) => unreachable!(),
             AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).upgrade(
                 data,
                 sec_web_socket_key,
@@ -987,8 +1008,15 @@ impl From<*mut H3Response> for AnyResponse {
         AnyResponse::H3(r)
     }
 }
+impl From<*mut H2Response> for AnyResponse {
+    #[inline]
+    fn from(r: *mut H2Response) -> Self {
+        AnyResponse::H2(r)
+    }
+}
 
 pub(crate) type H3Response = crate::h3::Response;
+pub(crate) type H2Response = crate::h2::Response;
 
 bitflags::bitflags! {
     /// Non-exhaustive bitset — values may carry

--- a/src/uws_sys/h2.rs
+++ b/src/uws_sys/h2.rs
@@ -1,0 +1,630 @@
+//! HTTP/2 bindings. Method names mirror NewApp/NewResponse/h3 1:1 so callers
+//! (including the AnyResponse dispatch arms) see the same surface regardless
+//! of transport.
+//!
+//! Unlike H3 (separate UDP socket), H2 shares the parent SSLApp's TLS
+//! listener via ALPN — `App::create` takes the parent `*mut App<true>`
+//! rather than TLS options, and there is no `listen()`/`ListenSocket`.
+
+use core::ffi::c_void;
+use core::ptr;
+
+use crate::SocketAddress;
+use crate::response::{State, WriteResult};
+use crate::thunk;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Request
+// ──────────────────────────────────────────────────────────────────────────
+
+bun_opaque::opaque_ffi! { pub struct Request; }
+
+impl Request {
+    pub fn set_yield(&mut self, y: bool) {
+        c::uws_h2_req_set_yield(self, y)
+    }
+    pub fn url(&mut self) -> &[u8] {
+        let mut p: *const u8 = ptr::null();
+        let n = c::uws_h2_req_get_url(self, &mut p);
+        // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
+        unsafe { bun_core::ffi::slice(p, n) }
+    }
+    pub fn method(&mut self) -> &[u8] {
+        let mut p: *const u8 = ptr::null();
+        let n = c::uws_h2_req_get_method(self, &mut p);
+        // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
+        unsafe { bun_core::ffi::slice(p, n) }
+    }
+    pub fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
+        let mut p: *const u8 = ptr::null();
+        // SAFETY: self is a live FFI handle; name ptr/len valid for read; out-ptr is a valid local
+        let n = unsafe { c::uws_h2_req_get_header(self, name.as_ptr(), name.len(), &raw mut p) };
+        if n == 0 {
+            None
+        } else {
+            // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
+            Some(unsafe { bun_core::ffi::slice(p, n) })
+        }
+    }
+    pub fn parameter(&mut self, idx: u16) -> &[u8] {
+        let mut p: *const u8 = ptr::null();
+        let n = c::uws_h2_req_get_parameter(self, idx, &mut p);
+        // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
+        unsafe { bun_core::ffi::slice(p, n) }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Response
+// ──────────────────────────────────────────────────────────────────────────
+
+bun_opaque::opaque_ffi! { pub struct Response; }
+
+impl Response {
+    pub fn end(&mut self, data: &[u8], close_connection: bool) {
+        // SAFETY: self is a live FFI handle; data ptr/len valid for read
+        unsafe { c::uws_h2_res_end(self, data.as_ptr(), data.len(), close_connection) }
+    }
+    pub fn try_end(&mut self, data: &[u8], total: usize, close_connection: bool) -> bool {
+        // SAFETY: self is a live FFI handle; data ptr/len valid for read
+        unsafe { c::uws_h2_res_try_end(self, data.as_ptr(), data.len(), total, close_connection) }
+    }
+    pub fn end_without_body(&mut self, close_connection: bool) {
+        c::uws_h2_res_end_without_body(self, close_connection)
+    }
+    pub fn end_stream(&mut self, close_connection: bool) {
+        c::uws_h2_res_end_stream(self, close_connection)
+    }
+    pub fn end_send_file(&mut self, write_offset: u64, close_connection: bool) {
+        c::uws_h2_res_end_sendfile(self, write_offset, close_connection)
+    }
+    pub fn write(&mut self, data: &[u8]) -> WriteResult {
+        let mut len: usize = data.len();
+        // SAFETY: self is a live FFI handle; data ptr valid for read; len out-ptr is a valid local
+        if unsafe { c::uws_h2_res_write(self, data.as_ptr(), &raw mut len) } {
+            WriteResult::WantMore(len)
+        } else {
+            WriteResult::Backpressure(len)
+        }
+    }
+    pub fn try_write_body(&mut self, data: &[u8], _is_first: bool) -> usize {
+        // node:http (the only caller) never reaches HTTP/2; fall through to
+        // the copying write for AnyResponse dispatch parity.
+        let _ = self.write(data);
+        data.len()
+    }
+    pub fn spill_body(&mut self, data: &[u8]) {
+        let _ = self.write(data);
+    }
+    pub fn write_status(&mut self, status: &[u8]) {
+        // SAFETY: self is a live FFI handle; status ptr/len valid for read
+        unsafe { c::uws_h2_res_write_status(self, status.as_ptr(), status.len()) }
+    }
+    pub fn write_header(&mut self, key: &[u8], value: &[u8]) {
+        // SAFETY: self is a live FFI handle; key/value ptr+len valid for read
+        unsafe {
+            c::uws_h2_res_write_header(self, key.as_ptr(), key.len(), value.as_ptr(), value.len())
+        }
+    }
+    pub fn write_header_int(&mut self, key: &[u8], value: u64) {
+        // SAFETY: self is a live FFI handle; key ptr/len valid for read
+        unsafe { c::uws_h2_res_write_header_int(self, key.as_ptr(), key.len(), value) }
+    }
+    pub fn write_mark(&mut self) {
+        c::uws_h2_res_write_mark(self)
+    }
+    pub fn mark_wrote_content_length_header(&mut self) {
+        c::uws_h2_res_mark_wrote_content_length_header(self)
+    }
+    pub fn mark_wrote_date_header(&mut self) {
+        c::uws_h2_res_mark_wrote_date_header(self)
+    }
+    pub fn write_continue(&mut self) {
+        c::uws_h2_res_write_continue(self)
+    }
+    pub fn write_informational(&mut self, _data: &[u8]) {
+        // node:http (the only caller) never reaches HTTP/2; kept for AnyResponse dispatch parity.
+    }
+    pub fn flush_headers(&mut self, immediate: bool) {
+        c::uws_h2_res_flush_headers(self, immediate)
+    }
+    pub fn pause(&mut self) {
+        c::uws_h2_res_pause(self)
+    }
+    pub fn resume(&mut self) {
+        c::uws_h2_res_resume(self)
+    }
+    pub fn timeout(&mut self, seconds: u8) {
+        c::uws_h2_res_timeout(self, seconds)
+    }
+    pub fn reset_timeout(&mut self) {
+        c::uws_h2_res_reset_timeout(self)
+    }
+    pub fn override_write_offset(&mut self, off: u64) {
+        c::uws_h2_res_override_write_offset(self, off)
+    }
+    pub fn get_buffered_amount(&mut self) -> u64 {
+        c::uws_h2_res_get_buffered_amount(self)
+    }
+    pub fn has_responded(&mut self) -> bool {
+        c::uws_h2_res_has_responded(self)
+    }
+    pub fn state(&mut self) -> State {
+        c::uws_h2_res_state(self)
+    }
+    pub fn should_close_connection(&mut self) -> bool {
+        self.state().is_http_connection_close()
+    }
+    pub fn is_corked(&self) -> bool {
+        false
+    }
+    pub fn uncork(&mut self) {}
+    pub fn is_connect_request(&self) -> bool {
+        false
+    }
+    pub fn prepare_for_sendfile(&mut self) {}
+    pub fn mark_needs_more(&mut self) {}
+    pub fn get_remote_socket_info(&mut self) -> Option<SocketAddress> {
+        let mut port: i32 = 0;
+        let mut is_ipv6: bool = false;
+        let mut ip_ptr: *const u8 = ptr::null();
+        let len = c::uws_h2_res_get_remote_address_info(self, &mut ip_ptr, &mut port, &mut is_ipv6);
+        if len == 0 {
+            return None;
+        }
+        // SAFETY: uws returns a pointer+len pair valid until the next address lookup
+        // on this thread; copied before returning.
+        let ip = unsafe { bun_core::ffi::slice(ip_ptr, len) };
+        Some(SocketAddress::new(ip, port, is_ipv6))
+    }
+    pub fn force_close(&mut self) {
+        c::uws_h2_res_force_close(self)
+    }
+
+    pub fn on_writable<UD, H>(&mut self, _handler: H, ud: *mut UD)
+    where
+        H: Fn(&mut UD, u64, &mut Response) -> bool + Copy + 'static,
+    {
+        // Safe fn item: nested local thunk, only coerced to the C-ABI
+        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
+        extern "C" fn cb<UD, H>(r: *mut Response, off: u64, p: *mut c_void) -> bool
+        where
+            H: Fn(&mut UD, u64, &mut Response) -> bool + Copy + 'static,
+        {
+            // SAFETY: uWS callback contract — `r` live, `p` is the registered `*mut UD`.
+            unsafe {
+                let Some(ud) = thunk::user_mut::<UD>(p) else {
+                    return true;
+                };
+                thunk::zst::<H>()(ud, off, thunk::handle_mut(r))
+            }
+        }
+        c::uws_h2_res_on_writable(self, Some(cb::<UD, H>), ud.cast())
+    }
+    pub fn clear_on_writable(&mut self) {
+        c::uws_h2_res_clear_on_writable(self)
+    }
+    pub fn on_aborted<UD, H>(&mut self, _handler: H, ud: *mut UD)
+    where
+        H: Fn(&mut UD, &mut Response) + Copy + 'static,
+    {
+        // Safe fn item: nested local thunk, only coerced to the C-ABI
+        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
+        extern "C" fn cb<UD, H>(r: *mut Response, p: *mut c_void)
+        where
+            H: Fn(&mut UD, &mut Response) + Copy + 'static,
+        {
+            // SAFETY: uWS callback contract — `r` live, `p` is the registered `*mut UD`.
+            unsafe {
+                let Some(ud) = thunk::user_mut::<UD>(p) else {
+                    return;
+                };
+                thunk::zst::<H>()(ud, thunk::handle_mut(r));
+            }
+        }
+        c::uws_h2_res_on_aborted(self, Some(cb::<UD, H>), ud.cast())
+    }
+    pub fn clear_aborted(&mut self) {
+        c::uws_h2_res_on_aborted(self, None, ptr::null_mut())
+    }
+    pub fn on_timeout<UD, H>(&mut self, _handler: H, ud: *mut UD)
+    where
+        H: Fn(&mut UD, &mut Response) + Copy + 'static,
+    {
+        // Safe fn item: nested local thunk, only coerced to the C-ABI
+        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
+        extern "C" fn cb<UD, H>(r: *mut Response, p: *mut c_void)
+        where
+            H: Fn(&mut UD, &mut Response) + Copy + 'static,
+        {
+            // SAFETY: uWS callback contract — `r` live, `p` is the registered `*mut UD`.
+            unsafe {
+                let Some(ud) = thunk::user_mut::<UD>(p) else {
+                    return;
+                };
+                thunk::zst::<H>()(ud, thunk::handle_mut(r));
+            }
+        }
+        c::uws_h2_res_on_timeout(self, Some(cb::<UD, H>), ud.cast())
+    }
+    pub fn clear_timeout(&mut self) {
+        c::uws_h2_res_on_timeout(self, None, ptr::null_mut())
+    }
+    pub fn on_data<UD, H>(&mut self, _handler: H, ud: *mut UD)
+    where
+        H: Fn(&mut UD, &mut Response, &[u8], bool) + Copy + 'static,
+    {
+        // Safe fn item: nested local thunk, only coerced to the C-ABI
+        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
+        extern "C" fn cb<UD, H>(
+            r: *mut Response,
+            chunk_ptr: *const u8,
+            len: usize,
+            last: bool,
+            p: *mut c_void,
+        ) where
+            H: Fn(&mut UD, &mut Response, &[u8], bool) + Copy + 'static,
+        {
+            // SAFETY: uWS callback contract — `r` live, `chunk_ptr[..len]` valid,
+            // `p` is the registered `*mut UD`.
+            unsafe {
+                let Some(ud) = thunk::user_mut::<UD>(p) else {
+                    return;
+                };
+                thunk::zst::<H>()(
+                    ud,
+                    thunk::handle_mut(r),
+                    thunk::c_slice(chunk_ptr, len),
+                    last,
+                );
+            }
+        }
+        c::uws_h2_res_on_data(self, Some(cb::<UD, H>), ud.cast())
+    }
+    pub fn clear_on_data(&mut self) {
+        c::uws_h2_res_on_data(self, None, ptr::null_mut())
+    }
+    pub fn corked(&mut self, handler: impl FnOnce()) {
+        // H2 has no corking; call the handler immediately.
+        let _ = self;
+        handler();
+    }
+    pub fn run_corked_with_type<UD>(&mut self, handler: fn(*mut UD), ud: *mut UD) {
+        // cork is synchronous, so we stack-allocate the (handler, ud) pair and
+        // recover it inside the trampoline — same shape as H1's
+        // `Response::run_corked_with_type` so `AnyResponse` can dispatch uniformly.
+        type Ctx<UD> = (fn(*mut UD), *mut UD);
+        // Safe fn item: nested local thunk, only coerced to the C-ABI
+        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
+        extern "C" fn cb<UD>(p: *mut c_void) {
+            // SAFETY: p points at a stack Ctx<UD> valid for this synchronous call.
+            let ctx = unsafe { &*p.cast::<Ctx<UD>>() };
+            (ctx.0)(ctx.1);
+        }
+        let mut ctx: Ctx<UD> = (handler, ud);
+        c::uws_h2_res_cork(self, (&raw mut ctx).cast(), cb::<UD>)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// App
+// ──────────────────────────────────────────────────────────────────────────
+
+bun_opaque::opaque_ffi! { pub struct App; }
+
+#[derive(Copy, Clone)]
+enum RouteKind {
+    Get,
+    Post,
+    Put,
+    Delete,
+    Patch,
+    Head,
+    Options,
+    Connect,
+    Trace,
+    Any,
+}
+
+/// Stamps one `pub fn $name<UD, H>(&mut self, p, ud, h)` per HTTP verb,
+/// each forwarding to [`App::route`] with the matching [`RouteKind`].
+/// `connect`/`trace` are intentionally omitted — h2 exposes those only via
+/// [`App::method`].
+macro_rules! h2_route_methods {
+    ($($name:ident => $kind:ident),* $(,)?) => {$(
+        pub fn $name<UD, H>(&mut self, p: &[u8], ud: *mut UD, h: H)
+        where
+            H: Fn(&mut UD, &mut Request, &mut Response) + Copy + 'static,
+        {
+            Self::route(RouteKind::$kind, self, p, ud, h);
+        }
+    )*};
+}
+
+impl App {
+    /// Attach to an existing SSLApp. Installs the ALPN callback on its
+    /// SSL_CTX and creates a child socket context that takes over
+    /// connections which negotiated "h2".
+    pub fn create(parent: *mut crate::app::App<true>, idle_timeout_s: u32) -> Option<*mut App> {
+        // SAFETY: parent is a live SSLApp FFI handle; uws owns the returned handle
+        let p = unsafe { c::uws_h2_create_app(parent.cast(), idle_timeout_s) };
+        if p.is_null() { None } else { Some(p) }
+    }
+    /// # Safety
+    /// `this` must be a live App handle previously returned by `App::create`;
+    /// it is freed by this call and must not be used afterwards.
+    pub unsafe fn destroy(this: *mut Self) {
+        // SAFETY: caller contract above
+        unsafe { c::uws_h2_app_destroy(this) }
+    }
+    pub fn close(&mut self) {
+        c::uws_h2_app_close(self)
+    }
+    pub fn clear_routes(&mut self) {
+        c::uws_h2_app_clear_routes(self)
+    }
+
+    fn route<UD, H>(which: RouteKind, this: &mut App, pattern: &[u8], ud: *mut UD, _handler: H)
+    where
+        H: Fn(&mut UD, &mut Request, &mut Response) + Copy + 'static,
+    {
+        // Safe fn item: nested local thunk, only coerced to the C-ABI
+        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
+        extern "C" fn cb<UD, H>(res: *mut Response, req: *mut Request, p: *mut c_void)
+        where
+            H: Fn(&mut UD, &mut Request, &mut Response) + Copy + 'static,
+        {
+            // SAFETY: uWS callback contract — `res`/`req` live disjoint handles,
+            // `p` is the registered `*mut UD` (non-null by route registration).
+            unsafe {
+                let Some(ud) = thunk::user_mut::<UD>(p) else {
+                    return;
+                };
+                thunk::zst::<H>()(ud, thunk::handle_mut(req), thunk::handle_mut(res));
+            }
+        }
+        let f = match which {
+            RouteKind::Get => c::uws_h2_app_get,
+            RouteKind::Post => c::uws_h2_app_post,
+            RouteKind::Put => c::uws_h2_app_put,
+            RouteKind::Delete => c::uws_h2_app_delete,
+            RouteKind::Patch => c::uws_h2_app_patch,
+            RouteKind::Head => c::uws_h2_app_head,
+            RouteKind::Options => c::uws_h2_app_options,
+            RouteKind::Connect => c::uws_h2_app_connect,
+            RouteKind::Trace => c::uws_h2_app_trace,
+            RouteKind::Any => c::uws_h2_app_any,
+        };
+        // SAFETY: this is a live FFI handle; pattern ptr/len valid for read; trampoline is `extern "C"`
+        unsafe {
+            f(
+                this,
+                pattern.as_ptr(),
+                pattern.len(),
+                Some(cb::<UD, H>),
+                ud.cast(),
+            )
+        }
+    }
+
+    h2_route_methods! {
+        get     => Get,
+        post    => Post,
+        put     => Put,
+        delete  => Delete,
+        patch   => Patch,
+        head    => Head,
+        options => Options,
+        any     => Any,
+    }
+
+    pub fn method<UD, H>(&mut self, m: bun_http_types::Method::Method, p: &[u8], ud: *mut UD, h: H)
+    where
+        H: Fn(&mut UD, &mut Request, &mut Response) + Copy + 'static,
+    {
+        use bun_http_types::Method::Method as M;
+        match m {
+            M::GET => self.get(p, ud, h),
+            M::POST => self.post(p, ud, h),
+            M::PUT => self.put(p, ud, h),
+            M::DELETE => self.delete(p, ud, h),
+            M::PATCH => self.patch(p, ud, h),
+            M::OPTIONS => self.options(p, ud, h),
+            M::HEAD => self.head(p, ud, h),
+            M::CONNECT => Self::route(RouteKind::Connect, self, p, ud, h),
+            M::TRACE => Self::route(RouteKind::Trace, self, p, ud, h),
+            _ => {}
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// extern "C"
+// ──────────────────────────────────────────────────────────────────────────
+
+mod c {
+    use super::*;
+
+    pub(super) type Handler =
+        Option<unsafe extern "C" fn(*mut Response, *mut Request, *mut c_void)>;
+
+    // Opaque handles in this module are `#[repr(C)]` with `UnsafeCell<[u8; 0]>`,
+    // so `&T`/`&mut T` are ABI-identical to a non-null pointer. Shims whose
+    // only pointer arg is the opaque handle (plus value types) are `safe fn`.
+    // Shims with (ptr,len), nullable raw, *mut c_void ctx stay unsafe.
+    unsafe extern "C" {
+        pub(super) fn uws_h2_create_app(parent: *mut c_void, idle_timeout_s: u32) -> *mut App;
+        pub(super) fn uws_h2_app_destroy(app: *mut App);
+        pub(super) safe fn uws_h2_app_close(app: &mut App);
+        pub(super) safe fn uws_h2_app_clear_routes(app: &mut App);
+        pub(super) safe fn uws_h2_res_write_continue(res: &mut Response);
+        pub(super) fn uws_h2_app_get(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_post(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_put(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_delete(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_patch(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_head(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_options(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_connect(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_trace(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+        pub(super) fn uws_h2_app_any(
+            app: *mut App,
+            p: *const u8,
+            n: usize,
+            h: Handler,
+            ud: *mut c_void,
+        );
+
+        pub(super) safe fn uws_h2_res_state(res: &mut Response) -> State;
+        pub(super) fn uws_h2_res_end(res: *mut Response, p: *const u8, n: usize, close: bool);
+        pub(super) safe fn uws_h2_res_end_stream(res: &mut Response, close: bool);
+        pub(super) safe fn uws_h2_res_force_close(res: &mut Response);
+        pub(super) fn uws_h2_res_try_end(
+            res: *mut Response,
+            p: *const u8,
+            n: usize,
+            total: usize,
+            close: bool,
+        ) -> bool;
+        pub(super) safe fn uws_h2_res_end_without_body(res: &mut Response, close: bool);
+        pub(super) safe fn uws_h2_res_pause(res: &mut Response);
+        pub(super) safe fn uws_h2_res_resume(res: &mut Response);
+        pub(super) fn uws_h2_res_write_status(res: *mut Response, p: *const u8, n: usize);
+        pub(super) fn uws_h2_res_write_header(
+            res: *mut Response,
+            kp: *const u8,
+            kn: usize,
+            vp: *const u8,
+            vn: usize,
+        );
+        pub(super) fn uws_h2_res_write_header_int(
+            res: *mut Response,
+            kp: *const u8,
+            kn: usize,
+            v: u64,
+        );
+        pub(super) safe fn uws_h2_res_mark_wrote_content_length_header(res: &mut Response);
+        pub(super) safe fn uws_h2_res_mark_wrote_date_header(res: &mut Response);
+        pub(super) safe fn uws_h2_res_write_mark(res: &mut Response);
+        pub(super) safe fn uws_h2_res_flush_headers(res: &mut Response, immediate: bool);
+        pub(super) fn uws_h2_res_write(res: *mut Response, p: *const u8, len: *mut usize) -> bool;
+        pub(super) safe fn uws_h2_res_override_write_offset(res: &mut Response, off: u64);
+        pub(super) safe fn uws_h2_res_has_responded(res: &mut Response) -> bool;
+        pub(super) safe fn uws_h2_res_get_buffered_amount(res: &mut Response) -> u64;
+        pub(super) safe fn uws_h2_res_reset_timeout(res: &mut Response);
+        pub(super) safe fn uws_h2_res_timeout(res: &mut Response, seconds: u8);
+        pub(super) safe fn uws_h2_res_end_sendfile(res: &mut Response, off: u64, close: bool);
+        // safe: `&mut Response` is ABI-identical to a non-null `*mut`;
+        // `cb`/`ud` are stored opaquely (never dereferenced by the C++ shim
+        // itself) — no preconditions on this call. Mirrors `uws_res_on_*`.
+        pub(super) safe fn uws_h2_res_on_writable(
+            res: &mut Response,
+            cb: Option<unsafe extern "C" fn(*mut Response, u64, *mut c_void) -> bool>,
+            ud: *mut c_void,
+        );
+        pub(super) safe fn uws_h2_res_clear_on_writable(res: &mut Response);
+        pub(super) safe fn uws_h2_res_on_aborted(
+            res: &mut Response,
+            cb: Option<unsafe extern "C" fn(*mut Response, *mut c_void)>,
+            ud: *mut c_void,
+        );
+        pub(super) safe fn uws_h2_res_on_timeout(
+            res: &mut Response,
+            cb: Option<unsafe extern "C" fn(*mut Response, *mut c_void)>,
+            ud: *mut c_void,
+        );
+        pub(super) safe fn uws_h2_res_on_data(
+            res: &mut Response,
+            cb: Option<unsafe extern "C" fn(*mut Response, *const u8, usize, bool, *mut c_void)>,
+            ud: *mut c_void,
+        );
+        // safe: cork is synchronous — `ud` is passed straight back to `cb`
+        // without being dereferenced by the C++ shim itself, so the call has
+        // no preconditions beyond the live opaque handle.
+        pub(super) safe fn uws_h2_res_cork(
+            res: &mut Response,
+            ud: *mut c_void,
+            cb: unsafe extern "C" fn(*mut c_void),
+        );
+        // Out-params are `&mut` (non-null, valid for write); the C shim only
+        // stores into them and returns a length — no read-through precondition.
+        pub(super) safe fn uws_h2_res_get_remote_address_info(
+            res: &mut Response,
+            ip: &mut *const u8,
+            port: &mut i32,
+            is_ipv6: &mut bool,
+        ) -> usize;
+
+        pub(super) safe fn uws_h2_req_set_yield(req: &mut Request, y: bool);
+        // Out-param `out` is `&mut *const u8` (non-null, valid for write); the C
+        // shim only stores a pointer into request-owned storage and returns its
+        // length — no read-through precondition, so `safe fn`.
+        pub(super) safe fn uws_h2_req_get_url(req: &mut Request, out: &mut *const u8) -> usize;
+        pub(super) safe fn uws_h2_req_get_method(req: &mut Request, out: &mut *const u8) -> usize;
+        pub(super) fn uws_h2_req_get_header(
+            req: *mut Request,
+            name: *const u8,
+            len: usize,
+            out: *mut *const u8,
+        ) -> usize;
+        pub(super) safe fn uws_h2_req_get_parameter(
+            req: &mut Request,
+            idx: u16,
+            out: &mut *const u8,
+        ) -> usize;
+    }
+}

--- a/src/uws_sys/h2.rs
+++ b/src/uws_sys/h2.rs
@@ -168,7 +168,8 @@ impl Response {
         let mut port: i32 = 0;
         let mut is_ipv6: bool = false;
         let mut ip_ptr: *const u8 = ptr::null();
-        let len = c::uws_h2_res_get_remote_address_info(self, &mut ip_ptr, &mut port, &mut is_ipv6);
+        let len = c::uws_h2_res_get_remote_address_info(self, &mut ip_ptr, &mut port, &mut is_ipv6)
+            as usize;
         if len == 0 {
             return None;
         }
@@ -607,7 +608,7 @@ mod c {
             ip: &mut *const u8,
             port: &mut i32,
             is_ipv6: &mut bool,
-        ) -> usize;
+        ) -> u64;
 
         pub(super) safe fn uws_h2_req_set_yield(req: &mut Request, y: bool);
         // Out-param `out` is `&mut *const u8` (non-null, valid for write); the C

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -358,6 +358,8 @@ pub mod app;
 pub mod body_reader_mixin;
 #[path = "ConnectingSocket.rs"]
 pub mod connecting_socket;
+#[path = "h2.rs"]
+pub mod h2;
 #[path = "h3.rs"]
 pub mod h3;
 #[path = "InternalLoopData.rs"]

--- a/src/uws_sys/libuwsockets_h2.cpp
+++ b/src/uws_sys/libuwsockets_h2.cpp
@@ -1,0 +1,291 @@
+// HTTP/2 C ABI for Zig. Mirrors the uws_h3_* surface in libuwsockets_h3.cpp
+// 1:1 (same parameter shapes, same callback signatures) so the Zig side can
+// pattern-match NewApp/NewResponse/H3 without protocol-specific branches.
+// Kept in its own TU so HTTP/1.1, HTTP/2 and HTTP/3 stay file-level
+// separable.
+
+// clang-format off
+#include "_libusockets.h"
+
+#include <bun-uws/src/App.h>
+#include <bun-uws/src/Http2App.h>
+#include <bun-uws/src/Http2Response.h>
+#include <bun-uws/src/Http2Request.h>
+#include <string_view>
+#include <string.h>
+// clang-format on
+
+extern "C" const char* ares_inet_ntop(int af, const char* src, char* dst, size_t size);
+
+using uWS::H2App;
+using uWS::Http2Request;
+using uWS::Http2Response;
+using uWS::Http2ResponseData;
+
+/* Unified-build: libuwsockets_h3.cpp defines equivalent string-view
+ * helpers (sv()/ffi_sv()) at file scope in the same TU. The h2 prefix
+ * already disambiguates; the anonymous namespace is belt-and-suspenders
+ * for that collision class. */
+namespace {
+inline std::string_view h2sv(const char* p, size_t n) { return p ? std::string_view { p, n } : std::string_view {}; }
+inline size_t h2out(std::string_view v, const char** dest)
+{
+    *dest = v.empty() ? "" : v.data();
+    return v.length();
+}
+}
+
+/* Bridges invoked from HttpContext<true>/TemplatedApp so those TUs don't
+ * need to include Http2App.h. */
+extern "C" us_socket_t* uws_internal_h2_adopt(void* h2Context,
+    us_socket_t* s, int oldExtSize, char* data, int length)
+{
+    return H2App::adoptIfNegotiated((uWS::Http2Context*)h2Context, s, oldExtSize, data, length);
+}
+
+extern "C" void uws_internal_h2_close_all(void* h2Context)
+{
+    us_socket_group_close_all(((uWS::Http2Context*)h2Context)->getSocketGroup());
+}
+
+extern "C" {
+
+typedef struct uws_h2_app_s uws_h2_app_t;
+typedef struct uws_h2_res_s uws_h2_res_t;
+typedef struct uws_h2_req_s uws_h2_req_t;
+
+typedef void (*uws_h2_method_handler)(uws_h2_res_t*, uws_h2_req_t*, void*);
+
+/* ───── app ───── */
+
+uws_h2_app_t* uws_h2_create_app(uws_app_t* parent, unsigned int idle_timeout_s)
+{
+    auto* sslApp = (uWS::TemplatedApp<true>*)parent;
+    return (uws_h2_app_t*)H2App::create(sslApp, idle_timeout_s);
+}
+
+void uws_h2_app_destroy(uws_h2_app_t* app) { delete (H2App*)app; }
+bool uws_h2_constructor_failed(uws_h2_app_t* app) { return !app || ((H2App*)app)->constructorFailed(); }
+void uws_h2_app_close(uws_h2_app_t* app) { ((H2App*)app)->close(); }
+void uws_h2_app_clear_routes(uws_h2_app_t* app) { ((H2App*)app)->clearRoutes(); }
+void* uws_h2_get_native_handle(uws_h2_app_t* app) { return ((H2App*)app)->getNativeHandle(); }
+
+#define H2_ROUTE(name, method)                                                                         \
+    void uws_h2_app_##name(uws_h2_app_t* app, const char* pattern, size_t pattern_len,                 \
+        uws_h2_method_handler handler, void* user_data)                                                \
+    {                                                                                                  \
+        if (handler == nullptr) return;                                                                \
+        ((H2App*)app)->method(h2sv(pattern, pattern_len), [handler, user_data](auto* res, auto* req) { \
+            handler((uws_h2_res_t*)res, (uws_h2_req_t*)req, user_data);                                \
+        });                                                                                            \
+    }
+H2_ROUTE(get, get)
+H2_ROUTE(post, post)
+H2_ROUTE(options, options)
+H2_ROUTE(delete, del)
+H2_ROUTE(patch, patch)
+H2_ROUTE(put, put)
+H2_ROUTE(head, head)
+H2_ROUTE(connect, connect)
+H2_ROUTE(trace, trace)
+H2_ROUTE(any, any)
+#undef H2_ROUTE
+
+/* ───── response ───── */
+
+int uws_h2_res_state(uws_h2_res_t* res) { return ((Http2Response*)res)->getHttpResponseData()->state; }
+
+void uws_h2_res_end(uws_h2_res_t* res, const char* data, size_t length, bool close_connection)
+{
+    Http2Response* r = (Http2Response*)res;
+    r->clearOnWritableAndAborted();
+    r->end(h2sv(data, length), close_connection);
+}
+
+void uws_h2_res_end_stream(uws_h2_res_t* res, bool close_connection)
+{
+    Http2Response* r = (Http2Response*)res;
+    r->clearOnWritableAndAborted();
+    r->sendTerminatingChunk(close_connection);
+}
+
+void uws_h2_res_force_close(uws_h2_res_t* res)
+{
+    Http2Response* r = (Http2Response*)res;
+    r->clearOnWritableAndAborted();
+    r->close();
+}
+
+bool uws_h2_res_try_end(uws_h2_res_t* res, const char* bytes, size_t len, size_t total_len, bool close)
+{
+    return ((Http2Response*)res)->tryEnd(h2sv(bytes, len), total_len, close).first;
+}
+
+void uws_h2_res_end_without_body(uws_h2_res_t* res, bool close_connection)
+{
+    Http2Response* r = (Http2Response*)res;
+    r->clearOnWritableAndAborted();
+    r->endWithoutBody(std::nullopt, close_connection);
+}
+
+void uws_h2_res_pause(uws_h2_res_t* res) { ((Http2Response*)res)->pause(); }
+void uws_h2_res_resume(uws_h2_res_t* res) { ((Http2Response*)res)->resume(); }
+void uws_h2_res_write_continue(uws_h2_res_t* res) { ((Http2Response*)res)->writeContinue(); }
+
+void uws_h2_res_write_status(uws_h2_res_t* res, const char* status, size_t length)
+{
+    ((Http2Response*)res)->writeStatus(h2sv(status, length));
+}
+
+void uws_h2_res_write_header(uws_h2_res_t* res, const char* key, size_t key_len,
+    const char* value, size_t value_len)
+{
+    ((Http2Response*)res)->writeHeader(h2sv(key, key_len), h2sv(value, value_len));
+}
+
+void uws_h2_res_write_header_int(uws_h2_res_t* res, const char* key, size_t key_len, uint64_t value)
+{
+    ((Http2Response*)res)->writeHeader(h2sv(key, key_len), value);
+}
+
+void uws_h2_res_mark_wrote_content_length_header(uws_h2_res_t* res)
+{
+    ((Http2Response*)res)->getHttpResponseData()->state |= Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+}
+
+void uws_h2_res_mark_wrote_date_header(uws_h2_res_t* res)
+{
+    ((Http2Response*)res)->getHttpResponseData()->state |= Http2ResponseData::HTTP_WROTE_DATE_HEADER;
+}
+
+void uws_h2_res_write_mark(uws_h2_res_t* res) { ((Http2Response*)res)->writeMark(); }
+void uws_h2_res_flush_headers(uws_h2_res_t* res, bool) { ((Http2Response*)res)->flushHeaders(); }
+
+bool uws_h2_res_write(uws_h2_res_t* res, const char* data, size_t* length)
+{
+    size_t written = 0;
+    bool ok = ((Http2Response*)res)->write(h2sv(data, *length), &written);
+    *length = written;
+    return ok;
+}
+
+uint64_t uws_h2_res_get_write_offset(uws_h2_res_t* res) { return ((Http2Response*)res)->getWriteOffset(); }
+void uws_h2_res_override_write_offset(uws_h2_res_t* res, uint64_t off) { ((Http2Response*)res)->overrideWriteOffset(off); }
+bool uws_h2_res_has_responded(uws_h2_res_t* res) { return ((Http2Response*)res)->hasResponded(); }
+size_t uws_h2_res_get_buffered_amount(uws_h2_res_t* res) { return ((Http2Response*)res)->getBufferedAmount(); }
+
+void uws_h2_res_reset_timeout(uws_h2_res_t*) {}
+void uws_h2_res_timeout(uws_h2_res_t*, uint8_t) {}
+void uws_h2_res_end_sendfile(uws_h2_res_t* res, uint64_t, bool close)
+{
+    ((Http2Response*)res)->sendTerminatingChunk(close);
+}
+void uws_h2_res_prepare_for_sendfile(uws_h2_res_t*) {}
+bool uws_h2_res_is_connect_request(uws_h2_res_t*) { return false; }
+void* uws_h2_res_get_native_handle(uws_h2_res_t* res) { return res; }
+void* uws_h2_res_get_socket_data(uws_h2_res_t* res) { return ((Http2Response*)res)->getSocketData(); }
+
+void uws_h2_res_on_writable(uws_h2_res_t* res, bool (*h)(uws_h2_res_t*, uint64_t, void*), void* opt)
+{
+    ((Http2Response*)res)->onWritable(opt, (Http2ResponseData::OnWritableCallback)h);
+}
+void uws_h2_res_clear_on_writable(uws_h2_res_t* res) { ((Http2Response*)res)->clearOnWritable(); }
+void uws_h2_res_on_aborted(uws_h2_res_t* res, void (*h)(uws_h2_res_t*, void*), void* opt)
+{
+    if (h)
+        ((Http2Response*)res)->onAborted(opt, (Http2ResponseData::OnAbortedCallback)h);
+    else
+        ((Http2Response*)res)->clearOnAborted();
+}
+void uws_h2_res_on_timeout(uws_h2_res_t* res, void (*h)(uws_h2_res_t*, void*), void* opt)
+{
+    if (h)
+        ((Http2Response*)res)->onTimeout(opt, (Http2ResponseData::OnTimeoutCallback)h);
+    else
+        ((Http2Response*)res)->clearOnTimeout();
+}
+void uws_h2_res_on_data(uws_h2_res_t* res, void (*h)(uws_h2_res_t*, const char*, size_t, bool, void*), void* opt)
+{
+    ((Http2Response*)res)->onData(opt, (Http2ResponseData::OnDataCallback)h);
+}
+
+void uws_h2_res_cork(uws_h2_res_t* res, void* ctx, void (*corker)(void*))
+{
+    ((Http2Response*)res)->cork([ctx, corker]() { corker(ctx); });
+}
+void uws_h2_res_uncork(uws_h2_res_t*) {}
+bool uws_h2_res_is_corked(uws_h2_res_t*) { return false; }
+
+uint64_t uws_h2_res_get_remote_address_info(uws_h2_res_t* res, const char** dest, int* port, bool* is_ipv6)
+{
+    /* Http2Response wraps a real us_socket_t. Mirror
+     * uws_res_get_remote_address_info (libuwsockets.cpp) and the H3
+     * wrapper: us_get_remote_address_info only memcpy()s raw
+     * in_addr/in6_addr bytes into b and sets *port — dest/is_ipv6 are
+     * vestigial — so stringify with inet_ntop here so the Zig side
+     * gets a text slice, not raw address bytes. */
+    static thread_local char b[64];
+    Http2Response* r = (Http2Response*)res;
+    int ipv6 = 0;
+    auto length = us_get_remote_address_info(b, r->socket, dest, port, &ipv6);
+    if (length == 0) {
+        *dest = b;
+        *is_ipv6 = false;
+        return 0;
+    }
+    if (length == 4) {
+        ares_inet_ntop(AF_INET, b, &b[4], 64 - 4);
+        *dest = &b[4];
+        *is_ipv6 = false;
+    } else {
+        ares_inet_ntop(AF_INET6, b, &b[16], 64 - 16);
+        *dest = &b[16];
+        *is_ipv6 = true;
+    }
+    return (uint64_t)strlen(*dest);
+}
+
+/* ───── request ───── */
+
+bool uws_h2_req_is_ancient(uws_h2_req_t*) { return false; }
+bool uws_h2_req_get_yield(uws_h2_req_t* req) { return ((Http2Request*)req)->getYield(); }
+void uws_h2_req_set_yield(uws_h2_req_t* req, bool y) { ((Http2Request*)req)->setYield(y); }
+
+size_t uws_h2_req_get_url(uws_h2_req_t* req, const char** dest)
+{
+    return h2out(((Http2Request*)req)->getFullUrl(), dest);
+}
+
+size_t uws_h2_req_get_method(uws_h2_req_t* req, const char** dest)
+{
+    return h2out(((Http2Request*)req)->getMethod(), dest);
+}
+
+size_t uws_h2_req_get_header(uws_h2_req_t* req, const char* lower, size_t lower_len, const char** dest)
+{
+    return h2out(((Http2Request*)req)->getHeader(h2sv(lower, lower_len)), dest);
+}
+
+void uws_h2_req_for_each_header(uws_h2_req_t* req,
+    void (*cb)(const char*, size_t, const char*, size_t, void*),
+    void* user_data)
+{
+    ((Http2Request*)req)->forEachHeader([cb, user_data](std::string_view name, std::string_view value) {
+        cb(name.empty() ? "" : name.data(), name.length(),
+            value.empty() ? "" : value.data(), value.length(), user_data);
+    });
+}
+
+size_t uws_h2_req_get_query(uws_h2_req_t* req, const char* key, size_t key_len, const char** dest)
+{
+    return h2out(key ? ((Http2Request*)req)->getQuery(h2sv(key, key_len))
+                     : ((Http2Request*)req)->getQuery(),
+        dest);
+}
+
+size_t uws_h2_req_get_parameter(uws_h2_req_t* req, unsigned short index, const char** dest)
+{
+    return h2out(((Http2Request*)req)->getParameter(index), dest);
+}
+
+} // extern "C"

--- a/src/uws_sys/libuwsockets_h2.cpp
+++ b/src/uws_sys/libuwsockets_h2.cpp
@@ -172,7 +172,7 @@ bool uws_h2_res_write(uws_h2_res_t* res, const char* data, size_t* length)
 uint64_t uws_h2_res_get_write_offset(uws_h2_res_t* res) { return ((Http2Response*)res)->getWriteOffset(); }
 void uws_h2_res_override_write_offset(uws_h2_res_t* res, uint64_t off) { ((Http2Response*)res)->overrideWriteOffset(off); }
 bool uws_h2_res_has_responded(uws_h2_res_t* res) { return ((Http2Response*)res)->hasResponded(); }
-size_t uws_h2_res_get_buffered_amount(uws_h2_res_t* res) { return ((Http2Response*)res)->getBufferedAmount(); }
+uint64_t uws_h2_res_get_buffered_amount(uws_h2_res_t* res) { return (uint64_t)((Http2Response*)res)->getBufferedAmount(); }
 
 void uws_h2_res_reset_timeout(uws_h2_res_t*) {}
 void uws_h2_res_timeout(uws_h2_res_t*, uint8_t) {}

--- a/src/uws_sys/libuwsockets_h2.cpp
+++ b/src/uws_sys/libuwsockets_h2.cpp
@@ -1,5 +1,5 @@
-// HTTP/2 C ABI for Zig. Mirrors the uws_h3_* surface in libuwsockets_h3.cpp
-// 1:1 (same parameter shapes, same callback signatures) so the Zig side can
+// HTTP/2 C ABI for Rust. Mirrors the uws_h3_* surface in libuwsockets_h3.cpp
+// 1:1 (same parameter shapes, same callback signatures) so the Rust side can
 // pattern-match NewApp/NewResponse/H3 without protocol-specific branches.
 // Kept in its own TU so HTTP/1.1, HTTP/2 and HTTP/3 stay file-level
 // separable.
@@ -222,7 +222,7 @@ uint64_t uws_h2_res_get_remote_address_info(uws_h2_res_t* res, const char** dest
      * uws_res_get_remote_address_info (libuwsockets.cpp) and the H3
      * wrapper: us_get_remote_address_info only memcpy()s raw
      * in_addr/in6_addr bytes into b and sets *port — dest/is_ipv6 are
-     * vestigial — so stringify with inet_ntop here so the Zig side
+     * vestigial — so stringify with inet_ntop here so the Rust side
      * gets a text slice, not raw address bytes. */
     static thread_local char b[64];
     Http2Response* r = (Http2Response*)res;

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -400,6 +400,44 @@ describe("Bun.serve http2: true", () => {
     });
   });
 
+  test("a malformed field name resets only its stream (§8.1.1); siblings continue", async () => {
+    // §8.2.1: field names MUST be lowercase tokens; a request carrying
+    // an invalid name is malformed, and §8.1.1 says that MUST be a
+    // stream error (not a connection error). Stream 1 carries an
+    // uppercase header name; stream 3 is a valid GET /hello on the
+    // same connection and must still succeed.
+    await withServer(async port => {
+      using h2 = await rawH2(port);
+      const authority = `127.0.0.1:${port}`;
+      // Stream 1: valid pseudo-headers + one literal header with an
+      // uppercase name. HPACK literal-without-indexing, new name:
+      // 0x00, name-len, name, value-len, value.
+      const bad = Buffer.concat([
+        Buffer.from([0x82, 0x87]), // :method GET, :scheme https
+        Buffer.from([0x44, "/hello".length]),
+        Buffer.from("/hello"),
+        Buffer.from([0x41, authority.length]),
+        Buffer.from(authority),
+        Buffer.from([0x00, "X-Bad".length]),
+        Buffer.from("X-Bad"),
+        Buffer.from([1]),
+        Buffer.from("v"),
+      ]);
+      h2.sock.write(h2.frame(0x01, 0x04 | 0x01, 1, bad));
+      // Stream 3: ordinary valid request.
+      h2.request(3, "GET", "/hello", true);
+
+      const rst = await h2.waitFor(f => f.type === 0x03 && f.sid === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(1); // PROTOCOL_ERROR
+      // No GOAWAY: the connection stays up for sibling streams.
+      expect(h2.frames.some(f => f.type === 0x07)).toBe(false);
+
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 3 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 3).map(f => f.payload));
+      expect(body.toString()).toBe("hello over h2");
+    });
+  });
+
   test("SETTINGS_ENABLE_PUSH value other than 0/1 → GOAWAY(PROTOCOL_ERROR)", async () => {
     // RFC 9113 §6.5.2: "Any value other than 0 or 1 MUST be treated as a
     // connection error of type PROTOCOL_ERROR." ENABLE_PUSH is a *defined*

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -438,6 +438,35 @@ describe("Bun.serve http2: true", () => {
     });
   });
 
+  test("a malformed trailer field name resets only its stream; siblings continue", async () => {
+    // §8.2.1 applies to trailer sections too. Stream 1: valid HEADERS,
+    // DATA, then a trailer HEADERS carrying an uppercase name. Stream 3:
+    // a valid GET on the same connection that must still succeed after
+    // stream 1 is RST — proves the trailer decode kept HPACK in sync
+    // and didn't GOAWAY.
+    await withServer(async port => {
+      using h2 = await rawH2(port);
+      h2.request(1, "POST", "/hold", false);
+      h2.sock.write(h2.frame(0x00, 0x00, 1, Buffer.from("x"))); // DATA, no END_STREAM
+      const badTrailer = Buffer.concat([
+        Buffer.from([0x00, "X-Trailer".length]),
+        Buffer.from("X-Trailer"),
+        Buffer.from([1]),
+        Buffer.from("t"),
+      ]);
+      h2.sock.write(h2.frame(0x01, 0x04 | 0x01, 1, badTrailer)); // HEADERS, END_HEADERS|END_STREAM
+      h2.request(3, "GET", "/hello", true);
+
+      const rst = await h2.waitFor(f => f.type === 0x03 && f.sid === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(1); // PROTOCOL_ERROR
+      expect(h2.frames.some(f => f.type === 0x07)).toBe(false); // no GOAWAY
+
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 3 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 3).map(f => f.payload));
+      expect(body.toString()).toBe("hello over h2");
+    });
+  });
+
   test("SETTINGS_ENABLE_PUSH value other than 0/1 → GOAWAY(PROTOCOL_ERROR)", async () => {
     // RFC 9113 §6.5.2: "Any value other than 0 or 1 MUST be treated as a
     // connection error of type PROTOCOL_ERROR." ENABLE_PUSH is a *defined*

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -655,9 +655,7 @@ describe.concurrent("Bun.serve http2: true", () => {
       // Stream 3 on the same connection must still succeed.
       h2.request(3, "GET", "/hello", true);
 
-      const rst = await h2.waitFor(
-        f => f.type === 0x03 && f.sid === 1 && f.payload.readUInt32BE(0) === 5,
-      );
+      const rst = await h2.waitFor(f => f.type === 0x03 && f.sid === 1 && f.payload.readUInt32BE(0) === 5);
       expect(rst.payload.readUInt32BE(0)).toBe(5); // STREAM_CLOSED
       expect(h2.frames.some(f => f.type === 0x07)).toBe(false); // no GOAWAY
 

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -438,6 +438,39 @@ describe("Bun.serve http2: true", () => {
     });
   });
 
+  test("a field value containing NUL/CR/LF resets only its stream (§8.2.1); siblings continue", async () => {
+    // §8.2.1: "A field value MUST NOT contain the zero value (ASCII NUL,
+    // 0x00), line feed (ASCII LF, 0x0a), or carriage return (ASCII CR,
+    // 0x0d) at any position." These are the bytes a downstream H1 hop
+    // would mis-parse as framing. Stream 1 carries a value with an
+    // embedded LF; stream 3 on the same connection must still succeed.
+    await withServer(async port => {
+      using h2 = await rawH2(port);
+      const authority = `127.0.0.1:${port}`;
+      const bad = Buffer.concat([
+        Buffer.from([0x82, 0x87]), // :method GET, :scheme https
+        Buffer.from([0x44, "/hello".length]),
+        Buffer.from("/hello"),
+        Buffer.from([0x41, authority.length]),
+        Buffer.from(authority),
+        Buffer.from([0x00, "x-bad".length]),
+        Buffer.from("x-bad"),
+        Buffer.from([3]),
+        Buffer.from("a\nb"),
+      ]);
+      h2.sock.write(h2.frame(0x01, 0x04 | 0x01, 1, bad));
+      h2.request(3, "GET", "/hello", true);
+
+      const rst = await h2.waitFor(f => f.type === 0x03 && f.sid === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(1); // PROTOCOL_ERROR
+      expect(h2.frames.some(f => f.type === 0x07)).toBe(false); // no GOAWAY
+
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 3 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 3).map(f => f.payload));
+      expect(body.toString()).toBe("hello over h2");
+    });
+  });
+
   test("a malformed trailer field name resets only its stream; siblings continue", async () => {
     // §8.2.1 applies to trailer sections too. Stream 1: valid HEADERS,
     // DATA, then a trailer HEADERS carrying an uppercase name. Stream 3:

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { createHash } from "crypto";
 import { bunEnv, bunExe, tls } from "harness";
 import { once } from "node:events";
 import nodetls from "node:tls";
@@ -97,9 +96,12 @@ for await (const line of console) {
 }
 `;
 
-async function withServer(body: (port: number, send: (cmd: string) => Promise<void>) => Promise<void>) {
+async function withServer(
+  body: (port: number, send: (cmd: string) => Promise<void>) => Promise<void>,
+  source: string = fixture,
+) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
+    cmd: [bunExe(), "-e", source],
     env: bunEnv,
     stdin: "pipe",
     stdout: "pipe",
@@ -210,14 +212,9 @@ describe("Bun.serve http2: true", () => {
     await withServer(async port => {
       const res = await fetchH2(port, "/big");
       expect(res.status).toBe(200);
-      const buf = new Uint8Array(await res.arrayBuffer());
+      const buf = Buffer.from(await res.arrayBuffer());
       expect(buf.length).toBe(256 * 1024);
-      // verify content integrity — 16-byte repeating pattern
-      const want = createHash("sha1")
-        .update(Buffer.alloc(256 * 1024, "abcdefghijklmnop"))
-        .digest("hex");
-      const got = createHash("sha1").update(buf).digest("hex");
-      expect(got).toBe(want);
+      expect(buf.equals(Buffer.alloc(256 * 1024, "abcdefghijklmnop"))).toBe(true);
     });
   });
 
@@ -248,7 +245,7 @@ describe("Bun.serve http2: true", () => {
       // Loopback over either stack; what matters is a well-formed text
       // address (not raw in_addr bytes) and a real ephemeral port.
       expect(["127.0.0.1", "::1", "::ffff:127.0.0.1"]).toContain(info.address);
-      expect(info.family === "IPv4" || info.family === "IPv6").toBe(true);
+      expect(["IPv4", "IPv6"]).toContain(info.family);
       expect(info.port).toBeGreaterThan(0);
     });
   });
@@ -330,7 +327,18 @@ describe("Bun.serve http2: true", () => {
       sock.write(frame(0x06, 0, 0, Buffer.alloc(8)));
       await waitFor(f => f.type === 0x06 && !!(f.flags & 0x01));
     };
-    return { sock, frame, request, frames, waitFor, pong };
+    return {
+      sock,
+      frame,
+      request,
+      frames,
+      waitFor,
+      pong,
+      [Symbol.dispose]() {
+        sock.on("error", () => {});
+        sock.destroy();
+      },
+    };
   }
 
   test("request terminated by a trailer section delivers body to the handler", async () => {
@@ -341,7 +349,7 @@ describe("Bun.serve http2: true", () => {
     // branch, not only from DATA(END_STREAM), or `await req.text()`
     // never resolves.
     await withServer(async port => {
-      const h2 = await rawH2(port);
+      using h2 = await rawH2(port);
       h2.request(1, "POST", "/echo", false);
       h2.sock.write(h2.frame(0x00, 0x00, 1, Buffer.from("trailed-body"))); // DATA, no END_STREAM
       // Trailer HEADERS carrying END_STREAM. HPACK literal-without-
@@ -359,7 +367,6 @@ describe("Bun.serve http2: true", () => {
       await h2.waitFor(f => f.type === 0x00 && f.sid === 1 && !!(f.flags & 0x01));
       const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 1).map(f => f.payload));
       expect(body.toString()).toBe("trailed-body");
-      h2.sock.destroy();
     });
   });
 
@@ -369,7 +376,7 @@ describe("Bun.serve http2: true", () => {
     // as a connection FLOW_CONTROL_ERROR. Without the int64 widening
     // guard the int32 add hits UB (UBSan trap on ASAN builds).
     await withServer(async port => {
-      const h2 = await rawH2(port);
+      using h2 = await rawH2(port);
       const setting = (id: number, v: number) => {
         const b = Buffer.alloc(6);
         b.writeUInt16BE(id, 0);
@@ -390,7 +397,6 @@ describe("Bun.serve http2: true", () => {
       const goaway = await h2.waitFor(f => f.type === 0x07);
       expect(goaway.payload.readUInt32BE(4)).toBe(3); // FLOW_CONTROL_ERROR
       h2.sock.on("error", () => {}); // RST after GOAWAY is expected
-      h2.sock.destroy();
     });
   });
 
@@ -400,7 +406,7 @@ describe("Bun.serve http2: true", () => {
     // setting with a value constraint — it's not in the "unknown settings
     // MUST be ignored" bucket even though the server never pushes.
     await withServer(async port => {
-      const h2 = await rawH2(port);
+      using h2 = await rawH2(port);
       const setting = (id: number, v: number) => {
         const b = Buffer.alloc(6);
         b.writeUInt16BE(id, 0);
@@ -415,7 +421,6 @@ describe("Bun.serve http2: true", () => {
       const goaway = await h2.waitFor(f => f.type === 0x07);
       expect(goaway.payload.readUInt32BE(4)).toBe(1); // PROTOCOL_ERROR
       h2.sock.on("error", () => {});
-      h2.sock.destroy();
     });
   });
 
@@ -436,7 +441,7 @@ describe("Bun.serve http2: true", () => {
       ["WINDOW_UPDATE inc=0", 0x08, u32(0)], // §6.9 stream error — but on idle → connection error
     ] as const) {
       await withServer(async port => {
-        const h2 = await rawH2(port);
+        using h2 = await rawH2(port);
         // Open and complete stream 1 so lastStreamId=1; then target stream 3 (idle).
         h2.request(1, "GET", "/hello", true);
         await h2.waitFor(f => f.sid === 1 && f.type === 0x00 && (f.flags & 0x1) !== 0);
@@ -455,7 +460,6 @@ describe("Bun.serve http2: true", () => {
         const goaway = await h2.waitFor(f => f.type === 0x07);
         expect(goaway.payload.readUInt32BE(4), `${label} on idle stream 3`).toBe(1);
         h2.sock.on("error", () => {});
-        h2.sock.destroy();
       });
     }
   });
@@ -468,7 +472,7 @@ describe("Bun.serve http2: true", () => {
     // delta, like handleWindowUpdate does, or a stream parked on
     // flow-control backpressure never resumes.
     await withServer(async port => {
-      const h2 = await rawH2(port);
+      using h2 = await rawH2(port);
       const setting = (id: number, v: number) => {
         const b = Buffer.alloc(6);
         b.writeUInt16BE(id, 0);
@@ -494,7 +498,6 @@ describe("Bun.serve http2: true", () => {
       await h2.waitFor(f => f.type === 0x00 && f.sid === 1 && !!(f.flags & 0x01));
       const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 1).map(f => f.payload));
       expect(body.toString()).toBe("hello over h2");
-      h2.sock.destroy();
     });
   });
 
@@ -505,7 +508,7 @@ describe("Bun.serve http2: true", () => {
     // malicious client could re-invoke the body callback after the
     // handler already finalised it on the first END_STREAM.
     await withServer(async port => {
-      const h2 = await rawH2(port);
+      using h2 = await rawH2(port);
       // /hold reads the body then blocks forever so the stream stays in
       // the server's map (half-closed remote, open local) when the
       // violating DATA arrives.
@@ -519,7 +522,6 @@ describe("Bun.serve http2: true", () => {
       h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("evil")));
       const rst = await h2.waitFor(f => f.type === 0x03 && f.sid === 1);
       expect(rst.payload.readUInt32BE(0)).toBe(5); // STREAM_CLOSED
-      h2.sock.destroy();
     });
   });
 
@@ -529,13 +531,15 @@ describe("Bun.serve http2: true", () => {
     // alone (TemplatedApp::close) would miss them. The abrupt path must
     // walk h2ChildContext the same way it walks webSocketContexts[].
     await withServer(async (port, send) => {
-      const h2 = await rawH2(port);
+      using h2 = await rawH2(port);
       h2.request(1, "POST", "/hold", false);
       h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("x")));
       await h2.pong(); // server has the stream open, handler is parked
       h2.sock.on("error", () => {}); // RST is expected
 
-      const closed = once(h2.sock, "close");
+      // once() rejects on 'error' (ECONNRESET on Windows when the
+      // server RSTs); wait for 'close' directly.
+      const closed = new Promise<void>(r => h2.sock.once("close", () => r()));
       await send("abrupt");
       // Without the h2ChildContext walk the socket would sit open until
       // the 10s idle timeout; the test's default 5s timeout makes that
@@ -551,7 +555,7 @@ describe("Bun.serve http2: true", () => {
     // shutdown the write side itself once the last stream drains,
     // otherwise the connection idles open until the 10s timeout.
     await withServer(async (port, send) => {
-      const h2 = await rawH2(port);
+      using h2 = await rawH2(port);
       h2.request(1, "GET", "/deferred", true);
       await h2.pong(); // handler is awaiting `deferred`
 
@@ -559,7 +563,8 @@ describe("Bun.serve http2: true", () => {
       const goaway = await h2.waitFor(f => f.type === 0x07);
       expect(goaway.payload.readUInt32BE(4)).toBe(0); // NO_ERROR
 
-      const ended = once(h2.sock, "end"); // server FIN
+      h2.sock.on("error", () => {});
+      const ended = new Promise<void>(r => h2.sock.once("end", () => r())); // server FIN
       await send("release");
       // Response completes over the still-open connection. The server
       // may split body + END_STREAM across two DATA frames, so wait
@@ -569,7 +574,6 @@ describe("Bun.serve http2: true", () => {
       expect(body.toString()).toBe("late");
       // … and the server shuts its write side promptly (no 10s idle wait).
       await ended;
-      h2.sock.destroy();
     });
   });
 
@@ -592,38 +596,22 @@ describe("Bun.serve http2: true", () => {
       console.log(server.port);
       for await (const line of console) if (line === "stop") { server.stop(true); break; }
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", sniFixture],
-      env: bunEnv,
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "inherit",
-    });
-    const reader = proc.stdout.getReader();
-    let buf = "";
-    while (!buf.includes("\n")) {
-      const { value, done } = await reader.read();
-      if (done) throw new Error("server exited before printing port");
-      buf += new TextDecoder().decode(value);
-    }
-    reader.releaseLock();
-    const port = parseInt(buf.trim(), 10);
-
-    // Connect with SNI "localhost" so sni_cb swaps to the per-SNI ctx.
-    const sock = nodetls.connect({
-      host: "127.0.0.1",
-      port,
-      servername: "localhost",
-      ALPNProtocols: ["h2", "http/1.1"],
-      rejectUnauthorized: false,
-    });
-    await once(sock, "secureConnect");
-    expect(sock.alpnProtocol).toBe("h2");
-    sock.destroy();
-
-    proc.stdin.write("stop\n");
-    proc.stdin.end();
-    expect(await proc.exited).toBe(0);
+    await withServer(async port => {
+      // Connect with SNI "localhost" so sni_cb swaps to the per-SNI ctx.
+      const sock = nodetls.connect({
+        host: "127.0.0.1",
+        port,
+        servername: "localhost",
+        ALPNProtocols: ["h2", "http/1.1"],
+        rejectUnauthorized: false,
+      });
+      try {
+        await once(sock, "secureConnect");
+        expect(sock.alpnProtocol).toBe("h2");
+      } finally {
+        sock.destroy();
+      }
+    }, sniFixture);
   });
 
   test("http2: true without tls throws", () => {

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -69,6 +69,9 @@ const server = serve({
       await req.text();
       await new Promise(() => {});
     }
+    if (url.pathname === "/deny") {
+      return new Response("no", { status: 401 });
+    }
     if (url.pathname === "/deferred") {
       await deferred.promise;
       return new Response("late");
@@ -148,7 +151,7 @@ async function withServer(
   expect(exitCode).toBe(0);
 }
 
-describe("Bun.serve http2: true", () => {
+describe.concurrent("Bun.serve http2: true", () => {
   test("simple GET over ALPN h2", async () => {
     await withServer(async port => {
       const res = await fetchH2(port, "/hello");
@@ -622,6 +625,45 @@ describe("Bun.serve http2: true", () => {
       h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("evil")));
       const rst = await h2.waitFor(f => f.type === 0x03 && f.sid === 1);
       expect(rst.payload.readUInt32BE(0)).toBe(5); // STREAM_CLOSED
+    });
+  });
+
+  test("trailer HEADERS racing an early response is stream-scoped; siblings continue", async () => {
+    // §8.1 lets the server RST_STREAM(NO_ERROR) after a complete
+    // response to stop an unread body, which markDone() does. An
+    // already-in-flight trailer HEADERS then arrives for a stream
+    // that's been erased from the map. §5.1 (closed) says such frames
+    // MUST be minimally processed and discarded; they must not GOAWAY
+    // the connection and kill siblings.
+    await withServer(async port => {
+      using h2 = await rawH2(port);
+      // Stream 1: POST to /deny, which responds 401 without reading →
+      // markDone() emits RST_STREAM(NO_ERROR) and erases the stream.
+      h2.request(1, "POST", "/deny", false);
+      await h2.waitFor(f => f.type === 0x03 && f.sid === 1 && f.payload.readUInt32BE(0) === 0);
+      // Client's in-flight body + trailer HEADERS now land on a closed
+      // stream. The server must decode the HPACK block (connection-
+      // scoped) and RST, not GOAWAY.
+      h2.sock.write(h2.frame(0x00, 0x00, 1, Buffer.from("body")));
+      const trailer = Buffer.concat([
+        Buffer.from([0x00, "x-trailer".length]),
+        Buffer.from("x-trailer"),
+        Buffer.from([1]),
+        Buffer.from("t"),
+      ]);
+      h2.sock.write(h2.frame(0x01, 0x04 | 0x01, 1, trailer));
+      // Stream 3 on the same connection must still succeed.
+      h2.request(3, "GET", "/hello", true);
+
+      const rst = await h2.waitFor(
+        f => f.type === 0x03 && f.sid === 1 && f.payload.readUInt32BE(0) === 5,
+      );
+      expect(rst.payload.readUInt32BE(0)).toBe(5); // STREAM_CLOSED
+      expect(h2.frames.some(f => f.type === 0x07)).toBe(false); // no GOAWAY
+
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 3 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 3).map(f => f.payload));
+      expect(body.toString()).toBe("hello over h2");
     });
   });
 

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -665,6 +665,37 @@ describe.concurrent("Bun.serve http2: true", () => {
     });
   });
 
+  test("HEADERS→RST_STREAM flood is bounded per-connection (CVE-2023-44487)", async () => {
+    // Rapid Reset: MAX_CONCURRENT_STREAMS bounds c->streams.size(),
+    // which stays ~0 when each HEADERS is immediately followed by
+    // RST_STREAM. The server bounds cumulative client resets and
+    // GOAWAYs with ENHANCE_YOUR_CALM once the threshold is crossed.
+    await withServer(async port => {
+      using h2 = await rawH2(port);
+      h2.sock.on("error", () => {}); // RST after GOAWAY is expected
+      const authority = `127.0.0.1:${port}`;
+      const hdrs = Buffer.concat([
+        Buffer.from([0x82, 0x87]), // :method GET, :scheme https
+        Buffer.from([0x44, "/hold".length]),
+        Buffer.from("/hold"),
+        Buffer.from([0x41, authority.length]),
+        Buffer.from(authority),
+      ]);
+      const rst = Buffer.alloc(4); // CANCEL = 8
+      rst.writeUInt32BE(8, 0);
+      // 1200 HEADERS+RST pairs; threshold is 1000.
+      const frames: Buffer[] = [];
+      for (let i = 0; i < 1200; i++) {
+        const sid = 2 * i + 1;
+        frames.push(h2.frame(0x01, 0x04 | 0x01, sid, hdrs));
+        frames.push(h2.frame(0x03, 0x00, sid, rst));
+      }
+      h2.sock.write(Buffer.concat(frames));
+      const goaway = await h2.waitFor(f => f.type === 0x07);
+      expect(goaway.payload.readUInt32BE(4)).toBe(0x0b); // ENHANCE_YOUR_CALM
+    });
+  });
+
   test("server.stop(true) force-closes live H2 connections", async () => {
     // H2 sockets are adopted out of the H1 context into a child context
     // via us_socket_context_adopt_socket, so closing the H1 context

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -1,0 +1,652 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "crypto";
+import { bunEnv, bunExe, tls } from "harness";
+import { once } from "node:events";
+import nodetls from "node:tls";
+
+// Bun.serve({ http2: true }) attaches to the HTTP/1 TLS listener via ALPN:
+// the server offers "h2,http/1.1" and adopts sockets that negotiate "h2"
+// into the HTTP/2 child context. Every fetch here forces protocol: "h2"
+// so a silent fallback to HTTP/1.1 surfaces as a protocol mismatch (the
+// response's Via-like assertion on the server side checks req.url,
+// headers, and body framing work end-to-end over the H2 path).
+//
+// Uses Bun's own HTTP/2 fetch client so both sides exercise lshpack.
+
+const fetchH2 = (port: number, path: string, init: RequestInit = {}) =>
+  fetch(`https://127.0.0.1:${port}${path}`, {
+    ...init,
+    protocol: "h2",
+    tls: { rejectUnauthorized: false },
+  } as RequestInit);
+
+const fixture = `
+import { serve } from "bun";
+
+const big = Buffer.alloc(256 * 1024, "abcdefghijklmnop");
+const deferred = Promise.withResolvers();
+
+const server = serve({
+  port: 0,
+  tls: ${JSON.stringify(tls)},
+  http2: true,
+  routes: {
+    "/api/:id": req => new Response("id=" + req.params.id, {
+      headers: { "x-route": "api" },
+    }),
+    "/static": new Response("from-static-route", {
+      headers: { "content-type": "text/plain", etag: '"v1"' },
+    }),
+  },
+  async fetch(req, server) {
+    const url = new URL(req.url);
+    if (url.pathname === "/ip") {
+      return Response.json(server.requestIP(req));
+    }
+    if (url.pathname === "/hello") {
+      return new Response("hello over h2", {
+        headers: { "x-proto": "h2", "content-type": "text/plain" },
+      });
+    }
+    if (url.pathname === "/echo") {
+      const body = await req.text();
+      return new Response(body, {
+        status: 201,
+        headers: {
+          "x-method": req.method,
+          "x-echo": req.headers.get("x-echo") ?? "",
+          "x-host": req.headers.get("host") ?? "",
+          "x-len": String(body.length),
+        },
+      });
+    }
+    if (url.pathname === "/big") {
+      return new Response(big, { headers: { "content-type": "application/octet-stream" } });
+    }
+    if (url.pathname === "/headers") {
+      return Response.json(Object.fromEntries(req.headers));
+    }
+    if (url.pathname === "/hold") {
+      await req.text();
+      await new Promise(() => {});
+    }
+    if (url.pathname === "/deferred") {
+      await deferred.promise;
+      return new Response("late");
+    }
+    if (url.pathname === "/stream") {
+      return new Response(new ReadableStream({
+        async start(ctrl) {
+          for (let i = 0; i < 4; i++) {
+            ctrl.enqueue(new TextEncoder().encode("chunk" + i + ";"));
+            await Bun.sleep(1);
+          }
+          ctrl.close();
+        },
+      }));
+    }
+    return new Response("not found", { status: 404 });
+  },
+});
+console.log(server.port);
+for await (const line of console) {
+  if (line === "graceful") { server.stop(false); console.log("ack"); continue; }
+  if (line === "abrupt")   { server.stop(true);  console.log("ack"); continue; }
+  if (line === "release")  { deferred.resolve(); console.log("ack"); continue; }
+  if (line === "stop")     { server.stop(true);  break; }
+}
+`;
+
+async function withServer(body: (port: number, send: (cmd: string) => Promise<void>) => Promise<void>) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const reader = proc.stdout.getReader();
+  let buf = "";
+  const readLine = async (): Promise<string> => {
+    while (!buf.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("server exited before printing a line");
+      buf += new TextDecoder().decode(value);
+    }
+    const nl = buf.indexOf("\n");
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    return line;
+  };
+  const port = parseInt(await readLine(), 10);
+  if (!Number.isFinite(port)) throw new Error("bad port");
+  // Send a control command and wait for the server's "ack" so the
+  // caller knows the effect (GOAWAY written, deferred resolved, …)
+  // has happened before it proceeds.
+  const send = async (cmd: string) => {
+    proc.stdin.write(cmd + "\n");
+    proc.stdin.flush();
+    const ack = await readLine();
+    if (ack !== "ack") throw new Error("expected ack, got " + JSON.stringify(ack));
+  };
+  let bodyErr: unknown;
+  try {
+    await body(port, send);
+  } catch (e) {
+    bodyErr = e;
+  }
+  reader.releaseLock();
+  proc.stdin.write("stop\n");
+  proc.stdin.end();
+  const exitCode = await proc.exited;
+  // Surface the fetch error first (it's the symptom the test cares
+  // about); the server's exit code is the root cause and stderr is
+  // already inherited so the crash is visible either way.
+  if (bodyErr) throw bodyErr;
+  expect(exitCode).toBe(0);
+}
+
+describe("Bun.serve http2: true", () => {
+  test("simple GET over ALPN h2", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/hello");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-proto")).toBe("h2");
+      expect(res.headers.get("content-type")).toBe("text/plain");
+      expect(await res.text()).toBe("hello over h2");
+    });
+  });
+
+  test("POST body + response headers echoed", async () => {
+    await withServer(async port => {
+      const payload = Buffer.alloc(9000, "Z").toString();
+      const res = await fetchH2(port, "/echo", {
+        method: "POST",
+        headers: { "x-echo": "roundtrip", "content-type": "text/plain" },
+        body: payload,
+      });
+      expect(res.status).toBe(201);
+      expect(res.headers.get("x-method")).toBe("POST");
+      expect(res.headers.get("x-echo")).toBe("roundtrip");
+      // :authority → host synthesis on the server side
+      expect(res.headers.get("x-host")).toContain("127.0.0.1");
+      expect(res.headers.get("x-len")).toBe(String(payload.length));
+      expect(await res.text()).toBe(payload);
+    });
+  });
+
+  test("request headers decode via HPACK and reach the handler", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/headers", {
+        headers: {
+          "x-a": "1",
+          "x-b": "two",
+          "accept": "application/json",
+        },
+      });
+      expect(res.status).toBe(200);
+      const got = (await res.json()) as Record<string, string>;
+      expect(got["x-a"]).toBe("1");
+      expect(got["x-b"]).toBe("two");
+      expect(got["accept"]).toBe("application/json");
+      expect(got["host"]).toContain("127.0.0.1");
+    });
+  });
+
+  test("user routes and static routes are mirrored onto the H2 router", async () => {
+    await withServer(async port => {
+      const r1 = await fetchH2(port, "/api/bun");
+      expect(r1.headers.get("x-route")).toBe("api");
+      expect(await r1.text()).toBe("id=bun");
+
+      const r2 = await fetchH2(port, "/static");
+      expect(r2.status).toBe(200);
+      expect(r2.headers.get("etag")).toBe('"v1"');
+      expect(await r2.text()).toBe("from-static-route");
+    });
+  });
+
+  test("multi-frame response body (>16KiB) with flow control", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/big");
+      expect(res.status).toBe(200);
+      const buf = new Uint8Array(await res.arrayBuffer());
+      expect(buf.length).toBe(256 * 1024);
+      // verify content integrity — 16-byte repeating pattern
+      const want = createHash("sha1")
+        .update(Buffer.alloc(256 * 1024, "abcdefghijklmnop"))
+        .digest("hex");
+      const got = createHash("sha1").update(buf).digest("hex");
+      expect(got).toBe(want);
+    });
+  });
+
+  test("streamed ReadableStream response arrives intact", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/stream");
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("chunk0;chunk1;chunk2;chunk3;");
+    });
+  });
+
+  test("multiple requests multiplex on one TLS connection", async () => {
+    await withServer(async port => {
+      // Bun's H2 fetch client pools connections per origin; firing these
+      // concurrently exercises multiplexing + HPACK dynamic-table reuse.
+      const results = await Promise.all(
+        Array.from({ length: 8 }, (_, i) => fetchH2(port, "/api/" + i).then(r => r.text())),
+      );
+      expect(results).toEqual(Array.from({ length: 8 }, (_, i) => "id=" + i));
+    });
+  });
+
+  test("server.requestIP(req) returns the peer's textual address", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/ip");
+      expect(res.status).toBe(200);
+      const info = (await res.json()) as { address: string; port: number; family: string };
+      // Loopback over either stack; what matters is a well-formed text
+      // address (not raw in_addr bytes) and a real ephemeral port.
+      expect(["127.0.0.1", "::1", "::ffff:127.0.0.1"]).toContain(info.address);
+      expect(info.family === "IPv4" || info.family === "IPv6").toBe(true);
+      expect(info.port).toBeGreaterThan(0);
+    });
+  });
+
+  test("HTTP/1.1 still works on the same listener when h2 is enabled", async () => {
+    await withServer(async port => {
+      // Force http/1.1 so the assertion stays meaningful once fetch's
+      // default starts offering h2: proves the ALPN cb falls through to
+      // http/1.1 and the H1 parser on the same TLS port still works.
+      const res = await fetch(`https://127.0.0.1:${port}/hello`, {
+        protocol: "http1.1",
+        tls: { rejectUnauthorized: false },
+      } as RequestInit);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("hello over h2");
+    });
+  });
+
+  // Raw TLS+H2 client for wire-level / lifecycle assertions. Speaks just
+  // enough HPACK (static-table literals) to issue a single request and
+  // parses inbound frames into {type, flags, sid, payload}. `pong()`
+  // writes a PING and resolves on the ACK — a deterministic barrier
+  // proving the server processed everything written before it.
+  type RawFrame = { type: number; flags: number; sid: number; payload: Buffer };
+  async function rawH2(port: number) {
+    const frame = (type: number, flags: number, sid: number, payload: Buffer = Buffer.alloc(0)) => {
+      const hdr = Buffer.alloc(9);
+      hdr.writeUIntBE(payload.length, 0, 3);
+      hdr[3] = type;
+      hdr[4] = flags;
+      hdr.writeUInt32BE(sid, 5);
+      return Buffer.concat([hdr, payload]);
+    };
+    const request = (sid: number, method: "GET" | "POST", path: string, endStream: boolean) => {
+      const authority = `127.0.0.1:${port}`;
+      const hpack = Buffer.concat([
+        Buffer.from([method === "GET" ? 0x82 : 0x83, 0x87]), // :method idx, :scheme https idx7
+        Buffer.from([0x44, path.length]), // :path literal, name idx 4
+        Buffer.from(path),
+        Buffer.from([0x41, authority.length]), // :authority literal, name idx 1
+        Buffer.from(authority),
+      ]);
+      sock.write(frame(0x01, 0x04 | (endStream ? 0x01 : 0), sid, hpack));
+    };
+    const sock = nodetls.connect({ host: "127.0.0.1", port, ALPNProtocols: ["h2"], rejectUnauthorized: false });
+    await once(sock, "secureConnect");
+    expect(sock.alpnProtocol).toBe("h2");
+    sock.write(Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"));
+    sock.write(frame(0x04, 0, 0)); // empty client SETTINGS
+
+    const frames: RawFrame[] = [];
+    const waiters: { pred: (f: RawFrame) => boolean; resolve: (f: RawFrame) => void }[] = [];
+    let rx = Buffer.alloc(0);
+    let off = 0;
+    sock.on("data", chunk => {
+      rx = Buffer.concat([rx, chunk]);
+      while (off + 9 <= rx.length) {
+        const len = rx.readUIntBE(off, 3);
+        if (off + 9 + len > rx.length) break;
+        const f: RawFrame = {
+          type: rx[off + 3],
+          flags: rx[off + 4],
+          sid: rx.readUInt32BE(off + 5) & 0x7fffffff,
+          payload: Buffer.from(rx.subarray(off + 9, off + 9 + len)),
+        };
+        frames.push(f);
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (waiters[i].pred(f)) waiters.splice(i, 1)[0].resolve(f);
+        }
+        off += 9 + len;
+      }
+    });
+    const waitFor = (pred: (f: RawFrame) => boolean): Promise<RawFrame> => {
+      const hit = frames.find(pred);
+      if (hit) return Promise.resolve(hit);
+      return new Promise(resolve => waiters.push({ pred, resolve }));
+    };
+    const pong = async () => {
+      sock.write(frame(0x06, 0, 0, Buffer.alloc(8)));
+      await waitFor(f => f.type === 0x06 && !!(f.flags & 0x01));
+    };
+    return { sock, frame, request, frames, waitFor, pong };
+  }
+
+  test("request terminated by a trailer section delivers body to the handler", async () => {
+    // RFC 9113 §8.1: HEADERS → DATA (no END_STREAM) → HEADERS(trailers,
+    // END_STREAM). gRPC clients, Node http2 with the trailers option,
+    // and `curl --trailer` all terminate this way. The server must
+    // dispatch last=true to the body callback from the trailers
+    // branch, not only from DATA(END_STREAM), or `await req.text()`
+    // never resolves.
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      h2.request(1, "POST", "/echo", false);
+      h2.sock.write(h2.frame(0x00, 0x00, 1, Buffer.from("trailed-body"))); // DATA, no END_STREAM
+      // Trailer HEADERS carrying END_STREAM. HPACK literal-without-
+      // indexing (0x00 prefix): name len, name, value len, value.
+      const trailer = Buffer.concat([
+        Buffer.from([0x00, "x-trailer".length]),
+        Buffer.from("x-trailer"),
+        Buffer.from(["t".length]),
+        Buffer.from("t"),
+      ]);
+      h2.sock.write(h2.frame(0x01, 0x04 | 0x01, 1, trailer)); // HEADERS, END_HEADERS|END_STREAM
+
+      // /echo returns the body it read; getting a DATA(END_STREAM)
+      // back proves req.text() resolved with what we sent.
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 1 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 1).map(f => f.payload));
+      expect(body.toString()).toBe("trailed-body");
+      h2.sock.destroy();
+    });
+  });
+
+  test("SETTINGS_INITIAL_WINDOW_SIZE delta that overflows a stream window → GOAWAY(FLOW_CONTROL_ERROR)", async () => {
+    // RFC 9113 §6.9.2: a change to SETTINGS_INITIAL_WINDOW_SIZE that
+    // causes any flow-control window to exceed 2³¹-1 MUST be treated
+    // as a connection FLOW_CONTROL_ERROR. Without the int64 widening
+    // guard the int32 add hits UB (UBSan trap on ASAN builds).
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      const setting = (id: number, v: number) => {
+        const b = Buffer.alloc(6);
+        b.writeUInt16BE(id, 0);
+        b.writeUInt32BE(v, 2);
+        return b;
+      };
+      // 1. INITIAL_WINDOW_SIZE = 0 so new streams start at 0.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(4, 0)));
+      // 2. Open stream 1 on /hold (handler parks; stream stays open).
+      h2.request(1, "POST", "/hold", false);
+      // 3. WINDOW_UPDATE stream 1 by 2³¹-1 → sendWindow = INT32_MAX.
+      const inc = Buffer.alloc(4);
+      inc.writeUInt32BE(0x7fffffff, 0);
+      h2.sock.write(h2.frame(0x08, 0, 1, inc));
+      // 4. INITIAL_WINDOW_SIZE = 2³¹-1 → delta = 2³¹-1, would overflow.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(4, 0x7fffffff)));
+
+      const goaway = await h2.waitFor(f => f.type === 0x07);
+      expect(goaway.payload.readUInt32BE(4)).toBe(3); // FLOW_CONTROL_ERROR
+      h2.sock.on("error", () => {}); // RST after GOAWAY is expected
+      h2.sock.destroy();
+    });
+  });
+
+  test("SETTINGS_ENABLE_PUSH value other than 0/1 → GOAWAY(PROTOCOL_ERROR)", async () => {
+    // RFC 9113 §6.5.2: "Any value other than 0 or 1 MUST be treated as a
+    // connection error of type PROTOCOL_ERROR." ENABLE_PUSH is a *defined*
+    // setting with a value constraint — it's not in the "unknown settings
+    // MUST be ignored" bucket even though the server never pushes.
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      const setting = (id: number, v: number) => {
+        const b = Buffer.alloc(6);
+        b.writeUInt16BE(id, 0);
+        b.writeUInt32BE(v, 2);
+        return b;
+      };
+      // ENABLE_PUSH = 0 is valid → ACK'd.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(2, 0)));
+      await h2.pong();
+      // ENABLE_PUSH = 2 is invalid → GOAWAY(PROTOCOL_ERROR).
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(2, 2)));
+      const goaway = await h2.waitFor(f => f.type === 0x07);
+      expect(goaway.payload.readUInt32BE(4)).toBe(1); // PROTOCOL_ERROR
+      h2.sock.on("error", () => {});
+      h2.sock.destroy();
+    });
+  });
+
+  test("RST_STREAM / WINDOW_UPDATE on an idle stream → GOAWAY(PROTOCOL_ERROR)", async () => {
+    // RFC 9113 §5.1 (idle): "Receiving any frame other than HEADERS or
+    // PRIORITY on a stream in this state MUST be treated as a connection
+    // error of type PROTOCOL_ERROR." §6.4 repeats it for RST_STREAM.
+    // The *closed* case is distinct: §5.1 explicitly permits late
+    // RST_STREAM/WINDOW_UPDATE there as a race allowance.
+    const u32 = (v: number) => {
+      const b = Buffer.alloc(4);
+      b.writeUInt32BE(v, 0);
+      return b;
+    };
+    for (const [label, type, payload] of [
+      ["RST_STREAM", 0x03, u32(0)], // error code = 0
+      ["WINDOW_UPDATE", 0x08, u32(1)], // non-zero increment
+      ["WINDOW_UPDATE inc=0", 0x08, u32(0)], // §6.9 stream error — but on idle → connection error
+    ] as const) {
+      await withServer(async port => {
+        const h2 = await rawH2(port);
+        // Open and complete stream 1 so lastStreamId=1; then target stream 3 (idle).
+        h2.request(1, "GET", "/hello", true);
+        await h2.waitFor(f => f.sid === 1 && f.type === 0x00 && (f.flags & 0x1) !== 0);
+        const seen = h2.frames.length;
+        // Late frame on closed stream 1 → §5.1 MUST ignore. No GOAWAY, and
+        // no RST back on stream 1 either (would itself break §5.1's
+        // "MUST NOT send frames other than PRIORITY on a closed stream").
+        h2.sock.write(h2.frame(type, 0, 1, payload));
+        await h2.pong();
+        expect(
+          h2.frames.slice(seen).some(f => f.type === 0x07 || (f.type === 0x03 && f.sid === 1)),
+          `${label} on closed stream 1`,
+        ).toBe(false);
+        // Same frame on idle stream 3 → connection error.
+        h2.sock.write(h2.frame(type, 0, 3, payload));
+        const goaway = await h2.waitFor(f => f.type === 0x07);
+        expect(goaway.payload.readUInt32BE(4), `${label} on idle stream 3`).toBe(1);
+        h2.sock.on("error", () => {});
+        h2.sock.destroy();
+      });
+    }
+  });
+
+  test("raising SETTINGS_INITIAL_WINDOW_SIZE drains backpressured streams", async () => {
+    // RFC 9113 §6.9.2: a change to INITIAL_WINDOW_SIZE adjusts every
+    // open stream's send window — equivalent to a per-stream
+    // WINDOW_UPDATE. Clients that BDP-autotune (nghttp2, Chrome) open
+    // windows this way. handleSettings must drain after applying the
+    // delta, like handleWindowUpdate does, or a stream parked on
+    // flow-control backpressure never resumes.
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      const setting = (id: number, v: number) => {
+        const b = Buffer.alloc(6);
+        b.writeUInt16BE(id, 0);
+        b.writeUInt32BE(v, 2);
+        return b;
+      };
+      // INITIAL_WINDOW_SIZE=0 so stream 1 starts with sendWindow=0;
+      // open the connection window so only the per-stream window
+      // blocks the response body.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(4, 0)));
+      const connInc = Buffer.alloc(4);
+      connInc.writeUInt32BE(1 << 20, 0);
+      h2.sock.write(h2.frame(0x08, 0, 0, connInc)); // WINDOW_UPDATE stream 0
+      h2.request(1, "GET", "/hello", true);
+      // Response HEADERS proves the handler ran; the body is parked
+      // in backpressure because sendWindow=0.
+      await h2.waitFor(f => f.type === 0x01 && f.sid === 1);
+      await h2.pong();
+      expect(h2.frames.some(f => f.type === 0x00 && f.sid === 1 && f.payload.length > 0)).toBe(false);
+
+      // Raise the per-stream window via SETTINGS — not WINDOW_UPDATE.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(4, 65535)));
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 1 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 1).map(f => f.payload));
+      expect(body.toString()).toBe("hello over h2");
+      h2.sock.destroy();
+    });
+  });
+
+  test("DATA after END_STREAM is rejected with RST_STREAM(STREAM_CLOSED)", async () => {
+    // RFC 9113 §5.1: DATA in half-closed(remote) MUST be a STREAM_CLOSED
+    // stream error. The server's async handler keeps the stream open
+    // (server side hasn't responded yet), so without this guard a
+    // malicious client could re-invoke the body callback after the
+    // handler already finalised it on the first END_STREAM.
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      // /hold reads the body then blocks forever so the stream stays in
+      // the server's map (half-closed remote, open local) when the
+      // violating DATA arrives.
+      h2.request(1, "POST", "/hold", false);
+      h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("hello"))); // DATA, END_STREAM
+      await h2.pong();
+      // No spurious RST(NO_ERROR) on a cleanly-ended body.
+      expect(h2.frames.filter(f => f.type === 0x03 && f.sid === 1)).toEqual([]);
+
+      // Violate §5.1: DATA on a half-closed(remote) stream.
+      h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("evil")));
+      const rst = await h2.waitFor(f => f.type === 0x03 && f.sid === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(5); // STREAM_CLOSED
+      h2.sock.destroy();
+    });
+  });
+
+  test("server.stop(true) force-closes live H2 connections", async () => {
+    // H2 sockets are adopted out of the H1 context into a child context
+    // via us_socket_context_adopt_socket, so closing the H1 context
+    // alone (TemplatedApp::close) would miss them. The abrupt path must
+    // walk h2ChildContext the same way it walks webSocketContexts[].
+    await withServer(async (port, send) => {
+      const h2 = await rawH2(port);
+      h2.request(1, "POST", "/hold", false);
+      h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("x")));
+      await h2.pong(); // server has the stream open, handler is parked
+      h2.sock.on("error", () => {}); // RST is expected
+
+      const closed = once(h2.sock, "close");
+      await send("abrupt");
+      // Without the h2ChildContext walk the socket would sit open until
+      // the 10s idle timeout; the test's default 5s timeout makes that
+      // an observable failure.
+      await closed;
+    });
+  });
+
+  test("graceful stop: in-flight H2 response completes and connection FINs", async () => {
+    // After server.stop() sends GOAWAY, an async handler's response
+    // completes via cork() outside any uSockets event — there is no
+    // on_data/on_writable epilogue to run sweep(), so cork() must
+    // shutdown the write side itself once the last stream drains,
+    // otherwise the connection idles open until the 10s timeout.
+    await withServer(async (port, send) => {
+      const h2 = await rawH2(port);
+      h2.request(1, "GET", "/deferred", true);
+      await h2.pong(); // handler is awaiting `deferred`
+
+      await send("graceful");
+      const goaway = await h2.waitFor(f => f.type === 0x07);
+      expect(goaway.payload.readUInt32BE(4)).toBe(0); // NO_ERROR
+
+      const ended = once(h2.sock, "end"); // server FIN
+      await send("release");
+      // Response completes over the still-open connection. The server
+      // may split body + END_STREAM across two DATA frames, so wait
+      // for the terminator and concatenate all stream-1 DATA payloads.
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 1 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 1).map(f => f.payload));
+      expect(body.toString()).toBe("late");
+      // … and the server shuts its write side promptly (no 10s idle wait).
+      await ended;
+      h2.sock.destroy();
+    });
+  });
+
+  test("ALPN offers h2 on per-SNI SSL_CTX (tls.serverName)", async () => {
+    // With tls.serverName set, addServerName() creates a fresh per-SNI
+    // SSL_CTX. BoringSSL's sni_cb swaps ssl->ctx to it *before*
+    // ssl_negotiate_alpn reads alpn_select_cb, so the ALPN callback
+    // must be installed on that per-SNI ctx too — otherwise an SNI-
+    // routed connection silently falls back to http/1.1 and http2: true
+    // is a no-op. H3 already does this (us_quic_prepare_ssl_ctx on
+    // each SNI entry).
+    const sniFixture = `
+      import { serve } from "bun";
+      const server = serve({
+        port: 0,
+        tls: { ...${JSON.stringify(tls)}, serverName: "localhost" },
+        http2: true,
+        fetch: () => new Response("sni-ok"),
+      });
+      console.log(server.port);
+      for await (const line of console) if (line === "stop") { server.stop(true); break; }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", sniFixture],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const reader = proc.stdout.getReader();
+    let buf = "";
+    while (!buf.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("server exited before printing port");
+      buf += new TextDecoder().decode(value);
+    }
+    reader.releaseLock();
+    const port = parseInt(buf.trim(), 10);
+
+    // Connect with SNI "localhost" so sni_cb swaps to the per-SNI ctx.
+    const sock = nodetls.connect({
+      host: "127.0.0.1",
+      port,
+      servername: "localhost",
+      ALPNProtocols: ["h2", "http/1.1"],
+      rejectUnauthorized: false,
+    });
+    await once(sock, "secureConnect");
+    expect(sock.alpnProtocol).toBe("h2");
+    sock.destroy();
+
+    proc.stdin.write("stop\n");
+    proc.stdin.end();
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("http2: true without tls throws", () => {
+    expect(() =>
+      Bun.serve({
+        port: 0,
+        http2: true,
+        fetch: () => new Response("x"),
+      }),
+    ).toThrow(/HTTP\/2 requires 'tls'/);
+  });
+
+  test("http2: true with http1: false throws", () => {
+    // http2 attaches via ALPN to the http1 listener, so http1 must stay enabled.
+    expect(() =>
+      Bun.serve({
+        port: 0,
+        tls,
+        http2: true,
+        http3: true,
+        http1: false,
+        fetch: () => new Response("x"),
+      }),
+    ).toThrow(/http2 requires http1/);
+  });
+});


### PR DESCRIPTION
`Bun.serve({ tls, http2: true })` now offers `h2,http/1.1` via ALPN on the existing TLS listener. Connections that negotiate `h2` are adopted from the HTTP/1 socket group into an HTTP/2 group and served over RFC 9113 framing with HPACK via lshpack. Everything else continues to speak HTTP/1.1 on the same port. Defaults to off. WebSocket over h2 is not supported.

```ts
Bun.serve({
  port: 0,
  tls: { cert, key },
  http2: true,
  fetch: req => new Response("hello"),
});
```

## How it's wired

The interface mirrors what `http3: true` already does, so Rust's `AnyResponse`/`AnyRequest` dispatch works unchanged and `server/mod.rs` doesn't need protocol-specific branches beyond construction.

**uWebSockets** (`packages/bun-uws/src/Http2*.h`)
- `H2App` / `Http2Context` / `Http2Response` / `Http2Request` mirror `Http3*`.
- `Http2Context` is a heap struct with an embedded `us_socket_group_t` + static `h2VTable`, same shape as `HttpContext<SSL>`. `H2App::create()` installs an ALPN select cb on the parent SSLApp's root `sslCtx` and each per-SNI `domainCtx` (`addServerName` propagates it; `sni_cb` swaps `ssl->ctx` before BoringSSL reads `alpn_select_cb`, so every ctx needs a copy).
- `HttpContext<true>::onData<IsNodeHttp>` checks ALPN at the top of each read; on `h2` it destructs the H1 per-socket state, `us_socket_adopt`s the socket into the H2 group (kind `.dynamic` → `h2VTable`), and dispatches the initial bytes (preface + client SETTINGS). The `SSL*` stays on the socket so TLS decryption continues transparently.
- Per-connection state (lshpack enc/dec, stream map, flow-control windows, frame-parse accumulator) lives in the adopted socket's ext. `Http2Response` is heap-allocated per stream, teardown deferred to `sweep()` so callers can touch the handle after `end()`/`tryEnd()` returns (matching H3's lsquic `process_conns()` deferral).
- Frame parser handles DATA / HEADERS / CONTINUATION / SETTINGS / WINDOW_UPDATE / PING / RST_STREAM / GOAWAY / PRIORITY per RFC 9113. HPACK via `lshpack` (same library the fetch client uses).

**C ABI** (`src/uws_sys/libuwsockets_h2.cpp`): `uws_h2_*` mirrors `uws_h3_*` 1:1.

**Rust** (`src/uws_sys/h2.rs`): mirrors `h3.rs` minus `ListenSocket`/`listen` (H2 shares the TCP listener). `AnyResponse`/`AnyRequest`/`ResponseKind`/`UWSResponseKind`/`SinkID`/`StartTag`/`CtxTag`/`NativePromiseContext::Tag` each gain an `H2` arm.

**MUX const-generic**: the last const-generic on `RequestContext` / `HTTPServerWritable` / `AnyRequestContext` / `NativePromiseContext` changes from `const HTTP3: bool` to `const MUX: u8` (`MUX_H1=0, MUX_H2=1, MUX_H3=2`). H2 and H3 share every stream-multiplexed semantic branch (connection-specific header filter, no transfer-encoding, `end_without_body` close flag, onAborted post-completion, TE→400) via `IS_MUX = MUX != MUX_H1`. Only concrete-type selection (`AnyResponse`/`AnyRequest` variant, `FetchHeaders::create_from_*`, `callRoute*`, sink name) branches on `IS_H2` vs `IS_H3`.

**server/mod.rs** wires `h2_app` alongside `h3_app`: created against the parent SSLApp in `listen()` (no separate `listen()` call), routes mirrored in `set_routes()`, GOAWAY on graceful `stop`, force-close on abrupt stop via `TemplatedApp::close()` walking the H2 group like it walks WS groups, destroyed in `deinit`.

## Tests

`test/js/bun/http/serve-http2.test.ts` (20 tests): basic GET, POST body + response headers echoed, HPACK header decode, user/static route mirroring, multi-frame >16KiB body with flow control, streamed ReadableStream response, multiplexed requests on one connection, `server.requestIP()`, HTTP/1.1 fallback on the same listener, trailers, SETTINGS/RST_STREAM/WINDOW_UPDATE protocol-error handling, `stop(true)` force-close, graceful stop, per-SNI ALPN, and option validation.

`serve-http3.test.ts` (48 tests) and `node-http2.test.js` (307 tests) still pass.

## Relationship to #29962 and #33487

This supersedes closed PR #29962. The `Http2*.h` layer is ported forward from that PR with the `onData<IsNodeHttp>` template rebase and 11-field `us_socket_vtable_t`; the Rust side is new (that PR was Zig-era).

Open PR #33487 also installs `SSL_CTX_set_alpn_select_cb` (in `us_ssl_ctx_build_raw`). This PR's `installH2Alpn` installs on the already-built `SSL_CTX`; when #33487 lands, `installH2Alpn` wins because it runs second, and can be folded into the user-supplied protocol list.

Fixes #14672

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 44 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http2.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/167] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/debug/codegen/JSSink.lut.h from /workspace/bun/build/debug/codegen/JSSink.lut.txt
[2/167] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/167] gen cpp.rs (cppbind)
[4/167] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts

... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4c11ece8f)

test/js/bun/http/serve-http2.test.ts:
(pass) Bun.serve http2: true > request headers decode via HPACK and reach the handler [45.26ms]
(pass) Bun.serve http2: true > HTTP/1.1 still works on the same listener when h2 is enabled [43.06ms]
(pass) Bun.serve http2: true > simple GET over ALPN h2 [48.07ms]
(pass) Bun.serve http2: true > multi-frame response body (>16KiB) with flow control [45.92ms]
(pass) Bun.serve http2: true > http2: true without tls throws [0.13ms]
(pass) Bun.serve http2: true > http2: true with http1: false throws [0.07ms]
(pass) Bun.serve http2: true > multiple requests multiplex on one TLS connection [45.19ms]
(pass) Bun.serve http2: true > server.requestIP(req) returns the peer's textual address [44.67ms]
(pass) Bun.serve http2: true > POST body + response headers echoed [47.49ms]
(pass) Bun.serve http2: true > streamed ReadableStream response arrives intact [51.31ms]
(pass) Bun.serve http2: true > user routes and static routes are mirrored onto the H2 router [52.14ms]
(pass) Bun.serve http2: true > request terminated by a trailer section delivers body to the handler [48.94ms]
(pass) Bun.serve http2: true > a fi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http2.test.ts"
bun test v1.4.0 (13805dd3b)

test/js/bun/http/serve-http2.test.ts:
(pass) Bun.serve http2: true > multi-frame response body (>16KiB) with flow control [559.72ms]
(pass) Bun.serve http2: true > request headers decode via HPACK and reach the handler [581.69ms]
(pass) Bun.serve http2: true > simple GET over ALPN h2 [632.90ms]
(pass) Bun.serve http2: true > POST body + response headers echoed [601.56ms]
(pass) Bun.serve http2: true > user routes and static routes are mirrored onto the H2 router [594.77ms]
(pass) Bun.serve http2: true > streamed ReadableStream response arrives intact [1004.25ms]
(pass) Bun.serve http2: true > multiple requests multiplex on one TLS connection [1013.63ms]
(pass) Bun.serve http2: true > HTTP/1.1 still works on the same listener when h2 is enabled [1008.44ms]
(pass) Bun.serve http2: true > server.requestIP(req) returns the peer's textual address [1021.48ms]
(pass) Bun.serve http2: true > request terminated by a trailer section delivers body to the handler [1033.26ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 639ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen cpp.rs (cppbind)
[2/125] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 7 sinks, 84 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[3/125] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[4/125] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRoute
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/serve.d.ts                      |   12 +
 packages/bun-uws/src/App.h                         |   26 +
 packages/bun-uws/src/Http2App.h                    |  349 ++++++
 packages/bun-uws/src/Http2Context.h                | 1118 ++++++++++++++++++++
 packages/bun-uws/src/Http2ContextData.h            |   23 +
 packages/bun-uws/src/Http2Request.h                |  121 +++
 packages/bun-uws/src/Http2Response.h               |  160 +++
 packages/bun-uws/src/Http2ResponseData.h           |  103 ++
 packages/bun-uws/src/HttpContext.h                 |   81 ++
 packages/bun-uws/src/HttpContextData.h             |   10 +
 src/codegen/generate-jssink.ts                     |    2 +
 src/jsc/FetchHeaders.rs                            |    6 +
 src/jsc/bindings/CookieMap.cpp                     |    4 +
 src/jsc/bindings/NativePromiseContext.h            |    2 +
 src/jsc/bindings/NodeHTTP.cpp                      |   57 +
 src/jsc/bindings/ServerRouteList.cpp               |   15 +
 src/jsc/bindings/Sink.h                            |    3 +-
 src/jsc/bindings/ZigGlobalObject.cpp               |   26 +
 src/jsc/bindings/ZigGlobalObject.h                 |   15 +-
 src/jsc/bindings/bindings.cpp                      |   26 +
 src/jsc/bindings/headers-handwritten.h             |    1 +
 src/jsc/bindings/headers.h                         |   30 +
 .../bindings/webcore/streams/BunStreamSource.cpp   |    1 +
 src/runtime/api/NativePromiseContext.rs            |  104 +-
 src/runtime/bake/DevServer.rs                      |    4 +-
 src/runtime/server/AnyRequestContext.rs            |   74 +-
 src/runtime/server/FileResponseStream.rs           |    4 +-
 src/runtime/server/FileRoute.rs                    |   17 +
 src/runtime/server/HTMLBundle.rs                   |    2 +-
 src/runtime/server/NodeHTTPResponse.rs             |    3 +
 src/runtime/server/RequestContext.rs               |  356 ++++---
 src/runtime/server/ServerConfig.rs                
... (truncated)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
packages/bun-types/serve.d.ts                 0      0      0
packages/bun-uws/src/App.h                    0      0      0
packages/bun-uws/src/Http2App.h               3      4      0
packages/bun-uws/src/Http2Context.h           9     11      0
packages/bun-uws/src/Http2ContextData.h       0      0      0
packages/bun-uws/src/Http2Request.h           1      2      0
packages/bun-uws/src/Http2Response.h          2      2      0
packages/bun-uws/src/Http2ResponseData.h      1      1      0
packages/bun-uws/src/HttpContext.h            0      0      0
packages/bun-uws/src/HttpContextData.h        0      0      0
src/codegen/generate-jssink.ts                0      0      0
src/jsc/FetchHeaders.rs                       0      0      0
src/jsc/bindings/CookieMap.cpp                0      0      0
src/jsc/bindings/NativePromiseContext.h       0      0      0
src/jsc/bindings/NodeHTTP.cpp                 0      0      0
src/jsc/bindings/ServerRouteList.cpp          0      0      0
(+ 28 more files)
```

</details>

<!-- robobun:evidence:end -->