### PR TITLE
fs: return negative BigIntStats *Ns for pre-epoch timestamps

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -5021,14 +5021,6 @@ impl Timespec {
             .unwrap_or(i64::MAX as u64)
     }
 
-    /// Signed nanoseconds (wrapping). Port of `bun.timespec.nsSigned`.
-    #[inline]
-    pub fn ns_signed(&self) -> i64 {
-        let ns_per_sec = self.sec.wrapping_mul(Self::NS_PER_S);
-        let ns_from_nsec = self.nsec.div_euclid(Self::NS_PER_MS);
-        ns_per_sec.wrapping_add(ns_from_nsec)
-    }
-
     /// Milliseconds (signed, wrapping).
     #[inline]
     pub fn ms(&self) -> i64 {

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -657,10 +657,10 @@ extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatsObject(Zig::GlobalObject*
     int64_t mtimeMs,
     int64_t ctimeMs,
     int64_t birthtimeMs,
-    uint64_t atimeNs,
-    uint64_t mtimeNs,
-    uint64_t ctimeNs,
-    uint64_t birthtimeNs)
+    int64_t atimeNs,
+    int64_t mtimeNs,
+    int64_t ctimeNs,
+    int64_t birthtimeNs)
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -20,6 +20,7 @@
 #include <JavaScriptCore/PropertyNameArray.h>
 #include "ZigGlobalObject.h"
 #include "JavaScriptCore/DateInstance.h"
+#include <wtf/Int128.h>
 #if !OS(WINDOWS)
 #include <sys/stat.h>
 #endif
@@ -642,6 +643,14 @@ extern "C" JSC::EncodedJSValue Bun__createJSStatsObject(Zig::GlobalObject* globa
     return JSC::JSValue::encode(object);
 }
 
+static constexpr WTF::Int128 kNsPerSec = 1'000'000'000;
+static constexpr WTF::Int128 kNsPerMs = 1'000'000;
+
+static ALWAYS_INLINE WTF::Int128 timespecToNs(int64_t sec, int64_t nsec)
+{
+    return static_cast<WTF::Int128>(sec) * kNsPerSec + static_cast<WTF::Int128>(nsec);
+}
+
 extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatsObject(Zig::GlobalObject* globalObject,
     uint64_t dev,
     uint64_t ino,
@@ -653,19 +662,26 @@ extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatsObject(Zig::GlobalObject*
     uint64_t size,
     uint64_t blksize,
     uint64_t blocks,
-    int64_t atimeMs,
-    int64_t mtimeMs,
-    int64_t ctimeMs,
-    int64_t birthtimeMs,
-    int64_t atimeNs,
-    int64_t mtimeNs,
-    int64_t ctimeNs,
-    int64_t birthtimeNs)
+    int64_t atimeSec,
+    int64_t atimeNsec,
+    int64_t mtimeSec,
+    int64_t mtimeNsec,
+    int64_t ctimeSec,
+    int64_t ctimeNsec,
+    int64_t birthtimeSec,
+    int64_t birthtimeNsec)
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* structure = getStructure<true>(globalObject);
+
+    // Node computes atimeNs = sec * 1e9n + nsec and atimeMs = atimeNs / 1e6n.
+    const WTF::Int128 atimeNs = timespecToNs(atimeSec, atimeNsec);
+    const WTF::Int128 mtimeNs = timespecToNs(mtimeSec, mtimeNsec);
+    const WTF::Int128 ctimeNs = timespecToNs(ctimeSec, ctimeNsec);
+    const WTF::Int128 birthtimeNs = timespecToNs(birthtimeSec, birthtimeNsec);
+
     // Node.js fills a BigInt64Array via static_cast<int64_t>(uint64_t).
     JSC::JSValue js_dev = JSC::JSBigInt::createFrom(globalObject, static_cast<int64_t>(dev));
     RETURN_IF_EXCEPTION(scope, {});
