### PR TITLE
glob: fall back to lstat when the literal-tail stat fails on a broken symlink

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -677,14 +677,23 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                     // statat follows symlinks; a broken link still exists as an
                     // entry, so fall back to lstat like directory iteration does.
                     Err(e) => match A::lstatat(fd, pathz_ref) {
-                        Ok(lst) if !self.walker.error_on_broken_symlinks => lst,
-                        lstat_result => {
+                        Ok(lst) => {
+                            if self.walker.error_on_broken_symlinks {
+                                self.close_disallowing_cwd(fd);
+                                return Ok(Err(e.with_path(
+                                    self.walker.pattern_components[idx as usize]
+                                        .pattern_slice(&self.walker.pattern),
+                                )));
+                            }
+                            lst
+                        }
+                        Err(le) => {
                             self.close_disallowing_cwd(fd);
-                            if lstat_result.is_err() && e.get_errno() == E::ENOENT {
+                            if le.get_errno() == E::ENOENT {
                                 self.iter_state = IterState::GetNext;
                                 return Ok(Ok(()));
                             }
-                            return Ok(Err(e.with_path(
+                            return Ok(Err(le.with_path(
                                 self.walker.pattern_components[idx as usize]
                                     .pattern_slice(&self.walker.pattern),
                             )));

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -673,19 +673,25 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                 // SAFETY: dupe_z NUL-terminates
                 let pathz_ref = ZStr::from_slice_with_nul(&pathz[..]);
                 let stat_result: Stat = match A::statat(fd, pathz_ref) {
-                    Err(e_) => {
-                        let e: SysError = e_;
-                        self.close_disallowing_cwd(fd);
-                        if e.get_errno() == E::ENOENT {
-                            self.iter_state = IterState::GetNext;
-                            return Ok(Ok(()));
-                        }
-                        return Ok(Err(e.with_path(
-                            self.walker.pattern_components[idx as usize]
-                                .pattern_slice(&self.walker.pattern),
-                        )));
-                    }
                     Ok(stat) => stat,
+                    // statat follows symlinks, so a dangling or cyclic link
+                    // fails (ENOENT/ELOOP) even though the directory entry
+                    // exists. Retry without following so this path agrees with
+                    // directory iteration, which sees the entry regardless.
+                    Err(e) => match A::lstatat(fd, pathz_ref) {
+                        Ok(lst) if !self.walker.error_on_broken_symlinks => lst,
+                        lstat_result => {
+                            self.close_disallowing_cwd(fd);
+                            if lstat_result.is_err() && e.get_errno() == E::ENOENT {
+                                self.iter_state = IterState::GetNext;
+                                return Ok(Ok(()));
+                            }
+                            return Ok(Err(e.with_path(
+                                self.walker.pattern_components[idx as usize]
+                                    .pattern_slice(&self.walker.pattern),
+                            )));
+                        }
+                    },
                 };
                 self.close_disallowing_cwd(fd);
                 let mode = stat_result.st_mode as u32;

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -669,15 +669,28 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                 let pat_slice = self.walker.pattern_components[idx as usize]
                     .pattern_slice(&self.walker.pattern)
                     .to_vec();
+                let trailing_sep = self.walker.pattern_components[idx as usize].trailing_sep;
                 let pathz = dupe_z(&pat_slice);
                 // SAFETY: dupe_z NUL-terminates
                 let pathz_ref = ZStr::from_slice_with_nul(&pathz[..]);
-                let stat_result: Stat = match A::statat(fd, pathz_ref) {
-                    Ok(stat) => stat,
-                    // statat follows symlinks; a broken link still exists as an
-                    // entry, so fall back to lstat like directory iteration does.
-                    Err(e) => match A::lstatat(fd, pathz_ref) {
-                        Ok(lst) => {
+                // lstat first so a plain miss stays one syscall; only follow
+                // through to statat when the entry is actually a symlink.
+                let stat_result: Stat = match A::lstatat(fd, pathz_ref) {
+                    Err(le) => {
+                        self.close_disallowing_cwd(fd);
+                        if le.get_errno() == E::ENOENT {
+                            self.iter_state = IterState::GetNext;
+                            return Ok(Ok(()));
+                        }
+                        return Ok(Err(le.with_path(
+                            self.walker.pattern_components[idx as usize]
+                                .pattern_slice(&self.walker.pattern),
+                        )));
+                    }
+                    Ok(lst) if !S::ISLNK(lst.st_mode as u32) => lst,
+                    Ok(lst) => match A::statat(fd, pathz_ref) {
+                        Ok(st) => st,
+                        Err(e) => {
                             if self.walker.error_on_broken_symlinks {
                                 self.close_disallowing_cwd(fd);
                                 return Ok(Err(e.with_path(
@@ -687,24 +700,15 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                             }
                             lst
                         }
-                        Err(le) => {
-                            self.close_disallowing_cwd(fd);
-                            if le.get_errno() == E::ENOENT {
-                                self.iter_state = IterState::GetNext;
-                                return Ok(Ok(()));
-                            }
-                            return Ok(Err(le.with_path(
-                                self.walker.pattern_components[idx as usize]
-                                    .pattern_slice(&self.walker.pattern),
-                            )));
-                        }
                     },
                 };
                 self.close_disallowing_cwd(fd);
                 let mode = stat_result.st_mode as u32;
-                let matches = (S::ISDIR(mode) && !self.walker.only_files)
-                    || S::ISREG(mode)
-                    || !self.walker.only_files;
+                let matches = if trailing_sep {
+                    S::ISDIR(mode) && !self.walker.only_files
+                } else {
+                    S::ISREG(mode) || !self.walker.only_files
+                };
                 if matches {
                     if let Some(path) = self
                         .walker

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -674,10 +674,8 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                 let pathz_ref = ZStr::from_slice_with_nul(&pathz[..]);
                 let stat_result: Stat = match A::statat(fd, pathz_ref) {
                     Ok(stat) => stat,
-                    // statat follows symlinks, so a dangling or cyclic link
-                    // fails (ENOENT/ELOOP) even though the directory entry
-                    // exists. Retry without following so this path agrees with
-                    // directory iteration, which sees the entry regardless.
+                    // statat follows symlinks; a broken link still exists as an
+                    // entry, so fall back to lstat like directory iteration does.
                     Err(e) => match A::lstatat(fd, pathz_ref) {
                         Ok(lst) if !self.walker.error_on_broken_symlinks => lst,
                         lstat_result => {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1952,10 +1952,6 @@ pub mod dir_entry_accessor {
         /// Like statat but does not follow symlinks.
         fn lstatat(handle: DirEntryHandle, path_: &ZStr) -> Maybe<Stat> {
             let mut buf = PathBuffer::uninit();
-            if let Some(entry) = handle.value {
-                return Syscall::lstatat(entry.fd, path_);
-            }
-
             let path: &ZStr = if !Platform::AUTO.is_absolute(path_.as_bytes()) {
                 if let Some(entry) = handle.value {
                     let slice = resolve_path::join_string_buf::<bun_paths::platform::Auto>(

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1125,6 +1125,47 @@ describe.skipIf(!canCreateDirSymlink)("literal path segment through a symlinked 
     );
     expect(norm(result)).toEqual(["linkdir/file.txt"]);
   });
+
+  // The literal-tail fast path resolves the name with a following stat, which
+  // fails (ENOENT/ELOOP) on a broken or cyclic link even though the directory
+  // entry exists. That must behave like the wildcard path: yield the entry
+  // under onlyFiles:false, and never let a single unresolvable name throw.
+  test.skipIf(isWindows)("literal pattern naming a broken symlink matches wildcard behaviour", () => {
+    using dir = tempDir("glob-scan-symlink-literal-broken", {
+      "a.txt": "x",
+      "sub/keep.txt": "x",
+    });
+    const cwd = String(dir);
+    fs.symlinkSync("nowhere", path.join(cwd, "dangling"));
+    fs.symlinkSync("cyc2", path.join(cwd, "cyc1"));
+    fs.symlinkSync("cyc1", path.join(cwd, "cyc2"));
+    fs.symlinkSync("nowhere", path.join(cwd, "sub", "dangling"));
+    fs.symlinkSync("cyc2", path.join(cwd, "sub", "cyc1"));
+    fs.symlinkSync("cyc1", path.join(cwd, "sub", "cyc2"));
+
+    const scan = (p: string, o: GlobScanOptions) => norm(Array.from(new Glob(p).scanSync({ cwd, ...o })));
+
+    // onlyFiles:false yields the link itself; literal and wildcard agree.
+    expect(scan("dangling", { onlyFiles: false })).toEqual(["dangling"]);
+    expect(scan("dangling*", { onlyFiles: false })).toEqual(["dangling"]);
+    expect(scan("cyc1", { onlyFiles: false })).toEqual(["cyc1"]);
+    expect(scan("cyc1*", { onlyFiles: false })).toEqual(["cyc1"]);
+
+    // onlyFiles:true never yields a link whose target cannot be resolved, and
+    // naming an ELOOP entry does not throw.
+    expect(scan("dangling", { onlyFiles: true })).toEqual([]);
+    expect(scan("cyc1", { onlyFiles: true })).toEqual([]);
+
+    // Literal tail reached via an iterated parent still agrees.
+    expect(scan("*/dangling", { onlyFiles: false })).toEqual(["sub/dangling"]);
+    expect(scan("*/cyc1", { onlyFiles: false })).toEqual(["sub/cyc1"]);
+    expect(scan("*/cyc1", { onlyFiles: true })).toEqual([]);
+
+    // throwErrorOnBrokenSymlink still surfaces the failure.
+    expect(() => [...new Glob("dangling").scanSync({ cwd, onlyFiles: false, throwErrorOnBrokenSymlink: true })]).toThrow(
+      /ENOENT/,
+    );
+  });
 });
 
 // A directory the user can read but not write (RX-only grant) must still be

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1161,10 +1161,13 @@ describe.skipIf(!canCreateDirSymlink)("literal path segment through a symlinked 
     expect(scan("*/cyc1", { onlyFiles: false })).toEqual(["sub/cyc1"]);
     expect(scan("*/cyc1", { onlyFiles: true })).toEqual([]);
 
-    // throwErrorOnBrokenSymlink still surfaces the failure.
-    expect(() => [
-      ...new Glob("dangling").scanSync({ cwd, onlyFiles: false, throwErrorOnBrokenSymlink: true }),
-    ]).toThrow(/ENOENT/);
+    // throwErrorOnBrokenSymlink still surfaces the original following-stat error.
+    const throwing = (p: string, onlyFiles: boolean) => () => [
+      ...new Glob(p).scanSync({ cwd, onlyFiles, throwErrorOnBrokenSymlink: true }),
+    ];
+    expect(throwing("dangling", false)).toThrow(/ENOENT/);
+    expect(throwing("cyc1", false)).toThrow(/ELOOP/);
+    expect(throwing("cyc1", true)).toThrow(/ELOOP/);
   });
 });
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1161,6 +1161,14 @@ describe.skipIf(!canCreateDirSymlink)("literal path segment through a symlinked 
     expect(scan("*/cyc1", { onlyFiles: false })).toEqual(["sub/cyc1"]);
     expect(scan("*/cyc1", { onlyFiles: true })).toEqual([]);
 
+    // A trailing `/` means directories-only; a broken link (or regular file)
+    // never satisfies that, and literal/wildcard agree.
+    expect(scan("dangling/", { onlyFiles: false })).toEqual([]);
+    expect(scan("dangling*/", { onlyFiles: false })).toEqual([]);
+    expect(scan("cyc1/", { onlyFiles: false })).toEqual([]);
+    expect(scan("a.txt/", { onlyFiles: false })).toEqual([]);
+    expect(scan("a.txt*/", { onlyFiles: false })).toEqual([]);
+
     // throwErrorOnBrokenSymlink still surfaces the original following-stat error.
     const throwing = (p: string, onlyFiles: boolean) => () => [
       ...new Glob(p).scanSync({ cwd, onlyFiles, throwErrorOnBrokenSymlink: true }),

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1162,9 +1162,9 @@ describe.skipIf(!canCreateDirSymlink)("literal path segment through a symlinked 
     expect(scan("*/cyc1", { onlyFiles: true })).toEqual([]);
 
     // throwErrorOnBrokenSymlink still surfaces the failure.
-    expect(() => [...new Glob("dangling").scanSync({ cwd, onlyFiles: false, throwErrorOnBrokenSymlink: true })]).toThrow(
-      /ENOENT/,
-    );
+    expect(() => [
+      ...new Glob("dangling").scanSync({ cwd, onlyFiles: false, throwErrorOnBrokenSymlink: true }),
+    ]).toThrow(/ENOENT/);
   });
 });
 


### PR DESCRIPTION
## What

`Bun.Glob.scanSync` with a fully-literal last component disagreed with the wildcard path (and `fs.globSync`, and node) when that name is a broken symlink:

```js
symlinkSync("nowhere", R + "/dangling");
symlinkSync("cyc2", R + "/cyc1"); symlinkSync("cyc1", R + "/cyc2");

[...new Bun.Glob("dangling*").scanSync({ cwd: R, onlyFiles: false })] // ["dangling"]
[...new Bun.Glob("dangling" ).scanSync({ cwd: R, onlyFiles: false })] // []            (entry vanishes)
[...new Bun.Glob("cyc1*"    ).scanSync({ cwd: R, onlyFiles: false })] // ["cyc1"]
[...new Bun.Glob("cyc1"     ).scanSync({ cwd: R, onlyFiles: false })] // throws ELOOP  (whole scan aborts)
```

So whether a symlink entry exists at all depended on whether the pattern happened to contain a metacharacter, and naming an `ELOOP` entry killed the scan.

## Why

The literal-tail optimization in `GlobWalker.rs` resolves a single literal last component with a following `statat()` instead of iterating the directory. `statat` follows symlinks, so a dangling link yields `ENOENT` (swallowed as "no match") and a cyclic link yields `ELOOP` (propagated as the scan error), even though the directory entry exists. The directory-iteration path sees the entry via `readdir` and yields it under `onlyFiles:false`.

## Fix

Probe `lstatat` first (so a plain miss stays one syscall) and only follow through to `statat` when lstat reports a symlink:

- If `lstatat` fails, its errno drives the outcome: `ENOENT` skips (entry truly absent), anything else is propagated.
- If the entry is not a symlink, use the lstat result directly.
- If the entry is a symlink, `statat` resolves the target. When that fails the lstat mode (`S_IFLNK`) is kept, so the existing `S::ISREG(mode) || !only_files` gate yields it under `onlyFiles:false` and drops it under `onlyFiles:true`, matching the wildcard path. `throwErrorOnBrokenSymlink: true` surfaces the `statat` error (`ENOENT`/`ELOOP`).

The `matches` gate now also honors `trailing_sep`: a directory-only pattern like `name/` never yields a broken link (or a regular file), matching what `match_pattern_file` already does on the wildcard path.

## Scope

The sibling fully-literal **absolute** fast path in `Iterator::init()` (`GlobWalker.rs:427`) is intentionally not touched here. That path has a deeper pre-existing bug: its match never reaches `matched_paths`, so `new Bun.Glob("/abs/file.txt").scanSync({})` already returns `[]` on main even for a real regular file, and it also ignores `only_files`. Adding an lstat fallback there would be unobservable until that output bug is fixed; tracked as a follow-up.

## Verification

New test in `test/js/bun/glob/scan.test.ts` covers dangling and cyclic links under both `onlyFiles` values, at cwd level and via an iterated parent (`*/name`), trailing-`/` variants (literal and wildcard), plus `throwErrorOnBrokenSymlink` for both `ENOENT` and `ELOOP`. Fails on main at the first assertion, passes with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/glob/scan.test.ts

<!-- robobun:evidence:end -->