### PR TITLE
cli: stop --jsx-* flags from switching the automatic JSX runtime to production

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1448,10 +1448,6 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 } else {
                     api::JsxRuntime::Automatic
                 },
-                // Match `Pragma::default()` so that passing only e.g.
-                // `--jsx-import-source` doesn't silently flip the automatic
-                // runtime from jsx-dev-runtime to jsx-runtime. `set_production`
-                // flips this later when NODE_ENV=production.
                 development: true,
                 side_effects: jsx_side_effects,
             });

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1448,7 +1448,11 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 } else {
                     api::JsxRuntime::Automatic
                 },
-                development: false,
+                // Match `Pragma::default()` so that passing only e.g.
+                // `--jsx-import-source` doesn't silently flip the automatic
+                // runtime from jsx-dev-runtime to jsx-runtime. `set_production`
+                // flips this later when NODE_ENV=production.
+                development: true,
                 side_effects: jsx_side_effects,
             });
         } else {
@@ -1464,7 +1468,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 } else {
                     prev.runtime
                 },
-                development: false,
+                development: prev.development,
                 side_effects: jsx_side_effects,
             });
         }

--- a/test/bundler/transpiler/jsx-cli-flags.test.ts
+++ b/test/bundler/transpiler/jsx-cli-flags.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Passing a --jsx-* CLI flag must not flip the automatic runtime from
+// jsx-dev-runtime (development) to jsx-runtime (production). The flag only
+// overrides the field it names; dev/prod selection follows NODE_ENV exactly as
+// it does when no --jsx-* flag is present.
+describe.concurrent("jsx: --jsx-* CLI flags preserve development runtime", () => {
+  const shimFiles = {
+    "node_modules/react/package.json": JSON.stringify({
+      name: "react",
+      version: "1.0.0",
+      exports: {
+        ".": "./index.js",
+        "./jsx-runtime": "./prod.js",
+        "./jsx-dev-runtime": "./dev.js",
+      },
+    }),
+    "node_modules/react/index.js": "module.exports = {};",
+    "node_modules/react/prod.js":
+      "exports.jsx = () => ({ rt: 'PROD' }); exports.jsxs = exports.jsx; exports.Fragment = {};",
+    "node_modules/react/dev.js": "exports.jsxDEV = () => ({ rt: 'DEV' }); exports.Fragment = {};",
+    "a.jsx": "console.log(JSON.stringify(<div/>));",
+  };
+
+  const cases: Array<[extraArgs: string[], nodeEnv: string | undefined, expected: "DEV" | "PROD"]> = [
+    // Baselines (no --jsx-* flags): dev by default, prod only when NODE_ENV=production.
+    [[], undefined, "DEV"],
+    [[], "development", "DEV"],
+    [[], "production", "PROD"],
+    // Any --jsx-* flag must not change the dev/prod selection.
+    [["--jsx-import-source=react"], undefined, "DEV"],
+    [["--jsx-import-source=react"], "development", "DEV"],
+    [["--jsx-import-source=react"], "production", "PROD"],
+    [["--jsx-fragment=Fragment"], undefined, "DEV"],
+    [["--jsx-fragment=Fragment"], "development", "DEV"],
+    [["--jsx-fragment=Fragment"], "production", "PROD"],
+    [["--jsx-factory=h"], undefined, "DEV"],
+    [["--jsx-runtime=automatic"], undefined, "DEV"],
+    [["--jsx-runtime=automatic"], "production", "PROD"],
+  ];
+
+  for (const [extraArgs, nodeEnv, expected] of cases) {
+    const label = `bun ${extraArgs.join(" ") || "(no flags)"} NODE_ENV=${nodeEnv ?? "<unset>"} -> ${expected}`;
+    test(label, async () => {
+      using dir = tempDir("jsx-cli-dev", shimFiles);
+      const env: Record<string, string | undefined> = { ...bunEnv, NODE_ENV: nodeEnv };
+      if (nodeEnv === undefined) delete env.NODE_ENV;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...extraArgs, "a.jsx"],
+        env,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
+      expect(exitCode).toBe(0);
+    });
+  }
+});

--- a/test/bundler/transpiler/jsx-cli-flags.test.ts
+++ b/test/bundler/transpiler/jsx-cli-flags.test.ts
@@ -23,27 +23,44 @@ describe.concurrent("jsx: --jsx-* CLI flags preserve development runtime", () =>
     "a.jsx": "console.log(JSON.stringify(<div/>));",
   };
 
