### PR TITLE
node:dns: implement resolveTlsa (TLSA records)

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -33,7 +33,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:dns`](https://nodejs.org/api/dns.html)
 
-🟢 Fully implemented. Missing `resolveTlsa`. Bun ignores the `Resolver` `maxTimeout` option, and the callback-style `Resolver` class cannot be subclassed (`dns.promises.Resolver` can).
+🟢 Fully implemented. Bun ignores the `Resolver` `maxTimeout` option, and the callback-style `Resolver` class cannot be subclassed (`dns.promises.Resolver` can).
 
 ### [`node:events`](https://nodejs.org/api/events.html)
 

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -220,6 +220,8 @@ pub enum NSType {
     ns_t_nsec = 47,
     /// DNS Public Key (RFC4034)
     ns_t_dnskey = 48,
+    /// TLSA certificate association (RFC6698)
+    ns_t_tlsa = 52,
     /// Transaction key
     ns_t_tkey = 249,
     /// Transaction signature.
@@ -1166,6 +1168,145 @@ impl struct_ares_caa_reply {
             // SAFETY: same invariant as `property_bytes` — `value` points to
             // `length` bytes owned by the reply node for `&self`'s lifetime.
             unsafe { core::slice::from_raw_parts(self.value, self.length) }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// TLSA — c-ares has no legacy `ares_parse_tlsa_reply`; it's exposed only via
+// the newer `ares_dns_record` API. We parse into a Rust-owned linked list so
+// the rest of the resolver pipeline (which expects a `*mut R` list head) sees
+// the same shape as the other reply structs.
+// ──────────────────────────────────────────────────────────────────────────
+
+bun_opaque::opaque_ffi! { pub struct ares_dns_record_t; }
+bun_opaque::opaque_ffi! { pub struct ares_dns_rr_t; }
+
+pub const ARES_SECTION_ANSWER: c_int = 1;
+pub const ARES_REC_TYPE_TLSA: c_int = 52;
+pub const ARES_RR_TLSA_CERT_USAGE: c_int = ARES_REC_TYPE_TLSA * 100 + 1;
+pub const ARES_RR_TLSA_SELECTOR: c_int = ARES_REC_TYPE_TLSA * 100 + 2;
+pub const ARES_RR_TLSA_MATCH: c_int = ARES_REC_TYPE_TLSA * 100 + 3;
+pub const ARES_RR_TLSA_DATA: c_int = ARES_REC_TYPE_TLSA * 100 + 4;
+
+unsafe extern "C" {
+    pub fn ares_dns_parse(
+        buf: *const u8,
+        buf_len: usize,
+        flags: c_uint,
+        dnsrec: *mut *mut ares_dns_record_t,
+    ) -> c_int;
+    pub fn ares_dns_record_destroy(dnsrec: *mut ares_dns_record_t);
+    pub fn ares_dns_record_rr_cnt(dnsrec: *const ares_dns_record_t, sect: c_int) -> usize;
+    pub fn ares_dns_record_rr_get_const(
+        dnsrec: *const ares_dns_record_t,
+        sect: c_int,
+        idx: usize,
+    ) -> *const ares_dns_rr_t;
+    pub fn ares_dns_rr_get_type(rr: *const ares_dns_rr_t) -> c_int;
+    pub fn ares_dns_rr_get_u8(rr: *const ares_dns_rr_t, key: c_int) -> u8;
+    pub fn ares_dns_rr_get_bin(
+        rr: *const ares_dns_rr_t,
+        key: c_int,
+        len: *mut usize,
+    ) -> *const u8;
+}
+
+/// Rust-owned TLSA reply node; shaped like the other `struct_ares_*_reply`
+/// linked lists so the generic list walker and `ares_reply_callback` thunk
+/// apply unchanged.
+pub struct struct_ares_tlsa_reply {
+    pub next: *mut struct_ares_tlsa_reply,
+    pub cert_usage: u8,
+    pub selector: u8,
+    pub match_: u8,
+    pub data: Box<[u8]>,
+}
+
+impl AresReply for struct_ares_tlsa_reply {
+    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
+        // SAFETY: caller guarantees `out` is a valid stack slot.
+        unsafe { *out = ptr::null_mut() };
+
+        let mut dnsrec: *mut ares_dns_record_t = ptr::null_mut();
+        // SAFETY: caller upholds the `AresReply::parse` contract; `abuf[..alen]`
+        // is the c-ares response buffer and `&mut dnsrec` is a valid out-param.
+        let status = unsafe {
+            ares_dns_parse(
+                abuf,
+                usize::try_from(alen).unwrap_or(0),
+                0,
+                &raw mut dnsrec,
+            )
+        };
+        if status != ARES_SUCCESS {
+            // SAFETY: c-ares accepts null here.
+            unsafe { ares_dns_record_destroy(dnsrec) };
+            return status;
+        }
+        // SAFETY: `dnsrec` is non-null on success; destroyed below.
+        scopeguard::defer! { unsafe { ares_dns_record_destroy(dnsrec) }; }
+
+        let mut head: *mut Self = ptr::null_mut();
+        let mut tail: *mut *mut Self = &raw mut head;
+        // SAFETY: `dnsrec` is a live record for the duration of this scope.
+        let rr_count = unsafe { ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER) };
+        for i in 0..rr_count {
+            // SAFETY: `i < rr_count`; returned pointer borrows from `dnsrec`.
+            let rr = unsafe { ares_dns_record_rr_get_const(dnsrec, ARES_SECTION_ANSWER, i) };
+            if rr.is_null() {
+                continue;
+            }
+            // SAFETY: `rr` is non-null and borrows from `dnsrec`.
+            if unsafe { ares_dns_rr_get_type(rr) } != ARES_REC_TYPE_TLSA {
+                continue;
+            }
+            let mut data_len: usize = 0;
+            // SAFETY: `rr` is a valid TLSA record; key is `ARES_DATATYPE_BIN`.
+            let data_ptr = unsafe { ares_dns_rr_get_bin(rr, ARES_RR_TLSA_DATA, &raw mut data_len) };
+            if data_ptr.is_null() || data_len == 0 {
+                continue;
+            }
+            // SAFETY: c-ares guarantees `data_ptr[..data_len]` is readable while
+            // `dnsrec` is live; we copy into a Rust-owned buffer before destroy.
+            let data: Box<[u8]> =
+                unsafe { core::slice::from_raw_parts(data_ptr, data_len) }.into();
+            let node = Box::into_raw(Box::new(Self {
+                next: ptr::null_mut(),
+                // SAFETY: `rr` is a valid TLSA record; keys are `ARES_DATATYPE_U8`.
+                cert_usage: unsafe { ares_dns_rr_get_u8(rr, ARES_RR_TLSA_CERT_USAGE) },
+                selector: unsafe { ares_dns_rr_get_u8(rr, ARES_RR_TLSA_SELECTOR) },
+                match_: unsafe { ares_dns_rr_get_u8(rr, ARES_RR_TLSA_MATCH) },
+                data,
+            }));
+            // SAFETY: `tail` always points at either `head` or the `.next` slot
+            // of the previously appended node (both valid for write).
+            unsafe {
+                *tail = node;
+                tail = &raw mut (*node).next;
+            }
+        }
+
+        if head.is_null() {
+            return Error::ENODATA as c_int;
+        }
+        // SAFETY: caller guarantees `out` is a valid stack slot.
+        unsafe { *out = head };
+        ARES_SUCCESS
+    }
+}
+
+impl struct_ares_tlsa_reply {
+    /// Walk and drop a Rust-owned list built by `AresReply::parse`.
+    ///
+    /// # Safety
+    /// `this` must be null or the head returned from `parse`; not aliased.
+    pub unsafe fn destroy(this: *mut Self) {
+        let mut p = this;
+        while !p.is_null() {
+            // SAFETY: each node was `Box::into_raw`'d in `parse`.
+            let node = unsafe { Box::from_raw(p) };
+            p = node.next;
         }
     }
 }

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1252,7 +1252,7 @@ impl AresReply for struct_ares_tlsa_reply {
             // SAFETY: c-ares guarantees `data_ptr[..data_len]` is readable while
             // `dnsrec` is live; we copy into a Rust-owned buffer before destroy.
             let data: Box<[u8]> = unsafe { core::slice::from_raw_parts(data_ptr, data_len) }.into();
-            let node = Box::into_raw(Box::new(Self {
+            let node = bun_core::heap::into_raw(Box::new(Self {
                 next: ptr::null_mut(),
                 // SAFETY: `rr` is a valid TLSA record; keys are `ARES_DATATYPE_U8`.
                 cert_usage: unsafe { ares_dns_rr_get_u8(rr, ARES_RR_TLSA_CERT_USAGE) },
@@ -1283,8 +1283,8 @@ impl struct_ares_tlsa_reply {
     pub unsafe fn destroy(this: *mut Self) {
         let mut p = this;
         while !p.is_null() {
-            // SAFETY: each node was `Box::into_raw`'d in `parse`.
-            let node = unsafe { Box::from_raw(p) };
+            // SAFETY: each node was `heap::into_raw`'d in `parse`.
+            let node = unsafe { bun_core::heap::take(p) };
             p = node.next;
         }
     }
@@ -1395,6 +1395,7 @@ pub struct struct_any_reply {
     pub naptr_reply: *mut struct_ares_naptr_reply,
     pub soa_reply: *mut struct_ares_soa_reply,
     pub caa_reply: *mut struct_ares_caa_reply,
+    pub tlsa_reply: *mut struct_ares_tlsa_reply,
 }
 
 impl Default for struct_any_reply {
@@ -1410,6 +1411,7 @@ impl Default for struct_any_reply {
             naptr_reply: ptr::null_mut(),
             soa_reply: ptr::null_mut(),
             caa_reply: ptr::null_mut(),
+            tlsa_reply: ptr::null_mut(),
         }
     }
 }
@@ -1549,6 +1551,14 @@ impl struct_any_reply {
             last_error = Some(result);
         }
 
+        // SAFETY: see `ares_parse_mx_reply` call above.
+        result = unsafe { struct_ares_tlsa_reply::parse(abuf, alen, &raw mut reply.tlsa_reply) };
+        if result == ARES_SUCCESS {
+            any_success = true;
+        } else {
+            last_error = Some(result);
+        }
+
         if !any_success {
             return Err(Error::get(last_error.unwrap()).unwrap());
         }
@@ -1586,6 +1596,7 @@ impl Drop for struct_any_reply {
             if !self.caa_reply.is_null() {
                 ares_free_data(self.caa_reply.cast::<c_void>());
             }
+            struct_ares_tlsa_reply::destroy(self.tlsa_reply);
         }
     }
 }

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1172,13 +1172,7 @@ impl struct_ares_caa_reply {
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// TLSA — c-ares has no legacy `ares_parse_tlsa_reply`; it's exposed only via
-// the newer `ares_dns_record` API. We parse into a Rust-owned linked list so
-// the rest of the resolver pipeline (which expects a `*mut R` list head) sees
-// the same shape as the other reply structs.
-// ──────────────────────────────────────────────────────────────────────────
-
+// TLSA — c-ares has no legacy `ares_parse_tlsa_reply`, only the `ares_dns_record` API.
 bun_opaque::opaque_ffi! { pub struct ares_dns_record_t; }
 bun_opaque::opaque_ffi! { pub struct ares_dns_rr_t; }
 
@@ -1208,9 +1202,7 @@ unsafe extern "C" {
     pub fn ares_dns_rr_get_bin(rr: *const ares_dns_rr_t, key: c_int, len: *mut usize) -> *const u8;
 }
 
-/// Rust-owned TLSA reply node; shaped like the other `struct_ares_*_reply`
-/// linked lists so the generic list walker and `ares_reply_callback` thunk
-/// apply unchanged.
+/// Rust-owned TLSA reply node; `next`-linked to match the other reply structs.
 pub struct struct_ares_tlsa_reply {
     pub next: *mut struct_ares_tlsa_reply,
     pub cert_usage: u8,
@@ -1286,10 +1278,8 @@ impl AresReply for struct_ares_tlsa_reply {
 }
 
 impl struct_ares_tlsa_reply {
-    /// Walk and drop a Rust-owned list built by `AresReply::parse`.
-    ///
     /// # Safety
-    /// `this` must be null or the head returned from `parse`; not aliased.
+    /// `this` must be null or the list head from `parse`; not aliased.
     pub unsafe fn destroy(this: *mut Self) {
         let mut p = this;
         while !p.is_null() {

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1205,11 +1205,7 @@ unsafe extern "C" {
     ) -> *const ares_dns_rr_t;
     pub fn ares_dns_rr_get_type(rr: *const ares_dns_rr_t) -> c_int;
     pub fn ares_dns_rr_get_u8(rr: *const ares_dns_rr_t, key: c_int) -> u8;
-    pub fn ares_dns_rr_get_bin(
-        rr: *const ares_dns_rr_t,
-        key: c_int,
-        len: *mut usize,
-    ) -> *const u8;
+    pub fn ares_dns_rr_get_bin(rr: *const ares_dns_rr_t, key: c_int, len: *mut usize) -> *const u8;
 }
 
 /// Rust-owned TLSA reply node; shaped like the other `struct_ares_*_reply`
@@ -1231,14 +1227,8 @@ impl AresReply for struct_ares_tlsa_reply {
         let mut dnsrec: *mut ares_dns_record_t = ptr::null_mut();
         // SAFETY: caller upholds the `AresReply::parse` contract; `abuf[..alen]`
         // is the c-ares response buffer and `&mut dnsrec` is a valid out-param.
-        let status = unsafe {
-            ares_dns_parse(
-                abuf,
-                usize::try_from(alen).unwrap_or(0),
-                0,
-                &raw mut dnsrec,
-            )
-        };
+        let status =
+            unsafe { ares_dns_parse(abuf, usize::try_from(alen).unwrap_or(0), 0, &raw mut dnsrec) };
         if status != ARES_SUCCESS {
             // SAFETY: c-ares accepts null here.
             unsafe { ares_dns_record_destroy(dnsrec) };
@@ -1269,8 +1259,7 @@ impl AresReply for struct_ares_tlsa_reply {
             }
             // SAFETY: c-ares guarantees `data_ptr[..data_len]` is readable while
             // `dnsrec` is live; we copy into a Rust-owned buffer before destroy.
-            let data: Box<[u8]> =
-                unsafe { core::slice::from_raw_parts(data_ptr, data_len) }.into();
+            let data: Box<[u8]> = unsafe { core::slice::from_raw_parts(data_ptr, data_len) }.into();
             let node = Box::into_raw(Box::new(Self {
                 next: ptr::null_mut(),
                 // SAFETY: `rr` is a valid TLSA record; keys are `ARES_DATATYPE_U8`.

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1252,12 +1252,19 @@ impl AresReply for struct_ares_tlsa_reply {
             // SAFETY: c-ares guarantees `data_ptr[..data_len]` is readable while
             // `dnsrec` is live; we copy into a Rust-owned buffer before destroy.
             let data: Box<[u8]> = unsafe { core::slice::from_raw_parts(data_ptr, data_len) }.into();
+            // SAFETY: `rr` is a valid TLSA record; all three keys are `ARES_DATATYPE_U8`.
+            let (cert_usage, selector, match_) = unsafe {
+                (
+                    ares_dns_rr_get_u8(rr, ARES_RR_TLSA_CERT_USAGE),
+                    ares_dns_rr_get_u8(rr, ARES_RR_TLSA_SELECTOR),
+                    ares_dns_rr_get_u8(rr, ARES_RR_TLSA_MATCH),
+                )
+            };
             let node = bun_core::heap::into_raw(Box::new(Self {
                 next: ptr::null_mut(),
-                // SAFETY: `rr` is a valid TLSA record; keys are `ARES_DATATYPE_U8`.
-                cert_usage: unsafe { ares_dns_rr_get_u8(rr, ARES_RR_TLSA_CERT_USAGE) },
-                selector: unsafe { ares_dns_rr_get_u8(rr, ARES_RR_TLSA_SELECTOR) },
-                match_: unsafe { ares_dns_rr_get_u8(rr, ARES_RR_TLSA_MATCH) },
+                cert_usage,
+                selector,
+                match_,
                 data,
             }));
             // SAFETY: `tail` always points at either `head` or the `.next` slot

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -619,6 +619,23 @@ var InternalResolver = class Resolver {
       );
   }
 
+  resolveTlsa(hostname, callback) {
+    if (typeof callback !== "function") {
+      throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
+    }
+
+    Resolver.#getResolver(this)
+      .resolveTlsa(hostname)
+      .then(
+        results => {
+          callback(null, results);
+        },
+        error => {
+          callback(withTranslatedError(error));
+        },
+      );
+  }
+
   resolveTxt(hostname, callback) {
     if (arguments.length > 2) {
       callback = arguments[2];
@@ -709,6 +726,7 @@ var {
   resolvePtr,
   resolveSoa,
   resolveSrv,
+  resolveTlsa,
   reverse,
   resolveTxt,
 } = InternalResolver.prototype;
@@ -877,6 +895,9 @@ const promises = {
   resolveCaa(hostname) {
     return translateErrorCode(dns.resolveCaa(hostname));
   },
+  resolveTlsa(hostname) {
+    return translateErrorCode(dns.resolveTlsa(hostname));
+  },
   resolveNs(hostname) {
     return translateErrorCode(dns.resolveNs(hostname));
   },
@@ -974,6 +995,10 @@ const promises = {
       return translateErrorCode(Resolver.#getResolver(this).resolveCaa(hostname));
     }
 
+    resolveTlsa(hostname) {
+      return translateErrorCode(Resolver.#getResolver(this).resolveTlsa(hostname));
+    }
+
     resolveTxt(hostname) {
       return translateErrorCode(Resolver.#getResolver(this).resolveTxt(hostname));
     }
@@ -1014,6 +1039,7 @@ for (const [method, pMethod] of [
   [resolvePtr, promises.resolvePtr],
   [resolveSoa, promises.resolveSoa],
   [resolveSrv, promises.resolveSrv],
+  [resolveTlsa, promises.resolveTlsa],
   [resolveTxt, promises.resolveTxt],
   [resolveNaptr, promises.resolveNaptr],
 ]) {
@@ -1046,6 +1072,7 @@ export default {
   resolvePtr,
   resolveSoa,
   resolveSrv,
+  resolveTlsa,
   resolveTxt,
   resolveNaptr,
   promises,

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -620,9 +620,13 @@ var InternalResolver = class Resolver {
   }
 
   resolveTlsa(hostname, callback) {
+    if (arguments.length > 2) {
+      callback = arguments[2];
+    }
     if (typeof callback !== "function") {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
     }
+    callback = guardCallback(callback);
 
     Resolver.#getResolver(this)
       .resolveTlsa(hostname)

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -63,6 +63,7 @@ BUN_DECLARE_HOST_FUNCTION(Bun__DNS__resolveSoa);
 BUN_DECLARE_HOST_FUNCTION(Bun__DNS__resolveNaptr);
 BUN_DECLARE_HOST_FUNCTION(Bun__DNS__resolveMx);
 BUN_DECLARE_HOST_FUNCTION(Bun__DNS__resolveCaa);
+BUN_DECLARE_HOST_FUNCTION(Bun__DNS__resolveTlsa);
 BUN_DECLARE_HOST_FUNCTION(Bun__DNS__resolveNs);
 BUN_DECLARE_HOST_FUNCTION(Bun__DNS__resolvePtr);
 BUN_DECLARE_HOST_FUNCTION(Bun__DNS__resolveCname);
@@ -404,6 +405,8 @@ static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
     dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "resolveMx"_s), 2, Bun__DNS__resolveMx, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
     dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "resolveCaa"_s), 2, Bun__DNS__resolveCaa, ImplementationVisibility::Public, NoIntrinsic,
+        JSC::PropertyAttribute::DontDelete | 0);
+    dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "resolveTlsa"_s), 2, Bun__DNS__resolveTlsa, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
     dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "resolveNs"_s), 2, Bun__DNS__resolveNs, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -316,8 +316,8 @@ pub(crate) fn tlsa_reply_to_js_response(
     cares_list_to_js_array(this, global_this, tlsa_reply_to_js)
 }
 
-pub(crate) fn tlsa_reply_to_js(
-    this: &mut c_ares::struct_ares_tlsa_reply,
+fn tlsa_reply_to_js(
+    this: &c_ares::struct_ares_tlsa_reply,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
     let obj = JSValue::create_empty_object(global_this, 4);

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -617,7 +617,8 @@ fn any_reply_to_js(
         + (!this.ptr_reply.is_null()) as usize
         + (!this.naptr_reply.is_null()) as usize
         + (!this.soa_reply.is_null()) as usize
-        + (!this.caa_reply.is_null()) as usize;
+        + (!this.caa_reply.is_null()) as usize
+        + (!this.tlsa_reply.is_null()) as usize;
 
     let array = JSValue::create_empty_array(global_this, len)?;
     let mut i: u32 = 0;
@@ -677,6 +678,12 @@ fn any_reply_to_js(
         let response =
             caa_reply_to_js_response(unsafe { &mut *this.caa_reply }, global_this, b"caa")?;
         any_reply_append_all(global_this, array, &mut i, response, b"caa")?;
+    }
+    if !this.tlsa_reply.is_null() {
+        // SAFETY: non-null Rust-owned linked list head.
+        let response =
+            tlsa_reply_to_js_response(unsafe { &mut *this.tlsa_reply }, global_this, b"tlsa")?;
+        any_reply_append_all(global_this, array, &mut i, response, b"tlsa")?;
     }
 
     Ok(array)

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -247,6 +247,7 @@ impl_cares_linked!(
     c_ares::struct_ares_mx_reply,
     c_ares::struct_ares_txt_reply,
     c_ares::struct_ares_naptr_reply,
+    c_ares::struct_ares_tlsa_reply,
 );
 
 fn cares_list_to_js_array<T: CAresLinked>(
@@ -302,6 +303,48 @@ fn caa_reply_to_js(
     let property = bstr::String::borrow_utf8(this.property_bytes());
     let value = this.value_bytes();
     obj.put_may_be_index(global_this, &property, utf8_to_js(global_this, value)?)?;
+
+    Ok(obj)
+}
+
+// ── struct_ares_tlsa_reply ─────────────────────────────────────────────────
+pub(crate) fn tlsa_reply_to_js_response(
+    this: &mut c_ares::struct_ares_tlsa_reply,
+    global_this: &JSGlobalObject,
+    _lookup_name: &'static [u8],
+) -> JsResult<JSValue> {
+    cares_list_to_js_array(this, global_this, tlsa_reply_to_js)
+}
+
+pub(crate) fn tlsa_reply_to_js(
+    this: &mut c_ares::struct_ares_tlsa_reply,
+    global_this: &JSGlobalObject,
+) -> JsResult<JSValue> {
+    let obj = JSValue::create_empty_object(global_this, 4);
+
+    obj.put(
+        global_this,
+        b"certUsage",
+        JSValue::js_number(this.cert_usage as f64),
+    );
+    obj.put(
+        global_this,
+        b"selector",
+        JSValue::js_number(this.selector as f64),
+    );
+    obj.put(
+        global_this,
+        b"match",
+        JSValue::js_number(this.match_ as f64),
+    );
+    obj.put(
+        global_this,
+        b"data",
+        bun_jsc::array_buffer::ArrayBuffer::create::<{ bun_jsc::JSType::ArrayBuffer }>(
+            global_this,
+            &this.data,
+        )?,
+    );
 
     Ok(obj)
 }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3366,9 +3366,7 @@ impl_cares_record_type!(
     super::cares_jsc::caa_reply_to_js_response
 );
 
-// TLSA — reply list is Rust-owned (built via `ares_dns_parse`, see
-// `struct_ares_tlsa_reply::parse`), so `destroy` walks and drops Boxes
-// instead of calling `ares_free_data`.
+// TLSA reply list is Rust-owned; `destroy` drops Boxes instead of `ares_free_data`.
 impl CAresRecordType for c_ares::struct_ares_tlsa_reply {
     const TYPE_NAME: &'static str = "tlsa";
     const SYSCALL: &'static str = "queryTlsa";

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3399,11 +3399,9 @@ impl c_ares::ReplyHandler<c_ares::struct_ares_tlsa_reply>
         timeouts: i32,
         results: *mut c_ares::struct_ares_tlsa_reply,
     ) {
-        let result = if results.is_null() {
-            None
-        } else {
-            Some(results)
-        };
+        // SAFETY: `ares_reply_callback` hands over the list head built by
+        // `struct_ares_tlsa_reply::parse`, which `destroy` frees.
+        let result = NonNull::new(results).map(|reply| unsafe { OwnedReply::adopt(reply) });
         Self::on_cares_complete(core::ptr::from_mut(self), status, timeouts, result);
     }
 }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3256,6 +3256,7 @@ pub enum PendingCacheField {
     PendingNaptrCacheCares,
     PendingMxCacheCares,
     PendingCaaCacheCares,
+    PendingTlsaCacheCares,
     PendingNsCacheCares,
     PendingPtrCacheCares,
     PendingCnameCacheCares,
@@ -3364,6 +3365,50 @@ impl_cares_record_type!(
     ns_t_caa,
     super::cares_jsc::caa_reply_to_js_response
 );
+
+// TLSA — reply list is Rust-owned (built via `ares_dns_parse`, see
+// `struct_ares_tlsa_reply::parse`), so `destroy` walks and drops Boxes
+// instead of calling `ares_free_data`.
+impl CAresRecordType for c_ares::struct_ares_tlsa_reply {
+    const TYPE_NAME: &'static str = "tlsa";
+    const SYSCALL: &'static str = "queryTlsa";
+    const CACHE_FIELD: PendingCacheField = PendingCacheField::PendingTlsaCacheCares;
+    const NS_TYPE: c_ares::NSType = c_ares::NSType::ns_t_tlsa;
+    const RAW_CALLBACK: unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int) =
+        c_ares::ares_reply_callback::<
+            c_ares::struct_ares_tlsa_reply,
+            ResolveInfoRequest<c_ares::struct_ares_tlsa_reply>,
+        >;
+    fn to_js_response(
+        &mut self,
+        global: &JSGlobalObject,
+        type_name: &'static str,
+    ) -> JsResult<JSValue> {
+        super::cares_jsc::tlsa_reply_to_js_response(self, global, type_name.as_bytes())
+    }
+    unsafe fn destroy(this: *mut Self) {
+        // SAFETY: caller contract — `this` is the list head handed to the
+        // completion callback; Rust-owned, not aliased.
+        unsafe { c_ares::struct_ares_tlsa_reply::destroy(this) }
+    }
+}
+impl c_ares::ReplyHandler<c_ares::struct_ares_tlsa_reply>
+    for ResolveInfoRequest<c_ares::struct_ares_tlsa_reply>
+{
+    fn on_reply(
+        &mut self,
+        status: Option<c_ares::Error>,
+        timeouts: i32,
+        results: *mut c_ares::struct_ares_tlsa_reply,
+    ) {
+        let result = if results.is_null() {
+            None
+        } else {
+            Some(results)
+        };
+        Self::on_cares_complete(core::ptr::from_mut(self), status, timeouts, result);
+    }
+}
 
 // `any` — handler receives `Option<Box<struct_any_reply>>` (parser allocates the
 // aggregate); release it via `heap::into_raw_nn` so the rest of the pipeline sees a
@@ -3552,6 +3597,8 @@ type MxPendingCache =
     HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_mx_reply>, 32>;
 type CaaPendingCache =
     HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_caa_reply>, 32>;
+type TlsaPendingCache =
+    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_tlsa_reply>, 32>;
 type NSPendingCache = HiveArray<resolve_info_request::PendingCacheKey<NsHostent>, 32>;
 type PtrPendingCache = HiveArray<resolve_info_request::PendingCacheKey<PtrHostent>, 32>;
 type CnamePendingCache = HiveArray<resolve_info_request::PendingCacheKey<CnameHostent>, 32>;
@@ -3594,6 +3641,7 @@ pub struct Resolver {
     pub(crate) pending_naptr_cache_cares: JsCell<NaptrPendingCache>,
     pub(crate) pending_mx_cache_cares: JsCell<MxPendingCache>,
     pub(crate) pending_caa_cache_cares: JsCell<CaaPendingCache>,
+    pub(crate) pending_tlsa_cache_cares: JsCell<TlsaPendingCache>,
     pub(crate) pending_ns_cache_cares: JsCell<NSPendingCache>,
     pub(crate) pending_ptr_cache_cares: JsCell<PtrPendingCache>,
     pub(crate) pending_cname_cache_cares: JsCell<CnamePendingCache>,
@@ -3854,6 +3902,7 @@ pub enum RecordType {
     PTR = 12,
     SOA = 6,
     SRV = 33,
+    TLSA = 52,
     TXT = 16,
     ANY = 255,
 }
@@ -3863,11 +3912,11 @@ bun_core::comptime_string_map! {
         b"A" => RecordType::A, b"AAAA" => RecordType::AAAA, b"ANY" => RecordType::ANY,
         b"CAA" => RecordType::CAA, b"CNAME" => RecordType::CNAME, b"MX" => RecordType::MX,
         b"NS" => RecordType::NS, b"PTR" => RecordType::PTR, b"SOA" => RecordType::SOA,
-        b"SRV" => RecordType::SRV, b"TXT" => RecordType::TXT,
+        b"SRV" => RecordType::SRV, b"TLSA" => RecordType::TLSA, b"TXT" => RecordType::TXT,
         b"a" => RecordType::A, b"aaaa" => RecordType::AAAA, b"any" => RecordType::ANY,
         b"caa" => RecordType::CAA, b"cname" => RecordType::CNAME, b"mx" => RecordType::MX,
         b"ns" => RecordType::NS, b"ptr" => RecordType::PTR, b"soa" => RecordType::SOA,
-        b"srv" => RecordType::SRV, b"txt" => RecordType::TXT,
+        b"srv" => RecordType::SRV, b"tlsa" => RecordType::TLSA, b"txt" => RecordType::TXT,
     };
 }
 
@@ -3938,6 +3987,7 @@ impl Resolver {
             pending_naptr_cache_cares: JsCell::new(HiveArray::init()),
             pending_mx_cache_cares: JsCell::new(HiveArray::init()),
             pending_caa_cache_cares: JsCell::new(HiveArray::init()),
+            pending_tlsa_cache_cares: JsCell::new(HiveArray::init()),
             pending_ns_cache_cares: JsCell::new(HiveArray::init()),
             pending_ptr_cache_cares: JsCell::new(HiveArray::init()),
             pending_cname_cache_cares: JsCell::new(HiveArray::init()),
@@ -4044,6 +4094,7 @@ impl Resolver {
             pending_naptr_cache_cares,
             pending_mx_cache_cares,
             pending_caa_cache_cares,
+            pending_tlsa_cache_cares,
             pending_ns_cache_cares,
             pending_ptr_cache_cares,
             pending_cname_cache_cares,
@@ -4193,6 +4244,7 @@ impl Resolver {
             PendingCacheField::PendingNaptrCacheCares => field!(pending_naptr_cache_cares),
             PendingCacheField::PendingMxCacheCares => field!(pending_mx_cache_cares),
             PendingCacheField::PendingCaaCacheCares => field!(pending_caa_cache_cares),
+            PendingCacheField::PendingTlsaCacheCares => field!(pending_tlsa_cache_cares),
             PendingCacheField::PendingNsCacheCares => field!(pending_ns_cache_cares),
             PendingCacheField::PendingPtrCacheCares => field!(pending_ptr_cache_cares),
             PendingCacheField::PendingCnameCacheCares => field!(pending_cname_cache_cares),
@@ -4951,7 +5003,9 @@ impl Resolver {
                     None => {
                         return Err(global_this.throw_invalid_argument_property_value(
                             b"record",
-                            Some("one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT"),
+                            Some(
+                                "one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TLSA, TXT",
+                            ),
                             record_type_value,
                         ));
                     }
@@ -4996,6 +5050,9 @@ impl Resolver {
             }
             RecordType::SRV => {
                 self.do_resolve_cares::<c_ares::struct_ares_srv_reply>(name.slice(), global_this)
+            }
+            RecordType::TLSA => {
+                self.do_resolve_cares::<c_ares::struct_ares_tlsa_reply>(name.slice(), global_this)
             }
             RecordType::TXT => {
                 self.do_resolve_cares::<c_ares::struct_ares_txt_reply>(name.slice(), global_this)
@@ -5305,6 +5362,13 @@ impl Resolver {
         resolve_caa,
         "resolveCaa",
         c_ares::struct_ares_caa_reply,
+        false
+    );
+    resolve_record_fn!(
+        global_resolve_tlsa,
+        resolve_tlsa,
+        "resolveTlsa",
+        c_ares::struct_ares_tlsa_reply,
         false
     );
     resolve_record_fn!(global_resolve_ns, resolve_ns, "resolveNs", NsHostent, true);
@@ -6047,6 +6111,7 @@ export_host_fn!(Resolver::global_resolve_mx, "Bun__DNS__resolveMx");
 export_host_fn!(Resolver::global_resolve_naptr, "Bun__DNS__resolveNaptr");
 export_host_fn!(Resolver::global_resolve_srv, "Bun__DNS__resolveSrv");
 export_host_fn!(Resolver::global_resolve_caa, "Bun__DNS__resolveCaa");
+export_host_fn!(Resolver::global_resolve_tlsa, "Bun__DNS__resolveTlsa");
 export_host_fn!(Resolver::global_resolve_ns, "Bun__DNS__resolveNs");
 export_host_fn!(Resolver::global_resolve_ptr, "Bun__DNS__resolvePtr");
 export_host_fn!(Resolver::global_resolve_cname, "Bun__DNS__resolveCname");

--- a/src/runtime/node/node.classes.ts
+++ b/src/runtime/node/node.classes.ts
@@ -46,6 +46,10 @@ export default [
         fn: "resolveCaa",
         length: 1,
       },
+      resolveTlsa: {
+        fn: "resolveTlsa",
+        length: 1,
+      },
       resolveNs: {
         fn: "resolveNs",
         length: 1,

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -287,7 +287,7 @@ describe("dns", () => {
     test("resolve() with a UTF-16 invalid record type throws TypeError", () => {
       // @ts-expect-error
       expect(() => Bun.dns.resolve("localhost", utf16("BOGUS"))).toThrow(
-        `The property "record" is invalid. Expected one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, received type string ('BOGUS')`,
+        `The property "record" is invalid. Expected one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TLSA, TXT, received type string ('BOGUS')`,
       );
     });
   });

--- a/test/js/node/dns/dns-resolve-tlsa-fixture.ts
+++ b/test/js/node/dns/dns-resolve-tlsa-fixture.ts
@@ -1,0 +1,78 @@
+// Mock-DNS server for TLSA records. Runs in a subprocess so the Resolver's
+// native backing (freed only at GC finalization) doesn't trip LSan in the
+// parent test process. Structured like dns-resolver-concurrent-timeout-fixture.ts.
+import dgram from "node:dgram";
+import dns from "node:dns";
+
+const certData = Buffer.from("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "hex");
+
+function buildTlsaResponse(query: Buffer): Buffer {
+  let off = 12;
+  while (query[off] !== 0) off += query[off] + 1;
+  off += 1; // root label
+  off += 4; // QTYPE + QCLASS
+  const question = query.subarray(12, off);
+
+  const header = Buffer.alloc(12);
+  query.copy(header, 0, 0, 2); // id
+  header.writeUInt16BE(0x8180, 2); // standard response, RA
+  header.writeUInt16BE(1, 4); // QDCOUNT
+  header.writeUInt16BE(1, 6); // ANCOUNT
+
+  const rdata = Buffer.concat([Buffer.from([3, 1, 1]), certData]);
+  const answer = Buffer.alloc(12 + rdata.length);
+  answer.writeUInt16BE(0xc00c, 0); // name: pointer to question name
+  answer.writeUInt16BE(52, 2); // TYPE = TLSA
+  answer.writeUInt16BE(1, 4); // CLASS = IN
+  answer.writeUInt32BE(60, 6); // TTL
+  answer.writeUInt16BE(rdata.length, 10); // RDLENGTH
+  rdata.copy(answer, 12);
+
+  return Buffer.concat([header, question, answer]);
+}
+
+function normalize(records: any[]) {
+  return records.map(r => ({
+    ...r,
+    data: r.data instanceof ArrayBuffer ? Buffer.from(r.data).toString("hex") : r.data,
+    dataIsArrayBuffer: r.data instanceof ArrayBuffer,
+  }));
+}
+
+const server = dgram.createSocket("udp4");
+server.on("message", (msg, rinfo) => {
+  server.send(buildTlsaResponse(msg), rinfo.port, rinfo.address);
+});
+server.on("error", err => {
+  console.error(err);
+  process.exit(1);
+});
+
+server.bind(0, "127.0.0.1", () => {
+  const resolver = new dns.promises.Resolver();
+  resolver.setServers([`127.0.0.1:${(server.address() as dgram.AddressInfo).port}`]);
+
+  Promise.all([
+    resolver.resolveTlsa("_443._tcp.example.org"),
+    resolver.resolve("_443._tcp.example.org", "TLSA"),
+    resolver.resolveAny("_443._tcp.example.org"),
+  ]).then(
+    ([byMethod, byRrtype, any]) => {
+      console.log(
+        JSON.stringify({
+          byMethod: normalize(byMethod),
+          byRrtype: normalize(byRrtype),
+          byAny: normalize(any.filter((r: any) => r.type === "TLSA")),
+        }),
+      );
+      resolver.cancel();
+      server.close();
+    },
+    err => {
+      console.error(err);
+      resolver.cancel();
+      server.close();
+      process.exit(1);
+    },
+  );
+});

--- a/test/js/node/dns/dns-resolve-tlsa.test.ts
+++ b/test/js/node/dns/dns-resolve-tlsa.test.ts
@@ -20,12 +20,17 @@ test("dns.resolveTlsa is exposed everywhere node:dns exposes it", () => {
 
 test("resolver.resolve accepts 'TLSA' as an rrtype", () => {
   const resolver = new dns.promises.Resolver({ timeout: 500, tries: 1 });
-  // Must not throw ERR_INVALID_ARG_VALUE synchronously.
-  const p = resolver.resolve("tlsa.invalid", "TLSA");
-  expect(p).toBeInstanceOf(Promise);
-  // Swallow the eventual rejection so the test doesn't leave an unhandled rejection.
-  p.catch(() => {});
-  resolver.cancel();
+  // Point at an unreachable local address so no real network traffic is sent.
+  resolver.setServers(["127.0.0.1:1"]);
+  try {
+    // Must not throw ERR_INVALID_ARG_VALUE synchronously.
+    const p = resolver.resolve("tlsa.invalid", "TLSA");
+    expect(p).toBeInstanceOf(Promise);
+    // Swallow the eventual rejection so the test doesn't leave an unhandled rejection.
+    p.catch(() => {});
+  } finally {
+    resolver.cancel();
+  }
 });
 
 describe("dns.resolveTlsa against a local mock server", () => {

--- a/test/js/node/dns/dns-resolve-tlsa.test.ts
+++ b/test/js/node/dns/dns-resolve-tlsa.test.ts
@@ -1,7 +1,8 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import dgram from "node:dgram";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import dns from "node:dns";
 import dnsPromises from "node:dns/promises";
+import { join } from "node:path";
 import util from "node:util";
 
 // https://github.com/oven-sh/bun/issues/6581
@@ -18,112 +19,40 @@ test("dns.resolveTlsa is exposed everywhere node:dns exposes it", () => {
   expect(dns.resolveTlsa[util.promisify.custom]).toBe(dns.promises.resolveTlsa);
 });
 
-test("resolver.resolve accepts 'TLSA' as an rrtype", () => {
-  const resolver = new dns.promises.Resolver({ timeout: 500, tries: 1 });
-  // Point at an unreachable local address so no real network traffic is sent.
-  resolver.setServers(["127.0.0.1:1"]);
-  try {
-    // Must not throw ERR_INVALID_ARG_VALUE synchronously.
-    const p = resolver.resolve("tlsa.invalid", "TLSA");
-    expect(p).toBeInstanceOf(Promise);
-    // Swallow the eventual rejection so the test doesn't leave an unhandled rejection.
-    p.catch(() => {});
-  } finally {
-    resolver.cancel();
-  }
-});
-
-describe("dns.resolveTlsa against a local mock server", () => {
-  // SHA-256 of an empty string, used as the certificate association data.
-  const certData = Buffer.from("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "hex");
-
-  let server: dgram.Socket;
-  let resolver: InstanceType<typeof dns.promises.Resolver>;
-
-  // Minimal DNS responder: echoes the question, attaches one TLSA answer
-  // (type 52, RFC 6698 wire format: u8 cert_usage, u8 selector, u8 matching, data[]).
-  function buildTlsaResponse(query: Buffer): Buffer {
-    let off = 12;
-    while (query[off] !== 0) off += query[off] + 1;
-    off += 1; // root label
-    off += 4; // QTYPE + QCLASS
-    const question = query.subarray(12, off);
-
-    const header = Buffer.alloc(12);
-    query.copy(header, 0, 0, 2); // id
-    header.writeUInt16BE(0x8180, 2); // standard response, RA
-    header.writeUInt16BE(1, 4); // QDCOUNT
-    header.writeUInt16BE(1, 6); // ANCOUNT
-
-    const rdata = Buffer.concat([Buffer.from([3, 1, 1]), certData]);
-    const answer = Buffer.alloc(12 + rdata.length);
-    answer.writeUInt16BE(0xc00c, 0); // name: pointer to question name
-    answer.writeUInt16BE(52, 2); // TYPE = TLSA
-    answer.writeUInt16BE(1, 4); // CLASS = IN
-    answer.writeUInt32BE(60, 6); // TTL
-    answer.writeUInt16BE(rdata.length, 10); // RDLENGTH
-    rdata.copy(answer, 12);
-
-    return Buffer.concat([header, question, answer]);
-  }
-
-  beforeAll(async () => {
-    server = dgram.createSocket("udp4");
-    server.on("message", (msg, rinfo) => {
-      server.send(buildTlsaResponse(msg), rinfo.port, rinfo.address);
-    });
-    await new Promise<void>(resolve => server.bind(0, "127.0.0.1", resolve));
-    resolver = new dns.promises.Resolver();
-    resolver.setServers([`127.0.0.1:${server.address().port}`]);
-  });
-
-  afterAll(() => {
-    resolver?.cancel();
-    server?.close();
-  });
-
-  test("Resolver.prototype.resolveTlsa returns {certUsage, selector, match, data}", async () => {
-    const records = await resolver.resolveTlsa("_443._tcp.example.org");
-    expect(Array.isArray(records)).toBe(true);
-    expect(records.length).toBe(1);
-
-    const rec = records[0];
-    expect(rec.certUsage).toBe(3);
-    expect(rec.selector).toBe(1);
-    expect(rec.match).toBe(1);
-    expect(rec.data).toBeInstanceOf(ArrayBuffer);
-    expect(Buffer.from(rec.data).equals(certData)).toBe(true);
-  });
-
-  test("resolver.resolve(name, 'TLSA') returns TLSA records", async () => {
-    const records = await resolver.resolve("_443._tcp.example.org", "TLSA");
-    expect(records.length).toBe(1);
-    expect(records[0].certUsage).toBe(3);
-    expect(Buffer.from(records[0].data).equals(certData)).toBe(true);
-  });
-
-  test("resolver.resolveAny includes TLSA records as {type: 'TLSA', ...}", async () => {
-    const records = await resolver.resolveAny("_443._tcp.example.org");
-    const tlsa = records.filter(r => r.type === "TLSA");
-    expect(tlsa.length).toBe(1);
-    expect(tlsa[0].certUsage).toBe(3);
-    expect(tlsa[0].selector).toBe(1);
-    expect(tlsa[0].match).toBe(1);
-    expect(tlsa[0].data).toBeInstanceOf(ArrayBuffer);
-    expect(Buffer.from(tlsa[0].data).equals(certData)).toBe(true);
-  });
-});
-
 test("dns.resolveTlsa error carries syscall=queryTlsa and a translated code", async () => {
   // A >255-byte label is rejected by c-ares before any network I/O.
-  const resolver = new dns.promises.Resolver({ timeout: 100, tries: 1 });
   let err: any;
   try {
-    await resolver.resolveTlsa(Buffer.alloc(300, "a").toString());
+    await dns.promises.resolveTlsa(Buffer.alloc(300, "a").toString());
   } catch (e) {
     err = e;
   }
   expect(err).toBeDefined();
   expect(err.syscall).toBe("queryTlsa");
   expect(err.code).not.toStartWith("DNS_");
+});
+
+// The mock-server round-trip runs in a subprocess: a `new dns.Resolver()` native
+// backing is only freed at GC finalization, which can race process exit under
+// LSan. Matching the sibling dns-*-fixture.ts tests in this directory.
+test("resolveTlsa / resolve(name,'TLSA') / resolveAny parse TLSA answers from a local server", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "dns-resolve-tlsa-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr.trim()).toBe("");
+  const out = JSON.parse(stdout.trim());
+
+  const certHex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+  const rec = { certUsage: 3, selector: 1, match: 1, data: certHex, dataIsArrayBuffer: true };
+  expect(out).toEqual({
+    byMethod: [rec],
+    byRrtype: [rec],
+    byAny: [{ ...rec, type: "TLSA" }],
+  });
+  expect(exitCode).toBe(0);
 });

--- a/test/js/node/dns/dns-resolve-tlsa.test.ts
+++ b/test/js/node/dns/dns-resolve-tlsa.test.ts
@@ -101,6 +101,17 @@ describe("dns.resolveTlsa against a local mock server", () => {
     expect(records[0].certUsage).toBe(3);
     expect(Buffer.from(records[0].data).equals(certData)).toBe(true);
   });
+
+  test("resolver.resolveAny includes TLSA records as {type: 'TLSA', ...}", async () => {
+    const records = await resolver.resolveAny("_443._tcp.example.org");
+    const tlsa = records.filter(r => r.type === "TLSA");
+    expect(tlsa.length).toBe(1);
+    expect(tlsa[0].certUsage).toBe(3);
+    expect(tlsa[0].selector).toBe(1);
+    expect(tlsa[0].match).toBe(1);
+    expect(tlsa[0].data).toBeInstanceOf(ArrayBuffer);
+    expect(Buffer.from(tlsa[0].data).equals(certData)).toBe(true);
+  });
 });
 
 test("dns.resolveTlsa error carries syscall=queryTlsa and a translated code", async () => {

--- a/test/js/node/dns/dns-resolve-tlsa.test.ts
+++ b/test/js/node/dns/dns-resolve-tlsa.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import dgram from "node:dgram";
+import dns from "node:dns";
+import dnsPromises from "node:dns/promises";
+import util from "node:util";
+
+// https://github.com/oven-sh/bun/issues/6581
+// TLSA record support was added to Node.js in v22.15.0 / v23.9.0.
+
+test("dns.resolveTlsa is exposed everywhere node:dns exposes it", () => {
+  expect(typeof dns.resolveTlsa).toBe("function");
+  expect(typeof dns.promises.resolveTlsa).toBe("function");
+  expect(typeof dnsPromises.resolveTlsa).toBe("function");
+  expect(typeof dns.Resolver.prototype.resolveTlsa).toBe("function");
+  expect(typeof dns.promises.Resolver.prototype.resolveTlsa).toBe("function");
+
+  // util.promisify(dns.resolveTlsa) uses the promises implementation.
+  expect(dns.resolveTlsa[util.promisify.custom]).toBe(dns.promises.resolveTlsa);
+});
+
+test("resolver.resolve accepts 'TLSA' as an rrtype", () => {
+  const resolver = new dns.promises.Resolver({ timeout: 500, tries: 1 });
+  // Must not throw ERR_INVALID_ARG_VALUE synchronously.
+  const p = resolver.resolve("tlsa.invalid", "TLSA");
+  expect(p).toBeInstanceOf(Promise);
+  // Swallow the eventual rejection so the test doesn't leave an unhandled rejection.
+  p.catch(() => {});
+  resolver.cancel();
+});
+
+describe("dns.resolveTlsa against a local mock server", () => {
+  // SHA-256 of an empty string, used as the certificate association data.
+  const certData = Buffer.from("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "hex");
+
+  let server: dgram.Socket;
+  let resolver: InstanceType<typeof dns.promises.Resolver>;
+
+  // Minimal DNS responder: echoes the question, attaches one TLSA answer
+  // (type 52, RFC 6698 wire format: u8 cert_usage, u8 selector, u8 matching, data[]).
+  function buildTlsaResponse(query: Buffer): Buffer {
+    let off = 12;
+    while (query[off] !== 0) off += query[off] + 1;
+    off += 1; // root label
+    off += 4; // QTYPE + QCLASS
+    const question = query.subarray(12, off);
+
+    const header = Buffer.alloc(12);
+    query.copy(header, 0, 0, 2); // id
+    header.writeUInt16BE(0x8180, 2); // standard response, RA
+    header.writeUInt16BE(1, 4); // QDCOUNT
+    header.writeUInt16BE(1, 6); // ANCOUNT
+
+    const rdata = Buffer.concat([Buffer.from([3, 1, 1]), certData]);
+    const answer = Buffer.alloc(12 + rdata.length);
+    answer.writeUInt16BE(0xc00c, 0); // name: pointer to question name
+    answer.writeUInt16BE(52, 2); // TYPE = TLSA
+    answer.writeUInt16BE(1, 4); // CLASS = IN
+    answer.writeUInt32BE(60, 6); // TTL
+    answer.writeUInt16BE(rdata.length, 10); // RDLENGTH
+    rdata.copy(answer, 12);
+
+    return Buffer.concat([header, question, answer]);
+  }
+
+  beforeAll(async () => {
+    server = dgram.createSocket("udp4");
+    server.on("message", (msg, rinfo) => {
+      server.send(buildTlsaResponse(msg), rinfo.port, rinfo.address);
+    });
+    await new Promise<void>(resolve => server.bind(0, "127.0.0.1", resolve));
+    resolver = new dns.promises.Resolver();
+    resolver.setServers([`127.0.0.1:${server.address().port}`]);
+  });
+
+  afterAll(() => {
+    resolver?.cancel();
+    server?.close();
+  });
+
+  test("Resolver.prototype.resolveTlsa returns {certUsage, selector, match, data}", async () => {
+    const records = await resolver.resolveTlsa("_443._tcp.example.org");
+    expect(Array.isArray(records)).toBe(true);
+    expect(records.length).toBe(1);
+
+    const rec = records[0];
+    expect(rec.certUsage).toBe(3);
+    expect(rec.selector).toBe(1);
+    expect(rec.match).toBe(1);
+    expect(rec.data).toBeInstanceOf(ArrayBuffer);
+    expect(Buffer.from(rec.data).equals(certData)).toBe(true);
+  });
+
+  test("resolver.resolve(name, 'TLSA') returns TLSA records", async () => {
+    const records = await resolver.resolve("_443._tcp.example.org", "TLSA");
+    expect(records.length).toBe(1);
+    expect(records[0].certUsage).toBe(3);
+    expect(Buffer.from(records[0].data).equals(certData)).toBe(true);
+  });
+});
+
+test("dns.resolveTlsa error carries syscall=queryTlsa and a translated code", async () => {
+  // A >255-byte label is rejected by c-ares before any network I/O.
+  const resolver = new dns.promises.Resolver({ timeout: 100, tries: 1 });
+  let err: any;
+  try {
+    await resolver.resolveTlsa(Buffer.alloc(300, "a").toString());
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err.syscall).toBe("queryTlsa");
+  expect(err.code).not.toStartWith("DNS_");
+});

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -638,6 +638,7 @@ describe("a third argument shifts the callback", () => {
     ["dns.resolvePtr", dns.resolvePtr],
     ["dns.resolveSoa", dns.resolveSoa],
     ["dns.resolveSrv", dns.resolveSrv],
+    ["dns.resolveTlsa", dns.resolveTlsa],
     ["dns.resolveTxt", dns.resolveTxt],
     ["dns.reverse", dns.reverse],
   ];

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -26,6 +26,7 @@ test("it exists", () => {
   expect(dns.resolveNaptr).toBeDefined();
   expect(dns.resolveMx).toBeDefined();
   expect(dns.resolveCaa).toBeDefined();
+  expect(dns.resolveTlsa).toBeDefined();
   expect(dns.resolveNs).toBeDefined();
   expect(dns.resolvePtr).toBeDefined();
   expect(dns.resolveCname).toBeDefined();
@@ -42,6 +43,7 @@ test("it exists", () => {
   expect(dns.promises.resolveNaptr).toBeDefined();
   expect(dns.promises.resolveMx).toBeDefined();
   expect(dns.promises.resolveCaa).toBeDefined();
+  expect(dns.promises.resolveTlsa).toBeDefined();
   expect(dns.promises.resolveNs).toBeDefined();
   expect(dns.promises.resolvePtr).toBeDefined();
   expect(dns.promises.resolveCname).toBeDefined();
@@ -58,6 +60,7 @@ test("it exists", () => {
   expect(dns_promises.resolveNaptr).toBeDefined();
   expect(dns_promises.resolveMx).toBeDefined();
   expect(dns_promises.resolveCaa).toBeDefined();
+  expect(dns_promises.resolveTlsa).toBeDefined();
   expect(dns_promises.resolveNs).toBeDefined();
   expect(dns_promises.resolvePtr).toBeDefined();
   expect(dns_promises.resolveCname).toBeDefined();
@@ -566,6 +569,7 @@ describe("test invalid arguments", () => {
     // TODO: dns.resolveAny is not implemented yet
     ["dns.resolveCname", dns.resolveCname],
     ["dns.resolveCaa", dns.resolveCaa],
+    ["dns.resolveTlsa", dns.resolveTlsa],
     ["dns.resolveMx", dns.resolveMx],
     ["dns.resolveNaptr", dns.resolveNaptr],
     ["dns.resolveNs", dns.resolveNs],
@@ -760,6 +764,7 @@ describe("uses `dns.promises` implementations for `util.promisify` factory", () 
     "resolvePtr",
     "resolveSoa",
     "resolveSrv",
+    "resolveTlsa",
     "resolveTxt",
     "resolveNaptr",
   ])("%s", method => {


### PR DESCRIPTION
## Problem

`dns.resolveTlsa`, `dns.promises.resolveTlsa`, and `Resolver.prototype.resolveTlsa` are all `undefined` in Bun, and `resolver.resolve(name, 'TLSA')` throws `ERR_INVALID_ARG_VALUE`. Node.js added TLSA support in v22.15.0 / v23.9.0, so any DANE/TLSA consumer written against current Node dies with `dns.resolveTlsa is not a function`.

```js
import dns from 'node:dns';
const R = new dns.promises.Resolver();
typeof dns.resolveTlsa            // 'undefined' (node: 'function')
typeof dns.promises.resolveTlsa   // 'undefined' (node: 'function')
typeof R.resolveTlsa              // 'undefined' (node: 'function')
R.resolve('x', 'TLSA')            // throws ERR_INVALID_ARG_VALUE (node: accepted)
```

## Cause

TLSA (DNS type 52, RFC 6698) was never wired into the resolver. Unlike the other record types, c-ares exposes no legacy `ares_parse_tlsa_reply`; TLSA is only available via the newer `ares_dns_record` API. No part of that API was bound.

## Fix

- **`src/cares_sys/c_ares.rs`**: add `ns_t_tlsa = 52`; bind the minimal `ares_dns_record` subset (`ares_dns_parse`, `ares_dns_record_destroy`, `ares_dns_record_rr_cnt`, `ares_dns_record_rr_get_const`, `ares_dns_rr_get_type`, `ares_dns_rr_get_u8`, `ares_dns_rr_get_bin`); add a Rust-owned `struct_ares_tlsa_reply` linked list whose `AresReply::parse` walks the answer section and copies each TLSA record out before destroying the c-ares record. Shaping it as a `next`-linked list means the generic `ares_reply_callback` thunk and the rest of the resolver pipeline apply unchanged.
- **`src/runtime/dns_jsc/dns.rs`**: add `PendingTlsaCacheCares`, the per-type pending cache, `RecordType::TLSA`, the rrtype map entry, the `resolve()` dispatch arm, `resolve_tlsa` / `global_resolve_tlsa`, and the `Bun__DNS__resolveTlsa` export. `CAresRecordType::destroy` for TLSA drops the Rust-owned boxes instead of calling `ares_free_data`.
- **`src/runtime/dns_jsc/cares_jsc.rs`**: `tlsa_reply_to_js` builds `{certUsage, selector, match, data: ArrayBuffer}` (matching Node's shape and `@types/node`'s `TlsaRecord`).
- **`src/jsc/bindings/BunObject.cpp`** / **`src/runtime/node/node.classes.ts`** / **`src/js/node/dns.ts`**: expose `resolveTlsa` on `Bun.dns`, the `DNSResolver` prototype, `node:dns`, `dns.promises`, both `Resolver` classes, and the `util.promisify` custom hook.

## Verification

`test/js/node/dns/dns-resolve-tlsa.test.ts` asserts the API surface and runs a local UDP mock that serves a TLSA answer (cert usage 3, selector 1, match 1, SHA-256 data), verifying both `resolver.resolveTlsa(name)` and `resolver.resolve(name, 'TLSA')` return `{certUsage: 3, selector: 1, match: 1, data: ArrayBuffer}` with the exact bytes. Also extends `node-dns.test.js` existence / promisify / invalid-argument tables.

Fixes #6581

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/dns/resolve-dns.test.ts test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->