@@ -687,13 +703,13 @@ extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatsObject(Zig::GlobalObject*
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSValue js_blocks = JSC::JSBigInt::createFrom(globalObject, static_cast<int64_t>(blocks));
     RETURN_IF_EXCEPTION(scope, {});
-    JSC::JSValue js_atimeMs = JSC::JSBigInt::createFrom(globalObject, atimeMs);
+    JSC::JSValue js_atimeMs = JSC::JSBigInt::createFrom(globalObject, atimeNs / kNsPerMs);
     RETURN_IF_EXCEPTION(scope, {});
-    JSC::JSValue js_mtimeMs = JSC::JSBigInt::createFrom(globalObject, mtimeMs);
+    JSC::JSValue js_mtimeMs = JSC::JSBigInt::createFrom(globalObject, mtimeNs / kNsPerMs);
     RETURN_IF_EXCEPTION(scope, {});
-    JSC::JSValue js_ctimeMs = JSC::JSBigInt::createFrom(globalObject, ctimeMs);
+    JSC::JSValue js_ctimeMs = JSC::JSBigInt::createFrom(globalObject, ctimeNs / kNsPerMs);
     RETURN_IF_EXCEPTION(scope, {});
-    JSC::JSValue js_birthtimeMs = JSC::JSBigInt::createFrom(globalObject, birthtimeMs);
+    JSC::JSValue js_birthtimeMs = JSC::JSBigInt::createFrom(globalObject, birthtimeNs / kNsPerMs);
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSValue js_atimeNs = JSC::JSBigInt::createFrom(globalObject, atimeNs);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/runtime/node/Stat.rs
+++ b/src/runtime/node/Stat.rs
@@ -8,7 +8,6 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 // libc-stat → uv_stat_t field copy on both POSIX and Windows there.
 pub use bun_sys::PosixStat;
 
-const MS_PER_S: i64 = bun_core::time::MS_PER_S as i64;
 const NS_PER_MS: i64 = bun_core::time::NS_PER_MS as i64;
 const NS_PER_S: i64 = bun_core::time::NS_PER_S as i64;
 
@@ -52,9 +51,8 @@ impl<const BIG: bool> StatType<BIG> {
     }
 
     fn to_time_ms_i64(ts: StatTimespec) -> i64 {
-        let (sec, nsec) = Self::timespec_parts(ts);
-        sec.saturating_mul(MS_PER_S)
-            .saturating_add(nsec / NS_PER_MS)
+        // Node computes BigIntStats *Ms as `*Ns / 1_000_000n`.
+        Self::to_nanoseconds(ts) / NS_PER_MS
     }
 
     fn to_time_ms_f64(ts: StatTimespec) -> f64 {

--- a/src/runtime/node/Stat.rs
+++ b/src/runtime/node/Stat.rs
@@ -8,15 +8,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 // libc-stat → uv_stat_t field copy on both POSIX and Windows there.
 pub use bun_sys::PosixStat;
 
-const NS_PER_MS: i64 = bun_core::time::NS_PER_MS as i64;
-const NS_PER_S: i64 = bun_core::time::NS_PER_S as i64;
-
-/// Stats and BigIntStats classes from node:fs
-// `BIG` selects the BigIntStats (i64) vs Stats (f64) flavour. A
-// const-generic-dependent type alias (`if BIG { i64 } else { f64 }`) is not
-// expressible in stable Rust, so `to_time_ms` is split into
-// `to_time_ms_i64` / `to_time_ms_f64` and called from the appropriate
-// branch in `stat_to_js`.
+/// Stats and BigIntStats classes from node:fs. `BIG` selects BigIntStats vs Stats.
 pub struct StatType<const BIG: bool> {
     pub value: PosixStat,
 }
@@ -42,17 +34,6 @@ impl<const BIG: bool> StatType<BIG> {
         );
         #[cfg(not(windows))]
         (ts.sec, ts.nsec)
-    }
-
-    #[inline]
-    fn to_nanoseconds(ts: StatTimespec) -> i64 {
-        let (sec, nsec) = Self::timespec_parts(ts);
-        sec.saturating_mul(NS_PER_S).saturating_add(nsec)
-    }
-
-    fn to_time_ms_i64(ts: StatTimespec) -> i64 {
-        // Node computes BigIntStats *Ms as `*Ns / 1_000_000n`.
-        Self::to_nanoseconds(ts) / NS_PER_MS
     }
 
     fn to_time_ms_f64(ts: StatTimespec) -> f64 {
@@ -84,10 +65,10 @@ impl<const BIG: bool> StatType<BIG> {
         let b_time = Self::get_birthtime(stat_);
 
         if BIG {
-            let atime_ms: i64 = Self::to_time_ms_i64(a_time);
-            let mtime_ms: i64 = Self::to_time_ms_i64(m_time);
-            let ctime_ms: i64 = Self::to_time_ms_i64(c_time);
-            let birthtime_ms: i64 = Self::to_time_ms_i64(b_time);
+            let (a_sec, a_nsec) = Self::timespec_parts(a_time);
+            let (m_sec, m_nsec) = Self::timespec_parts(m_time);
+            let (c_sec, c_nsec) = Self::timespec_parts(c_time);
+            let (b_sec, b_nsec) = Self::timespec_parts(b_time);
 
             return bun_jsc::from_js_host_call(global, || {
                 Bun__createJSBigIntStatsObject(
@@ -102,14 +83,14 @@ impl<const BIG: bool> StatType<BIG> {
                     stat_.size,
                     stat_.blksize,
                     stat_.blocks,
-                    atime_ms,
-                    mtime_ms,
-                    ctime_ms,
-                    birthtime_ms,
-                    Self::to_nanoseconds(a_time),
-                    Self::to_nanoseconds(m_time),
-                    Self::to_nanoseconds(c_time),
-                    Self::to_nanoseconds(b_time),
+                    a_sec,
+                    a_nsec,
+                    m_sec,
+                    m_nsec,
+                    c_sec,
+                    c_nsec,
+                    b_sec,
+                    b_nsec,
                 )
             });
         }
@@ -173,14 +154,14 @@ unsafe extern "C" {
         size: u64,
         blksize: u64,
         blocks: u64,
-        atime_ms: i64,
-        mtime_ms: i64,
-        ctime_ms: i64,
-        birthtime_ms: i64,
-        atime_ns: i64,
-        mtime_ns: i64,
-        ctime_ns: i64,
-        birthtime_ns: i64,
+        atime_sec: i64,
+        atime_nsec: i64,
+        mtime_sec: i64,
+        mtime_nsec: i64,
+        ctime_sec: i64,
+        ctime_nsec: i64,
+        birthtime_sec: i64,
+        birthtime_nsec: i64,
     ) -> JSValue;
 }
 

--- a/src/runtime/node/Stat.rs
+++ b/src/runtime/node/Stat.rs
@@ -33,64 +33,37 @@ impl<const BIG: bool> StatType<BIG> {
         Self { value: *stat_ }
     }
 
+    /// Node.js reinterprets stat times via `static_cast<unsigned long>`, which
+    /// on win32 is 32-bit (libuv's Y2038 wrap); on other platforms the cast is
+    /// a 64-bit bit-pattern round-trip, so negative values survive as pre-epoch.
     #[inline]
-    fn to_nanoseconds(ts: StatTimespec) -> i64 {
-        // On windows, Node.js purposefully misinterprets time values
-        // > On win32, time is stored in uint64_t and starts from 1601-01-01.
-        // > libuv calculates tv_sec and tv_nsec from it and converts to signed long,
-        // > which causes Y2038 overflow. On the other platforms it is safe to treat
-        // > negative values as pre-epoch time.
+    fn timespec_parts(ts: StatTimespec) -> (i64, i64) {
         #[cfg(windows)]
-        let (tv_sec, tv_nsec): (i64, i64) = (
+        return (
             ((ts.sec as i32) as u32) as i64,
             ((ts.nsec as i32) as u32) as i64,
         );
         #[cfg(not(windows))]
-        let (tv_sec, tv_nsec): (i64, i64) = (ts.sec, ts.nsec);
+        (ts.sec, ts.nsec)
+    }
 
-        tv_sec.saturating_mul(NS_PER_S).saturating_add(tv_nsec)
+    #[inline]
+    fn to_nanoseconds(ts: StatTimespec) -> i64 {
+        let (sec, nsec) = Self::timespec_parts(ts);
+        sec.saturating_mul(NS_PER_S).saturating_add(nsec)
     }
 
     // Split into i64/f64 variants for const-generic type selection — see the
     // struct-level note.
     fn to_time_ms_i64(ts: StatTimespec) -> i64 {
-        // On windows, Node.js purposefully misinterprets time values
-        // > On win32, time is stored in uint64_t and starts from 1601-01-01.
-        // > libuv calculates tv_sec and tv_nsec from it and converts to signed long,
-        // > which causes Y2038 overflow. On the other platforms it is safe to treat
-        // > negative values as pre-epoch time.
-        #[cfg(windows)]
-        let (tv_sec, tv_nsec): (i64, i64) = (
-            ((ts.sec as i32) as u32) as i64,
-            ((ts.nsec as i32) as u32) as i64,
-        );
-        #[cfg(not(windows))]
-        let (tv_sec, tv_nsec): (i64, i64) = (ts.sec as i64, ts.nsec as i64);
-
-        let sec: i64 = tv_sec;
-        let nsec: i64 = tv_nsec;
+        let (sec, nsec) = Self::timespec_parts(ts);
         (sec * MS_PER_S).saturating_add(nsec / NS_PER_MS)
     }
 
     fn to_time_ms_f64(ts: StatTimespec) -> f64 {
-        // On windows, Node.js purposefully misinterprets time values
-        // > On win32, time is stored in uint64_t and starts from 1601-01-01.
-        // > libuv calculates tv_sec and tv_nsec from it and converts to signed long,
-        // > which causes Y2038 overflow. On the other platforms it is safe to treat
-        // > negative values as pre-epoch time.
-        #[cfg(windows)]
-        let (tv_sec, tv_nsec): (f64, f64) = (
-            ((ts.sec as i32) as u32) as f64,
-            ((ts.nsec as i32) as u32) as f64,
-        );
-        #[cfg(not(windows))]
-        let (tv_sec, tv_nsec): (f64, f64) = (ts.sec as f64, ts.nsec as f64);
-
-        // Use floating-point arithmetic to preserve sub-millisecond precision.
-        // Node.js returns fractional milliseconds (e.g. 1773248895434.0544).
-        let sec_ms: f64 = tv_sec * 1000.0;
-        let nsec_ms: f64 = tv_nsec / 1_000_000.0;
-        sec_ms + nsec_ms
+        let (sec, nsec) = Self::timespec_parts(ts);
+        // Floating-point to preserve sub-millisecond precision (e.g. 1773248895434.0544).
+        (sec as f64) * 1000.0 + (nsec as f64) / 1_000_000.0
     }
 
     fn get_birthtime(stat_: &PosixStat) -> StatTimespec {

--- a/src/runtime/node/Stat.rs
+++ b/src/runtime/node/Stat.rs
@@ -53,7 +53,8 @@ impl<const BIG: bool> StatType<BIG> {
 
     fn to_time_ms_i64(ts: StatTimespec) -> i64 {
         let (sec, nsec) = Self::timespec_parts(ts);
-        sec.saturating_mul(MS_PER_S).saturating_add(nsec / NS_PER_MS)
+        sec.saturating_mul(MS_PER_S)
+            .saturating_add(nsec / NS_PER_MS)
     }
 
     fn to_time_ms_f64(ts: StatTimespec) -> f64 {

--- a/src/runtime/node/Stat.rs
+++ b/src/runtime/node/Stat.rs
@@ -10,6 +10,7 @@ pub use bun_sys::PosixStat;
 
 const MS_PER_S: i64 = bun_core::time::MS_PER_S as i64;
 const NS_PER_MS: i64 = bun_core::time::NS_PER_MS as i64;
+const NS_PER_S: i64 = bun_core::time::NS_PER_S as i64;
 
 /// Stats and BigIntStats classes from node:fs
 // `BIG` selects the BigIntStats (i64) vs Stats (f64) flavour. A
@@ -33,11 +34,21 @@ impl<const BIG: bool> StatType<BIG> {
     }
 
     #[inline]
-    fn to_nanoseconds(ts: StatTimespec) -> u64 {
-        if ts.sec < 0 {
-            return ts.ns_signed().max(0) as u64;
-        }
-        ts.ns()
+    fn to_nanoseconds(ts: StatTimespec) -> i64 {
+        // On windows, Node.js purposefully misinterprets time values
+        // > On win32, time is stored in uint64_t and starts from 1601-01-01.
+        // > libuv calculates tv_sec and tv_nsec from it and converts to signed long,
+        // > which causes Y2038 overflow. On the other platforms it is safe to treat
+        // > negative values as pre-epoch time.
+        #[cfg(windows)]
+        let (tv_sec, tv_nsec): (i64, i64) = (
+            ((ts.sec as i32) as u32) as i64,
+            ((ts.nsec as i32) as u32) as i64,
+        );
+        #[cfg(not(windows))]
+        let (tv_sec, tv_nsec): (i64, i64) = (ts.sec, ts.nsec);
+
+        tv_sec.saturating_mul(NS_PER_S).saturating_add(tv_nsec)
     }
 
     // Split into i64/f64 variants for const-generic type selection — see the
@@ -198,10 +209,10 @@ unsafe extern "C" {
         mtime_ms: i64,
         ctime_ms: i64,
         birthtime_ms: i64,
-        atime_ns: u64,
-        mtime_ns: u64,
-        ctime_ns: u64,
-        birthtime_ns: u64,
+        atime_ns: i64,
+        mtime_ns: i64,
+        ctime_ns: i64,
+        birthtime_ns: i64,
     ) -> JSValue;
 }
 

--- a/src/runtime/node/Stat.rs
+++ b/src/runtime/node/Stat.rs
@@ -53,7 +53,7 @@ impl<const BIG: bool> StatType<BIG> {
 
     fn to_time_ms_i64(ts: StatTimespec) -> i64 {
         let (sec, nsec) = Self::timespec_parts(ts);
-        (sec * MS_PER_S).saturating_add(nsec / NS_PER_MS)
+        sec.saturating_mul(MS_PER_S).saturating_add(nsec / NS_PER_MS)
     }
 
     fn to_time_ms_f64(ts: StatTimespec) -> f64 {

--- a/src/runtime/node/Stat.rs
+++ b/src/runtime/node/Stat.rs
@@ -33,9 +33,7 @@ impl<const BIG: bool> StatType<BIG> {
         Self { value: *stat_ }
     }
 
-    /// Node.js reinterprets stat times via `static_cast<unsigned long>`, which
-    /// on win32 is 32-bit (libuv's Y2038 wrap); on other platforms the cast is
-    /// a 64-bit bit-pattern round-trip, so negative values survive as pre-epoch.
+    /// Matches Node's `static_cast<unsigned long>` of stat times: 32-bit wrap on win32, signed-preserving elsewhere.
     #[inline]
     fn timespec_parts(ts: StatTimespec) -> (i64, i64) {
         #[cfg(windows)]
@@ -53,8 +51,6 @@ impl<const BIG: bool> StatType<BIG> {
         sec.saturating_mul(NS_PER_S).saturating_add(nsec)
     }
 
-    // Split into i64/f64 variants for const-generic type selection — see the
-    // struct-level note.
     fn to_time_ms_i64(ts: StatTimespec) -> i64 {
         let (sec, nsec) = Self::timespec_parts(ts);
         (sec * MS_PER_S).saturating_add(nsec / NS_PER_MS)

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4806,6 +4806,43 @@ it("new Stats", () => {
   expect(Math.abs(withBigInt.birthtime.getTime() - withoutBigInt.birthtime.getTime())).toBeLessThanOrEqual(1);
 });
 
+// On Windows, Node.js deliberately reinterprets stat times via `unsigned long` (see
+// libuv Y2038 note), so pre-epoch semantics there are not "negative ns".
+it.skipIf(isWindows)("BigIntStats *Ns fields are negative for pre-epoch timestamps", () => {
+  using dir = tempDir("bigintstats-pre-epoch", { "f.txt": "x" });
+  const f = join(String(dir), "f.txt");
+
+  // 1969-12-20T10:13:19.750Z; kernel stores this as {sec: -1000001, nsec: 750000000}.
+  const preEpoch = new Date(-1_000_000_250);
+  fs.utimesSync(f, preEpoch, preEpoch);
+
+  const st = statSync(f, { bigint: true });
+  expect({
+    atimeNs: st.atimeNs,
+    mtimeNs: st.mtimeNs,
+    atimeMs: st.atimeMs,
+    mtimeMs: st.mtimeMs,
+  }).toEqual({
+    atimeNs: -1_000_000_250_000_000n,
+    mtimeNs: -1_000_000_250_000_000n,
+    atimeMs: -1_000_000_250n,
+    mtimeMs: -1_000_000_250n,
+  });
+  // Documented invariant: xtimeNs / 1_000_000n === xtimeMs
+  expect(st.mtimeNs / 1_000_000n).toBe(st.mtimeMs);
+  expect(st.atimeNs / 1_000_000n).toBe(st.atimeMs);
+  expect(st.mtime.toISOString()).toBe("1969-12-20T10:13:19.750Z");
+
+  // A small negative offset just below the epoch.
+  fs.utimesSync(f, new Date(-500), new Date(-500));
+  const st2 = statSync(f, { bigint: true });
+  expect({ atimeNs: st2.atimeNs, mtimeNs: st2.mtimeNs }).toEqual({
+    atimeNs: -500_000_000n,
+    mtimeNs: -500_000_000n,
+  });
+  expect(st2.atimeNs / 1_000_000n).toBe(st2.atimeMs);
+});
+
 it("test syscall errno, issue#4198", () => {
   const path = `${tmpdir()}/non-existent-${Date.now()}.txt`;
   expect(() => openSync(path, "r")).toThrow("no such file or directory");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4855,9 +4855,11 @@ it.skipIf(isWindows)("BigIntStats *Ns does not clamp for post-2262 timestamps", 
   // The invariant must hold regardless of what the filesystem stored.
   expect(st.mtimeNs / 1_000_000n).toBe(st.mtimeMs);
   expect(st.atimeNs / 1_000_000n).toBe(st.atimeMs);
+  // i64::MAX: a saturating 64-bit intermediate would produce exactly this.
+  expect(st.mtimeNs).not.toBe(9_223_372_036_854_775_807n);
 
-  // Only assert exact values if the filesystem round-tripped the timestamp.
-  if (st.mtimeMs === BigInt(far.getTime())) {
+  // Round-trip check via the independent non-bigint (f64) path.
+  if (statSync(f).mtimeMs === far.getTime()) {
     expect({ mtimeNs: st.mtimeNs, atimeNs: st.atimeNs }).toEqual({
       mtimeNs: 13_569_465_600_000_000_000n,
       atimeNs: 13_569_465_600_000_000_000n,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4855,10 +4855,9 @@ it.skipIf(isWindows)("BigIntStats *Ns does not clamp for post-2262 timestamps", 
   // The invariant must hold regardless of what the filesystem stored.
   expect(st.mtimeNs / 1_000_000n).toBe(st.mtimeMs);
   expect(st.atimeNs / 1_000_000n).toBe(st.atimeMs);
-  // i64::MAX: a saturating 64-bit intermediate would produce exactly this.
-  expect(st.mtimeNs).not.toBe(9_223_372_036_854_775_807n);
 
-  // Round-trip check via the independent non-bigint (f64) path.
+  // Round-trip check via the independent non-bigint (f64) path; APFS stores i64 ns
+  // and clamps year-2400 at exactly i64::MAX, so only FSes that store wider sec run this.
   if (statSync(f).mtimeMs === far.getTime()) {
     expect({ mtimeNs: st.mtimeNs, atimeNs: st.atimeNs }).toEqual({
       mtimeNs: 13_569_465_600_000_000_000n,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4843,6 +4843,28 @@ it.skipIf(isWindows)("BigIntStats *Ns fields are negative for pre-epoch timestam
   expect(st2.atimeNs / 1_000_000n).toBe(st2.atimeMs);
 });
 
+it.skipIf(isWindows)("BigIntStats *Ns does not clamp for post-2262 timestamps", () => {
+  using dir = tempDir("bigintstats-far-future", { "f.txt": "x" });
+  const f = join(String(dir), "f.txt");
+
+  // sec = 13_569_465_600 (> i64::MAX / 1e9); ext4/btrfs/XFS-bigtime store this exactly.
+  const far = new Date("2400-01-01T00:00:00.000Z");
+  fs.utimesSync(f, far, far);
+  const st = statSync(f, { bigint: true });
+
+  // The invariant must hold regardless of what the filesystem stored.
+  expect(st.mtimeNs / 1_000_000n).toBe(st.mtimeMs);
+  expect(st.atimeNs / 1_000_000n).toBe(st.atimeMs);
+
+  // Only assert exact values if the filesystem round-tripped the timestamp.
+  if (st.mtimeMs === BigInt(far.getTime())) {
+    expect({ mtimeNs: st.mtimeNs, atimeNs: st.atimeNs }).toEqual({
+      mtimeNs: 13_569_465_600_000_000_000n,
+      atimeNs: 13_569_465_600_000_000_000n,
+    });
+  }
+});
+
 it("test syscall errno, issue#4198", () => {
   const path = `${tmpdir()}/non-existent-${Date.now()}.txt`;
   expect(() => openSync(path, "r")).toThrow("no such file or directory");


### PR DESCRIPTION
## Problem

`fs.statSync(path, { bigint: true })` returns `0n` for `atimeNs`/`mtimeNs`/`ctimeNs`/`birthtimeNs` whenever the file's timestamp is before 1970-01-01. The `*Ms` fields and `Date` getters on the same object are correctly negative, so the object contradicts itself and the documented invariant `xtimeNs / 1_000_000n === xtimeMs` is broken.

```js
import fs from 'node:fs';
const f = './pre-epoch-file';
fs.writeFileSync(f, 'x');
fs.utimesSync(f, new Date(-1_000_000_250), new Date(-1_000_000_250));
const st = fs.statSync(f, { bigint: true });
console.log(st.mtimeMs);  // -1000000250n  (correct in both)
console.log(st.mtimeNs);  // node: -1000000250000000n ; bun: 0n
console.log(st.mtimeNs / 1_000_000n === st.mtimeMs);  // node: true ; bun: false
```

## Cause

`to_nanoseconds()` in `src/runtime/node/Stat.rs` returned `u64`. When `tv_sec < 0` it computed `ts.ns_signed().max(0) as u64`, clamping every pre-epoch timestamp to zero. The FFI boundary (`Bun__createJSBigIntStatsObject`) typed the `*Ns` params as `uint64_t`, so the sign had nowhere to go.

## Fix

Pass raw `(tv_sec, tv_nsec)` pairs across the FFI (after Node's per-platform `unsigned long` reinterpretation) and compute `ns = sec * 1e9 + nsec` and `ms = ns / 1e6` in C++ with `WTF::Int128`, then `JSBigInt::createFrom(Int128)`. This mirrors Node's `nsFromTimeSpecBigInt` and `atimeMs = atimeNs / kNsPerMsBigInt`, so `xtimeNs / 1_000_000n === xtimeMs` holds by construction and neither pre-epoch negatives nor post-2262 positives (ext4's 34-bit `tv_sec`) lose range to 64-bit saturation.

Also removes now-dead helpers:
- `Timespec::ns_signed()` in `bun_core::util` (sole caller was the old clamp path; its body also wrongly divided `nsec` by `NS_PER_MS`)
- `to_nanoseconds` / `to_time_ms_i64` in `Stat.rs` (the BigInt path no longer does arithmetic on the Rust side)

## Verification

New tests in `test/js/node/fs/fs.test.ts`:
- Pre-epoch: sets atime/mtime to `1969-12-20T10:13:19.750Z` and asserts `mtimeNs == -1_000_000_250_000_000n` with `xtimeNs / 1_000_000n === xtimeMs`. Fails on main (`atimeNs: 0n`).
- Post-2262: sets mtime to `2400-01-01` (sec > `i64::MAX / 1e9`) and asserts `mtimeNs == 13_569_465_600_000_000_000n` when the filesystem round-trips it. Guards against regressing the far-future range while fixing the negative range.

Both are skipped on Windows, where Node deliberately reinterprets stat times through 32-bit `unsigned long`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->