-  const cases: Array<[extraArgs: string[], nodeEnv: string | undefined, expected: "DEV" | "PROD"]> = [
+  type Case = [
+    extraArgs: string[],
+    nodeEnv: string | undefined,
+    bunfig: string | undefined,
+    expected: "DEV" | "PROD",
+  ];
+  const cases: Case[] = [
     // Baselines (no --jsx-* flags): dev by default, prod only when NODE_ENV=production.
-    [[], undefined, "DEV"],
-    [[], "development", "DEV"],
-    [[], "production", "PROD"],
-    // Any --jsx-* flag must not change the dev/prod selection.
-    [["--jsx-import-source=react"], undefined, "DEV"],
-    [["--jsx-import-source=react"], "development", "DEV"],
-    [["--jsx-import-source=react"], "production", "PROD"],
-    [["--jsx-fragment=Fragment"], undefined, "DEV"],
-    [["--jsx-fragment=Fragment"], "development", "DEV"],
-    [["--jsx-fragment=Fragment"], "production", "PROD"],
-    [["--jsx-factory=h"], undefined, "DEV"],
-    [["--jsx-runtime=automatic"], undefined, "DEV"],
-    [["--jsx-runtime=automatic"], "production", "PROD"],
+    [[], undefined, undefined, "DEV"],
+    [[], "development", undefined, "DEV"],
+    [[], "production", undefined, "PROD"],
+    // Any --jsx-* flag must not change the dev/prod selection (no bunfig: fresh-construct branch).
+    [["--jsx-import-source=react"], undefined, undefined, "DEV"],
+    [["--jsx-import-source=react"], "development", undefined, "DEV"],
+    [["--jsx-import-source=react"], "production", undefined, "PROD"],
+    [["--jsx-fragment=Fragment"], undefined, undefined, "DEV"],
+    [["--jsx-fragment=Fragment"], "development", undefined, "DEV"],
+    [["--jsx-fragment=Fragment"], "production", undefined, "PROD"],
+    [["--jsx-factory=h"], undefined, undefined, "DEV"],
+    [["--jsx-runtime=automatic"], undefined, undefined, "DEV"],
+    [["--jsx-runtime=automatic"], "production", undefined, "PROD"],
+    // With a bunfig present, opts.jsx is already populated and CLI flags go through the
+    // merge-with-bunfig branch, which must preserve bunfig's `development` value.
+    [["--jsx-import-source=react"], undefined, "", "DEV"],
+    [["--jsx-import-source=react"], "production", "", "PROD"],
+    [["--jsx-fragment=Fragment"], undefined, "", "DEV"],
+    [["--jsx-import-source=react"], undefined, 'jsx = "react-jsx"\n', "PROD"],
+    [["--jsx-import-source=react"], undefined, 'jsx = "react-jsxDEV"\n', "DEV"],
   ];
 
-  for (const [extraArgs, nodeEnv, expected] of cases) {
-    const label = `bun ${extraArgs.join(" ") || "(no flags)"} NODE_ENV=${nodeEnv ?? "<unset>"} -> ${expected}`;
+  for (const [extraArgs, nodeEnv, bunfig, expected] of cases) {
+    const bunfigLabel =
+      bunfig === undefined ? "no bunfig" : bunfig === "" ? "empty bunfig" : `bunfig ${bunfig.trim()}`;
+    const label = `bun ${extraArgs.join(" ") || "(no flags)"} NODE_ENV=${nodeEnv ?? "<unset>"} [${bunfigLabel}] -> ${expected}`;
     test(label, async () => {
-      using dir = tempDir("jsx-cli-dev", shimFiles);
+      const files: Record<string, string> = { ...shimFiles };
+      if (bunfig !== undefined) files["bunfig.toml"] = bunfig;
+      using dir = tempDir("jsx-cli-dev", files);
       const env: Record<string, string | undefined> = { ...bunEnv, NODE_ENV: nodeEnv };
       if (nodeEnv === undefined) delete env.NODE_ENV;
       await using proc = Bun.spawn({

--- a/test/bundler/transpiler/jsx-cli-flags.test.ts
+++ b/test/bundler/transpiler/jsx-cli-flags.test.ts
@@ -23,12 +23,7 @@ describe.concurrent("jsx: --jsx-* CLI flags preserve development runtime", () =>
     "a.jsx": "console.log(JSON.stringify(<div/>));",
   };
 
-  type Case = [
-    extraArgs: string[],
-    nodeEnv: string | undefined,
-    bunfig: string | undefined,
-    expected: "DEV" | "PROD",
-  ];
+  type Case = [extraArgs: string[], nodeEnv: string | undefined, bunfig: string | undefined, expected: "DEV" | "PROD"];
   const cases: Case[] = [
     // Baselines (no --jsx-* flags): dev by default, prod only when NODE_ENV=production.
     [[], undefined, undefined, "DEV"],
@@ -54,8 +49,7 @@ describe.concurrent("jsx: --jsx-* CLI flags preserve development runtime", () =>
   ];
 
   for (const [extraArgs, nodeEnv, bunfig, expected] of cases) {
-    const bunfigLabel =
-      bunfig === undefined ? "no bunfig" : bunfig === "" ? "empty bunfig" : `bunfig ${bunfig.trim()}`;
+    const bunfigLabel = bunfig === undefined ? "no bunfig" : bunfig === "" ? "empty bunfig" : `bunfig ${bunfig.trim()}`;
     const label = `bun ${extraArgs.join(" ") || "(no flags)"} NODE_ENV=${nodeEnv ?? "<unset>"} [${bunfigLabel}] -> ${expected}`;
     test(label, async () => {
       const files: Record<string, string> = { ...shimFiles };

--- a/test/bundler/transpiler/jsx-production.test.ts
+++ b/test/bundler/transpiler/jsx-production.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 // https://github.com/oven-sh/bun/issues/3768
@@ -42,5 +42,65 @@ describe.concurrent("jsx", () => {
         expect(await proc.exited).toBe(0);
       });
     }
+  }
+});
+
+// Passing a --jsx-* CLI flag must not flip the automatic runtime from
+// jsx-dev-runtime (development) to jsx-runtime (production). The flag only
+// overrides the field it names; dev/prod selection follows NODE_ENV exactly as
+// it does when no --jsx-* flag is present.
+describe.concurrent("jsx: --jsx-* CLI flags preserve development runtime", () => {
+  const shimFiles = {
+    "node_modules/react/package.json": JSON.stringify({
+      name: "react",
+      version: "1.0.0",
+      exports: {
+        ".": "./index.js",
+        "./jsx-runtime": "./prod.js",
+        "./jsx-dev-runtime": "./dev.js",
+      },
+    }),
+    "node_modules/react/index.js": "module.exports = {};",
+    "node_modules/react/prod.js":
+      "exports.jsx = () => ({ rt: 'PROD' }); exports.jsxs = exports.jsx; exports.Fragment = {};",
+    "node_modules/react/dev.js": "exports.jsxDEV = () => ({ rt: 'DEV' }); exports.Fragment = {};",
+    "a.jsx": "console.log(JSON.stringify(<div/>));",
+  };
+
+  const cases: Array<[extraArgs: string[], nodeEnv: string | undefined, expected: "DEV" | "PROD"]> = [
+    // Baselines (no --jsx-* flags): dev by default, prod only when NODE_ENV=production.
+    [[], undefined, "DEV"],
+    [[], "development", "DEV"],
+    [[], "production", "PROD"],
+    // Any --jsx-* flag must not change the dev/prod selection.
+    [["--jsx-import-source=react"], undefined, "DEV"],
+    [["--jsx-import-source=react"], "development", "DEV"],
+    [["--jsx-import-source=react"], "production", "PROD"],
+    [["--jsx-fragment=Fragment"], undefined, "DEV"],
+    [["--jsx-fragment=Fragment"], "development", "DEV"],
+    [["--jsx-fragment=Fragment"], "production", "PROD"],
+    [["--jsx-factory=h"], undefined, "DEV"],
+    [["--jsx-runtime=automatic"], undefined, "DEV"],
+    [["--jsx-runtime=automatic"], "production", "PROD"],
+  ];
+
+  for (const [extraArgs, nodeEnv, expected] of cases) {
+    const label = `bun ${extraArgs.join(" ") || "(no flags)"} NODE_ENV=${nodeEnv ?? "<unset>"} -> ${expected}`;
+    test(label, async () => {
+      using dir = tempDir("jsx-cli-dev", shimFiles);
+      const env: Record<string, string | undefined> = { ...bunEnv, NODE_ENV: nodeEnv };
+      if (nodeEnv === undefined) delete env.NODE_ENV;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...extraArgs, "a.jsx"],
+        env,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
+      expect(exitCode).toBe(0);
+    });
   }
 });

--- a/test/bundler/transpiler/jsx-production.test.ts
+++ b/test/bundler/transpiler/jsx-production.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 // https://github.com/oven-sh/bun/issues/3768
@@ -42,65 +42,5 @@ describe.concurrent("jsx", () => {
         expect(await proc.exited).toBe(0);
       });
     }
-  }
-});
-
-// Passing a --jsx-* CLI flag must not flip the automatic runtime from
-// jsx-dev-runtime (development) to jsx-runtime (production). The flag only
-// overrides the field it names; dev/prod selection follows NODE_ENV exactly as
-// it does when no --jsx-* flag is present.
-describe.concurrent("jsx: --jsx-* CLI flags preserve development runtime", () => {
-  const shimFiles = {
-    "node_modules/react/package.json": JSON.stringify({
-      name: "react",
-      version: "1.0.0",
-      exports: {
-        ".": "./index.js",
-        "./jsx-runtime": "./prod.js",
-        "./jsx-dev-runtime": "./dev.js",
-      },
-    }),
-    "node_modules/react/index.js": "module.exports = {};",
-    "node_modules/react/prod.js":
-      "exports.jsx = () => ({ rt: 'PROD' }); exports.jsxs = exports.jsx; exports.Fragment = {};",
-    "node_modules/react/dev.js": "exports.jsxDEV = () => ({ rt: 'DEV' }); exports.Fragment = {};",
-    "a.jsx": "console.log(JSON.stringify(<div/>));",
-  };
-
-  const cases: Array<[extraArgs: string[], nodeEnv: string | undefined, expected: "DEV" | "PROD"]> = [
-    // Baselines (no --jsx-* flags): dev by default, prod only when NODE_ENV=production.
-    [[], undefined, "DEV"],
-    [[], "development", "DEV"],
-    [[], "production", "PROD"],
-    // Any --jsx-* flag must not change the dev/prod selection.
-    [["--jsx-import-source=react"], undefined, "DEV"],
-    [["--jsx-import-source=react"], "development", "DEV"],
-    [["--jsx-import-source=react"], "production", "PROD"],
-    [["--jsx-fragment=Fragment"], undefined, "DEV"],
-    [["--jsx-fragment=Fragment"], "development", "DEV"],
-    [["--jsx-fragment=Fragment"], "production", "PROD"],
-    [["--jsx-factory=h"], undefined, "DEV"],
-    [["--jsx-runtime=automatic"], undefined, "DEV"],
-    [["--jsx-runtime=automatic"], "production", "PROD"],
-  ];
-
-  for (const [extraArgs, nodeEnv, expected] of cases) {
-    const label = `bun ${extraArgs.join(" ") || "(no flags)"} NODE_ENV=${nodeEnv ?? "<unset>"} -> ${expected}`;
-    test(label, async () => {
-      using dir = tempDir("jsx-cli-dev", shimFiles);
-      const env: Record<string, string | undefined> = { ...bunEnv, NODE_ENV: nodeEnv };
-      if (nodeEnv === undefined) delete env.NODE_ENV;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), ...extraArgs, "a.jsx"],
-        env,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
-      expect(exitCode).toBe(0);
-    });
   }
 });


