### PR TITLE
paths: terminate recursive mkdir walk when a confirmed parent still yields ENOENT

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -313,50 +313,48 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
 #[cold]
 #[inline(never)]
 unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
-    loop {
-        // SAFETY: field projections through the caller-provided provenance
-        // root; see fn safety contract. Project `enable` narrowly so callers
-        // may hold borrows into disjoint `options` sub-fields.
-        if unsafe { (*this).options.enable.contains(Enable::CACHE) } {
-            // SAFETY: caller-provided provenance root; `env_mut()` itself
-            // encapsulates the BackRef deref + singleton-liveness invariant.
-            let env = unsafe { &*this }.env_mut();
-            // SAFETY: shared read of `options`; disjoint from `cache_directory_path`.
-            let cache_dir = fetch_cache_directory_path(env, Some(unsafe { &(*this).options }));
-            // SAFETY: see fn safety contract.
-            unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
-
-            match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
-                Ok(d) => return d,
-                Err(_) => {
-                    // SAFETY: narrow `&mut enable` projection; disjoint from
-                    // any `&options.{registries,scope}` the caller may hold.
-                    unsafe { (*this).options.enable.set(Enable::CACHE, false) };
-                    // SAFETY: see fn safety contract.
-                    unsafe { (*this).cache_directory_path = ZBox::from_bytes(b"") };
-                    continue;
-                }
-            }
-        }
-
+    // SAFETY: field projections through the caller-provided provenance
+    // root; see fn safety contract. Project `enable` narrowly so callers
+    // may hold borrows into disjoint `options` sub-fields.
+    if unsafe { (*this).options.enable.contains(Enable::CACHE) } {
+        // SAFETY: caller-provided provenance root; `env_mut()` itself
+        // encapsulates the BackRef deref + singleton-liveness invariant.
+        let env = unsafe { &*this }.env_mut();
+        // SAFETY: shared read of `options`; disjoint from `cache_directory_path`.
+        let cache_dir = fetch_cache_directory_path(env, Some(unsafe { &(*this).options }));
         // SAFETY: see fn safety contract.
-        unsafe {
-            (*this).cache_directory_path =
-                ZBox::from_bytes(path::resolve_path::join_abs_string::<path::platform::Auto>(
-                    FileSystem::instance().top_level_dir(),
-                    &[b"node_modules", b".cache"],
-                ))
-        };
+        unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
 
-        match Dir::cwd().make_open_path(b"node_modules/.cache", Default::default()) {
-            Ok(d) => return d,
+        return match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
+            Ok(d) => d,
             Err(err) => {
                 bun_core::pretty_errorln!(
-                    "<r><red>error<r>: bun is unable to write files: {}",
+                    "<r><red>error<r>: cache directory \"{}\" is not creatable: {}",
+                    bun_fmt::s(&cache_dir.path),
                     bun_fmt::s(err.name())
                 );
                 Global::crash();
             }
+        };
+    }
+
+    // SAFETY: see fn safety contract.
+    unsafe {
+        (*this).cache_directory_path =
+            ZBox::from_bytes(path::resolve_path::join_abs_string::<path::platform::Auto>(
+                FileSystem::instance().top_level_dir(),
+                &[b"node_modules", b".cache"],
+            ))
+    };
+
+    match Dir::cwd().make_open_path(b"node_modules/.cache", Default::default()) {
+        Ok(d) => d,
+        Err(err) => {
+            bun_core::pretty_errorln!(
+                "<r><red>error<r>: bun is unable to write files: {}",
+                bun_fmt::s(err.name())
+            );
+            Global::crash();
         }
     }
 }

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -375,7 +375,7 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
 pub struct CacheDir {
     pub path: Vec<u8>,
     pub is_node_modules: bool,
-    /// True only for `BUN_INSTALL_CACHE_DIR` / bunfig `install.cache.dir`.
+    /// `BUN_INSTALL_CACHE_DIR`, `--cache-dir`, or bunfig `install.cache.dir`.
     pub is_explicit: bool,
 }
 

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -325,17 +325,29 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
         // SAFETY: see fn safety contract.
         unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
 
