### PR TITLE
node:crypto: accept ArrayBuffer where Node's getArrayBufferOrView does

### DIFF
--- a/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
@@ -344,7 +344,7 @@ std::optional<SignJobCtx> SignJobCtx::fromJS(JSGlobalObject* globalObject, Throw
 
     Vector<uint8_t> signatureData;
     if (mode == Mode::Verify) {
-        auto signatureView = getArrayBufferOrView2(globalObject, scope, signatureValue, "signature"_s, jsUndefined(), true);
+        auto signatureView = getArrayBufferOrView2(globalObject, scope, signatureValue, "signature"_s, jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});
         signatureData.append(std::span { signatureView->data(), signatureView->size() });
     }

--- a/src/jsc/bindings/node/crypto/CryptoUtil.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.cpp
@@ -654,18 +654,13 @@ JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, Throw
 }
 
 // maybe replace other getArrayBufferOrView
-GCOwnedDataScope<std::span<const uint8_t>> getArrayBufferOrView2(JSGlobalObject* globalObject, ThrowScope& scope, JSValue dataValue, ASCIILiteral argName, JSValue encodingValue, bool arrayBufferViewOnly)
+GCOwnedDataScope<std::span<const uint8_t>> getArrayBufferOrView2(JSGlobalObject* globalObject, ThrowScope& scope, JSValue dataValue, ASCIILiteral argName, JSValue encodingValue)
 {
     using Return = GCOwnedDataScope<std::span<const uint8_t>>;
 
     if (auto* view = dynamicDowncast<JSArrayBufferView>(dataValue)) {
         return { view, view->span() };
     }
-
-    if (arrayBufferViewOnly) {
-        ERR::INVALID_ARG_INSTANCE(scope, globalObject, argName, "Buffer, TypedArray, or DataView"_s, dataValue);
-        return { nullptr, {} };
-    };
 
     if (auto* arrayBuffer = dynamicDowncast<JSArrayBuffer>(dataValue)) {
         return { arrayBuffer, arrayBuffer->impl()->span() };
@@ -744,18 +739,29 @@ JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, Throw
         return view;
     }
 
-    auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value);
-    if (!view) {
-        ERR::INVALID_ARG_TYPE_INSTANCE(scope, globalObject, argName, "string"_s, "Buffer, TypedArray, or DataView"_s, value);
-        return {};
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
+        if (view->isDetached()) {
+            throwTypeError(globalObject, scope, "Buffer is detached"_s);
+            return {};
+        }
+        return view;
     }
 
-    if (view->isDetached()) {
-        throwTypeError(globalObject, scope, "Buffer is detached"_s);
-        return {};
+    if (auto* arrayBuffer = dynamicDowncast<JSC::JSArrayBuffer>(value)) {
+        auto* impl = arrayBuffer->impl();
+        if (!impl || impl->isDetached()) {
+            throwTypeError(globalObject, scope, "Buffer is detached"_s);
+            return {};
+        }
+        RefPtr<JSC::ArrayBuffer> buffer(impl);
+        auto* structure = globalObject->typedArrayStructure(JSC::TypeUint8, impl->isResizableOrGrowableShared());
+        auto* view = JSC::JSUint8Array::create(globalObject, structure, WTF::move(buffer), 0, impl->byteLength());
+        RETURN_IF_EXCEPTION(scope, {});
+        return view;
     }
 
-    return view;
+    ERR::INVALID_ARG_TYPE_INSTANCE(scope, globalObject, argName, "string"_s, "ArrayBuffer, Buffer, TypedArray, or DataView"_s, value);
+    return {};
 }
 
 std::optional<std::span<const uint8_t>> getBuffer(JSC::JSValue maybeBuffer)

