### PR TITLE
windows: evaluate FileIdFullDirectoryInformation for node dir_iterator (investigation, no win)

### DIFF
--- a/src/runtime/node/dir_iterator.rs
+++ b/src/runtime/node/dir_iterator.rs
@@ -445,8 +445,22 @@ mod platform {
     use bun_sys::windows::ntdll;
     use bun_sys::windows::{
         BOOLEAN, FALSE, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
-        FILE_DIRECTORY_INFORMATION, IO_STATUS_BLOCK, TRUE, UNICODE_STRING, Win32ErrorExt as _,
+        FILE_DIRECTORY_INFORMATION, FILE_ID_FULL_DIR_INFORMATION, IO_STATUS_BLOCK, TRUE,
+        UNICODE_STRING, Win32ErrorExt as _,
     };
+
+    // The shared prefix (through `FileNameLength`) of both info classes is
+    // layout-identical; only the `FileName` offset differs. Static asserts for
+    // both layouts live alongside the struct definitions in
+    // `bun_windows_sys::externs`.
+    const _: () = assert!(
+        offset_of!(FILE_DIRECTORY_INFORMATION, NextEntryOffset)
+            == offset_of!(FILE_ID_FULL_DIR_INFORMATION, NextEntryOffset)
+            && offset_of!(FILE_DIRECTORY_INFORMATION, FileAttributes)
+                == offset_of!(FILE_ID_FULL_DIR_INFORMATION, FileAttributes)
+            && offset_of!(FILE_DIRECTORY_INFORMATION, FileNameLength)
+                == offset_of!(FILE_ID_FULL_DIR_INFORMATION, FileNameLength)
+    );
 
     // While the official api docs guarantee FILE_BOTH_DIR_INFORMATION to be aligned properly
     // this may not always be the case (e.g. due to faulty VM/Sandboxing tools)
@@ -546,6 +560,11 @@ mod platform {
         pub index: usize,
         pub end_index: usize,
         pub first: bool,
+        /// Starts at `FileIdFullDirectoryInformation` (reparse tag + file id in
+        /// the same enumeration); falls back to `FileDirectoryInformation` if
+        /// the filesystem/redirector rejects it with
+        /// `STATUS_INVALID_INFO_CLASS` / `STATUS_NOT_SUPPORTED`.
+        pub info_class: w::FILE_INFORMATION_CLASS,
         pub name_data: <Select<USE_WINDOWS_OSPATH> as WindowsOsPath>::NameData,
         /// Optional kernel-side wildcard filter passed to NtQueryDirectoryFile.
         /// Evaluated by FsRtlIsNameInExpression (case-insensitive, supports `*` and `?`).
@@ -597,7 +616,7 @@ mod platform {
 
                     // SAFETY: FFI; `dir` is a directory HANDLE, `buf` is 8192 8-byte-aligned
                     // bytes, `io`/`filter_us` live on this stack frame for the call duration.
-                    let rc = unsafe {
+                    let mut rc = unsafe {
                         ntdll::NtQueryDirectoryFile(
                             self.dir.native(),
                             core::ptr::null_mut(),
@@ -606,7 +625,7 @@ mod platform {
                             &mut io,
                             self.buf.as_mut_ptr().cast(),
                             self.buf.len() as u32,
-                            w::FILE_INFORMATION_CLASS::FileDirectoryInformation,
+                            self.info_class,
                             FALSE as BOOLEAN,
                             filter_ptr,
                             if self.first {
@@ -616,6 +635,40 @@ mod platform {
                             },
                         )
                     };
+
+                    // Some redirectors / filter drivers reject
+                    // FileIdFullDirectoryInformation. Fall back once, on the
+                    // first call only (RestartScan=TRUE), so no entries are
+                    // lost.
+                    if self.first
+                        && self.info_class
+                            == w::FILE_INFORMATION_CLASS::FileIdFullDirectoryInformation
+                        && matches!(
+                            rc,
+                            w::NTSTATUS::INVALID_INFO_CLASS
+                                | w::NTSTATUS::NOT_SUPPORTED
+                                | w::NTSTATUS::NOT_IMPLEMENTED
+                        )
+                    {
+                        self.info_class = w::FILE_INFORMATION_CLASS::FileDirectoryInformation;
+                        io = bun_core::ffi::zeroed();
+                        // SAFETY: same preconditions as the call above.
+                        rc = unsafe {
+                            ntdll::NtQueryDirectoryFile(
+                                self.dir.native(),
+                                core::ptr::null_mut(),
+                                core::ptr::null_mut(),
+                                core::ptr::null_mut(),
+                                &mut io,
+                                self.buf.as_mut_ptr().cast(),
+                                self.buf.len() as u32,
+                                self.info_class,
+                                FALSE as BOOLEAN,
+                                filter_ptr,
+                                TRUE as BOOLEAN,
+                            )
+                        };
+                    }
 
                     self.first = false;
 
@@ -700,8 +753,14 @@ mod platform {
                 // what remains in buf (source) so a misbehaving driver cannot
                 // walk us past the end of either buffer.
                 let max_name_u16 = <Select<USE_WINDOWS_OSPATH> as WindowsOsPath>::max_name_u16();
-                let name_byte_offset =
-                    entry_offset + offset_of!(FILE_DIRECTORY_INFORMATION, FileName);
+                let file_name_field_offset = if self.info_class
+                    == w::FILE_INFORMATION_CLASS::FileIdFullDirectoryInformation
+                {
+                    offset_of!(FILE_ID_FULL_DIR_INFORMATION, FileName)
+                } else {
+                    offset_of!(FILE_DIRECTORY_INFORMATION, FileName)
+                };
+                let name_byte_offset = entry_offset + file_name_field_offset;
                 let buf_remaining_u16 =
                     self.buf.len().saturating_sub(name_byte_offset) / size_of::<u16>();
                 let name_len_u16 = (file_name_length / 2)
@@ -709,9 +768,10 @@ mod platform {
                     .min(buf_remaining_u16);
                 // name_byte_offset + name_len_u16*2 ≤ buf.len() by clamp above.
                 // `buf` follows the 8-byte `Fd` in a `repr(C, align(8))` struct so
-                // it is itself 8-byte aligned, and per MS docs each record (and
-                // thus its FileName at offset 64) lands on an 8-byte boundary —
-                // bytemuck checks the u8→u16 alignment at runtime.
+                // it is itself 8-byte aligned, and per MS docs each record lands
+                // on an 8-byte boundary; the FileName field offset (64 or 80) is
+                // a multiple of 2 for both classes — bytemuck checks the u8→u16
+                // alignment at runtime.
                 let dir_info_name: &[u16] = bytemuck::cast_slice(
                     &self.buf[name_byte_offset..name_byte_offset + name_len_u16 * 2],
                 );
@@ -934,12 +994,14 @@ where
         }
         #[cfg(windows)]
         {
+            use bun_sys::windows as w;
             return Self {
                 iter: NewIterator {
                     dir,
                     index: 0,
                     end_index: 0,
                     first: true,
+                    info_class: w::FILE_INFORMATION_CLASS::FileIdFullDirectoryInformation,
                     // zero-init avoids the invalid_value lint on integer arrays
                     buf: [0u8; 8192],
                     // SAFETY: NameData is [u8; 513] or [u16; 257]; zero is a valid bit pattern.

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -157,6 +157,7 @@ pub use bun_windows_sys::FILE_DEVICE_NAMED_PIPE;
 pub use bun_windows_sys::FILE_DEVICE_NULL;
 pub use bun_windows_sys::FILE_DIRECTORY_FILE;
 pub use bun_windows_sys::FILE_DIRECTORY_INFORMATION;
+pub use bun_windows_sys::FILE_ID_FULL_DIR_INFORMATION;
 pub use bun_windows_sys::FILE_FS_DEVICE_INFORMATION;
 pub use bun_windows_sys::FILE_FS_VOLUME_INFORMATION;
 pub use bun_windows_sys::FILE_INFO_BY_HANDLE_CLASS;

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -382,6 +382,28 @@ pub struct FILE_DIRECTORY_INFORMATION {
     pub FileName: [WCHAR; 1],
 }
 
+/// `FILE_ID_FULL_DIR_INFORMATION` (`ntifs.h`) — `NtQueryDirectoryFile` record
+/// for `FileIdFullDirectoryInformation`. Superset of
+/// `FILE_DIRECTORY_INFORMATION`: the first 64 bytes (through `FileNameLength`)
+/// are layout-identical, then `EaSize` (the reparse tag when
+/// `FILE_ATTRIBUTE_REPARSE_POINT` is set) and `FileId`.
+#[repr(C)]
+pub struct FILE_ID_FULL_DIR_INFORMATION {
+    pub NextEntryOffset: ULONG,
+    pub FileIndex: ULONG,
+    pub CreationTime: LARGE_INTEGER,
+    pub LastAccessTime: LARGE_INTEGER,
+    pub LastWriteTime: LARGE_INTEGER,
+    pub ChangeTime: LARGE_INTEGER,
+    pub EndOfFile: LARGE_INTEGER,
+    pub AllocationSize: LARGE_INTEGER,
+    pub FileAttributes: ULONG,
+    pub FileNameLength: ULONG,
+    pub EaSize: ULONG,
+    pub FileId: LARGE_INTEGER,
+    pub FileName: [WCHAR; 1],
+}
+
 /// `FILE_INFORMATION_CLASS` (`wdm.h`) — selector for `NtQuery*` /
 /// `NtSetInformationFile`. Newtype-over-u32 so unmapped values round-trip.
 #[repr(transparent)]
@@ -393,6 +415,7 @@ impl FILE_INFORMATION_CLASS {
     pub const FileDispositionInformation: Self = Self(13);
     pub const FileAllInformation: Self = Self(18);
     pub const FileEndOfFileInformation: Self = Self(20);
+    pub const FileIdFullDirectoryInformation: Self = Self(38);
     pub const FileDispositionInformationEx: Self = Self(64);
 }
 
@@ -474,6 +497,18 @@ const _: () = {
     assert!(core::mem::size_of::<FILE_FS_DEVICE_INFORMATION>() == 8);
     assert!(core::mem::size_of::<FILE_FS_VOLUME_INFORMATION>() == 24);
     assert!(core::mem::offset_of!(FILE_FS_VOLUME_INFORMATION, VolumeSerialNumber) == 8);
+    // FILE_ID_FULL_DIR_INFORMATION shares the FILE_DIRECTORY_INFORMATION prefix
+    // through FileNameLength; the directory iterator reads NextEntryOffset /
+    // FileAttributes / FileNameLength from the shared prefix regardless of
+    // which class is active.
+    assert!(core::mem::offset_of!(FILE_DIRECTORY_INFORMATION, FileAttributes) == 56);
+    assert!(core::mem::offset_of!(FILE_DIRECTORY_INFORMATION, FileNameLength) == 60);
+    assert!(core::mem::offset_of!(FILE_DIRECTORY_INFORMATION, FileName) == 64);
+    assert!(core::mem::offset_of!(FILE_ID_FULL_DIR_INFORMATION, FileAttributes) == 56);
+    assert!(core::mem::offset_of!(FILE_ID_FULL_DIR_INFORMATION, FileNameLength) == 60);
+    assert!(core::mem::offset_of!(FILE_ID_FULL_DIR_INFORMATION, EaSize) == 64);
+    assert!(core::mem::offset_of!(FILE_ID_FULL_DIR_INFORMATION, FileId) == 72);
+    assert!(core::mem::offset_of!(FILE_ID_FULL_DIR_INFORMATION, FileName) == 80);
 };
 
 /// `DEVICE_TYPE` values (`ntddk.h`).
@@ -1050,6 +1085,8 @@ impl NTSTATUS {
     /// `NtSetInformationFile(FileDispositionInformation)`.
     pub const CANNOT_DELETE: NTSTATUS = NTSTATUS(0xC000_0121);
     pub const NOT_IMPLEMENTED: NTSTATUS = NTSTATUS(0xC000_0002);
+    pub const INVALID_INFO_CLASS: NTSTATUS = NTSTATUS(0xC000_0003);
+    pub const NOT_SUPPORTED: NTSTATUS = NTSTATUS(0xC000_00BB);
     pub const NO_MORE_FILES: NTSTATUS = NTSTATUS(0x8000_0006);
     pub const NO_SUCH_FILE: NTSTATUS = NTSTATUS(0xC000_000F);
     /// `STATUS_TIMEOUT` — returned by `NtWaitForSingleObject` /


### PR DESCRIPTION
## Summary

Investigation into whether switching `NtQueryDirectoryFile` from `FileDirectoryInformation` (class 1) to `FileIdFullDirectoryInformation` (class 38) in the node directory iterator removes per-entry follow-up syscalls and speeds up `fs.readdir({ withFileTypes: true })`.

**Result: no win.** `readdir({ withFileTypes: true })` on Windows already does zero per-entry follow-up syscalls. The iterator's `kind` (derived from `FILE_ATTRIBUTE_DIRECTORY` / `FILE_ATTRIBUTE_REPARSE_POINT` in the enumeration record) is consumed directly by `readdir_with_entries_u16`; the `Unknown → lstatat` fallback in the u8 path never fires on Windows because NTFS never yields `Unknown`.

## Benchmark

Windows Server 2019, NTFS, release builds, warm cache, 20-50 iterations per case, alternating build order across 4 runs. Tree: `node_modules` from a `next`/`react`/`webpack`/`vite`/`eslint` install (16,787 entries across 1,555 directories), plus a synthetic 5,000-file flat directory.

| case | entries | `FileDirectoryInformation` (median) | `FileIdFullDirectoryInformation` (median) | delta |
|---|---|---|---|---|
| `readdirSync` recursive `withFileTypes` (node_modules) | 16,787 | 42.2 ms | 42.6 ms | +1% (noise) |
| `readdirSync` recursive names-only (node_modules) | 16,787 | 37.1 ms | 37.9 ms | +2% (noise) |
| `readdirSync` per-package `withFileTypes` (166 dirs) | 1,993 | 2.41 ms | 2.44 ms | +1% (noise) |
| `readdirSync` flat dir `withFileTypes` | 5,000 | 1.400 ms | 1.442 ms | **+3%** |
| `readdirSync` flat dir names-only | 5,000 | 1.160 ms | 1.184 ms | **+2%** |

Correctness check: both builds produce identical output for the recursive `withFileTypes` walk (same 16,787 entries, same name+kind hash). All 26 `readdir`-filtered tests in `fs.test.ts` pass.

The wide-directory regression matches the record-size arithmetic: the `FILE_ID_FULL_DIR_INFORMATION` header is 80 bytes vs 64 for `FILE_DIRECTORY_INFORMATION`. With the same 8 KiB enumeration buffer that means ~15% fewer entries per `NtQueryDirectoryFile` call on typical filenames, which shows up as ~2-3% wall time when a single directory is large enough to need many refills. On node_modules shapes (many small directories, one refill each) the difference is below run-to-run noise.

## Callers that do per-entry follow-ups today

None of these are helped by the richer info class:

| caller | per-entry syscall | what it needs | satisfiable by `FileIdFullDirectoryInformation` |
|---|---|---|---|
| `readdir*` (all variants) | none | - | - |
| `fs.cp` recursive | `GetFileAttributesW` per file (`node_fs.rs:8991`) | `FILE_ATTRIBUTE_DIRECTORY`/`REPARSE_POINT` | already in `FILE_DIRECTORY_INFORMATION`; plumbing, not info class |
| shell `ls -l` | `lstatat` per entry | nlink, uid, gid | no (no info class has these) |
| glob symlink resolve | `openat` + stat per symlink | target kind + dev/ino | no (needs target, not link) |
| install bin cleanup | `openat` per symlink | target exists | no |

## What the richer class would provide

- `EaSize` carries the reparse tag when `FILE_ATTRIBUTE_REPARSE_POINT` is set; this would let `Dirent.isSymbolicLink()` distinguish symlinks from junctions and app-exec links. libuv's `fs__scandir` (which backs Node's `fs.readdir`) does not check the tag either, so current behavior already matches Node on this path.
- `FileId` has no consumer.

## What's in this branch

`src/runtime/node/dir_iterator.rs` tries `FileIdFullDirectoryInformation` first and falls back to `FileDirectoryInformation` on `STATUS_INVALID_INFO_CLASS` / `STATUS_NOT_SUPPORTED` / `STATUS_NOT_IMPLEMENTED` (fallback only on the first `RestartScan=TRUE` call so no entries are lost). The shared-prefix offsets (`NextEntryOffset`, `FileAttributes`, `FileNameLength`) are identical between the two layouts, asserted at compile time; only the `FileName` offset (64 vs 80) is selected at runtime based on the active class. Buffer size is unchanged at 8192.

## Recommendation

Close without merging. The switch is perf-neutral on node_modules-shaped trees and a small regression on wide directories, with no functional gain. If any of the per-entry follow-ups above are worth removing, they need the existing `FILE_DIRECTORY_INFORMATION` fields plumbed through the iterator result, not a different info class.
