### PR TITLE
Bun.serve: honor requestCert/rejectUnauthorized on per-serverName tls entries

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -179,6 +179,10 @@ static int us_ssl_is_socket_ex_idx = -1;
  * (node's ssl.verifyError() verdict) as (void*)(intptr_t). */
 static int us_ssl_inline_reject_enabled_ex_idx = -1;
 static int us_ssl_inline_reject_err_ex_idx = -1;
+/* (SSL_CTX) packed client-certificate policy of a Bun.serve per-serverName
+ * entry — see us_ssl_ctx_set_sni_policy. Absent on node:tls SecureContexts,
+ * whose policy is server-level. */
+static int us_ctx_sni_policy_ex_idx = -1;
 /* Defined in Rust (src/uws_sys/SocketKind.rs) so the ordinal tracks the enum. */
 extern const unsigned char BUN_SOCKET_KIND_BUN_SOCKET_TLS;
 extern const unsigned char BUN_SOCKET_KIND_UWS_HTTP_TLS;
@@ -392,6 +396,7 @@ static void us_ex_idx_init(void) {
   us_sni_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
   us_ctx_cache_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, bun_ssl_ctx_cache_on_free);
   us_ctx_user_ca_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+  us_ctx_sni_policy_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
   us_ssl_reneg_state_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_reneg_state_free);
   us_ssl_sni_pending_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_sni_pending_free);
   us_ssl_listener_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
@@ -2605,6 +2610,55 @@ static struct sni_node_t *resolve_listener_ctx(struct us_listen_socket_t *ls, co
   return (struct sni_node_t *)sni_find(ls->sni, hostname);
 }
 
