### PR TITLE
dns: drop the retransmit timer in check_timeouts once no query is pending

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4126,9 +4126,7 @@ impl Resolver {
                     c_ares::ARES_SOCKET_BAD,
                     c_ares::ARES_SOCKET_BAD,
                 );
-                // c-ares detaches a query only after its callback returns, so
-                // `request_completed` may have re-armed against a still-counted
-                // query; re-check now (mirrors `on_dns_poll`).
+                // See `on_dns_poll` — c-ares detaches post-callback, so re-check.
                 if self.any_requests_pending() {
                     let _ = self.add_timer(Some(&now));
                 } else {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4110,10 +4110,10 @@ impl Resolver {
             // SAFETY: `state` is the boxed per-thread `RuntimeState`; single-threaded JS heap.
             unsafe { (*state).timer.increment_timer_ref(-1, uws_loop) };
             // SAFETY: `deref_this` is the heap allocation from `init`. This releases the
-            // ref taken by `add_timer` (no local `ref_()` pairing). The timer is
-            // only ACTIVE while at least one pending request also holds an
-            // `IntrusiveRc<Resolver>`, so this `deref` cannot drop the last ref
-            // and `*self` stays live for the rest of the function body.
+            // ref taken by `add_timer` (no local `ref_()` pairing). When the
+            // post-`ares_process_fd` re-check below called `remove_timer()`
+            // this may be the final release; nothing dereferences `*self` after
+            // this point (same shape as `on_dns_poll`'s `ref_scope` guard).
             unsafe { Self::deref(deref_this) };
         }
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4109,11 +4109,9 @@ impl Resolver {
             let state = crate::jsc_hooks::runtime_state();
             // SAFETY: `state` is the boxed per-thread `RuntimeState`; single-threaded JS heap.
             unsafe { (*state).timer.increment_timer_ref(-1, uws_loop) };
-            // SAFETY: `deref_this` is the heap allocation from `init`. This releases the
-            // ref taken by `add_timer` (no local `ref_()` pairing). When the
-            // post-`ares_process_fd` re-check below called `remove_timer()`
-            // this may be the final release; nothing dereferences `*self` after
-            // this point (same shape as `on_dns_poll`'s `ref_scope` guard).
+            // SAFETY: `deref_this` is the heap allocation from `init`; releases
+            // `add_timer`'s ref. May be the final release; nothing touches
+            // `*self` after this point.
             unsafe { Self::deref(deref_this) };
         }
 
@@ -4129,9 +4127,8 @@ impl Resolver {
                     c_ares::ARES_SOCKET_BAD,
                 );
                 // c-ares detaches a query only after its callback returns, so
-                // `request_completed` (run inside the callback above) may have
-                // re-armed the timer against a still-counted query. Re-check
-                // now that `ares_process_fd` has returned; mirrors `on_dns_poll`.
+                // `request_completed` may have re-armed against a still-counted
+                // query; re-check now (mirrors `on_dns_poll`).
                 if self.any_requests_pending() {
                     let _ = self.add_timer(Some(&now));
                 } else {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4128,7 +4128,15 @@ impl Resolver {
                     c_ares::ARES_SOCKET_BAD,
                     c_ares::ARES_SOCKET_BAD,
                 );
-                let _ = self.add_timer(Some(&now));
+                // c-ares detaches a query only after its callback returns, so
+                // `request_completed` (run inside the callback above) may have
+                // re-armed the timer against a still-counted query. Re-check
+                // now that `ares_process_fd` has returned; mirrors `on_dns_poll`.
+                if self.any_requests_pending() {
+                    let _ = self.add_timer(Some(&now));
+                } else {
+                    self.remove_timer();
+                }
             }
         }
     }

--- a/test/js/node/dns/dns-lookup-keepalive.test.ts
+++ b/test/js/node/dns/dns-lookup-keepalive.test.ts
@@ -43,14 +43,19 @@ describe("dns.Resolver does not keep the event loop alive after the last query t
     return JSON.parse(stdout.trim()) as { delay: number; code: string };
   }
 
