### PR TITLE
node:crypto: throw ERR_UNKNOWN_ENCODING for invalid Sign#sign() outputEncoding

### DIFF
--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -471,9 +471,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSignProtoFuncSign, (JSC::JSGlobalObject * lexicalGlob
     EXCEPTION_ASSERT(!!signature == !scope.exception());
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Node applies the output encoding via ret.toString(encoding) after the
-    // native sign succeeds, so key/padding/sign errors take precedence over
-    // ERR_UNKNOWN_ENCODING.
     JSValue outputEncodingValue = callFrame->argument(1);
     BufferEncodingType outputEncoding = BufferEncodingType::buffer;
     if (outputEncodingValue.toBoolean(lexicalGlobalObject)) {

--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -434,17 +434,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSignProtoFuncSign, (JSC::JSGlobalObject * lexicalGlob
         return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "key"_s, "ArrayBuffer, Buffer, TypedArray, DataView, string, KeyObject, or CryptoKey"_s, options);
     }
 
-    JSValue outputEncodingValue = callFrame->argument(1);
-    BufferEncodingType outputEncoding = BufferEncodingType::buffer;
-    if (outputEncodingValue.toBoolean(lexicalGlobalObject)) {
-        auto parsed = WebCore::parseEnumerationAllowBuffer(*lexicalGlobalObject, outputEncodingValue);
-        RETURN_IF_EXCEPTION(scope, {});
-        if (!parsed) {
-            return Bun::ERR::UNKNOWN_ENCODING(scope, lexicalGlobalObject, outputEncodingValue);
-        }
-        outputEncoding = parsed.value();
-    }
-
     // Get RSA padding mode and salt length if applicable
     int32_t padding = getPadding(lexicalGlobalObject, scope, options, {});
     RETURN_IF_EXCEPTION(scope, {});
@@ -481,6 +470,20 @@ JSC_DEFINE_HOST_FUNCTION(jsSignProtoFuncSign, (JSC::JSGlobalObject * lexicalGlob
     JSUint8Array* signature = signWithKey(lexicalGlobalObject, thisObject, keyPtr, dsaSigEnc, padding, saltLen);
     EXCEPTION_ASSERT(!!signature == !scope.exception());
     RETURN_IF_EXCEPTION(scope, {});
+
+    // Node applies the output encoding via ret.toString(encoding) after the
+    // native sign succeeds, so key/padding/sign errors take precedence over
+    // ERR_UNKNOWN_ENCODING.
+    JSValue outputEncodingValue = callFrame->argument(1);
+    BufferEncodingType outputEncoding = BufferEncodingType::buffer;
+    if (outputEncodingValue.toBoolean(lexicalGlobalObject)) {
+        auto parsed = WebCore::parseEnumerationAllowBuffer(*lexicalGlobalObject, outputEncodingValue);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!parsed) {
+            return Bun::ERR::UNKNOWN_ENCODING(scope, lexicalGlobalObject, outputEncodingValue);
+        }
+        outputEncoding = parsed.value();
+    }
 
     // If output encoding is not buffer, convert the signature to the requested encoding
     if (outputEncoding != BufferEncodingType::buffer) {

--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -435,8 +435,15 @@ JSC_DEFINE_HOST_FUNCTION(jsSignProtoFuncSign, (JSC::JSGlobalObject * lexicalGlob
     }
 
     JSValue outputEncodingValue = callFrame->argument(1);
-    auto outputEncoding = parseEnumeration<BufferEncodingType>(*lexicalGlobalObject, outputEncodingValue).value_or(BufferEncodingType::buffer);
-    RETURN_IF_EXCEPTION(scope, {});
+    BufferEncodingType outputEncoding = BufferEncodingType::buffer;
+    if (outputEncodingValue.toBoolean(lexicalGlobalObject)) {
+        auto parsed = WebCore::parseEnumerationAllowBuffer(*lexicalGlobalObject, outputEncodingValue);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!parsed) {
+            return Bun::ERR::UNKNOWN_ENCODING(scope, lexicalGlobalObject, outputEncodingValue);
+        }
+        outputEncoding = parsed.value();
+    }
 
     // Get RSA padding mode and salt length if applicable
     int32_t padding = getPadding(lexicalGlobalObject, scope, options, {});

--- a/test/js/node/crypto/crypto.test.ts
+++ b/test/js/node/crypto/crypto.test.ts
@@ -233,6 +233,33 @@ describe("crypto.createSign()/.verifySign()", () => {
       expect(verify).toBeTrue();
     },
   );
+
+  it("Sign#sign() throws ERR_UNKNOWN_ENCODING for an invalid outputEncoding", () => {
+    const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+    const invalid = ["rot13", "utf-42", 123, {}] as const;
+    for (const encoding of invalid) {
+      expect(() => crypto.createSign("sha256").update("m").sign(privateKey, encoding as any)).toThrow(
+        expect.objectContaining({
+          code: "ERR_UNKNOWN_ENCODING",
+          message: `Unknown encoding: ${typeof encoding === "object" ? "{}" : encoding}`,
+        }),
+      );
+    }
+
+    const falsy = [undefined, null, "", 0, false] as const;
+    for (const encoding of falsy) {
+      const out = crypto.createSign("sha256").update("m").sign(privateKey, encoding as any);
+      expect(Buffer.isBuffer(out)).toBeTrue();
+    }
+
+    const asBuffer = crypto.createSign("sha256").update("m").sign(privateKey, "buffer" as any);
+    expect(Buffer.isBuffer(asBuffer)).toBeTrue();
+
+    const asHex = crypto.createSign("sha256").update("m").sign(privateKey, "hex");
+    expect(typeof asHex).toBe("string");
+    expect(asHex.length).toBe(512);
+  });
 });
 
 it("should send cipher events in the right order", async () => {

--- a/test/js/node/crypto/crypto.test.ts
+++ b/test/js/node/crypto/crypto.test.ts
@@ -239,7 +239,12 @@ describe("crypto.createSign()/.verifySign()", () => {
 
     const invalid = ["rot13", "utf-42", 123, {}] as const;
     for (const encoding of invalid) {
-      expect(() => crypto.createSign("sha256").update("m").sign(privateKey, encoding as any)).toThrow(
+      expect(() =>
+        crypto
+          .createSign("sha256")
+          .update("m")
+          .sign(privateKey, encoding as any),
+      ).toThrow(
         expect.objectContaining({
           code: "ERR_UNKNOWN_ENCODING",
           message: `Unknown encoding: ${typeof encoding === "object" ? "{}" : encoding}`,
@@ -249,11 +254,17 @@ describe("crypto.createSign()/.verifySign()", () => {
 
     const falsy = [undefined, null, "", 0, false] as const;
     for (const encoding of falsy) {
-      const out = crypto.createSign("sha256").update("m").sign(privateKey, encoding as any);
+      const out = crypto
+        .createSign("sha256")
+        .update("m")
+        .sign(privateKey, encoding as any);
       expect(Buffer.isBuffer(out)).toBeTrue();
     }
 
-    const asBuffer = crypto.createSign("sha256").update("m").sign(privateKey, "buffer" as any);
+    const asBuffer = crypto
+      .createSign("sha256")
+      .update("m")
+      .sign(privateKey, "buffer" as any);
     expect(Buffer.isBuffer(asBuffer)).toBeTrue();
 
     const asHex = crypto.createSign("sha256").update("m").sign(privateKey, "hex");


### PR DESCRIPTION
## Repro

`Sign.prototype.sign(key, outputEncoding)` silently ignores an unknown `outputEncoding` and returns a `Buffer`, where Node.js throws `ERR_UNKNOWN_ENCODING`. Bun's own `Verify.prototype.verify(key, sig, encoding)` already throws for the same input, so the two halves disagree.

```js
import crypto from 'node:crypto';
const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
const out = crypto.createSign('sha256').update('m').sign(privateKey, 'rot13');
// Node v26.3.0: TypeError [ERR_UNKNOWN_ENCODING]: Unknown encoding: rot13
// Bun:          Buffer(256)
```

The caller expects a string and gets a Buffer; something like `sig.toLowerCase()` then TypeErrors far from the cause.

## Cause

`jsSignProtoFuncSign` parses the encoding with `parseEnumeration<BufferEncodingType>(...).value_or(BufferEncodingType::buffer)`, so a present-but-unparseable value falls back to `buffer` instead of throwing.

## Fix

When `outputEncoding` is truthy, parse it (allowing the literal `"buffer"`) and throw `ERR_UNKNOWN_ENCODING` if the parse fails. Falsy values (`undefined`, `null`, `''`, `0`, `false`) still default to Buffer, matching Node's `encoding || getDefaultEncoding()` followed by `ret.toString(encoding)`.

## Verification

All nine cases now match Node v26.3.0 byte-for-byte:

```
sign(key)              => Buffer(256)
sign(key, undefined)   => Buffer(256)
sign(key, null)        => Buffer(256)
sign(key, '')          => Buffer(256)
sign(key, 'buffer')    => Buffer(256)
sign(key, 'hex')       => string(512)
sign(key, 'rot13')     THROWS ERR_UNKNOWN_ENCODING "Unknown encoding: rot13"
sign(key, 123)         THROWS ERR_UNKNOWN_ENCODING "Unknown encoding: 123"
sign(key, {})          THROWS ERR_UNKNOWN_ENCODING "Unknown encoding: {}"
```

New test in `test/js/node/crypto/crypto.test.ts` covers the invalid, falsy, `'buffer'`, and `'hex'` paths; fails on released Bun (`Received function did not throw`), passes with this change. `test/js/node/test/parallel/test-crypto-sign-verify.js` still passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/crypto.test.ts
bun test v1.4.0 (b835c4b19)

test/js/node/crypto/crypto.test.ts:
(pass) CryptoHasher > CryptoHasher.algorithms [2.75ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 [3.29ms]
(pass) CryptoHasher > CryptoHasher.hash blake2b256 [1.66ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 multi-part [2.32ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 to Buffer [2.83ms]
(pass) CryptoHasher > new CryptoHasher blake2b512 [1.15ms]
(pass) CryptoHasher > CryptoHasher.hash blake2b512 [0.62ms]
(pass) CryptoHasher > new CryptoHasher blake2b512 multi-part [0.93ms]
(pass) CryptoHasher > new CryptoHasher blake2b512 to Buffer [1.04ms]
(pass) CryptoHasher > new CryptoHasher blake2s256 [0.91ms]
(pass) CryptoHasher > CryptoHasher.hash blake2s256 [0.36ms]
(pass) CryptoHasher > new CryptoHasher blake2s256 multi-part [0.58ms]
(pass) CryptoHasher > new CryptoHasher blake2s256 to Buffer [0.94ms]
(pass) CryptoHasher > new CryptoHasher md4 [0.71ms]
(pass) CryptoHasher > CryptoHasher.hash md4 [0.33ms]
(pass) CryptoHash
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d39285462)

test/js/node/crypto/crypto.test.ts:
(pass) CryptoHasher > CryptoHasher.algorithms [0.11ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 [3.05ms]
(pass) CryptoHasher > CryptoHasher.hash blake2b256 [0.06ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 multi-part [0.05ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 to Buffer [0.06ms]
(pass) CryptoHasher > new CryptoHasher blake2b512 [0.02ms]
(pass) CryptoHasher > CryptoHasher.hash blake2b512
(pass) CryptoHasher > new CryptoHasher blake2b512 multi-part
(pass) CryptoHasher > new CryptoHasher blake2b512 to Buffer [0.01ms]
(pass) CryptoHasher > new CryptoHasher blake2s256 [0.01ms]
(pass) CryptoHasher > CryptoHasher.hash blake2s256
(pass) CryptoHasher > new CryptoHasher blake2s256 multi-part
(pass) CryptoHasher > new CryptoHasher blake2s256 to Buffer [0.02ms]
(pass) CryptoHasher > new CryptoHasher md4
(pass) CryptoHasher > CryptoHasher.hash md4
(pass) CryptoHasher > new CryptoHasher md4 multi-part
(pass) CryptoHasher > new CryptoHasher md4 to Buffer
(pass) CryptoHasher > new CryptoHasher md5 [0.01ms]
(pass) CryptoHasher > CryptoHasher.hash md5
(pass) CryptoHasher > new C
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/crypto.test.ts
bun test v1.4.0 (b835c4b19)

test/js/node/crypto/crypto.test.ts:
(pass) CryptoHasher > CryptoHasher.algorithms [2.65ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 [3.35ms]
(pass) CryptoHasher > CryptoHasher.hash blake2b256 [1.66ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 multi-part [2.34ms]
(pass) CryptoHasher > new CryptoHasher blake2b256 to Buffer [2.49ms]
(pass) CryptoHasher > new CryptoHasher blake2b512 [1.39ms]
(pass) CryptoHasher > CryptoHasher.hash blake2b512 [0.59ms]
(pass) CryptoHasher > new CryptoHasher blake2b512 multi-part [0.90ms]
(pass) CryptoHasher > new CryptoHasher blake2b512 to Buffer [0.98ms]
(pass) CryptoHasher > new CryptoHasher blake2s256 [0.90ms]
(pass) CryptoHasher > CryptoHasher.hash blake2s256 [0.35ms]
(pass) CryptoHasher > new CryptoHasher blake2s256 multi-part [0.59ms]
(pass) CryptoHasher > new CryptoHasher blake2s256 to Buffer [0.91ms]
(pass) CryptoHasher > new CryptoHasher md4 [0.71ms]
(pass) CryptoHasher > CryptoHasher.hash md4 [0.32ms]
(pass) CryptoHash
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 774ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/node/crypto/JSSign.cpp | 15 +++++++++----
 test/js/node/crypto/crypto.test.ts      | 38 +++++++++++++++++++++++++++++++++
 2 files changed, 49 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/node/crypto/JSSign.cpp      2      4      0
test/js/node/crypto/crypto.test.ts           1      1      0
```

</details>

<!-- robobun:evidence:end -->