### PR TITLE
test(fetch): cover textStream() empty-decode stall edges

### DIFF
--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -666,14 +666,13 @@ for (const { body, fn } of bodyTypes) {
           });
           const res = await fetch(`http://127.0.0.1:${server.port}/`);
           let received = "";
-          let error: unknown;
+          let error: any;
           try {
             for await (const ch of res.textStream()) received += ch;
           } catch (e) {
             error = e;
           }
-          expect(received).toBe("A");
-          expect(error).toBeInstanceOf(Error);
+          expect({ code: error?.code, received }).toEqual({ code: "ECONNRESET", received: "A" });
         });
       }
       if (body === Request) {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -613,6 +613,28 @@ for (const { body, fn } of bodyTypes) {
         // loop going. Each non-empty enqueue (and the initial read) banks one
         // re-pull via m_pullAgain, so the stall appears once two consecutive
         // pulls decode to nothing.
+        const rawChunkedServer = async (body: (sock: net.Socket) => Promise<void>) => {
+          const listening = Promise.withResolvers<void>();
+          const server = net.createServer(sock => {
+            sock.on("error", () => {});
+            sock.once("data", async () => {
+              sock.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
+              await body(sock);
+            });
+          });
+          server.listen(0, "127.0.0.1", () => listening.resolve());
+          await listening.promise;
+          return {
+            port: (server.address() as net.AddressInfo).port,
+            [Symbol.asyncDispose]: () => new Promise<void>(r => server.close(() => r())),
+          };
+        };
+        const writeChunk = async (sock: net.Socket, bytes: number[]) => {
+          sock.write(bytes.length.toString(16) + "\r\n");
+          sock.write(Uint8Array.from(bytes));
+          sock.write("\r\n");
+          await new Promise(r => setImmediate(r));
+        };
         test.each([
           ["leading 4-byte char split 2-way", [[0xf0, 0x9f], [0xab, 0xa0], [0x42]], "🫠B"],
           ["leading 4-byte char split 3-way", [[0xf0], [0x9f, 0xab], [0xa0], [0x42]], "🫠B"],
@@ -621,35 +643,38 @@ for (const { body, fn } of bodyTypes) {
           ["4-byte char byte-at-a-time", [[0x41], [0xf0], [0x9f], [0xab], [0xa0], [0x42]], "A🫠B"],
           ["3-byte char byte-at-a-time", [[0x41], [0xe4], [0xb8], [0xad], [0x42]], "A中B"],
           ["BOM byte-at-a-time then text", [[0xef], [0xbb], [0xbf], [0x68], [0x69]], "hi"],
+          ["incomplete tail only then close", [[0xf0], [0x9f]], "\ufffd"],
+          ["text then incomplete tail then close", [[0x41], [0xf0], [0x9f]], "A\ufffd"],
+          ["BOM prefix only then close", [[0xef], [0xbb]], "\ufffd"],
         ])(
           "completes a fetch textStream() when consecutive chunks decode to nothing: %s",
           async (_, parts, expected) => {
-            const listening = Promise.withResolvers<void>();
-            const server = net.createServer(sock => {
-              sock.once("data", async () => {
-                sock.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
-                for (const p of parts) {
-                  sock.write(p.length.toString(16) + "\r\n");
-                  sock.write(Uint8Array.from(p));
-                  sock.write("\r\n");
-                  await new Promise(r => setImmediate(r));
-                }
-                sock.end("0\r\n\r\n");
-              });
+            await using server = await rawChunkedServer(async sock => {
+              for (const p of parts) await writeChunk(sock, p);
+              sock.end("0\r\n\r\n");
             });
-            server.listen(0, "127.0.0.1", () => listening.resolve());
-            await listening.promise;
-            try {
-              const { port } = server.address() as net.AddressInfo;
-              const res = await fetch(`http://127.0.0.1:${port}/`);
-              const chunks = await Array.fromAsync(res.textStream());
-              for (const chunk of chunks) expect(typeof chunk).toBe("string");
-              expect(chunks.join("")).toBe(expected);
-            } finally {
-              await new Promise<void>(r => server.close(() => r()));
-            }
+            const res = await fetch(`http://127.0.0.1:${server.port}/`);
+            const chunks = await Array.fromAsync(res.textStream());
+            for (const chunk of chunks) expect(typeof chunk).toBe("string");
+            expect(chunks.join("")).toBe(expected);
           },
         );
+        test("rejects a fetch textStream() when the connection drops after an empty decode", async () => {
+          await using server = await rawChunkedServer(async sock => {
+            for (const p of [[0x41], [0xf0], [0x9f]]) await writeChunk(sock, p);
+            sock.destroy();
+          });
+          const res = await fetch(`http://127.0.0.1:${server.port}/`);
+          let received = "";
+          let error: unknown;
+          try {
+            for await (const ch of res.textStream()) received += ch;
+          } catch (e) {
+            error = e;
+          }
+          expect(received).toBe("A");
+          expect(error).toBeInstanceOf(Error);
+        });
       }
       if (body === Request) {
         test("streams an incoming request body server-side", async () => {
@@ -693,6 +718,34 @@ for (const { body, fn } of bodyTypes) {
           expect(result.chunks.join("")).toBe("hello world 🫠");
           expect(result.bodyUsedAfter).toBe(true);
           expect(result.secondCallThrew).toBe(true);
+        });
+        test("completes server-side when a multi-byte character is split across upload chunks", async () => {
+          const done = Promise.withResolvers<string>();
+          await using server = Bun.serve({
+            port: 0,
+            async fetch(req) {
+              try {
+                done.resolve((await Array.fromAsync(req.textStream())).join(""));
+              } catch (e: any) {
+                done.reject(e);
+              }
+              return new Response("ok");
+            },
+          });
+          const connected = Promise.withResolvers<void>();
+          const sock = net.connect(server.port, "127.0.0.1", () => connected.resolve());
+          sock.on("error", () => {});
+          await connected.promise;
+          sock.write("POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n");
+          for (const p of [[0x41], [0xf0], [0x9f], [0xab, 0xa0], [0x42]]) {
+            sock.write(p.length.toString(16) + "\r\n");
+            sock.write(Uint8Array.from(p));
+            sock.write("\r\n");
+            await new Promise(r => setImmediate(r));
+          }
+          sock.write("0\r\n\r\n");
+          expect(await done.promise).toBe("A🫠B");
+          sock.end();
         });
         test("rejects when the client aborts mid-upload server-side", async () => {
           const firstChunk = Promise.withResolvers<void>();

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -576,6 +576,12 @@ for (const { body, fn } of bodyTypes) {
         expect((await p2).done).toBe(true);
         expect(source.locked).toBe(false);
       });
+      const writeChunk = async (sock: net.Socket, bytes: number[]) => {
+        sock.write(bytes.length.toString(16) + "\r\n");
+        sock.write(Uint8Array.from(bytes));
+        sock.write("\r\n");
+        await new Promise(r => setImmediate(r));
+      };
       if (body === Response) {
         test("streams a fetch response body", async () => {
           await using server = Bun.serve({
@@ -628,12 +634,6 @@ for (const { body, fn } of bodyTypes) {
             port: (server.address() as net.AddressInfo).port,
             [Symbol.asyncDispose]: () => new Promise<void>(r => server.close(() => r())),
           };
-        };
-        const writeChunk = async (sock: net.Socket, bytes: number[]) => {
-          sock.write(bytes.length.toString(16) + "\r\n");
-          sock.write(Uint8Array.from(bytes));
-          sock.write("\r\n");
-          await new Promise(r => setImmediate(r));
         };
         test.each([
           ["leading 4-byte char split 2-way", [[0xf0, 0x9f], [0xab, 0xa0], [0x42]], "🫠B"],
@@ -736,16 +736,14 @@ for (const { body, fn } of bodyTypes) {
           const sock = net.connect(server.port, "127.0.0.1", () => connected.resolve());
           sock.on("error", () => {});
           await connected.promise;
-          sock.write("POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n");
-          for (const p of [[0x41], [0xf0], [0x9f], [0xab, 0xa0], [0x42]]) {
-            sock.write(p.length.toString(16) + "\r\n");
-            sock.write(Uint8Array.from(p));
-            sock.write("\r\n");
-            await new Promise(r => setImmediate(r));
+          try {
+            sock.write("POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n");
+            for (const p of [[0x41], [0xf0], [0x9f], [0xab, 0xa0], [0x42]]) await writeChunk(sock, p);
+            sock.write("0\r\n\r\n");
+            expect(await done.promise).toBe("A🫠B");
+          } finally {
+            sock.end();
           }
-          sock.write("0\r\n\r\n");
-          expect(await done.promise).toBe("A🫠B");
-          sock.end();
         });
         test("rejects when the client aborts mid-upload server-side", async () => {
           const firstChunk = Promise.withResolvers<void>();


### PR DESCRIPTION
Follow-up to #36180. Test-only.

Adds regression coverage for the additional faces of the native-adapter empty-decode stall, all verified to hang on b22e0e6d0a (the commit before #36180) and pass on d549845554:

- **close-after-empty**: a body that ends in (or is only) an incomplete UTF-8 tail reaches the flush decode and closes (`"\ufffd"`) instead of stalling on the final pull.
- **BOM-carry then close**: `[EF][BB]` then FIN covers the other null-returning branch of `streamingUTF8Decode` (the possible-BOM hold-back).
- **error-after-empty**: a socket drop while the last pull decoded to nothing surfaces as a rejection instead of an idle hang.
- **`req.textStream()` server-side**: a chunked upload that splits a code point across chunks completes (same `ByteStream` adapter as the fetch-response path).

Also refactors the raw-socket chunked origin into a `rawChunkedServer` helper with `Symbol.asyncDispose` so each case is a three-line `await using`.

```
$ bun bd test test/js/web/fetch/body.test.ts -t textStream
100 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/body.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/body.test.ts
bun test v1.4.0 (0cdbb3a60)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [5.03ms]
(pass) Request > constructor > null [3.19ms]
(pass) Request > constructor > string > "" [6.13ms]
(pass) Request > constructor > string > "Hello world" [1.53ms]
(pass) Request > constructor > string > "🫠" [1.42ms]
(pass) Request > constructor > string > "⁉️" [1.37ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [8.69ms]
(pass) Request > constructor > ArrayBuffer > small buffer [5.06ms]
(pass) Request > constructor > ArrayBuffer > large buffer [4.85ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [1.88ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [1.76ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [4.13ms]
(pass) Request > constructor > Buffer > empty buffer [1.53ms]
(pass) Request > constructor > Buffer > small buffer [1.52ms]
(pass) Request > constructor > Buffer > large buffer [4.65ms]
(pass) Request > constructor > Uint8Array > empty buffer [1.26ms]
(pass) Request > constructor > Uint8Array > small buffer [1.78ms]
(pass) Request > constructor > Uint8Array > large buffer [3.91ms]
(pass) Request > constructor > Uint8ClampedArray > empty buffer [1.63ms]
(pass) Request > constructor > Uint8ClampedArray > small buffer [1.55ms]
(pass) Request > constructor > Uint8ClampedArray > large buffer [3.41ms]
(pass) Request > constructor > Uint16Array > empty buffer [1.67ms]
(pass) Request > constructor > Uint16Array > small buffer [1.95ms]
(pass) Request > constructor > Uint16Array > large buffer [6.16ms]
(pass) Request > constructor > Uint32Array > empty buffer [19.54ms]
(pass) Request > constructor > Uint32Array > small buffer [2.43ms]
(pass) Request > constructor > Uint32Array > large buffer [10.54ms]
(pass) Request > constructor > Int8Array > empty buffer [1.41ms]
(
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/fetch/body.test.ts | 96 ++++++++++++++++++++++++++++++++----------
 1 file changed, 73 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
test/js/web/fetch/body.test.ts      7     10      0
```

</details>

<!-- robobun:evidence:end -->