### PR TITLE
test(napi): extend the direct-compile fast path to Windows

### DIFF
--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -115,8 +115,10 @@ function posixCompileArgs(target: GypTarget, include: string, out: string): stri
 // MSVC toolchain + Windows SDK, so unlike cl.exe it works without a Developer Command
 // Prompt. This mirrors the node-gyp-generated MSBuild invocation for the addons here:
 // one translation unit per source, win_delay_load_hook.cc linked in, /DELAYLOAD:node.exe
-// so the hook can redirect the import to the host process at load time.
-function windowsCompileArgs(target: GypTarget, include: string, lib: string, scratch: string, out: string): string[] {
+// so the hook can redirect the import to the host process at load time. Every output
+// (objects, /OUT, /PDB) lands in the per-target scratch dir; tryBuildFast promotes the
+// .node and .pdb into build/Debug only after the link exits cleanly.
+function windowsCompileArgs(target: GypTarget, include: string, lib: string, scratch: string): string[] {
   return [
     "clang-cl",
     "/nologo",
@@ -138,7 +140,7 @@ function windowsCompileArgs(target: GypTarget, include: string, lib: string, scr
     "/DLL",
     "/DEBUG",
     `/OUT:${join(scratch, `${target.target_name}.node`)}`,
-    `/PDB:${join(out, `${target.target_name}.pdb`)}`,
+    `/PDB:${join(scratch, `${target.target_name}.pdb`)}`,
     lib,
     "delayimp.lib",
     "/DELAYLOAD:node.exe",
@@ -178,7 +180,7 @@ async function tryBuildFast(dir: string): Promise<boolean> {
         const child = spawn({
           cmd:
             process.platform === "win32"
-              ? windowsCompileArgs(target, headers.include, headers.lib!, tmp, outDir)
+              ? windowsCompileArgs(target, headers.include, headers.lib!, tmp)
               : posixCompileArgs(target, headers.include, tmp),
           cwd: dir,
           stderr: "pipe",
@@ -197,7 +199,12 @@ async function tryBuildFast(dir: string): Promise<boolean> {
           );
           return false;
         }
-        renameSync(process.platform === "win32" ? join(tmp, `${target.target_name}.node`) : tmp, output);
+        if (process.platform === "win32") {
+          renameSync(join(tmp, `${target.target_name}.node`), output);
+          renameSync(join(tmp, `${target.target_name}.pdb`), join(outDir, `${target.target_name}.pdb`));
+        } else {
+          renameSync(tmp, output);
+        }
         return true;
       } catch (error) {
         console.warn(`direct compile of ${target.target_name} in ${dir} failed, falling back to node-gyp: ${error}`);

--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -1,8 +1,8 @@
 import { spawn, spawnSync } from "bun";
 import { existsSync, renameSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { bunExe, bunEnv, isCI, isMusl } from "../../harness";
 
 // Tests that intentionally abort and should not generate core dumps when they abort
@@ -57,11 +57,15 @@ function parseSimpleBindingGyp(text: string): GypTarget[] | null {
 
 // Read-only lookup of the header tree node-gyp itself installs. Never downloads or
 // mutates the cache; if it isn't complete we fall back to node-gyp (which fills it).
-function findNodeHeaders(): string | null {
+// On Windows the import library lives next to the headers and is required for linking,
+// so we return it too; POSIX just leaves `lib` undefined.
+function findNodeHeaders(): { include: string; lib?: string } | null {
   const candidates: string[] = [];
   if (process.env.npm_config_devdir) candidates.push(process.env.npm_config_devdir);
   if (process.platform === "darwin") {
     candidates.push(join(homedir(), "Library", "Caches", "node-gyp"));
+  } else if (process.platform === "win32") {
+    if (process.env.LOCALAPPDATA) candidates.push(join(process.env.LOCALAPPDATA, "node-gyp", "Cache"));
   } else {
     if (process.env.XDG_CACHE_HOME) candidates.push(join(process.env.XDG_CACHE_HOME, "node-gyp"));
     candidates.push(join(homedir(), ".cache", "node-gyp"));
@@ -70,9 +74,11 @@ function findNodeHeaders(): string | null {
     const base = join(devDir, NODE_HEADERS_VERSION);
     const include = join(base, "include", "node");
     // node-gyp writes `installVersion` last, only after the headers finish extracting.
-    if (existsSync(join(base, "installVersion")) && existsSync(join(include, "node_api.h"))) {
-      return include;
-    }
+    if (!(existsSync(join(base, "installVersion")) && existsSync(join(include, "node_api.h")))) continue;
+    if (process.platform !== "win32") return { include };
+    // node-gyp lays the import library out as `<cache>/<version>/<arch>/node.lib`.
+    const lib = join(base, process.arch, "node.lib");
+    if (existsSync(lib)) return { include, lib };
   }
   return null;
 }
@@ -83,62 +89,117 @@ function compilerFor(cxx: boolean): string {
   return process.env.CC || "cc";
 }
 
-// node-gyp's fixed per-addon bootstrap (bun x + python gyp configure + make) costs several
-// seconds per directory. When binding.gyp is the trivial shape used by every addon in this
-// suite and the node headers are already cached, one direct compiler invocation produces
-// the same build/Debug/<target>.node in well under a second. Returns false to fall back.
+function posixCompileArgs(target: GypTarget, include: string, out: string): string[] {
+  const cxx = target.sources[0].endsWith(".cc");
+  return [
+    compilerFor(cxx),
+    ...(cxx ? ["-std=gnu++20"] : []),
+    "-shared",
+    "-fPIC",
+    "-g",
+    "-O0",
+    ...(process.platform === "darwin" ? ["-undefined", "dynamic_lookup"] : []),
+    `-I${include}`,
+    `-DNODE_GYP_MODULE_NAME=${target.target_name}`,
+    "-DBUILDING_NODE_EXTENSION",
+    "-DDEBUG",
+    "-D_DEBUG",
+    ...(target.defines ?? []).map(define => `-D${define}`),
+    ...target.sources,
+    "-o",
+    out,
+  ];
+}
+
+// clang-cl is on PATH on every Windows CI/dev image (scoop llvm) and auto-detects the
+// MSVC toolchain + Windows SDK, so unlike cl.exe it works without a Developer Command
+// Prompt. This mirrors the node-gyp-generated MSBuild invocation for the addons here:
+// one translation unit per source, win_delay_load_hook.cc linked in, /DELAYLOAD:node.exe
+// so the hook can redirect the import to the host process at load time.
+function windowsCompileArgs(target: GypTarget, include: string, lib: string, out: string): string[] {
+  return [
+    "clang-cl",
+    "/nologo",
+    ...(target.sources[0].endsWith(".cc") ? ["/std:c++20", "/EHsc"] : []),
+    "/MDd",
+    "/Od",
+    `/I${include}`,
+    `/DNODE_GYP_MODULE_NAME=${target.target_name}`,
+    "/DBUILDING_NODE_EXTENSION",
+    "/DDEBUG",
+    "/D_DEBUG",
+    '/DHOST_BINARY="node.exe"',
+    ...(target.defines ?? []).map(define => `/D${define}`),
+    ...target.sources,
+    join(import.meta.dir, "win_delay_load_hook.cc"),
+    `/Fo${out}${sep}`,
+    "/link",
+    "/DLL",
+    `/OUT:${join(out, `${target.target_name}.node`)}`,
+    lib,
+    "delayimp.lib",
+    "/DELAYLOAD:node.exe",
+  ];
+}
+
+// node-gyp's fixed per-addon bootstrap (bun x + python gyp configure + make/MSBuild) costs
+// several seconds per directory. When binding.gyp is the trivial shape used by every addon
+// in this suite and the node headers are already cached, one direct compiler invocation
+// produces the same build/Debug/<target>.node in well under a second. Returns false to
+// fall back.
 async function tryBuildFast(dir: string): Promise<boolean> {
-  if (process.platform === "win32") return false;
   const gypPath = join(dir, "binding.gyp");
   if (!existsSync(gypPath)) return false;
   const targets = parseSimpleBindingGyp(await Bun.file(gypPath).text());
   if (targets === null) return false;
-  const nodeInclude = findNodeHeaders();
-  if (nodeInclude === null) return false;
+  const headers = findNodeHeaders();
+  if (headers === null) return false;
+  if (process.platform === "win32" && Bun.which("clang-cl") === null) return false;
 
   const outDir = join(dir, "build", "Debug");
   await mkdir(outDir, { recursive: true });
 
   const results = await Promise.all(
     targets.map(async target => {
-      const cxx = target.sources[0].endsWith(".cc");
       // Compile to a temporary name and rename so a partial artifact is never loadable.
       const output = join(outDir, `${target.target_name}.node`);
-      const tmpOutput = join(outDir, `.${target.target_name}.${process.pid}.tmp.node`);
+      // Windows: clang-cl scatters per-source .obj files next to the .node, so give each
+      // target its own scratch dir and let /Fo + /OUT place the final artifact there.
+      // POSIX: the driver writes only the final shared object, so a temp filename suffices.
+      const tmp =
+        process.platform === "win32"
+          ? join(outDir, `.${target.target_name}.${process.pid}.tmp`)
+          : join(outDir, `.${target.target_name}.${process.pid}.tmp.node`);
       try {
+        if (process.platform === "win32") await mkdir(tmp, { recursive: true });
         const child = spawn({
-          cmd: [
-            compilerFor(cxx),
-            ...(cxx ? ["-std=gnu++20"] : []),
-            "-shared",
-            "-fPIC",
-            "-g",
-            "-O0",
-            ...(process.platform === "darwin" ? ["-undefined", "dynamic_lookup"] : []),
-            `-I${nodeInclude}`,
-            `-DNODE_GYP_MODULE_NAME=${target.target_name}`,
-            "-DBUILDING_NODE_EXTENSION",
-            "-DDEBUG",
-            "-D_DEBUG",
-            ...(target.defines ?? []).map(define => `-D${define}`),
-            ...target.sources,
-            "-o",
-            tmpOutput,
-          ],
+          cmd:
+            process.platform === "win32"
+              ? windowsCompileArgs(target, headers.include, headers.lib!, tmp)
+              : posixCompileArgs(target, headers.include, tmp),
           cwd: dir,
           stderr: "pipe",
-          stdout: "ignore",
+          stdout: "pipe",
           stdin: "ignore",
           env: bunEnv,
         });
-        const [stderr, exitCode] = await Promise.all([new Response(child.stderr).text(), child.exited]);
+        const [stderr, stdout, exitCode] = await Promise.all([
+          new Response(child.stderr).text(),
+          new Response(child.stdout).text(),
+          child.exited,
+        ]);
         if (exitCode !== 0) {
           console.warn(
-            `direct compile of ${target.target_name} in ${dir} failed, falling back to node-gyp:\n${stderr}`,
+            `direct compile of ${target.target_name} in ${dir} failed, falling back to node-gyp:\n${stdout}${stderr}`,
           );
           return false;
         }
-        renameSync(tmpOutput, output);
+        if (process.platform === "win32") {
+          renameSync(join(tmp, `${target.target_name}.node`), output);
+          await rm(tmp, { recursive: true, force: true });
+        } else {
+          renameSync(tmp, output);
+        }
         return true;
       } catch (error) {
         console.warn(`direct compile of ${target.target_name} in ${dir} failed, falling back to node-gyp: ${error}`);

--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -116,13 +116,14 @@ function posixCompileArgs(target: GypTarget, include: string, out: string): stri
 // Prompt. This mirrors the node-gyp-generated MSBuild invocation for the addons here:
 // one translation unit per source, win_delay_load_hook.cc linked in, /DELAYLOAD:node.exe
 // so the hook can redirect the import to the host process at load time.
-function windowsCompileArgs(target: GypTarget, include: string, lib: string, out: string): string[] {
+function windowsCompileArgs(target: GypTarget, include: string, lib: string, scratch: string, out: string): string[] {
   return [
     "clang-cl",
     "/nologo",
     ...(target.sources[0].endsWith(".cc") ? ["/std:c++20", "/EHsc"] : []),
     "/MTd",
     "/Od",
+    "/Z7",
     `/I${include}`,
     `/DNODE_GYP_MODULE_NAME=${target.target_name}`,
     "/DBUILDING_NODE_EXTENSION",
@@ -132,10 +133,12 @@ function windowsCompileArgs(target: GypTarget, include: string, lib: string, out
     ...(target.defines ?? []).map(define => `/D${define}`),
     ...target.sources,
     join(import.meta.dir, "win_delay_load_hook.cc"),
-    `/Fo${out}${sep}`,
+    `/Fo${scratch}${sep}`,
     "/link",
     "/DLL",
-    `/OUT:${join(out, `${target.target_name}.node`)}`,
+    "/DEBUG",
+    `/OUT:${join(scratch, `${target.target_name}.node`)}`,
+    `/PDB:${join(out, `${target.target_name}.pdb`)}`,
     lib,
     "delayimp.lib",
     "/DELAYLOAD:node.exe",
@@ -175,7 +178,7 @@ async function tryBuildFast(dir: string): Promise<boolean> {
         const child = spawn({
           cmd:
             process.platform === "win32"
-              ? windowsCompileArgs(target, headers.include, headers.lib!, tmp)
+              ? windowsCompileArgs(target, headers.include, headers.lib!, tmp, outDir)
               : posixCompileArgs(target, headers.include, tmp),
           cwd: dir,
           stderr: "pipe",
@@ -200,7 +203,9 @@ async function tryBuildFast(dir: string): Promise<boolean> {
         console.warn(`direct compile of ${target.target_name} in ${dir} failed, falling back to node-gyp: ${error}`);
         return false;
       } finally {
-        if (process.platform === "win32") await rm(tmp, { recursive: true, force: true });
+        // Best-effort: a transient EBUSY/EPERM here must not override the return value and
+        // turn a successful fast-path build (or a clean fallback) into a hard test failure.
+        if (process.platform === "win32") await rm(tmp, { recursive: true, force: true }).catch(() => {});
       }
     }),
   );

--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -121,7 +121,7 @@ function windowsCompileArgs(target: GypTarget, include: string, lib: string, out
     "clang-cl",
     "/nologo",
     ...(target.sources[0].endsWith(".cc") ? ["/std:c++20", "/EHsc"] : []),
-    "/MDd",
+    "/MTd",
     "/Od",
     `/I${include}`,
     `/DNODE_GYP_MODULE_NAME=${target.target_name}`,
@@ -194,16 +194,13 @@ async function tryBuildFast(dir: string): Promise<boolean> {
           );
           return false;
         }
-        if (process.platform === "win32") {
-          renameSync(join(tmp, `${target.target_name}.node`), output);
-          await rm(tmp, { recursive: true, force: true });
-        } else {
-          renameSync(tmp, output);
-        }
+        renameSync(process.platform === "win32" ? join(tmp, `${target.target_name}.node`) : tmp, output);
         return true;
       } catch (error) {
         console.warn(`direct compile of ${target.target_name} in ${dir} failed, falling back to node-gyp: ${error}`);
         return false;
+      } finally {
+        if (process.platform === "win32") await rm(tmp, { recursive: true, force: true });
       }
     }),
   );

--- a/test/napi/node-napi-tests/win_delay_load_hook.cc
+++ b/test/napi/node-napi-tests/win_delay_load_hook.cc
@@ -1,0 +1,44 @@
+/*
+ * When this file is linked to a DLL, it sets up a delay-load hook that
+ * intervenes when the DLL is trying to load the host executable
+ * dynamically. Instead of trying to locate the .exe file it'll just
+ * return a handle to the process image.
+ *
+ * This allows compiled addons to work when the host executable is renamed.
+ *
+ * Copied from node-gyp (MIT). The direct-compile fast path in harness.ts
+ * links this in so it does not have to locate the copy inside whichever
+ * bunx-cached node-gyp install happens to exist.
+ */
+
+#ifdef _MSC_VER
+
+#pragma managed(push, off)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+#include <delayimp.h>
+#include <string.h>
+
+static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  HMODULE m;
+  if (event != dliNotePreLoadLibrary)
+    return NULL;
+
+  if (_stricmp(info->szDll, HOST_BINARY) != 0)
+    return NULL;
+
+  m = GetModuleHandle(TEXT("libnode.dll"));
+  if (m == NULL) m = GetModuleHandle(NULL);
+  return (FARPROC) m;
+}
+
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
+
+#pragma managed(pop)
+
+#endif


### PR DESCRIPTION
## What does this PR do?

Speeds up the 55 `do.test.ts` wrappers under `test/napi/node-napi-tests/` on Windows by letting the existing `tryBuildFast` path handle that platform too.

#33622 added a fast path that bypasses node-gyp on POSIX by invoking the platform compiler directly once the node headers are cached. On Windows the function returned `false` immediately, so every addon still went through `bun x node-gyp@11 configure build` (python gyp + MSBuild), which is ~4-5s per directory once warm and 30-40s for whichever file runs first in a shard and has to install node-gyp and download headers. The 38s `7_factory_wrap/do.test.ts` observed on `windows 2019 x64` in build 83901 is that cold cost; the next file in the same shard took 4.55s.

Change:

- `findNodeHeaders` now also probes `%LOCALAPPDATA%\node-gyp\Cache\<version>` and, on Windows, additionally requires the matching `<arch>\node.lib` import library.
- `win_delay_load_hook.cc` is vendored next to the harness (copied from node-gyp, MIT). It is the same hook node-gyp links into every addon so `/DELAYLOAD:node.exe` resolves to the host process.
- `windowsCompileArgs` drives `clang-cl` to produce `build\Debug\<target>.node` directly: headers via `/I`, the gyp defines, the sources plus the delay-load hook, then `/link /DLL` against `node.lib` with `/DELAYLOAD:node.exe` and `delayimp.lib`. `clang-cl` is on `PATH` on every Windows CI/dev image via the scoop LLVM install and auto-detects the MSVC toolchain, so it works outside a Developer Command Prompt.
- The POSIX command line is unchanged, just pulled out into `posixCompileArgs` so `tryBuildFast` can branch on platform.
- Any failure (headers not cached, `clang-cl` missing, compile error) returns `false` and falls back to `buildWithNodeGyp` exactly as before.

## How did you verify your code works?

Timed on a Windows Server 2019 x64 machine, system Bun, node headers already cached:

| | main | this PR |
|---|---|---|
| `7_factory_wrap/do.test.ts` | 4.06s | 0.48s |
| full `node-napi-tests/` suite (55 files) | 377.7s | 22.1s |

Both runs: 123 pass, 25 todo, 0 fail.

Cold start (no header cache) is unchanged: the fast path sees no headers, returns `false`, node-gyp downloads them and builds the first addon; every subsequent file in that shard then takes the fast path.

On Linux (debug+ASAN, headers cached) the full suite is still 124 pass / 24 todo / 0 fail and the POSIX fast path still fires for every addon; `7_factory_wrap` timing is unchanged since the POSIX path already existed.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->