--- a/src/jsc/bindings/node/crypto/CryptoUtil.h
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.h
@@ -60,7 +60,7 @@ int32_t getPadding(JSC::JSGlobalObject* globalObject, JSC::ThrowScope&, JSValue 
 std::optional<int32_t> getSaltLength(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, JSValue options);
 DSASigEnc getDSASigEnc(JSC::JSGlobalObject* globalObject, JSC::ThrowScope&, JSValue options);
 bool convertP1363ToDER(const ncrypto::Buffer<const unsigned char>& p1363Sig, const ncrypto::EVPKeyPointer& pkey, WTF::Vector<uint8_t>& derBuffer);
-GCOwnedDataScope<std::span<const uint8_t>> getArrayBufferOrView2(JSGlobalObject* globalObject, ThrowScope& scope, JSValue dataValue, ASCIILiteral argName, JSValue encodingValue, bool arrayBufferViewOnly = false);
+GCOwnedDataScope<std::span<const uint8_t>> getArrayBufferOrView2(JSGlobalObject* globalObject, ThrowScope& scope, JSValue dataValue, ASCIILiteral argName, JSValue encodingValue);
 JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, ThrowScope& scope, JSValue value, ASCIILiteral argName, JSValue encodingValue, bool defaultBufferEncoding = false);
 JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, ThrowScope& scope, JSValue value, ASCIILiteral argName, BufferEncodingType encoding);
 JSValue getStringOption(JSGlobalObject* globalObject, JSValue options, const WTF::ASCIILiteral& name);