-        return match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
-            Ok(d) => d,
-            Err(err) => {
+        match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
+            Ok(d) => return d,
+            Err(err) if cache_dir.is_explicit => {
                 bun_core::pretty_errorln!(
-                    "<r><red>error<r>: cache directory \"{}\" is not creatable: {}",
-                    bun_fmt::s(&cache_dir.path),
+                    "<r><red>error<r>: cache directory {} is not creatable: {}",
+                    bun_fmt::quote(&cache_dir.path),
                     bun_fmt::s(err.name())
                 );
                 Global::crash();
             }
-        };
+            Err(err) => {
+                bun_core::pretty_errorln!(
+                    "<r><yellow>warn<r>: cache directory {} is not creatable: {}, falling back to node_modules/.cache",
+                    bun_fmt::quote(&cache_dir.path),
+                    bun_fmt::s(err.name())
+                );
+                // SAFETY: narrow `&mut enable` projection; disjoint from
+                // any `&options.{registries,scope}` the caller may hold.
+                unsafe { (*this).options.enable.set(Enable::CACHE, false) };
+                // SAFETY: see fn safety contract.
+                unsafe { (*this).cache_directory_path = ZBox::from_bytes(b"") };
+            }
+        }
     }
 
     // SAFETY: see fn safety contract.
@@ -362,6 +374,9 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
 pub struct CacheDir {
     pub path: Vec<u8>,
     pub is_node_modules: bool,
+    /// Set when the path came from `BUN_INSTALL_CACHE_DIR` or bunfig's
+    /// `install.cache.dir` (user asked for this directory specifically).
+    pub is_explicit: bool,
 }
 
 pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Options>) -> CacheDir {
@@ -369,6 +384,7 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
         return CacheDir {
             path: FileSystem::instance().abs(&[dir]).to_vec(),
             is_node_modules: false,
+            is_explicit: true,
         };
     }
 
@@ -377,6 +393,7 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
             return CacheDir {
                 path: FileSystem::instance().abs(&[opts.cache_directory]).to_vec(),
                 is_node_modules: false,
+                is_explicit: true,
             };
         }
     }
@@ -386,6 +403,7 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
         return CacheDir {
             path: FileSystem::instance().abs(&parts).to_vec(),
             is_node_modules: false,
+            is_explicit: false,
         };
     }
 
@@ -394,6 +412,7 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
         return CacheDir {
             path: FileSystem::instance().abs(&parts).to_vec(),
             is_node_modules: false,
+            is_explicit: false,
         };
     }
 
