### PR TITLE
test(regression/26207): dedupe via test.each and assert stderr

### DIFF
--- a/test/regression/issue/26207.test.ts
+++ b/test/regression/issue/26207.test.ts
@@ -2,122 +2,90 @@
 // bun run --filter and --workspaces should fall back to bun's node symlink
 // when NODE env var points to a non-existent path
 
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { chmodSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-test("bun run --workspaces creates node symlink when NODE env points to non-existent path", async () => {
-  await using dir = tempDir("workspaces-node-fallback", {
-    "package.json": JSON.stringify({
-      name: "root",
-      workspaces: ["packages/*"],
-    }),
-    "packages/a/package.json": JSON.stringify({
-      name: "a",
-      scripts: {
-        test: "node -e \"console.log('node works')\"",
+// Each test owns its own tempDir and subprocess, so they are safe to run in parallel.
+describe.concurrent("issue 26207", () => {
+  test.each([
+    ["--workspaces", ["--workspaces"]],
+    ["--filter", ["--filter", "*"]],
+  ])("bun run %s creates node symlink when NODE env points to non-existent path", async (_label, flags) => {
+    await using dir = tempDir("26207-node-fallback", {
+      "package.json": JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+      }),
+      "packages/a/package.json": JSON.stringify({
+        name: "a",
+        scripts: {
+          test: "node -e \"console.log('node works')\"",
+        },
+      }),
+    });
+
+    // Set NODE to a non-existent path and remove system node from PATH
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", ...flags, "test"],
+      env: {
+        ...bunEnv,
+        NODE: "/nonexistent/path/to/node",
+        PATH: "/usr/bin", // PATH without node
       },
-    }),
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should succeed because bun creates a symlink to its own node
+    expect(stderr).toBe("");
+    expect(stdout).toContain("node works");
+    expect(exitCode).toBe(0);
   });
 
-  // Set NODE to a non-existent path and remove system node from PATH
-  const env = {
-    ...bunEnv,
-    NODE: "/nonexistent/path/to/node",
-    PATH: "/usr/bin", // PATH without node
-  };
+  // Skip on Windows: shebang scripts (#!/usr/bin/env node) are Unix-specific
+  test.skipIf(isWindows)("bun run --workspaces runs scripts that have #!/usr/bin/env node shebang", async () => {
+    await using dir = tempDir("26207-shebang", {
+      "package.json": JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+      }),
+      "packages/a/package.json": JSON.stringify({
+        name: "a",
+        scripts: {
+          build: "./build.js",
+        },
+      }),
+      // Create an executable script with node shebang
+      "packages/a/build.js": "#!/usr/bin/env node\nconsole.log('build script ran');",
+    });
 
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "run", "--workspaces", "test"],
-    env,
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    // Make the script executable
+    chmodSync(`${dir}/packages/a/build.js`, 0o755);
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // Should succeed because bun creates a symlink to its own node
-  expect(stdout).toContain("node works");
-  expect(exitCode).toBe(0);
-});
-
-test("bun run --filter creates node symlink when NODE env points to non-existent path", async () => {
-  await using dir = tempDir("filter-node-fallback", {
-    "package.json": JSON.stringify({
-      name: "root",
-      workspaces: ["packages/*"],
-    }),
-    "packages/a/package.json": JSON.stringify({
-      name: "a",
-      scripts: {
-        test: "node -e \"console.log('node works from filter')\"",
+    // Remove system node from PATH, and clear NODE/npm_node_execpath to avoid
+    // interfering with bun's node symlink creation
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--workspaces", "build"],
+      env: {
+        ...bunEnv,
+        NODE: undefined,
+        npm_node_execpath: undefined,
+        PATH: "/usr/bin", // PATH without node
       },
-    }),
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should succeed because bun creates a symlink to its own node
+    expect(stderr).toBe("");
+    expect(stdout).toContain("build script ran");
+    expect(exitCode).toBe(0);
   });
-
-  // Set NODE to a non-existent path and remove system node from PATH
-  const env = {
-    ...bunEnv,
-    NODE: "/nonexistent/path/to/node",
-    PATH: "/usr/bin", // PATH without node
-  };
-
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "run", "--filter", "*", "test"],
-    env,
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // Should succeed because bun creates a symlink to its own node
-  expect(stdout).toContain("node works from filter");
-  expect(exitCode).toBe(0);
-});
-
-// Skip on Windows: shebang scripts (#!/usr/bin/env node) are Unix-specific
-test.skipIf(isWindows)("bun run --workspaces runs scripts that have #!/usr/bin/env node shebang", async () => {
-  await using dir = tempDir("workspaces-shebang", {
-    "package.json": JSON.stringify({
-      name: "root",
-      workspaces: ["packages/*"],
-    }),
-    "packages/a/package.json": JSON.stringify({
-      name: "a",
-      scripts: {
-        build: "./build.js",
-      },
-    }),
-    // Create an executable script with node shebang
-    "packages/a/build.js": "#!/usr/bin/env node\nconsole.log('build script ran');",
-  });
-
-  // Make the script executable
-  chmodSync(`${dir}/packages/a/build.js`, 0o755);
-
-  // Remove system node from PATH, and clear NODE/npm_node_execpath to avoid
-  // interfering with bun's node symlink creation
-  const env = {
-    ...bunEnv,
-    NODE: undefined,
-    npm_node_execpath: undefined,
-    PATH: "/usr/bin", // PATH without node
-  };
-
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "run", "--workspaces", "build"],
-    env,
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // Should succeed because bun creates a symlink to its own node
-  expect(stdout).toContain("build script ran");
-  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/26207.test.ts
+++ b/test/regression/issue/26207.test.ts
@@ -6,8 +6,11 @@ import { describe, expect, test } from "bun:test";
 import { chmodSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-// Each test owns its own tempDir and subprocess, so they are safe to run in parallel.
-describe.concurrent("issue 26207", () => {
+// These cases must stay serial: every one forces the fake-node fallback and in
+// debug builds `create_fake_temporary_node_executable` wipes the shared
+// `bun-node-debug` temp dir before recreating it, so concurrent runs can race
+// on that delete/recreate sequence.
+describe("issue 26207", () => {
   test.each([
     ["--workspaces", ["--workspaces"]],
     ["--filter", ["--filter", "*"]],


### PR DESCRIPTION
### What does this PR do?

Cleanup of `test/regression/issue/26207.test.ts`:

- collapse the two near-identical `--workspaces` / `--filter` cases into a single `test.each` over the flag variant
- add `expect(stderr).toBe("")` to each case so unexpected error output fails the test (stderr was previously piped but never checked)
- use `await using` for the spawned subprocesses
- add a comment explaining why these cases must stay serial

No tests are deleted or skipped; the same three scenarios are covered with stronger assertions. Net -29 lines.

**No speedup.** This started as an attempt to make the file faster on ASAN (18.4s in `expected-durations.json`) via `describe.concurrent`, but every case forces the fake-node fallback path and in debug builds `create_fake_temporary_node_executable` unconditionally wipes the shared `bun-node-debug` temp dir (`src/install/lib.rs:578-583` on POSIX, `:702-720` on Windows) before recreating it, so the three concurrent subprocesses can race on that delete/recreate sequence. Running the three cases concurrently 240 times locally (8-way, 30 rounds) did not trigger the race, but `test/cli/install/bun-run.test.ts` already documents the same hazard in its Windows-side comment and I don't want to add a second dependency on it. Making the POSIX path race-tolerant (its own inline comment already notes the `delete_tree` is redundant given the EEXIST handling below it) would unblock concurrency here but is out of scope for a test-only change.

### How did you verify your code works?

`bun bd test test/regression/issue/26207.test.ts` passes with 9 `expect()` calls (up from 6). Wall time is unchanged vs `main` since the cases remain serial.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->