### PR TITLE
FileSystemRouter: keep percent-encoded '/' and '?' inside their route segment

### DIFF
--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -70,7 +70,6 @@ impl URLPath {
 pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::DecodeError> {
     let mut decoded_pathname: &[u8] = possibly_encoded_pathname_;
     let mut decoded_storage: Option<Box<[u8]>> = None;
-    let mut needs_redirect = false;
     let mut query_start: Option<usize> =
         possibly_encoded_pathname_.iter().rposition(|&b| b == b'?');
     let mut literal_slash_offsets: Vec<usize> = Vec::new();
@@ -88,11 +87,7 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
                 .windows(3)
                 .position(|w| w[0] == b'%' && w[1] == b'2' && matches!(w[2], b'F' | b'f'));
             let chunk = &rest[..encoded_slash.unwrap_or(rest.len())];
-            PercentEncoding::decode_fault_tolerant::<_, true>(
-                &mut buf,
-                chunk,
-                Some(&mut needs_redirect),
-            )?;
+            PercentEncoding::decode_fault_tolerant::<_, true>(&mut buf, chunk)?;
             let Some(encoded_slash) = encoded_slash else {
                 break;
             };
@@ -103,11 +98,7 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
         query_start = None;
         if let Some(q) = raw_query_start {
             query_start = Some(buf.len());
-            PercentEncoding::decode_fault_tolerant::<_, true>(
-                &mut buf,
-                &capped[q..],
-                Some(&mut needs_redirect),
-            )?;
+            PercentEncoding::decode_fault_tolerant::<_, true>(&mut buf, &capped[q..])?;
         }
         // Freeze into a heap-stable Box and park it in `decoded_storage` before
         // borrowing: the slice fields in the returned URLPath borrow from this

--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -222,12 +222,6 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
 
     Ok(URLPath {
         literal_slashes,
-        extname: extend(if !is_source_map {
-            extname
-        } else {
-            backup_extname
-        }),
-        is_source_map,
         pathname: extend(decoded_pathname),
         path: extend(if decoded_pathname.len() == 1 {
             b"."

--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -20,6 +20,33 @@ pub struct URLPath {
     /// `URLPath` must not be `Clone`: copying the slice fields without this
     /// owner would re-introduce the dangling hazard.
     _decoded_storage: Option<Box<[u8]>>,
+    /// `/` bytes in `pathname` that were percent-decoded from the input and
+    /// are therefore segment content, not segment separators.
+    pub literal_slashes: LiteralSlashes,
+}
+
+/// Addresses of the `/` bytes within a decoded path buffer that came from a
+/// percent-encoded input byte. Identity is by address, so any sub-slice of the
+/// path can be queried. Sorted ascending; empty for un-encoded input.
+#[derive(Default)]
+pub struct LiteralSlashes(Vec<*const u8>);
+
+impl LiteralSlashes {
+    #[inline]
+    pub fn is_separator(&self, byte: &u8) -> bool {
+        *byte == b'/' && self.0.binary_search(&core::ptr::from_ref(byte)).is_err()
+    }
+
+    #[inline]
+    pub fn find_separator(&self, s: &[u8]) -> Option<usize> {
+        s.iter().position(|b| self.is_separator(b))
+    }
+
+    #[inline]
+    pub fn contains_any(&self, s: &[u8]) -> bool {
+        let range = s.as_ptr_range();
+        self.0.iter().any(|p| range.contains(p))
+    }
 }
 
 impl URLPath {
@@ -43,14 +70,45 @@ impl URLPath {
 pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::DecodeError> {
     let mut decoded_pathname: &[u8] = possibly_encoded_pathname_;
     let mut decoded_storage: Option<Box<[u8]>> = None;
+    let mut needs_redirect = false;
+    let mut query_start: Option<usize> =
+        possibly_encoded_pathname_.iter().rposition(|&b| b == b'?');
+    let mut literal_slash_offsets: Vec<usize> = Vec::new();
+
     if strings::index_of_char(decoded_pathname, b'%').is_some() {
         // The in-place decode buffer is capped at 16384 bytes of input.
         let capped = &possibly_encoded_pathname_[..possibly_encoded_pathname_.len().min(16384)];
+        let raw_query_start = capped.iter().rposition(|&b| b == b'?');
+        let raw_path = &capped[..raw_query_start.unwrap_or(capped.len())];
 
         let mut buf: Vec<u8> = Vec::with_capacity(capped.len());
-        let n = PercentEncoding::decode_fault_tolerant::<_, true>(&mut buf, capped)?;
-        debug_assert!(n as usize <= buf.len());
-        buf.truncate(n as usize);
+        let mut rest = raw_path;
+        loop {
+            let encoded_slash = rest
+                .windows(3)
+                .position(|w| w[0] == b'%' && w[1] == b'2' && matches!(w[2], b'F' | b'f'));
+            let chunk = &rest[..encoded_slash.unwrap_or(rest.len())];
+            PercentEncoding::decode_fault_tolerant::<_, true>(
+                &mut buf,
+                chunk,
+                Some(&mut needs_redirect),
+            )?;
+            let Some(encoded_slash) = encoded_slash else {
+                break;
+            };
+            literal_slash_offsets.push(buf.len());
+            buf.push(b'/');
+            rest = &rest[encoded_slash + 3..];
+        }
+        query_start = None;
+        if let Some(q) = raw_query_start {
+            query_start = Some(buf.len());
+            PercentEncoding::decode_fault_tolerant::<_, true>(
+                &mut buf,
+                &capped[q..],
+                Some(&mut needs_redirect),
+            )?;
+        }
         // Freeze into a heap-stable Box and park it in `decoded_storage` before
         // borrowing: the slice fields in the returned URLPath borrow from this
         // allocation, and the Box is later moved into that same URLPath, so the
@@ -68,6 +126,8 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
     if decoded_pathname.is_empty() {
         decoded_pathname = b"/";
         decoded_storage = None;
+        query_start = None;
+        literal_slash_offsets.clear();
     }
 
     let mut question_mark_i: i32 = -1;
@@ -78,10 +138,11 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
     let mut i: i32 = i32::try_from(decoded_pathname.len()).expect("int cast") - 1;
 
     while i >= 0 {
-        let c = decoded_pathname[usize::try_from(i).expect("int cast")];
+        let idx = usize::try_from(i).expect("int cast");
+        let c = decoded_pathname[idx];
 
         match c {
-            b'?' => {
+            b'?' if query_start == Some(idx) => {
                 question_mark_i = question_mark_i.max(i);
                 if question_mark_i < period_i {
                     period_i = -1;
@@ -94,7 +155,7 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
             b'.' => {
                 period_i = period_i.max(i);
             }
-            b'/' => {
+            b'/' if literal_slash_offsets.binary_search(&idx).is_err() => {
                 last_slash = last_slash.max(i);
             }
             _ => {}
@@ -152,7 +213,21 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
         unsafe { bun_collections::detach_lifetime(s) }
     }
 
+    let literal_slashes = LiteralSlashes(
+        literal_slash_offsets
+            .iter()
+            .map(|&offset| decoded_pathname[offset..].as_ptr())
+            .collect(),
+    );
+
     Ok(URLPath {
+        literal_slashes,
+        extname: extend(if !is_source_map {
+            extname
+        } else {
+            backup_extname
+        }),
+        is_source_map,
         pathname: extend(decoded_pathname),
         path: extend(if decoded_pathname.len() == 1 {
             b"."

--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -28,7 +28,7 @@ pub struct URLPath {
 /// Addresses of the `/` bytes within a decoded path buffer that came from a
 /// percent-encoded input byte. Identity is by address, so any sub-slice of the
 /// path can be queried. Sorted ascending; empty for un-encoded input.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct LiteralSlashes(Vec<*const u8>);
 
 impl LiteralSlashes {

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -16,7 +16,7 @@ use bun_collections::{ArrayHashMap, StringHashMap};
 use bun_core::strings;
 use bun_paths::{self, PathBuffer, SEP, SEP_STR};
 
-use bun_http_types::URLPath::URLPath;
+use bun_http_types::URLPath::{LiteralSlashes, URLPath};
 
 // ──────────────────────────────────────────────────────────────────────────
 // Cross-crate name aliases. These are pure re-exports of real lower-tier types
@@ -226,11 +226,12 @@ impl Routes {
     ) -> Option<Match<'p>> {
         // Trim trailing slash
         let mut path = url_path.path;
+        let sep = &url_path.literal_slashes;
         let mut redirect = false;
 
         // Normalize trailing slash
         // "/foo/bar/index/" => "/foo/bar/index"
-        if !path.is_empty() && path[path.len() - 1] == b'/' {
+        if !path.is_empty() && sep.is_separator(&path[path.len() - 1]) {
             path = &path[0..path.len() - 1];
             redirect = true;
         }
@@ -238,7 +239,7 @@ impl Routes {
         // Normal case: "/foo/bar/index" => "/foo/bar"
         // Pathological: "/foo/bar/index/index/index/index/index/index" => "/foo/bar"
         // Extremely pathological: "/index/index/index/index/index/index/index" => "index"
-        while path.ends_with(b"/index") {
+        while path.ends_with(b"/index") && sep.is_separator(&path[path.len() - b"/index".len()]) {
             path = &path[0..path.len() - b"/index".len()];
             redirect = true;
         }
@@ -249,7 +250,7 @@ impl Routes {
         }
 
         // one final time, trim trailing slash
-        while !path.is_empty() && path[path.len() - 1] == b'/' {
+        while !path.is_empty() && sep.is_separator(&path[path.len() - 1]) {
             path = &path[0..path.len() - 1];
             redirect = true;
         }
@@ -276,7 +277,7 @@ impl Routes {
             return None;
         }
 
-        if let Some(route_ptr) = self.match_(path, params) {
+        if let Some(route_ptr) = self.match_(path, params, sep) {
             // SAFETY: pointers from static_/dynamic alias Box<Route> stored in
             // self.list, which outlives self.
             let route = unsafe { &*route_ptr };
@@ -296,6 +297,7 @@ impl Routes {
         &self,
         path: &'p [u8],
         params: &mut route_param::List<'p>,
+        sep: &LiteralSlashes,
     ) -> Option<*const Route> {
         // its cleaned, so now we search the big list of strings
         let start = self.dynamic_start?;
@@ -308,7 +310,7 @@ impl Routes {
             .zip(dynamic_match_names.iter())
             .zip(dynamic.iter())
         {
-            if Pattern::match_::<true>(path, &case_sensitive_name[1..], name, params) {
+            if Pattern::match_::<true>(path, &case_sensitive_name[1..], name, params, sep) {
                 return Some(&raw const **route);
             }
         }
@@ -320,17 +322,25 @@ impl Routes {
         &self,
         pathname_: &'p [u8],
         params: &mut route_param::List<'p>,
+        sep: &LiteralSlashes,
     ) -> Option<*const Route> {
-        let pathname = strings::trim_left(pathname_, b"/");
+        let mut pathname = pathname_;
+        while !pathname.is_empty() && sep.is_separator(&pathname[0]) {
+            pathname = &pathname[1..];
+        }
 
         if pathname.is_empty() {
             return self.index.map(|p| p.as_ptr().cast_const());
         }
 
+        if sep.contains_any(pathname) {
+            return self.match_dynamic(pathname, params, sep);
+        }
+
         self.static_
             .get(pathname)
             .copied()
-            .or_else(|| self.match_dynamic(pathname, params))
+            .or_else(|| self.match_dynamic(pathname, params, sep))
     }
 }
 
@@ -1161,6 +1171,7 @@ pub mod pattern {
             // case-insensitive, must not have a leading slash
             match_name: &[u8],
             params: &mut route_param::List<'a>,
+            sep: &LiteralSlashes,
         ) -> bool {
             let mut offset: RoutePathInt = 0;
             let mut path_ = path;
@@ -1170,8 +1181,7 @@ pub mod pattern {
 
                 match pattern.value {
                     Value::Static(str_) => {
-                        let segment =
-                            &path_[0..path_.iter().position(|&b| b == b'/').unwrap_or(path_.len())];
+                        let segment = &path_[0..sep.find_separator(path_).unwrap_or(path_.len())];
                         if !str_.eql_bytes(segment) {
                             params.clear(); // shrinkRetainingCapacity(0)
                             return false;
@@ -1188,7 +1198,7 @@ pub mod pattern {
                         }
                     }
                     Value::Dynamic(dynamic) => {
-                        if let Some(i) = path_.iter().position(|&b| b == b'/') {
+                        if let Some(i) = sep.find_separator(path_) {
                             params.push(Param {
                                 name: dynamic.str(name),
                                 value: &path_[0..i],
@@ -1720,7 +1730,13 @@ mod tests {
                 parameters.clear();
 
                 'fail: {
-                    if !Pattern::match_::<true>(pathname, pattern, pattern, &mut parameters) {
+                    if !Pattern::match_::<true>(
+                        pathname,
+                        pattern,
+                        pattern,
+                        &mut parameters,
+                        &LiteralSlashes::default(),
+                    ) {
                         eprintln!(
                             "Expected pattern \"{}\" to match \"{}\"",
                             bstr::BStr::new(pattern),

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -271,6 +271,7 @@ impl Routes {
                     pathname: url_path.pathname,
                     file_path: index.abs_path.as_bytes(),
                     query_string: url_path.query_string,
+                    literal_slashes: url_path.literal_slashes.clone(),
                 });
             }
 
@@ -287,6 +288,7 @@ impl Routes {
                 pathname: url_path.pathname,
                 file_path: route.abs_path.as_bytes(),
                 query_string: url_path.query_string,
+                literal_slashes: url_path.literal_slashes.clone(),
             });
         }
 
@@ -1086,6 +1088,12 @@ pub struct Match<'a> {
     // moment any `&mut MatchedRoute` is taken.
     pub params: *mut route_param::List<'a>,
     pub query_string: &'a [u8],
+    /// Which `/` bytes in `pathname` are literal (percent-decoded) rather
+    /// than separators. Owned: the `URLPath` that produced it does not
+    /// outlive the match, but the byte addresses it records stay valid
+    /// because the decode buffer is moved, not copied, into the match's
+    /// backing allocation.
+    pub literal_slashes: LiteralSlashes,
 }
 
 impl<'a> Match<'a> {
@@ -1119,11 +1127,21 @@ impl<'a> Match<'a> {
             // pointer value itself.
             params: self.params.cast::<route_param::List<'static>>(),
             query_string: d(self.query_string),
+            literal_slashes: self.literal_slashes,
         }
     }
 
+    /// Strips leading separator slashes only; a leading `/` that was
+    /// percent-decoded from the input is param content and is kept.
     pub fn pathname_without_leading_slash(&self) -> &[u8] {
-        strings::trim_left(self.pathname, b"/")
+        let mut s = self.pathname;
+        while let [first, rest @ ..] = s {
+            if !self.literal_slashes.is_separator(first) {
+                break;
+            }
+            s = rest;
+        }
+        s
     }
 }
 

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1243,15 +1243,19 @@ pub mod pattern {
                                     name: dynamic.str(name),
                                     value: path_,
                                 });
-                                path_ = b"";
-                                let _ = path_;
+                                return true;
                             }
-
-                            return true;
+                            // A required segment follows but no separator is left in
+                            // the path: this route cannot match.
+                            params.clear(); // shrinkRetainingCapacity(0)
+                            return false;
                         }
 
                         if !ALLOW_OPTIONAL_CATCH_ALL {
-                            return true;
+                            // No separator left in the path, but required segments
+                            // remain in the pattern: this route cannot match.
+                            params.clear(); // shrinkRetainingCapacity(0)
+                            return false;
                         }
                     }
                     Value::CatchAll(dynamic) => {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -1294,7 +1294,7 @@ impl PercentEncoding {
         writer: &mut impl bun_core::io::Write,
         input: &[u8],
     ) -> Result<u32, DecodeError> {
-        Self::decode_fault_tolerant::<_, false>(writer, input)
+        Self::decode_fault_tolerant::<_, false>(writer, input, None)
     }
 
     /// Decode percent-encoded input into allocated memory.
@@ -1320,7 +1320,9 @@ impl PercentEncoding {
     pub fn decode_fault_tolerant<W: bun_core::io::Write, const FAULT_TOLERANT: bool>(
         writer: &mut W,
         input: &[u8],
+        needs_redirect: Option<&mut bool>,
     ) -> Result<u32, DecodeError> {
+        let mut needs_redirect = needs_redirect;
         let mut i: usize = 0;
         let mut written: u32 = 0;
         // unlike JavaScript's decodeURIComponent, we are not handling invalid surrogate pairs
@@ -1338,11 +1340,14 @@ impl PercentEncoding {
                             // This is an invalid %-encoded string, intended to be swapped out at build time by webpack-html-plugin
                             // We don't process HTML, so rewriting this URL path won't happen
                             // But we want to be a little more fault tolerant here than just throwing up an error for something that works in other tools
-                            // So we just skip over it
+                            // So we just skip over it and issue a redirect
+                            // We issue a redirect because various other tooling client-side may validate URLs
+                            // We can't expect other tools to be as fault tolerant
                             if i + b"PUBLIC_URL%".len() < input.len()
                                 && &input[i + 1..][..b"PUBLIC_URL%".len()] == b"PUBLIC_URL%"
                             {
                                 i += b"PUBLIC_URL%".len() + 1;
+                                *needs_redirect.as_deref_mut().unwrap() = true;
                                 continue;
                             }
                             return Err(DecodeError::DecodingError);

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -1294,7 +1294,7 @@ impl PercentEncoding {
         writer: &mut impl bun_core::io::Write,
         input: &[u8],
     ) -> Result<u32, DecodeError> {
-        Self::decode_fault_tolerant::<_, false>(writer, input, None)
+        Self::decode_fault_tolerant::<_, false>(writer, input)
     }
 
     /// Decode percent-encoded input into allocated memory.
@@ -1320,9 +1320,7 @@ impl PercentEncoding {
     pub fn decode_fault_tolerant<W: bun_core::io::Write, const FAULT_TOLERANT: bool>(
         writer: &mut W,
         input: &[u8],
-        needs_redirect: Option<&mut bool>,
     ) -> Result<u32, DecodeError> {
-        let mut needs_redirect = needs_redirect;
         let mut i: usize = 0;
         let mut written: u32 = 0;
         // unlike JavaScript's decodeURIComponent, we are not handling invalid surrogate pairs
@@ -1340,14 +1338,11 @@ impl PercentEncoding {
                             // This is an invalid %-encoded string, intended to be swapped out at build time by webpack-html-plugin
                             // We don't process HTML, so rewriting this URL path won't happen
                             // But we want to be a little more fault tolerant here than just throwing up an error for something that works in other tools
-                            // So we just skip over it and issue a redirect
-                            // We issue a redirect because various other tooling client-side may validate URLs
-                            // We can't expect other tools to be as fault tolerant
+                            // So we just skip over it
                             if i + b"PUBLIC_URL%".len() < input.len()
                                 && &input[i + 1..][..b"PUBLIC_URL%".len()] == b"PUBLIC_URL%"
                             {
                                 i += b"PUBLIC_URL%".len() + 1;
-                                *needs_redirect.as_deref_mut().unwrap() = true;
                                 continue;
                             }
                             return Err(DecodeError::DecodingError);

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -678,6 +678,56 @@ it(".params decodes percent escapes in a route segment exactly once", () => {
   expect(percent.params.id).toBe("100%25");
 });
 
+it("percent-encoded slash and question mark stay inside their route segment", () => {
+  using dir = tempDir("fsr-encoded-delimiters", {
+    "index.tsx": "export default 1;",
+    "top.tsx": "export default 1;",
+    "a/b.tsx": "export default 1;",
+    "user/[name].tsx": "export default 1;",
+  });
+
+  const router = new FileSystemRouter({ dir: String(dir), style: "nextjs" });
+
+  // Un-encoded paths keep their exact segments, params, query and pathname.
+  const plain = router.match("/user/alice?x=1")!;
+  expect(plain.name).toBe("/user/[name]");
+  expect(plain.pathname).toBe("/user/alice?x=1");
+  expect(plain.params).toEqual({ name: "alice" });
+  expect(plain.query).toEqual({ name: "alice", x: "1" });
+  expect(router.match("/user/alice/settings.json")).toBeNull();
+
+  const staticRoute = router.match("/a/b")!;
+  expect(staticRoute.name).toBe("/a/b");
+  expect(staticRoute.params).toEqual({});
+
+  // A literal "?" in the path still starts the query string.
+  const literalQuery = router.match("/user/carol?tab=2")!;
+  expect(literalQuery.name).toBe("/user/[name]");
+  expect(literalQuery.params).toEqual({ name: "carol" });
+  expect(literalQuery.query).toEqual({ name: "carol", tab: "2" });
+
+  // "%2F" decodes to a slash that is part of the single segment it appears in.
+  const slash = router.match("/user/a%2Fb")!;
+  expect(slash.name).toBe("/user/[name]");
+  expect(slash.pathname).toBe("/user/a/b");
+  expect(slash.params).toEqual({ name: "a/b" });
+  expect(slash.query).toEqual({ name: "a/b" });
+
+  // A single encoded segment does not match a two-segment static route, and a
+  // decoded leading slash is segment content rather than a separator.
+  expect(router.match("/a%2Fb")).toBeNull();
+  expect(router.match("/top")!.name).toBe("/top");
+  expect(router.match("/%2Ftop")).toBeNull();
+
+  // "%3F" decodes to a question mark that is part of the segment, not the
+  // start of the query string.
+  const questionMark = router.match("/user/x%3Fy=1")!;
+  expect(questionMark.name).toBe("/user/[name]");
+  expect(questionMark.pathname).toBe("/user/x?y=1");
+  expect(questionMark.params).toEqual({ name: "x?y=1" });
+  expect(questionMark.query).toEqual({ name: "x?y=1" });
+});
+
 it("caps the number of parsed query string parameters instead of crashing", async () => {
   // A query string with more parameters than the iterator's fixed-size visited
   // bitset (2048 entries) must not be able to take down the process when

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -166,6 +166,28 @@ it(".params keeps a leading percent-decoded slash on a top-level dynamic route",
   expect(name).toBe("/foo");
 });
 
+it("a percent-decoded slash does not satisfy a required following segment", () => {
+  // set up the test
+  const { dir } = make(["[category]/[item].tsx"]);
+
+  const router = new Bun.FileSystemRouter({
+    dir,
+    style: "nextjs",
+  });
+
+  // "foo%2Fbar" is one segment containing a literal slash, so the two-segment
+  // route has no match for it.
+  expect(router.match("/foo%2Fbar")).toBeNull();
+
+  // Neither does a plain single segment: a route with a required following
+  // segment must not match an under-length path with empty params.
+  expect(router.match("/foo")).toBeNull();
+
+  // A real separator still yields both params.
+  const twoSegments = router.match("/foo/bar")!;
+  expect(twoSegments.params).toEqual({ category: "foo", item: "bar" });
+});
+
 it(".params works on dynamic routes", () => {
   // set up the test
   const { dir } = make(["index.tsx", "posts/[id].tsx", "posts.tsx"]);

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -148,6 +148,24 @@ it("should match dynamic routes", () => {
   expect(filePath).toBe(`${dir}/posts/[id].tsx`);
 });
 
+it(".params keeps a leading percent-decoded slash on a top-level dynamic route", () => {
+  // set up the test
+  const { dir } = make(["[name].tsx"]);
+
+  const router = new Bun.FileSystemRouter({
+    dir,
+    style: "nextjs",
+  });
+
+  const {
+    params: { name },
+  } = router.match("/%2Ffoo")!;
+
+  // The decoded slash is param content, not a separator, so it must not be
+  // stripped along with the leading route separator.
+  expect(name).toBe("/foo");
+});
+
 it(".params works on dynamic routes", () => {
   // set up the test
   const { dir } = make(["index.tsx", "posts/[id].tsx", "posts.tsx"]);


### PR DESCRIPTION
## What

\`Bun.FileSystemRouter.match\` percent-decoded the entire request path before locating the query string and splitting the path into segments. As a result, an encoded \`%2F\` or \`%3F\` inside a single path segment behaved like a raw \`/\` or \`?\`: it could split one segment into two, cut the path off as a query string, or move text between route params and the query.

This change locates the query string on the raw (still-encoded) input and tracks which \`/\` bytes were produced by percent-decoding, so the router treats those as part of their segment rather than as separators.

- \`/user/a%2Fb\` against \`user/[name].tsx\` now matches with \`params.name === "a/b"\` (one segment) instead of being seen as two segments.
- \`/user/x%3Fy\` keeps \`x?y\` as the param value instead of starting the query string at \`%3F\`.
- Un-encoded paths, a literal \`?\` in the path, and percent-encoded query strings behave exactly as before.

## Test

\`test/js/bun/util/filesystem_router.test.ts\`: "percent-encoded slash and question mark stay inside their route segment" — asserts un-encoded paths are unchanged and covers \`%2F\` / \`%3F\` inside a dynamic segment, plus static-route and leading-slash cases.

## Behavior change beyond the percent-encoded case (please review)

Fixing the literal-slash matching surfaced a **pre-existing** router bug that this PR now also fixes, and it is user-visible: when a dynamic segment consumed the whole path while required segments still remained in the pattern, `Pattern::match_` returned a *match with empty params* instead of no match. On released Bun, a routes dir containing only `[category]/[item].tsx` answers `router.match("/foo")` with `{ name: "/[category]/[item]", params: {} }`; with this change it returns `null` (as does `/foo%2Fbar`, now a single segment after decoding). Next.js returns `null` for both, so I believe this is the correct behavior, but it changes results for under-length paths independent of any percent-encoding, so I'm flagging it as a decision rather than folding it in silently. The optional-catch-all follow-up (`[a]/[[...rest]]` with path `/foo`) still matches with the catch-all omitted. Covered by two new assertions in `filesystem_router.test.ts`.