+#define US_SNI_POLICY_REQUEST_CERT ((uintptr_t)1)
+#define US_SNI_POLICY_REJECT_UNAUTHORIZED ((uintptr_t)2)
+
+static _Atomic uint32_t us_sni_sid_ctx_counter = 0;
+
+/* Record the client-certificate policy of a per-serverName entry on its
+ * SSL_CTX and give it a session-id context of its own: SSL_set_SSL_CTX copies
+ * the certificate (with its sid_ctx) but not verify_mode, so the SNI switch
+ * reapplies the policy per connection, and a session established under any
+ * other context is never resumed under this one (a resumed handshake skips
+ * client authentication entirely). */
+void us_ssl_ctx_set_sni_policy(SSL_CTX *ctx, int request_cert, int reject_unauthorized) {
+  if (!ctx) return;
+  us_ex_idx_ensure();
+  uintptr_t packed = (request_cert ? US_SNI_POLICY_REQUEST_CERT : 0) |
+                     (reject_unauthorized ? US_SNI_POLICY_REJECT_UNAUTHORIZED : 0);
+  SSL_CTX_set_ex_data(ctx, us_ctx_sni_policy_ex_idx, (void *)packed);
+  uint32_t sid = atomic_fetch_add(&us_sni_sid_ctx_counter, 1) + 1;
+  SSL_CTX_set_session_id_context(ctx, (const uint8_t *)&sid, sizeof(sid));
+}
+
+/* Every SNI context switch goes through here: SSL_set_SSL_CTX alone leaves
+ * verify_mode as inherited from the default context at accept, so a
+ * per-serverName entry's requestCert/rejectUnauthorized are added on top of
+ * it (the connection's inherited requirement is kept). A context without a
+ * recorded policy (node:tls SecureContext, whose policy is server-level)
+ * leaves the connection's verify mode untouched. */
+static void us_ssl_apply_selected_ctx(SSL *ssl, SSL_CTX *ctx) {
+  SSL_set_SSL_CTX(ssl, ctx);
+  if (us_ctx_sni_policy_ex_idx < 0) return;
+  uintptr_t policy = (uintptr_t)SSL_CTX_get_ex_data(ctx, us_ctx_sni_policy_ex_idx);
+  if (!(policy & US_SNI_POLICY_REQUEST_CERT)) return;
+  int mode = SSL_get_verify_mode(ssl) | SSL_VERIFY_PEER;
+  if (policy & US_SNI_POLICY_REJECT_UNAUTHORIZED) mode |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+  SSL_set_verify(ssl, mode, us_verify_callback);
+}
+
+/* Whether the SNI-selected context of this connection demands closing on a
+ * client-certificate verification error (requestCert && rejectUnauthorized
+ * of the per-serverName entry). */
+int us_socket_server_name_reject_unauthorized(struct us_socket_t *s) {
+  if (!s->ssl || us_ctx_sni_policy_ex_idx < 0) return 0;
+  SSL_CTX *ctx = SSL_get_SSL_CTX(s_ssl(s));
+  if (!ctx) return 0;
+  uintptr_t packed = (uintptr_t)SSL_CTX_get_ex_data(ctx, us_ctx_sni_policy_ex_idx);
+  return (packed & US_SNI_POLICY_REQUEST_CERT) &&
+         (packed & US_SNI_POLICY_REJECT_UNAUTHORIZED);
+}
+
 /* Extracts the host_name from the ClientHello's server_name extension.
  * Returns the length written to `out` (NUL-terminated), or 0 if absent /
  * malformed. BoringSSL does document SSL_get_servername as usable inside
@@ -2654,7 +2708,7 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
   if (pending && pending->state == 2) {
     pending->state = 0;
     if (pending->resolved_ctx) {
-      SSL_set_SSL_CTX(ssl, pending->resolved_ctx);
+      us_ssl_apply_selected_ctx(ssl, pending->resolved_ctx);
       SSL_CTX_free(pending->resolved_ctx);
       pending->resolved_ctx = NULL;
       return ssl_select_cert_success;
@@ -2674,7 +2728,7 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
       if (us_client_hello_servername(hello, resumed_host, sizeof(resumed_host))) {
         struct sni_node_t *resumed_node = resolve_listener_ctx(resumed_ls, resumed_host);
         if (resumed_node) {
-          SSL_set_SSL_CTX(ssl, resumed_node->ctx);
+          us_ssl_apply_selected_ctx(ssl, resumed_node->ctx);
         }
       }
     }
@@ -2751,7 +2805,7 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
     return ssl_select_cert_retry;
   }
   if (dyn) {
-    SSL_set_SSL_CTX(ssl, dyn);
+    us_ssl_apply_selected_ctx(ssl, dyn);
     SSL_CTX_free(dyn);
     return ssl_select_cert_success;
   }
@@ -2761,7 +2815,7 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
   if (ls) {
     struct sni_node_t *node = resolve_listener_ctx(ls, hostname);
     if (node) {
-      SSL_set_SSL_CTX(ssl, node->ctx);
+      us_ssl_apply_selected_ctx(ssl, node->ctx);
     }
   }
   return ssl_select_cert_success;
@@ -2790,7 +2844,7 @@ static int sni_cb(SSL *ssl, int *al, void *arg) {
      * listener). */
     struct sni_node_t *node = resolve_listener_ctx(ls, hostname);
     if (node) {
-      SSL_set_SSL_CTX(ssl, node->ctx);
+      us_ssl_apply_selected_ctx(ssl, node->ctx);
     }
   }
   return SSL_TLSEXT_ERR_OK;

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -422,6 +422,15 @@ void us_listen_socket_on_server_name(struct us_listen_socket_t *ls,
  * after the socket closed (no-op). */
 void us_socket_sni_resolve(us_socket_r s, struct ssl_ctx_st *ctx, int error);
 void *us_socket_server_name_userdata(us_socket_r s);
+/* Records a per-serverName entry's client-certificate policy on its SSL_CTX
+ * so the SNI switch adds it to the connection's inherited one, and gives the
+ * context its own session-id context so sessions from other contexts are not
+ * resumed under it. Contexts without one keep the server-level policy. */
+void us_ssl_ctx_set_sni_policy(struct ssl_ctx_st *ctx, int request_cert,
+    int reject_unauthorized);
+/* 1 iff the SNI-selected context for this connection demands closing on a
+ * client-certificate verification error. */
+int us_socket_server_name_reject_unauthorized(us_socket_r s);
 /* Socket-level SNI resolver, for a server-side socket adopted into TLS with no
  * listen socket behind it. Same contract as the listener resolver: an owned
  * SSL_CTX ref or NULL; *abort_handshake 1 = drop silently, 2 = suspend. */

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -135,7 +135,7 @@ public:
 
 
     /* Server name */
-    TemplatedApp &&addServerName(const std::string &hostname_pattern, SocketContextOptions options = {}, bool *success = nullptr) {
+    TemplatedApp &&addServerName(const std::string &hostname_pattern, SocketContextOptions options = {}, bool *success = nullptr, bool applyClientCertPolicy = false) {
 
         /* Do nothing if not even on SSL */
         if constexpr (SSL) {
@@ -144,6 +144,12 @@ public:
             if (!domainCtx) {
                 if (success) *success = false;
                 return std::move(*this);
+            }
+            /* A per-serverName entry carries its own client-certificate
+             * policy; the default entry's own hostname keeps the app-level
+             * one. */
+            if (applyClientCertPolicy) {
+                us_ssl_ctx_set_sni_policy(domainCtx, options.request_cert, options.reject_unauthorized);
             }
             auto *domainRouter = new HttpRouter<typename HttpContextData<SSL>::RouterData>();
             int result = 0;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -154,7 +154,11 @@ private:
             HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
             // Set per-socket authorization status
             auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
-            if(httpContextData->flags.rejectUnauthorized) {
+            /* The app-level flag reflects the default entry; a per-serverName
+             * entry adds its own client-certificate policy for its name. */
+            bool rejectUnauthorized = httpContextData->flags.rejectUnauthorized ||
+                us_socket_server_name_reject_unauthorized(s);
+            if(rejectUnauthorized) {
                 if(!success || verify_error.error != 0) {
                     // we failed to handshake, close the socket
                     us_socket_close(s, 0, nullptr);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2705,7 +2705,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let server_name = unsafe { bun_core::ffi::cstr(name_ptr) };
                 // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
                 if bun_opaque::opaque_deref_mut(app)
-                    .add_server_name_with_options(server_name, &ssl_options)
+                    .add_server_name_with_options(server_name, &ssl_options, false)
                     .is_err()
                 {
                     if !global.has_exception() && !throw_ssl_error_if_necessary(global) {
@@ -2787,7 +2787,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 }
                 // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
                 if bun_opaque::opaque_deref_mut(app)
-                    .add_server_name_with_options(sni_name, &sni_opts)
+                    .add_server_name_with_options(sni_name, &sni_opts, true)
                     .is_err()
                 {
                     if !global.has_exception() && !throw_ssl_error_if_necessary(global) {

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -342,6 +342,7 @@ impl<const SSL: bool> App<SSL> {
         &mut self,
         hostname_pattern: &core::ffi::CStr,
         opts: &BunSocketContextOptions,
+        apply_client_cert_policy: bool,
     ) -> Result<(), AddServerNameError> {
         // SAFETY: self is a valid app; hostname_pattern is NUL-terminated.
         let rc = unsafe {
@@ -350,6 +351,7 @@ impl<const SSL: bool> App<SSL> {
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 hostname_pattern.as_ptr(),
                 *opts,
+                i32::from(apply_client_cert_policy),
             )
         };
         if rc != 0 {
@@ -611,6 +613,7 @@ pub mod c {
             app: *mut uws_app_t,
             hostname_pattern: *const c_char,
             options: BunSocketContextOptions,
+            apply_client_cert_policy: c_int,
         ) -> i32;
         pub(crate) safe fn uws_filter(
             ssl: i32,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -647,7 +647,8 @@ extern "C"
   }
   int uws_add_server_name_with_options(
       int ssl, uws_app_t *app, const char *hostname_pattern,
-      struct us_bun_socket_context_options_t options)
+      struct us_bun_socket_context_options_t options,
+      int apply_client_cert_policy)
   {
     uWS::SocketContextOptions sco;
     memcpy(&sco, &options, sizeof(uWS::SocketContextOptions));
@@ -656,12 +657,12 @@ extern "C"
     if (ssl)
     {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->addServerName(hostname_pattern, sco, &success);
+      uwsApp->addServerName(hostname_pattern, sco, &success, apply_client_cert_policy != 0);
     }
     else
     {
       uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->addServerName(hostname_pattern, sco, &success);
+      uwsApp->addServerName(hostname_pattern, sco, &success, apply_client_cert_policy != 0);
     }
     return !success;
   }

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import tls from "node:tls";
+import { join } from "path";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
 import publicKey from "../../third_party/jsonwebtoken/pub.pem" with { type: "text" };
 
@@ -148,4 +151,72 @@ describe("Bun.serve SSL validations", () => {
       });
     }
   }
+});
+
+describe("Bun.serve per-serverName client certificate policy", () => {
+  const tlsFixtures = join(import.meta.dir, "..", "..", "node", "tls", "fixtures");
+  const serverKey = readFileSync(join(tlsFixtures, "agent10-key.pem"), "utf8");
+  const serverCert = readFileSync(join(tlsFixtures, "agent10-cert.pem"), "utf8");
+  // ec10 chains to ca5; agent1 chains to ca1 and is not trusted by ca5.
+  const clientCa = readFileSync(join(tlsFixtures, "ca5-cert.pem"), "utf8");
+  const trustedClient = {
+    key: readFileSync(join(tlsFixtures, "ec10-key.pem"), "utf8"),
+    cert: readFileSync(join(tlsFixtures, "ec10-cert.pem"), "utf8"),
+  };
+  const untrustedClient = {
+    key: readFileSync(join(tlsFixtures, "agent1-key.pem"), "utf8"),
+    cert: readFileSync(join(tlsFixtures, "agent1-cert.pem"), "utf8"),
+  };
+
+  function request(port: number, servername: string, clientTls: Record<string, string> = {}) {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const socket = tls.connect({ host: "127.0.0.1", port, servername, rejectUnauthorized: false, ...clientTls });
+    let received = "";
+    socket.on("secureConnect", () => {
+      socket.write(`GET / HTTP/1.1\r\nHost: ${servername}\r\nConnection: close\r\n\r\n`);
+    });
+    socket.on("data", chunk => (received += chunk.toString()));
+    // A rejected client sees either a clean close or a reset; both mean no response.
+    socket.on("error", () => {});
+    socket.on("close", () => resolve(received.split("\r\n")[0] || "connection closed without a response"));
+    return promise;
+  }
+
+  test("requestCert/rejectUnauthorized on a non-default serverName entry are enforced for that name only", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: [
+        { key: serverKey, cert: serverCert },
+        {
+          serverName: "admin.example.com",
+          key: serverKey,
+          cert: serverCert,
+          ca: clientCa,
+          requestCert: true,
+          rejectUnauthorized: true,
+        },
+        {
+          serverName: "lenient.example.com",
+          key: serverKey,
+          cert: serverCert,
+          ca: clientCa,
+          requestCert: true,
+          rejectUnauthorized: false,
+        },
+      ],
+      fetch: req => new Response(`served ${req.headers.get("host")}`),
+    });
+    const gatedNoCert = await request(server.port, "admin.example.com");
+    const gatedTrustedCert = await request(server.port, "admin.example.com", trustedClient);
+    const gatedUntrustedCert = await request(server.port, "admin.example.com", untrustedClient);
+    const lenientNoCert = await request(server.port, "lenient.example.com");
+    const defaultNoCert = await request(server.port, "localhost");
+    expect({ gatedNoCert, gatedTrustedCert, gatedUntrustedCert, lenientNoCert, defaultNoCert }).toEqual({
+      gatedNoCert: "connection closed without a response",
+      gatedTrustedCert: "HTTP/1.1 200 OK",
+      gatedUntrustedCert: "connection closed without a response",
+      lenientNoCert: "HTTP/1.1 200 OK",
+      defaultNoCert: "HTTP/1.1 200 OK",
+    });
+  });
 });

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -168,17 +168,22 @@ describe("Bun.serve per-serverName client certificate policy", () => {
     cert: readFileSync(join(tlsFixtures, "agent1-cert.pem"), "utf8"),
   };
 
-  function request(port: number, servername: string, clientTls: Record<string, string> = {}) {
-    const { promise, resolve } = Promise.withResolvers<string>();
+  type ClientOptions = { key?: string; cert?: string; session?: Buffer };
+  function request(port: number, servername: string, clientTls: ClientOptions = {}) {
+    const { promise, resolve } = Promise.withResolvers<{ status: string; session: Buffer | undefined }>();
     const socket = tls.connect({ host: "127.0.0.1", port, servername, rejectUnauthorized: false, ...clientTls });
     let received = "";
+    let session: Buffer | undefined;
     socket.on("secureConnect", () => {
       socket.write(`GET / HTTP/1.1\r\nHost: ${servername}\r\nConnection: close\r\n\r\n`);
     });
+    socket.on("session", buf => (session ??= buf));
     socket.on("data", chunk => (received += chunk.toString()));
     // A rejected client sees either a clean close or a reset; both mean no response.
     socket.on("error", () => {});
-    socket.on("close", () => resolve(received.split("\r\n")[0] || "connection closed without a response"));
+    socket.on("close", () =>
+      resolve({ status: received.split("\r\n")[0] || "connection closed without a response", session }),
+    );
     return promise;
   }
 
@@ -206,17 +211,46 @@ describe("Bun.serve per-serverName client certificate policy", () => {
       ],
       fetch: req => new Response(`served ${req.headers.get("host")}`),
     });
-    const gatedNoCert = await request(server.port, "admin.example.com");
-    const gatedTrustedCert = await request(server.port, "admin.example.com", trustedClient);
-    const gatedUntrustedCert = await request(server.port, "admin.example.com", untrustedClient);
-    const lenientNoCert = await request(server.port, "lenient.example.com");
-    const defaultNoCert = await request(server.port, "localhost");
+    const { status: gatedNoCert } = await request(server.port, "admin.example.com");
+    const { status: gatedTrustedCert } = await request(server.port, "admin.example.com", trustedClient);
+    const { status: gatedUntrustedCert } = await request(server.port, "admin.example.com", untrustedClient);
+    const { status: lenientNoCert } = await request(server.port, "lenient.example.com");
+    const { status: defaultNoCert } = await request(server.port, "localhost");
     expect({ gatedNoCert, gatedTrustedCert, gatedUntrustedCert, lenientNoCert, defaultNoCert }).toEqual({
       gatedNoCert: "connection closed without a response",
       gatedTrustedCert: "HTTP/1.1 200 OK",
       gatedUntrustedCert: "connection closed without a response",
       lenientNoCert: "HTTP/1.1 200 OK",
       defaultNoCert: "HTTP/1.1 200 OK",
+    });
+  });
+
+  test("a session established on the open default name cannot be resumed to bypass a gated name", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: [
+        { key: serverKey, cert: serverCert },
+        {
+          serverName: "admin.example.com",
+          key: serverKey,
+          cert: serverCert,
+          ca: clientCa,
+          requestCert: true,
+          rejectUnauthorized: true,
+        },
+      ],
+      fetch: req => new Response(`served ${req.headers.get("host")}`),
+    });
+    // Establish a resumable session on the open default name, then offer it on
+    // the gated name without presenting a client certificate.
+    const { status: defaultFresh, session } = await request(server.port, "localhost");
+    expect(session).toBeInstanceOf(Buffer);
+    const { status: defaultResumed } = await request(server.port, "localhost", { session });
+    const { status: gatedResumed } = await request(server.port, "admin.example.com", { session });
+    expect({ defaultFresh, defaultResumed, gatedResumed }).toEqual({
+      defaultFresh: "HTTP/1.1 200 OK",
+      defaultResumed: "HTTP/1.1 200 OK",
+      gatedResumed: "connection closed without a response",
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

With `Bun.serve({ tls: [ ...one entry per serverName... ] })`, the `requestCert` / `rejectUnauthorized` set on a non-default `serverName` entry did not take effect for connections to that name: the SNI context switch only carried over the certificate, and the handshake handler's close-on-verification-error decision was keyed on the default entry only. Client-certificate settings configured on a per-hostname entry were silently ignored for that hostname.

Now each per-`serverName` entry's client-certificate policy is recorded on its context and applied when SNI selects it — through one helper shared by every switch path (servername callback, the early select-certificate fallback, and the resume path) — and the handshake handler consults the selected context for the close decision. Per-name contexts also get their own session-id context so a session established under another context is not resumed under a gated entry.

Scope notes: the default entry and `node:tls` SecureContexts (server-level policy) are unchanged, and per-name policy is additive — an entry can add a client-certificate requirement for its name but does not remove one imposed by the default entry.

### How did you verify your code works?

Added a test to `test/js/bun/http/bun-serve-ssl.test.ts`: with `tls: [default, {serverName: "admin.example.com", ca, requestCert, rejectUnauthorized}, {serverName: "lenient.example.com", ca, requestCert, rejectUnauthorized: false}]`, a client to `admin.example.com` without a certificate (or with one not chaining to the entry's `ca`) is refused, with a valid one is served, and the lenient and default names are served. `bun bd test test/js/bun/http/bun-serve-ssl.test.ts` passes (17/17); the new test fails on the current release. Also drove the debug build across all requestCert × rejectUnauthorized combinations and confirmed a session resumed from the default name is not accepted under the gated name.

## Scope note: HTTP/3

This applies the per-`serverName` `requestCert` / `rejectUnauthorized` policy on the TLS-over-TCP listener. Bun's HTTP/3 server does not yet have client-certificate support at all, so an H3 connection is not client-cert gated regardless of this change — that is a pre-existing capability gap, not something introduced here, and it is out of scope for this PR.