### PR DESCRIPTION
## What

Passing any `--jsx-*` CLI flag (`--jsx-import-source`, `--jsx-fragment`, `--jsx-factory`, `--jsx-runtime`) to `bun <file.jsx>` silently flipped the automatic JSX runtime from development (`jsxDEV` / `<source>/jsx-dev-runtime`) to production (`jsx` / `<source>/jsx-runtime`), even when the flag had nothing to do with dev/prod selection. Setting `NODE_ENV=development` in the environment did not restore it; only an explicit `--define process.env.NODE_ENV='"development"'` did.

## Repro

```sh
d=$(mktemp -d); cd $d
mkdir -p node_modules/react/jsx-runtime node_modules/react/jsx-dev-runtime
echo 'exports.jsx=(t)=>({rt:"PROD"});exports.jsxs=exports.jsx' > node_modules/react/jsx-runtime/index.js
echo 'exports.jsxDEV=(t)=>({rt:"DEV"})' > node_modules/react/jsx-dev-runtime/index.js
printf '{"name":"react"}' > node_modules/react/package.json
echo 'console.log(JSON.stringify(<div/>))' > a.jsx

bun a.jsx                                                  # {"rt":"DEV"}   ok
bun --jsx-import-source=react a.jsx                        # {"rt":"PROD"}  dev lost, even though source == default
bun --jsx-fragment=Fragment a.jsx                          # {"rt":"PROD"}  unrelated flag also flips it
NODE_ENV=development bun --jsx-import-source=react a.jsx   # {"rt":"PROD"}  env NODE_ENV ignored
```

