### PR TITLE
shell: reject unsupported reserved words (while/for/until/case/!/{/...}) at parse time

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -409,7 +409,9 @@ pub(crate) fn shell_escape(
 
     let mut outbuf: Vec<u8> = Vec::new();
 
-    if bun_shell_parser::needs_escape_bunstr(*bunstr) {
+    if bun_shell_parser::needs_escape_bunstr(*bunstr)
+        || bun_shell_parser::parse::is_reserved_word_bunstr(*bunstr)
+    {
         let result = bun_shell_parser::escape_bun_str::<true>(*bunstr, &mut outbuf)?;
         if !result {
             return Err(global_this.throw(format_args!(

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -28,8 +28,8 @@ pub use super::subproc; // declared once in `shell/mod.rs`
 // (ShellErr, GlobalJS/Mini, shell_cmd_from_js, ShellSrcBuilder, TestingAPIs).
 pub use bun_shell_parser::parse::{
     IfClauseTok, LEX_JS_OBJREF_PREFIX, LEX_JS_STRING_PREFIX, LexerAscii, LexerUnicode, ParseError,
-    Parser, Token, ast, is_if_clause_keyword_bunstr, is_reserved_word_bunstr, is_reserved_word_text,
-    needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
+    Parser, Token, ast, is_if_clause_keyword_bunstr, is_reserved_word_bunstr,
+    is_reserved_word_text, needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
 };
 
 pub const WINDOWS_DEV_NULL: &ZStr = bun_core::zstr!("NUL");

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -27,9 +27,9 @@ pub use super::subproc; // declared once in `shell/mod.rs`
 // (still-draft) JSC bridge below. This file keeps the JSC-coupled half
 // (ShellErr, GlobalJS/Mini, shell_cmd_from_js, ShellSrcBuilder, TestingAPIs).
 pub use bun_shell_parser::parse::{
-    IfClauseTok, LEX_JS_OBJREF_PREFIX, LEX_JS_STRING_PREFIX, LexerAscii, LexerUnicode, ParseError,
-    Parser, Token, ast, is_if_clause_keyword_bunstr, is_reserved_word_bunstr,
-    is_reserved_word_text, needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
+    LEX_JS_OBJREF_PREFIX, LEX_JS_STRING_PREFIX, LexerAscii, LexerUnicode, ParseError, Parser,
+    Token, ast, is_reserved_word_bunstr, is_reserved_word_text, needs_escape_bunstr,
+    needs_escape_utf8_ascii_latin1,
 };
 
 pub const WINDOWS_DEV_NULL: &ZStr = bun_core::zstr!("NUL");

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -28,8 +28,8 @@ pub use super::subproc; // declared once in `shell/mod.rs`
 // (ShellErr, GlobalJS/Mini, shell_cmd_from_js, ShellSrcBuilder, TestingAPIs).
 pub use bun_shell_parser::parse::{
     IfClauseTok, LEX_JS_OBJREF_PREFIX, LEX_JS_STRING_PREFIX, LexerAscii, LexerUnicode, ParseError,
-    Parser, Token, ast, is_if_clause_keyword_bunstr, needs_escape_bunstr,
-    needs_escape_utf8_ascii_latin1,
+    Parser, Token, ast, is_if_clause_keyword_bunstr, is_reserved_word_bunstr, is_reserved_word_text,
+    needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
 };
 
 pub const WINDOWS_DEV_NULL: &ZStr = bun_core::zstr!("NUL");
@@ -611,7 +611,7 @@ impl<'a> ShellSrcBuilder<'a> {
             // `needs_escape_bunstr` is true for empty strings: `${''}` must still
             // produce an argument. Routing through appendJSStrRef makes the \x08
             // marker recognized regardless of quote context (e.g. inside single quotes).
-            if needs_escape_bunstr(bunstr) || is_if_clause_keyword_bunstr(bunstr) {
+            if needs_escape_bunstr(bunstr) || is_reserved_word_bunstr(bunstr) {
                 self.append_js_str_ref(bunstr)?;
                 return Ok(true);
             }
@@ -635,7 +635,7 @@ impl<'a> ShellSrcBuilder<'a> {
             return Ok(false);
         }
         if ALLOW_ESCAPE {
-            if needs_escape_utf8_ascii_latin1(utf8) || IfClauseTok::from_text(utf8).is_some() {
+            if needs_escape_utf8_ascii_latin1(utf8) || is_reserved_word_text(utf8) {
                 let bunstr = OwnedString::new(BunString::clone_utf8(utf8));
                 self.append_js_str_ref(bunstr.get())?;
                 return Ok(true);

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1956,7 +1956,16 @@ struct ParsedRedirect<'bump> {
 /// `{`/`}` arrive as `BraceBegin`/`BraceEnd` tokens and are checked on that
 /// path; `in` is omitted because it is only reserved inside `for`/`case`.
 const UNSUPPORTED_RESERVED_WORDS: &[&[u8]] = &[
-    b"!", b"while", b"until", b"for", b"do", b"done", b"case", b"esac", b"select", b"function",
+    b"!",
+    b"while",
+    b"until",
+    b"for",
+    b"do",
+    b"done",
+    b"case",
+    b"esac",
+    b"select",
+    b"function",
 ];
 
 pub fn is_unsupported_reserved_word(txt: &[u8]) -> bool {

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -998,6 +998,33 @@ impl<'bump> Parser<'bump> {
             _ => {}
         }
 
+        if let Token::Text(range) = self.peek() {
+            if self.delimits(self.peek_n(1))
+                && !self.is_interpolated_position(range.start)
+                && is_unsupported_reserved_word(self.text(range))
+            {
+                self.add_error(format_args!(
+                    "\"{}\" is a reserved shell keyword that Bun Shell does not support yet.",
+                    bstr::BStr::new(self.text(range))
+                ))?;
+                return Err(ParseError::Unsupported.into());
+            }
+        }
+
+        if matches!(self.peek().tag(), TokenTag::BraceBegin | TokenTag::BraceEnd)
+            && self.delimits(self.peek_n(1))
+        {
+            let word: &str = if self.peek().tag() == TokenTag::BraceBegin {
+                "{"
+            } else {
+                "}"
+            };
+            self.add_error(format_args!(
+                "\"{word}\" is a reserved shell keyword that Bun Shell does not support yet."
+            ))?;
+            return Err(ParseError::Unsupported.into());
+        }
+
         self.parse_simple_cmd()?
             .to_expr(self.alloc)
             .map_err(Into::into)
@@ -1916,6 +1943,24 @@ fn join_error_msgs<'bump>(
 struct ParsedRedirect<'bump> {
     flags: ast::RedirectFlags,
     redirect: Option<ast::Redirect<'bump>>,
+}
+
+/// Reserved words whose constructs Bun Shell does not implement yet. If one of
+/// these reaches `parse_compound_cmd` in command position (a bare, delimited
+/// `.Text` token, not quoted, not from a JS-interpolated string), the parse
+/// fails up front instead of falling through to `parse_simple_cmd`, where the
+/// word would be dispatched as an external command while the surrounding
+/// statements still execute.
+///
+/// `if`/`then`/`elif`/`else`/`fi` and `[[`/`]]` are recognized separately;
+/// `{`/`}` arrive as `BraceBegin`/`BraceEnd` tokens and are checked on that
+/// path; `in` is omitted because it is only reserved inside `for`/`case`.
+const UNSUPPORTED_RESERVED_WORDS: &[&[u8]] = &[
+    b"!", b"while", b"until", b"for", b"do", b"done", b"case", b"esac", b"select", b"function",
+];
+
+pub fn is_unsupported_reserved_word(txt: &[u8]) -> bool {
+    UNSUPPORTED_RESERVED_WORDS.iter().any(|&w| txt == w)
 }
 
 /// We make it so that `if`/`else`/`elif`/`then`/`fi` need to be single,
@@ -4112,6 +4157,23 @@ pub fn is_if_clause_keyword_bunstr(bunstr: BunString) -> bool {
     [If, Else, Elif, Then, Fi]
         .iter()
         .any(|&kw| bunstr.eql_comptime(<&'static str>::from(kw)))
+}
+
+/// True for any text the parser treats specially when it appears as a bare
+/// delimited word in command position: the implemented `if`-clause keywords
+/// plus the `UNSUPPORTED_RESERVED_WORDS` that `parse_compound_cmd` rejects.
+/// Template-literal interpolation uses this to route such values through
+/// `append_js_str_ref` so they land in `js_string_ranges` and the parser sees
+/// them as data, not syntax.
+pub fn is_reserved_word_text(txt: &[u8]) -> bool {
+    IfClauseTok::from_text(txt).is_some() || is_unsupported_reserved_word(txt)
+}
+
+pub fn is_reserved_word_bunstr(bunstr: BunString) -> bool {
+    is_if_clause_keyword_bunstr(bunstr)
+        || UNSUPPORTED_RESERVED_WORDS
+            .iter()
+            .any(|&w| bunstr.eql_comptime(core::str::from_utf8(w).expect("ascii table")))
 }
 
 // ───────────────────────────── SmolList ─────────────────────────────

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1945,9 +1945,7 @@ struct ParsedRedirect<'bump> {
     redirect: Option<ast::Redirect<'bump>>,
 }
 
-/// Reserved words `parse_compound_cmd` rejects so they are not dispatched as
-/// external commands. `{`/`}` lex as `BraceBegin`/`BraceEnd` and are handled
-/// there; `in` is only reserved inside `for`/`case` so it is omitted.
+/// Reserved words `parse_compound_cmd` rejects instead of dispatching as commands.
 const UNSUPPORTED_RESERVED_WORDS: &[&[u8]] = &[
     b"!",
     b"while",
@@ -4161,9 +4159,6 @@ pub fn is_if_clause_keyword_bunstr(bunstr: BunString) -> bool {
         .any(|&kw| bunstr.eql_comptime(<&'static str>::from(kw)))
 }
 
-/// `if`-clause keywords plus `UNSUPPORTED_RESERVED_WORDS`: every word
-/// `parse_compound_cmd` treats as syntax when it appears bare in command
-/// position.
 pub fn is_reserved_word_text(txt: &[u8]) -> bool {
     IfClauseTok::from_text(txt).is_some() || is_unsupported_reserved_word(txt)
 }

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1945,16 +1945,9 @@ struct ParsedRedirect<'bump> {
     redirect: Option<ast::Redirect<'bump>>,
 }
 
-/// Reserved words whose constructs Bun Shell does not implement yet. If one of
-/// these reaches `parse_compound_cmd` in command position (a bare, delimited
-/// `.Text` token, not quoted, not from a JS-interpolated string), the parse
-/// fails up front instead of falling through to `parse_simple_cmd`, where the
-/// word would be dispatched as an external command while the surrounding
-/// statements still execute.
-///
-/// `if`/`then`/`elif`/`else`/`fi` and `[[`/`]]` are recognized separately;
-/// `{`/`}` arrive as `BraceBegin`/`BraceEnd` tokens and are checked on that
-/// path; `in` is omitted because it is only reserved inside `for`/`case`.
+/// Reserved words `parse_compound_cmd` rejects so they are not dispatched as
+/// external commands. `{`/`}` lex as `BraceBegin`/`BraceEnd` and are handled
+/// there; `in` is only reserved inside `for`/`case` so it is omitted.
 const UNSUPPORTED_RESERVED_WORDS: &[&[u8]] = &[
     b"!",
     b"while",
@@ -4168,12 +4161,9 @@ pub fn is_if_clause_keyword_bunstr(bunstr: BunString) -> bool {
         .any(|&kw| bunstr.eql_comptime(<&'static str>::from(kw)))
 }
 
-/// True for any text the parser treats specially when it appears as a bare
-/// delimited word in command position: the implemented `if`-clause keywords
-/// plus the `UNSUPPORTED_RESERVED_WORDS` that `parse_compound_cmd` rejects.
-/// Template-literal interpolation uses this to route such values through
-/// `append_js_str_ref` so they land in `js_string_ranges` and the parser sees
-/// them as data, not syntax.
+/// `if`-clause keywords plus `UNSUPPORTED_RESERVED_WORDS`: every word
+/// `parse_compound_cmd` treats as syntax when it appears bare in command
+/// position.
 pub fn is_reserved_word_text(txt: &[u8]) -> bool {
     IfClauseTok::from_text(txt).is_some() || is_unsupported_reserved_word(txt)
 }

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1960,7 +1960,7 @@ const UNSUPPORTED_RESERVED_WORDS: &[&[u8]] = &[
 ];
 
 pub fn is_unsupported_reserved_word(txt: &[u8]) -> bool {
-    UNSUPPORTED_RESERVED_WORDS.iter().any(|&w| txt == w)
+    UNSUPPORTED_RESERVED_WORDS.contains(&txt)
 }
 
 /// We make it so that `if`/`else`/`elif`/`then`/`fi` need to be single,

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -2377,9 +2377,7 @@ done`
     .error(msg("for"))
     .runAsTest("for-in body does not run with empty loop var");
 
-  TestBuilder.command`until true; do echo body; done`
-    .error(msg("until"))
-    .runAsTest("until loop is rejected");
+  TestBuilder.command`until true; do echo body; done`.error(msg("until")).runAsTest("until loop is rejected");
 
   TestBuilder.command`! echo hi`.error(msg("!")).runAsTest("pipeline negation is rejected");
 
@@ -2397,7 +2395,9 @@ done`
     .error(msg("while"))
     .runAsTest("reserved word inside if-else body is rejected");
 
-  TestBuilder.command`echo whilex`.stdout("whilex\n").runAsTest("reserved-word prefix of a longer word is not reserved");
+  TestBuilder.command`echo whilex`
+    .stdout("whilex\n")
+    .runAsTest("reserved-word prefix of a longer word is not reserved");
 
   TestBuilder.command`echo while${"x"}`
     .stdout("whilex\n")

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -2420,12 +2420,14 @@ done`
     .error(msg("while"))
     .runAsTest("reserved word inside if-else body is rejected");
 
-  TestBuilder.command`echo whilex`
-    .stdout("whilex\n")
+  TestBuilder.command`whilex`
+    .stderr("bun: command not found: whilex\n")
+    .exitCode(1)
     .runAsTest("reserved-word prefix of a longer word is not reserved");
 
-  TestBuilder.command`echo while${"x"}`
-    .stdout("whilex\n")
+  TestBuilder.command`while${"x"}`
+    .stderr("bun: command not found: whilex\n")
+    .exitCode(1)
     .runAsTest("reserved word glued to an interpolated suffix is not reserved");
 });
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -181,6 +181,31 @@ describe("bunshell", () => {
       expect(stdout.toString()).toEqual("a  b\n");
     });
 
+    test("$.escape of a reserved shell word quotes it", async () => {
+      const words = [
+        "if",
+        "then",
+        "elif",
+        "else",
+        "fi",
+        "while",
+        "until",
+        "for",
+        "do",
+        "done",
+        "case",
+        "esac",
+        "select",
+        "function",
+        "!",
+      ];
+      for (const w of words) expect({ in: w, out: $.escape(w) }).toEqual({ in: w, out: `"${w}"` });
+      // `{ raw: $.escape(v) }` must round-trip the same as `${v}` in command position.
+      const { stderr, exitCode } = await $`${{ raw: $.escape("while") }}`.nothrow().quiet();
+      expect(stderr.toString()).toBe("bun: command not found: while\n");
+      expect(exitCode).toBe(1);
+    });
+
     test("quotes values containing a tab, carriage return, or question mark", async () => {
       expect($.escape("a\tb")).toEqual('"a\tb"');
       expect($.escape("a\rb")).toEqual('"a\rb"');

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -2336,6 +2336,74 @@ cat redir_out`
   });
 });
 
+describe("unsupported reserved words fail at parse time", () => {
+  // A reserved word in command position must not be dispatched as an external
+  // command: before this was rejected, `while false; do BODY; done` ran BODY
+  // once with exit 0, and `for f in a b c; do ...; done` ran one iteration
+  // with $f empty.
+  const words = ["while", "until", "for", "do", "done", "case", "esac", "select", "function", "!", "{", "}"] as const;
+  const msg = (w: string) => `"${w}" is a reserved shell keyword that Bun Shell does not support yet.`;
+
+  for (const w of words) {
+    TestBuilder.command`${{ raw: w }} BUN_SHELL_SENTINEL_NEVER_RUNS`
+      .error(msg(w))
+      .runAsTest(`bare ${w} in command position is a parse error`);
+
+    TestBuilder.command`${{ raw: `"${w}"` }}`
+      .stderr(`bun: command not found: ${w}\n`)
+      .exitCode(1)
+      .runAsTest(`quoted ${w} is not a reserved word`);
+
+    TestBuilder.command`${w}`
+      .stderr(`bun: command not found: ${w}\n`)
+      .exitCode(1)
+      .runAsTest(`interpolated ${w} is not a reserved word`);
+
+    TestBuilder.command`echo ${{ raw: w }}`.stdout(`${w}\n`).runAsTest(`${w} in argument position stays a plain word`);
+  }
+
+  TestBuilder.command`while false
+do
+  echo BODY-RAN-EVEN-THOUGH-GUARD-IS-FALSE
+done
+echo tail`
+    .error(msg("while"))
+    .runAsTest("while-false body does not run");
+
+  TestBuilder.command`for f in one two three
+do
+  echo "iteration f=[$f]"
+done`
+    .error(msg("for"))
+    .runAsTest("for-in body does not run with empty loop var");
+
+  TestBuilder.command`until true; do echo body; done`
+    .error(msg("until"))
+    .runAsTest("until loop is rejected");
+
+  TestBuilder.command`! echo hi`.error(msg("!")).runAsTest("pipeline negation is rejected");
+
+  TestBuilder.command`{ echo hi; echo bye; }`.error(msg("{")).runAsTest("brace group is rejected");
+
+  TestBuilder.command`echo before; while false; do echo body; done`
+    .error(msg("while"))
+    .runAsTest("reserved word after a valid statement still fails the whole parse");
+
+  TestBuilder.command`echo $(while false; do echo x; done)`
+    .error(msg("while"))
+    .runAsTest("reserved word inside command substitution is rejected");
+
+  TestBuilder.command`if false; then echo a; else while false; do echo b; done; fi`
+    .error(msg("while"))
+    .runAsTest("reserved word inside if-else body is rejected");
+
+  TestBuilder.command`echo whilex`.stdout("whilex\n").runAsTest("reserved-word prefix of a longer word is not reserved");
+
+  TestBuilder.command`echo while${"x"}`
+    .stdout("whilex\n")
+    .runAsTest("reserved word glued to an interpolated suffix is not reserved");
+});
+
 describe("condexprs", () => {
   TestBuilder.command`[[ -f package.json ]] && echo yes!`.file("package.json", "hi").stdout("yes!\n").runAsTest("-f");
   TestBuilder.command`[[ -f mumbo.jumbo ]] && echo yes!`.exitCode(1).runAsTest("-f non-existent");


### PR DESCRIPTION
Bun Shell does not implement `while`/`until`/`for`/`do`/`done`/`case`/`esac`/`select`/`function`, pipeline negation `!`, or brace groups `{ }`. Before this change those words fell through `parse_compound_cmd` into `parse_simple_cmd` and were dispatched as external commands. Each keyword surfaced only as `bun: command not found: while` on stderr while every other statement in the script still ran, so control flow was silently wrong:

```js
import { $ } from "bun";

const w = await $`while false
do
  echo BODY-RAN-EVEN-THOUGH-GUARD-IS-FALSE
done
echo tail`.nothrow().quiet();
// before: exit 0, stdout "BODY-RAN-EVEN-THOUGH-GUARD-IS-FALSE\ntail\n"

const f = await $`for f in one two three
do
  echo "iteration f=[$f]"
done`.nothrow().quiet();
// before: stdout "iteration f=[]\n" (one iteration, loop var empty)
```

The `for` case in particular composes into data loss: `for f in a b c; do rm -rf "$dir/$f"; done` ran one iteration with `$f` empty, i.e. `rm -rf "$dir/"`.

### Cause

`parse_compound_cmd` only special-cased `(`, `if`, and `[[`. Any other leading word reached `parse_simple_cmd`, which treated `while`/`do`/`done`/... as ordinary command names. The newline-separated body statements were parsed and executed as independent commands.

### Fix

`parse_compound_cmd` now recognizes the unimplemented reserved words when they appear in command position as a bare, delimited `.Text` token (same "looks like a keyword" predicate `if` already uses: not quoted, not from a JS-interpolated value, followed by a delimiter) and fails the parse with

```
"while" is a reserved shell keyword that Bun Shell does not support yet.
```

matching how `&` and `|&` are already rejected. `{`/`}` arrive as `BraceBegin`/`BraceEnd` tokens and are checked on that token path when immediately followed by a delimiter (so brace expansion `{a,b}` and `echo { }` are untouched).

`ShellSrcBuilder::append_bun_str`/`append_utf8` now route interpolated values that equal any reserved word through `append_js_str_ref`, extending the existing `if`/`then`/`elif`/`else`/`fi` treatment so `` $`${"while"}` `` stays a plain command word rather than tripping the new check.

### Verification

New `describe("unsupported reserved words fail at parse time", ...)` block in `test/js/bun/shell/bunshell.test.ts` covers, for every word: bare command position is a parse error; quoted, interpolated, and argument-position occurrences are unchanged; plus the two reproductions above, nested `if`/`$(...)` positions, and `whilex`/`while${"x"}` non-matches. 20 of these fail on current `main`; all 58 pass with the fix, and the rest of `bunshell.test.ts` (472 pass / 0 fail) is unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->