### PR TITLE
sys(windows): keep FILE_SYNCHRONOUS_IO_NONALERT when opening with O::NOFOLLOW

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7131,7 +7131,7 @@ fn openat_windows_impl(dir: Fd, norm: &bun_core::WStr, flags: i32, perm: Mode) -
     let opts: u32 = if follow {
         blocking_flag
     } else {
-        w::FILE_OPEN_REPARSE_POINT
+        blocking_flag | w::FILE_OPEN_REPARSE_POINT
     };
 
     let mut attributes: u32 = w::FILE_ATTRIBUTE_NORMAL;


### PR DESCRIPTION
#### What

`openat_windows_impl` computes `NtCreateFile` `CreateOptions` as `blocking_flag` (i.e. `FILE_SYNCHRONOUS_IO_NONALERT` unless `O::NONBLOCK` is set) when following symlinks, but as bare `FILE_OPEN_REPARSE_POINT` when `O::NOFOLLOW` is set. The reparse-point branch dropped the sync flag entirely, so a `NOFOLLOW` open would return an asynchronous file object. Our synchronous `ReadFile`/`WriteFile` callers pass a null `hEvent`/`lpOverlapped`, which is undefined on an async handle.

The directory-open path just above (`open_dir_at_windows_nt_path`) already does this correctly: it computes `open_reparse` as `FILE_OPEN_REPARSE_POINT` or `0` and ORs it into the options alongside `FILE_SYNCHRONOUS_IO_NONALERT`.

#### Fix

OR `FILE_OPEN_REPARSE_POINT` into `blocking_flag` rather than replacing it.

#### Why no regression test

There is no JS-reachable path that issues a read or write against a handle from this branch:

- `fs.openSync`/`fs.open` on Windows route through `sys_uv::open` → `uv_fs_open` (node_fs.rs:6044, sys_uv.rs:84), never `openat_windows_impl`. The JS-side flag value is also translated by `bun_libuv_sys::O::to_bun_o` (types.rs:1619), which has no `NOFOLLOW` mapping, so the bit cannot be passed in from JS.
- `fs.readSync`/`fs.writeSync` on Windows route through `uv_fs_read`/`uv_fs_write` (sys_uv.rs:584), not raw `ReadFile`/`WriteFile`.
- The `fs.cp` `O::NOFOLLOW` opens are gated to Linux/Android (node_fs.rs:8666) and FreeBSD (node_fs.rs:8834).
- Tarball extraction zeroes `NOFOLLOW` under `cfg!(windows)`.
- The one live Windows caller of the file branch with `O::NOFOLLOW` is `lstatat` (sys/lib.rs:862), which only calls `fstat` then `close` on the handle; `NtQueryInformationFile` does not depend on the sync bit, so the defect is not observable there.

This is a latent code-inspection fix with no fail-before test possible today. Verified with `cargo check -p bun_sys --target x86_64-pc-windows-msvc`.
