### PR TITLE
dotenv: stop panicking on nested `${...}` inside `${VAR:-default}`

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1145,12 +1145,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Left-to-right expansion of `$NAME` / `${NAME}` / `${NAME:-default}`.
-    /// `${...}` finds its closing brace by depth counting (`${` opens, `}`
-    /// closes, `\x` is skipped), so a nested `${A:-${B}}` pairs correctly and
-    /// no slice index can invert. Malformed references (unterminated `${`,
-    /// junk after the key) are emitted literally; the loader never aborts on
-    /// input shape. The `:-` default clause is itself expanded via a bounded
-    /// recursive call so `${A:-${B:-c}}` composes.
+    /// `${...}` locates its matching `}` by depth (`${` opens, `}` closes,
+    /// `\x` skipped); malformed forms fall through as literal text. The `:-`
+    /// default clause is expanded recursively.
     fn expand_into(map: &Map, value: &[u8], out: &mut Vec<u8>, depth: u8) -> bool {
         #[inline]
         fn is_ident(b: u8) -> bool {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1206,7 +1206,10 @@ impl<'a> Parser<'a> {
                 };
                 changed = true;
                 let inner = &value[inner_start..close];
-                let key_end = inner.iter().position(|&c| !is_ident(c)).unwrap_or(inner.len());
+                let key_end = inner
+                    .iter()
+                    .position(|&c| !is_ident(c))
+                    .unwrap_or(inner.len());
                 let key = &inner[..key_end];
                 let rest = &inner[key_end..];
                 if rest.is_empty() {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1137,79 +1137,113 @@ impl<'a> Parser<'a> {
         if value.len() < 2 {
             return Ok(None);
         }
-
         self.value_buffer.clear();
-
-        let mut pos = value.len() - 2;
-        let mut last = value.len();
-        loop {
-            if value[pos] == b'$' {
-                if pos > 0 && value[pos - 1] == b'\\' {
-                    // PERF: splice at the front is O(n)
-                    self.value_buffer
-                        .splice(0..0, value[pos..last].iter().copied());
-                    pos -= 1;
-                } else {
-                    let mut end = if value[pos + 1] == b'{' {
-                        pos + 2
-                    } else {
-                        pos + 1
-                    };
-                    let key_start = end;
-                    // Forward scans are bounded by `last`, not `value.len()`: the
-                    // right-to-left outer loop has already consumed `value[last..]`
-                    // into `value_buffer`, so a `${A:-${B}}` whose `:-` clause nests
-                    // another reference must not re-scan the inner bytes (that would
-                    // leave `end > last` and panic on the `value[end..last]` splice).
-                    while end < last {
-                        match value[end] {
-                            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' => {
-                                end += 1;
-                                continue;
-                            }
-                            _ => break,
-                        }
-                    }
-                    let lookup_value = map.get(&value[key_start..end]);
-                    let default_value: &[u8] = if value[end..last].starts_with(b":-") {
-                        end += b":-".len();
-                        let value_start = end;
-                        while end < last {
-                            match value[end] {
-                                b'}' | b'\\' => break,
-                                _ => {
-                                    end += 1;
-                                    continue;
-                                }
-                            }
-                        }
-                        &value[value_start..end]
-                    } else {
-                        b""
-                    };
-                    if end < last && value[end] == b'}' {
-                        end += 1;
-                    }
-                    self.value_buffer
-                        .splice(0..0, value[end..last].iter().copied());
-                    self.value_buffer
-                        .splice(0..0, lookup_value.unwrap_or(default_value).iter().copied());
-                }
-                last = pos;
-            }
-            if pos == 0 {
-                if last == value.len() {
-                    return Ok(None);
-                }
-                break;
-            }
-            pos -= 1;
-        }
-        if last > 0 {
-            self.value_buffer
-                .splice(0..0, value[..last].iter().copied());
+        if !Self::expand_into(map, value, self.value_buffer, 0) {
+            return Ok(None);
         }
         Ok(Some(self.value_buffer.as_slice()))
+    }
+
+    /// Left-to-right expansion of `$NAME` / `${NAME}` / `${NAME:-default}`.
+    /// `${...}` finds its closing brace by depth counting (`${` opens, `}`
+    /// closes, `\x` is skipped), so a nested `${A:-${B}}` pairs correctly and
+    /// no slice index can invert. Malformed references (unterminated `${`,
+    /// junk after the key) are emitted literally; the loader never aborts on
+    /// input shape. The `:-` default clause is itself expanded via a bounded
+    /// recursive call so `${A:-${B:-c}}` composes.
+    fn expand_into(map: &Map, value: &[u8], out: &mut Vec<u8>, depth: u8) -> bool {
+        #[inline]
+        fn is_ident(b: u8) -> bool {
+            matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+        }
+
+        let mut pos = 0;
+        let mut changed = false;
+        while pos < value.len() {
+            let b = value[pos];
+            if b == b'\\' && value.get(pos + 1) == Some(&b'$') {
+                out.push(b'$');
+                pos += 2;
+                changed = true;
+                continue;
+            }
+            if b != b'$' || pos + 1 >= value.len() {
+                out.push(b);
+                pos += 1;
+                continue;
+            }
+            let next = value[pos + 1];
+            if next == b'{' {
+                let inner_start = pos + 2;
+                let close = {
+                    let mut i = inner_start;
+                    let mut nest = 1usize;
+                    loop {
+                        if i >= value.len() {
+                            break None;
+                        }
+                        match value[i] {
+                            b'\\' if i + 1 < value.len() => i += 2,
+                            b'$' if value.get(i + 1) == Some(&b'{') => {
+                                nest += 1;
+                                i += 2;
+                            }
+                            b'}' => {
+                                nest -= 1;
+                                if nest == 0 {
+                                    break Some(i);
+                                }
+                                i += 1;
+                            }
+                            _ => i += 1,
+                        }
+                    }
+                };
+                let Some(close) = close else {
+                    out.extend_from_slice(&value[pos..]);
+                    pos = value.len();
+                    continue;
+                };
+                changed = true;
+                let inner = &value[inner_start..close];
+                let key_end = inner.iter().position(|&c| !is_ident(c)).unwrap_or(inner.len());
+                let key = &inner[..key_end];
+                let rest = &inner[key_end..];
+                if rest.is_empty() {
+                    if let Some(v) = map.get(key) {
+                        out.extend_from_slice(v);
+                    }
+                } else if let Some(default) = rest.strip_prefix(b":-") {
+                    if let Some(v) = map.get(key) {
+                        out.extend_from_slice(v);
+                    } else if depth < 200 {
+                        Self::expand_into(map, default, out, depth + 1);
+                    } else {
+                        out.extend_from_slice(default);
+                    }
+                } else {
+                    out.extend_from_slice(&value[pos..=close]);
+                }
+                pos = close + 1;
+                continue;
+            }
+            if is_ident(next) {
+                changed = true;
+                let key_start = pos + 1;
+                let mut k = key_start;
+                while k < value.len() && is_ident(value[k]) {
+                    k += 1;
+                }
+                if let Some(v) = map.get(&value[key_start..k]) {
+                    out.extend_from_slice(v);
+                }
+                pos = k;
+                continue;
+            }
+            out.push(b'$');
+            pos += 1;
+        }
+        changed
     }
 
     fn parse<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1156,7 +1156,12 @@ impl<'a> Parser<'a> {
                         pos + 1
                     };
                     let key_start = end;
-                    while end < value.len() {
+                    // Forward scans are bounded by `last`, not `value.len()`: the
+                    // right-to-left outer loop has already consumed `value[last..]`
+                    // into `value_buffer`, so a `${A:-${B}}` whose `:-` clause nests
+                    // another reference must not re-scan the inner bytes (that would
+                    // leave `end > last` and panic on the `value[end..last]` splice).
+                    while end < last {
                         match value[end] {
                             b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' => {
                                 end += 1;
@@ -1166,10 +1171,10 @@ impl<'a> Parser<'a> {
                         }
                     }
                     let lookup_value = map.get(&value[key_start..end]);
-                    let default_value: &[u8] = if value[end..].starts_with(b":-") {
+                    let default_value: &[u8] = if value[end..last].starts_with(b":-") {
                         end += b":-".len();
                         let value_start = end;
-                        while end < value.len() {
+                        while end < last {
                             match value[end] {
                                 b'}' | b'\\' => break,
                                 _ => {
@@ -1182,7 +1187,7 @@ impl<'a> Parser<'a> {
                     } else {
                         b""
                     };
-                    if end < value.len() && value[end] == b'}' {
+                    if end < last && value[end] == b'}' {
                         end += 1;
                     }
                     self.value_buffer

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -252,43 +252,83 @@ test(".env value expansion", () => {
   expect(stdout).toBe("foo|foo bar|foo foo bar moo");
 });
 
-test(".env nested ${...} inside :- default does not panic", () => {
-  // A ${NAME} reference nested in a ${VAR:-default} clause used to push the
-  // forward default scan past the right-to-left `last` boundary and panic on
-  // the `value[end..last]` slice before any user code ran.
+test(".env ${VAR:-default} with nested references", () => {
+  // A ${NAME} nested inside a ${VAR:-default} clause used to panic the loader
+  // ("slice index starts at N but ends at M") before any user code ran. The
+  // expander now scans left-to-right, pairs `${` with its matching `}` by
+  // depth, and expands the default clause recursively, so every case below
+  // loads and malformed forms fall through as literals.
   const dir = tempDirWithFiles("dotenv-expand-nested", {
     ".env": [
-      "NESTD_FALLBACK=localhost",
-      "NESTD_HOST=${NESTD_UNSET:-${NESTD_FALLBACK}}",
-      "NESTD_Y=${NESTD_UNSET:-${NESTD_ALSO_UNSET}}",
-      "NESTD_Z=${NESTD_UNSET:-${NESTD_ALSO_UNSET:-c}}",
-      "NESTD_W=${NESTD_UNSET:-x${NESTD_ALSO_UNSET}}",
-      'NESTD_Q="${NESTD_UNSET:-${NESTD_ALSO_UNSET}}"',
-      "NESTD_PRESET=hi",
-      "NESTD_P=${NESTD_PRESET:-${NESTD_ALSO_UNSET}}",
+      "NSTD_FALLBACK=localhost",
+      "NSTD_SET=hi",
+      "NSTD_HOST=${NSTD_UNSET:-${NSTD_FALLBACK}}",
+      "NSTD_EMPTY=${NSTD_UNSET:-${NSTD_ALSO_UNSET}}",
+      "NSTD_DEEP=${NSTD_UNSET:-${NSTD_ALSO_UNSET:-c}}",
+      "NSTD_PREFIX=${NSTD_UNSET:-x${NSTD_ALSO_UNSET}}",
+      'NSTD_QUOTED="${NSTD_UNSET:-${NSTD_ALSO_UNSET:-${NSTD_FALLBACK}}}suffix"',
+      "NSTD_SET_WINS=${NSTD_SET:-${NSTD_ALSO_UNSET}}",
+      "NSTD_BARE=${NSTD_UNSET:-$NSTD_FALLBACK}",
+      "NSTD_DOLLAR=${NSTD_UNSET:-$}",
+      "NSTD_DUBL=$${NSTD_UNSET:-${NSTD_FALLBACK}}",
+      "NSTD_NOKEY=${:-${NSTD_FALLBACK}}",
+      "NSTD_AROUND=pre${NSTD_UNSET:-$NSTD_FALLBACK}post",
+      "NSTD_TWO=${NSTD_FALLBACK}${NSTD_UNSET:-$NSTD_FALLBACK}",
+      "NSTD_PATH=$NSTD_FALLBACK/${NSTD_UNSET:-$NSTD_FALLBACK}/x",
+      "NSTD_UNTERM=${NSTD_UNSET:-${",
+      "NSTD_UNTERM2=${NSTD_UNSET",
+      "NSTD_BSLASH=${NSTD_UNSET:-a\\b}",
+      "NSTD_DASH=${NSTD_UNSET-${NSTD_FALLBACK}}",
     ].join("\n"),
     "index.ts":
-      "const e = process.env;" +
-      "console.log(JSON.stringify({" +
-      "HOST:e.NESTD_HOST,Y:e.NESTD_Y,Z:e.NESTD_Z,W:e.NESTD_W,Q:e.NESTD_Q,P:e.NESTD_P" +
-      "}));",
+      "const keys = process.argv.slice(2);" +
+      "const out = {};" +
+      "for (const k of keys) out[k] = process.env[k];" +
+      "console.log(JSON.stringify(out));",
   });
-  const result = Bun.spawnSync([bunExe(), `${dir}/index.ts`], {
+  const keys = [
+    "NSTD_HOST",
+    "NSTD_EMPTY",
+    "NSTD_DEEP",
+    "NSTD_PREFIX",
+    "NSTD_QUOTED",
+    "NSTD_SET_WINS",
+    "NSTD_BARE",
+    "NSTD_DOLLAR",
+    "NSTD_DUBL",
+    "NSTD_NOKEY",
+    "NSTD_AROUND",
+    "NSTD_TWO",
+    "NSTD_PATH",
+    "NSTD_UNTERM",
+    "NSTD_UNTERM2",
+    "NSTD_BSLASH",
+    "NSTD_DASH",
+  ];
+  const result = Bun.spawnSync([bunExe(), `${dir}/index.ts`, ...keys], {
     cwd: dir,
     env: { ...bunEnv, NODE_ENV: undefined },
   });
   const stdout = result.stdout.toString("utf8").trim();
   expect(stdout).toStartWith("{");
-  // The loader does not yet implement full recursive default expansion, so the
-  // enclosing `}` can leak through; the contract here is that loading never
-  // aborts and the inner reference is resolved.
   expect(JSON.parse(stdout)).toEqual({
-    HOST: "localhost}",
-    Y: "}",
-    Z: "c}",
-    W: "x}",
-    Q: "}",
-    P: "hi}",
+    NSTD_HOST: "localhost",
+    NSTD_EMPTY: "",
+    NSTD_DEEP: "c",
+    NSTD_PREFIX: "x",
+    NSTD_QUOTED: "localhostsuffix",
+    NSTD_SET_WINS: "hi",
+    NSTD_BARE: "localhost",
+    NSTD_DOLLAR: "$",
+    NSTD_DUBL: "$localhost",
+    NSTD_NOKEY: "localhost",
+    NSTD_AROUND: "prelocalhostpost",
+    NSTD_TWO: "localhostlocalhost",
+    NSTD_PATH: "localhost/localhost/x",
+    NSTD_UNTERM: "${NSTD_UNSET:-${",
+    NSTD_UNTERM2: "${NSTD_UNSET",
+    NSTD_BSLASH: "a\\b",
+    NSTD_DASH: "${NSTD_UNSET-${NSTD_FALLBACK}}",
   });
   expect(result.exitCode).toBe(0);
 });

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -252,6 +252,47 @@ test(".env value expansion", () => {
   expect(stdout).toBe("foo|foo bar|foo foo bar moo");
 });
 
+test(".env nested ${...} inside :- default does not panic", () => {
+  // A ${NAME} reference nested in a ${VAR:-default} clause used to push the
+  // forward default scan past the right-to-left `last` boundary and panic on
+  // the `value[end..last]` slice before any user code ran.
+  const dir = tempDirWithFiles("dotenv-expand-nested", {
+    ".env": [
+      "NESTD_FALLBACK=localhost",
+      "NESTD_HOST=${NESTD_UNSET:-${NESTD_FALLBACK}}",
+      "NESTD_Y=${NESTD_UNSET:-${NESTD_ALSO_UNSET}}",
+      "NESTD_Z=${NESTD_UNSET:-${NESTD_ALSO_UNSET:-c}}",
+      "NESTD_W=${NESTD_UNSET:-x${NESTD_ALSO_UNSET}}",
+      'NESTD_Q="${NESTD_UNSET:-${NESTD_ALSO_UNSET}}"',
+      "NESTD_PRESET=hi",
+      "NESTD_P=${NESTD_PRESET:-${NESTD_ALSO_UNSET}}",
+    ].join("\n"),
+    "index.ts":
+      "const e = process.env;" +
+      "console.log(JSON.stringify({" +
+      "HOST:e.NESTD_HOST,Y:e.NESTD_Y,Z:e.NESTD_Z,W:e.NESTD_W,Q:e.NESTD_Q,P:e.NESTD_P" +
+      "}));",
+  });
+  const result = Bun.spawnSync([bunExe(), `${dir}/index.ts`], {
+    cwd: dir,
+    env: { ...bunEnv, NODE_ENV: undefined },
+  });
+  const stdout = result.stdout.toString("utf8").trim();
+  expect(stdout).toStartWith("{");
+  // The loader does not yet implement full recursive default expansion, so the
+  // enclosing `}` can leak through; the contract here is that loading never
+  // aborts and the inner reference is resolved.
+  expect(JSON.parse(stdout)).toEqual({
+    HOST: "localhost}",
+    Y: "}",
+    Z: "c}",
+    W: "x}",
+    Q: "}",
+    P: "hi}",
+  });
+  expect(result.exitCode).toBe(0);
+});
+
 test(".env comments", () => {
   using dir = tempDir("dotenv-comments", {
     ".env": "#FOZ\nFOO = foo#FAIL\nBAR='bar' #BAZ",

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -252,13 +252,11 @@ test(".env value expansion", () => {
   expect(stdout).toBe("foo|foo bar|foo foo bar moo");
 });
 
-test(".env ${VAR:-default} with nested references", () => {
-  // A ${NAME} nested inside a ${VAR:-default} clause used to panic the loader
-  // ("slice index starts at N but ends at M") before any user code ran. The
-  // expander now scans left-to-right, pairs `${` with its matching `}` by
-  // depth, and expands the default clause recursively, so every case below
-  // loads and malformed forms fall through as literals.
-  const dir = tempDirWithFiles("dotenv-expand-nested", {
+test(".env ${VAR:-default} with nested references (issue #32411)", () => {
+  // https://github.com/oven-sh/bun/issues/32411
+  // `${` pairs with its matching `}` by depth and the `:-` default is expanded
+  // recursively; malformed forms (unterminated, non-`:-`) fall through as literals.
+  using dir = tempDir("dotenv-expand-nested", {
     ".env": [
       "NSTD_FALLBACK=localhost",
       "NSTD_SET=hi",
@@ -306,7 +304,7 @@ test(".env ${VAR:-default} with nested references", () => {
     "NSTD_DASH",
   ];
   const result = Bun.spawnSync([bunExe(), `${dir}/index.ts`, ...keys], {
-    cwd: dir,
+    cwd: String(dir),
     env: { ...bunEnv, NODE_ENV: undefined },
   });
   const stdout = result.stdout.toString("utf8").trim();


### PR DESCRIPTION
A `.env` line like

```env
HOST=${HOST:-${DEFAULT_HOST}}
```

crashed every `bun` invocation in that directory with

```
panic: slice index starts at 9 but ends at 5
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

before any user code ran (rc 134, core). Any `:-` default clause containing a `$` triggered it: `${A:-$B}`, `${A:-${B}}`, `${A:-$}`, `${A:-${B:-c}}`, `$${A:-${B}}`, `${:-${B}}`, quoted/prefixed variants, and unterminated `${A:-${`.

### Cause

`Parser::expand_value` in `src/dotenv/env_loader.rs` scanned the value right-to-left for `$`, tracking `last` as the start of the most recently processed (nearest-to-the-right) reference. When the outer `${A:-...}` was reached, its `:-` default clause was then scanned *forward* bounded only by `value.len()`, so it walked straight across the inner reference that begins at `last`, landed on the inner's closing `}`, and left `end > last`. The subsequent `value[end..last]` splice inverted and panicked.

### Fix

Replace the reverse `$` scan + forward default scan with one left-to-right depth-counting pass:

- `${...}` finds its closing `}` by depth (`${` opens, `}` closes, `\x` is skipped), so every slice is bounded by a matched index and cannot invert.
- Bare `${KEY}` resolves to the key's value or empty.
- `${KEY:-default}` resolves to the key's value if set; otherwise the default clause is itself expanded recursively, so `${A:-${B:-c}}` composes the way dotenv-expand / docker-compose users expect.
- Unterminated `${...` and junk after the key (`${A-x}`, `${A.x}`) fall through as the literal input; the loader never aborts on shape.
- `$IDENT` and `\$` keep their existing behaviour.

### Verification

```sh
printf "DEFAULT_HOST=localhost\nHOST=\${UNSET:-\${DEFAULT_HOST}}\n" > .env
bun -e "console.log(process.env.HOST)"   # before: panic rc 134; after: localhost
```

`test/cli/run/env.test.ts` gains a table covering the nested, quoted, prefixed, bare-`$`, empty-key, unterminated, backslash, and non-`:-` forms. The existing `.env value expansion` test is unchanged and still passes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->

Fixes #32411
