### PR TITLE
dns: reject non-canonical IP strings in reverse(), lookupService() and setLocalAddress()

### DIFF
--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -258,7 +258,9 @@ function validateLocalAddresses(first, second) {
     if (firstFamily === secondFamily) {
       throw localAddressError(`Cannot specify two IPv${firstFamily} addresses.`);
     }
+    return [stripZoneId(first), stripZoneId(second)];
   }
+  return [stripZoneId(first)];
 }
 
 function invalidHostname(hostname) {
@@ -394,7 +396,7 @@ function lookupService(address, port, callback) {
   }
 
   callback = guardCallback(callback);
-  dns.lookupService(address, +port).then(
+  dns.lookupService(stripZoneId(address), +port).then(
     results => {
       callback(null, ...results);
     },
@@ -702,7 +704,7 @@ var InternalResolver = class Resolver {
     callback = guardCallback(callback);
 
     Resolver.#getResolver(this)
-      .reverse(ip)
+      .reverse(stripZoneId(ip))
       .then(
         results => {
           callback(null, results);
@@ -714,8 +716,7 @@ var InternalResolver = class Resolver {
   }
 
   setLocalAddress(first, second) {
-    validateLocalAddresses(first, second);
-    Resolver.#getResolver(this).setLocalAddress(first, second);
+    Resolver.#getResolver(this).setLocalAddress(...validateLocalAddresses(first, second));
   }
 
   setServers(servers) {
@@ -850,7 +851,7 @@ const promises = {
     validatePort(port, "port");
 
     try {
-      return translateErrorCode(dns.lookupService(address, +port)).then(([hostname, service]) => ({
+      return translateErrorCode(dns.lookupService(stripZoneId(address), +port)).then(([hostname, service]) => ({
         hostname,
         service,
       }));
@@ -925,7 +926,7 @@ const promises = {
     if (isIP(ip) === 0) {
       return Promise.$reject(reverseInvalidIPError(ip));
     }
-    return translateErrorCode(dns.reverse(ip));
+    return translateErrorCode(dns.reverse(stripZoneId(ip)));
   },
 
   Resolver: class Resolver {
@@ -1021,12 +1022,11 @@ const promises = {
       if (isIP(ip) === 0) {
         return Promise.$reject(reverseInvalidIPError(ip));
       }
-      return translateErrorCode(Resolver.#getResolver(this).reverse(ip));
+      return translateErrorCode(Resolver.#getResolver(this).reverse(stripZoneId(ip)));
     }
 
     setLocalAddress(first, second) {
-      validateLocalAddresses(first, second);
-      Resolver.#getResolver(this).setLocalAddress(first, second);
+      Resolver.#getResolver(this).setLocalAddress(...validateLocalAddresses(first, second));
     }
 
     setServers(servers) {

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -120,10 +120,7 @@ function stripZoneId(host) {
   return pct === -1 ? host : host.slice(0, pct);
 }
 
-// The address uv_inet_pton would parse out of `ip`, in the form ares_inet_pton
-// accepts, or null. uv_inet_pton only strips a zone id when parsing as IPv6, so
-// "1.2.3.4%x" is invalid while "fe80::1%br_lan" is fe80::1 even though isIP()
-// rejects the underscore in the zone.
+// uv_inet_pton semantics: a zone id is dropped from an IPv6 literal, whatever it contains.
 function normalizeIP(ip) {
   if (isIP(ip) === 4) return ip;
   const bare = stripZoneId(ip);

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -120,6 +120,30 @@ function stripZoneId(host) {
   return pct === -1 ? host : host.slice(0, pct);
 }
 
+// The address uv_inet_pton would parse out of `ip`, in the form ares_inet_pton
+// accepts, or null. uv_inet_pton only strips a zone id when parsing as IPv6, so
+// "1.2.3.4%x" is invalid while "fe80::1%br_lan" is fe80::1 even though isIP()
+// rejects the underscore in the zone.
+function normalizeIP(ip) {
+  if (isIP(ip) === 4) return ip;
+  const bare = stripZoneId(ip);
+  return isIP(bare) === 6 ? bare : null;
+}
+
+// Node reports the caller's string, zone id included, on a failed reverse().
+function reverseOn(object, address, ip) {
+  const promise = object.reverse(address);
+  if (address === ip) return promise;
+  return promise.catch(error => {
+    error = withTranslatedError(error);
+    if (typeof error?.hostname === "string") {
+      error.hostname = ip;
+      error.message = `${error.syscall} ${error.code} ${ip}`;
+    }
+    return Promise.$reject(error);
+  });
+}
+
 function setServersOn(servers, object) {
   validateArray(servers, "servers");
 
@@ -245,22 +269,25 @@ function validateResolve(hostname, callback) {
 
 function validateLocalAddresses(first, second) {
   validateString(first, "ipv4");
-  const firstFamily = isIP(first);
-  if (firstFamily === 0) {
-    throw localAddressError("Invalid IP address.");
-  }
   if (typeof second !== "undefined") {
     validateString(second, "ipv6");
-    const secondFamily = isIP(second);
-    if (secondFamily === 0) {
-      throw localAddressError("Invalid IP address.");
-    }
-    if (firstFamily === secondFamily) {
-      throw localAddressError(`Cannot specify two IPv${firstFamily} addresses.`);
-    }
-    return [stripZoneId(first), stripZoneId(second)];
   }
-  return [stripZoneId(first)];
+  const firstAddress = normalizeIP(first);
+  if (firstAddress === null) {
+    throw localAddressError("Invalid IP address.");
+  }
+  if (typeof second === "undefined") {
+    return [firstAddress];
+  }
+  const secondAddress = normalizeIP(second);
+  if (secondAddress === null) {
+    throw localAddressError("Invalid IP address.");
+  }
+  const firstFamily = isIP(firstAddress);
+  if (firstFamily === isIP(secondAddress)) {
+    throw localAddressError(`Cannot specify two IPv${firstFamily} addresses.`);
+  }
+  return [firstAddress, secondAddress];
 }
 
 function invalidHostname(hostname) {
@@ -698,21 +725,20 @@ var InternalResolver = class Resolver {
     if (typeof callback !== "function") {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
     }
-    if (isIP(ip) === 0) {
+    const address = normalizeIP(ip);
+    if (address === null) {
       throw reverseInvalidIPError(ip);
     }
     callback = guardCallback(callback);
 
-    Resolver.#getResolver(this)
-      .reverse(stripZoneId(ip))
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    reverseOn(Resolver.#getResolver(this), address, ip).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   setLocalAddress(first, second) {
@@ -923,10 +949,11 @@ const promises = {
   },
   reverse(ip) {
     validateString(ip, "name");
-    if (isIP(ip) === 0) {
+    const address = normalizeIP(ip);
+    if (address === null) {
       return Promise.$reject(reverseInvalidIPError(ip));
     }
-    return translateErrorCode(dns.reverse(stripZoneId(ip)));
+    return translateErrorCode(reverseOn(dns, address, ip));
   },
 
   Resolver: class Resolver {
@@ -1019,10 +1046,11 @@ const promises = {
 
     reverse(ip) {
       validateString(ip, "name");
-      if (isIP(ip) === 0) {
+      const address = normalizeIP(ip);
+      if (address === null) {
         return Promise.$reject(reverseInvalidIPError(ip));
       }
-      return translateErrorCode(Resolver.#getResolver(this).reverse(stripZoneId(ip)));
+      return translateErrorCode(reverseOn(Resolver.#getResolver(this), address, ip));
     }
 
     setLocalAddress(first, second) {

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -43,6 +43,7 @@ const errorCodes = {
 const IANA_DNS_PORT = 53;
 const IPv6RE = /^\[([^[\]]*)\]/;
 const addrSplitRE = /(^.+?)(?::(\d+))?$/;
+const UV_EINVAL = process.platform === "win32" ? -4071 : -22;
 
 function translateErrorCode(promise: Promise<any>) {
   return promise.catch(error => {
@@ -96,6 +97,21 @@ function setDefaultResultOrder(order) {
 
 function getDefaultResultOrder() {
   return defaultResultOrder();
+}
+
+function reverseInvalidIPError(ip) {
+  const err = new Error(ip ? `getHostByAddr EINVAL ${ip}` : "getHostByAddr EINVAL");
+  err.errno = UV_EINVAL;
+  err.code = "EINVAL";
+  err.syscall = "getHostByAddr";
+  if (ip) err.hostname = ip;
+  return err;
+}
+
+function localAddressError(message) {
+  const err = $makeTypeError(message);
+  err.code = "ERR_INVALID_ARG_VALUE";
+  return err;
 }
 
 // ares_inet_pton rejects IPv6 zone identifiers; Node's uv_inet_pton strips them.
@@ -228,9 +244,20 @@ function validateResolve(hostname, callback) {
 }
 
 function validateLocalAddresses(first, second) {
-  validateString(first);
+  validateString(first, "ipv4");
+  const firstFamily = isIP(first);
+  if (firstFamily === 0) {
+    throw localAddressError("Invalid IP address.");
+  }
   if (typeof second !== "undefined") {
-    validateString(second);
+    validateString(second, "ipv6");
+    const secondFamily = isIP(second);
+    if (secondFamily === 0) {
+      throw localAddressError("Invalid IP address.");
+    }
+    if (firstFamily === secondFamily) {
+      throw localAddressError(`Cannot specify two IPv${firstFamily} addresses.`);
+    }
   }
 }
 
@@ -358,12 +385,13 @@ function lookupService(address, port, callback) {
     throw $ERR_MISSING_ARGS("address", "port", "callback");
   }
 
+  if (isIP(address) === 0) {
+    throw $ERR_INVALID_ARG_VALUE("address", address);
+  }
+  validatePort(port, "port");
   if (typeof callback !== "function") {
     throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
   }
-
-  validateString(address);
-  validatePort(port, "port");
 
   callback = guardCallback(callback);
   dns.lookupService(address, +port).then(
@@ -664,8 +692,12 @@ var InternalResolver = class Resolver {
     if (arguments.length > 2) {
       callback = arguments[2];
     }
+    validateString(ip, "name");
     if (typeof callback !== "function") {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
+    }
+    if (isIP(ip) === 0) {
+      throw reverseInvalidIPError(ip);
     }
     callback = guardCallback(callback);
 
@@ -812,7 +844,9 @@ const promises = {
       throw $ERR_MISSING_ARGS("address", "port");
     }
 
-    validateString(address);
+    if (isIP(address) === 0) {
+      throw $ERR_INVALID_ARG_VALUE("address", address);
+    }
     validatePort(port, "port");
 
     try {
@@ -887,6 +921,10 @@ const promises = {
     return translateErrorCode(dns.resolveCname(hostname));
   },
   reverse(ip) {
+    validateString(ip, "name");
+    if (isIP(ip) === 0) {
+      return Promise.$reject(reverseInvalidIPError(ip));
+    }
     return translateErrorCode(dns.reverse(ip));
   },
 
@@ -979,6 +1017,10 @@ const promises = {
     }
 
     reverse(ip) {
+      validateString(ip, "name");
+      if (isIP(ip) === 0) {
+        return Promise.$reject(reverseInvalidIPError(ip));
+      }
       return translateErrorCode(Resolver.#getResolver(this).reverse(ip));
     }
 

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -127,18 +127,25 @@ function normalizeIP(ip) {
   return isIP(bare) === 6 ? bare : null;
 }
 
-// Node reports the caller's string, zone id included, on a failed reverse().
+// Node reports the caller's address argument, zone id included, on a failure.
+function rejectWithHostname(error, hostname) {
+  error = withTranslatedError(error);
+  if (typeof error?.hostname === "string") {
+    error.hostname = hostname;
+    error.message = `${error.syscall} ${error.code} ${hostname}`;
+  }
+  return Promise.$reject(error);
+}
+
 function reverseOn(object, address, ip) {
   const promise = object.reverse(address);
   if (address === ip) return promise;
-  return promise.catch(error => {
-    error = withTranslatedError(error);
-    if (typeof error?.hostname === "string") {
-      error.hostname = ip;
-      error.message = `${error.syscall} ${error.code} ${ip}`;
-    }
-    return Promise.$reject(error);
-  });
+  return promise.catch(error => rejectWithHostname(error, ip));
+}
+
+// The native error names the "address|port" request key, so always rewrite it.
+function lookupServiceFor(address, port) {
+  return dns.lookupService(stripZoneId(address), port).catch(error => rejectWithHostname(error, address));
 }
 
 function setServersOn(servers, object) {
@@ -420,7 +427,7 @@ function lookupService(address, port, callback) {
   }
 
   callback = guardCallback(callback);
-  dns.lookupService(stripZoneId(address), +port).then(
+  lookupServiceFor(address, +port).then(
     results => {
       callback(null, ...results);
     },
@@ -874,7 +881,7 @@ const promises = {
     validatePort(port, "port");
 
     try {
-      return translateErrorCode(dns.lookupService(stripZoneId(address), +port)).then(([hostname, service]) => ({
+      return translateErrorCode(lookupServiceFor(address, +port)).then(([hostname, service]) => ({
         hostname,
         service,
       }));

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -602,7 +602,7 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
     let srvError;
     const srv = dgram.createSocket("udp4");
     try {
-      srv.on("error", err => (srvError = err));
+      srv.on("error", err => (srvError ??= err));
       await new Promise((resolve, reject) => {
         srv.once("error", reject);
         srv.bind(0, "127.0.0.1", resolve);
@@ -743,8 +743,10 @@ describe("dns.lookupService rejects non-IP address strings", () => {
     // lookupService() resolves PTR through the default resolver, so point it at a
     // local NXDOMAIN responder in a child process. The responder records each name.
     const wire = [];
+    let srvError;
     const srv = dgram.createSocket("udp4");
     try {
+      srv.on("error", err => (srvError ??= err));
       await new Promise((resolve, reject) => {
         srv.once("error", reject);
         srv.bind(0, "127.0.0.1", resolve);
@@ -780,6 +782,7 @@ describe("dns.lookupService rejects non-IP address strings", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(srvError).toBeUndefined();
       expect(stderr).toBe("");
       expect(JSON.parse(stdout)).toEqual([
         {

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -739,30 +739,70 @@ describe("dns.lookupService rejects non-IP address strings", () => {
     );
   });
 
-  it("accepts an IPv6 zone id and resolves the address without it", async () => {
-    // getnameinfo for ::1 is environment dependent, so assert that the zoned
-    // form yields the same outcome as the bare one rather than a specific result.
-    const settle = p =>
-      p.then(
-        v => ({ ok: v }),
-        e => ({ err: e.code }),
-      );
-    const viaCallback = address => {
-      const { promise, resolve } = Promise.withResolvers();
-      dns.lookupService(address, 22, (err, hostname, service) =>
-        resolve(err ? { err: err.code } : { ok: { hostname, service } }),
-      );
-      return promise;
-    };
-    const [zonedP, bareP, zonedCb, bareCb] = await Promise.all([
-      settle(dns_promises.lookupService("::1%lo0", 22)),
-      settle(dns_promises.lookupService("::1", 22)),
-      viaCallback("::1%lo0"),
-      viaCallback("::1"),
-    ]);
-    expect(zonedP).toEqual(bareP);
-    expect(zonedCb).toEqual(bareCb);
-    expect(zonedP.err).not.toBe("ERR_INVALID_ARG_VALUE");
+  it("strips an IPv6 zone id for the query and reports the caller's address on failure", async () => {
+    // lookupService() resolves PTR through the default resolver, so point it at a
+    // local NXDOMAIN responder in a child process. The responder records each name.
+    const wire = [];
+    const srv = dgram.createSocket("udp4");
+    try {
+      await new Promise((resolve, reject) => {
+        srv.once("error", reject);
+        srv.bind(0, "127.0.0.1", resolve);
+      });
+      srv.on("message", (m, ri) => {
+        let o = 12;
+        const labels = [];
+        while (m[o]) {
+          labels.push(m.subarray(o + 1, o + 1 + m[o]).toString());
+          o += 1 + m[o];
+        }
+        wire.push(labels.join("."));
+        const h = Buffer.alloc(12);
+        h.writeUInt16BE(m.readUInt16BE(0), 0);
+        h.writeUInt16BE(0x8183, 2);
+        h.writeUInt16BE(1, 4);
+        srv.send(Buffer.concat([h, m.subarray(12, o + 5)]), ri.port, ri.address);
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const dns = require("node:dns");
+           dns.setServers(["127.0.0.1:" + process.argv[1]]);
+           const shape = e => ({ code: e.code, syscall: e.syscall, hostname: e.hostname, message: e.message });
+           const cb = new Promise(resolve => dns.lookupService("2001:db8::a%lo0", 22, e => resolve(shape(e))));
+           const promise = dns.promises.lookupService("2001:db8::b", 22).then(() => "resolved", shape);
+           Promise.all([cb, promise]).then(r => console.log(JSON.stringify(r)));`,
+          String(srv.address().port),
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        {
+          code: "ENOTFOUND",
+          syscall: "getnameinfo",
+          hostname: "2001:db8::a%lo0",
+          message: "getnameinfo ENOTFOUND 2001:db8::a%lo0",
+        },
+        {
+          code: "ENOTFOUND",
+          syscall: "getnameinfo",
+          hostname: "2001:db8::b",
+          message: "getnameinfo ENOTFOUND 2001:db8::b",
+        },
+      ]);
+      expect(exitCode).toBe(0);
+      expect(wire.sort()).toEqual([
+        "a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
+        "b.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
+      ]);
+    } finally {
+      await new Promise(resolve => srv.close(resolve));
+    }
   });
 });
 

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -561,6 +561,168 @@ test("dns.promises.reverse", async () => {
   }
 });
 
+describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
+  const invalid = [
+    "1.2.3",
+    "127.1",
+    "1",
+    "0x7f000001",
+    "10/8",
+    "256.1.1.1",
+    "999.9.9.9",
+    "not-an-ip",
+    "1.2.3.4.5",
+    " 1.2.3.4",
+    "1.2.3.4 ",
+    "",
+  ];
+
+  const UV_EINVAL = isWindows ? -4071 : -22;
+
+  it.each(invalid)("callback form throws synchronously for %j", ip => {
+    let called = false;
+    expect(() => dns.reverse(ip, () => (called = true))).toThrow(
+      expect.objectContaining({ code: "EINVAL", errno: UV_EINVAL, syscall: "getHostByAddr" }),
+    );
+    expect(called).toBe(false);
+  });
+
+  it("callback form validates argument types in order", () => {
+    // non-string ip is ERR_INVALID_ARG_TYPE for "name", checked before callback
+    expect(() => dns.reverse(123, () => {})).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+    expect(() => dns.reverse(123, 456)).toThrow(/"name" argument/);
+    // callback is validated before the IP string is parsed
+    expect(() => dns.reverse("1.2.3", 123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+  });
+
+  it("promises form rejects asynchronously and never queries", async () => {
+    // Local PTR responder: records every queried name and answers with a fixed PTR.
+    const wire = [];
+    let srvError;
+    const srv = dgram.createSocket("udp4");
+    try {
+      srv.on("error", err => (srvError = err));
+      await new Promise((resolve, reject) => {
+        srv.once("error", reject);
+        srv.bind(0, "127.0.0.1", resolve);
+      });
+      srv.on("message", (m, ri) => {
+        let o = 12;
+        const labels = [];
+        while (m[o]) {
+          labels.push(m.subarray(o + 1, o + 1 + m[o]).toString());
+          o += 1 + m[o];
+        }
+        o++;
+        wire.push(labels.join("."));
+        const q = m.subarray(12, o + 4);
+        const enc = n =>
+          Buffer.concat([
+            ...n.split(".").map(p => Buffer.concat([Buffer.from([p.length]), Buffer.from(p)])),
+            Buffer.from([0]),
+          ]);
+        const rd = enc("host.example");
+        const a = Buffer.concat([Buffer.from([0xc0, 12, 0, 12, 0, 1, 0, 0, 0, 60, 0, rd.length]), rd]);
+        const h = Buffer.alloc(12);
+        h.writeUInt16BE(m.readUInt16BE(0), 0);
+        h.writeUInt16BE(0x8180, 2);
+        h.writeUInt16BE(1, 4);
+        h.writeUInt16BE(1, 6);
+        srv.send(Buffer.concat([h, q, a]), ri.port, ri.address);
+      });
+
+      const resolver = new dns.promises.Resolver({ timeout: 1500, tries: 1 });
+      resolver.setServers([`127.0.0.1:${srv.address().port}`]);
+
+      for (const ip of invalid) {
+        const p = resolver.reverse(ip);
+        expect(p).toBeInstanceOf(Promise);
+        let err;
+        await p.catch(e => (err = e));
+        expect(err).toEqual(
+          expect.objectContaining({
+            code: "EINVAL",
+            errno: UV_EINVAL,
+            syscall: "getHostByAddr",
+            ...(ip ? { hostname: ip } : {}),
+          }),
+        );
+        expect("hostname" in err).toBe(!!ip);
+      }
+
+      // top-level dns.promises.reverse should behave the same
+      for (const ip of ["999.9.9.9", "not-an-ip", "1.2.3.4.5"]) {
+        await expect(dns.promises.reverse(ip)).rejects.toEqual(
+          expect.objectContaining({ code: "EINVAL", syscall: "getHostByAddr", hostname: ip }),
+        );
+      }
+
+      // non-string input is a synchronous ERR_INVALID_ARG_TYPE even in the promises form
+      expect(() => dns.promises.reverse(123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+
+      // control: valid IPv4 and IPv6 still reach the local responder
+      expect(await resolver.reverse("192.0.2.1")).toEqual(["host.example"]);
+      expect(await resolver.reverse("2001:db8::5")).toEqual(["host.example"]);
+      expect(srvError).toBeUndefined();
+      expect(wire).toEqual([
+        "1.2.0.192.in-addr.arpa",
+        "5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
+      ]);
+    } finally {
+      await new Promise(resolve => srv.close(resolve));
+    }
+  });
+});
+
+describe("dns.lookupService rejects non-IP address strings", () => {
+  it.each(["127.1", "1.2.3", "0x7f000001", "google.com", "", 123])(
+    "throws ERR_INVALID_ARG_VALUE synchronously for %j",
+    address => {
+      const expected = expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" });
+      expect(() => dns.lookupService(address, 22, () => {})).toThrow(expected);
+      expect(() => dns.promises.lookupService(address, 22)).toThrow(expected);
+    },
+  );
+
+  it("validates arguments in Node's order (address, port, callback)", () => {
+    expect(() => dns.lookupService("127.1", "bad", 123)).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+    );
+    expect(() => dns.lookupService("1.2.3.4", "bad", 123)).toThrow(
+      expect.objectContaining({ code: "ERR_SOCKET_BAD_PORT" }),
+    );
+    expect(() => dns.lookupService("1.2.3.4", 22, 123)).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
+});
+
+describe("Resolver.setLocalAddress validates IP strings", () => {
+  it.each([
+    [["127.1"], "ERR_INVALID_ARG_VALUE", "Invalid IP address."],
+    [["0x7f000001"], "ERR_INVALID_ARG_VALUE", "Invalid IP address."],
+    [[""], "ERR_INVALID_ARG_VALUE", "Invalid IP address."],
+    [["1.2.3.4", "127.1"], "ERR_INVALID_ARG_VALUE", "Invalid IP address."],
+    [["1.2.3.4", "5.6.7.8"], "ERR_INVALID_ARG_VALUE", "Cannot specify two IPv4 addresses."],
+    [["::1", "::2"], "ERR_INVALID_ARG_VALUE", "Cannot specify two IPv6 addresses."],
+    [[123], "ERR_INVALID_ARG_TYPE", /"ipv4" argument/],
+    [["1.2.3.4", 123], "ERR_INVALID_ARG_TYPE", /"ipv6" argument/],
+  ])("rejects %j with %s", (args, code, message) => {
+    for (const Resolver of [dns.Resolver, dns.promises.Resolver]) {
+      const r = new Resolver();
+      expect(() => r.setLocalAddress(...args)).toThrow(expect.objectContaining({ code }));
+      expect(() => r.setLocalAddress(...args)).toThrow(message);
+    }
+  });
+
+  it.each([[["1.2.3.4"]], [["::1"]], [["1.2.3.4", "::1"]], [["::1", "1.2.3.4"]]])("accepts %j", args => {
+    for (const Resolver of [dns.Resolver, dns.promises.Resolver]) {
+      const r = new Resolver();
+      expect(() => r.setLocalAddress(...args)).not.toThrow();
+    }
+  });
+});
+
 describe("test invalid arguments", () => {
   it.each([
     // TODO: dns.resolveAny is not implemented yet
@@ -612,10 +774,10 @@ describe("test invalid arguments", () => {
   it("dns.lookupService", async () => {
     expect(() => {
       dns.lookupService("", 443, (err, hostname, service) => {});
-    }).toThrow("Expected address to be a non-empty string for 'lookupService'.");
+    }).toThrow("The argument 'address' is invalid. Received ''");
     expect(() => {
       dns.lookupService("google.com", 443, (err, hostname, service) => {});
-    }).toThrow(`The "address" argument is invalid. Received type string ('google.com')`);
+    }).toThrow("The argument 'address' is invalid. Received 'google.com'");
   });
 });
 

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -660,14 +660,21 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
       // non-string input is a synchronous ERR_INVALID_ARG_TYPE even in the promises form
       expect(() => dns.promises.reverse(123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
 
-      // control: valid IPv4 and IPv6 still reach the local responder
+      // control: valid IPv4 and IPv6 still reach the local responder, and an
+      // IPv6 zone id is stripped the way uv_inet_pton strips it (c-ares rejects it)
+      const v6ptr = last => `${last}.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa`;
       expect(await resolver.reverse("192.0.2.1")).toEqual(["host.example"]);
       expect(await resolver.reverse("2001:db8::5")).toEqual(["host.example"]);
+      expect(await resolver.reverse("2001:db8::6%lo0")).toEqual(["host.example"]);
+
+      const cbResolver = new dns.Resolver({ timeout: 1500, tries: 1 });
+      cbResolver.setServers([`127.0.0.1:${srv.address().port}`]);
+      const { promise, resolve, reject } = Promise.withResolvers();
+      cbResolver.reverse("2001:db8::7%lo0", (err, hostnames) => (err ? reject(err) : resolve(hostnames)));
+      expect(await promise).toEqual(["host.example"]);
+
       expect(srvError).toBeUndefined();
-      expect(wire).toEqual([
-        "1.2.0.192.in-addr.arpa",
-        "5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
-      ]);
+      expect(wire).toEqual(["1.2.0.192.in-addr.arpa", v6ptr(5), v6ptr(6), v6ptr(7)]);
     } finally {
       await new Promise(resolve => srv.close(resolve));
     }
@@ -695,6 +702,32 @@ describe("dns.lookupService rejects non-IP address strings", () => {
       expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
     );
   });
+
+  it("accepts an IPv6 zone id and resolves the address without it", async () => {
+    // getnameinfo for ::1 is environment dependent, so assert that the zoned
+    // form yields the same outcome as the bare one rather than a specific result.
+    const settle = p =>
+      p.then(
+        v => ({ ok: v }),
+        e => ({ err: e.code }),
+      );
+    const viaCallback = address => {
+      const { promise, resolve } = Promise.withResolvers();
+      dns.lookupService(address, 22, (err, hostname, service) =>
+        resolve(err ? { err: err.code } : { ok: { hostname, service } }),
+      );
+      return promise;
+    };
+    const [zonedP, bareP, zonedCb, bareCb] = await Promise.all([
+      settle(dns_promises.lookupService("::1%lo0", 22)),
+      settle(dns_promises.lookupService("::1", 22)),
+      viaCallback("::1%lo0"),
+      viaCallback("::1"),
+    ]);
+    expect(zonedP).toEqual(bareP);
+    expect(zonedCb).toEqual(bareCb);
+    expect(zonedP.err).not.toBe("ERR_INVALID_ARG_VALUE");
+  });
 });
 
 describe("Resolver.setLocalAddress validates IP strings", () => {
@@ -715,7 +748,15 @@ describe("Resolver.setLocalAddress validates IP strings", () => {
     }
   });
 
-  it.each([[["1.2.3.4"]], [["::1"]], [["1.2.3.4", "::1"]], [["::1", "1.2.3.4"]]])("accepts %j", args => {
+  it.each([
+    [["1.2.3.4"]],
+    [["::1"]],
+    [["1.2.3.4", "::1"]],
+    [["::1", "1.2.3.4"]],
+    // uv_inet_pton strips an IPv6 zone id; c-ares would reject it
+    [["fe80::1%lo0"]],
+    [["1.2.3.4", "fe80::1%lo0"]],
+  ])("accepts %j", args => {
     for (const Resolver of [dns.Resolver, dns.promises.Resolver]) {
       const r = new Resolver();
       expect(() => r.setLocalAddress(...args)).not.toThrow();

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 import * as dgram from "node:dgram";
 import * as dns from "node:dns";
@@ -596,12 +596,44 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
     expect(() => dns.reverse("1.2.3", 123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
   });
 
-  it("promises form rejects asynchronously and never queries", async () => {
-    // Local PTR responder: records every queried name and answers with a fixed PTR.
+  it("top-level dns.promises.reverse rejects asynchronously", async () => {
+    for (const ip of ["999.9.9.9", "not-an-ip", "1.2.3.4.5"]) {
+      await expect(dns.promises.reverse(ip)).rejects.toEqual(
+        expect.objectContaining({ code: "EINVAL", syscall: "getHostByAddr", hostname: ip }),
+      );
+    }
+    // non-string input is a synchronous ERR_INVALID_ARG_TYPE even in the promises form
+    expect(() => dns.promises.reverse(123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+  });
+
+  // The tests below share one loopback PTR responder. It records every queried
+  // name, answers "host.example", and returns NXDOMAIN for names whose first
+  // label is a hex letter (…::a through …::f). Each test consumes the names it
+  // expects to have produced, so an invalid input that leaked a query would show
+  // up in the next test's expectation.
+  describe("against a local PTR responder", () => {
     const wire = [];
+    let srv;
     let srvError;
-    const srv = dgram.createSocket("udp4");
-    try {
+    let resolver;
+    let cbResolver;
+
+    const v6ptr = last => `${last}.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa`;
+    const notFound = ip =>
+      expect.objectContaining({
+        code: "ENOTFOUND",
+        syscall: "getHostByAddr",
+        hostname: ip,
+        message: `getHostByAddr ENOTFOUND ${ip}`,
+      });
+    const cbReverse = ip => {
+      const { promise, resolve } = Promise.withResolvers();
+      cbResolver.reverse(ip, (err, hostnames) => resolve(err ?? hostnames));
+      return promise;
+    };
+
+    beforeAll(async () => {
+      srv = dgram.createSocket("udp4");
       srv.on("error", err => (srvError ??= err));
       await new Promise((resolve, reject) => {
         srv.once("error", reject);
@@ -624,7 +656,6 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
           ]);
         const rd = enc("host.example");
         const a = Buffer.concat([Buffer.from([0xc0, 12, 0, 12, 0, 1, 0, 0, 0, 60, 0, rd.length]), rd]);
-        // Names whose first label is a hex letter (…::a through …::f) get NXDOMAIN.
         const nxdomain = /^[a-f]$/.test(labels[0]);
         const h = Buffer.alloc(12);
         h.writeUInt16BE(m.readUInt16BE(0), 0);
@@ -633,85 +664,60 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
         h.writeUInt16BE(nxdomain ? 0 : 1, 6);
         srv.send(nxdomain ? Buffer.concat([h, q]) : Buffer.concat([h, q, a]), ri.port, ri.address);
       });
+      const servers = [`127.0.0.1:${srv.address().port}`];
+      resolver = new dns.promises.Resolver({ timeout: 1500, tries: 1 });
+      resolver.setServers(servers);
+      cbResolver = new dns.Resolver({ timeout: 1500, tries: 1 });
+      cbResolver.setServers(servers);
+    });
 
-      const resolver = new dns.promises.Resolver({ timeout: 1500, tries: 1 });
-      resolver.setServers([`127.0.0.1:${srv.address().port}`]);
+    afterAll(async () => {
+      await new Promise(resolve => srv.close(resolve));
+    });
 
-      for (const ip of invalid) {
-        const p = resolver.reverse(ip);
-        expect(p).toBeInstanceOf(Promise);
-        let err;
-        await p.catch(e => (err = e));
-        expect(err).toEqual(
-          expect.objectContaining({
-            code: "EINVAL",
-            errno: UV_EINVAL,
-            syscall: "getHostByAddr",
-            ...(ip ? { hostname: ip } : {}),
-          }),
-        );
-        expect("hostname" in err).toBe(!!ip);
-      }
+    it.each(invalid)("promises Resolver rejects %j without querying", async ip => {
+      const p = resolver.reverse(ip);
+      expect(p).toBeInstanceOf(Promise);
+      let err;
+      await p.catch(e => (err = e));
+      expect(err).toEqual(
+        expect.objectContaining({
+          code: "EINVAL",
+          errno: UV_EINVAL,
+          syscall: "getHostByAddr",
+          ...(ip ? { hostname: ip } : {}),
+        }),
+      );
+      expect("hostname" in err).toBe(!!ip);
+    });
 
-      // top-level dns.promises.reverse should behave the same
-      for (const ip of ["999.9.9.9", "not-an-ip", "1.2.3.4.5"]) {
-        await expect(dns.promises.reverse(ip)).rejects.toEqual(
-          expect.objectContaining({ code: "EINVAL", syscall: "getHostByAddr", hostname: ip }),
-        );
-      }
-
-      // non-string input is a synchronous ERR_INVALID_ARG_TYPE even in the promises form
-      expect(() => dns.promises.reverse(123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
-
-      // A zone id on an IPv4 literal is invalid, as it is for uv_inet_pton.
+    it("rejects a zone id on an IPv4 literal, as uv_inet_pton does", async () => {
       await expect(resolver.reverse("192.0.2.1%lo0")).rejects.toEqual(
         expect.objectContaining({ code: "EINVAL", hostname: "192.0.2.1%lo0" }),
       );
+    });
 
-      // control: valid IPv4 and IPv6 still reach the local responder, and an
-      // IPv6 zone id is stripped the way uv_inet_pton strips it (c-ares rejects
-      // it), even one isIP() would not accept, like an interface name with "_".
-      const v6ptr = last => `${last}.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa`;
+    it("queries valid IPv4 and IPv6 literals", async () => {
+      expect(wire.splice(0)).toEqual([]);
       expect(await resolver.reverse("192.0.2.1")).toEqual(["host.example"]);
       expect(await resolver.reverse("2001:db8::5")).toEqual(["host.example"]);
+      expect(wire.splice(0)).toEqual(["1.2.0.192.in-addr.arpa", v6ptr(5)]);
+    });
+
+    it("strips an IPv6 zone id before querying, including one isIP() rejects", async () => {
       expect(await resolver.reverse("2001:db8::6%lo0")).toEqual(["host.example"]);
       expect(await resolver.reverse("2001:db8::7%br_lan")).toEqual(["host.example"]);
-
-      const cbResolver = new dns.Resolver({ timeout: 1500, tries: 1 });
-      cbResolver.setServers([`127.0.0.1:${srv.address().port}`]);
-      const cbReverse = ip => {
-        const { promise, resolve } = Promise.withResolvers();
-        cbResolver.reverse(ip, (err, hostnames) => resolve(err ?? hostnames));
-        return promise;
-      };
       expect(await cbReverse("2001:db8::8%br_lan")).toEqual(["host.example"]);
+      expect(wire.splice(0)).toEqual([v6ptr(6), v6ptr(7), v6ptr(8)]);
+    });
 
-      // A failed lookup reports the caller's string, zone id included, like Node.
-      const notFound = ip =>
-        expect.objectContaining({
-          code: "ENOTFOUND",
-          syscall: "getHostByAddr",
-          hostname: ip,
-          message: `getHostByAddr ENOTFOUND ${ip}`,
-        });
+    it("reports the caller's string, zone id included, when the lookup fails", async () => {
       await expect(resolver.reverse("2001:db8::a%br_lan")).rejects.toEqual(notFound("2001:db8::a%br_lan"));
       expect(await cbReverse("2001:db8::b%lo0")).toEqual(notFound("2001:db8::b%lo0"));
       await expect(resolver.reverse("2001:db8::c")).rejects.toEqual(notFound("2001:db8::c"));
-
+      expect(wire.splice(0)).toEqual([v6ptr("a"), v6ptr("b"), v6ptr("c")]);
       expect(srvError).toBeUndefined();
-      expect(wire).toEqual([
-        "1.2.0.192.in-addr.arpa",
-        v6ptr(5),
-        v6ptr(6),
-        v6ptr(7),
-        v6ptr(8),
-        v6ptr("a"),
-        v6ptr("b"),
-        v6ptr("c"),
-      ]);
-    } finally {
-      await new Promise(resolve => srv.close(resolve));
-    }
+    });
   });
 });
 

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -574,6 +574,7 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
     "1.2.3.4.5",
     " 1.2.3.4",
     "1.2.3.4 ",
+    "%lo0",
     "",
   ];
 
@@ -623,12 +624,14 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
           ]);
         const rd = enc("host.example");
         const a = Buffer.concat([Buffer.from([0xc0, 12, 0, 12, 0, 1, 0, 0, 0, 60, 0, rd.length]), rd]);
+        // Names whose first label is a hex letter (…::a through …::f) get NXDOMAIN.
+        const nxdomain = /^[a-f]$/.test(labels[0]);
         const h = Buffer.alloc(12);
         h.writeUInt16BE(m.readUInt16BE(0), 0);
-        h.writeUInt16BE(0x8180, 2);
+        h.writeUInt16BE(nxdomain ? 0x8183 : 0x8180, 2);
         h.writeUInt16BE(1, 4);
-        h.writeUInt16BE(1, 6);
-        srv.send(Buffer.concat([h, q, a]), ri.port, ri.address);
+        h.writeUInt16BE(nxdomain ? 0 : 1, 6);
+        srv.send(nxdomain ? Buffer.concat([h, q]) : Buffer.concat([h, q, a]), ri.port, ri.address);
       });
 
       const resolver = new dns.promises.Resolver({ timeout: 1500, tries: 1 });
@@ -660,21 +663,52 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
       // non-string input is a synchronous ERR_INVALID_ARG_TYPE even in the promises form
       expect(() => dns.promises.reverse(123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
 
+      // A zone id on an IPv4 literal is invalid, as it is for uv_inet_pton.
+      await expect(resolver.reverse("192.0.2.1%lo0")).rejects.toEqual(
+        expect.objectContaining({ code: "EINVAL", hostname: "192.0.2.1%lo0" }),
+      );
+
       // control: valid IPv4 and IPv6 still reach the local responder, and an
-      // IPv6 zone id is stripped the way uv_inet_pton strips it (c-ares rejects it)
+      // IPv6 zone id is stripped the way uv_inet_pton strips it (c-ares rejects
+      // it), even one isIP() would not accept, like an interface name with "_".
       const v6ptr = last => `${last}.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa`;
       expect(await resolver.reverse("192.0.2.1")).toEqual(["host.example"]);
       expect(await resolver.reverse("2001:db8::5")).toEqual(["host.example"]);
       expect(await resolver.reverse("2001:db8::6%lo0")).toEqual(["host.example"]);
+      expect(await resolver.reverse("2001:db8::7%br_lan")).toEqual(["host.example"]);
 
       const cbResolver = new dns.Resolver({ timeout: 1500, tries: 1 });
       cbResolver.setServers([`127.0.0.1:${srv.address().port}`]);
-      const { promise, resolve, reject } = Promise.withResolvers();
-      cbResolver.reverse("2001:db8::7%lo0", (err, hostnames) => (err ? reject(err) : resolve(hostnames)));
-      expect(await promise).toEqual(["host.example"]);
+      const cbReverse = ip => {
+        const { promise, resolve } = Promise.withResolvers();
+        cbResolver.reverse(ip, (err, hostnames) => resolve(err ?? hostnames));
+        return promise;
+      };
+      expect(await cbReverse("2001:db8::8%br_lan")).toEqual(["host.example"]);
+
+      // A failed lookup reports the caller's string, zone id included, like Node.
+      const notFound = ip =>
+        expect.objectContaining({
+          code: "ENOTFOUND",
+          syscall: "getHostByAddr",
+          hostname: ip,
+          message: `getHostByAddr ENOTFOUND ${ip}`,
+        });
+      await expect(resolver.reverse("2001:db8::a%br_lan")).rejects.toEqual(notFound("2001:db8::a%br_lan"));
+      expect(await cbReverse("2001:db8::b%lo0")).toEqual(notFound("2001:db8::b%lo0"));
+      await expect(resolver.reverse("2001:db8::c")).rejects.toEqual(notFound("2001:db8::c"));
 
       expect(srvError).toBeUndefined();
-      expect(wire).toEqual(["1.2.0.192.in-addr.arpa", v6ptr(5), v6ptr(6), v6ptr(7)]);
+      expect(wire).toEqual([
+        "1.2.0.192.in-addr.arpa",
+        v6ptr(5),
+        v6ptr(6),
+        v6ptr(7),
+        v6ptr(8),
+        v6ptr("a"),
+        v6ptr("b"),
+        v6ptr("c"),
+      ]);
     } finally {
       await new Promise(resolve => srv.close(resolve));
     }
@@ -682,7 +716,9 @@ describe("dns.reverse rejects invalid IP strings with EINVAL", () => {
 });
 
 describe("dns.lookupService rejects non-IP address strings", () => {
-  it.each(["127.1", "1.2.3", "0x7f000001", "google.com", "", 123])(
+  // Unlike reverse() and setLocalAddress(), Node gates lookupService() on isIP()
+  // itself, so a zone id isIP() rejects is rejected here too.
+  it.each(["127.1", "1.2.3", "0x7f000001", "google.com", "", 123, "fe80::1%br_lan"])(
     "throws ERR_INVALID_ARG_VALUE synchronously for %j",
     address => {
       const expected = expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" });
@@ -738,8 +774,13 @@ describe("Resolver.setLocalAddress validates IP strings", () => {
     [["1.2.3.4", "127.1"], "ERR_INVALID_ARG_VALUE", "Invalid IP address."],
     [["1.2.3.4", "5.6.7.8"], "ERR_INVALID_ARG_VALUE", "Cannot specify two IPv4 addresses."],
     [["::1", "::2"], "ERR_INVALID_ARG_VALUE", "Cannot specify two IPv6 addresses."],
+    [["::1%lo0", "::2%lo0"], "ERR_INVALID_ARG_VALUE", "Cannot specify two IPv6 addresses."],
+    // a zone id is only stripped from an IPv6 literal
+    [["1.2.3.4%lo0"], "ERR_INVALID_ARG_VALUE", "Invalid IP address."],
     [[123], "ERR_INVALID_ARG_TYPE", /"ipv4" argument/],
     [["1.2.3.4", 123], "ERR_INVALID_ARG_TYPE", /"ipv6" argument/],
+    // both types are checked before either value is parsed
+    [["not-an-ip", 123], "ERR_INVALID_ARG_TYPE", /"ipv6" argument/],
   ])("rejects %j with %s", (args, code, message) => {
     for (const Resolver of [dns.Resolver, dns.promises.Resolver]) {
       const r = new Resolver();
@@ -753,9 +794,11 @@ describe("Resolver.setLocalAddress validates IP strings", () => {
     [["::1"]],
     [["1.2.3.4", "::1"]],
     [["::1", "1.2.3.4"]],
-    // uv_inet_pton strips an IPv6 zone id; c-ares would reject it
+    // uv_inet_pton strips an IPv6 zone id (whatever it contains); c-ares would reject it
     [["fe80::1%lo0"]],
     [["1.2.3.4", "fe80::1%lo0"]],
+    [["fe80::1%br_lan"]],
+    [["fe80::1%br_lan", "1.2.3.4"]],
   ])("accepts %j", args => {
     for (const Resolver of [dns.Resolver, dns.promises.Resolver]) {
       const r = new Resolver();


### PR DESCRIPTION
### What does this PR do?

`ares_inet_pton` (the parser used by c-ares) accepts short numeric strings and zero-fills the missing octets, plus `0x` hex and `/CIDR` forms. Bun handed `dns.reverse()` / `dns.lookupService()` / `Resolver.setLocalAddress()` input straight to it, so for example `reverse("1.2.3")` silently issued a PTR query for `0.3.2.1.in-addr.arpa` (i.e. `1.2.3.0`) and resolved whatever came back, `lookupService("127.1", 22)` ran `getnameinfo` for `127.1.0.0`, and `setLocalAddress("127.1")` bound a zero-padded source address. Inputs `ares_inet_pton` did reject surfaced `ENOTIMP` from `reverse()`. Node gates all of these on `uv_inet_pton` (strict dotted quad / IPv6 literal) and rejects before anything reaches the resolver.

This validates the input in the `node:dns` wrappers, with the existing `isIP()` from `internal/net/isIP`, before it reaches the native channel:

- `reverse()` (callback `Resolver.prototype`, top-level `promises.reverse`, `promises.Resolver.prototype`): a string that is not an IP literal throws (callback form) or rejects (promises forms) with `{code: "EINVAL", errno: UV_EINVAL, syscall: "getHostByAddr", hostname}`. Non-string input is `ERR_INVALID_ARG_TYPE` for `"name"` first, and the callback type is checked before the address, which is Node's order. `errno` is the platform value of `UV_EINVAL` (`-4071` on Windows, `-22` elsewhere), as in `node/dgram.ts`.
- `lookupService()` (callback and promises): `isIP(address) === 0` throws `ERR_INVALID_ARG_VALUE` synchronously, before `validatePort` and the callback check, which is Node's order.
- `Resolver.setLocalAddress()`: `validateLocalAddresses` checks both argument types (`"ipv4"`, `"ipv6"`), then rejects a non-IP value with `ERR_INVALID_ARG_VALUE` `"Invalid IP address."` and two addresses of one family with `"Cannot specify two IPvN addresses."`.

Zone ids. Node hands `reverse()` and `setLocalAddress()` input to `uv_inet_pton`, which drops a `%zone` suffix from an IPv6 literal, whatever the zone text is. `ares_inet_pton` rejects the suffix. The new `normalizeIP()` does what `uv_inet_pton` does: an IPv4 literal is used as is, otherwise the zone is cut off with the existing `stripZoneId()` and the rest must be IPv6. So `fe80::1%br_lan` reaches c-ares as `fe80::1` (`isIP()` alone rejects the underscore), and `1.2.3.4%x` stays invalid. When a `reverse()` fails after the zone was removed, `reverseOn()` puts the caller's string back into `hostname` and `message`, as Node reports it. `lookupService()` keeps the plain `isIP()` gate because Node gates it on `isIP()` too, strips the zone for the native call, and on failure also reports the caller's address: before this change the native error named its internal `"address|port"` request key there (`getnameinfo ENOTFOUND 1.2.3.4|22`), and Node's callback form reports the address. Before this change a zoned literal got `ENOTIMP` from `reverse()`, `ERR_INVALID_ARG_VALUE` from `lookupService()` and `ERR_INVALID_IP_ADDRESS` from `setLocalAddress()`. One difference remains: Node keeps the scope id in `lookupService()`, Bun resolves the address without it.

Fixes #37313 (the `reverse("")` case). #37316 and #37317 report the same `reverse()` behavior and were closed as duplicates.

### How did you verify your code works?

New tests in `test/js/node/dns/node-dns.test.js` spin up a loopback UDP PTR responder, point a `promises.Resolver` at it, and assert that every invalid input (`"1.2.3"`, `"127.1"`, `"1"`, `"0x7f000001"`, `"10/8"`, `"256.1.1.1"`, `"999.9.9.9"`, `"not-an-ip"`, `"1.2.3.4.5"`, space-padded, `""`) rejects with `EINVAL` without anything reaching the socket, while valid `192.0.2.1` and `2001:db8::5` still resolve through it, and zoned `2001:db8::6%lo0`, `2001:db8::7%br_lan` and `2001:db8::8%br_lan` arrive at the responder as the bare ip6.arpa names through the promises and callback resolvers. The responder answers NXDOMAIN for `…::a` to `…::f`, and those rejections are asserted to carry the caller's zoned string in `hostname` and `message`. `192.0.2.1%lo0` and `%lo0` are rejected. `setLocalAddress()` accepts zoned forms (including `%br_lan`), rejects `1.2.3.4%lo0`, and reports the `"ipv6"` type error for `("not-an-ip", 123)`. For `lookupService()`, a child process points the default resolver at a local NXDOMAIN responder: `2001:db8::a%lo0` (callback) and `2001:db8::b` (promises) reach the responder as bare ip6.arpa names and reject with `hostname` and `message` naming the caller's address (without the change they name `2001:db8::a|22` and `2001:db8::b|22`), and `lookupService("fe80::1%br_lan")` is rejected as in Node. Additional cases cover the synchronous throw in the callback form, the `name`/`callback` validation order, and the `lookupService` / `setLocalAddress` validation matrix. The same assertions were verified against Node v26.3.0, and the existing `test/js/node/test/parallel/test-dns-{setlocaladdress,lookupService,lookupService-promises}.js` continue to pass.

Rebased onto main after #39552 landed. That change shifts a third argument into the callback slot at the top of `reverse()`. The rebase keeps that shift first and runs the `name` / `callback` / `isIP` checks after it, which is the order Node uses. The "a third argument shifts the callback" cases from #39552 pass together with the new tests (59 of 59 locally).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->



