### PR TITLE
spawn: reap on the owning event loop in the waiter-thread fallback

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2544,6 +2544,10 @@ pub mod ffi {
     // SAFETY: integer-array struct on the gated targets; all-zero is valid.
     #[cfg(all(unix, not(target_vendor = "apple")))]
     unsafe impl Zeroable for libc::sigset_t {}
+    // SAFETY: C POD (integer/union-of-POD fields only); zero-init before
+    // `waitid` is the documented usage.
+    #[cfg(unix)]
+    unsafe impl Zeroable for libc::siginfo_t {}
     // SAFETY: C POD (integer/array/raw-pointer fields only); all-zero is valid.
     #[cfg(unix)]
     unsafe impl Zeroable for libc::utsname {}

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -260,17 +260,17 @@ impl Process {
         let _ = sync_;
     }
 
+    /// The waiter thread only observes exit (`WNOWAIT`); the reap happens
+    /// here, on the loop that owns `poller`/`status`, so `kill()` never sees
+    /// a live poller for a pid the kernel could have recycled.
+    ///
     /// # Safety
     /// `this` carries the +1 ref taken when the waiter-thread task was queued.
     /// `ScopedRef::adopt` releases it on return — which may free `this` — so
     /// this takes `*mut Self`, not `&mut self` (a `&mut` argument's
     /// Stacked-Borrows protector outliving the allocation is UB; see :215).
     #[cfg(unix)]
-    pub(crate) unsafe fn on_wait_pid_from_waiter_thread(
-        this: *mut Self,
-        waitpid_result: &bun_sys::Result<WaitPidResult>,
-        rusage: &Rusage,
-    ) {
+    pub(crate) unsafe fn on_wait_pid_from_waiter_thread(this: *mut Self) {
         // SAFETY: caller contract — adopts the queued +1 ref.
         let _g = unsafe { bun_ptr::ScopedRef::<Process>::adopt(this) };
         // SAFETY: `_g` keeps `this` live for this block.
@@ -280,7 +280,7 @@ impl Process {
             waiter.unref(ctx);
             self_.poller = Poller::Detached;
         }
-        self_.on_wait_pid(waitpid_result, rusage);
+        self_.wait_posix(false);
     }
 
     /// # Safety
@@ -967,12 +967,11 @@ pub mod waiter_thread_posix {
 
     pub type ConcurrentQueue<T> = UnboundedQueue<TaskQueueEntry<T>>;
 
-    /// Posted to the JS event loop from the waiter thread when a `wait4()`
-    /// resolves. Maps to `task_tag::ProcessWaiterThreadTask` in `jsc::Task`.
+    /// Posted to the JS event loop from the waiter thread once the child is
+    /// observed to have exited (still a zombie — the owning loop reaps it).
+    /// Maps to `task_tag::ProcessWaiterThreadTask` in `jsc::Task`.
     pub struct ResultTask<T: 'static> {
-        pub(crate) result: bun_sys::Result<WaitPidResult>,
         pub(crate) subprocess: *mut T,
-        pub(crate) rusage: Rusage,
     }
 
     impl<T: ProcessLike> ResultTask<T> {
@@ -988,9 +987,7 @@ pub mod waiter_thread_posix {
         pub(crate) fn run_from_main_thread(self) {
             // SAFETY: subprocess strong-ref'd before append(); released by
             // on_wait_pid_from_waiter_thread → deref().
-            unsafe {
-                T::on_wait_pid_from_waiter_thread(self.subprocess, &self.result, &self.rusage)
-            };
+            unsafe { T::on_wait_pid_from_waiter_thread(self.subprocess) };
         }
     }
 
@@ -998,7 +995,6 @@ pub mod waiter_thread_posix {
     /// the embedded intrusive `task: AnyTaskWithExtraContext` (`.ctx == self`).
     #[repr(C)]
     pub(crate) struct ResultTaskMini<T: 'static> {
-        pub(crate) result: bun_sys::Result<WaitPidResult>,
         pub(crate) subprocess: *mut T,
         pub(crate) task: AnyTaskWithExtraContext,
     }
@@ -1010,10 +1006,8 @@ pub mod waiter_thread_posix {
         }
 
         pub(crate) fn run_from_main_thread(self) {
-            let result = self.result;
-            let subprocess = self.subprocess;
             // SAFETY: see ResultTask::run_from_main_thread.
-            unsafe { T::on_wait_pid_from_waiter_thread(subprocess, &result, &rusage_zeroed()) };
+            unsafe { T::on_wait_pid_from_waiter_thread(self.subprocess) };
         }
 
         /// Stored thunk for `AnyTaskWithExtraContext` (`fn(*mut T, *mut C)`
@@ -1035,11 +1029,7 @@ pub mod waiter_thread_posix {
         fn event_loop(&self) -> EventLoopHandle;
         /// # Safety
         /// `this` must be a live, strong-ref'd pointer; callee releases one ref.
-        unsafe fn on_wait_pid_from_waiter_thread(
-            this: *mut Self,
-            result: &bun_sys::Result<WaitPidResult>,
-            rusage: &Rusage,
-        );
+        unsafe fn on_wait_pid_from_waiter_thread(this: *mut Self);
     }
 
     impl ProcessLike for Process {
@@ -1053,13 +1043,9 @@ pub mod waiter_thread_posix {
             self.event_loop
         }
         #[inline]
-        unsafe fn on_wait_pid_from_waiter_thread(
-            this: *mut Self,
-            result: &bun_sys::Result<WaitPidResult>,
-            rusage: &Rusage,
-        ) {
+        unsafe fn on_wait_pid_from_waiter_thread(this: *mut Self) {
             // SAFETY: caller contract.
-            unsafe { Process::on_wait_pid_from_waiter_thread(this, result, rusage) };
+            unsafe { Process::on_wait_pid_from_waiter_thread(this) };
         }
     }
 
@@ -1112,13 +1098,11 @@ pub mod waiter_thread_posix {
                 if pid == 0 {
                     remove = true;
                 } else {
-                    let mut rusage = rusage_zeroed();
-                    let result = posix_spawn::wait4(pid, libc::WNOHANG as u32, Some(&mut rusage));
-                    let matched = match &result {
-                        Err(_) => true,
-                        Ok(r) => r.pid == pid,
-                    };
-                    if matched {
+                    // Do not reap here — the owning event loop reaps in
+                    // `on_wait_pid_from_waiter_thread`, keeping the pid a zombie
+                    // (never recycled) while `Process::kill` may still signal it.
+                    let exited = posix_spawn::poll_exited_no_reap(pid).unwrap_or(true);
+                    if exited {
                         remove = true;
 
                         match T::event_loop(process_ref) {
@@ -1126,9 +1110,7 @@ pub mod waiter_thread_posix {
                                 let ct = ConcurrentTask::create(Task::new(
                                     T::TASK_TAG,
                                     ResultTask::<T>::new(ResultTask {
-                                        result,
                                         subprocess: process,
-                                        rusage,
                                     })
                                     .cast(),
                                 ));
@@ -1136,7 +1118,6 @@ pub mod waiter_thread_posix {
                             }
                             EventLoopHandle::Mini(mut mini) => {
                                 let out = ResultTaskMini::<T>::new(ResultTaskMini {
-                                    result,
                                     subprocess: process,
                                     task: AnyTaskWithExtraContext::default(),
                                 });

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -793,6 +793,35 @@ pub mod posix_spawn {
         }
     }
 
+    /// Non-blocking check for whether `pid` has terminated, WITHOUT reaping
+    /// it (`WNOWAIT`). The child stays a zombie — its pid cannot be recycled —
+    /// until the caller reaps it with [`wait4`].
+    #[cfg(unix)]
+    pub fn poll_exited_no_reap(pid: pid_t) -> sys::Result<bool> {
+        loop {
+            let mut info: libc::siginfo_t = bun_core::ffi::zeroed();
+            // SAFETY: `info` is a valid out-pointer for the call's duration.
+            let rc = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    libc::id_t::try_from(pid).expect("int cast"),
+                    &raw mut info,
+                    libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+                )
+            };
+            match errno(rc) {
+                // SAFETY: `waitid` succeeded; the union arm read by `si_pid()`
+                // is the one it populated (or the zeroed init when no child
+                // was waitable under `WNOHANG`).
+                Errno::SUCCESS => return sys::Result::Ok(unsafe { info.si_pid() } == pid),
+                Errno::INTR => continue,
+                e => {
+                    return sys::Result::Err(sys::Error::from_code_int(e.0, SYSCALL_WAITPID));
+                }
+            }
+        }
+    }
+
     // Higher-tier re-exports (`Process`/`Status`/`spawn_process`/`sync`/
     // `Windows*`) live in `bun_spawn::posix_spawn::bun_spawn`, which augments
     // this module — they need event-loop types this `-sys` crate cannot name.

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -703,6 +703,43 @@ describe("spawn unref and kill should not hang", () => {
     await proc.exited;
     expect().pass();
   });
+
+  it.skipIf(isWindows)("kill after exit is a no-op on the waiter thread path", async () => {
+    const script = /* js */ `
+      for (let i = 0; i < 5; i++) {
+        const proc = Bun.spawn({
+          cmd: [process.execPath, "-e", "process.exit(42)"],
+          stdout: "ignore",
+          stderr: "ignore",
+          stdin: "ignore",
+        });
+        const code = await proc.exited;
+        for (let j = 0; j < 5; j++) {
+          proc.kill();
+          proc.kill(9);
+        }
+        if (code !== 42 || proc.exitCode !== 42 || proc.signalCode !== null) {
+          throw new Error("unexpected: " + JSON.stringify({ code, exitCode: proc.exitCode, signalCode: proc.signalCode }));
+        }
+      }
+      console.log("done");
+    `;
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        BUN_GARBAGE_COLLECTOR_LEVEL: "1",
+        BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("done");
+    expect(exitCode).toBe(0);
+  });
 });
 
 async function runTest(sleep: string, order = ["sleep", "kill", "unref", "exited"]) {


### PR DESCRIPTION
## What

On the waiter-thread process-exit fallback (used when a pidfd cannot be opened, or when `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1` is set), the child was previously reaped with `wait4` on the waiter thread while the `Process` state (`poller`/`status`) was only updated later on the owning event loop. This change moves the reap onto the owning event loop so state and reap happen together, matching how the pidfd / `EVFILT_PROC` paths already behave.

- The waiter thread now only *observes* exit via `waitid(P_PID, pid, WEXITED | WNOHANG | WNOWAIT)` (new `poll_exited_no_reap` helper) and posts the notification task; it never consumes the child.
- `on_wait_pid_from_waiter_thread` performs the `wait4` on the owning loop, so the child remains a zombie until that point and its pid cannot be handed to another process while a `Process` still references it.
- Side effect: exits routed through a `MiniEventLoop` on this path now carry real resource usage instead of zeroed values.

The pidfd and `EVFILT_PROC` paths are unchanged.

## How to observe

With `BUN_GARBAGE_COLLECTOR_LEVEL=1 BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1`, spawn a short-lived child, `await proc.exited`, then call `proc.kill()` — it is a safe no-op and `exitCode` / `signalCode` are unchanged. Killing a still-running child on this path continues to deliver the signal promptly. The cross-thread ordering itself is closed by construction (the pid is only released by the loop that owns the `Process`) rather than by an observable test.

## Test

- `test/js/bun/spawn/spawn.test.ts` — `kill after exit is a no-op on the waiter thread path`
- `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1 bun bd test test/js/bun/spawn/spawn.test.ts` — 136 pass, 0 fail
