### PR TITLE
fetch: keep textStream() pulling when a native chunk decodes to nothing

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -403,10 +403,7 @@ static void nativeStorePendingView(JSC::VM& vm, JSNativeStreamSourceAdapter* ada
 }
 
 // Text mode: decode `bytes` against `state` and enqueue the resulting string
-// (empty strings are skipped). A non-flush chunk that decodes to nothing arms
-// m_pullAgain via callPullIfNeeded so the pull loop keeps going while the held-
-// back bytes wait for the rest of the sequence (same contract as
-// textDecodeReadRequestChunkSteps).
+// (empty strings are skipped; an empty non-flush decode re-arms the pull loop).
 static void nativeEnqueueTextChunk(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, StreamingUTF8DecodeState& state, std::span<const uint8_t> bytes, bool flush)
 {
     auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -403,14 +403,22 @@ static void nativeStorePendingView(JSC::VM& vm, JSNativeStreamSourceAdapter* ada
 }
 
 // Text mode: decode `bytes` against `state` and enqueue the resulting string
-// (empty strings are skipped).
+// (empty strings are skipped). A non-flush chunk that decodes to nothing arms
+// m_pullAgain via callPullIfNeeded so the pull loop keeps going while the held-
+// back bytes wait for the rest of the sequence (same contract as
+// textDecodeReadRequestChunkSteps).
 static void nativeEnqueueTextChunk(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, StreamingUTF8DecodeState& state, std::span<const uint8_t> bytes, bool flush)
 {
     auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* decoded = streamingUTF8Decode(globalObject, bytes, state, flush);
     RETURN_IF_EXCEPTION(scope, void());
-    if (!decoded || !decoded->length() || !controller)
+    if (!controller)
         return;
+    if (!decoded || !decoded->length()) {
+        if (!flush)
+            RELEASE_AND_RETURN(scope, readableStreamDefaultControllerCallPullIfNeeded(globalObject, controller));
+        return;
+    }
     readableStreamDefaultControllerEnqueue(globalObject, controller, decoded);
     RETURN_IF_EXCEPTION(scope, void());
 }

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -608,6 +608,43 @@ for (const { body, fn } of bodyTypes) {
           // The native-handle buffered fast path must not bypass the decode.
           expect(await res.textStream().text()).toBe("a\ufffdb");
         });