@@ -402,12 +421,14 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
         return CacheDir {
             path: FileSystem::instance().abs(&parts).to_vec(),
             is_node_modules: false,
+            is_explicit: false,
         };
     }
 
     let fallback_parts: [&[u8]; 1] = [b"node_modules/.bun-cache"];
     CacheDir {
         is_node_modules: true,
+        is_explicit: false,
         path: FileSystem::instance().abs(&fallback_parts).to_vec(),
     }
 }

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -336,11 +336,14 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
                 Global::crash();
             }
             Err(err) => {
-                bun_core::pretty_errorln!(
-                    "<r><yellow>warn<r>: cache directory {} is not creatable: {}, falling back to node_modules/.cache",
-                    bun_fmt::quote(&cache_dir.path),
-                    bun_fmt::s(err.name())
-                );
+                // SAFETY: shared read of `options.log_level`; see fn safety contract.
+                if unsafe { (*this).options.log_level } != LogLevel::Silent {
+                    bun_core::pretty_errorln!(
+                        "<r><yellow>warn<r>: cache directory {} is not creatable: {}, falling back to node_modules/.cache",
+                        bun_fmt::quote(&cache_dir.path),
+                        bun_fmt::s(err.name())
+                    );
+                }
                 // SAFETY: narrow `&mut enable` projection; disjoint from
                 // any `&options.{registries,scope}` the caller may hold.
                 unsafe { (*this).options.enable.set(Enable::CACHE, false) };

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -344,8 +344,6 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
                 // SAFETY: narrow `&mut enable` projection; disjoint from
                 // any `&options.{registries,scope}` the caller may hold.
                 unsafe { (*this).options.enable.set(Enable::CACHE, false) };
-                // SAFETY: see fn safety contract.
-                unsafe { (*this).cache_directory_path = ZBox::from_bytes(b"") };
             }
         }
     }

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -374,8 +374,7 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
 pub struct CacheDir {
     pub path: Vec<u8>,
     pub is_node_modules: bool,
-    /// Set when the path came from `BUN_INSTALL_CACHE_DIR` or bunfig's
-    /// `install.cache.dir` (user asked for this directory specifically).
+    /// True only for `BUN_INSTALL_CACHE_DIR` / bunfig `install.cache.dir`.
     pub is_explicit: bool,
 }
 

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -207,6 +207,14 @@ pub enum MakePathStep<E> {
 /// `previous()` (returning `Err(e)` when there is none — i.e. the very first
 /// component's parent does not exist).
 ///
+/// Once the walk has advanced forward at all, a subsequent `NotFound` is
+/// terminal: the parent was just confirmed `Created`/`Exists`, so stepping
+/// back would only bounce between the two forever. This is exactly what
+/// happens when a component is a dangling symlink (the link itself is
+/// `EEXIST` but any child is `ENOENT`) or a procfs-like path that cannot host
+/// children. `node_fs::mkdir_recursive_os_path_impl` encodes the same rule by
+/// running a distinct forward pass where `ENOENT` is fatal.
+///
 /// `mkdir` is invoked with `component.path`: a borrowed prefix slice into the
 /// original input, never NUL-terminated. Callers that need a sentinel must
 /// copy into a scratch buffer.
@@ -217,14 +225,17 @@ pub fn make_path_with<'a, T: PathChar, E>(
     let Some(mut comp) = it.last() else {
         return Ok(());
     };
+    let mut advanced = false;
     loop {
         match mkdir(comp.path)? {
             MakePathStep::Created | MakePathStep::Exists => {
+                advanced = true;
                 comp = match it.next() {
                     Some(c) => c,
                     None => return Ok(()),
                 };
             }
+            MakePathStep::NotFound(e) if advanced => return Err(e),
             MakePathStep::NotFound(e) => {
                 comp = match it.previous() {
                     Some(c) => c,
@@ -388,5 +399,53 @@ mod tests {
         assert_eq!(it.next().unwrap().name, b"b");
         assert_eq!(it.next().unwrap().name, b"c");
         assert!(it.next().is_none());
+    }
+
+    #[test]
+    fn make_path_terminates_when_parent_exists_but_child_is_enoent() {
+        // Model a dangling symlink at `/a/b`: mkdir `/a/b` → EEXIST (the link
+        // itself exists) but mkdir `/a/b/c` → ENOENT (the link target does
+        // not). Without the forward-pass termination this loops forever.
+        let it = ComponentIterator::init(&b"/a/b/c"[..], PathFormat::Posix).unwrap();
+        let mut calls = 0u32;
+        let r = make_path_with(it, |p| {
+            calls += 1;
+            assert!(calls < 100, "runaway loop");
+            match p {
+                b"/a" | b"/a/b" => Ok(MakePathStep::Exists),
+                b"/a/b/c" => Ok(MakePathStep::NotFound(())),
+                _ => unreachable!(),
+            }
+        });
+        assert!(r.is_err());
+        // leaf ENOENT → parent EEXIST → leaf ENOENT → stop.
+        assert_eq!(calls, 3);
+    }
+
+    #[test]
+    fn make_path_walks_back_then_forward() {
+        // `/a` exists, `/a/b` and `/a/b/c` do not.
+        let it = ComponentIterator::init(&b"/a/b/c"[..], PathFormat::Posix).unwrap();
+        let mut created: Vec<&[u8]> = vec![];
+        let mut calls = 0u32;
+        let r = make_path_with::<u8, ()>(it, |p| {
+            calls += 1;
+            assert!(calls < 100, "runaway loop");
+            if p == b"/a" {
+                return Ok(MakePathStep::Exists);
+            }
+            if created.iter().any(|c| *c == p) {
+                return Ok(MakePathStep::Exists);
+            }
+            let parent = &p[..p.iter().rposition(|b| *b == b'/').unwrap()];
+            if parent == b"/a" || created.iter().any(|c| *c == parent) {
+                created.push(p);
+                Ok(MakePathStep::Created)
+            } else {
+                Ok(MakePathStep::NotFound(()))
+            }
+        });
+        assert!(r.is_ok());
+        assert_eq!(created, vec![&b"/a/b"[..], &b"/a/b/c"[..]]);
     }
 }

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -205,11 +205,8 @@ pub enum MakePathStep<E> {
 /// Starts at `it.last()`; on `Created`/`Exists` advances via `next()`
 /// (returning `Ok(())` when there is none), on `NotFound(e)` steps back via
 /// `previous()` (returning `Err(e)` when there is none — i.e. the very first
-/// component's parent does not exist).
-///
-/// Once the walk has advanced forward, a subsequent `NotFound` is terminal:
-/// the parent was just confirmed to exist, so stepping back would oscillate
-/// (e.g. a dangling symlink is `EEXIST` itself but `ENOENT` for any child).
+/// component's parent does not exist). Once the walk has advanced forward,
+/// `NotFound` is terminal (the just-confirmed parent cannot host the child).
 ///
 /// `mkdir` is invoked with `component.path`: a borrowed prefix slice into the
 /// original input, never NUL-terminated. Callers that need a sentinel must

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -207,13 +207,9 @@ pub enum MakePathStep<E> {
 /// `previous()` (returning `Err(e)` when there is none — i.e. the very first
 /// component's parent does not exist).
 ///
-/// Once the walk has advanced forward at all, a subsequent `NotFound` is
-/// terminal: the parent was just confirmed `Created`/`Exists`, so stepping
-/// back would only bounce between the two forever. This is exactly what
-/// happens when a component is a dangling symlink (the link itself is
-/// `EEXIST` but any child is `ENOENT`) or a procfs-like path that cannot host
-/// children. `node_fs::mkdir_recursive_os_path_impl` encodes the same rule by
-/// running a distinct forward pass where `ENOENT` is fatal.
+/// Once the walk has advanced forward, a subsequent `NotFound` is terminal:
+/// the parent was just confirmed to exist, so stepping back would oscillate
+/// (e.g. a dangling symlink is `EEXIST` itself but `ENOENT` for any child).
 ///
 /// `mkdir` is invoked with `component.path`: a borrowed prefix slice into the
 /// original input, never NUL-terminated. Callers that need a sentinel must
@@ -403,9 +399,7 @@ mod tests {
 
     #[test]
     fn make_path_terminates_when_parent_exists_but_child_is_enoent() {
-        // Model a dangling symlink at `/a/b`: mkdir `/a/b` → EEXIST (the link
-        // itself exists) but mkdir `/a/b/c` → ENOENT (the link target does
-        // not). Without the forward-pass termination this loops forever.
+        // `/a/b` is a dangling symlink: EEXIST itself, ENOENT for any child.
         let it = ComponentIterator::init(&b"/a/b/c"[..], PathFormat::Posix).unwrap();
         let mut calls = 0u32;
         let r = make_path_with(it, |p| {

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -193,8 +193,8 @@ pub enum MakePathStep<E> {
     Created,
     /// Directory already exists (`EEXIST`). Walk advances forward.
     Exists,
-    /// A parent is missing (`ENOENT`). Walk steps back one component;
-    /// if there is no previous component the carried error is returned.
+    /// A parent is missing (`ENOENT`). Returns the error if the walk has
+    /// already advanced or there is no previous component; else steps back.
     NotFound(E),
 }
 

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -205,8 +205,7 @@ pub enum MakePathStep<E> {
 /// Starts at `it.last()`; on `Created`/`Exists` advances via `next()`
 /// (returning `Ok(())` when there is none), on `NotFound(e)` steps back via
 /// `previous()` (returning `Err(e)` when there is none — i.e. the very first
-/// component's parent does not exist). Once the walk has advanced forward,
-/// `NotFound` is terminal (the just-confirmed parent cannot host the child).
+/// component's parent does not exist).
 ///
 /// `mkdir` is invoked with `component.path`: a borrowed prefix slice into the
 /// original input, never NUL-terminated. Callers that need a sentinel must

--- a/test/cli/install/bun-install-cache-dir.test.ts
+++ b/test/cli/install/bun-install-cache-dir.test.ts
@@ -35,11 +35,7 @@ describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", ()
       stderr: "pipe",
       timeout: 15_000,
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // On hang, Bun.spawn's timeout fires and the child is killed with a
     // signal. With the fix, bun exits on its own (registry is unreachable).

--- a/test/cli/install/bun-install-cache-dir.test.ts
+++ b/test/cli/install/bun-install-cache-dir.test.ts
@@ -3,16 +3,8 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { symlinkSync } from "node:fs";
 import { join } from "node:path";
 
-// A dangling symlink (link itself exists, target does not) makes the
-// recursive cache-dir creation loop oscillate: mkdir(link/child) → ENOENT,
-// mkdir(link) → EEXIST, repeat. The process spun forever at ~50k mkdirat/s
-// with no output. With the fix, the cache-dir open fails and install falls
-// back to node_modules/.cache.
-//
-// Windows is skipped: symlink creation needs Developer Mode / admin, and the
-// fix is in the shared path walk so POSIX coverage is sufficient.
 describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", () => {
-  test("bun install exits instead of spinning in mkdirat", { timeout: 60_000 }, async () => {
+  test("bun install exits instead of spinning in mkdirat", async () => {
     using dir = tempDir("cache-dir-dangling", {
       "proj/package.json": JSON.stringify({
         name: "x",
@@ -37,8 +29,6 @@ describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", ()
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // On hang, Bun.spawn's timeout fires and the child is killed with a
-    // signal. With the fix, bun exits on its own (registry is unreachable).
     expect({ signalCode: proc.signalCode, stdout, stderr }).toMatchObject({
       signalCode: null,
     });

--- a/test/cli/install/bun-install-cache-dir.test.ts
+++ b/test/cli/install/bun-install-cache-dir.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { symlinkSync } from "node:fs";
+import { existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
-describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", () => {
+describe.skipIf(isWindows)("install cache directory inside a dangling symlink", () => {
   function setup() {
     const dir = tempDir("cache-dir-dangling", {
       "proj/package.json": JSON.stringify({
@@ -14,26 +14,25 @@ describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", ()
     });
     const root = String(dir);
     symlinkSync(join(root, "does-not-exist"), join(root, "dangling"));
-    const cacheDir = join(root, "dangling", "cache");
+    return { dir, root, dangling: join(root, "dangling"), cwd: join(root, "proj") };
+  }
+
+  function explicitEnv(cacheDir: string) {
     return {
-      dir,
-      cacheDir,
-      env: {
-        ...bunEnv,
-        BUN_INSTALL_CACHE_DIR: cacheDir,
-        BUN_CONFIG_REGISTRY: "http://127.0.0.1:1/",
-      },
-      cwd: join(root, "proj"),
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: cacheDir,
+      BUN_CONFIG_REGISTRY: "http://127.0.0.1:1/",
     };
   }
 
   test.concurrent("bun install exits with a cache-directory error instead of spinning in mkdirat", async () => {
     const ctx = setup();
     using _dir = ctx.dir;
+    const cacheDir = join(ctx.dangling, "cache");
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install"],
       cwd: ctx.cwd,
-      env: ctx.env,
+      env: explicitEnv(cacheDir),
       stdout: "pipe",
       stderr: "pipe",
       timeout: 15_000,
@@ -42,7 +41,7 @@ describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", ()
 
     expect({ signalCode: proc.signalCode, stdout, stderr }).toMatchObject({
       signalCode: null,
-      stderr: expect.stringContaining(`cache directory "${ctx.cacheDir}" is not creatable: ENOENT`),
+      stderr: expect.stringContaining(`error: cache directory "${cacheDir}" is not creatable: ENOENT`),
     });
     expect(stderr).not.toContain("ConnectionRefused");
     expect(exitCode).not.toBe(0);
@@ -51,10 +50,11 @@ describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", ()
   test.concurrent("runtime auto-install exits with a cache-directory error instead of spinning", async () => {
     const ctx = setup();
     using _dir = ctx.dir;
+    const cacheDir = join(ctx.dangling, "cache");
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `require("any-pkg")`],
       cwd: ctx.cwd,
-      env: ctx.env,
+      env: explicitEnv(cacheDir),
       stdout: "pipe",
       stderr: "pipe",
       timeout: 15_000,
@@ -63,8 +63,37 @@ describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", ()
 
     expect({ signalCode: proc.signalCode, stdout, stderr }).toMatchObject({
       signalCode: null,
-      stderr: expect.stringContaining(`cache directory "${ctx.cacheDir}" is not creatable: ENOENT`),
+      stderr: expect.stringContaining(`error: cache directory "${cacheDir}" is not creatable: ENOENT`),
     });
+    expect(exitCode).not.toBe(0);
+  });
+
+  test.concurrent("implicit $HOME-derived cache dir warns and falls back to node_modules/.cache", async () => {
+    const ctx = setup();
+    using _dir = ctx.dir;
+    const env = { ...bunEnv, BUN_CONFIG_REGISTRY: "http://127.0.0.1:1/" };
+    delete env.BUN_INSTALL_CACHE_DIR;
+    delete env.BUN_INSTALL;
+    delete env.XDG_CACHE_HOME;
+    env.HOME = ctx.dangling;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: ctx.cwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ signalCode: proc.signalCode, stdout, stderr }).toMatchObject({
+      signalCode: null,
+      stderr: expect.stringContaining(`is not creatable: ENOENT, falling back to node_modules/.cache`),
+    });
+    expect(stderr).toContain("warn: cache directory");
+    expect(stderr).toContain("ConnectionRefused");
+    expect(existsSync(join(ctx.cwd, "node_modules", ".cache"))).toBe(true);
     expect(exitCode).not.toBe(0);
   });
 });

--- a/test/cli/install/bun-install-cache-dir.test.ts
+++ b/test/cli/install/bun-install-cache-dir.test.ts
@@ -47,6 +47,38 @@ describe.skipIf(isWindows)("install cache directory inside a dangling symlink", 
     expect(exitCode).not.toBe(0);
   });
 
+  test.concurrent("bunfig install.cache.dir exits with a cache-directory error instead of spinning", async () => {
+    using dir = tempDir("cache-dir-dangling-bunfig", {
+      "proj/package.json": JSON.stringify({ name: "x", version: "1.0.0", dependencies: { "any-pkg": "1.0.0" } }),
+    });
+    const root = String(dir);
+    symlinkSync(join(root, "does-not-exist"), join(root, "dangling"));
+    const cacheDir = join(root, "dangling", "cache");
+    await Bun.write(
+      join(root, "proj", "bunfig.toml"),
+      `[install]\nregistry = "http://127.0.0.1:1/"\n[install.cache]\ndir = ${JSON.stringify(cacheDir)}\n`,
+    );
+    const env = { ...bunEnv };
+    delete env.BUN_INSTALL_CACHE_DIR;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(root, "proj"),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ signalCode: proc.signalCode, stdout, stderr }).toMatchObject({
+      signalCode: null,
+      stderr: expect.stringContaining(`error: cache directory "${cacheDir}" is not creatable: ENOENT`),
+    });
+    expect(stderr).not.toContain("ConnectionRefused");
+    expect(exitCode).not.toBe(0);
+  });
+
   test.concurrent("runtime auto-install exits with a cache-directory error instead of spinning", async () => {
     const ctx = setup();
     using _dir = ctx.dir;

--- a/test/cli/install/bun-install-cache-dir.test.ts
+++ b/test/cli/install/bun-install-cache-dir.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { symlinkSync } from "node:fs";
+import { join } from "node:path";
+
+// A dangling symlink (link itself exists, target does not) makes the
+// recursive cache-dir creation loop oscillate: mkdir(link/child) → ENOENT,
+// mkdir(link) → EEXIST, repeat. The process spun forever at ~50k mkdirat/s
+// with no output. With the fix, the cache-dir open fails and install falls
+// back to node_modules/.cache.
+//
+// Windows is skipped: symlink creation needs Developer Mode / admin, and the
+// fix is in the shared path walk so POSIX coverage is sufficient.
+describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", () => {
+  test("bun install exits instead of spinning in mkdirat", { timeout: 60_000 }, async () => {
+    using dir = tempDir("cache-dir-dangling", {
+      "proj/package.json": JSON.stringify({
+        name: "x",
+        version: "1.0.0",
+        dependencies: { "any-pkg": "1.0.0" },
+      }),
+    });
+    const root = String(dir);
+    symlinkSync(join(root, "does-not-exist"), join(root, "dangling"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(root, "proj"),
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(root, "dangling", "cache"),
+        BUN_CONFIG_REGISTRY: "http://127.0.0.1:1/",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // On hang, Bun.spawn's timeout fires and the child is killed with a
+    // signal. With the fix, bun exits on its own (registry is unreachable).
+    expect({ signalCode: proc.signalCode, stdout, stderr }).toMatchObject({
+      signalCode: null,
+    });
+    expect(stderr).toContain("error");
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/test/cli/install/bun-install-cache-dir.test.ts
+++ b/test/cli/install/bun-install-cache-dir.test.ts
@@ -4,8 +4,8 @@ import { symlinkSync } from "node:fs";
 import { join } from "node:path";
 
 describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", () => {
-  test("bun install exits instead of spinning in mkdirat", async () => {
-    using dir = tempDir("cache-dir-dangling", {
+  function setup() {
+    const dir = tempDir("cache-dir-dangling", {
       "proj/package.json": JSON.stringify({
         name: "x",
         version: "1.0.0",
@@ -14,15 +14,26 @@ describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", ()
     });
     const root = String(dir);
     symlinkSync(join(root, "does-not-exist"), join(root, "dangling"));
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: join(root, "proj"),
+    const cacheDir = join(root, "dangling", "cache");
+    return {
+      dir,
+      cacheDir,
       env: {
         ...bunEnv,
-        BUN_INSTALL_CACHE_DIR: join(root, "dangling", "cache"),
+        BUN_INSTALL_CACHE_DIR: cacheDir,
         BUN_CONFIG_REGISTRY: "http://127.0.0.1:1/",
       },
+      cwd: join(root, "proj"),
+    };
+  }
+
+  test.concurrent("bun install exits with a cache-directory error instead of spinning in mkdirat", async () => {
+    const ctx = setup();
+    using _dir = ctx.dir;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: ctx.cwd,
+      env: ctx.env,
       stdout: "pipe",
       stderr: "pipe",
       timeout: 15_000,
@@ -31,8 +42,29 @@ describe.skipIf(isWindows)("BUN_INSTALL_CACHE_DIR inside a dangling symlink", ()
 
     expect({ signalCode: proc.signalCode, stdout, stderr }).toMatchObject({
       signalCode: null,
+      stderr: expect.stringContaining(`cache directory "${ctx.cacheDir}" is not creatable: ENOENT`),
     });
-    expect(stderr).toContain("error");
+    expect(stderr).not.toContain("ConnectionRefused");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test.concurrent("runtime auto-install exits with a cache-directory error instead of spinning", async () => {
+    const ctx = setup();
+    using _dir = ctx.dir;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `require("any-pkg")`],
+      cwd: ctx.cwd,
+      env: ctx.env,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ signalCode: proc.signalCode, stdout, stderr }).toMatchObject({
+      signalCode: null,
+      stderr: expect.stringContaining(`cache directory "${ctx.cacheDir}" is not creatable: ENOENT`),
+    });
     expect(exitCode).not.toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

`bun install` and the runtime auto-installer spin forever at ~50k `mkdirat`/s, burning a full core with no output, when the resolved install cache directory is inside a path whose parent exists but cannot host children (e.g. a dangling symlink to an unmounted disk, or a procfs path).

## Repro

```sh
D=$(mktemp -d); cd "$D"
ln -s "$D/does-not-exist" dangling
mkdir proj && cd proj
printf '{"name":"x","version":"1.0.0","dependencies":{"any-pkg":"1.0.0"}}\n' > package.json
BUN_INSTALL_CACHE_DIR="$D/dangling/cache" BUN_CONFIG_REGISTRY=http://127.0.0.1:9/ \
  timeout 10 strace -f -c -e trace=mkdirat bun install
# rc=124; strace shows ~500k mkdirat calls, 100% ENOENT/EEXIST, still running at 10s
```

The raw loop:

```
mkdirat(".../dangling/cache") = -1 ENOENT
mkdirat(".../dangling")       = -1 EEXIST
mkdirat(".../dangling/cache") = -1 ENOENT
... forever
```

## Cause

`bun_paths::make_path_with` drives the shared back-then-forward `mkdir -p` walk used by `bun_sys::mkdir_recursive_at` (POSIX and Windows) and the libarchive `u16` variant. On `ENOENT` it steps back to the parent; on `Created`/`EEXIST` it steps forward. When the parent is a dangling symlink the walk oscillates forever. `fs.mkdirSync(path, {recursive: true})` already throws `ENOENT` cleanly on the same path because `node_fs::mkdir_recursive_os_path_impl` runs a distinct forward pass where `ENOENT` is fatal.

## Fix

- **`make_path_with`**: once the walk has advanced forward (parent confirmed `Created`/`Exists`), a subsequent `NotFound` returns the error instead of stepping back. The normal "walk back to the first existing ancestor, then forward" path is unchanged.
- **`ensure_cache_directory`**: when `make_open_path` on the resolved cache directory fails, surface the error instead of silently disabling the cache. `CacheDir` now carries `is_explicit`, true only when the path came from `BUN_INSTALL_CACHE_DIR` or bunfig's `install.cache.dir`:
  - explicit path: print `error: cache directory "<path>" is not creatable: <errno>` and exit.
  - implicit default (`$BUN_INSTALL`, `$XDG_CACHE_HOME`, `$HOME`, or the in-tree fallback): print `warn: cache directory "<path>" is not creatable: <errno>, falling back to node_modules/.cache` and continue. This preserves the existing fallback for unwritable `$HOME/.bun` (root-owned after `sudo`, read-only `$HOME` in containers).

After:

```
$ BUN_INSTALL_CACHE_DIR="$D/dangling/cache" bun install
bun install v1.4.0
error: cache directory "/tmp/.../dangling/cache" is not creatable: ENOENT
$ echo $?
1

$ HOME="$D/dangling" bun install    # no BUN_INSTALL_CACHE_DIR
bun install v1.4.0
warn: cache directory "/tmp/.../dangling/.bun/install/cache/" is not creatable: ENOENT, falling back to node_modules/.cache
Resolving dependencies
...
```

## Verification

- `USE_SYSTEM_BUN=1 bun test test/cli/install/bun-install-cache-dir.test.ts`: all three tests fail (processes spin, test-runner timeout).
- `bun bd test test/cli/install/bun-install-cache-dir.test.ts`: all three pass in ~150-300ms, asserting `signalCode === null` and the exact error/warn text. The implicit-path test also asserts `node_modules/.cache` exists on disk and that resolution continued past cache init.
- `cargo test -p bun_paths component_iterator`: new `make_path_terminates_when_parent_exists_but_child_is_enoent` unit test passes; positive-path walk test unchanged.
- `bun bd test test/js/node/fs/fs-mkdir.test.ts` and `test/cli/install/bun-install-retry.test.ts`: still green.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-cache-dir.test.ts

<!-- robobun:evidence:end -->