### PR TITLE
node:os: floor fractional cgroup CPU quota in availableParallelism()

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1725,9 +1725,11 @@ JSC_DEFINE_HOST_FUNCTION(functionNavigatorGetPlatform, (JSC::JSGlobalObject * gl
 #endif
 }
 
+extern "C" int32_t Bun__availableParallelism();
+
 JSC_DEFINE_HOST_FUNCTION(functionNavigatorGetHardwareConcurrency, (JSC::JSGlobalObject*, JSC::CallFrame*))
 {
-    return JSValue::encode(JSC::jsNumber(WTF::numberOfProcessorCores()));
+    return JSValue::encode(JSC::jsNumber(Bun__availableParallelism()));
 }
 
 JSC_DECLARE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins);

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -158,8 +158,7 @@ static int bun__cgroup2_constrained_cpu(const char* cgroup_root, const char* buf
     return min_cpus;
 }
 
-// cgroup v1: cpu.cfs_{quota,period}_us under the "cpu" controller's path
-// (whole-token match, so "cpuacct" alone is skipped).
+// cgroup v1: cpu.cfs_{quota,period}_us under the "cpu" (whole-token) controller path.
 static int bun__cgroup1_constrained_cpu(const char* cgroup_root, char* buf)
 {
     char filename[4097];
@@ -216,16 +215,13 @@ static int bun__cgroup_constrained_cpu(const char* proc_self_cgroup, const char*
 }
 #endif
 
-// navigator.hardwareConcurrency / os.availableParallelism(). On Linux this
-// matches libuv's uv_available_parallelism(): min(sched_getaffinity, cgroup
-// quota) with fractional quotas truncated toward zero, where
-// WTF::numberOfProcessorCores() rounds them up. BUN_INTERNAL_CGROUP_ROOT is a
-// test-only override that returns the fixture's cgroup value directly.
+// navigator.hardwareConcurrency / os.availableParallelism(): libuv semantics (floor cgroup quota), not WTF's ceil.
 extern "C" int32_t Bun__availableParallelism()
 {
 #if OS(LINUX)
     static const int cached = [] {
         if (const char* root = getenv("BUN_INTERNAL_CGROUP_ROOT")) {
+            // Test-only override: return the fixture's cgroup value, ignore host affinity.
             char proc_path[4097];
             snprintf(proc_path, sizeof(proc_path), "%s/proc_self_cgroup", root);
             int constrained = bun__cgroup_constrained_cpu(proc_path, root);

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -228,41 +228,38 @@ static int bun__cgroup_constrained_cpu(const char* proc_self_cgroup, const char*
 // which is fine for JSC's internal pool sizing but over-reports for
 // Node-facing worker-pool sizing.
 //
-// BUN_INTERNAL_CGROUP_ROOT replaces the /sys/fs/cgroup prefix and
-// expects /proc/self/cgroup at "<root>/proc_self_cgroup"; it exists only
-// so the test suite can exercise fractional quotas without CAP_SYS_ADMIN.
+// BUN_INTERNAL_CGROUP_ROOT exists only so the test suite can exercise
+// fractional quotas without CAP_SYS_ADMIN: it reads
+// "<root>/proc_self_cgroup" and "<root>/..." in place of the real paths and
+// bypasses the host sysconf/affinity min so the fixture alone determines the
+// result.
 extern "C" int32_t Bun__availableParallelism()
 {
 #if OS(LINUX)
-    static int cached = 0;
-    if (cached > 0)
-        return cached;
+    static const int cached = [] {
+        if (const char* root = getenv("BUN_INTERNAL_CGROUP_ROOT")) {
+            char proc_path[4097];
+            snprintf(proc_path, sizeof(proc_path), "%s/proc_self_cgroup", root);
+            int constrained = bun__cgroup_constrained_cpu(proc_path, root);
+            return constrained > 0 ? constrained : 1;
+        }
 
-    long rc = sysconf(_SC_NPROCESSORS_ONLN);
+        long rc = sysconf(_SC_NPROCESSORS_ONLN);
 
-    cpu_set_t set;
-    CPU_ZERO(&set);
-    if (sched_getaffinity(0, sizeof(set), &set) == 0) {
-        long n = CPU_COUNT(&set);
-        if (n > 0 && (rc < 1 || n < rc))
-            rc = n;
-    }
+        cpu_set_t set;
+        CPU_ZERO(&set);
+        if (sched_getaffinity(0, sizeof(set), &set) == 0) {
+            long n = CPU_COUNT(&set);
+            if (n > 0 && (rc < 1 || n < rc))
+                rc = n;
+        }
 
-    const char* root = getenv("BUN_INTERNAL_CGROUP_ROOT");
-    char proc_path[4097];
-    const char* proc_self_cgroup = "/proc/self/cgroup";
-    const char* cgroup_root = "/sys/fs/cgroup";
-    if (root != NULL) {
-        snprintf(proc_path, sizeof(proc_path), "%s/proc_self_cgroup", root);
-        proc_self_cgroup = proc_path;
-        cgroup_root = root;
-    }
+        int constrained = bun__cgroup_constrained_cpu("/proc/self/cgroup", "/sys/fs/cgroup");
+        if (constrained > 0 && (rc < 1 || constrained < rc))
+            rc = constrained;
 
-    int constrained = bun__cgroup_constrained_cpu(proc_self_cgroup, cgroup_root);
-    if (constrained > 0 && (rc < 1 || constrained < rc))
-        rc = constrained;
-
-    cached = rc < 1 ? 1 : (int)rc;
+        return rc < 1 ? 1 : (int)rc;
+    }();
     return cached;
 #else
     return WTF::numberOfProcessorCores();

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1,6 +1,7 @@
 // when we don't want to use @cInclude, we can just stick wrapper functions here
 #include "root.h"
 #include <cstdio>
+#include <wtf/NumberOfCores.h>
 
 #if !OS(WINDOWS)
 #include <sys/resource.h>
@@ -96,6 +97,175 @@ extern "C" int32_t bun_sysconf__SC_NPROCESSORS_ONLN()
     return sysinfo.dwNumberOfProcessors;
 #else
     return sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+}
+
+#if OS(LINUX)
+#include <sched.h>
+
+static int bun__slurp(const char* path, char* buf, size_t len)
+{
+    int fd;
+    do {
+        fd = open(path, O_RDONLY | O_CLOEXEC);
+    } while (fd == -1 && errno == EINTR);
+    if (fd < 0)
+        return -1;
+    ssize_t n;
+    do {
+        n = read(fd, buf, len - 1);
+    } while (n == -1 && errno == EINTR);
+    close(fd);
+    if (n < 0)
+        return -1;
+    buf[n] = '\0';
+    return 0;
+}
+
+// cgroup v2: walk from the leaf named in /proc/self/cgroup up to the
+// mount root, taking the tightest cpu.max at any level.
+static int bun__cgroup2_constrained_cpu(const char* cgroup_root, const char* buf)
+{
+    char path[4097];
+    char filename[4097];
+    char line[64];
+    long long quota, period;
+    int min_cpus = 0;
+    size_t root_len = strlen(cgroup_root);
+
+    const char* p = buf + 4; /* skip "0::/" */
+    int n = (int)strcspn(p, "\n");
+    snprintf(path, sizeof(path), "%s/%.*s", cgroup_root, n, p);
+
+    while (strncmp(path, cgroup_root, root_len) == 0) {
+        snprintf(filename, sizeof(filename), "%s/cpu.max", path);
+        if (bun__slurp(filename, line, sizeof(line)) == 0
+            && strncmp(line, "max", 3) != 0
+            && sscanf(line, "%lld %lld", &quota, &period) == 2
+            && period > 0 && quota > 0) {
+            int cpus = (int)(quota / period);
+            if (cpus < 1)
+                cpus = 1;
+            if (min_cpus == 0 || cpus < min_cpus)
+                min_cpus = cpus;
+        }
+        if (strcmp(path, cgroup_root) == 0)
+            break;
+        char* slash = strrchr(path, '/');
+        if (slash == NULL)
+            break;
+        *slash = '\0';
+    }
+    return min_cpus;
+}
+
+// cgroup v1: find the line whose controller list contains "cpu" as a
+// whole token ("cpu", "cpu,cpuacct", "cpuacct,cpu") and read
+// cpu.cfs_{quota,period}_us from that path, falling back to the root
+// mount when the controller line is absent.
+static int bun__cgroup1_constrained_cpu(const char* cgroup_root, char* buf)
+{
+    char filename[4097];
+    char line[32];
+    long long quota, period;
+    const char* rel = "";
+    int rel_len = 0;
+
+    for (char* p = buf; p && *p;) {
+        char* ctl = strchr(p, ':');
+        if (!ctl) break;
+        ctl++;
+        char* path = strchr(ctl, ':');
+        if (!path) break;
+        for (char* tok = ctl; tok < path;) {
+            int len = (int)strcspn(tok, ",:");
+            if (len == 3 && strncmp(tok, "cpu", 3) == 0) {
+                path++;
+                if (*path == '/') path++;
+                rel = path;
+                rel_len = (int)strcspn(path, "\n");
+                goto found;
+            }
+            tok += len + 1;
+        }
+        p = strchr(path, '\n');
+        if (p) p++;
+    }
+found:
+    snprintf(filename, sizeof(filename), "%s/cpu/%.*s/cpu.cfs_quota_us", cgroup_root, rel_len, rel);
+    if (bun__slurp(filename, line, sizeof(line)) != 0)
+        return 0;
+    if (sscanf(line, "%lld", &quota) != 1 || quota <= 0)
+        return 0;
+
+    snprintf(filename, sizeof(filename), "%s/cpu/%.*s/cpu.cfs_period_us", cgroup_root, rel_len, rel);
+    if (bun__slurp(filename, line, sizeof(line)) != 0)
+        return 0;
+    if (sscanf(line, "%lld", &period) != 1 || period <= 0)
+        return 0;
+
+    int cpus = (int)(quota / period);
+    return cpus < 1 ? 1 : cpus;
+}
+
+static int bun__cgroup_constrained_cpu(const char* proc_self_cgroup, const char* cgroup_root)
+{
+    char buf[1024];
+    if (bun__slurp(proc_self_cgroup, buf, sizeof(buf)) != 0)
+        return 0;
+    if (strncmp(buf, "0::/", 4) == 0)
+        return bun__cgroup2_constrained_cpu(cgroup_root, buf);
+    return bun__cgroup1_constrained_cpu(cgroup_root, buf);
+}
+#endif
+
+// navigator.hardwareConcurrency / os.availableParallelism().
+//
+// On Linux this mirrors libuv's uv_available_parallelism(): the minimum of
+// sched_getaffinity's CPU count and the cgroup v1/v2 CPU quota, where a
+// fractional quota is truncated toward zero (so --cpus=2.5 reports 2, the
+// same as Node.js). WTF::numberOfProcessorCores() rounds that quota up,
+// which is fine for JSC's internal pool sizing but over-reports for
+// Node-facing worker-pool sizing.
+//
+// BUN_INTERNAL_CGROUP_ROOT replaces the /sys/fs/cgroup prefix and
+// expects /proc/self/cgroup at "<root>/proc_self_cgroup"; it exists only
+// so the test suite can exercise fractional quotas without CAP_SYS_ADMIN.
+extern "C" int32_t Bun__availableParallelism()
+{
+#if OS(LINUX)
+    static int cached = 0;
+    if (cached > 0)
+        return cached;
+
+    long rc = sysconf(_SC_NPROCESSORS_ONLN);
+
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    if (sched_getaffinity(0, sizeof(set), &set) == 0) {
+        long n = CPU_COUNT(&set);
+        if (n > 0 && (rc < 1 || n < rc))
+            rc = n;
+    }
+
+    const char* root = getenv("BUN_INTERNAL_CGROUP_ROOT");
+    char proc_path[4097];
+    const char* proc_self_cgroup = "/proc/self/cgroup";
+    const char* cgroup_root = "/sys/fs/cgroup";
+    if (root != NULL) {
+        snprintf(proc_path, sizeof(proc_path), "%s/proc_self_cgroup", root);
+        proc_self_cgroup = proc_path;
+        cgroup_root = root;
+    }
+
+    int constrained = bun__cgroup_constrained_cpu(proc_self_cgroup, cgroup_root);
+    if (constrained > 0 && (rc < 1 || constrained < rc))
+        rc = constrained;
+
+    cached = rc < 1 ? 1 : (int)rc;
+    return cached;
+#else
+    return WTF::numberOfProcessorCores();
 #endif
 }
 

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -122,8 +122,7 @@ static int bun__slurp(const char* path, char* buf, size_t len)
     return 0;
 }
 
-// cgroup v2: walk from the leaf named in /proc/self/cgroup up to the
-// mount root, taking the tightest cpu.max at any level.
+// cgroup v2: tightest cpu.max on the path from the leaf to the mount root.
 static int bun__cgroup2_constrained_cpu(const char* cgroup_root, const char* buf)
 {
     char path[4097];
@@ -159,10 +158,8 @@ static int bun__cgroup2_constrained_cpu(const char* cgroup_root, const char* buf
     return min_cpus;
 }
 
-// cgroup v1: find the line whose controller list contains "cpu" as a
-// whole token ("cpu", "cpu,cpuacct", "cpuacct,cpu") and read
-// cpu.cfs_{quota,period}_us from that path, falling back to the root
-// mount when the controller line is absent.
+// cgroup v1: cpu.cfs_{quota,period}_us under the "cpu" controller's path
+// (whole-token match, so "cpuacct" alone is skipped).
 static int bun__cgroup1_constrained_cpu(const char* cgroup_root, char* buf)
 {
     char filename[4097];
@@ -219,20 +216,11 @@ static int bun__cgroup_constrained_cpu(const char* proc_self_cgroup, const char*
 }
 #endif
 
-// navigator.hardwareConcurrency / os.availableParallelism().
-//
-// On Linux this mirrors libuv's uv_available_parallelism(): the minimum of
-// sched_getaffinity's CPU count and the cgroup v1/v2 CPU quota, where a
-// fractional quota is truncated toward zero (so --cpus=2.5 reports 2, the
-// same as Node.js). WTF::numberOfProcessorCores() rounds that quota up,
-// which is fine for JSC's internal pool sizing but over-reports for
-// Node-facing worker-pool sizing.
-//
-// BUN_INTERNAL_CGROUP_ROOT exists only so the test suite can exercise
-// fractional quotas without CAP_SYS_ADMIN: it reads
-// "<root>/proc_self_cgroup" and "<root>/..." in place of the real paths and
-// bypasses the host sysconf/affinity min so the fixture alone determines the
-// result.
+// navigator.hardwareConcurrency / os.availableParallelism(). On Linux this
+// matches libuv's uv_available_parallelism(): min(sched_getaffinity, cgroup
+// quota) with fractional quotas truncated toward zero, where
+// WTF::numberOfProcessorCores() rounds them up. BUN_INTERNAL_CGROUP_ROOT is a
+// test-only override that returns the fixture's cgroup value directly.
 extern "C" int32_t Bun__availableParallelism()
 {
 #if OS(LINUX)

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
 
@@ -231,6 +231,53 @@ it("devNull", () => {
 
 it("availableParallelism", () => {
   expect(os.availableParallelism()).toBeGreaterThan(0);
+});
+
+// A fractional cgroup CPU quota (k8s `limits.cpu: 2500m`, `docker --cpus=2.5`)
+// must be floored to match Node.js / libuv's uv_available_parallelism(), so
+// worker pools sized from os.availableParallelism() don't overshoot the quota.
+describe.skipIf(!isLinux)("availableParallelism: cgroup cpu quota rounding", () => {
+  const cases = [
+    { name: "cgroup v2", files: { proc_self_cgroup: "0::/\n", "cpu.max": "{q} 100000\n" } },
+    {
+      name: "cgroup v1",
+      files: {
+        proc_self_cgroup: "2:cpu,cpuacct:/\n1:memory:/\n",
+        "cpu/cpu.cfs_quota_us": "{q}\n",
+        "cpu/cpu.cfs_period_us": "100000\n",
+      },
+    },
+  ];
+  const script = 'process.stdout.write(require("os").availableParallelism() + " " + navigator.hardwareConcurrency)';
+  const run = async root => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_INTERNAL_CGROUP_ROOT: String(root) },
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(proc.exitCode).toBe(0);
+    return stdout;
+  };
+
+  for (const { name, files } of cases) {
+    it.concurrent(name, async () => {
+      const fill = q => Object.fromEntries(Object.entries(files).map(([k, v]) => [k, v.replace("{q}", q)]));
+
+      // 2.5 CPUs: Node.js reports 2; Bun previously reported 3.
+      using dirFrac = tempDir("cgroup-frac", fill("250000"));
+      expect(await run(dirFrac)).toBe("2 2");
+
+      // 0.5 CPUs: still floored, but clamped to at least 1.
+      using dirSub = tempDir("cgroup-sub", fill("50000"));
+      expect(await run(dirSub)).toBe("1 1");
+
+      // Integer quota is unchanged.
+      using dirInt = tempDir("cgroup-int", fill("200000"));
+      expect(await run(dirInt)).toBe("2 2");
+    });
+  }
 });
 
 it("loadavg", () => {


### PR DESCRIPTION
## What

`navigator.hardwareConcurrency` and `os.availableParallelism()` now truncate a fractional cgroup CPU quota toward zero, matching Node.js.

## Why

Both values previously flowed through `WTF::numberOfProcessorCores()`, which rounds the cgroup `cpu.max` quota **up** (`(quota + period - 1) / period`). Node.js uses libuv's `uv_available_parallelism()`, which truncates (`quota / period`). So under a fractional limit:

```
$ docker run --rm --cpus=2.5 oven/bun:canary bun -e 'console.log(require("os").availableParallelism())'
3
$ docker run --rm --cpus=2.5 node:24-slim   node -e 'console.log(require("os").availableParallelism())'
2
```

This is the common k8s `resources.limits.cpu: 2500m` shape. Anything sized from `availableParallelism()` (worker_threads / Piscina pools, Jest `--maxWorkers=%`, ported concurrency configs) runs one extra parallel unit under Bun and hits CFS throttling on the first burst. Integer quotas and cpuset affinity already agreed; only the fractional case diverged.

## How

Added `Bun__availableParallelism()` in `c-bindings.cpp` that mirrors libuv's Linux path: `min(sched_getaffinity count, floor(cgroup quota))`, clamped to `>= 1`, for both cgroup v1 (`cpu.cfs_{quota,period}_us`) and v2 (`cpu.max`, walking the hierarchy). `navigator.hardwareConcurrency` now calls this instead of `WTF::numberOfProcessorCores()`; `os.availableParallelism()` already delegates to `navigator.hardwareConcurrency`. Non-Linux still defers to WTF.

`WTF::numberOfProcessorCores()` itself is fixed to floor in oven-sh/WebKit#364; this PR ships the behaviour without waiting on a WebKit bump.

## Testing

CI runners can't create real fractional-quota cgroups (no `CAP_SYS_ADMIN`, `/sys/fs/cgroup` is read-only), so the new function honors `BUN_INTERNAL_CGROUP_ROOT` to read the cgroup files from a test-supplied directory, bypassing the host affinity/sysconf min so the fixture alone determines the result. The added tests in `test/js/node/os/os.test.js` cover cgroup v1 and v2 with quotas of 2.5 (floors to 2), 0.5 (clamps to 1), and 2.0 (unchanged).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/os/os.test.js

<!-- robobun:evidence:end -->