### PR TITLE
bundler(splitting): rewrite self dynamic imports to the chunk path

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -394,11 +394,8 @@ impl<'a> LinkerContext<'a> {
 
     pub fn is_external_dynamic_import(&self, record: &ImportRecord) -> bool {
         use crate::linker_graph::FileColumns as _;
-        // A dynamic import of a file that is itself an entry point (user-specified
-        // or promoted via dynamic_import_entry_points) becomes a runtime `import()`
-        // of that entry's chunk. This includes a file dynamically importing itself:
-        // excluding that case leaves the record pointing at an unwrapped file, and
-        // the printer then emits a call to a wrapper that was never generated.
+        // Self-imports count too: every dynamic-import target is an entry point,
+        // and splitting never wraps it, so the record must become a chunk import.
         self.graph.code_splitting
             && record.kind == ImportKind::Dynamic
             && self.graph.files.items_entry_point_kind()[record.source_index.get() as usize]

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -394,8 +394,6 @@ impl<'a> LinkerContext<'a> {
 
     pub fn is_external_dynamic_import(&self, record: &ImportRecord) -> bool {
         use crate::linker_graph::FileColumns as _;
-        // Self-imports count too: every dynamic-import target is an entry point,
-        // and splitting never wraps it, so the record must become a chunk import.
         self.graph.code_splitting
             && record.kind == ImportKind::Dynamic
             && self.graph.files.items_entry_point_kind()[record.source_index.get() as usize]

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -392,13 +392,18 @@ impl<'a> LinkerContext<'a> {
         self.pending_task_count.fetch_sub(1, Ordering::Relaxed);
     }
 
-    pub fn is_external_dynamic_import(&self, record: &ImportRecord, source_index: u32) -> bool {
+    pub fn is_external_dynamic_import(&self, record: &ImportRecord) -> bool {
         use crate::linker_graph::FileColumns as _;
+        // A dynamic import of a file that is itself an entry point (user-specified
+        // or promoted via dynamic_import_entry_points) becomes a runtime `import()`
+        // of that entry's chunk. This includes a file dynamically importing itself:
+        // excluding that case leaves the record pointing at an unwrapped file, and
+        // the printer then emits a call to a wrapper that was never generated
+        // (issue #6621).
         self.graph.code_splitting
             && record.kind == ImportKind::Dynamic
             && self.graph.files.items_entry_point_kind()[record.source_index.get() as usize]
                 .is_entry_point()
-            && record.source_index.get() != source_index
     }
 
     /// Note: this should call a `MimallocArena` debug hook
@@ -2722,7 +2727,7 @@ impl<'a> LinkerContext<'a> {
 
             for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid()
-                    && !self.is_external_dynamic_import(record, source_index)
+                    && !self.is_external_dynamic_import(record)
                     && !ctx.file_entry_bits[record.source_index.get() as usize]
                         .is_set(entry_points_count)
                 {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -398,8 +398,7 @@ impl<'a> LinkerContext<'a> {
         // or promoted via dynamic_import_entry_points) becomes a runtime `import()`
         // of that entry's chunk. This includes a file dynamically importing itself:
         // excluding that case leaves the record pointing at an unwrapped file, and
-        // the printer then emits a call to a wrapper that was never generated
-        // (issue #6621).
+        // the printer then emits a call to a wrapper that was never generated.
         self.graph.code_splitting
             && record.kind == ImportKind::Dynamic
             && self.graph.files.items_entry_point_kind()[record.source_index.get() as usize]

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -166,7 +166,7 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
                 for &import_record_id in part.import_record_indices.slice() {
                     let import_record = &mut import_records[import_record_id as usize];
                     if import_record.source_index.is_valid()
-                        && ctx.is_external_dynamic_import(import_record, source_index)
+                        && ctx.is_external_dynamic_import(import_record)
                     {
                         let other_chunk_index =
                             entry_point_chunk_indices[import_record.source_index.get() as usize];

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -313,7 +313,7 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                             if record.source_index.is_valid()
                                 && (record.kind == ImportKind::Stmt || is_part_in_this_chunk)
                             {
-                                if self.c.is_external_dynamic_import(record, source_index) {
+                                if self.c.is_external_dynamic_import(record) {
                                     // Don't follow import() dependencies
                                     continue;
                                 }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -894,7 +894,7 @@ pub fn scan_imports_and_exports(
                     let is_external_dyn = rec_source_index.is_valid() && {
                         let record = &col_ref!(import_records_list)[id].as_slice()
                             [import_record_index as usize];
-                        this.is_external_dynamic_import(record, source_index)
+                        this.is_external_dynamic_import(record)
                     };
                     if !rec_source_index.is_valid() || is_external_dyn {
                         if output_format == Format::InternalBakeDev {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -290,7 +290,6 @@ describe("bundler", () => {
     },
   });
 
-  // https://github.com/oven-sh/bun/issues/6621
   // A file that dynamically imports itself must resolve to its own chunk, not
   // to an unwrapped `require_<name>()` call that was never emitted.
   itBundled("splitting/EntryDynamicImportsItself", {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -290,6 +290,89 @@ describe("bundler", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/6621
+  // A file that dynamically imports itself must resolve to its own chunk, not
+  // to an unwrapped `require_<name>()` call that was never emitted.
+  itBundled("splitting/EntryDynamicImportsItself", {
+    files: {
+      "/entry.js": /* js */ `
+        export const v = "V";
+        export async function reload() {
+          const m = await import("./entry.js");
+          return "got " + m.v + " " + typeof m.reload;
+        }
+        reload().then(x => console.log(x));
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      env,
+      stdout: "got V function",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").not.toContain("require_entry");
+    },
+  });
+
+  // Same as above, but the self-importing file is not a user-specified entry
+  // point. It becomes a dynamic-import entry point and its code lands in a
+  // shared chunk; the self-import must still resolve to its entry chunk.
+  itBundled("splitting/NonEntryDynamicImportsItself", {
+    files: {
+      "/main.js": /* js */ `
+        import { self, name } from "./lib.js";
+        self().then(got => console.log("main:", name, got));
+      `,
+      "/lib.js": /* js */ `
+        export const name = "lib";
+        export async function self() {
+          const m = await import("./lib.js");
+          return m.name + " " + typeof m.self;
+        }
+      `,
+    },
+    entryPoints: ["/main.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: {
+      file: "/out/main.js",
+      env,
+      stdout: "main: lib lib function",
+    },
+  });
+
+  // Lazy-recursion idiom: the function re-imports its own file on each
+  // iteration. Exercises the minified path as well.
+  itBundled("splitting/SelfDynamicImportRecursionMinified", {
+    files: {
+      "/entry.js": /* js */ `
+        export async function loop(n) {
+          if (n <= 0) return "done";
+          const m = await import("./entry.js");
+          return m.loop(n - 1);
+        }
+        loop(3).then(x => console.log(x));
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    minifySyntax: true,
+    outdir: "/out",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      env,
+      stdout: "done",
+    },
+  });
+
   itBundled("splitting/CircularDynamicImportsWithCSS", {
     files: {
       "/entry.js": `

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -298,7 +298,7 @@ describe("bundler", () => {
         export const v = "V";
         export async function reload() {
           const m = await import("./entry.js");
-          return "got " + m.v + " " + typeof m.reload;
+          return "got " + m.v + " " + (m.reload === reload);
         }
         reload().then(x => console.log(x));
       `,
@@ -310,7 +310,7 @@ describe("bundler", () => {
     run: {
       file: "/out/entry.js",
       env,
-      stdout: "got V function",
+      stdout: "got V true",
     },
     onAfterBundle(api) {
       api.expectFile("/out/entry.js").not.toContain("require_entry");
@@ -330,7 +330,7 @@ describe("bundler", () => {
         export const name = "lib";
         export async function self() {
           const m = await import("./lib.js");
-          return m.name + " " + typeof m.self;
+          return m.name + " " + (m.self === self);
         }
       `,
     },
@@ -341,7 +341,7 @@ describe("bundler", () => {
     run: {
       file: "/out/main.js",
       env,
-      stdout: "main: lib lib function",
+      stdout: "main: lib lib true",
     },
   });
 


### PR DESCRIPTION
### What does this PR do?

Fixes `bun build --splitting` emitting a call to a nonexistent `require_<name>()` wrapper when a module dynamically imports itself, which made the build succeed but throw `ReferenceError` at runtime.

```js
// entry.mjs
export const v = "V";
export async function reload() {
  const m = await import("./entry.mjs");
  return "got " + m.v + " " + typeof m.reload;
}
reload().then(x => console.log(x));
```

```
$ bun build entry.mjs --splitting --format=esm --outdir dist && bun dist/entry.js
4 |   const m = await Promise.resolve().then(() => require_entry());
                                                   ^
ReferenceError: require_entry is not defined
```

The same input works under the runtime, under node, and under `bun build` without `--splitting`. Reproduces for entry-point and non-entry self-imports and with `--minify`. esbuild has the same defect.

Under code splitting the linker does not wrap dynamic-import targets; instead `computeCrossChunkDependencies` rewrites each such record to `import("./<chunk>")` and invalidates its `source_index` so the printer takes the external-`import()` branch. That rewrite is gated on `is_external_dynamic_import`, which excluded `record.source_index == source_index`. A self-import therefore kept a valid `source_index`, the printer took the internal branch, and emitted a call to `wrapper_ref` (`require_entry`). Since `wrap == WrapKind::None`, no definition for that symbol was ever generated.

The fix drops the self-import exclusion. A file that dynamically imports itself is always an entry point (user-specified or promoted via `dynamic_import_entry_points`), so its entry chunk exists and `entry_point_chunk_indices` resolves. The record is now rewritten to `import("./<own chunk>")` like any other split-point dynamic import. ESM module caching handles the self-reference, and the chunk-hash walk already tolerates cycles via `chunk_visit_map`.

After:

```js
// dist/entry.js
var v = "V";
async function reload() {
  const m = await import("./entry.js");
  return "got " + m.v + " " + typeof m.reload;
}
reload().then((x) => console.log(x));
export { v, reload };
```

The output now carries the same dead `__require` shim that every other cross-chunk dynamic import already emits under splitting; that is pre-existing (#35579) and not touched here.

### How did you verify your code works?

Added three cases to `test/bundler/bundler_splitting.test.ts`:

- `splitting/EntryDynamicImportsItself`: entry point imports itself
- `splitting/NonEntryDynamicImportsItself`: statically-imported library imports itself (code lands in a shared chunk, self-import resolves to the dynamic-entry chunk)
- `splitting/SelfDynamicImportRecursionMinified`: lazy-recursion idiom under `--minify`

All three fail with `ReferenceError: require_<name> is not defined` before this change and pass after:

```
USE_SYSTEM_BUN=1 bun test test/bundler/bundler_splitting.test.ts -t 'DynamicImportsItself|SelfDynamicImportRecursion'   # 3 fail
bun bd test test/bundler/bundler_splitting.test.ts -t 'DynamicImportsItself|SelfDynamicImportRecursion'                 # 3 pass
```

Regression sweep: `bundler_splitting`, `esbuild/splitting`, `bundler_edgecase`, `bundler_compile_splitting`, `bundler_regressions`, `metafile`, and `bun-build-api` suites all pass with the change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_splitting.test.ts
bun test v1.4.0 (e66873eec)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [912.24ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [561.61ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [556.46ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [596.42ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [561.41ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [622.20ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [559.52ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [761.81ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [565.82ms]
311 |       file: "/out/entry.js",
312 |       env,
313 |       stdout: "got V true",
314 |     },
315 |     onAfterBundle(api) {
316 |       api.expectFile("/out/entry.js").not.toContain("require_entry");
                                                ^
error: expect(received).not.toContain(expected)

Expected to not contain: "require_entry"
Recei
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e7b209b68)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [37.23ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [12.85ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [13.39ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [12.53ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [12.93ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [13.52ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [13.11ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [21.69ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [14.30ms]
(pass) bundler > splitting/EntryDynamicImportsItself [11.87ms]
(pass) bundler > splitting/NonEntryDynamicImportsItself [10.62ms]
(pass) bundler > splitting/SelfDynamicImportRecursionMinified [9.47ms]
(pass) bundler > splitting/CircularDynamicImportsWithCSS [12.51ms]
(pass) bundler > splitting/ManyCrossChunkExportAliasCollisions [1692.52ms]

 14 pass
 0 fail
 20019 expect() calls
Ran 14 tests across 1 file. [2.31s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_splitting.test.ts
bun test v1.4.0 (e66873eec)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [908.43ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [551.82ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [564.81ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [565.09ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [550.12ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [594.00ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [578.61ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [734.05ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [538.24ms]
(pass) bundler > splitting/EntryDynamicImportsItself [510.06ms]
(pass) bundler > splitting/NonEntryDynamicImportsItself [784.47ms]
(pass) bundler > splitting/SelfDynamicImportRecursionMinified [353.60ms]
(pass) bundler > splitting/CircularDynamicImportsWithCSS [583.86ms]
(pass) bundler > splitting/ManyCrossChunkExportAliasCollisions [5115.84ms]

 14
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       |  5 +-
 .../computeCrossChunkDependencies.rs               |  2 +-
 .../findAllImportedPartsInJSOrder.rs               |  2 +-
 .../linker_context/scanImportsAndExports.rs        |  2 +-
 test/bundler/bundler_splitting.test.ts             | 82 ++++++++++++++++++++++
 5 files changed, 87 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/LinkerContext.rs                                  5      6      0
…bundler/linker_context/computeCrossChunkDependencies.rs      3      1      0
…bundler/linker_context/findAllImportedPartsInJSOrder.rs      2      1      0
src/bundler/linker_context/scanImportsAndExports.rs           2      1      0
test/bundler/bundler_splitting.test.ts                        3      5      0
```

</details>

<!-- robobun:evidence:end -->