### PR TITLE
Reject non-transferable structured-clone tags on the advanced IPC channel

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2844,6 +2844,7 @@ class StructuredCloneableSerialize {
 class StructuredCloneableDeserialize {
   public:
     static std::optional<JSC::EncodedJSValue> fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject*, const uint8_t*&, const uint8_t*);
+    static bool isTagForTransfer(uint8_t tag);
 };
 
 }
@@ -2876,6 +2877,14 @@ function writeCppSerializers() {
     `;
   }
 
+  function isTagForTransferForEachClass(klass) {
+    return `
+    if (tag == ${klass.structuredClone.tag}) {
+      return ${!!klass.structuredClone.transferable};
+    }
+    `;
+  }
+
   output += `
   std::optional<StructuredCloneableSerialize> StructuredCloneableSerialize::fromJS(JSC::JSValue value)
   {
@@ -2889,6 +2898,14 @@ function writeCppSerializers() {
   {
     ${structuredClonable.map(fromTagDeserializeForEachClass).join("\n").trim()}
     return std::nullopt;
+  }
+  `;
+
+  output += `
+  bool StructuredCloneableDeserialize::isTagForTransfer(uint8_t tag)
+  {
+    ${structuredClonable.map(isTagForTransferForEachClass).join("\n").trim()}
+    return true;
   }
   `;
 

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2128,6 +2128,18 @@ pub struct SerializedFlags {
     pub(crate) for_cross_process_transfer: bool,
     pub(crate) for_storage: bool,
 }
+impl SerializedFlags {
+    fn bits(self) -> u8 {
+        let mut bits: u8 = 0;
+        if self.for_cross_process_transfer {
+            bits |= 1 << 0;
+        }
+        if self.for_storage {
+            bits |= 1 << 1;
+        }
+        bits
+    }
+}
 
 /// `JSValue.SerializedScriptValue` — owned view over a
 /// `WebCore::SerializedScriptValue` byte buffer. Call `deinit` to free.
@@ -2620,11 +2632,15 @@ impl JSValue {
     }
 
     // ── Structured clone. ────────────────────────
-    /// `JSValue.deserialize(bytes, global)`.
-    pub(crate) fn deserialize(bytes: &[u8], global: &JSGlobalObject) -> JsResult<JSValue> {
+    /// `JSValue.deserialize(bytes, global, flags)`.
+    pub(crate) fn deserialize(
+        bytes: &[u8],
+        global: &JSGlobalObject,
+        flags: SerializedFlags,
+    ) -> JsResult<JSValue> {
         // SAFETY: `global` is live; `bytes` valid for the call.
         host_fn::from_js_host_call(global, || unsafe {
-            Bun__JSValue__deserialize(global, bytes.as_ptr(), bytes.len())
+            Bun__JSValue__deserialize(global, bytes.as_ptr(), bytes.len(), flags.bits())
         })
     }
     /// `JSValue.serialize(global, flags)` — structured-clone to bytes.
@@ -2633,15 +2649,8 @@ impl JSValue {
         global: &JSGlobalObject,
         flags: SerializedFlags,
     ) -> JsResult<SerializedScriptValue> {
-        let mut bits: u8 = 0;
-        if flags.for_cross_process_transfer {
-            bits |= 1 << 0;
-        }
-        if flags.for_storage {
-            bits |= 1 << 1;
-        }
         let ext = host_fn::from_js_host_call_generic(global, || {
-            Bun__serializeJSValue(global, self, bits)
+            Bun__serializeJSValue(global, self, flags.bits())
         })?;
         if ext.bytes.is_null() || ext.handle.is_null() {
             return Err(JsError::Thrown);
@@ -2713,6 +2722,7 @@ unsafe extern "C" {
         global: *const JSGlobalObject,
         data: *const u8,
         len: usize,
+        flags: u8,
     ) -> JSValue;
     safe fn Bun__serializeJSValue(
         global: &JSGlobalObject,

--- a/src/jsc/bindings/Serialization.cpp
+++ b/src/jsc/bindings/Serialization.cpp
@@ -59,10 +59,11 @@ extern "C" void Bun__SerializedScriptSlice__free(SerializedScriptValue* value)
     value->deref();
 }
 
-extern "C" EncodedJSValue Bun__JSValue__deserialize(JSGlobalObject* globalObject, const uint8_t* bytes, size_t size)
+extern "C" EncodedJSValue Bun__JSValue__deserialize(JSGlobalObject* globalObject, const uint8_t* bytes, size_t size, const SerializedFlags flags)
 {
     Vector<uint8_t> vector(std::span { bytes, size });
+    auto forTransfer = (static_cast<uint8_t>(flags) & static_cast<uint8_t>(SerializedFlags::ForCrossProcessTransfer)) ? SerializationForCrossProcessTransfer::Yes : SerializationForCrossProcessTransfer::No;
     /// ?! did i just give ownership of these bytes to JSC?
-    auto scriptValue = SerializedScriptValue::createFromWireBytes(WTF::move(vector));
+    auto scriptValue = SerializedScriptValue::createFromWireBytes(WTF::move(vector), forTransfer);
     return JSValue::encode(scriptValue->deserialize(*globalObject, globalObject));
 }

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -7105,7 +7105,7 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                       ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-            ,
+                                                ,
         m_forTransfer);
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3137,7 +3137,8 @@ public:
         ,
         Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& serializedVideoChunks, Vector<WebCodecsVideoFrameData>&& serializedVideoFrames
 #endif
-    )
+        ,
+        SerializationForCrossProcessTransfer forTransfer = SerializationForCrossProcessTransfer::No)
     {
         if (!buffer.size())
             return std::make_pair(jsNull(), SerializationReturnCode::UnspecifiedError);
@@ -3159,6 +3160,7 @@ public:
             WTF::move(serializedVideoChunks), WTF::move(serializedVideoFrames)
 #endif
         );
+        deserializer.m_forTransfer = forTransfer;
         if (!deserializer.isValid())
             return std::make_pair(JSValue(), SerializationReturnCode::ValidationError);
         return deserializer.deserialize();
@@ -5082,6 +5084,10 @@ private:
         //     return JSValue();
 
         // read bun types
+        if (m_forTransfer == SerializationForCrossProcessTransfer::Yes && !StructuredCloneableDeserialize::isTagForTransfer(tag)) {
+            fail();
+            return JSValue();
+        }
         if (auto value = StructuredCloneableDeserialize::fromTagDeserialize(tag, m_lexicalGlobalObject, m_ptr, m_end)) {
             JSValue deserialized = JSValue::decode(value.value());
             if (deserialized.isEmpty()) {
@@ -5583,6 +5589,7 @@ private:
     const uint8_t* m_ptr;
     const uint8_t* const m_end;
     unsigned m_version;
+    SerializationForCrossProcessTransfer m_forTransfer { SerializationForCrossProcessTransfer::No };
     Vector<CachedString> m_constantPool;
     // Mirrors CloneSerializer's m_objectPool: ObjectReferenceTag indexes into this.
     // Only values the serializer passed to recordObject() may be appended here (via
@@ -7098,7 +7105,8 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                       ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-    );
+            ,
+        m_forTransfer);
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;
     // Deserialize may throw an exception. Similar to serialize (~L6240, SerializedScriptValue::create),

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -173,9 +173,11 @@ public:
     // Vector<URLKeepingBlobAlive> blobHandles() const { return crossThreadCopy(m_blobHandles); }
     // void writeBlobsToDiskForIndexedDB(CompletionHandler<void(IDBValue&&)>&&);
     // IDBValue writeBlobsToDiskForIndexedDBSynchronously();
-    static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
+    static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data, SerializationForCrossProcessTransfer forTransfer = SerializationForCrossProcessTransfer::No)
     {
-        return adoptRef(*new SerializedScriptValue(WTF::move(data)));
+        auto value = adoptRef(*new SerializedScriptValue(WTF::move(data)));
+        value->m_forTransfer = forTransfer;
+        return value;
     }
     const Vector<uint8_t>& wireBytes() const { return m_data; }
 
@@ -284,6 +286,7 @@ private:
     // Fast path for postMessage with pure strings - avoids serialization overhead
     String m_fastPathString;
     FastPath m_fastPath { FastPath::None };
+    SerializationForCrossProcessTransfer m_forTransfer { SerializationForCrossProcessTransfer::No };
     size_t m_memoryCost { 0 };
 
     FixedVector<SimpleInMemoryPropertyTableEntry> m_simpleInMemoryPropertyTable {};

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -372,7 +372,22 @@ mod advanced {
                 }
 
                 let message = &data[HEADER_LENGTH..][..message_len as usize];
-                let deserialized = JSValue::deserialize(message, global)?;
+                let deserialized = match JSValue::deserialize(
+                    message,
+                    global,
+                    SerializedFlags {
+                        for_cross_process_transfer: true,
+                        for_storage: false,
+                    },
+                ) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        if global.clear_exception_except_termination() {
+                            return Err(IPCDecodeError::InvalidFormat);
+                        }
+                        return Err(IPCDecodeError::JSTerminated);
+                    }
+                };
 
                 Ok(DecodeIPCMessageResult {
                     bytes_consumed: HEADER_LENGTH_U32 + message_len,

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -253,22 +253,10 @@ pub enum IPCDecodeError {
     #[error("InvalidFormat")]
     InvalidFormat,
     // —— bun.JSError variants ——
-    #[error("JSError")]
-    JSError,
     #[error("JSTerminated")]
     JSTerminated,
     #[error("OutOfMemory")]
     OutOfMemory,
-}
-
-impl From<JsError> for IPCDecodeError {
-    fn from(e: JsError) -> Self {
-        match e {
-            JsError::Thrown => IPCDecodeError::JSError,
-            JsError::Terminated => IPCDecodeError::JSTerminated,
-            JsError::OutOfMemory => IPCDecodeError::OutOfMemory,
-        }
-    }
 }
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
@@ -1931,11 +1919,7 @@ fn on_data2(send_queue: &mut SendQueue, all_data: &[u8]) {
                         log!("hit NotEnoughBytes");
                         return;
                     }
-                    Err(
-                        IPCDecodeError::InvalidFormat
-                        | IPCDecodeError::JSError
-                        | IPCDecodeError::JSTerminated,
-                    ) => {
+                    Err(IPCDecodeError::InvalidFormat | IPCDecodeError::JSTerminated) => {
                         send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
                         return;
                     }
@@ -1973,11 +1957,7 @@ fn on_data2(send_queue: &mut SendQueue, all_data: &[u8]) {
                             log!("hit NotEnoughBytes");
                             return;
                         }
-                        Err(
-                            IPCDecodeError::InvalidFormat
-                            | IPCDecodeError::JSError
-                            | IPCDecodeError::JSTerminated,
-                        ) => {
+                        Err(IPCDecodeError::InvalidFormat | IPCDecodeError::JSTerminated) => {
                             send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
                             return;
                         }
@@ -2017,11 +1997,7 @@ fn on_data2(send_queue: &mut SendQueue, all_data: &[u8]) {
                         log!("hit NotEnoughBytes2");
                         return;
                     }
-                    Err(
-                        IPCDecodeError::InvalidFormat
-                        | IPCDecodeError::JSError
-                        | IPCDecodeError::JSTerminated,
-                    ) => {
+                    Err(IPCDecodeError::InvalidFormat | IPCDecodeError::JSTerminated) => {
                         send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
                         return;
                     }
@@ -2183,11 +2159,7 @@ pub mod IPCHandlers {
                                 log!("hit NotEnoughBytes3");
                                 return;
                             }
-                            Err(
-                                IPCDecodeError::InvalidFormat
-                                | IPCDecodeError::JSError
-                                | IPCDecodeError::JSTerminated,
-                            ) => {
+                            Err(IPCDecodeError::InvalidFormat | IPCDecodeError::JSTerminated) => {
                                 send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
                                 return;
                             }
@@ -2232,9 +2204,7 @@ pub mod IPCHandlers {
                                     return;
                                 }
                                 Err(
-                                    IPCDecodeError::InvalidFormat
-                                    | IPCDecodeError::JSError
-                                    | IPCDecodeError::JSTerminated,
+                                    IPCDecodeError::InvalidFormat | IPCDecodeError::JSTerminated,
                                 ) => {
                                     send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
                                     return;

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -157,6 +157,50 @@ describe("ipc mode advanced", () => {
       expect(exitCode).toBe(0);
     },
   );
+
+  it.skipIf(isWindows)(
+    "closes the channel when a frame carries a Blob tag, which the sender never emits on this channel",
+    async () => {
+      // The advanced channel's serializer refuses to encode Blob (it sends an empty
+      // object instead), so the receiver must not accept the Blob tag from the wire.
+      // The child builds a real serialized Blob with bun:jsc and frames it by hand.
+      // prettier-ignore
+      const parent = `
+      const child = Bun.spawn({
+        cmd: [
+          process.execPath, "-e",
+          'process.on("disconnect", () => process.exit(42));' +
+          'const payload = Buffer.from(new Uint8Array(require("bun:jsc").serialize(new Blob(["abc"]))));' +
+          'const header = Buffer.alloc(5); header[0] = 0x02; header.writeUInt32LE(payload.length, 1);' +
+          'require("fs").writeSync(3, Buffer.concat([header, payload]));',
+        ],
+        stdio: ["ignore", "inherit", "inherit"],
+        serialization: "advanced",
+        ipc(msg) { console.error("UNEXPECTED_IPC_MESSAGE", Object.prototype.toString.call(msg)); child.kill(); },
+      });
+      console.log("CHILD_EXIT", await child.exited);
+    `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", parent],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout.trim()).toBe("CHILD_EXIT 42");
+      expect(stderr).not.toContain("UNEXPECTED_IPC_MESSAGE");
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  it("Blob still round-trips through in-process structuredClone", async () => {
+    const cloned = structuredClone(new Blob(["abc"]));
+    expect(cloned).toBeInstanceOf(Blob);
+    expect(await cloned.text()).toBe("abc");
+  });
 });
 
 // getIPCInstance error path: on Windows, windowsConfigureClient can open the


### PR DESCRIPTION
## What

The advanced (structured-clone) IPC serializer already declines to encode Bun-only cloneable types marked non-transferable — `Blob` and `net.BlockList` — for cross-process transfer; it writes an empty object instead. The deserializer, however, dispatched any Bun tag it found in an incoming frame, so the two sides disagreed about what the channel carries.

This change makes the deserializer symmetric with the serializer:

- Codegen emits `StructuredCloneableDeserialize::isTagForTransfer(tag)` alongside the existing `fromTagDeserialize`, driven by each class's `structuredClone.transferable` flag in `.classes.ts`.
- The cross-process flag (`SerializationForCrossProcessTransfer`) is threaded from `Bun__JSValue__deserialize` into `CloneDeserializer`, and `readTerminal` fails (the usual `DataCloneError` path) on a non-transferable Bun tag when the payload arrived cross-process.
- The advanced IPC decoder now clears the pending exception when a frame fails to deserialize (matching the JSON-mode decoder), so the channel closes cleanly instead of leaving an unchecked exception behind. Termination is preserved.

In-process `structuredClone` / worker `postMessage` are untouched — they never set the cross-process flag — and sending a `Blob` over an advanced IPC channel still delivers `{}` as before.

## How to observe

- `bun test test/js/bun/spawn/spawn.ipc.test.ts -t "carries a Blob tag"`: a child writes an advanced-mode frame whose payload is a serialized `Blob`; the parent closes the channel (child sees `disconnect`) rather than surfacing a `Blob` in its `ipc` callback.
- `bun test test/js/bun/spawn/spawn.ipc.test.ts -t "structuredClone"`: in-process cloning of a `Blob` still round-trips.

## Test

Added both cases to `test/js/bun/spawn/spawn.ipc.test.ts`; the full file passes.