### PR TITLE
bundler: emit __promiseAll helper when an unwrapped file awaits multiple async ESM wrappers

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -866,11 +866,8 @@ pub fn scan_imports_and_exports(
             );
 
             let parts_len = col_ref!(parts_list)[id].len() as usize;
-            // Static imports of async ESM-wrapped modules become `await init_X()`
-            // calls in this file's wrapper prefix. Two or more of those are
-            // coalesced into `await __promiseAll([...])` at codegen time. Count
-            // them across all parts so the part that observes the second one can
-            // pull in the runtime helper.
+            // Counted across every part of this file: `InsideWrapperPrefix`
+            // coalesces the whole file's async init calls into one statement.
             let mut async_esm_init_count: u32 = 0;
             for part_index in 0..parts_len {
                 let mut to_esm_uses: u32 = 0;

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -866,10 +866,17 @@ pub fn scan_imports_and_exports(
             );
 
             let parts_len = col_ref!(parts_list)[id].len() as usize;
+            // Static imports of async ESM-wrapped modules become `await init_X()`
+            // calls in this file's wrapper prefix. Two or more of those are
+            // coalesced into `await __promiseAll([...])` at codegen time. Count
+            // them across all parts so the part that observes the second one can
+            // pull in the runtime helper.
+            let mut async_esm_init_count: u32 = 0;
             for part_index in 0..parts_len {
                 let mut to_esm_uses: u32 = 0;
                 let mut to_common_js_uses: u32 = 0;
                 let mut runtime_require_uses: u32 = 0;
+                let mut promise_all_uses: u32 = 0;
 
                 // Imports of wrapped files must depend on the wrapper
                 // Iterate by index so each iteration re-borrows
@@ -996,6 +1003,16 @@ pub fn scan_imports_and_exports(
                                 1,
                                 Index::source(other_source_index),
                             )?;
+
+                            if kind == ImportKind::Stmt
+                                && other_flags.wrap == WrapKind::Esm
+                                && other_flags.is_async_or_has_async_dependency
+                            {
+                                async_esm_init_count += 1;
+                                if async_esm_init_count >= 2 {
+                                    promise_all_uses = 1;
+                                }
+                            }
                         }
 
                         // This is an ES6 import of a CommonJS module, so it needs the
@@ -1147,6 +1164,13 @@ pub fn scan_imports_and_exports(
                         Index::part(part_index as u32),
                         b"__reExport",
                         re_export_uses,
+                    )?;
+
+                    this.graph.generate_runtime_symbol_import_and_use(
+                        source_index,
+                        Index::part(part_index as u32),
+                        b"__promiseAll",
+                        promise_all_uses,
                     )?;
                 }
             }

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -428,4 +428,109 @@ describe("bundler", () => {
       expect(bundled).not.toMatch(/await\s+__promiseAll\s*\(/);
     },
   });