## Cause

`src/runtime/cli/Arguments.rs` constructs an `api::Jsx` when any `--jsx-*` flag is present and hardcoded `development: false` in both the fresh-construct branch and the merge-with-bunfig branch. With no `--jsx-*` flags, `transform.jsx` stays `None` and `BundleOptions::from_api` keeps `Pragma::default()`, which has `development: true`. So the presence of any flag re-derived JSX options without the development default, and nothing downstream on the `bun run` path restores it unless `NODE_ENV` reaches the define map (the `LoadAllWithoutInlining` env behavior used by `bun run` skips that injection).

## Fix

Default `development: true` to match `Pragma::default()`, bunfig, and `JSBundler`. In the bunfig-merge branch, preserve `prev.development` instead of overwriting it. `NODE_ENV=production` still switches to the production runtime via `set_production()` exactly as before.

## Verification

New parameterized test in `test/bundler/transpiler/jsx-cli-flags.test.ts` spawns `bun a.jsx` with a shim `react` package whose `jsx-runtime` and `jsx-dev-runtime` report which one was imported, across the matrix of `--jsx-*` flags and `NODE_ENV` values. 6 of the 12 cases fail before this change (all `--jsx-*` + dev cases emit `PROD`); all 12 pass after.

The test lives in its own file rather than `jsx-production.test.ts` because the existing describe block in that file spawns a heavy fixture (react-dom render + `Bun.build` + dynamic import) that races the 5s default timeout under debug+ASAN builds, independently of this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/jsx-cli-flags.test.ts
bun test v1.4.0 (e4812883e)

