### PR TITLE
timers: emit TimeoutNaNWarning when the delay coerces to NaN

### DIFF
--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -184,7 +184,6 @@ impl All {
                                 TimeoutWarning::TimeoutNegativeWarning,
                             );
                         } else if !countdown.is_undefined()
-                            && countdown.is_number()
                             && countdown_double.is_nan()
                             && !self.warned_not_number
                         {

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -579,6 +579,41 @@ it("setTimeout does not leak a pending exception when emitting a timeout warning
   expect(exitCode).toBe(0);
 });
 
+it("setTimeout emits TimeoutNaNWarning when the delay coerces to NaN", async () => {
+  // Node coerces the delay via ToNumber before deciding which warning to emit, so a
+  // string/object/array/function delay that becomes NaN must warn the same as a literal NaN.
+  // undefined is special-cased in both runtimes and must not warn.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const seen = [];
+        process.on("warning", w => seen.push(w.name));
+        setTimeout(() => {});                                 // undefined: no warning
+        setTimeout(() => {}, undefined);                      // undefined: no warning
+        setTimeout(() => {}, "abc");                          // ToNumber -> NaN
+        setTimeout(() => {}, {});                             // NaN
+        setTimeout(() => {}, [1, 2]);                         // NaN
+        setTimeout(() => {}, () => 5);                        // NaN
+        setTimeout(() => {}, { valueOf() { return NaN; } });  // NaN
+        setTimeout(() => {}, "4000000000");                   // coerced overflow
+        setTimeout(() => {}, { valueOf() { return -3; } });   // coerced negative
+        setImmediate(() => process.nextTick(() => console.log(JSON.stringify(seen))));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // NaN and Negative warnings are emitted once per process; Overflow warns every time.
+  expect(JSON.parse(stdout.trim())).toEqual(["TimeoutNaNWarning", "TimeoutOverflowWarning", "TimeoutNegativeWarning"]);
+  expect(exitCode).toBe(0);
+});
+
 it("clearTimeout with a numeric id is a no-op after a timeout promoted to an interval is cleared and collected", async () => {
   // A setTimeout whose numeric id has been observed via `+timer` registers itself in the
   // setTimeout id map. Assigning `_repeat` promotes it to a setInterval after its first


### PR DESCRIPTION
## What

`setTimeout`/`setInterval` only emitted `TimeoutNaNWarning` when the delay argument was already the number `NaN`. A delay that *coerces* to NaN (a string like `"abc"`, a plain object, `[1,2]`, a function, or `{valueOf(){return NaN}}`) silently became a 1ms timer with no diagnostic.

Node coerces via `after *= 1` and then classifies, so every NaN-producing value warns:

```js
const seen = [];
process.on('warning', w => seen.push(w.name));
setTimeout(() => {}, 'abc');
setTimeout(() => {}, {});
setTimeout(() => {}, '4000000000');
setTimeout(() => {}, { valueOf() { return -3; } });
setTimeout(() => console.log(JSON.stringify(seen)), 100);
```

| runtime | output |
| --- | --- |
| node v26.3.0 | `["TimeoutNaNWarning","TimeoutOverflowWarning","TimeoutNegativeWarning"]` |
| bun before | `["TimeoutOverflowWarning","TimeoutNegativeWarning"]` |
| bun after | `["TimeoutNaNWarning","TimeoutOverflowWarning","TimeoutNegativeWarning"]` |

## Why

`js_value_to_countdown` in `src/runtime/timer/Timer.rs` gated the NaN branch on `countdown.is_number()`, which tests the *original* JSValue rather than the coerced `countdown_double`. The overflow and negative branches already inspect the coerced double, so only the NaN branch was checking before coercion. Dropping that predicate makes all three branches consistent.

`undefined` (including a missing delay argument) is still special-cased and does not warn, matching Node and preserving the fix for #18159.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/web/timers/setTimeout.test.js -t 'coerces to NaN'   # fails
bun bd test test/js/web/timers/setTimeout.test.js -t 'coerces to NaN'                 # passes
bun bd test test/regression/issue/18159/18159.test.ts                                  # still passes
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/timers/setTimeout.test.js

<!-- robobun:evidence:end -->