### PR TITLE
bundler: report the output-format reason when top-level await is rejected for cjs/iife

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1891,9 +1891,7 @@ impl<'a> LinkerContext<'a> {
         hasher.digest()
     }
 
-    /// The cjs and iife output formats run the entry point as a synchronous
-    /// function body, so a top-level `await` cannot be represented. Report
-    /// one error per file, at the `await`, with the format switch that fixes it.
+    /// One error per file with a top-level `await`, pointing at the `await`.
     fn reject_top_level_await(&self, format_name: &str, from_js_api: bool) {
         let parse_graph = self.parse_graph();
         let tla_keywords = parse_graph.ast.items_top_level_await_keyword();

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -733,6 +733,19 @@ impl<'a> LinkerContext<'a> {
         // Validate top-level await for all files first.
         // SAFETY: scalar `bool` read of a field disjoint from `self` (= `(*bundle).linker`).
         if unsafe { (*bundle).has_any_top_level_await_modules } {
+            let unsupported_format = match self.options.output_format {
+                Format::Cjs => Some("cjs"),
+                Format::Iife => Some("iife"),
+                Format::Esm | Format::InternalBakeDev => None,
+            };
+            if let Some(format_name) = unsupported_format {
+                // Only `Bun.build()` installs a completion; the CLI never does.
+                // SAFETY: discriminant read of a field disjoint from `self`.
+                let from_js_api = unsafe { (*bundle).completion.is_some() };
+                self.reject_top_level_await(format_name, from_js_api);
+                return Err(LinkError::BuildFailed);
+            }
+
             // SAFETY: `parse_graph` is a backref to `BundleV2.graph`, disjoint
             // from `*self` (= `BundleV2.linker`). The SoA column slices below
             // are physically disjoint and the underlying slabs do not
@@ -1876,6 +1889,37 @@ impl<'a> LinkerContext<'a> {
         hasher.write(&chunk.output_source_map.suffix);
 
         hasher.digest()
+    }
+
+    /// The cjs and iife output formats run the entry point as a synchronous
+    /// function body, so a top-level `await` cannot be represented. Report
+    /// one error per file, at the `await`, with the format switch that fixes it.
+    fn reject_top_level_await(&self, format_name: &str, from_js_api: bool) {
+        let parse_graph = self.parse_graph();
+        let tla_keywords = parse_graph.ast.items_top_level_await_keyword();
+        let input_files = parse_graph.input_files.items_source();
+        let note: &'static [u8] = if from_js_api {
+            b"Use format: \"esm\" to allow top-level await"
+        } else {
+            b"Use --format=esm to allow top-level await"
+        };
+
+        for (source_index, tla_keyword) in tla_keywords.iter().enumerate() {
+            if tla_keyword.len == 0 {
+                continue;
+            }
+            self.log_disjoint().add_range_error_fmt_with_notes(
+                Some(&input_files[source_index]),
+                *tla_keyword,
+                Box::new([Data {
+                    text: std::borrow::Cow::Borrowed(note),
+                    ..Default::default()
+                }]),
+                format_args!(
+                    "Top-level await is currently not supported with the \"{format_name}\" output format"
+                ),
+            );
+        }
     }
 
     pub(crate) fn validate_tla(

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2463,7 +2463,7 @@ pub mod parse_worker {
         opts.features.allow_runtime = !task.source_index.is_runtime();
         opts.features.unwrap_commonjs_to_esm =
             output_format == options::Format::Esm && FeatureFlags::UNWRAP_COMMONJS_TO_ESM;
-        // cjs/iife reject top-level await after the parse with a format-specific error.
+        // The linker rejects top-level await for cjs/iife output (`reject_top_level_await`).
         opts.features.top_level_await = true;
         opts.features.auto_import_jsx = task.jsx.parse && topts.auto_import_jsx;
         opts.features.trim_unused_imports =

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2463,8 +2463,10 @@ pub mod parse_worker {
         opts.features.allow_runtime = !task.source_index.is_runtime();
         opts.features.unwrap_commonjs_to_esm =
             output_format == options::Format::Esm && FeatureFlags::UNWRAP_COMMONJS_TO_ESM;
-        opts.features.top_level_await = output_format == options::Format::Esm
-            || output_format == options::Format::InternalBakeDev;
+        // Always parse with the Module goal so top-level await is accepted
+        // syntactically; formats that cannot represent it (cjs/iife) are
+        // rejected after the parse with a format-specific error.
+        opts.features.top_level_await = true;
         opts.features.auto_import_jsx = task.jsx.parse && topts.auto_import_jsx;
         opts.features.trim_unused_imports =
             loader.is_typescript() || topts.trim_unused_imports.unwrap_or(false);

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2463,9 +2463,7 @@ pub mod parse_worker {
         opts.features.allow_runtime = !task.source_index.is_runtime();
         opts.features.unwrap_commonjs_to_esm =
             output_format == options::Format::Esm && FeatureFlags::UNWRAP_COMMONJS_TO_ESM;
-        // Always parse with the Module goal so top-level await is accepted
-        // syntactically; formats that cannot represent it (cjs/iife) are
-        // rejected after the parse with a format-specific error.
+        // cjs/iife reject top-level await after the parse with a format-specific error.
         opts.features.top_level_await = true;
         opts.features.auto_import_jsx = task.jsx.parse && topts.auto_import_jsx;
         opts.features.trim_unused_imports =

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -856,6 +856,27 @@ impl<'a> Parser<'a> {
 
         parse_tracer.end();
 
+        // Top-level await parses under the Module goal regardless of output
+        // format. Reject it here for formats that cannot represent it so the
+        // diagnostic points at the format mismatch instead of the generic
+        // `"await" can only be used inside an "async" function` lexer error.
+        if p.top_level_await_keyword.len > 0 && p.options.bundle {
+            let format_name: Option<&'static str> = match p.options.output_format {
+                options::Format::Cjs => Some("cjs"),
+                options::Format::Iife => Some("iife"),
+                options::Format::Esm | options::Format::InternalBakeDev => None,
+            };
+            if let Some(format_name) = format_name {
+                p.log().add_range_error_fmt(
+                    Some(p.source),
+                    p.top_level_await_keyword,
+                    format_args!(
+                        "Top-level await is currently not supported with the \"{format_name}\" output format"
+                    ),
+                );
+            }
+        }
+
         // Halt parsing right here if there were any errors
         // This fixes various conditions that would cause crashes due to the AST being in an invalid state while visiting
         // In a number of situations, we continue to parsing despite errors so that we can report more errors to the user

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -856,23 +856,6 @@ impl<'a> Parser<'a> {
 
         parse_tracer.end();
 
-        if p.top_level_await_keyword.len > 0 && p.options.bundle {
-            let format_name: Option<&'static str> = match p.options.output_format {
-                options::Format::Cjs => Some("cjs"),
-                options::Format::Iife => Some("iife"),
-                options::Format::Esm | options::Format::InternalBakeDev => None,
-            };
-            if let Some(format_name) = format_name {
-                p.log().add_range_error_fmt(
-                    Some(p.source),
-                    p.top_level_await_keyword,
-                    format_args!(
-                        "Top-level await is currently not supported with the \"{format_name}\" output format"
-                    ),
-                );
-            }
-        }
-
         // Halt parsing right here if there were any errors
         // This fixes various conditions that would cause crashes due to the AST being in an invalid state while visiting
         // In a number of situations, we continue to parsing despite errors so that we can report more errors to the user

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -856,10 +856,6 @@ impl<'a> Parser<'a> {
 
         parse_tracer.end();
 
-        // Top-level await parses under the Module goal regardless of output
-        // format. Reject it here for formats that cannot represent it so the
-        // diagnostic points at the format mismatch instead of the generic
-        // `"await" can only be used inside an "async" function` lexer error.
         if p.top_level_await_keyword.len > 0 && p.options.bundle {
             let format_name: Option<&'static str> = match p.options.output_format {
                 options::Format::Cjs => Some("cjs"),

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 // Tests for CommonJS <> ESM interop, specifically the __toESM helper behavior.
@@ -656,5 +657,69 @@ describe("bundler", () => {
     bundleErrors: {
       "/entry.js": ['Top-level await is currently not supported with the "cjs" output format'],
     },
+  });
+
+  // The note names the switch that fits the entry point: the CLI flag for
+  // `bun build`, the config key for `Bun.build()`.
+  describe("top-level await format error note", () => {
+    const files = {
+      "entry.mjs": `export const v = await Promise.resolve("TLA-OK");`,
+      "build.mjs": /* js */ `
+        const result = await Bun.build({
+          entrypoints: ["./entry.mjs"],
+          format: process.argv[2],
+          throw: false,
+        });
+        console.log("success:", result.success);
+        for (const log of result.logs) {
+          console.log(log.message);
+          for (const note of log.notes) console.log("note:", note.message);
+        }
+      `,
+    };
+
+    test.concurrent.each(["cjs", "iife"])("bun build --format=%s suggests --format=esm", async format => {
+      using dir = tempDir("tla-format-note-cli", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "entry.mjs", `--format=${format}`],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(normalizeBunSnapshot(stderr, String(dir))).toBe(
+        `1 | export const v = await Promise.resolve("TLA-OK");
+                     ^
+error: Top-level await is currently not supported with the "${format}" output format
+    at <dir>/entry.mjs:1:18
+
+note: Use --format=esm to allow top-level await`,
+      );
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent.each(["cjs", "iife"])('Bun.build({ format: "%s" }) suggests format: "esm"', async format => {
+      using dir = tempDir("tla-format-note-api", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.mjs", format],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toBe(
+        `success: false
+Top-level await is currently not supported with the "${format}" output format
+note: Use format: "esm" to allow top-level await
+`,
+      );
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
   });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -597,4 +597,64 @@ describe("bundler", () => {
       stdout: "loaded ok",
     },
   });
+
+  // Top-level await in a valid ES module bundled to cjs/iife must be rejected
+  // for the output-format reason, not the generic "await can only be used
+  // inside an async function" script-context error.
+  itBundled("cjs/TopLevelAwaitInESModuleFormatError", {
+    files: {
+      "/entry.mjs": /* js */ `
+        const v = await Promise.resolve("TLA-OK");
+        console.log(v);
+        export const out = v;
+      `,
+    },
+    entryPointsRaw: ["./entry.mjs"],
+    format: "cjs",
+    target: "node",
+    bundleErrors: {
+      "/entry.mjs": ['Top-level await is currently not supported with the "cjs" output format'],
+    },
+  });
+  itBundled("iife/TopLevelAwaitInESModuleFormatError", {
+    files: {
+      "/entry.mjs": /* js */ `
+        const v = await Promise.resolve("TLA-OK");
+        export const out = v;
+      `,
+    },
+    entryPointsRaw: ["./entry.mjs"],
+    format: "iife",
+    target: "browser",
+    bundleErrors: {
+      "/entry.mjs": ['Top-level await is currently not supported with the "iife" output format'],
+    },
+  });
+  itBundled("cjs/TopLevelAwaitImportFormatError", {
+    files: {
+      "/entry.js": /* js */ `
+        const mod = await import("./other.js");
+        console.log(mod);
+      `,
+      "/other.js": `export const x = 1;`,
+    },
+    format: "cjs",
+    target: "node",
+    bundleErrors: {
+      "/entry.js": ['Top-level await is currently not supported with the "cjs" output format'],
+    },
+  });
+  itBundled("cjs/TopLevelAwaitUsingFormatError", {
+    files: {
+      "/entry.js": /* js */ `
+        await using r = { async [Symbol.asyncDispose]() {} };
+        console.log(r);
+      `,
+    },
+    format: "cjs",
+    target: "node",
+    bundleErrors: {
+      "/entry.js": ['Top-level await is currently not supported with the "cjs" output format'],
+    },
+  });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -661,7 +661,7 @@ describe("bundler", () => {
 
   // The note names the switch that fits the entry point: the CLI flag for
   // `bun build`, the config key for `Bun.build()`.
-  describe("top-level await format error note", () => {
+  describe.each(["cjs", "iife"])("top-level await format error note (%s)", format => {
     const files = {
       "entry.mjs": `export const v = await Promise.resolve("TLA-OK");`,
       "build.mjs": /* js */ `
@@ -678,7 +678,7 @@ describe("bundler", () => {
       `,
     };
 
-    test.concurrent.each(["cjs", "iife"])("bun build --format=%s suggests --format=esm", async format => {
+    test.concurrent("bun build suggests --format=esm", async () => {
       using dir = tempDir("tla-format-note-cli", files);
       await using proc = Bun.spawn({
         cmd: [bunExe(), "build", "entry.mjs", `--format=${format}`],
@@ -701,7 +701,7 @@ note: Use --format=esm to allow top-level await`,
       expect(exitCode).toBe(1);
     });
 
-    test.concurrent.each(["cjs", "iife"])('Bun.build({ format: "%s" }) suggests format: "esm"', async format => {
+    test.concurrent('Bun.build() suggests format: "esm"', async () => {
       using dir = tempDir("tla-format-note-api", files);
       await using proc = Bun.spawn({
         cmd: [bunExe(), "build.mjs", format],

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -3515,7 +3515,6 @@ describe.concurrent("bundler", () => {
       `,
     },
     format: "iife",
-    todo: true,
     bundleErrors: {
       "/entry.js": ['Top-level await is currently not supported with the "iife" output format'],
     },
@@ -3538,7 +3537,6 @@ describe.concurrent("bundler", () => {
       `,
     },
     format: "cjs",
-    todo: true,
     bundleErrors: {
       "/entry.js": ['Top-level await is currently not supported with the "cjs" output format'],
     },


### PR DESCRIPTION
### Problem
- `bun build --format=cjs` (or `iife`) on a valid ES module with top-level `await` fails with `"await" can only be used inside an "async" function`. The source is fine: the output format cannot represent top-level await. The wrong message sends users to "fix" valid code. The same happens for `for await`, `await using`, `await import()`, and `--bytecode` (which defaults to cjs, #25300).
- Cause: `ParseTask` turned off `features.top_level_await` for every format except esm (`src/bundler/ParseTask.rs:2466`). The parser then read `await` as an identifier and the lexer raised its script-context error.

### Fix
- The bundler always parses with the Module goal, so `top_level_await_keyword` is recorded for every file.
- `LinkerContext::link` rejects the bundle next to `validate_tla` when the output format is cjs or iife: one error per file, at the `await`, with esbuild's wording: `Top-level await is currently not supported with the "cjs" output format`.
- The error carries a note with the fix that matches the entry point: `Use --format=esm to allow top-level await` for `bun build`, `Use format: "esm" to allow top-level await` for `Bun.build()`. Only `Bun.build()` installs a completion handle on `BundleV2`, so `completion.is_some()` tells the two apart.
- Verified: `test/bundler/bundler_cjs.test.ts` (8 new cases: the four TLA forms under cjs/iife, plus the CLI and API note for each format). The two `default/TopLevelAwait{CJS,IIFE}` esbuild parity tests are no longer `todo`. All of `test/bundler/esbuild/default.test.ts`, `bundler_edgecase`, `bundler_splitting`, and `bundler_bun` pass.

### Background
- The parser has two goals for a file. Under the Script goal `await` is an identifier. Under the Module goal `await` at top level is an expression and the parser records its range in `top_level_await_keyword`. `features.top_level_await` picks the goal.
- The linker already has a TLA pass (`validate_tla`) that forbids `require()` of a module with top-level await. The new check runs first in that block and returns `BuildFailed` before any wrapper or chunk is generated.
- Side effect: `var await = 42` at module scope is now rejected for cjs/iife output, the same as for esm output and the same as esbuild.

<details><summary>Notes</summary>

- Stock bun: `"await" can only be used inside an "async" function` plus a follow-on `Unexpected .` for `await Promise.resolve()`.
- esbuild reports one error per `await` occurrence. This PR reports one per file, at the last recorded top-level `await`, which is the range the existing TLA machinery already stores.
- The first revision of this PR put the gate in the parser (`parse_entry.rs`). It moved to the linker so the bundler can tell the CLI and the JS API apart for the note.
- `bun build --compile --bytecode` now reports the format error too. `--format=esm` with `--compile --bytecode` builds.
- Related: #29246 takes a broader DCE-aware approach to the same area.

</details>

Related: #25300 hits the same misdiagnosis through `--bytecode`, which defaults to cjs. That build still needs `--format=esm` to succeed. The note now says so.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 86 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts test/bundler/esbuild/default.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [810.62ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [370.80ms]
(pass) bundler > cjs/__toESM_import_syntax_function [352.17ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [416.66ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [357.60ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [346.93ms]
(pass) bundler > cjs/__toESM_target_node [418.95ms]
(pass) bundler > cjs/__toESM_target_browser [356.56ms]
(pass) bundler > cjs/__toESM_target_bun [354.56ms]
(pass) bundler > cjs/__toESM_format_esm [385.09ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [382.35ms]
(pass) bundler > cjs/__toESM_mjs_reexport [436.19ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [358.52ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [711.31ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [361.49ms]
(pa
... (truncated)

release without fix: 10 failed, 86 skipped
bun test v1.4.1-canary.1 (a6c4cc276)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [19.93ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [9.49ms]
(pass) bundler > cjs/__toESM_import_syntax_function [8.68ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [9.21ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [9.87ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [9.37ms]
(pass) bundler > cjs/__toESM_target_node [10.28ms]
(pass) bundler > cjs/__toESM_target_browser [9.62ms]
(pass) bundler > cjs/__toESM_target_bun [8.17ms]
(pass) bundler > cjs/__toESM_format_esm [8.69ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [9.15ms]
(pass) bundler > cjs/__toESM_mjs_reexport [8.17ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [8.07ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [8.23ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [7.88ms]
(pass) bundler > cjs/__toESM_default_prop_no_esModule [7.53ms]
(pass) bundler > cjs/__toESM_mixed_import_styles [10.10ms]
(pass) bundler > cjs/__toESM_esModule_non_true [7.49ms]
(pass) bundler > cjs/__toESM_esModule_false [8.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 86 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts test/bundler/esbuild/default.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [875.16ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [381.37ms]
(pass) bundler > cjs/__toESM_import_syntax_function [437.93ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [356.03ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [377.59ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [422.45ms]
(pass) bundler > cjs/__toESM_target_node [438.48ms]
(pass) bundler > cjs/__toESM_target_browser [386.36ms]
(pass) bundler > cjs/__toESM_target_bun [431.14ms]
(pass) bundler > cjs/__toESM_format_esm [386.07ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [441.55ms]
(pass) bundler > cjs/__toESM_mjs_reexport [372.48ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [441.36ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [715.41ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [365.61ms]
(pa
... (truncated)

release with fix: 86 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6c7658d617
  features     baseline

23 deps, 131 codegen, 1172 objects in 675ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 26 installs across 63 packages (no changes) [15.00ms]
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] gen .bind.ts → GeneratedBindings.cpp
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Proc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs         |  42 ++++++++++++
 src/bundler/ParseTask.rs             |   4 +-
 test/bundler/bundler_cjs.test.ts     | 127 ++++++++++++++++++++++++++++++++++-
 test/bundler/esbuild/default.test.ts |   2 -
 4 files changed, 170 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/bundler/LinkerContext.rs              8      3      0
src/bundler/ParseTask.rs                  4      3      0
test/bundler/bundler_cjs.test.ts          3      4      0
test/bundler/esbuild/default.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->