### PR TITLE
resolver: inherit auto-install settings in Worker threads

### DIFF
--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -74,9 +74,9 @@ impl AnyEventLoop {
         }
     }
 
-    pub fn execution_forbidden(&self) -> bool {
+    pub fn has_termination_request(&self) -> bool {
         match self {
-            AnyEventLoop::Js { owner } => owner.execution_forbidden(),
+            AnyEventLoop::Js { owner } => owner.has_termination_request(),
             AnyEventLoop::Mini(_) => false,
         }
     }

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -74,6 +74,13 @@ impl AnyEventLoop {
         }
     }
 
+    pub fn execution_forbidden(&self) -> bool {
+        match self {
+            AnyEventLoop::Js { owner } => owner.execution_forbidden(),
+            AnyEventLoop::Mini(_) => false,
+        }
+    }
+
     /// Convert to an owned [`EventLoopHandle`]. Thin alias for
     /// [`EventLoopHandle::from_any`].
     #[inline]

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -53,7 +53,7 @@ bun_dispatch::link_interface! {
         fn tick();
         fn auto_tick();
         fn auto_tick_active();
-        fn execution_forbidden() -> bool;
+        fn has_termination_request() -> bool;
         fn global_object() -> *mut ();
         fn bun_vm() -> *mut ();
         fn stdout() -> *mut ();

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -53,6 +53,7 @@ bun_dispatch::link_interface! {
         fn tick();
         fn auto_tick();
         fn auto_tick_active();
+        fn execution_forbidden() -> bool;
         fn global_object() -> *mut ();
         fn bun_vm() -> *mut ();
         fn stdout() -> *mut ();

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -879,8 +879,8 @@ impl PackageManager {
     /// Raw-pointer wake for concurrent task-thread callers (see
     /// `isolated_install::Installer::Task::callback`). Never materializes
     /// `&mut PackageManager`, so two task threads finishing simultaneously do
-    /// not hold aliased exclusive borrows. `on_wake` is read-only; the handler
-    /// receives the raw `*mut`;
+    /// not hold aliased exclusive borrows. `on_wake` is serialized under its
+    /// own mutex; each handler receives the raw `*mut`;
     /// `event_loop.wakeup()` is the cross-thread signal and is
     /// internally synchronized — we reach it via `addr_of_mut!` so the `&mut`
     /// covers only the event-loop field, never the whole `PackageManager`.

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2301,11 +2301,14 @@ pub(crate) fn init_with_runtime_once(
         );
         wr!(root_dir, root_dir);
         wr!(ast_arena, bun_alloc::Arena::new());
-        // reborrow `&mut *env` so the local stays usable for
-        // the post-construction `BUN_MANIFEST_CACHE` / `options.load`
-        // reads. `BackRef` stores a raw pointer —
-        // ending the reborrow here does not alias the later uses.
-        wr!(env, Some(bun_ptr::BackRef::new_mut(&mut *env)));
+        wr!(
+            env,
+            Some(bun_ptr::BackRef::new_mut(&mut *bun_core::heap::into_raw(
+                Box::new(dot_env::Loader::init_with_map(
+                    env.map.clone_with_allocator()?,
+                ))
+            )))
+        );
         wr!(
             thread_pool,
             ThreadPool::init(thread_pool::Config {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -393,6 +393,7 @@ pub struct PackageManager {
 
     pub on_wake: bun_core::Mutex<Vec<WakeHandler>>,
     pub failed_root_dependencies: bun_core::Mutex<Vec<(DependencyID, &'static str)>>,
+    pub runtime_wake_via_handlers: AtomicBool,
 
     pub peer_dependencies: LinearFifo<DependencyID, DynamicBuffer<DependencyID>>,
 
@@ -898,7 +899,9 @@ impl PackageManager {
                     (h.get_handler())(ctx.as_ptr(), this.cast::<c_void>());
                 }
             }
-            (*core::ptr::addr_of_mut!((*this).event_loop)).wakeup();
+            if !(*core::ptr::addr_of!((*this).runtime_wake_via_handlers)).load(Ordering::Acquire) {
+                (*core::ptr::addr_of_mut!((*this).event_loop)).wakeup();
+            }
         }
     }
 
@@ -1940,6 +1943,7 @@ pub fn init(
         wr!(global_link_dir_path, Box::default());
         wr!(on_wake, bun_core::Mutex::new(Vec::new()));
         wr!(failed_root_dependencies, bun_core::Mutex::new(Vec::new()));
+        wr!(runtime_wake_via_handlers, AtomicBool::new(false));
         wr!(
             peer_dependencies,
             LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()
@@ -2304,9 +2308,9 @@ pub(crate) fn init_with_runtime_once(
         wr!(
             env,
             Some(bun_ptr::BackRef::new_mut(&mut *bun_core::heap::into_raw(
-                Box::new(dot_env::Loader::init_with_map(
-                    env.map.clone_with_allocator()?,
-                ))
+                Box::new(dot_env::Loader::init_with_map(bun_core::handle_oom(
+                    env.map.clone_with_allocator()
+                ),))
             )))
         );
         wr!(
@@ -2329,6 +2333,7 @@ pub(crate) fn init_with_runtime_once(
         // erased *mut () set by tier-6; `js_current()` resolves the per-thread JS
         // event loop via `bun_io::__bun_get_vm_ctx` (link-time, definer in bun_runtime).
         wr!(event_loop, AnyEventLoop::js_current());
+        (*core::ptr::addr_of_mut!((*p).runtime_wake_via_handlers)).store(true, Ordering::Release);
         wr!(
             original_package_json_path,
             ZBox::from_vec_with_nul(original_package_json_path)
@@ -2379,6 +2384,7 @@ pub(crate) fn init_with_runtime_once(
         wr!(global_link_dir_path, Box::default());
         wr!(on_wake, bun_core::Mutex::new(Vec::new()));
         wr!(failed_root_dependencies, bun_core::Mutex::new(Vec::new()));
+        wr!(runtime_wake_via_handlers, AtomicBool::new(false));
         wr!(
             peer_dependencies,
             LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2333,7 +2333,6 @@ pub(crate) fn init_with_runtime_once(
         // erased *mut () set by tier-6; `js_current()` resolves the per-thread JS
         // event loop via `bun_io::__bun_get_vm_ctx` (link-time, definer in bun_runtime).
         wr!(event_loop, AnyEventLoop::js_current());
-        (*core::ptr::addr_of_mut!((*p).runtime_wake_via_handlers)).store(true, Ordering::Release);
         wr!(
             original_package_json_path,
             ZBox::from_vec_with_nul(original_package_json_path)
@@ -2384,7 +2383,7 @@ pub(crate) fn init_with_runtime_once(
         wr!(global_link_dir_path, Box::default());
         wr!(on_wake, bun_core::Mutex::new(Vec::new()));
         wr!(failed_root_dependencies, bun_core::Mutex::new(Vec::new()));
-        wr!(runtime_wake_via_handlers, AtomicBool::new(false));
+        wr!(runtime_wake_via_handlers, AtomicBool::new(true));
         wr!(
             peer_dependencies,
             LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -391,7 +391,8 @@ pub struct PackageManager {
     pub global_dir: Option<bun_sys::Dir>,
     pub global_link_dir_path: Box<[u8]>,
 
-    pub on_wake: WakeHandler,
+    pub on_wake: bun_core::Mutex<Vec<WakeHandler>>,
+    pub failed_root_dependencies: bun_core::Mutex<Vec<(DependencyID, &'static str)>>,
 
     pub peer_dependencies: LinearFifo<DependencyID, DynamicBuffer<DependencyID>>,
 
@@ -863,22 +864,16 @@ impl PackageManager {
 
     pub fn fail_root_resolution(
         &mut self,
-        dependency: &Dependency,
+        _dependency: &Dependency,
         dependency_id: DependencyID,
         err: Error,
     ) {
-        if let Some(ctx) = self.on_wake.context {
-            // SAFETY: `ctx` is the `WakeHandler::context` registered alongside
-            // this callback (a live `*mut Queue`); see `runtime::jsc_hooks`.
-            unsafe {
-                (self.on_wake.get_on_dependency_error())(
-                    ctx.as_ptr(),
-                    dependency,
-                    dependency_id,
-                    err.name(),
-                );
-            }
-        }
+        self.failed_root_dependencies
+            .lock()
+            .push((dependency_id, err.name()));
+        let this: *mut Self = self;
+        // SAFETY: `this` names the live singleton; `wake_raw` only forms field pointers.
+        unsafe { Self::wake_raw(this) };
     }
 
     /// Raw-pointer wake for concurrent task-thread callers (see
@@ -898,11 +893,10 @@ impl PackageManager {
         // borrow) and `wakeup()` is internally synchronized for cross-thread use.
         unsafe {
             let on_wake = &*core::ptr::addr_of!((*this).on_wake);
-            if let Some(ctx) = on_wake.context {
-                // `WakeHandler.handler`'s second arg is the erased
-                // `*mut PackageManager` (`bun_install_types` cannot name this
-                // type); cast back to `*mut c_void` here.
-                (on_wake.get_handler())(ctx.as_ptr(), this.cast::<c_void>());
+            for h in on_wake.lock().iter() {
+                if let Some(ctx) = h.context {
+                    (h.get_handler())(ctx.as_ptr(), this.cast::<c_void>());
+                }
             }
             (*core::ptr::addr_of_mut!((*this).event_loop)).wakeup();
         }
@@ -1944,7 +1938,8 @@ pub fn init(
         wr!(global_link_dir, None);
         wr!(global_dir, None);
         wr!(global_link_dir_path, Box::default());
-        wr!(on_wake, WakeHandler::default());
+        wr!(on_wake, bun_core::Mutex::new(Vec::new()));
+        wr!(failed_root_dependencies, bun_core::Mutex::new(Vec::new()));
         wr!(
             peer_dependencies,
             LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()
@@ -2300,7 +2295,10 @@ pub(crate) fn init_with_runtime_once(
             }
         );
         wr!(network_task_fifo, NetworkQueue::init());
-        wr!(log, std::ptr::from_mut(log));
+        wr!(
+            log,
+            bun_core::heap::into_raw(Box::new(bun_ast::Log::default()))
+        );
         wr!(root_dir, root_dir);
         wr!(ast_arena, bun_alloc::Arena::new());
         // reborrow `&mut *env` so the local stays usable for
@@ -2376,7 +2374,8 @@ pub(crate) fn init_with_runtime_once(
         wr!(global_link_dir, None);
         wr!(global_dir, None);
         wr!(global_link_dir_path, Box::default());
-        wr!(on_wake, WakeHandler::default());
+        wr!(on_wake, bun_core::Mutex::new(Vec::new()));
+        wr!(failed_root_dependencies, bun_core::Mutex::new(Vec::new()));
         wr!(
             peer_dependencies,
             LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -879,8 +879,8 @@ impl PackageManager {
     /// Raw-pointer wake for concurrent task-thread callers (see
     /// `isolated_install::Installer::Task::callback`). Never materializes
     /// `&mut PackageManager`, so two task threads finishing simultaneously do
-    /// not hold aliased exclusive borrows. `on_wake` is serialized under its
-    /// own mutex; each handler receives the raw `*mut`;
+    /// not hold aliased exclusive borrows. `on_wake` access is locked; the handler
+    /// receives the raw `*mut`;
     /// `event_loop.wakeup()` is the cross-thread signal and is
     /// internally synchronized — we reach it via `addr_of_mut!` so the `&mut`
     /// covers only the event-loop field, never the whole `PackageManager`.

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -495,7 +495,7 @@ pub fn enqueue_dependency_to_root(
                     // below; `sleep_until`/`tick_raw` hold no `&mut` across
                     // this callback, so this is the unique live borrow.
                     let manager = unsafe { &mut *self.manager };
-                    if manager.event_loop.execution_forbidden() {
+                    if manager.event_loop.has_termination_request() {
                         return true;
                     }
                     if manager.pending_task_count() > 0 {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -527,6 +527,7 @@ pub fn enqueue_dependency_to_root(
                 this.start_progress_bar_if_none();
             }
 
+            this.event_loop = bun_event_loop::AnyEventLoop::js_current();
             let mgr: *mut PackageManager = this;
             let mut closure = Closure {
                 err: None,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -495,6 +495,9 @@ pub fn enqueue_dependency_to_root(
                     // below; `sleep_until`/`tick_raw` hold no `&mut` across
                     // this callback, so this is the unique live borrow.
                     let manager = unsafe { &mut *self.manager };
+                    if manager.event_loop.execution_forbidden() {
+                        return true;
+                    }
                     if manager.pending_task_count() > 0 {
                         // All callbacks void: `VoidRunTasksCallbacks` (below)
                         // has `Ctx = ()` and every `HAS_* = false`.

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -308,7 +308,14 @@ impl hooks::AutoInstaller for PackageManager {
     // ── PackageManager ops ────────────────────────────────────────────────
 
     fn set_on_wake(&mut self, handler: hooks::WakeHandler) {
-        self.on_wake = handler;
+        let mut list = self.on_wake.lock();
+        if !list.iter().any(|h| h.context == handler.context) {
+            list.push(handler);
+        }
+    }
+
+    fn remove_on_wake(&mut self, context: core::ptr::NonNull<core::ffi::c_void>) {
+        self.on_wake.lock().retain(|h| h.context != Some(context));
     }
 
     fn path_for_resolution<'b>(

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -314,7 +314,7 @@ impl hooks::AutoInstaller for PackageManager {
         }
     }
 
-    fn remove_on_wake(&mut self, context: core::ptr::NonNull<core::ffi::c_void>) {
+    fn remove_on_wake(&self, context: core::ptr::NonNull<core::ffi::c_void>) {
         self.on_wake.lock().retain(|h| h.context != Some(context));
     }
 

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1328,36 +1328,21 @@ pub struct TaskCallbackContext {
 /// `handler`'s second parameter (`*PackageManager`) is erased to
 /// `*mut c_void` because that concrete type lives in `bun_install` (a higher
 /// tier); `bun_install::PackageManager::wake` casts at the call site.
-/// `on_dependency_error`'s `Dependency` parameter is *not* erased — the type
-/// lives in this crate — so callers pass the borrow directly.
 // Clone: bitwise OK — `context` is a non-owning opaque backref the runtime
 // installed; the handler fn-ptrs are POD.
 #[derive(Default, Copy, Clone)]
 pub struct WakeHandler {
     pub context: Option<NonNull<c_void>>,
     pub handler: Option<fn(*mut c_void, *mut c_void)>,
-    pub on_dependency_error:
-        Option<unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str)>,
 }
 
 impl WakeHandler {
     #[inline]
     pub fn get_handler(&self) -> fn(*mut c_void, *mut c_void) {
         // `handler` is Some whenever `context` is Some: the sole installer
-        // (runtime::jsc_hooks) sets `context`, `handler`, and
-        // `on_dependency_error` together in one struct literal, and callers
-        // gate on `context.is_some()` before invoking — so this unwrap cannot
-        // fire.
+        // (runtime::jsc_hooks) sets both together, and callers gate on
+        // `context.is_some()` before invoking — so this unwrap cannot fire.
         self.handler.unwrap()
-    }
-
-    #[inline]
-    pub fn get_on_dependency_error(
-        &self,
-    ) -> unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str) {
-        // Same invariant as `get_handler`: set together with `context` by the
-        // sole installer; callers gate on `context.is_some()`.
-        self.on_dependency_error.unwrap()
     }
 }
 

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1472,7 +1472,7 @@ pub trait AutoInstaller {
 
     // ── PackageManager ops ────────────────────────────────────────────────
     fn set_on_wake(&mut self, handler: WakeHandler);
-    fn remove_on_wake(&mut self, context: NonNull<c_void>);
+    fn remove_on_wake(&self, context: NonNull<c_void>);
     fn path_for_resolution<'b>(
         &mut self,
         package_id: PackageID,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1489,6 +1489,7 @@ pub trait AutoInstaller {
 
     // ── PackageManager ops ────────────────────────────────────────────────
     fn set_on_wake(&mut self, handler: WakeHandler);
+    fn remove_on_wake(&mut self, context: NonNull<c_void>);
     fn path_for_resolution<'b>(
         &mut self,
         package_id: PackageID,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1321,7 +1321,7 @@ pub struct TaskCallbackContext {
 }
 
 /// Opaque
-/// (ctx-ptr + 2 fn-ptrs) handle the runtime installs to nudge the JS event
+/// (ctx-ptr + fn-ptr) handle the runtime installs to nudge the JS event
 /// loop when a network task completes. The resolver only stores and forwards
 /// it; the fields are `Option` so `Default` is all-None.
 ///
@@ -1329,7 +1329,7 @@ pub struct TaskCallbackContext {
 /// `*mut c_void` because that concrete type lives in `bun_install` (a higher
 /// tier); `bun_install::PackageManager::wake` casts at the call site.
 // Clone: bitwise OK — `context` is a non-owning opaque backref the runtime
-// installed; the handler fn-ptrs are POD.
+// installed; the handler fn-ptr is POD.
 #[derive(Default, Copy, Clone)]
 pub struct WakeHandler {
     pub context: Option<NonNull<c_void>>,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1339,10 +1339,8 @@ pub struct WakeHandler {
 impl WakeHandler {
     #[inline]
     pub fn get_handler(&self) -> fn(*mut c_void, *mut c_void) {
-        // `handler` is Some whenever `context` is Some: the sole installer
-        // (runtime::jsc_hooks) sets both together, and callers gate on
-        // `context.is_some()` before invoking — so this unwrap cannot fire.
-        self.handler.unwrap()
+        self.handler
+            .expect("runtime::jsc_hooks sets handler whenever context is Some")
     }
 }
 

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -300,6 +300,7 @@ impl<const PROGRESS: bool> run_tasks::RunTasksCallbacks for QueueRunTasksCallbac
 
 impl Queue {
     pub fn enqueue(&mut self, global_object: &JSGlobalObject, opts: InitOpts<'_>) {
+        let _guard = bun_resolver::auto_install_lock();
         bun_core::scoped_log!(AsyncModule, "enqueue: {}", bstr::BStr::new(opts.specifier));
         let mut module = AsyncModule::init(opts, global_object).expect("unreachable");
         module.poll_ref.ref_(bun_io::posix_event_loop::get_vm_ctx(
@@ -381,9 +382,58 @@ impl Queue {
     }
 
     pub fn on_poll(&mut self) {
+        let _guard = bun_resolver::auto_install_lock();
         bun_core::scoped_log!(AsyncModule, "onPoll");
         self.run_tasks();
+        self.drain_failed_root_dependencies();
         self.poll_modules();
+    }
+
+    fn drain_failed_root_dependencies(&mut self) {
+        let pm = VirtualMachine::get().as_mut().package_manager();
+        let mut failed = pm.failed_root_dependencies.lock();
+        if failed.is_empty() {
+            return;
+        }
+        failed.retain(|&(dep_id, err)| {
+            let vm = VirtualMachine::get().as_mut();
+            let dep = match vm
+                .package_manager()
+                .lockfile
+                .buffers
+                .dependencies
+                .get(dep_id as usize)
+            {
+                Some(d) => d.clone(),
+                None => return false,
+            };
+            let before = self.map.len();
+            self.map.retain_mut(|module| {
+                for pending in module.parse_result.pending_imports.iter() {
+                    if pending.root_dependency_id != dep_id {
+                        continue;
+                    }
+                    let import_record_id = pending.import_record_id;
+                    let vm = VirtualMachine::get().as_mut();
+                    let name = bun_ptr::RawSlice::new(vm.package_manager().lockfile.str(&dep.name));
+                    module
+                        .resolve_error(
+                            vm,
+                            import_record_id,
+                            &PackageResolveError {
+                                name: name.slice(),
+                                err,
+                                url: b"",
+                                version: dep.version.clone(),
+                            },
+                        )
+                        .expect("unreachable");
+                    return false;
+                }
+                true
+            });
+            before == self.map.len()
+        });
     }
 
     pub fn run_tasks(&mut self) {

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -717,6 +717,7 @@ impl AsyncModule {
         let jsc_vm = VirtualMachine::get().as_mut();
         jsc_vm.modules.scheduled -= 1;
         if jsc_vm.modules.scheduled == 0 {
+            let _guard = bun_resolver::auto_install_lock();
             jsc_vm.package_manager().end_progress_bar();
         }
         let mut log = bun_ast::Log::init();

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -3,8 +3,7 @@ use core::ffi::c_void;
 use bun_alloc::Arena as ArenaAllocator;
 use bun_bundler::transpiler::ParseResult;
 use bun_core::{OwnedString, String as BunString, ZigString};
-use bun_install::dependency::Dependency;
-use bun_install::{DependencyID, Resolution};
+use bun_install::Resolution;
 use bun_io::KeepAlive;
 use bun_options_types::LoaderExt as _;
 use bun_options_types::schema::api;
@@ -312,59 +311,6 @@ impl Queue {
         self.vm().package_manager().drain_dependency_list();
     }
 
-    /// # Safety
-    /// `ctx` must point to a live [`Queue`] (the `WakeHandler::context`
-    /// registered in `runtime::jsc_hooks`).
-    pub unsafe fn on_dependency_error(
-        ctx: *mut c_void,
-        dependency: &Dependency,
-        root_dependency_id: DependencyID,
-        err: &'static str,
-    ) {
-        // SAFETY: ctx was registered as *Queue when installing this callback.
-        let this: &mut Queue = unsafe { bun_ptr::callback_ctx::<Queue>(ctx) };
-        bun_core::scoped_log!(
-            AsyncModule,
-            "onDependencyError: {}",
-            bstr::BStr::new(this.vm().package_manager().lockfile.str(&dependency.name))
-        );
-
-        // retain_mut lets Drop free removed modules.
-        this.map.retain_mut(|module| {
-            for pending in module.parse_result.pending_imports.iter() {
-                if pending.root_dependency_id != root_dependency_id {
-                    continue;
-                }
-                let import_record_id = pending.import_record_id;
-                // S017: per-thread VM singleton (safe accessor) instead of
-                // `container_of`-derived `*mut`; provenance is the original
-                // allocation, disjoint from the `&mut module` borrow above.
-                let vm = VirtualMachine::get().as_mut();
-                // reshaped for borrowck — `lockfile.str()` ties the
-                // returned slice to `&vm`, which conflicts with passing
-                // `&mut vm` to `resolve_error`. The lockfile string buffer is
-                // stable across `resolve_error` (no realloc on the error
-                // path); detach the borrow via raw ptr.
-                let name =
-                    bun_ptr::RawSlice::new(vm.package_manager().lockfile.str(&dependency.name));
-                module
-                    .resolve_error(
-                        vm,
-                        import_record_id,
-                        &PackageResolveError {
-                            name: name.slice(),
-                            err,
-                            url: b"",
-                            version: dependency.version.clone(),
-                        },
-                    )
-                    .expect("unreachable");
-                return false; // continue :outer — drop this module
-            }
-            true
-        });
-    }
-
     pub fn on_wake_handler(ctx: *mut c_void, _: *mut c_void) {
         bun_core::scoped_log!(AsyncModule, "onWake");
         let queue = ctx.cast::<Queue>();
@@ -390,12 +336,16 @@ impl Queue {
     }
 
     fn drain_failed_root_dependencies(&mut self) {
-        let pm = VirtualMachine::get().as_mut().package_manager();
-        let mut failed = pm.failed_root_dependencies.lock();
-        if failed.is_empty() {
-            return;
-        }
-        failed.retain(|&(dep_id, err)| {
+        let drained = {
+            let pm = VirtualMachine::get().as_mut().package_manager();
+            let mut failed = pm.failed_root_dependencies.lock();
+            if failed.is_empty() {
+                return;
+            }
+            core::mem::take(&mut *failed)
+        };
+        let mut leftover = Vec::new();
+        for (dep_id, err) in drained {
             let vm = VirtualMachine::get().as_mut();
             let dep = match vm
                 .package_manager()
@@ -405,7 +355,7 @@ impl Queue {
                 .get(dep_id as usize)
             {
                 Some(d) => d.clone(),
-                None => return false,
+                None => continue,
             };
             let before = self.map.len();
             self.map.retain_mut(|module| {
@@ -432,8 +382,18 @@ impl Queue {
                 }
                 true
             });
-            before == self.map.len()
-        });
+            if before == self.map.len() {
+                leftover.push((dep_id, err));
+            }
+        }
+        if !leftover.is_empty() {
+            VirtualMachine::get()
+                .as_mut()
+                .package_manager()
+                .failed_root_dependencies
+                .lock()
+                .extend(leftover);
+        }
     }
 
     pub fn run_tasks(&mut self) {

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -387,12 +387,10 @@ impl Queue {
             }
         }
         if !leftover.is_empty() {
-            VirtualMachine::get()
-                .as_mut()
-                .package_manager()
-                .failed_root_dependencies
-                .lock()
-                .extend(leftover);
+            let pm = VirtualMachine::get().as_mut().package_manager();
+            if pm.on_wake.lock().len() > 1 {
+                pm.failed_root_dependencies.lock().extend(leftover);
+            }
         }
     }
 

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1233,7 +1233,6 @@ impl AsyncModule {
             (*jsc_vm).transpiler.linker.log = log_ptr;
             (*jsc_vm).transpiler.log = log_ptr;
             (*jsc_vm).transpiler.resolver.log = log_nn;
-            (*jsc_vm).package_manager().log = log_ptr;
         }
         let _restore = scopeguard::guard((jsc_vm, old_log), |(jsc_vm, old_log)| {
             // SAFETY: same per-thread VM; restoring the original log pointers
@@ -1243,7 +1242,6 @@ impl AsyncModule {
                 (*jsc_vm).transpiler.linker.log = old_log_ptr;
                 (*jsc_vm).transpiler.log = old_log_ptr;
                 (*jsc_vm).transpiler.resolver.log = old_log;
-                (*jsc_vm).package_manager().log = old_log_ptr;
             }
         });
 

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -126,6 +126,10 @@ impl VM {
         crate::cpp::JSC__VM__clearHasTerminationRequest(self)
     }
 
+    pub fn has_termination_request(&self) -> bool {
+        crate::cpp::JSC__VM__hasTerminationRequest(self)
+    }
+
     #[track_caller]
     pub fn throw_error(&self, global_object: &JSGlobalObject, value: JSValue) -> JsError {
         crate::validation_scope!(scope, global_object);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3668,7 +3668,7 @@ impl VirtualMachine {
         vm_ref.hot_reload = parent.hot_reload;
         vm_ref.initial_script_execution_context_identifier = worker.execution_context_id() as i32;
         vm_ref.transpiler.resolver.store_fd = opts.store_fd;
-        // Auto-install settings (wired post-init by run_command::wire_transpiler_from_ctx).
+        // Settings run_command::wire_transpiler_from_ctx applied post-init.
         {
             let b = &mut vm_ref.transpiler;
             let p = &parent.transpiler;
@@ -3676,6 +3676,7 @@ impl VirtualMachine {
             b.options.install = p.options.install;
             b.options.prefer_offline_install = p.options.prefer_offline_install;
             b.options.prefer_latest_install = p.options.prefer_latest_install;
+            b.options.no_macros = p.options.no_macros;
             b.resolver.opts.global_cache = p.resolver.opts.global_cache;
             b.resolver.opts.install = p.resolver.opts.install;
             b.resolver.opts.prefer_offline_install = p.resolver.opts.prefer_offline_install;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3668,6 +3668,25 @@ impl VirtualMachine {
         vm_ref.hot_reload = parent.hot_reload;
         vm_ref.initial_script_execution_context_identifier = worker.execution_context_id() as i32;
         vm_ref.transpiler.resolver.store_fd = opts.store_fd;
+        // Inherit the auto-install / global-cache resolver settings the main
+        // thread received from the CLI (`run_command::wire_transpiler_from_ctx`).
+        // `Transpiler::init` built the worker's options via
+        // `BundleOptions::from_api`, which defaults `global_cache` to `disable`,
+        // so without this a Worker cannot resolve bare specifiers from the
+        // global cache even when the parent already populated it. The `install`
+        // backref points at the CLI-owned `Box<BunInstall>` (process-lifetime,
+        // read-only) and is safe to share.
+        {
+            let b = &mut vm_ref.transpiler;
+            let p = &parent.transpiler;
+            b.options.global_cache = p.options.global_cache;
+            b.options.install = p.options.install;
+            b.options.prefer_offline_install = p.options.prefer_offline_install;
+            b.options.prefer_latest_install = p.options.prefer_latest_install;
+            b.resolver.opts.global_cache = p.resolver.opts.global_cache;
+            b.resolver.opts.install = p.resolver.opts.install;
+            b.resolver.opts.prefer_offline_install = p.resolver.opts.prefer_offline_install;
+        }
         if opts.graph.is_none() {
             vm_ref.transpiler.configure_linker();
         } else {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3668,14 +3668,9 @@ impl VirtualMachine {
         vm_ref.hot_reload = parent.hot_reload;
         vm_ref.initial_script_execution_context_identifier = worker.execution_context_id() as i32;
         vm_ref.transpiler.resolver.store_fd = opts.store_fd;
-        // Inherit the auto-install / global-cache resolver settings the main
-        // thread received from the CLI (`run_command::wire_transpiler_from_ctx`).
-        // `Transpiler::init` built the worker's options via
-        // `BundleOptions::from_api`, which defaults `global_cache` to `disable`,
-        // so without this a Worker cannot resolve bare specifiers from the
-        // global cache even when the parent already populated it. The `install`
-        // backref points at the CLI-owned `Box<BunInstall>` (process-lifetime,
-        // read-only) and is safe to share.
+        // Auto-install settings are CLI-wired post-init
+        // (`run_command::wire_transpiler_from_ctx`), not carried by
+        // `TransformOptions`, so inherit them from the parent.
         {
             let b = &mut vm_ref.transpiler;
             let p = &parent.transpiler;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3668,9 +3668,7 @@ impl VirtualMachine {
         vm_ref.hot_reload = parent.hot_reload;
         vm_ref.initial_script_execution_context_identifier = worker.execution_context_id() as i32;
         vm_ref.transpiler.resolver.store_fd = opts.store_fd;
-        // Auto-install settings are CLI-wired post-init
-        // (`run_command::wire_transpiler_from_ctx`), not carried by
-        // `TransformOptions`, so inherit them from the parent.
+        // Auto-install settings (wired post-init by run_command::wire_transpiler_from_ctx).
         {
             let b = &mut vm_ref.transpiler;
             let p = &parent.transpiler;

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1332,7 +1332,10 @@ bun_event_loop::link_impl_JsEventLoop! {
         tick() => (*this).tick(),
         auto_tick() => (*this).auto_tick(),
         auto_tick_active() => (*this).auto_tick_active(),
-        has_termination_request() => (*this).vm_ref().jsc_vm().has_termination_request(),
+        has_termination_request() => {
+            let vm = (*this).vm_ref();
+            vm.jsc_vm().has_termination_request() || vm.is_shutting_down
+        },
         global_object() => (*this).global.map_or(core::ptr::null_mut(), |p| p.as_ptr().cast()),
         bun_vm() => (*this).virtual_machine.map_or(core::ptr::null_mut(), |p| p.as_ptr().cast()),
         stdout() => (*this).vm_ref().as_mut().rare_data().stdout().cast(),

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1332,7 +1332,7 @@ bun_event_loop::link_impl_JsEventLoop! {
         tick() => (*this).tick(),
         auto_tick() => (*this).auto_tick(),
         auto_tick_active() => (*this).auto_tick_active(),
-        execution_forbidden() => (*this).vm_ref().jsc_vm().execution_forbidden(),
+        has_termination_request() => (*this).vm_ref().jsc_vm().has_termination_request(),
         global_object() => (*this).global.map_or(core::ptr::null_mut(), |p| p.as_ptr().cast()),
         bun_vm() => (*this).virtual_machine.map_or(core::ptr::null_mut(), |p| p.as_ptr().cast()),
         stdout() => (*this).vm_ref().as_mut().rare_data().stdout().cast(),

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1332,6 +1332,7 @@ bun_event_loop::link_impl_JsEventLoop! {
         tick() => (*this).tick(),
         auto_tick() => (*this).auto_tick(),
         auto_tick_active() => (*this).auto_tick_active(),
+        execution_forbidden() => (*this).vm_ref().jsc_vm().execution_forbidden(),
         global_object() => (*this).global.map_or(core::ptr::null_mut(), |p| p.as_ptr().cast()),
         bun_vm() => (*this).virtual_machine.map_or(core::ptr::null_mut(), |p| p.as_ptr().cast()),
         stdout() => (*this).vm_ref().as_mut().rare_data().stdout().cast(),

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -975,7 +975,7 @@ impl WebWorker {
         // SAFETY: `vm` is a valid heap-allocated VM ptr (checked above).
         unsafe {
             let b = &mut (*vm).transpiler;
-            b.resolver.env_loader = NonNull::new(b.env);
+            b.resolver.env_loader = NonNull::new(parent.transpiler.env);
 
             if let Some(graph) = parent.standalone_module_graph {
                 (hooks.apply_standalone_runtime_flags)(b, graph);
@@ -1243,6 +1243,7 @@ impl WebWorker {
             // SAFETY: vm_ptr valid; unpublished above under vm_lock, so no
             // other thread can dereference it now — `&mut` is exclusive.
             let vm = unsafe { &mut *vm_ptr };
+            vm.transpiler.resolver.remove_package_manager_wake();
             // terminate() set the JSC termination flag to interrupt running JS;
             // clear it so process.on('exit') handlers can run. teardownJSCVM
             // re-sets it for the JSC VM teardown.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1243,7 +1243,6 @@ impl WebWorker {
             // SAFETY: vm_ptr valid; unpublished above under vm_lock, so no
             // other thread can dereference it now — `&mut` is exclusive.
             let vm = unsafe { &mut *vm_ptr };
-            vm.transpiler.resolver.remove_package_manager_wake();
             // terminate() set the JSC termination flag to interrupt running JS;
             // clear it so process.on('exit') handlers can run. teardownJSCVM
             // re-sets it for the JSC VM teardown.
@@ -1289,6 +1288,7 @@ impl WebWorker {
             if let Some(hooks) = runtime_hooks() {
                 (hooks.close_dns_for_terminate)();
             }
+            vm.transpiler.resolver.remove_package_manager_wake();
             // Stop cross-thread posters first: markTerminating() serializes
             // with postTaskTo() on the contexts-map lock, so after this call
             // every task another thread has already enqueued is visible to the

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -975,7 +975,7 @@ impl WebWorker {
         // SAFETY: `vm` is a valid heap-allocated VM ptr (checked above).
         unsafe {
             let b = &mut (*vm).transpiler;
-            b.resolver.env_loader = NonNull::new(parent.transpiler.env);
+            b.resolver.env_loader = NonNull::new(b.env);
 
             if let Some(graph) = parent.standalone_module_graph {
                 (hooks.apply_standalone_runtime_flags)(b, graph);

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -50,7 +50,9 @@ pub use tsconfig_json::TSConfigJSON;
 // `result` / `standalone_module_graph` sibling modules.
 /// Re-export so dependents can spell `bun_resolver::install_types::AutoInstaller`.
 pub use ::bun_install_types::resolver_hooks as install_types;
-pub use resolver::{AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver};
+pub use resolver::{
+    AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver, auto_install_lock,
+};
 pub use result::{
     DebugLogs, DirEntryResolveQueueItem, FlushMode, LoadResult, MatchResult, MatchStatus, PathPair,
     PendingResolution, PendingResolutionTag, Result, ResultFlags, ResultUnion,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -451,7 +451,7 @@ thread_local! {
 /// Serializes `PackageManager` singleton access across JS VMs for the runtime
 /// auto-install path. Reentrant on the owning thread because
 /// `PackageManager::sleep_until` pumps the JS event loop under the lock.
-/// SAFETY: the returned guard must be dropped on the thread that acquired it.
+/// SAFETY: the guard is `!Send`, so it is always dropped on the acquiring thread.
 #[must_use = "the mutex unlocks immediately if the guard is dropped"]
 pub fn auto_install_lock() -> AutoInstallGuard {
     let depth = AUTO_INSTALL_LOCK_DEPTH.with(|d| {
@@ -463,11 +463,15 @@ pub fn auto_install_lock() -> AutoInstallGuard {
     if acquired {
         AUTO_INSTALL_LOCK.lock();
     }
-    AutoInstallGuard { acquired }
+    AutoInstallGuard {
+        acquired,
+        _not_send: core::marker::PhantomData,
+    }
 }
 
 pub struct AutoInstallGuard {
     acquired: bool,
+    _not_send: core::marker::PhantomData<*const ()>,
 }
 
 impl Drop for AutoInstallGuard {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -908,10 +908,10 @@ impl<'a> Resolver<'a> {
         if let (Some(pm), Some(ctx)) = (self.package_manager, self.on_wake_package_manager.context)
         {
             // SAFETY: BACKREF — `package_manager` names the process-static
-            // singleton; `remove_on_wake` only touches the `on_wake` field via
-            // its own mutex (the `wake_raw` serialization barrier), so no
-            // `auto_install_lock` is needed here.
-            unsafe { &mut *pm.as_ptr() }.remove_on_wake(ctx);
+            // singleton; `remove_on_wake` takes `&self` and only touches the
+            // `on_wake` field via its own mutex (the `wake_raw` serialization
+            // barrier), so no `auto_install_lock` is needed here.
+            unsafe { &*pm.as_ptr() }.remove_on_wake(ctx);
         }
     }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -905,12 +905,13 @@ impl<'a> Resolver<'a> {
 
     /// Called from Worker shutdown so `PackageManager::wake_raw` cannot reach this VM after teardown.
     pub fn remove_package_manager_wake(&mut self) {
-        if let (Some(mut pm), Some(ctx)) =
-            (self.package_manager, self.on_wake_package_manager.context)
+        if let (Some(pm), Some(ctx)) = (self.package_manager, self.on_wake_package_manager.context)
         {
-            let _guard = auto_install_lock();
-            // SAFETY: BACKREF — `package_manager` names the process-static singleton.
-            unsafe { pm.as_mut() }.remove_on_wake(ctx);
+            // SAFETY: BACKREF — `package_manager` names the process-static
+            // singleton; `remove_on_wake` only touches the `on_wake` field via
+            // its own mutex (the `wake_raw` serialization barrier), so no
+            // `auto_install_lock` is needed here.
+            unsafe { &mut *pm.as_ptr() }.remove_on_wake(ctx);
         }
     }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -443,6 +443,42 @@ macro_rules! bufs {
 // (the resolver mutex is one of the two documented guards for the entries singleton).
 pub(crate) static RESOLVER_MUTEX: Mutex = Mutex::new();
 
+static AUTO_INSTALL_LOCK: Mutex = Mutex::new();
+thread_local! {
+    static AUTO_INSTALL_LOCK_DEPTH: core::cell::Cell<u32> = const { core::cell::Cell::new(0) };
+}
+
+/// Serializes `PackageManager` singleton access across JS VMs for the runtime
+/// auto-install path. Reentrant on the owning thread because
+/// `PackageManager::sleep_until` pumps the JS event loop under the lock.
+/// SAFETY: the returned guard must be dropped on the thread that acquired it.
+#[must_use = "the mutex unlocks immediately if the guard is dropped"]
+pub fn auto_install_lock() -> AutoInstallGuard {
+    let depth = AUTO_INSTALL_LOCK_DEPTH.with(|d| {
+        let v = d.get();
+        d.set(v + 1);
+        v
+    });
+    let acquired = depth == 0;
+    if acquired {
+        AUTO_INSTALL_LOCK.lock();
+    }
+    AutoInstallGuard { acquired }
+}
+
+pub struct AutoInstallGuard {
+    acquired: bool,
+}
+
+impl Drop for AutoInstallGuard {
+    fn drop(&mut self) {
+        AUTO_INSTALL_LOCK_DEPTH.with(|d| d.set(d.get() - 1));
+        if self.acquired {
+            AUTO_INSTALL_LOCK.unlock();
+        }
+    }
+}
+
 type BinFolderArray = BoundedArray<&'static [u8], 128>;
 // `BoundedArray` has no const constructor; init lazily under
 // `BIN_FOLDERS_LOADED`.
@@ -861,6 +897,17 @@ impl<'a> Resolver<'a> {
         // singleton, live for the resolver's lifetime once installed; `&mut
         // self` ⇒ exclusive access to the only Rust handle.
         self.package_manager.map(|mut pm| unsafe { pm.as_mut() })
+    }
+
+    /// Called from Worker shutdown so `PackageManager::wake_raw` cannot reach this VM after teardown.
+    pub fn remove_package_manager_wake(&mut self) {
+        if let (Some(mut pm), Some(ctx)) =
+            (self.package_manager, self.on_wake_package_manager.context)
+        {
+            let _guard = auto_install_lock();
+            // SAFETY: BACKREF — `package_manager` names the process-static singleton.
+            unsafe { pm.as_mut() }.remove_on_wake(ctx);
+        }
     }
 
     /// Safe read-only accessor for the optional `DotEnv::Loader` back-reference.
@@ -2868,6 +2915,7 @@ impl<'a> Resolver<'a> {
             && let Some(esm_ref) = esm_.as_ref()
             && strings::is_npm_package_name(esm_ref.name)
         {
+            let _auto_install_guard = auto_install_lock();
             let esm = esm_ref.with_auto_version();
             'load_module_from_cache: {
                 // If the source directory doesn't have a node_modules directory, we can

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -459,27 +459,27 @@ pub fn auto_install_lock() -> AutoInstallGuard {
         d.set(v + 1);
         v
     });
-    let acquired = depth == 0;
-    if acquired {
+    if depth == 0 {
         AUTO_INSTALL_LOCK.lock();
     }
     AutoInstallGuard {
-        acquired,
         _not_send: core::marker::PhantomData,
     }
 }
 
 pub struct AutoInstallGuard {
-    acquired: bool,
     _not_send: core::marker::PhantomData<*const ()>,
 }
 
 impl Drop for AutoInstallGuard {
     fn drop(&mut self) {
-        AUTO_INSTALL_LOCK_DEPTH.with(|d| d.set(d.get() - 1));
-        if self.acquired {
-            AUTO_INSTALL_LOCK.unlock();
-        }
+        AUTO_INSTALL_LOCK_DEPTH.with(|d| {
+            let v = d.get() - 1;
+            d.set(v);
+            if v == 0 {
+                AUTO_INSTALL_LOCK.unlock();
+            }
+        });
     }
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -432,22 +432,6 @@ unsafe fn init_runtime_state(
                     t.resolver.on_wake_package_manager = bun_resolver::install_types::WakeHandler {
                         context: core::ptr::NonNull::new(ptr::addr_of_mut!((*vm).modules).cast()),
                         handler: Some(bun_jsc::async_module::Queue::on_wake_handler),
-                        on_dependency_error: Some({
-                            unsafe fn adapter(
-                                ctx: *mut core::ffi::c_void,
-                                dep: &bun_resolver::install_types::Dependency,
-                                id: bun_resolver::install_types::DependencyID,
-                                err: &'static str,
-                            ) {
-                                // SAFETY: `ctx` is the `WakeHandler::context` set just above to `&mut (*vm).modules` (a live `Queue`).
-                                unsafe {
-                                    bun_jsc::async_module::Queue::on_dependency_error(
-                                        ctx, dep, id, err,
-                                    )
-                                }
-                            }
-                            adapter
-                        }),
                     };
                     // Branch on `opts.graph` here — with a module graph,
                     // auto_jsx=true would

--- a/test/cli/run/run-autoinstall-worker.test.ts
+++ b/test/cli/run/run-autoinstall-worker.test.ts
@@ -1,0 +1,175 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Auto-install / global-cache resolution was never enabled inside Worker
+// threads: the Worker's resolver was initialised with `global_cache = disable`
+// (the `BundleOptions::from_api` default) and never inherited the parent VM's
+// auto-install settings, so the same bare specifier that auto-installs and
+// loads on the main thread failed with ERR_MODULE_NOT_FOUND in a Worker of the
+// same process, even with the global cache already warm.
+
+const tarballPath = join(import.meta.dir, "..", "install", "registry", "packages", "no-deps", "no-deps-2.0.0.tgz");
+const tarball = readFileSync(tarballPath);
+
+let registry: ReturnType<typeof Bun.serve>;
+beforeAll(() => {
+  registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (pathname === "/no-deps") {
+        return Response.json({
+          name: "no-deps",
+          "dist-tags": { latest: "2.0.0" },
+          versions: {
+            "2.0.0": {
+              name: "no-deps",
+              version: "2.0.0",
+              dist: {
+                tarball: `http://localhost:${registry.port}/no-deps/-/no-deps-2.0.0.tgz`,
+                integrity: "sha512-W3duJKZPcMIG5rA1io5cSK/bhW9rWFz+jFxZsKS/3suK4qHDkQNxUTEXee9/hTaAoDCeHWQqogukWYKzfr6X4g==",
+                shasum: "8d304fcfc3c743ed39a8afbaefa03f5cd2a42c98",
+              },
+            },
+          },
+        });
+      }
+      if (pathname === "/no-deps/-/no-deps-2.0.0.tgz") {
+        return new Response(tarball, { headers: { "Content-Type": "application/octet-stream" } });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+});
+
+afterAll(() => {
+  registry?.stop(true);
+});
+
+test("Worker resolves bare specifier from global cache warmed by main thread", async () => {
+  using dir = tempDir("autoinstall-worker", {
+    "bunfig.toml": `[install]\nregistry = "http://localhost:${registry.port}/"\n`,
+    "index.ts": `
+      const m = await import("no-deps");
+      console.log("MAIN " + m.name + "@" + m.version);
+      const w = new Worker(new URL("./worker.ts", import.meta.url).href);
+      const msg = await new Promise<string>((resolve, reject) => {
+        w.onmessage = e => resolve(String(e.data));
+        w.onerror = e => reject(e.message ?? e);
+      });
+      console.log(msg);
+      await w.terminate();
+    `,
+    "worker.ts": `
+      try {
+        const m = await import("no-deps");
+        postMessage("WORKER OK " + m.name + "@" + m.version);
+      } catch (e: any) {
+        postMessage("WORKER FAILED " + (e?.code ?? "") + " " + String(e?.message ?? e).split("\\n")[0]);
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Cannot find package");
+  expect(stdout).toContain("MAIN no-deps@2.0.0");
+  expect(stdout).toContain("WORKER OK no-deps@2.0.0");
+  expect(stdout).not.toContain("WORKER FAILED");
+  expect(exitCode).toBe(0);
+});
+
+test("Worker auto-installs bare specifier when main thread has not", async () => {
+  using dir = tempDir("autoinstall-worker-cold", {
+    "bunfig.toml": `[install]\nregistry = "http://localhost:${registry.port}/"\n`,
+    "index.ts": `
+      const w = new Worker(new URL("./worker.ts", import.meta.url).href);
+      const msg = await new Promise<string>((resolve, reject) => {
+        w.onmessage = e => resolve(String(e.data));
+        w.onerror = e => reject(e.message ?? e);
+      });
+      console.log(msg);
+      await w.terminate();
+    `,
+    "worker.ts": `
+      try {
+        const m = await import("no-deps");
+        postMessage("WORKER OK " + m.name + "@" + m.version);
+      } catch (e: any) {
+        postMessage("WORKER FAILED " + (e?.code ?? "") + " " + String(e?.message ?? e).split("\\n")[0]);
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Cannot find package");
+  expect(stdout).toContain("WORKER OK no-deps@2.0.0");
+  expect(stdout).not.toContain("WORKER FAILED");
+  expect(exitCode).toBe(0);
+});
+
+test("Worker respects --install=force from parent process", async () => {
+  using dir = tempDir("autoinstall-worker-force", {
+    "bunfig.toml": `[install]\nregistry = "http://localhost:${registry.port}/"\n`,
+    "node_modules/placeholder/package.json": JSON.stringify({ name: "placeholder", version: "0.0.0" }),
+    "index.ts": `
+      const w = new Worker(new URL("./worker.ts", import.meta.url).href);
+      const msg = await new Promise<string>((resolve, reject) => {
+        w.onmessage = e => resolve(String(e.data));
+        w.onerror = e => reject(e.message ?? e);
+      });
+      console.log(msg);
+      await w.terminate();
+    `,
+    "worker.ts": `
+      try {
+        const m = await import("no-deps");
+        postMessage("WORKER OK " + m.name + "@" + m.version);
+      } catch (e: any) {
+        postMessage("WORKER FAILED " + (e?.code ?? "") + " " + String(e?.message ?? e).split("\\n")[0]);
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=force", "index.ts"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Cannot find package");
+  expect(stdout).toContain("WORKER OK no-deps@2.0.0");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/run/run-autoinstall-worker.test.ts
+++ b/test/cli/run/run-autoinstall-worker.test.ts
@@ -3,15 +3,10 @@ import { bunEnv, bunExe, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-// Auto-install / global-cache resolution was never enabled inside Worker
-// threads: the Worker's resolver was initialised with `global_cache = disable`
-// (the `BundleOptions::from_api` default) and never inherited the parent VM's
-// auto-install settings, so the same bare specifier that auto-installs and
-// loads on the main thread failed with ERR_MODULE_NOT_FOUND in a Worker of the
-// same process, even with the global cache already warm.
+// https://github.com/oven-sh/bun/issues/29018
 
-const tarballPath = join(import.meta.dir, "..", "install", "registry", "packages", "no-deps", "no-deps-2.0.0.tgz");
-const tarball = readFileSync(tarballPath);
+const pkgDir = join(import.meta.dir, "..", "install", "registry", "packages", "no-deps");
+const tarball = readFileSync(join(pkgDir, "no-deps-2.0.0.tgz"));
 
 let registry: ReturnType<typeof Bun.serve>;
 beforeAll(() => {
@@ -49,43 +44,55 @@ afterAll(() => {
   registry?.stop(true);
 });
 
-test("Worker resolves bare specifier from global cache warmed by main thread", async () => {
-  using dir = tempDir("autoinstall-worker", {
-    "bunfig.toml": `[install]\nregistry = "http://localhost:${registry.port}/"\n`,
-    "index.ts": `
-      const m = await import("no-deps");
-      console.log("MAIN " + m.name + "@" + m.version);
-      const w = new Worker(new URL("./worker.ts", import.meta.url).href);
-      const msg = await new Promise<string>((resolve, reject) => {
-        w.onmessage = e => resolve(String(e.data));
-        w.onerror = e => reject(e.message ?? e);
-      });
-      console.log(msg);
-      await w.terminate();
-    `,
-    "worker.ts": `
-      try {
-        const m = await import("no-deps");
-        postMessage("WORKER OK " + m.name + "@" + m.version);
-      } catch (e: any) {
-        postMessage("WORKER FAILED " + (e?.code ?? "") + " " + String(e?.message ?? e).split("\\n")[0]);
-      }
-    `,
-  });
+const workerTs = `
+  try {
+    const m = await import("no-deps");
+    postMessage("WORKER OK " + m.name + "@" + m.version);
+  } catch (e: any) {
+    postMessage("WORKER FAILED " + (e?.code ?? "") + " " + String(e?.message ?? e).split("\\n")[0]);
+  }
+`;
 
+const indexTs = ({ prelude = "", epilogue = "" } = {}) => `
+  ${prelude}
+  const w = new Worker(new URL("./worker.ts", import.meta.url).href);
+  const msg = await new Promise<string>((resolve, reject) => {
+    w.onmessage = e => resolve(String(e.data));
+    w.onerror = e => reject(e.message ?? e);
+  });
+  console.log(msg);
+  await w.terminate();
+  ${epilogue}
+`;
+
+async function run(opts: { prefix: string; flags?: string[]; extraFiles?: Record<string, string>; index: string }) {
+  using dir = tempDir(opts.prefix, {
+    "bunfig.toml": `[install]\nregistry = "http://localhost:${registry.port}/"\n`,
+    "worker.ts": workerTs,
+    "index.ts": opts.index,
+    ...(opts.extraFiles ?? {}),
+  });
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "index.ts"],
+    cmd: [bunExe(), ...(opts.flags ?? []), "index.ts"],
     cwd: String(dir),
-    env: {
-      ...bunEnv,
-      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
-    },
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
     stdout: "pipe",
     stderr: "pipe",
   });
-
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
 
+test.concurrent("Worker resolves bare specifier from global cache warmed by main thread", async () => {
+  const { stdout, stderr, exitCode } = await run({
+    prefix: "autoinstall-worker-warm",
+    index: indexTs({
+      prelude: `
+        const m = await import("no-deps");
+        console.log("MAIN " + m.name + "@" + m.version);
+      `,
+    }),
+  });
   expect(stderr).not.toContain("Cannot find package");
   expect(stdout).toContain("MAIN no-deps@2.0.0");
   expect(stdout).toContain("WORKER OK no-deps@2.0.0");
@@ -93,84 +100,47 @@ test("Worker resolves bare specifier from global cache warmed by main thread", a
   expect(exitCode).toBe(0);
 });
 
-test("Worker auto-installs bare specifier when main thread has not", async () => {
-  using dir = tempDir("autoinstall-worker-cold", {
-    "bunfig.toml": `[install]\nregistry = "http://localhost:${registry.port}/"\n`,
-    "index.ts": `
-      const w = new Worker(new URL("./worker.ts", import.meta.url).href);
-      const msg = await new Promise<string>((resolve, reject) => {
-        w.onmessage = e => resolve(String(e.data));
-        w.onerror = e => reject(e.message ?? e);
-      });
-      console.log(msg);
-      await w.terminate();
-    `,
-    "worker.ts": `
-      try {
-        const m = await import("no-deps");
-        postMessage("WORKER OK " + m.name + "@" + m.version);
-      } catch (e: any) {
-        postMessage("WORKER FAILED " + (e?.code ?? "") + " " + String(e?.message ?? e).split("\\n")[0]);
-      }
-    `,
+test.concurrent("Worker auto-installs bare specifier when main thread has not", async () => {
+  const { stdout, stderr, exitCode } = await run({
+    prefix: "autoinstall-worker-cold",
+    index: indexTs(),
   });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "index.ts"],
-    cwd: String(dir),
-    env: {
-      ...bunEnv,
-      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
   expect(stderr).not.toContain("Cannot find package");
   expect(stdout).toContain("WORKER OK no-deps@2.0.0");
   expect(stdout).not.toContain("WORKER FAILED");
   expect(exitCode).toBe(0);
 });
 
-test("Worker respects --install=force from parent process", async () => {
-  using dir = tempDir("autoinstall-worker-force", {
-    "bunfig.toml": `[install]\nregistry = "http://localhost:${registry.port}/"\n`,
-    "node_modules/placeholder/package.json": JSON.stringify({ name: "placeholder", version: "0.0.0" }),
-    "index.ts": `
-      const w = new Worker(new URL("./worker.ts", import.meta.url).href);
-      const msg = await new Promise<string>((resolve, reject) => {
-        w.onmessage = e => resolve(String(e.data));
-        w.onerror = e => reject(e.message ?? e);
-      });
-      console.log(msg);
-      await w.terminate();
-    `,
-    "worker.ts": `
-      try {
-        const m = await import("no-deps");
-        postMessage("WORKER OK " + m.name + "@" + m.version);
-      } catch (e: any) {
-        postMessage("WORKER FAILED " + (e?.code ?? "") + " " + String(e?.message ?? e).split("\\n")[0]);
-      }
-    `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--install=force", "index.ts"],
-    cwd: String(dir),
-    env: {
-      ...bunEnv,
-      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+test.concurrent("Worker respects --install=force from parent process", async () => {
+  const { stdout, stderr, exitCode } = await run({
+    prefix: "autoinstall-worker-force",
+    flags: ["--install=force"],
+    extraFiles: {
+      "node_modules/placeholder/package.json": JSON.stringify({ name: "placeholder", version: "0.0.0" }),
     },
-    stdout: "pipe",
-    stderr: "pipe",
+    index: indexTs(),
   });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
   expect(stderr).not.toContain("Cannot find package");
   expect(stdout).toContain("WORKER OK no-deps@2.0.0");
   expect(exitCode).toBe(0);
 });
+
+test.concurrent(
+  "main-thread auto-install still works after a Worker that used auto-install is terminated",
+  async () => {
+    const { stdout, stderr, exitCode } = await run({
+      prefix: "autoinstall-worker-after-terminate",
+      flags: ["--install=force"],
+      index: indexTs({
+        epilogue: `
+          const m = await import("no-deps");
+          console.log("MAIN " + m.name + "@" + m.version);
+        `,
+      }),
+    });
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout).toContain("WORKER OK no-deps@2.0.0");
+    expect(stdout).toContain("MAIN no-deps@2.0.0");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/cli/run/run-autoinstall-worker.test.ts
+++ b/test/cli/run/run-autoinstall-worker.test.ts
@@ -29,7 +29,8 @@ beforeAll(() => {
               version: "2.0.0",
               dist: {
                 tarball: `http://localhost:${registry.port}/no-deps/-/no-deps-2.0.0.tgz`,
-                integrity: "sha512-W3duJKZPcMIG5rA1io5cSK/bhW9rWFz+jFxZsKS/3suK4qHDkQNxUTEXee9/hTaAoDCeHWQqogukWYKzfr6X4g==",
+                integrity:
+                  "sha512-W3duJKZPcMIG5rA1io5cSK/bhW9rWFz+jFxZsKS/3suK4qHDkQNxUTEXee9/hTaAoDCeHWQqogukWYKzfr6X4g==",
                 shasum: "8d304fcfc3c743ed39a8afbaefa03f5cd2a42c98",
               },
             },


### PR DESCRIPTION
## Problem

Auto-install (and resolution from an already-warm global cache) never applies inside Worker threads. The same bare specifier that auto-installs and loads on the main thread fails with `ERR_MODULE_NOT_FOUND` in a `new Worker(...)` of the same process. Warming the cache from the main thread first does not help.

```js
// run from a dir with no node_modules in the ancestry
const m = await import("no-deps");                  // main thread: auto-installs + loads fine
console.log("MAIN", m.name);
new Worker("./w.mjs");
// w.mjs: await import("no-deps") -> ERR_MODULE_NOT_FOUND
```

Output:
```
MAIN no-deps
WORKER FAILED ERR_MODULE_NOT_FOUND Cannot find package 'no-deps' from '.../w.mjs'
```

## Cause

`Transpiler::init` builds the worker's `BundleOptions` via `BundleOptions::from_api`, which hard-codes `global_cache: GlobalCache::disable`. The main thread overwrites that from the CLI context in `run_command::wire_transpiler_from_ctx`, but `VirtualMachine::init_worker` never copied those fields from the parent VM, so the worker's resolver kept `global_cache == disable` and the global-cache branch in `load_node_modules` was unreachable.

Enabling it exposed a second problem: the `PackageManager` singleton was single-VM. `Resolver::get_package_manager` wrote a per-VM `WakeHandler` onto the process-static singleton's `on_wake` field with no synchronization, and `init_with_runtime_once` captured the caller's `log`/`env`/`event_loop` pointers. A worker that reached auto-install would overwrite `on_wake` with a pointer into the worker VM; after `w.terminate()` those backrefs dangled.

## Fix

`VirtualMachine::init_worker` copies `global_cache`, `install`, `prefer_offline_install`, `prefer_latest_install`, and `no_macros` from the parent transpiler into the worker's transpiler, alongside the existing `store_fd` / `standalone_module_graph` / `hot_reload` copies.

To make the auto-install machinery safe across multiple VMs:

- `PackageManager.on_wake` is now a `Mutex<Vec<WakeHandler>>`. `set_on_wake` appends (idempotent by context), `remove_on_wake` removes by context, and `wake_raw` broadcasts to every registered VM under the lock.
- `fail_root_resolution` records `(dependency_id, err)` in `PackageManager.failed_root_dependencies` and broadcasts a wake; each VM's `Queue::on_poll` drains entries matching its own pending modules on its own thread (instead of running JSC operations on the wrong thread). Unclaimed entries are dropped once no other VM is registered to claim them. The now-dead `WakeHandler.on_dependency_error` field, accessor, `Queue::on_dependency_error`, and `jsc_hooks` adapter are removed.
- `auto_install_lock()` is a reentrant (`!Send`) process-global guard held around the resolver's global-cache block and `Queue::{on_poll, enqueue}`, so two JS threads cannot hold `&mut PackageManager` at once. Reentrant on the owning thread because `enqueue_dependency_to_root` calls `PackageManager::sleep_until`, which pumps the JS event loop under the lock.
- `init_with_runtime_once` heap-allocates its own `bun_ast::Log` and a clone of the caller's `DotEnv::Loader` instead of storing backrefs into the caller's storage. The env clone routes OOM through `handle_oom` so the field-write block stays infallible. `resume_loading_module` no longer redirects `pm.log`.
- `enqueue_dependency_to_root` re-seats `pm.event_loop` to the calling VM's loop immediately before `sleep_until` (under `auto_install_lock`). A `runtime_wake_via_handlers` flag makes `wake_raw` skip the explicit `event_loop.wakeup()` in the runtime path (the `on_wake` broadcast already wakes each registered VM via `enqueue_task_concurrent`), so `wake_raw` never dereferences a potentially-stale per-VM loop after a worker terminates.
- Worker `shutdown` calls `Resolver::remove_package_manager_wake` before the VM is destroyed.

## Known limitation (follow-up)

`on_package_download_error` / `on_package_manifest_error` are still dispatched to whichever VM's `Queue` is inside `run_tasks` when the completed task is drained, not necessarily the VM whose module is pending. With two VMs concurrently auto-installing, a network error on one VM's download can be drained by the other VM (which finds no matching pending module), leaving the owning VM's import promise unsettled. The `VoidRunTasksCallbacks` path inside `sleep_until` already dropped these errors on the floor on a single VM before this PR; fixing it properly requires reworking `run_tasks` error dispatch to record errors on the `PackageManager` (as `failed_root_dependencies` does) and having each VM claim its own, which is a larger refactor of `RunTasksCallbacks` than this change should carry.

## Verification

`test/cli/run/run-autoinstall-worker.test.ts` runs against a local `Bun.serve` registry stub (no public npm) and covers:
- Worker resolving from a cache warmed by the main thread
- Worker auto-installing cold (main thread never imported the package, so the worker is first to initialise the singleton)
- Worker honouring `--install=force` with a `node_modules` folder present
- Main thread resolving via the PackageManager after a worker that used auto-install has terminated

All four fail on main with `WORKER FAILED ERR_MODULE_NOT_FOUND Cannot find package 'no-deps'` and pass with this change.

Fixes #29018

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/run-autoinstall-worker.test.ts
bun test v1.4.0 (6d4807128)

test/cli/run/run-autoinstall-worker.test.ts:
104 |   const { stdout, stderr, exitCode } = await run({
105 |     prefix: "autoinstall-worker-cold",
106 |     index: indexTs(),
107 |   });
108 |   expect(stderr).not.toContain("Cannot find package");
109 |   expect(stdout).toContain("WORKER OK no-deps@2.0.0");
                       ^
error: expect(received).toContain(expected)

Expected to contain: "WORKER OK no-deps@2.0.0"
Received: "WORKER FAILED ERR_MODULE_NOT_FOUND Cannot find package 'no-deps' from '/tmp/autoinstall-worker-cold_1LpLbC/worker.ts'\n"

      at <anonymous> (/workspace/bun/test/cli/run/run-autoinstall-worker.test.ts:109:18)
(fail) Worker auto-installs bare specifier when main thread has not [466.85ms]
119 |       "node_modules/placeholder/package.json": JSON.stringify({ name: "placeholder", version: "0.0.0" }),
120 |     },
121 |     index: indexTs(),
122 |   });
123 |   expect(stderr).not.toContain("Cannot find package");
124 |   expect(stdout).to
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3dea2cbbe)

test/cli/run/run-autoinstall-worker.test.ts:
(pass) Worker respects --install=force from parent process [16.68ms]
(pass) Worker resolves bare specifier from global cache warmed by main thread [25.99ms]
(pass) Worker auto-installs bare specifier when main thread has not [23.87ms]
(pass) main-thread auto-install still works after a Worker that used auto-install is terminated [22.82ms]

 4 pass
 0 fail
 16 expect() calls
Ran 4 tests across 1 file. [705.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/run-autoinstall-worker.test.ts
bun test v1.4.0 (6d4807128)

test/cli/run/run-autoinstall-worker.test.ts:
(pass) Worker auto-installs bare specifier when main thread has not [541.92ms]
(pass) Worker resolves bare specifier from global cache warmed by main thread [610.76ms]
(pass) Worker respects --install=force from parent process [560.33ms]
(pass) main-thread auto-install still works after a Worker that used auto-install is terminated [562.84ms]

 4 pass
 0 fail
 16 expect() calls
Ran 4 tests across 1 file. [2.82s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 705ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[2/7] gen cpp.rs (cppbind)
[3/7] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_js_parser v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/event_loop/AnyEventLoop.rs                     |   7 +
 src/event_loop/lib.rs                              |   1 +
 src/install/PackageManager.rs                      |  65 +++++----
 .../PackageManager/PackageManagerEnqueue.rs        |   4 +
 src/install/auto_installer.rs                      |   9 +-
 src/install_types/resolver_hooks.rs                |  26 +---
 src/jsc/AsyncModule.rs                             | 121 +++++++++--------
 src/jsc/VM.rs                                      |   4 +
 src/jsc/VirtualMachine.rs                          |  13 ++
 src/jsc/event_loop.rs                              |   4 +
 src/jsc/web_worker.rs                              |   1 +
 src/resolver/lib.rs                                |   4 +-
 src/resolver/resolver.rs                           |  53 ++++++++
 src/runtime/jsc_hooks.rs                           |  16 ---
 test/cli/run/run-autoinstall-worker.test.ts        | 146 +++++++++++++++++++++
 15 files changed, 349 insertions(+), 125 deletions(-)
```

</details>

**gate history** · 10 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/event_loop/AnyEventLoop.rs                           2      3      0
src/event_loop/lib.rs                                    2      3      0
src/install/PackageManager.rs                           14     13      0
src/install/PackageManager/PackageManagerEnqueue.rs      6      4      0
src/install/auto_installer.rs                            3      3      0
src/install_types/resolver_hooks.rs                      6      6      0
src/jsc/AsyncModule.rs                                  10      9      0
src/jsc/VM.rs                                            1      1      0
src/jsc/VirtualMachine.rs                                6      4      0
src/jsc/event_loop.rs                                    3      5      0
src/jsc/web_worker.rs                                    6      5      0
src/resolver/lib.rs                                      1      2      0
src/resolver/resolver.rs                                14     15      0
src/runtime/jsc_hooks.rs                                 3      1      0
test/cli/run/run-autoinstall-worker.test.ts              1      6      0
```

</details>

<!-- robobun:evidence:end -->