### PR TITLE
compile: verify the downloaded target executable against the registry integrity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,16 +1008,20 @@ dependencies = [
  "bstr",
  "bun_alloc",
  "bun_ast",
+ "bun_base64",
  "bun_collections",
  "bun_core",
  "bun_semver",
+ "bun_sha_hmac",
  "bun_wyhash",
+ "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
  "libc",
  "scopeguard",
  "strum",
+ "thiserror",
 ]
 
 [[package]]
@@ -1983,6 +1987,7 @@ dependencies = [
  "bun_errno",
  "bun_exe_format",
  "bun_http",
+ "bun_install_types",
  "bun_io",
  "bun_js_parser",
  "bun_libarchive",

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -78,7 +78,7 @@ pub mod auto_installer;
 pub mod config_version;
 pub mod dependency;
 pub mod hosted_git_info;
-pub mod integrity;
+pub use bun_install_types::integrity;
 pub mod padding_checker;
 pub mod postinstall_optimizer;
 

--- a/src/install_types/Cargo.toml
+++ b/src/install_types/Cargo.toml
@@ -11,6 +11,8 @@ workspace = true
 
 [dependencies]
 strum.workspace = true
+thiserror.workspace = true
+bytemuck = "1"
 bstr.workspace = true
 scopeguard.workspace = true
 const_format.workspace = true
@@ -19,7 +21,9 @@ enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
 bun_alloc.workspace = true
+bun_base64.workspace = true
 bun_core.workspace = true
+bun_sha_hmac.workspace = true
 bun_collections.workspace = true
 bun_ast.workspace = true
 bun_semver.workspace = true

--- a/src/install_types/integrity.rs
+++ b/src/install_types/integrity.rs
@@ -33,7 +33,7 @@ impl Default for Integrity {
 
 const EMPTY_DIGEST_BUF: [u8; DIGEST_BUF_LEN] = [0u8; DIGEST_BUF_LEN];
 
-const DIGEST_BUF_LEN: usize = {
+pub const DIGEST_BUF_LEN: usize = {
     let mut m = SHA1_DIGEST_LEN;
     if SHA512_DIGEST_LEN > m {
         m = SHA512_DIGEST_LEN;
@@ -47,8 +47,12 @@ const DIGEST_BUF_LEN: usize = {
     m
 };
 
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[error("InvalidCharacter")]
+pub struct InvalidCharacter;
+
 impl Integrity {
-    pub(crate) fn parse_sha_sum(buf: &[u8]) -> crate::Result<Integrity> {
+    pub fn parse_sha_sum(buf: &[u8]) -> Result<Integrity, InvalidCharacter> {
         if buf.is_empty() {
             return Ok(Integrity {
                 tag: Tag::UNKNOWN,
@@ -65,7 +69,7 @@ impl Integrity {
             .len()
             .min(buf.len());
         if !end.is_multiple_of(2) {
-            return Err(crate::Error::InvalidCharacter);
+            return Err(InvalidCharacter);
         }
         let mut out_i: usize = 0;
         let mut i: usize = 0;
@@ -80,8 +84,8 @@ impl Integrity {
         while i < end {
             // npm sha1 strings are always [0-9a-f]; canonical hex_pair_value
             // narrows the original over-broad b'g'..=b'z' acceptance.
-            integrity.value[out_i] = bun_core::fmt::hex_pair_value(buf[i], buf[i + 1])
-                .ok_or(crate::Error::InvalidCharacter)?;
+            integrity.value[out_i] =
+                bun_core::fmt::hex_pair_value(buf[i], buf[i + 1]).ok_or(InvalidCharacter)?;
             out_i += 1;
             i += 2;
         }
@@ -332,12 +336,12 @@ impl Tag {
 /// algorithm so `verify()` can compare against the lockfile value. When
 /// there is no expected value yet (first install of a GitHub/remote
 /// tarball) we default to SHA-512 to match `for_bytes`.
-pub(crate) struct Streaming {
+pub struct Streaming {
     pub expected: Integrity,
     pub hasher: Hasher,
 }
 
-pub(crate) enum Hasher {
+pub enum Hasher {
     None,
     Sha1(Crypto::SHA1),
     Sha256(Crypto::SHA256),
@@ -346,7 +350,7 @@ pub(crate) enum Hasher {
 }
 
 impl Streaming {
-    pub(crate) fn init(expected: &Integrity, compute_if_missing: bool) -> Streaming {
+    pub fn init(expected: &Integrity, compute_if_missing: bool) -> Streaming {
         Streaming {
             expected: *expected,
             hasher: match expected.tag {
@@ -365,7 +369,7 @@ impl Streaming {
         }
     }
 
-    pub(crate) fn update(&mut self, bytes: &[u8]) {
+    pub fn update(&mut self, bytes: &[u8]) {
         if bytes.is_empty() {
             return;
         }
@@ -378,7 +382,7 @@ impl Streaming {
         }
     }
 
-    pub(crate) fn final_(&mut self) -> Integrity {
+    pub fn final_(&mut self) -> Integrity {
         let mut out: [u8; DIGEST_BUF_LEN] = EMPTY_DIGEST_BUF;
         match &mut self.hasher {
             Hasher::None => Integrity::default(),
@@ -432,7 +436,7 @@ impl Streaming {
     /// Returns true if the computed digest matches `expected`, or if no
     /// expected value was supplied. Callers that need to persist the
     /// computed value should call `final_()` instead.
-    pub(crate) fn verify(&mut self) -> bool {
+    pub fn verify(&mut self) -> bool {
         if !self.expected.tag.is_supported() {
             return true;
         }

--- a/src/install_types/integrity.rs
+++ b/src/install_types/integrity.rs
@@ -93,7 +93,7 @@ impl Integrity {
         Ok(integrity)
     }
 
-    pub(crate) fn parse(buf: &[u8]) -> Integrity {
+    pub fn parse(buf: &[u8]) -> Integrity {
         let mut strongest = Integrity::default();
         for entry in buf.split(|c: &u8| c.is_ascii_whitespace()) {
             let parsed = Self::parse_entry(entry);
@@ -176,7 +176,7 @@ impl Integrity {
     }
 
     /// Compute a sha512 integrity hash from raw bytes (e.g. a downloaded tarball).
-    pub(crate) fn for_bytes(bytes: &[u8]) -> Integrity {
+    pub fn for_bytes(bytes: &[u8]) -> Integrity {
         const LEN: usize = SHA512_DIGEST_LEN;
         let mut value: [u8; DIGEST_BUF_LEN] = EMPTY_DIGEST_BUF;
         // SAFETY: engine is null (default).
@@ -282,22 +282,22 @@ pub struct Tag(pub u8);
 unsafe impl bytemuck::NoUninit for Tag {}
 
 impl Tag {
-    pub(crate) const UNKNOWN: Tag = Tag(0);
+    pub const UNKNOWN: Tag = Tag(0);
     /// "shasum" in the metadata
-    pub(crate) const SHA1: Tag = Tag(1);
+    pub const SHA1: Tag = Tag(1);
     /// The value is a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) value
     pub const SHA256: Tag = Tag(2);
     /// The value is a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) value
-    pub(crate) const SHA384: Tag = Tag(3);
+    pub const SHA384: Tag = Tag(3);
     /// The value is a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) value
-    pub(crate) const SHA512: Tag = Tag(4);
+    pub const SHA512: Tag = Tag(4);
 
     #[inline]
     pub fn is_supported(self) -> bool {
         self.0 >= Tag::SHA1.0 && self.0 <= Tag::SHA512.0
     }
 
-    pub(crate) fn parse(buf: &[u8]) -> (Tag, usize) {
+    pub fn parse(buf: &[u8]) -> (Tag, usize) {
         let Some(i) = strings::index_of_char(&buf[0..buf.len().min(7)], b'-') else {
             return (Tag::UNKNOWN, 0);
         };

--- a/src/install_types/lib.rs
+++ b/src/install_types/lib.rs
@@ -1,7 +1,10 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
 pub mod NodeLinker;
+pub mod integrity;
 pub mod resolver_hooks;
+
+pub use integrity::Integrity;
 
 pub use resolver_hooks::{
     Architecture, AutoInstaller, Behavior, Dependency, DependencyGroup, DependencyID,

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -122,11 +122,19 @@ impl CompileTarget {
 
     /// The npm registry to fetch the target executable from.
     pub fn npm_registry_url<'e>(env: &'e bun_dotenv::Loader) -> &'e [u8] {
-        if let Some(registry) = env.get(b"BUN_CONFIG_REGISTRY") {
-            if strings::has_prefix(registry, b"http://")
-                || strings::has_prefix(registry, b"https://")
-            {
-                return bun_core::without_trailing_slash(registry);
+        // technically, npm_config is case in-sensitive
+        const REGISTRY_KEYS: [&[u8]; 3] = [
+            b"BUN_CONFIG_REGISTRY",
+            b"NPM_CONFIG_REGISTRY",
+            b"npm_config_registry",
+        ];
+        for registry_key in REGISTRY_KEYS {
+            if let Some(registry) = env.get(registry_key) {
+                if strings::has_prefix(registry, b"http://")
+                    || strings::has_prefix(registry, b"https://")
+                {
+                    return bun_core::without_trailing_slash(registry);
+                }
             }
         }
         Self::DEFAULT_NPM_REGISTRY

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -111,16 +111,63 @@ impl CompileTarget {
         self.eql(&CompileTarget::default())
     }
 
-    pub fn to_npm_registry_url<'a>(&self, buf: &'a mut [u8]) -> crate::Result<&'a [u8]> {
-        if let Some(url) = env_var::BUN_COMPILE_TARGET_TARBALL_URL.get() {
-            if strings::has_prefix(url, b"http://") || strings::has_prefix(url, b"https://") {
-                // The env var slice is `&'static [u8]`,
-                // which outlives `'a`, so return it directly instead of copying into `buf`.
-                return Ok(url);
+    pub const DEFAULT_NPM_REGISTRY: &[u8] = b"https://registry.npmjs.org";
+
+    /// An explicit tarball URL from `BUN_COMPILE_TARGET_TARBALL_URL`, if set.
+    pub fn tarball_url_override() -> Option<&'static [u8]> {
+        env_var::BUN_COMPILE_TARGET_TARBALL_URL.get().filter(|url| {
+            strings::has_prefix(url, b"http://") || strings::has_prefix(url, b"https://")
+        })
+    }
+
+    /// The npm registry to fetch the target executable from.
+    pub fn npm_registry_url<'e>(env: &'e bun_dotenv::Loader) -> &'e [u8] {
+        if let Some(registry) = env.get(b"BUN_CONFIG_REGISTRY") {
+            if strings::has_prefix(registry, b"http://")
+                || strings::has_prefix(registry, b"https://")
+            {
+                return bun_core::without_trailing_slash(registry);
             }
         }
+        Self::DEFAULT_NPM_REGISTRY
+    }
 
-        self.to_npm_registry_url_with_url(buf, b"https://registry.npmjs.org")
+    /// `@oven/bun-linux-x64-musl-baseline` (`scope_separator` is `/` or `%2f`)
+    fn write_npm_package_name(
+        &self,
+        w: &mut impl std::io::Write,
+        scope_separator: &[u8],
+    ) -> std::io::Result<()> {
+        w.write_all(b"@oven")?;
+        w.write_all(scope_separator)?;
+        w.write_all(b"bun-")?;
+        w.write_all(self.os.npm_name().as_bytes())?;
+        w.write_all(b"-")?;
+        w.write_all(self.arch.npm_name().as_bytes())?;
+        w.write_all(self.libc.npm_name().as_bytes())?;
+        if self.baseline {
+            w.write_all(b"-baseline")?;
+        }
+        Ok(())
+    }
+
+    /// The registry document URL for this target's npm package, e.g.
+    /// `https://registry.npmjs.org/@oven%2fbun-linux-x64`
+    pub fn to_npm_manifest_url_with_url<'a>(
+        &self,
+        buf: &'a mut [u8],
+        registry_url: &[u8],
+    ) -> crate::Result<&'a [u8]> {
+        if !self.is_supported() {
+            return Err(crate::Error::UnsupportedTarget);
+        }
+
+        Self::finish_url(buf, |cursor: &mut &mut [u8]| {
+            cursor.write_all(registry_url)?;
+            cursor.write_all(b"/")?;
+            self.write_npm_package_name(cursor, b"%2f")?;
+            Ok(())
+        })
     }
 
     pub(crate) fn to_npm_registry_url_with_url<'a>(
@@ -139,17 +186,11 @@ impl CompileTarget {
         let libc = self.libc.npm_name();
         let baseline: &[u8] = if self.baseline { b"-baseline" } else { b"" };
 
-        let total = buf.len();
-        let mut cursor: &mut [u8] = buf;
         // https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-0.1.6.tgz
-        let res = (|| -> std::io::Result<()> {
+        Self::finish_url(buf, |cursor: &mut &mut [u8]| {
             cursor.write_all(registry_url)?;
-            cursor.write_all(b"/@oven/bun-")?;
-            cursor.write_all(os)?;
-            cursor.write_all(b"-")?;
-            cursor.write_all(arch.as_bytes())?;
-            cursor.write_all(libc.as_bytes())?;
-            cursor.write_all(baseline)?;
+            cursor.write_all(b"/")?;
+            self.write_npm_package_name(cursor, b"/")?;
             cursor.write_all(b"/-/bun-")?;
             cursor.write_all(os)?;
             cursor.write_all(b"-")?;
@@ -162,7 +203,16 @@ impl CompileTarget {
                 self.version.major, self.version.minor, self.version.patch,
             )?;
             Ok(())
-        })();
+        })
+    }
+
+    fn finish_url<'a>(
+        buf: &'a mut [u8],
+        write: impl FnOnce(&mut &mut [u8]) -> std::io::Result<()>,
+    ) -> crate::Result<&'a [u8]> {
+        let total = buf.len();
+        let mut cursor: &mut [u8] = buf;
+        let res = write(&mut cursor);
 
         match res {
             Ok(()) => {

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -20,7 +20,7 @@ pub struct CompileTarget {
     pub os: OperatingSystem,
     pub(crate) arch: Architecture,
     pub(crate) baseline: bool,
-    pub(crate) version: Version,
+    pub version: Version,
     pub(crate) libc: Libc,
 }
 
@@ -178,7 +178,7 @@ impl CompileTarget {
         })
     }
 
-    pub(crate) fn to_npm_registry_url_with_url<'a>(
+    pub fn to_npm_registry_url_with_url<'a>(
         &self,
         buf: &'a mut [u8],
         registry_url: &[u8],

--- a/src/standalone_graph/Cargo.toml
+++ b/src/standalone_graph/Cargo.toml
@@ -30,6 +30,7 @@ bun_exe_format.workspace = true
 bun_http.workspace = true
 bun_parsers.workspace = true
 bun_libarchive.workspace = true
+bun_install_types.workspace = true
 bun_io.workspace = true
 bun_js_parser.workspace = true
 bun_ast.workspace = true

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1623,7 +1623,148 @@ pub(crate) fn inject(
 }
 
 use bun_core::Environment::OperatingSystem as CompileTargetOs;
+use bun_install_types::integrity::Integrity;
 pub use bun_options_types::compile_target::CompileTarget;
+
+const NPM_MANIFEST_HEADERS_BUF: &[u8] =
+    b"Acceptapplication/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
+
+fn http_get(
+    url_bytes: &[u8],
+    headers_buf: &[u8],
+    env: &mut bun_dotenv::Loader,
+    refresher: &mut bun_core::Progress::Progress,
+    initial_capacity: usize,
+) -> crate::Result<Box<bun_core::MutableString>> {
+    let mut body = Box::new(bun_core::MutableString::init(initial_capacity)?);
+    let url = bun_url::URL::parse(url_bytes);
+
+    let mut header_entries = bun_http::headers::EntryList::default();
+    if !headers_buf.is_empty() {
+        const NAME_LEN: u32 = "Accept".len() as u32;
+        header_entries.append(bun_http::headers::Entry {
+            name: bun_http::headers::api::StringPointer {
+                offset: 0,
+                length: NAME_LEN,
+            },
+            value: bun_http::headers::api::StringPointer {
+                offset: NAME_LEN,
+                length: u32::try_from(headers_buf.len()).expect("int cast") - NAME_LEN,
+            },
+        })?;
+    }
+
+    // Note: reshaped for borrowck — `get_http_proxy_for` borrows
+    // `env` for the proxy URL lifetime; read the bool first.
+    let reject_unauthorized = env.get_tls_reject_unauthorized();
+    let http_proxy: Option<bun_url::URL<'_>> = env.get_http_proxy_for(&url);
+    let progress = refresher.start(b"Downloading", 0);
+
+    let mut async_http = Box::new(bun_http::AsyncHTTP::init_sync(
+        bun_http::Method::GET,
+        url,
+        header_entries,
+        headers_buf,
+        &raw mut *body,
+        b"",
+        http_proxy,
+        None,
+        bun_http::FetchRedirect::Follow,
+    ));
+    async_http.client.progress_node = core::ptr::NonNull::new(core::ptr::from_mut(progress));
+    async_http.client.flags.reject_unauthorized = reject_unauthorized;
+    let send_result = async_http.send_sync();
+
+    progress.end();
+    let status_code = send_result?.status_code() as u16;
+
+    // Return errors without printing - let caller handle the messaging
+    match status_code {
+        404 => return Err(crate::Error::TargetNotFound),
+        403 | 429 | 499..=599 => return Err(crate::Error::NetworkError),
+        200 => {}
+        _ => return Err(crate::Error::NetworkError),
+    }
+    Ok(body)
+}
+
+/// Looks up the target's release in the npm registry manifest and returns
+/// the tarball URL together with the digest the registry reports for it.
+fn resolve_release(
+    target: &CompileTarget,
+    env: &mut bun_dotenv::Loader,
+    refresher: &mut bun_core::Progress::Progress,
+) -> crate::Result<(Box<[u8]>, Integrity)> {
+    let registry: Box<[u8]> = Box::from(CompileTarget::npm_registry_url(env));
+    let mut url_buffer = [0u8; 2048];
+    let manifest_url: Box<[u8]> =
+        Box::from(target.to_npm_manifest_url_with_url(&mut url_buffer, &registry)?);
+    let manifest = http_get(
+        &manifest_url,
+        NPM_MANIFEST_HEADERS_BUF,
+        env,
+        refresher,
+        64 * 1024,
+    )?;
+    if manifest.list.is_empty() {
+        return Err(crate::Error::InvalidResponse);
+    }
+
+    let source = bun_ast::Source::init_path_string("manifest.json", manifest.list.as_slice());
+    let mut log = bun_ast::Log::init();
+    bun_ast::initialize_store();
+    let _reset_guard = bun_ast::StoreResetGuard::new();
+    let parsed = bun_parsers::json::ParsedJson::parse_json(&source, &mut log)
+        .map_err(|_| crate::Error::InvalidResponse)?;
+    let versions = parsed
+        .root
+        .get(b"versions")
+        .ok_or(crate::Error::InvalidResponse)?;
+
+    let version_str = format!(
+        "{}.{}.{}",
+        target.version.major, target.version.minor, target.version.patch
+    );
+    let dist = versions
+        .get(version_str.as_bytes())
+        .ok_or(crate::Error::TargetNotFound)?
+        .get(b"dist")
+        .ok_or(crate::Error::InvalidResponse)?;
+
+    let integrity = 'integrity: {
+        if let Some(field) = dist.get(b"integrity") {
+            if let Some(sri) = field.as_utf8_string_literal() {
+                let integrity = Integrity::parse(sri);
+                if integrity.tag.is_supported() {
+                    break 'integrity integrity;
+                }
+            }
+        }
+        if let Some(field) = dist.get(b"shasum") {
+            if let Some(shasum) = field.as_utf8_string_literal() {
+                if let Ok(integrity) = Integrity::parse_sha_sum(shasum) {
+                    if integrity.tag.is_supported() {
+                        break 'integrity integrity;
+                    }
+                }
+            }
+        }
+        return Err(crate::Error::MissingIntegrity);
+    };
+
+    let tarball_url: Box<[u8]> = 'tarball: {
+        if let Some(field) = dist.get(b"tarball") {
+            if let Some(url) = field.as_utf8_string_literal() {
+                if !url.is_empty() {
+                    break 'tarball Box::from(url);
+                }
+            }
+        }
+        Box::from(target.to_npm_registry_url_with_url(&mut url_buffer, &registry)?)
+    };
+
+    Ok((tarball_url, integrity))
+}
 
 /// Moved up from `bun_options_types` (T3) so it can name
 /// `bun_http::AsyncHTTP` directly
@@ -1640,60 +1781,26 @@ pub(crate) fn download_to_path(
     {
         refresher.refresh();
 
-        // TODO: This is way too much code necessary to send a single HTTP request...
-        let mut compressed_archive_bytes =
-            Box::new(bun_core::MutableString::init(24 * 1024 * 1024)?);
-        let mut url_buffer = [0u8; 2048];
-        let url_str = match target.to_npm_registry_url(&mut url_buffer) {
-            Ok(s) => s,
-            Err(err) => {
-                // Return error without printing - let caller decide how to handle
-                return Err(err.into());
-            }
-        };
-        let url_str_copy: Box<[u8]> = Box::from(url_str);
-        let url = bun_url::URL::parse(&url_str_copy);
-        {
-            // The unconditional
-            // `progress.end()` below is sufficient: no fallible call sits between
-            // `refresher.start` and it, so every exit path (including the
-            // error returns after it) ends the node exactly once.
-            // Note: reshaped for borrowck — `get_http_proxy_for` borrows
-            // `env` for the proxy URL lifetime; read the bool first.
-            let reject_unauthorized = env.get_tls_reject_unauthorized();
-            let http_proxy: Option<bun_url::URL<'_>> = env.get_http_proxy_for(&url);
-            let progress = refresher.start(b"Downloading", 0);
-
-            let mut async_http = Box::new(bun_http::AsyncHTTP::init_sync(
-                bun_http::Method::GET,
-                url,
-                Default::default(),
-                b"",
-                &raw mut *compressed_archive_bytes,
-                b"",
-                http_proxy,
-                None,
-                bun_http::FetchRedirect::Follow,
-            ));
-            async_http.client.progress_node =
-                core::ptr::NonNull::new(core::ptr::from_mut(progress));
-            async_http.client.flags.reject_unauthorized = reject_unauthorized;
-            let send_result = async_http.send_sync();
-
-            progress.end();
-            let status_code = send_result?.status_code() as u16;
-
-            match status_code {
-                404 => {
-                    // Return error without printing - let caller handle the messaging
-                    return Err(crate::Error::TargetNotFound);
+        // An explicit `BUN_COMPILE_TARGET_TARBALL_URL` has no registry
+        // metadata to check the download against.
+        let (tarball_url, expected_integrity): (Box<[u8]>, Option<Integrity>) =
+            match CompileTarget::tarball_url_override() {
+                Some(url) => (Box::from(url), None),
+                None => {
+                    let (url, integrity) = resolve_release(target, env, &mut refresher)?;
+                    (url, Some(integrity))
                 }
-                403 | 429 | 499..=599 => {
-                    // Return error without printing - let caller handle the messaging
-                    return Err(crate::Error::NetworkError);
-                }
-                200 => {}
-                _ => return Err(crate::Error::NetworkError),
+            };
+
+        let compressed_archive_bytes =
+            http_get(&tarball_url, b"", env, &mut refresher, 24 * 1024 * 1024)?;
+        if compressed_archive_bytes.list.is_empty() {
+            // Return error without printing - let caller handle the messaging
+            return Err(crate::Error::InvalidResponse);
+        }
+        if let Some(expected) = expected_integrity {
+            if !expected.verify(compressed_archive_bytes.list.as_slice()) {
+                return Err(crate::Error::IntegrityCheckFailed);
             }
         }
 
@@ -1701,11 +1808,6 @@ pub(crate) fn download_to_path(
         {
             refresher.refresh();
             // defer compressed_archive_bytes.list.deinit(allocator) — handled by Drop
-
-            if compressed_archive_bytes.list.is_empty() {
-                // Return error without printing - let caller handle the messaging
-                return Err(crate::Error::InvalidResponse);
-            }
 
             {
                 // Note: reshaped for borrowck — `refresher.start` borrows
@@ -1763,7 +1865,7 @@ pub(crate) fn download_to_path(
                     } else {
                         bun_core::zstr!("bun")
                     };
-                    let mv = bun_sys::move_file_z(tmpdir.fd(), src_name, Fd::INVALID, dest_z);
+                    let mv = bun_sys::move_file_z(tmpdir.fd(), src_name, Fd::cwd(), dest_z);
                     if mv.is_err() {
                         if !did_retry {
                             did_retry = true;
@@ -1867,6 +1969,14 @@ pub fn to_executable(
                     )),
                     crate::Error::ExtractionFailed => CompileResult::fail_fmt(format_args!(
                         "Failed to extract executable for '{}'. The download may be incomplete.",
+                        target
+                    )),
+                    crate::Error::IntegrityCheckFailed => CompileResult::fail_fmt(format_args!(
+                        "The downloaded executable for '{}' did not match the integrity value reported by the npm registry. Please try again.",
+                        target
+                    )),
+                    crate::Error::MissingIntegrity => CompileResult::fail_fmt(format_args!(
+                        "The npm registry did not report a supported integrity value for '{}'.",
                         target
                     )),
                     crate::Error::UnsupportedTarget => CompileResult::fail_fmt(format_args!(

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1718,7 +1718,7 @@ fn resolve_release(
     let mut log = bun_ast::Log::init();
     bun_ast::initialize_store();
     let _reset_guard = bun_ast::StoreResetGuard::new();
-    let parsed = bun_parsers::json::ParsedJson::parse_json(&source, &mut log)
+    let parsed = bun_parsers::json::ParsedJson::parse_npm_manifest(&source, &mut log)
         .map_err(|_| crate::Error::InvalidRegistryMetadata)?;
     let versions = parsed
         .root

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1626,12 +1626,12 @@ use bun_core::Environment::OperatingSystem as CompileTargetOs;
 use bun_install_types::integrity::Integrity;
 pub use bun_options_types::compile_target::CompileTarget;
 
-const NPM_MANIFEST_HEADERS_BUF: &[u8] =
-    b"Acceptapplication/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
+const NPM_MANIFEST_ACCEPT: &[u8] =
+    b"application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
 
 fn http_get(
     url_bytes: &[u8],
-    headers_buf: &[u8],
+    accept: Option<&[u8]>,
     env: &mut bun_dotenv::Loader,
     refresher: &mut bun_core::Progress::Progress,
     initial_capacity: usize,
@@ -1639,17 +1639,21 @@ fn http_get(
     let mut body = Box::new(bun_core::MutableString::init(initial_capacity)?);
     let url = bun_url::URL::parse(url_bytes);
 
+    const ACCEPT_NAME: &[u8] = b"Accept";
+    let mut headers_buf: Vec<u8> = Vec::new();
     let mut header_entries = bun_http::headers::EntryList::default();
-    if !headers_buf.is_empty() {
-        const NAME_LEN: u32 = "Accept".len() as u32;
+    if let Some(value) = accept {
+        headers_buf.reserve_exact(ACCEPT_NAME.len() + value.len());
+        headers_buf.extend_from_slice(ACCEPT_NAME);
+        headers_buf.extend_from_slice(value);
         header_entries.append(bun_http::headers::Entry {
             name: bun_http::headers::api::StringPointer {
                 offset: 0,
-                length: NAME_LEN,
+                length: ACCEPT_NAME.len() as u32,
             },
             value: bun_http::headers::api::StringPointer {
-                offset: NAME_LEN,
-                length: u32::try_from(headers_buf.len()).expect("int cast") - NAME_LEN,
+                offset: ACCEPT_NAME.len() as u32,
+                length: u32::try_from(value.len()).expect("int cast"),
             },
         })?;
     }
@@ -1664,7 +1668,7 @@ fn http_get(
         bun_http::Method::GET,
         url,
         header_entries,
-        headers_buf,
+        &headers_buf,
         &raw mut *body,
         b"",
         http_proxy,
@@ -1701,7 +1705,7 @@ fn resolve_release(
         Box::from(target.to_npm_manifest_url_with_url(&mut url_buffer, &registry)?);
     let manifest = http_get(
         &manifest_url,
-        NPM_MANIFEST_HEADERS_BUF,
+        Some(NPM_MANIFEST_ACCEPT),
         env,
         refresher,
         64 * 1024,
@@ -1793,7 +1797,7 @@ pub(crate) fn download_to_path(
             };
 
         let compressed_archive_bytes =
-            http_get(&tarball_url, b"", env, &mut refresher, 24 * 1024 * 1024)?;
+            http_get(&tarball_url, None, env, &mut refresher, 24 * 1024 * 1024)?;
         if compressed_archive_bytes.list.is_empty() {
             // Return error without printing - let caller handle the messaging
             return Err(crate::Error::InvalidResponse);

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1707,7 +1707,7 @@ fn resolve_release(
         64 * 1024,
     )?;
     if manifest.list.is_empty() {
-        return Err(crate::Error::InvalidResponse);
+        return Err(crate::Error::InvalidRegistryMetadata);
     }
 
     let source = bun_ast::Source::init_path_string("manifest.json", manifest.list.as_slice());
@@ -1715,11 +1715,11 @@ fn resolve_release(
     bun_ast::initialize_store();
     let _reset_guard = bun_ast::StoreResetGuard::new();
     let parsed = bun_parsers::json::ParsedJson::parse_json(&source, &mut log)
-        .map_err(|_| crate::Error::InvalidResponse)?;
+        .map_err(|_| crate::Error::InvalidRegistryMetadata)?;
     let versions = parsed
         .root
         .get(b"versions")
-        .ok_or(crate::Error::InvalidResponse)?;
+        .ok_or(crate::Error::InvalidRegistryMetadata)?;
 
     let version_str = format!(
         "{}.{}.{}",
@@ -1729,7 +1729,7 @@ fn resolve_release(
         .get(version_str.as_bytes())
         .ok_or(crate::Error::TargetNotFound)?
         .get(b"dist")
-        .ok_or(crate::Error::InvalidResponse)?;
+        .ok_or(crate::Error::InvalidRegistryMetadata)?;
 
     let integrity = 'integrity: {
         if let Some(field) = dist.get(b"integrity") {
@@ -1965,6 +1965,10 @@ pub fn to_executable(
                     )),
                     crate::Error::InvalidResponse => CompileResult::fail_fmt(format_args!(
                         "Downloaded file for '{}' appears to be corrupted. Please try again.",
+                        target
+                    )),
+                    crate::Error::InvalidRegistryMetadata => CompileResult::fail_fmt(format_args!(
+                        "The registry returned unusable metadata for '{}'. Please try again.",
                         target
                     )),
                     crate::Error::ExtractionFailed => CompileResult::fail_fmt(format_args!(

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -10,6 +10,10 @@ pub enum Error {
     InvalidResponse,
     #[error("ExtractionFailed")]
     ExtractionFailed,
+    #[error("IntegrityCheckFailed")]
+    IntegrityCheckFailed,
+    #[error("MissingIntegrity")]
+    MissingIntegrity,
     #[error("UnsupportedTarget")]
     UnsupportedTarget,
     #[error("InvalidSourceMap")]
@@ -45,6 +49,8 @@ impl Error {
             Self::NetworkError => "NetworkError",
             Self::InvalidResponse => "InvalidResponse",
             Self::ExtractionFailed => "ExtractionFailed",
+            Self::IntegrityCheckFailed => "IntegrityCheckFailed",
+            Self::MissingIntegrity => "MissingIntegrity",
             Self::UnsupportedTarget => "UnsupportedTarget",
             Self::InvalidSourceMap => "InvalidSourceMap",
             Self::SourceMapTooLarge => "SourceMapTooLarge",

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
     NetworkError,
     #[error("InvalidResponse")]
     InvalidResponse,
+    #[error("InvalidRegistryMetadata")]
+    InvalidRegistryMetadata,
     #[error("ExtractionFailed")]
     ExtractionFailed,
     #[error("IntegrityCheckFailed")]
@@ -48,6 +50,7 @@ impl Error {
             Self::TargetNotFound => "TargetNotFound",
             Self::NetworkError => "NetworkError",
             Self::InvalidResponse => "InvalidResponse",
+            Self::InvalidRegistryMetadata => "InvalidRegistryMetadata",
             Self::ExtractionFailed => "ExtractionFailed",
             Self::IntegrityCheckFailed => "IntegrityCheckFailed",
             Self::MissingIntegrity => "MissingIntegrity",

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -809,6 +809,7 @@ describe("compile --target executable download", () => {
     dir: string,
     integrity: (tarball: Uint8Array) => string,
     manifest?: (defaults: Record<string, unknown>) => Record<string, unknown>,
+    registryEnvKey: "BUN_CONFIG_REGISTRY" | "NPM_CONFIG_REGISTRY" = "BUN_CONFIG_REGISTRY",
   ) {
     const tarball = await makeTarball();
     using server = Bun.serve({
@@ -843,7 +844,10 @@ describe("compile --target executable download", () => {
       cmd: [bunExe(), "build", "--compile", `--target=${target}`, join(dir, "app.js"), "--outfile", "out/app"],
       env: {
         ...bunEnv,
-        BUN_CONFIG_REGISTRY: server.url.origin,
+        BUN_CONFIG_REGISTRY: undefined,
+        NPM_CONFIG_REGISTRY: undefined,
+        npm_config_registry: undefined,
+        [registryEnvKey]: server.url.origin,
         BUN_INSTALL_CACHE_DIR: cacheDir,
         // A released bun ignores BUN_CONFIG_REGISTRY here; keep it from
         // reaching the public registry by pointing the proxy at ourselves.
@@ -883,6 +887,22 @@ describe("compile --target executable download", () => {
     expect(stderr).toContain("did not match the integrity value reported by the npm registry");
     expect(existsSync(cachedExecutable)).toBe(false);
     expect(exitCode).not.toBe(0);
+  });
+
+  test("resolves the target through NPM_CONFIG_REGISTRY when BUN_CONFIG_REGISTRY is not set", async () => {
+    using dir = tempDir("build-compile-target-npm-config-registry", {
+      "app.js": `console.log("hi");`,
+    });
+    const { stderr, cachedExecutable } = await compileWithRegistry(
+      String(dir),
+      tarball => sriFor(tarball),
+      undefined,
+      "NPM_CONFIG_REGISTRY",
+    );
+
+    expect(stderr).not.toContain("did not match the integrity value");
+    expect(stderr).not.toContain("appears to be corrupted");
+    expect(existsSync(cachedExecutable)).toBe(true);
   });
 
   test("reports unusable registry metadata as a metadata error, not a corrupted download", async () => {

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -893,7 +893,7 @@ describe("compile --target executable download", () => {
 
     expect(stderr).toContain("did not match the integrity value reported by the npm registry");
     expect(existsSync(cachedExecutable)).toBe(false);
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 
   for (const registryEnvKey of ["NPM_CONFIG_REGISTRY", "npm_config_registry"] as const) {
@@ -941,7 +941,7 @@ describe("compile --target executable download", () => {
 
     expect(stderr).toContain("did not match the integrity value reported by the npm registry");
     expect(existsSync(cachedExecutable)).toBe(false);
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 
   test("reports unusable registry metadata as a metadata error, not a corrupted download", async () => {
@@ -957,7 +957,7 @@ describe("compile --target executable download", () => {
     expect(stderr).toContain("registry returned unusable metadata");
     expect(stderr).not.toContain("appears to be corrupted");
     expect(existsSync(cachedExecutable)).toBe(false);
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 });
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -863,7 +863,6 @@ describe("compile --target executable download", () => {
     return { stdout, stderr, exitCode, cachedExecutable: join(cacheDir, target) };
   }
 
-
   function shasumOnly(manifest: Record<string, any>) {
     const versionEntry = manifest.versions[version];
     versionEntry.dist.shasum = versionEntry.dist.integrity;

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -805,14 +805,18 @@ describe("compile --target executable download", () => {
     return "sha512-" + new Bun.CryptoHasher("sha512").update(bytes).digest("base64");
   }
 
-  async function compileWithRegistry(dir: string, integrity: (tarball: Uint8Array) => string) {
+  async function compileWithRegistry(
+    dir: string,
+    integrity: (tarball: Uint8Array) => string,
+    manifest?: (defaults: Record<string, unknown>) => Record<string, unknown>,
+  ) {
     const tarball = await makeTarball();
     using server = Bun.serve({
       port: 0,
       fetch(req) {
         const pathname = decodeURIComponent(new URL(req.url).pathname);
         if (pathname === `/@oven/${packageName}`) {
-          return Response.json({
+          const defaults = {
             name: `@oven/${packageName}`,
             versions: {
               [version]: {
@@ -824,7 +828,8 @@ describe("compile --target executable download", () => {
                 },
               },
             },
-          });
+          };
+          return Response.json(manifest ? manifest(defaults) : defaults);
         }
         if (pathname === `/-/${packageName}-${version}.tgz`) {
           return new Response(tarball);
@@ -876,6 +881,22 @@ describe("compile --target executable download", () => {
     );
 
     expect(stderr).toContain("did not match the integrity value reported by the npm registry");
+    expect(existsSync(cachedExecutable)).toBe(false);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("reports unusable registry metadata as a metadata error, not a corrupted download", async () => {
+    using dir = tempDir("build-compile-target-registry-metadata", {
+      "app.js": `console.log("hi");`,
+    });
+    const { stderr, exitCode, cachedExecutable } = await compileWithRegistry(
+      String(dir),
+      tarball => sriFor(tarball),
+      () => ({ name: `@oven/${packageName}`, versions: { [version]: { name: `@oven/${packageName}`, version } } }),
+    );
+
+    expect(stderr).toContain("registry returned unusable metadata");
+    expect(stderr).not.toContain("appears to be corrupted");
     expect(existsSync(cachedExecutable)).toBe(false);
     expect(exitCode).not.toBe(0);
   });

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -782,4 +782,103 @@ describe("compiled binary in a deleted cwd", () => {
   );
 });
 
+describe("compile --target executable download", () => {
+  // The current platform with a version that isn't the running build, so
+  // `--compile` has to fetch the executable from the registry.
+  const os = isMacOS ? "darwin" : isLinux ? "linux" : isWindows ? "windows" : "unknown";
+  const arch = isArm64 ? "aarch64" : "x64";
+  const musl = isMusl ? "-musl" : "";
+  const version = "0.0.1";
+  const packageName = `bun-${os}-${arch}${musl}`;
+  const target = `${packageName}-v${version}`;
+
+  async function makeTarball() {
+    const executableName = isWindows ? "bun.exe" : "bun";
+    const archive = new Bun.Archive(
+      { [`package/bin/${executableName}`]: Buffer.alloc(1024, "not really an executable") },
+      { compress: "gzip" },
+    );
+    return new Uint8Array(await (await archive.blob()).arrayBuffer());
+  }
+
+  function sriFor(bytes: Uint8Array) {
+    return "sha512-" + new Bun.CryptoHasher("sha512").update(bytes).digest("base64");
+  }
+
+  async function compileWithRegistry(dir: string, integrity: (tarball: Uint8Array) => string) {
+    const tarball = await makeTarball();
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const pathname = decodeURIComponent(new URL(req.url).pathname);
+        if (pathname === `/@oven/${packageName}`) {
+          return Response.json({
+            name: `@oven/${packageName}`,
+            versions: {
+              [version]: {
+                name: `@oven/${packageName}`,
+                version,
+                dist: {
+                  tarball: `${server.url.origin}/-/${packageName}-${version}.tgz`,
+                  integrity: integrity(tarball),
+                },
+              },
+            },
+          });
+        }
+        if (pathname === `/-/${packageName}-${version}.tgz`) {
+          return new Response(tarball);
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    const cacheDir = join(dir, "cache");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", `--target=${target}`, join(dir, "app.js"), "--outfile", "out/app"],
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_REGISTRY: server.url.origin,
+        BUN_INSTALL_CACHE_DIR: cacheDir,
+        // A released bun ignores BUN_CONFIG_REGISTRY here; keep it from
+        // reaching the public registry by pointing the proxy at ourselves.
+        HTTP_PROXY: server.url.origin,
+        HTTPS_PROXY: server.url.origin,
+        NO_PROXY: "127.0.0.1,localhost",
+      },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, cachedExecutable: join(cacheDir, target) };
+  }
+
+  test("installs the downloaded executable when it matches the registry integrity", async () => {
+    using dir = tempDir("build-compile-target-integrity-match", {
+      "app.js": `console.log("hi");`,
+    });
+    const { stderr, cachedExecutable } = await compileWithRegistry(String(dir), sriFor);
+
+    // The payload is not a real bun executable, so linking the module
+    // graph into it may fail afterwards; the download itself must have
+    // been verified and installed into the cache.
+    expect(stderr).not.toContain("did not match the integrity value");
+    expect(existsSync(cachedExecutable)).toBe(true);
+  });
+
+  test("rejects the downloaded executable when it does not match the registry integrity", async () => {
+    using dir = tempDir("build-compile-target-integrity-mismatch", {
+      "app.js": `console.log("hi");`,
+    });
+    const { stderr, exitCode, cachedExecutable } = await compileWithRegistry(String(dir), tarball =>
+      sriFor(Buffer.alloc(tarball.byteLength, "x")),
+    );
+
+    expect(stderr).toContain("did not match the integrity value reported by the npm registry");
+    expect(existsSync(cachedExecutable)).toBe(false);
+    expect(exitCode).not.toBe(0);
+  });
+});
+
 // file command test works well

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -809,7 +809,7 @@ describe("compile --target executable download", () => {
     dir: string,
     integrity: (tarball: Uint8Array) => string,
     manifest?: (defaults: Record<string, unknown>) => Record<string, unknown>,
-    registryEnvKey: "BUN_CONFIG_REGISTRY" | "NPM_CONFIG_REGISTRY" = "BUN_CONFIG_REGISTRY",
+    registryEnvKey: "BUN_CONFIG_REGISTRY" | "NPM_CONFIG_REGISTRY" | "npm_config_registry" = "BUN_CONFIG_REGISTRY",
   ) {
     const tarball = await makeTarball();
     using server = Bun.serve({
@@ -863,6 +863,14 @@ describe("compile --target executable download", () => {
     return { stdout, stderr, exitCode, cachedExecutable: join(cacheDir, target) };
   }
 
+
+  function shasumOnly(manifest: Record<string, any>) {
+    const versionEntry = manifest.versions[version];
+    versionEntry.dist.shasum = versionEntry.dist.integrity;
+    delete versionEntry.dist.integrity;
+    return manifest;
+  }
+
   test("installs the downloaded executable when it matches the registry integrity", async () => {
     using dir = tempDir("build-compile-target-integrity-match", {
       "app.js": `console.log("hi");`,
@@ -889,20 +897,52 @@ describe("compile --target executable download", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  test("resolves the target through NPM_CONFIG_REGISTRY when BUN_CONFIG_REGISTRY is not set", async () => {
-    using dir = tempDir("build-compile-target-npm-config-registry", {
+  for (const registryEnvKey of ["NPM_CONFIG_REGISTRY", "npm_config_registry"] as const) {
+    test(`resolves the target through ${registryEnvKey} when BUN_CONFIG_REGISTRY is not set`, async () => {
+      using dir = tempDir("build-compile-target-npm-config-registry", {
+        "app.js": `console.log("hi");`,
+      });
+      const { stderr, cachedExecutable } = await compileWithRegistry(
+        String(dir),
+        tarball => sriFor(tarball),
+        undefined,
+        registryEnvKey,
+      );
+
+      expect(stderr).not.toContain("did not match the integrity value");
+      expect(stderr).not.toContain("appears to be corrupted");
+      expect(existsSync(cachedExecutable)).toBe(true);
+    });
+  }
+
+  test("installs the downloaded executable when it matches the registry shasum", async () => {
+    using dir = tempDir("build-compile-target-shasum-match", {
       "app.js": `console.log("hi");`,
     });
     const { stderr, cachedExecutable } = await compileWithRegistry(
       String(dir),
-      tarball => sriFor(tarball),
-      undefined,
-      "NPM_CONFIG_REGISTRY",
+      tarball => new Bun.CryptoHasher("sha1").update(tarball).digest("hex"),
+      defaults => shasumOnly(defaults),
     );
 
     expect(stderr).not.toContain("did not match the integrity value");
     expect(stderr).not.toContain("appears to be corrupted");
     expect(existsSync(cachedExecutable)).toBe(true);
+  });
+
+  test("rejects the downloaded executable when it does not match the registry shasum", async () => {
+    using dir = tempDir("build-compile-target-shasum-mismatch", {
+      "app.js": `console.log("hi");`,
+    });
+    const { stderr, exitCode, cachedExecutable } = await compileWithRegistry(
+      String(dir),
+      tarball => new Bun.CryptoHasher("sha1").update(Buffer.alloc(tarball.byteLength, "x")).digest("hex"),
+      defaults => shasumOnly(defaults),
+    );
+
+    expect(stderr).toContain("did not match the integrity value reported by the npm registry");
+    expect(existsSync(cachedExecutable)).toBe(false);
+    expect(exitCode).not.toBe(0);
   });
 
   test("reports unusable registry metadata as a metadata error, not a corrupted download", async () => {

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -959,6 +959,47 @@ describe("compile --target executable download", () => {
     expect(existsSync(cachedExecutable)).toBe(false);
     expect(exitCode).toBe(1);
   });
+
+  test("BUN_COMPILE_TARGET_TARBALL_URL skips the manifest lookup and integrity verification", async () => {
+    using dir = tempDir("build-compile-target-url-override", {
+      "app.js": `console.log("hi");`,
+    });
+    const tarball = await makeTarball();
+    let manifestRequests = 0;
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const pathname = decodeURIComponent(new URL(req.url).pathname);
+        if (pathname.endsWith(".tgz")) return new Response(tarball);
+        manifestRequests++;
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    const cacheDir = join(String(dir), "cache");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", `--target=${target}`, join(String(dir), "app.js"), "--outfile", "out/app"],
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_REGISTRY: undefined,
+        NPM_CONFIG_REGISTRY: undefined,
+        npm_config_registry: undefined,
+        BUN_COMPILE_TARGET_TARBALL_URL: `${server.url.origin}/${packageName}.tgz`,
+        BUN_INSTALL_CACHE_DIR: cacheDir,
+        HTTP_PROXY: server.url.origin,
+        HTTPS_PROXY: server.url.origin,
+        NO_PROXY: "127.0.0.1,localhost",
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(manifestRequests).toBe(0);
+    expect(stderr).not.toContain("did not match the integrity value");
+    expect(existsSync(join(cacheDir, target))).toBe(true);
+  });
 });
 
 // file command test works well


### PR DESCRIPTION
## What

When `bun build --compile` targets a platform other than the one running the build, the target's `bun` executable is downloaded from the npm registry (`@oven/bun-<target>`) and installed into the cache. This change:

- Fetches the target's release from the npm registry manifest and checks the downloaded tarball against the `dist.integrity` (falling back to `dist.shasum`) the registry reports for that version, before decompressing/extracting it. If the digest does not match, the compile fails with a clear error and nothing is written into the cache.
- Reuses the existing `Integrity` implementation from the package manager (moved into `bun_install_types` so `bun_standalone_graph` can depend on it; `bun_install` re-exports it, no call sites changed).
- Honors `BUN_CONFIG_REGISTRY` for the target download (manifest + tarball) instead of always using `https://registry.npmjs.org`.
- Leaves the explicit `BUN_COMPILE_TARGET_TARBALL_URL` override unchanged — an arbitrary tarball URL has no registry metadata to check against.
- Passes `Fd::cwd()` (instead of an invalid fd) as the destination dir when moving the extracted executable into the cache, so the cross-device fallback path works.

## How to observe

Point the compile at a registry via `BUN_CONFIG_REGISTRY` (and `BUN_INSTALL_CACHE_DIR` at an empty dir), then compile for a target/version that isn't the running build:

- If the registry's `dist.integrity` matches the tarball, the executable is extracted into the cache and the build proceeds.
- If it doesn't, the build fails with `The downloaded executable for '<target>' did not match the integrity value reported by the npm registry.` and the cache stays empty.

## Test

`test/bundler/bun-build-compile.test.ts` — new `compile --target executable download` block stands up a local registry with `Bun.serve({ port: 0 })` serving the manifest + tarball and covers both the matching and mismatching digest cases (no public network access).

## Also included: `send_sync` response-metadata leak

The new download tests run `bun build --compile` under the ASAN lane's leak detection and exposed a pre-existing leak in the shared synchronous HTTP client (`src/http/AsyncHTTP.rs`): `send_sync` suppressed the drop of the response metadata (header list + backing buffer) and returned only the borrowed response, so both allocations were lost on **every** `send_sync` call — install, publish, create, audit, upgrade, and compile all share it. This PR makes `send_sync` return the owning metadata (whose existing `Drop` reclaims both) with a `Deref` to the response, so no call site changes. It is included here because it is what turned this PR's ASAN lane red; happy to split it into its own PR if preferred.
