### PR TITLE
install: resolve concurrent auto-install cache races into a shared cache dir

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -854,7 +854,6 @@ pub fn path_for_cached_npm_path<'a>(
 
     #[cfg(windows)]
     {
-        let _ = cache_dir;
         let mut path_buf = PathBuffer::uninit();
         let cache_path = ZStr::from_buf(&cache_path_buf, cache_path_len);
         let joined = path::resolve_path::join_abs_string_buf_z::<path::platform::Windows>(
@@ -862,28 +861,52 @@ pub fn path_for_cached_npm_path<'a>(
             &mut path_buf,
             &[cache_path.as_bytes()],
         );
-        return match sys::readlink(joined, &mut buf.0[..]) {
-            Ok(n) => Ok(&mut buf.0[..n]),
+        match sys::readlink(joined, &mut buf.0[..]) {
+            Ok(n) => return Ok(&mut buf.0[..n]),
+            Err(err) if err.get_errno() == sys::E::ENOENT => {}
             Err(err) => {
                 let _ = sys::unlink(joined);
-                Err(err.into())
+                return Err(err.into());
             }
-        };
+        }
     }
 
     #[cfg(not(windows))]
     {
         let cache_path = ZStr::from_buf(&cache_path_buf, cache_path_len);
         match sys::readlinkat(cache_dir, cache_path, &mut buf.0[..]) {
-            Ok(n) => Ok(&mut buf.0[..n]),
+            Ok(n) => return Ok(&mut buf.0[..n]),
+            Err(err) if err.get_errno() == sys::E::ENOENT => {}
             Err(err) => {
                 // if we run into an error, delete the symlink
                 // so that we don't repeatedly try to read it
                 let _ = sys::unlinkat(cache_dir, cache_path);
-                Err(Error::from(err))
+                return Err(Error::from(err));
             }
         }
     }
+
+    // The version-index symlink `<cache>/<name>/<ver>...` does not exist. A
+    // concurrent writer publishes the data folder `<cache>/<name>@<ver>...`
+    // (via `renameat`) before it creates the index symlink, and
+    // `determine_preinstall_state` probes the data folder, so we can land here
+    // with the package fully extracted. Fall back to the data folder path.
+    cache_path_buf[package_name.len()] = b'@';
+    let folder_name = ZStr::from_buf(&cache_path_buf, cache_path_len);
+    if sys::directory_exists_at(cache_dir, folder_name).unwrap_or(false) {
+        let cache_dir_path = this.cache_directory_path.as_bytes();
+        let mut n = cache_dir_path.len();
+        buf.0[..n].copy_from_slice(cache_dir_path);
+        if n > 0 && buf.0[n - 1] != SEP {
+            buf.0[n] = SEP;
+            n += 1;
+        }
+        buf.0[n..n + cache_path_len].copy_from_slice(folder_name.as_bytes());
+        n += cache_path_len;
+        return Ok(&mut buf.0[..n]);
+    }
+
+    Err(Error::FileNotFound)
 }
 
 pub fn path_for_resolution<'a>(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -479,10 +479,14 @@ pub fn enqueue_dependency_to_root(
         }
     }
 