test/bundler/transpiler/jsx-cli-flags.test.ts:
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun (no flags) NODE_ENV=<unset> [no bunfig] -> DEV [996.95ms]
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun (no flags) NODE_ENV=development [no bunfig] -> DEV [757.11ms]
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun (no flags) NODE_ENV=production [no bunfig] -> PROD [748.38ms]
64 |         stdout: "pipe",
65 |         stderr: "pipe",
66 |       });
67 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
68 |       expect(stderr).toBe("");
69 |       expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
                                 ^
error: expect(received).toBe(expected)

Expected: "{"rt":"DEV"}"
Received: "{"rt":"PROD"}"

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-cli-flags.test.ts:69:29)
(fail) jsx: --jsx-* CLI flags pre
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/jsx-cli-flags.test.ts:
64 |         stdout: "pipe",
65 |         stderr: "pipe",
66 |       });
67 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
68 |       expect(stderr).toBe("");
69 |       expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
                                 ^
error: expect(received).toBe(expected)

Expected: "{"rt":"DEV"}"
Received: "{"rt":"PROD"}"

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-cli-flags.test.ts:69:29)
64 |         stdout: "pipe",
65 |         stderr: "pipe",
66 |       });
67 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
68 |       expect(stderr).toBe("");
69 |       expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
                                 ^
error: expect(received).toBe(expected)

Expected: "{"rt":"DEV"}"
Received: "{"rt":"PROD"}"

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-cli-flags.test.ts:69:29)
64 |         stdout: "pipe",
65 |         stderr: "pipe",
66 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/jsx-cli-flags.test.ts
bun test v1.4.0 (e4812883e)

test/bundler/transpiler/jsx-cli-flags.test.ts:
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun (no flags) NODE_ENV=<unset> [no bunfig] -> DEV [1043.19ms]
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun (no flags) NODE_ENV=production [no bunfig] -> PROD [1064.69ms]
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun (no flags) NODE_ENV=development [no bunfig] -> DEV [1198.58ms]
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun --jsx-import-source=react NODE_ENV=<unset> [no bunfig] -> DEV [1190.26ms]
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun --jsx-import-source=react NODE_ENV=production [no bunfig] -> PROD [1054.65ms]
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun --jsx-import-source=react NODE_ENV=development [no bunfig] -> DEV [2363.22ms]
(pass) jsx: --jsx-* CLI flags preserve development runtime > bun --jsx-fragment=Fragment NODE_ENV=development [no bunfig] ->
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e4812883e7
  features     baseline

22 deps, 108 codegen, 1171 objects in 9631ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] fetch zlib
[zlib] up to date
[3/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1234] fetch tinycc
[tinycc] up to date
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] gen ErrorCode+*.h
[7/1234] gen .bind.ts → GeneratedBindings.cpp
[8/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1234] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[10/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[11/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/Arguments.rs                  |  4 +-
 test/bundler/transpiler/jsx-cli-flags.test.ts | 73 +++++++++++++++++++++++++++
 2 files changed, 75 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/cli/Arguments.rs                       7      3      0
test/bundler/transpiler/jsx-cli-flags.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->