### PR TITLE
Intl.Collator: honor locale-tailored caseFirst default (da, mt)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-365-964a64fa";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -138,6 +138,43 @@ describe("Intl.Collator", () => {
     expect(c.compare("a", "á")).toBe(0);
     expect(c.compare("a", "b")).toBeLessThan(0);
   });
+
+  describe("caseFirst honors the locale's CLDR default", () => {
+    // da and mt tailor [caseFirst upper] in CLDR: uppercase sorts before lowercase
+    // when no caseFirst option / -u-kf- extension is supplied. Previously Bun forced
+    // UCOL_CASE_FIRST=OFF unconditionally, clobbering that default.
+    test.each(["da", "mt"])("%s defaults to caseFirst:'upper'", loc => {
+      const c = new Intl.Collator(loc);
+      expect(c.resolvedOptions().caseFirst).toBe("upper");
+      expect(c.compare("a", "A")).toBe(1);
+      expect(["apple", "Apple", "APPLE"].sort(c.compare)).toEqual(["APPLE", "Apple", "apple"]);
+    });
+
+    test("en still defaults to caseFirst:'false'", () => {
+      const c = new Intl.Collator("en");
+      expect(c.resolvedOptions().caseFirst).toBe("false");
+      expect(c.compare("a", "A")).toBe(-1);
+      expect(["apple", "Apple", "APPLE"].sort(c.compare)).toEqual(["apple", "Apple", "APPLE"]);
+    });
+
+    test("explicit caseFirst option overrides the locale default", () => {
+      expect(new Intl.Collator("da", { caseFirst: "false" }).resolvedOptions().caseFirst).toBe("false");
+      expect(new Intl.Collator("da", { caseFirst: "false" }).compare("a", "A")).toBe(-1);
+      expect(new Intl.Collator("en", { caseFirst: "upper" }).resolvedOptions().caseFirst).toBe("upper");
+      expect(new Intl.Collator("en", { caseFirst: "upper" }).compare("a", "A")).toBe(1);
+    });
+
+    test("-u-kf- extension overrides the locale default", () => {
+      const c = new Intl.Collator("da-u-kf-false");
+      expect(c.resolvedOptions().caseFirst).toBe("false");
+      expect(c.compare("a", "A")).toBe(-1);
+    });
+
+    test("String.prototype.localeCompare picks up the locale default", () => {
+      expect("a".localeCompare("A", "da")).toBe(1);
+      expect("a".localeCompare("A", "en")).toBe(-1);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Depends on oven-sh/WebKit#365 (the load-bearing fix). This PR bumps `WEBKIT_VERSION` to that PR's preview build and adds regression coverage; it will switch to the merged main sha before landing.

## Repro

```js
for (const loc of ["da", "mt", "en"]) {
  const c = new Intl.Collator(loc);
  console.log(loc, c.resolvedOptions().caseFirst, c.compare("a", "A"),
    ["apple","Apple","APPLE"].sort(c.compare));
}
console.log("a".localeCompare("A", "da"));
// bun : da "false" -1 [apple,Apple,APPLE] | mt "false" -1 [...] | en "false" -1 | -1
// node: da "upper"  1 [APPLE,Apple,apple] | mt "upper"  1 [...] | en "false" -1 |  1
```

## Cause

CLDR's collation data for `da` (Danish) and `mt` (Maltese) specifies `[caseFirst upper]`: uppercase sorts before lowercase by default. JSC's `IntlCollator::initializeCollator` called `ucol_setAttribute(UCOL_CASE_FIRST, UCOL_OFF)` unconditionally when no `caseFirst` option or `-u-kf-` extension was supplied, overwriting the locale tailoring, and `resolvedOptions().caseFirst` was derived only from the option/extension (never from the opened collator).

## Fix

`resolveLocale` already leaves the `Kf` extension as a null `String` when neither an option nor a Unicode extension requests a value. oven-sh/WebKit#365 checks for that null and:

* skips the `ucol_setAttribute(UCOL_CASE_FIRST, ...)` call so the tailored default stays in effect, and
* reads `ucol_getAttribute(UCOL_CASE_FIRST)` back into `m_caseFirst` so `resolvedOptions()` and the ASCII-comparison fast-path gate see the real value.

This mirrors the existing `UCOL_ALTERNATE_HANDLING` / `m_ignorePunctuation` read-back in the same function. An explicit `{ caseFirst: "false" }` or `-u-kf-false` still forces `UCOL_OFF` as before.

## Verification

Built `vendor/WebKit` at `549170099226` + the patch with `bun run build:local`:

```
(pass) Intl.Collator > caseFirst honors the locale's CLDR default > da defaults to caseFirst:'upper'
(pass) Intl.Collator > caseFirst honors the locale's CLDR default > mt defaults to caseFirst:'upper'
(pass) Intl.Collator > caseFirst honors the locale's CLDR default > en still defaults to caseFirst:'false'
(pass) Intl.Collator > caseFirst honors the locale's CLDR default > explicit caseFirst option overrides the locale default
(pass) Intl.Collator > caseFirst honors the locale's CLDR default > -u-kf- extension overrides the locale default
(pass) Intl.Collator > caseFirst honors the locale's CLDR default > String.prototype.localeCompare picks up the locale default
 37 pass / 0 fail
```

The `da`, `mt` and `localeCompare` cases fail against the current release (`USE_SYSTEM_BUN=1`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->