+
+  itBundled("bundler/__promiseAll is emitted when an unwrapped entry awaits two async ESM wrappers", {
+    files: {
+      "/entry.mjs": `
+        import { a } from "./a.mjs";
+        import { b } from "./b.mjs";
+        console.log("got", a, b);
+        console.log("dyn", Object.keys(await import("./a.mjs")).join(","), Object.keys(await import("./b.mjs")).join(","));
+      `,
+      "/a.mjs": `export const a = await Promise.resolve("A");`,
+      "/b.mjs": `export const b = await Promise.resolve("B");`,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: "got A B\ndyn a b\n",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      // The entry itself is not wrapped, so the parallel-init `await` is emitted
+      // at the top level of the chunk. The helper must be defined, not just
+      // referenced.
+      expect(bundled).toMatch(/await\s+__promiseAll\s*\(\s*\[/);
+      expect(bundled).toContain("var __promiseAll = ");
+    },
+  });
+
+  itBundled("bundler/__promiseAll is emitted when an unwrapped entry awaits three async ESM wrappers", {
+    files: {
+      "/entry.mjs": `
+        import { a } from "./a.mjs";
+        import { b } from "./b.mjs";
+        import { c } from "./c.mjs";
+        console.log("got", a, b, c);
+        await import("./a.mjs");
+        await import("./b.mjs");
+        await import("./c.mjs");
+      `,
+      "/a.mjs": `export const a = await Promise.resolve("A");`,
+      "/b.mjs": `export const b = await Promise.resolve("B");`,
+      "/c.mjs": `export const c = await Promise.resolve("C");`,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: "got A B C\n",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(/await\s+__promiseAll\s*\(\s*\[/);
+      expect(bundled).toContain("var __promiseAll = ");
+      expect(bundled).toContain("init_a()");
+      expect(bundled).toContain("init_b()");
+      expect(bundled).toContain("init_c()");
+    },
+  });
+
+  itBundled("bundler/__promiseAll is emitted when an unwrapped non-entry file awaits two async ESM wrappers", {
+    files: {
+      "/entry.mjs": `
+        import { joined } from "./mid.mjs";
+        console.log("got", joined);
+        await import("./a.mjs");
+        await import("./b.mjs");
+      `,
+      "/mid.mjs": `
+        import { a } from "./a.mjs";
+        import { b } from "./b.mjs";
+        export const joined = a + b;
+      `,
+      "/a.mjs": `export const a = await Promise.resolve("A");`,
+      "/b.mjs": `export const b = await Promise.resolve("B");`,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: "got AB\n",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(/await\s+__promiseAll\s*\(\s*\[/);
+      expect(bundled).toContain("var __promiseAll = ");
+    },
+  });
+
+  itBundled("bundler/__promiseAll is not emitted when an unwrapped entry awaits a single async ESM wrapper", {
+    files: {
+      "/entry.mjs": `
+        import { a } from "./a.mjs";
+        console.log("got", a);
+        console.log("dyn", Object.keys(await import("./a.mjs")).join(","));
+      `,
+      "/a.mjs": `export const a = await Promise.resolve("A");`,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: "got A\ndyn a\n",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(/await\s+init_a\s*\(\s*\)\s*;/);
+      expect(bundled).not.toContain("__promiseAll");
+    },
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes `bun build` producing a bundle that references the `__promiseAll` runtime helper without defining it, so the build exits 0 but the artifact throws `ReferenceError: __promiseAll is not defined` on first evaluation.

### Repro

```js
// a.mjs
export const a = await Promise.resolve("A");
// b.mjs
export const b = await Promise.resolve("B");
// entry.mjs
import { a } from "./a.mjs";
import { b } from "./b.mjs";
console.log("got", a, b);
console.log("dyn", Object.keys(await import("./a.mjs")).join(","), Object.keys(await import("./b.mjs")).join(","));
```

```
$ bun build entry.mjs --outdir dist && bun dist/entry.js
38 | await __promiseAll([
           ^
ReferenceError: __promiseAll is not defined
```

Reproduces on any target, with or without `--minify`, via CLI and `Bun.build` (`success: true`, empty `logs`). `--splitting` is unaffected. esbuild 0.28.1 builds and runs the same input correctly.

### Cause

The helper exists but is never marked used at the failing emission site:

- The helper is defined at `src/runtime.js:328` and resolved to `promise_all_runtime_ref` at `src/bundler/LinkerContext.rs:546-547`.
- `should_remove_import_export_stmt` (`LinkerContext.rs:2073`, call at `:2192-2195`) hands each static import of an async ESM-wrapped module to `InsideWrapperPrefix::append_async_dependency` (`:4300`), which on the second async dependency rewrites `await init_a()` into `await __promiseAll([init_a(), init_b()])` (`:4354-4400`). This runs for every importer, wrapped or not.
- The only place `promise_all_runtime_ref` is marked used is `create_wrapper_for_file` (`:3120`) inside the `WrapKind::Esm` arm (count at `:3239-3260`, `generate_symbol_import_and_use` at `:3328-3339`), i.e. only when the importer is itself lazily wrapped. `WrapKind::None => {}` (`:3342`) does nothing, so an unwrapped importer (the entry, or a statically linked intermediate) references the helper but never pulls its runtime part in, and tree-shaking drops the definition.

### Fix

In step 6 of `scan_imports_and_exports`, where each part's import records are already scanned to count `__toESM` / `__toCommonJS` / `__require` / `__reExport` uses, also count static imports of async ESM-wrapped modules across the file's parts. When the second such import is seen, generate a `__promiseAll` runtime symbol use on that part so the helper survives tree-shaking. A single async wrapped import still emits a bare `await init_x()` and does not pull the helper in.

### Trigger / control matrix

Fires when an unwrapped module statically imports two or more modules that are both top-level-await (transitively async) and lazily ESM-wrapped (because they are also reached by `import()` somewhere).

- Triggers (failed before, pass now): 2 TLA modules static+dynamic at the entry; 3 TLA modules; unwrapped non-entry intermediate importing 2 TLA modules.
- Controls (unchanged): 1 async wrapped dep still emits a bare `await init_a()` with no `__promiseAll`; the existing wrapped-importer cases in this file keep passing.

### Relationship to #33337

#33337 contains the same step-6 counting as part of a larger change that also reworks `InsideWrapperPrefix` to preserve import order and removes the `create_wrapper_for_file` counting. This PR is the minimal `__promiseAll` fix on its own; if #33337 lands first this one is redundant.

### How did you verify your code works?

New tests in `test/bundler/bundler_promiseall_deadcode.test.ts` cover the three trigger shapes and the single-dependency control, and each runs the bundled output as well as asserting on its contents. The three existing `__promiseAll` tests in that file and `bundler_edgecase.test.ts` / `bundler_splitting.test.ts` / `bundler_regressions.test.ts` continue to pass.