-  for (const [name, stmt] of [
-    ["resolveCaa", `r.resolveCaa("x.invalid", done);`],
-    ["resolve4", `r.resolve4("x.invalid", done);`],
-    ["reverse", `r.reverse("192.0.2.1", done);`],
+  for (const [name, stmt, expected] of [
+    ["resolveCaa", `r.resolveCaa("x.invalid", done);`, "ETIMEOUT"],
+    ["resolve4", `r.resolve4("x.invalid", done);`, "ETIMEOUT"],
+    // ares_gethostbyaddr swallows the PTR query status and reports ENOTFOUND
+    // after the file-lookup fallback; the PTR query itself still completes
+    // via the retransmit timer.
+    ["reverse", `r.reverse("192.0.2.1", done);`, "ENOTFOUND"],
   ] as const) {
     test.concurrent(name, async () => {
       const { delay, code } = await run(stmt);
-      expect(typeof code).toBe("string");
+      // ETIMEOUT proves completion routed through `check_timeouts`
+      // (the path changed here), not `on_dns_poll`.
+      expect(code).toBe(expected);
       // Before the fix: delay ≈ 1000 ms (one retransmit-timer interval).
       expect(delay).toBeLessThan(500);
     });

--- a/test/js/node/dns/dns-lookup-keepalive.test.ts
+++ b/test/js/node/dns/dns-lookup-keepalive.test.ts
@@ -1,7 +1,58 @@
-import { expect, test } from "bun:test";
-import "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
 test("expect dns.lookup to keep the process alive", () => {
   expect([join(import.meta.dir, "dns-fixture.js")]).toRun();
+});
+
+// When the last outstanding query on a Resolver completes via the retransmit
+// timer (c-ares timeout, not socket I/O), `check_timeouts` must not leave the
+// timer re-armed: `request_completed` runs inside the c-ares callback, before
+// c-ares has detached the query, so `any_requests_pending()` can still read
+// true there. Without the post-`ares_process_fd` re-check the timer stays
+// ACTIVE with its `+1` ref on the native Resolver. Observable as a ~1 s tail
+// between the last callback and process exit; under `bun test` on the asan
+// lane the exit GC runs before that timer fires and LSan flags the Resolver
+// allocation as a direct leak.
+describe("dns.Resolver does not keep the event loop alive after the last query times out", () => {
+  async function run(stmt: string) {
+    const src = `
+      const dns = require("node:dns");
+      const dgram = require("node:dgram");
+      const sock = dgram.createSocket("udp4");
+      sock.bind(0, "127.0.0.1", () => {
+        const r = new dns.Resolver({ timeout: 100, tries: 1 });
+        r.setServers(["127.0.0.1:" + sock.address().port]);
+        let cb_t, code;
+        const done = err => { cb_t = Date.now(); code = err && err.code; sock.close(); };
+        ${stmt}
+        process.on("exit", () => {
+          console.log(JSON.stringify({ delay: Date.now() - cb_t, code }));
+        });
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    return JSON.parse(stdout.trim()) as { delay: number; code: string };
+  }
+
+  for (const [name, stmt] of [
+    ["resolveCaa", `r.resolveCaa("x.invalid", done);`],
+    ["resolve4", `r.resolve4("x.invalid", done);`],
+    ["reverse", `r.reverse("192.0.2.1", done);`],
+  ] as const) {
+    test.concurrent(name, async () => {
+      const { delay, code } = await run(stmt);
+      expect(typeof code).toBe("string");
+      // Before the fix: delay ≈ 1000 ms (one retransmit-timer interval).
+      expect(delay).toBeLessThan(500);
+    });
+  }
 });


### PR DESCRIPTION
## Problem

Creating a `new dns.Resolver()`, issuing a single query that completes via c-ares timeout, and then letting the event loop exit keeps the loop alive for one extra retransmit interval (~1 s) after the callback. Under `bun test` on the asan lane the test runner exits before that interval elapses and LeakSanitizer reports the `Box<Resolver>` (~25 KB) as a direct leak from `Resolver::init` / `Resolver::new_resolver`.

Repro:

```js
const dns = require("node:dns");
const dgram = require("node:dgram");
const sock = dgram.createSocket("udp4");
sock.bind(0, "127.0.0.1", () => {
  const r = new dns.Resolver({ timeout: 100, tries: 1 });
  r.setServers(["127.0.0.1:" + sock.address().port]);
  r.resolveCaa("x", () => { t = Date.now(); sock.close(); });
  process.on("exit", () => console.log(Date.now() - t));
});
```

| | delay |
|---|---|
| node 26 | `0` |
| bun (before) | `1001` |
| bun (after) | `9` |

## Cause

`Resolver::check_timeouts` (the 1 s retransmit driver) pumps `ares_process_fd(BAD, BAD)`, which synchronously fires the completion callback for a timed-out query. The callback's deferred `request_completed()` consults `any_requests_pending()`, which falls through to `ares_queue_active_queries()`. c-ares detaches a query only after its callback returns, so that read is still nonzero inside the callback, and `request_completed()` re-arms the timer (taking a fresh `+1` ref on the Resolver). Back in `check_timeouts`, `add_timer(Some(&now))` sees the timer already ACTIVE and returns, leaving it armed with nothing actually pending.

If the event loop keeps running (`bun run`) the next timer fire releases the ref. `bun test` calls `global_exit()` once the test phase is Done, without draining pending timers; `cancel_all_timeout_objects` skips `EventLoopTimerTag::DNSResolver`, so the `+1` survives the exit GC's `finalize` → `deref` and the allocation is never freed.

`on_dns_poll` (the socket-I/O completion path) already handles this with a post-`ares_process_fd` re-check that calls `remove_timer()`; `check_timeouts` did not.

## Fix

After `ares_process_fd` in `check_timeouts`, re-check `any_requests_pending()` and call `remove_timer()` when nothing is pending (undoing the spurious re-arm), otherwise keep the existing `add_timer(Some(&now))`. Same shape as `on_dns_poll`.

## Verification

`test/js/node/dns/dns-lookup-keepalive.test.ts` spawns a child per record type (`resolveCaa`, `resolve4`, `reverse`) against a mute local UDP server and asserts the gap between the callback and process exit is `< 500` ms (was `~1000`). Fails on main, passes with this change. The original LSan repro under `BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1` now reports no leaks.

Related but distinct from #35776 (sync-reject ordering) and #33815 (sub-second timer interval); this PR is only about the disarm at completion time.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-lookup-keepalive.test.ts
bun test v1.4.0 (0e6ed3ccb)

test/js/node/dns/dns-lookup-keepalive.test.ts:
(pass) expect dns.lookup to keep the process alive [518.86ms]
55 |       const { delay, code } = await run(stmt);
56 |       // ETIMEOUT proves completion routed through `check_timeouts`
57 |       // (the path changed here), not `on_dns_poll`.
58 |       expect(code).toBe(expected);
59 |       // Before the fix: delay ≈ 1000 ms (one retransmit-timer interval).
60 |       expect(delay).toBeLessThan(500);
                         ^
error: expect(received).toBeLessThan(expected)

Expected: < 500
Received: 998

      at <anonymous> (/workspace/bun/test/js/node/dns/dns-lookup-keepalive.test.ts:60:21)
(fail) dns.Resolver does not keep the event loop alive after the last query times out > resolveCaa [2823.44ms]
55 |       const { delay, code } = await run(stmt);
56 |       // ETIMEOUT proves completion routed through `check_timeouts`
57 |       // (the path changed here), not `on_dns_poll`.
58 |       expect(code).toBe(
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/dns/dns-lookup-keepalive.test.ts:
(pass) expect dns.lookup to keep the process alive [20.02ms]
55 |       const { delay, code } = await run(stmt);
56 |       // ETIMEOUT proves completion routed through `check_timeouts`
57 |       // (the path changed here), not `on_dns_poll`.
58 |       expect(code).toBe(expected);
59 |       // Before the fix: delay ≈ 1000 ms (one retransmit-timer interval).
60 |       expect(delay).toBeLessThan(500);
                         ^
error: expect(received).toBeLessThan(expected)

Expected: < 500
Received: 1000

      at <anonymous> (/workspace/bun/test/js/node/dns/dns-lookup-keepalive.test.ts:60:21)
(fail) dns.Resolver does not keep the event loop alive after the last query times out > resolveCaa [2024.71ms]
55 |       const { delay, code } = await run(stmt);
56 |       // ETIMEOUT proves completion routed through `check_timeouts`
57 |       // (the path changed here), not `on_dns_poll`.
58 |       expect(code).toBe(expected);
59 |       // Before the fix: delay ≈ 1000 ms (one retransmit-timer interval).
60 |       expect(delay).toBeLessThan(500);
                         ^
error: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-lookup-keepalive.test.ts
bun test v1.4.0 (0e6ed3ccb)

test/js/node/dns/dns-lookup-keepalive.test.ts:
(pass) expect dns.lookup to keep the process alive [511.22ms]
(pass) dns.Resolver does not keep the event loop alive after the last query times out > resolveCaa [1824.66ms]
(pass) dns.Resolver does not keep the event loop alive after the last query times out > resolve4 [1808.79ms]
(pass) dns.Resolver does not keep the event loop alive after the last query times out > reverse [1804.20ms]

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [4.91s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 653ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/70] cxx obj/src/jsc/bindings/sqlite/NodeSqlite.cpp.o
[2/70] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[3/70] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/70] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/dns_jsc/dns.rs                    | 15 ++++---
 test/js/node/dns/dns-lookup-keepalive.test.ts | 60 ++++++++++++++++++++++++++-
 2 files changed, 67 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/dns_jsc/dns.rs                        10      6      0
test/js/node/dns/dns-lookup-keepalive.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->