--- a/src/jsc/bindings/node/crypto/JSCipherPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipherPrototype.cpp
@@ -56,6 +56,10 @@ JSC_DEFINE_HOST_FUNCTION(jsCipherUpdate, (JSC::JSGlobalObject * lexicalGlobalObj
     WTF::String dataString = WTF::nullString();
     WTF::String encodingString = WTF::nullString();
 
+    if (!dataValue.isString() && !dynamicDowncast<JSC::JSArrayBufferView>(dataValue)) {
+        return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "data"_s, "string or an instance of Buffer, TypedArray, or DataView"_s, dataValue);
+    }
+
     JSArrayBufferView* dataView = getArrayBufferOrView(lexicalGlobalObject, scope, dataValue, "data"_s, encodingValue);
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -814,6 +814,32 @@ describe("ArrayBuffer accepted where Node accepts it", () => {
     const ref = a.computeSecret(b.getPublicKey());
     expect(a.computeSecret(toAB(b.getPublicKey())).equals(ref)).toBe(true);
   });
+
+  it("createCipheriv iv and key.passphrase accept an ArrayBuffer", () => {
+    const key = Buffer.alloc(32, 1);
+    const iv = Buffer.alloc(12, 2);
+    const enc = crypto.createCipheriv("aes-256-gcm", key, toAB(iv));
+    Buffer.concat([enc.update("x"), enc.final()]);
+    expect(enc.getAuthTag().length).toBe(16);
+
+    const { privateKey } = crypto.generateKeyPairSync("ec", {
+      namedCurve: "P-256",
+      privateKeyEncoding: { type: "pkcs8", format: "pem", cipher: "aes-128-cbc", passphrase: "secret" },
+    });
+    const keyObj = crypto.createPrivateKey({ key: privateKey, passphrase: toAB(Buffer.from("secret")) });
+    expect(keyObj.asymmetricKeyType).toBe("ec");
+  });
+
+  it("cipher.update still rejects an ArrayBuffer like Node does", () => {
+    const cipher = crypto.createCipheriv("aes-256-gcm", Buffer.alloc(32, 1), Buffer.alloc(12, 2));
+    expect(() => cipher.update(new ArrayBuffer(4))).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          'The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of ArrayBuffer',
+      }),
+    );
+  });
 });
 
 it("x25519", () => {

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -744,13 +744,76 @@ it("Cipheriv.update throws expected error for invalid data", () => {
   );
 });
 
-it("verifyOneShot should not accept strings for signatures", () => {
+it("verifyOneShot rejects non-string non-BufferSource signature with the Node error message", () => {
   const data = Buffer.alloc(1);
-  expect(() => {
-    crypto.verify(null, data, "test", "oops");
-  }).toThrow(
-    "The \"signature\" argument must be an instance of Buffer, TypedArray, or DataView. Received type string ('oops')",
+  expect(() => crypto.verify(null, data, "test", 1)).toThrow(
+    expect.objectContaining({
+      code: "ERR_INVALID_ARG_TYPE",
+      message:
+        'The "signature" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received type number (1)',
+    }),
   );
+});
+
+describe("ArrayBuffer accepted where Node accepts it", () => {
+  const toAB = b => b.buffer.slice(b.byteOffset, b.byteOffset + b.length);
+
+  it("crypto.verify / Verify#verify accept an ArrayBuffer signature", () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const msg = Buffer.from("hello");
+    const sig = crypto.sign("sha256", msg, privateKey);
+    const sigAB = toAB(sig);
+    expect(sigAB).toBeInstanceOf(ArrayBuffer);
+
+    expect(crypto.verify("sha256", msg, publicKey, sigAB)).toBe(true);
+    expect(crypto.createVerify("sha256").update(msg).verify(publicKey, sigAB)).toBe(true);
+
+    const sab = new SharedArrayBuffer(sig.length);
+    new Uint8Array(sab).set(sig);
+    expect(crypto.verify("sha256", msg, publicKey, sab)).toBe(true);
+  });
+
+  it("cipher.setAAD / decipher.setAuthTag accept an ArrayBuffer", () => {
+    const key = Buffer.alloc(32, 1);
+    const iv = Buffer.alloc(12, 2);
+    const aad = Buffer.from("additional data");
+
+    const enc = crypto.createCipheriv("aes-256-gcm", key, iv);
+    enc.setAAD(toAB(aad));
+    const ct = Buffer.concat([enc.update("hello"), enc.final()]);
+    const tag = enc.getAuthTag();
+
+    const dec = crypto.createDecipheriv("aes-256-gcm", key, iv);
+    dec.setAAD(toAB(aad));
+    dec.setAuthTag(toAB(tag));
+    expect(Buffer.concat([dec.update(ct), dec.final()]).toString()).toBe("hello");
+  });
+
+  it("ECDH computeSecret / setPrivateKey / convertKey accept an ArrayBuffer", () => {
+    const a = crypto.createECDH("prime256v1");
+    const b = crypto.createECDH("prime256v1");
+    a.generateKeys();
+    b.generateKeys();
+
+    const secretFromAB = a.computeSecret(toAB(b.getPublicKey()));
+    expect(secretFromAB.equals(a.computeSecret(b.getPublicKey()))).toBe(true);
+
+    const c = crypto.createECDH("prime256v1");
+    c.setPrivateKey(toAB(a.getPrivateKey()));
+    expect(c.getPublicKey().equals(a.getPublicKey())).toBe(true);
+
+    const compressed = crypto.ECDH.convertKey(toAB(a.getPublicKey()), "prime256v1", null, null, "compressed");
+    expect(compressed.length).toBe(33);
+  });
+
+  it("DiffieHellman computeSecret accepts an ArrayBuffer", () => {
+    const a = crypto.createDiffieHellmanGroup("modp14");
+    const b = crypto.createDiffieHellmanGroup("modp14");
+    a.generateKeys();
+    b.generateKeys();
+    const ref = a.computeSecret(b.getPublicKey());
+    expect(a.computeSecret(toAB(b.getPublicKey())).equals(ref)).toBe(true);
+  });
 });
 
 it("x25519", () => {

--- a/test/js/node/test/parallel/test-crypto-sign-verify.js
+++ b/test/js/node/test/parallel/test-crypto-sign-verify.js
@@ -495,8 +495,8 @@ assert.throws(
   assert.throws(() => crypto.sign(null, data, input), errObj);
   assert.throws(() => crypto.verify(null, data, input, sig), errObj);
 
-  errObj.message = 'The "signature" argument must be an instance of ' +
-                   'Buffer, TypedArray, or DataView.' +
+  errObj.message = 'The "signature" argument must be of type string or an instance of ' +
+                   'ArrayBuffer, Buffer, TypedArray, or DataView.' +
                    common.invalidArgTypeHelper(input);
   assert.throws(() => crypto.verify(null, data, 'test', input), errObj);
 });


### PR DESCRIPTION
## What does this PR do?

`node:crypto` rejects a raw `ArrayBuffer` at every call site that routes through `getArrayBufferOrView()` in `CryptoUtil.cpp`, while Node's helper of the same name accepts `ArrayBuffer` (and `SharedArrayBuffer`). The documented type for these arguments includes `<ArrayBuffer>`.

### Repro

```js
import * as crypto from "node:crypto";
const toAB = b => b.buffer.slice(b.byteOffset, b.byteOffset + b.length);
const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
const sig = crypto.sign("sha256", Buffer.from("m"), privateKey);

crypto.verify("sha256", Buffer.from("m"), publicKey, toAB(sig));
// node: true
// bun:  TypeError [ERR_INVALID_ARG_TYPE]: The "signature" argument must be an instance of
//       Buffer, TypedArray, or DataView. Received an instance of ArrayBuffer
```

Same rejection for `Verify#verify` signature, `decipher.setAuthTag`, `cipher.setAAD`, `ECDH`/`DiffieHellman` `computeSecret`/`setPrivateKey`/`setPublicKey`, `ECDH.convertKey`, `createCipheriv` iv, `createDiffieHellman` prime/generator, and the `key.passphrase` option. A `DataView` or `Uint8Array` over the same `ArrayBuffer` was already accepted.

### Cause

`getArrayBufferOrView()` only did `dynamicDowncast<JSArrayBufferView>(value)`; a `JSArrayBuffer` fell through to the `ERR_INVALID_ARG_TYPE` path. Separately, the one-shot `crypto.verify` signature passed `arrayBufferViewOnly = true` into `getArrayBufferOrView2`, a restriction Node no longer has (it accepts string and ArrayBuffer there).

### Fix

- `getArrayBufferOrView()` now recognizes a `JSArrayBuffer` and returns a `Uint8Array` view over the same backing store (handles shared/resizable). The rejection message now lists `ArrayBuffer`, matching Node.
- `cipher.update()` is the one caller whose Node counterpart still rejects `ArrayBuffer` for `data`, so it keeps a dedicated type check in front of the helper with Node's exact message.
- Dropped the `arrayBufferViewOnly` flag from `getArrayBufferOrView2` and its only caller; Node's one-shot `verify` signature goes through the full `getArrayBufferOrView` validator.
- Resynced the `test-crypto-sign-verify.js` assertion for the one-shot signature error message to the Node v26.3.0 wording.

### Verification

`bun bd test test/js/node/crypto/node-crypto.test.js` (206 pass) and all 120 `test/js/node/test/parallel/test-crypto-*.js` files pass. The new `describe("ArrayBuffer accepted where Node accepts it")` suite fails under `USE_SYSTEM_BUN=1`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.0 (ca1f68e1d)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.00ms]
(pass) crypto.randomInt should return a number [2.18ms]
(pass) crypto.randomInt with no arguments [4.07ms]
(pass) crypto.randomInt with one argument [2.30ms]
(pass) crypto.randomInt with a callback [35.55ms]
(pass) createHash > rsa-md5 - "Hello World" [7.86ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.31ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.83ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.92ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.14ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.27ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.74ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.84ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.73ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.82ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.80ms]
(pass) create
... (truncated)

release without fix: 18 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.14ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.08ms]
(pass) crypto.randomInt with one argument [0.03ms]
(pass) crypto.randomInt with a callback [0.79ms]
(pass) createHash > rsa-md5 - "Hello World" [0.17ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.07ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.03ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha1 - "Hello World" [0.16ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.06ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.03ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" [0.02ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pass) createHash > rs
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.0 (ca1f68e1d)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.05ms]
(pass) crypto.randomInt should return a number [2.12ms]
(pass) crypto.randomInt with no arguments [3.81ms]
(pass) crypto.randomInt with one argument [2.17ms]
(pass) crypto.randomInt with a callback [35.95ms]
(pass) createHash > rsa-md5 - "Hello World" [7.96ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.30ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.84ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.92ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.09ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.23ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.73ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.80ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.76ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.83ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.82ms]
(pass) create
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 734ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/71] gen cpp.rs (cppbind)
[1/71] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/node/crypto/CryptoSignJob.cpp     |  2 +-
 src/jsc/bindings/node/crypto/CryptoUtil.cpp        | 34 +++++---
 src/jsc/bindings/node/crypto/CryptoUtil.h          |  2 +-
 src/jsc/bindings/node/crypto/JSCipherPrototype.cpp |  4 +
 test/js/node/crypto/node-crypto.test.js            | 99 ++++++++++++++++++++--
 .../node/test/parallel/test-crypto-sign-verify.js  |  4 +-
 6 files changed, 122 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/jsc/bindings/node/crypto/CryptoSignJob.cpp             2      1      0
src/jsc/bindings/node/crypto/CryptoUtil.cpp                3      2      0
src/jsc/bindings/node/crypto/CryptoUtil.h                  1      1      0
src/jsc/bindings/node/crypto/JSCipherPrototype.cpp         1      1      0
test/js/node/crypto/node-crypto.test.js                    3      2      0
test/js/node/test/parallel/test-crypto-sign-verify.js      2      1      0
```

</details>

<!-- robobun:evidence:end -->