### PR TITLE
cli: `bun repl --help` prints the repl help, not `bun run`'s

### DIFF
--- a/src/options_types/command_tag.rs
+++ b/src/options_types/command_tag.rs
@@ -214,6 +214,7 @@ pub static LOADS_CONFIG: TagTable<bool> = TagTable({
     a[Tag::AutoCommand as usize] = true;
     a[Tag::RunCommand as usize] = true;
     a[Tag::RunAsNodeCommand as usize] = true;
+    a[Tag::ReplCommand as usize] = true;
     a[Tag::OutdatedCommand as usize] = true;
     a[Tag::UpdateInteractiveCommand as usize] = true;
     a[Tag::PublishCommand as usize] = true;

--- a/src/options_types/command_tag.rs
+++ b/src/options_types/command_tag.rs
@@ -214,7 +214,6 @@ pub static LOADS_CONFIG: TagTable<bool> = TagTable({
     a[Tag::AutoCommand as usize] = true;
     a[Tag::RunCommand as usize] = true;
     a[Tag::RunAsNodeCommand as usize] = true;
-    a[Tag::ReplCommand as usize] = true;
     a[Tag::OutdatedCommand as usize] = true;
     a[Tag::UpdateInteractiveCommand as usize] = true;
     a[Tag::PublishCommand as usize] = true;

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -665,9 +665,7 @@ pub(crate) static BASE_RUNTIME_TRANSPILER_TABLE: &clap::ConvertedTable =
 pub(crate) fn tag_table(cmd: CommandTag) -> &'static clap::ConvertedTable {
     match cmd {
         CommandTag::AutoCommand => AUTO_TABLE,
-        CommandTag::RunCommand | CommandTag::RunAsNodeCommand | CommandTag::ReplCommand => {
-            RUN_TABLE
-        }
+        CommandTag::RunCommand | CommandTag::RunAsNodeCommand => RUN_TABLE,
         CommandTag::BuildCommand => BUILD_TABLE,
         CommandTag::TestCommand => TEST_TABLE,
         CommandTag::BunxCommand => RUN_TABLE,
@@ -714,7 +712,15 @@ pub use bun_bunfig::arguments::{load_config, load_config_path, load_config_with_
 /// `command::tag_params(cmd)` does a runtime lookup of the per-subcommand
 /// param table, and the per-`cmd` blocks below are guarded by
 /// `if matches!(cmd, …)`.
-pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformOptions> {
+///
+/// `help_as` is the tag whose help text is printed on `--help` or a clap parse
+/// error. It equals `cmd` except for `bun repl`, which parses as `RunCommand`
+/// but prints `ReplCommand`'s help.
+pub fn parse(
+    cmd: CommandTag,
+    help_as: CommandTag,
+    ctx: Context<'_>,
+) -> crate::Result<api::TransformOptions> {
     let mut diag = clap::Diagnostic::default();
     let table = tag_table(cmd);
 
@@ -723,7 +729,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         clap::ParseOptions {
             diagnostic: Some(&mut diag),
             stop_after_positional_at: match cmd {
-                CommandTag::RunCommand | CommandTag::ReplCommand => 2,
+                CommandTag::RunCommand => 2,
                 CommandTag::AutoCommand | CommandTag::RunAsNodeCommand => 1,
                 _ => 0,
             },
@@ -733,13 +739,13 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         Err(err) => {
             // Report useful error and exit
             let _ = diag.report(Output::error_writer(), err);
-            command::tag_print_help(cmd, false);
+            command::tag_print_help(help_as, false);
             Global::exit(1);
         }
     };
 
     if args.flag(b"--help") {
-        command::tag_print_help(cmd, true);
+        command::tag_print_help(help_as, true);
         Output::flush();
         Global::exit(0);
     }
@@ -789,20 +795,14 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
     // BUN_FEATURE_FLAG_NO_ORPHANS env var in main()→install() instead.
     if matches!(
         cmd,
-        CommandTag::RunCommand
-            | CommandTag::AutoCommand
-            | CommandTag::TestCommand
-            | CommandTag::ReplCommand
+        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::TestCommand
     ) {
         if args.flag(b"--no-orphans") {
             bun_io::parent_death_watchdog::enable();
         }
     }
 
-    if matches!(
-        cmd,
-        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::ReplCommand
-    ) {
+    if matches!(cmd, CommandTag::RunCommand | CommandTag::AutoCommand) {
         ctx.filters = slice_to_owned(args.options(b"--filter"));
         ctx.workspaces = args.flag(b"--workspaces");
         ctx.if_present = args.flag(b"--if-present");
@@ -919,7 +919,6 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             | CommandTag::RunCommand
             | CommandTag::BuildCommand
             | CommandTag::TestCommand
-            | CommandTag::ReplCommand
     ) {
         if !args.options(b"--conditions").is_empty() {
             opts.conditions = slice_to_owned(args.options(b"--conditions"));
@@ -933,7 +932,6 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             | CommandTag::RunCommand
             | CommandTag::TestCommand
             | CommandTag::RunAsNodeCommand
-            | CommandTag::ReplCommand
     ) {
         {
             let preloads = args.options(b"--preload");
@@ -1398,10 +1396,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
     let jsx_runtime = args.option(b"--jsx-runtime");
     let jsx_side_effects = args.flag(b"--jsx-side-effects");
 
-    if matches!(
-        cmd,
-        CommandTag::AutoCommand | CommandTag::RunCommand | CommandTag::ReplCommand
-    ) {
+    if matches!(cmd, CommandTag::AutoCommand | CommandTag::RunCommand) {
         // "run.silent" in bunfig.toml
         if args.flag(b"--silent") {
             ctx.debug.silent = true;
@@ -1433,10 +1428,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
 
     if matches!(
         cmd,
-        CommandTag::RunCommand
-            | CommandTag::AutoCommand
-            | CommandTag::BunxCommand
-            | CommandTag::ReplCommand
+        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::BunxCommand
     ) {
         // "run.bun" in bunfig.toml
         if args.flag(b"--bun") {
@@ -1542,10 +1534,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         ctx.debug.output_file = of.into();
     }
 
-    if matches!(
-        cmd,
-        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::ReplCommand
-    ) {
+    if matches!(cmd, CommandTag::RunCommand | CommandTag::AutoCommand) {
         if let Some(shell) = args.option(b"--shell") {
             if shell == b"bun" {
                 ctx.debug.use_system_shell = false;

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -711,11 +711,7 @@ pub use bun_bunfig::arguments::{load_config, load_config_path, load_config_with_
 ///
 /// `command::tag_params(cmd)` does a runtime lookup of the per-subcommand
 /// param table, and the per-`cmd` blocks below are guarded by
-/// `if matches!(cmd, …)`.
-///
-/// `help_as` is the tag whose help text is printed on `--help` or a clap parse
-/// error. It equals `cmd` except for `bun repl`, which parses as `RunCommand`
-/// but prints `ReplCommand`'s help.
+/// `if matches!(cmd, …)`. `help_as` selects the `--help` / parse-error text.
 pub fn parse(
     cmd: CommandTag,
     help_as: CommandTag,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -665,7 +665,7 @@ pub(crate) static BASE_RUNTIME_TRANSPILER_TABLE: &clap::ConvertedTable =
 pub(crate) fn tag_table(cmd: CommandTag) -> &'static clap::ConvertedTable {
     match cmd {
         CommandTag::AutoCommand => AUTO_TABLE,
-        CommandTag::RunCommand | CommandTag::RunAsNodeCommand => RUN_TABLE,
+        CommandTag::RunCommand | CommandTag::RunAsNodeCommand | CommandTag::ReplCommand => RUN_TABLE,
         CommandTag::BuildCommand => BUILD_TABLE,
         CommandTag::TestCommand => TEST_TABLE,
         CommandTag::BunxCommand => RUN_TABLE,
@@ -721,7 +721,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         clap::ParseOptions {
             diagnostic: Some(&mut diag),
             stop_after_positional_at: match cmd {
-                CommandTag::RunCommand => 2,
+                CommandTag::RunCommand | CommandTag::ReplCommand => 2,
                 CommandTag::AutoCommand | CommandTag::RunAsNodeCommand => 1,
                 _ => 0,
             },
@@ -924,6 +924,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             | CommandTag::RunCommand
             | CommandTag::TestCommand
             | CommandTag::RunAsNodeCommand
+            | CommandTag::ReplCommand
     ) {
         {
             let preloads = args.options(b"--preload");

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -711,8 +711,12 @@ pub use bun_bunfig::arguments::{load_config, load_config_path, load_config_with_
 ///
 /// `command::tag_params(cmd)` does a runtime lookup of the per-subcommand
 /// param table, and the per-`cmd` blocks below are guarded by
-/// `if matches!(cmd, …)`.
-pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformOptions> {
+/// `if matches!(cmd, …)`. `help_as` selects the `--help` / parse-error text.
+pub fn parse(
+    cmd: CommandTag,
+    help_as: CommandTag,
+    ctx: Context<'_>,
+) -> crate::Result<api::TransformOptions> {
     let mut diag = clap::Diagnostic::default();
     let table = tag_table(cmd);
 
@@ -731,13 +735,13 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         Err(err) => {
             // Report useful error and exit
             let _ = diag.report(Output::error_writer(), err);
-            command::tag_print_help(cmd, false);
+            command::tag_print_help(help_as, false);
             Global::exit(1);
         }
     };
 
     if args.flag(b"--help") {
-        command::tag_print_help(cmd, true);
+        command::tag_print_help(help_as, true);
         Output::flush();
         Global::exit(0);
     }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -665,7 +665,9 @@ pub(crate) static BASE_RUNTIME_TRANSPILER_TABLE: &clap::ConvertedTable =
 pub(crate) fn tag_table(cmd: CommandTag) -> &'static clap::ConvertedTable {
     match cmd {
         CommandTag::AutoCommand => AUTO_TABLE,
-        CommandTag::RunCommand | CommandTag::RunAsNodeCommand | CommandTag::ReplCommand => RUN_TABLE,
+        CommandTag::RunCommand | CommandTag::RunAsNodeCommand | CommandTag::ReplCommand => {
+            RUN_TABLE
+        }
         CommandTag::BuildCommand => BUILD_TABLE,
         CommandTag::TestCommand => TEST_TABLE,
         CommandTag::BunxCommand => RUN_TABLE,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -789,14 +789,20 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
     // BUN_FEATURE_FLAG_NO_ORPHANS env var in main()→install() instead.
     if matches!(
         cmd,
-        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::TestCommand
+        CommandTag::RunCommand
+            | CommandTag::AutoCommand
+            | CommandTag::TestCommand
+            | CommandTag::ReplCommand
     ) {
         if args.flag(b"--no-orphans") {
             bun_io::parent_death_watchdog::enable();
         }
     }
 
-    if matches!(cmd, CommandTag::RunCommand | CommandTag::AutoCommand) {
+    if matches!(
+        cmd,
+        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::ReplCommand
+    ) {
         ctx.filters = slice_to_owned(args.options(b"--filter"));
         ctx.workspaces = args.flag(b"--workspaces");
         ctx.if_present = args.flag(b"--if-present");
@@ -913,6 +919,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             | CommandTag::RunCommand
             | CommandTag::BuildCommand
             | CommandTag::TestCommand
+            | CommandTag::ReplCommand
     ) {
         if !args.options(b"--conditions").is_empty() {
             opts.conditions = slice_to_owned(args.options(b"--conditions"));
@@ -1391,7 +1398,10 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
     let jsx_runtime = args.option(b"--jsx-runtime");
     let jsx_side_effects = args.flag(b"--jsx-side-effects");
 
-    if matches!(cmd, CommandTag::AutoCommand | CommandTag::RunCommand) {
+    if matches!(
+        cmd,
+        CommandTag::AutoCommand | CommandTag::RunCommand | CommandTag::ReplCommand
+    ) {
         // "run.silent" in bunfig.toml
         if args.flag(b"--silent") {
             ctx.debug.silent = true;
@@ -1423,7 +1433,10 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
 
     if matches!(
         cmd,
-        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::BunxCommand
+        CommandTag::RunCommand
+            | CommandTag::AutoCommand
+            | CommandTag::BunxCommand
+            | CommandTag::ReplCommand
     ) {
         // "run.bun" in bunfig.toml
         if args.flag(b"--bun") {
@@ -1529,7 +1542,10 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         ctx.debug.output_file = of.into();
     }
 
-    if matches!(cmd, CommandTag::RunCommand | CommandTag::AutoCommand) {
+    if matches!(
+        cmd,
+        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::ReplCommand
+    ) {
         if let Some(shell) = args.option(b"--shell") {
             if shell == b"bun" {
                 ctx.debug.use_system_shell = false;

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -711,12 +711,8 @@ pub use bun_bunfig::arguments::{load_config, load_config_path, load_config_with_
 ///
 /// `command::tag_params(cmd)` does a runtime lookup of the per-subcommand
 /// param table, and the per-`cmd` blocks below are guarded by
-/// `if matches!(cmd, …)`. `help_as` selects the `--help` / parse-error text.
-pub fn parse(
-    cmd: CommandTag,
-    help_as: CommandTag,
-    ctx: Context<'_>,
-) -> crate::Result<api::TransformOptions> {
+/// `if matches!(cmd, …)`.
+pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformOptions> {
     let mut diag = clap::Diagnostic::default();
     let table = tag_table(cmd);
 
@@ -735,13 +731,13 @@ pub fn parse(
         Err(err) => {
             // Report useful error and exit
             let _ = diag.report(Output::error_writer(), err);
-            command::tag_print_help(help_as, false);
+            command::tag_print_help(cmd, false);
             Global::exit(1);
         }
     };
 
     if args.flag(b"--help") {
-        command::tag_print_help(help_as, true);
+        command::tag_print_help(cmd, true);
         Output::flush();
         Global::exit(0);
     }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1544,7 +1544,15 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_repl(log: &mut bun_ast::Log) -> CmdResult {
-        // Inits with RunCommand (repl reuses run params).
+        // Inits with RunCommand (repl reuses run's param table), so `--help`
+        // inside `arguments::parse` would print `bun run`'s help. Intercept it
+        // here first.
+        for a in bun::argv().iter().skip(2) {
+            if matches!(a, b"--help" | b"-h") {
+                tag_print_help(Tag::ReplCommand, true);
+                Global::exit(0);
+            }
+        }
         let ctx = init(Tag::RunCommand, log)?;
         super::repl_command::ReplCommand::exec(ctx)
     }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1102,6 +1102,17 @@ pub mod command {
         }
     }
 
+    /// `ContextData.create` — see [`create_context_data_help_as`].
+    #[track_caller]
+    #[inline(always)]
+    pub fn create_context_data(
+        cmd: Tag,
+        log: &mut bun_ast::Log,
+    ) -> crate::Result<&'static mut ContextData> {
+        create_context_data_help_as(cmd, cmd, log)
+    }
+    pub use create_context_data as init;
+
     /// `ContextData.create` — populates the global ctx and runs `Arguments::parse`.
     ///
     /// `Tag` lacks `ConstParamTy` (lower-tier crate), so `cmd` is a runtime
@@ -1111,6 +1122,11 @@ pub mod command {
     /// borrow at the time of return; callers thread it down via the `ctx`
     /// parameter rather than re-deriving.
     ///
+    /// `help_as` is the user-facing subcommand: recorded in `CMD` / the crash
+    /// handler and used by `arguments::parse` for `--help` / parse-error
+    /// output. It equals `cmd` everywhere except `bun repl`, which parses as
+    /// `RunCommand`.
+    ///
     /// `#[inline(never)]`: this is the `init` step of the `bun run <script>`
     /// dispatch chain (`exec_auto_or_run → init → RunCommand::exec_with_cfg`)
     /// and must stay a concrete symbol so `src/startup.order` can place it —
@@ -1118,22 +1134,23 @@ pub mod command {
     /// would otherwise make it an inlining candidate, scattering those callees.
     #[track_caller]
     #[inline(never)]
-    pub fn create_context_data(
+    pub fn create_context_data_help_as(
         cmd: Tag,
+        help_as: Tag,
         log: &mut bun_ast::Log,
     ) -> crate::Result<&'static mut ContextData> {
         // SAFETY: single-threaded CLI startup — no other thread exists yet.
         // `CMD` is read by debug logging and `run_command` (feedback dispatch).
-        unsafe { CMD.write(Some(cmd)) };
+        unsafe { CMD.write(Some(help_as)) };
         // The crash handler can't read `CMD` (lower-tier crate); mirror the
         // one-byte command tag into its `cli_state` so crash-report trace
         // strings encode the running subcommand (Zig: `Cli.cmd = command`).
-        bun_crash_handler::cli_state::set_cmd_char(cmd.char());
+        bun_crash_handler::cli_state::set_cmd_char(help_as.char());
 
         let ctx = write_context_no_parse(log);
 
         if USES_GLOBAL_OPTIONS[cmd] {
-            ctx.args = arguments::parse(cmd, ctx)?;
+            ctx.args = arguments::parse(cmd, help_as, ctx)?;
         }
 
         #[cfg(windows)]
@@ -1151,7 +1168,6 @@ pub mod command {
 
         Ok(ctx)
     }
-    pub use create_context_data as init;
 
     /// Full subcommand dispatch.
     ///
@@ -1544,7 +1560,7 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_repl(log: &mut bun_ast::Log) -> CmdResult {
-        let ctx = init(Tag::ReplCommand, log)?;
+        let ctx = create_context_data_help_as(Tag::RunCommand, Tag::ReplCommand, log)?;
         super::repl_command::ReplCommand::exec(ctx)
     }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1120,12 +1120,8 @@ pub mod command {
     /// Returns `&'static mut` to the process-global `CONTEXT_DATA`. Sound
     /// because CLI dispatch is single-threaded and this is the sole live
     /// borrow at the time of return; callers thread it down via the `ctx`
-    /// parameter rather than re-deriving.
-    ///
-    /// `help_as` is the user-facing subcommand: recorded in `CMD` / the crash
-    /// handler and used by `arguments::parse` for `--help` / parse-error
-    /// output. It equals `cmd` everywhere except `bun repl`, which parses as
-    /// `RunCommand`.
+    /// parameter rather than re-deriving. `help_as` is the user-facing
+    /// subcommand for `CMD`, the crash handler, and `--help` output.
     ///
     /// `#[inline(never)]`: this is the `init` step of the `bun run <script>`
     /// dispatch chain (`exec_auto_or_run → init → RunCommand::exec_with_cfg`)

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1102,17 +1102,6 @@ pub mod command {
         }
     }
 
-    /// `ContextData.create` — see [`create_context_data_help_as`].
-    #[track_caller]
-    #[inline(always)]
-    pub fn create_context_data(
-        cmd: Tag,
-        log: &mut bun_ast::Log,
-    ) -> crate::Result<&'static mut ContextData> {
-        create_context_data_help_as(cmd, cmd, log)
-    }
-    pub use create_context_data as init;
-
     /// `ContextData.create` — populates the global ctx and runs `Arguments::parse`.
     ///
     /// `Tag` lacks `ConstParamTy` (lower-tier crate), so `cmd` is a runtime
@@ -1120,8 +1109,7 @@ pub mod command {
     /// Returns `&'static mut` to the process-global `CONTEXT_DATA`. Sound
     /// because CLI dispatch is single-threaded and this is the sole live
     /// borrow at the time of return; callers thread it down via the `ctx`
-    /// parameter rather than re-deriving. `help_as` is the user-facing
-    /// subcommand for `CMD`, the crash handler, and `--help` output.
+    /// parameter rather than re-deriving.
     ///
     /// `#[inline(never)]`: this is the `init` step of the `bun run <script>`
     /// dispatch chain (`exec_auto_or_run → init → RunCommand::exec_with_cfg`)
@@ -1130,23 +1118,22 @@ pub mod command {
     /// would otherwise make it an inlining candidate, scattering those callees.
     #[track_caller]
     #[inline(never)]
-    pub fn create_context_data_help_as(
+    pub fn create_context_data(
         cmd: Tag,
-        help_as: Tag,
         log: &mut bun_ast::Log,
     ) -> crate::Result<&'static mut ContextData> {
         // SAFETY: single-threaded CLI startup — no other thread exists yet.
         // `CMD` is read by debug logging and `run_command` (feedback dispatch).
-        unsafe { CMD.write(Some(help_as)) };
+        unsafe { CMD.write(Some(cmd)) };
         // The crash handler can't read `CMD` (lower-tier crate); mirror the
         // one-byte command tag into its `cli_state` so crash-report trace
         // strings encode the running subcommand (Zig: `Cli.cmd = command`).
-        bun_crash_handler::cli_state::set_cmd_char(help_as.char());
+        bun_crash_handler::cli_state::set_cmd_char(cmd.char());
 
         let ctx = write_context_no_parse(log);
 
         if USES_GLOBAL_OPTIONS[cmd] {
-            ctx.args = arguments::parse(cmd, help_as, ctx)?;
+            ctx.args = arguments::parse(cmd, ctx)?;
         }
 
         #[cfg(windows)]
@@ -1164,6 +1151,7 @@ pub mod command {
 
         Ok(ctx)
     }
+    pub use create_context_data as init;
 
     /// Full subcommand dispatch.
     ///
@@ -1556,7 +1544,8 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_repl(log: &mut bun_ast::Log) -> CmdResult {
-        let ctx = create_context_data_help_as(Tag::RunCommand, Tag::ReplCommand, log)?;
+        // Inits with RunCommand (repl reuses run params).
+        let ctx = init(Tag::RunCommand, log)?;
         super::repl_command::ReplCommand::exec(ctx)
     }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1102,6 +1102,17 @@ pub mod command {
         }
     }
 
+    /// `ContextData.create` — see [`create_context_data_help_as`].
+    #[track_caller]
+    #[inline(always)]
+    pub fn create_context_data(
+        cmd: Tag,
+        log: &mut bun_ast::Log,
+    ) -> crate::Result<&'static mut ContextData> {
+        create_context_data_help_as(cmd, cmd, log)
+    }
+    pub use create_context_data as init;
+
     /// `ContextData.create` — populates the global ctx and runs `Arguments::parse`.
     ///
     /// `Tag` lacks `ConstParamTy` (lower-tier crate), so `cmd` is a runtime
@@ -1118,22 +1129,23 @@ pub mod command {
     /// would otherwise make it an inlining candidate, scattering those callees.
     #[track_caller]
     #[inline(never)]
-    pub fn create_context_data(
+    pub fn create_context_data_help_as(
         cmd: Tag,
+        help_as: Tag,
         log: &mut bun_ast::Log,
     ) -> crate::Result<&'static mut ContextData> {
         // SAFETY: single-threaded CLI startup — no other thread exists yet.
         // `CMD` is read by debug logging and `run_command` (feedback dispatch).
-        unsafe { CMD.write(Some(cmd)) };
+        unsafe { CMD.write(Some(help_as)) };
         // The crash handler can't read `CMD` (lower-tier crate); mirror the
         // one-byte command tag into its `cli_state` so crash-report trace
         // strings encode the running subcommand (Zig: `Cli.cmd = command`).
-        bun_crash_handler::cli_state::set_cmd_char(cmd.char());
+        bun_crash_handler::cli_state::set_cmd_char(help_as.char());
 
         let ctx = write_context_no_parse(log);
 
         if USES_GLOBAL_OPTIONS[cmd] {
-            ctx.args = arguments::parse(cmd, ctx)?;
+            ctx.args = arguments::parse(cmd, help_as, ctx)?;
         }
 
         #[cfg(windows)]
@@ -1151,7 +1163,6 @@ pub mod command {
 
         Ok(ctx)
     }
-    pub use create_context_data as init;
 
     /// Full subcommand dispatch.
     ///
@@ -1544,8 +1555,7 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_repl(log: &mut bun_ast::Log) -> CmdResult {
-        // Inits with RunCommand (repl reuses run params).
-        let ctx = init(Tag::RunCommand, log)?;
+        let ctx = create_context_data_help_as(Tag::RunCommand, Tag::ReplCommand, log)?;
         super::repl_command::ReplCommand::exec(ctx)
     }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1544,16 +1544,10 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_repl(log: &mut bun_ast::Log) -> CmdResult {
-        // Inits with RunCommand (repl reuses run's param table), so `--help`
-        // inside `arguments::parse` would print `bun run`'s help. Intercept it
-        // here first.
-        for a in bun::argv().iter().skip(2) {
-            if matches!(a, b"--help" | b"-h") {
-                tag_print_help(Tag::ReplCommand, true);
-                Global::exit(0);
-            }
-        }
-        let ctx = init(Tag::RunCommand, log)?;
+        // Repl reuses run's param table (see `arguments::tag_table`), but
+        // inits with its own tag so `arguments::parse`'s `--help` and
+        // parse-error paths print repl's help, not `bun run`'s.
+        let ctx = init(Tag::ReplCommand, log)?;
         super::repl_command::ReplCommand::exec(ctx)
     }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1544,9 +1544,6 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_repl(log: &mut bun_ast::Log) -> CmdResult {
-        // Repl reuses run's param table (see `arguments::tag_table`), but
-        // inits with its own tag so `arguments::parse`'s `--help` and
-        // parse-error paths print repl's help, not `bun run`'s.
         let ctx = init(Tag::ReplCommand, log)?;
         super::repl_command::ReplCommand::exec(ctx)
     }

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -126,6 +126,21 @@ describe("bun", () => {
       }
     });
   });
+  describe("repl --help", () => {
+    test.concurrent.each(["--help", "-h"])("bun repl %s prints repl help, not run help", async flag => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "repl", flag],
+        env: { ...bunEnv, NO_COLOR: "1" },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const out = stdout + stderr;
+      const usage = out.split(/\r?\n/).find(l => l.startsWith("Usage:")) ?? "";
+      expect(usage).toBe("Usage: bun repl [flags]");
+      expect(out).not.toContain("bun run");
+      expect(exitCode).toBe(0);
+    });
+  });
   describe("test command line arguments", () => {
     test("test --config, issue #4128", () => {
       const path = `${tmpdir()}/bunfig-${Date.now()}.toml`;

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -140,6 +140,33 @@ describe("bun", () => {
       expect(out).not.toContain("bun run");
       expect(exitCode).toBe(0);
     });
+
+    test("bun repl parse error prints repl help, not run help", async () => {
+      // -e with no value triggers clap's error path inside arguments::parse
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "repl", "-e"],
+        env: { ...bunEnv, NO_COLOR: "1" },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const out = stdout + stderr;
+      expect(out).toContain("requires a value");
+      expect(out).toContain("bun repl");
+      expect(out).not.toContain("bun run");
+      expect(exitCode).toBe(1);
+    });
+
+    test("bun repl does not intercept --help after passthrough cutoff", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "repl", "-e", "console.log(JSON.stringify(process.argv.slice(1)))", "foo", "--help"],
+        env: { ...bunEnv, NO_COLOR: "1" },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe('["--help"]');
+      expect(exitCode).toBe(0);
+    });
   });
   describe("test command line arguments", () => {
     test("test --config, issue #4128", () => {

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -126,8 +126,8 @@ describe("bun", () => {
       }
     });
   });
-  describe("repl --help", () => {
-    test.concurrent.each(["--help", "-h"])("bun repl %s prints repl help, not run help", async flag => {
+  describe.concurrent("repl --help", () => {
+    test.each(["--help", "-h"])("bun repl %s prints repl help, not run help", async flag => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "repl", flag],
         env: { ...bunEnv, NO_COLOR: "1" },


### PR DESCRIPTION
## Repro

```console
$ bun repl --help | head -1
Usage: bun run [flags] <file or script>
$ bun repl -e 2>&1 | sed -n '1p;2p'
error: The argument '-e' requires a value but none was supplied.
Usage: bun run [flags] <file or script>
```

## Cause

`exec_repl` calls `init(Tag::RunCommand, log)` so the repl can reuse `bun run`'s param table. `arguments::parse` then dispatches both `--help` and the clap parse-error path to `tag_print_help(cmd)` with `cmd == RunCommand`, so `bun repl --help` / `bun repl -h` / `bun repl -e` (missing value) all print `bun run`'s help. The Zig code did the same (`Command.init(allocator, log, .RunCommand)`), so this predates the Rust rewrite.

## Fix

Thread a separate `help_as: CommandTag` through `create_context_data` and `arguments::parse`, consumed only by the two `tag_print_help` calls and the `CMD` / crash-handler byte. `cmd` stays `RunCommand` throughout the parse pipeline, so every downstream tag gate (`Arguments.rs`, `LOADS_CONFIG`, `Bunfig::parse`) sees exactly what it did on main. `create_context_data` becomes an `#[inline(always)]` shim around the new `create_context_data_help_as`; `exec_repl` calls the latter with `(Tag::RunCommand, Tag::ReplCommand)`.

## Verification

New `describe.concurrent("repl --help")` block in `test/cli/bun.test.ts`:

- `bun repl --help` / `bun repl -h` print `Usage: bun repl [flags]` and no `bun run`
- `bun repl -e` (missing value) prints the diagnostic followed by repl help, not run help
- `bun repl -e code foo --help` still runs with `--help` in `process.argv` (passthrough unchanged)

The first three fail on main; the fourth guards against an earlier argv-pre-scan approach that over-intercepted. `test/js/bun/repl/repl.test.ts` (147 tests) passes.

The package-manager `--help` placeholder stripping reported alongside this is covered separately by #34313 / #34317.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/bun.test.ts
bun test v1.4.0 (2e43fd6b2)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [112.31ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [102.88ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [100.66ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [108.55ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [207.81ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [130.11ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists [665.31ms]
134 |         stderr: "pipe",
135 |       });
136 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
137 |       const out = stdout + stderr;
138 |       const usage = out.split(/\r
... (truncated)

release without fix: 3 failed, 2 skipped
bun test v1.4.0-canary.1 (7bfd51808)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [2.48ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [1.95ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [1.71ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [1.45ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [2.88ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [2.37ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists [11.54ms]
134 |         stderr: "pipe",
135 |       });
136 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
137 |       const out = stdout + stderr;
138 |       const usage = out.split(/\r?\n/).find(l => l.startsWith("Usage:")) ?? "";
139 |       expect(usage).toBe("Usage: bun repl [flags]");
                          ^
error: expect(received).
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/bun.test.ts
bun test v1.4.0 (2e43fd6b2)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [113.62ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [109.08ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [101.39ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [103.16ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [211.06ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [131.77ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists [660.56ms]
(pass) bun > repl --help > bun repl --help prints repl help, not run help [133.18ms]
(pass) bun > repl --help > bun repl -h prints repl help, not run help [109.72ms]
(pass) bun > repl --help > bun repl parse error prints repl help, not run help [1
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 618ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 56s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.0-canary.1+2e43fd6b2
[build] done
bun test v1.4.0-canary.1 (2e43fd6b2)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [2.30ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [1.89ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [1.70ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [1.74ms]
(todo) bun > N
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/Arguments.rs | 12 ++++++++----
 src/runtime/cli/mod.rs       | 24 +++++++++++++++++-------
 test/cli/bun.test.ts         | 42 ++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 67 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                          reads  edits  tests
src/runtime/cli/Arguments.rs     14     11      0
src/runtime/cli/mod.rs           10     10      0
test/cli/bun.test.ts              1      5      0
```

</details>

<!-- robobun:evidence:end -->