### PR TITLE
test: convert tempDirWithFiles callers to `using tempDir`

### DIFF
--- a/test/bake/dev/import-meta-inline-negative.test.ts
+++ b/test/bake/dev/import-meta-inline-negative.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("import.meta properties are NOT inlined without bake framework", async () => {
-  const dir = tempDirWithFiles("import-meta-no-inline", {
+  await using dir = tempDir("import-meta-no-inline", {
     "index.ts": `
       console.log("dir:", import.meta.dir);
       console.log("dirname:", import.meta.dirname);  

--- a/test/bake/dev/response-to-bake-response.test.ts
+++ b/test/bake/dev/response-to-bake-response.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "node:path";
 
 test("Response -> import { Response } from 'bun:app' transform in server components", async () => {
-  const dir = tempDirWithFiles("response-transform", {
+  await using dir = tempDir("response-transform", {
     "server-component.js": `
       export const mode = "ssr";
       export const streaming = false;
@@ -61,7 +61,7 @@ test("Response -> import { Response } from 'bun:app' transform in server compone
 });
 
 test("Response import is added for global Response in various contexts", async () => {
-  const dir = tempDirWithFiles("response-contexts", {
+  await using dir = tempDir("response-contexts", {
     "server.js": `
       export const mode = "ssr";
       
@@ -102,7 +102,7 @@ test("Response import is added for global Response in various contexts", async (
 });
 
 test("Response import is not added when Response is already imported or shadowed", async () => {
-  const dir = tempDirWithFiles("response-shadowing", {
+  await using dir = tempDir("response-shadowing", {
     "server.js": `
       export const mode = "ssr";
       
@@ -159,7 +159,7 @@ test("Response import is not added when Response is already imported or shadowed
 });
 
 test("Response import is NOT added in client components", async () => {
-  const dir = tempDirWithFiles("client-no-transform", {
+  await using dir = tempDir("client-no-transform", {
     "client-component.js": `
       "use client";
       
@@ -219,7 +219,7 @@ test("Response import is NOT added in client components", async () => {
 });
 
 test("Response import is added when Response is global, but not when shadowed", async () => {
-  const dir = tempDirWithFiles("response-shadowing", {
+  await using dir = tempDir("response-shadowing", {
     "server-component.js": `
       export const mode = "ssr";
 

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -1,6 +1,6 @@
 import { frameworkRouterInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import path from "path";
 
 const { parseRoutePattern, FrameworkRouter } = frameworkRouterInternals;
@@ -79,7 +79,7 @@ describe("pattern parse", () => {
 });
 
 test("discovers from filesystem paths", () => {
-  const dir = tempDirWithFiles("fsr", {
+  using dir = tempDir("fsr", {
     "hello.tsx": "1",
     "meow/_layout.tsx": "1",
     "meow/bark/[param]/hello.tsx": "1",

--- a/test/bundler/bun-build-compile-wasm.test.ts
+++ b/test/bundler/bun-build-compile-wasm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, tempDirWithFiles } from "harness";
+import { bunEnv, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.build compile with wasm", () => {
@@ -7,7 +7,7 @@ describe("Bun.build compile with wasm", () => {
     // This test ensures that embedded wasm modules compile and run correctly
     // The regression was that the module prefix wasn't being set correctly
 
-    const dir = tempDirWithFiles("build-compile-wasm", {
+    await using dir = tempDir("build-compile-wasm", {
       "app.js": `
         // Import a wasm module and properly instantiate it
         import wasmPath from "./test.wasm";

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { rmSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 
@@ -957,7 +957,7 @@ error: Hello World`,
   });
 
   test("does not crash", async () => {
-    const dir = tempDirWithFiles("bundler-compile-shadcn", {
+    await using dir = tempDir("bundler-compile-shadcn", {
       "frontend.tsx": `console.log("Hello, world!");`,
       "index.html": `<!doctype html>
 <html lang="en">
@@ -1072,7 +1072,7 @@ const server = serve({
 
   // When compiling with 8+ entry points, the main entry point should still run correctly.
   test("compile with 8+ entry points runs main entry correctly", async () => {
-    const dir = tempDirWithFiles("compile-many-entries", {
+    await using dir = tempDir("compile-many-entries", {
       "app.js": `console.log("IT WORKS");`,
       "assets/file-1": "",
       "assets/file-2": "",

--- a/test/bundler/bundler_defer.test.ts
+++ b/test/bundler/bundler_defer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import * as path from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -137,7 +137,7 @@ describe("defer", () => {
   {
     let action: string[] = [];
     test("onstart throwing an error works", async () => {
-      const folder = tempDirWithFiles("plugin", {
+      await using folder = tempDir("plugin", {
         "index.ts": "export const foo = {}",
       });
       try {
@@ -467,7 +467,7 @@ console.log("FOOOO", foo);
   });
 
   test("integration", async () => {
-    const folder = tempDirWithFiles("integration", {
+    await using folder = tempDir("integration", {
       "module_data.json": "{}",
       "package.json": `{
     "name": "integration-test",

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
@@ -364,7 +364,7 @@ console.log("About manifest:", aboutHtml);
   // changes; otherwise the browser 304s to a body that points at chunks the
   // server no longer has.
   test("html-import/etag-changes-with-referenced-chunks", async () => {
-    const dir = tempDirWithFiles("html-etag", {
+    await using dir = tempDir("html-etag", {
       "server.ts": `import m from "./index.html"; console.log(JSON.stringify(m));`,
       "index.html": `<!doctype html><script type="module" src="./app.ts"></script>`,
       "app.ts": `console.log(1);`,

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("bunfig.toml test options", () => {
   test("randomize with seed produces consistent order", async () => {
-    const dir = tempDirWithFiles("bunfig-test-randomize-seed", {
+    await using dir = tempDir("bunfig-test-randomize-seed", {
       "test.test.ts": `
         import { test, expect } from "bun:test";
         test("alpha", () => {
@@ -76,7 +76,7 @@ describe("bunfig.toml test options", () => {
   });
 
   test("seed without randomize errors", async () => {
-    const dir = tempDirWithFiles("bunfig-test-seed-no-randomize", {
+    await using dir = tempDir("bunfig-test-seed-no-randomize", {
       "test.test.ts": `
         import { test, expect } from "bun:test";
         test("test 1", () => expect(1).toBe(1));
@@ -105,7 +105,7 @@ describe("bunfig.toml test options", () => {
   });
 
   test("seed with randomize=false errors", async () => {
-    const dir = tempDirWithFiles("bunfig-test-seed-randomize-false", {
+    await using dir = tempDir("bunfig-test-seed-randomize-false", {
       "test.test.ts": `
         import { test, expect } from "bun:test";
         test("test 1", () => expect(1).toBe(1));
@@ -134,7 +134,7 @@ describe("bunfig.toml test options", () => {
   });
 
   test("rerunEach option works", async () => {
-    const dir = tempDirWithFiles("bunfig-test-rerun-each", {
+    await using dir = tempDir("bunfig-test-rerun-each", {
       "test.test.ts": `
         import { test, expect } from "bun:test";
         let counter = 0;
@@ -168,7 +168,7 @@ describe("bunfig.toml test options", () => {
   });
 
   test("all test options together", async () => {
-    const dir = tempDirWithFiles("bunfig-test-all-options", {
+    await using dir = tempDir("bunfig-test-all-options", {
       "test.test.ts": `
         import { test, expect } from "bun:test";
         test("test 1", () => expect(1).toBe(1));

--- a/test/cli/console-depth.test.ts
+++ b/test/cli/console-depth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("console depth", () => {
   const deepObject = {
@@ -32,7 +32,7 @@ describe("console depth", () => {
   }
 
   test("default console depth should be 2", async () => {
-    const dir = tempDirWithFiles("console-depth-default", {
+    await using dir = tempDir("console-depth-default", {
       "test.js": testScript,
     });
 
@@ -62,7 +62,7 @@ describe("console depth", () => {
   });
 
   test("--console-depth flag sets custom depth", async () => {
-    const dir = tempDirWithFiles("console-depth-cli", {
+    await using dir = tempDir("console-depth-cli", {
       "test.js": testScript,
     });
 
@@ -94,7 +94,7 @@ describe("console depth", () => {
   });
 
   test("--console-depth with higher value shows deeper nesting", async () => {
-    const dir = tempDirWithFiles("console-depth-high", {
+    await using dir = tempDir("console-depth-high", {
       "test.js": testScript,
     });
 
@@ -138,7 +138,7 @@ describe("console depth", () => {
   });
 
   test("bunfig.toml console.depth configuration", async () => {
-    const dir = tempDirWithFiles("console-depth-bunfig", {
+    await using dir = tempDir("console-depth-bunfig", {
       "test.js": testScript,
       "bunfig.toml": `[console]\ndepth = 4`,
     });
@@ -173,7 +173,7 @@ describe("console depth", () => {
   });
 
   test("CLI flag overrides bunfig.toml", async () => {
-    const dir = tempDirWithFiles("console-depth-override", {
+    await using dir = tempDir("console-depth-override", {
       "test.js": testScript,
       "bunfig.toml": `[console]\ndepth = 6`,
     });
@@ -204,7 +204,7 @@ describe("console depth", () => {
   });
 
   test("invalid --console-depth value shows error", async () => {
-    const dir = tempDirWithFiles("console-depth-invalid", {
+    await using dir = tempDir("console-depth-invalid", {
       "test.js": testScript,
     });
 
@@ -230,7 +230,7 @@ describe("console depth", () => {
   });
 
   test("edge case: depth 0 should show infinite depth", async () => {
-    const dir = tempDirWithFiles("console-depth-zero", {
+    await using dir = tempDir("console-depth-zero", {
       "test.js": testScript,
     });
 
@@ -274,7 +274,7 @@ describe("console depth", () => {
   });
 
   test("bunfig.toml depth=0 should show infinite depth", async () => {
-    const dir = tempDirWithFiles("console-depth-bunfig-zero", {
+    await using dir = tempDir("console-depth-bunfig-zero", {
       "test.js": testScript,
       "bunfig.toml": `[console]\ndepth = 0`,
     });
@@ -326,7 +326,7 @@ describe("console depth", () => {
       console.warn("WARN:", obj);
     `;
 
-    const dir = tempDirWithFiles("console-depth-multiple", {
+    await using dir = tempDir("console-depth-multiple", {
       "test.js": testScriptMultiple,
     });
 

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, forEachLine, isASAN, isCI, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, forEachLine, isASAN, isCI, tempDir } from "harness";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -12,7 +12,7 @@ describe("--hot with many directories", () => {
     "handles 129 directories being updated simultaneously",
     async () => {
       // Create initial test structure
-      const tmpdir = tempDirWithFiles("hot-many-dirs", {
+      await using tmpdir = tempDir("hot-many-dirs", {
         "entry.js": `console.log('Initial load');`,
       });
 

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -1,13 +1,13 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDir } from "harness";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 describe.todoIf(isBroken && isWindows)("--watch works", async () => {
   for (const watchedFile of ["entry.js", "tmp.js"]) {
     test(`with ${watchedFile}`, async () => {
-      const tmpdir_ = tempDirWithFiles("watch-fixture", {
+      await using tmpdir_ = tempDir("watch-fixture", {
         "tmp.js": "console.log('hello #1')",
         "entry.js": "import './tmp.js'",
         "package.json": JSON.stringify({ name: "foo", version: "0.0.1" }),

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import fs, { readdirSync } from "fs";
-import { bunEnv, bunExe, isWindows, nodeExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, nodeExe, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
 // Whether `bun init` emits CLAUDE.md depends on a `claude` binary being on
@@ -28,7 +28,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   }, 240_000);
 
   test("bun init works", async () => {
-    const temp = tempDirWithFiles("bun-init-works", {});
+    await using temp = tempDir("bun-init-works", {});
 
     const { exited } = Bun.spawn({
       cmd: [bunExe(), "init", "-y"],
@@ -64,7 +64,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   }, 30_000);
 
   test("bun init falls back to --yes when stdin is not a TTY", async () => {
-    const temp = tempDirWithFiles("bun-init-no-tty", {});
+    await using temp = tempDir("bun-init-no-tty", {});
 
     // stdin is a pipe we never write to. Previously this hung at the template
     // menu waiting for a keystroke that never arrives.
@@ -91,7 +91,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   }, 30_000);
 
   test("bun init in folder", async () => {
-    const temp = tempDirWithFiles("bun-init-in-folder", {
+    await using temp = tempDir("bun-init-in-folder", {
       "mydir": {
         "index.ts": "// mydir/index.ts",
         "README.md": "// mydir/README.md",
@@ -122,7 +122,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   });
 
   test("bun init error rather than overwriting file", async () => {
-    const temp = tempDirWithFiles("bun-init-error-rather-than-overwriting-file", {
+    await using temp = tempDir("bun-init-error-rather-than-overwriting-file", {
       "mydir": "don't delete me!!!",
     });
     const { exited } = Bun.spawn({
@@ -137,7 +137,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   });
 
   test("bun init utf-8", async () => {
-    const temp = tempDirWithFiles("bun-init-utf-8", {});
+    await using temp = tempDir("bun-init-utf-8", {});
     const { exited } = Bun.spawn({
       cmd: [bunExe(), "init", "-y", "u t f ∞™/subpath"],
       cwd: temp,
@@ -161,7 +161,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   });
 
   test("bun init twice", async () => {
-    const temp = tempDirWithFiles("bun-init-twice", {});
+    await using temp = tempDir("bun-init-twice", {});
     const { exited } = Bun.spawn({
       cmd: [bunExe(), "init", "-y", "mydir"],
       cwd: temp,
@@ -238,7 +238,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   });
 
   test("bun init --react works", async () => {
-    const temp = tempDirWithFiles("bun-init--react-works", {});
+    await using temp = tempDir("bun-init--react-works", {});
 
     const { exited } = Bun.spawn({
       cmd: [bunExe(), "init", "--react"],
@@ -262,7 +262,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   }, 30_000);
 
   test("bun init --react=tailwind works", async () => {
-    const temp = tempDirWithFiles("bun-init--react=tailwind-works", {});
+    await using temp = tempDir("bun-init--react=tailwind-works", {});
 
     const { exited } = Bun.spawn({
       cmd: [bunExe(), "init", "--react=tailwind"],
@@ -286,7 +286,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   }, 30_000);
 
   test("bun init --react=shadcn works", async () => {
-    const temp = tempDirWithFiles("bun-init--react=shadcn-works", {});
+    await using temp = tempDir("bun-init--react=shadcn-works", {});
 
     const { exited } = Bun.spawn({
       cmd: [bunExe(), "init", "--react=shadcn"],
@@ -318,7 +318,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   test.each(["-y", "--react", "--react=tailwind", "--react=shadcn"])(
     "bun init %s installs TypeScript 6, typechecks, and builds",
     async flag => {
-      const temp = tempDirWithFiles(`bun-init-ts6${flag.replace(/[^a-z]+/g, "-")}`, {});
+      await using temp = tempDir(`bun-init-ts6${flag.replace(/[^a-z]+/g, "-")}`, {});
 
       await using init = Bun.spawn({
         cmd: [bunExe(), "init", flag],
@@ -375,7 +375,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     // inherit stdout/stderr so its output reaches the parent's pipe — a
     // previous regression left the child with closed fds 1/2 and the install
     // output was silently dropped.
-    const temp = tempDirWithFiles("bun-init-inherits-install-output", {});
+    await using temp = tempDir("bun-init-inherits-install-output", {});
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "init", "-y"],
@@ -399,7 +399,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   test("bun init --minimal only creates package.json and tsconfig.json", async () => {
     // Regression test for https://github.com/oven-sh/bun/issues/26050
     // --minimal should not create .cursor/, CLAUDE.md, .gitignore, or README.md
-    const temp = tempDirWithFiles("bun-init-minimal", {});
+    await using temp = tempDir("bun-init-minimal", {});
 
     const { exited } = Bun.spawn({
       cmd: [bunExe(), "init", "--minimal", "-y"],

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isPosix, randomPort, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isPosix, randomPort, tempDir } from "harness";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -463,7 +463,7 @@ test.todo("junit reporter", async () => {
   let reporter: JUnitReporter;
   let session: InspectorSession;
 
-  const tempdir = tempDirWithFiles("junit-reporter", {
+  await using tempdir = tempDir("junit-reporter", {
     "package.json": `
       {
         "type": "module",

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, DirectoryTree, gunzipJsonRequest, lazyPromiseLike, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, DirectoryTree, gunzipJsonRequest, lazyPromiseLike, tempDir } from "harness";
 import { join } from "node:path";
 import { resolveBulkAdvisoryFixture } from "./registry/fixtures/audit/audit-fixtures";
 
@@ -47,7 +47,7 @@ function doAuditTest(
   },
 ) {
   test(label, async () => {
-    const dir = tempDirWithFiles("bun-test-audit-" + label.replace(/[^a-zA-Z0-9]/g, "-"), options.files);
+    await using dir = tempDir("bun-test-audit-" + label.replace(/[^a-zA-Z0-9]/g, "-"), options.files);
 
     const cmd = [bunExe(), "audit", ...(options.args ?? [])];
 

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { rmSync } from "fs";
-import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDir } from "harness";
 import { join } from "path";
 
 const normalizeBunSnapshot = (str: string) => {
@@ -121,7 +121,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
       const patchFilename = filepathEscape(`is-even@${version}.patch`);
       const patchVersion = patchVersion_ ?? version;
       test(version, async () => {
-        const filedir = tempDirWithFiles("patch1", {
+        await using filedir = tempDir("patch1", {
           "package.json": JSON.stringify({
             "name": "bun-patch-test",
             "module": "index.ts",
@@ -149,7 +149,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
   });
 
   test("should patch a non-hoisted dependency", async () => {
-    const filedir = tempDirWithFiles("patch1", {
+    await using filedir = tempDir("patch1", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -179,7 +179,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
       const patchFilename = filepathEscape(`is-even@${version}.patch`);
       const patchVersion = patchVersion_ ?? version;
       test(version, async () => {
-        const filedir = tempDirWithFiles("patch1", {
+        await using filedir = tempDir("patch1", {
           "package.json": JSON.stringify({
             "name": "bun-patch-test",
             "module": "index.ts",
@@ -208,7 +208,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
   test("should patch a transitive dependency", async () => {
     const version = "0.1.2";
     const patchFilename = filepathEscape(`is-odd@${version}.patch`);
-    const filedir = tempDirWithFiles("patch1", {
+    await using filedir = tempDir("patch1", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -237,7 +237,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
       const patchfileName = filepathEscape(`is-even@${version}.patch`);
       const patchVersion = patchVersion_ ?? version;
       test(version, async () => {
-        const filedir = tempDirWithFiles("patch1", {
+        await using filedir = tempDir("patch1", {
           "package.json": JSON.stringify({
             "name": "bun-patch-test",
             "module": "index.ts",
@@ -280,7 +280,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
   });
 
   it("should patch a transitive dependency after it was already installed", async () => {
-    const filedir = tempDirWithFiles("patch1", {
+    await using filedir = tempDir("patch1", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -326,7 +326,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
       const patchFilename = filepathEscape(`is-even@${version}.patch`);
       const patchVersion = patchVersion_ ?? version;
       test(version, async () => {
-        const filedir = tempDirWithFiles("patch1", {
+        await using filedir = tempDir("patch1", {
           "package.json": JSON.stringify({
             "name": "bun-patch-test",
             "module": "index.ts",
@@ -360,7 +360,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
       const patchFilename = filepathEscape(`is-even@${version}.patch`);
       const patchVersion = patchVersion_ ?? version;
       test(version, async () => {
-        const filedir = tempDirWithFiles("patch1", {
+        await using filedir = tempDir("patch1", {
           "package.json": JSON.stringify({
             "name": "bun-patch-test",
             "module": "index.ts",
@@ -408,7 +408,7 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
 
   it("should update a transitive dependency when the patchfile changes", async () => {
     $.throws(true);
-    const filedir = tempDirWithFiles("patch1", {
+    await using filedir = tempDir("patch1", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -462,7 +462,7 @@ index aa7c7012cda790676032d1b01d78c0b69ec06360..6048e7cb462b3f9f6ac4dc21aacf9a09
 `;
 
     $.throws(true);
-    const filedir = tempDirWithFiles("patch1", {
+    await using filedir = tempDir("patch1", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -501,7 +501,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
   };
 `;
 
-    const filedir = tempDirWithFiles("patch1", {
+    await using filedir = tempDir("patch1", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -574,7 +574,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     const patchEnv = bunEnv;
 
     test("should create patch for package and commit it", async () => {
-      const filedir = tempDirWithFiles("patch-isolated", {
+      await using filedir = tempDir("patch-isolated", {
         "package.json": JSON.stringify({
           "name": "bun-patch-isolated-test",
           "module": "index.ts",
@@ -635,7 +635,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     });
 
     test("should patch transitive dependency with isolated linker", async () => {
-      const filedir = tempDirWithFiles("patch-isolated-transitive", {
+      await using filedir = tempDir("patch-isolated-transitive", {
         "package.json": JSON.stringify({
           "name": "bun-patch-isolated-transitive-test",
           "module": "index.ts",
@@ -690,7 +690,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     });
 
     test("should handle scoped packages with isolated linker", async () => {
-      const filedir = tempDirWithFiles("patch-isolated-scoped", {
+      await using filedir = tempDir("patch-isolated-scoped", {
         "package.json": JSON.stringify({
           "name": "bun-patch-isolated-scoped-test",
           "module": "index.ts",
@@ -748,7 +748,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     });
 
     test("should work with workspaces and isolated linker", async () => {
-      const filedir = tempDirWithFiles("patch-isolated-workspace", {
+      await using filedir = tempDir("patch-isolated-workspace", {
         "package.json": JSON.stringify({
           "name": "workspace-root",
           "workspaces": ["packages/*"],
@@ -811,7 +811,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     });
 
     test("should preserve patch after reinstall with isolated linker", async () => {
-      const filedir = tempDirWithFiles("patch-isolated-reinstall", {
+      await using filedir = tempDir("patch-isolated-reinstall", {
         "package.json": JSON.stringify({
           "name": "bun-patch-isolated-reinstall-test",
           "module": "index.ts",
@@ -856,7 +856,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     });
 
     test("should handle multiple patches with isolated linker", async () => {
-      const filedir = tempDirWithFiles("patch-isolated-multiple", {
+      await using filedir = tempDir("patch-isolated-multiple", {
         "package.json": JSON.stringify({
           "name": "bun-patch-isolated-multiple-test",
           "module": "index.ts",
@@ -955,7 +955,7 @@ index 0000000000000000000000000000000000000000..2f9a147b6e5d17254f1bfce0d4e109a2
 `;
 
   test("install with an empty cache downloads the package unpatched", async () => {
-    const filedir = tempDirWithFiles("patch-remove", {
+    await using filedir = tempDir("patch-remove", {
       "package.json": JSON.stringify({
         name: "remove-patch-test",
         dependencies: {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -15,7 +15,7 @@ import {
   runBunInstall,
   runBunUpdate,
   stderrForInstall,
-  tempDirWithFiles,
+  tempDir,
   tls,
   tmpdirSync,
   toBeValidBin,
@@ -6538,7 +6538,7 @@ describe("semver", () => {
 });
 
 test("doesn't error when the migration is out of sync", async () => {
-  const cwd = tempDirWithFiles("out-of-sync-1", {
+  await using cwd = tempDir("out-of-sync-1", {
     "package.json": JSON.stringify({
       "devDependencies": {
         "no-deps": "1.0.0",

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -11,7 +11,6 @@ import {
   readdirSorted,
   runBunInstall,
   tempDir,
-  tempDirWithFiles,
   textLockfile,
   toBeValidBin,
   toBeWorkspaceLink,
@@ -457,7 +456,7 @@ describe.concurrent("bun-install", () => {
   });
 
   it("should work when moving workspace packages", async () => {
-    const package_dir = tempDirWithFiles("lol", {
+    await using package_dir = tempDir("lol", {
       "package.json": JSON.stringify({
         "name": "my-workspace",
         private: "true",
@@ -529,7 +528,7 @@ describe.concurrent("bun-install", () => {
   });
 
   it("should work when renaming a single workspace package", async () => {
-    const package_dir = tempDirWithFiles("lol", {
+    await using package_dir = tempDir("lol", {
       "package.json": JSON.stringify({
         "name": "my-workspace",
         private: "true",
@@ -7402,7 +7401,7 @@ describe.concurrent("bun-install", () => {
   });
 
   it("should handle installing workspaces with more complicated globs", async () => {
-    const package_dir = tempDirWithFiles("complicated-glob", {
+    await using package_dir = tempDir("complicated-glob", {
       "package.json": JSON.stringify({
         name: "package3",
         version: "0.0.1",
@@ -7459,7 +7458,7 @@ describe.concurrent("bun-install", () => {
   });
 
   it("should handle installing workspaces with multiple glob patterns", async () => {
-    const package_dir = tempDirWithFiles("multi-glob", {
+    await using package_dir = tempDir("multi-glob", {
       "package.json": JSON.stringify({
         name: "main",
         version: "0.0.1",
@@ -7522,7 +7521,7 @@ describe.concurrent("bun-install", () => {
   });
 
   it.todo("should handle installing workspaces with absolute glob patterns", async () => {
-    const package_dir = tempDirWithFiles("absolute-glob", {
+    await using package_dir = tempDir("absolute-glob", {
       "package.json": base =>
         JSON.stringify({
           name: "package3",

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { exists, mkdir, rm } from "fs/promises";
-import { bunEnv, bunExe, pack, runBunInstall, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
 import fs from "node:fs/promises";
 import { join } from "path";
 
@@ -1339,7 +1339,7 @@ describe("files", () => {
   });
 
   test("excluded entries within included directories are not included", async () => {
-    const dir = tempDirWithFiles("bun-pack-files-excluded-entries", {
+    await using dir = tempDir("bun-pack-files-excluded-entries", {
       "package.json": `
       {
         "name": "pack-excluded-entries-from-files",

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,6 +1,6 @@
 import { $, ShellOutput } from "bun";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import { join } from "path";
 
 const expectNoError = (o: ShellOutput) => expect(o.stderr.toString()).not.toContain("error");
@@ -11,7 +11,7 @@ setDefaultTimeout(1000 * 60 * 5);
 
 describe("error messages", () => {
   test("'bun patch' with no package name shows a usage example", async () => {
-    const dir = tempDirWithFiles("bun-patch-noarg", {
+    await using dir = tempDir("bun-patch-noarg", {
       "package.json": JSON.stringify({ name: "t" }),
     });
     await using proc = Bun.spawn({
@@ -29,7 +29,7 @@ describe("error messages", () => {
   });
 
   test("'bun patch --commit' with no directory shows a usage example", async () => {
-    const dir = tempDirWithFiles("bun-patch-commit-noarg", {
+    await using dir = tempDir("bun-patch-commit-noarg", {
       "package.json": JSON.stringify({ name: "t" }),
     });
     await using proc = Bun.spawn({
@@ -47,7 +47,7 @@ describe("error messages", () => {
   });
 
   test("'bun patch-commit' with no directory shows a usage example", async () => {
-    const dir = tempDirWithFiles("bun-patchcommit-noarg", {
+    await using dir = tempDir("bun-patchcommit-noarg", {
       "package.json": JSON.stringify({ name: "t" }),
     });
     await using proc = Bun.spawn({
@@ -78,7 +78,7 @@ describe("bun patch <pkg>", async () => {
       ];
       for (const [arg, path] of args) {
         test(arg, async () => {
-          const tempdir = tempDirWithFiles("lol", {
+          await using tempdir = tempDir("lol", {
             "package.json": JSON.stringify({
               "name": "my-workspace",
               private: "true",
@@ -153,7 +153,7 @@ describe("bun patch <pkg>", async () => {
       ];
       for (const [arg, path] of args) {
         test(arg, async () => {
-          const tempdir = tempDirWithFiles("lol", {
+          await using tempdir = tempDir("lol", {
             "package.json": JSON.stringify({
               "name": "my-workspace",
               private: "true",
@@ -231,7 +231,7 @@ describe("bun patch <pkg>", async () => {
       ];
       for (const [arg, path] of args) {
         test(arg, async () => {
-          const tempdir = tempDirWithFiles("lol", {
+          await using tempdir = tempDir("lol", {
             "package.json": JSON.stringify({
               "name": "my-workspace",
               private: "true",
@@ -317,7 +317,7 @@ describe("bun patch <pkg>", async () => {
       ];
       for (const [arg, path, version, patch_path] of args) {
         test(arg, async () => {
-          const tempdir = tempDirWithFiles("lol", {
+          await using tempdir = tempDir("lol", {
             "package.json": JSON.stringify({
               "name": "my-workspace",
               private: "true",
@@ -396,7 +396,7 @@ describe("bun patch <pkg>", async () => {
       test(
         `${pkgName}@${version}`,
         async () => {
-          const tempdir = tempDirWithFiles("popular", {
+          await using tempdir = tempDir("popular", {
             "package.json": JSON.stringify({
               "name": "bun-patch-test",
               "module": "index.ts",
@@ -466,7 +466,7 @@ describe("bun patch <pkg>", async () => {
     makeTest("@types/uuencode", "0.0.3", "@types/uuencode");
   });
   test("should patch a package when it is already patched", async () => {
-    const tempdir = tempDirWithFiles("lol", {
+    await using tempdir = tempDir("lol", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -554,7 +554,7 @@ module.exports = function isOdd(i) {
   });
 
   test("bad patch arg", async () => {
-    const tempdir = tempDirWithFiles("lol", {
+    await using tempdir = tempDir("lol", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -573,7 +573,7 @@ module.exports = function isOdd(i) {
   });
 
   test("bad patch commit arg", async () => {
-    const tempdir = tempDirWithFiles("lol", {
+    await using tempdir = tempDir("lol", {
       "package.json": JSON.stringify({
         "name": "bun-patch-test",
         "module": "index.ts",
@@ -617,7 +617,7 @@ module.exports = function isOdd(i) {
     test(name, async () => {
       $.throws(true);
 
-      const filedir = tempDirWithFiles("patch1", {
+      await using filedir = tempDir("patch1", {
         "package.json": JSON.stringify({
           "name": "bun-patch-test",
           "module": "index.ts",
@@ -661,7 +661,7 @@ Once you're done with your changes, run:
   test(
     "overwriting module with multiple levels of directories",
     async () => {
-      const filedir = tempDirWithFiles("patch1", {
+      await using filedir = tempDir("patch1", {
         "package.json": JSON.stringify({
           "name": "bun-patch-test",
           "module": "index.ts",
@@ -765,7 +765,7 @@ Once you're done with your changes, run:
     for (const patchArg of patchArgs) {
       $.throws(true);
 
-      const filedir = tempDirWithFiles("patch1", {
+      await using filedir = tempDir("patch1", {
         "package.json": JSON.stringify({
           "name": "bun-patch-test",
           "module": "index.ts",
@@ -791,7 +791,7 @@ module.exports = function isEven() {
         await $`echo ${newCode} > node_modules/is-even/index.js`.env(bunEnv).cwd(filedir);
       }
 
-      const tempdir = tempDirWithFiles("unpatched", {
+      await using tempdir = tempDir("unpatched", {
         "package.json": JSON.stringify({
           "name": "bun-patch-test",
           "module": "index.ts",
@@ -820,7 +820,7 @@ module.exports = function isEven() {
     for (const patchArg of patchArgs) {
       $.throws(true);
 
-      const filedir = tempDirWithFiles("patch1", {
+      await using filedir = tempDir("patch1", {
         "package.json": JSON.stringify({
           "name": "bun-patch-test",
           "module": "index.ts",
@@ -848,7 +848,7 @@ module.exports = function isOdd() {
         await $`echo ${newCode} > node_modules/is-even/node_modules/is-odd/index.js`.env(bunEnv).cwd(filedir);
       }
 
-      const tempdir = tempDirWithFiles("unpatched", {
+      await using tempdir = tempDir("unpatched", {
         "package.json": JSON.stringify({
           "name": "bun-patch-test",
           "module": "index.ts",

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 async function runPmPkg(args: string[], cwd: string, expectSuccess = true) {
@@ -200,7 +200,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should fail gracefully when no package.json found", async () => {
-      const emptyDir = tempDirWithFiles("empty-test", {});
+      await using emptyDir = tempDir("empty-test", {});
 
       const { error, code } = await runPmPkg(["get", "name"], emptyDir, false);
       expect(code).toBe(1);
@@ -338,7 +338,7 @@ describe("bun pm pkg", () => {
     it("should write literal keys when setting with bracket notation", async () => {
       // Key-path segments parsed from a bracket path must stay alive until
       // the file is written; otherwise the printer serializes freed bytes.
-      const bracketDir = tempDirWithFiles("pm-pkg-bracket-set", {
+      await using bracketDir = tempDir("pm-pkg-bracket-set", {
         "package.json": JSON.stringify({ name: "x", version: "1.0.0" }, null, 2),
       });
 
@@ -482,7 +482,7 @@ describe("bun pm pkg", () => {
 
   describe("workspace compatibility", () => {
     it("should work in workspace root", async () => {
-      const workspaceDir = tempDirWithFiles("workspace-test", {
+      await using workspaceDir = tempDir("workspace-test", {
         "package.json": JSON.stringify({
           name: "workspace-root",
           version: "1.0.0",
@@ -502,7 +502,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should work in workspace package directory", async () => {
-      const workspaceDir = tempDirWithFiles("workspace-test", {
+      await using workspaceDir = tempDir("workspace-test", {
         "package.json": JSON.stringify({
           name: "workspace-root",
           workspaces: ["packages/*"],
@@ -522,7 +522,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should modify workspace package.json without affecting root", async () => {
-      const workspaceDir = tempDirWithFiles("workspace-test", {
+      await using workspaceDir = tempDir("workspace-test", {
         "package.json": JSON.stringify({
           name: "workspace-root",
           version: "1.0.0",
@@ -551,7 +551,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should modify root without affecting workspace packages", async () => {
-      const workspaceDir = tempDirWithFiles("workspace-test", {
+      await using workspaceDir = tempDir("workspace-test", {
         "package.json": JSON.stringify({
           name: "workspace-root",
           version: "1.0.0",
@@ -860,7 +860,7 @@ describe("bun pm pkg", () => {
 
     it("should verify npm compatibility with real-world patterns", async () => {
       // Create a package.json structure similar to real projects
-      const realWorldDir = tempDirWithFiles("real-world-test", {
+      await using realWorldDir = tempDir("real-world-test", {
         "package.json": JSON.stringify(
           {
             name: "my-project",
@@ -956,7 +956,7 @@ describe("bun pm pkg", () => {
 
     it("should not modify package.json if no fixes are needed", async () => {
       // First, create a package.json that doesn't need fixing
-      const goodDir = tempDirWithFiles("good-package", {
+      await using goodDir = tempDir("good-package", {
         "package.json": JSON.stringify(
           {
             name: "good-package",
@@ -982,7 +982,7 @@ describe("bun pm pkg", () => {
 
     it("should handle package.json with existing bin files", async () => {
       // Create a package with an actual bin file
-      const binDir = tempDirWithFiles("bin-test", {
+      await using binDir = tempDir("bin-test", {
         "package.json": JSON.stringify(
           {
             name: "BIN-PACKAGE",
@@ -1030,7 +1030,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should handle malformed package.json gracefully", async () => {
-      const malformedDir = tempDirWithFiles("malformed-test", {
+      await using malformedDir = tempDir("malformed-test", {
         "package.json": '{"name": "test", invalid}',
       });
 
@@ -1044,7 +1044,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should handle non-object package.json", async () => {
-      const nonObjectDir = tempDirWithFiles("non-object-test", {
+      await using nonObjectDir = tempDir("non-object-test", {
         "package.json": '"this is not an object"',
       });
 
@@ -1058,7 +1058,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should fix multiple issues in one run", async () => {
-      const multiIssueDir = tempDirWithFiles("multi-issue-test", {
+      await using multiIssueDir = tempDir("multi-issue-test", {
         "package.json": JSON.stringify(
           {
             name: "MULTIPLE-ISSUES-PACKAGE",
@@ -1090,7 +1090,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should not crash on empty bin object", async () => {
-      const emptyBinDir = tempDirWithFiles("empty-bin-test", {
+      await using emptyBinDir = tempDir("empty-bin-test", {
         "package.json": JSON.stringify(
           {
             name: "EMPTY-BIN-PACKAGE",
@@ -1114,7 +1114,7 @@ describe("bun pm pkg", () => {
     });
 
     it("should handle missing package.json file", async () => {
-      const emptyDir = tempDirWithFiles("empty-test", {});
+      await using emptyDir = tempDir("empty-test", {});
 
       try {
         const { code, error } = await runPmPkg(["fix"], emptyDir, false);

--- a/test/cli/install/bun-pm-scan.test.ts
+++ b/test/cli/install/bun-pm-scan.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 describe("bun pm scan", () => {
   describe("configuration", () => {
     test("shows error when no security scanner configured", async () => {
-      const dir = tempDirWithFiles("scan-no-config", {
+      await using dir = tempDir("scan-no-config", {
         "package.json": JSON.stringify({ name: "test", dependencies: { "left-pad": "^1.0.0" } }),
         "bun.lockb": "",
       });
@@ -25,7 +25,7 @@ describe("bun pm scan", () => {
     });
 
     test("shows error when lockfile doesn't exist", async () => {
-      const dir = tempDirWithFiles("scan-no-lockfile", {
+      await using dir = tempDir("scan-no-lockfile", {
         "package.json": JSON.stringify({ name: "test", dependencies: {} }),
         "bunfig.toml": `[install.security]\nscanner = "test-scanner"`,
       });
@@ -65,7 +65,7 @@ describe("bun pm scan", () => {
 
   describe("scanner execution", () => {
     test("scanner receives correct package format", async () => {
-      const dir = tempDirWithFiles("scan-package-format", {
+      await using dir = tempDir("scan-package-format", {
         "package.json": JSON.stringify({
           name: "test-app",
           dependencies: {
@@ -117,7 +117,7 @@ describe("bun pm scan", () => {
     });
 
     test("scanner version validation", async () => {
-      const dir = tempDirWithFiles("scan-version-check", {
+      await using dir = tempDir("scan-version-check", {
         "package.json": JSON.stringify({ name: "test", dependencies: { "left-pad": "^1.0.0" } }),
         "scanner.js": `
           module.exports = {
@@ -151,7 +151,7 @@ describe("bun pm scan", () => {
 
   describe("vulnerability detection", () => {
     test("detects fatal vulnerabilities", async () => {
-      const dir = tempDirWithFiles("scan-fatal", {
+      await using dir = tempDir("scan-fatal", {
         "package.json": JSON.stringify({
           name: "test-app",
           dependencies: { lodash: "^4.0.0" },
@@ -194,7 +194,7 @@ describe("bun pm scan", () => {
     });
 
     test("detects warning vulnerabilities", async () => {
-      const dir = tempDirWithFiles("scan-warn", {
+      await using dir = tempDir("scan-warn", {
         "package.json": JSON.stringify({
           name: "test-app",
           dependencies: { axios: "^0.21.0" },
@@ -236,7 +236,7 @@ describe("bun pm scan", () => {
     });
 
     test("handles mixed vulnerabilities", async () => {
-      const dir = tempDirWithFiles("scan-mixed", {
+      await using dir = tempDir("scan-mixed", {
         "package.json": JSON.stringify({
           name: "test-app",
           dependencies: {
@@ -302,7 +302,7 @@ describe("bun pm scan", () => {
     });
 
     test("no vulnerabilities found", async () => {
-      const dir = tempDirWithFiles("scan-clean", {
+      await using dir = tempDir("scan-clean", {
         "package.json": JSON.stringify({
           name: "test-app",
           dependencies: { lodash: "^4.0.0" },
@@ -337,7 +337,7 @@ describe("bun pm scan", () => {
 
   describe("dependency paths", () => {
     test("shows correct path for direct dependencies", async () => {
-      const dir = tempDirWithFiles("scan-direct-dep", {
+      await using dir = tempDir("scan-direct-dep", {
         "package.json": JSON.stringify({
           name: "my-app",
           dependencies: { express: "^4.0.0" },
@@ -382,7 +382,7 @@ describe("bun pm scan", () => {
     });
 
     test("shows correct path for transitive dependencies", async () => {
-      const dir = tempDirWithFiles("scan-transitive-dep", {
+      await using dir = tempDir("scan-transitive-dep", {
         "package.json": JSON.stringify({
           name: "my-app",
           dependencies: { express: "^4.0.0" },
@@ -436,7 +436,7 @@ describe("bun pm scan", () => {
 
   describe("error handling", () => {
     test("handles scanner crash", async () => {
-      const dir = tempDirWithFiles("scan-crash", {
+      await using dir = tempDir("scan-crash", {
         "package.json": JSON.stringify({
           name: "test",
           dependencies: { "left-pad": "^1.0.0" },
@@ -471,7 +471,7 @@ describe("bun pm scan", () => {
     });
 
     test("handles invalid JSON from scanner", async () => {
-      const dir = tempDirWithFiles("scan-bad-json", {
+      await using dir = tempDir("scan-bad-json", {
         "package.json": JSON.stringify({
           name: "test",
           dependencies: { "left-pad": "^1.0.0" },
@@ -507,7 +507,7 @@ describe("bun pm scan", () => {
     });
 
     test("handles missing required fields in advisory", async () => {
-      const dir = tempDirWithFiles("scan-missing-fields", {
+      await using dir = tempDir("scan-missing-fields", {
         "package.json": JSON.stringify({
           name: "test",
           dependencies: { lodash: "^4.0.0" },
@@ -547,7 +547,7 @@ describe("bun pm scan", () => {
 
   describe("output formatting", () => {
     test("singular vs plural in summary", async () => {
-      const dir = tempDirWithFiles("scan-singular", {
+      await using dir = tempDir("scan-singular", {
         "package.json": JSON.stringify({
           name: "test",
           dependencies: { "left-pad": "^1.0.0" },
@@ -593,7 +593,7 @@ describe("bun pm scan", () => {
     });
 
     test("shows timing for slow scans", async () => {
-      const dir = tempDirWithFiles("scan-slow", {
+      await using dir = tempDir("scan-slow", {
         "package.json": JSON.stringify({
           name: "test",
           dependencies: { "left-pad": "^1.0.0" },
@@ -632,7 +632,7 @@ describe("bun pm scan", () => {
 
   describe("differences from bun add/install", () => {
     test("does not show 'installation aborted' message", async () => {
-      const dir = tempDirWithFiles("scan-no-abort-msg", {
+      await using dir = tempDir("scan-no-abort-msg", {
         "package.json": JSON.stringify({
           name: "test",
           dependencies: { lodash: "^4.0.0" },

--- a/test/cli/install/bun-pm-version.test.ts
+++ b/test/cli/install/bun-pm-version.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 
 describe.concurrent("bun pm version", () => {
@@ -122,7 +122,7 @@ describe.concurrent("bun pm version", () => {
     });
 
     it("shows help with version previews", async () => {
-      const testDir1 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir1 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "2.5.3" }, null, 2),
       });
 
@@ -134,7 +134,7 @@ describe.concurrent("bun pm version", () => {
       expect(output1).toContain("minor      2.5.3 → 2.6.0");
       expect(output1).toContain("major      2.5.3 → 3.0.0");
 
-      const testDir2 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir2 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "1.0.0-alpha.0" }, null, 2),
       });
 
@@ -148,7 +148,7 @@ describe.concurrent("bun pm version", () => {
       expect(output2).toContain("1.1.0-alpha.0");
       expect(output2).toContain("2.0.0-alpha.0");
 
-      const testDir3 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir3 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "1.0.0" }, null, 2),
       });
 
@@ -165,7 +165,7 @@ describe.concurrent("bun pm version", () => {
       expect(output3).toContain("1.1.0-beta.0");
       expect(output3).toContain("2.0.0-beta.0");
 
-      const testDir4 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir4 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test" }, null, 2),
       });
 
@@ -218,7 +218,7 @@ describe.concurrent("bun pm version", () => {
     });
 
     it("handles empty package.json", async () => {
-      const testDir = tempDirWithFiles(`version-${i++}`, {
+      await using testDir = tempDir(`version-${i++}`, {
         "package.json": "{}",
       });
 
@@ -234,7 +234,7 @@ describe.concurrent("bun pm version", () => {
 
   describe("error handling", () => {
     it("handles various error conditions", async () => {
-      const testDir2 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir2 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "invalid-version" }, null, 2),
       });
 
@@ -275,7 +275,7 @@ describe.concurrent("bun pm version", () => {
     });
 
     it("handles missing package.json like npm", async () => {
-      const testDir = tempDirWithFiles(`version-${i++}`, {
+      await using testDir = tempDir(`version-${i++}`, {
         "README.md": "# Test project",
       });
 
@@ -291,7 +291,7 @@ describe.concurrent("bun pm version", () => {
     });
 
     it("handles empty string package.json like npm", async () => {
-      const testDir = tempDirWithFiles(`version-${i++}`, {
+      await using testDir = tempDir(`version-${i++}`, {
         "package.json": '""',
       });
 
@@ -305,7 +305,7 @@ describe.concurrent("bun pm version", () => {
     });
 
     it("handles malformed JSON like npm", async () => {
-      const testDir = tempDirWithFiles(`version-${i++}`, {
+      await using testDir = tempDir(`version-${i++}`, {
         "package.json": '{ "name": "test", invalid json }',
       });
 
@@ -500,7 +500,7 @@ describe.concurrent("bun pm version", () => {
             }
   }`;
 
-      const testDir1 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir1 = tempDir(`version-${i++}`, {
         "package.json": originalJson1,
       });
 
@@ -530,7 +530,7 @@ describe.concurrent("bun pm version", () => {
 
   describe("prerelease handling", () => {
     it("handles custom preid and prerelease scenarios", async () => {
-      const testDir1 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir1 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "1.0.0" }, null, 2),
       });
 
@@ -542,7 +542,7 @@ describe.concurrent("bun pm version", () => {
       expect(code1).toBe(0);
       expect(output1.trim()).toBe("v1.0.1-beta.0");
 
-      const testDir3 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir3 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "1.0.0" }, null, 2),
       });
 
@@ -554,7 +554,7 @@ describe.concurrent("bun pm version", () => {
       expect(code3).toBe(0);
       expect(output3.trim()).toBe("v1.0.1-0");
 
-      const testDir5 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir5 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "1.0.0-alpha" }, null, 2),
       });
 
@@ -566,7 +566,7 @@ describe.concurrent("bun pm version", () => {
       expect(code5).toBe(0);
       expect(output5.trim()).toBe("v1.0.0-alpha.1");
 
-      const testDir6 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir6 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "1.0.0-3" }, null, 2),
       });
 
@@ -636,7 +636,7 @@ describe.concurrent("bun pm version", () => {
       ];
 
       for (const scenario of scenarios) {
-        const testDir = tempDirWithFiles(`version-${i++}`, {
+        await using testDir = tempDir(`version-${i++}`, {
           "package.json": JSON.stringify({ name: "test", version: scenario.version }, null, 2),
         });
 
@@ -653,7 +653,7 @@ describe.concurrent("bun pm version", () => {
         }
       }
 
-      const testDir2 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir2 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "1.0.3-alpha.1" }, null, 2),
       });
 
@@ -669,7 +669,7 @@ describe.concurrent("bun pm version", () => {
 
   describe("lifecycle scripts", () => {
     it("runs lifecycle scripts in correct order and handles failures", async () => {
-      const testDir1 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir1 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify(
           {
             name: "test",
@@ -696,7 +696,7 @@ describe.concurrent("bun pm version", () => {
       const logContent = await Bun.file(join(testDir1, "lifecycle.log")).text();
       expect(logContent.trim()).toBe("step1\nstep2\nstep3");
 
-      const testDir2 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir2 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify(
           {
             name: "test",
@@ -726,7 +726,7 @@ describe.concurrent("bun pm version", () => {
       expect(eventContent.trim()).toBe("preversion");
       expect(scriptContent.trim()).toContain("echo $npm_lifecycle_event");
 
-      const testDir3 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir3 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify(
           {
             name: "test",
@@ -754,7 +754,7 @@ describe.concurrent("bun pm version", () => {
       const packageJson = await Bun.file(join(testDir3, "package.json")).json();
       expect(packageJson.version).toBe("1.0.0");
 
-      const testDir4 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir4 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify(
           {
             name: "test",
@@ -783,7 +783,7 @@ describe.concurrent("bun pm version", () => {
       const content = await Bun.file(join(testDir4, "version-output.txt")).text();
       expect(content.trim()).toBe("built");
 
-      const testDir5 = tempDirWithFiles(`version-${i++}`, {
+      await using testDir5 = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify(
           {
             name: "test",
@@ -837,7 +837,7 @@ describe.concurrent("bun pm version", () => {
     });
 
     it("should work from subdirectories", async () => {
-      const testDir = tempDirWithFiles(`version-${i++}`, {
+      await using testDir = tempDir(`version-${i++}`, {
         "package.json": JSON.stringify({ name: "test", version: "1.0.0" }, null, 2),
         "src/index.js": "console.log('hello');",
       });

--- a/test/cli/install/bun-pm-why.test.ts
+++ b/test/cli/install/bun-pm-why.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { existsSync, mkdtempSync, realpathSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -102,7 +102,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should show direct dependency", async () => {
-    const tempDir = tempDirWithFiles(`why-direct-dependency-${i++}`, {
+    await using tmpDir = tempDir(`why-direct-dependency-${i++}`, {
       "package.json": JSON.stringify({
         name: "foo",
         version: "0.0.1",
@@ -114,7 +114,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -123,7 +123,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout, exited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "lodash"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -138,7 +138,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should show nested dependencies", async () => {
-    const tempDir = tempDirWithFiles(`why-nested-${i++}`, {
+    await using tmpDir = tempDir(`why-nested-${i++}`, {
       "package.json": JSON.stringify({
         name: "foo",
         version: "0.0.1",
@@ -150,7 +150,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "inherit",
       stderr: "inherit",
@@ -159,7 +159,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout, exited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "mime-types"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
@@ -174,7 +174,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should handle workspace dependencies", async () => {
-    const tempDir = tempDirWithFiles(`why-workspace-${i++}`, {
+    await using tmpDir = tempDir(`why-workspace-${i++}`, {
       "package.json": JSON.stringify({
         name: "workspace-root",
         version: "1.0.0",
@@ -198,7 +198,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "inherit",
       stderr: "inherit",
@@ -207,7 +207,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout, exited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "pkg-a"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
@@ -220,7 +220,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should handle npm aliases", async () => {
-    const tempDir = tempDirWithFiles(`why-alias-${i++}`, {
+    await using tmpDir = tempDir(`why-alias-${i++}`, {
       "package.json": JSON.stringify({
         name: "foo",
         version: "0.0.1",
@@ -232,7 +232,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "inherit",
       stderr: "inherit",
@@ -241,7 +241,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "alias-pkg"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
@@ -256,7 +256,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should show error for non-existent package", async () => {
-    const tempDir = tempDirWithFiles(`why-non-existent-${i++}`, {
+    await using tmpDir = tempDir(`why-non-existent-${i++}`, {
       "package.json": JSON.stringify({
         name: "foo",
         version: "0.0.1",
@@ -268,7 +268,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "inherit",
       stderr: "inherit",
@@ -277,7 +277,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "non-existent-package"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -293,7 +293,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should show dependency types correctly", async () => {
-    const tempDir = tempDirWithFiles(`why-dependency-types-${i++}`, {
+    await using tmpDir = tempDir(`why-dependency-types-${i++}`, {
       "package.json": JSON.stringify({
         name: "foo",
         version: "0.0.1",
@@ -314,7 +314,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -323,7 +323,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout: devStdout, exited: devExited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "typescript"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -334,7 +334,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout: peerStdout, exited: peerExited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "react"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -345,7 +345,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout: optStdout, exited: optExited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "chalk"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
@@ -356,7 +356,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should handle packages with multiple versions", async () => {
-    const tempDir = tempDirWithFiles(`why-multi-version-${i++}`, {
+    await using tmpDir = tempDir(`why-multi-version-${i++}`, {
       "package.json": JSON.stringify({
         name: "multi-version-test",
         version: "1.0.0",
@@ -369,7 +369,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
@@ -378,7 +378,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout, exited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "react"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
@@ -429,7 +429,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should support version constraints in the query", async () => {
-    const tempDir = tempDirWithFiles(`why-version-test-${i++}`, {
+    await using tmpDir = tempDir(`why-version-test-${i++}`, {
       "package.json": JSON.stringify({
         name: "version-test",
         version: "1.0.0",
@@ -442,7 +442,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
@@ -451,7 +451,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout, exited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "react@^18.0.0"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
@@ -466,7 +466,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
   });
 
   it("should handle nested workspaces", async () => {
-    const tempDir = tempDirWithFiles(`why-workspace-${i++}`, {
+    await using tmpDir = tempDir(`why-workspace-${i++}`, {
       "package.json": JSON.stringify({
         name: "workspace-root",
         version: "1.0.0",
@@ -497,7 +497,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const install = spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -506,7 +506,7 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
 
     const { stdout, exited } = spawn({
       cmd: [bunExe(), ...cmd.split(" "), "lodash"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { realpathSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDirWithFiles, toTOMLString } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, toTOMLString } from "harness";
 import { join as pathJoin } from "node:path";
 
 describe.each(["bun run", "bun"])(`%s`, cmd => {
@@ -18,7 +18,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
         },
       });
 
-      const cwd = tempDirWithFiles("run.where.node", {
+      await using cwd = tempDir("run.where.node", {
         "bunfig.toml": bunfig,
         "package.json": JSON.stringify(
           {
@@ -68,7 +68,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
         },
       });
 
-      const cwd = tempDirWithFiles(Bun.hash(bunfig).toString(36), {
+      using cwd = tempDir(Bun.hash(bunfig).toString(36), {
         "bunfig.toml": bunfig,
         "package.json": JSON.stringify(
           {
@@ -104,7 +104,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
         },
       });
 
-      const cwd = tempDirWithFiles("run.shell.system-" + Bun.hash(bunfig).toString(32), {
+      await using cwd = tempDir("run.shell.system-" + Bun.hash(bunfig).toString(32), {
         "bunfig.toml": bunfig,
         "package.json": JSON.stringify(
           {
@@ -142,7 +142,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
       },
     });
 
-    const cwd = tempDirWithFiles("run.where.node", {
+    await using cwd = tempDir("run.where.node", {
       "bunfig.toml": bunfig,
       "package.json": JSON.stringify(
         {
@@ -181,7 +181,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
       },
     });
 
-    const cwd = tempDirWithFiles("run.where.node", {
+    await using cwd = tempDir("run.where.node", {
       "bunfig.toml": bunfig,
       "package.json": JSON.stringify(
         {
@@ -218,7 +218,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
       },
     });
 
-    const cwd = tempDirWithFiles("run.where.node", {
+    await using cwd = tempDir("run.where.node", {
       "my-home/.bunfig.toml": bunfig,
       "package.json": JSON.stringify(
         {

--- a/test/cli/install/bun-security-scanner-workspaces.test.ts
+++ b/test/cli/install/bun-security-scanner-workspaces.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 import { getRegistry, startRegistry, stopRegistry } from "./simple-dummy-registry";
 
@@ -70,7 +70,7 @@ describe.concurrent("security scanner workspaces", () => {
 }`,
     };
 
-    const dir = tempDirWithFiles("scanner-workspaces", files);
+    await using dir = tempDir("scanner-workspaces", files);
 
     await Bun.write(
       join(dir, "bunfig.toml"),
@@ -145,7 +145,7 @@ scanner = "./scanner.js"`,
 }`,
     };
 
-    const dir = tempDirWithFiles("scanner-workspaces-hoisted", files);
+    await using dir = tempDir("scanner-workspaces-hoisted", files);
 
     await Bun.write(
       join(dir, "bunfig.toml"),
@@ -219,7 +219,7 @@ scanner = "./scanner.js"`,
 }`,
     };
 
-    const dir = tempDirWithFiles("scanner-workspaces-isolated", files);
+    await using dir = tempDir("scanner-workspaces-isolated", files);
 
     await Bun.write(
       join(dir, "bunfig.toml"),

--- a/test/cli/install/bun-update-security-edge-cases.test.ts
+++ b/test/cli/install/bun-update-security-edge-cases.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("bun update security edge cases", () => {
   test("bun update detects vulnerability in updated version that was safe before", async () => {
     // Start with an exact version that's "safe"
-    const dir = tempDirWithFiles("update-new-vuln", {
+    await using dir = tempDir("update-new-vuln", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -91,7 +91,7 @@ module.exports = {
   });
 
   test("bun update <pkg> detects vulnerability in the specific updated package", async () => {
-    const dir = tempDirWithFiles("update-specific-vuln", {
+    await using dir = tempDir("update-specific-vuln", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -159,7 +159,7 @@ module.exports = {
   test("bun update detects newly discovered vulnerability in existing package", async () => {
     // Scenario: A package in lockfile was safe when installed,
     // but a vulnerability was discovered later (without version change)
-    const dir = tempDirWithFiles("update-newly-discovered", {
+    await using dir = tempDir("update-newly-discovered", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -237,7 +237,7 @@ module.exports = {
   test("bun pm scan detects vulnerability in existing transitive dependency after adding package", async () => {
     // Scenario: After adding a new package, running pm scan finds vulnerabilities
     // in existing transitive dependencies
-    const dir = tempDirWithFiles("scan-after-add", {
+    await using dir = tempDir("scan-after-add", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -306,7 +306,7 @@ module.exports = {
 
   test("bun update with version range change exposes vulnerability", async () => {
     // Scenario: package.json is updated to allow newer versions that have vulnerabilities
-    const dir = tempDirWithFiles("update-range-vuln", {
+    await using dir = tempDir("update-range-vuln", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -382,7 +382,7 @@ module.exports = {
 
   test("bun pm scan detects newly discovered vulnerabilities in existing lockfile", async () => {
     // Scenario: Running pm scan with updated vulnerability database finds new issues
-    const dir = tempDirWithFiles("scan-new-vuln-db", {
+    await using dir = tempDir("scan-new-vuln-db", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {

--- a/test/cli/install/bun-update-security-scan-all.test.ts
+++ b/test/cli/install/bun-update-security-scan-all.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 describe("bun update security scanning", () => {
   test("bun update without arguments scans all packages", async () => {
-    const dir = tempDirWithFiles("update-scan-all", {
+    await using dir = tempDir("update-scan-all", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -91,7 +91,7 @@ module.exports = {
   });
 
   test("bun update with specific packages only scans those packages", async () => {
-    const dir = tempDirWithFiles("update-scan-specific", {
+    await using dir = tempDir("update-scan-specific", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -172,7 +172,7 @@ scanner = "./scanner.js"
   });
 
   test("bun update respects security scanner configuration", async () => {
-    const dir = tempDirWithFiles("update-no-scanner", {
+    await using dir = tempDir("update-no-scanner", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -208,7 +208,7 @@ scanner = "./scanner.js"
   });
 
   test("bun update aborts on fatal vulnerabilities", async () => {
-    const dir = tempDirWithFiles("update-abort-fatal", {
+    await using dir = tempDir("update-abort-fatal", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -268,7 +268,7 @@ scanner = "./scanner.js"
   });
 
   test.todo("bun update prompts for warnings when TTY available - requires TTY for interactive prompt", async () => {
-    const dir = tempDirWithFiles("update-prompt-warnings", {
+    await using dir = tempDir("update-prompt-warnings", {
       "package.json": JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -330,7 +330,7 @@ module.exports = {
   });
 
   test("bun update shows dependency paths correctly", async () => {
-    const dir = tempDirWithFiles("update-dep-paths", {
+    await using dir = tempDir("update-dep-paths", {
       "package.json": JSON.stringify({
         name: "my-app",
         dependencies: {

--- a/test/cli/install/bun-update-security-simple.test.ts
+++ b/test/cli/install/bun-update-security-simple.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("security scanner blocks bun update with fatal advisory", async () => {
-  const dir = tempDirWithFiles("bun-update-security", {
+  await using dir = tempDir("bun-update-security", {
     "package.json": JSON.stringify({
       name: "test-app",
       version: "1.0.0",
@@ -65,7 +65,7 @@ test("security scanner blocks bun update with fatal advisory", async () => {
 });
 
 test("security scanner does not run on bun update when not configured", async () => {
-  const dir = tempDirWithFiles("bun-update-no-security", {
+  await using dir = tempDir("bun-update-no-security", {
     "package.json": JSON.stringify({
       name: "test-app",
       version: "1.0.0",

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -1,6 +1,6 @@
 import { expect, setDefaultTimeout, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, pack, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, pack, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 setDefaultTimeout(1000 * 60 * 5);
@@ -134,7 +134,7 @@ const lockfiles = ["package-lock.json", "yarn.lock", "pnpm-lock.yaml"];
 
 for (const lockfile of lockfiles) {
   test(`should create bun.lock if ${lockfile} migration fails`, async () => {
-    const testDir = tempDirWithFiles("migration-failure", {
+    await using testDir = tempDir("migration-failure", {
       "package.json": JSON.stringify({
         name: "pkg",
         dependencies: {
@@ -175,7 +175,7 @@ test("npm lockfile migration skips extraneous packages that also declare inBundl
     phantomDependencies[`phantom-dep-${i}`] = "1.0.0";
   }
 
-  const testDir = tempDirWithFiles("migrate-extraneous-inbundle", {
+  await using testDir = tempDir("migrate-extraneous-inbundle", {
     "package.json": JSON.stringify({
       name: "extraneous-test",
       workspaces: ["packages/pkg0"],
@@ -233,7 +233,7 @@ test("package-lock.json migration requires integrity for tarball URLs outside th
 
   const offRegistryUrl = `http://localhost:${server.port}/lodash-4.17.21.tgz`;
 
-  const testDir = tempDirWithFiles("migrate-off-registry-tarball", {
+  await using testDir = tempDir("migrate-off-registry-tarball", {
     "package.json": JSON.stringify({
       name: "off-registry-tarball-test",
       version: "1.0.0",
@@ -286,7 +286,7 @@ test("package-lock.json migration requires integrity for tarball URLs outside th
 test("package-lock.json migration rejects git committish values that are not a single path component", async () => {
   // The value after "#" in a git `resolved` field becomes a cache folder name, so migration
   // must only accept a single safe path component (same rule the bun.lock parser applies).
-  const testDir = tempDirWithFiles("migrate-git-committish-validation", {
+  await using testDir = tempDir("migrate-git-committish-validation", {
     "package.json": JSON.stringify({
       name: "git-committish-test",
       version: "1.0.0",
@@ -345,7 +345,7 @@ test("package-lock.json migration keeps dependencies declared as arbitrary tarba
 
   const tarballUrl = `http://localhost:${server.port}/baz-0.0.3.tgz`;
 
-  const testDir = tempDirWithFiles("migrate-arbitrary-tarball-url", {
+  await using testDir = tempDir("migrate-arbitrary-tarball-url", {
     "package.json": JSON.stringify({
       name: "arbitrary-tarball-url-test",
       version: "1.0.0",
@@ -441,7 +441,7 @@ async function install(testDir: string, ...args: string[]) {
 }
 
 test.concurrent("package-lock.json migration does not platform-skip a regular file: folder dependency", async () => {
-  const testDir = tempDirWithFiles(
+  await using testDir = tempDir(
     "migrate-folder-platform",
     filePlatformFixture("a", "vendor/a", [`!${process.platform}`], [`!${process.arch}`]),
   );
@@ -467,7 +467,7 @@ test.concurrent.each([
 ])(
   "package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependency %s at %s",
   async (name, folder) => {
-    const testDir = tempDirWithFiles("migrate-folder-name", filePlatformFixture(name, folder, [], []));
+    await using testDir = tempDir("migrate-folder-name", filePlatformFixture(name, folder, [], []));
 
     const first = await install(testDir);
     expect(first.stderr).toContain("migrated lockfile from package-lock.json");
@@ -489,7 +489,7 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
   // the packed package's `os`/`cpu` arrays in its lockfile entry, and a fresh resolve of
   // the same package.json extracts and installs the tarball regardless of them.
   const nonMatching = { os: [`!${process.platform}`], cpu: [`!${process.arch}`] };
-  const testDir = tempDirWithFiles("migrate-tarball-platform", {
+  await using testDir = tempDir("migrate-tarball-platform", {
     "package.json": JSON.stringify({ name: "repro", dependencies: { a: "file:./a-1.0.0.tgz" } }),
     "src-a/package.json": JSON.stringify({ name: "a", version: "1.0.0", ...nonMatching }),
   });
@@ -521,7 +521,7 @@ test.concurrent("pnpm-lock.yaml migration does not platform-skip a regular file:
   // The pnpm migration copied the lockfile's `os`/`cpu` arrays into every package the
   // same way the npm one did. pnpm records them for any `packages:` entry whose manifest
   // declares them, so a `file:` folder dependency was silently dropped on a mismatch.
-  const testDir = tempDirWithFiles("migrate-pnpm-folder-platform", {
+  await using testDir = tempDir("migrate-pnpm-folder-platform", {
     "package.json": JSON.stringify({ name: "repro", dependencies: { a: "file:./vendor/a" } }),
     "vendor/a/package.json": JSON.stringify({
       name: "a",

--- a/test/cli/install/migration/pnpm-comprehensive.test.ts
+++ b/test/cli/install/migration/pnpm-comprehensive.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("pnpm comprehensive migration tests", () => {
   test("large single package with many dependencies", async () => {
-    const tempDir = tempDirWithFiles("pnpm-large-single", {
+    await using tmpDir = tempDir("pnpm-large-single", {
       "package.json": JSON.stringify(
         {
           name: "large-app",
@@ -309,7 +309,7 @@ snapshots:
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -323,14 +323,14 @@ snapshots:
     }
     expect(exitCode).toBe(0);
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("large-single-package");
   }, 200000);
 
   test("complex monorepo with cross-dependencies", async () => {
-    const tempDir = tempDirWithFiles("pnpm-complex-workspace", {
+    await using tmpDir = tempDir("pnpm-complex-workspace", {
       "package.json": JSON.stringify(
         {
           name: "monorepo-root",
@@ -737,7 +737,7 @@ snapshots:
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -751,14 +751,14 @@ snapshots:
     }
     expect(exitCode).toBe(0);
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("complex-monorepo");
   });
 
   test("pnpm with patches and overrides", async () => {
-    const tempDir = tempDirWithFiles("pnpm-patches-overrides", {
+    await using tmpDir = tempDir("pnpm-patches-overrides", {
       "package.json": JSON.stringify(
         {
           name: "patches-test",
@@ -875,7 +875,7 @@ snapshots:
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install", "--lockfile-only"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -889,14 +889,14 @@ snapshots:
     }
     expect(exitCode).toBe(0);
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("patches-overrides");
   });
 
   test("pnpm v6 format (unsupported)", async () => {
-    const tempDir = tempDirWithFiles("pnpm-v6", {
+    await using tmpDir = tempDir("pnpm-v6", {
       "package.json": JSON.stringify({
         name: "v6-format-test",
         version: "1.0.0",
@@ -919,7 +919,7 @@ packages:
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -934,7 +934,7 @@ packages:
   });
 
   test("pnpm with peer dependencies and auto-install-peers", async () => {
-    const tempDir = tempDirWithFiles("pnpm-peer-deps", {
+    await using tmpDir = tempDir("pnpm-peer-deps", {
       "package.json": JSON.stringify(
         {
           name: "peer-deps-test",
@@ -1037,7 +1037,7 @@ snapshots:
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -1051,9 +1051,9 @@ snapshots:
     }
     expect(exitCode).toBe(0);
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("peer-deps-auto-install");
   });
 });

--- a/test/cli/install/migration/pnpm-lock-migration.test.ts
+++ b/test/cli/install/migration/pnpm-lock-migration.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("pnpm-lock.yaml migration", () => {
   test("simple pnpm lockfile migration produces correct bun.lock", async () => {
-    const tempDir = tempDirWithFiles("pnpm-migrate-simple", {
+    await using tmpDir = tempDir("pnpm-migrate-simple", {
       "package.json": JSON.stringify(
         {
           name: "simple-pnpm-test",
@@ -56,7 +56,7 @@ snapshots:
     // Run bun pm migrate
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -74,16 +74,16 @@ snapshots:
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
 
     // Check that bun.lock was created
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
     // Read and snapshot the migrated lockfile
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("simple-pnpm-migration");
 
     // Verify install works with migrated lockfile
     await using installProc = Bun.spawn({
       cmd: [bunExe(), "install", "--frozen-lockfile"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -103,12 +103,12 @@ snapshots:
     expect(installExitCode).toBe(0);
 
     // Verify packages were installed
-    expect(fs.existsSync(join(tempDir, "node_modules/is-number"))).toBe(true);
-    expect(fs.existsSync(join(tempDir, "node_modules/left-pad"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "node_modules/is-number"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "node_modules/left-pad"))).toBe(true);
   });
 
   test("pnpm workspace lockfile migration", async () => {
-    const tempDir = tempDirWithFiles("pnpm-migrate-workspace", {
+    await using tmpDir = tempDir("pnpm-migrate-workspace", {
       "package.json": JSON.stringify(
         {
           name: "monorepo-root",
@@ -236,7 +236,7 @@ snapshots:
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -253,16 +253,16 @@ snapshots:
     // Check migration message in stderr
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
 
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("workspace-pnpm-migration");
-    const packageJson = JSON.parse(fs.readFileSync(join(tempDir, "package.json"), "utf8"));
+    const packageJson = JSON.parse(fs.readFileSync(join(tmpDir, "package.json"), "utf8"));
     expect(packageJson).toMatchSnapshot("workspace-pnpm-migration-package-json");
   });
 
   test("pnpm with npm protocol aliases", async () => {
-    const tempDir = tempDirWithFiles("pnpm-migrate-npm-aliases", {
+    await using tmpDir = tempDir("pnpm-migrate-npm-aliases", {
       "package.json": JSON.stringify(
         {
           name: "alias-test",
@@ -324,7 +324,7 @@ snapshots:
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -341,15 +341,15 @@ snapshots:
     // Check migration message in stderr
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
 
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("npm-aliases-pnpm-migration");
   });
 
   test("handles different pnpm lockfile versions", async () => {
     // Test version 8
-    const v8Dir = tempDirWithFiles("pnpm-v8", {
+    await using v8Dir = tempDir("pnpm-v8", {
       "package.json": JSON.stringify({ name: "v8-test", dependencies: { "lodash": "^4.17.21" } }),
       "pnpm-lock.yaml": `lockfileVersion: '8.0'
 importers:
@@ -379,7 +379,7 @@ snapshots:
   });
 
   test("handles missing pnpm-lock.yaml gracefully", async () => {
-    const tempDir = tempDirWithFiles("pnpm-migrate-missing", {
+    await using tmpDir = tempDir("pnpm-migrate-missing", {
       "package.json": JSON.stringify({
         name: "test",
         version: "1.0.0",
@@ -388,7 +388,7 @@ snapshots:
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",

--- a/test/cli/install/migration/pnpm-migration-complete.test.ts
+++ b/test/cli/install/migration/pnpm-migration-complete.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("PNPM Migration Complete Test Suite", () => {
   test("comprehensive PNPM migration with all edge cases", async () => {
     // ===== SECTION 1: Basic Dependencies =====
-    const basicTest = tempDirWithFiles("pnpm-basic", {
+    await using basicTest = tempDir("pnpm-basic", {
       "package.json": JSON.stringify({
         name: "basic-test",
         version: "1.0.0",
@@ -92,7 +92,7 @@ snapshots:
     expect(basicLockfile).toMatchSnapshot("basic-dependencies");
 
     // ===== SECTION 2: Canary Versions =====
-    const canaryTest = tempDirWithFiles("pnpm-canary", {
+    await using canaryTest = tempDir("pnpm-canary", {
       "package.json": JSON.stringify({
         name: "canary-test",
         dependencies: {
@@ -157,7 +157,7 @@ snapshots:
     expect(canaryLockfile).toMatchSnapshot("canary-versions");
 
     // ===== SECTION 3: Complex Monorepo with Workspaces =====
-    const monorepoTest = tempDirWithFiles("pnpm-monorepo", {
+    await using monorepoTest = tempDir("pnpm-monorepo", {
       "package.json": JSON.stringify({
         name: "monorepo-root",
         private: true,
@@ -242,7 +242,7 @@ snapshots:
     expect(monorepoLockfile).toMatchSnapshot("monorepo-workspaces");
 
     // ===== SECTION 4: Patches and Overrides =====
-    const patchesTest = tempDirWithFiles("pnpm-patches", {
+    await using patchesTest = tempDir("pnpm-patches", {
       "patches/lodash@4.17.21.patch": `diff --git a/lib/application.js b/lib/application.js
 index 1234567..abcdefg 100644
 --- a/lib/application.js
@@ -318,7 +318,7 @@ snapshots:
     expect(patchesLockfile).toMatchSnapshot("patches-overrides");
 
     // ===== SECTION 5: File and Link Dependencies =====
-    const fileLinksTest = tempDirWithFiles("pnpm-file-links", {
+    await using fileLinksTest = tempDir("pnpm-file-links", {
       "shared/config/package.json": JSON.stringify({ name: "hi" }),
       "local-pkg/package.json": JSON.stringify({ name: "hi2" }),
       "package.json": JSON.stringify({
@@ -378,7 +378,7 @@ snapshots:
     expect(fileLinksLockfile).toMatchSnapshot("file-link-deps");
 
     // ===== SECTION 6: Custom Registries =====
-    const registriesTest = tempDirWithFiles("pnpm-registries", {
+    await using registriesTest = tempDir("pnpm-registries", {
       "package.json": JSON.stringify({
         name: "registries-test",
         dependencies: {
@@ -431,7 +431,7 @@ snapshots:
     expect(registriesLockfile).toMatchSnapshot("custom-registries");
 
     // ===== SECTION 7: Peer Dependencies =====
-    const peerDepsTest = tempDirWithFiles("pnpm-peer-deps", {
+    await using peerDepsTest = tempDir("pnpm-peer-deps", {
       "package.json": JSON.stringify({
         name: "peer-deps-test",
         dependencies: {
@@ -534,7 +534,7 @@ snapshots:
     expect(peerDepsLockfile).toMatchSnapshot("peer-dependencies");
 
     // ===== SECTION 9: Duplicate Packages =====
-    const duplicatesTest = tempDirWithFiles("pnpm-duplicates", {
+    await using duplicatesTest = tempDir("pnpm-duplicates", {
       "package.json": JSON.stringify({
         name: "duplicates-test",
         dependencies: {
@@ -624,7 +624,7 @@ snapshots:
     expect(duplicatesLockfile).toMatchSnapshot("duplicate-packages");
 
     // ===== SECTION 10: Catalogs =====
-    const catalogsTest = tempDirWithFiles("pnpm-catalogs", {
+    await using catalogsTest = tempDir("pnpm-catalogs", {
       "pnpm-workspace.yaml": `packages: []
 
 catalog:
@@ -723,7 +723,7 @@ snapshots:
     expect(catalogsLockfile).toMatchSnapshot("catalogs");
 
     // ===== SECTION 12: Integrity Hashes =====
-    const integrityTest = tempDirWithFiles("pnpm-integrity", {
+    await using integrityTest = tempDir("pnpm-integrity", {
       "package.json": JSON.stringify({
         name: "integrity-test",
         dependencies: {
@@ -778,7 +778,7 @@ snapshots:
     expect(integrityLockfile).toMatchSnapshot("integrity-hashes");
 
     // ===== SECTION 13: Version Zero Bug Test =====
-    const versionZeroTest = tempDirWithFiles("pnpm-version-zero", {
+    await using versionZeroTest = tempDir("pnpm-version-zero", {
       "package.json": JSON.stringify({
         name: "version-zero-test",
         dependencies: {
@@ -822,7 +822,7 @@ snapshots:
     expect(versionZeroLockfile).toMatchSnapshot("version-zero");
 
     // ===== SECTION 14: Mixed Dependency Types =====
-    const mixedDepsTest = tempDirWithFiles("pnpm-mixed-deps", {
+    await using mixedDepsTest = tempDir("pnpm-mixed-deps", {
       "package.json": JSON.stringify({
         name: "mixed-deps-test",
         dependencies: {
@@ -912,7 +912,7 @@ snapshots:
     expect(mixedDepsLockfile).toMatchSnapshot("mixed-dependency-types");
 
     // ===== SECTION 15: Circular Workspace Dependencies =====
-    const circularTest = tempDirWithFiles("pnpm-circular", {
+    await using circularTest = tempDir("pnpm-circular", {
       "package.json": JSON.stringify({
         name: "circular-test",
         workspaces: ["packages/*"],

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("yarn.lock migration basic", () => {
   test("simple yarn.lock migration produces correct bun.lock", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-simple", {
+    await using tmpDir = tempDir("yarn-migration-simple", {
       "package.json": JSON.stringify(
         {
           name: "simple-test",
@@ -31,7 +31,7 @@ is-number@^7.0.0:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -45,14 +45,14 @@ is-number@^7.0.0:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("simple-yarn-migration");
   });
 
   test("yarn.lock with packages containing long build tags", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-build-tags", {
+    await using tmpDir = tempDir("yarn-migration-build-tags", {
       "package.json": JSON.stringify(
         {
           name: "build-tags-test",
@@ -128,7 +128,7 @@ to-fast-properties@^2.0.0:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -142,9 +142,9 @@ to-fast-properties@^2.0.0:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
 
     // Verify that long build tags are preserved correctly
     expect(bunLockContent).toContain("4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81");
@@ -159,7 +159,7 @@ to-fast-properties@^2.0.0:
     // Install should work after migration
     const installResult = await Bun.spawn({
       cmd: [bunExe(), "install"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -171,7 +171,7 @@ to-fast-properties@^2.0.0:
   });
 
   test("yarn.lock with extremely long build tags (regression test)", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-extreme-build-tags", {
+    await using tmpDir = tempDir("yarn-migration-extreme-build-tags", {
       "package.json": JSON.stringify(
         {
           name: "extreme-build-tags-test",
@@ -198,7 +198,7 @@ test-package@1.0.0-alpha.beta.gamma.delta.epsilon.zeta.eta.theta.iota.kappa.lamb
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -208,7 +208,7 @@ test-package@1.0.0-alpha.beta.gamma.delta.epsilon.zeta.eta.theta.iota.kappa.lamb
     const exitCode = await migrateResult.exited;
     expect(exitCode).toBe(0);
 
-    const bunLockPath = join(tempDir, "bun.lock");
+    const bunLockPath = join(tmpDir, "bun.lock");
     expect(fs.existsSync(bunLockPath)).toBe(true);
 
     const bunLockContent = fs.readFileSync(bunLockPath, "utf8");
@@ -226,7 +226,7 @@ test-package@1.0.0-alpha.beta.gamma.delta.epsilon.zeta.eta.theta.iota.kappa.lamb
   });
 
   test("complex yarn.lock with multiple dependencies and versions", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-complex", {
+    await using tmpDir = tempDir("yarn-migration-complex", {
       "package.json": JSON.stringify(
         {
           name: "complex-test",
@@ -714,7 +714,7 @@ vary@~1.1.2:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -728,14 +728,14 @@ vary@~1.1.2:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("complex-yarn-migration");
   });
 
   test("yarn.lock with npm aliases", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-aliases", {
+    await using tmpDir = tempDir("yarn-migration-aliases", {
       "package.json": JSON.stringify(
         {
           name: "alias-test",
@@ -786,7 +786,7 @@ undici-types@~5.26.4:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -800,9 +800,9 @@ undici-types@~5.26.4:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("aliases-yarn-migration");
 
     // Verify that npm aliases are handled correctly
@@ -811,7 +811,7 @@ undici-types@~5.26.4:
   });
 
   test("yarn.lock with resolutions", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-resolutions", {
+    await using tmpDir = tempDir("yarn-migration-resolutions", {
       "package.json": JSON.stringify(
         {
           name: "resolutions-test",
@@ -876,7 +876,7 @@ webpack@^5.89.0:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -890,9 +890,9 @@ webpack@^5.89.0:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("resolutions-yarn-migration");
 
     // Verify resolutions are handled
@@ -900,7 +900,7 @@ webpack@^5.89.0:
   });
 
   test("yarn.lock with workspace dependencies", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-workspace", {
+    await using tmpDir = tempDir("yarn-migration-workspace", {
       "package.json": JSON.stringify(
         {
           name: "workspace-root",
@@ -974,7 +974,7 @@ lodash@^4.17.21:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -988,9 +988,9 @@ lodash@^4.17.21:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("workspace-yarn-migration");
 
     // TODO: Workspace dependencies are not yet supported in yarn migration
@@ -998,7 +998,7 @@ lodash@^4.17.21:
   });
 
   test("yarn.lock with scoped packages and parent/child relationships", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-scoped", {
+    await using tmpDir = tempDir("yarn-migration-scoped", {
       "package.json": JSON.stringify(
         {
           name: "scoped-test",
@@ -1089,7 +1089,7 @@ babel-loader/chalk@^2.4.2:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -1103,9 +1103,9 @@ babel-loader/chalk@^2.4.2:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("scoped-yarn-migration");
 
     // Verify scoped packages are at the bottom
@@ -1124,7 +1124,7 @@ babel-loader/chalk@^2.4.2:
 
   test("migration with realistic complex yarn.lock", async () => {
     // Create a realistic yarn.lock with various edge cases
-    const tempDir = tempDirWithFiles("yarn-migration-complex-realistic", {
+    await using tmpDir = tempDir("yarn-migration-complex-realistic", {
       "package.json": JSON.stringify(
         {
           name: "complex-app",
@@ -1314,7 +1314,7 @@ webpack@^5.75.0:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -1323,9 +1323,9 @@ webpack@^5.75.0:
 
     const exitCode = await migrateResult.exited;
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("complex-realistic-yarn-migration");
 
     // Verify key features are migrated
@@ -1352,14 +1352,14 @@ describe("bun pm migrate for existing yarn.lock", () => {
     const packageJsonContent = await Bun.file(join(import.meta.dir, "yarn", folder, "package.json")).text();
     const yarnLockContent = await Bun.file(join(import.meta.dir, "yarn", folder, "yarn.lock")).text();
 
-    const tempDir = tempDirWithFiles("yarn-lock-migration-", {
+    await using tmpDir = tempDir("yarn-lock-migration-", {
       "package.json": packageJsonContent,
       "yarn.lock": yarnLockContent,
     });
 
     const migrateResult = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -1367,14 +1367,14 @@ describe("bun pm migrate for existing yarn.lock", () => {
     });
 
     expect(migrateResult.exited).resolves.toBe(0);
-    expect(Bun.file(join(tempDir, "bun.lock")).exists()).resolves.toBe(true);
+    expect(Bun.file(join(tmpDir, "bun.lock")).exists()).resolves.toBe(true);
 
-    const bunLockContent = await Bun.file(join(tempDir, "bun.lock")).text();
+    const bunLockContent = await Bun.file(join(tmpDir, "bun.lock")).text();
     expect(bunLockContent).toMatchSnapshot(folder);
   });
 
   test("yarn.lock with packages that have os/cpu requirements", async () => {
-    const tempDir = tempDirWithFiles("yarn-migration-os-cpu", {
+    await using tmpDir = tempDir("yarn-migration-os-cpu", {
       "package.json": JSON.stringify(
         {
           name: "os-cpu-test",
@@ -1454,7 +1454,7 @@ fsevents@^2.3.2:
     // Run bun pm migrate
     const migrateResult = await Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
+      cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -1468,9 +1468,9 @@ fsevents@^2.3.2:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tempDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("os-cpu-yarn-migration");
 
     // Verify that the lockfile contains the expected os/cpu metadata by checking the snapshot

--- a/test/cli/install/test-dev-peer-dependency-priority.test.ts
+++ b/test/cli/install/test-dev-peer-dependency-priority.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 // Each test has its own tempDirWithFiles and spawns its own processes; nothing is shared.
 test.concurrent("workspace devDependencies should take priority over peerDependencies for resolution", async () => {
-  const dir = tempDirWithFiles("dev-peer-priority", {
+  await using dir = tempDir("dev-peer-priority", {
     "package.json": JSON.stringify({
       name: "test-monorepo",
       version: "1.0.0",
@@ -112,7 +112,7 @@ test.concurrent("workspace devDependencies should take priority over peerDepende
 });
 
 test.concurrent("devDependencies and peerDependencies with different versions should coexist", async () => {
-  const dir = tempDirWithFiles("dev-peer-different-versions", {
+  await using dir = tempDir("dev-peer-different-versions", {
     "package.json": JSON.stringify({
       name: "test-monorepo",
       version: "1.0.0",
@@ -173,7 +173,7 @@ test.concurrent("devDependencies and peerDependencies with different versions sh
 });
 
 test.concurrent("dependency behavior comparison prioritizes devDependencies", async () => {
-  const dir = tempDirWithFiles("behavior-comparison", {
+  await using dir = tempDir("behavior-comparison", {
     "package.json": JSON.stringify({
       name: "test-app",
       version: "1.0.0",
@@ -220,7 +220,7 @@ test.concurrent("dependency behavior comparison prioritizes devDependencies", as
 });
 
 test.concurrent("Next.js monorepo scenario should not make unnecessary network requests", async () => {
-  const dir = tempDirWithFiles("nextjs-monorepo", {
+  await using dir = tempDir("nextjs-monorepo", {
     "package.json": JSON.stringify({
       name: "nextjs-monorepo",
       version: "1.0.0",

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -1,30 +1,30 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "path";
-import { bunEnv, bunExe, fakeNodeRun, tempDirWithFiles } from "../../harness";
+import { bunEnv, bunExe, fakeNodeRun, tempDir } from "../../harness";
 
 describe("fake node cli", () => {
   test("the node cli actually works", () => {
-    const temp = tempDirWithFiles("fake-node", {
+    using temp = tempDir("fake-node", {
       "index.ts": "console.log(Bun.version)",
     });
     expect(fakeNodeRun(temp, join(temp, "index.ts")).stdout).toBe(Bun.version);
   });
   test("doesnt resolve bins", () => {
-    const temp = tempDirWithFiles("fake-node", {
+    using temp = tempDir("fake-node", {
       "vite.js": "console.log('pass')",
       "node_modules/.bin/vite": "#!/usr/bin/sh\necho fail && exit 1",
     });
     expect(fakeNodeRun(temp, "vite").stdout).toBe("pass");
   });
   test("doesnt resolve scripts", () => {
-    const temp = tempDirWithFiles("fake-node", {
+    using temp = tempDir("fake-node", {
       "vite.js": "console.log('pass')",
       "package.json": '{"scripts":{"vite":"echo fail && exit 1"}}',
     });
     expect(fakeNodeRun(temp, "vite").stdout).toBe("pass");
   });
   test("can run a script named run.js", () => {
-    const temp = tempDirWithFiles("fake-node", {
+    using temp = tempDir("fake-node", {
       "run.js": "console.log('pass')",
       "run/index.js": "console.log('fail')",
       "node_modules/run/index.js": "console.log('fail')",
@@ -35,7 +35,7 @@ describe("fake node cli", () => {
     // Bun supports JSX and TS, and node doesnt, so our behavior here differs a bit
     // Hopefully these priorization rules will not break any node apps.
     test("picks tsx over any other ext", () => {
-      const temp = tempDirWithFiles("fake-node", {
+      using temp = tempDir("fake-node", {
         "build.js": "console.log('fail (build.js)')",
         "build.jsx": "console.log('fail (build.jsx)')",
         "build.cjs": "console.log('fail (build.cjs)')",
@@ -48,7 +48,7 @@ describe("fake node cli", () => {
       expect(fakeNodeRun(temp, "build").stdout).toBe("pass");
     });
     test("picks jsx over ts", () => {
-      const temp = tempDirWithFiles("fake-node", {
+      using temp = tempDir("fake-node", {
         "build.js": "console.log('fail (build.js)')",
         "build.jsx": "console.log('pass')",
         "build.cjs": "console.log('fail (build.cjs)')",
@@ -60,7 +60,7 @@ describe("fake node cli", () => {
       expect(fakeNodeRun(temp, "build").stdout).toBe("pass");
     });
     test("picks mts over ts", () => {
-      const temp = tempDirWithFiles("fake-node", {
+      using temp = tempDir("fake-node", {
         "build.js": "console.log('fail (build.js)')",
         "build.cjs": "console.log('fail (build.cjs)')",
         "build.mjs": "console.log('fail (build.mjs)')",
@@ -71,7 +71,7 @@ describe("fake node cli", () => {
       expect(fakeNodeRun(temp, "build").stdout).toBe("pass");
     });
     test("picks ts over js/cjs/etc", () => {
-      const temp = tempDirWithFiles("fake-node", {
+      using temp = tempDir("fake-node", {
         "build.js": "console.log('fail (build.js)')",
         "build.cjs": "console.log('fail (build.cjs)')",
         "build.mjs": "console.log('fail (build.mjs)')",
@@ -83,12 +83,12 @@ describe("fake node cli", () => {
   });
 
   test("node -e ", () => {
-    const temp = tempDirWithFiles("fake-node", {});
+    using temp = tempDir("fake-node", {});
     expect(fakeNodeRun(temp, ["-e", "console.log('pass')"]).stdout).toBe("pass");
   });
 
   test("process args work", () => {
-    const temp = tempDirWithFiles("fake-node", {
+    using temp = tempDir("fake-node", {
       "index.js": "console.log(JSON.stringify(process.argv.slice(1)))",
     });
     expect(fakeNodeRun(temp, ["index", "a", "b", "c"]).stdout).toBe(
@@ -102,7 +102,7 @@ describe("fake node cli", () => {
   // stdin is platform-dependent (Windows may inherit a console), so pin
   // a piped stdin here.
   test("no args with piped stdin errors with 'Missing script'", () => {
-    const temp = tempDirWithFiles("fake-node", {});
+    using temp = tempDir("fake-node", {});
     const result = Bun.spawnSync([bunExe(), "--bun", "node"], {
       cwd: temp,
       env: { ...bunEnv, NODE_ENV: undefined },

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -10,6 +10,7 @@ import {
   isDebug,
   isLinux,
   isWindows,
+  tempDir,
   tempDirWithFiles,
 } from "harness";
 import { parseEnv } from "node:util";
@@ -33,7 +34,7 @@ function bunRunWithoutTrim(file: string, env?: Record<string, string>) {
 
 describe(".env file is loaded", () => {
   test(".env", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=bar\n",
       "index.ts": "console.log(process.env.FOO);",
     });
@@ -41,7 +42,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe("bar");
   });
   test(".env.local", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=fail\nBAR=baz\n",
       ".env.local": "FOO=bar\n",
       "index.ts": "console.log(process.env.FOO, process.env.BAR);",
@@ -50,7 +51,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe("bar baz");
   });
   test(".env.development (NODE_ENV=undefined)", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=fail\nBAR=baz\n",
       ".env.development": "FOO=bar\n",
       ".env.local": "LOCAL=true\n",
@@ -60,7 +61,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe("undefined bar baz true");
   });
   test(".env.development (NODE_ENV=development)", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=fail\nBAR=baz\n",
       ".env.development": "FOO=bar\n",
       ".env.local": "LOCAL=true\n",
@@ -70,7 +71,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe("bar baz true");
   });
   test(".env.production", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=fail\nBAR=baz\n",
       ".env.production": "FOO=bar\n",
       ".env.local": "LOCAL=true\n",
@@ -80,7 +81,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe("bar baz true");
   });
   test(".env.development and .env.test ignored when NODE_ENV=production", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=bar\nBAR=baz\n",
       ".env.development": "FOO=development\n",
       ".env.development.local": "FOO=development.local\n",
@@ -93,7 +94,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe("bar baz true");
   });
   test(".env.production and .env.test ignored when NODE_ENV=development", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=bar\nBAR=baz\n",
       ".env.production": "FOO=production\n",
       ".env.production.local": "FOO=production.local\n",
@@ -106,7 +107,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe("bar baz true");
   });
   test(".env and .env.test used in testing", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "A=a\n",
       ".env.test.local": "B=b\n",
       ".env.test": "C=c\n",
@@ -120,7 +121,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "a b c undefined");
   });
   test(".env.local ignored when bun test", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FAILED=false\n",
       ".env.local": "FAILED=true\n",
       "index.test.ts": "console.log(process.env.FAILED);",
@@ -129,7 +130,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "false");
   });
   test(".env.development and .env.production ignored when bun test", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FAILED=false\n",
       ".env.development": "FAILED=development\n",
       ".env.development.local": "FAILED=development.local\n",
@@ -141,7 +142,7 @@ describe(".env file is loaded", () => {
     expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "false");
   });
   test("NODE_ENV is automatically set to test within bun test", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       "index.test.ts": "console.log(process.env.NODE_ENV);",
     });
     const { stdout } = bunTest(`${dir}/index.test.ts`);
@@ -150,7 +151,7 @@ describe(".env file is loaded", () => {
 });
 describe("dotenv priority", () => {
   test("process env overrides everything else", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=.env\n",
       ".env.development": "FOO=.env.development\n",
       ".env.development.local": "FOO=.env.development.local\n",
@@ -169,7 +170,7 @@ describe("dotenv priority", () => {
     expect(stdout2).toBe(`bun test ${Bun.version_with_sha}\n` + "override");
   });
   test(".env.{NODE_ENV}.local overrides .env.local", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=.env\n",
       ".env.development": "FOO=.env.development\n",
       ".env.development.local": "FOO=.env.development.local\n",
@@ -189,7 +190,7 @@ describe("dotenv priority", () => {
     expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.test.local");
   });
   test(".env.local overrides .env.{NODE_ENV}", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=.env\n",
       ".env.development": "FOO=.env.development\n",
       ".env.production": "FOO=.env.production\n",
@@ -207,7 +208,7 @@ describe("dotenv priority", () => {
     expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.test");
   });
   test(".env.{NODE_ENV} overrides .env", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": "FOO=.env\n",
       ".env.development": "FOO=.env.development\n",
       ".env.production": "FOO=.env.production\n",
@@ -225,7 +226,7 @@ describe("dotenv priority", () => {
 });
 
 test(".env colon assign", () => {
-  const dir = tempDirWithFiles("dotenv-colon", {
+  using dir = tempDir("dotenv-colon", {
     ".env": "FOO: foo",
     "index.ts": "console.log(process.env.FOO);",
   });
@@ -234,7 +235,7 @@ test(".env colon assign", () => {
 });
 
 test(".env export assign", () => {
-  const dir = tempDirWithFiles("dotenv-export", {
+  using dir = tempDir("dotenv-export", {
     ".env": "export FOO = foo\nexport = bar",
     "index.ts": "console.log(process.env.FOO, process.env.export);",
   });
@@ -243,7 +244,7 @@ test(".env export assign", () => {
 });
 
 test(".env value expansion", () => {
-  const dir = tempDirWithFiles("dotenv-expand", {
+  using dir = tempDir("dotenv-expand", {
     ".env": "FOO=foo\nBAR=$FOO bar\nMOO=${FOO} ${BAR:-fail} ${MOZ:-moo}",
     "index.ts": "console.log([process.env.FOO, process.env.BAR, process.env.MOO].join('|'));",
   });
@@ -252,7 +253,7 @@ test(".env value expansion", () => {
 });
 
 test(".env comments", () => {
-  const dir = tempDirWithFiles("dotenv-comments", {
+  using dir = tempDir("dotenv-comments", {
     ".env": "#FOZ\nFOO = foo#FAIL\nBAR='bar' #BAZ",
     "index.ts": "console.log(process.env.FOO, process.env.BAR);",
   });
@@ -261,7 +262,7 @@ test(".env comments", () => {
 });
 
 test(".env process variables no comments", () => {
-  const dir = tempDirWithFiles("env-no-comments", {
+  using dir = tempDir("env-no-comments", {
     "index.ts": "console.log(process.env.TEST1, process.env.TEST2);",
   });
   const { stdout } = bunRun(`${dir}/index.ts`, { TEST1: "test#1", TEST2: '"test#2"' });
@@ -277,7 +278,7 @@ describe("package scripts load from .env.production and .env.development", () =>
         "test": `'${bunExe()}' run index.ts`,
       },
     };
-    const dir = tempDirWithFiles("dotenv-package-script-prod", {
+    using dir = tempDir("dotenv-package-script-prod", {
       "index.ts": "console.log(process.env.TEST);",
       "package.json": JSON.stringify(pkgjson),
       ".env.production": "TEST=prod",
@@ -295,7 +296,7 @@ describe("package scripts load from .env.production and .env.development", () =>
         "test": `'${bunExe()}' run index.ts`,
       },
     };
-    const dir = tempDirWithFiles("dotenv-package-script-prod", {
+    using dir = tempDir("dotenv-package-script-prod", {
       "index.ts": "console.log(process.env.TEST);",
       "package.json": JSON.stringify(pkgjson),
       ".env.production": "TEST=prod",
@@ -308,7 +309,7 @@ describe("package scripts load from .env.production and .env.development", () =>
 });
 
 test(".env escaped dollar sign", () => {
-  const dir = tempDirWithFiles("dotenv-dollar", {
+  using dir = tempDir("dotenv-dollar", {
     ".env": "FOO=foo\nBAR=\\$FOO",
     "index.ts": "console.log(process.env.FOO, process.env.BAR);",
   });
@@ -317,7 +318,7 @@ test(".env escaped dollar sign", () => {
 });
 
 test(".env doesnt crash with 159 bytes", () => {
-  const dir = tempDirWithFiles("dotenv-159", {
+  using dir = tempDir("dotenv-159", {
     ".env":
       "123456789=1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678" +
       "\n",
@@ -342,7 +343,7 @@ test(".env doesnt crash with 159 bytes", () => {
 test(
   ".env with 50000 entries",
   () => {
-    const dir = tempDirWithFiles("dotenv-many-entries", {
+    using dir = tempDir("dotenv-many-entries", {
       ".env": new Array(50000)
         .fill(null)
         .map((_, i) => `TEST_VAR${i}=TEST_VAL${i}`)
@@ -365,7 +366,7 @@ test(
 );
 
 test(".env space edgecase (issue #411)", () => {
-  const dir = tempDirWithFiles("dotenv-issue-411", {
+  using dir = tempDir("dotenv-issue-411", {
     ".env": "VARNAME=A B",
     "index.ts": "console.log('[' + process.env.VARNAME + ']');",
   });
@@ -383,7 +384,7 @@ test(".env does not byte-trim 0xA0 out of UTF-8 values", () => {
     D: "x",
   });
 
-  const dir = tempDirWithFiles("dotenv-utf8-nbsp", {
+  using dir = tempDir("dotenv-utf8-nbsp", {
     ".env": "A=x\u0920\nB=\u00A0x\u00A0\n",
     "index.ts": "console.log(JSON.stringify({ A: process.env.A, B: process.env.B }));",
   });
@@ -392,7 +393,7 @@ test(".env does not byte-trim 0xA0 out of UTF-8 values", () => {
 });
 
 test(".env special characters 1 (issue #2823)", () => {
-  const dir = tempDirWithFiles("dotenv-issue-2823", {
+  using dir = tempDir("dotenv-issue-2823", {
     ".env": 'A="a$t"\nC=`c\\$v`',
     "index.ts": "console.log('[' + process.env.A + ']', '[' + process.env.C + ']');",
   });
@@ -401,7 +402,7 @@ test(".env special characters 1 (issue #2823)", () => {
 });
 
 test("env escaped quote (issue #2484)", () => {
-  const dir = tempDirWithFiles("env-issue-2484", {
+  using dir = tempDir("env-issue-2484", {
     "index.ts": "console.log(process.env.VALUE, process.env.VALUE2);",
   });
   const { stdout } = bunRun(`${dir}/index.ts`, { VALUE: `\\"`, VALUE2: `\\\\"` });
@@ -409,7 +410,7 @@ test("env escaped quote (issue #2484)", () => {
 });
 
 test(".env Windows-style newline (issue #3042)", () => {
-  const dir = tempDirWithFiles("dotenv-issue-3042", {
+  using dir = tempDir("dotenv-issue-3042", {
     ".env": "FOO=\rBAR='bar\r\rbaz'\r\nMOO=moo\r",
     "index.ts": "console.log([process.env.FOO, process.env.BAR, process.env.MOO].join('|'));",
   });
@@ -418,7 +419,7 @@ test(".env Windows-style newline (issue #3042)", () => {
 });
 
 test(".env with zero length strings", () => {
-  const dir = tempDirWithFiles("dotenv-issue-zerolength", {
+  using dir = tempDir("dotenv-issue-zerolength", {
     ".env": "FOO=''\n",
     "index.ts":
       "function i(a){return a}\nconsole.log([process.env.FOO,i(process.env).FOO,process.env.FOO.length,i(process.env).FOO.length].join('|'));",
@@ -428,7 +429,7 @@ test(".env with zero length strings", () => {
 });
 
 test("process with zero length environment variable", () => {
-  const dir = tempDirWithFiles("process-issue-zerolength", {
+  using dir = tempDir("process-issue-zerolength", {
     "index.ts": "console.log(`'${process.env.TEST_ENV_VAR}'`);",
   });
   const { stdout } = bunRun(`${dir}/index.ts`, {
@@ -438,7 +439,7 @@ test("process with zero length environment variable", () => {
 });
 
 test(".env in a folder doesn't throw an error", () => {
-  const dir = tempDirWithFiles("dotenv-issue-3670", {
+  using dir = tempDir("dotenv-issue-3670", {
     ".env": {
       ".env.local": "FOO=''\n",
     },
@@ -450,7 +451,7 @@ test(".env in a folder doesn't throw an error", () => {
 });
 
 test("#3911", () => {
-  const dir = tempDirWithFiles("dotenv", {
+  using dir = tempDir("dotenv", {
     ".env": 'KEY="a\\nb"',
     "index.ts": "console.log(process.env.KEY);",
   });
@@ -485,7 +486,7 @@ describe(".env quoted value with trailing junk does not swallow following lines"
     });
 
     test(".env file", () => {
-      const dir = tempDirWithFiles("dotenv-trailing-junk", {
+      using dir = tempDir("dotenv-trailing-junk", {
         ".env": `A=${q}hello${q} junk\nB=${q}x${q}\nC=3\n`,
         "index.ts": "console.log(JSON.stringify({A: process.env.A, B: process.env.B, C: process.env.C}));",
       });
@@ -498,7 +499,7 @@ describe(".env quoted value with trailing junk does not swallow following lines"
 describe("boundary tests", () => {
   // TODO: this is a regression in bun ~1.0.15 ish
   test.todo("src boundary", () => {
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": 'KEY="a\\n"',
       "index.ts": "console.log(process.env.KEY);",
     });
@@ -506,7 +507,7 @@ describe("boundary tests", () => {
     // should be "a\n" but console.log adds a newline
     expect(stdout).toBe("a\n\n");
 
-    const dir2 = tempDirWithFiles("dotenv", {
+    using dir2 = tempDir("dotenv", {
       ".env": 'KEY="a\\n',
       "index.ts": "console.log(process.env.KEY);",
     });
@@ -517,13 +518,13 @@ describe("boundary tests", () => {
 
   test("buffer boundary", () => {
     const expected = "a".repeat(4094);
-    const dir = tempDirWithFiles("dotenv", {
+    using dir = tempDir("dotenv", {
       ".env": `KEY="${expected + "a"}"`,
       "index.ts": "console.log(process.env.KEY);",
     });
     const { stdout } = bunRun(`${dir}/index.ts`);
 
-    const dir2 = tempDirWithFiles("dotenv", {
+    using dir2 = tempDir("dotenv", {
       ".env": `KEY="${expected + "\\n"}"`,
       "index.ts": "console.log(process.env.KEY);",
     });
@@ -657,7 +658,7 @@ describe(".env with a UTF-8 BOM", () => {
   const bom = "\uFEFF";
 
   test("automatic .env load keeps the first variable", () => {
-    const dir = tempDirWithFiles("dotenv-bom", {
+    using dir = tempDir("dotenv-bom", {
       ".env": `${bom}BUNTEST_BOM_A=1\r\nBUNTEST_BOM_B=2\r\n`,
       "index.ts": "console.log(JSON.stringify({A: process.env.BUNTEST_BOM_A, B: process.env.BUNTEST_BOM_B}));",
     });
@@ -666,7 +667,7 @@ describe(".env with a UTF-8 BOM", () => {
   });
 
   test("--env-file keeps the first variable", () => {
-    const dir = tempDirWithFiles("dotenv-bom-envfile", {
+    using dir = tempDir("dotenv-bom-envfile", {
       "with-bom.env": `${bom}BUNTEST_BOM_A=1\nBUNTEST_BOM_B=2\n`,
       "index.ts": "console.log(JSON.stringify({A: process.env.BUNTEST_BOM_A, B: process.env.BUNTEST_BOM_B}));",
     });
@@ -686,7 +687,7 @@ describe(".env with a UTF-8 BOM", () => {
 });
 
 test.if(isWindows)("environment variables are case-insensitive on Windows", () => {
-  const dir = tempDirWithFiles("dotenv", {
+  using dir = tempDir("dotenv", {
     ".env": "FOO=bar\n",
     "index.ts": "console.log(process.env.FOO, process.env.foo, process.env.fOo);",
   });
@@ -696,7 +697,7 @@ test.if(isWindows)("environment variables are case-insensitive on Windows", () =
 
 describe("process.env is not inlined", () => {
   test("basic case", () => {
-    const tmp = tempDirWithFiles("env-inlining", {
+    using tmp = tempDir("env-inlining", {
       "index.ts": `process.env.NODE_ENV = "production";
 process.env.YOLO = "woo!";
 console.log(process.env.NODE_ENV, process.env.YOLO);`,
@@ -709,7 +710,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
     ).toBe("production woo!");
   });
   test("pass explicit NODE_ENV case", () => {
-    const tmp = tempDirWithFiles("env-inlining", {
+    using tmp = tempDir("env-inlining", {
       "index.ts": `console.log(process.env.NODE_ENV);
 process.env.NODE_ENV = "development";
 process.env.YOLO = "woo!";
@@ -723,7 +724,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
     ).toBe("production\ndevelopment woo!");
   });
   test("pass weird NODE_ENV case", () => {
-    const tmp = tempDirWithFiles("env-inlining", {
+    using tmp = tempDir("env-inlining", {
       "index.ts": `console.log(process.env.NODE_ENV);
 process.env.NODE_ENV = "development";
 process.env.YOLO = "woo!";
@@ -737,7 +738,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
     ).toBe("buh\ndevelopment woo!");
   });
   test("in bun test", () => {
-    const tmp = tempDirWithFiles("env-inlining", {
+    using tmp = tempDir("env-inlining", {
       "index.test.ts": `test("my test", () => {
   console.log(process.env.NODE_ENV);
   process.env.NODE_ENV = "development";
@@ -752,7 +753,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
     ).toBe(`bun test ${Bun.version_with_sha}\n` + "test\ndevelopment woo!");
   });
   test("in bun test with explicit setting", () => {
-    const tmp = tempDirWithFiles("env-inlining", {
+    using tmp = tempDir("env-inlining", {
       "index.test.ts": `test("my test", () => {
   console.log(process.env.NODE_ENV);
   process.env.NODE_ENV = "development";
@@ -768,7 +769,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
     ).toBe(`bun test ${Bun.version_with_sha}\n` + "production\ndevelopment woo!");
   });
   test("in bun test with dynamic access", () => {
-    const tmp = tempDirWithFiles("env-inlining", {
+    using tmp = tempDir("env-inlining", {
       "index.test.ts": `const dynamic = () => require('process')['e' + String('nv')];
 test("my test", () => {
   console.log(dynamic().NODE_ENV);
@@ -781,7 +782,7 @@ test("my test", () => {
     );
   });
   test("in bun test with dynamic access + explicit set", () => {
-    const tmp = tempDirWithFiles("env-inlining", {
+    using tmp = tempDir("env-inlining", {
       "index.test.ts": `const dynamic = () => require('process')['e' + String('nv')];
 test("my test", () => {
   console.log(dynamic().NODE_ENV);
@@ -796,7 +797,7 @@ test("my test", () => {
 });
 
 test("NODE_ENV has a default value", () => {
-  const tmp = tempDirWithFiles("default-node-env", {
+  using tmp = tempDir("default-node-env", {
     "index.ts": `const dynamic = () => require('process')['e' + String('nv')];
 console.log(process.env.NODE_ENV);
 console.log(dynamic().NODE_ENV);
@@ -812,7 +813,7 @@ test("NODE_ENV default is not propogated in bun run", () => {
     process.platform !== "win32"
       ? "env | grep -v npm_lifecycle_script | grep NODE_ENV && exit 1 || true"
       : "node -e 'if(process.env.NODE_ENV)throw(1)'";
-  const tmp = tempDirWithFiles("default-node-env", {
+  using tmp = tempDir("default-node-env", {
     "package.json": '{"scripts":{"show-env":' + JSON.stringify(getenv) + "}}",
   });
   expect(bunRunAsScript(tmp, "show-env", {}).stdout).toBe("");
@@ -831,7 +832,7 @@ for (const shell of ["system", "bun"]) {
 
   describe(`script runner with ${shell} shell`, () => {
     test("does not pass variables from .env files into scripts", () => {
-      const tmp = tempDirWithFiles("script-runner-env", {
+      using tmp = tempDir("script-runner-env", {
         "package.json": '{"scripts":{"show-env":"' + show_env_script + '"}}',
 
         ".env.development": "ENV_FILE_NAME=.env.development",
@@ -863,7 +864,7 @@ for (const shell of ["system", "bun"]) {
       },
     ]) {
       test("explicit NODE_ENV=" + NODE_ENV, () => {
-        const tmp = tempDirWithFiles("script-runner-env", {
+        using tmp = tempDir("script-runner-env", {
           "package.json": '{"scripts":{"show-env":"' + show_env_script + '"}}',
 
           ".env.development": "ENV_FILE_NAME=.env.development",
@@ -883,7 +884,7 @@ for (const shell of ["system", "bun"]) {
         // TODO: couldnt get a working thing for this on windows
         const run_index_script = `NODE_ENV=${NODE_ENV} bun run index.ts`;
 
-        const tmp = tempDirWithFiles("script-runner-env", {
+        using tmp = tempDir("script-runner-env", {
           "package.json": '{"scripts":{"start":"' + run_index_script + '"}}',
           "index.ts": "console.log(`ENV_FILE_NAME=${process.env.ENV_FILE_NAME}, NODE_ENV=${process.env.NODE_ENV}`);",
 
@@ -919,7 +920,7 @@ todoOnPosix("setting process.env coerces the value to a string", () => {
 });
 
 test("NODE_ENV=test loads .env.test even when .env.production exists", () => {
-  const dir = tempDirWithFiles("dotenv", {
+  using dir = tempDir("dotenv", {
     "index.ts": "console.log(process.env.AWESOME);",
     ".env.production": "AWESOME=production",
     ".env.test": "AWESOME=test",
@@ -932,7 +933,7 @@ describe("env loader buffer handling", () => {
   test("handles large quoted values with escape sequences", () => {
     // This test ensures the env loader properly handles large values that exceed the initial buffer size
     // The env loader doesn't process escape sequences, so \\\\ remains as \\\\
-    const dir = tempDirWithFiles("dotenv-buffer-overflow", {
+    using dir = tempDir("dotenv-buffer-overflow", {
       ".env": `OVERFLOW_VAR="${"\\\\".repeat(2049)}"`, // 2049 * 2 = 4098 characters
       "index.ts": "console.log(process.env.OVERFLOW_VAR?.length || 0);",
     });
@@ -941,7 +942,7 @@ describe("env loader buffer handling", () => {
   });
 
   test("handles multiple large values in same file", () => {
-    const dir = tempDirWithFiles("dotenv-multiple-large", {
+    using dir = tempDir("dotenv-multiple-large", {
       ".env": `
 LARGE1="${"a".repeat(3000)}"
 LARGE2="${"b".repeat(3000)}"
@@ -957,7 +958,7 @@ LARGE3="${"c".repeat(3000)}"
   test("handles escape sequences at buffer boundaries", () => {
     // Test that values with content near the old 4096-byte buffer boundary work correctly
     const prefix = "x".repeat(4090);
-    const dir = tempDirWithFiles("dotenv-boundary-escape", {
+    using dir = tempDir("dotenv-boundary-escape", {
       ".env": `BOUNDARY="${prefix}suffix"`, // Total length would exceed 4096
       "index.ts": "console.log(process.env.BOUNDARY?.length || 0);",
     });
@@ -983,7 +984,7 @@ const canUseRunuser =
   hasNobodyUser();
 
 test.skipIf(!canUseRunuser)("process.env is preserved when cwd lacks read permission", () => {
-  const dir = tempDirWithFiles("env-eacces", {
+  using dir = tempDir("env-eacces", {
     // Script lives in the readable root; the cwd will be a separate
     // execute-only directory.
     "script.ts": "console.log(JSON.stringify(!!process.env.MY_VAR));",
@@ -1043,7 +1044,7 @@ test.skipIf(!canUseRunuser)("process.env is preserved when cwd lacks read permis
 // `handle_alloc_error` before any user code ran. It must surface as a
 // recoverable error. ASAN-only: ASAN rejects the 1 TiB request deterministically.
 test.skipIf(!isASAN || isWindows)(".env with a huge lying st_size does not abort the process", async () => {
-  const dir = tempDirWithFiles("dotenv-huge-sparse", {
+  await using dir = tempDir("dotenv-huge-sparse", {
     ".env": "",
     "app.js": `console.log("reached user code");`,
   });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { symlinkSync } from "node:fs";
 import { join } from "path";
 
@@ -249,7 +249,7 @@ describe("bun", () => {
   });
 
   test("run pre and post scripts, in order", () => {
-    const dir = tempDirWithFiles("testworkspace", {
+    using dir = tempDir("testworkspace", {
       dep0: {
         "write.js": "await Bun.write('out.txt', 'success')",
         "readwrite.js": "console.log(await Bun.file('out.txt').text()); await Bun.write('post.txt', 'great success')",
@@ -274,7 +274,7 @@ describe("bun", () => {
   });
 
   test("respect dependency order", () => {
-    const dir = tempDirWithFiles("testworkspace", {
+    using dir = tempDir("testworkspace", {
       dep0: {
         "index.js": [
           "await new Promise((resolve) => setTimeout(resolve, 100))",
@@ -324,7 +324,7 @@ describe("bun", () => {
         },
       }),
     };
-    const dir = tempDirWithFiles("testworkspace", {
+    using dir = tempDir("testworkspace", {
       main: {
         "index.js": `console.log(await Bun.file("../${largeNamePkgName}/out.txt").text())`,
         "package.json": JSON.stringify({
@@ -348,7 +348,7 @@ describe("bun", () => {
   });
 
   test("ignore dependency order on cycle, preserving pre and post script order", () => {
-    const dir = tempDirWithFiles("testworkspace", {
+    using dir = tempDir("testworkspace", {
       dep0: {
         "write.js": "await Bun.write('out.txt', 'success')",
         "readwrite.js":
@@ -389,7 +389,7 @@ describe("bun", () => {
   });
 
   test("detect cycle of length > 2", () => {
-    const dir = tempDirWithFiles("testworkspace", {
+    using dir = tempDir("testworkspace", {
       dep0: {
         "package.json": JSON.stringify({
           name: "dep0",
@@ -440,7 +440,7 @@ describe("bun", () => {
     runInCwdFailure(cwd_root, "*", "x", /Failed to read .*malformed2.*package\.json/);
   });
   test("nonzero exit code on failure", () => {
-    const dir = tempDirWithFiles("testworkspace", {
+    using dir = tempDir("testworkspace", {
       dep0: {
         "package.json": JSON.stringify({
           name: "dep0",
@@ -562,7 +562,7 @@ describe("bun", () => {
   });
 
   test("--elide-lines is a no-op (not an error) when stdout is not a terminal", () => {
-    const dir = tempDirWithFiles("testworkspace", {
+    using dir = tempDir("testworkspace", {
       packages: {
         dep0: {
           "index.js": Array(20).fill("console.log('log_line');").join("\n"),
@@ -593,7 +593,7 @@ describe("bun", () => {
   });
 
   test("self-referential directory symlink in a workspace does not loop", () => {
-    const dir = tempDirWithFiles("filter-symlink-loop", {
+    using dir = tempDir("filter-symlink-loop", {
       packages: {
         pkga: {
           "package.json": JSON.stringify({ name: "pkga", scripts: { present: "echo scripta" } }),
@@ -633,7 +633,7 @@ describe("bun", () => {
   });
 
   test("warning names which package.json failed to parse", async () => {
-    const dir = tempDirWithFiles("filter-bad-pkgjson", {
+    await using dir = tempDir("filter-bad-pkgjson", {
       packages: {
         good: {
           "package.json": JSON.stringify({ name: "good", scripts: { go: "echo ok" } }),

--- a/test/cli/run/require-and-import-trailing.test.ts
+++ b/test/cli/run/require-and-import-trailing.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 
 test("require() with trailing slash", () => {
-  const requireDir = tempDirWithFiles("require-trailing", {
+  using requireDir = tempDir("require-trailing", {
     "package.json": `
     {
       // Comments!
@@ -15,7 +15,7 @@ test("require() with trailing slash", () => {
 });
 
 test("import() with trailing slash", async () => {
-  const importDir = tempDirWithFiles("import-trailing", {
+  await using importDir = tempDir("import-trailing", {
     "package.json": `
     {
       // Comments!

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -10,7 +10,7 @@ import {
   isMacOS,
   isMusl,
   isWindows,
-  tempDirWithFiles,
+  tempDir,
 } from "harness";
 import { join } from "path";
 
@@ -59,7 +59,7 @@ describe.concurrent("require.cache", () => {
 
       console.log("Text length:", text.length);
 
-      const dir = tempDirWithFiles("require-cache-bug-leak-1", {
+      await using dir = tempDir("require-cache-bug-leak-1", {
         "index.js": text,
         "require-cache-bug-leak-fixture.js": `
           const path = require.resolve("./index.js");
@@ -117,7 +117,7 @@ describe.concurrent("require.cache", () => {
 
       console.log("Text length:", text.length);
 
-      const dir = tempDirWithFiles("require-cache-bug-leak-3", {
+      await using dir = tempDir("require-cache-bug-leak-3", {
         "index.js": text,
         "require-cache-bug-leak-fixture.js": `
           const path = require.resolve("./index.js");
@@ -166,7 +166,7 @@ describe.concurrent("require.cache", () => {
         text += `export const superDuperExtraCrazyLongNameWowSuchNameLongYouveNeverSeenANameThisLongForACommonJSModuleExport${i} = 1;\n`;
       }
 
-      const dir = tempDirWithFiles("require-cache-bug-leak-4", {
+      await using dir = tempDir("require-cache-bug-leak-4", {
         "index.js": text,
         "require-cache-bug-leak-fixture.js": `
           const path = require.resolve("./index.js");
@@ -226,7 +226,7 @@ describe.concurrent("require.cache", () => {
 
         console.log("Text length:", text.length);
 
-        const dir = tempDirWithFiles("require-cache-bug-leak-2", {
+        await using dir = tempDir("require-cache-bug-leak-2", {
           "index.js": text,
           "require-cache-bug-leak-fixture.js": `
           const path = require.resolve("./index.js");

--- a/test/cli/run/run-process-env.test.ts
+++ b/test/cli/run/run-process-env.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { bunExe, bunRunAsScript, tempDirWithFiles } from "harness";
+import { bunExe, bunRunAsScript, tempDir } from "harness";
 
 describe("process.env", () => {
   test("npm_lifecycle_event", () => {
     const scriptName = "start:dev";
 
-    const dir = tempDirWithFiles("processenv", {
+    using dir = tempDir("processenv", {
       "package.json": JSON.stringify({ "scripts": { [`${scriptName}`]: `'${bunExe()}' run index.ts` } }),
       "index.ts": "console.log(process.env.npm_lifecycle_event);",
     });
@@ -15,7 +15,7 @@ describe("process.env", () => {
 
   // https://github.com/oven-sh/bun/issues/3589
   test("npm_lifecycle_event should have the value of the last call", () => {
-    const dir = tempDirWithFiles("processenv_ls_call", {
+    using dir = tempDir("processenv_ls_call", {
       "package.json": JSON.stringify({ scripts: { first: `'${bunExe()}' run --cwd lsc second` } }),
       "lsc": {
         "package.json": JSON.stringify({ scripts: { second: `'${bunExe()}' run index.ts` } }),

--- a/test/cli/run/run-quote.test.ts
+++ b/test/cli/run/run-quote.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "bun:test";
-import { bunEnv, bunExe, bunRunAsScript, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRunAsScript, tempDir } from "harness";
 
 it("should handle quote escapes", () => {
   const package_json = JSON.stringify({
@@ -9,13 +9,13 @@ it("should handle quote escapes", () => {
   });
   expect(package_json).toContain('\\"');
   expect(package_json).toContain("\\\\");
-  const dir = tempDirWithFiles("run-quote", { "package.json": package_json });
+  using dir = tempDir("run-quote", { "package.json": package_json });
   const { stdout } = bunRunAsScript(dir, "test");
   expect(stdout).toBe(`test\\${dir}`);
 });
 
 it("keeps pass-through arguments containing tabs and question marks as single words", async () => {
-  const dir = tempDirWithFiles("run-quote-passthrough", {
+  await using dir = tempDir("run-quote-passthrough", {
     "package.json": JSON.stringify({
       scripts: {
         args: `${bunExe()} print-args.js`,

--- a/test/cli/run/sql-preconnect.test.ts
+++ b/test/cli/run/sql-preconnect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("--sql-preconnect", () => {
   test("should attempt to preconnect to PostgreSQL on startup", async () => {
@@ -22,7 +22,7 @@ describe("--sql-preconnect", () => {
       },
     });
 
-    const testDir = tempDirWithFiles("sql-preconnect-test", {
+    await using testDir = tempDir("sql-preconnect-test", {
       "index.js": `console.log("Script executed");`,
     });
 
@@ -58,7 +58,7 @@ describe("--sql-preconnect", () => {
       },
     });
 
-    const testDir = tempDirWithFiles("sql-no-preconnect", {
+    await using testDir = tempDir("sql-no-preconnect", {
       "index.js": `console.log("Normal script executed");`,
     });
 

--- a/test/cli/run/tsconfig-override.test.ts
+++ b/test/cli/run/tsconfig-override.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "node:path";
 
 describe("bun run --tsconfig-override", () => {
   test("should use custom tsconfig for path resolution", async () => {
-    const dir = tempDirWithFiles("run-tsconfig-override", {
+    await using dir = tempDir("run-tsconfig-override", {
       "index.ts": `
         import { helper } from '@helpers/math';
         console.log(helper());
@@ -70,7 +70,7 @@ describe("bun run --tsconfig-override", () => {
   });
 
   test("should work with relative tsconfig path", async () => {
-    const dir = tempDirWithFiles("run-tsconfig-relative", {
+    await using dir = tempDir("run-tsconfig-relative", {
       "src/main.ts": `
         import { lib } from '@lib/util';
         console.log(lib());
@@ -111,7 +111,7 @@ describe("bun run --tsconfig-override", () => {
   });
 
   test("should work with monorepo-style paths", async () => {
-    const dir = tempDirWithFiles("run-tsconfig-monorepo", {
+    await using dir = tempDir("run-tsconfig-monorepo", {
       "apps/web/src/index.ts": `
         import { Button } from '@ui/components';
         import { config } from '@shared/config';
@@ -158,7 +158,7 @@ describe("bun run --tsconfig-override", () => {
   });
 
   test("should work with nested directories and complex paths", async () => {
-    const dir = tempDirWithFiles("run-tsconfig-nested", {
+    await using dir = tempDir("run-tsconfig-nested", {
       "frontend/src/pages/home.ts": `
         import { api } from '~/api/client';
         import { utils } from '#/utils/helpers';
@@ -207,7 +207,7 @@ describe("bun run --tsconfig-override", () => {
   });
 
   test("should handle extending tsconfig with overrides", async () => {
-    const dir = tempDirWithFiles("run-tsconfig-extends", {
+    await using dir = tempDir("run-tsconfig-extends", {
       "src/app.ts": `
         import { core } from '@core/main';
         import { feature } from '@features/auth';
@@ -263,7 +263,7 @@ describe("bun run --tsconfig-override", () => {
   });
 
   test("should work from different working directories", async () => {
-    const dir = tempDirWithFiles("run-tsconfig-cwd", {
+    await using dir = tempDir("run-tsconfig-cwd", {
       "project/src/main.ts": `
         import { helper } from '@utils/math';
         console.log('Result:', helper(5, 3));

--- a/test/cli/run/workspaces.test.ts
+++ b/test/cli/run/workspaces.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("bun run --workspaces runs script in all workspace packages", async () => {
-  const dir = tempDirWithFiles("workspaces-test", {
+  await using dir = tempDir("workspaces-test", {
     "package.json": JSON.stringify({
       name: "root",
       workspaces: ["packages/*"],
@@ -42,7 +42,7 @@ test("bun run --workspaces runs script in all workspace packages", async () => {
 });
 
 test("bun run --workspaces --if-present succeeds when script is missing", async () => {
-  const dir = tempDirWithFiles("workspaces-if-present", {
+  await using dir = tempDir("workspaces-if-present", {
     "package.json": JSON.stringify({
       name: "root",
       workspaces: ["packages/*"],
@@ -75,7 +75,7 @@ test("bun run --workspaces --if-present succeeds when script is missing", async 
 });
 
 test("bun run --workspaces fails when no packages have the script", async () => {
-  const dir = tempDirWithFiles("workspaces-no-script", {
+  await using dir = tempDir("workspaces-no-script", {
     "package.json": JSON.stringify({
       name: "root",
       workspaces: ["packages/*"],

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1325,7 +1325,7 @@ describe("bun test", () => {
   });
 
   test("--tsconfig-override works", () => {
-    const dir = tempDirWithFiles("test-tsconfig-override", {
+    using dir = tempDir("test-tsconfig-override", {
       "math.test.ts": `
         import { describe, test, expect } from "bun:test";
         import { add } from "@utils/math";
@@ -1391,7 +1391,7 @@ describe("bun test", () => {
   });
 
   test("--tsconfig-override works with monorepo spec tsconfig", () => {
-    const dir = tempDirWithFiles("test-tsconfig-monorepo", {
+    using dir = tempDir("test-tsconfig-monorepo", {
       "packages/app/src/index.ts": `
         export function getMessage() {
           return "Hello from app";

--- a/test/cli/test/claudecode-flag.test.ts
+++ b/test/cli/test/claudecode-flag.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 let testEnv: NodeJS.Dict<string>;
 
@@ -10,7 +10,7 @@ beforeAll(() => {
 });
 
 test("CLAUDECODE=1 shows quiet test output (only failures)", async () => {
-  const dir = tempDirWithFiles("claudecode-test-quiet", {
+  await using dir = tempDir("claudecode-test-quiet", {
     "test2.test.js": `
       import { test, expect } from "bun:test";
 
@@ -47,7 +47,7 @@ test("CLAUDECODE=1 shows quiet test output (only failures)", async () => {
 });
 
 test("CLAUDECODE=1 vs CLAUDECODE=0 comparison", async () => {
-  const dir = tempDirWithFiles("claudecode-test-compare", {
+  await using dir = tempDir("claudecode-test-compare", {
     "test3.test.js": `
       import { test, expect } from "bun:test";
 
@@ -112,7 +112,7 @@ test("CLAUDECODE=1 vs CLAUDECODE=0 comparison", async () => {
 });
 
 test("CLAUDECODE flag handles no test files found", () => {
-  const dir = tempDirWithFiles("empty-project", {
+  using dir = tempDir("empty-project", {
     "package.json": `{
       "name": "empty-project",
       "version": "1.0.0"

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import path from "path";
 
 test("coverage crash", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "demo.test.ts": `class Y {
   #hello
 }`,
@@ -21,7 +21,7 @@ test("coverage crash", () => {
 });
 
 test("lcov coverage reporter", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "demo2.ts": `
 import { Y } from "./demo1";
 
@@ -58,7 +58,7 @@ export class Y {
 });
 
 test("coverage excludes node_modules directory", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "node_modules/pi/index.js": `
     export const pi = 3.14;
     `,
@@ -81,7 +81,7 @@ test("coverage excludes node_modules directory", () => {
 });
 
 test("coveragePathIgnorePatterns - single pattern string", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = "ignore-me.ts"
@@ -141,7 +141,7 @@ Ran 1 test across 1 file."
 });
 
 test("coveragePathIgnorePatterns - partial coverage without nan", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = "ignore-me.ts"
@@ -206,7 +206,7 @@ Ran 1 test across 1 file."
 });
 
 test("coveragePathIgnorePatterns - array of patterns", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = ["utils/**", "*.config.ts"]
@@ -271,7 +271,7 @@ Ran 1 test across 1 file."
 });
 
 test("coveragePathIgnorePatterns - glob patterns", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = ["**/*.spec.ts", "test-utils/**"]
@@ -340,7 +340,7 @@ Ran 1 test across 2 files."
 });
 
 test("coveragePathIgnorePatterns - lcov reporter", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = "ignore-me.ts"
@@ -409,7 +409,7 @@ end_of_record"
 });
 
 test("coveragePathIgnorePatterns - invalid config type", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = 123
@@ -448,7 +448,7 @@ Invalid Bunfig: failed to load bunfig"
 });
 
 test("coveragePathIgnorePatterns - invalid array item", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = ["valid-pattern", 123]
@@ -487,7 +487,7 @@ Invalid Bunfig: failed to load bunfig"
 });
 
 test("coveragePathIgnorePatterns - empty array", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = []
@@ -540,7 +540,7 @@ Ran 1 test across 1 file."
 });
 
 test("coveragePathIgnorePatterns - ignore all files", () => {
-  const dir = tempDirWithFiles("cov", {
+  using dir = tempDir("cov", {
     "bunfig.toml": `
 [test]
 coveragePathIgnorePatterns = "**"

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("pathIgnorePatterns", () => {
   test("bunfig - single pattern string", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "bunfig.toml": `
 [test]
 pathIgnorePatterns = "ignore-me.test.ts"
@@ -36,7 +36,7 @@ test("ignored test", () => {
   });
 
   test("bunfig - array of patterns", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "bunfig.toml": `
 [test]
 pathIgnorePatterns = ["helpers/**", "*.setup.test.ts"]
@@ -76,7 +76,7 @@ test("setup test", () => {
   });
 
   test("bunfig - glob pattern with **", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "bunfig.toml": `
 [test]
 pathIgnorePatterns = "**/integration/**"
@@ -109,7 +109,7 @@ test("integration test", () => {
   });
 
   test("CLI flag - single pattern", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "keep.test.ts": `
 import { test, expect } from "bun:test";
 test("kept test", () => {
@@ -138,7 +138,7 @@ test("skipped test", () => {
   });
 
   test("CLI flag - multiple patterns", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "app.test.ts": `
 import { test, expect } from "bun:test";
 test("app test", () => {
@@ -177,7 +177,7 @@ test("fixture test", () => {
   });
 
   test("bunfig - invalid config type", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "bunfig.toml": `
 [test]
 pathIgnorePatterns = 123
@@ -202,7 +202,7 @@ test("should pass", () => {
   });
 
   test("bunfig - invalid array item", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "bunfig.toml": `
 [test]
 pathIgnorePatterns = ["valid-pattern", 123]
@@ -227,7 +227,7 @@ test("should pass", () => {
   });
 
   test("bunfig - empty array is a no-op", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "bunfig.toml": `
 [test]
 pathIgnorePatterns = []
@@ -253,7 +253,7 @@ test("should pass", () => {
   });
 
   test("CLI flag overrides bunfig", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "bunfig.toml": `
 [test]
 pathIgnorePatterns = "a.test.ts"
@@ -289,7 +289,7 @@ test("b test", () => {
   });
 
   test("bare directory name pattern prunes entire subtree", () => {
-    const dir = tempDirWithFiles("path-ignore", {
+    using dir = tempDir("path-ignore", {
       "root.test.ts": `
 import { test, expect } from "bun:test";
 test("root test", () => {

--- a/test/cli/test/test-randomize.test.ts
+++ b/test/cli/test/test-randomize.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 // test:
@@ -75,7 +75,7 @@ test.concurrent("--randomize and --seed work", async () => {
 // birthday-paradox search takes several seconds and would starve siblings.
 test("--randomize: files whose u32-truncated path hashes collide get distinct per-file orders", async () => {
   // tempDirWithFiles already realpaths os.tmpdir(), so tmpRoot is canonical.
-  const tmpRoot = tempDirWithFiles("randomize-hash-collision", {});
+  await using tmpRoot = tempDir("randomize-hash-collision", {});
 
   // Birthday collision on u32 is ~77k names at 50%; at 400k the miss
   // probability is exp(-400000^2 / 2^33) ~= 8e-9.
@@ -134,7 +134,7 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
 }, 60_000);
 
 test.concurrent("randomizes order of files", async () => {
-  const dir = tempDirWithFiles(
+  await using dir = tempDir(
     "randomize-order-of-files",
     Object.fromEntries(
       Array.from({ length: 20 }, (_, i) => [

--- a/test/cli/update_interactive_formatting.test.ts
+++ b/test/cli/update_interactive_formatting.test.ts
@@ -1,7 +1,7 @@
 import { dlopen, FFIType } from "bun:ffi";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { closeSync, createReadStream } from "fs";
-import { bunEnv, bunExe, isMusl, isWindows, tempDirWithFiles, VerdaccioRegistry } from "harness";
+import { bunEnv, bunExe, isMusl, isWindows, tempDir, VerdaccioRegistry } from "harness";
 import { join } from "path";
 
 let registry: VerdaccioRegistry;
@@ -19,7 +19,7 @@ afterAll(() => {
 
 describe("bun update --interactive", () => {
   it("should handle package names of unusual lengths", async () => {
-    const dir = tempDirWithFiles("update-interactive-test", {
+    await using dir = tempDir("update-interactive-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -130,7 +130,7 @@ describe("bun update --interactive", () => {
   });
 
   it("should handle version strings of unusual lengths", async () => {
-    const dir = tempDirWithFiles("update-interactive-versions-test", {
+    await using dir = tempDir("update-interactive-versions-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -182,7 +182,7 @@ describe("bun update --interactive", () => {
 
   it("should truncate extremely long package names", async () => {
     const extremelyLongPackageName = "a".repeat(100);
-    const dir = tempDirWithFiles("update-interactive-truncate-test", {
+    await using dir = tempDir("update-interactive-truncate-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -223,7 +223,7 @@ describe("bun update --interactive", () => {
   });
 
   it("should show workspace column with --filter", async () => {
-    const dir = tempDirWithFiles("update-interactive-workspace-col-test", {
+    await using dir = tempDir("update-interactive-workspace-col-test", {
       "package.json": JSON.stringify({
         name: "root",
         version: "1.0.0",
@@ -261,7 +261,7 @@ describe("bun update --interactive", () => {
   });
 
   it("should handle catalog dependencies in interactive update", async () => {
-    const dir = tempDirWithFiles("update-interactive-catalog-test", {
+    await using dir = tempDir("update-interactive-catalog-test", {
       "package.json": JSON.stringify({
         name: "root",
         version: "1.0.0",
@@ -303,7 +303,7 @@ describe("bun update --interactive", () => {
   });
 
   it("should handle mixed dependency types with various name lengths", async () => {
-    const dir = tempDirWithFiles("update-interactive-mixed-test", {
+    await using dir = tempDir("update-interactive-mixed-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -387,7 +387,7 @@ describe("bun update --interactive", () => {
     let slaveOpen = true;
 
     try {
-      const dir = tempDirWithFiles("update-interactive-narrow-tty", {
+      await using dir = tempDir("update-interactive-narrow-tty", {
         "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -462,7 +462,7 @@ registry = "${registryUrl}"
   });
 
   it("should update packages when 'a' (select all) is used", async () => {
-    const dir = tempDirWithFiles("update-interactive-select-all", {
+    await using dir = tempDir("update-interactive-select-all", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -531,7 +531,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle workspace updates with recursive flag", async () => {
-    const dir = tempDirWithFiles("update-interactive-workspace-recursive", {
+    await using dir = tempDir("update-interactive-workspace-recursive", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -587,7 +587,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle catalog updates correctly", async () => {
-    const dir = tempDirWithFiles("update-interactive-catalog-actual", {
+    await using dir = tempDir("update-interactive-catalog-actual", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -651,7 +651,7 @@ registry = "${registryUrl}"
   });
 
   it("should work correctly when run from inside a workspace directory", async () => {
-    const dir = tempDirWithFiles("update-interactive-from-workspace", {
+    await using dir = tempDir("update-interactive-from-workspace", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -721,7 +721,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle basic interactive update with select all", async () => {
-    const dir = tempDirWithFiles("update-interactive-basic", {
+    await using dir = tempDir("update-interactive-basic", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -768,7 +768,7 @@ registry = "${registryUrl}"
   });
 
   it("should preserve version prefixes for all semver range types in catalogs", async () => {
-    const dir = tempDirWithFiles("update-interactive-semver-prefixes", {
+    await using dir = tempDir("update-interactive-semver-prefixes", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -830,7 +830,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle catalog updates in workspaces.catalogs object", async () => {
-    const dir = tempDirWithFiles("update-interactive-workspaces-catalogs", {
+    await using dir = tempDir("update-interactive-workspaces-catalogs", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -900,7 +900,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle mixed workspace and catalog dependencies", async () => {
-    const dir = tempDirWithFiles("update-interactive-mixed-deps", {
+    await using dir = tempDir("update-interactive-mixed-deps", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -970,7 +970,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle selecting specific packages in interactive mode", async () => {
-    const dir = tempDirWithFiles("update-interactive-selective", {
+    await using dir = tempDir("update-interactive-selective", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1029,7 +1029,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle empty catalog definitions gracefully", async () => {
-    const dir = tempDirWithFiles("update-interactive-empty-catalog", {
+    await using dir = tempDir("update-interactive-empty-catalog", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1085,7 +1085,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle cancellation (Ctrl+C) gracefully", async () => {
-    const dir = tempDirWithFiles("update-interactive-cancel", {
+    await using dir = tempDir("update-interactive-cancel", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1135,7 +1135,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle packages with pre-release versions correctly", async () => {
-    const dir = tempDirWithFiles("update-interactive-prerelease", {
+    await using dir = tempDir("update-interactive-prerelease", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1187,7 +1187,7 @@ registry = "${registryUrl}"
   });
 
   it("should update catalog in workspaces object (not workspaces.catalogs)", async () => {
-    const dir = tempDirWithFiles("update-interactive-workspaces-catalog", {
+    await using dir = tempDir("update-interactive-workspaces-catalog", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1249,7 +1249,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle scoped packages in catalogs correctly", async () => {
-    const dir = tempDirWithFiles("update-interactive-scoped-catalog", {
+    await using dir = tempDir("update-interactive-scoped-catalog", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1309,7 +1309,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle catalog updates when running from root with filter", async () => {
-    const dir = tempDirWithFiles("update-interactive-filter-catalog", {
+    await using dir = tempDir("update-interactive-filter-catalog", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1373,7 +1373,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle multiple catalog definitions with same package", async () => {
-    const dir = tempDirWithFiles("update-interactive-multi-catalog", {
+    await using dir = tempDir("update-interactive-multi-catalog", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1441,7 +1441,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle version ranges with multiple conditions", async () => {
-    const dir = tempDirWithFiles("update-interactive-complex-ranges", {
+    await using dir = tempDir("update-interactive-complex-ranges", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1499,7 +1499,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle dry-run mode correctly", async () => {
-    const dir = tempDirWithFiles("update-interactive-dry-run", {
+    await using dir = tempDir("update-interactive-dry-run", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1551,7 +1551,7 @@ registry = "${registryUrl}"
   });
 
   it("should handle keyboard navigation correctly", async () => {
-    const dir = tempDirWithFiles("update-interactive-navigation", {
+    await using dir = tempDir("update-interactive-navigation", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1603,7 +1603,7 @@ registry = "${registryUrl}"
 
   // Comprehensive tests from separate file
   it("comprehensive interactive update test with all scenarios", async () => {
-    const dir = tempDirWithFiles("update-interactive-comprehensive", {
+    await using dir = tempDir("update-interactive-comprehensive", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1747,7 +1747,7 @@ registry = "${registryUrl}"
   });
 
   it("interactive update with workspace filters", async () => {
-    const dir = tempDirWithFiles("update-interactive-filter", {
+    await using dir = tempDir("update-interactive-filter", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1816,7 +1816,7 @@ registry = "${registryUrl}"
   });
 
   it("interactive update with workspaces.catalogs structure", async () => {
-    const dir = tempDirWithFiles("update-interactive-workspaces-catalogs", {
+    await using dir = tempDir("update-interactive-workspaces-catalogs", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1907,7 +1907,7 @@ registry = "${registryUrl}"
   });
 
   it("interactive update dry run mode", async () => {
-    const dir = tempDirWithFiles("update-interactive-dry-run", {
+    await using dir = tempDir("update-interactive-dry-run", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -1965,7 +1965,7 @@ registry = "${registryUrl}"
   });
 
   it("should preserve npm: alias prefix when updating packages", async () => {
-    const dir = tempDirWithFiles("update-interactive-npm-alias", {
+    await using dir = tempDir("update-interactive-npm-alias", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"
@@ -2010,7 +2010,7 @@ registry = "${registryUrl}"
   });
 
   it("interactive update with mixed dependency types", async () => {
-    const dir = tempDirWithFiles("update-interactive-mixed", {
+    await using dir = tempDir("update-interactive-mixed", {
       "bunfig.toml": `[install]
 cache = false
 registry = "${registryUrl}"

--- a/test/cli/update_interactive_snapshots.test.ts
+++ b/test/cli/update_interactive_snapshots.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("bun update --interactive snapshots", () => {
   it("should not crash with various package name lengths", async () => {
-    const dir = tempDirWithFiles("update-interactive-snapshot-test", {
+    await using dir = tempDir("update-interactive-snapshot-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -61,7 +61,7 @@ describe("bun update --interactive snapshots", () => {
 
   it("should handle extremely long package names without crashing", async () => {
     const veryLongName = "a".repeat(80);
-    const dir = tempDirWithFiles("update-interactive-long-names", {
+    await using dir = tempDir("update-interactive-long-names", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -96,7 +96,7 @@ describe("bun update --interactive snapshots", () => {
   });
 
   it("should handle complex version strings without crashing", async () => {
-    const dir = tempDirWithFiles("update-interactive-complex-versions", {
+    await using dir = tempDir("update-interactive-complex-versions", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",

--- a/test/cli/user-agent.test.ts
+++ b/test/cli/user-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("--user-agent flag", () => {
   test("custom user agent is sent in HTTP requests", async () => {
@@ -26,7 +26,7 @@ try {
 }
 `;
 
-    const dir = tempDirWithFiles("user-agent-test", {
+    await using dir = tempDir("user-agent-test", {
       "test.js": testScript,
     });
 
@@ -63,7 +63,7 @@ try {
 }
 `;
 
-    const dir = tempDirWithFiles("user-agent-default-test", {
+    await using dir = tempDir("user-agent-default-test", {
       "test.js": testScript,
     });
 

--- a/test/internal/int_from_float.test.ts
+++ b/test/internal/int_from_float.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 
 /**
  * Tests for bun.intFromFloat function
@@ -23,7 +23,7 @@ function normalizeCSSOutput(output: string): string {
 describe("bun.intFromFloat function", () => {
   test("handles normal finite values within range", async () => {
     // Test CSS dimension serialization which uses intFromFloat(i32, value)
-    const dir = tempDirWithFiles("int-from-float-normal", {
+    await using dir = tempDir("int-from-float-normal", {
       "input.css": ".test { width: 42px; height: -10px; margin: 0px; }",
     });
 
@@ -48,7 +48,7 @@ describe("bun.intFromFloat function", () => {
 
   test("handles extremely large values (original crash case)", async () => {
     // This was the original failing case - large values should not crash
-    const dir = tempDirWithFiles("int-from-float-large", {
+    await using dir = tempDir("int-from-float-large", {
       "input.css": `
 .test-large { border-radius: 3.40282e38px; }
 .test-negative-large { border-radius: -3.40282e38px; }
@@ -78,7 +78,7 @@ describe("bun.intFromFloat function", () => {
 
   test("handles percentage values", async () => {
     // Test percentage conversion which uses intFromFloat(i32, value)
-    const dir = tempDirWithFiles("int-from-float-percentage", {
+    await using dir = tempDir("int-from-float-percentage", {
       "input.css": `
 .test-percent1 { width: 50%; }
 .test-percent2 { width: 100.0%; }
@@ -113,7 +113,7 @@ describe("bun.intFromFloat function", () => {
 
   test("fractional values that should not convert to int", async () => {
     // Test that fractional values are properly handled
-    const dir = tempDirWithFiles("int-from-float-fractional", {
+    await using dir = tempDir("int-from-float-fractional", {
       "input.css": `
 .test-frac { 
   width: 10.5px;

--- a/test/js/bun/bundler/yaml-bundler.test.js
+++ b/test/js/bun/bundler/yaml-bundler.test.js
@@ -1,8 +1,8 @@
 import { expect, it } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 
 it("can bundle yaml files", async () => {
-  const dir = tempDirWithFiles("yaml-bundle", {
+  await using dir = tempDir("yaml-bundle", {
     "index.js": `
       import yamlData from "./config.yaml";
       import ymlData from "./config.yml";
@@ -35,7 +35,7 @@ it("can bundle yaml files", async () => {
 });
 
 it("yaml files work with Bun.build API", async () => {
-  const dir = tempDirWithFiles("yaml-build-api", {
+  await using dir = tempDir("yaml-build-api", {
     "input.js": `
       import config from "./config.yaml";
       export default config;

--- a/test/js/bun/fetch/node-use-system-ca.test.ts
+++ b/test/js/bun/fetch/node-use-system-ca.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { promises as fs } from "fs";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 // Gate network tests behind environment variable to avoid CI flakes
@@ -77,7 +77,7 @@ testHttpsRequest();
   });
 
   test("should validate NODE_USE_SYSTEM_CA environment variable parsing", async () => {
-    const testDir = tempDirWithFiles("node-use-system-ca-env", {});
+    await using testDir = tempDir("node-use-system-ca-env", {});
 
     const testScript = `
 // Test that the environment variable is read correctly

--- a/test/js/bun/glob/proto.test.ts
+++ b/test/js/bun/glob/proto.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 import { symlink } from "fs/promises";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import path from "path";
 
 test("Object prototype followSymlinks", async () => {
-  const dir = tempDirWithFiles("glob-follow", {
+  await using dir = tempDir("glob-follow", {
     "abc/def/file.txt": "file",
     "symed/file2.txt": "file",
   });

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -699,7 +699,7 @@ describe("absolute path pattern", async () => {
 describe("glob scan should not escape cwd boundary", () => {
   test("pattern .*/* should not match parent directory via ..", async () => {
     // Create a directory structure where we can verify paths don't escape cwd
-    const tempdir = tempDirWithFiles("glob-cwd-escape", {
+    await using tempdir = tempDir("glob-cwd-escape", {
       ".hidden": {
         "file.txt": "hidden file content",
       },
@@ -731,7 +731,7 @@ describe("glob scan should not escape cwd boundary", () => {
   });
 
   test("pattern .*/**/*.ts should not escape cwd", async () => {
-    const tempdir = tempDirWithFiles("glob-cwd-escape-ts", {
+    await using tempdir = tempDir("glob-cwd-escape-ts", {
       ".config": {
         "settings.ts": "export default {}",
         "nested": {
@@ -769,14 +769,14 @@ describe("glob scan should not escape cwd boundary", () => {
 
 describe("glob.scan wildcard fast path", async () => {
   test("works", async () => {
-    const tempdir = tempDirWithFiles("glob-scan-wildcard-fast-path", {
+    await using tempdir = tempDir("glob-scan-wildcard-fast-path", {
       "lol.md": "",
       "lol2.md": "",
       "shouldnt-show.md23243": "",
       "shouldnt-show.ts": "",
     });
     const glob = new Glob("*.md");
-    const entries = await Array.fromAsync(glob.scan(tempdir));
+    const entries = await Array.fromAsync(glob.scan(String(tempdir)));
     // bun root dir
     expect(entries.sort()).toEqual(["lol.md", "lol2.md"].sort());
   });
@@ -785,9 +785,9 @@ describe("glob.scan wildcard fast path", async () => {
   describe("fast-path detection edgecase", async () => {
     function runTest(pattern: string, files: Record<string, string>, expected: string[]) {
       test(`pattern: ${pattern}`, async () => {
-        const tempdir = tempDirWithFiles("glob-scan-wildcard-fast-path", files);
+        await using tempdir = tempDir("glob-scan-wildcard-fast-path", files);
         const glob = new Glob(pattern);
-        const entries = await Array.fromAsync(glob.scan(tempdir));
+        const entries = await Array.fromAsync(glob.scan(String(tempdir)));
         expect(entries.sort()).toEqual(expected.sort());
       });
     }
@@ -856,7 +856,7 @@ test.skipIf(process.platform === "win32")("patterns with many components", () =>
   files[parts.join("/") + "/hit.txt"] = "";
   files[parts.slice(0, depth - 1).join("/") + "/miss.txt"] = "";
 
-  const dir = tempDirWithFiles("glob-deep", files);
+  using dir = tempDir("glob-deep", files);
 
   // Exact-depth pattern: depth `*` components + literal tail
   const star = Array(depth).fill("*").join("/") + "/hit.txt";

--- a/test/js/bun/http/bun-listen-connect-args.test.ts
+++ b/test/js/bun/http/bun-listen-connect-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, test } from "bun:test";
-import { cwdScope, isWindows, rmScope, tempDirWithFiles } from "harness";
+import { cwdScope, isWindows, tempDir } from "harness";
 
 describe.if(!isWindows)("unix socket", () => {
   test("valid", () => {
@@ -38,11 +38,10 @@ describe.if(!isWindows)("unix socket", () => {
 
     for (const args of permutations) {
       test(`${JSON.stringify(args)}`, async () => {
-        const tempdir = tempDirWithFiles("test-socket", {
+        await using tempdir = tempDir("test-socket", {
           "foo.txt": "bar",
         });
-        using cwd = cwdScope(tempdir);
-        using rm = rmScope(tempdir);
+        using cwd = cwdScope(String(tempdir));
         for (let i = 0; i < 100; i++) {
           using server = Bun.listen({
             ...args,

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { join } from "path";
 
 test("dev server html route: non-GET/HEAD requests complete without hanging", async () => {
-  const dir = tempDirWithFiles("html-route-405", {
+  await using dir = tempDir("html-route-405", {
     "index.html": `<!DOCTYPE html><html><head><title>t</title></head><body>hi</body></html>`,
   });
   const { default: html } = await import(join(dir, "index.html"));

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 async function getServerUrl(process: Subprocess) {
   // Read the port number from stdout
@@ -39,7 +39,7 @@ async function getServerUrl(process: Subprocess) {
 }
 
 test.concurrent("bun ./index.html", async () => {
-  const dir = tempDirWithFiles("html-entry-test", {
+  await using dir = tempDir("html-entry-test", {
     "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>
@@ -145,7 +145,7 @@ test.concurrent("bun ./index.html", async () => {
 });
 
 test.concurrent("bun ./index.html ./about.html", async () => {
-  const dir = tempDirWithFiles("html-multiple-entries-test", {
+  await using dir = tempDir("html-multiple-entries-test", {
     "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>
@@ -295,7 +295,7 @@ env = "BUN_PUBLIC_*"
 });
 
 test.concurrent("bun *.html", async () => {
-  const dir = tempDirWithFiles("html-glob-test", {
+  await using dir = tempDir("html-glob-test", {
     "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>
@@ -489,7 +489,7 @@ test.concurrent("bun *.html", async () => {
 });
 
 test.concurrent("bun serve svg files with correct Content-Type", async () => {
-  const dir = tempDirWithFiles("svg-content-type-test", {
+  await using dir = tempDir("svg-content-type-test", {
     "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>
@@ -545,7 +545,7 @@ test.concurrent("bun serve svg files with correct Content-Type", async () => {
 });
 
 test.concurrent("bun serve files with correct Content-Type headers", async () => {
-  const dir = tempDirWithFiles("content-type-test", {
+  await using dir = tempDir("content-type-test", {
     "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>
@@ -636,7 +636,7 @@ test.concurrent("bun serve files with correct Content-Type headers", async () =>
 });
 
 test("importing bun:main from HTML entry preload does not crash", async () => {
-  const dir = tempDirWithFiles("html-entry-bun-main", {
+  await using dir = tempDir("html-entry-bun-main", {
     "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>

--- a/test/js/bun/http/bun-serve-html-manifest.test.ts
+++ b/test/js/bun/http/bun-serve-html-manifest.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, rmScope, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 describe("Bun.serve HTML manifest", () => {
   it("serves HTML import with manifest", async () => {
-    const dir = tempDirWithFiles("serve-html", {
+    await using dir = tempDir("serve-html", {
       "server.ts": `
         import index from "./index.html";
         
@@ -40,8 +40,6 @@ describe("Bun.serve HTML manifest", () => {
       "styles.css": `body { background: red; }`,
       "app.js": `console.log("Hello from app");`,
     });
-
-    using cleanup = { [Symbol.dispose]: () => rmScope(dir) };
 
     const proc = Bun.spawn({
       cmd: [bunExe(), "run", join(dir, "server.ts")],
@@ -97,7 +95,7 @@ describe("Bun.serve HTML manifest", () => {
   });
 
   it("serves HTML with bundled assets", async () => {
-    const dir = tempDirWithFiles("serve-html-bundled", {
+    await using dir = tempDir("serve-html-bundled", {
       "build.ts": `
         const result = await Bun.build({
           entrypoints: ["./server.ts"],
@@ -151,8 +149,6 @@ describe("Bun.serve HTML manifest", () => {
       "shared.css": `body { margin: 0; }`,
       "app.js": `console.log("App loaded");`,
     });
-
-    using cleanup = { [Symbol.dispose]: () => rmScope(dir) };
 
     // Build first
     const buildProc = Bun.spawn({
@@ -221,7 +217,7 @@ describe("Bun.serve HTML manifest", () => {
   });
 
   it("validates manifest files exist", async () => {
-    const dir = tempDirWithFiles("serve-html-validate", {
+    await using dir = tempDir("serve-html-validate", {
       "test.ts": `
         // Create a fake manifest
         const fakeManifest = {
@@ -255,8 +251,6 @@ describe("Bun.serve HTML manifest", () => {
       `,
     });
 
-    using cleanup = { [Symbol.dispose]: () => rmScope(dir) };
-
     const proc = Bun.spawn({
       cmd: [bunExe(), "run", join(dir, "test.ts")],
       cwd: dir,
@@ -273,7 +267,7 @@ describe("Bun.serve HTML manifest", () => {
   });
 
   it("serves manifest with proper headers", async () => {
-    const dir = tempDirWithFiles("serve-html-headers", {
+    await using dir = tempDir("serve-html-headers", {
       "server.ts": `
         import index from "./index.html";
         
@@ -309,8 +303,6 @@ describe("Bun.serve HTML manifest", () => {
 </html>`,
       "test.css": `h1 { color: red; }`,
     });
-
-    using cleanup = { [Symbol.dispose]: () => rmScope(dir) };
 
     // Build first to generate the manifest
     await using buildProc = Bun.spawn({

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1,6 +1,6 @@
 import type { Server, Subprocess } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 function replaceHash(html: string) {
@@ -21,7 +21,7 @@ function extractHash(html: string, file_kind: "css" | "js") {
 }
 
 test("serve html", async () => {
-  const dir = tempDirWithFiles("html-css-js", {
+  await using dir = tempDir("html-css-js", {
     "dashboard.html": /*html*/ `
       <!DOCTYPE html>
       <html>
@@ -359,7 +359,7 @@ export default p;
   });
 
   test("serve html with failing plugin", async () => {
-    const dir = tempDirWithFiles("html-css-js-failing-plugin", {
+    await using dir = tempDir("html-css-js-failing-plugin", {
       "bunfig.toml": /* toml */ `
 [serve.static]
 plugins = ["./plugin.ts"]
@@ -417,7 +417,7 @@ export default p;
   });
 
   test("empty plugin array", async () => {
-    const dir = tempDirWithFiles("html-css-js-empty-plugins", {
+    await using dir = tempDir("html-css-js-empty-plugins", {
       "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>
@@ -495,7 +495,7 @@ plugins = []`,
       </html>
     `;
 
-    const dir = tempDirWithFiles("html-css-js-concurrent-plugins", {
+    await using dir = tempDir("html-css-js-concurrent-plugins", {
       "index.html": createHtmlFile("Home Page", "index.js"),
       "about.html": createHtmlFile("About Page", "about.js"),
       "contact.html": createHtmlFile("Contact Page", "contact.js"),
@@ -622,7 +622,7 @@ async function waitForServer(
 }
 
 test("serve html error handling", async () => {
-  const dir = tempDirWithFiles("bun-serve-html-error-handling", {
+  await using dir = tempDir("bun-serve-html-error-handling", {
     "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>
@@ -679,7 +679,7 @@ test("serve html error handling", async () => {
 });
 
 test("wildcard static routes", async () => {
-  const dir = tempDirWithFiles("bun-serve-html-error-handling", {
+  await using dir = tempDir("bun-serve-html-error-handling", {
     "index.html": /*html*/ `
       <!DOCTYPE html>
       <html>

--- a/test/js/bun/http/bun-serve-propagate-errors.test.ts
+++ b/test/js/bun/http/bun-serve-propagate-errors.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("Bun.serve() propagates errors to the parent fixture", async () => {
   const code = `import { test } from "bun:test";
@@ -17,7 +17,7 @@ test("Bun.serve() propagates errors to the parent", async () => {
   server.stop(true);
 });
 `;
-  const dir = tempDirWithFiles("propagate-errors", {
+  await using dir = tempDir("propagate-errors", {
     "package.json": JSON.stringify({
       name: "test",
       version: "0.0.0",

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1,14 +1,6 @@
 import type { Server, ServerWebSocket, Socket } from "bun";
 import { describe, expect, test } from "bun:test";
-import {
-  bunEnv,
-  bunExe,
-  isWindows,
-  normalizeBunSnapshot,
-  rejectUnauthorizedScope,
-  tempDirWithFiles,
-  tls,
-} from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, rejectUnauthorizedScope, tempDir, tls } from "harness";
 import path from "path";
 
 describe.concurrent("Server", () => {
@@ -1336,7 +1328,7 @@ describe("HEAD requests #15355", () => {
   });
 
   test("HEAD requests should not have body", async () => {
-    const dir = tempDirWithFiles("fsr", {
+    await using dir = tempDir("fsr", {
       "hello": "Hello World",
     });
 

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -1,4 +1,4 @@
-import { bunExe, tempDirWithFiles } from "harness";
+import { bunExe, tempDir, tempDirWithFiles } from "harness";
 import * as path from "path";
 
 const loaders = ["js", "jsx", "ts", "tsx", "json", "jsonc", "toml", "yaml", "text", "sqlite", "file"];
@@ -354,7 +354,7 @@ describe("?raw", () => {
     test(name, async () => {
       const filename = "abcd.js";
       const code = "export const a = 'demo';";
-      const question_raw = tempDirWithFiles("import-attributes", {
+      await using question_raw = tempDir("import-attributes", {
         [filename]: code,
       });
       expect(await fn(question_raw, null, filename + "?raw")).toEqual({ default: code });

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -1,7 +1,7 @@
 const { iniInternals } = require("bun:internal-for-testing");
 const { parse } = iniInternals;
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("parse ini", () => {
   test("weird section", () => {
@@ -316,7 +316,7 @@ hello = "\\\\$\{LOL}"
     function envVarTest(args: { name: string; ini: string; env: Record<string, string>; expected: any }) {
       const { name, ini, env, expected } = args;
       test(name, async () => {
-        const tempdir = tempDirWithFiles("hi", { "foo.ini": ini });
+        await using tempdir = tempDir("hi", { "foo.ini": ini });
         const inipath = `${tempdir}/foo.ini`.replaceAll("\\", "/");
         const code = /* ts */ `
 const { iniInternals } = require("bun:internal-for-testing");

--- a/test/js/bun/io/bun-write-leak.test.ts
+++ b/test/js/bun/io/bun-write-leak.test.ts
@@ -2,13 +2,13 @@ import { expect, test } from "bun:test";
 import path from "node:path";
 
 import "harness";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/10588
 test(
   "Bun.write should not leak the output data",
   async () => {
-    const dir = tempDirWithFiles("bun-write-leak-fixture", {
+    await using dir = tempDir("bun-write-leak-fixture", {
       "bun-write-leak-fixture.js": await Bun.file(path.join(import.meta.dir, "bun-write-leak-fixture.js")).text(),
       "out.bin": "here",
     });

--- a/test/js/bun/namespace-prototype-pollution.test.ts
+++ b/test/js/bun/namespace-prototype-pollution.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("namespace imports should not inherit from Object.prototype", async () => {
-  const dir = tempDirWithFiles("namespace-pollution", {
+  await using dir = tempDir("namespace-pollution", {
     "mod.mjs": `export const value = "original";`,
     "test.mjs": `
       import * as mod from './mod.mjs';

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -2,7 +2,7 @@ import { $ } from "bun";
 import { patchInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import fs from "fs/promises";
-import { tempDirWithFiles as __tempDirWithFiles, bunEnv, bunExe } from "harness";
+import { tempDirWithFiles as __tempDirWithFiles, bunEnv, bunExe, tempDir } from "harness";
 import { join as __join } from "node:path";
 const { parse, apply, makeDiff } = patchInternals;
 
@@ -80,12 +80,12 @@ function removeCapacity(patch: any): any {
 describe("apply", () => {
   test("edgecase", async () => {
     const newcontents = "module.exports = x => x % 420 === 0;";
-    const tempdir2 = tempDirWithFiles("patch-test2", {
+    await using tempdir2 = tempDir("patch-test2", {
       ".bun/install/cache/is-even@1.0.0": {
         "index.js": "module.exports = x => x % 2 === 0;",
       },
     });
-    const tempdir = tempDirWithFiles("patch-test", {
+    await using tempdir = tempDir("patch-test", {
       a: {},
       ["node_modules/is-even"]: {
         "index.js": newcontents,
@@ -103,7 +103,7 @@ describe("apply", () => {
   });
 
   test("empty", async () => {
-    const tempdir = tempDirWithFiles("patch-test", {
+    await using tempdir = tempDir("patch-test", {
       a: {},
       b: {},
     });
@@ -126,7 +126,7 @@ describe("apply", () => {
         "a/byebye.txt": "goodbye :(",
         "b/hey.txt": "hello!",
       };
-      const tempdir = tempDirWithFiles("patch-test", files);
+      await using tempdir = tempDir("patch-test", files);
 
       const afolder = join(tempdir, "a");
       const bfolder = join(tempdir, "b");
@@ -151,7 +151,7 @@ describe("apply", () => {
         "a": {},
         "b/newfile.txt": "hey im new here!",
       };
-      const tempdir = tempDirWithFiles("patch-test", files);
+      await using tempdir = tempDir("patch-test", files);
 
       const afolder = join(tempdir, "a");
       const bfolder = join(tempdir, "b");
@@ -168,7 +168,7 @@ describe("apply", () => {
         "a": {},
         "b/newfile.txt": "hey im new here!\nhello",
       };
-      const tempdir = tempDirWithFiles("patch-test", files);
+      await using tempdir = tempDir("patch-test", files);
 
       const afolder = join(tempdir, "a");
       const bfolder = join(tempdir, "b");
@@ -187,7 +187,7 @@ describe("apply", () => {
         "a/hey.txt": "hello!",
         "b/heynow.txt": "hello!",
       };
-      const tempdir = tempDirWithFiles("patch-test", files);
+      await using tempdir = tempDir("patch-test", files);
 
       const afolder = join(tempdir, "a");
       const bfolder = join(tempdir, "b");
@@ -203,7 +203,7 @@ describe("apply", () => {
     });
 
     test("to a destination dir longer than the path buffer throws instead of crashing", async () => {
-      const tempdir = tempDirWithFiles("patch-test", { "from.txt": "hello!" });
+      await using tempdir = tempDir("patch-test", { "from.txt": "hello!" });
 
       await using proc = Bun.spawn({
         cmd: [
@@ -244,7 +244,7 @@ describe("apply", () => {
         "b/bar/hi.txt": "hello!",
         "b/bar/lmao.txt": "lmao!",
       };
-      const tempdir = tempDirWithFiles("patch-test", files);
+      await using tempdir = tempDir("patch-test", files);
 
       const afolder = join(tempdir, "a");
       const bfolder = join(tempdir, "b");
@@ -286,7 +286,7 @@ describe("apply", () => {
         "b/hi.txt": "hi!",
       };
 
-      const tempdir = tempDirWithFiles("patch-test", files);
+      await using tempdir = tempDir("patch-test", files);
 
       const afolder = join(tempdir, "a");
       const bfolder = join(tempdir, "b");
@@ -308,7 +308,7 @@ describe("apply", () => {
       const afile = `hello!\n`;
       const bfile = `hello!\nwassup?\n`;
 
-      const tempdir = tempDirWithFiles("patch-test", {
+      await using tempdir = tempDir("patch-test", {
         "a/hello.txt": afile,
         "b/hello.txt": bfile,
       });
@@ -327,7 +327,7 @@ describe("apply", () => {
       const afile = `hello!\nwassup?\n`;
       const bfile = `hello!\n`;
 
-      const tempdir = tempDirWithFiles("patch-test", {
+      await using tempdir = tempDir("patch-test", {
         "a/hello.txt": afile,
         "b/hello.txt": bfile,
       });
@@ -346,7 +346,7 @@ describe("apply", () => {
       const afile = `hello!\n`;
       const bfile = `lol\nhello!\nwassup?\n`;
 
-      const tempdir = tempDirWithFiles("patch-test", {
+      await using tempdir = tempDir("patch-test", {
         "a/hello.txt": afile,
         "b/hello.txt": bfile,
       });
@@ -365,7 +365,7 @@ describe("apply", () => {
       const afile = `hello!\nwassup?\nlmao\n`;
       const bfile = `wassup?\n`;
 
-      const tempdir = tempDirWithFiles("patch-test", {
+      await using tempdir = tempDir("patch-test", {
         "a/hello.txt": afile,
         "b/hello.txt": bfile,
       });
@@ -426,7 +426,7 @@ describe("apply", () => {
 19.5 lol hi
 20`;
 
-      const tempdir = tempDirWithFiles("patch-test", {
+      await using tempdir = tempDir("patch-test", {
         "a/hello.txt": afile,
         "b/hello.txt": bfile,
       });
@@ -487,7 +487,7 @@ describe("apply", () => {
 19.5 lol hi
 20`;
 
-      const tempdir = tempDirWithFiles("patch-test", {
+      await using tempdir = tempDir("patch-test", {
         "a/hello.txt": afile,
         "b/hello.txt": bfile,
       });
@@ -542,7 +542,7 @@ describe("apply", () => {
   // cases below used to crash `bun install` when applying patchedDependencies.
   describe.concurrent("malformed patches do not crash", () => {
     test("file creation hunk with empty parts creates an empty file", async () => {
-      const dir = tempDirWithFiles("patch-empty-parts", { ".keep": "" });
+      await using dir = tempDir("patch-empty-parts", { ".keep": "" });
 
       await using proc = Bun.spawn({
         cmd: [
@@ -579,7 +579,7 @@ describe("apply", () => {
     });
 
     test("header deleting more lines than the target file has returns EINVAL", async () => {
-      const dir = tempDirWithFiles("patch-underflow", { "target.txt": "only line\n" });
+      await using dir = tempDir("patch-underflow", { "target.txt": "only line\n" });
 
       await using proc = Bun.spawn({
         cmd: [

--- a/test/js/bun/resolve/bun-lock.test.ts
+++ b/test/js/bun/resolve/bun-lock.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { join } from "path";
 
 const lockfile = `{
@@ -14,7 +14,7 @@ const lockfile = `{
 }`;
 
 test("import bun.lock file as json", async () => {
-  const dir = tempDirWithFiles("bun-lock", {
+  await using dir = tempDir("bun-lock", {
     "bun.lock": lockfile,
     "index.ts": `
     import lockfile from './bun.lock';

--- a/test/js/bun/resolve/jsonc.test.ts
+++ b/test/js/bun/resolve/jsonc.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { join } from "path";
 test("empty jsonc - package.json", async () => {
-  const dir = tempDirWithFiles("jsonc", {
+  await using dir = tempDir("jsonc", {
     "package.json": ``,
     "index.ts": `
     import pkg from './package.json';
@@ -13,7 +13,7 @@ test("empty jsonc - package.json", async () => {
 });
 
 test("empty jsonc - tsconfig.json", async () => {
-  const dir = tempDirWithFiles("jsonc", {
+  await using dir = tempDir("jsonc", {
     "tsconfig.json": ``,
     "index.ts": `
     import tsconfig from './tsconfig.json';
@@ -28,7 +28,7 @@ test("import anything.jsonc as json", async () => {
     // comment
     "trailingComma": 0,
   }`;
-  const dir = tempDirWithFiles("jsonc", {
+  await using dir = tempDir("jsonc", {
     "anything.jsonc": jsoncFile,
     "index.ts": `
     import file from './anything.jsonc';
@@ -41,7 +41,7 @@ test("import anything.jsonc as json", async () => {
 
 test("imported JSON strings match JSON.parse exactly (escapes, lone surrogates, non-ASCII)", async () => {
   const json = `{"lone":"\\ud800","pair":"\\ud83d\\ude00","mix":"a\\udfffz","e":"caf\\u00e9\\ud800x","lit":"é🚀","esc\\nkey":"a\\n\\"b\\""}`;
-  const dir = tempDirWithFiles("jsonc", {
+  await using dir = tempDir("jsonc", {
     "weird.json": json,
     "weird.jsonc": json,
     "index.ts": `

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -88,7 +88,7 @@ function writePackageJSONImportsFixture() {
 }
 
 it("file url in import resolves", async () => {
-  const dir = tempDirWithFiles("fileurl", {
+  await using dir = tempDir("fileurl", {
     "index.js": "export const foo = 1;",
   });
   writeFileSync(`${dir}/test.js`, `import {foo} from '${pathToFileURL(dir)}/index.js';\nconsole.log(foo);`);
@@ -109,7 +109,7 @@ it("file url in import resolves", async () => {
 });
 
 it("invalid file url in import throws error", async () => {
-  const dir = tempDirWithFiles("fileurl", {});
+  await using dir = tempDir("fileurl", {});
   writeFileSync(`${dir}/test.js`, `import {foo} from 'file://\0invalid url';\nconsole.log(foo);`);
 
   const { exitCode, stdout, stderr } = Bun.spawnSync({
@@ -122,7 +122,7 @@ it("invalid file url in import throws error", async () => {
 });
 
 it("file url in await import resolves", async () => {
-  const dir = tempDirWithFiles("fileurl", {
+  await using dir = tempDir("fileurl", {
     "index.js": "export const foo = 1;",
   });
   writeFileSync(`${dir}/test.js`, `const {foo} = await import('${pathToFileURL(dir)}/index.js');\nconsole.log(foo);`);
@@ -138,7 +138,7 @@ it("file url in await import resolves", async () => {
 
 it("file url with special characters in await import resolves", async () => {
   const filename = "🅱️ndex.js";
-  const dir = tempDirWithFiles("file url", {
+  await using dir = tempDir("file url", {
     [filename]: "export const foo = 1;",
   });
   console.log(dir);
@@ -158,7 +158,7 @@ it("file url with special characters in await import resolves", async () => {
 
 it("file url with special characters not encoded in await import resolves", async () => {
   const filename = "🅱️ndex.js";
-  const dir = tempDirWithFiles("file url", {
+  await using dir = tempDir("file url", {
     [filename]: "export const foo = 1;",
   });
   writeFileSync(
@@ -177,7 +177,7 @@ it("file url with special characters not encoded in await import resolves", asyn
 
 it("file url with special characters in import statement resolves", async () => {
   const filename = "🅱️ndex.js";
-  const dir = tempDirWithFiles("file url", {
+  await using dir = tempDir("file url", {
     [filename]: "export const foo = 1;",
   });
   writeFileSync(
@@ -196,7 +196,7 @@ it("file url with special characters in import statement resolves", async () => 
 
 it("file url with special characters not encoded in import statement resolves", async () => {
   const filename = "🅱️ndex.js";
-  const dir = tempDirWithFiles("file url", {
+  await using dir = tempDir("file url", {
     [filename]: "export const foo = 1;",
   });
   writeFileSync(`${dir}/test.js`, `import {foo} from '${pathToFileURL(dir)}/${filename}';\nconsole.log(foo);`);
@@ -211,7 +211,7 @@ it("file url with special characters not encoded in import statement resolves", 
 });
 
 it("file url in require resolves", async () => {
-  const dir = tempDirWithFiles("fileurl", {
+  await using dir = tempDir("fileurl", {
     "index.js": "export const foo = 1;",
   });
   writeFileSync(`${dir}/test.js`, `const {foo} = require('${pathToFileURL(dir)}/index.js');\nconsole.log(foo);`);
@@ -227,7 +227,7 @@ it("file url in require resolves", async () => {
 
 it("file url with special characters in require resolves", async () => {
   const filename = "🅱️ndex.js";
-  const dir = tempDirWithFiles("file url", {
+  await using dir = tempDir("file url", {
     [filename]: "export const foo = 1;",
   });
   writeFileSync(
@@ -245,7 +245,7 @@ it("file url with special characters in require resolves", async () => {
 });
 
 it("file url in require.resolve resolves", async () => {
-  const dir = tempDirWithFiles("fileurl", {
+  await using dir = tempDir("fileurl", {
     "index.js": "export const foo = 1;",
   });
   writeFileSync(`${dir}/test.js`, `const to = require.resolve('${pathToFileURL(dir)}/index.js');\nconsole.log(to);`);
@@ -261,7 +261,7 @@ it("file url in require.resolve resolves", async () => {
 
 it("file url with special characters in require resolves", async () => {
   const filename = "🅱️ndex.js";
-  const dir = tempDirWithFiles("file url", {
+  await using dir = tempDir("file url", {
     [filename]: "export const foo = 1;",
   });
   writeFileSync(
@@ -415,7 +415,7 @@ it("can resolve with source directories that do not exist", () => {
   // This seems to be a bug in their code, not using a concrete file path for
   // this virtual module, such as 'node_modules/@vue/server-renderer/index.js',
   // but the same exact resolution happens and succeeds in Node.js
-  const dir = tempDirWithFiles("resolve", {
+  using dir = tempDir("resolve", {
     "node_modules/vue/index.js": "export default 123;",
     "test.js": `
       const { createRequire } = require('module');
@@ -1043,7 +1043,7 @@ it("resolves through many directories without corrupting the dir cache", async (
   files[`${deep}/leaf.js`] = `module.exports = require("pkg-3") + require("pkg-77");`;
   files["index.js"] = `let total = 0;\n${imports}console.log(total);\nconsole.log(require("./${deep}/leaf.js"));`;
 
-  const dir = tempDirWithFiles("dir-cache-stress", files);
+  await using dir = tempDir("dir-cache-stress", files);
   await using proc = Bun.spawn({
     cmd: [bunExe(), "index.js"],
     env: bunEnv,

--- a/test/js/bun/resolve/resolver-permission-denied-ancestor.test.ts
+++ b/test/js/bun/resolve/resolver-permission-denied-ancestor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { chmodSync, rmSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // An ancestor directory the process may traverse but not read (mode 0o111 —
@@ -10,7 +10,7 @@ import { join } from "path";
 // directory". Root bypasses permission checks, so skip there.
 describe.skipIf(isWindows || process.getuid?.() === 0)("resolver with unreadable ancestor", () => {
   test("bun run works under an execute-only ancestor", () => {
-    const dir = tempDirWithFiles("xonly-ancestor", {
+    using dir = tempDir("xonly-ancestor", {
       "outer/project/package.json": JSON.stringify({
         name: "p",
         scripts: { start: "bun index.js" },
@@ -36,7 +36,7 @@ describe.skipIf(isWindows || process.getuid?.() === 0)("resolver with unreadable
   });
 
   test("errors on the requested directory itself stay fatal", () => {
-    const dir = tempDirWithFiles("unreadable-cwd", {
+    using dir = tempDir("unreadable-cwd", {
       "project/package.json": JSON.stringify({ name: "p", scripts: { start: "echo should-not-run" } }),
     });
     const project = join(dir, "project");

--- a/test/js/bun/s3/s3.leak.test.ts
+++ b/test/js/bun/s3/s3.leak.test.ts
@@ -1,6 +1,6 @@
 import type { S3Options } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, getSecret, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, getSecret, tempDir } from "harness";
 import path from "path";
 const s3Options: S3Options = {
   accessKeyId: getSecret("S3_R2_ACCESS_KEY"),
@@ -15,7 +15,7 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
     it(
       "s3().stream() should not leak",
       async () => {
-        const dir = tempDirWithFiles("s3-stream-leak-fixture", {
+        await using dir = tempDir("s3-stream-leak-fixture", {
           "s3-stream-leak-fixture.js": await Bun.file(path.join(import.meta.dir, "s3-stream-leak-fixture.js")).text(),
           "out.bin": "here",
         });
@@ -45,7 +45,7 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
     it(
       "s3().text() should not leak",
       async () => {
-        const dir = tempDirWithFiles("s3-text-leak-fixture", {
+        await using dir = tempDir("s3-text-leak-fixture", {
           "s3-text-leak-fixture.js": await Bun.file(path.join(import.meta.dir, "s3-text-leak-fixture.js")).text(),
           "out.bin": "here",
         });
@@ -76,7 +76,7 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
     it(
       "s3().writer().write() should not leak",
       async () => {
-        const dir = tempDirWithFiles("s3-writer-leak-fixture", {
+        await using dir = tempDir("s3-writer-leak-fixture", {
           "s3-writer-leak-fixture.js": await Bun.file(path.join(import.meta.dir, "s3-writer-leak-fixture.js")).text(),
           "out.bin": "here",
         });
@@ -107,7 +107,7 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
     it(
       "s3().write() should not leak",
       async () => {
-        const dir = tempDirWithFiles("s3-write-leak-fixture", {
+        await using dir = tempDir("s3-write-leak-fixture", {
           "s3-write-leak-fixture.js": await Bun.file(path.join(import.meta.dir, "s3-write-leak-fixture.js")).text(),
           "out.bin": "here",
         });
@@ -139,7 +139,7 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
     it(
       "Bun.write should not leak",
       async () => {
-        const dir = tempDirWithFiles("bun-write-leak-fixture", {
+        await using dir = tempDir("bun-write-leak-fixture", {
           "bun-write-leak-fixture.js": await Bun.file(path.join(import.meta.dir, "bun-write-leak-fixture.js")).text(),
           "out.bin": "here",
         });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -3,7 +3,7 @@ import { S3Client, s3 as defaultS3, file, randomUUIDv7 } from "bun";
 import { describe, expect, it } from "bun:test";
 import child_process from "child_process";
 import { randomUUID } from "crypto";
-import { bunEnv, bunExe, dockerExe, getSecret, isCI, isDockerEnabled, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, dockerExe, getSecret, isCI, isDockerEnabled, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 const s3 = (...args) => defaultS3.file(...args);
 const S3 = (...args) => new S3Client(...args);
@@ -1028,7 +1028,7 @@ for (let credentials of allCredentials) {
         });
 
         it("Bun.write(s3file, file) should work with empty file", async () => {
-          const dir = tempDirWithFiles("fsr", {
+          await using dir = tempDir("fsr", {
             "hello.txt": "",
           });
           const tmp_filename = `${randomUUID()}.txt`;

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -915,7 +915,7 @@ booga"
     });
 
     test.if(isPosix && !isRoot)("glob over an unreadable directory reports the real error", async () => {
-      const dir = tempDirWithFiles("glob-eacces", { "placeholder.txt": "" });
+      await using dir = tempDir("glob-eacces", { "placeholder.txt": "" });
       const noaccess = join(dir, "noaccess").replaceAll("\\", "/");
       mkdirSync(noaccess);
       chmodSync(noaccess, 0o000);
@@ -1142,7 +1142,7 @@ booga"
     // to stderr or calling done(), so any errno other than NOTDIR/NOENT/NAMETOOLONG
     // (e.g. EACCES, ELOOP) left the shell promise unresolved forever.
     test.if(isPosix && !isRoot)("cd with EACCES fails with exit code 1 instead of hanging", async () => {
-      const dir = tempDirWithFiles("cd-eacces", { "placeholder.txt": "" });
+      await using dir = tempDir("cd-eacces", { "placeholder.txt": "" });
       const noaccess = join(dir, "noaccess");
       mkdirSync(noaccess);
       chmodSync(noaccess, 0o000);

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { isPosix, tempDirWithFiles } from "harness";
+import { isPosix, tempDir, tempDirWithFiles } from "harness";
 import { createTestBuilder } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -92,7 +92,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test("-a flag shows all files including . and ..", async () => {
-      const tempdir = tempDirWithFiles("ls-show-all", {});
+      await using tempdir = tempDir("ls-show-all", {});
       await $`touch .hidden regular; mkdir .hidden-dir`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -a`
         .setTempdir(tempdir)
@@ -106,7 +106,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test("-A flag shows almost all (excludes . and ..)", async () => {
-      const tempdir = tempDirWithFiles("ls-almost-all", {});
+      await using tempdir = tempDir("ls-almost-all", {});
       await $`touch .hidden regular`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -A`
         .setTempdir(tempdir)
@@ -138,7 +138,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test("multiple directories", async () => {
-      const tempdir = tempDirWithFiles("ls-multi-dirs", {});
+      await using tempdir = tempDir("ls-multi-dirs", {});
       await $`mkdir dir1 dir2; touch dir1/file1 dir2/file2`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls dir1 dir2`
         .setTempdir(tempdir)
@@ -156,13 +156,13 @@ describe.concurrent("bunshell ls", () => {
 
   describe("edge cases", () => {
     test("empty directory", async () => {
-      const tempdir = tempDirWithFiles("ls-empty", {});
+      await using tempdir = tempDir("ls-empty", {});
       await $`mkdir empty`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls empty`.setTempdir(tempdir).stdout("").run();
     });
 
     test("directory with only hidden files using -a", async () => {
-      const tempdir = tempDirWithFiles("ls-hidden-only-a", {});
+      await using tempdir = tempDir("ls-hidden-only-a", {});
       await $`mkdir hidden-only; touch hidden-only/.hidden1 hidden-only/.hidden2`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -a hidden-only`
         .setTempdir(tempdir)
@@ -171,7 +171,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test("very long filename", async () => {
-      const tempdir = tempDirWithFiles("ls-long-name", {});
+      await using tempdir = tempDir("ls-long-name", {});
       const longName = "a".repeat(100);
       await $`touch ${longName}`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls`
@@ -181,7 +181,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test("filename with spaces", async () => {
-      const tempdir = tempDirWithFiles("ls-spaces", {});
+      await using tempdir = tempDir("ls-spaces", {});
       await $`touch "file with spaces"`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls`
         .setTempdir(tempdir)
@@ -190,7 +190,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test.if(isPosix)("filename with special characters", async () => {
-      const tempdir = tempDirWithFiles("ls-special", {});
+      await using tempdir = tempDir("ls-special", {});
       await $`touch "file-with-!@#$%^&*()"`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls`
         .setTempdir(tempdir)
@@ -201,7 +201,7 @@ describe.concurrent("bunshell ls", () => {
 
   describe("flag combinations", () => {
     test("-Ra flag (recursive + show all)", async () => {
-      const tempdir = tempDirWithFiles("ls-ra", {});
+      await using tempdir = tempDir("ls-ra", {});
       await $`mkdir sub; touch .hidden sub/.hidden-sub`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -Ra`
         .setTempdir(tempdir)
@@ -211,7 +211,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test("-RA flag (recursive + almost all)", async () => {
-      const tempdir = tempDirWithFiles("ls-ra-caps", {});
+      await using tempdir = tempDir("ls-ra-caps", {});
       await $`mkdir sub; touch .hidden sub/.hidden-sub`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -RA`
         .setTempdir(tempdir)
@@ -222,7 +222,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test("-d with multiple directories", async () => {
-      const tempdir = tempDirWithFiles("ls-d-multi", {});
+      await using tempdir = tempDir("ls-d-multi", {});
       await $`mkdir dir1 dir2`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -d dir1 dir2`
         .setTempdir(tempdir)
@@ -272,7 +272,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test.if(isPosix)("permission denied directory", async () => {
-      const tempdir = tempDirWithFiles("ls-permission", {});
+      await using tempdir = tempDir("ls-permission", {});
       await $`mkdir restricted; chmod 000 restricted`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls restricted`
         .setTempdir(tempdir)
@@ -283,7 +283,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test.if(isPosix)("permission denied directory recursive", async () => {
-      const tempdir = tempDirWithFiles("ls-permission-recursive", {});
+      await using tempdir = tempDir("ls-permission-recursive", {});
       // Create 3-level deep directory structure with 3+ items per level
       await $`mkdir -p level1/level2/level3; 
                touch level1/file1 level1/file2 level1/file3;
@@ -307,7 +307,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test.if(isPosix)("broken symlink file", async () => {
-      const tempdir = tempDirWithFiles("ls-broken-symlink", {});
+      await using tempdir = tempDir("ls-broken-symlink", {});
       await $`touch will-remove; ln -s will-remove broken-link; rm will-remove`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls broken-link`
         .exitCode(1)
@@ -317,7 +317,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test.if(isPosix)("broken symlink directory", async () => {
-      const tempdir = tempDirWithFiles("ls-broken-symlink", {});
+      await using tempdir = tempDir("ls-broken-symlink", {});
       await $`mkdir will-remove; ln -s will-remove broken-link; rm -rf will-remove`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls broken-link`
         .exitCode(1)
@@ -327,7 +327,7 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test.if(isPosix)("broken symlink directory recursive", async () => {
-      const tempdir = tempDirWithFiles("ls-broken-symlink", {});
+      await using tempdir = tempDir("ls-broken-symlink", {});
       console.log("TEMPDIR", tempdir);
       await $`mkdir foo; cd foo; touch a b c; mkdir will-remove; ln -s will-remove broken-link; rm -rf will-remove`
         .quiet()

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { existsSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "path";
 import { createTestBuilder, sortedShellOutput } from "../util";
@@ -34,7 +34,7 @@ describe.concurrent("bunshell rm", () => {
     const files = {
       "existent.txt": "",
     };
-    const tempdir = tempDirWithFiles("rmforce", files);
+    await using tempdir = tempDir("rmforce", files);
 
     expect(await $`rm -f ${tempdir}/non_existent.txt`.then(o => o.exitCode)).toBe(0);
 
@@ -58,7 +58,7 @@ describe.concurrent("bunshell rm", () => {
       "existent.txt": "",
     };
 
-    const tempdir = tempDirWithFiles("rmrecursive", files);
+    await using tempdir = tempDir("rmrecursive", files);
 
     // test on a file
     {
@@ -121,7 +121,7 @@ foo/
       "sub_dir_files/file.txt": "",
     };
 
-    const tempdir = tempDirWithFiles("rmdir", files);
+    await using tempdir = tempDir("rmdir", files);
 
     {
       const { stdout, stderr, exitCode } = await $`rm -d ${tempdir}/existent.txt`;
@@ -262,7 +262,7 @@ test.skipIf(process.platform === "win32")(
           files[`target/d${i}/f${j}.txt`] = "";
         }
       }
-      const root = tempDirWithFiles(`rm-swap-${iter}`, files);
+      await using root = tempDir(`rm-swap-${iter}`, files);
       const victimDir = path.join(root, "victim");
       const victimFile = path.join(victimDir, "keep.txt");
       const target = path.join(root, "target");

--- a/test/js/bun/shell/lazy.test.ts
+++ b/test/js/bun/shell/lazy.test.ts
@@ -1,11 +1,11 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { join } from "path";
 
 test("$ is lazy", async () => {
-  const base = tempDirWithFiles("bun-lazy-test", {
+  await using base = tempDir("bun-lazy-test", {
     "bun-lazy": "789",
   });
   const path = join(base, "bun-lazy");

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, isASAN, isPosix, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, isASAN, isPosix, tempDir } from "harness";
 import { join } from "path";
 import { bunExe } from "./test_builder";
 import { createTestBuilder } from "./util";
@@ -404,7 +404,7 @@ describe.concurrent("fd leak", () => {
   describe.serial("#11816", async () => {
     function doit(builtin: boolean) {
       test(builtin ? "builtin" : "external", async () => {
-        const files = tempDirWithFiles("hi", {
+        await using files = tempDir("hi", {
           "input.txt": Array(2048).fill("a").join(""),
         });
         for (let j = 0; j < 10; j++) {
@@ -445,7 +445,7 @@ describe.concurrent("fd leak", () => {
   describe.serial("not leaking ParsedShellScript when ShellInterpreter never runs", () => {
     function doit(builtin: boolean) {
       test(builtin ? "builtin" : "external", async () => {
-        const files = tempDirWithFiles("hi", {
+        await using files = tempDir("hi", {
           "input.txt": Array(2048).fill("a").join(""),
         });
         // wrapping in a function

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2,7 +2,7 @@ import { spawnSync } from "bun";
 import { constants, Database, SQLiteError } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isMacOS, isMacOSVersionAtLeast, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -1530,7 +1530,7 @@ it("issue#7147", () => {
 });
 
 it("should close with WAL enabled", () => {
-  const dir = tempDirWithFiles("sqlite-wal-test", { "empty.txt": "" });
+  using dir = tempDir("sqlite-wal-test", { "empty.txt": "" });
   const file = path.join(dir, "my.db");
   const db = new Database(file);
   db.exec("PRAGMA journal_mode = WAL");
@@ -1990,7 +1990,7 @@ it("run() reports a closed database when a bound parameter's getter closes it", 
 // must be at least 8 bytes. A 1-byte Uint8Array used to be passed through
 // as-is and overflowed.
 it("fileControl rejects result TypedArrays smaller than 8 bytes", () => {
-  const dir = tempDirWithFiles("sqlite-fcntl-bounds", { "empty.txt": "" });
+  using dir = tempDir("sqlite-fcntl-bounds", { "empty.txt": "" });
   const db = new Database(path.join(dir, "my.db"));
 
   expect(() => db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, new Uint8Array(1))).toThrow(
@@ -2130,7 +2130,7 @@ it("decodes declared types leniently and accepts single-character declared types
 // grows. Run in a subprocess so a crash shows up as a non-zero exit code
 // instead of taking down the test runner.
 it("keeps database handles working when many Workers open databases concurrently", async () => {
-  const dir = tempDirWithFiles("sqlite-worker-registry", {
+  await using dir = tempDir("sqlite-worker-registry", {
     "main.js": `
       import { Database } from "bun:sqlite";
 
@@ -2218,7 +2218,7 @@ it("exit-time WAL checkpoint runs even with a never-finalized prepared statement
   // zombifies the connection and defers the WAL checkpoint to a finalize
   // that never comes; Bun__closeAllSQLiteDatabasesForTermination now
   // checkpoints explicitly first.
-  const dir = tempDirWithFiles("bun-sqlite-exit-zombie", {});
+  await using dir = tempDir("bun-sqlite-exit-zombie", {});
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/bun/test/describe.test.ts
+++ b/test/js/bun/test/describe.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { describe, expect, jest, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("blocks should handle a number, string, anonymous class, named class, or function for the first arg", () => {
   const numberMock = jest.fn();
@@ -78,7 +78,7 @@ describe("a named function should work for the second arg", () => {
 
 describe("shows first arg name correctly in test output", () => {
   test("describe block shows function name correctly in test output", async () => {
-    const test_dir = tempDirWithFiles(".", {
+    await using test_dir = tempDir(".", {
       "describe-test.test.js": `
       import { describe, test, expect } from "bun:test";
 
@@ -108,7 +108,7 @@ describe("shows first arg name correctly in test output", () => {
     expect(fullOutput).not.toInclude("[object Object] > should pass");
   });
   test("describe block shows named class correctly in test output", async () => {
-    const test_dir = tempDirWithFiles(".", {
+    await using test_dir = tempDir(".", {
       "describe-test.test.js": `
       import { describe, test, expect } from "bun:test";
 
@@ -137,7 +137,7 @@ describe("shows first arg name correctly in test output", () => {
   });
 
   test("describe block shows anonymous class correctly in test output", async () => {
-    const test_dir = tempDirWithFiles(".", {
+    await using test_dir = tempDir(".", {
       "describe-test.test.js": `
       import { describe, test, expect } from "bun:test";
 
@@ -167,7 +167,7 @@ describe("shows first arg name correctly in test output", () => {
 
 describe("passing arrow function as args", () => {
   test("passes if sole argument", () => {
-    const test_dir = tempDirWithFiles(".", {
+    using test_dir = tempDir(".", {
       "describe-test.test.js": `
       import { describe, test, expect } from "bun:test";
 
@@ -193,7 +193,7 @@ describe("passing arrow function as args", () => {
     expect(fullOutput).toInclude("0 fail");
   });
   test("throws an error if two arguments", () => {
-    const test_dir = tempDirWithFiles(".", {
+    using test_dir = tempDir(".", {
       "describe-test.test.js": `
       import { describe, test, expect } from "bun:test";
 

--- a/test/js/bun/test/done-async.test.ts
+++ b/test/js/bun/test/done-async.test.ts
@@ -17,7 +17,7 @@ test("done() causes the test to fail when it should", async () => {
 
   const $$ = new Bun.$.Shell();
   $$.nothrow();
-  $.cwd(String(dir));
+  $$.cwd(String(dir));
   $$.env(bunEnv);
   const result = await $$`${bunExe()} test`;
 

--- a/test/js/bun/test/done-async.test.ts
+++ b/test/js/bun/test/done-async.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 test("done() causes the test to fail when it should", async () => {
-  const dir = tempDirWithFiles("done", {
+  await using dir = tempDir("done", {
     "done.test.ts": await Bun.file(path.join(import.meta.dir, "done-infinity.fixture.ts")).text(),
     "package.json": JSON.stringify({
       name: "done",
@@ -17,7 +17,7 @@ test("done() causes the test to fail when it should", async () => {
 
   const $$ = new Bun.$.Shell();
   $$.nothrow();
-  $$.cwd(dir);
+  $.cwd(String(dir));
   $$.env(bunEnv);
   const result = await $$`${bunExe()} test`;
 

--- a/test/js/bun/test/expect-assertions.test.ts
+++ b/test/js/bun/test/expect-assertions.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 test("expect.assertions causes the test to fail when it should", async () => {
-  const dir = tempDirWithFiles("expect-assertions", {
+  await using dir = tempDir("expect-assertions", {
     "expect-assertions.test.ts": await Bun.file(path.join(import.meta.dir, "expect-assertions-fixture.ts")).text(),
     "package.json": JSON.stringify({
       name: "expect-assertions",
@@ -17,7 +17,7 @@ test("expect.assertions causes the test to fail when it should", async () => {
 
   const $$ = new Bun.$.Shell();
   $$.nothrow();
-  $$.cwd(dir);
+  $.cwd(String(dir));
   $$.env(bunEnv);
   const result = await $$`${bunExe()} test`;
 

--- a/test/js/bun/test/expect-assertions.test.ts
+++ b/test/js/bun/test/expect-assertions.test.ts
@@ -17,7 +17,7 @@ test("expect.assertions causes the test to fail when it should", async () => {
 
   const $$ = new Bun.$.Shell();
   $$.nothrow();
-  $.cwd(String(dir));
+  $$.cwd(String(dir));
   $$.env(bunEnv);
   const result = await $$`${bunExe()} test`;
 

--- a/test/js/bun/test/expect-extend-preload.test.ts
+++ b/test/js/bun/test/expect-extend-preload.test.ts
@@ -1,10 +1,10 @@
 import { file } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 test("custom matcher runs", async () => {
-  const dir = tempDirWithFiles("custom-matcher-preload-test-fixture", {
+  await using dir = tempDir("custom-matcher-preload-test-fixture", {
     "preload.ts": await file(join(import.meta.dir, "custom-matcher-preload-test-fixture-1.ts")).text(),
     "expect-extend.test.ts": await file(join(import.meta.dir, "custom-matcher-preload-test-fixture-2.ts")).text(),
     "bunfig.toml": `

--- a/test/js/bun/test/pretty-format-overflow.test.ts
+++ b/test/js/bun/test/pretty-format-overflow.test.ts
@@ -3,11 +3,11 @@
 // Platform: Windows x86_64_baseline, Bun v1.3.0
 
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("pretty_format should handle deeply nested objects without crashing", () => {
   test("deeply nested object with many properties", async () => {
-    const dir = tempDirWithFiles("pretty-format-overflow", {
+    await using dir = tempDir("pretty-format-overflow", {
       "nested.test.ts": `
 import { test, expect } from "bun:test";
 

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, DirectoryTree, isDebug, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, DirectoryTree, isDebug, tempDir, tempDirWithFiles } from "harness";
 
 function test1000000(arg1: any, arg218718132: any) {}
 
@@ -940,7 +940,7 @@ test("write snapshot from filter", async () => {
       expect(() => {throw new Error("${m}!")}).toThrowErrorMatchingInlineSnapshot(${a ? '`"' + m + '!"`' : ""});
     })
   `;
-  const dir = tempDirWithFiles("writesnapshotfromfilter", {
+  await using dir = tempDir("writesnapshotfromfilter", {
     "mytests": {
       "snap.test.ts": sver("a", false),
       "snap2.test.ts": sver("b", false),

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -714,7 +714,7 @@ test("my-test", () => {
 });
     `.trim();
 
-      const test_dir = tempDirWithFiles("unhandled-" + stage, {
+      using test_dir = tempDir("unhandled-" + stage, {
         "my-test.test.js": code,
         "package.json": "{}",
       });

--- a/test/js/bun/typescript/type-export.test.ts
+++ b/test/js/bun/typescript/type-export.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
 
 const ext = isWindows ? ".exe" : "";
 
@@ -161,7 +161,7 @@ describe("import not found", () => {
     ],
   ] as const)
     test.concurrent(`${name}`, async () => {
-      const dir = tempDirWithFiles("type-export", {
+      await using dir = tempDir("type-export", {
         "a.ts": ccase,
         "b.ts": /*js*/ `
           import { not_found } from "./a";
@@ -184,7 +184,7 @@ describe("import not found", () => {
 });
 
 test.concurrent("js file type export", async () => {
-  const dir = tempDirWithFiles("type-export", {
+  await using dir = tempDir("type-export", {
     "a.js": "export {not_found};",
   });
 
@@ -195,7 +195,7 @@ test.concurrent("js file type export", async () => {
 });
 
 test.concurrent("js file type import", async () => {
-  const dir = tempDirWithFiles("type-import", {
+  await using dir = tempDir("type-import", {
     "b.js": "import {type_only} from './ts.ts';",
     "ts.ts": "export type type_only = 'type_only';",
   });
@@ -208,7 +208,7 @@ test.concurrent("js file type import", async () => {
 });
 
 test.concurrent("js file type import with default export", async () => {
-  const dir = tempDirWithFiles("type-import", {
+  await using dir = tempDir("type-import", {
     "b.js": "import {type_only} from './ts.ts';",
     "ts.ts": "export type type_only = 'type_only'; export default function type_only() {};",
   });
@@ -221,7 +221,7 @@ test.concurrent("js file type import with default export", async () => {
 });
 
 test.concurrent("js file with through export", async () => {
-  const dir = tempDirWithFiles("type-import", {
+  await using dir = tempDir("type-import", {
     "b.js": "export {type_only} from './ts.ts';",
     "ts.ts": "export type type_only = 'type_only'; export default function type_only() {};",
   });
@@ -233,7 +233,7 @@ test.concurrent("js file with through export", async () => {
 });
 
 test.concurrent("js file with through export 2", async () => {
-  const dir = tempDirWithFiles("type-import", {
+  await using dir = tempDir("type-import", {
     "b.js": "import {type_only} from './ts.ts'; export {type_only};",
     "ts.ts": "export type type_only = 'type_only'; export default function type_only() {};",
   });
@@ -319,7 +319,7 @@ describe("check ownkeys from a star import", () => {
 });
 
 test.concurrent("check commonjs", async () => {
-  const dir = tempDirWithFiles("commonjs", {
+  await using dir = tempDir("commonjs", {
     ["main.ts"]: "const {my_value, my_type} = require('./a'); console.log(my_value, my_type);",
     ["a.ts"]: "module.exports = require('./b');",
     ["b.ts"]: "export const my_value = 'my_value'; export type my_type = 'my_type';",
@@ -331,7 +331,7 @@ test.concurrent("check commonjs", async () => {
 });
 
 test.concurrent("check merge", async () => {
-  const dir = tempDirWithFiles("merge", {
+  await using dir = tempDir("merge", {
     ["main.ts"]: "import {value} from './a'; console.log(value);",
     ["a.ts"]: "export * from './b'; export * from './c';",
     ["b.ts"]: "export const value = 'b';",

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 import fsPromises from "fs/promises";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 test("delete() and stat() should work with unicode paths", async () => {
-  const dir = tempDirWithFiles("delete-stat-unicode-path", {
+  await using dir = tempDir("delete-stat-unicode-path", {
     "another-file.txt": "HEY",
   });
   const filename = join(dir, "🌟.txt");
@@ -26,7 +26,7 @@ test("delete() and stat() should work with unicode paths", async () => {
 });
 
 test("writer.end() should not close the fd if it does not own the fd", async () => {
-  const dir = tempDirWithFiles("writer-end-fd", {
+  await using dir = tempDir("writer-end-fd", {
     "tmp.txt": "HI",
   });
   const filename = join(dir, "tmp.txt");
@@ -66,7 +66,7 @@ test("Bun.write() errors include async stack frames", async () => {
   // Use a file-as-directory-component path so it fails on both POSIX and
   // Windows. Bun.write recursively creates directories, so a plain
   // /nonexistent-path/ would succeed on Windows where / is the drive root.
-  const dir = tempDirWithFiles("bun-write-async-stack", { "blocker.txt": "x" });
+  await using dir = tempDir("bun-write-async-stack", { "blocker.txt": "x" });
   const badPath = join(dir, "blocker.txt", "cannot-write.txt");
   // Bun.write uses a sync fast path for inputs under 256KB on POSIX — use
   // 512KB to force the async (threadpool) path so we're actually testing the
@@ -117,7 +117,7 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
   // In debug builds this surfaces as "mimalloc: error: mi_free: invalid
   // (unaligned) pointer" on stderr; in release it silently corrupts the heap.
   const bom = Buffer.from([0xef, 0xbb, 0xbf]);
-  const dir = tempDirWithFiles("bun-file-json-bom", {
+  await using dir = tempDir("bun-file-json-bom", {
     // pure-ASCII body: exercises the direct ZigString path
     "ascii.json": Buffer.concat([bom, Buffer.from(JSON.stringify({ a: 1, b: "two" }))]),
     // non-ASCII body: exercises the toUTF16Alloc path

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -1,7 +1,7 @@
 import { $, which } from "bun";
 import { dlopen, ptr } from "bun:ffi";
 import { expect, test } from "bun:test";
-import { isArm64, isIntelMacOS, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { isArm64, isIntelMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { chmodSync, existsSync, mkdirSync, realpathSync, rmdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
@@ -205,11 +205,11 @@ if (isWindows) {
 
 test("Bun.which does not look in the current directory for bins", async () => {
   const cwd = process.cwd();
-  const dir = tempDirWithFiles("which", {
+  await using dir = tempDir("which", {
     "some_program_name": "#!/usr/bin/env sh\necho FAIL\nexit 0\n",
     "some_program_name.cmd": "@echo FAIL\n@exit 0\n",
   });
-  process.chdir(dir);
+  process.chdir(String(dir));
   try {
     if (!isWindows) {
       await $`chmod +x ./some_program_name`;
@@ -224,13 +224,13 @@ test("Bun.which does not look in the current directory for bins", async () => {
 
 test("Bun.which does look in the current directory when given a path with a slash", async () => {
   const cwd = process.cwd();
-  const dir = tempDirWithFiles("which", {
+  await using dir = tempDir("which", {
     "some_program_name": "#!/usr/bin/env sh\necho posix\nexit 0\n",
     "some_program_name.cmd": "@echo win32\n@exit 0\n",
     "folder/other_app": "#!/usr/bin/env sh\necho posix\nexit 0\n",
     "folder/other_app.cmd": "@echo win32\n@exit 0\n",
   });
-  process.chdir(dir);
+  process.chdir(String(dir));
   try {
     if (!isWindows) {
       await $`chmod +x ./some_program_name`;
@@ -252,12 +252,12 @@ test("Bun.which does look in the current directory when given a path with a slas
 
 test("Bun.which can find executables in a non-ascii directory", async () => {
   const cwd = process.cwd();
-  const dir = tempDirWithFiles("which-non-ascii-开始学习", {
+  await using dir = tempDir("which-non-ascii-开始学习", {
     "some_program_name": "#!/usr/bin/env sh\necho posix\nexit 0\n",
     "some_program_name.cmd": "@echo win32\n@exit 0\n",
   });
 
-  process.chdir(dir);
+  process.chdir(String(dir));
   try {
     if (!isWindows) {
       await $`chmod +x ./some_program_name`;

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -1,13 +1,13 @@
 import { file, spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 const xml2js = require("xml2js");
 
 describe("junit reporter", () => {
   it.each([false, true])("should generate valid junit xml for passing tests %s", async withCIEnvironmentVariables => {
-    const tmpDir = tempDirWithFiles("junit", {
+    await using tmpDir = tempDir("junit", {
       "package.json": "{}",
       "passing.test.js": `
         describe("root describe", () => {
@@ -151,7 +151,7 @@ describe("junit reporter", () => {
   });
 
   it("more scenarios", async () => {
-    const tmpDir = tempDirWithFiles("junit-comprehensive", {
+    await using tmpDir = tempDir("junit-comprehensive", {
       "package.json": "{}",
       "comprehensive.test.js": `
         import { test, expect, describe } from "bun:test";
@@ -317,7 +317,7 @@ describe("junit reporter", () => {
   });
 
   it("should report only the final result for a retried test", async () => {
-    const tmpDir = tempDirWithFiles("junit-retry", {
+    await using tmpDir = tempDir("junit-retry", {
       "package.json": "{}",
       "flaky.test.js": `
         import { test, expect } from "bun:test";
@@ -390,7 +390,7 @@ describe("junit reporter", () => {
   });
 
   it("produces well-formed XML when test names contain control characters", async () => {
-    const tmpDir = tempDirWithFiles("junit-ctrl", {
+    await using tmpDir = tempDir("junit-ctrl", {
       "package.json": "{}",
       "ctrl.test.js":
         'import { test } from "bun:test";\n' +
@@ -430,7 +430,7 @@ describe("junit reporter", () => {
   });
 
   it("escapes the classname attribute exactly once", async () => {
-    const tmpDir = tempDirWithFiles("junit-escape", {
+    await using tmpDir = tempDir("junit-escape", {
       "package.json": "{}",
       "escape.test.js": `
         import { describe, test } from "bun:test";
@@ -472,7 +472,7 @@ describe("junit reporter", () => {
   });
 
   it("keeps the test body's error in <failure> when afterEach also throws", async () => {
-    const tmpDir = tempDirWithFiles("junit-aftereach", {
+    await using tmpDir = tempDir("junit-aftereach", {
       "package.json": "{}",
       "after.test.js": `
         import { test, afterEach } from "bun:test";
@@ -504,7 +504,7 @@ describe("junit reporter", () => {
   });
 
   it("includes the error type, message and stack in <failure>", async () => {
-    const tmpDir = tempDirWithFiles("junit-failure", {
+    await using tmpDir = tempDir("junit-failure", {
       "package.json": "{}",
       "fail.test.js": `
         import { test, expect } from "bun:test";

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isPosix, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isLinux, isPosix, isWindows, tempDir } from "harness";
 import { mkfifo } from "mkfifo";
 import { isAbsolute, join } from "path";
 
@@ -28,7 +28,7 @@ for (const [name, copy] of impls) {
 
   describe("fs." + name, () => {
     test("single file", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
       });
 
@@ -38,7 +38,7 @@ for (const [name, copy] of impls) {
     });
 
     test("refuse to copy directory with 'recursive: false'", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
       });
 
@@ -50,7 +50,7 @@ for (const [name, copy] of impls) {
     });
 
     test("recursive directory structure - no destination", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b/e.txt": "e",
         "from/c.txt": "c",
@@ -66,7 +66,7 @@ for (const [name, copy] of impls) {
     });
 
     test("recursive directory structure - overwrite existing files by default", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b/e.txt": "e",
         "from/c.txt": "c",
@@ -87,7 +87,7 @@ for (const [name, copy] of impls) {
     });
 
     test("recursive directory structure - 'force: false' does not overwrite existing files", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "lose",
         "from/b/e.txt": "e",
         "from/c.txt": "c",
@@ -108,7 +108,7 @@ for (const [name, copy] of impls) {
     });
 
     test("'force: false' on a single file doesn't override", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "lose",
         "result/a.txt": "win",
       });
@@ -119,7 +119,7 @@ for (const [name, copy] of impls) {
     });
 
     test("'force: true' on a single file does override", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "win",
         "result/a.txt": "lose",
       });
@@ -130,7 +130,7 @@ for (const [name, copy] of impls) {
     });
 
     test("'force: false' + 'errorOnExist: true' can throw", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "lose",
         "result/a.txt": "win",
       });
@@ -147,7 +147,7 @@ for (const [name, copy] of impls) {
     });
 
     test("symlinks - single file", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
       });
 
@@ -166,7 +166,7 @@ for (const [name, copy] of impls) {
     });
 
     test("symlinks - single file recursive", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
       });
 
@@ -180,7 +180,7 @@ for (const [name, copy] of impls) {
     });
 
     test("symlinks - directory recursive", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b.txt": "b",
         "from/dir/c.txt": "c",
@@ -201,7 +201,7 @@ for (const [name, copy] of impls) {
     });
 
     test("symlinks - directory recursive 2", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b.txt": "b",
         "from/dir/c.txt": "c",
@@ -226,7 +226,7 @@ for (const [name, copy] of impls) {
       // Previously the ELOOP fallback on Linux/FreeBSD called symlink(src, dest),
       // so the copied link's target string was the path of the *source* symlink
       // and every copied link pointed back into the source tree.
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "target.txt": "hello",
         "from/keep": "",
       });
@@ -267,7 +267,7 @@ for (const [name, copy] of impls) {
       // node resolves a relative link target against the directory of the
       // source link and writes the absolute result into the copy. A verbatim
       // copy of the link (e.g. a whole-tree clonefile) would keep "../a.txt".
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/sub/keep.txt": "keep",
       });
@@ -282,7 +282,7 @@ for (const [name, copy] of impls) {
     });
 
     test.skipIf(isWindows)("recursive - file and directory modes are preserved into a fresh destination", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/d/f.txt": "x",
       });
       fs.chmodSync(join(basename, "from", "d", "f.txt"), 0o600);
@@ -302,7 +302,7 @@ for (const [name, copy] of impls) {
     });
 
     test.skipIf(isWindows)("recursive - FIFO inside the tree is rejected with ERR_FS_CP_FIFO_PIPE", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
       });
       mkfifo(join(basename, "from", "pipe"), 0o666);
@@ -313,7 +313,7 @@ for (const [name, copy] of impls) {
     });
 
     test("filter - works", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b.txt": "b",
       });
@@ -334,7 +334,7 @@ for (const [name, copy] of impls) {
     });
 
     test("filter - paths given are correct and relative", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b.txt": "b",
       });
@@ -342,7 +342,7 @@ for (const [name, copy] of impls) {
       const filter = jest.fn((src: string) => true);
 
       let prev = process.cwd();
-      process.chdir(basename);
+      process.chdir(String(basename));
 
       await copy(join(basename, "from"), join(basename, "result"), {
         filter,
@@ -359,7 +359,7 @@ for (const [name, copy] of impls) {
     });
 
     test("trailing slash", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b.txt": "b",
       });
@@ -371,7 +371,7 @@ for (const [name, copy] of impls) {
     });
 
     test("copy directory will ensure directory exists", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b.txt": "b",
       });
@@ -385,7 +385,7 @@ for (const [name, copy] of impls) {
     });
 
     test("relative paths for directories", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "from/a.txt": "a",
         "from/b.txt": "b",
         "from/a.dir": { "c.txt": "c" },
@@ -394,7 +394,7 @@ for (const [name, copy] of impls) {
       const filter = jest.fn((src: string) => true);
 
       let prev = process.cwd();
-      process.chdir(basename);
+      process.chdir(String(basename));
 
       await copy("from", "result", {
         recursive: true,
@@ -406,7 +406,7 @@ for (const [name, copy] of impls) {
     });
 
     test.if(process.platform === "win32")("should not throw EBUSY when copying the same file on windows", async () => {
-      const basename = tempDirWithFiles("cp", {
+      await using basename = tempDir("cp", {
         "hey": "hi",
       });
 
@@ -450,7 +450,7 @@ test.skipIf(!isWindows)("cpSync over symlinks does not leak Windows handles", ()
   };
 
   const N = 64;
-  const basename = tempDirWithFiles("cp-symlink-leak", {
+  using basename = tempDir("cp-symlink-leak", {
     "from/target.txt": "hello",
   });
   for (let i = 0; i < N; i++) {
@@ -476,7 +476,7 @@ test.skipIf(!isWindows)("cpSync over symlinks does not leak Windows handles", ()
 // links (Node's dereference:false default), and creating the copied link must not
 // require symlink privilege (junction fallback).
 test.skipIf(!isWindows)("cpSync recursive copies a junction as a link to the original target", () => {
-  const basename = tempDirWithFiles("cp-junction", {
+  using basename = tempDir("cp-junction", {
     "from/real/inner.txt": "inner",
   });
   fs.symlinkSync(join(basename, "from", "real"), join(basename, "from", "junction"), "junction");
@@ -498,7 +498,7 @@ test.skipIf(!isWindows)("cpSync recursive copies a junction as a link to the ori
 // `\\?\UNC\server\share\...`. The copied link's target must come out as the absolute
 // `\\server\share\...` form (libuv `fs__realpath_handle`), not a dangling relative path.
 test.skipIf(!isWindows)("cpSync recursive copies a directory symlink to a UNC target as a working link", () => {
-  const basename = tempDirWithFiles("cp-unc-link", {
+  using basename = tempDir("cp-unc-link", {
     "from/keep.txt": "keep",
     "real/inner.txt": "inner",
   });

--- a/test/js/node/fs/fs-birthtime-linux.test.ts
+++ b/test/js/node/fs/fs-birthtime-linux.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { isLinux, tempDirWithFiles } from "harness";
+import { isLinux, tempDir } from "harness";
 import { chmodSync, closeSync, fstatSync, lstatSync, openSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe.skipIf(!isLinux)("birthtime", () => {
   it("should return non-zero birthtime on Linux", () => {
-    const dir = tempDirWithFiles("birthtime-test", {
+    using dir = tempDir("birthtime-test", {
       "test.txt": "initial content",
     });
 
@@ -19,7 +19,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
   });
 
   it("birthtime should remain constant while other timestamps change", () => {
-    const dir = tempDirWithFiles("birthtime-immutable", {});
+    using dir = tempDir("birthtime-immutable", {});
     const filepath = join(dir, "immutable-test.txt");
 
     // Create file and capture birthtime
@@ -51,7 +51,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
   });
 
   it("birthtime should work with lstat and fstat", () => {
-    const dir = tempDirWithFiles("birthtime-variants", {
+    using dir = tempDir("birthtime-variants", {
       "test.txt": "content",
     });
 
@@ -73,7 +73,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
   });
 
   it("birthtime should work with BigInt stats", () => {
-    const dir = tempDirWithFiles("birthtime-bigint", {
+    using dir = tempDir("birthtime-bigint", {
       "test.txt": "content",
     });
 
@@ -94,7 +94,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
   });
 
   it("birthtime should be less than or equal to all other timestamps on creation", () => {
-    const dir = tempDirWithFiles("birthtime-ordering", {});
+    using dir = tempDir("birthtime-ordering", {});
     const filepath = join(dir, "new-file.txt");
 
     writeFileSync(filepath, "new content");

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,8 +1,8 @@
 import { expect, mock, test } from "bun:test";
 import { writeFile } from "fs/promises";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 test("fs.promises.writeFile async iterator", async () => {
-  const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator", {
+  await using dir = tempDir("fs-promises-writeFile-async-iterator", {
     "file1.txt": "0 Hello, world!",
   });
   const path = dir + "/file2.txt";
@@ -28,7 +28,7 @@ test("fs.promises.writeFile async iterator", async () => {
 });
 
 test("fs.promises.writeFile async iterator throws on invalid input", async () => {
-  const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator", {
+  await using dir = tempDir("fs-promises-writeFile-async-iterator", {
     "file1.txt": "0 Hello, world!",
   });
   const symbolStream = async function* () {

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -48,6 +48,6 @@ test("fs.promises.writeFile async iterator throws on invalid input", async () =>
   const fn = {
     [Symbol.asyncIterator]: mock(() => {}),
   };
-  expect(() => writeFile(dir, fn)).toThrow();
+  expect(() => writeFile(String(dir), fn)).toThrow();
   expect(fn[Symbol.asyncIterator]).not.toBeCalled();
 });

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir, tempDirWithFiles } from "harness";
 import { spawnSync } from "node:child_process";
 import { existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
         return;
       }
 
-      const targetDir = tempDirWithFiles("stat-seccomp-target", { "file.txt": "hello" });
+      await using targetDir = tempDir("stat-seccomp-target", { "file.txt": "hello" });
       // symlink created here rather than via tempDirWithFiles (which only
       // supports regular files).
       symlinkSync("file.txt", join(targetDir, "link.txt"));

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -292,7 +292,7 @@ it("fs.readv returns object", async done => {
 });
 
 it("fs.writev returns object", async done => {
-  const outpath = tempDirWithFiles("fswritevtest", { "a.txt": "b" });
+  await using outpath = tempDir("fswritevtest", { "a.txt": "b" });
   const fd = await promisify(fs.open)(join(outpath, "b.txt"), "w");
   const buffers = [Buffer.alloc(10), Buffer.alloc(10)];
   fs.writev(fd, buffers, 0, (err, bytesWritten, output) => {
@@ -2155,7 +2155,7 @@ describe("readFile", () => {
   });
 
   it("works with flags", async () => {
-    const mydir = tempDirWithFiles("fs-read", {});
+    await using mydir = tempDir("fs-read", {});
     console.log(mydir);
 
     for (const [flag, code] of [

--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -3,7 +3,7 @@
  * tested elsewhere. These tests check API compatibility with Node.js.
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { isWindows, tempDirWithFiles } from "harness";
+import { isWindows, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 
 let tmp: string;
@@ -270,7 +270,7 @@ describe("fs.promises.glob", () => {
 
 describe("fs.globSync exclude with withFileTypes", () => {
   it("invokes the exclude callback with Dirents when cwd differs from process.cwd()", () => {
-    const dir = tempDirWithFiles("glob-exclude-dirent", {
+    using dir = tempDir("glob-exclude-dirent", {
       "skip/inner.txt": "x",
       "keep/inner.txt": "y",
     });

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -1,4 +1,4 @@
-import { tempDirWithFiles } from "harness";
+import { tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 const assert = require("assert");
 const os = require("os");
@@ -290,7 +290,7 @@ test("fs.promises async stack with Promise.all", async () => {
 });
 
 it("an unused FileHandle.writer() does not prevent close()", async () => {
-  const dir = tempDirWithFiles("unused-writer", { "x.txt": "hello" });
+  await using dir = tempDir("unused-writer", { "x.txt": "hello" });
   const fh = await fsPromises.open(join(dir, "x.txt"), "r+");
   fh.writer(); // never written to, never ended
   // must not hang: the writer only refs the handle once a write happens
@@ -299,7 +299,7 @@ it("an unused FileHandle.writer() does not prevent close()", async () => {
 });
 
 it("sources created before close() refuse to use the stale fd", async () => {
-  const dir = tempDirWithFiles("stale-fd", { "x.txt": "hello" });
+  await using dir = tempDir("stale-fd", { "x.txt": "hello" });
   const file = join(dir, "x.txt");
 
   // writer
@@ -333,7 +333,7 @@ it("sources created before close() refuse to use the stale fd", async () => {
 });
 
 it("rm and promises.rm report ERR_FS_EISDIR for directories like rmSync", async () => {
-  const dir = tempDirWithFiles("rm-eisdir", { "sub/a.txt": "x" });
+  await using dir = tempDir("rm-eisdir", { "sub/a.txt": "x" });
   const target = join(dir, "sub");
   await expect(fsPromises.rm(target)).rejects.toMatchObject({ code: "ERR_FS_EISDIR" });
   const { promise, resolve } = Promise.withResolvers();
@@ -345,7 +345,7 @@ it("rm and promises.rm report ERR_FS_EISDIR for directories like rmSync", async 
 });
 
 it("close() while an operation is in flight actually closes the fd", async () => {
-  const dir = tempDirWithFiles("deferred-close", { "x.txt": "hello" });
+  await using dir = tempDir("deferred-close", { "x.txt": "hello" });
   const fh = await fsPromises.open(join(dir, "x.txt"), "r");
   const fd = fh.fd;
   // take an extra ref so close() defers, then release it
@@ -360,7 +360,7 @@ it("close() while an operation is in flight actually closes the fd", async () =>
 });
 
 it("fail()/end() with autoClose defer the close past an in-flight write", async () => {
-  const dir = tempDirWithFiles("writer-teardown", { "a.bin": "", "b.bin": "" });
+  await using dir = tempDir("writer-teardown", { "a.bin": "", "b.bin": "" });
   // fail() while a large write is on the threadpool must not close the fd
   // under it; the write completes, then the handle closes.
   {
@@ -388,7 +388,7 @@ it("fail()/end() with autoClose defer the close past an in-flight write", async 
 });
 
 it("teardown waits for every concurrent in-flight write", async () => {
-  const dir = tempDirWithFiles("writer-concurrent", { "a.bin": "" });
+  await using dir = tempDir("writer-concurrent", { "a.bin": "" });
   const fh = await fsPromises.open(join(dir, "a.bin"), "w");
   const w = fh.writer({ autoClose: true, start: 0 });
   const big = Buffer.alloc(4 << 20, 65);
@@ -419,7 +419,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   }
 
   test("readFile with a pre-aborted signal", async () => {
-    const dir = tempDirWithFiles("fs-abort-readfile", { "f.txt": "hello" });
+    await using dir = tempDir("fs-abort-readfile", { "f.txt": "hello" });
     const signal = AbortSignal.abort();
     expect.assertions(4);
     try {
@@ -430,7 +430,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   });
 
   test("readFile with a custom abort reason", async () => {
-    const dir = tempDirWithFiles("fs-abort-readfile-reason", { "f.txt": "hello" });
+    await using dir = tempDir("fs-abort-readfile-reason", { "f.txt": "hello" });
     const reason = new Error("my reason");
     expect.assertions(4);
     try {
@@ -441,7 +441,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   });
 
   test("readFile aborted while in flight", async () => {
-    const dir = tempDirWithFiles("fs-abort-readfile-inflight", { "f.txt": "hello" });
+    await using dir = tempDir("fs-abort-readfile-inflight", { "f.txt": "hello" });
     const ac = new AbortController();
     const reason = new Error("stop");
     const promise = fsPromises.readFile(join(dir, "f.txt"), { signal: ac.signal });
@@ -457,7 +457,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   // abort() with no reason stores the signal's lazily-created DOMException in a
   // common-reason slot; the cause must still be that exact object, not a copy.
   test("readFile aborted while in flight with the default abort reason", async () => {
-    const dir = tempDirWithFiles("fs-abort-readfile-inflight-default", { "f.txt": "hello" });
+    await using dir = tempDir("fs-abort-readfile-inflight-default", { "f.txt": "hello" });
     const ac = new AbortController();
     const promise = fsPromises.readFile(join(dir, "f.txt"), { signal: ac.signal });
     ac.abort();
@@ -470,7 +470,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   });
 
   test("appendFile with a pre-aborted signal", async () => {
-    const dir = tempDirWithFiles("fs-abort-appendfile", {});
+    await using dir = tempDir("fs-abort-appendfile", {});
     const signal = AbortSignal.abort();
     expect.assertions(4);
     try {
@@ -481,7 +481,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   });
 
   test("writeFile with a pre-aborted signal", async () => {
-    const dir = tempDirWithFiles("fs-abort-writefile", {});
+    await using dir = tempDir("fs-abort-writefile", {});
     const signal = AbortSignal.abort();
     expect.assertions(4);
     try {
@@ -492,7 +492,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   });
 
   test("writeFile of an async iterable with a pre-aborted signal", async () => {
-    const dir = tempDirWithFiles("fs-abort-writefile-iter", {});
+    await using dir = tempDir("fs-abort-writefile-iter", {});
     const signal = AbortSignal.abort();
     expect.assertions(4);
     try {
@@ -509,7 +509,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   });
 
   test("writeFile of an async iterable aborted between chunks", async () => {
-    const dir = tempDirWithFiles("fs-abort-writefile-iter-inflight", {});
+    await using dir = tempDir("fs-abort-writefile-iter-inflight", {});
     const ac = new AbortController();
     expect.assertions(4);
     try {
@@ -528,7 +528,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   });
 
   test("callback readFile and writeFile with a pre-aborted signal", async () => {
-    const dir = tempDirWithFiles("fs-abort-callback", { "f.txt": "hello" });
+    await using dir = tempDir("fs-abort-callback", { "f.txt": "hello" });
     const signal = AbortSignal.abort();
     const readErr = await new Promise(resolve => fs.readFile(join(dir, "f.txt"), { signal }, resolve));
     expectNodeAbortError(readErr, signal.reason);

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { expect, mock, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import path from "path";
 
 test("require.extensions shape makes sense", () => {
@@ -165,7 +165,7 @@ test("wrapping an existing extension but it's secretly sync esm", () => {
 test("mutating extensions is banned by some files", () => {
   // vercel is not allowed to mutate require.extensions
   const files = ["node_modules/next/dist/build/next-config-ts/index.js", "node_modules/@meteorjs/babel/index.js"];
-  const fixture = tempDirWithFiles(
+  using fixture = tempDir(
     "extensions-fixture",
     Object.fromEntries(
       files.map(file => [

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 describe("process.on", () => {
@@ -16,7 +16,7 @@ describe("process.on", () => {
   });
 
   it("should work inside --compile", () => {
-    const dir = tempDirWithFiles("process-on-test", {
+    using dir = tempDir("process-on-test", {
       "process-on-fixture.ts": require("fs").readFileSync(require.resolve("./process-on-fixture.ts"), "utf-8"),
       "package.json": `{
         "name": "process-on-test",
@@ -49,7 +49,7 @@ describe("process.on", () => {
   });
 
   it("should work inside a macro", () => {
-    const dir = tempDirWithFiles("process-on-test", {
+    using dir = tempDir("process-on-test", {
       "process-on-fixture.ts": require("fs").readFileSync(require.resolve("./process-on-fixture.ts"), "utf-8"),
       "entry.ts": `import { initialize } from "./process-on-fixture.ts" with {type: "macro"};
       initialize();`,

--- a/test/js/node/tls/test-node-extra-ca-certs.test.ts
+++ b/test/js/node/tls/test-node-extra-ca-certs.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("NODE_EXTRA_CA_CERTS", () => {
@@ -16,7 +16,7 @@ CgKCAQEAyOB7tY2Uo2lTNjJgGEhJAVZDWnHbLjbmTMP4pSXLlNMr9KdyaKE+J3xn
 xAz7TbGPHUBH5dqMzlWqEkZxcY9u9GL19SJPpC7dl8K8V5dKBwvgOubcLp4qLvZU
 -----END CERTIFICATE-----`;
 
-    const dir = tempDirWithFiles("test-extra-ca", {
+    await using dir = tempDir("test-extra-ca", {
       "extra-ca.pem": testCert,
       "test.js": `console.log('OK');`,
     });
@@ -39,7 +39,7 @@ xAz7TbGPHUBH5dqMzlWqEkZxcY9u9GL19SJPpC7dl8K8V5dKBwvgOubcLp4qLvZU
   });
 
   test("handles missing certificate file gracefully", async () => {
-    const dir = tempDirWithFiles("test-missing-ca", {
+    await using dir = tempDir("test-missing-ca", {
       "test.js": `console.log('OK');`,
     });
 
@@ -70,7 +70,7 @@ BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
 aWRnaXRzIFB0eSBMdGQwHhcNMTgwNDEwMDgwNzQ4WhcNMjgwNDA3MDgwNzQ4WjBF
 -----END CERTIFICATE-----`;
 
-    const dir = tempDirWithFiles("test-extra-and-system", {
+    await using dir = tempDir("test-extra-and-system", {
       "extra-ca.pem": testCert,
       "test.js": `console.log('OK');`,
     });
@@ -96,7 +96,7 @@ aWRnaXRzIFB0eSBMdGQwHhcNMTgwNDEwMDgwNzQ4WhcNMjgwNDA3MDgwNzQ4WjBF
 test("explicit ca option replaces the default trust store instead of appending to it", async () => {
   const fixtures = join(import.meta.dir, "fixtures");
 
-  const dir = tempDirWithFiles("ca-replaces-default", {
+  await using dir = tempDir("ca-replaces-default", {
     "main.js": `
       const tls = require("node:tls");
       const fs = require("node:fs");

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "bun";
-import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "path";
 
@@ -241,7 +241,7 @@ describe("fs.watchFile", () => {
   // observed to manifest as a crash on Windows (20 attempts on macOS with
   // 200 watchers and 20 GC cycles never crashed).
   test.skipIf(!isWindows)("no crash when finalize() races WorkPool deinit", async () => {
-    const dir = tempDirWithFiles(
+    await using dir = tempDir(
       "watchfile-gc",
       Object.fromEntries(Array.from({ length: 50 }, (_, i) => [`f${i}.txt`, `d`])),
     );
@@ -365,7 +365,7 @@ describe("fs.watchFile", () => {
   test("a throwing listener on the initial ENOENT callback keeps watching", async () => {
     // Fresh per-run directory so the target is guaranteed not to exist and
     // the initial stat takes the ENOENT path.
-    const dir = tempDirWithFiles("watchfile-throw", {
+    await using dir = tempDir("watchfile-throw", {
       ".keep": "",
     });
     const target = path.join(dir, "does-not-exist.txt");

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1,6 +1,6 @@
 import { $, randomUUIDv7, sql, SQL } from "bun";
 import { afterAll, describe, expect, mock, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isCI, isDockerEnabled, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDockerEnabled, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 const postgres = (...args) => new SQL(...args);
 
@@ -12330,7 +12330,7 @@ CREATE TABLE ${table_name} (
         describe("Integration with actual database operations", () => {
           describe("SQLite errors", () => {
             test("SQLite constraint violation throws SQLiteError", async () => {
-              const dir = tempDirWithFiles("sqlite-error-test", {});
+              await using dir = tempDir("sqlite-error-test", {});
               const dbPath = path.join(dir, "test.db");
 
               const db = new SQL({ filename: dbPath, adapter: "sqlite" });
@@ -12358,7 +12358,7 @@ CREATE TABLE ${table_name} (
             });
 
             test("SQLite syntax error throws SQLiteError", async () => {
-              const dir = tempDirWithFiles("sqlite-syntax-error-test", {});
+              await using dir = tempDir("sqlite-syntax-error-test", {});
               const dbPath = path.join(dir, "test.db");
 
               const db = new SQL({ filename: dbPath, adapter: "sqlite" });
@@ -12377,7 +12377,7 @@ CREATE TABLE ${table_name} (
             });
 
             test("SQLite database locked throws SQLiteError", async () => {
-              const dir = tempDirWithFiles("sqlite-locked-test", {});
+              await using dir = tempDir("sqlite-locked-test", {});
               const dbPath = path.join(dir, "test.db");
 
               await using db1 = new SQL({ filename: dbPath, adapter: "sqlite" });
@@ -12516,7 +12516,7 @@ CREATE TABLE ${table_name} (
     // regression corrupts the JS heap of the process that parses the response.
     test("result set following a zero-column result set uses its own column layout", async () => {
       const tableName = `t_${randomUUIDv7("hex").replaceAll("-", "")}`;
-      const fixtureDir = tempDirWithFiles("pg-zero-column-then-wide", {
+      await using fixtureDir = tempDir("pg-zero-column-then-wide", {
         "fixture.ts": `
 import { SQL } from "bun";
 

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1,6 +1,6 @@
 import { randomUUIDv7, SQL } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { rm, stat } from "node:fs/promises";
 import { join } from "node:path";
@@ -30,7 +30,7 @@ describe("Connection & Initialization", () => {
   });
 
   test("should connect to file-based SQLite database", async () => {
-    const dir = tempDirWithFiles("sqlite-db-test", {});
+    await using dir = tempDir("sqlite-db-test", {});
     const dbPath = path.join(dir, "test.db");
 
     const sql = new SQL(`sqlite://${dbPath}`);
@@ -83,7 +83,7 @@ describe("Connection & Initialization", () => {
   });
 
   test("onconnect receives Error when open fails (readonly non-existent)", async () => {
-    const dir = tempDirWithFiles("sqlite-onconnect-error", {});
+    await using dir = tempDir("sqlite-onconnect-error", {});
     const dbPath = join(dir, "missing.db");
 
     const onconnect = mock((err?: any) => {});
@@ -110,7 +110,7 @@ describe("Connection & Initialization", () => {
   });
 
   test("should create database file if it doesn't exist", async () => {
-    const dir = tempDirWithFiles("sqlite-create-test", {});
+    await using dir = tempDir("sqlite-create-test", {});
     const dbPath = path.join(dir, "new.db");
 
     const sql = new SQL(`sqlite://${dbPath}`);
@@ -124,7 +124,7 @@ describe("Connection & Initialization", () => {
   });
 
   test("should work with relative paths", async () => {
-    const dir = tempDirWithFiles("sqlite-test", {});
+    await using dir = tempDir("sqlite-test", {});
     const sql = new SQL({
       adapter: "sqlite",
       filename: path.join(dir, "test.db"),
@@ -158,7 +158,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should use DATABASE_URL for SQLite when it's a SQLite URL", async () => {
-      const dir = tempDirWithFiles("sqlite-env-test", {});
+      await using dir = tempDir("sqlite-env-test", {});
       const dbPath = path.join(dir, "env-test.db");
 
       Bun.env.DATABASE_URL = `sqlite://${dbPath}`;
@@ -191,7 +191,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle SQLITE_URL env var when specified", async () => {
-      const dir = tempDirWithFiles("sqlite-url-test", {});
+      await using dir = tempDir("sqlite-url-test", {});
       const dbPath = path.join(dir, "sqlite-url.db");
 
       // This doesn't exist in the current implementation but testing anyway
@@ -287,7 +287,7 @@ describe("Connection & Initialization", () => {
 
   describe("file:// Protocol URLs", () => {
     test("should handle file:// URLs", async () => {
-      const dir = tempDirWithFiles("file-protocol-test", {});
+      await using dir = tempDir("file-protocol-test", {});
       const dbPath = path.join(dir, "file-test.db");
 
       const sql = new SQL(`file://${dbPath}`);
@@ -303,7 +303,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle file: URLs without slashes", async () => {
-      const dir = tempDirWithFiles("file-no-slash-test", {});
+      await using dir = tempDir("file-no-slash-test", {});
       const dbPath = path.join(dir, "file-noslash.db");
 
       const sql = new SQL(`file:${dbPath}`);
@@ -328,7 +328,7 @@ describe("Connection & Initialization", () => {
 
   describe("Query Parameters in SQLite URLs", () => {
     test("should handle mode=ro (readonly)", async () => {
-      const dir = tempDirWithFiles("readonly-test", {});
+      await using dir = tempDir("readonly-test", {});
       const dbPath = path.join(dir, "readonly.db");
 
       // First create a database
@@ -355,7 +355,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle mode=rw (read-write)", async () => {
-      const dir = tempDirWithFiles("readwrite-test", {});
+      await using dir = tempDir("readwrite-test", {});
       const dbPath = path.join(dir, "readwrite.db");
 
       // Create database first
@@ -376,7 +376,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle mode=rwc (read-write-create)", async () => {
-      const dir = tempDirWithFiles("rwc-test", {});
+      await using dir = tempDir("rwc-test", {});
       const dbPath = path.join(dir, "rwc.db");
 
       const sql = new SQL(`sqlite://${dbPath}?mode=rwc`);
@@ -394,7 +394,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle multiple query parameters", async () => {
-      const dir = tempDirWithFiles("multi-param-test", {});
+      await using dir = tempDir("multi-param-test", {});
       const dbPath = path.join(dir, "multi.db");
 
       // Note: Only mode is supported for SQLite, other params should be ignored
@@ -408,7 +408,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should ignore fragment in URL", async () => {
-      const dir = tempDirWithFiles("fragment-test", {});
+      await using dir = tempDir("fragment-test", {});
       const dbPath = path.join(dir, "test#file.db");
 
       // # is a valid filename character in SQLite
@@ -427,7 +427,7 @@ describe("Connection & Initialization", () => {
 
   describe("Special Characters in Filenames", () => {
     test("should handle spaces in filename", async () => {
-      const dir = tempDirWithFiles("space-test", {});
+      await using dir = tempDir("space-test", {});
       const dbPath = path.join(dir, "test database.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
@@ -443,7 +443,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle special characters # and % in filename", async () => {
-      const dir = tempDirWithFiles("special-chars-test", {});
+      await using dir = tempDir("special-chars-test", {});
       const dbPath = path.join(dir, "test#123%data.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
@@ -459,7 +459,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle unicode characters in filename", async () => {
-      const dir = tempDirWithFiles("unicode-test", {});
+      await using dir = tempDir("unicode-test", {});
       const dbPath = path.join(dir, "测试数据库.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
@@ -475,7 +475,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle dots in filename", async () => {
-      const dir = tempDirWithFiles("dots-test", {});
+      await using dir = tempDir("dots-test", {});
       const dbPath = path.join(dir, "my.app.v2.0.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
@@ -493,7 +493,7 @@ describe("Connection & Initialization", () => {
 
   describe("Path Handling", () => {
     test("should handle absolute paths", async () => {
-      const dir = tempDirWithFiles("absolute-test", {});
+      await using dir = tempDir("absolute-test", {});
       const dbPath = path.resolve(dir, "absolute.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
@@ -509,11 +509,11 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle relative paths with ./", async () => {
-      const dir = tempDirWithFiles("relative-dot-test", {});
+      await using dir = tempDir("relative-dot-test", {});
       const originalCwd = process.cwd();
 
       try {
-        process.chdir(dir);
+        process.chdir(String(dir));
 
         const sql = new SQL("sqlite://./test.db");
         expect(sql.options.adapter).toBe("sqlite");
@@ -531,7 +531,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle paths with ../", async () => {
-      const parentDir = tempDirWithFiles("parent-test", {});
+      await using parentDir = tempDir("parent-test", {});
       const childDir = path.join(parentDir, "child");
       await Bun.$`mkdir -p ${childDir}`;
       const originalCwd = process.cwd();
@@ -555,7 +555,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle nested paths", async () => {
-      const dir = tempDirWithFiles("nested-test", {});
+      await using dir = tempDir("nested-test", {});
       const nestedPath = path.join(dir, "data", "databases", "app.db");
       await Bun.$`mkdir -p ${path.dirname(nestedPath)}`;
 
@@ -623,7 +623,7 @@ describe("Connection & Initialization", () => {
 
   describe("Mixed Configurations", () => {
     test("should prefer explicit URL over env var", async () => {
-      const dir = tempDirWithFiles("explicit-test", {});
+      await using dir = tempDir("explicit-test", {});
       const envPath = path.join(dir, "env.db");
       const explicitPath = path.join(dir, "explicit.db");
 
@@ -643,7 +643,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should prefer options object over URL", async () => {
-      const dir = tempDirWithFiles("options-override-test", {});
+      await using dir = tempDir("options-override-test", {});
       const urlPath = path.join(dir, "url.db");
       const optionsPath = path.join(dir, "options.db");
 
@@ -664,7 +664,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("should handle URL in options object", async () => {
-      const dir = tempDirWithFiles("url-in-options-test", {});
+      await using dir = tempDir("url-in-options-test", {});
       const dbPath = path.join(dir, "url-options.db");
 
       const sql = new SQL({
@@ -699,7 +699,7 @@ describe("Connection & Initialization", () => {
     });
 
     test("SQLite readonly mode creates connection but fails on missing file access", async () => {
-      const dir = tempDirWithFiles("ro-nonexist-test", {});
+      await using dir = tempDir("ro-nonexist-test", {});
       const dbPath = path.join(dir, "nonexistent.db");
 
       const sql = new SQL(`sqlite://${dbPath}?mode=ro`);
@@ -1249,7 +1249,7 @@ describe("SQLite-specific features", () => {
   });
 
   test("ATTACH DATABASE", async () => {
-    const dir = tempDirWithFiles("sqlite-attach-test", {});
+    await using dir = tempDir("sqlite-attach-test", {});
     const attachPath = path.join(dir, "attached.db");
 
     await sql`ATTACH DATABASE ${attachPath} AS attached`;
@@ -1481,7 +1481,7 @@ describe("SQL helpers", () => {
   });
 
   test("file execution", async () => {
-    const dir = tempDirWithFiles("sql-files", {
+    await using dir = tempDir("sql-files", {
       "schema.sql": `
           CREATE TABLE file_test (
             id INTEGER PRIMARY KEY,
@@ -1499,7 +1499,7 @@ describe("SQL helpers", () => {
   });
 
   test("file with parameters", async () => {
-    const dir = tempDirWithFiles("sql-params", {
+    await using dir = tempDir("sql-params", {
       "query.sql": `SELECT ? as param1, ? as param2`,
     });
 
@@ -1961,7 +1961,7 @@ describe("Performance & Edge Cases", () => {
 
 describe("WAL mode and concurrency", () => {
   test("can enable WAL mode", async () => {
-    const dir = tempDirWithFiles("sqlite-wal-test", {});
+    await using dir = tempDir("sqlite-wal-test", {});
     const dbPath = path.join(dir, "wal-test.db");
     const sql = new SQL(`sqlite://${dbPath}`);
 
@@ -2069,7 +2069,7 @@ describe("Memory and resource management", () => {
 
 describe("Connection URL Edge Cases", () => {
   test("handles various file:// URL formats", async () => {
-    const dir = tempDirWithFiles("sqlite-url-test", {});
+    await using dir = tempDir("sqlite-url-test", {});
 
     const dbPath1 = path.join(dir, "test1.db");
     const sql1 = new SQL(`file://${dbPath1}`);
@@ -2104,7 +2104,7 @@ describe("Connection URL Edge Cases", () => {
     ];
 
     for (const name of specialNames) {
-      const dir = tempDirWithFiles(`sqlite-special-${Math.random()}`, {});
+      await using dir = tempDir(`sqlite-special-${Math.random()}`, {});
       const dbPath = path.join(dir, name);
 
       const sql = new SQL(`sqlite://${dbPath}`);
@@ -2122,11 +2122,11 @@ describe("Connection URL Edge Cases", () => {
   });
 
   test("handles relative vs absolute paths", async () => {
-    const dir = tempDirWithFiles("sqlite-path-test", {});
+    await using dir = tempDir("sqlite-path-test", {});
     const originalCwd = process.cwd();
 
     try {
-      process.chdir(dir);
+      process.chdir(String(dir));
 
       const sql1 = new SQL("sqlite://./relative.db");
       await sql1`CREATE TABLE test (id INTEGER)`;
@@ -2147,7 +2147,7 @@ describe("Connection URL Edge Cases", () => {
   });
 
   test("handles readonly mode via URL parameters", async () => {
-    const dir = tempDirWithFiles("sqlite-readonly-test", {});
+    await using dir = tempDir("sqlite-readonly-test", {});
     const dbPath = path.join(dir, "readonly.db");
 
     const sql1 = new SQL(`sqlite://${dbPath}`);
@@ -2173,7 +2173,7 @@ describe("Connection URL Edge Cases", () => {
   });
 
   test("handles URI parameters for cache and other settings", async () => {
-    const dir = tempDirWithFiles("sqlite-uri-test", {});
+    await using dir = tempDir("sqlite-uri-test", {});
     const dbPath = path.join(dir, "uri.db");
 
     const sql = new SQL(`sqlite://${dbPath}?cache=shared&mode=rwc`);
@@ -2575,7 +2575,7 @@ describe("Indexes and Query Optimization", () => {
 
 describe("VACUUM and Database Maintenance", () => {
   test("VACUUM command", async () => {
-    const dir = tempDirWithFiles("sqlite-vacuum-test", {});
+    await using dir = tempDir("sqlite-vacuum-test", {});
     const dbPath = path.join(dir, "vacuum.db");
     const sql = new SQL(`sqlite://${dbPath}`);
 
@@ -2604,7 +2604,7 @@ describe("VACUUM and Database Maintenance", () => {
   });
 
   test("incremental VACUUM with auto_vacuum", async () => {
-    const dir = tempDirWithFiles("sqlite-auto-vacuum-test", {});
+    await using dir = tempDir("sqlite-auto-vacuum-test", {});
     const dbPath = path.join(dir, "auto_vacuum.db");
     const sql = new SQL(`sqlite://${dbPath}`);
 
@@ -2632,7 +2632,7 @@ describe("VACUUM and Database Maintenance", () => {
 
 describe("Backup and Restore Operations", () => {
   test("backup to another file", async () => {
-    const dir = tempDirWithFiles("sqlite-backup-test", {});
+    await using dir = tempDir("sqlite-backup-test", {});
     const sourcePath = path.join(dir, "source.db");
     const backupPath = path.join(dir, "backup.db");
 
@@ -3102,7 +3102,7 @@ describe("WITHOUT ROWID Tables", () => {
 
 describe("Concurrency and Locking", () => {
   test("concurrent reads work correctly", async () => {
-    const dir = tempDirWithFiles("sqlite-concurrent-test", {});
+    await using dir = tempDir("sqlite-concurrent-test", {});
     const dbPath = path.join(dir, "concurrent.db");
 
     const sql1 = new SQL(`sqlite://${dbPath}`);
@@ -3134,7 +3134,7 @@ describe("Concurrency and Locking", () => {
   });
 
   test("write lock prevents concurrent writes", async () => {
-    const dir = tempDirWithFiles("sqlite-write-lock-test", {});
+    await using dir = tempDir("sqlite-write-lock-test", {});
     const dbPath = path.join(dir, "writelock.db");
 
     const sql = new SQL(`sqlite://${dbPath}`);
@@ -3166,7 +3166,7 @@ describe("Concurrency and Locking", () => {
   });
 
   test("busy timeout handling", async () => {
-    const dir = tempDirWithFiles("sqlite-busy-test", {});
+    await using dir = tempDir("sqlite-busy-test", {});
     const dbPath = path.join(dir, "busy.db");
 
     const sql1 = new SQL(`sqlite://${dbPath}`);
@@ -3761,7 +3761,7 @@ describe("System Tables and Introspection", () => {
 
 describe("Error Recovery and Database Integrity", () => {
   test("handles corrupted data gracefully", async () => {
-    const dir = tempDirWithFiles("sqlite-corrupt-test", {});
+    await using dir = tempDir("sqlite-corrupt-test", {});
     const dbPath = path.join(dir, "test.db");
     const sql = new SQL(`sqlite://${dbPath}`);
 
@@ -3852,7 +3852,7 @@ describe("Temp Tables and Attached Databases", () => {
   });
 
   test("cross-database queries with ATTACH", async () => {
-    const dir = tempDirWithFiles("sqlite-attach-cross-test", {});
+    await using dir = tempDir("sqlite-attach-cross-test", {});
     const mainPath = path.join(dir, "main.db");
     const attachPath = path.join(dir, "attached.db");
 
@@ -4888,7 +4888,7 @@ describe("Query Normalization Fuzzing Tests", () => {
 
   describe("Result Modes", () => {
     test("values() mode returns arrays instead of objects", async () => {
-      const dir = tempDirWithFiles("sqlite-values-mode", {});
+      await using dir = tempDir("sqlite-values-mode", {});
       const sql = new SQL(`sqlite://${dir}/test.db`);
 
       await sql`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)`;
@@ -4911,7 +4911,7 @@ describe("Query Normalization Fuzzing Tests", () => {
     });
 
     test("raw() mode returns buffers for SQLite", async () => {
-      const dir = tempDirWithFiles("sqlite-raw-mode", {});
+      await using dir = tempDir("sqlite-raw-mode", {});
       const sql = new SQL(`sqlite://${dir}/test.db`);
 
       await sql`CREATE TABLE test (id INTEGER, name TEXT, data BLOB, score REAL)`;
@@ -4958,7 +4958,7 @@ describe("Query Normalization Fuzzing Tests", () => {
     });
 
     test("values() mode works with PRAGMA commands", async () => {
-      const dir = tempDirWithFiles("sqlite-values-pragma", {});
+      await using dir = tempDir("sqlite-values-pragma", {});
       const sql = new SQL(`sqlite://${dir}/test.db`);
 
       const pragmaValues = await sql`PRAGMA table_info('sqlite_master')`.values();

--- a/test/js/third_party/body-parser/express-bun-build-compile.test.ts
+++ b/test/js/third_party/body-parser/express-bun-build-compile.test.ts
@@ -1,14 +1,14 @@
 import { $ } from "bun";
 import { test } from "bun:test";
 import "harness";
-import { bunExe, tempDirWithFiles } from "harness";
+import { bunExe, tempDir } from "harness";
 import { join } from "path";
 
 $.throws(true);
 
 // https://github.com/oven-sh/bun/issues/10624
 test("Express hello world app supports bun build --compile --minify --sourcemap", async () => {
-  const dir = tempDirWithFiles("express-bun-build-compile", {
+  await using dir = tempDir("express-bun-build-compile", {
     "out.exe": "",
   });
 

--- a/test/js/web/fetch/blob-write.test.ts
+++ b/test/js/web/fetch/blob-write.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { expectMaxObjectTypeCount, tempDirWithFiles } from "harness";
+import { expectMaxObjectTypeCount, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
 test("blob.write() throws for data-backed blob", () => {
@@ -30,14 +30,14 @@ test("blob.delete() throws for data-backed blob", () => {
 });
 
 test("Bun.file(path).unlink() does not throw", async () => {
-  const dir = tempDirWithFiles("bun-unlink", { a: "Hello, world!" });
+  await using dir = tempDir("bun-unlink", { a: "Hello, world!" });
   const file = Bun.file(path.join(dir, "a"));
   expect(file.unlink()).resolves.toBeUndefined();
   expect(await Bun.file(path.join(dir, "a")).exists()).toBe(false);
 });
 
 test("Bun.file(path).delete() does not throw", async () => {
-  const dir = tempDirWithFiles("bun-unlink", { a: "Hello, world!" });
+  await using dir = tempDir("bun-unlink", { a: "Hello, world!" });
   const file = Bun.file(path.join(dir, "a"));
   expect(file.delete()).resolves.toBeUndefined();
   expect(await Bun.file(path.join(dir, "a")).exists()).toBe(false);
@@ -78,7 +78,7 @@ test("blob.stat() returns undefined for data-backed blob", async () => {
 });
 
 test("Bun.file(path).stat() returns stats", async () => {
-  const dir = tempDirWithFiles("bun-stat", { a: "Hello, world!" });
+  await using dir = tempDir("bun-stat", { a: "Hello, world!" });
   const file = Bun.file(path.join(dir, "a"));
   const stat = await file.stat();
   expect(stat).toBeDefined();

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -11,7 +11,7 @@ import {
   isMusl,
   isWindows,
   nodeExeMatchingAbi,
-  tempDirWithFiles,
+  tempDir,
 } from "harness";
 import { join } from "path";
 
@@ -73,7 +73,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   describe.each(["esm", "cjs"])("bundle .node files to %s via", format => {
     describe.each(["node", "bun"])("target %s", target => {
       it("Bun.build", async () => {
-        const dir = tempDirWithFiles("node-file-cli", {
+        await using dir = tempDir("node-file-cli", {
           "package.json": JSON.stringify({
             name: "napi-app",
             version: "1.0.0",
@@ -116,7 +116,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         it(
           "should work with --compile",
           async () => {
-            const dir = tempDirWithFiles("napi-app-compile-" + format, {
+            await using dir = tempDir("napi-app-compile-" + format, {
               "package.json": JSON.stringify({
                 name: "napi-app",
                 version: "1.0.0",
@@ -140,7 +140,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
               stderr: "inherit",
             });
             expect(build.success).toBeTrue();
-            const tmpdir = tempDirWithFiles("should-be-empty-except", {});
+            await using tmpdir = tempDir("should-be-empty-except", {});
             const result = spawnSync({
               cmd: [exe, "self"],
               env: { ...bunEnv, BUN_TMPDIR: tmpdir },
@@ -166,7 +166,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       }
 
       it("`bun build`", async () => {
-        const dir = tempDirWithFiles("node-file-build", {
+        await using dir = tempDir("node-file-build", {
           "package.json": JSON.stringify({
             name: "napi-app",
             version: "1.0.0",

--- a/test/regression/issue/026039.test.ts
+++ b/test/regression/issue/026039.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Test for https://github.com/oven-sh/bun/issues/26039
 // When parsing a bun.lock file with an empty registry URL for a scoped package,
 // bun should use the scope-specific registry from bunfig.toml, not the default npm registry.
 test("frozen lockfile should use scope-specific registry for scoped packages", async () => {
-  const dir = tempDirWithFiles("scoped-registry-test", {
+  await using dir = tempDir("scoped-registry-test", {
     "package.json": JSON.stringify({
       name: "test-scoped-registry",
       version: "1.0.0",
@@ -57,7 +57,7 @@ example = { url = "https://npm.pkg.github.com" }
 
 // Test that non-scoped packages still use the default registry when registry URL is empty
 test("frozen lockfile should use default registry for non-scoped packages", async () => {
-  const dir = tempDirWithFiles("non-scoped-registry-test", {
+  await using dir = tempDir("non-scoped-registry-test", {
     "package.json": JSON.stringify({
       name: "test-non-scoped-registry",
       version: "1.0.0",

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 it("duplicate dependencies should warn instead of error", () => {
   const package_json = JSON.stringify({
@@ -10,7 +10,7 @@ it("duplicate dependencies should warn instead of error", () => {
     },
   });
 
-  const dir = tempDirWithFiles("07740", {
+  using dir = tempDir("07740", {
     "package.json": package_json,
   });
 

--- a/test/regression/issue/09340.test.ts
+++ b/test/regression/issue/09340.test.ts
@@ -1,13 +1,13 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { readdirSync } from "node:fs";
 
 test("bun shell should move multiple files", async () => {
   const files = { file1: "", file2: "", file3: "" };
   const filenames = Object.keys(files);
-  const source = tempDirWithFiles("source", files);
-  const target = tempDirWithFiles("target", {});
+  await using source = tempDir("source", files);
+  await using target = tempDir("target", {});
 
   await $`mv ${filenames} ${target}`.cwd(source);
 

--- a/test/regression/issue/09555.test.ts
+++ b/test/regression/issue/09555.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { join } from "path";
 import { Readable } from "stream";
 describe("#09555", () => {
@@ -127,7 +127,7 @@ describe("#09555", () => {
   test("Bun.file() NativeReadable", async () => {
     const full = crypto.getRandomValues(new Uint8Array(1024 * 3));
     const sha = Bun.CryptoHasher.hash("sha256", full, "base64");
-    const dir = tempDirWithFiles("09555", {
+    await using dir = tempDir("09555", {
       "/file.blob": full,
     });
     await Bun.write(join(dir, "file.blob"), full);

--- a/test/regression/issue/09559.test.ts
+++ b/test/regression/issue/09559.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
-import { bunExe, tempDirWithFiles } from "harness";
+import { bunExe, tempDir } from "harness";
 import { join } from "path";
 
 test("bun build --target bun should support non-ascii source", async () => {
@@ -12,7 +12,7 @@ test("bun build --target bun should support non-ascii source", async () => {
     console.log(JSON.stringify({\u{6211}}));
   `,
   };
-  const source = tempDirWithFiles("source", files);
+  await using source = tempDir("source", files);
 
   $.throws(true);
   await $`${bunExe()} build --target bun ${join(source, "index.js")} --outfile ${join(source, "bundle.js")}`;

--- a/test/regression/issue/10887.test.ts
+++ b/test/regression/issue/10887.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("does not segfault", () => {
-  const dir = tempDirWithFiles("10887", {
+  using dir = tempDir("10887", {
     "index.ts": `
       function deco() {
         console.log('deco init');

--- a/test/regression/issue/11664.test.ts
+++ b/test/regression/issue/11664.test.ts
@@ -1,9 +1,9 @@
 import { test } from "bun:test";
-import { bunRun, tempDirWithFiles } from "harness";
+import { bunRun, tempDir } from "harness";
 import { join } from "path";
 
 test("does not segfault", () => {
-  const dir = tempDirWithFiles("segfault", {
+  using dir = tempDir("segfault", {
     "dir/a.ts": `
       import { mock } from "bun:test";
 

--- a/test/regression/issue/11806.test.ts
+++ b/test/regression/issue/11806.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunExe, tempDirWithFiles } from "harness";
+import { bunExe, tempDir } from "harness";
 
 test("11806", () => {
-  const dir = tempDirWithFiles("11806", {
+  using dir = tempDir("11806", {
     "package.json": JSON.stringify({
       "name": "project",
       "workspaces": ["apps/*"],

--- a/test/regression/issue/14945-lifecycle-script-crash.test.ts
+++ b/test/regression/issue/14945-lifecycle-script-crash.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("lifecycle script should handle directory deletion gracefully", async () => {
-  const dir = tempDirWithFiles("lifecycle-crash-test", {
+  await using dir = tempDir("lifecycle-crash-test", {
     "package.json": JSON.stringify({
       name: "test-package",
       version: "1.0.0",
@@ -46,7 +46,7 @@ test("lifecycle script should handle directory deletion gracefully", async () =>
 });
 
 test("lifecycle script with optional dependency should handle directory deletion", async () => {
-  const depDir = tempDirWithFiles("optional-dep", {
+  await using depDir = tempDir("optional-dep", {
     "package.json": JSON.stringify({
       name: "optional-dep",
       version: "1.0.0",
@@ -57,7 +57,7 @@ test("lifecycle script with optional dependency should handle directory deletion
     }),
   });
 
-  const mainDir = tempDirWithFiles("main-package", {
+  await using mainDir = tempDir("main-package", {
     "package.json": JSON.stringify({
       name: "main-package",
       version: "1.0.0",

--- a/test/regression/issue/14976/14976.test.ts
+++ b/test/regression/issue/14976/14976.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
-import { bunExe, tempDirWithFiles } from "harness";
+import { bunExe, tempDir } from "harness";
 import * as i from "./import_target";
 import { mile𐃘add1 as m, mile𐃘add1 } from "./import_target";
 
@@ -11,7 +11,7 @@ test("unicode imports", () => {
 });
 
 test("more unicode imports", async () => {
-  const dir = tempDirWithFiles("more-unicode-imports", {
+  await using dir = tempDir("more-unicode-imports", {
     "mod_importer.ts": `
       import { nထme as nထme𐃘1 } from "./mod\\u1011.ts";
       import { nထme as nထme𐃘2 } from "./modထ.ts";

--- a/test/regression/issue/17327.test.ts
+++ b/test/regression/issue/17327.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 test("issue #17327: extra bracket in error message with colors enabled", async () => {
-  const dir = tempDirWithFiles("17327", {
+  await using dir = tempDir("17327", {
     "test.ts": `
 const result = {success:false};
 const err = new Error(\`error: \${JSON.stringify(
@@ -59,7 +59,7 @@ throw err;
 });
 
 test("issue #17327: template literal syntax highlighting edge cases", async () => {
-  const dir = tempDirWithFiles("17327-edge", {
+  await using dir = tempDir("17327-edge", {
     "nested.ts": `
 const obj = {nested: {deep: true}};
 throw new Error(\`Complex: \${JSON.stringify(obj)}\`);

--- a/test/regression/issue/20321.test.ts
+++ b/test/regression/issue/20321.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { spawnSync } from "child_process";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("spawnSync should not crash when stdout is set to process.stderr (issue #20321)", () => {
   // Test with process.stderr as stdout
@@ -77,14 +77,14 @@ test("spawnSync should work with file descriptors directly", () => {
 
 test("spawnSync should handle the AWS CDK use case", () => {
   // This is the exact use case from AWS CDK that was failing
-  const dir = tempDirWithFiles("spawnsync-cdk", {
+  using dir = tempDir("spawnsync-cdk", {
     "test.js": `console.log("CDK output");`,
   });
 
   const proc = spawnSync(bunExe(), ["test.js"], {
     encoding: "utf-8",
     stdio: ["ignore", process.stderr, "inherit"],
-    cwd: dir,
+    cwd: String(dir),
     env: bunEnv,
   });
 

--- a/test/regression/issue/21680.test.ts
+++ b/test/regression/issue/21680.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 
 test("HTMLRewriter should not crash when element handler throws an exception - issue #21680", () => {
   // The most important test: ensure the original crashing case from the GitHub issue doesn't crash
   // This was the exact case from the issue that caused "ASSERTION FAILED: Unexpected exception observed"
 
   // Create a minimal HTML file for testing
-  const dir = tempDirWithFiles("htmlrewriter-crash-test", {
+  using dir = tempDir("htmlrewriter-crash-test", {
     "min.html": "<script></script>",
   });
 

--- a/test/regression/issue/21907.test.ts
+++ b/test/regression/issue/21907.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("CSS parser should handle extremely large floating-point values without crashing", async () => {
   // Test for regression of issue #21907: "integer part of floating point value out of bounds"
   // This was causing crashes on Windows when processing TailwindCSS with rounded-full class
 
-  const dir = tempDirWithFiles("css-large-float-regression", {
+  await using dir = tempDir("css-large-float-regression", {
     "input.css": `
 /* Tests intFromFloat(i32, value) in serializeDimension */
 .test-rounded-full {

--- a/test/regression/issue/22317.test.ts
+++ b/test/regression/issue/22317.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { join } from "node:path";
 
 // Regression test for https://github.com/oven-sh/bun/issues/22317
@@ -7,7 +7,7 @@ import { join } from "node:path";
 // entry points alongside multiple JS/TS entry points. This happens when glob
 // expansion (e.g. ./public/**/*) includes CSS files.
 test("issue 22317: build with CSS file entry points mixed with JS should not crash", async () => {
-  const dir = tempDirWithFiles("22317", {
+  await using dir = tempDir("22317", {
     "src/index.ts": `console.log("main");`,
     "src/server.worker.ts": `console.log("worker");`,
     "public/assets/index.css": `body { color: red; }`,

--- a/test/regression/issue/23649.test.ts
+++ b/test/regression/issue/23649.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/23649
 test("parser should not crash with assertion error on invalid async function syntax", async () => {
   // This used to cause: panic(main thread): reached unreachable code
   // when parsing invalid syntax where async function appears after missing comma
-  const dir = tempDirWithFiles("parser-assertion", {
+  await using dir = tempDir("parser-assertion", {
     "input.js": `
 const object = {
   a(el) {
@@ -66,7 +66,7 @@ const object = {
 
 test("parser should not crash with assertion error on labeled async function statement", async () => {
   // Similar case: labeled statement with async function
-  const dir = tempDirWithFiles("parser-assertion-label", {
+  await using dir = tempDir("parser-assertion-label", {
     "input.js": `
 b: async function(first) {
 }

--- a/test/regression/issue/24502/bun-pm-ls-all-invalid-package-id.test.ts
+++ b/test/regression/issue/24502/bun-pm-ls-all-invalid-package-id.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, runBunInstall, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, runBunInstall, tempDir } from "harness";
 
 test("unresolved optional peers don't crash", async () => {
-  const testDir = tempDirWithFiles("unresolved-optional-peer", {
+  await using testDir = tempDir("unresolved-optional-peer", {
     "package.json": JSON.stringify({
       name: "pkg",
       peerDependencies: {

--- a/test/regression/issue/25716.test.ts
+++ b/test/regression/issue/25716.test.ts
@@ -1,11 +1,11 @@
 // https://github.com/oven-sh/bun/issues/25716
 // Expose `--react-fast-refresh` option in `Bun.build` JS API
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { join } from "path";
 
 test.each(["browser", "bun"] as const)("Bun.build reactFastRefresh works with target: %s", async target => {
-  const dir = tempDirWithFiles("react-fast-refresh-test", {
+  await using dir = tempDir("react-fast-refresh-test", {
     "component.tsx": `
       import { useState } from "react";
 

--- a/test/regression/issue/25794.test.ts
+++ b/test/regression/issue/25794.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("CSS logical properties should not be stripped when nested rules are present", async () => {
   // Test for regression of issue #25794: CSS logical properties (e.g., inset-inline-end)
   // are stripped from bundler output when they appear in a nested selector that also
   // contains further nested rules (like pseudo-elements).
 
-  const dir = tempDirWithFiles("css-logical-properties-nested", {
+  await using dir = tempDir("css-logical-properties-nested", {
     "input.css": `.test-longform {
   background-color: teal;
 

--- a/test/regression/issue/26207.test.ts
+++ b/test/regression/issue/26207.test.ts
@@ -4,10 +4,10 @@
 
 import { expect, test } from "bun:test";
 import { chmodSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 test("bun run --workspaces creates node symlink when NODE env points to non-existent path", async () => {
-  const dir = tempDirWithFiles("workspaces-node-fallback", {
+  await using dir = tempDir("workspaces-node-fallback", {
     "package.json": JSON.stringify({
       name: "root",
       workspaces: ["packages/*"],
@@ -43,7 +43,7 @@ test("bun run --workspaces creates node symlink when NODE env points to non-exis
 });
 
 test("bun run --filter creates node symlink when NODE env points to non-existent path", async () => {
-  const dir = tempDirWithFiles("filter-node-fallback", {
+  await using dir = tempDir("filter-node-fallback", {
     "package.json": JSON.stringify({
       name: "root",
       workspaces: ["packages/*"],
@@ -80,7 +80,7 @@ test("bun run --filter creates node symlink when NODE env points to non-existent
 
 // Skip on Windows: shebang scripts (#!/usr/bin/env node) are Unix-specific
 test.skipIf(isWindows)("bun run --workspaces runs scripts that have #!/usr/bin/env node shebang", async () => {
-  const dir = tempDirWithFiles("workspaces-shebang", {
+  await using dir = tempDir("workspaces-shebang", {
     "package.json": JSON.stringify({
       name: "root",
       workspaces: ["packages/*"],

--- a/test/regression/issue/26647.test.ts
+++ b/test/regression/issue/26647.test.ts
@@ -2,13 +2,13 @@
 // Issue: https://github.com/oven-sh/bun/issues/26647
 import { expect, test } from "bun:test";
 import { existsSync, statSync } from "fs";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { join } from "path";
 
 // Test case: German umlaut characters
 test("Bun.file().stat() should handle UTF-8 paths with German umlauts", async () => {
   const content = "test content for umlaut file";
-  const dir = tempDirWithFiles("utf8-german-umlaut", {
+  await using dir = tempDir("utf8-german-umlaut", {
     "über café résumé.txt": content,
   });
   const filepath = join(dir, "über café résumé.txt");
@@ -29,7 +29,7 @@ test("Bun.file().stat() should handle UTF-8 paths with German umlauts", async ()
 // Test case: Japanese characters
 test("Bun.file().stat() should handle UTF-8 paths with Japanese characters", async () => {
   const content = "Japanese content";
-  const dir = tempDirWithFiles("utf8-japanese", {
+  await using dir = tempDir("utf8-japanese", {
     "日本語ファイル.txt": content,
   });
   const filepath = join(dir, "日本語ファイル.txt");
@@ -43,7 +43,7 @@ test("Bun.file().stat() should handle UTF-8 paths with Japanese characters", asy
 // Test case: Emoji characters
 test("Bun.file().stat() should handle UTF-8 paths with emoji", async () => {
   const content = "emoji file";
-  const dir = tempDirWithFiles("utf8-emoji", {
+  await using dir = tempDir("utf8-emoji", {
     "🌟.txt": content,
   });
   const filepath = join(dir, "🌟.txt");
@@ -57,7 +57,7 @@ test("Bun.file().stat() should handle UTF-8 paths with emoji", async () => {
 // Test case: Mixed special characters
 test("Bun.file().stat() should handle UTF-8 paths with mixed special characters", async () => {
   const content = "mixed content";
-  const dir = tempDirWithFiles("utf8-mixed", {
+  await using dir = tempDir("utf8-mixed", {
     "café_résumé_ñ_test.md": content,
   });
   const filepath = join(dir, "café_résumé_ñ_test.md");
@@ -70,7 +70,7 @@ test("Bun.file().stat() should handle UTF-8 paths with mixed special characters"
 
 // Test that .delete() also works with UTF-8 paths
 test("Bun.file().delete() should handle UTF-8 paths", async () => {
-  const dir = tempDirWithFiles("utf8-unlink", {
+  await using dir = tempDir("utf8-unlink", {
     "delete_üñíçödé.txt": "delete me",
   });
   const filepath = join(dir, "delete_üñíçödé.txt");
@@ -87,7 +87,7 @@ test("Bun.file().delete() should handle UTF-8 paths", async () => {
 // Test .text() to ensure it still works (this uses a different code path)
 test("Bun.file().text() should handle UTF-8 paths with special characters", async () => {
   const content = "content with umlauts: äöü";
-  const dir = tempDirWithFiles("utf8-text", {
+  await using dir = tempDir("utf8-text", {
     "read_äöü.txt": content,
   });
   const filepath = join(dir, "read_äöü.txt");

--- a/test/regression/issue/29787.test.ts
+++ b/test/regression/issue/29787.test.ts
@@ -33,11 +33,11 @@
 // bytes round-trip and the final `done` comes from the parent's real
 // `stdin.end()`.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { pathToFileURL } from "node:url";
 
 test("stdin stream stays open while concurrent fetch(file://) bodies finish (#29787)", async () => {
-  const dir = tempDirWithFiles("issue-29787-stdin-race", {
+  await using dir = tempDir("issue-29787-stdin-race", {
     "data.bin": Buffer.alloc(4096, 0x41).toString(),
   });
   const fileUrl = pathToFileURL(`${dir}/data.bin`).href;

--- a/test/regression/issue/3657.test.ts
+++ b/test/regression/issue/3657.test.ts
@@ -2,13 +2,13 @@
 // fs.watch on a directory should emit 'change' events for files created after the watch is established
 
 import { describe, expect, test } from "bun:test";
-import { isLinux, tempDirWithFiles } from "harness";
+import { isLinux, tempDir } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 
 describe.skipIf(!isLinux)("GitHub Issue #3657", () => {
   test("fs.watch on directory emits 'change' events for files created after watch starts", async () => {
-    const testDir = tempDirWithFiles("issue-3657", {});
+    await using testDir = tempDir("issue-3657", {});
     const testFile = path.join(testDir, "test.txt");
 
     const events: Array<{ eventType: string; filename: string | null }> = [];
@@ -57,7 +57,7 @@ describe.skipIf(!isLinux)("GitHub Issue #3657", () => {
   });
 
   test("fs.watch emits multiple 'change' events for repeated modifications", async () => {
-    const testDir = tempDirWithFiles("issue-3657-multi", {});
+    await using testDir = tempDir("issue-3657-multi", {});
     const testFile = path.join(testDir, "multi.txt");
 
     const events: Array<{ eventType: string; filename: string | null }> = [];

--- a/test/regression/issue/5228.test.js
+++ b/test/regression/issue/5228.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Test for issue #5228: Implement xit, xtest, xdescribe aliases for test.skip
 test("xit, xtest, and xdescribe aliases should work as test.skip/describe.skip", async () => {
@@ -34,7 +34,7 @@ describe("normal describe block", () => {
 });
 `;
 
-  const dir = tempDirWithFiles("issue-5228-test-1", {
+  await using dir = tempDir("issue-5228-test-1", {
     "test.js": testFile,
   });
 
@@ -78,7 +78,7 @@ test("passing test", () => {
 });
 `;
 
-  const dir = tempDirWithFiles("issue-5228-test-2", {
+  await using dir = tempDir("issue-5228-test-2", {
     "test.js": testFile,
   });
 
@@ -129,7 +129,7 @@ describe("normal describe", () => {
 });
 `;
 
-  const dir = tempDirWithFiles("issue-5228-test-3", {
+  await using dir = tempDir("issue-5228-test-3", {
     "test.js": testFile,
   });
 
@@ -180,7 +180,7 @@ xdescribe("imported xdescribe should work", () => {
 });
 `;
 
-  const dir = tempDirWithFiles("issue-5228-test-4", {
+  await using dir = tempDir("issue-5228-test-4", {
     "test.js": testFile,
   });
 

--- a/test/regression/issue/comma-operator-this-binding.test.ts
+++ b/test/regression/issue/comma-operator-this-binding.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("comma operator should strip 'this' binding in function calls", async () => {
-  const dir = tempDirWithFiles("comma-operator-test", {
+  await using dir = tempDir("comma-operator-test", {
     "test.js": `
 const doThing = () => {};
 

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -1,9 +1,9 @@
 import { beforeAll, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 test.skipIf(isWindows)("verify that we can call sigint 4096 times", () => {
-  const dir = tempDirWithFiles("ctrlc", {
+  using dir = tempDir("ctrlc", {
     "index.js": /*js*/ `
       let count = 0;
         process.exitCode = 1;
@@ -46,7 +46,7 @@ test.skipIf(isWindows)("verify that we can call sigint 4096 times", () => {
 });
 
 test.skipIf(isWindows)("verify that we forward SIGINT from parent to child in bun run", () => {
-  const dir = tempDirWithFiles("ctrlc", {
+  using dir = tempDir("ctrlc", {
     "index.js": `
       let count = 0;
       process.exitCode = 1;

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 test("cyclic imports with async dependencies should generate async wrappers", async () => {
-  const dir = tempDirWithFiles("cyclic-imports-async", {
+  await using dir = tempDir("cyclic-imports-async", {
     "build.ts": `
       import { build } from "bun";
       build({

--- a/test/regression/issue/hashbang-still-works.test.ts
+++ b/test/regression/issue/hashbang-still-works.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 describe.concurrent("hashbang-still-works", () => {
   test("hashbang still works after bounds check fix", async () => {
-    const dir = tempDirWithFiles("hashbang", {
+    await using dir = tempDir("hashbang", {
       "script.js": "#!/usr/bin/env bun\nconsole.log('hello');",
     });
 
@@ -25,7 +25,7 @@ describe.concurrent("hashbang-still-works", () => {
   });
 
   test("lexer handles single # character without bounds error", async () => {
-    const dir = tempDirWithFiles("single-hash", {
+    await using dir = tempDir("single-hash", {
       "single-hash.js": "#",
     });
 
@@ -43,7 +43,7 @@ describe.concurrent("hashbang-still-works", () => {
   });
 
   test("lexer should not crash on single # character", async () => {
-    const dir = tempDirWithFiles("single-hash", {
+    await using dir = tempDir("single-hash", {
       "single-hash.js": "#",
     });
 

--- a/test/regression/issue/malformed-integrity-base64.test.ts
+++ b/test/regression/issue/malformed-integrity-base64.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 test("malformed integrity base64 in lockfile should be handled gracefully", async () => {
-  const dir = tempDirWithFiles("malformed-integrity-test", {
+  await using dir = tempDir("malformed-integrity-test", {
     "package.json": JSON.stringify({
       name: "test-malformed-integrity",
       version: "1.0.0",

--- a/test/regression/issue/patch-bounds-check.test.ts
+++ b/test/regression/issue/patch-bounds-check.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDir } from "harness";
 
 const normalizeBunSnapshot = (str: string) => {
   str = normalizeBunSnapshot_(str);
@@ -10,7 +10,7 @@ const normalizeBunSnapshot = (str: string) => {
 };
 
 test("patch application should handle out-of-bounds line numbers gracefully", async () => {
-  const dir = tempDirWithFiles("patch-bounds-test", {
+  await using dir = tempDir("patch-bounds-test", {
     "package.json": JSON.stringify({
       name: "test-pkg",
       version: "1.0.0",
@@ -51,7 +51,7 @@ test("patch application should handle out-of-bounds line numbers gracefully", as
 });
 
 test("patch application should handle deletion beyond file bounds", async () => {
-  const dir = tempDirWithFiles("patch-deletion-bounds-test", {
+  await using dir = tempDir("patch-deletion-bounds-test", {
     "package.json": JSON.stringify({
       name: "test-pkg",
       version: "1.0.0",
@@ -93,7 +93,7 @@ test("patch application should handle deletion beyond file bounds", async () => 
 });
 
 test("patch application should work correctly with valid patches", async () => {
-  const dir = tempDirWithFiles("patch-valid-test", {
+  await using dir = tempDir("patch-valid-test", {
     "package.json": JSON.stringify({
       name: "test-pkg",
       version: "1.0.0",

--- a/test/regression/issue/test_env_loader_threading.test.ts
+++ b/test/regression/issue/test_env_loader_threading.test.ts
@@ -1,9 +1,9 @@
 import { spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunExe, tempDirWithFiles } from "harness";
+import { bunExe, tempDir } from "harness";
 
 test("env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO", async () => {
-  const dir = tempDirWithFiles("env-loader-threading", {
+  await using dir = tempDir("env-loader-threading", {
     ".env": "TEST_ENV_VAR=hello_world",
     "index.js": `console.log(process.env.TEST_ENV_VAR || 'undefined');`,
   });

--- a/test/regression/issue/update-interactive-formatting.test.ts
+++ b/test/regression/issue/update-interactive-formatting.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("bun update --interactive formatting regression", () => {
   it("should not underflow when dependency type text is longer than available space", async () => {
     // This test verifies the fix for the padding calculation underflow issue
     // in lines 745-750 of update_interactive_command.zig
-    const dir = tempDirWithFiles("formatting-regression-test", {
+    await using dir = tempDir("formatting-regression-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -44,7 +44,7 @@ describe("bun update --interactive formatting regression", () => {
   it("should handle dev tag length calculation correctly", async () => {
     // This test verifies that dev/peer/optional tags are properly accounted for
     // in the column width calculations
-    const dir = tempDirWithFiles("dev-tag-formatting-test", {
+    await using dir = tempDir("dev-tag-formatting-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -92,7 +92,7 @@ describe("bun update --interactive formatting regression", () => {
   it("should truncate extremely long package names without crashing", async () => {
     // This test verifies that package names longer than MAX_NAME_WIDTH (60) are handled
     const longPackageName = "extremely-long-package-name-that-exceeds-maximum-width-and-should-be-truncated";
-    const dir = tempDirWithFiles("truncate-test", {
+    await using dir = tempDir("truncate-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -132,7 +132,7 @@ describe("bun update --interactive formatting regression", () => {
   it("should handle long version strings without formatting issues", async () => {
     // This test verifies that version strings longer than MAX_VERSION_WIDTH (20) are handled
     const longVersion = "1.0.0-alpha.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.17.18.19.20.21.22.23.24.25";
-    const dir = tempDirWithFiles("long-version-test", {
+    await using dir = tempDir("long-version-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
@@ -174,7 +174,7 @@ describe("bun update --interactive formatting regression", () => {
     const maxWidthPackage = "a".repeat(60); // MAX_NAME_WIDTH
     const maxWidthVersion = "1.0.0-" + "a".repeat(15); // MAX_VERSION_WIDTH
 
-    const dir = tempDirWithFiles("max-width-test", {
+    await using dir = tempDir("max-width-test", {
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",

--- a/test/regression/issue/utf16-encoding-crash.test.ts
+++ b/test/regression/issue/utf16-encoding-crash.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import fs from "fs";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 
 // Test cases that verify Bun's UTF-16le behavior matches Node.js exactly
 const testCases = [
@@ -35,7 +35,7 @@ test("fs.readFile with utf16le encoding matches Node.js behavior for all byte le
     files[`test-${i}.bin`] = Buffer.from(testCase.bytes);
   });
 
-  const dir = tempDirWithFiles("utf16-node-compatibility", files);
+  using dir = tempDir("utf16-node-compatibility", files);
 
   testCases.forEach((testCase, i) => {
     const filePath = `${dir}/test-${i}.bin`;
@@ -53,7 +53,7 @@ test("fs.readFile with utf16le encoding matches Node.js behavior for all byte le
 });
 
 test("fs.readFile with ucs2 encoding matches utf16le behavior", () => {
-  const dir = tempDirWithFiles("ucs2-compatibility", {
+  using dir = tempDir("ucs2-compatibility", {
     "test.bin": Buffer.from([0x41, 0x42, 0x43]), // 3 bytes
   });
 


### PR DESCRIPTION
### What does this PR do?

Mechanically converts ~700 `const dir = tempDirWithFiles(...)` declarations that sit directly inside `test`/`it` callbacks to `await using dir = tempDir(...)` (async callbacks) or `using dir = tempDir(...)` (sync), so temp directories are removed when the test scope exits instead of leaking under `os.tmpdir()`.

`tempDir()` returns a `String` object (`DisposableString`), so call sites hitting `typeof x === "string"` checks are wrapped in `String(...)`:

| Sink | Behavior with a `String` object |
| --- | --- |
| `===`, `expect().toBe/toEqual/toContain` | mismatch / matcher error |
| `process.chdir`, `child_process` `cwd`, `cwdScope` | throws |
| `new $.Shell().cwd()` | throws |
| `glob.scan(dir)` | silently parsed as an options bag |

Deliberately left alone: module/`describe`/`beforeAll`-scope dirs, helper functions, `let`/reassignments, sync callbacks that return a promise or take `done`, and a loop in `bun-install-proxy.test.ts` that awaits after the loop body.

### How did you verify your code works?

`USE_SYSTEM_BUN=1 bun test --parallel --bail` over all 141 changed files against `1.4.0-canary.1+d54984555` (matches base commit). One residual: a `--parallel` worker crash (`preload not found`) on `bun-listen-connect-args.test.ts` that doesn't reproduce alone, in ordered pairs, or in small parallel batches — watching CI for it.