-    let resolution_id = match this.lockfile.buffers.resolutions[dep_id as usize] {
-        id if id == invalid_package_id => 'brk: {
-            this.drain_dependency_list();
+    // A disk-cached `.npm` manifest (including one written just now by a
+    // concurrent process) resolves `resolutions[dep_id]` synchronously above
+    // while only queuing the tarball download into `network_task_fifo`.
+    // Schedule it before deciding whether to wait.
+    this.drain_dependency_list();
 
+    let resolution_id = match this.lockfile.buffers.resolutions[dep_id as usize] {
+        id if id == invalid_package_id || this.pending_task_count() > 0 => 'brk: {
             struct Closure {
                 err: Option<crate::Error>,
                 // raw `*mut` — `sleep_until`

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync } from "fs";
+import { mkdirSync, readdirSync, rmSync } from "fs";
 import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
 import { join } from "path";
 
 //   --install=<val>                 Configure auto-install behavior. One of "auto" (default, auto-installs when no node_modules), "fallback" (missing packages only), "force" (always).
@@ -120,4 +122,128 @@ test("--install=fallback to install missing packages", async () => {
 
   expect(stderr?.toString("utf8")).not.toContain("error: Cannot find package 'is-odd'");
   expect(stdout?.toString("utf8")).toBe("true false\n");
+});
+
+// Two processes auto-installing into a shared cache can observe each other's
+// half-published state: the data folder `<cache>/pkg@ver@@host@@@1` is
+// renamed into place before the version-index symlink `<cache>/pkg/ver@@host@@@1`
+// is created. A reader that sees the first without the second must fall back
+// to the data folder path instead of failing with "Unexpected while resolving".
+test("auto-install resolves from the cache data folder when the version-index symlink is absent", async () => {
+  function tarHeader(name: string, size: number): Buffer {
+    const buf = Buffer.alloc(512, 0);
+    buf.write(name, 0, 100, "utf8");
+    buf.write(size.toString(8).padStart(11, "0") + "\0", 124);
+    buf.fill(" ", 148, 156);
+    buf.write("0", 156);
+    buf.write("ustar\0", 257);
+    buf.write("00", 263);
+    let sum = 0;
+    for (let i = 0; i < 512; i++) sum += buf[i];
+    buf.write(sum.toString(8).padStart(7, "0") + "\0", 148);
+    return buf;
+  }
+  function tarFile(name: string, body: string): Buffer[] {
+    const b = Buffer.from(body);
+    return [tarHeader(name, b.length), b, Buffer.alloc((512 - (b.length % 512)) % 512, 0)];
+  }
+  const tar = Buffer.concat([
+    ...tarFile("package/package.json", JSON.stringify({ name: "race-pkg", version: "1.0.0", main: "index.js" })),
+    ...tarFile("package/index.js", "module.exports = 'race-ok';\n"),
+    Buffer.alloc(1024, 0),
+  ]);
+  const tgz = gzipSync(tar);
+  const shasum = createHash("sha1").update(tgz).digest("hex");
+  const integrity = "sha512-" + createHash("sha512").update(tgz).digest("base64");
+
+  using registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const p = new URL(req.url).pathname;
+      if (p === "/race-pkg") {
+        return Response.json({
+          name: "race-pkg",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "race-pkg",
+              version: "1.0.0",
+              dist: { tarball: `http://127.0.0.1:${registry.port}/race-pkg-1.0.0.tgz`, shasum, integrity },
+            },
+          },
+        });
+      }
+      if (p === "/race-pkg-1.0.0.tgz") {
+        return new Response(tgz, { headers: { "Content-Type": "application/octet-stream" } });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  using dir = tempDir("autoinstall-index-race", {
+    "box/x.cjs": `console.log(require("race-pkg"));\n`,
+    "box/bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
+  });
+  const cache = join(String(dir), "cache");
+  const env = {
+    ...bunEnv,
+    BUN_INSTALL_CACHE_DIR: cache,
+    HOME: String(dir),
+    BUN_TMPDIR: String(dir),
+  };
+  const run = async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "x.cjs"],
+      cwd: join(String(dir), "box"),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  };
+
+  // First run: populates the cache (data folder + version-index symlink).
+  {
+    const { stdout, stderr, exitCode } = await run();
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toBe("race-ok\n");
+    expect(exitCode).toBe(0);
+  }
+
+  // Simulate the concurrent-writer window: the data folder exists but the
+  // `<cache>/race-pkg/` index directory (and its symlink) has not been
+  // created yet. Remove only the index directory.
+  const entries = readdirSync(cache);
+  expect(entries).toContain("race-pkg");
+  expect(entries.some(e => e.startsWith("race-pkg@1.0.0"))).toBe(true);
+  rmSync(join(cache, "race-pkg"), { recursive: true, force: true });
+
+  // Second run: must resolve from the data folder directly.
+  {
+    const { stdout, stderr, exitCode } = await run();
+    expect(stderr).not.toContain("Unexpected while resolving package");
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toBe("race-ok\n");
+    expect(exitCode).toBe(0);
+  }
+
+  // Now simulate the other half of the concurrent window: the `.npm` manifest
+  // is on disk (written by another process) but neither the data folder nor
+  // the index symlink exists yet. Resolving from the disk manifest must still
+  // schedule the tarball download instead of failing on a stale resolution.
+  for (const e of readdirSync(cache)) {
+    if (e.startsWith("race-pkg")) rmSync(join(cache, e), { recursive: true, force: true });
+  }
+  const left = readdirSync(cache);
+  expect(left.some(e => e.endsWith(".npm"))).toBe(true);
+  expect(left.some(e => e.startsWith("race-pkg"))).toBe(false);
+
+  {
+    const { stdout, stderr, exitCode } = await run();
+    expect(stderr).not.toContain("Unexpected while resolving package");
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toBe("race-ok\n");
+    expect(exitCode).toBe(0);
+  }
 });