+        // When a multi-byte character is split so that two (or more) consecutive
+        // native pulls each decode to the empty string, the adapter must keep
+        // pulling rather than stall with a read request still pending.
+        test.each([
+          ["4-byte char as [lead][cont][cont cont]", [[0x41], [0xf0], [0x9f], [0xab, 0xa0], [0x42]], "A🫠B"],
+          ["4-byte char byte-at-a-time", [[0x41], [0xf0], [0x9f], [0xab], [0xa0], [0x42]], "A🫠B"],
+          ["3-byte char byte-at-a-time", [[0x41], [0xe4], [0xb8], [0xad], [0x42]], "A中B"],
+          ["BOM byte-at-a-time then text", [[0xef], [0xbb], [0xbf], [0x68], [0x69]], "hi"],
+        ])(
+          "completes a fetch textStream() when consecutive chunks decode to nothing: %s",
+          async (_, parts, expected) => {
+            const listening = Promise.withResolvers<void>();
+            const server = net.createServer(sock => {
+              sock.once("data", async () => {
+                sock.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
+                for (const p of parts) {
+                  sock.write(p.length.toString(16) + "\r\n");
+                  sock.write(Uint8Array.from(p));
+                  sock.write("\r\n");
+                  await new Promise(r => setImmediate(r));
+                }
+                sock.end("0\r\n\r\n");
+              });
+            });
+            server.listen(0, "127.0.0.1", () => listening.resolve());
+            await listening.promise;
+            try {
+              const { port } = server.address() as net.AddressInfo;
+              const res = await fetch(`http://127.0.0.1:${port}/`);
+              const chunks = await Array.fromAsync(res.textStream());
+              for (const chunk of chunks) expect(typeof chunk).toBe("string");
+              expect(chunks.join("")).toBe(expected);
+            } finally {
+              await new Promise<void>(r => server.close(() => r()));
+            }
+          },
+        );
       }
       if (body === Request) {
         test("streams an incoming request body server-side", async () => {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -608,10 +608,15 @@ for (const { body, fn } of bodyTypes) {
           // The native-handle buffered fast path must not bypass the decode.
           expect(await res.textStream().text()).toBe("a\ufffdb");
         });
-        // When a multi-byte character is split so that two (or more) consecutive
-        // native pulls each decode to the empty string, the adapter must keep
-        // pulling rather than stall with a read request still pending.
+        // A native pull whose bytes all decode to the empty string (held back
+        // as an incomplete UTF-8 sequence or a BOM prefix) must keep the pull
+        // loop going. Each non-empty enqueue (and the initial read) banks one
+        // re-pull via m_pullAgain, so the stall appears once two consecutive
+        // pulls decode to nothing.
         test.each([
+          ["leading 4-byte char split 2-way", [[0xf0, 0x9f], [0xab, 0xa0], [0x42]], "🫠B"],
+          ["leading 4-byte char split 3-way", [[0xf0], [0x9f, 0xab], [0xa0], [0x42]], "🫠B"],
+          ["leading 3-byte char split 2-way", [[0xe4], [0xb8, 0xad], [0x42]], "中B"],
           ["4-byte char as [lead][cont][cont cont]", [[0x41], [0xf0], [0x9f], [0xab, 0xa0], [0x42]], "A🫠B"],
           ["4-byte char byte-at-a-time", [[0x41], [0xf0], [0x9f], [0xab], [0xa0], [0x42]], "A🫠B"],
           ["3-byte char byte-at-a-time", [[0x41], [0xe4], [0xb8], [0xad], [0x42]], "A中B"],


### PR DESCRIPTION
`Body.textStream()` over a native `ByteStream` (a fetch response body) stalls forever when a multi-byte UTF-8 character is split across three or more delivered chunks, i.e. whenever two consecutive native pulls each decode to the empty string.

## Reproduction

```js
const parts = [[0x41], [0xf0], [0x9f], [0xab, 0xa0], [0x42]]; // "A" + "🫠" + "B"
const server = Bun.serve({ port: 0, fetch: () => new Response(new ReadableStream({
  async start(c) { for (const p of parts) { c.enqueue(Uint8Array.from(p)); await new Promise(r => setTimeout(r, 20)); } c.close(); },
})) });
const res = await fetch(server.url);
let out = "";
for await (const ch of res.textStream()) out += ch;  // never resolves; only "A" is delivered
```

The same origin reads correctly via `res.text()`, `res.body.pipeThrough(new TextDecoderStream())`, and `textStream()` over a user-provided `ReadableStream` body.

## Cause

`nativeEnqueueTextChunk` holds back an incomplete UTF-8 tail and returns without enqueueing. In byte mode every pull that resolves with data enqueues something, which tail-calls `callPullIfNeeded` and arms `m_pullAgain`; in text mode an all-held-back chunk skips that, so once the one buffered re-pull (set by the preceding enqueue's `callPullIfNeeded`) is consumed, the spec pull-fulfilled handler sees `pullAgain == false` and stops. The outstanding read request is never fulfilled and `handle.pull()` is never called again.

The `SourceKind::TextDecode` path (`textDecodeReadRequestChunkSteps`, used when the body is already a materialized byte `ReadableStream`) already handles the empty-decode case by calling `readableStreamDefaultControllerCallPullIfNeeded`; the native adapter path did not.

## Fix

When a non-flush decode produces no output, call `readableStreamDefaultControllerCallPullIfNeeded(controller)`. Inside a pull this sets `m_pullAgain` so the loop continues; at other call sites (`nativeSourceStart` with `m_started == false`, the push-driven `onDrain`) it is either a no-op or correctly issues the next pull.

## Verification

```
$ bun bd test test/js/web/fetch/body.test.ts
440 pass, 0 fail, 4 skip
```

New `test.each` cases in `body.test.ts` drive a raw `net.Server` that delivers each body byte as its own HTTP chunk with an event-loop yield between writes, covering: 4-byte char split as `[lead][cont][cont cont]`, 4-byte char byte-at-a-time, 3-byte char byte-at-a-time, and a byte-at-a-time BOM. All four time out on main and pass with the fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body.test.ts
bun test v1.4.0 (adef51e8b)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [4.52ms]
(pass) Request > constructor > null [3.17ms]
(pass) Request > constructor > string > "" [5.94ms]
(pass) Request > constructor > string > "Hello world" [1.47ms]
(pass) Request > constructor > string > "🫠" [1.36ms]
(pass) Request > constructor > string > "⁉️" [1.10ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [8.35ms]
(pass) Request > constructor > ArrayBuffer > small buffer [4.72ms]
(pass) Request > constructor > ArrayBuffer > large buffer [4.21ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [1.66ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [1.81ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [3.89ms]
(pass) Request > constructor > Buffer > empty buffer [1.58ms]
(pass) Request > constructor > Buffer > small buffer [1.51ms]
(pass) Request > constructor > Buffer > large buffer [3.20ms]
(pass) Request > constructor 
... (truncated)

release without fix: 93 failed, 4 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [0.12ms]
(pass) Request > constructor > null [0.04ms]
(pass) Request > constructor > string > "" [0.11ms]
(pass) Request > constructor > string > "Hello world" [0.02ms]
(pass) Request > constructor > string > "🫠" [0.02ms]
(pass) Request > constructor > string > "⁉️"
(pass) Request > constructor > ArrayBuffer > empty buffer [0.14ms]
(pass) Request > constructor > ArrayBuffer > small buffer [0.15ms]
(pass) Request > constructor > ArrayBuffer > large buffer [3.00ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [0.05ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [0.04ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [3.40ms]
(pass) Request > constructor > Buffer > empty buffer [0.06ms]
(pass) Request > constructor > Buffer > small buffer [0.03ms]
(pass) Request > constructor > Buffer > large buffer [2.97ms]
(pass) Request > constructor > Uint8Array > empty buffer [0.02ms]
(pass) Request > constructor > Uint8Array > small buffer [0.04ms]
(pass) Request > constructor > Uint8Array > large buffer [3.0
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body.test.ts
bun test v1.4.0 (adef51e8b)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [4.43ms]
(pass) Request > constructor > null [3.24ms]
(pass) Request > constructor > string > "" [5.86ms]
(pass) Request > constructor > string > "Hello world" [1.51ms]
(pass) Request > constructor > string > "🫠" [1.34ms]
(pass) Request > constructor > string > "⁉️" [1.10ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [8.26ms]
(pass) Request > constructor > ArrayBuffer > small buffer [4.75ms]
(pass) Request > constructor > ArrayBuffer > large buffer [4.25ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [1.63ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [1.87ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [3.82ms]
(pass) Request > constructor > Buffer > empty buffer [1.50ms]
(pass) Request > constructor > Buffer > small buffer [1.54ms]
(pass) Request > constructor > Buffer > large buffer [3.32ms]
(pass) Request > constructor 
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     adef51e8b1
  features     baseline

22 deps, 108 codegen, 1171 objects in 825ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [22.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] gen ErrorCode+*.h
[4/1234] gen bindgenv2
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch tinycc
[tinycc] up to date
[9/1234] fetch zlib
[zlib] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[12/1234] subst deps/zlib/zlib.h
[13/1234] fetch zstd
[zstd] up to date
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../bindings/webcore/streams/BunStreamSource.cpp   |  9 +++--
 test/js/web/fetch/body.test.ts                     | 42 ++++++++++++++++++++++
 2 files changed, 49 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/jsc/bindings/webcore/streams/BunStreamSource.cpp      2      3      0
test/js/web/fetch/body.test.ts                            3      3      0
```

</details>

<!-- robobun:evidence:end -->