### PR DESCRIPTION
## Problem

Two `bun` processes cold-starting runtime auto-install into the same cache directory (the default `~/.bun/install/cache` is shared machine-wide) race, and one fails with

```
error: Unexpected while resolving package '<name>' from '<file>'
```

while the other succeeds and the cache ends up fully populated. ~25-55% of cold-start pairs hit this. Typical triggers are parallel test workers or CI shards on a fresh runner.

## Cause

The cache publish in `ExtractTarball::move_to_cache_directory` is two non-atomic steps:

1. `renameat2(tmp, "<cache>/<name>@<ver>@@host@@@1", RENAME_NOREPLACE)` publishes the data folder
2. `mkdirat("<cache>/<name>")` then `symlinkat(<abs data path>, index_dir, "<ver>@@host@@@1")` creates the version-index symlink

A concurrent reader in the window between (1) and (2) sees:

* `determine_preinstall_state` probes the **data folder**, finds it present, and marks the package `Done` (no download).
* `path_for_cached_npm_path` then `readlinkat`s the **index symlink**, gets `ENOENT`, `unlinkat`s it (also `ENOENT`), and returns `install::Error::Sys(ENOENT)` which `From<install::Error> for bun_core::Error` maps to `Unexpected`. The resolver's `FileNotFound` recovery never fires.

There is a second window: the winner writes its `.npm` manifest cache file before it extracts. A loser that reads that manifest resolves the version synchronously; `enqueue_dependency_with_main_and_success_fn` queues the tarball into `network_task_fifo` (unscheduled) and the scopeguard sets `resolutions[dep_id]`. `enqueue_dependency_to_root` then sees a valid resolution and returns without draining the fifo, so the tarball is never fetched and `path_for_resolution` fails for a package neither process has extracted.

## Fix

* `path_for_cached_npm_path`: on `readlink`/`readlinkat` `ENOENT`, fall back to probing the data folder `<cache>/<name>@<ver>@@host@@@1` directly. If it exists, return `<cache_directory_path>/<folder_name>` (the symlink target is exactly that path). The `unlinkat` on a missing symlink is dropped.
* `enqueue_dependency_to_root`: hoist `drain_dependency_list()` above the resolution check and enter the `sleep_until` loop while `pending_task_count() > 0`, so a tarball queued during a synchronous disk-manifest resolve actually runs. (This is the same enqueue fix as #34650, which reaches it from the stale-manifest-cache direction; the concurrent-writer case needs it too.)

No per-package lock file.

## Verification

New deterministic test in `test/cli/run/run-autoinstall.test.ts` that populates the cache via a loopback registry, then exercises both windows by (a) removing only the `<cache>/race-pkg/` index directory and (b) removing every `race-pkg*` entry while keeping the `.npm` manifest. Both assert a subsequent auto-install run prints `race-ok` and exits 0.

```
fail-before (bun bd, src/ stashed): error: Unexpected while resolving package 'race-pkg' from '<dir>/box/x.cjs'
pass-after  (bun bd, with fix):     auto-install resolves from the cache data folder when the version-index symlink is absent [1017ms]
```

6 concurrent cold auto-installs into a fresh cache, 5 rounds, repeated 10×: 300/300 succeed (was ~27/30 per round). 2-way pairs over a 4-package dependency chain: 200/200 succeed (was ~11/20 failing).